### PR TITLE
Fix contributing guidelines url in DEVELOPER.md

### DIFF
--- a/DEVELOPER.md
+++ b/DEVELOPER.md
@@ -8,7 +8,7 @@ This document describes how to set up your development environment and run TypeO
 * [Building](#building)
 * [Running Tests Locally](#running-tests-locally)
 
-See the [contribution guidelines](https://github.com/angular/angular/blob/master/CONTRIBUTING.md)
+See the [contribution guidelines](https://github.com/typeorm/typeorm/blob/master/CONTRIBUTING.md)
 if you'd like to contribute to Angular.
 
 ## Prerequisite Software
@@ -20,14 +20,14 @@ following products on your development machine:
   [Windows](http://windows.github.com)); [GitHub's Guide to Installing
   Git](https://help.github.com/articles/set-up-git) is a good source of information.
 * [Node.js](http://nodejs.org), (better to install latest version) which is used to run a development web server,
-  run tests, and generate distributable files. 
+  run tests, and generate distributable files.
   Depending on your system, you can install Node either from source or as a pre-packaged bundle.
 * [Mysql](https://www.mysql.com/) is required to run tests on this platform (or docker)
 * [MariaDB](https://mariadb.com/) is required to run tests on this platform (or docker)
 * [Postgres](https://www.postgresql.org/) is required to run tests on this platform (or docker)
 * [Oracle](https://www.oracle.com/database/index.html) is required to run tests on this platform
 * [Microsoft SQL Server](https://www.microsoft.com/en-us/cloud-platform/sql-server) is required to run tests on this platform
-* For MySQL, MariaDB and Postgres you can use [docker](https://www.docker.com/) instead (docker configuration is 
+* For MySQL, MariaDB and Postgres you can use [docker](https://www.docker.com/) instead (docker configuration is
  [here](https://github.com/typeorm/typeorm/blob/master/docker-compose.yml))
 
 ## Getting the Sources
@@ -57,7 +57,7 @@ Install all TypeORM dependencies by running this command:
 npm install
 ```
 
-During installation you may have some problems with some dependencies. 
+During installation you may have some problems with some dependencies.
 For example to proper install oracle driver you need to follow all instructions from
  [node-oracle documentation](https://github.com/oracle/node-oracledb).
 
@@ -86,7 +86,7 @@ You can link (or simply copy/paste) this directory into your project and test Ty
 It would be greatly appreciated if PRs that change code come with appropriate tests.
 
 To create a test for a specific issue opened on github, create a file: `test/github-issues/<num>/issue-<num>.ts` where
-`<num>` is the corresponding github issue. For example, if you were creating a PR to fix github issue #363, you'd 
+`<num>` is the corresponding github issue. For example, if you were creating a PR to fix github issue #363, you'd
 create `test/github-issues/363/issue-363.ts`.
 
 Most tests will benefit from using this template as a starting point:
@@ -113,16 +113,16 @@ describe("github issues > #<issue number> <issue title>", () => {
        // tests go here
 
     })));
-    
+
     // you can add additional tests if needed
 
 });
 ```
 
-If you place entities in `./entity/<entity-name>.ts` relative to your `issue-<num>.ts` file, 
+If you place entities in `./entity/<entity-name>.ts` relative to your `issue-<num>.ts` file,
 they will automatically be loaded.
 
-To run the tests, setup your environment configuration by copying `ormconfig.json.dist` into `ormconfig.json` and 
+To run the tests, setup your environment configuration by copying `ormconfig.json.dist` into `ormconfig.json` and
 replacing parameters with your own.
 
 Then run tests:
@@ -134,7 +134,7 @@ npm test
 You should execute test suites before submitting a PR to github.
 All the tests are executed on our Continuous Integration infrastructure and a PR could only be merged once the tests pass.
 
->**Hint:** you can use the `--grep` flag to pass a Regex to `gulp-mocha`. Only the tests have have `describe`/`it` 
+>**Hint:** you can use the `--grep` flag to pass a Regex to `gulp-mocha`. Only the tests have have `describe`/`it`
 >statements that match the Regex will be run. For example:
 >
 >```shell
@@ -143,8 +143,8 @@ All the tests are executed on our Continuous Integration infrastructure and a PR
 >
 >This is useful when trying to get a specific test or subset of tests to pass.
 
-## Using Docker 
+## Using Docker
 
-To run your tests you need dbms installed on your machine. Alternatively, you can use docker 
+To run your tests you need dbms installed on your machine. Alternatively, you can use docker
 with all dbms images inside it. To use dbms for your tests from docker simply run `docker-compose up`
 in the root of the project. Once all images are fetched and run you can run tests.


### PR DESCRIPTION
The url pointed to the contributing guidelines in angular repo, changed towards the one in this repo.