### PR TITLE
fix dealing with blank mysql date fields

### DIFF
--- a/src/driver/mysql/MysqlDriver.ts
+++ b/src/driver/mysql/MysqlDriver.ts
@@ -217,11 +217,17 @@ export class MysqlDriver implements Driver {
             case ColumnTypes.BOOLEAN:
                 return value === true ? 1 : 0;
             case ColumnTypes.DATE:
-                return moment(value).format("YYYY-MM-DD");
+                if (moment(value).isValid())
+                  return moment(value).format("YYYY-MM-DD");
+                else return '0000-00-00';
             case ColumnTypes.TIME:
-                return moment(value).format("HH:mm:ss");
+                if (moment(value).isValid())
+                    return moment(value).format("HH:mm:ss");
+                else return '00:00:00';
             case ColumnTypes.DATETIME:
-                return moment(value).format("YYYY-MM-DD HH:mm:ss");
+                if (moment(value).isValid())
+                  return moment(value).format("YYYY-MM-DD HH:mm:ss");
+                else return '0000-00-00 00:00:00';
             case ColumnTypes.JSON:
                 return JSON.stringify(value);
             case ColumnTypes.SIMPLE_ARRAY:
@@ -256,16 +262,22 @@ export class MysqlDriver implements Driver {
                 if (value instanceof Date)
                     return value;
 
-                return moment(value, "YYYY-MM-DD").toDate();
+                if (moment(value, "YYYY-MM-DD").isValid())
+                    return moment(value, "YYYY-MM-DD").toDate();
+                else return '0000-00-00';
 
             case ColumnTypes.TIME:
-                return moment(value, "HH:mm:ss").toDate();
+                if (moment(value, "HH:mm:ss").isValid())
+                    return moment(value, "HH:mm:ss").toDate();
+                else return '00:00:00';
 
             case ColumnTypes.DATETIME:
                 if (value instanceof Date)
                     return value;
-
-                return moment(value, "YYYY-MM-DD HH:mm:ss").toDate();
+                
+                if (moment(value, "YYYY-MM-DD HH:mm:ss").isValid())
+                    return moment(value, "YYYY-MM-DD HH:mm:ss").toDate();
+                else return '0000-00-00 00:00:00';
 
             case ColumnTypes.JSON:
                 return JSON.parse(value);


### PR DESCRIPTION
currently typeorm returns back a string 'Invalid Date' when a date or datetime or timestamp is set to 0000-00-00 00:00:00 in the database.. Also when persisting a date of 0000-00-00, automatically rewrites it to start of epoch, 1970-01-01 00:00:00 .. It's preferred to have the blank mysql dates as zeros and not an arbitrary date the makes no sense for anything in todays world.