### PR TITLE
Avoiding global npm installs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,7 @@ before_script:
   - sudo service mysql stop
   - sudo service postgresql stop
   - docker-compose up -d
-  - gulp createTravisOrmConfig
+  - npm run setup:config
 
 after_success:
   - bash <(curl -s https://codecov.io/bash)

--- a/DEVELOPER.md
+++ b/DEVELOPER.md
@@ -61,17 +61,20 @@ During installation you may have some problems with some dependencies.
 For example to proper install oracle driver you need to follow all instructions from
  [node-oracle documentation](https://github.com/oracle/node-oracledb).
 
-Also install these packages globally:
+## ORM config
 
-* `npm install -g gulp` (you might need to prefix this command with `sudo`)
-* `npm install -g typescript` (you might need to prefix this command with `sudo`)
+To create an initial `ormconfig.json` file, run the following command:
+
+```shell
+npm run setup:config
+```
 
 ## Building
 
 To build a distribution package of TypeORM run:
 
 ```shell
-gulp package
+npm run package
 ```
 
 This command will generate you a distribution package in the `build/package` directory.

--- a/gulpfile.ts
+++ b/gulpfile.ts
@@ -42,7 +42,7 @@ export class Gulpfile {
     @Task()
     compile() {
         return gulp.src("package.json", { read: false })
-            .pipe(shell(["tsc"]));
+            .pipe(shell(["npm run compile"]));
     }
 
     // -------------------------------------------------------------------------

--- a/package.json
+++ b/package.json
@@ -83,7 +83,10 @@
     "yargs": "^8.0.2"
   },
   "scripts": {
-    "test": "node_modules/.bin/gulp tests"
+    "test": "gulp tests",
+    "compile": "tsc",
+    "setup:config": "gulp createTravisOrmConfig",
+    "package": "gulp package"
   },
   "bin": {
     "typeorm": "./cli.js"


### PR DESCRIPTION
Updating development docs, `gulpfile.ts` and `.travis.yml` to avoid using global installs.

Using `gulp` and `tsc` commands as global does not guarantee the version being used is the one present on `package.json`, so development environment might be different for each person, which is anti-pattern.

## Changes

- Added all globally executed packages (`gulp` and `tsc`) as `script`s on `package.json` (Just the ones that I found on `gulpfile.ts`, `.travis.yml` and docs. Are there others that I am not aware of?)
- Updated `gulpfile.ts`, `travis.yml` to use such scripts instead
- Updated `DEVELOPMENT` docs to use `npm run <script>` instead of global `gulp` 

## Why doesn't current `.travis.yml` have `npm install -g`?

Travis masks this issue by forcing `node_modules/.bin` to be [part of the machine's `$PATH`](https://travis-ci.org/typeorm/typeorm/jobs/248750165#L493), therefore using the versions present on `package.json`, by running the following command before any user scripts are executed:

```shell
export PATH=./node_modules/.bin:$PATH
```

## References discussing this topic

- [Reddit discussion](https://www.reddit.com/r/node/comments/3nlzql/why_is_it_a_bad_idea_to_sudo_install_a_global_npm/)
- [No More Global Npm Packages - Joe Zimmerman](https://www.joezimjs.com/javascript/no-more-global-npm-packages/)
- [JavaScript Patterns for 2017 - Scott Allen at 50:58](https://youtu.be/hO7mzO83N1Q?t=50m58s)