### PR TITLE
Add missing TYPEORM_MIGRATIONS

### DIFF
--- a/src/connection/options-reader/ConnectionOptionsEnvReader.ts
+++ b/src/connection/options-reader/ConnectionOptionsEnvReader.ts
@@ -29,6 +29,7 @@ export class ConnectionOptionsEnvReader {
             extra: PlatformTools.getEnvVariable("TYPEORM_DRIVER_EXTRA") ? JSON.parse(PlatformTools.getEnvVariable("TYPEORM_DRIVER_EXTRA")) : undefined,
             autoSchemaSync: OrmUtils.toBoolean(PlatformTools.getEnvVariable("TYPEORM_AUTO_SCHEMA_SYNC")),
             entities: PlatformTools.getEnvVariable("TYPEORM_ENTITIES") ? PlatformTools.getEnvVariable("TYPEORM_ENTITIES").split(",") : [],
+            migrations: PlatformTools.getEnvVariable("TYPEORM_MIGRATIONS") ? PlatformTools.getEnvVariable("TYPEORM_MIGRATIONS").split(",") : [],
             subscribers: PlatformTools.getEnvVariable("TYPEORM_SUBSCRIBERS") ? PlatformTools.getEnvVariable("TYPEORM_SUBSCRIBERS").split(",") : [],
             entitySchemas: PlatformTools.getEnvVariable("TYPEORM_ENTITY_SCHEMAS") ? PlatformTools.getEnvVariable("TYPEORM_ENTITY_SCHEMAS").split(",") : [],
             logging: {


### PR DESCRIPTION
It seems that `TYPEORM_MIGRATIONS` variable is missing in `ConnectionOptionsEnvReader.ts`. I've added it. This probably caused migrations failure when using `ormconfig.env` (migrations couldn't be found).