### PR TITLE
Browser Package: Adds cli.js and fixes wrong naming for the SystemJS build

### DIFF
--- a/gulpfile.ts
+++ b/gulpfile.ts
@@ -105,7 +105,7 @@ export class Gulpfile {
         return [
             tsResult.js
                 .pipe(sourcemaps.write(".", { sourceRoot: "", includeContent: true }))
-                .pipe(gulp.dest("./build/browser"))
+                .pipe(gulp.dest("./build/package"))
         ];
     }
 
@@ -121,10 +121,10 @@ export class Gulpfile {
             .pipe(tsProject());
 
         return [
-            tsResult.dts.pipe(gulp.dest("./build/browser")),
+            tsResult.dts.pipe(gulp.dest("./build/package/browser")),
             tsResult.js
                 .pipe(sourcemaps.write(".", { sourceRoot: "", includeContent: true }))
-                .pipe(gulp.dest("./build/browser"))
+                .pipe(gulp.dest("./build/package/browser"))
         ];
     }
 
@@ -136,21 +136,15 @@ export class Gulpfile {
         return gulp.src("./build/browser/typeorm-browser.js")
             .pipe(uglify())
             .pipe(rename("typeorm-browser.min.js"))
-            .pipe(gulp.dest("./build/browser"));
+            .pipe(gulp.dest("./build/package"));
     }
 
     @Task()
     browserClearPackageDirectory(cb: Function) {
         return del([
             "./build/systemjs/**",
-             "./build/browser/src/**"
+             "./build/browser/**"
         ])
-    }
-
-    @Task()
-    browserCopyCliFile() {
-        return gulp.src("./build/package/cli.js")
-            .pipe(gulp.dest("./build/browser"))
     }
 
     // -------------------------------------------------------------------------
@@ -234,9 +228,7 @@ export class Gulpfile {
     packagePreparePackageFile() {
         return gulp.src("./package.json")
             .pipe(replace("\"private\": true,", "\"private\": false,"))
-            .pipe(gulp.dest("./build/package"))
-            .pipe(replace("\"name\": \"typeorm\",", "\"name\": \"typeorm-browser\","))
-            .pipe(gulp.dest("./build/browser"));
+            .pipe(gulp.dest("./build/package"));
     }
 
     /**
@@ -246,8 +238,7 @@ export class Gulpfile {
     packageCopyReadme() {
         return gulp.src("./README.md")
             .pipe(replace(/```typescript([\s\S]*?)```/g, "```javascript$1```"))
-            .pipe(gulp.dest("./build/package"))
-            .pipe(gulp.dest("./build/browser"));
+            .pipe(gulp.dest("./build/package"));
     }
 
     /**
@@ -256,7 +247,7 @@ export class Gulpfile {
     @Task()
     packageCopyShims() {
         return gulp.src(["./extra/typeorm-model-shim.js", "./extra/typeorm-class-transformer-shim.js"])
-            .pipe(gulp.dest("./build/browser"));
+            .pipe(gulp.dest("./build/package"));
     }
 
     /**
@@ -270,7 +261,6 @@ export class Gulpfile {
             ["packageCompile", "browserCompile", "browserCompileSystemJS"],
             ["packageMoveCompiledFiles", "browserUglify"],
             [
-                "browserCopyCliFile",
                 "browserClearPackageDirectory",
                 "packageClearPackageDirectory",
                 "packageReplaceReferences",

--- a/gulpfile.ts
+++ b/gulpfile.ts
@@ -62,7 +62,7 @@ export class Gulpfile {
             "!./src/typeorm-model-shim.ts",
             "!./src/platform/PlatformTools.ts"
         ])
-        .pipe(gulp.dest("./build/systemjs/typeorm-browser"))
+        .pipe(gulp.dest("./build/systemjs/typeorm"))
         .pipe(gulp.dest("./build/browser/src"));
     }
 
@@ -72,7 +72,7 @@ export class Gulpfile {
     @Task()
     browserCopyMainBrowserFile() {
         return gulp.src("./package.json", { read: false })
-            .pipe(file("typeorm-browser.ts", `export * from "./typeorm-browser/index";`))
+            .pipe(file("typeorm.ts", `export * from "./typeorm/index";`))
             .pipe(gulp.dest("./build/systemjs"));
     }
 
@@ -83,7 +83,7 @@ export class Gulpfile {
     browserCopyPlatformTools() {
         return gulp.src("./src/platform/BrowserPlatformTools.template")
             .pipe(rename("PlatformTools.ts"))
-            .pipe(gulp.dest("./build/systemjs/typeorm-browser/platform"))
+            .pipe(gulp.dest("./build/systemjs/typeorm/platform"))
             .pipe(gulp.dest("./build/browser/src/platform"));
     }
 

--- a/gulpfile.ts
+++ b/gulpfile.ts
@@ -62,7 +62,7 @@ export class Gulpfile {
             "!./src/typeorm-model-shim.ts",
             "!./src/platform/PlatformTools.ts"
         ])
-        .pipe(gulp.dest("./build/systemjs/typeorm"))
+        .pipe(gulp.dest("./build/systemjs/typeorm-browser"))
         .pipe(gulp.dest("./build/browser/src"));
     }
 
@@ -72,7 +72,7 @@ export class Gulpfile {
     @Task()
     browserCopyMainBrowserFile() {
         return gulp.src("./package.json", { read: false })
-            .pipe(file("typeorm.ts", `export * from "./typeorm/index";`))
+            .pipe(file("typeorm-browser.ts", `export * from "./typeorm-browser/index";`))
             .pipe(gulp.dest("./build/systemjs"));
     }
 
@@ -83,7 +83,7 @@ export class Gulpfile {
     browserCopyPlatformTools() {
         return gulp.src("./src/platform/BrowserPlatformTools.template")
             .pipe(rename("PlatformTools.ts"))
-            .pipe(gulp.dest("./build/systemjs/typeorm/platform"))
+            .pipe(gulp.dest("./build/systemjs/typeorm-browser/platform"))
             .pipe(gulp.dest("./build/browser/src/platform"));
     }
 
@@ -145,6 +145,12 @@ export class Gulpfile {
             "./build/systemjs/**",
              "./build/browser/src/**"
         ])
+    }
+
+    @Task()
+    browserCopyCliFile() {
+        return gulp.src("./build/package/cli.js")
+            .pipe(gulp.dest("./build/browser"))
     }
 
     // -------------------------------------------------------------------------
@@ -264,6 +270,7 @@ export class Gulpfile {
             ["packageCompile", "browserCompile", "browserCompileSystemJS"],
             ["packageMoveCompiledFiles", "browserUglify"],
             [
+                "browserCopyCliFile",
                 "browserClearPackageDirectory",
                 "packageClearPackageDirectory",
                 "packageReplaceReferences",

--- a/package.json
+++ b/package.json
@@ -35,6 +35,8 @@
     "websql",
     "websql-orm"
   ],
+  "browser": "./browser",
+  "module": "index",
   "devDependencies": {
     "@types/chai": "^4.0.4",
     "@types/chai-as-promised": "0.0.31",


### PR DESCRIPTION
As mentioned in #857 the `cli.js` file was missing from the package, which npm complains about. For consistency, I also renamed the internal name for the SystemJS build since otherwise the package would be called `typeorm-browser` but in the code it would still be `import { Entity } from "typeorm"` instead of `import { Entity } from "typeorm-browser"`. Is this a welcome change? 