### PR TITLE
Update documentation to remove references to self-initialised arrays

### DIFF
--- a/README-zh_CN.md
+++ b/README-zh_CN.md
@@ -863,7 +863,7 @@ export class Album {
         cascadeRemove: true  // 在移除Album时，会自动移除相册里的Photo
     })
     @JoinTable()
-    photos: Photo[] = []; // 初始化个Photo数组
+    photos: Photo[];
 }
 ```
   
@@ -880,7 +880,7 @@ export class Photo {
         cascadeUpdate: true, // 在更新Album时，会自动更新相册里的Photo 
         cascadeRemove: true  // 在移除Album时，会自动移除相册里的Photo
     })
-    albums: Album[] = []; // 初始化个Album数组
+    albums: Album[];
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -945,7 +945,7 @@ export class Album {
         cascadeUpdate: true // Allow to update a photo on album save
     })
     @JoinTable()
-    photos: Photo[] = []; // We initialize array for convinience here
+    photos: Photo[];
 }
 ```
   
@@ -961,7 +961,7 @@ export class Photo {
         cascadeInsert: true, // Allow to insert a new album on photo save
         cascadeUpdate: true // Allow to update an album on photo save
     })
-    albums: Album[] = []; // We initialize array for convinience here
+    albums: Album[];
 }
 ```
 


### PR DESCRIPTION
As per discussion in [#145](https://github.com/typeorm/typeorm/issues/145), self-initialised arrays on relations may lead to unintended updates as typeorm assumes an empty array means all relations have been removed. Hence, remove references to this practice from the documentation to avoid confusion.