### PR TITLE
New DebugLogger

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ however since API is already quite stable we don't expect too much breaking chan
 If we missed a note on some change or you have a questions on migrating from old version, 
 feel free to ask us and community.
 
+## 0.1.8
+* New DebugLogger ([#1302](https://github.com/typeorm/typeorm/issues/1302))
+
 ## 0.1.7
 
 * fixed bug with migrations execution in mssql ([#1254](https://github.com/typeorm/typeorm/issues/1254))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ If we missed a note on some change or you have a questions on migrating from old
 feel free to ask us and community.
 
 ## 0.1.8
-* New DebugLogger ([#1302](https://github.com/typeorm/typeorm/issues/1302))
+* New DebugLogger ([#1302](https://github.com/typeorm/typeorm/pull/1302))
 
 ## 0.1.7
 

--- a/docs/logging.md
+++ b/docs/logging.md
@@ -83,13 +83,14 @@ This code will log all queries which run more then `1 second`.
 
 ## Changing default logger
 
-TypeORM ships with 3 different types of logger:
+TypeORM ships with 4 different types of logger:
 
 * `advanced-console` - this is default which logs all messages onto the console using color 
 and sql syntax highlighting (using [chalk](https://github.com/chalk/chalk))
 * `simple-console` - this is a simple console logger which is exactly the same as the advanced logger, but it does not use any color highlighting.
 This logger can be used if you have problems / or don't like colorized logs
 * `file` - this logger writes all logs into `ormlogs.log` in the root folder of your project (near `package.json` and `ormconfig.json`)
+* `debug` - this logger uses [debug package](https://github.com/visionmedia/debug), to turn on logging set env variable `DEBUG=typeorm:*` (note logging option has no effect on this logger)
 
 You can enable any of them in connection options:
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -56,6 +56,12 @@
         "@types/chai": "4.0.4"
       }
     },
+    "@types/debug": {
+      "version": "0.0.30",
+      "resolved": "https://registry.npmjs.org/@types/debug/-/debug-0.0.30.tgz",
+      "integrity": "sha512-orGL5LXERPYsLov6CWs3Fh6203+dXzJkR7OnddIr2514Hsecwc8xRpzCapshBbKFImCsvS/mk6+FWiN5LyZJAQ==",
+      "dev": true
+    },
     "@types/glob": {
       "version": "5.0.33",
       "resolved": "https://registry.npmjs.org/@types/glob/-/glob-5.0.33.tgz",
@@ -696,10 +702,9 @@
       "dev": true
     },
     "debug": {
-      "version": "2.6.8",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.8.tgz",
-      "integrity": "sha1-5zFTHKLt4n0YgiJCfaF4IdaP9Pw=",
-      "dev": true,
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
+      "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
       "requires": {
         "ms": "2.0.0"
       }
@@ -1862,6 +1867,17 @@
             "lodash.create": "3.1.1",
             "mkdirp": "0.5.1",
             "supports-color": "3.1.2"
+          },
+          "dependencies": {
+            "debug": {
+              "version": "2.6.8",
+              "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.8.tgz",
+              "integrity": "sha1-5zFTHKLt4n0YgiJCfaF4IdaP9Pw=",
+              "dev": true,
+              "requires": {
+                "ms": "2.0.0"
+              }
+            }
           }
         },
         "supports-color": {
@@ -3653,8 +3669,7 @@
     "ms": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-      "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
-      "dev": true
+      "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
     },
     "mssql": {
       "version": "4.0.4",
@@ -3662,9 +3677,20 @@
       "integrity": "sha1-QW1n33ZTU2y2OElRiR+hpHVypJs=",
       "dev": true,
       "requires": {
-        "debug": "2.6.8",
+        "debug": "2.6.9",
         "generic-pool": "3.1.7",
         "tedious": "2.0.0"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "2.6.9",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+          "dev": true,
+          "requires": {
+            "ms": "2.0.0"
+          }
+        }
       }
     },
     "multipipe": {

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
   "devDependencies": {
     "@types/chai": "^4.0.4",
     "@types/chai-as-promised": "7.1.0",
+    "@types/debug": "0.0.30",
     "@types/mocha": "^2.2.42",
     "@types/node": "^8.0.41",
     "@types/rimraf": "^2.0.2",
@@ -79,6 +80,7 @@
     "app-root-path": "^2.0.1",
     "chalk": "^2.0.1",
     "cli-highlight": "^1.1.4",
+    "debug": "^3.1.0",
     "dotenv": "^4.0.0",
     "glob": "^7.1.2",
     "js-yaml": "^3.8.4",

--- a/src/connection/BaseConnectionOptions.ts
+++ b/src/connection/BaseConnectionOptions.ts
@@ -61,7 +61,7 @@ export interface BaseConnectionOptions {
     /**
      * Logger instance used to log queries and events in the ORM.
      */
-    readonly logger?: "advanced-console"|"simple-console"|"file"|Logger;
+    readonly logger?: "advanced-console"|"simple-console"|"file"|"debug"|Logger;
 
     /**
      * Maximum number of milliseconds query should be executed before logger log a warning.

--- a/src/logger/DebugLogger.ts
+++ b/src/logger/DebugLogger.ts
@@ -17,10 +17,6 @@ export class DebugLogger implements Logger {
     private debugInfo = debug("typeorm:info");
     private debugWarn = debug("typeorm:warn");
     
-    constructor() {
-        
-    }
-    
     /**
      * Logs query and parameters used in it.
      */

--- a/src/logger/DebugLogger.ts
+++ b/src/logger/DebugLogger.ts
@@ -1,6 +1,6 @@
-import { Logger } from "./Logger";
-import { QueryRunner } from "../";
-import { PlatformTools } from "../platform/PlatformTools";
+import {Logger} from "./Logger";
+import {QueryRunner} from "../";
+import {PlatformTools} from "../platform/PlatformTools";
 
 const debug = PlatformTools.load("debug");
 

--- a/src/logger/DebugLogger.ts
+++ b/src/logger/DebugLogger.ts
@@ -1,7 +1,8 @@
-import * as debug from "debug";
 import { Logger } from "./Logger";
 import { QueryRunner } from "../";
 import { PlatformTools } from "../platform/PlatformTools";
+
+const debug = PlatformTools.load("debug");
 
 /**
  * Performs logging of the events in TypeORM via debug library.

--- a/src/logger/DebugLogger.ts
+++ b/src/logger/DebugLogger.ts
@@ -26,7 +26,7 @@ export class DebugLogger implements Logger {
      */
     logQuery(query: string, parameters?: any[], queryRunner?: QueryRunner) {
         if (this.debugQuery.enabled) {
-            this.debugQuery(PlatformTools.highlightSql(query));
+            this.debugQuery(PlatformTools.highlightSql(query) + ";");
             if (parameters && parameters.length) {
                 this.debugQuery("parameters:", parameters);
             }
@@ -38,7 +38,7 @@ export class DebugLogger implements Logger {
      */
     logQueryError(error: string, query: string, parameters?: any[], queryRunner?: QueryRunner) {
         if (this.debugQueryError.enabled) {
-            this.debugQueryError(PlatformTools.highlightSql(query));
+            this.debugQueryError(PlatformTools.highlightSql(query) + ";");
             if (parameters && parameters.length) {
                 this.debugQueryError("parameters:", parameters);
             }
@@ -51,7 +51,7 @@ export class DebugLogger implements Logger {
      */
     logQuerySlow(time: number, query: string, parameters?: any[], queryRunner?: QueryRunner) {
         if (this.debugQuerySlow.enabled) {
-            this.debugQuerySlow(PlatformTools.highlightSql(query));
+            this.debugQuerySlow(PlatformTools.highlightSql(query) + ";");
             if (parameters && parameters.length) {
                 this.debugQuerySlow("parameters:", parameters);
             }

--- a/src/logger/DebugLogger.ts
+++ b/src/logger/DebugLogger.ts
@@ -1,0 +1,103 @@
+import * as debug from "debug";
+import { Logger } from "./Logger";
+import { QueryRunner } from "../";
+import { PlatformTools } from "../platform/PlatformTools";
+
+/**
+ * Performs logging of the events in TypeORM via debug library.
+ */
+export class DebugLogger implements Logger {
+    private debugQuery = debug("typeorm:query");
+    private debugQueryError = debug("typeorm:queryError");
+    private debugQuerySlow = debug("typeorm:querySlow");
+    private debugSchemaBuild = debug("typeorm:schemaBuild");
+    private debugMigration = debug("typeorm:migration");
+    
+    private debugLog = debug("typeorm:log");
+    private debugInfo = debug("typeorm:info");
+    private debugWarn = debug("typeorm:warn");
+    
+    constructor() {
+        
+    }
+    
+    /**
+     * Logs query and parameters used in it.
+     */
+    logQuery(query: string, parameters?: any[], queryRunner?: QueryRunner) {
+        if (this.debugQuery.enabled) {
+            this.debugQuery(PlatformTools.highlightSql(query));
+            if (parameters && parameters.length) {
+                this.debugQuery("parameters:", parameters);
+            }
+        }
+    }
+    
+    /**
+     * Logs query that failed.
+     */
+    logQueryError(error: string, query: string, parameters?: any[], queryRunner?: QueryRunner) {
+        if (this.debugQueryError.enabled) {
+            this.debugQueryError(PlatformTools.highlightSql(query));
+            if (parameters && parameters.length) {
+                this.debugQueryError("parameters:", parameters);
+            }
+            this.debugQueryError("error: ", error);
+        }
+    }
+    
+    /**
+     * Logs query that is slow.
+     */
+    logQuerySlow(time: number, query: string, parameters?: any[], queryRunner?: QueryRunner) {
+        if (this.debugQuerySlow.enabled) {
+            this.debugQuerySlow(PlatformTools.highlightSql(query));
+            if (parameters && parameters.length) {
+                this.debugQuerySlow("parameters:", parameters);
+            }
+            this.debugQuerySlow("execution time:", time);
+        }
+    }
+    
+    /**
+     * Logs events from the schema build process.
+     */
+    logSchemaBuild(message: string, queryRunner?: QueryRunner) {
+        if (this.debugSchemaBuild.enabled) {
+            this.debugSchemaBuild(message);
+        }
+    }
+    
+    /**
+     * Logs events from the migration run process.
+     */
+    logMigration(message: string, queryRunner?: QueryRunner) {
+        if (this.debugMigration.enabled) {
+            this.debugMigration(message);
+        }
+    }
+    
+    /**
+     * Perform logging using given logger.
+     * Log has its own level and message.
+     */
+    log(level: "log" | "info" | "warn", message: any, queryRunner?: QueryRunner) {
+        switch (level) {
+            case "log":
+                if (this.debugLog.enabled) {
+                    this.debugLog(message);
+                }
+                break;
+            case "info":
+                if (this.debugInfo.enabled) {
+                    this.debugInfo(message);
+                }
+                break;
+            case "warn":
+                if (this.debugWarn.enabled) {
+                    this.debugWarn(message);
+                }
+                break;
+        }
+    }
+}

--- a/src/logger/DebugLogger.ts
+++ b/src/logger/DebugLogger.ts
@@ -8,10 +8,10 @@ const debug = PlatformTools.load("debug");
  * Performs logging of the events in TypeORM via debug library.
  */
 export class DebugLogger implements Logger {
-    private debugQuery = debug("typeorm:query");
-    private debugQueryError = debug("typeorm:queryError");
-    private debugQuerySlow = debug("typeorm:querySlow");
-    private debugSchemaBuild = debug("typeorm:schemaBuild");
+    private debugQueryLog = debug("typeorm:query:log");
+    private debugQueryError = debug("typeorm:query:error");
+    private debugQuerySlow = debug("typeorm:query:slow");
+    private debugSchemaBuild = debug("typeorm:schema");
     private debugMigration = debug("typeorm:migration");
     
     private debugLog = debug("typeorm:log");
@@ -22,10 +22,10 @@ export class DebugLogger implements Logger {
      * Logs query and parameters used in it.
      */
     logQuery(query: string, parameters?: any[], queryRunner?: QueryRunner) {
-        if (this.debugQuery.enabled) {
-            this.debugQuery(PlatformTools.highlightSql(query) + ";");
+        if (this.debugQueryLog.enabled) {
+            this.debugQueryLog(PlatformTools.highlightSql(query) + ";");
             if (parameters && parameters.length) {
-                this.debugQuery("parameters:", parameters);
+                this.debugQueryLog("parameters:", parameters);
             }
         }
     }

--- a/src/logger/LoggerFactory.ts
+++ b/src/logger/LoggerFactory.ts
@@ -3,7 +3,7 @@ import {LoggerOptions} from "./LoggerOptions";
 import {SimpleConsoleLogger} from "./SimpleConsoleLogger";
 import {AdvancedConsoleLogger} from "./AdvancedConsoleLogger";
 import {FileLogger} from "./FileLogger";
-import { DebugLogger } from "./DebugLogger";
+import {DebugLogger} from "./DebugLogger";
 
 /**
  * Helps to create logger instances.

--- a/src/logger/LoggerFactory.ts
+++ b/src/logger/LoggerFactory.ts
@@ -3,6 +3,7 @@ import {LoggerOptions} from "./LoggerOptions";
 import {SimpleConsoleLogger} from "./SimpleConsoleLogger";
 import {AdvancedConsoleLogger} from "./AdvancedConsoleLogger";
 import {FileLogger} from "./FileLogger";
+import { DebugLogger } from "./DebugLogger";
 
 /**
  * Helps to create logger instances.
@@ -12,7 +13,7 @@ export class LoggerFactory {
     /**
      * Creates a new logger depend on a given connection's driver.
      */
-    create(logger?: "advanced-console"|"simple-console"|"file"|Logger, options?: LoggerOptions): Logger {
+    create(logger?: "advanced-console"|"simple-console"|"file"|"debug"|Logger, options?: LoggerOptions): Logger {
         if (logger instanceof Object)
             return logger as Logger;
 
@@ -26,6 +27,9 @@ export class LoggerFactory {
 
                 case "advanced-console":
                     return new AdvancedConsoleLogger(options);
+
+                case "debug":
+                    return new DebugLogger();
             }
         }
 

--- a/src/platform/PlatformTools.ts
+++ b/src/platform/PlatformTools.ts
@@ -100,6 +100,9 @@ export class PlatformTools {
                 case "path":
                     return require("path");
 
+                case "debug":
+                    return require("debug");
+
                 /**
                 *default
                 */


### PR DESCRIPTION
## Motivation
<a href="https://github.com/visionmedia/debug">The debug package</a> is the <a href="https://www.npmjs.com/browse/depended">9th most dependent package</a>, it's used by  express, koa, yeoman, babel, mocha, socket.io, eslint, morgan and <a href="https://www.npmjs.com/browse/depended/debug">more</a>. It works in both node.js and browser.
https://github.com/typeorm/typeorm/pull/634 https://github.com/typeorm/typeorm/issues/633

## What's new
- `ConnectOptions.logger` has new value `"debug"`
- New debug namespaces introduced:
```
typeorm:query
typeorm:queryError
typeorm:querySlow
typeorm:schemaBuild
typeorm:migration
typeorm:log
typeorm:info
typeorm:warn
```

## Drawbacks
- Debug dependency (debug itself has only one dependency, module ms)
- `ConnectOptions.logging?: LoggerOptions` is no longer used.
You need set env variable `DEBUG=typeorm:*` or call `debug.enable('typeorm:*');` in order to set log level.

## Benefits
- TypeORM log fits nicely next to others.
- You can start debugging every aspect of application by setting `DEBUG=*` and `logger: "debug"`.

## Example
Here's rest api example, I got a get request and then it reports which query TypeORM executed.

<img alt="api" src="https://user-images.githubusercontent.com/2387356/33611789-e7b2a280-d9cf-11e7-863a-ecb41d2f34e0.png">

## Discussion
- Use it as default logger and deprecate `logging` option and control everything via debug lib. That's basically how express does logging.
- Documentation changes
