### PR TITLE
sql.js: enable foreign keys and change tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ feel free to ask us and community.
 
 ## 0.1.10
 
-* `sqljs` driver now enforces FK integrity by default (same behavior as `sqlite`
+* `sqljs` driver now enforces FK integrity by default (same behavior as `sqlite`)
 
 ## 0.1.9
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ however since API is already quite stable we don't expect too much breaking chan
 If we missed a note on some change or you have a questions on migrating from old version, 
 feel free to ask us and community.
 
+## 0.1.10
+
+* `sqljs` driver now enforces FK integrity by default (same behavior as `sqlite`
+
 ## 0.1.9
 
 * fixed bug with sqlite and mysql schema synchronization when uuid column is used ([#1332](https://github.com/typeorm/typeorm/issues/1332))

--- a/src/driver/sqljs/SqljsDriver.ts
+++ b/src/driver/sqljs/SqljsDriver.ts
@@ -182,7 +182,16 @@ export class SqljsDriver extends AbstractSqliteDriver {
             this.databaseConnection = new this.sqlite.Database();
         }
 
-        return Promise.resolve(this.databaseConnection);
+        // Enable foreign keys for database
+        return new Promise<any>((ok, fail) => {
+            try {
+                this.databaseConnection.exec(`PRAGMA foreign_keys = ON;`);
+                ok(this.databaseConnection);
+            }
+            catch (e) {
+                fail(e);
+            }
+        });
     }
 
     /**

--- a/test/functional/sqljs/auto-save.ts
+++ b/test/functional/sqljs/auto-save.ts
@@ -1,7 +1,7 @@
 import "reflect-metadata";
 import {expect} from "chai";
-import {createConnection} from "../../../src/index";
 import {Post} from "./entity/Post";
+import {createTestingConnections} from "../../utils/test-utils";
 
 describe("sqljs driver > autosave", () => {
     it("should call autoSaveCallback on insert, update and delete", async () => {
@@ -10,13 +10,17 @@ describe("sqljs driver > autosave", () => {
             saves++;
         };
 
-        let connection = await createConnection({
-            type: "sqljs",
+        let connections = await createTestingConnections({
+            enabledDrivers: ["sqljs"],
             entities: [Post],
-            synchronize: true,
-            autoSaveCallback: callback,
-            autoSave: true
+            schemaCreate: true,
+            driverSpecific: {
+                autoSaveCallback: callback,
+                autoSave: true
+            }
         });
+
+        const connection = connections[0];
 
         let posts = [
             {
@@ -56,14 +60,18 @@ describe("sqljs driver > autosave", () => {
         const callback = (database: Uint8Array) => {
             saves++;
         };
-
-        let connection = await createConnection({
-            type: "sqljs",
+        
+        let connections = await createTestingConnections({
+            enabledDrivers: ["sqljs"],
             entities: [Post],
-            synchronize: true,
-            autoSaveCallback: callback,
-            autoSave: false
+            schemaCreate: true,
+            driverSpecific: {
+                autoSaveCallback: callback,
+                autoSave: false
+            }
         });
+
+        let connection = connections[0];
         
         const repository = connection.getRepository(Post);
         let post = new Post();

--- a/test/utils/test-utils.ts
+++ b/test/utils/test-utils.ts
@@ -107,6 +107,11 @@ export interface TestingOptions {
 
     };
 
+    /**
+     * Options that may be specific to a driver.
+     * They are passed down to the enabled drivers.
+     */
+    driverSpecific?: Object;
 }
 
 /**
@@ -178,7 +183,7 @@ export function setupTestingConnections(options?: TestingOptions): ConnectionOpt
             return true;
         })
         .map(connectionOptions => {
-            const newOptions: any = Object.assign({}, connectionOptions as ConnectionOptions, {
+            let newOptions: any = Object.assign({}, connectionOptions as ConnectionOptions, {
                 name: options && options.name ? options.name : connectionOptions.name,
                 entities: options && options.entities ? options.entities : [],
                 subscribers: options && options.subscribers ? options.subscribers : [],
@@ -186,6 +191,8 @@ export function setupTestingConnections(options?: TestingOptions): ConnectionOpt
                 dropSchema: options && (options.entities || options.entitySchemas) ? options.dropSchema : false,
                 cache: options ? options.cache : undefined,
             });
+            if (options && options.driverSpecific)
+                newOptions = Object.assign({}, options.driverSpecific, newOptions);
             if (options && options.schemaCreate)
                 newOptions.synchronize = options.schemaCreate;
             if (options && options.schema)


### PR DESCRIPTION
Follow up to #1321 as that PR went into `next` instead of master.
Also @pleerock's comment about sql.js tests is adressed.
These changes will have to go into `next` as well