### PR TITLE
In the case of .env file, it will load the default (global) .env file name.

### DIFF
--- a/src/connection/ConnectionOptionsReader.ts
+++ b/src/connection/ConnectionOptionsReader.ts
@@ -64,14 +64,15 @@ export class ConnectionOptionsReader {
     protected async load(): Promise<ConnectionOptions[]> {
 
         // try to find any of following configuration formats
-        const foundFileFormat = ["js", "json", "yml", "yaml", "xml"].find(format => {
+        const foundFileFormat = ["env", "js", "json", "yml", "yaml", "xml"].find(format => {
             return PlatformTools.fileExist(this.baseFilePath + "." + format);
         });
         
-        const foundEnvFile = PlatformTools.fileExist(".env")
-        
         // if .env file found then load all its variables into process.env using dotenv package
-        if (foundEnvFile) {
+        if (foundFileFormat === "env") {
+            const dotenv = PlatformTools.load("dotenv");
+            dotenv.config({ path: this.baseFilePath + ".env" });
+        } else if (PlatformTools.fileExist(".env")) {
             const dotenv = PlatformTools.load("dotenv");
             dotenv.config({ path: ".env" });
         }

--- a/src/connection/ConnectionOptionsReader.ts
+++ b/src/connection/ConnectionOptionsReader.ts
@@ -64,14 +64,16 @@ export class ConnectionOptionsReader {
     protected async load(): Promise<ConnectionOptions[]> {
 
         // try to find any of following configuration formats
-        const foundFileFormat = ["env", "js", "json", "yml", "yaml", "xml"].find(format => {
+        const foundFileFormat = ["js", "json", "yml", "yaml", "xml"].find(format => {
             return PlatformTools.fileExist(this.baseFilePath + "." + format);
         });
-
+        
+        const foundEnvFile = PlatformTools.fileExist(".env")
+        
         // if .env file found then load all its variables into process.env using dotenv package
-        if (foundFileFormat === "env") {
+        if (foundEnvFile) {
             const dotenv = PlatformTools.load("dotenv");
-            dotenv.config({ path: this.baseFilePath + ".env" });
+            dotenv.config({ path: ".env" });
         }
 
         // try to find connection options from any of available sources of configuration


### PR DESCRIPTION
It will introduce a breaking change because it will not locate ormconfig.env, instead it will search for a .env file.

Maybe its better to implement in a way that the 2 files work.