### PR TITLE
Support for persistence operations without wrapped transactions

### DIFF
--- a/src/entity-manager/EntityManager.ts
+++ b/src/entity-manager/EntityManager.ts
@@ -322,8 +322,7 @@ export class EntityManager {
     const options = target ? maybeOptions : maybeEntityOrOptions as SaveOptions;
 
     // execute save operation
-    await new EntityPersistExecutor(this.connection, this.queryRunner, "save", target, entity, options)
-      .executeNoTransaction();
+    await new EntityPersistExecutor(this.connection, this.queryRunner, "save", target, entity, options).executeNoTransaction();
     return entity;
   }
 
@@ -394,8 +393,7 @@ export class EntityManager {
     const options = target ? maybeOptions : maybeEntityOrOptions as SaveOptions;
 
     // execute save operation
-    await new EntityPersistExecutor(this.connection, this.queryRunner, "remove", target, entity, options)
-      .executeNoTransaction()
+    await new EntityPersistExecutor(this.connection, this.queryRunner, "remove", target, entity, options).executeNoTransaction();
     return entity;
   }
 

--- a/src/entity-manager/EntityManager.ts
+++ b/src/entity-manager/EntityManager.ts
@@ -1,36 +1,36 @@
-import {Connection} from "../connection/Connection";
-import {FindManyOptions} from "../find-options/FindManyOptions";
-import {ObjectType} from "../common/ObjectType";
-import {QueryRunnerProviderAlreadyReleasedError} from "../error/QueryRunnerProviderAlreadyReleasedError";
-import {FindOneOptions} from "../find-options/FindOneOptions";
-import {DeepPartial} from "../common/DeepPartial";
-import {RemoveOptions} from "../repository/RemoveOptions";
-import {SaveOptions} from "../repository/SaveOptions";
-import {NoNeedToReleaseEntityManagerError} from "../error/NoNeedToReleaseEntityManagerError";
-import {MongoRepository} from "../repository/MongoRepository";
-import {TreeRepository} from "../repository/TreeRepository";
-import {Repository} from "../repository/Repository";
-import {FindOptionsUtils} from "../find-options/FindOptionsUtils";
-import {PlainObjectToNewEntityTransformer} from "../query-builder/transformer/PlainObjectToNewEntityTransformer";
-import {PlainObjectToDatabaseEntityTransformer} from "../query-builder/transformer/PlainObjectToDatabaseEntityTransformer";
-import {CustomRepositoryNotFoundError} from "../error/CustomRepositoryNotFoundError";
-import {getMetadataArgsStorage} from "../index";
-import {AbstractRepository} from "../repository/AbstractRepository";
-import {CustomRepositoryCannotInheritRepositoryError} from "../error/CustomRepositoryCannotInheritRepositoryError";
-import {QueryRunner} from "../query-runner/QueryRunner";
-import {SelectQueryBuilder} from "../query-builder/SelectQueryBuilder";
-import {MongoDriver} from "../driver/mongodb/MongoDriver";
-import {RepositoryNotFoundError} from "../error/RepositoryNotFoundError";
-import {RepositoryNotTreeError} from "../error/RepositoryNotTreeError";
-import {RepositoryFactory} from "../repository/RepositoryFactory";
-import {TreeRepositoryNotSupportedError} from "../error/TreeRepositoryNotSupportedError";
-import {EntityMetadata} from "../metadata/EntityMetadata";
-import {QueryPartialEntity} from "../query-builder/QueryPartialEntity";
-import {EntityPersistExecutor} from "../persistence/EntityPersistExecutor";
-import {ObjectID} from "../driver/mongodb/typings";
-import {InsertResult} from "../query-builder/result/InsertResult";
-import {UpdateResult} from "../query-builder/result/UpdateResult";
-import {DeleteResult} from "../query-builder/result/DeleteResult";
+import { Connection } from "../connection/Connection";
+import { FindManyOptions } from "../find-options/FindManyOptions";
+import { ObjectType } from "../common/ObjectType";
+import { QueryRunnerProviderAlreadyReleasedError } from "../error/QueryRunnerProviderAlreadyReleasedError";
+import { FindOneOptions } from "../find-options/FindOneOptions";
+import { DeepPartial } from "../common/DeepPartial";
+import { RemoveOptions } from "../repository/RemoveOptions";
+import { SaveOptions } from "../repository/SaveOptions";
+import { NoNeedToReleaseEntityManagerError } from "../error/NoNeedToReleaseEntityManagerError";
+import { MongoRepository } from "../repository/MongoRepository";
+import { TreeRepository } from "../repository/TreeRepository";
+import { Repository } from "../repository/Repository";
+import { FindOptionsUtils } from "../find-options/FindOptionsUtils";
+import { PlainObjectToNewEntityTransformer } from "../query-builder/transformer/PlainObjectToNewEntityTransformer";
+import { PlainObjectToDatabaseEntityTransformer } from "../query-builder/transformer/PlainObjectToDatabaseEntityTransformer";
+import { CustomRepositoryNotFoundError } from "../error/CustomRepositoryNotFoundError";
+import { getMetadataArgsStorage } from "../index";
+import { AbstractRepository } from "../repository/AbstractRepository";
+import { CustomRepositoryCannotInheritRepositoryError } from "../error/CustomRepositoryCannotInheritRepositoryError";
+import { QueryRunner } from "../query-runner/QueryRunner";
+import { SelectQueryBuilder } from "../query-builder/SelectQueryBuilder";
+import { MongoDriver } from "../driver/mongodb/MongoDriver";
+import { RepositoryNotFoundError } from "../error/RepositoryNotFoundError";
+import { RepositoryNotTreeError } from "../error/RepositoryNotTreeError";
+import { RepositoryFactory } from "../repository/RepositoryFactory";
+import { TreeRepositoryNotSupportedError } from "../error/TreeRepositoryNotSupportedError";
+import { EntityMetadata } from "../metadata/EntityMetadata";
+import { QueryPartialEntity } from "../query-builder/QueryPartialEntity";
+import { EntityPersistExecutor } from "../persistence/EntityPersistExecutor";
+import { ObjectID } from "../driver/mongodb/typings";
+import { InsertResult } from "../query-builder/result/InsertResult";
+import { UpdateResult } from "../query-builder/result/UpdateResult";
+import { DeleteResult } from "../query-builder/result/DeleteResult";
 
 /**
  * Entity manager supposed to work with any entity, automatically find its repository and call its methods,
@@ -38,630 +38,706 @@ import {DeleteResult} from "../query-builder/result/DeleteResult";
  */
 export class EntityManager {
 
-    // -------------------------------------------------------------------------
-    // Public Properties
-    // -------------------------------------------------------------------------
+  // -------------------------------------------------------------------------
+  // Public Properties
+  // -------------------------------------------------------------------------
 
-    /**
-     * Connection used by this entity manager.
-     */
-    readonly connection: Connection;
+  /**
+   * Connection used by this entity manager.
+   */
+  readonly connection: Connection;
 
-    /**
-     * Custom query runner to be used for operations in this entity manager.
-     * Used only in non-global entity manager.
-     */
-    readonly queryRunner?: QueryRunner;
+  /**
+   * Custom query runner to be used for operations in this entity manager.
+   * Used only in non-global entity manager.
+   */
+  readonly queryRunner?: QueryRunner;
 
-    // -------------------------------------------------------------------------
-    // Protected Properties
-    // -------------------------------------------------------------------------
+  // -------------------------------------------------------------------------
+  // Protected Properties
+  // -------------------------------------------------------------------------
 
-    /**
-     * Once created and then reused by en repositories.
-     */
-    protected repositories: Repository<any>[] = [];
+  /**
+   * Once created and then reused by en repositories.
+   */
+  protected repositories: Repository<any>[] = [];
 
-    // -------------------------------------------------------------------------
-    // Constructor
-    // -------------------------------------------------------------------------
+  // -------------------------------------------------------------------------
+  // Constructor
+  // -------------------------------------------------------------------------
 
-    constructor(connection: Connection, queryRunner?: QueryRunner) {
-        this.connection = connection;
-        if (queryRunner) {
-            this.queryRunner = queryRunner;
-            // dynamic: this.queryRunner = manager;
-            Object.assign(this.queryRunner, { manager: this });
-        }
+  constructor(connection: Connection, queryRunner?: QueryRunner) {
+    this.connection = connection;
+    if (queryRunner) {
+      this.queryRunner = queryRunner;
+      // dynamic: this.queryRunner = manager;
+      Object.assign(this.queryRunner, { manager: this });
+    }
+  }
+
+  // -------------------------------------------------------------------------
+  // Public Methods
+  // -------------------------------------------------------------------------
+
+  /**
+   * Wraps given function execution (and all operations made there) in a transaction.
+   * All database operations must be executed using provided entity manager.
+   */
+  async transaction<T>(runInTransaction: (entityManger: EntityManager) => Promise<T>): Promise<T> {
+
+    if (this.connection.driver instanceof MongoDriver)
+      throw new Error(`Transactions aren't supported by MongoDB.`);
+
+    if (this.queryRunner && this.queryRunner.isReleased)
+      throw new QueryRunnerProviderAlreadyReleasedError();
+
+    if (this.queryRunner && this.queryRunner.isTransactionActive)
+      throw new Error(`Cannot start transaction because its already started`);
+
+    // if query runner is already defined in this class, it means this entity manager was already created for a single connection
+    // if its not defined we create a new query runner - single connection where we'll execute all our operations
+    const queryRunner = this.queryRunner || this.connection.createQueryRunner("master");
+
+    try {
+      await queryRunner.startTransaction();
+      const result = await runInTransaction(queryRunner.manager);
+      await queryRunner.commitTransaction();
+      return result;
+
+    } catch (err) {
+      try { // we throw original error even if rollback thrown an error
+        await queryRunner.rollbackTransaction();
+      } catch (rollbackError) { }
+      throw err;
+
+    } finally {
+      if (!this.queryRunner) // if we used a new query runner provider then release it
+        await queryRunner.release();
+    }
+  }
+
+  /**
+   * Executes raw SQL query and returns raw database results.
+   */
+  async query(query: string, parameters?: any[]): Promise<any> {
+    return this.connection.query(query, parameters, this.queryRunner);
+  }
+
+  /**
+   * Creates a new query builder that can be used to build a sql query.
+   */
+  createQueryBuilder<Entity>(entityClass: ObjectType<Entity> | Function | string, alias: string, queryRunner?: QueryRunner): SelectQueryBuilder<Entity>;
+
+  /**
+   * Creates a new query builder that can be used to build a sql query.
+   */
+  createQueryBuilder(queryRunner?: QueryRunner): SelectQueryBuilder<any>;
+
+  /**
+   * Creates a new query builder that can be used to build a sql query.
+   */
+  createQueryBuilder<Entity>(entityClass?: ObjectType<Entity> | Function | string | QueryRunner, alias?: string, queryRunner?: QueryRunner): SelectQueryBuilder<Entity> {
+    if (alias) {
+      return this.connection.createQueryBuilder(entityClass as Function | string, alias, queryRunner || this.queryRunner);
+
+    } else {
+      return this.connection.createQueryBuilder(entityClass as QueryRunner | undefined || this.queryRunner);
+    }
+  }
+
+  /**
+   * Checks if entity has an id.
+   */
+  hasId(entity: any): boolean;
+
+  /**
+   * Checks if entity of given schema name has an id.
+   */
+  hasId(target: Function | string, entity: any): boolean;
+
+  /**
+   * Checks if entity has an id by its Function type or schema name.
+   */
+  hasId(targetOrEntity: any | Function | string, maybeEntity?: any): boolean {
+    const target = arguments.length === 2 ? targetOrEntity : targetOrEntity.constructor;
+    const entity = arguments.length === 2 ? maybeEntity : targetOrEntity;
+    const metadata = this.connection.getMetadata(target);
+    return metadata.hasId(entity);
+  }
+
+  /**
+   * Gets entity mixed id.
+   */
+  getId(entity: any): any;
+
+  /**
+   * Gets entity mixed id.
+   */
+  getId(target: Function | string, entity: any): any;
+
+  /**
+   * Gets entity mixed id.
+   */
+  getId(targetOrEntity: any | Function | string, maybeEntity?: any): any {
+    const target = arguments.length === 2 ? targetOrEntity : targetOrEntity.constructor;
+    const entity = arguments.length === 2 ? maybeEntity : targetOrEntity;
+    const metadata = this.connection.getMetadata(target);
+    return metadata.getEntityIdMixedMap(entity);
+  }
+
+  /**
+   * Creates a new entity instance.
+   */
+  create<Entity>(entityClass: ObjectType<Entity>): Entity;
+
+  /**
+   * Creates a new entity instance and copies all entity properties from this object into a new entity.
+   * Note that it copies only properties that present in entity schema.
+   */
+  create<Entity>(entityClass: ObjectType<Entity> | string, plainObject: DeepPartial<Entity>): Entity;
+
+  /**
+   * Creates a new entities and copies all entity properties from given objects into their new entities.
+   * Note that it copies only properties that present in entity schema.
+   */
+  create<Entity>(entityClass: ObjectType<Entity> | string, plainObjects: DeepPartial<Entity>[]): Entity[];
+
+  /**
+   * Creates a new entity instance or instances.
+   * Can copy properties from the given object into new entities.
+   */
+  create<Entity>(entityClass: ObjectType<Entity> | string, plainObjectOrObjects?: DeepPartial<Entity> | DeepPartial<Entity>[]): Entity | Entity[] {
+    const metadata = this.connection.getMetadata(entityClass);
+
+    if (!plainObjectOrObjects)
+      return metadata.create();
+
+    if (plainObjectOrObjects instanceof Array)
+      return plainObjectOrObjects.map(plainEntityLike => this.create(entityClass, plainEntityLike));
+
+    const mergeIntoEntity = metadata.create();
+    const plainObjectToEntityTransformer = new PlainObjectToNewEntityTransformer(true);
+    plainObjectToEntityTransformer.transform(mergeIntoEntity, plainObjectOrObjects, metadata);
+    return mergeIntoEntity;
+  }
+
+  /**
+   * Merges two entities into one new entity.
+   */
+  merge<Entity>(entityClass: ObjectType<Entity> | string, mergeIntoEntity: Entity, ...entityLikes: DeepPartial<Entity>[]): Entity { // todo: throw exception if entity manager is released
+    const metadata = this.connection.getMetadata(entityClass);
+    const plainObjectToEntityTransformer = new PlainObjectToNewEntityTransformer();
+    entityLikes.forEach(object => plainObjectToEntityTransformer.transform(mergeIntoEntity, object, metadata));
+    return mergeIntoEntity;
+  }
+
+  /**
+   * Creates a new entity from the given plan javascript object. If entity already exist in the database, then
+   * it loads it (and everything related to it), replaces all values with the new ones from the given object
+   * and returns this new entity. This new entity is actually a loaded from the db entity with all properties
+   * replaced from the new object.
+   */
+  async preload<Entity>(entityClass: ObjectType<Entity> | string, entityLike: DeepPartial<Entity>): Promise<Entity | undefined> {
+    const metadata = this.connection.getMetadata(entityClass);
+    const plainObjectToDatabaseEntityTransformer = new PlainObjectToDatabaseEntityTransformer(this.connection.manager);
+    const transformedEntity = await plainObjectToDatabaseEntityTransformer.transform(entityLike, metadata);
+    if (transformedEntity)
+      return this.merge(entityClass, transformedEntity as Entity, entityLike);
+
+    return undefined;
+  }
+
+  /**
+   * Saves all given entities in the database.
+   * If entities do not exist in the database then inserts, otherwise updates.
+   */
+  save<Entity>(entity: Entity, options?: SaveOptions): Promise<Entity>;
+
+  /**
+   * Saves all given entities in the database.
+   * If entities do not exist in the database then inserts, otherwise updates.
+   */
+  save<Entity, T extends DeepPartial<Entity>>(targetOrEntity: ObjectType<Entity> | string, entity: T, options?: SaveOptions): Promise<T>;
+
+  /**
+   * Saves all given entities in the database.
+   * If entities do not exist in the database then inserts, otherwise updates.
+   */
+  save<Entity>(entities: Entity[], options?: SaveOptions): Promise<Entity[]>;
+
+  /**
+   * Saves all given entities in the database.
+   * If entities do not exist in the database then inserts, otherwise updates.
+   */
+  save<Entity, T extends DeepPartial<Entity>>(targetOrEntity: ObjectType<Entity> | string, entities: T[], options?: SaveOptions): Promise<T[]>;
+
+  /**
+   * Saves a given entity in the database.
+   */
+  save<Entity, T extends DeepPartial<Entity>>(targetOrEntity: (T | T[]) | ObjectType<Entity> | string, maybeEntityOrOptions?: T | T[], maybeOptions?: SaveOptions): Promise<T | T[]> {
+
+    // normalize mixed parameters
+    const target = (arguments.length > 1 && (targetOrEntity instanceof Function || typeof targetOrEntity === "string")) ? targetOrEntity as Function | string : undefined;
+    const entity: T | T[] = target ? maybeEntityOrOptions as T | T[] : targetOrEntity as T | T[];
+    const options = target ? maybeOptions : maybeEntityOrOptions as SaveOptions;
+
+    // execute save operation
+    return new EntityPersistExecutor(this.connection, this.queryRunner, "save", target, entity, options)
+      .execute()
+      .then(() => entity);
+  }
+
+  /**
+   * Saves all given entities in the database.
+   * If entities do not exist in the database then inserts, otherwise updates.
+   */
+  async saveNoTransaction<Entity>(entity: Entity, options?: SaveOptions): Promise<Entity>;
+
+  /**
+   * Saves all given entities in the database.
+   * If entities do not exist in the database then inserts, otherwise updates.
+   */
+  async saveNoTransaction<Entity, T extends DeepPartial<Entity>>(targetOrEntity: ObjectType<Entity> | string, entity: T, options?: SaveOptions): Promise<T>;
+
+  /**
+   * Saves all given entities in the database.
+   * If entities do not exist in the database then inserts, otherwise updates.
+   */
+  async saveNoTransaction<Entity>(entities: Entity[], options?: SaveOptions): Promise<Entity[]>;
+
+  /**
+   * Saves all given entities in the database.
+   * If entities do not exist in the database then inserts, otherwise updates.
+   */
+  async saveNoTransaction<Entity, T extends DeepPartial<Entity>>(targetOrEntity: ObjectType<Entity> | string, entities: T[], options?: SaveOptions): Promise<T[]>;
+
+  /**
+   * Saves a given entity in the database.
+   */
+  async saveNoTransaction<Entity, T extends DeepPartial<Entity>>(targetOrEntity: (T | T[]) | ObjectType<Entity> | string, maybeEntityOrOptions?: T | T[], maybeOptions?: SaveOptions): Promise<T | T[]> {
+
+    // normalize mixed parameters
+    const target = (targetOrEntity instanceof Function || typeof targetOrEntity === "string") ? targetOrEntity as Function | string : undefined;
+    const entity: T | T[] = target ? maybeEntityOrOptions as T | T[] : targetOrEntity as T | T[];
+    const options = target ? maybeOptions : maybeEntityOrOptions as SaveOptions;
+
+    // execute save operation
+    await new EntityPersistExecutor(this.connection, this.queryRunner, "save", target, entity, options)
+      .executeNoTransaction();
+    return entity;
+  }
+
+  /**
+   * Removes a given entity from the database.
+   */
+  remove<Entity>(entity: Entity): Promise<Entity>;
+
+  /**
+   * Removes a given entity from the database.
+   */
+  remove<Entity>(targetOrEntity: ObjectType<Entity> | string, entity: Entity, options?: RemoveOptions): Promise<Entity>;
+
+  /**
+   * Removes a given entity from the database.
+   */
+  remove<Entity>(entity: Entity[], options?: RemoveOptions): Promise<Entity>;
+
+  /**
+   * Removes a given entity from the database.
+   */
+  remove<Entity>(targetOrEntity: ObjectType<Entity> | string, entity: Entity[], options?: RemoveOptions): Promise<Entity[]>;
+
+  /**
+   * Removes a given entity from the database.
+   */
+  remove<Entity>(targetOrEntity: (Entity | Entity[]) | Function | string, maybeEntityOrOptions?: Entity | Entity[], maybeOptions?: RemoveOptions): Promise<Entity | Entity[]> {
+
+    // normalize mixed parameters
+    const target = (arguments.length > 1 && (targetOrEntity instanceof Function || typeof targetOrEntity === "string")) ? targetOrEntity as Function | string : undefined;
+    const entity: Entity | Entity[] = target ? maybeEntityOrOptions as Entity | Entity[] : targetOrEntity as Entity | Entity[];
+    const options = target ? maybeOptions : maybeEntityOrOptions as SaveOptions;
+
+    // execute save operation
+    return new EntityPersistExecutor(this.connection, this.queryRunner, "remove", target, entity, options)
+      .execute()
+      .then(() => entity);
+  }
+
+  /**
+   * Removes a given entity from the database.
+   */
+  async removeNoTransaction<Entity>(entity: Entity): Promise<Entity>;
+
+  /**
+   * Removes a given entity from the database.
+   */
+  async removeNoTransaction<Entity>(targetOrEntity: ObjectType<Entity> | string, entity: Entity, options?: RemoveOptions): Promise<Entity>;
+
+  /**
+   * Removes a given entity from the database.
+   */
+  async removeNoTransaction<Entity>(entity: Entity[], options?: RemoveOptions): Promise<Entity>;
+
+  /**
+   * Removes a given entity from the database.
+   */
+  async removeNoTransaction<Entity>(targetOrEntity: ObjectType<Entity> | string, entity: Entity[], options?: RemoveOptions): Promise<Entity[]>;
+
+  /**
+   * Removes a given entity from the database.
+   */
+  async removeNoTransaction<Entity>(targetOrEntity: (Entity | Entity[]) | Function | string, maybeEntityOrOptions?: Entity | Entity[], maybeOptions?: RemoveOptions): Promise<Entity | Entity[]> {
+
+    // normalize mixed parameters
+    const target = (targetOrEntity instanceof Function || typeof targetOrEntity === "string") ? targetOrEntity as Function | string : undefined;
+    const entity: Entity | Entity[] = target ? maybeEntityOrOptions as Entity | Entity[] : targetOrEntity as Entity | Entity[];
+    const options = target ? maybeOptions : maybeEntityOrOptions as SaveOptions;
+
+    // execute save operation
+    await new EntityPersistExecutor(this.connection, this.queryRunner, "remove", target, entity, options)
+      .executeNoTransaction()
+    return entity;
+  }
+
+  /**
+   * Inserts a given entity into the database.
+   * Unlike save method executes a primitive operation without cascades, relations and other operations included.
+   * Executes fast and efficient INSERT query.
+   * Does not check if entity exist in the database, so query will fail if duplicate entity is being inserted.
+   * You can execute bulk inserts using this method.
+   */
+  async insert<Entity>(target: ObjectType<Entity> | string, entity: QueryPartialEntity<Entity> | (QueryPartialEntity<Entity>[]), options?: SaveOptions): Promise<InsertResult> {
+    return this.createQueryBuilder()
+      .insert()
+      .into(target)
+      .values(entity)
+      .execute();
+  }
+
+  /**
+   * Updates entity partially. Entity can be found by a given conditions.
+   * Unlike save method executes a primitive operation without cascades, relations and other operations included.
+   * Executes fast and efficient UPDATE query.
+   * Does not check if entity exist in the database.
+   */
+  update<Entity>(target: ObjectType<Entity> | string, criteria: string | string[] | number | number[] | Date | Date[] | ObjectID | ObjectID[] | DeepPartial<Entity>, partialEntity: DeepPartial<Entity>, options?: SaveOptions): Promise<UpdateResult> {
+    if (typeof criteria === "string" ||
+      typeof criteria === "number" ||
+      criteria instanceof Date ||
+      criteria instanceof Array) {
+
+      return this.createQueryBuilder()
+        .update(target)
+        .set(partialEntity)
+        .whereInIds(criteria)
+        .execute();
+
+    } else {
+      return this.createQueryBuilder()
+        .update(target)
+        .set(partialEntity)
+        .where(criteria)
+        .execute();
+    }
+  }
+
+  /**
+   * Deletes entities by a given conditions.
+   * Unlike save method executes a primitive operation without cascades, relations and other operations included.
+   * Executes fast and efficient DELETE query.
+   * Does not check if entity exist in the database.
+   */
+  delete<Entity>(targetOrEntity: ObjectType<Entity> | string, criteria: string | string[] | number | number[] | Date | Date[] | ObjectID | ObjectID[] | DeepPartial<Entity>, options?: RemoveOptions): Promise<DeleteResult> {
+    if (typeof criteria === "string" ||
+      typeof criteria === "number" ||
+      criteria instanceof Date ||
+      criteria instanceof Array) {
+
+      return this.createQueryBuilder()
+        .delete()
+        .from(targetOrEntity)
+        .whereInIds(criteria)
+        .execute();
+
+    } else {
+      return this.createQueryBuilder()
+        .delete()
+        .from(targetOrEntity)
+        .where(criteria)
+        .execute();
+    }
+  }
+
+  /**
+   * Counts entities that match given options.
+   * Useful for pagination.
+   */
+  count<Entity>(entityClass: ObjectType<Entity> | string, options?: FindManyOptions<Entity>): Promise<number>;
+
+  /**
+   * Counts entities that match given conditions.
+   * Useful for pagination.
+   */
+  count<Entity>(entityClass: ObjectType<Entity> | string, conditions?: DeepPartial<Entity>): Promise<number>;
+
+  /**
+   * Counts entities that match given find options or conditions.
+   * Useful for pagination.
+   */
+  count<Entity>(entityClass: ObjectType<Entity> | string, optionsOrConditions?: FindManyOptions<Entity> | DeepPartial<Entity>): Promise<number> {
+    const metadata = this.connection.getMetadata(entityClass);
+    const qb = this.createQueryBuilder(entityClass, FindOptionsUtils.extractFindManyOptionsAlias(optionsOrConditions) || metadata.name);
+    return FindOptionsUtils.applyFindManyOptionsOrConditionsToQueryBuilder(qb, optionsOrConditions).getCount();
+  }
+
+  /**
+   * Finds entities that match given options.
+   */
+  find<Entity>(entityClass: ObjectType<Entity> | string, options?: FindManyOptions<Entity>): Promise<Entity[]>;
+
+  /**
+   * Finds entities that match given conditions.
+   */
+  find<Entity>(entityClass: ObjectType<Entity> | string, conditions?: DeepPartial<Entity>): Promise<Entity[]>;
+
+  /**
+   * Finds entities that match given find options or conditions.
+   */
+  find<Entity>(entityClass: ObjectType<Entity> | string, optionsOrConditions?: FindManyOptions<Entity> | DeepPartial<Entity>): Promise<Entity[]> {
+    const metadata = this.connection.getMetadata(entityClass);
+    const qb = this.createQueryBuilder(entityClass, FindOptionsUtils.extractFindManyOptionsAlias(optionsOrConditions) || metadata.name);
+    this.joinEagerRelations(qb, qb.alias, metadata);
+    return FindOptionsUtils.applyFindManyOptionsOrConditionsToQueryBuilder(qb, optionsOrConditions).getMany();
+  }
+
+  /**
+   * Finds entities that match given find options.
+   * Also counts all entities that match given conditions,
+   * but ignores pagination settings (from and take options).
+   */
+  findAndCount<Entity>(entityClass: ObjectType<Entity> | string, options?: FindManyOptions<Entity>): Promise<[Entity[], number]>;
+
+  /**
+   * Finds entities that match given conditions.
+   * Also counts all entities that match given conditions,
+   * but ignores pagination settings (from and take options).
+   */
+  findAndCount<Entity>(entityClass: ObjectType<Entity> | string, conditions?: DeepPartial<Entity>): Promise<[Entity[], number]>;
+
+  /**
+   * Finds entities that match given find options and conditions.
+   * Also counts all entities that match given conditions,
+   * but ignores pagination settings (from and take options).
+   */
+  findAndCount<Entity>(entityClass: ObjectType<Entity> | string, optionsOrConditions?: FindManyOptions<Entity> | DeepPartial<Entity>): Promise<[Entity[], number]> {
+    const metadata = this.connection.getMetadata(entityClass);
+    const qb = this.createQueryBuilder(entityClass, FindOptionsUtils.extractFindManyOptionsAlias(optionsOrConditions) || metadata.name);
+    this.joinEagerRelations(qb, qb.alias, metadata);
+    return FindOptionsUtils.applyFindManyOptionsOrConditionsToQueryBuilder(qb, optionsOrConditions).getManyAndCount();
+  }
+
+  /**
+   * Finds entities with ids.
+   * Optionally find options can be applied.
+   */
+  findByIds<Entity>(entityClass: ObjectType<Entity> | string, ids: any[], options?: FindManyOptions<Entity>): Promise<Entity[]>;
+
+  /**
+   * Finds entities with ids.
+   * Optionally conditions can be applied.
+   */
+  findByIds<Entity>(entityClass: ObjectType<Entity> | string, ids: any[], conditions?: DeepPartial<Entity>): Promise<Entity[]>;
+
+  /**
+   * Finds entities with ids.
+   * Optionally find options or conditions can be applied.
+   */
+  findByIds<Entity>(entityClass: ObjectType<Entity> | string, ids: any[], optionsOrConditions?: FindManyOptions<Entity> | DeepPartial<Entity>): Promise<Entity[]> {
+
+    // if no ids passed, no need to execute a query - just return an empty array of values
+    if (!ids.length)
+      return Promise.resolve([]);
+    const metadata = this.connection.getMetadata(entityClass);
+    const qb = this.createQueryBuilder(entityClass, FindOptionsUtils.extractFindManyOptionsAlias(optionsOrConditions) || metadata.name);
+    qb.whereInIds(ids.map(id => metadata.ensureEntityIdMap(id)));
+    FindOptionsUtils.applyFindManyOptionsOrConditionsToQueryBuilder(qb, optionsOrConditions);
+    this.joinEagerRelations(qb, qb.alias, metadata);
+    return qb.getMany();
+  }
+
+  /**
+   * Finds first entity that matches given find options.
+   */
+  findOne<Entity>(entityClass: ObjectType<Entity> | string, id?: string | number | Date | ObjectID, options?: FindOneOptions<Entity>): Promise<Entity | undefined>;
+
+  /**
+   * Finds first entity that matches given find options.
+   */
+  findOne<Entity>(entityClass: ObjectType<Entity> | string, options?: FindOneOptions<Entity>): Promise<Entity | undefined>;
+
+  /**
+   * Finds first entity that matches given conditions.
+   */
+  findOne<Entity>(entityClass: ObjectType<Entity> | string, conditions?: DeepPartial<Entity>, options?: FindOneOptions<Entity>): Promise<Entity | undefined>;
+
+  /**
+   * Finds first entity that matches given conditions.
+   */
+  findOne<Entity>(entityClass: ObjectType<Entity> | string, idOrOptionsOrConditions?: string | string[] | number | number[] | Date | Date[] | ObjectID | ObjectID[] | FindOneOptions<Entity> | DeepPartial<Entity>, maybeOptions?: FindOneOptions<Entity>): Promise<Entity | undefined> {
+
+    const metadata = this.connection.getMetadata(entityClass);
+    let alias: string = metadata.name;
+    if (FindOptionsUtils.isFindOneOptions(idOrOptionsOrConditions) && idOrOptionsOrConditions.join) {
+      alias = idOrOptionsOrConditions.join.alias;
+
+    } else if (maybeOptions && FindOptionsUtils.isFindOneOptions(maybeOptions) && maybeOptions.join) {
+      alias = maybeOptions.join.alias;
+    }
+    const qb = this.createQueryBuilder(entityClass, alias);
+
+    this.joinEagerRelations(qb, qb.alias, metadata);
+
+    if (maybeOptions) {
+      FindOptionsUtils.applyOptionsToQueryBuilder(qb, maybeOptions);
     }
 
-    // -------------------------------------------------------------------------
-    // Public Methods
-    // -------------------------------------------------------------------------
+    if (FindOptionsUtils.isFindOneOptions(idOrOptionsOrConditions)) {
+      FindOptionsUtils.applyOptionsToQueryBuilder(qb, idOrOptionsOrConditions);
 
-    /**
-     * Wraps given function execution (and all operations made there) in a transaction.
-     * All database operations must be executed using provided entity manager.
-     */
-    async transaction<T>(runInTransaction: (entityManger: EntityManager) => Promise<T>): Promise<T> {
+    } else if (idOrOptionsOrConditions instanceof Object) {
+      qb.where(idOrOptionsOrConditions as any);
 
-        if (this.connection.driver instanceof MongoDriver)
-            throw new Error(`Transactions aren't supported by MongoDB.`);
-
-        if (this.queryRunner && this.queryRunner.isReleased)
-            throw new QueryRunnerProviderAlreadyReleasedError();
-
-        if (this.queryRunner && this.queryRunner.isTransactionActive)
-            throw new Error(`Cannot start transaction because its already started`);
-
-        // if query runner is already defined in this class, it means this entity manager was already created for a single connection
-        // if its not defined we create a new query runner - single connection where we'll execute all our operations
-        const queryRunner = this.queryRunner || this.connection.createQueryRunner("master");
-
-        try {
-            await queryRunner.startTransaction();
-            const result = await runInTransaction(queryRunner.manager);
-            await queryRunner.commitTransaction();
-            return result;
-
-        } catch (err) {
-            try { // we throw original error even if rollback thrown an error
-                await queryRunner.rollbackTransaction();
-            } catch (rollbackError) { }
-            throw err;
-
-        } finally {
-            if (!this.queryRunner) // if we used a new query runner provider then release it
-                await queryRunner.release();
-        }
+    } else if (typeof idOrOptionsOrConditions === "string" || typeof idOrOptionsOrConditions === "number" || (idOrOptionsOrConditions as any) instanceof Date) {
+      qb.andWhereInIds(metadata.ensureEntityIdMap(idOrOptionsOrConditions));
     }
 
-    /**
-     * Executes raw SQL query and returns raw database results.
-     */
-    async query(query: string, parameters?: any[]): Promise<any> {
-        return this.connection.query(query, parameters, this.queryRunner);
+    return qb.getOne();
+  }
+
+  /**
+   * Clears all the data from the given table (truncates/drops it).
+   *
+   * Note: this method uses TRUNCATE and may not work as you expect in transactions on some platforms.
+   * @see https://stackoverflow.com/a/5972738/925151
+   */
+  async clear<Entity>(entityClass: ObjectType<Entity> | string): Promise<void> {
+    const metadata = this.connection.getMetadata(entityClass);
+    const queryRunner = this.queryRunner || this.connection.createQueryRunner("master");
+    try {
+      return await queryRunner.truncate(metadata.tablePath); // await is needed here because we are using finally
+
+    } finally {
+      if (!this.queryRunner)
+        await queryRunner.release();
+    }
+  }
+
+  /**
+   * Gets repository for the given entity class or name.
+   * If single database connection mode is used, then repository is obtained from the
+   * repository aggregator, where each repository is individually created for this entity manager.
+   * When single database connection is not used, repository is being obtained from the connection.
+   */
+  getRepository<Entity>(target: ObjectType<Entity> | string): Repository<Entity> {
+
+    // throw exception if there is no repository with this target registered
+    if (!this.connection.hasMetadata(target))
+      throw new RepositoryNotFoundError(this.connection.name, target);
+
+    // find already created repository instance and return it if found
+    const metadata = this.connection.getMetadata(target);
+    const repository = this.repositories.find(repository => repository.metadata === metadata);
+    if (repository)
+      return repository;
+
+    // if repository was not found then create it, store its instance and return it
+    const newRepository = new RepositoryFactory().create(this, metadata, this.queryRunner);
+    this.repositories.push(newRepository);
+    return newRepository;
+  }
+
+  /**
+   * Gets tree repository for the given entity class or name.
+   * If single database connection mode is used, then repository is obtained from the
+   * repository aggregator, where each repository is individually created for this entity manager.
+   * When single database connection is not used, repository is being obtained from the connection.
+   */
+  getTreeRepository<Entity>(target: ObjectType<Entity> | string): TreeRepository<Entity> {
+
+    // tree tables aren't supported by some drivers (mongodb)
+    if (this.connection.driver.treeSupport === false)
+      throw new TreeRepositoryNotSupportedError(this.connection.driver);
+
+    // check if repository is real tree repository
+    const repository = this.getRepository(target);
+    if (!(repository instanceof TreeRepository))
+      throw new RepositoryNotTreeError(target);
+
+    return repository;
+  }
+
+  /**
+   * Gets mongodb repository for the given entity class.
+   */
+  getMongoRepository<Entity>(target: string | ObjectType<Entity>): MongoRepository<Entity> {
+    return this.connection.getMongoRepository<Entity>(target);
+  }
+
+  /**
+   * Gets custom entity repository marked with @EntityRepository decorator.
+   */
+  getCustomRepository<T>(customRepository: ObjectType<T>): T {
+    const entityRepositoryMetadataArgs = getMetadataArgsStorage().entityRepositories.find(repository => {
+      return repository.target === (customRepository instanceof Function ? customRepository : (customRepository as any).constructor);
+    });
+    if (!entityRepositoryMetadataArgs)
+      throw new CustomRepositoryNotFoundError(customRepository);
+
+    const entityMetadata = entityRepositoryMetadataArgs.entity ? this.connection.getMetadata(entityRepositoryMetadataArgs.entity) : undefined;
+    const entityRepositoryInstance = new (entityRepositoryMetadataArgs.target as any)(this, entityMetadata);
+
+    // NOTE: dynamic access to protected properties. We need this to prevent unwanted properties in those classes to be exposed,
+    // however we need these properties for internal work of the class
+    if (entityRepositoryInstance instanceof AbstractRepository) {
+      if (!(entityRepositoryInstance as any)["manager"])
+        (entityRepositoryInstance as any)["manager"] = this;
+    }
+    if (entityRepositoryInstance instanceof Repository) {
+      if (!entityMetadata)
+        throw new CustomRepositoryCannotInheritRepositoryError(customRepository);
+
+      (entityRepositoryInstance as any)["manager"] = this;
+      (entityRepositoryInstance as any)["metadata"] = entityMetadata;
     }
 
-    /**
-     * Creates a new query builder that can be used to build a sql query.
-     */
-    createQueryBuilder<Entity>(entityClass: ObjectType<Entity>|Function|string, alias: string, queryRunner?: QueryRunner): SelectQueryBuilder<Entity>;
-
-    /**
-     * Creates a new query builder that can be used to build a sql query.
-     */
-    createQueryBuilder(queryRunner?: QueryRunner): SelectQueryBuilder<any>;
-
-    /**
-     * Creates a new query builder that can be used to build a sql query.
-     */
-    createQueryBuilder<Entity>(entityClass?: ObjectType<Entity>|Function|string|QueryRunner, alias?: string, queryRunner?: QueryRunner): SelectQueryBuilder<Entity> {
-        if (alias) {
-            return this.connection.createQueryBuilder(entityClass as Function|string, alias, queryRunner || this.queryRunner);
-
-        } else {
-            return this.connection.createQueryBuilder(entityClass as QueryRunner|undefined || this.queryRunner);
-        }
-    }
-
-    /**
-     * Checks if entity has an id.
-     */
-    hasId(entity: any): boolean;
-
-    /**
-     * Checks if entity of given schema name has an id.
-     */
-    hasId(target: Function|string, entity: any): boolean;
-
-    /**
-     * Checks if entity has an id by its Function type or schema name.
-     */
-    hasId(targetOrEntity: any|Function|string, maybeEntity?: any): boolean {
-        const target = arguments.length === 2 ? targetOrEntity : targetOrEntity.constructor;
-        const entity = arguments.length === 2 ? maybeEntity : targetOrEntity;
-        const metadata = this.connection.getMetadata(target);
-        return metadata.hasId(entity);
-    }
-
-    /**
-     * Gets entity mixed id.
-     */
-    getId(entity: any): any;
-
-    /**
-     * Gets entity mixed id.
-     */
-    getId(target: Function|string, entity: any): any;
-
-    /**
-     * Gets entity mixed id.
-     */
-    getId(targetOrEntity: any|Function|string, maybeEntity?: any): any {
-        const target = arguments.length === 2 ? targetOrEntity : targetOrEntity.constructor;
-        const entity = arguments.length === 2 ? maybeEntity : targetOrEntity;
-        const metadata = this.connection.getMetadata(target);
-        return metadata.getEntityIdMixedMap(entity);
-    }
-
-    /**
-     * Creates a new entity instance.
-     */
-    create<Entity>(entityClass: ObjectType<Entity>): Entity;
-
-    /**
-     * Creates a new entity instance and copies all entity properties from this object into a new entity.
-     * Note that it copies only properties that present in entity schema.
-     */
-    create<Entity>(entityClass: ObjectType<Entity>|string, plainObject: DeepPartial<Entity>): Entity;
-
-    /**
-     * Creates a new entities and copies all entity properties from given objects into their new entities.
-     * Note that it copies only properties that present in entity schema.
-     */
-    create<Entity>(entityClass: ObjectType<Entity>|string, plainObjects: DeepPartial<Entity>[]): Entity[];
-
-    /**
-     * Creates a new entity instance or instances.
-     * Can copy properties from the given object into new entities.
-     */
-    create<Entity>(entityClass: ObjectType<Entity>|string, plainObjectOrObjects?: DeepPartial<Entity>|DeepPartial<Entity>[]): Entity|Entity[] {
-        const metadata = this.connection.getMetadata(entityClass);
-
-        if (!plainObjectOrObjects)
-            return metadata.create();
-
-        if (plainObjectOrObjects instanceof Array)
-            return plainObjectOrObjects.map(plainEntityLike => this.create(entityClass, plainEntityLike));
-
-        const mergeIntoEntity = metadata.create();
-        const plainObjectToEntityTransformer = new PlainObjectToNewEntityTransformer(true);
-        plainObjectToEntityTransformer.transform(mergeIntoEntity, plainObjectOrObjects, metadata);
-        return mergeIntoEntity;
-    }
-
-    /**
-     * Merges two entities into one new entity.
-     */
-    merge<Entity>(entityClass: ObjectType<Entity>|string, mergeIntoEntity: Entity, ...entityLikes: DeepPartial<Entity>[]): Entity { // todo: throw exception if entity manager is released
-        const metadata = this.connection.getMetadata(entityClass);
-        const plainObjectToEntityTransformer = new PlainObjectToNewEntityTransformer();
-        entityLikes.forEach(object => plainObjectToEntityTransformer.transform(mergeIntoEntity, object, metadata));
-        return mergeIntoEntity;
-    }
-
-    /**
-     * Creates a new entity from the given plan javascript object. If entity already exist in the database, then
-     * it loads it (and everything related to it), replaces all values with the new ones from the given object
-     * and returns this new entity. This new entity is actually a loaded from the db entity with all properties
-     * replaced from the new object.
-     */
-    async preload<Entity>(entityClass: ObjectType<Entity>|string, entityLike: DeepPartial<Entity>): Promise<Entity|undefined> {
-        const metadata = this.connection.getMetadata(entityClass);
-        const plainObjectToDatabaseEntityTransformer = new PlainObjectToDatabaseEntityTransformer(this.connection.manager);
-        const transformedEntity = await plainObjectToDatabaseEntityTransformer.transform(entityLike, metadata);
-        if (transformedEntity)
-            return this.merge(entityClass, transformedEntity as Entity, entityLike);
-
-        return undefined;
-    }
-
-    /**
-     * Saves all given entities in the database.
-     * If entities do not exist in the database then inserts, otherwise updates.
-     */
-    save<Entity>(entity: Entity, options?: SaveOptions): Promise<Entity>;
-
-    /**
-     * Saves all given entities in the database.
-     * If entities do not exist in the database then inserts, otherwise updates.
-     */
-    save<Entity, T extends DeepPartial<Entity>>(targetOrEntity: ObjectType<Entity>|string, entity: T, options?: SaveOptions): Promise<T>;
-
-    /**
-     * Saves all given entities in the database.
-     * If entities do not exist in the database then inserts, otherwise updates.
-     */
-    save<Entity>(entities: Entity[], options?: SaveOptions): Promise<Entity[]>;
-
-    /**
-     * Saves all given entities in the database.
-     * If entities do not exist in the database then inserts, otherwise updates.
-     */
-    save<Entity, T extends DeepPartial<Entity>>(targetOrEntity: ObjectType<Entity>|string, entities: T[], options?: SaveOptions): Promise<T[]>;
-
-    /**
-     * Saves a given entity in the database.
-     */
-    save<Entity, T extends DeepPartial<Entity>>(targetOrEntity: (T|T[])|ObjectType<Entity>|string, maybeEntityOrOptions?: T|T[], maybeOptions?: SaveOptions): Promise<T|T[]> {
-
-        // normalize mixed parameters
-        const target = (arguments.length > 1 && (targetOrEntity instanceof Function || typeof targetOrEntity === "string")) ? targetOrEntity as Function|string : undefined;
-        const entity: T|T[] = target ? maybeEntityOrOptions as T|T[] : targetOrEntity as T|T[];
-        const options = target ? maybeOptions : maybeEntityOrOptions as SaveOptions;
-
-        // execute save operation
-        return new EntityPersistExecutor(this.connection, this.queryRunner, "save", target, entity, options)
-            .execute()
-            .then(() => entity);
-    }
-
-    /**
-     * Removes a given entity from the database.
-     */
-    remove<Entity>(entity: Entity): Promise<Entity>;
-
-    /**
-     * Removes a given entity from the database.
-     */
-    remove<Entity>(targetOrEntity: ObjectType<Entity>|string, entity: Entity, options?: RemoveOptions): Promise<Entity>;
-
-    /**
-     * Removes a given entity from the database.
-     */
-    remove<Entity>(entity: Entity[], options?: RemoveOptions): Promise<Entity>;
-
-    /**
-     * Removes a given entity from the database.
-     */
-    remove<Entity>(targetOrEntity: ObjectType<Entity>|string, entity: Entity[], options?: RemoveOptions): Promise<Entity[]>;
-
-    /**
-     * Removes a given entity from the database.
-     */
-    remove<Entity>(targetOrEntity: (Entity|Entity[])|Function|string, maybeEntityOrOptions?: Entity|Entity[], maybeOptions?: RemoveOptions): Promise<Entity|Entity[]> {
-
-        // normalize mixed parameters
-        const target = (arguments.length > 1 && (targetOrEntity instanceof Function || typeof targetOrEntity === "string")) ? targetOrEntity as Function|string : undefined;
-        const entity: Entity|Entity[] = target ? maybeEntityOrOptions as Entity|Entity[] : targetOrEntity as Entity|Entity[];
-        const options = target ? maybeOptions : maybeEntityOrOptions as SaveOptions;
-
-        // execute save operation
-        return new EntityPersistExecutor(this.connection, this.queryRunner, "remove", target, entity, options)
-            .execute()
-            .then(() => entity);
-    }
-
-    /**
-     * Inserts a given entity into the database.
-     * Unlike save method executes a primitive operation without cascades, relations and other operations included.
-     * Executes fast and efficient INSERT query.
-     * Does not check if entity exist in the database, so query will fail if duplicate entity is being inserted.
-     * You can execute bulk inserts using this method.
-     */
-    async insert<Entity>(target: ObjectType<Entity>|string, entity: QueryPartialEntity<Entity>|(QueryPartialEntity<Entity>[]), options?: SaveOptions): Promise<InsertResult> {
-        return this.createQueryBuilder()
-            .insert()
-            .into(target)
-            .values(entity)
-            .execute();
-    }
-
-    /**
-     * Updates entity partially. Entity can be found by a given conditions.
-     * Unlike save method executes a primitive operation without cascades, relations and other operations included.
-     * Executes fast and efficient UPDATE query.
-     * Does not check if entity exist in the database.
-     */
-    update<Entity>(target: ObjectType<Entity>|string, criteria: string|string[]|number|number[]|Date|Date[]|ObjectID|ObjectID[]|DeepPartial<Entity>, partialEntity: DeepPartial<Entity>, options?: SaveOptions): Promise<UpdateResult> {
-        if (typeof criteria === "string" ||
-            typeof criteria === "number" ||
-            criteria instanceof Date ||
-            criteria instanceof Array) {
-
-            return this.createQueryBuilder()
-                .update(target)
-                .set(partialEntity)
-                .whereInIds(criteria)
-                .execute();
-
-        } else {
-            return this.createQueryBuilder()
-                .update(target)
-                .set(partialEntity)
-                .where(criteria)
-                .execute();
-        }
-    }
-
-    /**
-     * Deletes entities by a given conditions.
-     * Unlike save method executes a primitive operation without cascades, relations and other operations included.
-     * Executes fast and efficient DELETE query.
-     * Does not check if entity exist in the database.
-     */
-    delete<Entity>(targetOrEntity: ObjectType<Entity>|string, criteria: string|string[]|number|number[]|Date|Date[]|ObjectID|ObjectID[]|DeepPartial<Entity>, options?: RemoveOptions): Promise<DeleteResult> {
-        if (typeof criteria === "string" ||
-            typeof criteria === "number" ||
-            criteria instanceof Date ||
-            criteria instanceof Array) {
-
-            return this.createQueryBuilder()
-                .delete()
-                .from(targetOrEntity)
-                .whereInIds(criteria)
-                .execute();
-
-        } else {
-            return this.createQueryBuilder()
-                .delete()
-                .from(targetOrEntity)
-                .where(criteria)
-                .execute();
-        }
-    }
-
-    /**
-     * Counts entities that match given options.
-     * Useful for pagination.
-     */
-    count<Entity>(entityClass: ObjectType<Entity>|string, options?: FindManyOptions<Entity>): Promise<number>;
-
-    /**
-     * Counts entities that match given conditions.
-     * Useful for pagination.
-     */
-    count<Entity>(entityClass: ObjectType<Entity>|string, conditions?: DeepPartial<Entity>): Promise<number>;
-
-    /**
-     * Counts entities that match given find options or conditions.
-     * Useful for pagination.
-     */
-    count<Entity>(entityClass: ObjectType<Entity>|string, optionsOrConditions?: FindManyOptions<Entity>|DeepPartial<Entity>): Promise<number> {
-        const metadata = this.connection.getMetadata(entityClass);
-        const qb = this.createQueryBuilder(entityClass, FindOptionsUtils.extractFindManyOptionsAlias(optionsOrConditions) || metadata.name);
-        return FindOptionsUtils.applyFindManyOptionsOrConditionsToQueryBuilder(qb, optionsOrConditions).getCount();
-    }
-
-    /**
-     * Finds entities that match given options.
-     */
-    find<Entity>(entityClass: ObjectType<Entity>|string, options?: FindManyOptions<Entity>): Promise<Entity[]>;
-
-    /**
-     * Finds entities that match given conditions.
-     */
-    find<Entity>(entityClass: ObjectType<Entity>|string, conditions?: DeepPartial<Entity>): Promise<Entity[]>;
-
-    /**
-     * Finds entities that match given find options or conditions.
-     */
-    find<Entity>(entityClass: ObjectType<Entity>|string, optionsOrConditions?: FindManyOptions<Entity>|DeepPartial<Entity>): Promise<Entity[]> {
-        const metadata = this.connection.getMetadata(entityClass);
-        const qb = this.createQueryBuilder(entityClass, FindOptionsUtils.extractFindManyOptionsAlias(optionsOrConditions) || metadata.name);
-        this.joinEagerRelations(qb, qb.alias, metadata);
-        return FindOptionsUtils.applyFindManyOptionsOrConditionsToQueryBuilder(qb, optionsOrConditions).getMany();
-    }
-
-    /**
-     * Finds entities that match given find options.
-     * Also counts all entities that match given conditions,
-     * but ignores pagination settings (from and take options).
-     */
-    findAndCount<Entity>(entityClass: ObjectType<Entity>|string, options?: FindManyOptions<Entity>): Promise<[Entity[], number]>;
-
-    /**
-     * Finds entities that match given conditions.
-     * Also counts all entities that match given conditions,
-     * but ignores pagination settings (from and take options).
-     */
-    findAndCount<Entity>(entityClass: ObjectType<Entity>|string, conditions?: DeepPartial<Entity>): Promise<[Entity[], number]>;
-
-    /**
-     * Finds entities that match given find options and conditions.
-     * Also counts all entities that match given conditions,
-     * but ignores pagination settings (from and take options).
-     */
-    findAndCount<Entity>(entityClass: ObjectType<Entity>|string, optionsOrConditions?: FindManyOptions<Entity>|DeepPartial<Entity>): Promise<[Entity[], number]> {
-        const metadata = this.connection.getMetadata(entityClass);
-        const qb = this.createQueryBuilder(entityClass, FindOptionsUtils.extractFindManyOptionsAlias(optionsOrConditions) || metadata.name);
-        this.joinEagerRelations(qb, qb.alias, metadata);
-        return FindOptionsUtils.applyFindManyOptionsOrConditionsToQueryBuilder(qb, optionsOrConditions).getManyAndCount();
-    }
-
-    /**
-     * Finds entities with ids.
-     * Optionally find options can be applied.
-     */
-    findByIds<Entity>(entityClass: ObjectType<Entity>|string, ids: any[], options?: FindManyOptions<Entity>): Promise<Entity[]>;
-
-    /**
-     * Finds entities with ids.
-     * Optionally conditions can be applied.
-     */
-    findByIds<Entity>(entityClass: ObjectType<Entity>|string, ids: any[], conditions?: DeepPartial<Entity>): Promise<Entity[]>;
-
-    /**
-     * Finds entities with ids.
-     * Optionally find options or conditions can be applied.
-     */
-    findByIds<Entity>(entityClass: ObjectType<Entity>|string, ids: any[], optionsOrConditions?: FindManyOptions<Entity>|DeepPartial<Entity>): Promise<Entity[]> {
-
-        // if no ids passed, no need to execute a query - just return an empty array of values
-        if (!ids.length)
-            return Promise.resolve([]);
-        const metadata = this.connection.getMetadata(entityClass);
-        const qb = this.createQueryBuilder(entityClass, FindOptionsUtils.extractFindManyOptionsAlias(optionsOrConditions) || metadata.name);
-        qb.whereInIds(ids.map(id => metadata.ensureEntityIdMap(id)));
-        FindOptionsUtils.applyFindManyOptionsOrConditionsToQueryBuilder(qb, optionsOrConditions);
-        this.joinEagerRelations(qb, qb.alias, metadata);
-        return qb.getMany();
-    }
-
-    /**
-     * Finds first entity that matches given find options.
-     */
-    findOne<Entity>(entityClass: ObjectType<Entity>|string, id?: string|number|Date|ObjectID, options?: FindOneOptions<Entity>): Promise<Entity|undefined>;
-
-    /**
-     * Finds first entity that matches given find options.
-     */
-    findOne<Entity>(entityClass: ObjectType<Entity>|string, options?: FindOneOptions<Entity>): Promise<Entity|undefined>;
-
-    /**
-     * Finds first entity that matches given conditions.
-     */
-    findOne<Entity>(entityClass: ObjectType<Entity>|string, conditions?: DeepPartial<Entity>, options?: FindOneOptions<Entity>): Promise<Entity|undefined>;
-
-    /**
-     * Finds first entity that matches given conditions.
-     */
-    findOne<Entity>(entityClass: ObjectType<Entity>|string, idOrOptionsOrConditions?: string|string[]|number|number[]|Date|Date[]|ObjectID|ObjectID[]|FindOneOptions<Entity>|DeepPartial<Entity>, maybeOptions?: FindOneOptions<Entity>): Promise<Entity|undefined> {
-
-        const metadata = this.connection.getMetadata(entityClass);
-        let alias: string = metadata.name;
-        if (FindOptionsUtils.isFindOneOptions(idOrOptionsOrConditions) && idOrOptionsOrConditions.join) {
-            alias = idOrOptionsOrConditions.join.alias;
-
-        } else if (maybeOptions && FindOptionsUtils.isFindOneOptions(maybeOptions) && maybeOptions.join) {
-            alias = maybeOptions.join.alias;
-        }
-        const qb = this.createQueryBuilder(entityClass, alias);
-
-        this.joinEagerRelations(qb, qb.alias, metadata);
-
-        if (maybeOptions) {
-            FindOptionsUtils.applyOptionsToQueryBuilder(qb, maybeOptions);
-        }
-
-        if (FindOptionsUtils.isFindOneOptions(idOrOptionsOrConditions)) {
-            FindOptionsUtils.applyOptionsToQueryBuilder(qb, idOrOptionsOrConditions);
-
-        } else if (idOrOptionsOrConditions instanceof Object) {
-            qb.where(idOrOptionsOrConditions as any);
-
-        } else if (typeof idOrOptionsOrConditions === "string" || typeof idOrOptionsOrConditions === "number" || (idOrOptionsOrConditions as any) instanceof Date) {
-            qb.andWhereInIds(metadata.ensureEntityIdMap(idOrOptionsOrConditions));
-        }
-
-        return qb.getOne();
-    }
-
-    /**
-     * Clears all the data from the given table (truncates/drops it).
-     *
-     * Note: this method uses TRUNCATE and may not work as you expect in transactions on some platforms.
-     * @see https://stackoverflow.com/a/5972738/925151
-     */
-    async clear<Entity>(entityClass: ObjectType<Entity>|string): Promise<void> {
-        const metadata = this.connection.getMetadata(entityClass);
-        const queryRunner = this.queryRunner || this.connection.createQueryRunner("master");
-        try {
-            return await queryRunner.truncate(metadata.tablePath); // await is needed here because we are using finally
-
-        } finally {
-            if (!this.queryRunner)
-                await queryRunner.release();
-        }
-    }
-
-    /**
-     * Gets repository for the given entity class or name.
-     * If single database connection mode is used, then repository is obtained from the
-     * repository aggregator, where each repository is individually created for this entity manager.
-     * When single database connection is not used, repository is being obtained from the connection.
-     */
-    getRepository<Entity>(target: ObjectType<Entity>|string): Repository<Entity> {
-
-        // throw exception if there is no repository with this target registered
-        if (!this.connection.hasMetadata(target))
-            throw new RepositoryNotFoundError(this.connection.name, target);
-
-        // find already created repository instance and return it if found
-        const metadata = this.connection.getMetadata(target);
-        const repository = this.repositories.find(repository => repository.metadata === metadata);
-        if (repository)
-            return repository;
-
-        // if repository was not found then create it, store its instance and return it
-        const newRepository = new RepositoryFactory().create(this, metadata, this.queryRunner);
-        this.repositories.push(newRepository);
-        return newRepository;
-    }
-
-    /**
-     * Gets tree repository for the given entity class or name.
-     * If single database connection mode is used, then repository is obtained from the
-     * repository aggregator, where each repository is individually created for this entity manager.
-     * When single database connection is not used, repository is being obtained from the connection.
-     */
-    getTreeRepository<Entity>(target: ObjectType<Entity>|string): TreeRepository<Entity> {
-
-        // tree tables aren't supported by some drivers (mongodb)
-        if (this.connection.driver.treeSupport === false)
-            throw new TreeRepositoryNotSupportedError(this.connection.driver);
-
-        // check if repository is real tree repository
-        const repository = this.getRepository(target);
-        if (!(repository instanceof TreeRepository))
-            throw new RepositoryNotTreeError(target);
-
-        return repository;
-    }
-
-    /**
-     * Gets mongodb repository for the given entity class.
-     */
-    getMongoRepository<Entity>(target: string|ObjectType<Entity>): MongoRepository<Entity> {
-        return this.connection.getMongoRepository<Entity>(target);
-    }
-
-    /**
-     * Gets custom entity repository marked with @EntityRepository decorator.
-     */
-    getCustomRepository<T>(customRepository: ObjectType<T>): T {
-        const entityRepositoryMetadataArgs = getMetadataArgsStorage().entityRepositories.find(repository => {
-            return repository.target === (customRepository instanceof Function ? customRepository : (customRepository as any).constructor);
-        });
-        if (!entityRepositoryMetadataArgs)
-            throw new CustomRepositoryNotFoundError(customRepository);
-
-        const entityMetadata = entityRepositoryMetadataArgs.entity ? this.connection.getMetadata(entityRepositoryMetadataArgs.entity) : undefined;
-        const entityRepositoryInstance = new (entityRepositoryMetadataArgs.target as any)(this, entityMetadata);
-
-        // NOTE: dynamic access to protected properties. We need this to prevent unwanted properties in those classes to be exposed,
-        // however we need these properties for internal work of the class
-        if (entityRepositoryInstance instanceof AbstractRepository) {
-            if (!(entityRepositoryInstance as any)["manager"])
-                (entityRepositoryInstance as any)["manager"] = this;
-        }
-        if (entityRepositoryInstance instanceof Repository) {
-            if (!entityMetadata)
-                throw new CustomRepositoryCannotInheritRepositoryError(customRepository);
-
-            (entityRepositoryInstance as any)["manager"] = this;
-            (entityRepositoryInstance as any)["metadata"] = entityMetadata;
-        }
-
-        return entityRepositoryInstance;
-    }
-
-    /**
-     * Releases all resources used by entity manager.
-     * This is used when entity manager is created with a single query runner,
-     * and this single query runner needs to be released after job with entity manager is done.
-     */
-    async release(): Promise<void> {
-        if (!this.queryRunner)
-            throw new NoNeedToReleaseEntityManagerError();
-
-        return this.queryRunner.release();
-    }
-
-    // -------------------------------------------------------------------------
-    // Protected Methods
-    // -------------------------------------------------------------------------
-
-    /**
-     * Joins all eager relations recursively.
-     */
-    protected joinEagerRelations(qb: SelectQueryBuilder<any>, alias: string, metadata: EntityMetadata) {
-        metadata.eagerRelations.forEach(relation => {
-            const relationAlias = alias + "_" + relation.propertyPath.replace(".", "_");
-            qb.leftJoinAndSelect(alias + "." + relation.propertyPath, relationAlias);
-            this.joinEagerRelations(qb, relationAlias, relation.inverseEntityMetadata);
-        });
-    }
+    return entityRepositoryInstance;
+  }
+
+  /**
+   * Releases all resources used by entity manager.
+   * This is used when entity manager is created with a single query runner,
+   * and this single query runner needs to be released after job with entity manager is done.
+   */
+  async release(): Promise<void> {
+    if (!this.queryRunner)
+      throw new NoNeedToReleaseEntityManagerError();
+
+    return this.queryRunner.release();
+  }
+
+  // -------------------------------------------------------------------------
+  // Protected Methods
+  // -------------------------------------------------------------------------
+
+  /**
+   * Joins all eager relations recursively.
+   */
+  protected joinEagerRelations(qb: SelectQueryBuilder<any>, alias: string, metadata: EntityMetadata) {
+    metadata.eagerRelations.forEach(relation => {
+      const relationAlias = alias + "_" + relation.propertyPath.replace(".", "_");
+      qb.leftJoinAndSelect(alias + "." + relation.propertyPath, relationAlias);
+      this.joinEagerRelations(qb, relationAlias, relation.inverseEntityMetadata);
+    });
+  }
 
 }

--- a/src/entity-manager/EntityManager.ts
+++ b/src/entity-manager/EntityManager.ts
@@ -376,7 +376,7 @@ export class EntityManager {
   /**
    * Removes a given entity from the database.
    */
-  async removeNoTransaction<Entity>(entity: Entity[], options?: RemoveOptions): Promise<Entity>;
+  async removeNoTransaction<Entity>(entity: Entity[], options?: RemoveOptions): Promise<Entity[]>;
 
   /**
    * Removes a given entity from the database.

--- a/src/find-options/FindOptionsUtils.ts
+++ b/src/find-options/FindOptionsUtils.ts
@@ -1,153 +1,153 @@
-import {FindManyOptions} from "./FindManyOptions";
-import {FindOneOptions} from "./FindOneOptions";
-import {SelectQueryBuilder} from "../query-builder/SelectQueryBuilder";
-
+import { FindManyOptions } from "./FindManyOptions";
+import { FindOneOptions } from "./FindOneOptions";
+import { SelectQueryBuilder } from "../query-builder/SelectQueryBuilder";
+import { DeepPartial } from '../common/DeepPartial';
 /**
  * Utilities to work with FindOptions.
  */
 export class FindOptionsUtils {
 
-    /**
-     * Checks if given object is really instance of FindOneOptions interface.
-     */
-    static isFindOneOptions(obj: any): obj is FindOneOptions<any> {
-        const possibleOptions: FindOneOptions<any> = obj;
-        return possibleOptions &&
-                (
-                    possibleOptions.select instanceof Array ||
-                    possibleOptions.where instanceof Object ||
-                    possibleOptions.relations instanceof Array ||
-                    possibleOptions.join instanceof Object ||
-                    possibleOptions.order instanceof Object ||
-                    possibleOptions.cache instanceof Object ||
-                    typeof possibleOptions.cache === "boolean" ||
-                    typeof possibleOptions.cache === "number" ||
-                    possibleOptions.loadRelationIds instanceof Object ||
-                    typeof possibleOptions.loadRelationIds === "boolean"
-                );
+  /**
+   * Checks if given object is really instance of FindOneOptions interface.
+   */
+  static isFindOneOptions(obj: any): obj is FindOneOptions<any> {
+    const possibleOptions: FindOneOptions<any> = obj;
+    return possibleOptions &&
+      (
+        possibleOptions.select instanceof Array ||
+        possibleOptions.where instanceof Object ||
+        possibleOptions.relations instanceof Array ||
+        possibleOptions.join instanceof Object ||
+        possibleOptions.order instanceof Object ||
+        possibleOptions.cache instanceof Object ||
+        typeof possibleOptions.cache === "boolean" ||
+        typeof possibleOptions.cache === "number" ||
+        possibleOptions.loadRelationIds instanceof Object ||
+        typeof possibleOptions.loadRelationIds === "boolean"
+      );
+  }
+
+  /**
+   * Checks if given object is really instance of FindManyOptions interface.
+   */
+  static isFindManyOptions(obj: any): obj is FindManyOptions<any> {
+    const possibleOptions: FindManyOptions<any> = obj;
+    return possibleOptions && (
+      this.isFindOneOptions(possibleOptions) ||
+      typeof (possibleOptions as FindManyOptions<any>).skip === "number" ||
+      typeof (possibleOptions as FindManyOptions<any>).take === "number"
+    );
+  }
+
+  /**
+   * Checks if given object is really instance of FindOptions interface.
+   */
+  static extractFindManyOptionsAlias(object: any): string | undefined {
+    if (this.isFindManyOptions(object) && object.join)
+      return object.join.alias;
+
+    return undefined;
+  }
+
+  /**
+   * Applies give find many options to the given query builder.
+   */
+  static applyFindManyOptionsOrConditionsToQueryBuilder<T>(qb: SelectQueryBuilder<T>, options: FindManyOptions<T> | DeepPartial<T> | undefined): SelectQueryBuilder<T> {
+    if (this.isFindManyOptions(options))
+      return this.applyOptionsToQueryBuilder(qb, options);
+
+    if (options)
+      return qb.where(options);
+
+    return qb;
+  }
+
+  /**
+   * Applies give find options to the given query builder.
+   */
+  static applyOptionsToQueryBuilder<T>(qb: SelectQueryBuilder<T>, options: FindOneOptions<T> | FindManyOptions<T> | undefined): SelectQueryBuilder<T> {
+
+    // if options are not set then simply return query builder. This is made for simplicity of usage.
+    if (!options || (!this.isFindOneOptions(options) && !this.isFindManyOptions(options)))
+      return qb;
+
+    // apply all options from FindOptions
+    if (options.select) {
+      qb.select(options.select.map(selection => qb.alias + "." + selection));
     }
 
-    /**
-     * Checks if given object is really instance of FindManyOptions interface.
-     */
-    static isFindManyOptions(obj: any): obj is FindManyOptions<any> {
-        const possibleOptions: FindManyOptions<any> = obj;
-        return possibleOptions && (
-            this.isFindOneOptions(possibleOptions) ||
-            typeof (possibleOptions as FindManyOptions<any>).skip === "number" ||
-            typeof (possibleOptions as FindManyOptions<any>).take === "number"
-        );
-    }
+    if (options.where)
+      qb.where(options.where);
 
-    /**
-     * Checks if given object is really instance of FindOptions interface.
-     */
-    static extractFindManyOptionsAlias(object: any): string|undefined {
-        if (this.isFindManyOptions(object) && object.join)
-            return object.join.alias;
+    if ((options as FindManyOptions<T>).skip)
+      qb.skip((options as FindManyOptions<T>).skip!);
 
-        return undefined;
-    }
+    if ((options as FindManyOptions<T>).take)
+      qb.take((options as FindManyOptions<T>).take!);
 
-    /**
-     * Applies give find many options to the given query builder.
-     */
-    static applyFindManyOptionsOrConditionsToQueryBuilder<T>(qb: SelectQueryBuilder<T>, options: FindManyOptions<T>|Partial<T>|undefined): SelectQueryBuilder<T> {
-        if (this.isFindManyOptions(options))
-            return this.applyOptionsToQueryBuilder(qb, options);
-
-        if (options)
-            return qb.where(options);
-
-        return qb;
-    }
-
-    /**
-     * Applies give find options to the given query builder.
-     */
-    static applyOptionsToQueryBuilder<T>(qb: SelectQueryBuilder<T>, options: FindOneOptions<T>|FindManyOptions<T>|undefined): SelectQueryBuilder<T> {
-
-        // if options are not set then simply return query builder. This is made for simplicity of usage.
-        if (!options || (!this.isFindOneOptions(options) && !this.isFindManyOptions(options)))
-            return qb;
-
-        // apply all options from FindOptions
-        if (options.select) {
-            qb.select(options.select.map(selection => qb.alias + "." + selection));
+    if (options.order)
+      Object.keys(options.order).forEach(key => {
+        const order = ((options as FindOneOptions<T>).order as any)[key as any];
+        switch (order) {
+          case 1:
+            qb.addOrderBy(qb.alias + "." + key, "ASC");
+            break;
+          case -1:
+            qb.addOrderBy(qb.alias + "." + key, "DESC");
+            break;
+          case "ASC":
+            qb.addOrderBy(qb.alias + "." + key, "ASC");
+            break;
+          case "DESC":
+            qb.addOrderBy(qb.alias + "." + key, "DESC");
+            break;
         }
+      });
 
-        if (options.where)
-            qb.where(options.where);
+    if (options.relations)
+      options.relations.forEach(relation => {
+        qb.leftJoinAndSelect(qb.alias + "." + relation, relation);
+      });
 
-        if ((options as FindManyOptions<T>).skip)
-            qb.skip((options as FindManyOptions<T>).skip!);
+    if (options.join) {
+      if (options.join.leftJoin)
+        Object.keys(options.join.leftJoin).forEach(key => {
+          qb.leftJoin(options.join!.leftJoin![key], key);
+        });
 
-        if ((options as FindManyOptions<T>).take)
-            qb.take((options as FindManyOptions<T>).take!);
+      if (options.join.innerJoin)
+        Object.keys(options.join.innerJoin).forEach(key => {
+          qb.innerJoin(options.join!.innerJoin![key], key);
+        });
 
-        if (options.order)
-            Object.keys(options.order).forEach(key => {
-                const order = ((options as FindOneOptions<T>).order as any)[key as any];
-                switch (order) {
-                    case 1:
-                        qb.addOrderBy(qb.alias + "." + key, "ASC");
-                        break;
-                    case -1:
-                        qb.addOrderBy(qb.alias + "." + key, "DESC");
-                        break;
-                    case "ASC":
-                        qb.addOrderBy(qb.alias + "." + key, "ASC");
-                        break;
-                    case "DESC":
-                        qb.addOrderBy(qb.alias + "." + key, "DESC");
-                        break;
-                }
-            });
+      if (options.join.leftJoinAndSelect)
+        Object.keys(options.join.leftJoinAndSelect).forEach(key => {
+          qb.leftJoinAndSelect(options.join!.leftJoinAndSelect![key], key);
+        });
 
-        if (options.relations)
-            options.relations.forEach(relation => {
-                qb.leftJoinAndSelect(qb.alias + "." + relation, relation);
-            });
-
-        if (options.join) {
-            if (options.join.leftJoin)
-                Object.keys(options.join.leftJoin).forEach(key => {
-                    qb.leftJoin(options.join!.leftJoin![key], key);
-                });
-
-            if (options.join.innerJoin)
-                Object.keys(options.join.innerJoin).forEach(key => {
-                    qb.innerJoin(options.join!.innerJoin![key], key);
-                });
-
-            if (options.join.leftJoinAndSelect)
-                Object.keys(options.join.leftJoinAndSelect).forEach(key => {
-                    qb.leftJoinAndSelect(options.join!.leftJoinAndSelect![key], key);
-                });
-
-            if (options.join.innerJoinAndSelect)
-                Object.keys(options.join.innerJoinAndSelect).forEach(key => {
-                    qb.innerJoinAndSelect(options.join!.innerJoinAndSelect![key], key);
-                });
-        }
-
-        if (options.cache) {
-            if (options.cache instanceof Object) {
-                const cache = options.cache as { id: any, milliseconds: number };
-                qb.cache(cache.id, cache.milliseconds);
-            } else {
-                qb.cache(options.cache);
-            }
-        }
-
-        if (options.loadRelationIds === true) {
-            qb.loadAllRelationIds();
-
-        } else if (options.loadRelationIds instanceof Object) {
-            qb.loadAllRelationIds(options.loadRelationIds as any);
-        }
-
-        return qb;
+      if (options.join.innerJoinAndSelect)
+        Object.keys(options.join.innerJoinAndSelect).forEach(key => {
+          qb.innerJoinAndSelect(options.join!.innerJoinAndSelect![key], key);
+        });
     }
+
+    if (options.cache) {
+      if (options.cache instanceof Object) {
+        const cache = options.cache as { id: any, milliseconds: number };
+        qb.cache(cache.id, cache.milliseconds);
+      } else {
+        qb.cache(options.cache);
+      }
+    }
+
+    if (options.loadRelationIds === true) {
+      qb.loadAllRelationIds();
+
+    } else if (options.loadRelationIds instanceof Object) {
+      qb.loadAllRelationIds(options.loadRelationIds as any);
+    }
+
+    return qb;
+  }
 
 }

--- a/src/find-options/FindOptionsUtils.ts
+++ b/src/find-options/FindOptionsUtils.ts
@@ -1,7 +1,7 @@
 import { FindManyOptions } from "./FindManyOptions";
 import { FindOneOptions } from "./FindOneOptions";
 import { SelectQueryBuilder } from "../query-builder/SelectQueryBuilder";
-import { DeepPartial } from '../common/DeepPartial';
+import { DeepPartial } from "../common/DeepPartial";
 /**
  * Utilities to work with FindOptions.
  */

--- a/src/persistence/EntityPersistExecutor.ts
+++ b/src/persistence/EntityPersistExecutor.ts
@@ -165,7 +165,8 @@ export class EntityPersistExecutor {
         entity: entity,
         canBeInserted: this.mode === "save",
         canBeUpdated: this.mode === "save",
-        mustBeRemoved: this.mode === "remove"
+        mustBeRemoved: this.mode === "remove",
+        reloadEntity: (this.options || {}).reloadEntity
       }));
     });
 

--- a/src/persistence/Subject.ts
+++ b/src/persistence/Subject.ts
@@ -1,7 +1,7 @@
-import {ObjectLiteral} from "../common/ObjectLiteral";
-import {EntityMetadata} from "../metadata/EntityMetadata";
-import {SubjectChangeMap} from "./SubjectChangeMap";
-import {OrmUtils} from "../util/OrmUtils";
+import { ObjectLiteral } from "../common/ObjectLiteral";
+import { EntityMetadata } from "../metadata/EntityMetadata";
+import { SubjectChangeMap } from "./SubjectChangeMap";
+import { OrmUtils } from "../util/OrmUtils";
 
 /**
  * Subject is a subject of persistence.
@@ -15,193 +15,202 @@ import {OrmUtils} from "../util/OrmUtils";
  */
 export class Subject {
 
-    // -------------------------------------------------------------------------
-    // Properties
-    // -------------------------------------------------------------------------
+  // -------------------------------------------------------------------------
+  // Properties
+  // -------------------------------------------------------------------------
 
-    /**
-     * Entity metadata of the subject entity.
-     */
-    metadata: EntityMetadata;
+  /**
+   * Entity metadata of the subject entity.
+   */
+  metadata: EntityMetadata;
 
-    /**
-     * Subject identifier.
-     * This identifier is not limited to table entity primary columns.
-     * This can be entity id or ids as well as some unique entity properties, like name or title.
-     * Insert / Update / Remove operation will be executed by a given identifier.
-     */
-    identifier: ObjectLiteral|undefined = undefined;
+  /**
+   * Subject identifier.
+   * This identifier is not limited to table entity primary columns.
+   * This can be entity id or ids as well as some unique entity properties, like name or title.
+   * Insert / Update / Remove operation will be executed by a given identifier.
+   */
+  identifier: ObjectLiteral | undefined = undefined;
 
-    /**
-     * Gets entity sent to the persistence (e.g. changed entity).
-     * If entity is not set then this subject is created only for the entity loaded from the database,
-     * or this subject is used for the junction operation (junction operations are relying only on identifier).
-     */
-    entity?: ObjectLiteral;
+  /**
+   * Gets entity sent to the persistence (e.g. changed entity).
+   * If entity is not set then this subject is created only for the entity loaded from the database,
+   * or this subject is used for the junction operation (junction operations are relying only on identifier).
+   */
+  entity?: ObjectLiteral;
 
-    /**
-     * Database entity.
-     * THIS IS NOT RAW ENTITY DATA, its a real entity.
-     */
-    databaseEntity?: ObjectLiteral;
+  /**
+   * Database entity.
+   * THIS IS NOT RAW ENTITY DATA, its a real entity.
+   */
+  databaseEntity?: ObjectLiteral;
 
-    /**
-     * Changes needs to be applied in the database for the given subject.
-     */
-    changeMaps: SubjectChangeMap[] = [];
+  /**
+   * Changes needs to be applied in the database for the given subject.
+   */
+  changeMaps: SubjectChangeMap[] = [];
 
-    /**
-     * Generated values returned by a database (for example generated id or default values).
-     * Used in insert and update operations.
-     * Has entity-like structure (not just column database name and values).
-     */
-    generatedMap?: ObjectLiteral;
+  /**
+   * Generated values returned by a database (for example generated id or default values).
+   * Used in insert and update operations.
+   * Has entity-like structure (not just column database name and values).
+   */
+  generatedMap?: ObjectLiteral;
 
-    /**
-     * Inserted values with updated values of special and default columns.
-     * Has entity-like structure (not just column database name and values).
-     */
-    insertedValueSet?: ObjectLiteral;
+  /**
+   * Inserted values with updated values of special and default columns.
+   * Has entity-like structure (not just column database name and values).
+   */
+  insertedValueSet?: ObjectLiteral;
 
-    /**
-     * Indicates if this subject can be inserted into the database.
-     * This means that this subject either is newly persisted, either can be inserted by cascades.
-     */
-    canBeInserted: boolean = false;
+  /**
+   * Indicates if this subject can be inserted into the database.
+   * This means that this subject either is newly persisted, either can be inserted by cascades.
+   */
+  canBeInserted: boolean = false;
 
-    /**
-     * Indicates if this subject can be updated in the database.
-     * This means that this subject either was persisted, either can be updated by cascades.
-     */
-    canBeUpdated: boolean = false;
+  /**
+   * Indicates if this subject can be updated in the database.
+   * This means that this subject either was persisted, either can be updated by cascades.
+   */
+  canBeUpdated: boolean = false;
 
-    /**
-     * Indicates if this subject MUST be removed from the database.
-     * This means that this subject either was removed, either was removed by cascades.
-     */
-    mustBeRemoved: boolean = false;
+  /**
+   * Indicates if this subject MUST be removed from the database.
+   * This means that this subject either was removed, either was removed by cascades.
+   */
+  mustBeRemoved: boolean = false;
 
-    // -------------------------------------------------------------------------
-    // Constructor
-    // -------------------------------------------------------------------------
+  /**
+   *  Indicates if this subject should be reloaded when a persistence operation
+   * has been performed
+  */
+  reloadEntity: boolean = true;
 
-    constructor(options: {
-        metadata: EntityMetadata,
-        entity?: ObjectLiteral,
-        databaseEntity?: ObjectLiteral,
-        canBeInserted?: boolean,
-        canBeUpdated?: boolean,
-        mustBeRemoved?: boolean,
-        identifier?: ObjectLiteral,
-        changeMaps?: SubjectChangeMap[]
-    }) {
-        this.metadata = options.metadata;
-        this.entity = options.entity;
-        this.databaseEntity = options.databaseEntity;
-        if (options.canBeInserted !== undefined)
-            this.canBeInserted = options.canBeInserted;
-        if (options.canBeUpdated !== undefined)
-            this.canBeUpdated = options.canBeUpdated;
-        if (options.mustBeRemoved !== undefined)
-            this.mustBeRemoved = options.mustBeRemoved;
-        if (options.identifier !== undefined)
-            this.identifier = options.identifier;
-        if (options.changeMaps !== undefined)
-            this.changeMaps.push(...options.changeMaps);
+  // -------------------------------------------------------------------------
+  // Constructor
+  // -------------------------------------------------------------------------
 
-        if (this.entity) {
-            this.identifier = this.metadata.getEntityIdMap(this.entity);
+  constructor(options: {
+    metadata: EntityMetadata,
+    entity?: ObjectLiteral,
+    databaseEntity?: ObjectLiteral,
+    canBeInserted?: boolean,
+    canBeUpdated?: boolean,
+    mustBeRemoved?: boolean,
+    identifier?: ObjectLiteral,
+    changeMaps?: SubjectChangeMap[],
+    reloadEntity?: boolean
+  }) {
+    this.metadata = options.metadata;
+    this.entity = options.entity;
+    this.databaseEntity = options.databaseEntity;
+    if (options.canBeInserted !== undefined)
+      this.canBeInserted = options.canBeInserted;
+    if (options.canBeUpdated !== undefined)
+      this.canBeUpdated = options.canBeUpdated;
+    if (options.mustBeRemoved !== undefined)
+      this.mustBeRemoved = options.mustBeRemoved;
+    if (options.identifier !== undefined)
+      this.identifier = options.identifier;
+    if (options.changeMaps !== undefined)
+      this.changeMaps.push(...options.changeMaps);
+    if (options.reloadEntity !== undefined)
+      this.reloadEntity = options.reloadEntity;
 
-        } else if (this.databaseEntity) {
-            this.identifier = this.metadata.getEntityIdMap(this.databaseEntity);
-        }
+    if (this.entity) {
+      this.identifier = this.metadata.getEntityIdMap(this.entity);
+
+    } else if (this.databaseEntity) {
+      this.identifier = this.metadata.getEntityIdMap(this.databaseEntity);
     }
+  }
 
-    // -------------------------------------------------------------------------
-    // Accessors
-    // -------------------------------------------------------------------------
+  // -------------------------------------------------------------------------
+  // Accessors
+  // -------------------------------------------------------------------------
 
-    /**
-     * Checks if this subject must be inserted into the database.
-     * Subject can be inserted into the database if it is allowed to be inserted (explicitly persisted or by cascades)
-     * and if it does not have database entity set.
-     */
-    get mustBeInserted() {
-        return this.canBeInserted && !this.databaseEntity;
-    }
+  /**
+   * Checks if this subject must be inserted into the database.
+   * Subject can be inserted into the database if it is allowed to be inserted (explicitly persisted or by cascades)
+   * and if it does not have database entity set.
+   */
+  get mustBeInserted() {
+    return this.canBeInserted && !this.databaseEntity;
+  }
 
-    /**
-     * Checks if this subject must be updated into the database.
-     * Subject can be updated in the database if it is allowed to be updated (explicitly persisted or by cascades)
-     * and if it does have differentiated columns or relations.
-     */
-    get mustBeUpdated() {
-        return this.canBeUpdated && this.identifier && (this.changeMaps.length > 0 || !!this.metadata.objectIdColumn); // for mongodb we do not compute changes - we always update entity
-    }
+  /**
+   * Checks if this subject must be updated into the database.
+   * Subject can be updated in the database if it is allowed to be updated (explicitly persisted or by cascades)
+   * and if it does have differentiated columns or relations.
+   */
+  get mustBeUpdated() {
+    return this.canBeUpdated && this.identifier && (this.changeMaps.length > 0 || !!this.metadata.objectIdColumn); // for mongodb we do not compute changes - we always update entity
+  }
 
-    // -------------------------------------------------------------------------
-    // Public Methods
-    // -------------------------------------------------------------------------
+  // -------------------------------------------------------------------------
+  // Public Methods
+  // -------------------------------------------------------------------------
 
-    /**
-     * Creates a value set needs to be inserted / updated in the database.
-     * Value set is based on the entity and change maps of the subject.
-     * Important note: this method pops data from this subject's change maps.
-     */
-    createValueSetAndPopChangeMap(): ObjectLiteral {
-        const changeMapsWithoutValues: SubjectChangeMap[] = [];
-        const changeSet = this.changeMaps.reduce((updateMap, changeMap) => {
-            let value = changeMap.value;
-            if (value instanceof Subject) {
+  /**
+   * Creates a value set needs to be inserted / updated in the database.
+   * Value set is based on the entity and change maps of the subject.
+   * Important note: this method pops data from this subject's change maps.
+   */
+  createValueSetAndPopChangeMap(): ObjectLiteral {
+    const changeMapsWithoutValues: SubjectChangeMap[] = [];
+    const changeSet = this.changeMaps.reduce((updateMap, changeMap) => {
+      let value = changeMap.value;
+      if (value instanceof Subject) {
 
-                // referenced columns can refer on values both which were just inserted and which were present in the model
-                // if entity was just inserted valueSets must contain all values from the entity and values just inserted in the database
-                // so, here we check if we have a value set then we simply use it as value to get our reference column values
-                // otherwise simply use an entity which cannot be just inserted at the moment and have all necessary data
-                value = value.insertedValueSet ? value.insertedValueSet : value.entity;
-            }
-            // value = changeMap.valueFactory ? changeMap.valueFactory(value) : changeMap.column.createValueMap(value);
+        // referenced columns can refer on values both which were just inserted and which were present in the model
+        // if entity was just inserted valueSets must contain all values from the entity and values just inserted in the database
+        // so, here we check if we have a value set then we simply use it as value to get our reference column values
+        // otherwise simply use an entity which cannot be just inserted at the moment and have all necessary data
+        value = value.insertedValueSet ? value.insertedValueSet : value.entity;
+      }
+      // value = changeMap.valueFactory ? changeMap.valueFactory(value) : changeMap.column.createValueMap(value);
 
-            let valueMap: ObjectLiteral|undefined;
-            if (this.metadata.isJunction && changeMap.column) {
-                valueMap = changeMap.column.createValueMap(changeMap.column.referencedColumn!.getEntityValue(value));
+      let valueMap: ObjectLiteral | undefined;
+      if (this.metadata.isJunction && changeMap.column) {
+        valueMap = changeMap.column.createValueMap(changeMap.column.referencedColumn!.getEntityValue(value));
 
-            } else if (changeMap.column) {
-                valueMap = changeMap.column.createValueMap(value);
+      } else if (changeMap.column) {
+        valueMap = changeMap.column.createValueMap(value);
 
-            } else if (changeMap.relation) {
+      } else if (changeMap.relation) {
 
-                // value can be a related object, for example: post.question = { id: 1 }
-                // or value can be a null or direct relation id, e.g. post.question = 1
-                // if its a direction relation id then we just set it to the valueMap,
-                // however if its an object then we need to extract its relation id map and set it to the valueMap
-                if (value instanceof Object) {
+        // value can be a related object, for example: post.question = { id: 1 }
+        // or value can be a null or direct relation id, e.g. post.question = 1
+        // if its a direction relation id then we just set it to the valueMap,
+        // however if its an object then we need to extract its relation id map and set it to the valueMap
+        if (value instanceof Object) {
 
-                    // get relation id, e.g. referenced column name and its value,
-                    // for example: { id: 1 } which then will be set to relation, e.g. post.category = { id: 1 }
-                    const relationId = changeMap.relation!.getRelationIdMap(value);
+          // get relation id, e.g. referenced column name and its value,
+          // for example: { id: 1 } which then will be set to relation, e.g. post.category = { id: 1 }
+          const relationId = changeMap.relation!.getRelationIdMap(value);
 
-                    // but relation id can be empty, for example in the case when you insert a new post with category
-                    // and both post and category are newly inserted objects (by cascades) and in this case category will not have id
-                    // this means we need to insert post without question id and update post's questionId once question be inserted
-                    // that's why we create a new changeMap operation for future updation of the post entity
-                    if (relationId === undefined) {
-                        changeMapsWithoutValues.push(changeMap);
-                        this.canBeUpdated = true;
-                        return updateMap;
-                    }
-                    valueMap = changeMap.relation!.createValueMap(relationId);
-
-                } else { // value can be "null" or direct relation id here
-                    valueMap = changeMap.relation!.createValueMap(value);
-                }
-            }
-
-            OrmUtils.mergeDeep(updateMap, valueMap);
+          // but relation id can be empty, for example in the case when you insert a new post with category
+          // and both post and category are newly inserted objects (by cascades) and in this case category will not have id
+          // this means we need to insert post without question id and update post's questionId once question be inserted
+          // that's why we create a new changeMap operation for future updation of the post entity
+          if (relationId === undefined) {
+            changeMapsWithoutValues.push(changeMap);
+            this.canBeUpdated = true;
             return updateMap;
-        }, {} as ObjectLiteral);
-        this.changeMaps = changeMapsWithoutValues;
-        return changeSet;
-    }
+          }
+          valueMap = changeMap.relation!.createValueMap(relationId);
+
+        } else { // value can be "null" or direct relation id here
+          valueMap = changeMap.relation!.createValueMap(value);
+        }
+      }
+
+      OrmUtils.mergeDeep(updateMap, valueMap);
+      return updateMap;
+    }, {} as ObjectLiteral);
+    this.changeMaps = changeMapsWithoutValues;
+    return changeSet;
+  }
 
 }

--- a/src/persistence/SubjectExecutor.ts
+++ b/src/persistence/SubjectExecutor.ts
@@ -203,7 +203,7 @@ export class SubjectExecutor {
                     .insert()
                     .into(subjects[0].metadata.target)
                     .values(insertMaps)
-                    .updateEntity(true)
+                    .updateEntity(subjects[0].reloadEntity)
                     .callListeners(false)
                     .execute();
             }

--- a/src/repository/RemoveOptions.ts
+++ b/src/repository/RemoveOptions.ts
@@ -9,4 +9,9 @@ export interface RemoveOptions {
      */
     data?: any;
 
+    /**
+     * Flag to determine whether the entity that is being persisted
+     * should be reloaded during the persistence operation
+     */
+    reloadEntity?: boolean;
 }

--- a/src/repository/SaveOptions.ts
+++ b/src/repository/SaveOptions.ts
@@ -9,4 +9,9 @@ export interface SaveOptions {
      */
     data?: any;
 
+    /**
+     * Flag to determine whether the entity that is being persisted
+     * should be reloaded during the persistence operation
+     */
+    reloadEntity?: boolean;
 }


### PR DESCRIPTION
Hi Guys

Firstly, congratulations on typeOrm (coming from an enterprise java background, I appreciate the effort that has gone into putting this together).

The pull request covers some changes that enables the 'save' and 'remove' persistence operations to be performed without wrapping transactions so that the transaction scope can be managed outside of typeOrm (whilst still using the typeOrm interfaces into the underlying persistence store).

The need comes from a system that I am working on where the transaction model includes various application level guards, and transaction state is distributed across a bunch of underlying persistence stores.

I originally made the mods against 0.1.6.0 (happy to provide these to you if you would like) but thought that it would be better to redo them against the 0.2.0 branch given the amount of work you guys have done on the persistence layer.

For my sample tests, using 2000 double entity inserts I get a 50% performance increase in my use cases because where I am handling the transaction state out-of-line of the persistence operations.  Obviously this is very particular to my use case, however by allowing the 'save' and 'remove' operations to be (optionally) performed without a transaction wrapper (as per the low level 'insert', 'update', 'delete' etc. operations) I suspect others will get performance boosts.

One thing to note, at 0.2.0 the 'save' operation (on MySQL) there is an 'INSERT' operation and a 'SELECT' operation at 0.2.0, whilst at 0.1.6.0 there was only an 'INSERT' operation.  As a result the time for the 'save' operation nearly doubles (in my tests the average time for 2000 entity inserts was 4792ms at 0.1.6.0 which increases to 8301ms at 0.2.0).

Obviously you are doin this 'SELECT' operation for a good reason :)

Do you think it is possible to optionally overrode the 'SELECT' (which I assume is an entity reload) through a save option?  In may cases I imagine that the need for an entity reload is not required or, the reload has already been taken account of in client code.

I will have a look  to see if I can find the place where the reload occurs myself and propose a pull-request, but it could be something you might want to consider when you look at 0.2.0 or beyond.

Once again, thanks for all of the efforts on this.

Cheers
Stuart 