### PR TITLE
Add common type aliases to normalizeTypes (#861)

### DIFF
--- a/src/driver/mysql/MysqlDriver.ts
+++ b/src/driver/mysql/MysqlDriver.ts
@@ -332,16 +332,16 @@ export class MysqlDriver implements Driver {
         if (column.type === Number || column.type === "integer") {
             return "int";
 
-        } else if (column.type === String) {
+        } else if (column.type === String || column.type === "string") {
             return "varchar";
 
-        } else if (column.type === Date) {
+        } else if (column.type === Date || column.type === "date") {
             return "datetime";
 
         } else if ((column.type as any) === Buffer) {
             return "blob";
 
-        } else if (column.type === Boolean) {
+        } else if (column.type === Boolean || column.type === "boolean") {
             return "tinyint";
 
         } else if (column.type === "uuid") {

--- a/src/driver/oracle/OracleDriver.ts
+++ b/src/driver/oracle/OracleDriver.ts
@@ -311,16 +311,16 @@ export class OracleDriver implements Driver {
      */
     normalizeType(column: { type?: ColumnType, length?: number, precision?: number, scale?: number, isArray?: boolean }): string {
         let type = "";
-        if (column.type === Number) {
+        if (column.type === Number || column.type === "integer") {
             type += "integer";
 
-        } else if (column.type === String) {
+        } else if (column.type === String || column.type === "string") {
             type += "nvarchar2";
 
-        } else if (column.type === Date) {
+        } else if (column.type === Date || column.type === "date") {
             type += "timestamp(0)";
 
-        } else if (column.type === Boolean) {
+        } else if (column.type === Boolean || column.type === "boolean") {
             type += "number(1)";
 
         } else if (column.type === "simple-array") {

--- a/src/driver/postgres/PostgresDriver.ts
+++ b/src/driver/postgres/PostgresDriver.ts
@@ -358,16 +358,16 @@ export class PostgresDriver implements Driver {
      */
     normalizeType(column: { type?: ColumnType, length?: number, precision?: number, scale?: number, isArray?: boolean }): string {
         let type = "";
-        if (column.type === Number) {
+        if (column.type === Number || column.type === "integer") {
             type += "integer";
 
-        } else if (column.type === String) {
+        } else if (column.type === String || column.type === "string") {
             type += "character varying";
 
-        } else if (column.type === Date) {
+        } else if (column.type === Date || column.type === "date") {
             type += "timestamp";
 
-        } else if (column.type === Boolean) {
+        } else if (column.type === Boolean || column.type === "boolean") {
             type += "boolean";
 
         } else if (column.type === "simple-array") {

--- a/src/driver/sqlite-abstract/AbstractSqliteDriver.ts
+++ b/src/driver/sqlite-abstract/AbstractSqliteDriver.ts
@@ -282,16 +282,16 @@ export class AbstractSqliteDriver implements Driver {
      * Creates a database type from a given column metadata.
      */
     normalizeType(column: { type?: ColumnType, length?: number, precision?: number, scale?: number }): string {
-        if (column.type === Number || column.type === "int") {
+        if (column.type === Number || column.type === "int" || column.type === "integer") {
             return "integer";
 
-        } else if (column.type === String) {
+        } else if (column.type === String || column.type === "string") {
             return "varchar";
 
-        } else if (column.type === Date) {
+        } else if (column.type === Date || column.type === "date") {
             return "datetime";
 
-        } else if (column.type === Boolean) {
+        } else if (column.type === Boolean || column.type === "boolean") {
             return "boolean";
 
         } else if (column.type === "uuid") {

--- a/src/driver/sqlserver/SqlServerDriver.ts
+++ b/src/driver/sqlserver/SqlServerDriver.ts
@@ -326,16 +326,16 @@ export class SqlServerDriver implements Driver {
      * Creates a database type from a given column metadata.
      */
     normalizeType(column: { type?: ColumnType, length?: number, precision?: number, scale?: number }): string {
-        if (column.type === Number) {
+        if (column.type === Number || column.type === "integer") {
             return "int";
 
-        } else if (column.type === String) {
+        } else if (column.type === String || column.type === "string") {
             return "nvarchar";
 
-        } else if (column.type === Date) {
+        } else if (column.type === Date || column.type === "date") {
             return "datetime";
 
-        } else if (column.type === Boolean) {
+        } else if (column.type === Boolean || column.type === "boolean") {
             return "bit";
 
         } else if ((column.type as any) === Buffer) {
@@ -346,9 +346,6 @@ export class SqlServerDriver implements Driver {
 
         } else if (column.type === "simple-array") {
             return "ntext";
-
-        } else if (column.type === "integer") {
-            return "int";
 
         } else if (column.type === "dec") {
             return "decimal";


### PR DESCRIPTION
I have done a (very) simple implementation, I have used "string", "integer", "date" and "boolean".
I believe it would be nice to have something common for float and double. 

Please take a look and if you agree I can add these + tests so that it is complete.

Thanks
