### PR TITLE
Fix for issues #549, #244, #572 and #221.

### DIFF
--- a/src/driver/Driver.ts
+++ b/src/driver/Driver.ts
@@ -110,6 +110,11 @@ export interface Driver {
     normalizeDefault(column: ColumnMetadata): string;
 
     /**
+     * Normalizes "isUnique" value of the column.
+     */
+    normalizeIsUnique(column: ColumnMetadata): boolean;
+
+    /**
      * Normalizes "default" value of the column.
      */
     createFullType(column: ColumnSchema): string;

--- a/src/driver/mongodb/MongoDriver.ts
+++ b/src/driver/mongodb/MongoDriver.ts
@@ -242,6 +242,13 @@ export class MongoDriver implements Driver {
     }
 
     /**
+     * Normalizes "isUnique" value of the column.
+     */
+    normalizeIsUnique(column: ColumnMetadata): boolean {
+        throw new Error(`MongoDB is schema-less, not supported by this driver.`);
+    }
+    
+    /**
      * Normalizes "default" value of the column.
      */
     createFullType(column: ColumnSchema): string {

--- a/src/driver/mysql/MysqlDriver.ts
+++ b/src/driver/mysql/MysqlDriver.ts
@@ -376,6 +376,14 @@ export class MysqlDriver implements Driver {
         }
     }
 
+    /**
+     * Normalizes "isUnique" value of the column.
+     */
+    normalizeIsUnique(column: ColumnMetadata): boolean {
+        return column.isUnique || 
+            !!column.entityMetadata.indices.find(index => index.isUnique && index.columns.length === 1 && index.columns[0] === column);
+    }
+    
     createFullType(column: ColumnSchema): string {
         let type = column.type;
 

--- a/src/driver/oracle/OracleDriver.ts
+++ b/src/driver/oracle/OracleDriver.ts
@@ -354,6 +354,13 @@ export class OracleDriver implements Driver {
         }
     }
 
+    /**
+     * Normalizes "isUnique" value of the column.
+     */
+    normalizeIsUnique(column: ColumnMetadata): boolean {
+        return column.isUnique;
+    }
+
     createFullType(column: ColumnSchema): string {
         let type = column.type;
 

--- a/src/driver/postgres/PostgresDriver.ts
+++ b/src/driver/postgres/PostgresDriver.ts
@@ -449,6 +449,13 @@ export class PostgresDriver implements Driver {
     }
 
     /**
+     * Normalizes "isUnique" value of the column.
+     */
+    normalizeIsUnique(column: ColumnMetadata): boolean {
+        return column.isUnique;
+    }
+
+    /**
      * Normalizes "default" value of the column.
      */
     createFullType(column: ColumnSchema): string {

--- a/src/driver/sqlite-abstract/AbstractSqliteDriver.ts
+++ b/src/driver/sqlite-abstract/AbstractSqliteDriver.ts
@@ -327,6 +327,13 @@ export class AbstractSqliteDriver implements Driver {
     }
 
     /**
+     * Normalizes "isUnique" value of the column.
+     */
+    normalizeIsUnique(column: ColumnMetadata): boolean {
+        return column.isUnique;
+    }
+    
+    /**
      * Normalizes "default" value of the column.
      */
     createFullType(column: ColumnSchema): string {

--- a/src/driver/sqlserver/SqlServerDriver.ts
+++ b/src/driver/sqlserver/SqlServerDriver.ts
@@ -386,6 +386,13 @@ export class SqlServerDriver implements Driver {
         }
     }
 
+    /**
+     * Normalizes "isUnique" value of the column.
+     */
+    normalizeIsUnique(column: ColumnMetadata): boolean {
+        return column.isUnique;
+    }
+
     createFullType(column: ColumnSchema): string {
         let type = column.type;
 

--- a/src/schema-builder/schema/TableSchema.ts
+++ b/src/schema-builder/schema/TableSchema.ts
@@ -223,7 +223,7 @@ export class TableSchema {
                     columnSchema.comment !== columnMetadata.comment ||
                     (!columnSchema.isGenerated && !this.compareDefaultValues(driver.normalizeDefault(columnMetadata), columnSchema.default)) || // we included check for generated here, because generated columns already can have default values
                     columnSchema.isNullable !== columnMetadata.isNullable ||
-                    columnSchema.isUnique !== columnMetadata.isUnique ||
+                    columnSchema.isUnique !== driver.normalizeIsUnique(columnMetadata) ||
                     // columnSchema.isPrimary !== columnMetadata.isPrimary ||
                     columnSchema.isGenerated !== columnMetadata.isGenerated;
         });

--- a/test/functional/database-schema/unique-index/entity/person.ts
+++ b/test/functional/database-schema/unique-index/entity/person.ts
@@ -1,0 +1,19 @@
+import { Entity } from "../../../../../src/decorator/entity/Entity";
+import { PrimaryGeneratedColumn } from "../../../../../src/decorator/columns/PrimaryGeneratedColumn";
+import { Column } from "../../../../../src/decorator/columns/Column";
+import { Index } from "../../../../../src/decorator/Index";
+
+@Entity()
+export class Person {
+
+    @PrimaryGeneratedColumn()
+    id: number;
+
+    @Column()
+    firstname: string;
+
+    @Column()
+    @Index({ unique: true })
+    lastname: string;
+
+}

--- a/test/functional/database-schema/unique-index/entity/user.ts
+++ b/test/functional/database-schema/unique-index/entity/user.ts
@@ -1,0 +1,19 @@
+import { Entity } from "../../../../../src/decorator/entity/Entity";
+import { PrimaryGeneratedColumn } from "../../../../../src/decorator/columns/PrimaryGeneratedColumn";
+import { Column } from "../../../../../src/decorator/columns/Column";
+import { Index } from "../../../../../src/decorator/Index";
+
+@Entity()
+@Index("unique_user_twitter_id", (user: User) => [user.twitter_id], { unique: true })
+export class User {
+
+    @PrimaryGeneratedColumn({ type: "int" })
+    user_id: number;
+
+    @Column()
+    user_name: string;
+
+    @Column({ length: 25 })
+    twitter_id: string;
+
+}

--- a/test/functional/database-schema/unique-index/unique-index-test.ts
+++ b/test/functional/database-schema/unique-index/unique-index-test.ts
@@ -1,0 +1,29 @@
+import "reflect-metadata";
+import {closeTestingConnections, createTestingConnections, reloadTestingDatabases} from "../../../utils/test-utils";
+import {Connection} from "../../../../src/connection/Connection";
+ 
+import {Person} from "./entity/person";
+import {User} from "./entity/user";
+
+describe("indices > reading index from entity schema and updating database", () => {
+
+    let connections: Connection[];
+    before(async () => connections = await createTestingConnections({
+        entities: [Person, User],
+        schemaCreate: true,
+        dropSchema: true
+    }));
+    beforeEach(() => reloadTestingDatabases(connections));
+    after(() => closeTestingConnections(connections));
+
+    describe("create index", function() {
+
+        it("should just work", () => Promise.all(connections.map(async connection => {
+            
+            await connection.synchronize(false);
+
+        })));
+
+    });
+
+});


### PR DESCRIPTION
Add normalizeIsUnique method to driver interface and use it to check if a column is isUnique compared to what the DB schema reports. There are differences on how a DB handles the unique column case.

MySQL - MariaDB consider a column as unique if there is a unique index on the column, without the need for a unique constraint. 
So we need to adjust on how we resolve differences so that we take this into account (only for this DB type).

This fixes #549, #244, #572 and #221