### PR TITLE
Fix engine option being ignored

### DIFF
--- a/src/schema-builder/RdbmsSchemaBuilder.ts
+++ b/src/schema-builder/RdbmsSchemaBuilder.ts
@@ -175,7 +175,7 @@ export class RdbmsSchemaBuilder implements SchemaBuilder {
             this.connection.logger.logSchemaBuild(`creating a new table: ${metadata.tableName}`);
 
             // create a new table schema and sync it in the database
-            const tableSchema = new TableSchema(metadata.tableName, this.metadataColumnsToColumnSchemas(metadata.columns), true);
+            const tableSchema = new TableSchema(metadata.tableName, this.metadataColumnsToColumnSchemas(metadata.columns), true, metadata.engine);
             this.tableSchemas.push(tableSchema);
             await this.queryRunner.createTable(tableSchema);
         });

--- a/src/schema-builder/schema/TableSchema.ts
+++ b/src/schema-builder/schema/TableSchema.ts
@@ -57,7 +57,7 @@ export class TableSchema {
     // Constructor
     // -------------------------------------------------------------------------
 
-    constructor(name: string, columns?: ColumnSchema[]|ObjectLiteral[], justCreated?: boolean) {
+    constructor(name: string, columns?: ColumnSchema[]|ObjectLiteral[], justCreated?: boolean, engine?: string) {
         this.name = name;
         if (columns) {
             this.columns = (columns as any[]).map(column => { // as any[] is a temporary fix (some weird compiler error)
@@ -71,6 +71,8 @@ export class TableSchema {
 
         if (justCreated !== undefined)
             this.justCreated = justCreated;
+
+        this.engine = engine;
     }
 
     // -------------------------------------------------------------------------


### PR DESCRIPTION
`MySqlQueryRunner` references `TableSchema#engine`, but the engine parameter wasn't set when creating tables.