### PR TITLE
Let know to lazy relation wrapper that entity was loaded using query builder

### DIFF
--- a/src/lazy-loading/LazyRelationsWrapper.ts
+++ b/src/lazy-loading/LazyRelationsWrapper.ts
@@ -56,6 +56,12 @@ export class LazyRelationsWrapper {
                     }
 
                     this[promiseIndex] = qb.getMany().then(results => {
+                        // remove information about current entity because we joined it
+                        if (relation.hasInverseSide) {
+                            results.map(result => {
+                                delete (result as any)["__has__" + relation.inverseRelation.propertyName + "__"];
+                            });
+                        }
                         this[index] = results;
                         this[resolveIndex] = true;
                         delete this[promiseIndex];
@@ -73,6 +79,10 @@ export class LazyRelationsWrapper {
                         .where(relation.entityMetadata.targetName + "." + relation.inverseEntityMetadata.firstPrimaryColumn.propertyName + "=:id", { id: relation.entityMetadata.getEntityIdMixedMap(this) });
 
                     this[promiseIndex] = qb.getMany().then(results => {
+                        // remove information about current entity because we joined it
+                        results.map(result => {
+                            delete (result as any)["__has__" + relation.inverseRelation.propertyName + "__"];
+                        });
                         this[index] = results;
                         this[resolveIndex] = true;
                         delete this[promiseIndex];
@@ -104,6 +114,10 @@ export class LazyRelationsWrapper {
                     }
 
                     this[promiseIndex] = qb.getOne().then(result => {
+                        // remove information about current entity because we joined it
+                        if (relation.hasInverseSide && result) {
+                            delete (result as any)["__has__" + relation.inverseRelation.propertyName + "__"];
+                        };
                         this[index] = result;
                         this[resolveIndex] = true;
                         delete this[promiseIndex];

--- a/src/query-builder/transformer/RawSqlResultsToEntityTransformer.ts
+++ b/src/query-builder/transformer/RawSqlResultsToEntityTransformer.ts
@@ -175,6 +175,7 @@ export class RawSqlResultsToEntityTransformer {
 
                     if (relation.isLazy) {
                         entity["__" + propertyName + "__"] = result;
+                        entity["__has__" + propertyName + "__"] = true;
                     } else {
                         entity[propertyName] = result;
                     }


### PR DESCRIPTION
Maked for lazy relations related entity to be not loaded again after selecting with join and fetching it from current entity. Added `__has__*=true` to RawSqlResultsToEntityTransformer.
But then some tests make failed, and i founded that if we have inverse side relation, ex. category.posts <-> post.category, when we fetching post from category (category.posts), categories (post.categories) will be also added in result set with empty array, because it persist in join method in LazyRelationWrapper, and it will be added as alias to query builder and then to RawSqlResultsToEntityTransformer. The only solution i found is to remove `__has__*` value from result object in LazyRelationWrapper.