### PR TITLE
Allow empty host, if extra.socketPath is set

### DIFF
--- a/ormconfig.travis.json
+++ b/ormconfig.travis.json
@@ -1,4 +1,3 @@
-
 [
   {
     "skip": false,

--- a/ormconfig.travis.json
+++ b/ormconfig.travis.json
@@ -1,17 +1,5 @@
+
 [
-  {
-    "skip": false,
-    "name": "mysql",
-    "driver": {
-      "type": "mysql",
-      "username": "test",
-      "password": "test",
-      "database": "test",
-      "extra": {
-        "socketPath": "/var/run/mysqld/mysqld.sock"
-      }
-    }
-  },
   {
     "skip": false,
     "name": "mysql",

--- a/ormconfig.travis.json
+++ b/ormconfig.travis.json
@@ -8,7 +8,7 @@
       "password": "test",
       "database": "test",
       "extra": {
-        "socketPath": "./mysql.sock"
+        "socketPath": "/var/run/mysqld/mysqld.sock"
       }
     }
   },

--- a/ormconfig.travis.json
+++ b/ormconfig.travis.json
@@ -4,6 +4,19 @@
     "name": "mysql",
     "driver": {
       "type": "mysql",
+      "username": "test",
+      "password": "test",
+      "database": "test",
+      "extra": {
+        "socketPath": "/tmp/mysql.sock"
+      }
+    }
+  },
+  {
+    "skip": false,
+    "name": "mysql",
+    "driver": {
+      "type": "mysql",
       "host": "localhost",
       "port": 3306,
       "username": "test",

--- a/ormconfig.travis.json
+++ b/ormconfig.travis.json
@@ -8,7 +8,7 @@
       "password": "test",
       "database": "test",
       "extra": {
-        "socketPath": "/tmp/mysql.sock"
+        "socketPath": "./mysql.sock"
       }
     }
   },

--- a/src/driver/mysql/MysqlDriver.ts
+++ b/src/driver/mysql/MysqlDriver.ts
@@ -74,8 +74,10 @@ export class MysqlDriver implements Driver {
         this.mysql = mysql;
 
         // validate options to make sure everything is set
-        if (!this.options.host || (this.options.extra && !this.options.extra.socketPath))
-            throw new DriverOptionNotSetError("host or socketPath");
+        if (!this.options.host && this.options.extra && !this.options.extra.socketPath)
+            throw new DriverOptionNotSetError("socketPath (or host)");
+        else if (!this.options.extra && !this.options.host)
+            throw new DriverOptionNotSetError("host");
         if (!this.options.username)
             throw new DriverOptionNotSetError("username");
         if (!this.options.database)

--- a/src/driver/mysql/MysqlDriver.ts
+++ b/src/driver/mysql/MysqlDriver.ts
@@ -74,8 +74,8 @@ export class MysqlDriver implements Driver {
         this.mysql = mysql;
 
         // validate options to make sure everything is set
-        if (!this.options.host)
-            throw new DriverOptionNotSetError("host");
+        if (!this.options.host || (this.options.extra && !this.options.extra.socketPath))
+            throw new DriverOptionNotSetError("host or socketPath");
         if (!this.options.username)
             throw new DriverOptionNotSetError("username");
         if (!this.options.database)


### PR DESCRIPTION
I found this issue while deploying to google cloud, as they use unix sockets for mysql.

A workaround is just to define `host` as some string, because the mysql driver is preferring `socketPath` over host.