### PR TITLE
Cordova Driver: add check if the location option is set

### DIFF
--- a/src/driver/cordova/CordovaDriver.ts
+++ b/src/driver/cordova/CordovaDriver.ts
@@ -31,6 +31,9 @@ export class CordovaDriver extends AbstractSqliteDriver {
         if (!this.options.database)
             throw new DriverOptionNotSetError("database");
 
+        if (!this.options.location)
+            throw new DriverOptionNotSetError("location");
+
         // load sqlite package
         this.loadDependencies();
     }


### PR DESCRIPTION
This adds the, in #890 mentioned, check if the `location` option is set. I will write proper docs and an example for it tomorrow.

fixes #890