### PR TITLE
Improve DirectoryExportedClassesLoader

### DIFF
--- a/src/util/DirectoryExportedClassesLoader.ts
+++ b/src/util/DirectoryExportedClassesLoader.ts
@@ -6,16 +6,16 @@ import {PlatformTools} from "../platform/PlatformTools";
 export function importClassesFromDirectories(directories: string[], formats = [".js", ".ts"]): Function[] {
 
     function loadFileClasses(exported: any, allLoaded: Function[]) {
-        if (exported instanceof Function) {
+        if (typeof exported === "function") {
             allLoaded.push(exported);
 
-        } else if (exported instanceof Object) {
+        } else if (Array.isArray(exported)) {
+            exported.forEach((i: any) => loadFileClasses(i, allLoaded));
+
+        } else if (typeof exported === "object") {
             Object.keys(exported).forEach(key => loadFileClasses(exported[key], allLoaded));
 
-        } else if (exported instanceof Array) {
-            exported.forEach((i: any) => loadFileClasses(i, allLoaded));
         }
-
         return allLoaded;
     }
 


### PR DESCRIPTION
1. Moved array checking on top of the object checking since Array is the instance/typeof object
2. Replaced ```instanceof``` calls with ```typeof``` calls.

For some reason, the ```exported instanceof Object``` check is giving ```false``` in my Jest test files when i'm creating DB connection so the typeorm is unable to process entities/migrations/subscribers. This may be caused by heavy VM contexts manipulating in Jest itself.