### PR TITLE
Remove deprecated imports for generated migrations

### DIFF
--- a/src/commands/MigrationGenerateCommand.ts
+++ b/src/commands/MigrationGenerateCommand.ts
@@ -111,7 +111,7 @@ export class MigrationGenerateCommand {
      * Gets contents of the migration file.
      */
     protected static getTemplate(name: string, timestamp: number, upSqls: string[], downSqls: string[]): string {
-        return `import {Connection, EntityManager, MigrationInterface, QueryRunner} from "typeorm";
+        return `import {MigrationInterface, QueryRunner} from "typeorm";
 
 export class ${name}${timestamp} implements MigrationInterface {
 


### PR DESCRIPTION
Spotted two unnecessary imports (according to the latest changelog) in a migration I’ve just generated.