### PR TITLE
Wrong column name

### DIFF
--- a/docs/relations.md
+++ b/docs/relations.md
@@ -140,7 +140,7 @@ category: Category;
 ```
 
 The relation now refers to `name` of the `Category` entity, instead of `id`.
-Column name for such relation will become `categoryId`
+Column name for such relation will become `categoryName`
 
 ## `@JoinTable` options
 


### PR DESCRIPTION
I think you meant `categoryName` instead of `categoryId` here.

You wrote...

> When we set `@JoinColumn` it creates a column in the database automatically named `propertyName + referencedColumnName`.

... before so I think it should be named `categoryName`.

Please correct me if I'm wrong.

By the way: Can I change this behavior? I would prefer `propertyName + referencedEntityName + referencedColumnName` for my DB design.

