### PR TITLE
Clarifying Migration Executer Error Msg

### DIFF
--- a/src/migration/MigrationExecutor.ts
+++ b/src/migration/MigrationExecutor.ts
@@ -223,7 +223,7 @@ export class MigrationExecutor {
             const migrationClassName = (migration.constructor as any).name;
             const migrationTimestamp = parseInt(migrationClassName.substr(-13));
             if (!migrationTimestamp)
-                throw new Error(`Migration class name should contain a class name at the end of the file. ${migrationClassName} migration name is wrong.`);
+                throw new Error(`${migrationClassName} migration name is wrong. Migration class name should have a UNIX timestamp appended. `);
 
             return new Migration(migrationTimestamp, migrationClassName, migration);
         });


### PR DESCRIPTION
"Migration class name should contain a class name at the end of the file. ${migrationClassName} migration name is wrong."

Was receiving this error and was not sure what it meant. I discovered that the migration class name requires a timestamp, but the error thrown did not describe this properly.

${migrationClassName} migration name is wrong. Migration class name should have a UNIX timestamp appended. 