### PR TITLE
bug(require/browser): debug package was required outside of class

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ feel free to ask us and community.
 ## 0.1.10
 
 * `sqljs` driver now enforces FK integrity by default (same behavior as `sqlite`)
+* fixed issue that broke browser support in 0.1.8 because of the debug package ([#1344](https://github.com/typeorm/typeorm/pull/1344))
 
 ## 0.1.9
 

--- a/src/logger/DebugLogger.ts
+++ b/src/logger/DebugLogger.ts
@@ -2,21 +2,21 @@ import {Logger} from "./Logger";
 import {QueryRunner} from "../";
 import {PlatformTools} from "../platform/PlatformTools";
 
-const debug = PlatformTools.load("debug");
-
 /**
  * Performs logging of the events in TypeORM via debug library.
  */
 export class DebugLogger implements Logger {
-    private debugQueryLog = debug("typeorm:query:log");
-    private debugQueryError = debug("typeorm:query:error");
-    private debugQuerySlow = debug("typeorm:query:slow");
-    private debugSchemaBuild = debug("typeorm:schema");
-    private debugMigration = debug("typeorm:migration");
+    private debug = PlatformTools.load("debug");
+
+    private debugQueryLog = this.debug("typeorm:query:log");
+    private debugQueryError = this.debug("typeorm:query:error");
+    private debugQuerySlow = this.debug("typeorm:query:slow");
+    private debugSchemaBuild = this.debug("typeorm:schema");
+    private debugMigration = this.debug("typeorm:migration");
     
-    private debugLog = debug("typeorm:log");
-    private debugInfo = debug("typeorm:info");
-    private debugWarn = debug("typeorm:warn");
+    private debugLog = this.debug("typeorm:log");
+    private debugInfo = this.debug("typeorm:info");
+    private debugWarn = this.debug("typeorm:warn");
     
     /**
      * Logs query and parameters used in it.


### PR DESCRIPTION
The debug package was required outside of DebugLogger which broke the browser support. It has to be required inside the class to only be loaded when the logger is used (in node).

fixes #1336 
fixes typeorm/ionic-example#4