### PR TITLE
Fixed junction bug

### DIFF
--- a/src/persistence/SubjectOperationExecutor.ts
+++ b/src/persistence/SubjectOperationExecutor.ts
@@ -89,8 +89,8 @@ export class SubjectOperationExecutor {
             !this.updateSubjects.length &&
             !this.removeSubjects.length &&
             !this.relationUpdateSubjects.length &&
-            !subjects.some(subject => !subject.junctionInserts.length) &&
-            !subjects.some(subject => !subject.junctionRemoves.length))
+            !subjects.some(subject => !!subject.junctionInserts.length) &&
+            !subjects.some(subject => !!subject.junctionRemoves.length))
             return;
 
         // start execute queries in a transaction


### PR DESCRIPTION
Fixes this case:
````
    // persist some initial data
    // Photo has ManyToMany relation with Tag and Album
    let photo = new Photo();

    let tag = new Tag();
    let album = new Album();
    album.tags = [tag];

    await connection.entityManager.persist([tag, photo, album]);

    // fun starts here
    album.photos = [photo]; // add a single photo
    album.tags = []; // now remove that single tag
    await connection.entityManager.persist(album);

    // now load the album which we just updated
    let loadedAlbum = await connection.entityManager.findOneById(Album, 1, {
        alias: 'album',
        leftJoinAndSelect: {
            'photo': 'album.photos',
            'tag': 'album.tags'
        }
    });

    // relations were not updated
    if(loadedAlbum.photos.length === 0) {
        console.error('No photos stored, but I've added one!');
    }
    if(loadedAlbum.tags.length !== 0) {
        console.error('There still are some tags left, but I've removed that last one!');
    }
````