### PR TITLE
Add MongoDB ObjectId conversion to `findOneById` method

### DIFF
--- a/src/entity-manager/MongoEntityManager.ts
+++ b/src/entity-manager/MongoEntityManager.ts
@@ -163,7 +163,10 @@ export class MongoEntityManager extends EntityManager {
      */
     async findOneById<Entity>(entityClassOrName: ObjectType<Entity>|string, id: any, optionsOrConditions?: FindOneOptions<Entity>|Partial<Entity>): Promise<Entity|undefined> {
         const query = this.convertFindOneOptionsOrConditionsToMongodbQuery(optionsOrConditions) || {};
-        query["_id"] = id;
+        const objectIdInstance = PlatformTools.load("mongodb").ObjectID;
+        query["_id"] = (id instanceof objectIdInstance)
+            ? id
+            : new objectIdInstance(id);
         const cursor = await this.createEntityCursor(entityClassOrName, query);
         if (FindOptionsUtils.isFindOneOptions(optionsOrConditions)) {
             if (optionsOrConditions.order)


### PR DESCRIPTION
This PR allows to find by object id hex string, like the ids that are stored on frontend side (serialized).

```ts
repository.findOneById("59ef6396f31bc72f0477af8c");
```

However it would be nice to have this kind of feature in `findByIds` method too.
I wanted to do this but I don't know what this line is doing there (MongoEntityManager.ts, line 129):
```ts
return id[metadata.objectIdColumn!.propertyName];
```
Can I safely convert it to the `ObjectId` instance? Or I should check if `id` is string and convert, otherwise let the lookup thing do the work?