### PR TITLE
Support fixed length column data type.

### DIFF
--- a/src/decorator/options/ColumnOptions.ts
+++ b/src/decorator/options/ColumnOptions.ts
@@ -80,4 +80,10 @@ export interface ColumnOptions {
      */
     readonly localTimezone?: boolean;
 
+    /**
+     * Indicates if column's type will be set as a fixed-length data type.
+     * Works only with "string" columns.
+     */
+    readonly fixedLength?: boolean;
+
 }

--- a/src/driver/mongodb/MongoQueryRunner.ts
+++ b/src/driver/mongodb/MongoQueryRunner.ts
@@ -643,7 +643,7 @@ export class MongoQueryRunner implements QueryRunner {
     /**
      * Creates a database type from a given column metadata.
      */
-    normalizeType(typeOptions: { type: ColumnType, length?: string|number, precision?: number, scale?: number, timezone?: boolean, fixedLength?: boolean }) {
+    normalizeType(typeOptions: { type: ColumnType, length?: string|number, precision?: number, scale?: number, timezone?: boolean, fixedLength?: boolean }): string {
         throw new Error(`Schema update queries are not supported by MongoDB driver.`);
     }
 

--- a/src/driver/mongodb/MongoQueryRunner.ts
+++ b/src/driver/mongodb/MongoQueryRunner.ts
@@ -643,7 +643,7 @@ export class MongoQueryRunner implements QueryRunner {
     /**
      * Creates a database type from a given column metadata.
      */
-    normalizeType(typeOptions: { type: ColumnType, length?: string|number, precision?: number, scale?: number, timezone?: boolean }) {
+    normalizeType(typeOptions: { type: ColumnType, length?: string|number, precision?: number, scale?: number, timezone?: boolean, fixedLength?: boolean }) {
         throw new Error(`Schema update queries are not supported by MongoDB driver.`);
     }
 

--- a/src/driver/mysql/MysqlQueryRunner.ts
+++ b/src/driver/mysql/MysqlQueryRunner.ts
@@ -685,11 +685,15 @@ export class MysqlQueryRunner implements QueryRunner {
     /**
      * Creates a database type from a given column metadata.
      */
-    normalizeType(typeOptions: { type: ColumnType, length?: string|number, precision?: number, scale?: number, timezone?: boolean }) {
+    normalizeType(typeOptions: { type: ColumnType, length?: string|number, precision?: number, scale?: number, timezone?: boolean, fixedLength?: boolean }) {
 
         switch (typeOptions.type) {
             case "string":
-                return "varchar(" + (typeOptions.length ? typeOptions.length : 255) + ")";
+                if (typeOptions.fixedLength) {
+                    return "char(" + (typeOptions.length ? typeOptions.length : 255) + ")";
+                } else {
+                    return "varchar(" + (typeOptions.length ? typeOptions.length : 255) + ")";
+                }
             case "text":
                 return "text";
             case "boolean":

--- a/src/driver/mysql/MysqlQueryRunner.ts
+++ b/src/driver/mysql/MysqlQueryRunner.ts
@@ -685,7 +685,7 @@ export class MysqlQueryRunner implements QueryRunner {
     /**
      * Creates a database type from a given column metadata.
      */
-    normalizeType(typeOptions: { type: ColumnType, length?: string|number, precision?: number, scale?: number, timezone?: boolean, fixedLength?: boolean }) {
+    normalizeType(typeOptions: { type: ColumnType, length?: string|number, precision?: number, scale?: number, timezone?: boolean, fixedLength?: boolean }): string {
 
         switch (typeOptions.type) {
             case "string":

--- a/src/driver/oracle/OracleQueryRunner.ts
+++ b/src/driver/oracle/OracleQueryRunner.ts
@@ -742,7 +742,7 @@ AND cons.constraint_name = cols.constraint_name AND cons.owner = cols.owner ORDE
     /**
      * Creates a database type from a given column metadata.
      */
-    normalizeType(typeOptions: { type: ColumnType, length?: string|number, precision?: number, scale?: number, timezone?: boolean, fixedLength?: boolean }) {
+    normalizeType(typeOptions: { type: ColumnType, length?: string|number, precision?: number, scale?: number, timezone?: boolean, fixedLength?: boolean }): string {
         switch (typeOptions.type) {
             case "string":
                 if (typeOptions.fixedLength) {

--- a/src/driver/oracle/OracleQueryRunner.ts
+++ b/src/driver/oracle/OracleQueryRunner.ts
@@ -742,10 +742,14 @@ AND cons.constraint_name = cols.constraint_name AND cons.owner = cols.owner ORDE
     /**
      * Creates a database type from a given column metadata.
      */
-    normalizeType(typeOptions: { type: ColumnType, length?: string|number, precision?: number, scale?: number, timezone?: boolean }) {
+    normalizeType(typeOptions: { type: ColumnType, length?: string|number, precision?: number, scale?: number, timezone?: boolean, fixedLength?: boolean }) {
         switch (typeOptions.type) {
             case "string":
-                return "varchar2(" + (typeOptions.length ? typeOptions.length : 255) + ")";
+                if (typeOptions.fixedLength) {
+                    return "char(" + (typeOptions.length ? typeOptions.length : 255) + ")";
+                } else {
+                    return "varchar2(" + (typeOptions.length ? typeOptions.length : 255) + ")";                    
+                }
             case "text":
                 return "clob";
             case "boolean":

--- a/src/driver/postgres/PostgresQueryRunner.ts
+++ b/src/driver/postgres/PostgresQueryRunner.ts
@@ -744,10 +744,14 @@ where constraint_type = 'PRIMARY KEY' and tc.table_catalog = '${this.dbName}'`;
     /**
      * Creates a database type from a given column metadata.
      */
-    normalizeType(typeOptions: { type: ColumnType, length?: string|number, precision?: number, scale?: number, timezone?: boolean }): string {
+    normalizeType(typeOptions: { type: ColumnType, length?: string|number, precision?: number, scale?: number, timezone?: boolean, fixedLength?: boolean }): string {
         switch (typeOptions.type) {
             case "string":
-                return "character varying(" + (typeOptions.length ? typeOptions.length : 255) + ")";
+                if (typeOptions.fixedLength) {
+                    return "character(" + (typeOptions.length ? typeOptions.length : 255) + ")";
+                } else {
+                    return "character varying(" + (typeOptions.length ? typeOptions.length : 255) + ")";
+                }
             case "text":
                 return "text";
             case "boolean":

--- a/src/driver/sqlite/SqliteQueryRunner.ts
+++ b/src/driver/sqlite/SqliteQueryRunner.ts
@@ -727,7 +727,7 @@ export class SqliteQueryRunner implements QueryRunner {
     /**
      * Creates a database type from a given column metadata.
      */
-    normalizeType(typeOptions: { type: ColumnType, length?: string|number, precision?: number, scale?: number, timezone?: boolean, fixedLength?: boolean }) {
+    normalizeType(typeOptions: { type: ColumnType, length?: string|number, precision?: number, scale?: number, timezone?: boolean, fixedLength?: boolean }): string {
         switch (typeOptions.type) {
             case "string":
                 return "character varying(" + (typeOptions.length ? typeOptions.length : 255) + ")";

--- a/src/driver/sqlite/SqliteQueryRunner.ts
+++ b/src/driver/sqlite/SqliteQueryRunner.ts
@@ -727,7 +727,7 @@ export class SqliteQueryRunner implements QueryRunner {
     /**
      * Creates a database type from a given column metadata.
      */
-    normalizeType(typeOptions: { type: ColumnType, length?: string|number, precision?: number, scale?: number, timezone?: boolean }) {
+    normalizeType(typeOptions: { type: ColumnType, length?: string|number, precision?: number, scale?: number, timezone?: boolean, fixedLength?: boolean }) {
         switch (typeOptions.type) {
             case "string":
                 return "character varying(" + (typeOptions.length ? typeOptions.length : 255) + ")";

--- a/src/driver/sqlserver/SqlServerQueryRunner.ts
+++ b/src/driver/sqlserver/SqlServerQueryRunner.ts
@@ -791,10 +791,14 @@ WHERE columnUsages.TABLE_CATALOG = '${this.dbName}' AND tableConstraints.TABLE_C
     /**
      * Creates a database type from a given column metadata.
      */
-    normalizeType(typeOptions: { type: ColumnType, length?: string|number, precision?: number, scale?: number, timezone?: boolean }) {
+    normalizeType(typeOptions: { type: ColumnType, length?: string|number, precision?: number, scale?: number, timezone?: boolean, fixedLength?: boolean }) {
         switch (typeOptions.type) {
             case "string":
-                return "nvarchar(" + (typeOptions.length ? typeOptions.length : 255) + ")";
+                if (typeOptions.fixedLength) {
+                    return "nchar(" + (typeOptions.length ? typeOptions.length : 255) + ")";
+                } else {
+                    return "nvarchar(" + (typeOptions.length ? typeOptions.length : 255) + ")";
+                }
             case "text":
                 return "ntext";
             case "boolean":

--- a/src/driver/sqlserver/SqlServerQueryRunner.ts
+++ b/src/driver/sqlserver/SqlServerQueryRunner.ts
@@ -791,7 +791,7 @@ WHERE columnUsages.TABLE_CATALOG = '${this.dbName}' AND tableConstraints.TABLE_C
     /**
      * Creates a database type from a given column metadata.
      */
-    normalizeType(typeOptions: { type: ColumnType, length?: string|number, precision?: number, scale?: number, timezone?: boolean, fixedLength?: boolean }) {
+    normalizeType(typeOptions: { type: ColumnType, length?: string|number, precision?: number, scale?: number, timezone?: boolean, fixedLength?: boolean }): string {
         switch (typeOptions.type) {
             case "string":
                 if (typeOptions.fixedLength) {

--- a/src/driver/websql/WebsqlQueryRunner.ts
+++ b/src/driver/websql/WebsqlQueryRunner.ts
@@ -737,7 +737,7 @@ export class WebsqlQueryRunner implements QueryRunner {
     /**
      * Creates a database type from a given column metadata.
      */
-    normalizeType(typeOptions: { type: ColumnType, length?: string|number, precision?: number, scale?: number, timezone?: boolean }) {
+    normalizeType(typeOptions: { type: ColumnType, length?: string|number, precision?: number, scale?: number, timezone?: boolean, fixedLength?: boolean }) {
         switch (typeOptions.type) {
             case "string":
                 return "character varying(" + (typeOptions.length ? typeOptions.length : 255) + ")";

--- a/src/driver/websql/WebsqlQueryRunner.ts
+++ b/src/driver/websql/WebsqlQueryRunner.ts
@@ -737,7 +737,7 @@ export class WebsqlQueryRunner implements QueryRunner {
     /**
      * Creates a database type from a given column metadata.
      */
-    normalizeType(typeOptions: { type: ColumnType, length?: string|number, precision?: number, scale?: number, timezone?: boolean, fixedLength?: boolean }) {
+    normalizeType(typeOptions: { type: ColumnType, length?: string|number, precision?: number, scale?: number, timezone?: boolean, fixedLength?: boolean }): string {
         switch (typeOptions.type) {
             case "string":
                 return "character varying(" + (typeOptions.length ? typeOptions.length : 255) + ")";

--- a/src/metadata/ColumnMetadata.ts
+++ b/src/metadata/ColumnMetadata.ts
@@ -126,6 +126,12 @@ export class ColumnMetadata {
      */
     readonly localTimezone?: boolean;
 
+    /**
+     * Indicates if column's type will be set as a fixed-length data type.
+     * Works only with "string" columns.
+     */
+    readonly fixedLength?: boolean;
+
     // ---------------------------------------------------------------------
     // Private Properties
     // ---------------------------------------------------------------------
@@ -174,6 +180,8 @@ export class ColumnMetadata {
             this.timezone = args.options.timezone;
         if (args.options.localTimezone)
             this.localTimezone = args.options.localTimezone;
+        if (args.options.fixedLength)
+            this.fixedLength = args.options.fixedLength;
     }
 
     // ---------------------------------------------------------------------

--- a/src/query-runner/QueryRunner.ts
+++ b/src/query-runner/QueryRunner.ts
@@ -79,7 +79,7 @@ export interface QueryRunner {
     /**
      * Converts a column type of the metadata to the database column's type.
      */
-    normalizeType(typeOptions: { type: ColumnType, length?: string|number, precision?: number, scale?: number, timezone?: boolean }): any;
+    normalizeType(typeOptions: { type: ColumnType, length?: string|number, precision?: number, scale?: number, timezone?: boolean, fixedLength?: boolean }): any;
 
     /**
      * Checks if "DEFAULT" values in the column metadata and in the database schema are equal.

--- a/src/query-runner/QueryRunner.ts
+++ b/src/query-runner/QueryRunner.ts
@@ -79,7 +79,7 @@ export interface QueryRunner {
     /**
      * Converts a column type of the metadata to the database column's type.
      */
-    normalizeType(typeOptions: { type: ColumnType, length?: string|number, precision?: number, scale?: number, timezone?: boolean, fixedLength?: boolean }): any;
+    normalizeType(typeOptions: { type: ColumnType, length?: string|number, precision?: number, scale?: number, timezone?: boolean, fixedLength?: boolean }): string;
 
     /**
      * Checks if "DEFAULT" values in the column metadata and in the database schema are equal.


### PR DESCRIPTION
Well, I had some time and as I had mentioned in #343. This pull request tries to implement that feature.
Please take a look and if needed feel free to make any changes in it.

**Some notes:**
I didn't add support to SQLite and Web SQL because I want to discuss some another minor changes.

For example:
`CHARACTER`, `VARCHAR`, `VARYING CHARACTER`, `NCHAR`, `NVARCHAR` are all the same as `TEXT`.
Refer to [3.1.1. Affinity Name Examples](https://www.sqlite.org/datatype3.html#affinity_name_examples)

For this two specific drivers, there is no way to add a `fixedLength` attribute.

This brings some improvements, like this piece of code:
```ts
        switch (typeOptions.type) {
            case "string":
                return "character varying(" + (typeOptions.length ? typeOptions.length : 255) + ")";
            case "text":
                return "text";
        }
```

Can be simplified to this:
```ts
        switch (typeOptions.type) {
            case "string":
            case "text":
                return "text";
        }
```

It's just a line, but it ends up being one less type to worry about.

Also are some inconsistencies on the `normalizeType` signature.
https://github.com/typeorm/typeorm/blob/master/src/query-runner/QueryRunner.ts#L82

Most drivers don't have a return type, except for Postgres (string).
For example:
**MySQL:** https://github.com/typeorm/typeorm/blob/master/src/driver/mysql/MysqlQueryRunner.ts#L688
**Postgres**: https://github.com/typeorm/typeorm/blob/master/src/driver/postgres/PostgresQueryRunner.ts#L747

**--- EDIT ---**
Also, is there any special reason for SQL Server uses `NVARCHAR` and Oracle uses `VARCHAR2` type?
I mean, Oracle also have a type with unicode support (`NVARCHAR2`).
https://docs.oracle.com/cd/B28359_01/server.111/b28318/datatype.htm#CNCPT1821

I didn't make this changes on this PR, if you agree with that we can do another one later.
Let me know what you think about it.

[]'s