### PR TITLE
test: add failing test case for #929

### DIFF
--- a/test/github-issues/929/entity/TestEntity.ts
+++ b/test/github-issues/929/entity/TestEntity.ts
@@ -1,0 +1,14 @@
+import {Entity} from "../../../../src/decorator/entity/Entity";
+import {PrimaryGeneratedColumn} from "../../../../src/decorator/columns/PrimaryGeneratedColumn";
+import {Column} from "../../../../src/decorator/columns/Column";
+
+@Entity()
+export class TestEntity {
+
+    @PrimaryGeneratedColumn()
+    id: number;
+
+    @Column()
+    name: string;
+
+}

--- a/test/github-issues/929/issue-929.ts
+++ b/test/github-issues/929/issue-929.ts
@@ -1,0 +1,68 @@
+import "reflect-metadata";
+import {closeTestingConnections, createTestingConnections, reloadTestingDatabases} from "../../utils/test-utils";
+import {Connection} from "../../../src/connection/Connection";
+import {expect} from "chai";
+import { TestEntity } from "./entity/TestEntity";
+
+describe("github issues > #929 sub-queries should set their own parameters on execution", () => {
+
+    let connections: Connection[];
+    before(async () => connections = await createTestingConnections({
+        entities: [__dirname + "/entity/*{.js,.ts}"],
+        schemaCreate: true,
+        dropSchema: true,
+        enabledDrivers: ["postgres"] // we can properly test lazy-relations only on one platform
+    }));
+    beforeEach(() => reloadTestingDatabases(connections));
+    after(() => closeTestingConnections(connections));
+
+    it("should persist successfully and return persisted entity", () => Promise.all(connections.map(async connection => {
+
+        // create objects to save
+        const testEntity1 = new TestEntity();
+        testEntity1.name = "Entity #1";
+
+        const testEntity2 = new TestEntity();
+        testEntity2.name = "Entity #2";
+
+        const testEntity3 = new TestEntity();
+        testEntity3.name = "Entity #3";
+
+        const testEntity4 = new TestEntity();
+        testEntity4.name = "Entity #4";
+
+        // persist
+        await connection.manager.save([
+            testEntity1,
+            testEntity2,
+            testEntity3,
+            testEntity4
+        ]);
+
+        const queryBuilder = connection.manager.createQueryBuilder(TestEntity, "testEntity");
+
+        const subQuery = queryBuilder
+            .subQuery()
+            .from(TestEntity, "innerTestEntity")
+            .select(["id"])
+            .where("innerTestEntity.id = :innerId", { innerId: 1 });
+
+        const mainQuery = queryBuilder
+            .select("testEntity")
+            .where(`testEntity.id IN ${subQuery.getQuery()}`);
+            // .setParameters({innerId: 1});
+
+            /**
+             * To @pleerock:
+             * using setParameters should work, but I think sub queries should set their
+             * own parameters on execution
+             */
+
+
+        const result = await mainQuery.getMany();
+
+        expect(result).not.to.be.empty;
+        expect(result).to.eql({ id: 1, name: "Entity #1" });
+    })));
+
+});


### PR DESCRIPTION
When using subqueries parameters are not set in the subquery when executing the main query. 

Subqueries should set their own parameters on execution. This PR add a failing test-case for this.

Example code:
```ts
const queryBuilder = connection.manager.createQueryBuilder(TestEntity, "testEntity");

const subQuery = queryBuilder
  .subQuery()
  .from(TestEntity, "innerTestEntity")
  .select(["id"])
  .where("innerTestEntity.id = :innerId", { innerId: 1 });

const mainQuery = queryBuilder
  .select("testEntity")
  .where(`testEntity.id IN ${subQuery.getQuery()}`);
  // .setParameters({innerId: 1}); // this would make it work, but subqueries should set their own parameters on execution
```

The code above currently generates the following query: 

```sql
SELECT "testEntity"."id" AS "testEntity_id", "testEntity"."name" AS "testEntity_name" 
FROM "test_entity" "testEntity" WHERE "testEntity"."id" 
IN (SELECT id FROM "test_entity" "innerTestEntity" WHERE "innerTestEntity"."id" = :innerId)
```

when fixed closes #929