### PR TITLE
pass pool cluster options to base mysql library

### DIFF
--- a/src/driver/mysql/MysqlDriver.ts
+++ b/src/driver/mysql/MysqlDriver.ts
@@ -191,7 +191,7 @@ export class MysqlDriver implements Driver {
     async connect(): Promise<void> {
 
         if (this.options.replication) {
-            this.poolCluster = this.mysql.createPoolCluster();
+            this.poolCluster = this.mysql.createPoolCluster(this.options.replication);
             this.options.replication.slaves.forEach((slave, index) => {
                 this.poolCluster.add("SLAVE" + index, this.createConnectionOptions(this.options, slave));
             });


### PR DESCRIPTION
I noticed the poolClusterOptions were not actually being passed to mysqljs. Looks like mysql2 needs this as well, though I didn't test it.

https://github.com/mysqljs/mysql/blob/master/index.js#L35
https://github.com/mysqljs/mysql#poolcluster-options
https://github.com/sidorares/node-mysql2/blob/ef9fc1b5f4faa53db55a6f1d30f7c4be4bd277bd/index.js#L20