### PR TITLE
Export ObjectType and ObjectLiteral

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -18,6 +18,8 @@ import {MongoRepository} from "./repository/MongoRepository";
 // -------------------------------------------------------------------------
 
 export * from "./container";
+export * from "./common/ObjectType";
+export * from "./common/ObjectLiteral";
 export * from "./decorator/columns/Column";
 export * from "./decorator/columns/CreateDateColumn";
 export * from "./decorator/columns/DiscriminatorColumn";


### PR DESCRIPTION
I was creating an API that has a base service class to do common rest commands (i.e. `get`, `find`, `create`), etc, and I was trying to do something like this:

```ts
import { getConnection, EntityManager, ObjectType } from 'typeorm';

export abstract class AbstractService<T> {
  protected entityManager: EntityManager;

  constructor(private entityClass: ObjectType<T>) {
    this.entityManager = getConnection().entityManager;
  }

  async find(params): Promise<T[]> {
    return this.entityManager.find(this.entityClass);
  }
  // ... other methods...
}

// usage in another file:
export class UserService extends AbstractService<User> {
  constructor() {
    super(User);
  }
}
```

but `ObjectType` isn't exported, so TypeScript was complaining. It wouldn't let me do `import { ObjectType } from 'typeorm/common` either (`module not found`).

This PR adds them as exports so that the above is possible without TypeScript complaining.