### PR TITLE
Add missing `create` overloads in `BaseEntity`

### DIFF
--- a/src/repository/BaseEntity.ts
+++ b/src/repository/BaseEntity.ts
@@ -103,8 +103,20 @@ export class BaseEntity {
     /**
      * Creates a new entity instance.
      */
-    static create<T extends BaseEntity>(this: ObjectType<T>): T {
-        return (this as any).getRepository().create();
+    static create<T extends BaseEntity>(this: ObjectType<T>): T;
+    /**
+     * Creates a new entities and copies all entity properties from given objects into their new entities.
+     * Note that it copies only properties that present in entity schema.
+     */
+    static create<T extends BaseEntity>(this: ObjectType<T>, entityLikeArray: DeepPartial<T>[]): T;
+    /**
+     * Creates a new entity instance and copies all entity properties from this object into a new entity.
+     * Note that it copies only properties that present in entity schema.
+     */
+    static create<T extends BaseEntity>(this: ObjectType<T>, entityLike: DeepPartial<T>): T;
+   
+    static create<T extends BaseEntity>(this: ObjectType<T>, entityOrEntities?: any): T {
+        return (this as any).getRepository().create(entityOrEntities);
     }
 
     /**


### PR DESCRIPTION
This PR adds missing `create` overloads in `BaseEntity` to behave just like the `Repository`.