### PR TITLE
Exit process after finishing migrations

### DIFF
--- a/src/commands/MigrationRevertCommand.ts
+++ b/src/commands/MigrationRevertCommand.ts
@@ -45,6 +45,8 @@ export class MigrationRevertCommand {
         } catch (err) {
             console.error(err);
             // throw err;
+        } finally {
+            process.exit(0);
         }
     }
 

--- a/src/commands/MigrationRunCommand.ts
+++ b/src/commands/MigrationRunCommand.ts
@@ -45,6 +45,8 @@ export class MigrationRunCommand {
         } catch (err) {
             console.error(err);
             // throw err;
+        } finally {
+            process.exit(0);
         }
     }
 


### PR DESCRIPTION
Hi there,
For some reason, after running migrations or reverting them, node process doesn't quit, which makes it hard to run on staging servers or CI (results in timeouts because of hanged process).
I've made a quick fix but I'm not 100% convinced this is the right way to handle this.

What do you think?