### PR TITLE
Correct typo in function name

### DIFF
--- a/src/platform/BrowserPlatformTools.template
+++ b/src/platform/BrowserPlatformTools.template
@@ -33,7 +33,7 @@ export class PlatformTools {
     /**
      * Normalizes given path. Does "path.normalize".
      */
-    static pathNormilize(pathStr: string): string {
+    static pathNormalize(pathStr: string): string {
         if (this.type === "browser")
             throw new Error(`This option/function is not supported in the browser environment. Failed operation: path.normalize("${pathStr}").`);
 

--- a/src/platform/PlatformTools.ts
+++ b/src/platform/PlatformTools.ts
@@ -120,7 +120,7 @@ export class PlatformTools {
     /**
      * Normalizes given path. Does "path.normalize".
      */
-    static pathNormilize(pathStr: string): string {
+    static pathNormalize(pathStr: string): string {
         return path.normalize(pathStr);
     }
 

--- a/src/util/DirectoryExportedClassesLoader.ts
+++ b/src/util/DirectoryExportedClassesLoader.ts
@@ -20,7 +20,7 @@ export function importClassesFromDirectories(directories: string[], formats = ["
     }
 
     const allFiles = directories.reduce((allDirs, dir) => {
-        return allDirs.concat(PlatformTools.load("glob").sync(PlatformTools.pathNormilize(dir)));
+        return allDirs.concat(PlatformTools.load("glob").sync(PlatformTools.pathNormalize(dir)));
     }, [] as string[]);
 
     const dirs = allFiles
@@ -39,7 +39,7 @@ export function importClassesFromDirectories(directories: string[], formats = ["
 export function importJsonsFromDirectories(directories: string[], format = ".json"): any[] {
 
     const allFiles = directories.reduce((allDirs, dir) => {
-        return allDirs.concat(PlatformTools.load("glob").sync(PlatformTools.pathNormilize(dir)));
+        return allDirs.concat(PlatformTools.load("glob").sync(PlatformTools.pathNormalize(dir)));
     }, [] as string[]);
 
     return allFiles


### PR DESCRIPTION
To keep spelling consistent between path.normalize and PlatformTools.pathNormalize
Normilize -> Normalize
( i  -> a )