### PR TITLE
Correct table name to 'photometadata' in one-to-one relation example

### DIFF
--- a/README.md
+++ b/README.md
@@ -633,7 +633,7 @@ If you run the app you'll see a new generated table, and it will contain a colum
 
 ```shell
 +-------------+--------------+----------------------------+
-|                         photo                           |
+|                      photometadata                      |
 +-------------+--------------+----------------------------+
 | id          | int(11)      | PRIMARY KEY AUTO_INCREMENT |
 | height      | int(11)      |                            |

--- a/README.md
+++ b/README.md
@@ -840,7 +840,7 @@ createConnection(options).then(async connection => {
     // Get repository
     let photoRepository = connection.getRepository(Photo);
 
-    // First we should persist a photo
+    // Persisting a photo also persist the metadata
     await photoRepository.persist(photo);
 
     console.log("Photo is saved, photo metadata is saved too.")


### PR DESCRIPTION
Correct table name to 'photometadata' in one-to-one relation example in README.md file