### PR TITLE
Persist/Remove multiple unrelated entities in one entityManager call

### DIFF
--- a/src/entity-manager/EntityManager.ts
+++ b/src/entity-manager/EntityManager.ts
@@ -103,7 +103,9 @@ export class EntityManager extends BaseEntityManager {
                     if (target.length === 0)
                         return Promise.resolve(target);
 
-                    return this.getRepository<Entity[]>(target[0].constructor).persist(entity as Entity[], options);
+                    return Promise.all(target.map((t, i) => {
+                        return this.getRepository<Entity>(t.constructor).persist((entity as Entity[])[i], options);
+                    }));
                 } else {
                     return this.getRepository<Entity>(target.constructor).persist(entity as Entity, options);
                 }
@@ -178,7 +180,9 @@ export class EntityManager extends BaseEntityManager {
         } else {
             // todo: throw exception if constructor in target is not set
             if (target instanceof Array) {
-                return this.getRepository<Entity[]>(target[0].constructor).remove(entity as Entity[], options);
+                return Promise.all(target.map((t, i) => {
+                    return this.getRepository<Entity>(t.constructor).remove((entity as Entity[])[i], options);
+                }));
             } else {
                 return this.getRepository<Entity>(target.constructor).remove(entity as Entity, options);
             }

--- a/test/github-issues/363/entity/Car.ts
+++ b/test/github-issues/363/entity/Car.ts
@@ -1,0 +1,12 @@
+import { Entity } from "../../../../src/decorator/entity/Entity";
+import { PrimaryGeneratedColumn } from "../../../../src/decorator/columns/PrimaryGeneratedColumn";
+import { Column } from "../../../../src/decorator/columns/Column";
+
+@Entity()
+export class Car {
+    @PrimaryGeneratedColumn()
+    id: number;
+
+    @Column()
+    name: string;
+}

--- a/test/github-issues/363/entity/Fruit.ts
+++ b/test/github-issues/363/entity/Fruit.ts
@@ -1,0 +1,12 @@
+import { Entity } from "../../../../src/decorator/entity/Entity";
+import { PrimaryGeneratedColumn } from "../../../../src/decorator/columns/PrimaryGeneratedColumn";
+import { Column } from "../../../../src/decorator/columns/Column";
+
+@Entity()
+export class Fruit {
+    @PrimaryGeneratedColumn()
+    id: number;
+
+    @Column()
+    name: string;
+}

--- a/test/github-issues/363/issue-363.ts
+++ b/test/github-issues/363/issue-363.ts
@@ -1,0 +1,76 @@
+import "reflect-metadata";
+import {createTestingConnections, closeTestingConnections, reloadTestingDatabases} from "../../utils/test-utils";
+import {Connection} from "../../../src/connection/Connection";
+import {expect} from "chai";
+import {Car} from "./entity/Car";
+import {Fruit} from "./entity/Fruit";
+
+describe("github issues > #363 Can't save 2 unrelated entity types in a single persist call", () => {
+
+    let connections: Connection[];
+    before(async () => connections = await createTestingConnections({
+        entities: [__dirname + "/entity/*{.js,.ts}"],
+        schemaCreate: true,
+        dropSchemaOnConnection: true,
+    }));
+    beforeEach(() => reloadTestingDatabases(connections));
+    after(() => closeTestingConnections(connections));
+
+    it("entityManager should allow you to save unrelated entities with one persist call", () => Promise.all(connections.map(async connection => {
+
+        const car = new Car();
+        car.name = "Ferrari";
+
+        const fruit = new Fruit();
+        fruit.name = "Banana";
+
+        const [savedCar, savedFruit] = await connection.entityManager.persist([car, fruit]);
+
+        expect(savedFruit).to.have.property("name", "Banana");
+        expect(savedFruit).to.be.instanceof(Fruit);
+
+        expect(savedCar).to.have.property("name", "Ferrari");
+        expect(savedCar).to.be.instanceof(Car);
+
+        const cars = await connection.entityManager.find(Car);
+
+        // before the changes in this PR, all the tests before this one actually passed
+        expect(cars).to.length(1);
+        expect(cars[0]).to.have.property("name", "Ferrari");
+
+        const fruits = await connection.entityManager.find(Fruit);
+
+        expect(fruits).to.length(1);
+        expect(fruits[0]).to.have.property("name", "Banana");
+
+    })));
+
+    it("entityManager should allow you to delete unrelated entities with one remove call", () => Promise.all(connections.map(async connection => {
+
+        const fruit = new Fruit();
+        fruit.name = "Banana";
+
+        const fruit2 = new Fruit();
+        fruit2.name = "Apple";
+
+        const [savedFruit] = await connection.entityManager.persist([fruit, fruit2]);
+
+        const car = new Car();
+        car.name = "Ferrari";
+
+        const savedCar = await connection.entityManager.persist(car);
+
+        await connection.entityManager.remove([savedCar, savedFruit]);
+
+        const cars = await connection.entityManager.find(Car);
+
+        expect(cars).to.length(0);
+
+        const fruits = await connection.entityManager.find(Fruit);
+
+        expect(fruits).to.length(1);
+        expect(fruits[0]).to.have.property("name", "Apple");
+
+    })));
+
+});


### PR DESCRIPTION
This changes the behavior of `entityManager` to correctly handle persisting and removing multiple unrelated entities in one call.

Resolves #363 