### PR TITLE
Escape parent id join condition

### DIFF
--- a/src/query-builder/SelectQueryBuilder.ts
+++ b/src/query-builder/SelectQueryBuilder.ts
@@ -1271,7 +1271,7 @@ export class SelectQueryBuilder<Entity> extends QueryBuilder<Entity> {
             if (metadata.parentEntityMetadata && metadata.parentEntityMetadata.inheritanceType === "class-table" && metadata.parentIdColumns) {
                 const alias = "parentIdColumn_" + metadata.parentEntityMetadata.tableName;
                 const condition = metadata.parentIdColumns.map(parentIdColumn => {
-                    return this.expressionMap.mainAlias!.name + "." + parentIdColumn.propertyPath + " = " + alias + "." + parentIdColumn.referencedColumn!.propertyPath;
+                    return this.expressionMap.mainAlias!.name + "." + parentIdColumn.propertyPath + " = " + this.escape(alias) + "." + this.escape(parentIdColumn.referencedColumn!.propertyPath);
                 }).join(" AND ");
                 const join = " JOIN " + this.escape(metadata.parentEntityMetadata.tableName) + " " + this.escape(alias) + " ON " + this.replacePropertyNames(condition);
                 joins.push(join);


### PR DESCRIPTION
Before this fix, this exception would be thrown from the db:
" missing FROM-clause entry for table "parentidcolumn_XX"
due to lowercase vs uppercase