### PR TITLE
Naming strategy joinTableColumnName has to know if it is called from the owning or owned (inverse) context

### DIFF
--- a/src/metadata-builder/JunctionEntityMetadataBuilder.ts
+++ b/src/metadata-builder/JunctionEntityMetadataBuilder.ts
@@ -54,7 +54,7 @@ export class JunctionEntityMetadataBuilder {
                 return (!joinColumnArgs.referencedColumnName || joinColumnArgs.referencedColumnName === referencedColumn.propertyName) &&
                     !!joinColumnArgs.name;
             }) : undefined;
-            const columnName = joinColumn && joinColumn.name ? joinColumn.name : this.connection.namingStrategy.joinTableColumnName(relation.entityMetadata.tableNameWithoutPrefix, referencedColumn.propertyName, referencedColumn.databaseName);
+            const columnName = joinColumn && joinColumn.name ? joinColumn.name : this.connection.namingStrategy.joinTableColumnName(relation.entityMetadata.tableNameWithoutPrefix, referencedColumn.propertyName, referencedColumn.databaseName, false);
 
             return new ColumnMetadata({
                 connection: this.connection,
@@ -81,7 +81,7 @@ export class JunctionEntityMetadataBuilder {
                 return (!joinColumnArgs.referencedColumnName || joinColumnArgs.referencedColumnName === inverseReferencedColumn.propertyName) &&
                     !!joinColumnArgs.name;
             }) : undefined;
-            const columnName = joinColumn && joinColumn.name ? joinColumn.name : this.connection.namingStrategy.joinTableColumnName(relation.inverseEntityMetadata.tableNameWithoutPrefix, inverseReferencedColumn.propertyName, inverseReferencedColumn.databaseName);
+            const columnName = joinColumn && joinColumn.name ? joinColumn.name : this.connection.namingStrategy.joinTableColumnName(relation.inverseEntityMetadata.tableNameWithoutPrefix, inverseReferencedColumn.propertyName, inverseReferencedColumn.databaseName, true);
 
             return new ColumnMetadata({
                 connection: this.connection,

--- a/src/metadata-builder/JunctionEntityMetadataBuilder.ts
+++ b/src/metadata-builder/JunctionEntityMetadataBuilder.ts
@@ -54,7 +54,8 @@ export class JunctionEntityMetadataBuilder {
                 return (!joinColumnArgs.referencedColumnName || joinColumnArgs.referencedColumnName === referencedColumn.propertyName) &&
                     !!joinColumnArgs.name;
             }) : undefined;
-            const columnName = joinColumn && joinColumn.name ? joinColumn.name : this.connection.namingStrategy.joinTableColumnName(relation.entityMetadata.tableNameWithoutPrefix, referencedColumn.propertyName, referencedColumn.databaseName, false);
+            const columnName = joinColumn && joinColumn.name ? joinColumn.name
+                : this.connection.namingStrategy.joinTableColumnName(relation.entityMetadata.tableNameWithoutPrefix, referencedColumn.propertyName, referencedColumn.databaseName);
 
             return new ColumnMetadata({
                 connection: this.connection,
@@ -81,7 +82,8 @@ export class JunctionEntityMetadataBuilder {
                 return (!joinColumnArgs.referencedColumnName || joinColumnArgs.referencedColumnName === inverseReferencedColumn.propertyName) &&
                     !!joinColumnArgs.name;
             }) : undefined;
-            const columnName = joinColumn && joinColumn.name ? joinColumn.name : this.connection.namingStrategy.joinTableColumnName(relation.inverseEntityMetadata.tableNameWithoutPrefix, inverseReferencedColumn.propertyName, inverseReferencedColumn.databaseName, true);
+            const columnName = joinColumn && joinColumn.name ? joinColumn.name
+                : this.connection.namingStrategy.joinTableInverseColumnName(relation.inverseEntityMetadata.tableNameWithoutPrefix, inverseReferencedColumn.propertyName, inverseReferencedColumn.databaseName);
 
             return new ColumnMetadata({
                 connection: this.connection,

--- a/src/naming-strategy/DefaultNamingStrategy.ts
+++ b/src/naming-strategy/DefaultNamingStrategy.ts
@@ -60,8 +60,12 @@ export class DefaultNamingStrategy implements NamingStrategyInterface {
         return columnName + "_" + index;
     }
 
-    joinTableColumnName(tableName: string, propertyName: string, columnName?: string, inverse?: boolean): string {
+    joinTableColumnName(tableName: string, propertyName: string, columnName?: string): string {
         return camelCase(tableName + "_" + (columnName ? columnName : propertyName));
+    }
+
+    joinTableInverseColumnName(tableName: string, propertyName: string, columnName?: string): string {
+        return this.joinTableColumnName(tableName, propertyName, columnName);
     }
 
     foreignKeyName(tableName: string, columnNames: string[], referencedTableName: string, referencedColumnNames: string[]): string {

--- a/src/naming-strategy/DefaultNamingStrategy.ts
+++ b/src/naming-strategy/DefaultNamingStrategy.ts
@@ -60,7 +60,7 @@ export class DefaultNamingStrategy implements NamingStrategyInterface {
         return columnName + "_" + index;
     }
 
-    joinTableColumnName(tableName: string, propertyName: string, columnName?: string): string {
+    joinTableColumnName(tableName: string, propertyName: string, columnName?: string, inverse?: boolean): string {
         return camelCase(tableName + "_" + (columnName ? columnName : propertyName));
     }
 

--- a/src/naming-strategy/NamingStrategyInterface.ts
+++ b/src/naming-strategy/NamingStrategyInterface.ts
@@ -60,8 +60,11 @@ export interface NamingStrategyInterface {
 
     /**
      * Gets the name of the column used for columns in the junction tables.
+     *
+     * The reverse?:boolean parameter denotes if the joinTableColumnName is called for the junctionColumn (false)
+     * or the inverseJunctionColumns (true)
      */
-    joinTableColumnName(tableName: string, propertyName: string, columnName?: string): string;
+    joinTableColumnName(tableName: string, propertyName: string, columnName?: string, inverse?: boolean): string;
 
     /**
      * Gets the name of the foreign key.

--- a/src/naming-strategy/NamingStrategyInterface.ts
+++ b/src/naming-strategy/NamingStrategyInterface.ts
@@ -64,7 +64,13 @@ export interface NamingStrategyInterface {
      * The reverse?:boolean parameter denotes if the joinTableColumnName is called for the junctionColumn (false)
      * or the inverseJunctionColumns (true)
      */
-    joinTableColumnName(tableName: string, propertyName: string, columnName?: string, inverse?: boolean): string;
+    joinTableColumnName(tableName: string, propertyName: string, columnName?: string): string;
+
+    /**
+     * Gets the name of the column used for columns in the junction tables from the invers side of the relationship.
+     *
+     */
+    joinTableInverseColumnName(tableName: string, propertyName: string, columnName?: string): string;
 
     /**
      * Gets the name of the foreign key.

--- a/test/github-issues/1282/entity/Animal.ts
+++ b/test/github-issues/1282/entity/Animal.ts
@@ -1,0 +1,19 @@
+import {Column, Entity, PrimaryGeneratedColumn} from "../../../../src/index";
+import {Category} from "./Category";
+import {JoinTable} from "../../../../src/decorator/relations/JoinTable";
+import {ManyToMany} from "../../../../src/decorator/relations/ManyToMany";
+
+@Entity()
+export class Animal {
+
+    @PrimaryGeneratedColumn()
+    id: number;
+
+    @Column()
+    name: string;
+
+    @ManyToMany(type => Category, {eager: true})
+    @JoinTable()
+    categories: Category[];
+
+}

--- a/test/github-issues/1282/entity/Category.ts
+++ b/test/github-issues/1282/entity/Category.ts
@@ -1,0 +1,9 @@
+import {Entity, PrimaryGeneratedColumn} from "../../../../src/index";
+
+@Entity()
+export class Category {
+
+    @PrimaryGeneratedColumn()
+    id: number;
+
+}

--- a/test/github-issues/1282/issue-1282.ts
+++ b/test/github-issues/1282/issue-1282.ts
@@ -25,14 +25,11 @@ describe("github issue > #1282 FEATURE REQUEST - Naming strategy joinTableColumn
 
         await connection.getRepository(Animal).find();
 
-        // joinTbelColumnName was called at least twice
-        expect(namingStrategy.calls.length).greaterThan(1);
+        // make sure both functions
+        expect(namingStrategy.calledJoinTableColumnName.length).greaterThan(0);
 
-        // the first call was with inverse=false - i.e. for the owning part of the relation
-        expect(namingStrategy.calls[0]).to.be.false;
+        expect(namingStrategy.calledJoinTableInverseColumnName.length).greaterThan(1);
 
-        // the second call was with invers=true - i.e. for the owned part of the relation
-        expect(namingStrategy.calls[1]).to.be.true;
 
     })));
 

--- a/test/github-issues/1282/issue-1282.ts
+++ b/test/github-issues/1282/issue-1282.ts
@@ -1,0 +1,39 @@
+import "reflect-metadata";
+import {expect} from "chai";
+import {closeTestingConnections, createTestingConnections, reloadTestingDatabases} from "../../utils/test-utils";
+import {Connection} from "../../../src/connection/Connection";
+import {Animal} from "./entity/Animal";
+import {NamingStrategyUnderTest} from "./naming/NamingStrategyUnderTest";
+
+
+describe("github issue > #1282 FEATURE REQUEST - Naming strategy joinTableColumnName if it is called from the owning or owned (inverse) context ", () => {
+
+    let connections: Connection[];
+    let namingStrategy = new NamingStrategyUnderTest();
+
+    before(async () => connections = await createTestingConnections({
+        entities: [__dirname + "/entity/*{.js,.ts}"],
+        namingStrategy
+    }));
+    beforeEach(() => {
+        return reloadTestingDatabases(connections);
+    });
+    after(() => closeTestingConnections(connections));
+
+
+    it("NamingStrategyUnderTest#", () => Promise.all(connections.map(async connection => {
+
+        await connection.getRepository(Animal).find();
+
+        // joinTbelColumnName was called at least twice
+        expect(namingStrategy.calls.length).greaterThan(1);
+
+        // the first call was with inverse=false - i.e. for the owning part of the relation
+        expect(namingStrategy.calls[0]).to.be.false;
+
+        // the second call was with invers=true - i.e. for the owned part of the relation
+        expect(namingStrategy.calls[1]).to.be.true;
+
+    })));
+
+});

--- a/test/github-issues/1282/issue-1282.ts
+++ b/test/github-issues/1282/issue-1282.ts
@@ -4,6 +4,7 @@ import {closeTestingConnections, createTestingConnections, reloadTestingDatabase
 import {Connection} from "../../../src/connection/Connection";
 import {Animal} from "./entity/Animal";
 import {NamingStrategyUnderTest} from "./naming/NamingStrategyUnderTest";
+import {ColumnMetadata} from "../../../src/metadata/ColumnMetadata";
 
 
 describe("github issue > #1282 FEATURE REQUEST - Naming strategy joinTableColumnName if it is called from the owning or owned (inverse) context ", () => {
@@ -25,11 +26,20 @@ describe("github issue > #1282 FEATURE REQUEST - Naming strategy joinTableColumn
 
         await connection.getRepository(Animal).find();
 
-        // make sure both functions
-        expect(namingStrategy.calledJoinTableColumnName.length).greaterThan(0);
+        let metadata = connection.getManyToManyMetadata(Animal, "categories");
 
-        expect(namingStrategy.calledJoinTableInverseColumnName.length).greaterThan(1);
+        let columns:  ColumnMetadata[];
+        if (metadata !== undefined) {
+            columns = metadata.columns;
+        } else {
+            columns = [];
+        }
 
+        expect(columns.find((column: ColumnMetadata) => column.databaseName === "animalIdForward"))
+            .not.to.be.undefined;
+
+        expect(columns.find((column: ColumnMetadata) => column.databaseName === "categoryIdInverse"))
+            .not.to.be.undefined;
 
     })));
 

--- a/test/github-issues/1282/naming/NamingStrategyUnderTest.ts
+++ b/test/github-issues/1282/naming/NamingStrategyUnderTest.ts
@@ -3,10 +3,17 @@ import { NamingStrategyInterface } from "../../../../src/naming-strategy/NamingS
 
 export class NamingStrategyUnderTest extends DefaultNamingStrategy implements NamingStrategyInterface {
 
-    calls: boolean[] = [];
+    calledJoinTableColumnName: boolean[] = [];
 
-    joinTableColumnName(tableName: string, propertyName: string, columnName?: string, inverse = false): string {
-        this.calls.push(inverse);
-        return super.joinTableColumnName(tableName, propertyName, columnName, inverse);
+    calledJoinTableInverseColumnName: boolean[] = [];
+
+    joinTableColumnName(tableName: string, propertyName: string, columnName?: string): string {
+        this.calledJoinTableColumnName.push(true);
+        return super.joinTableColumnName(tableName, propertyName, columnName);
+    }
+
+    joinTableInverseColumnName(tableName: string, propertyName: string, columnName?: string): string {
+        this.calledJoinTableInverseColumnName.push(true);
+        return super.joinTableInverseColumnName(tableName, propertyName, columnName);
     }
 }

--- a/test/github-issues/1282/naming/NamingStrategyUnderTest.ts
+++ b/test/github-issues/1282/naming/NamingStrategyUnderTest.ts
@@ -1,5 +1,6 @@
 import { DefaultNamingStrategy } from "../../../../src/naming-strategy/DefaultNamingStrategy";
 import { NamingStrategyInterface } from "../../../../src/naming-strategy/NamingStrategyInterface";
+import {camelCase} from "../../../../src/util/StringUtils";
 
 export class NamingStrategyUnderTest extends DefaultNamingStrategy implements NamingStrategyInterface {
 
@@ -9,11 +10,11 @@ export class NamingStrategyUnderTest extends DefaultNamingStrategy implements Na
 
     joinTableColumnName(tableName: string, propertyName: string, columnName?: string): string {
         this.calledJoinTableColumnName.push(true);
-        return super.joinTableColumnName(tableName, propertyName, columnName);
+        return camelCase(tableName + "_" + (columnName ? columnName : propertyName) + "_forward");
     }
 
     joinTableInverseColumnName(tableName: string, propertyName: string, columnName?: string): string {
         this.calledJoinTableInverseColumnName.push(true);
-        return super.joinTableInverseColumnName(tableName, propertyName, columnName);
+        return camelCase(tableName + "_" + (columnName ? columnName : propertyName) + "_inverse");
     }
 }

--- a/test/github-issues/1282/naming/NamingStrategyUnderTest.ts
+++ b/test/github-issues/1282/naming/NamingStrategyUnderTest.ts
@@ -1,0 +1,12 @@
+import { DefaultNamingStrategy } from "../../../../src/naming-strategy/DefaultNamingStrategy";
+import { NamingStrategyInterface } from "../../../../src/naming-strategy/NamingStrategyInterface";
+
+export class NamingStrategyUnderTest extends DefaultNamingStrategy implements NamingStrategyInterface {
+
+    calls: boolean[] = [];
+
+    joinTableColumnName(tableName: string, propertyName: string, columnName?: string, inverse = false): string {
+        this.calls.push(inverse);
+        return super.joinTableColumnName(tableName, propertyName, columnName, inverse);
+    }
+}

--- a/test/utils/test-utils.ts
+++ b/test/utils/test-utils.ts
@@ -3,6 +3,7 @@ import {createConnection, createConnections} from "../../src/index";
 import {Connection} from "../../src/connection/Connection";
 import {EntitySchema} from "../../src/entity-schema/EntitySchema";
 import {DatabaseType} from "../../src/driver/types/DatabaseType";
+import {NamingStrategyInterface} from "../../src/naming-strategy/NamingStrategyInterface";
 
 /**
  * Interface in which data is stored in ormconfig.json of the project.
@@ -68,6 +69,12 @@ export interface TestingOptions {
     schema?: string;
 
     /**
+     * Naming strategy defines how auto-generated names for such things like table name, or table column gonna be
+     * generated.
+     */
+    namingStrategy?: NamingStrategyInterface;
+
+    /**
      * Schema name used for postgres driver.
      */
     cache?: boolean|{
@@ -117,7 +124,8 @@ export function setupSingleTestingConnection(driverType: DatabaseType, options: 
         schemaCreate: options.schemaCreate ? options.schemaCreate : false,
         enabledDrivers: [driverType],
         cache: options.cache,
-        schema: options.schema ? options.schema : undefined
+        schema: options.schema ? options.schema : undefined,
+        namingStrategy: options.namingStrategy ? options.namingStrategy : undefined
     });
     if (!testingConnections.length)
         throw new Error(`Unable to run tests because connection options for "${driverType}" are not set.`);
@@ -182,6 +190,8 @@ export function setupTestingConnections(options?: TestingOptions): ConnectionOpt
                 newOptions.synchronize = options.schemaCreate;
             if (options && options.schema)
                 newOptions.schema = options.schema;
+            if (options && options.namingStrategy)
+                newOptions.namingStrategy = options.namingStrategy;
             return newOptions;
         });
 }


### PR DESCRIPTION
PR for feature request https://github.com/typeorm/typeorm/issues/1282

Including simple tests.