### PR TITLE
Allow mixed strings and classes in `entities` parameter

### DIFF
--- a/src/connection/BaseConnectionOptions.ts
+++ b/src/connection/BaseConnectionOptions.ts
@@ -25,7 +25,7 @@ export interface BaseConnectionOptions {
      * Accepts both entity classes and directories where from entities need to be loaded.
      * Directories support glob patterns.
      */
-    readonly entities?: Function[]|string[];
+    readonly entities?: (Function|string)[];
 
     /**
      * Subscribers to be loaded for this connection.

--- a/src/connection/ConnectionMetadataBuilder.ts
+++ b/src/connection/ConnectionMetadataBuilder.ts
@@ -29,7 +29,7 @@ export class ConnectionMetadataBuilder {
     /**
      * Builds migration instances for the given classes or directories.
      */
-    buildMigrations(migrations: Function[]|string[]): MigrationInterface[] {
+    buildMigrations(migrations: (Function|string)[]): MigrationInterface[] {
         const [migrationClasses, migrationDirectories] = OrmUtils.splitClassesAndStrings(migrations);
         const allMigrationClasses = [...migrationClasses, ...importClassesFromDirectories(migrationDirectories)];
         return allMigrationClasses.map(migrationClass => getFromContainer<MigrationInterface>(migrationClass));
@@ -38,7 +38,7 @@ export class ConnectionMetadataBuilder {
     /**
      * Builds subscriber instances for the given classes or directories.
      */
-    buildSubscribers(subscribers: Function[]|string[]): EntitySubscriberInterface<any>[] {
+    buildSubscribers(subscribers: (Function|string)[]): EntitySubscriberInterface<any>[] {
         const [subscriberClasses, subscriberDirectories] = OrmUtils.splitClassesAndStrings(subscribers || []);
         const allSubscriberClasses = [...subscriberClasses, ...importClassesFromDirectories(subscriberDirectories)];
         return getMetadataArgsStorage()

--- a/src/connection/ConnectionMetadataBuilder.ts
+++ b/src/connection/ConnectionMetadataBuilder.ts
@@ -49,7 +49,7 @@ export class ConnectionMetadataBuilder {
     /**
      * Builds entity metadatas for the given classes or directories.
      */
-    buildEntityMetadatas(entities: Function[]|string[], schemas: EntitySchema[]|string[]): EntityMetadata[] {
+    buildEntityMetadatas(entities: (Function|string)[], schemas: (EntitySchema|string)[]): EntityMetadata[] {
         const [entityClasses, entityDirectories] = OrmUtils.splitClassesAndStrings(entities || []);
         const allEntityClasses = [...entityClasses, ...importClassesFromDirectories(entityDirectories)];
         const decoratorEntityMetadatas = new EntityMetadataBuilder(this.connection, getMetadataArgsStorage()).build(allEntityClasses);

--- a/src/util/OrmUtils.ts
+++ b/src/util/OrmUtils.ts
@@ -11,10 +11,10 @@ export class OrmUtils {
         });
     }
 
-    static splitClassesAndStrings<T>(clsesAndStrings: T[]|string[]): [T[], string[]] {
+    static splitClassesAndStrings<T>(clsesAndStrings: (string|T)[]): [T[], string[]] {
         return [
-            (clsesAndStrings as T[]).filter(cls => typeof cls !== "string"),
-            (clsesAndStrings as string[]).filter(str => typeof str === "string"),
+            (clsesAndStrings).filter((cls): cls is T => typeof cls !== "string"),
+            (clsesAndStrings).filter((str): str is string => typeof str === "string"),
         ];
     }
 


### PR DESCRIPTION
The current implementation forbids mixing strings and objects in the `entities` parameter of a connection:
```typescript
createConnection({
    /* ... */
    entities:  [
        'path/to/entities',
        EntityClass
    ]
});
```
```
Type '(string | typeof EntityClass)[]' is not assignable to type 'string[] | Function[] | undefined'.
        Type '(string | typeof EntityClass)[]' is not assignable to type 'Function[]'.
          Type 'string | typeof EntityClass' is not assignable to type 'Function'.
            Type 'string' is not assignable to type 'Function'.
```
This PR changes the parameter type from `string[]|Function[]` to `(string|Function)[]` allowing the usage above.