### PR TITLE
QueryRunner.renameColumn in Sqlite and Postgres

### DIFF
--- a/test/functional/driver/query-runner/entity/User.ts
+++ b/test/functional/driver/query-runner/entity/User.ts
@@ -1,0 +1,14 @@
+import {Column, Entity, PrimaryGeneratedColumn} from "../../../../../src/index";
+
+@Entity()
+export class User {
+
+    @PrimaryGeneratedColumn()
+    id: number;
+
+    @Column()
+    name: string;
+
+    firstname: string;
+
+}

--- a/test/functional/driver/query-runner/rename-column.ts
+++ b/test/functional/driver/query-runner/rename-column.ts
@@ -1,0 +1,44 @@
+import "reflect-metadata";
+import {closeTestingConnections, createTestingConnections, reloadTestingDatabases} from "../../../utils/test-utils";
+import {Connection} from "../../../../src/connection/Connection";
+import {User} from "./entity/User";
+import {expect} from "chai";
+
+describe("driver > query runner > rename column", () => {
+
+    let connections: Connection[] = [];
+    before(async () => connections = await createTestingConnections({
+        entities: [__dirname + "/entity/*{.js,.ts}"]
+    }));
+    beforeEach(() => reloadTestingDatabases(connections));
+    after(() => closeTestingConnections(connections));
+
+    it("should rename a column", () => Promise.all(connections.map(async connection => {
+        const user = new User();
+        user.name = "Max";
+
+        const userRepository = connection.getRepository(User);
+        await userRepository.save(user);
+
+        const queryRunner = connection.createQueryRunner();
+        await queryRunner.renameColumn("user", "name", "firstname");
+
+        const table = await queryRunner.getTable("user");
+
+        expect(table).to.not.be.undefined;
+
+        if (table) {
+            const column = table.findColumnByName("firstname");
+            expect(column).to.not.be.undefined;
+        }
+
+        const loadedUser = await connection.createQueryBuilder()
+            .select()
+            .from(User, "user")
+            .select("user.id")
+            .where("user.firstname = :name", {name: "Max"});
+
+        expect(loadedUser).to.not.be.undefined;
+    })));
+
+});


### PR DESCRIPTION
Because auf #1428 I looked at the sqlite code for `renameColumn` which didn't change anything, it just recreated the table. The fix that I wrote isn't the prettiest but I don't know of a better way right now.
Thanks to the test I also notices a syntax error in postgres when renaming columns.

It seems like this is an area (query runner methods that change the table) without many tests. Might be a good idea to add some more?!