### PR TITLE
order option support both object and array

### DIFF
--- a/docs/find-options.md
+++ b/docs/find-options.md
@@ -45,6 +45,12 @@ userRepository.find({
     }
 });
 ```
+```typescript
+// or use array
+userRepository.find({ 
+    order: [["name", "ASC"], ["id", "DESC"]]
+});
+```
 
 `find` methods which return multiple entities (`find`, `findAndCount`, `findByIds`) also accept following options:
 

--- a/src/find-options/FindOneOptions.ts
+++ b/src/find-options/FindOneOptions.ts
@@ -1,6 +1,12 @@
 import {JoinOptions} from "./JoinOptions";
 import {ObjectLiteral} from "../common/ObjectLiteral";
 
+export type OrderDirection = "ASC" | "DESC";
+export type ObjectOrderOption<Entity> = { [P in keyof Entity]?: OrderDirection };
+export type ArrayOrderOptionItem<Entity> = [keyof Entity, OrderDirection];
+export type ArrayOrderOption<Entity> = ArrayOrderOptionItem<Entity>[];
+export type OrderOption<Entity> = ObjectOrderOption<Entity> | ArrayOrderOption<Entity>;
+
 /**
  * Defines a special criteria to find specific entity.
  */
@@ -13,7 +19,7 @@ export interface FindOneOptions<Entity> {
     /**
      * Simple condition that should be applied to match entities.
      */
-    where?: Partial<Entity>|ObjectLiteral;
+    where?: Partial<Entity> | ObjectLiteral;
 
     /**
      * Indicates what relations of entity should be loaded (simplified left join form).
@@ -28,6 +34,6 @@ export interface FindOneOptions<Entity> {
     /**
      * Order, in which entities should be ordered.
      */
-    order?: { [P in keyof Entity]?: "ASC"|"DESC" };
+    order?: OrderOption<Entity>;
 
 }

--- a/src/find-options/FindOptionsUtils.ts
+++ b/src/find-options/FindOptionsUtils.ts
@@ -1,5 +1,5 @@
 import {FindManyOptions} from "./FindManyOptions";
-import {FindOneOptions} from "./FindOneOptions";
+import {ArrayOrderOption, FindOneOptions, ObjectOrderOption} from "./FindOneOptions";
 import {ObjectLiteral} from "../common/ObjectLiteral";
 import {SelectQueryBuilder} from "../query-builder/SelectQueryBuilder";
 
@@ -109,10 +109,17 @@ export class FindOptionsUtils {
         if ((options as FindManyOptions<T>).take)
             qb.take((options as FindManyOptions<T>).take!);
 
-        if (options.order)
-            Object.keys(options.order).forEach(key => {
-                qb.addOrderBy(qb.alias + "." + key, (options as FindOneOptions<T>).order![key as any]);
-            });
+        if (options.order) {
+            if (options.order instanceof Array) {
+                for (let [key, dir] of options.order as ArrayOrderOption<T>) {
+                    qb.addOrderBy(qb.alias + "." + key, dir);
+                }
+            } else {
+                Object.keys(options.order).forEach(key => {
+                    qb.addOrderBy(qb.alias + "." + key, (options.order as ObjectOrderOption<T>)![key as any]);
+                });
+            }
+        }
 
         if (options.relations)
             options.relations.forEach(relation => {

--- a/test/functional/repository/find-options/repository-find-options.ts
+++ b/test/functional/repository/find-options/repository-find-options.ts
@@ -119,4 +119,30 @@ describe("repository > find options", () => {
         // })));
     })));
 
+    it("should order by columns", () => Promise.all(connections.map(async (connection) => {
+        const repository = connection.getRepository(Category);
+
+        const animals = ["Dogs", "Cats", "Dogs", "Eagles"];
+        for (let animal of animals) {
+            const category = repository.create({name: animal});
+            await repository.save(category);
+        }
+
+        const arrayOrderResult = await repository.find({order: [["name", "ASC"], ["id", "DESC"]]});
+        const objectOrderResult = await repository.find({order: {"name": "ASC", "id": "DESC"}});
+
+        const indexOfCats = arrayOrderResult.findIndex(o => o.name === "Cats");
+        const indexOfDogs = arrayOrderResult.findIndex(o => o.name === "Dogs");
+        const secondFieldOrder = arrayOrderResult.filter(o => o.name === "Dogs");
+
+        expect(arrayOrderResult).to.be.an("array");
+        expect(objectOrderResult).to.be.an("array");
+
+        expect(arrayOrderResult).eql(objectOrderResult, "result should be the same");
+
+        expect(indexOfCats).is.lessThan(indexOfDogs, "Cats should before Dogs");
+
+        expect(secondFieldOrder[0].id).is.greaterThan(secondFieldOrder[1].id, "id should have ordered");
+    })));
+
 });


### PR DESCRIPTION
so we can take advantages from both object and array types
object is easy to create literally and modify each key-value
array is easy to insert and do mapping

pass parameters through network or load saved options from database we mostly use array or string to keep orders. it is easier to map into array than object.

I think `TypeORM` is meant to make things easy.