### PR TITLE
fixes mysql datetime issues when persisting records

### DIFF
--- a/src/driver/mysql/MysqlDriver.ts
+++ b/src/driver/mysql/MysqlDriver.ts
@@ -217,11 +217,17 @@ export class MysqlDriver implements Driver {
             case ColumnTypes.BOOLEAN:
                 return value === true ? 1 : 0;
             case ColumnTypes.DATE:
-                return moment(value).format("YYYY-MM-DD");
+                if (moment(value).isValid())
+                    return moment(value).format("YYYY-MM-DD");
+                else return '0000-00-00';
             case ColumnTypes.TIME:
-                return moment(value).format("HH:mm:ss");
+                if (moment(value).isValid())
+                    return moment(value).format("HH:mm:ss");
+                else return '00:00:00';
             case ColumnTypes.DATETIME:
-                return moment(value).format("YYYY-MM-DD HH:mm:ss");
+                if (moment(value).isValid())
+                    return moment(value).format("YYYY-MM-DD HH:mm:ss");
+                else return '0000-00-00 00:00:00';
             case ColumnTypes.JSON:
                 return JSON.stringify(value);
             case ColumnTypes.SIMPLE_ARRAY:


### PR DESCRIPTION
current behavior attempts to insert 'Invalid Date' string into database when moment cannot parse date string. typically due to the default mysql datatime value of 0000-00-00 00:00:00 creates the invalid date issue. This fix allows invalid dates to go into the database as 0000-00-00 00:00:00 and not 01-01-1970 00:00:00 ..