### PR TITLE
Fixed missing comma in createConnection example

### DIFF
--- a/README.md
+++ b/README.md
@@ -377,7 +377,7 @@ createConnection({
     port: 3306,
     username: "root",
     password: "admin",
-    database: "test"
+    database: "test",
     entities: [
         __dirname + "/entity/*.js"
     ],


### PR DESCRIPTION
There was a comma missing in createConnection example in the readme.