### PR TITLE
Support type-safe returns when using transactions

### DIFF
--- a/src/entity-manager/EntityManager.ts
+++ b/src/entity-manager/EntityManager.ts
@@ -84,7 +84,7 @@ export class EntityManager {
      * Wraps given function execution (and all operations made there) in a transaction.
      * All database operations must be executed using provided entity manager.
      */
-    async transaction(runInTransaction: (entityManger: EntityManager) => Promise<any>): Promise<any> {
+    async transaction<T>(runInTransaction: (entityManger: EntityManager) => Promise<T>): Promise<T> {
 
         if (this.connection.driver instanceof MongoDriver)
             throw new Error(`Transactions aren't supported by MongoDB.`);

--- a/test/functional/query-builder/locking/query-builder-locking.ts
+++ b/test/functional/query-builder/locking/query-builder-locking.ts
@@ -275,6 +275,8 @@ describe("query builder > locking", () => {
                         .getOne().should.be.rejectedWith(LockNotSupportedOnGivenDriverError)
                 ]);
             });
+
+        return;
     })));
 
 });

--- a/test/functional/transaction/return-data-from-transaction/entity/Category.ts
+++ b/test/functional/transaction/return-data-from-transaction/entity/Category.ts
@@ -1,0 +1,14 @@
+import {Entity} from "../../../../../src/decorator/entity/Entity";
+import {PrimaryGeneratedColumn} from "../../../../../src/decorator/columns/PrimaryGeneratedColumn";
+import {Column} from "../../../../../src/decorator/columns/Column";
+
+@Entity()
+export class Category {
+
+    @PrimaryGeneratedColumn()
+    id: number;
+
+    @Column()
+    name: string;
+
+}

--- a/test/functional/transaction/return-data-from-transaction/entity/Post.ts
+++ b/test/functional/transaction/return-data-from-transaction/entity/Post.ts
@@ -1,0 +1,14 @@
+import {Entity} from "../../../../../src/decorator/entity/Entity";
+import {PrimaryGeneratedColumn} from "../../../../../src/decorator/columns/PrimaryGeneratedColumn";
+import {Column} from "../../../../../src/decorator/columns/Column";
+
+@Entity()
+export class Post {
+
+    @PrimaryGeneratedColumn()
+    id: number;
+
+    @Column()
+    title: string;
+
+}

--- a/test/functional/transaction/return-data-from-transaction/return-data-from-transaction.ts
+++ b/test/functional/transaction/return-data-from-transaction/return-data-from-transaction.ts
@@ -1,0 +1,90 @@
+import "reflect-metadata";
+import {createTestingConnections, closeTestingConnections, reloadTestingDatabases} from "../../../utils/test-utils";
+import {Connection} from "../../../../src/connection/Connection";
+import {Post} from "./entity/Post";
+import {Category} from "./entity/Category";
+import {expect} from "chai";
+
+describe("transaction > return data from transaction", () => {
+
+    let connections: Connection[];
+    before(async () => connections = await createTestingConnections({
+        entities: [__dirname + "/entity/*{.js,.ts}"],
+        schemaCreate: true,
+        dropSchemaOnConnection: true,
+        enabledDrivers: ["mysql", "sqlite", "postgres"] // todo: for some reasons mariadb tests are not passing here
+    }));
+    beforeEach(() => reloadTestingDatabases(connections));
+    after(() => closeTestingConnections(connections));
+
+    it("should allow to return typed data from transaction", () => Promise.all(connections.map(async connection => {
+
+        const { postId, categoryId } = await connection.manager.transaction<{ postId: number, categoryId: number }>(async entityManager => {
+
+            const post = new Post();
+            post.title = "Post #1";
+            await entityManager.save(post);
+
+            const category = new Category();
+            category.name = "Category #1";
+            await entityManager.save(category);
+
+            return {
+                postId: post.id,
+                categoryId: category.id
+            };
+
+        });
+
+        const post = await connection.manager.findOne(Post, { where: { title: "Post #1" }});
+        expect(post).not.to.be.empty;
+        post!.should.be.eql({
+            id: postId,
+            title: "Post #1"
+        });
+
+        const category = await connection.manager.findOne(Category, { where: { name: "Category #1" }});
+        expect(category).not.to.be.empty;
+        category!.should.be.eql({
+            id: categoryId,
+            name: "Category #1"
+        });
+
+    })));
+
+    it("should allow to return typed data from transaction using type inference", () => Promise.all(connections.map(async connection => {
+
+        const { postId, categoryId } = await connection.manager.transaction(async entityManager => {
+
+            const post = new Post();
+            post.title = "Post #1";
+            await entityManager.save(post);
+
+            const category = new Category();
+            category.name = "Category #1";
+            await entityManager.save(category);
+
+            return {
+                postId: post.id,
+                categoryId: category.id
+            };
+
+        });
+
+        const post = await connection.manager.findOne(Post, { where: { title: "Post #1" }});
+        expect(post).not.to.be.empty;
+        post!.should.be.eql({
+            id: postId,
+            title: "Post #1"
+        });
+
+        const category = await connection.manager.findOne(Category, { where: { name: "Category #1" }});
+        expect(category).not.to.be.empty;
+        category!.should.be.eql({
+            id: categoryId,
+            name: "Category #1"
+        });
+
+    })));
+
+});


### PR DESCRIPTION
Resolves #696 

## Problem:
``manager.transaction`` does not allow to use type-safe returns.

## Solution:
``manager.transaction`` should leverage generics & type inference to allow type-safe transaction returns.

## Notes:
It seems that TS compiler sometimes might shout at us for not using explicit returns (look at the "fixed" testcase in file ``query-builder-locking.ts``). It's probably due to the fact that TypeORM is configured to use ``noImplicitReturns`` flag, and with my fix, compiler has to create a union type (earlier it was always ``any``, so it didn't care much). I hope this won't affect acceptance of my PR, I don't think it's that much of a deal (but well, I might be wrong).