### PR TITLE
Fix problem with ConnectionOptionsReader when loading config with entities specified directly

### DIFF
--- a/src/connection/ConnectionOptionsReader.ts
+++ b/src/connection/ConnectionOptionsReader.ts
@@ -113,7 +113,7 @@ export class ConnectionOptionsReader {
 
             if (options.entities) {
                 const entities = (options.entities as any[]).map(entity => {
-                    if (typeof entity === "string" || entity.substr(0, 1) !== "/")
+                    if (typeof entity === "string" && entity.substr(0, 1) !== "/")
                         return this.baseFilePath + "/" + entity;
 
                     return entity;
@@ -122,7 +122,7 @@ export class ConnectionOptionsReader {
             }
             if (options.subscribers) {
                 const subscribers = (options.subscribers as any[]).map(subscriber => {
-                    if (typeof subscriber === "string" || subscriber.substr(0, 1) !== "/")
+                    if (typeof subscriber === "string" && subscriber.substr(0, 1) !== "/")
                         return this.baseFilePath + "/" + subscriber;
 
                     return subscriber;
@@ -131,7 +131,7 @@ export class ConnectionOptionsReader {
             }
             if (options.migrations) {
                 const migrations = (options.migrations as any[]).map(migration => {
-                    if (typeof migration === "string" || migration.substr(0, 1) !== "/")
+                    if (typeof migration === "string" && migration.substr(0, 1) !== "/")
                         return this.baseFilePath + "/" + migration;
 
                     return migration;

--- a/src/decorator/Index.ts
+++ b/src/decorator/Index.ts
@@ -35,7 +35,7 @@ export function Index(name: string, fields: (object?: any) => (any[]|{ [key: str
 /**
  * Composite index must be set on entity classes and must specify entity's fields to be indexed.
  */
-export function Index(nameOrFieldsOrOptions?: string|string[]|((object: any) => any[])|IndexOptions,
+export function Index(nameOrFieldsOrOptions?: string|string[]|((object: any) => (any[]|{ [key: string]: number }))|IndexOptions,
                       maybeFieldsOrOptions?: ((object?: any) => (any[]|{ [key: string]: number }))|IndexOptions|string[],
                       maybeOptions?: IndexOptions): Function {
     const name = typeof nameOrFieldsOrOptions === "string" ? nameOrFieldsOrOptions : undefined;

--- a/src/entity-manager/MongoEntityManager.ts
+++ b/src/entity-manager/MongoEntityManager.ts
@@ -509,7 +509,7 @@ export class MongoEntityManager extends EntityManager {
     /**
      * Converts FindManyOptions to mongodb query.
      */
-    protected convertFindManyOptionsOrConditionsToMongodbQuery<Entity>(optionsOrConditions: FindOneOptions<Entity>|Partial<Entity>|undefined): ObjectLiteral|undefined {
+    protected convertFindManyOptionsOrConditionsToMongodbQuery<Entity>(optionsOrConditions: FindManyOptions<Entity>|Partial<Entity>|undefined): ObjectLiteral|undefined {
         if (!optionsOrConditions)
             return undefined;
 

--- a/test/functional/connection-options-reader/configs/class-entities.ts
+++ b/test/functional/connection-options-reader/configs/class-entities.ts
@@ -1,0 +1,30 @@
+import {PrimaryGeneratedColumn} from "../../../../src/decorator/columns/PrimaryGeneratedColumn";
+import {Column} from "../../../../src/decorator/columns/Column";
+import {Entity} from "../../../../src/decorator/entity/Entity";
+
+@Entity()
+export class Post {
+
+    @PrimaryGeneratedColumn()
+    id: number;
+
+    @Column()
+    title: string;
+
+    constructor(id: number, title: string) {
+        this.id = id;
+        this.title = title;
+    }
+}
+
+module.exports = {
+  type: "mysql",
+  name: "test-conn",
+  host: "localhost",
+  port: 3306,
+  username: "test",
+  password: "test",
+  database: "test",
+  logging: false,
+  entities: [Post],
+};

--- a/test/functional/connection-options-reader/connection-options-reader.ts
+++ b/test/functional/connection-options-reader/connection-options-reader.ts
@@ -1,0 +1,14 @@
+import {expect} from "chai";
+import {ConnectionOptions} from "../../../src/connection/ConnectionOptions";
+import {ConnectionOptionsReader} from "../../../src/connection/ConnectionOptionsReader";
+
+describe("ConnectionOptionsReader", () => {
+  it("properly loads config with entities specified", async () => {
+    type EntititesList = Function[] | string[];
+    const connectionOptionsReader = new ConnectionOptionsReader({ root: __dirname, configName: "configs/class-entities" });
+    const options: ConnectionOptions = await connectionOptionsReader.get("test-conn");
+    expect(options.entities).to.be.an.instanceOf(Array);
+    const entities: EntititesList = options.entities as EntititesList;
+    expect(entities.length).to.equal(1);
+  });
+});


### PR DESCRIPTION
Due to incorrect check, `ConnectionOptionsReader` failed when anything but a array of strings was provided to `entities`, `migrations` or `subscribers` connection options. Fix was to simply change `||` to `&&`.

As for commit with types changes it was simply needed for me to start the work on fix. Typescript 2.4.2 doesn't have a problem with what was previously but using 2.5.2 caused compilation to fail.