### PR TITLE
fix bug when apply `skip` and `take` option to findAndCount(fix #867)

### DIFF
--- a/src/find-options/FindOptionsUtils.ts
+++ b/src/find-options/FindOptionsUtils.ts
@@ -92,7 +92,7 @@ export class FindOptionsUtils {
     static applyOptionsToQueryBuilder<T>(qb: SelectQueryBuilder<T>, options: FindOneOptions<T>|FindManyOptions<T>|undefined): SelectQueryBuilder<T> {
 
         // if options are not set then simply return query builder. This is made for simplicity of usage.
-        if (!options || !this.isFindOneOptions(options))
+        if (!options || (!this.isFindOneOptions(options) && !this.isFindManyOptions(options)))
             return qb;
 
         // apply all options from FindOptions

--- a/test/github-issues/867/entity/User.ts
+++ b/test/github-issues/867/entity/User.ts
@@ -1,0 +1,17 @@
+import {Entity} from "../../../../src/decorator/entity/Entity";
+import {PrimaryGeneratedColumn} from "../../../../src/decorator/columns/PrimaryGeneratedColumn";
+import {Index} from "../../../../src/decorator/Index";
+import {Column} from "../../../../src/decorator/columns/Column";
+
+@Entity()
+export class User {
+
+    @PrimaryGeneratedColumn()
+    @Index()
+    id: number;
+
+    @Column()
+    @Index()
+    username: string;
+
+}

--- a/test/github-issues/867/issue-867.ts
+++ b/test/github-issues/867/issue-867.ts
@@ -1,0 +1,35 @@
+import "reflect-metadata";
+import {closeTestingConnections, createTestingConnections, reloadTestingDatabases} from "../../utils/test-utils";
+import {Connection} from "../../../src/connection/Connection";
+import {User} from "./entity/User";
+import {expect} from "chai";
+
+describe("github issues > #867 result of `findAndCount` is wrong when apply `skip` and `take` option", () => {
+
+    let connections: Connection[];
+    before(async () => connections = await createTestingConnections({
+        entities: [__dirname + "/entity/*{.js,.ts}"],
+        schemaCreate: true,
+        dropSchema: true,
+    }));
+    beforeEach(() => reloadTestingDatabases(connections));
+    after(() => closeTestingConnections(connections));
+
+    it("should work perfectly", () => Promise.all(connections.map(async connection => {
+        const userRepository = connection.getRepository(User);
+        const users = new Array(5).fill(0).map((n, i) => {
+            const user = new User();
+            user.username = `User_${i}`;
+            return user;
+        });
+        await userRepository.save(users);
+        const [ foundUsers, totalCount ] = await userRepository.findAndCount({
+            skip: 1,
+            take: 2
+        });
+        expect(totalCount).to.equal(5);
+        expect(foundUsers).to.have.lengthOf(2);
+        expect(foundUsers[0].username).to.equal("User_1");
+    })));
+
+});


### PR DESCRIPTION
see #867 

then function `applyOptionsToQueryBuilder` will be called by both `applyFindOneOptionsOrConditionsToQueryBuilder` and `applyFindManyOptionsOrConditionsToQueryBuilder`，but it only check `isFindOneOptions` in source file `src/find-options/FindOptionsUtils.ts` at line 95