### PR TITLE
feature: findOneOrFail

### DIFF
--- a/docs/entity-manager-api.md
+++ b/docs/entity-manager-api.md
@@ -167,17 +167,25 @@ but ignores pagination settings (from and take options).
 const [timbers, timbersCount] = await manager.findAndCount(User, { firstName: "Timber" });
 ```
 
-* `findByIds` - Finds entities by given ids.
+* `findByIds` - Finds multiple entities by id.
 
 ```typescript
 const users = await manager.findByIds(User, [1, 2, 3]);
 ```
 
-* `findOne` - Finds first entity that matches given id or find options.
+* `findOne` - Finds the first entity that matches some id or find options.
 
 ```typescript
 const user = await manager.findOne(User, 1);
 const timber = await manager.findOne(User, { firstName: "Timber" });
+```
+
+* `findOneOrFail` - Finds the first entity that matches some id or find options.
+Rejects the returned promise if nothing matches.
+
+```typescript
+const user = await manager.findOneOrFail(User, 1);
+const timber = await manager.findOneOrFail(User, { firstName: "Timber" });
 ```
 
 * `clear` - Clears all the data from the given table (truncates/drops it).

--- a/docs/repository-api.md
+++ b/docs/repository-api.md
@@ -169,17 +169,25 @@ but ignores pagination settings (`from` and `take` options).
 const [timbers, timbersCount] = await repository.findAndCount({ firstName: "Timber" });
 ```
 
-* `findByIds` - Finds entities by given ids.
+* `findByIds` - Finds multiple entities by id.
 
 ```typescript
 const users = await repository.findByIds([1, 2, 3]);
 ```
 
-* `findOne` - Finds first entity that matches given id or find options.
+* `findOne` - Finds first entity that matches some id or find options.
 
 ```typescript
 const user = await repository.findOne(1);
 const timber = await repository.findOne({ firstName: "Timber" });
+```
+
+* `findOneOrFail` - Finds the first entity that matches the some id or find options.
+Rejects the returned promise if nothing matches.
+
+```typescript
+const user = await repository.findOneOrFail(1);
+const timber = await repository.findOneOrFail({ firstName: "Timber" });
 ```
 
 * `query` - Executes a raw SQL query.

--- a/src/entity-manager/EntityManager.ts
+++ b/src/entity-manager/EntityManager.ts
@@ -1,6 +1,7 @@
 import {Connection} from "../connection/Connection";
 import {FindManyOptions} from "../find-options/FindManyOptions";
 import {ObjectType} from "../common/ObjectType";
+import { EntityNotFoundError } from "../error/EntityNotFoundError";
 import {QueryRunnerProviderAlreadyReleasedError} from "../error/QueryRunnerProviderAlreadyReleasedError";
 import {FindOneOptions} from "../find-options/FindOneOptions";
 import {DeepPartial} from "../common/DeepPartial";
@@ -536,6 +537,33 @@ export class EntityManager {
         }
 
         return qb.getOne();
+    }
+
+    /**
+     * Finds first entity that matches given find options or rejects the returned promise on error.
+     */
+    findOneOrFail<Entity>(entityClass: ObjectType<Entity>|string, id?: string|number|Date|ObjectID, options?: FindOneOptions<Entity>): Promise<Entity>;
+
+    /**
+     * Finds first entity that matches given find options or rejects the returned promise on error.
+     */
+    findOneOrFail<Entity>(entityClass: ObjectType<Entity>|string, options?: FindOneOptions<Entity>): Promise<Entity>;
+
+    /**
+     * Finds first entity that matches given conditions or rejects the returned promise on error.
+     */
+    findOneOrFail<Entity>(entityClass: ObjectType<Entity>|string, conditions?: DeepPartial<Entity>, options?: FindOneOptions<Entity>): Promise<Entity>;
+
+    /**
+     * Finds first entity that matches given conditions or rejects the returned promise on error.
+     */
+    findOneOrFail<Entity>(entityClass: ObjectType<Entity>|string, idOrOptionsOrConditions?: string|string[]|number|number[]|Date|Date[]|ObjectID|ObjectID[]|FindOneOptions<Entity>|DeepPartial<Entity>, maybeOptions?: FindOneOptions<Entity>): Promise<Entity> {
+        return this.findOne(entityClass, idOrOptionsOrConditions as any, maybeOptions).then((value) => {
+            if (value === undefined) {
+                return Promise.reject(new EntityNotFoundError());
+            }
+            return Promise.resolve(value);
+        });
     }
 
     /**

--- a/src/entity-manager/EntityManager.ts
+++ b/src/entity-manager/EntityManager.ts
@@ -560,7 +560,9 @@ export class EntityManager {
     findOneOrFail<Entity>(entityClass: ObjectType<Entity>|string, idOrOptionsOrConditions?: string|string[]|number|number[]|Date|Date[]|ObjectID|ObjectID[]|FindOneOptions<Entity>|DeepPartial<Entity>, maybeOptions?: FindOneOptions<Entity>): Promise<Entity> {
         return this.findOne(entityClass, idOrOptionsOrConditions as any, maybeOptions).then((value) => {
             if (value === undefined) {
-                return Promise.reject(new EntityNotFoundError());
+                return Promise.reject(new EntityNotFoundError(
+                        (typeof entityClass === "string") ? entityClass : entityClass.constructor.name,
+                        JSON.stringify(idOrOptionsOrConditions)));
             }
             return Promise.resolve(value);
         });

--- a/src/entity-manager/EntityManager.ts
+++ b/src/entity-manager/EntityManager.ts
@@ -560,9 +560,7 @@ export class EntityManager {
     findOneOrFail<Entity>(entityClass: ObjectType<Entity>|string, idOrOptionsOrConditions?: string|string[]|number|number[]|Date|Date[]|ObjectID|ObjectID[]|FindOneOptions<Entity>|DeepPartial<Entity>, maybeOptions?: FindOneOptions<Entity>): Promise<Entity> {
         return this.findOne(entityClass, idOrOptionsOrConditions as any, maybeOptions).then((value) => {
             if (value === undefined) {
-                return Promise.reject(new EntityNotFoundError(
-                        (typeof entityClass === "string") ? entityClass : entityClass.constructor.name,
-                        JSON.stringify(idOrOptionsOrConditions)));
+                return Promise.reject(new EntityNotFoundError(entityClass, idOrOptionsOrConditions));
             }
             return Promise.resolve(value);
         });

--- a/src/error/EntityNotFoundError.ts
+++ b/src/error/EntityNotFoundError.ts
@@ -1,4 +1,5 @@
-import { ObjectType } from "../";
+import {ObjectType} from "../common/ObjectType";
+
 /**
  * Thrown when no result could be found in methods which are not allowed to return undefined or an empty set.
  */

--- a/src/error/EntityNotFoundError.ts
+++ b/src/error/EntityNotFoundError.ts
@@ -1,0 +1,13 @@
+/**
+ * Thrown when no result could be found in methods which are not allowed to return undefined or an empty set.
+ */
+export class EntityNotFoundError extends Error {
+    name = "EntityNotFound";
+
+    constructor() {
+        super();
+        Object.setPrototypeOf(this, EntityNotFoundError.prototype);
+        this.message = `No such entity.`;
+    }
+
+}

--- a/src/error/EntityNotFoundError.ts
+++ b/src/error/EntityNotFoundError.ts
@@ -4,10 +4,10 @@
 export class EntityNotFoundError extends Error {
     name = "EntityNotFound";
 
-    constructor() {
+    constructor(entityClass: string, criteria: string) {
         super();
         Object.setPrototypeOf(this, EntityNotFoundError.prototype);
-        this.message = `No such entity.`;
+        this.message = `Could not find any entity of type "${entityClass}" matching: ${criteria}`;
     }
 
 }

--- a/src/error/EntityNotFoundError.ts
+++ b/src/error/EntityNotFoundError.ts
@@ -1,13 +1,24 @@
+import { ObjectType } from "../";
 /**
  * Thrown when no result could be found in methods which are not allowed to return undefined or an empty set.
  */
 export class EntityNotFoundError extends Error {
     name = "EntityNotFound";
 
-    constructor(entityClass: string, criteria: string) {
+    constructor(entityClass: ObjectType<any>|string, criteria: any) {
         super();
         Object.setPrototypeOf(this, EntityNotFoundError.prototype);
-        this.message = `Could not find any entity of type "${entityClass}" matching: ${criteria}`;
+
+        const className = (typeof entityClass === "string") ? entityClass : entityClass.constructor.name;
+        const criteriaString = this.stringifyCriteria(criteria);
+        this.message = `Could not find any entity of type "${className}" matching: ${criteriaString}`;
+    }
+
+    private stringifyCriteria(criteria: any): string {
+        try {
+            return JSON.stringify(criteria, null, 4);
+        } catch (e) { }
+        return "" + criteria;
     }
 
 }

--- a/src/repository/Repository.ts
+++ b/src/repository/Repository.ts
@@ -284,6 +284,28 @@ export class Repository<Entity extends ObjectLiteral> {
     }
 
     /**
+     * Finds first entity that matches given options.
+     */
+    findOneOrFail(id?: string|number|Date|ObjectID, options?: FindOneOptions<Entity>): Promise<Entity>;
+
+    /**
+     * Finds first entity that matches given options.
+     */
+    findOneOrFail(options?: FindOneOptions<Entity>): Promise<Entity>;
+
+    /**
+     * Finds first entity that matches given conditions.
+     */
+    findOneOrFail(conditions?: DeepPartial<Entity>, options?: FindOneOptions<Entity>): Promise<Entity>;
+
+    /**
+     * Finds first entity that matches given conditions.
+     */
+    findOneOrFail(optionsOrConditions?: string|number|Date|ObjectID|FindOneOptions<Entity>|DeepPartial<Entity>, maybeOptions?: FindOneOptions<Entity>): Promise<Entity> {
+        return this.manager.findOneOrFail(this.metadata.target, optionsOrConditions as any, maybeOptions);
+    }
+
+    /**
      * Executes a raw SQL query and returns a raw database results.
      * Raw query execution is supported only by relational databases (MongoDB is not supported).
      */

--- a/test/functional/repository/find-methods/repostiory-find-methods.ts
+++ b/test/functional/repository/find-methods/repostiory-find-methods.ts
@@ -4,6 +4,7 @@ import {closeTestingConnections, createTestingConnections, reloadTestingDatabase
 import {Connection} from "../../../../src/connection/Connection";
 import {Post} from "./entity/Post";
 import {User} from "./model/User";
+import {EntityNotFoundError} from "../../../../src/error/EntityNotFoundError";
 
 describe("repository > find methods", () => {
 
@@ -499,6 +500,90 @@ describe("repository > find methods", () => {
             expect(loadedUser).to.be.undefined;
         })));
 
+    });
+
+    describe("findOneOrFail", function() {
+
+        it("should return entity by a given id", () => Promise.all(connections.map(async connection => {
+            const userRepository = connection.getRepository<User>("User");
+            const promises: Promise<User>[] = [];
+            for (let i = 0; i < 100; i++) {
+                const user: User = {
+                    id: i,
+                    firstName: "name #" + i,
+                    secondName: "Doe"
+                };
+                promises.push(userRepository.save(user));
+            }
+
+            const savedUsers = await Promise.all(promises);
+            savedUsers.length.should.be.equal(100); // check if they all are saved
+
+            let loadedUser = (await userRepository.findOneOrFail(0))!;
+            loadedUser.id.should.be.equal(0);
+            loadedUser.firstName.should.be.equal("name #0");
+            loadedUser.secondName.should.be.equal("Doe");
+
+            loadedUser = (await userRepository.findOneOrFail(1))!;
+            loadedUser.id.should.be.equal(1);
+            loadedUser.firstName.should.be.equal("name #1");
+            loadedUser.secondName.should.be.equal("Doe");
+
+            loadedUser = (await userRepository.findOneOrFail(99))!;
+            loadedUser.id.should.be.equal(99);
+            loadedUser.firstName.should.be.equal("name #99");
+            loadedUser.secondName.should.be.equal("Doe");
+        })));
+
+        it("should return entity by a given id and find options", () => Promise.all(connections.map(async connection => {
+            const userRepository = connection.getRepository<User>("User");
+            const promises: Promise<User>[] = [];
+            for (let i = 0; i < 100; i++) {
+                const user: User = {
+                    id: i,
+                    firstName: "name #" + i,
+                    secondName: "Doe"
+                };
+                promises.push(userRepository.save(user));
+            }
+
+            const savedUsers = await Promise.all(promises);
+            savedUsers.length.should.be.equal(100); // check if they all are saved
+
+            let loadedUser = await userRepository.findOneOrFail(0, {
+                where: {
+                    secondName: "Doe"
+                }
+            });
+            loadedUser!.id.should.be.equal(0);
+            loadedUser!.firstName.should.be.equal("name #0");
+            loadedUser!.secondName.should.be.equal("Doe");
+
+            loadedUser = await userRepository.findOneOrFail(1, {
+                where: {
+                    secondName: "Dorian"
+                }
+            });
+            expect(loadedUser).to.be.undefined;
+        })));
+
+        it("should throw an error if nothing was found", () => Promise.all(connections.map(async connection => {
+            const userRepository = connection.getRepository<User>("User");
+            const promises: Promise<User>[] = [];
+            for (let i = 0; i < 100; i++) {
+                const user: User = {
+                    id: i,
+                    firstName: "name #" + i,
+                    secondName: "Doe"
+                };
+                promises.push(userRepository.save(user));
+            }
+
+            const savedUsers = await Promise.all(promises);
+            savedUsers.length.should.be.equal(100); // check if they all are saved
+
+            expect(async () => await userRepository.findOneOrFail(100)).should.be.rejectedWith(EntityNotFoundError);
+        })));
     });
 
 });


### PR DESCRIPTION
Close #1149 

Seems that simple to implement.

I'm not quite satisfied with testing though:
- I could not find the test for `findOne` on `EntityManager` to add the tests for `findOneOrFail`
- Also I'm not sure copy/pasting the tests for `findOne` is the right thing to do. With pure unit tests I would simply assert that `manager.findOneOrFail` calls `manager.findOne` and does the right thing if it gets `undefined` in return. Then I would test that `repository.findOneOrFail` forwards the call to `manager.findOneOrFail`. These tests are obviously higher level and I don't have enough knowledge of this project to know what's right to do.

