### PR TITLE
Resolve issue #542

### DIFF
--- a/src/repository/Repository.ts
+++ b/src/repository/Repository.ts
@@ -278,7 +278,7 @@ export class Repository<Entity extends ObjectLiteral> {
      * Optionally find options can be applied.
      */
     findByIds(ids: any[], optionsOrConditions?: FindManyOptions<Entity>|DeepPartial<Entity>): Promise<Entity[]> {
-        return this.manager.findByIds(this.metadata.target, optionsOrConditions as any);
+        return this.manager.findByIds(this.metadata.target, ids, optionsOrConditions as any);
     }
 
     /**


### PR DESCRIPTION
It appears that `Repository.findByIds()` wasn't actually passing the `ids` parameter to `EntityManager.findByIds()`.