### PR TITLE
Specs to show one-to-one relation integrity isn't respected

### DIFF
--- a/src/metadata-builder/EntityMetadataBuilder.ts
+++ b/src/metadata-builder/EntityMetadataBuilder.ts
@@ -108,10 +108,13 @@ export class EntityMetadataBuilder {
                 // create entity's relations join columns (for many-to-one and one-to-one owner)
                 entityMetadata.relations.filter(relation => relation.isOneToOne || relation.isManyToOne).forEach(relation => {
                     const joinColumns = this.metadataArgsStorage.filterJoinColumns(relation.target, relation.propertyName);
-                    const foreignKey = this.relationJoinColumnBuilder.build(joinColumns, relation); // create a foreign key based on its metadata args
+                    const { foreignKey, uniqueConstraint } = this.relationJoinColumnBuilder.build(joinColumns, relation); // create a foreign key based on its metadata args
                     if (foreignKey) {
                         relation.registerForeignKeys(foreignKey); // push it to the relation and thus register there a join column
                         entityMetadata.foreignKeys.push(foreignKey);
+                    }
+                    if (uniqueConstraint) {
+                        entityMetadata.uniques.push(uniqueConstraint);
                     }
                 });
 

--- a/test/functional/persistence/one-to-one/entity/AccessToken.ts
+++ b/test/functional/persistence/one-to-one/entity/AccessToken.ts
@@ -1,0 +1,19 @@
+import {PrimaryColumn} from "../../../../../src/decorator/columns/PrimaryColumn";
+import {Entity} from "../../../../../src/decorator/entity/Entity";
+import {JoinColumn} from "../../../../../src/decorator/relations/JoinColumn";
+import {OneToOne} from "../../../../../src/decorator/relations/OneToOne";
+import {User} from "./User";
+import {Generated} from "../../../../../src/decorator/Generated";
+
+@Entity()
+export class AccessToken {
+
+    @PrimaryColumn("int")
+    @Generated()
+    primaryKey: number;
+
+    @OneToOne(type => User, user => user.access_token)
+    @JoinColumn()
+    user: User;
+
+}

--- a/test/functional/persistence/one-to-one/entity/User.ts
+++ b/test/functional/persistence/one-to-one/entity/User.ts
@@ -1,0 +1,21 @@
+import {AccessToken} from "./AccessToken";
+import {OneToOne} from "../../../../../src/decorator/relations/OneToOne";
+import {Column} from "../../../../../src/decorator/columns/Column";
+import {PrimaryColumn} from "../../../../../src/decorator/columns/PrimaryColumn";
+import {Entity} from "../../../../../src/decorator/entity/Entity";
+import {Generated} from "../../../../../src/decorator/Generated";
+
+@Entity()
+export class User {
+
+    @PrimaryColumn("int")
+    @Generated()
+    primaryKey: number;
+
+    @Column()
+    email: string;
+
+    @OneToOne(type => AccessToken, token => token.user)
+    access_token: AccessToken;
+
+}

--- a/test/functional/persistence/one-to-one/persistence-one-to-one.ts
+++ b/test/functional/persistence/one-to-one/persistence-one-to-one.ts
@@ -1,0 +1,86 @@
+import "reflect-metadata";
+import {expect} from "chai";
+import {Connection} from "../../../../src/connection/Connection";
+import {User} from "./entity/User";
+import {AccessToken} from "./entity/AccessToken";
+import {closeTestingConnections, createTestingConnections, reloadTestingDatabases} from "../../../utils/test-utils";
+
+describe("persistence > one-to-one", function() {
+
+    // -------------------------------------------------------------------------
+    // Setup
+    // -------------------------------------------------------------------------
+
+    let connections: Connection[];
+    before(() => {
+        return createTestingConnections({
+            entities: [User, AccessToken],
+            schemaCreate: true,
+            dropSchema: true,
+        }).then(all => connections = all);
+    });
+    after(() => closeTestingConnections(connections));
+    beforeEach(() => reloadTestingDatabases(connections));
+
+    // -------------------------------------------------------------------------
+    // Specifications
+    // -------------------------------------------------------------------------
+
+    describe("set the relation with proper item", function() {
+
+        it("should have an access token", () => Promise.all(connections.map(async connection => {
+            const userRepository = connection.getRepository(User);
+            const accessTokenRepository = connection.getRepository(AccessToken);
+
+            const newUser = userRepository.create();
+            newUser.email = "mwelnick@test.com";
+            await userRepository.save(newUser);
+
+            const newAccessToken = accessTokenRepository.create();
+            newAccessToken.user = newUser;
+            await accessTokenRepository.save(newAccessToken);
+
+
+            const loadedUser = await userRepository.findOne({
+                where: { email: "mwelnick@test.com" },
+                relations: ["access_token"]
+            });
+
+            expect(loadedUser).not.to.be.empty;
+            expect(loadedUser!.access_token).not.to.be.empty;
+        })));
+
+    });
+
+    describe("doesnt allow the same relation to be used twice", function() {
+
+        it("should reject the saving attempt", () => Promise.all(connections.map(async connection => {
+            const userRepository = connection.getRepository(User);
+            const accessTokenRepository = connection.getRepository(AccessToken);
+
+            const newUser = userRepository.create();
+            newUser.email = "mwelnick@test.com";
+            await userRepository.save(newUser);
+
+            const newAccessToken1 = accessTokenRepository.create();
+            newAccessToken1.user = newUser;
+            await accessTokenRepository.save(newAccessToken1);
+
+            const newAccessToken2 = accessTokenRepository.create();
+            newAccessToken2.user = newUser;
+
+            let error: Error | null = null;
+            try {
+                await accessTokenRepository.save(newAccessToken2);
+            } catch (err) {
+                error = err;
+            }
+
+            expect(error).to.be.instanceof(Error);
+            expect(await userRepository.count({})).to.equal(1);
+            expect(await accessTokenRepository.count({})).to.equal(1);
+        })));
+
+    });
+
+});

--- a/test/functional/query-builder/relational/with-one/query-builder-relational-set-one-to-one-inverse.ts
+++ b/test/functional/query-builder/relational/with-one/query-builder-relational-set-one-to-one-inverse.ts
@@ -185,7 +185,7 @@ describe("query builder > relational query builder > set operation > one-to-one 
         expect(loadedPost3!.image).to.be.null;
     })));
 
-    it("should set entity relation of a multiple entities", () => Promise.all(connections.map(async connection => {
+    it("should raise error when setting entity relation of a multiple entities", () => Promise.all(connections.map(async connection => {
 
         const image1 = new Image();
         image1.url = "image #1";
@@ -211,35 +211,27 @@ describe("query builder > relational query builder > set operation > one-to-one 
         post3.title = "post #3";
         await connection.manager.save(post3);
 
-        await connection
-            .createQueryBuilder()
-            .relation(Image, "post")
-            .of({ id: 3 })
-            .set([{ id: 1 }, { id: 3 }]);
+        let error: null | Error = null;
+        try {
+            await connection
+                .createQueryBuilder()
+                .relation(Image, "post")
+                .of({ id: 3 })
+                .set([{ id: 1 }, { id: 3 }]);
+        } catch (e) {
+            error = e;
+        }
+
+        expect(error).to.be.an.instanceof(Error);
 
         let loadedPost1 = await connection.manager.findOne(Post, 1, { relations: ["image"] });
-        expect(loadedPost1!.image).to.be.eql({ id: 3, url: "image #3" });
+        expect(loadedPost1!.image).to.be.undefined;
 
         let loadedPost2 = await connection.manager.findOne(Post, 2, { relations: ["image"] });
         expect(loadedPost2!.image).to.be.null;
 
         let loadedPost3 = await connection.manager.findOne(Post, 3, { relations: ["image"] });
-        expect(loadedPost3!.image).to.be.eql({ id: 3, url: "image #3" });
-
-        await connection
-            .createQueryBuilder()
-            .relation(Image, "post")
-            .of({ id: 3 })
-            .set(null);
-
-        loadedPost1 = await connection.manager.findOne(Post, 1, { relations: ["image"] });
-        expect(loadedPost1!.image).to.be.null;
-
-        loadedPost2 = await connection.manager.findOne(Post, 2, { relations: ["image"] });
-        expect(loadedPost2!.image).to.be.null;
-
-        loadedPost3 = await connection.manager.findOne(Post, 3, { relations: ["image"] });
-        expect(loadedPost3!.image).to.be.null;
+        expect(loadedPost3!.image).to.be.undefined;
     })));
 
 });

--- a/test/functional/query-builder/relational/with-one/query-builder-relational-set-one-to-one.ts
+++ b/test/functional/query-builder/relational/with-one/query-builder-relational-set-one-to-one.ts
@@ -185,7 +185,7 @@ describe("query builder > relational query builder > set operation > one-to-one 
         expect(loadedPost3!.image).to.be.null;
     })));
 
-    it("should set entity relation of a multiple entities", () => Promise.all(connections.map(async connection => {
+    it("should raise error when setting entity relation of a multiple entities", () => Promise.all(connections.map(async connection => {
 
         const image1 = new Image();
         image1.url = "image #1";
@@ -211,35 +211,27 @@ describe("query builder > relational query builder > set operation > one-to-one 
         post3.title = "post #3";
         await connection.manager.save(post3);
 
-        await connection
-            .createQueryBuilder()
-            .relation(Post, "image")
-            .of([{ id: 1 }, { id: 3 }])
-            .set({ id: 3 });
+        let error: null | Error = null;
+        try {
+            await connection
+                .createQueryBuilder()
+                .relation(Post, "image")
+                .of([{ id: 1 }, { id: 3 }])
+                .set({ id: 3 });
+        } catch (e) {
+            error = e;
+        }
+
+        expect(error).to.be.instanceof(Error);
 
         let loadedPost1 = await connection.manager.findOne(Post, 1, { relations: ["image"] });
-        expect(loadedPost1!.image).to.be.eql({ id: 3, url: "image #3" });
+        expect(loadedPost1!.image).to.be.undefined;
 
         let loadedPost2 = await connection.manager.findOne(Post, 2, { relations: ["image"] });
         expect(loadedPost2!.image).to.be.null;
 
         let loadedPost3 = await connection.manager.findOne(Post, 3, { relations: ["image"] });
-        expect(loadedPost3!.image).to.be.eql({ id: 3, url: "image #3" });
-
-        await connection
-            .createQueryBuilder()
-            .relation(Post, "image")
-            .of([{ id: 1 }, { id: 3 }])
-            .set(null);
-
-        loadedPost1 = await connection.manager.findOne(Post, 1, { relations: ["image"] });
-        expect(loadedPost1!.image).to.be.null;
-
-        loadedPost2 = await connection.manager.findOne(Post, 2, { relations: ["image"] });
-        expect(loadedPost2!.image).to.be.null;
-
-        loadedPost3 = await connection.manager.findOne(Post, 3, { relations: ["image"] });
-        expect(loadedPost3!.image).to.be.null;
+        expect(loadedPost3!.image).to.be.undefined;
     })));
 
 });


### PR DESCRIPTION
Hi!

Before investing more time on a bugfix, do you think those specs are correct?

For relational databases, I want to add a `UNIQUE` constraint on the foreign key column in order to enforce `OneToOne` relation in both ways.