### PR TITLE
WebSQL version should be a string

### DIFF
--- a/docs/connection-options.md
+++ b/docs/connection-options.md
@@ -174,7 +174,7 @@ See [SSL options](https://github.com/mysqljs/mysql#ssl-options).
 
 * `database` - Database name
 
-* `version` - Version number of the database
+* `version` - Version string of the database
 
 * `description` - Database description
 

--- a/src/driver/websql/WebSqlConnectionOptions.ts
+++ b/src/driver/websql/WebSqlConnectionOptions.ts
@@ -18,7 +18,7 @@ export interface WebSqlConnectionOptions extends BaseConnectionOptions {
     /**
      * Database version.
      */
-    readonly version: number;
+    readonly version: string;
 
     /**
      * Database description.


### PR DESCRIPTION
Looking at the [standard](https://www.w3.org/TR/webdatabase/#introduction), the version parameter when opening a new websql connection should be a string.

fixed #998 