### PR TITLE
Fix column naming for deeper embedded entities

### DIFF
--- a/src/metadata/EmbeddedMetadata.ts
+++ b/src/metadata/EmbeddedMetadata.ts
@@ -172,7 +172,6 @@ export class EmbeddedMetadata {
 
         if (this.customPrefix === undefined) {
             prefixes.push(this.propertyName);
-
         } else if (typeof this.customPrefix === "string") {
             prefixes.push(this.customPrefix);
         }
@@ -185,7 +184,7 @@ export class EmbeddedMetadata {
     }
 
     protected buildParentPrefixes(): string[] {
-        return this.parentEmbeddedMetadata ? this.parentEmbeddedMetadata.buildParentPrefixes().concat(this.prefix || this.propertyName) : [this.prefix || this.propertyName];
+        return [this.prefix || this.propertyName];
     }
 
     protected buildEmbeddedMetadataTree(): EmbeddedMetadata[] {

--- a/test/functional/columns/embedded-columns/columns-embedded-columns.ts
+++ b/test/functional/columns/embedded-columns/columns-embedded-columns.ts
@@ -1,0 +1,107 @@
+import "reflect-metadata";
+
+import {expect} from "chai";
+
+import {Connection} from "../../../../src/connection/Connection";
+import {closeTestingConnections, createTestingConnections, reloadTestingDatabases} from "../../../utils/test-utils";
+
+import {SimplePost} from "./entity/SimplePost";
+import {SimpleCounters} from "./entity/SimpleCounters";
+import {Information} from "./entity/Information";
+
+import {Post} from "./entity/Post";
+
+describe("columns > embedded columns", () => {
+
+    let connections: Connection[];
+    before(async () => connections = await createTestingConnections({
+        entities: [__dirname + "/entity/*{.js,.ts}"],
+        enabledDrivers: ["postgres", "mysql"],
+    }));
+    beforeEach(() => reloadTestingDatabases(connections));
+    after(() => closeTestingConnections(connections));
+
+    it("should insert / update / remove entity with embedded correctly", () => Promise.all(connections.map(async connection => {
+        const postRepository = connection.getRepository(SimplePost);
+
+        // save few posts
+        const post = new SimplePost();
+        post.title = "Post";
+        post.text = "Everything about post";
+        post.counters = new SimpleCounters();
+        post.counters.likes = 5;
+        post.counters.comments = 1;
+        post.counters.favorites = 10;
+        post.counters.information = new Information();
+        post.counters.information.description = "Hello post";
+        await postRepository.save(post);
+
+        const loadedPost = await postRepository.findOne({ title: "Post" });
+
+        expect(loadedPost).to.be.not.empty;
+        expect(loadedPost!.counters).to.be.not.empty;
+        expect(loadedPost!.counters.information).to.be.not.empty;
+        loadedPost!.should.be.instanceOf(SimplePost);
+        loadedPost!.title.should.be.equal("Post");
+        loadedPost!.text.should.be.equal("Everything about post");
+        loadedPost!.counters.should.be.instanceOf(SimpleCounters);
+        loadedPost!.counters.likes.should.be.equal(5);
+        loadedPost!.counters.comments.should.be.equal(1);
+        loadedPost!.counters.favorites.should.be.equal(10);
+        loadedPost!.counters.information.should.be.instanceOf(Information);
+        loadedPost!.counters.information.description.should.be.equal("Hello post");
+
+        post.title = "Updated post";
+        post.counters.comments = 2;
+        post.counters.information.description = "Hello updated post";
+        await postRepository.save(post);
+
+        const loadedUpdatedPost = await postRepository.findOne({ title: "Updated post" });
+
+        expect(loadedUpdatedPost).to.be.not.empty;
+        expect(loadedUpdatedPost!.counters).to.be.not.empty;
+        expect(loadedUpdatedPost!.counters.information).to.be.not.empty;
+        loadedUpdatedPost!.should.be.instanceOf(SimplePost);
+        loadedUpdatedPost!.title.should.be.equal("Updated post");
+        loadedUpdatedPost!.text.should.be.equal("Everything about post");
+        loadedUpdatedPost!.counters.should.be.instanceOf(SimpleCounters);
+        loadedUpdatedPost!.counters.likes.should.be.equal(5);
+        loadedUpdatedPost!.counters.comments.should.be.equal(2);
+        loadedUpdatedPost!.counters.favorites.should.be.equal(10);
+        loadedUpdatedPost!.counters.information.should.be.instanceOf(Information);
+        loadedUpdatedPost!.counters.information.description.should.be.equal("Hello updated post");
+
+        await postRepository.remove(post);
+
+        const removedPost = await postRepository.findOne({ title: "Post" });
+        const removedUpdatedPost = await postRepository.findOne({ title: "Updated post" });
+        expect(removedPost).to.be.empty;
+        expect(removedUpdatedPost).to.be.empty;
+    })));
+
+    it("should properly generate column names", () => Promise.all(connections.map(async connection => {
+        const postRepository = connection.getRepository(Post);
+        const columns = postRepository.metadata.columns;
+        const databaseColumns = columns.map(c => c.databaseName);
+
+        expect(databaseColumns).to.have.members([
+            "id",
+            "title",
+            "text",
+
+            "countersLikes",
+            "countersComments",
+            "countersFavorites",
+
+            "countersInformationDescription",
+            "countersTestDataDescription",
+
+            "testCountersLikes",
+            "testCountersComments",
+            "testCountersFavorites",
+
+            "testCountersInformationDescription",
+            "testCountersTestDataDescription",
+        ]);
+    })));
+});

--- a/test/functional/columns/embedded-columns/entity/Counters.ts
+++ b/test/functional/columns/embedded-columns/entity/Counters.ts
@@ -1,0 +1,20 @@
+import { Column } from "../../../../../src/decorator/columns/Column";
+
+import { Information } from "./Information";
+
+export class Counters {
+    @Column()
+    likes: number;
+
+    @Column()
+    comments: number;
+
+    @Column()
+    favorites: number;
+
+    @Column(type => Information)
+    information: Information;
+
+    @Column(type => Information, { prefix: "testData" })
+    data: Information;
+}

--- a/test/functional/columns/embedded-columns/entity/Information.ts
+++ b/test/functional/columns/embedded-columns/entity/Information.ts
@@ -1,0 +1,6 @@
+import { Column } from "../../../../../src/decorator/columns/Column";
+
+export class Information {
+    @Column()
+    description: string;
+}

--- a/test/functional/columns/embedded-columns/entity/Post.ts
+++ b/test/functional/columns/embedded-columns/entity/Post.ts
@@ -1,0 +1,23 @@
+import { Entity } from "../../../../../src/decorator/entity/Entity";
+import { Column } from "../../../../../src/decorator/columns/Column";
+import { PrimaryGeneratedColumn } from "../../../../../src/decorator/columns/PrimaryGeneratedColumn";
+
+import { Counters } from "./Counters";
+
+@Entity()
+export class Post {
+    @PrimaryGeneratedColumn()
+    id: number;
+
+    @Column()
+    title: string;
+
+    @Column()
+    text: string;
+
+    @Column(type => Counters)
+    counters: Counters;
+
+    @Column(type => Counters, { prefix: "testCounters" })
+    otherCounters: Counters;
+}

--- a/test/functional/columns/embedded-columns/entity/SimpleCounters.ts
+++ b/test/functional/columns/embedded-columns/entity/SimpleCounters.ts
@@ -1,0 +1,17 @@
+import { Column } from "../../../../../src/decorator/columns/Column";
+
+import { Information } from "./Information";
+
+export class SimpleCounters {
+    @Column()
+    likes: number;
+
+    @Column()
+    comments: number;
+
+    @Column()
+    favorites: number;
+
+    @Column(type => Information)
+    information: Information;
+}

--- a/test/functional/columns/embedded-columns/entity/SimplePost.ts
+++ b/test/functional/columns/embedded-columns/entity/SimplePost.ts
@@ -1,0 +1,20 @@
+import { Entity } from "../../../../../src/decorator/entity/Entity";
+import { Column } from "../../../../../src/decorator/columns/Column";
+import { PrimaryGeneratedColumn } from "../../../../../src/decorator/columns/PrimaryGeneratedColumn";
+
+import { SimpleCounters } from "./SimpleCounters";
+
+@Entity()
+export class SimplePost {
+    @PrimaryGeneratedColumn()
+    id: number;
+
+    @Column()
+    title: string;
+
+    @Column()
+    text: string;
+
+    @Column(type => SimpleCounters)
+    counters: SimpleCounters;
+}


### PR DESCRIPTION
Example from provided test would be "countersInformationDescription" which previously would get database name "countersCountersInformationDescription". Problem was that parentEmbeddedMetadata was already taken into consideration when building prefix so anything deeper than one level would add earlier prefixes multiple times.

Previously `buildParentPrefixes` for `countersInformationDescription` would be `["counters", "counters_information]` and now it is simply `["counters_information"]`.

The base test for insert, update, remove is basically the same as the one for embedded columns for MongoDB.