### PR TITLE
Update documentation for `select`, `NULL`, and subscribers

### DIFF
--- a/docs/entities.md
+++ b/docs/entities.md
@@ -394,6 +394,7 @@ You can specify array of values or specify a enum class.
 * `array: boolean` - Used for postgres column types which can be array (for example int[])
 * `transformer: { from(value: DatabaseType): EntityType, to(value: EntityType): DatabaseType }` - Used to
 marshal properties of arbitrary type `EntityType` into a type `DatabaseType` supported by the database.
+* `select: boolean` - Defines whether or not to hide this column by default when making queries. When set to `false`, the column data will not show with a standard query. By default column is `select: true`
 
 Note: most of those column options are RDBMS-specific and aren't available in `MongoDB`.
 

--- a/docs/entity-manager-api.md
+++ b/docs/entity-manager-api.md
@@ -97,7 +97,7 @@ const user = await manager.preload(User, partialUser);
 If the entity already exist in the database then it's updated.
 If the entity does not exist in the database yet it's inserted.
 It saves all given entities in a single transaction (in the case of entity manager is not transactional).
-Also supports partial updating since all undefined properties are skipped.
+Also supports partial updating since all undefined properties are skipped. In order to make a value `NULL`, you must manually set the property to equal `null`.
 
 ```typescript
 await manager.save(user);

--- a/docs/listeners-and-subscribers.md
+++ b/docs/listeners-and-subscribers.md
@@ -71,7 +71,7 @@ export class Post {
 ### `@BeforeUpdate`
 
 You can define a method with any name in the entity and mark it with `@BeforeUpdate`
-and TypeORM will call it before an existing entity is updated using repository/manager `save`.
+and TypeORM will call it before an existing entity is updated using repository/manager `save`. Keep in mind, however, that this will occur only when information is changed in the model. If you run `save` without modifying anything from the model, `@BeforeUpdate` and `@AfterUpdate` will not run.
 Example:
 
 ```typescript

--- a/docs/select-query-builder.md
+++ b/docs/select-query-builder.md
@@ -23,6 +23,7 @@
 * [Set locking](#set-locking)
 * [Partial selection](#partial-selection)
 * [Using subqueries](#using-subqueries)
+* [Hidden Columns](#hidden-columns)
 
 ## What is `QueryBuilder`
 
@@ -912,3 +913,37 @@ const posts = await connection
     .from(Post, "post")
     .getRawMany();
 ```
+## Hidden Columns
+
+If the model you are querying has a column with a `select: false` column, you must use the `addSelect` function in order to retreive the information from the column.
+
+Let's say you have the following entity:
+
+```typescript
+import {Entity, PrimaryGeneratedColumn, Column} from "typeorm";
+
+@Entity()
+export class User {
+    
+    @PrimaryGeneratedColumn()
+    id: number;
+    
+    @Column()
+    name: string;
+
+    @Column({select: false})
+    name: string;
+}
+```
+
+Using a standard `find` or query, you will not recieve the `name` property for the model. However, if you do the following:
+
+```typescript
+const users = await connection.getRepository(User)
+    .createQueryBuilder()
+    .select("user.id", "id")
+    .addSelect("user.password")
+    .getMany();
+```
+
+You will get the property `password` in your query.


### PR DESCRIPTION
This should add a few lines of documentation that were mentioned in a few issues I was involved in:
#1490 #1483 #828