### PR TITLE
resolve entity and schema dir paths

### DIFF
--- a/src/util/DirectoryExportedClassesLoader.ts
+++ b/src/util/DirectoryExportedClassesLoader.ts
@@ -28,7 +28,7 @@ export function importClassesFromDirectories(directories: string[], formats = ["
             const dtsExtension = file.substring(file.length - 5, file.length);
             return formats.indexOf(path.extname(file)) !== -1 && dtsExtension !== ".d.ts";
         })
-        .map(file => require(file));
+        .map(file => require(path.resolve(file)));
 
     return loadFileClasses(dirs, []);
 }
@@ -41,5 +41,5 @@ export function importJsonsFromDirectories(directories: string[], format = ".jso
 
     return allFiles
         .filter(file => path.extname(file) === format)
-        .map(file => require(file));
+        .map(file => require(path.resolve(file)));
 }


### PR DESCRIPTION
I know very little about the inter-working of this system. This fixed the issue of loading up entities from ormconfig.json using relative path of the root directory.