### PR TITLE
Optimize 'group' function in 'RawSqlResultsToEntityTransformer'

### DIFF
--- a/src/query-builder/transformer/RawSqlResultsToEntityTransformer.ts
+++ b/src/query-builder/transformer/RawSqlResultsToEntityTransformer.ts
@@ -52,9 +52,9 @@ export class RawSqlResultsToEntityTransformer {
             const id = alias.metadata.primaryColumns.map(column => rawResult[alias.name + "_" + column.databaseName]).join("_"); // todo: check partial
             if (!id) return;
 
-            let group: { id: any, items: any[] }
+            let group: { id: any, items: any[] };
             if (id in groupedResults) {
-                group = groupedResults[id]
+                group = groupedResults[id];
             } else {
                 group = { id: id, items: [] };
             }

--- a/src/query-builder/transformer/RawSqlResultsToEntityTransformer.ts
+++ b/src/query-builder/transformer/RawSqlResultsToEntityTransformer.ts
@@ -47,20 +47,24 @@ export class RawSqlResultsToEntityTransformer {
      * Groups given raw results by ids of given alias.
      */
     protected group(rawResults: any[], alias: Alias): any[][] {
-        const groupedResults: { id: any, items: any[] }[] = [];
+        const groupedResults: { [key: string]: { id: any, items: any[] } } = {};
         rawResults.forEach(rawResult => {
             const id = alias.metadata.primaryColumns.map(column => rawResult[alias.name + "_" + column.databaseName]).join("_"); // todo: check partial
             if (!id) return;
 
-            let group = groupedResults.find(groupedResult => groupedResult.id === id);
-            if (!group) {
+            let group: { id: any, items: any[] }
+            if (id in groupedResults) {
+                group = groupedResults[id]
+            } else {
                 group = { id: id, items: [] };
-                groupedResults.push(group);
             }
 
             group.items.push(rawResult);
         });
-        return groupedResults.map(group => group.items);
+
+        return Object.keys(groupedResults).map(function(key, index) {
+            return groupedResults[key].items;
+         });
     }
 
     /**


### PR DESCRIPTION
Hi @pleerock,
I think there is an opportunity to optimize `group` function that sits inside `RawSqlResultsToEntityTransformer` by switching from quadratic to the linear algorithm.

What do you think about the following fix?
I've got a quite significant performance improvement out of it on my local test (e.g. select of 140k records works ~10 seconds instead of 4 minutes).
