### PR TITLE
Cordova driver: Fixes wrong disconnect call and added location option

### DIFF
--- a/src/driver/cordova/CordovaDriver.ts
+++ b/src/driver/cordova/CordovaDriver.ts
@@ -46,7 +46,7 @@ export class CordovaDriver extends AbstractSqliteDriver {
     async disconnect(): Promise<void> {
         return new Promise<void>((ok, fail) => {
             this.queryRunner = undefined;
-            this.databaseConnection.close((err: any) => err ? fail(err) : ok());
+            this.databaseConnection.close(ok, fail);
         });
     }
     
@@ -69,7 +69,7 @@ export class CordovaDriver extends AbstractSqliteDriver {
      */
     protected createDatabaseConnection() {
         return new Promise<void>((ok, fail) => {
-            this.sqlite.openDatabase({name: this.options.database, location: "default"}, (db: any) => {
+            this.sqlite.openDatabase({name: this.options.database, location: this.options.location}, (db: any) => {
                 const databaseConnection = db;
                 ok(databaseConnection);
             }, (error: any) => {


### PR DESCRIPTION
While using the cordova driver I found a small bug where the `disconnect` call was wrong. I also added the `location` option to the `open` call of the database. Before the option was specified but never used.