### PR TITLE
fixed bug when primary key has custom name

### DIFF
--- a/src/metadata/EntityMetadata.ts
+++ b/src/metadata/EntityMetadata.ts
@@ -556,6 +556,31 @@ export class EntityMetadata {
     }
 
     /**
+     * Same as `getEntityIdMap` but the key of the map will be the column names instead of the property names. 
+     */
+    getEntityIdColumnMap(entity: any): ObjectLiteral|undefined {
+        return this.transformIdMapToColumnNames(this.getEntityIdMap(entity));
+    }
+
+    transformIdMapToColumnNames(idMap: ObjectLiteral|undefined) {
+        if (!idMap) {
+            return idMap;
+        }
+        const map: ObjectLiteral = {};
+        Object.keys(idMap).forEach(propertyName => {
+            const column = this.getColumnByPropertyName(propertyName);
+            if (column) {
+                map[column.name] = idMap[propertyName];
+            }
+        });
+        return map;
+    }
+
+    getColumnByPropertyName(propertyName: string) {
+        return this._columns.find(column => column.propertyName === propertyName);
+    }
+    
+    /**
      * Checks if column with the given property name exist.
      */
     hasColumnWithPropertyName(propertyName: string): boolean {

--- a/test/functional/persistence/custom-column-name-pk/custom-column-name-pk.ts
+++ b/test/functional/persistence/custom-column-name-pk/custom-column-name-pk.ts
@@ -1,0 +1,55 @@
+import "reflect-metadata";
+import {setupTestingConnections, closeConnections, reloadDatabases} from "../../../utils/test-utils";
+import {Connection} from "../../../../src/connection/Connection";
+import {Post} from "./entity/Post";
+import {Category} from "./entity/Category";
+
+describe("persistence > cascade operations with custom name", () => {
+
+    let connections: Connection[];
+    before(async () => connections = await setupTestingConnections({
+        entities: [__dirname + "/entity/*{.js,.ts}"],
+        schemaCreate: true,
+    }));
+    beforeEach(() => reloadDatabases(connections));
+    after(() => closeConnections(connections));
+
+    describe("cascade update", function() {
+
+        it("should remove relation", () => Promise.all(connections.map(async connection => {
+
+            // create first post and category and save them
+            const post1 = new Post();
+            post1.title = "Hello Post #1";
+
+            const category1 = new Category();
+            category1.name = "Category saved by cascades #1";
+            category1.posts = [post1];
+
+            await connection.entityManager.persist(category1);
+
+            category1.posts = [];
+
+            await connection.entityManager.persist(category1);
+
+            // now check
+            const posts = await connection.entityManager.find(Post, {
+                alias: "post",
+                leftJoinAndSelect: {
+                    category: "post.category"
+                },
+                orderBy: {
+                    "post.id": "ASC"
+                }
+            });
+            console.log(posts);
+
+            posts.should.be.eql([{
+                id: 1,
+                title: "Hello Post #1"
+            }]);
+        })));
+
+    });
+
+});

--- a/test/functional/persistence/custom-column-name-pk/entity/Category.ts
+++ b/test/functional/persistence/custom-column-name-pk/entity/Category.ts
@@ -1,0 +1,21 @@
+import {Table} from "../../../../../src/decorator/tables/Table";
+import {PrimaryColumn} from "../../../../../src/decorator/columns/PrimaryColumn";
+import {Column} from "../../../../../src/decorator/columns/Column";
+import {Post} from "./Post";
+import {OneToMany} from "../../../../../src/decorator/relations/OneToMany";
+
+@Table()
+export class Category {
+
+    @PrimaryColumn("int", {generated: true, name: "theId"})
+    id: number;
+
+    @Column()
+    name: string;
+
+    @OneToMany(type => Post, post => post.category, {
+        cascadeInsert: true
+    })
+    posts: Post[];
+
+}

--- a/test/functional/persistence/custom-column-name-pk/entity/Post.ts
+++ b/test/functional/persistence/custom-column-name-pk/entity/Post.ts
@@ -1,0 +1,21 @@
+import {Table} from "../../../../../src/decorator/tables/Table";
+import {PrimaryColumn} from "../../../../../src/decorator/columns/PrimaryColumn";
+import {Column} from "../../../../../src/decorator/columns/Column";
+import {ManyToOne} from "../../../../../src/decorator/relations/ManyToOne";
+import {Category} from "./Category";
+
+@Table()
+export class Post {
+
+    @PrimaryColumn("int", {generated: true, name: "theId"})
+    id: number;
+
+    @Column()
+    title: string;
+
+    @ManyToOne(type => Category, category => category.posts, {
+        cascadeInsert: true
+    })
+    category: Category;
+
+}


### PR DESCRIPTION
in some cases the PersistOperationExecutor used the property names instead of column names for update/delete statements.
This PR fixes these problems.