### PR TITLE
Docs: Make variable User obvious

### DIFF
--- a/docs/working-with-entity-manager.md
+++ b/docs/working-with-entity-manager.md
@@ -8,6 +8,7 @@ Example how to use it:
  
 ```typescript
 import {getManager} from "typeorm";
+import {User} from "./entity/User";
 
 const entityManager = getManager(); // you can also get it via getConnection().manager
 const user = await entityManager.findOneById(User, 1);


### PR DESCRIPTION
For a new user, they may get confused with where the variable `User` come from on line `const user = await entityManager.findOneById(User, 1);`