### PR TITLE
WIP: Joins with Subquery

### DIFF
--- a/gulpfile.ts
+++ b/gulpfile.ts
@@ -375,6 +375,7 @@ export class Gulpfile {
     @SequenceTask("ci-tests")
     ciTests() {
         return [
+            "clean",
             "compile",
             "tslint",
             "wait",

--- a/src/query-builder/SelectQueryBuilder.ts
+++ b/src/query-builder/SelectQueryBuilder.ts
@@ -1210,7 +1210,8 @@ export class SelectQueryBuilder<Entity> extends QueryBuilder<Entity> implements 
                     const hasMainAlias = this.expressionMap.selects.some(select => select.selection === join.alias.name);
                     if (hasMainAlias) {
                         allSelects.push({ selection: this.escape(join.alias.name!) + ".*" });
-                        excludedSelects.push({ selection: this.escape(join.alias.name!) });
+                        const excludedSelect = this.expressionMap.selects.find(select => select.selection === join.alias.name);
+                        excludedSelects.push(excludedSelect!);
                     }
                 }
             });

--- a/test/github-issues/1476/entity/Item.ts
+++ b/test/github-issues/1476/entity/Item.ts
@@ -1,0 +1,11 @@
+import { Entity, PrimaryColumn, Column } from "../../../../src/index";
+
+
+@Entity()
+export class Item {
+    @PrimaryColumn()
+    itemId: number;
+
+    @Column()
+    planId: number;
+}

--- a/test/github-issues/1476/entity/Plan.ts
+++ b/test/github-issues/1476/entity/Plan.ts
@@ -1,0 +1,11 @@
+import { Entity, PrimaryColumn, Column } from "../../../../src/index";
+
+
+@Entity()
+export class Plan {
+    @PrimaryColumn()
+    planId: number;
+
+    @Column()
+    planName: string;
+}

--- a/test/github-issues/1476/issue-1476.ts
+++ b/test/github-issues/1476/issue-1476.ts
@@ -1,0 +1,59 @@
+import "reflect-metadata";
+import { expect } from "chai";
+
+import { Connection } from "../../../src/connection/Connection";
+import { closeTestingConnections, createTestingConnections, reloadTestingDatabases } from "../../utils/test-utils";
+import { Plan } from "./entity/Plan";
+import { Item } from "./entity/Item";
+
+describe("github issues > #1476 subqueries", () => {
+
+    let connections: Connection[] = [];
+    before(async () => connections = await createTestingConnections({
+        entities: [__dirname + "/entity/*{.js,.ts}"],
+        enabledDrivers: ["mysql", "mariadb", "sqlite", "sqljs"]
+    }));
+    beforeEach(() => reloadTestingDatabases(connections));
+    after(() => closeTestingConnections(connections));
+
+    it("should", () => Promise.all(connections.map(async connection => {
+        const planRepo = connection.getRepository(Plan);
+        const itemRepo = connection.getRepository(Item);
+        
+        const plan1 = new Plan();
+        plan1.planId = 1;
+        plan1.planName = "Test";
+
+        await planRepo.save(plan1);
+
+        const item1 = new Item();
+        item1.itemId = 1;
+        item1.planId = 1;
+
+        const item2 = new Item();
+        item2.itemId = 2;
+        item2.planId = 1;
+
+        await itemRepo.save([item1, item2]);
+
+        const plans = await planRepo
+            .createQueryBuilder("b")
+            .leftJoinAndSelect(
+                subQuery => {
+                    return subQuery
+                        .select(`COUNT("planId")`, `total`)
+                        .addSelect(`planId`)
+                        .from(Item, "items")
+                        .groupBy(`items.planId`);
+            }, "i", `i.planId = b.planId`)
+            .getRawMany();
+
+        expect(plans).to.not.be.undefined;
+
+        const plan = plans![0];
+        expect(plan.b_planId).to.be.equal(1);
+        expect(plan.b_planName).to.be.equal("Test");
+        expect(plan.total).to.be.equal(2);
+        expect(plan.planId).to.be.equal(1);
+    })));
+});


### PR DESCRIPTION
I'm not completely happy with this fix it doesn't work for postgres and works around the problem rather than fixing it.

The reason postgres is excluded from the tests is that the query that gets generated with the fix looks like this:
```sql
SELECT "b"."planId" AS "b_planId", "b"."planName" AS "b_planName", "i".* FROM "plan" "b"
LEFT JOIN (SELECT COUNT("planId") AS "total",
planId FROM "item" "items" GROUP BY "items"."planId") "i" ON i.planId = "b"."planId"
```
Postgres doesn't like the unescaped column planId in the subquery and i.planId on the "ON"-statement.

From my findings, the both are not escaped because [`SelectQueryBuilder::replacePropertyNames()`](https://github.com/typeorm/typeorm/blob/master/src/query-builder/QueryBuilder.ts#L514) doesn't have any metadata to compare and replace it with. The metadata is missing because [`JoinAttribute::metadata`](https://github.com/typeorm/typeorm/blob/master/src/query-builder/JoinAttribute.ts#L136) can't find any metadata as `entityOrProperty` is neither an entity nor a property but rather a special kind of subquery. I couldn't come up with a proper way to differentiate between an entity and a subquery.
But if we somehow get metadata for subqueries, [`SelectQueryBuilder::join()`](https://github.com/typeorm/typeorm/blob/master/src/query-builder/SelectQueryBuilder.ts#L1129) will have to change as subqueries are currently only evaluated if no metadata exists.

Fixes #1476