### PR TITLE
Documentation Grammar and Punctuation Fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -309,16 +309,16 @@ creating more entities.
 ## Step-by-Step Guide
 
 What are you expecting from ORM?
-First of all you are expecting it will create a database tables for you
-and find / insert / update / delete your data without pain and  
-having to write lot of hardly maintainable SQL queries.
-This guide will show you how to setup TypeORM from scratch and make it to do what you are expecting from ORM.
+First of all, you are expecting it will create database tables for you
+and find / insert / update / delete your data without the pain of  
+having to write lots of hardly maintainable SQL queries.
+This guide will show you how to setup TypeORM from scratch and make it do what you are expecting from ORM.
 
 ### Create a model
 
 Working with database starts from creating tables. 
 How do you tell TypeORM to create a database table?
-Answer is - thought the models. 
+Answer is - through the models. 
 Your models in your app - are your database tables.
 
 For example, you have a `Photo` model:
@@ -334,14 +334,14 @@ export class Photo {
 ```
 
 And you want to store photos in your database.
-To store things in the database first you need a database table.
-And database tables are created from your models.
-Not all models, but only those you defined as *entities*. 
+To store things in the database, first you need a database table,
+and database tables are created from your models.
+Not all models, but only those you define as *entities*. 
         
 ### Create an entity
 
-*Entity* is your model decorated by `@Entity` decorator.
-Database table will be created for such model.
+*Entity* is your model decorated by an `@Entity` decorator.
+A database table will be created for such models.
 You work with entities everywhere with TypeORM.
 You can load/insert/update/remove and perform other operations with them.
 
@@ -361,13 +361,13 @@ export class Photo {
 }
 ```
 
-Now database table will be created for `Photo` entity and we'll be able to work with it anywhere in our app.
+Now, a database table will be created for the `Photo` entity and we'll be able to work with it anywhere in our app.
 We have created a database table, however what table can exist without columns?
 Let's create a few columns in our database table.
         
 ### Adding table columns
 
-To add database columns you simply need to decorate entity's properties you want to make a columns
+To add database columns, you simply need to decorate an entity's properties you want to make into a column
 with a `@Column` decorator.
 
 ```typescript
@@ -399,17 +399,16 @@ export class Photo {
 Now `id`, `name`, `description`, `filename`, `views` and `isPublished` columns will be added to the `photo` table.
 Column types in the database are inferred from the property types you used, e.g.
 `number` will be converted into `integer`, `string` into `varchar`, `boolean` into `bool`, etc.
-But you can use any column type your database support by implicitly specify a column type into `@Column` decorator.
+But you can use any column type your database supports by implicitly specifying a column type into the `@Column` decorator.
 
-We generated a database table with columns.
-But there is one thing left.
-Each database table must have a column with primary key. 
+We generated a database table with columns, but there is one thing left.
+Each database table must have a column with a primary key. 
 
 ### Creating a primary column
 
-Each entity **must** have at least one primary column.
-This is requirement and you can't avoid it. 
-To make a column a primary you need to use `@PrimaryColumn` decorator.
+Each entity **must** have at least one primary key column.
+This is a requirement and you can't avoid it. 
+To make a column a primary key, you need to use `@PrimaryColumn` decorator.
 
 ```typescript
 import {Entity, Column, PrimaryColumn} from "typeorm";
@@ -440,7 +439,7 @@ export class Photo {
 ### Creating an auto generated column
 
 Now, let's say you want your id column to be auto-generated (this is known as auto-increment / sequence / serial / generated identity column).
-To do that you need to change `@PrimaryColumn` decorator to `@PrimaryGeneratedColumn` decorator:
+To do that, you need to change the `@PrimaryColumn` decorator to a `@PrimaryGeneratedColumn` decorator:
 
 ```typescript
 import {Entity, Column, PrimaryGeneratedColumn} from "typeorm";
@@ -504,8 +503,8 @@ export class Photo {
 ```
 
 Column types are database-specific.
-You can set any column type your database support.
-More information on supported column types you can find [here](./docs/entities.md#column-types).
+You can set any column type your database supports.
+More information on supported column types can be found [here](./docs/entities.md#column-types).
 
 ### Creating a connection to the database
 
@@ -619,8 +618,8 @@ createConnection(/*...*/).then(connection => {
 ```
 
 Once your entity is saved it will get a newly generated id.
-`save` method returns instance of same object you pass to it.
-Its not a new copy of an object, it modifies its "id" and returns it.
+`save` method returns an instance of the same object you pass to it.
+It's not a new copy of the object, it modifies its "id" and returns it.
   
 ### Using async/await syntax
 
@@ -812,7 +811,7 @@ export class PhotoMetadata {
      
 Here, we are using a new decorator called `@OneToOne`. It allows us to create a one-to-one relationship between two entities. 
 `type => Photo` is a function that returns the class of the entity with which we want to make our relationship. 
-We are forced to use a function that returns a class, instead of using class directly, because of the language specifics.
+We are forced to use a function that returns a class, instead of using the class directly, because of the language specifics.
 We can also write it as `() => Photo`, but we use `type => Photo` as a convention to increase code readability.
 The type variable itself does not contain anything.
 
@@ -948,11 +947,11 @@ createConnection(/*...*/).then(async connection => {
 }).catch(error => console.log(error));
 ```
         
-Here photos will contain an array of photos from the database, and each photo will contain its photo metadata.
+Here, photos will contain an array of photos from the database, and each photo will contain its photo metadata.
 Learn more about Find Options in [this documentation](./docs/find-options.md).
 
-Using find options is good and dead simple, but if you need more complex query you should use `QueryBuilder` instead.
-`QueryBuilder` allows to use more complex queries in an elegant way:
+Using find options is good and dead simple, but if you need a more complex query, you should use `QueryBuilder` instead.
+`QueryBuilder` allows more complex queries to be used in an elegant way:
 
 ```typescript
 import {createConnection} from "typeorm";
@@ -972,9 +971,9 @@ createConnection(/*...*/).then(async connection => {
 }).catch(error => console.log(error));
 ```
 
-`QueryBuilder` allows to create and execute SQL query of almost any complexity.
-When you work with `QueryBuilder` think like you are creating SQL query.
-In this example "photo" and "metadata" are aliases applied to selected photos.
+`QueryBuilder` allows creation and execution of SQL queries of almost any complexity.
+When you work with `QueryBuilder`, think like you are creating an SQL query.
+In this example, "photo" and "metadata" are aliases applied to selected photos.
 You use aliases to access columns and properties of the selected data.
 
 ### Using cascades to automatically save related objects
@@ -1000,7 +999,7 @@ export class Photo {
 * **cascadeUpdate** - automatically update metadata in the relation if something is changed in this object.
 * **cascadeRemove** - automatically remove metadata from its table if you removed metadata from photo object.
 
-Using `cascadeInsert` allows us not to separately save photo and separately save metadata objects now. 
+Using `cascadeInsert` allows us to not have to separately save photo and metadata objects now. 
 Now we can simply save a photo object, and the metadata object will be saved automatically because of cascade options.
 
 ```typescript
@@ -1214,7 +1213,7 @@ const loadedPhoto = await connection
 
 ### Using QueryBuilder
 
-You can use QueryBuilder to build SQL query of almost any complexity. For example, you can do this:
+You can use QueryBuilder to build SQL queries of almost any complexity. For example, you can do this:
 
 ```typescript
 let photos = await connection

--- a/docs/active-record-data-mapper.md
+++ b/docs/active-record-data-mapper.md
@@ -6,11 +6,11 @@
 
 ## What is the Active Record pattern?
 
-In TypeORM you can use both, the Active Record and the Data Mapper patterns.
+In TypeORM you can use both the Active Record and the Data Mapper patterns.
 
-Using the Active Record approach, you define all your query methods inside the model itself, and you save, remove and load objects using model methods. 
+Using the Active Record approach, you define all your query methods inside the model itself, and you save, remove, and load objects using model methods. 
 
-Simply said the Active Record pattern is an approach to access your database within your models. 
+Simply said, the Active Record pattern is an approach to access your database within your models. 
 You can read more about the Active Record pattern on [Wikipedia](https://en.wikipedia.org/wiki/Active_record_pattern).
 
 Example:
@@ -36,8 +36,8 @@ export class User extends BaseEntity {
 }
 ```
 
-All active-record entities must extend the `BaseEntity` class which provides methods to work with the entity.
-Example how to work with such entity:
+All active-record entities must extend the `BaseEntity` class, which provides methods to work with the entity.
+Example of how to work with such entity:
 
 ```typescript
 
@@ -57,11 +57,11 @@ const newUsers = await User.find({ isActive: true });
 const timber = await User.findOne({ firstName: "Timber", lastName: "Saw" });
 ```
 
-`BaseEntity` has most of methods standard `Repository` has.
-Most of the times you don't need to use `Repository` or `EntityManager` with active record entities.
+`BaseEntity` has most of the methods of  the standard `Repository`.
+Most of the time you don't need to use `Repository` or `EntityManager` with active record entities.
 
-Now let's say we want to create a function that returns users by first and last names. 
-We can create such function as a static method in a `User` class:
+Now let's say we want to create a function that returns users by first and last name. 
+We can create such functions as a static method in a `User` class:
 
 ```typescript
 import {BaseEntity, Entity, PrimaryGeneratedColumn, Column} from "typeorm";
@@ -99,13 +99,13 @@ const timber = await User.findByName("Timber", "Saw");
 
 ## What is the Data Mapper pattern?
 
-In TypeORM you can use both Active Record and Data Mapper patterns.
+In TypeORM you can use both the Active Record and Data Mapper patterns.
 
-Using the Data Mapper, approach you define all your query methods separate classes called "repositories", 
-and you save, remove, load objects using repositories. 
+Using the Data Mapper approach, you define all your query methods in separate classes called "repositories", 
+and you save, remove, and load objects using repositories. 
 In data mapper your entities are very dumb - they just define their properties and may have some "dummy" methods.  
 
-Simply said data mapper is an approach to access your database within repositories instead of models. 
+Simply said, data mapper is an approach to access your database within repositories instead of models. 
 You can read more about data mapper on [Wikipedia](https://en.wikipedia.org/wiki/Data_mapper_pattern).
 
 Example:
@@ -130,7 +130,7 @@ export class User {
 
 }
 ```
-Example how to work with such entity:
+Example of how to work with such entity:
 
 ```typescript
 const userRepository = connection.getRepository(User);
@@ -151,8 +151,8 @@ const newUsers = await userRepository.find({ isActive: true });
 const timber = await userRepository.findOne({ firstName: "Timber", lastName: "Saw" });
 ```
 
-Now let's say we want to create a function that returns users by first and last names. 
-We can create such function in a "custom repository".
+Now let's say we want to create a function that returns users by first and last name. 
+We can create such a function in a "custom repository".
 
 ```typescript
 import {EntityRepository, Repository} from "typeorm";
@@ -186,6 +186,6 @@ The decision is up to you.
 Both strategies have their own cons and pros.
 
 One thing we should always keep in mind in software development is how we are going to maintain it.
-The `Data Mapper` approach helps you to keep maintainability of your software which is more effective in bigger apps.
-The `Active record` approach helps you to keep things simple which work good in a small apps.
+The `Data Mapper` approach helps you with maintainability of your software which is more effective in bigger apps.
+The `Active record` approach helps you to keep things simple which works good in small apps.
  And simplicity is always a key to better maintainability.

--- a/docs/caching.md
+++ b/docs/caching.md
@@ -39,12 +39,12 @@ const users = await connection
     });
 ```
 
-This will execute a query to fetch all admin users and cache its result.
-Next time when you execute same code it will get admin users from the cache.
-Default cache time is equal to `1000 ms`, e.g. 1 second.
-This means cache will be invalid 1 second after you called the query builder code.
-In practice, it means that if users open user page 150 times within 3 seconds only three queries will be executed during this period.
-All users inserted during the 1 second of caching won't be returned to the user.
+This will execute a query to fetch all admin users and cache the results.
+Next time you execute the same code, it will get all admin users from the cache.
+Default cache lifetime is equal to `1000 ms`, e.g. 1 second.
+This means the cache will be invalid 1 second after the query builder code is called.
+In practice, this means that if users open the user page 150 times within 3 seconds, only three queries will be executed during this period.
+Any users inserted during the 1 second cache window won't be returned to the user.
 
 You can change cache time manually via `QueryBuilder`:
 
@@ -104,8 +104,8 @@ const users = await connection
     });
 ```
 
-It will allow you to granular control your cache,
-for example, clear cached results when you insert a new user:
+This gives you granular control of your cache,
+for example, clearing cached results when you insert a new user:
 
 ```typescript
 await connection.queryResultCache.remove(["users_admins"]);

--- a/docs/custom-repository.md
+++ b/docs/custom-repository.md
@@ -54,7 +54,7 @@ and you can access any method created inside it and any method in the standard e
 
 ## Custom repository extends standard AbstractRepository
 
-Second way to create a custom repository is to extend `AbstractRepository`:
+The second way to create a custom repository is to extend `AbstractRepository`:
 
 ```typescript
 import {EntityRepository, AbstractRepository} from "typeorm";
@@ -88,15 +88,15 @@ await userRepository.createAndSave("Timber", "Saw");
 const timber = await userRepository.findByName("Timber", "Saw");
 ```
 
-The difference between this type of repository and the previous one is, that it does not expose all methods `Repository` has.
+The difference between this type of repository and the previous one is that it does not expose all the methods `Repository` has.
 `AbstractRepository` does not have any public methods, 
-it only has protected methods like `manager` and `repository` which you can use in your own
+it only has protected methods, like `manager` and `repository`, which you can use in your own
 public methods.
 Extending `AbstractRepository` is useful if you don't want to expose all methods the standard `Repository` has to the public.
 
 ## Custom repository without extends
 
-Third way to create a repository is to not extend anything, 
+The third way to create a repository is to not extend anything, 
 but define a constructor which always accepts an entity manager instance:
 
 ```typescript
@@ -136,13 +136,13 @@ const timber = await userRepository.findByName("Timber", "Saw");
 
 This type of repository does not extend anything - you only need to define a constructor
 which must accept `EntityManager`. Then you can use it everywhere in your repository methods.
-Also this type of repository is not bound to a specific entity.
-Thus you can operate with multiple entities inside them. 
+Also, this type of repository is not bound to a specific entity,
+thus, you can operate with multiple entities inside them. 
 
 ## Using custom repositories in transactions or why custom repositories cannot be services
 
-Custom repositories cannot be services. 
-Because there isn't a single instance of a custom repository (just like regular repositories or entity manager) in the app.
+Custom repositories cannot be services, 
+because there isn't a single instance of a custom repository (just like regular repositories or entity manager) in the app.
 Besides the fact that there can be multiple connections in your app (where entity manager and repositories are different)
 repositories and managers are different in transactions as well. 
 For example:

--- a/docs/decorator-reference.md
+++ b/docs/decorator-reference.md
@@ -49,12 +49,12 @@ This code will create a database table named "users".
 
 You can also specify some additional entity options:
 
-* `name` - table name. If not specified then table name is generated from entity class name
-* `database` - database name in selected DB server
-* `schema` - schema name
-* `engine` - database engine to be set during table creation (works only in some databases)
-* `skipSync` - entities marked with this decorator are skipped from schema updates
-* `orderBy` - specifies default ordering for entities when using `find` operations and `QueryBuilder`
+* `name` - table name. If not specified, then table name is generated from entity class name.
+* `database` - database name in selected DB server.
+* `schema` - schema name.
+* `engine` - database engine to be set during table creation (works only in some databases).
+* `skipSync` - entities marked with this decorator are skipped from schema updates.
+* `orderBy` - specifies default ordering for entities when using `find` operations and `QueryBuilder`.
 
 Example:
 
@@ -106,13 +106,13 @@ export class User {
 * `type: ColumnType` - Column type. One of the [supported column types](entities.md#column-types).
 * `name: string` - Column name in the database table. 
 By default the column name is generated from the name of the property.
-You can change it by specifying your own name
-* `length: string|number` - Column type's length. For example if you want to create `varchar(150)` type 
+You can change it by specifying your own name.
+* `length: string|number` - Column type's length. For example, if you want to create `varchar(150)` type 
 you specify column type and length options.
 * `nullable: boolean` - Makes column `NULL` or `NOT NULL` in the database. 
 By default column is `nullable: false`.
 * `default: string` - Adds database-level column's `DEFAULT` value. 
-* `primary: boolean` - Marks column as primary. Same if you use `@PrimaryColumn`.
+* `primary: boolean` - Marks column as primary. Same as using  `@PrimaryColumn`.
 * `unique: boolean` - Marks column as unique column (creates unique constraint).
 * `comment: string` - Database's column comment. Not supported by all database types.
 * `precision: number` - The precision for a decimal (exact numeric) column (applies only for decimal column), which is the maximum
@@ -124,7 +124,7 @@ Used in some column types.
 * `collation: string` - Defines a column collation.
 * `enum: string[]|AnyEnum` - Used in `enum` column type to specify list of allowed enum values.
 You can specify array of values or specify a enum class.
-* `array: boolean` - Used for postgres column types which can be array (for example int[])
+* `array: boolean` - Used for postgres column types which can be array (for example int[]).
 
 Learn more about [entity columns](entities.md#entity-columns).
 
@@ -148,7 +148,7 @@ Learn more about [entity columns](entities.md#entity-columns).
 
 #### `@PrimaryGeneratedColumn`
 
-Marks a property in your entity as a table generated primary column.
+Marks a property in your entity as a table-generated primary column.
 Column it creates is primary and its value is auto-generated.
 Example:
 
@@ -164,10 +164,10 @@ export class User {
 
 There are two generation strategies:
 
-* `increment` - uses AUTO_INCREMENT / SERIAL / SEQUENCE (depend on database type) to generate incremental number
-* `uuid` - generates unique `uuid` string
+* `increment` - uses AUTO_INCREMENT / SERIAL / SEQUENCE (depend on database type) to generate incremental number.
+* `uuid` - generates unique `uuid` string.
 
-Default generation strategy is `increment`, to change it to `uuid` simple pass it as first argument to decorator:
+Default generation strategy is `increment`, to change it to `uuid`, simply pass it as the first argument to decorator:
 
 ```typescript
 @Entity()
@@ -219,7 +219,7 @@ export class User {
 #### `@UpdateDateColumn`
 
 Special column that is automatically set to the entity's update time 
-each time you call `save` of entity manager or repository.
+each time you call `save` from entity manager or repository.
 You don't need to write a value into this column - it will be automatically set.
 
 ```typescript
@@ -235,7 +235,7 @@ export class User {
 #### `@VersionColumn`
 
 Special column that is automatically set to the entity's version (incremental number)  
-each time you call `save` of entity manager or repository.
+each time you call `save` from entity manager or repository.
 You don't need to write a value into this column - it will be automatically set.
 
 ```typescript
@@ -250,7 +250,7 @@ export class User {
 
 #### `@Generated`
 
-Marks column to have a generated value. For example:
+Marks column to be a generated value. For example:
 
 ```typescript
 @Entity()
@@ -263,7 +263,7 @@ export class User {
 }
 ```
 
-Value will be generated only once before inserting the entity into the database.
+Value will be generated only once, before inserting the entity into the database.
 
 ## Relation decorators
 
@@ -380,8 +380,8 @@ Learn more about [many-to-many relations](many-to-many-relations.md).
 
 #### `@JoinColumn`
 
-Defines which side of the relation contains join column with foreign key and 
-allows to customize join column name and referenced column name. 
+Defines which side of the relation contains the join column with a foreign key and 
+allows you to customize the join column name and referenced column name. 
 Example:
 
 ```typescript
@@ -401,8 +401,8 @@ export class Post {
 #### `@JoinTable`
 
 Used for `many-to-many` relations and describes join columns of the "junction" table.
-Junction table is a special separate table created automatically by TypeORM with columns referenced to the related entities.
-You can change the column names inside the junction table and their referenced columns as easy as with `@JoinColumn` decorator. You can also change the name of the generated "junction" table.
+Junction table is a special, separate table created automatically by TypeORM with columns referenced to the related entities.
+You can change the column names inside the junction table and their referenced columns with the `@JoinColumn` decorator. You can also change the name of the generated "junction" table.
 Example:
 
 ```typescript
@@ -427,13 +427,13 @@ export class Post {
 ```
 
 If the destination table has composite primary keys, 
-then array of properties must be send to `@JoinTable` decorator.
+then an array of properties must be sent to the `@JoinTable` decorator.
 
 #### `@RelationId`
 
-Loads id (or ids) of specific relation into property.
-For example if you have many-to-one `category` in your `Post` entity
-you can have category id by marking a new property with `@RelationId`.
+Loads id (or ids) of specific relations into properties.
+For example, if you have a many-to-one `category` in your `Post` entity,
+you can have a new category id by marking a new property with `@RelationId`.
 Example:
 
 ```typescript
@@ -449,7 +449,7 @@ export class Post {
 }
 ```
 
-This functionality works for all kind of relations including `many-to-many`:
+This functionality works for all kind of relations, including `many-to-many`:
 
 ```typescript
 @Entity()
@@ -465,7 +465,7 @@ export class Post {
 ```
 
 Relation id is used only for representation.
-The underlying relation is not added/removed/changed when chaning the value.
+The underlying relation is not added/removed/changed when chaining the value.
 
 ## Subscriber and listener decorators
 
@@ -605,8 +605,8 @@ Learn more about [listeners](listeners-and-subscribers.md).
 
 #### `@EventSubscriber`
 
-Marks a class as an event subscriber which can listen to specific entity events or any entity events.
-Events are firing using `QueryBuilder` and repository/manager methods.
+Marks a class as an event subscriber which can listen to specific entity events or any entity's events.
+Events are fired using `QueryBuilder` and repository/manager methods.
 Example:
 
 ```typescript
@@ -632,7 +632,7 @@ export class PostSubscriber implements EntitySubscriberInterface<Post> {
 ```
 
 You can implement any method from `EntitySubscriberInterface`.
-To listen to any entity you just omit `listenTo` method and use `any`:
+To listen to any entity, you just omit the `listenTo` method and use `any`:
 
 ```typescript
 @EventSubscriber()
@@ -654,11 +654,11 @@ Learn more about [subscribers](listeners-and-subscribers.md).
 
 #### `@Index`
 
-This decorator allows to create database index for a specific column or columns.
-It also allows to mark column or columns to be unique.
-Decorator can be applied to columns or entity itself.
-Use it on a column when index on a single column is needed.
-And use it on the entity when a single index on multiple columns is required.
+This decorator allows you to create a database index for a specific column or columns.
+It also allows you to mark column or columns to be unique.
+This decorator can be applied to columns or an entity itself.
+Use it on a column when an index on a single column is needed
+and use it on the entity when a single index on multiple columns is required.
 Examples:
 
 ```typescript
@@ -697,7 +697,7 @@ Learn more about [indices](indices.md).
 #### `@Transaction`, `@TransactionManager` and `@TransactionRepository`
 
 `@Transaction` is used on a method and wraps all its execution into a single database transaction.
-All database queries must be performed using the by `@TransactionManager` provided manager 
+All database queries must be performed using the `@TransactionManager` provided manager 
 or with the transaction repositories injected with `@TransactionRepository`.
 Examples:
 
@@ -730,7 +730,7 @@ Learn more about [transactions](transactions.md).
 
 #### `@EntityRepository`
 
-Marks custom class as entity repository.
+Marks a custom class as an entity repository.
 Example:
 
 ```typescript

--- a/docs/entity-manager-api.md
+++ b/docs/entity-manager-api.md
@@ -57,7 +57,7 @@ const userId = manager.getId(user); // userId === 1
 ```
 
 * `create` - Creates a new instance of `User`. Optionally accepts an object literal with user properties
-which will be written into newly created user object
+which will be written into newly created user object.
 
 ```typescript
 const user = manager.create(User); // same as const user = new User();
@@ -68,15 +68,15 @@ const user = manager.create(User, {
 }); // same as const user = new User(); user.firstName = "Timber"; user.lastName = "Saw";
 ```
 
-* `merge` - Merges multiple entities into a single entity
+* `merge` - Merges multiple entities into a single entity.
 
 ```typescript
 const user = new User();
 manager.merge(User, user, { firstName: "Timber" }, { lastName: "Saw" }); // same as user.firstName = "Timber"; user.lastName = "Saw";
 ```
 
-* `preload` - Creates a new entity from the given plan javascript object. If entity already exist in the database, then
-it loads it (and everything related to it), replaces all values with the new ones from the given object
+* `preload` - Creates a new entity from the given plain javascript object. If the entity already exist in the database, then
+it loads it (and everything related to it), replaces all values with the new ones from the given object,
 and returns the new entity. The new entity is actually loaded from the database entity with all properties
 replaced from the new object.
 
@@ -94,8 +94,8 @@ const user = await manager.preload(User, partialUser);
 ```
 
 * `save` - Saves a given entity or array of entities.
-If the entity already exist in the database then it's updated.
-If the entity does not exist in the database yet it's inserted.
+If the entity already exists in the database, then it's updated.
+If the entity does not exist in the database yet, it's inserted.
 It saves all given entities in a single transaction (in the case of entity manager is not transactional).
 Also supports partial updating since all undefined properties are skipped.
 
@@ -123,7 +123,7 @@ await manager.updateById(User, 1, { firstName: "Rizzrak" });
 ```
 
 * `remove` - Removes a given entity or array of entities.
-It removes all given entities in a single transaction (in the case of entity manager is not transactional).
+It removes all given entities in a single transaction (in the case of entity, manager is not transactional).
 
 ```typescript
 await manager.remove(user);
@@ -206,7 +206,7 @@ const categoryRepository = manager.getTreeRepository(Category);
 ```
 
 * `getMongoRepository` - Gets `MongoRepository` to perform operations on a specific entity.
- Learn more about [MongoDB](./mongodb.md) documentation.
+ Learn more about [MongoDB](./mongodb.md).
 
 ```typescript
 const userRepository = manager.getMongoRepository(User);
@@ -219,7 +219,7 @@ const userRepository = manager.getMongoRepository(User);
 const myUserRepository = manager.getCustomRepository(UserRepository);
 ```
 
-* `release` - Releases query runner of a entity manager. 
+* `release` - Releases query runner of an entity manager. 
 Used only when query runner was created and managed manually.
 
 ```typescript

--- a/docs/example-with-express.md
+++ b/docs/example-with-express.md
@@ -6,8 +6,8 @@
 
 ## Initial setup
 
-Lets create a simple application called "user" which stores users in the database
-and allow to create, update, remove, get a list of all users and a single user by id
+Let's create a simple application called "user" which stores users in the database
+and allows us to create, update, remove, and get a list of all users, as well as a single user by id
 within web api.
 
 First, create a directory called "user":
@@ -32,7 +32,7 @@ npm i typescript --save-dev
 ```
 
 Then let's create a `tsconfig.json` file which contains the configuration required for the application to 
-compile and run. Create it using your favorite editor and put following configuration:
+compile and run. Create it using your favorite editor and put the following configuration:
 
 ```json
 {
@@ -47,7 +47,7 @@ compile and run. Create it using your favorite editor and put following configur
 }
 ``` 
 
-Now lets create main application endpoint - `app.ts` inside `src` directory:
+Now let's create a main application endpoint - `app.ts` inside the `src` directory:
 
 ```
 mkdir src
@@ -55,30 +55,30 @@ cd src
 touch app.ts
 ```
 
-Let's add simple `console.log` inside it:
+Let's add a simple `console.log` inside it:
 
 ```typescript
 console.log("Application is up and running");
 ```
 
-Now its time to run our application.
-To run it you need to compile your typescript project first:
+Now it's time to run our application.
+To run it, you need to compile your typescript project first:
 
 ```
 tsc
 ```
 
-Once you compile it you should have `src/app.js` file generated.
-You can run it:
+Once you compile it, you should have a `src/app.js` file generated.
+You can run it using:
 
 ```
 node src/app.js
 ```
 
-You should see "Application is up and running" message in your console just right after you run the application.
+You should see the, "Application is up and running" message in your console right after you run the application.
 
 You must compile your files each time you make a change.
-Alternatively you can setup watcher or install [ts-node](http://github.com/ts-node/ts-node) to avoid manual compilation each time.
+Alternatively, you can setup watcher or install [ts-node](http://github.com/ts-node/ts-node) to avoid manual compilation each time.
 
 ## Adding Express to the application
 
@@ -93,7 +93,7 @@ npm i express body-parser @types/express @types/body-parser --save
 * `@types/express` is used to have a type information when using express
 * `@types/body-parser` is used to have a type information when using body parser
 
-Let's edit `src/app.ts` file and add express-related logic:
+Let's edit the `src/app.ts` file and add express-related logic:
 
 ```typescript
 import * as express from "express";
@@ -131,13 +131,13 @@ app.listen(3000);
 ```
 
 Now you can compile and run your project.
-You should have a express server running now with working routes.
-However those routes do not return any content yet.
+You should have an express server running now with working routes.
+However, those routes do not return any content yet.
 
 ## Adding TypeORM to the application
 
-Finally lets add TypeORM to the application. 
-In this example we will use `mysql` driver.
+Finally, let's add TypeORM to the application. 
+In this example, we will use `mysql` driver.
 Setup process for other drivers is similar.
 
 Let's install the required packages first:
@@ -242,7 +242,7 @@ export function UsersListAction(req: Request, res: Response) {
 }
 ```
 
-You even don't need `getConnection` in this example - you can directly use `getRepository` function:
+You don't even need `getConnection` in this example - you can directly use the `getRepository` function:
 
 ```typescript
 import {getRepository} from "typeorm";

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -13,8 +13,8 @@
 
 ## How do I update a database schema?
 
-One of the main responsibility of TypeORM is to keep your database tables in sync with your entities.
-There are two ways that help you to achieve this:
+One of the main responsibilities of TypeORM is to keep your database tables in sync with your entities.
+There are two ways that help you achieve this:
 
 * Use `synchronize: true` in your connection options:
     
@@ -26,7 +26,7 @@ There are two ways that help you to achieve this:
     });
     ```
 
-    This option automatically synces your database tables with the given entities each time you run this code. 
+    This option automatically syncs your database tables with the given entities each time you run this code. 
     This option is perfect during development, but in production you may not want this option to be enabled.
 
 * Use command line tools and run schema sync manually in the command line:
@@ -36,15 +36,15 @@ There are two ways that help you to achieve this:
     ```
     
     This command will execute schema synchronization. 
-    Note, to make command line tools to work, you must create a ormconfig.json file.
+    Note, to make command line tools work, you must create an ormconfig.json file.
 
 Schema sync is extremely fast. 
-If you are considering to disable synchronize option during development because of performance issues, 
+If you are considering the disable synchronize option during development because of performance issues, 
 first check how fast it is.
 
 ## How do I change a column name in the database?
 
-By default column names are generated from property names.
+By default, column names are generated from property names.
 You can simply change it by specifying a `name` column option:
 
 ```typescript
@@ -108,36 +108,36 @@ export class Photo {
 ```
 
 This example does not have a `@JoinColumn` which is incorrect.
-Why? Because to make a real relation we need to create a column in the database.
+Why? Because to make a real relation, we need to create a column in the database.
 We need to create a column `userId` in `photo` or `photoId` in `user`.
 But which column should be created - `userId` or `photoId`?
-TypeORM cannot decide it for you. 
-To make a decision you must use `@JoinColumn` on one of the sides.
+TypeORM cannot decide for you. 
+To make a decision, you must use `@JoinColumn` on one of the sides.
 If you put `@JoinColumn` in `Photo` then a column called `userId` will be created in the `photo` table.
 If you put `@JoinColumn` in `User` then a column called `photoId` will be created in the `user` table.
-The side with `@JoinColumn` will be called "owner side of the relationship".
-The other side of the relation, without `@JoinColumn` is called "inverse (non-owner) side of relationship".
+The side with `@JoinColumn` will be called the "owner side of the relationship".
+The other side of the relation, without `@JoinColumn`, is called the "inverse (non-owner) side of relationship".
 
-Same in a `@ManyToMany` relation you use `@JoinTable` to show the owner side of the relation.
+It is the same in a `@ManyToMany` relation. You use `@JoinTable` to show the owner side of the relation.
 
-In `@ManyToOne` or `@OneToMany` relations `@JoinColumn` is not necessary because 
-both decorators are different and where you put `@ManyToOne` decorator that table will have relational column. 
+In `@ManyToOne` or `@OneToMany` relations, `@JoinColumn` is not necessary because 
+both decorators are different, and the table where you put the `@ManyToOne` decorator will have the relational column. 
 
 `@JoinColumn` and `@JoinTable` decorators can also be used to specify additional
 join column / junction table settings, like join column name or junction table name. 
 
 ## How do I add extra columns into many-to-many (junction) table?
 
-Its not possible to add extra columns into the table created by a many-to-many relation.
-You'll need to create a separate entity and bind it using two many-to-one relations with target entities
-(effect will be same as creating a many-to-many table), 
+It's not possible to add extra columns into a table created by a many-to-many relation.
+You'll need to create a separate entity and bind it using two many-to-one relations with the target entities
+(the effect will be same as creating a many-to-many table), 
 and add extra columns in there.
 
 ## How to use TypeORM with a dependency injection tool?
 
-In TypeORM you can use service containers. Service containers allow you to inject custom services in some places, like in subscribers or custom naming strategies. Or for example, you can get access to ConnectionManager from any place using a service container.
+In TypeORM you can use service containers. Service containers allow you to inject custom services in some places, like in subscribers or custom naming strategies. For example, you can get access to ConnectionManager from any place using a service container.
 
-Here is a example for how you can setup typedi service containers with TypeORM. But note, that you can setup any service container with TypeORM.
+Here is an example for how you can set up typedi service containers with TypeORM. Note: you can setup any service container with TypeORM.
 
 ```typescript
 import {useContainer, createConnection} from "typeorm";
@@ -150,20 +150,20 @@ createConnection({/* ... */});
 
 ## How to handle outDir TypeScript compiler option?
 
-When you are using the `outDir` compiler option don't forget to copy assets and resources your app is using into the output directory.
-Or make sure to setup correct paths to those assets.
+When you are using the `outDir` compiler option, don't forget to copy assets and resources your app is using into the output directory.
+Otherwise, make sure to setup correct paths to those assets.
 
-One important thing to know is, that when you remove or move entities, the old entities are left untouched inside the ouput directory.
-For example you create a `Post` entity and rename it to `Blog`.
-You no longer have `Post.ts` in your project, however `Post.js` is left inside the output directory.
-Now when TypeORM reads entities from your output directory it sees two entities - `Post` and `Blog`.
+One important thing to know is that when you remove or move entities, the old entities are left untouched inside the ouput directory.
+For example, you create a `Post` entity and rename it to `Blog`,
+you no longer have `Post.ts` in your project. However, `Post.js` is left inside the output directory.
+Now, when TypeORM reads entities from your output directory, it sees two entities - `Post` and `Blog`.
 This may be a source of bugs. 
-That's why when you remove and move entities with `outDir` enabled its strongly recommended to remove your output directory and recompile the project again. 
+That's why when you remove and move entities with `outDir` enabled, it's strongly recommended to remove your output directory and recompile the project again. 
 
 ## How to use TypeORM with ts-node?
 
 You can prevent compiling files each time using [ts-node](https://github.com/TypeStrong/ts-node).
-If you are using ts-node you can specify `ts` entities inside your connection options:
+If you are using ts-node, you can specify `ts` entities inside your connection options:
 
 ```
 {
@@ -174,9 +174,9 @@ If you are using ts-node you can specify `ts` entities inside your connection op
 
 Also, if you are compiling js files into the same folder where your typescript files are, 
 make sure to use the `outDir` compiler option to prevent 
-[this issues](https://github.com/TypeStrong/ts-node/issues/432). 
+[this issue](https://github.com/TypeStrong/ts-node/issues/432). 
 
-Also if you want to use the ts-node CLI you can execute TypeORM the following way:
+Also, if you want to use the ts-node CLI, you can execute TypeORM the following way:
 
 ```
 ts-node ./node_modules/bin/typeorm schema:sync

--- a/docs/logging.md
+++ b/docs/logging.md
@@ -48,12 +48,12 @@ If you want to enable logging of failed queries only then only add `error`:
 
 There are other options you can use:
 
-* `query` - log all queries
-* `error` - log all failed queries and error
-* `schema` - log the schema build process
-* `warn` - log internal orm warnings
-* `info` - log internal orm informative messages
-* `log` - log internal orm log messages
+* `query` - logs all queries.
+* `error` - logs all failed queries and errors.
+* `schema` - logs the schema build process.
+* `warn` - logs internal orm warnings.
+* `info` - logs internal orm informative messages.
+* `log` - logs internal orm log messages.
 
 You can specify as many options as needed. 
 If you want to enable all logging you can simply specify `logging: "all"`:
@@ -68,7 +68,7 @@ If you want to enable all logging you can simply specify `logging: "all"`:
 
 ## Log long-running queries
 
-If you have performance issues you can log queries that take too much time to execute
+If you have performance issues, you can log queries that take too much time to execute
 by setting `maxQueryExecutionTime` in connection options:
 
 ```typescript
@@ -85,12 +85,12 @@ This code will log all queries which run more then `1 second`.
 
 TypeORM ships with 4 different types of logger:
 
-* `advanced-console` - this is default which logs all messages onto the console using color 
-and sql syntax highlighting (using [chalk](https://github.com/chalk/chalk))
+* `advanced-console` - this is the default logger which logs all messages into the console using color 
+and sql syntax highlighting (using [chalk](https://github.com/chalk/chalk)).
 * `simple-console` - this is a simple console logger which is exactly the same as the advanced logger, but it does not use any color highlighting.
-This logger can be used if you have problems / or don't like colorized logs
-* `file` - this logger writes all logs into `ormlogs.log` in the root folder of your project (near `package.json` and `ormconfig.json`)
-* `debug` - this logger uses [debug package](https://github.com/visionmedia/debug), to turn on logging set env variable `DEBUG=typeorm:*` (note logging option has no effect on this logger)
+This logger can be used if you have problems / or don't like colorized logs.
+* `file` - this logger writes all logs into `ormlogs.log` in the root folder of your project (near `package.json` and `ormconfig.json`).
+* `debug` - this logger uses [debug package](https://github.com/visionmedia/debug), to turn on logging set your env variable `DEBUG=typeorm:*` (note logging option has no effect on this logger).
 
 You can enable any of them in connection options:
 
@@ -135,8 +135,8 @@ createConnection({
 });
 ```
 
-If you defined your connection options in `ormconfig` file,
-then you can use it and override following way:
+If you defined your connection options in the `ormconfig` file,
+then you can use it and override it in the following way:
 
 ```typescript
 import {createConnection, getConnectionOptions} from "typeorm";
@@ -152,8 +152,8 @@ getConnectionOptions().then(connectionOptions => {
 });
 ```
 
-Logger methods can accept `QueryRunner` when its available. Its helpful if you want to log additional data.
-Also via query runner you can get access to additional data passed during persist/remove. For example:
+Logger methods can accept `QueryRunner` when it's available. It's helpful if you want to log additional data.
+Also, via query runner, you can get access to additional data passed during persist/remove. For example:
 
 ```typescript
 // user sends request during entity save

--- a/docs/migrations.md
+++ b/docs/migrations.md
@@ -71,8 +71,8 @@ Before creating a new migration you need to setup your connection options proper
 
 Here we setup two options:
 
-* `"migrations": ["migration/*.js"]` - indicates that typeorm must load migrations from the given "migration" directory
-* `"cli": { "migrationsDir": "migration" }` - indicates that the CLI must create new migrations in the "migration" directory
+* `"migrations": ["migration/*.js"]` - indicates that typeorm must load migrations from the given "migration" directory.
+* `"cli": { "migrationsDir": "migration" }` - indicates that the CLI must create new migrations in the "migration" directory.
 
 Once you setup connection options you can create a new migration using CLI:
 
@@ -80,12 +80,12 @@ Once you setup connection options you can create a new migration using CLI:
 typeorm migrations:create -n PostRefactoring
 ```
 
-To use CLI commands you need to install typeorm globally (`npm i typeorm -g`).
-Also make sure your locally typeorm version matches the global version.
+To use CLI commands, you need to install typeorm globally (`npm i typeorm -g`).
+Also, make sure your local typeorm version matches the global version.
 Learn more about the [TypeORM CLI](./using-cli.md).
 
 Here, `PostRefactoring` is the name of the migration - you can specify any name you want.
-After you run the command you can see a new file generated in "migration" directory, 
+After you run the command you can see a new file generated in the "migration" directory 
 named `{TIMESTAMP}-PostRefactoring.ts` where `{TIMESTAMP}` is the current timestamp when the migration was generated.
 Now you can open the file and add your migration sql queries there.
 
@@ -114,7 +114,7 @@ There are two methods you must fill with your migration code: `up` and `down`.
 `down` method is used to revert the last migration.
 
 Inside both `up` and `down` you have a `QueryRunner` object.
-All database operations are executing using this object.
+All database operations are executed using this object.
 Learn more about [query runner](./query-runner.md).
 
 Let's see what the migration looks like with our `Post` changes:
@@ -138,7 +138,7 @@ export class PostRefactoringTIMESTAMP implements MigrationInterface {
 
 ## Running and reverting migrations
 
-Once you have a migration to run on production you can run them using a CLI command:
+Once you have a migration to run on production, you can run them using a CLI command:
 
 ```
 typeorm migrations:run
@@ -161,14 +161,14 @@ If you need to revert multiple migrations you must call this command multiple ti
 
 TypeORM is able to automatically generate migration files with schema changes you made.
 
-Let's say you have a `Post` entity with a `title` column. And you have changed the name `title` to `name`.
+Let's say you have a `Post` entity with a `title` column, and you have changed the name `title` to `name`.
 You can run following command:
 
 ```
 typeorm migrations:generate -n PostRefactoring
 ```
 
-And it will generate a new migration called `{TIMESTAMP}-PostRefactoring.ts` with following content:
+And it will generate a new migration called `{TIMESTAMP}-PostRefactoring.ts` with the following content:
 
 ```typescript
 import {MigrationInterface, QueryRunner} from "typeorm";

--- a/docs/relational-query-builder.md
+++ b/docs/relational-query-builder.md
@@ -1,11 +1,11 @@
 # Working with Relations
 
-`RelationQueryBuilder` is special type of `QueryBuilder` which allows you to work with your relations.
-Using it you can bind entities to each other in the database without need to load any entities.
-Or you can load related entities easily.
+`RelationQueryBuilder` is a special type of `QueryBuilder` which allows you to work with your relations.
+Using it, you can bind entities to each other in the database without the need to load any entities,
+or you can load related entities easily.
 Examples:
 
-For example we have a `Post` entity and it has a many-to-many relation to `Category` called `categories`.
+For example, we have a `Post` entity and it has a many-to-many relation to `Category` called `categories`.
 Let's add a new category to this many-to-many relation:
                        
 ```typescript
@@ -29,17 +29,17 @@ post.categories.push(category);
 await postRepository.save(post);
 ```
 
-But more efficient because it does a minimal number of operations and binds entities in the database,
-unlike calling bulky `save` method call.
+But more efficient, because it does a minimal number of operations, and binds entities in the database,
+unlike calling a bulky `save` method call.
 
-Also, other benefit of such an approach is that you don't need to load every related entity before pushing into it.
-For example if you have ten thousand categories inside a single post, adding a new post to this list may become problematic for you, 
-because the standard way of doing this, is to load the post with all ten thousand categories, push a new category
-and save it. This results in very heavy performance and basically inapplicable in production results.
+Also, another benefit of such an approach is that you don't need to load every related entity before pushing into it.
+For example, if you have ten thousand categories inside a single post, adding new posts to this list may become problematic for you, 
+because the standard way of doing this is to load the post with all ten thousand categories, push a new category,
+and save it. This results in very heavy performance costs and is basically inapplicable in production results.
 However, using `RelationQueryBuilder` solves this problem.
 
-Also, there is no real need to use entities when you "bind" things, you can use entity ids instead.
-For example, lets add a category with id = 3 into post with id = 1:
+Also, there is no real need to use entities when you "bind" things, since you can use entity ids instead.
+For example, let's add a category with id = 3 into post with id = 1:
 
 ```typescript
 import {getConnection} from "typeorm";
@@ -51,7 +51,7 @@ await getConnection()
     .add(3);
 ```
 
-If you are using composite primary keys you have to pass them as id map, for example:
+If you are using composite primary keys, you have to pass them as an id map, for example:
 
 ```typescript
 import {getConnection} from "typeorm";
@@ -63,7 +63,7 @@ await getConnection()
     .add({ firstCategoryId: 2, secondCategoryId: 4 });
 ```
 
-Same way you add new entities, you can remove them:    
+You can remove entities the same way you add them:    
          
 ```typescript
 import {getConnection} from "typeorm";
@@ -104,8 +104,8 @@ await getConnection()
 ```
 
 Besides updating relations, the relational query builder also allows you to load relational entities.
-For example, lets say inside a `Post` entity we have a many-to-many `categories` relation and a many-to-one `user` relation.
-To load those relations you can use following code:
+For example, lets say inside a `Post` entity we have a many-to-many `categories` relation and a many-to-one `user` relation,
+to load those relations you can use following code:
 
 ```typescript
 import {getConnection} from "typeorm";

--- a/docs/relations.md
+++ b/docs/relations.md
@@ -25,7 +25,7 @@ There are several options you can specify for relations:
 * `cascadeUpdate: boolean` - If set to true, the related object will be updated in the database on entity save.
 * `cascadeRemove: boolean` - If set to true, the related object will be removed from the database on entity save and without related object.
 * `cascadeAll: boolean` - Sets `cascadeInsert`, `cascadeUpdate`, `cascadeRemove` at once.
-* `onDelete: "RESTRICT"|"CASCADE"|"SET NULL"` - specifies how foreign key should behave when referenced object is deleted
+* `onDelete: "RESTRICT"|"CASCADE"|"SET NULL"` - specifies how foreign keys should behave when referenced object is deleted.
 * `primary: boolean` - Indicates whether this relation's column will be a primary column or not.
 * `nullable: boolean` - Indicates whether this relation's column is nullable or not. By default it is nullable.
 It's not recommended to set it to false if you are using cascades in your relations.
@@ -90,27 +90,27 @@ question.categories = [category1, category2];
 await connection.manager.save(question);
 ```
 
-As you can see in this example we did not called `save` for `category1` and `category2`.
+As you can see in this example we did not call `save` for `category1` and `category2`.
 They will be automatically inserted, because we set `cascadeInsert` to true.
 
-When using `cascadeUpdate` `save` is called for each object in, that is in a relation with the entity being saved.
-This means, that each entity in the relation will be automatically changed if they exist in the database.
+When using `cascadeUpdate`, `save` is called for each object that is in a relation with the entity being saved.
+This means that each entity in the relation will be automatically changed if they exist in the database.
 
-When using `cascadeRemove` `remove` is called for each object missing in the relation.
-Good example of this method is the relation between `Question` and `Answer` entities.
-When you remove a `Question` which has `answers: Answer[]` relation you want to remove all answers from the database as well.
+When using `cascadeRemove`, `remove` is called for each object missing in the relation.
+A good example of this method is the relation between `Question` and `Answer` entities.
+When you remove a `Question` which has an `answers: Answer[]` relation you want to remove all answers from the database as well.
 
 Keep in mind - great power comes with great responsibility.
-Cascades may seem a good and easy way to work with relations, 
+Cascades may seem like a good and easy way to work with relations, 
 but they may also bring bugs and security issues when some undesired object is being saved into the database. 
 Also, they provide a less explicit way of saving new objects into the database.
 
 ## `@JoinColumn` options
 
 `@JoinColumn` not only defines which side of the relation contains the join column with a foreign key, 
-but also allows to customize join column name and referenced column name. 
+but also allows you to customize join column name and referenced column name. 
 
-When we set `@JoinColumn` it creates a column in the database automatically named `propertyName + referencedColumnName`.
+When we set `@JoinColumn`, it automtically creates a column in the database named `propertyName + referencedColumnName`.
 For example:
 
 ```typescript
@@ -128,7 +128,7 @@ If you want to change this name in the database you can specify a custom join co
 category: Category;
 ```
 
-Join columns are always a reference to some columns (using a foreign key).
+Join columns are always a reference to some other columns (using a foreign key).
 By default your relation always refers to the primary column of the related entity.
 If you want to create relation with other columns of the related entity -
 you can specify them in `@JoinColumn` as well:
@@ -140,7 +140,7 @@ category: Category;
 ```
 
 The relation now refers to `name` of the `Category` entity, instead of `id`.
-Column name for such relation will become `categoryName`
+Column name for that relation will become `categoryName`
 
 ## `@JoinTable` options
 
@@ -165,5 +165,5 @@ You can also change the name of the generated "junction" table.
 categories: Category[];
 ```
 
-If destination table has composite primary keys, 
-then array of properties must be send to `@JoinTable`.
+If the destination table has composite primary keys, 
+then an array of properties must be sent to `@JoinTable`.

--- a/docs/repository-api.md
+++ b/docs/repository-api.md
@@ -70,16 +70,16 @@ const user = repository.create({
 }); // same as const user = new User(); user.firstName = "Timber"; user.lastName = "Saw";
 ```
 
-* `merge` - Merges multiple entities into a single entity
+* `merge` - Merges multiple entities into a single entity.
 
 ```typescript
 const user = new User();
 repository.merge(user, { firstName: "Timber" }, { lastName: "Saw" }); // same as user.firstName = "Timber"; user.lastName = "Saw";
 ```
 
-* `preload` - Creates a new entity from the given plain javascript object. If the entity already exist in the database, then
-it loads it (and everything related to it), replaces all values with the new ones from the given object
-and returns the new entity. The new entity is actually an entity loaded from the db with all properties
+* `preload` - Creates a new entity from the given plain javascript object. If the entity already exists in the database, then
+it loads it (and everything related to it), replaces all values with the new ones from the given object,
+and returns the new entity. The new entity is actually an entity loaded from the database with all properties
 replaced from the new object.
 
 ```typescript
@@ -98,7 +98,7 @@ const user = await repository.preload(partialUser);
 * `save` - Saves a given entity or array of entities.
 If the entity already exist in the database, it is updated.
 If the entity does not exist in the database, it is inserted.
-It saves all given entities in a single transaction (in the case of entity manager is not transactional).
+It saves all given entities in a single transaction (in the case of entity, manager is not transactional).
 Also supports partial updating since all undefined properties are skipped.
 
 ```typescript
@@ -125,7 +125,7 @@ await repository.updateById(1, { firstName: "Rizzrak" });
 ```
 
 * `remove` - Removes a given entity or array of entities.
-It removes all given entities in a single transaction (in the case of entity manager is not transactional).
+It removes all given entities in a single transaction (in the case of entity, manager is not transactional).
 
 ```typescript
 await repository.remove(user);

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -4,18 +4,18 @@ See what amazing new features we are expecting to land in the next TypeORM versi
 
 ## Note on 1.0.0 release
 
-We are planning to release a final stable `1.0.0` version somewhere in summer 2018.
-However TypeORM is already actively used in number of big production systems.
-Main API is already very stable, there are only few issues currently we have in following areas:
+We are planning to release a final stable `1.0.0` version somewhere in Summer 2018.
+However, TypeORM is already actively used in a number of big production systems.
+The main API is already very stable, and there are only a few issues currently in the following areas:
 `cascades`, `class and single table inheritance`, `naming strategy`, `subscribers`, `tree tables`.
-All issues in those areas are planning to be fixed in next minor versions.
-Your donations and contribution play a big role in achieving this goal.
-TypeORM follows a semantic versioning and until `1.0.0` breaking changes may appear in `0.x.x` versions,
-however since API is already quite stable we don't expect too much breaking changes.  
+All issues in those areas are planned to be fixed in upcoming minor versions.
+Your donations and contributions play a big role in achieving this goal.
+TypeORM follows a semantic versioning and until `1.0.0`, breaking changes may appear in `0.x.x` versions.
+However, since the API is already quite stable we don't expect too many breaking changes.  
 
 ## How to install latest development version?
 
-To install latest development version use following command:
+To install latest development version use the following command:
 
 ```
 npm i typeorm@next

--- a/docs/select-query-builder.md
+++ b/docs/select-query-builder.md
@@ -100,9 +100,9 @@ There are several ways how you can create a `Query Builder`:
         .getOne();
     ```
 
-There are 5 diffrent `QueryBuilder`s available:
+There are 5 different `QueryBuilder` types available:
 
-* `SelectQueryBuilder` used to build and execute `SELECT` queries. Example:
+* `SelectQueryBuilder` - used to build and execute `SELECT` queries. Example:
 
     ```typescript
     import {getConnection} from "typeorm";
@@ -115,7 +115,7 @@ There are 5 diffrent `QueryBuilder`s available:
         .getOne();
     ```
 
-* `InsertQueryBuilder` used to build and execute `INSERT` queries. Example:
+* `InsertQueryBuilder` - used to build and execute `INSERT` queries. Example:
 
     ```typescript
     import {getConnection} from "typeorm";
@@ -131,7 +131,7 @@ There are 5 diffrent `QueryBuilder`s available:
         .execute();
     ```
 
-* `UpdateQueryBuilder` used to build and execute `UPDATE` queries. Example:
+* `UpdateQueryBuilder` - used to build and execute `UPDATE` queries. Example:
                           
     ```typescript
     import {getConnection} from "typeorm";
@@ -143,7 +143,7 @@ There are 5 diffrent `QueryBuilder`s available:
         .where("id = :id", { id: 1 })
         .execute();
     ```
-* `DeleteQueryBuilder` used to build and execute `DELETE` queries. Example:
+* `DeleteQueryBuilder` - used to build and execute `DELETE` queries. Example:
                                                     
     ```typescript
     import {getConnection} from "typeorm";
@@ -156,15 +156,15 @@ There are 5 diffrent `QueryBuilder`s available:
         .execute();
     ```
 
-* `RelationQueryBuilder` used to build and execute relation-specific operations [TBD]. 
+* `RelationQueryBuilder` - used to build and execute relation-specific operations [TBD]. 
 
 You can switch between different types of query builder within any of them,
-once you do it - you will get a new instance of query builder (unlike all other methods).
+once you do, you will get a new instance of query builder (unlike all other methods).
 
 ## Getting values using `QueryBuilder`
 
 To get a single result from the database, 
-for example to get a user by id or name you must use `getOne`:
+for example to get a user by id or name, you must use `getOne`:
 
 ```typescript
 const timber = await getRepository(User)
@@ -174,7 +174,7 @@ const timber = await getRepository(User)
 ``` 
 
 To get multiple results from the database, 
-for example to get all users from the database use `getMany`:
+for example, to get all users from the database, use `getMany`:
 
 ```typescript
 const users = await getRepository(User)
@@ -183,11 +183,11 @@ const users = await getRepository(User)
 ```
 
 There are two types of results you can get using select query builder: **entities** or **raw results**.
-Most of the times you need to select real entities from your database, for example users. 
-For this purpose you use `getOne` and `getMany`.
+Most of the time, you need to select real entities from your database, for example, users. 
+For this purpose, you use `getOne` and `getMany`.
 But sometimes you need to select some specific data, let's say the *sum of all user photos*. 
-This data is not an entity, its called raw data.
-To get raw data you use `getRawOne` and `getRawMany`.
+This data is not an entity, it's called raw data.
+To get raw data, you use `getRawOne` and `getRawMany`.
 Examples:
 
 ```typescript
@@ -213,7 +213,7 @@ const photosSums = await getRepository(User)
 
 We used `createQueryBuilder("user")`. But what is "user"?
 It's just a regular SQL alias. 
-We use aliases everywhere in except when we work with selected data.
+We use aliases everywhere, except when we work with selected data.
 
 `createQueryBuilder("user")` is equivalent to:
 
@@ -223,13 +223,13 @@ createQueryBuilder()
     .from(User, "user")
 ```
 
-Which will result into following sql query:
+Which will result in the following sql query:
 
 ```sql
 SELECT ... FROM users user
 ```
 
-In this SQL query `users` is the table name and `user` is an alias we assign to this table.
+In this SQL query, `users` is the table name, and `user` is an alias we assign to this table.
 Later we use this alias to access the table:
 
 ```typescript
@@ -239,15 +239,15 @@ createQueryBuilder()
     .where("user.name = :name", { name: "Timber" })
 ```
 
-Which produce following SQL query:
+Which produces the following SQL query:
 
 ```sql
 SELECT ... FROM users user WHERE user.name = 'Timber'
 ```
 
-See, we used the users table using the `user` alias we assigned when we created a query builder.
+See, we used the users table by using the `user` alias we assigned when we created a query builder.
 
-One query builder is not limited to one alias, they can have are multiple aliases.
+One query builder is not limited to one alias, they can have multiple aliases.
 Each select can have its own alias,
 you can select from multiple tables each with its own alias, 
 you can join multiple tables each with its own alias.
@@ -256,9 +256,9 @@ You can use those aliases to access tables are you selecting (or data you are se
 ## Using parameters to escape data
 
 We used `where("user.name = :name", { name: "Timber" })`.
-What does `{ name: "Timber" }` stands for? It's a parameter we used to prevent SQL injection.
+What does `{ name: "Timber" }` stand for? It's a parameter we used to prevent SQL injection.
 We could have written: `where("user.name = '" + name + "')`, 
-however this is not safe as it opens the code to SQL injections.
+however this is not safe, as it opens the code to SQL injections.
 The safe way is to use this special syntax: `where("user.name = :name", { name: "Timber" })`,
 where `:name` is a parameter name and the value is specified in an object: `{ name: "Timber" }`.
 
@@ -282,7 +282,7 @@ createQueryBuilder("user")
     .where("user.name = :name", { name: "Timber" })
 ```
 
-Will produce:
+Which will produce:
 
 ```sql
 SELECT ... FROM users user WHERE user.name = 'Timber'
@@ -296,13 +296,13 @@ createQueryBuilder("user")
     .andWhere("user.lastName = :lastName", { lastName: "Saw" });
 ```
 
-Will produce the following SQL query:
+Which will produce the following SQL query:
 
 ```sql
 SELECT ... FROM users user WHERE user.firstName = 'Timber' AND user.lastName = 'Saw'
 ```
 
-You can add `OR` into an exist `WHERE` expression:
+You can add `OR` into an existing `WHERE` expression:
 
 ```typescript
 createQueryBuilder("user")
@@ -310,7 +310,7 @@ createQueryBuilder("user")
     .orWhere("user.lastName = :lastName", { lastName: "Saw" });
 ```
 
-Will produce the following SQL query:
+Which will produce the following SQL query:
 
 ```sql
 SELECT ... FROM users user WHERE user.firstName = 'Timber' OR user.lastName = 'Saw'
@@ -319,9 +319,9 @@ SELECT ... FROM users user WHERE user.firstName = 'Timber' OR user.lastName = 'S
 You can combine as many `AND` and `OR` expressions as you need.
 If you use `.where` more than once you'll override all previous `WHERE` expressions.
 
-Note: be careful with `orWhere` - if you use complex expressions with both `AND` and `OR` expressions
+Note: be careful with `orWhere` - if you use complex expressions with both `AND` and `OR` expressions,
 keep in mind that they are stacked without any pretences. 
-Sometimes you'll need to create a where string instead and avoid using `orWhere`. 
+Sometimes you'll need to create a where string instead, and avoid using `orWhere`. 
 
 ## Adding `HAVING` expression
 
@@ -332,7 +332,7 @@ createQueryBuilder("user")
     .having("user.name = :name", { name: "Timber" })
 ```
 
-Will produce following SQL query:
+Which will produce following SQL query:
 
 ```sql
 SELECT ... FROM users user HAVING user.name = 'Timber'
@@ -346,7 +346,7 @@ createQueryBuilder("user")
     .andHaving("user.lastName = :lastName", { lastName: "Saw" });
 ```
 
-Will produce the following SQL query:
+Which will produce the following SQL query:
 
 ```sql
 SELECT ... FROM users user HAVING user.firstName = 'Timber' AND user.lastName = 'Saw'
@@ -360,7 +360,7 @@ createQueryBuilder("user")
     .orHaving("user.lastName = :lastName", { lastName: "Saw" });
 ```
 
-Will produce the following SQL query:
+Which will produce the following SQL query:
 
 ```sql
 SELECT ... FROM users user HAVING user.firstName = 'Timber' OR user.lastName = 'Saw'
@@ -371,20 +371,20 @@ If you use `.having` more than once you'll override all previous `HAVING` expres
 
 ## Adding `ORDER BY` expression
 
-Adding a `ORDER BY` expression is easy as:
+Adding an `ORDER BY` expression is easy as:
 
 ```typescript
 createQueryBuilder("user")
     .orderBy("user.id")
 ```
 
-Will produce:
+Which will produce:
 
 ```sql
 SELECT ... FROM users user ORDER BY user.id
 ```
 
-You can change the order direction from ascendant to descendant (or versa):
+You can change the ordering direction from ascending to descending (or versa):
 
 ```typescript
 createQueryBuilder("user")
@@ -402,7 +402,7 @@ createQueryBuilder("user")
     .addOrderBy("user.id");
 ```
 
-You can also usea map of order-by fields:
+You can also use a map of order-by fields:
 
 ```typescript
 createQueryBuilder("user")
@@ -423,7 +423,7 @@ createQueryBuilder("user")
     .groupBy("user.id")
 ```
 
-This Will produce the following SQL query:
+Which will produce the following SQL query:
 
 ```sql
 SELECT ... FROM users user GROUP BY user.id
@@ -453,28 +453,28 @@ Which will produce the following SQL query:
 SELECT ... FROM users user LIMIT 10
 ```
 
-The resulting SQL query depends of database type.
-Note LIMIT may not work as you may expect if you are using complex queries with joins or subqueries.
-If you are using pagination its recommended to use `take` instead.
+The resulting SQL query depends on the type of database (SQL, mySQL, Postgres, etc).
+Note: LIMIT may not work as you may expect if you are using complex queries with joins or subqueries.
+If you are using pagination, it's recommended to use `take` instead.
 
 ## Adding `OFFSET` expression
 
-Adding SQL `OFFSET` expression is easy as:
+Adding an SQL `OFFSET` expression is easy as:
 
 ```typescript
 createQueryBuilder("user")
     .offset(10)
 ```
 
-Will produce the following SQL query:
+Which will produce the following SQL query:
 
 ```sql
 SELECT ... FROM users user OFFSET 10
 ```
 
-The resulting SQL query depends of database type.
-Note OFFSET may not work as you may expect if you are using complex queries with joins or subqueries.
-If you are using pagination its recommended to use `skip` instead.
+The resulting SQL query depends on the type of database (SQL, mySQL, Postgres, etc).
+Note: OFFSET may not work as you may expect if you are using complex queries with joins or subqueries.
+If you are using pagination, it's recommended to use `skip` instead.
 
 ## Joining relations
 
@@ -516,7 +516,7 @@ export class Photo {
 }
 ```
 
-Now let's say you want to load user "Timber" with all his photos:
+Now let's say you want to load user "Timber" with all of his photos:
 
 ```typescript
 const user = await createQueryBuilder("user")
@@ -525,7 +525,7 @@ const user = await createQueryBuilder("user")
     .getOne();
 ```
 
-You'll get following result:
+You'll get the following result:
 
 ```typescript
 {
@@ -541,10 +541,10 @@ You'll get following result:
 }
 ```
 
-As you can see `leftJoinAndSelect` automatically loaded all of timber's photos.
+As you can see `leftJoinAndSelect` automatically loaded all of Timber's photos.
 The first argument is the relation you want to load and the second argument is an alias you assign to this relation's table.
 You can use this alias anywhere in query builder.
-For example, lets take all timber's photos which aren't removed.
+For example, let's take all Timber's photos which aren't removed.
 
 ```typescript
 const user = await createQueryBuilder("user")
@@ -571,7 +571,7 @@ const user = await createQueryBuilder("user")
     .getOne();
 ```
 
-This will generate following sql query:
+This will generate the following sql query:
 
 ```sql
 SELECT user.*, photo.* FROM users user 
@@ -581,7 +581,7 @@ SELECT user.*, photo.* FROM users user
 
 ## Inner and left joins
 
-If you want to use `INNER JOIN` instead of `JEFT JOIN` just use `innerJoinAndSelect` instead:
+If you want to use `INNER JOIN` instead of `LEFT JOIN` just use `innerJoinAndSelect` instead:
 
 ```typescript
 const user = await createQueryBuilder("user")
@@ -598,14 +598,14 @@ SELECT user.*, photo.* FROM users user
     WHERE user.name = 'Timber'
 ```
 
-Difference between `LEFT JOIN` and `INNER JOIN` is that `INNER JOIN` won't return a user if it does not have any photos.
+The difference between `LEFT JOIN` and `INNER JOIN` is that `INNER JOIN` won't return a user if it does not have any photos.
 `LEFT JOIN` will return you the user even if it doesn't have photos.
-To learn more about different join types refer to the SQL documentation.
+To learn more about different join types, refer to the [SQL documentation](https://msdn.microsoft.com/en-us/library/zt8wzxy4.aspx).
 
 ## Join without selection
 
 You can join data without its selection.
-To do that use `leftJoin` or `innerJoin`:
+To do that, use `leftJoin` or `innerJoin`:
 
 ```typescript
 const user = await createQueryBuilder("user")
@@ -622,11 +622,11 @@ SELECT user.* FROM users user
     WHERE user.name = 'Timber'
 ```
 
-This will select timber if he has photos, but won't return his photos. 
+This will select Timber if he has photos, but won't return his photos. 
 
 ## Joining any entity or table
 
-You can not only join relations, but also other not related entities or tables.
+You can join not only relations, but also other unrelated entities or tables.
 Examples:
 
 ```typescript
@@ -660,14 +660,14 @@ const user = await createQueryBuilder("user")
     .getOne();
 ```
 
-This will load timber's profile photo and set it to `user.profilePhoto`.
+This will load Timber's profile photo and set it to `user.profilePhoto`.
 If you want to load and map a single entity use `leftJoinAndMapOne`.
 If you want to load and map multiple entities use `leftJoinAndMapMany`.
 
 ## Getting the generated query
 
 Sometimes you may want to get the SQL query generated by `QueryBuilder`.
-To do it use `getSql`:
+To do so, use `getSql`:
 
 ```typescript
 const sql = createQueryBuilder("user")
@@ -691,11 +691,11 @@ This query will return users and print the used sql statement to the console.
 ## Getting raw results
 
 There are two types of results you can get using select query builder: **entities** and **raw results**.
-Most of times you need to select real entities from your database, for example users. 
-For this purpose you use `getOne` and `getMany`.
-But sometimes you need to select specific data, let's say the *sum of all user photos*. 
-Such data is not a entity, its called raw data.
-To get raw data you use `getRawOne` and `getRawMany`.
+Most of the time, you need to select real entities from your database, for example, users. 
+For this purpose, you use `getOne` and `getMany`.
+However, sometimes you need to select specific data, like the *sum of all user photos*. 
+Such data is not a entity, it's called raw data.
+To get raw data, you use `getRawOne` and `getRawMany`.
 Examples:
 
 ```typescript
@@ -719,8 +719,8 @@ const photosSums = await getRepository(User)
 
 ## Streaming result data
 
-You can use `stream` which returns you stream.
-Streaming returns you raw data and you must handle entities transformation manually:
+You can use `stream` which returns you a stream.
+Streaming returns you raw data and you must handle entity transformation manually:
 
 ```typescript
 const stream = await getRepository(User)
@@ -731,8 +731,8 @@ const stream = await getRepository(User)
 
 ## Using pagination
 
-Most of the times when you develope an application you need pagination functionality.
-This is used if you have pagination, page slider or infinite scroll components in your application.
+Most of the time when you develop an application, you need pagination functionality.
+This is used if you have pagination, page slider, or infinite scroll components in your application.
 
 ```typescript
 const users = await getRepository(User)
@@ -752,7 +752,7 @@ const users = await getRepository(User)
     .getMany();
 ```
 
-This will give you all users with their photos except first 10.
+This will give you all except the first 10 users with their photos.
 You can combine those methods:
 
 ```typescript
@@ -767,14 +767,14 @@ const users = await getRepository(User)
 This will skip the first 5 users and take 10 users after them.
 
 
-`take` and `skip` may look like we are using `limit` and `offset`, but they don't.
+`take` and `skip` may look like we are using `limit` and `offset`, but they aren't.
 `limit` and `offset` may not work as you expect once you have more complicated queries with joins or subqueries.
 Using `take` and `skip` will prevent those issues.
 
 ## Set locking
 
 QueryBuilder supports both optimistic and pessimistic locking.
-To use pessimistic read locking use following method:
+To use pessimistic read locking use the following method:
 
 ```typescript
 const users = await getRepository(User)
@@ -783,7 +783,7 @@ const users = await getRepository(User)
     .getMany();
 ```
 
-To use pessimistic write locking use following method:
+To use pessimistic write locking use the following method:
 
 ```typescript
 const users = await getRepository(User)
@@ -792,7 +792,7 @@ const users = await getRepository(User)
     .getMany();
 ```
 
-To use optimistic locking use following method:
+To use optimistic locking use the following method:
 
 ```typescript
 const users = await getRepository(User)
@@ -801,11 +801,11 @@ const users = await getRepository(User)
     .getMany();
 ```
 
-Optimistic locking works in conjunction with `@Version` and `@UpdatedDate` decorators.
+Optimistic locking works in conjunction with both `@Version` and `@UpdatedDate` decorators.
 
 ## Partial selection
 
-If you want to select only some entity properties you can use the following syntax:
+If you want to select only some entity properties, you can use the following syntax:
 
 ````typescript
 const users = await getRepository(User)
@@ -817,7 +817,7 @@ const users = await getRepository(User)
     .getMany();
 ````
 
-This will only select `id` and `name` of `User`.
+This will only select the `id` and `name` of `User`.
 
 ## Using subqueries
 
@@ -832,7 +832,7 @@ const posts = qb
     .getMany();
 ```
 
-More elegant way to do the same:
+A more elegant way to do the same:
 
 ```typescript
 const posts = await connection.getRepository(Post)
@@ -897,7 +897,7 @@ const posts = await connection
 
 If you want to add a subselect as a "second from" use `addFrom`.
 
-You can use subselects in a `SELECT` statements as well:
+You can use subselects in `SELECT` statements as well:
 
 ```typescript
 const posts = await connection

--- a/docs/sequelize-migration.md
+++ b/docs/sequelize-migration.md
@@ -138,9 +138,9 @@ export class Task {
 }
 ```
 
-Its highly recommended to define one entity class per file.
+It's highly recommended to define one entity class per file.
 TypeORM allows you to use your classes as database models
-and provides you a declarative way to define what part of your model 
+and provides a declarative way to define what part of your model 
 will become part of your database table.
 The power of TypeScript gives you type hinting and other useful features that you can use in classes.
 
@@ -257,13 +257,13 @@ or
 const employee = Employee.create({ name: "John Doe", title: "senior engineer" });
 ```
 
-if you want to load an exist entity from the database and replace some of its properties you can use following method:
+if you want to load an existing entity from the database and replace some of its properties you can use the following method:
 
 ```typescript
 const employee = await Employee.preload({ id: 1, name: "John Doe" });
 ```
 
-To access properties in sequelize you do following:
+To access properties in sequelize you do the following:
 
 ```typescript
 console.log(employee.get('name'));

--- a/docs/support.md
+++ b/docs/support.md
@@ -12,7 +12,7 @@ If you have a question, you can ask it on [StackOverflow](https://stackoverflow.
 
 If you want community support, or simply want to chat with friendly TypeORM enthusiasts and users, you can do it in [gitter](https://gitter.im/typeorm/typeorm).
 
-### Want a professional commercial support?
+### Want professional commercial support?
 
 The TypeORM core team is always ready to provide professional commercial support.
 We are ready to work with any team in any part of the world.

--- a/docs/support.md
+++ b/docs/support.md
@@ -2,15 +2,15 @@
 
 ### Found a bug or want to propose a new feature?
 
-If you found a bug, issue, or you just want to propose a new feature create [an issue on github](https://github.com/typeorm/typeorm/issues).
+If you found a bug, issue, or you just want to propose a new feature, create [an issue on github](https://github.com/typeorm/typeorm/issues).
 
 ### Have a question?
 
-If you have a question you can ask it on [StackOverflow](https://stackoverflow.com/questions/tagged/typeorm).
+If you have a question, you can ask it on [StackOverflow](https://stackoverflow.com/questions/tagged/typeorm).
 
-### Want a community support?
+### Want community support?
 
-If you want a community support or simply want to chat with friendly TypeORM enthusiasts and users you can do it in [gitter](https://gitter.im/typeorm/typeorm).
+If you want community support, or simply want to chat with friendly TypeORM enthusiasts and users, you can do it in [gitter](https://gitter.im/typeorm/typeorm).
 
 ### Want a professional commercial support?
 

--- a/docs/transactions.md
+++ b/docs/transactions.md
@@ -81,8 +81,8 @@ using the `@TransactionRepository() customRepository: CustomRepository`.
 
 `QueryRunner` provides a single database connection.
 Transactions are organized using query runners. 
-Single transaction can be established only on a single query runner.
-You can manally create a query runner instance and control transaction state manually using it.
+Single transactions can only be established on a single query runner.
+You can manually create a query runner instance and use it to manually control transaction state.
 Example:
 
 ```typescript
@@ -125,8 +125,8 @@ try {
 There are 3 methods to control transactions in `QueryRunner`:
 
 
-* `startTransaction` - starts a new transaction inside the query runner instance
-* `commitTransaction` - commits all changes made using the query runner instance
-* `rollbackTransaction` - rolls all changes made using the query runner instance back
+* `startTransaction` - starts a new transaction inside the query runner instance.
+* `commitTransaction` - commits all changes made using the query runner instance.
+* `rollbackTransaction` - rolls all changes made using the query runner instance back.
 
 Learn more about [Query Runner](./query-runner.md).

--- a/docs/tree-entities.md
+++ b/docs/tree-entities.md
@@ -9,7 +9,8 @@ TypeORM supports the Adjacency list and Closure table patterns for storing tree 
 
 Adjacency list is a simple model with self-referencing. 
 The benefit of this approach is simplicity, 
-drawback is that you can't load big tree in once because of join limitations.
+drawback is that you can't load big trees in all at once because of join limitations.
+To learn more about the benefits and use of Adjacency Lists look at [this article by Matthew Schinckel](http://schinckel.net/2014/09/13/long-live-adjacency-lists/).
 Example:
 
 ```typescript
@@ -40,7 +41,7 @@ export class Category {
 
 
 Closure table stores relations between parent and child in a separate table in a special way. 
-Its efficient in both reads and writes. 
+It's efficient in both reads and writes. 
 To learn more about closure table take a look at [this awesome presentation by Bill Karwin](https://www.slideshare.net/billkarwin/models-for-hierarchical-data). 
 Example:
 

--- a/docs/using-cli.md
+++ b/docs/using-cli.md
@@ -33,8 +33,8 @@ It creates all files needed for a basic project with TypeORM:
 * src/index.ts
 
 Then you can run `npm install` to install all dependencies.
-Once all dependencies are installed you need to modify `ormconfig.json` and insert your own database settings.
-After that you can run your application by running `npm start`.
+Once all dependencies are installed, you need to modify `ormconfig.json` and insert your own database settings.
+After that, you can run your application by running `npm start`.
 
 All files are generated in the current directory.
 If you want to generate them in a special directory you can use `--name`: 
@@ -72,9 +72,9 @@ You can create a new entity using CLI:
 typeorm entity:create -n User
 ```
 
-where `User` is entity file and class name. 
+where `User` is an entity file and class name. 
 Running the command will create a new empty entity in `entitiesDir` of the project.
-To setup `entitiesDir` of the project you must add it in connection options:
+To setup the `entitiesDir` of the project you must add it in connection options:
 
 ```
 {
@@ -103,8 +103,8 @@ You can create a new subscriber using CLI:
 typeorm subscriber:create -n UserSubscriber
 ```
 
-where `UserSubscriber` is subscriber file and class name. 
-Running following command will create a new empty subscriber in the `subscribersDir` of the project.
+where `UserSubscriber` is a subscriber file and class name. 
+Running the following command will create a new empty subscriber in the `subscribersDir` of the project.
 To setup `subscribersDir` you must add it in connection options:
 
 ```
@@ -134,7 +134,7 @@ You can create a new migration using CLI:
 typeorm migration:create -n UserMigration
 ```
 
-where `UserMigration` is migration file and class name. 
+where `UserMigration` is a migration file and class name. 
 Running the command will create a new empty migration in the `migrationsDir` of the project.
 To setup `migrationsDir` you must add it in connection options:
 
@@ -165,7 +165,7 @@ and writes all sql queries that must be executed to update the database.
 typeorm migration:generate -n UserMigration
 ```
 
-Rule of thumb is to generate a migration after each entity change.
+The rule of thumb is to generate a migration after each entity change.
 
 Learn more about [Migrations](./migrations.md).
 
@@ -181,7 +181,7 @@ Learn more about [Migrations](./migrations.md).
 
 ## Revert migrations
 
-To revert last executed migration use following command:
+To revert the last executed migration use the following command:
 
 ```
 typeorm migrations:revert
@@ -199,8 +199,8 @@ typeorm schema:sync
 ```
 
 Be careful running this command in production - 
-schema sync may bring you data loose if you don't use it wisely.
-Check sql queries it will run before running this query on production.
+schema sync may cause data loss if you don't use it wisely.
+Check which sql queries it will run before running on production.
 
 ## Log sync database schema queries without actual running them
 
@@ -212,13 +212,13 @@ typeorm schema:log
 
 ## Drop database schema
 
-To complete drop a database schema use:
+To completely drop a database schema use:
 
 ```
 typeorm schema:drop
 ```
 
-Be careful with this command on production since it completely remove data from your database.
+Be careful with this command on production since it completely removes data from your database.
 
 ## Run any sql query
 

--- a/docs/working-with-repository.md
+++ b/docs/working-with-repository.md
@@ -2,8 +2,8 @@
 
 `Repository` is just like `EntityManager` but its operations are limited to a concrete entity.
 
-You can access repository via `getRepository(Entity)` 
-or from `Connection#getRepository` or from `EntityManager#getRepository`.
+You can access repository via `getRepository(Entity)`, 
+`Connection#getRepository`, or `EntityManager#getRepository`.
 Example:
  
 ```typescript
@@ -17,7 +17,7 @@ await userRepository.save(user);
 ```
 
 There are 3 types of repositories:
-* `Repository` - Regular repository for any entity
+* `Repository` - Regular repository for any entity.
 * `TreeRepository` - Repository, extensions of `Repository` used for tree-entities 
 (like entities marked with `@ClosureEntity` decorator). 
 Has special methods to work with tree structures.


### PR DESCRIPTION
Minor grammar and punctuation fixes to documentation. Some are for readability, some for comprehension, and others to keep formatting in line with surrounding documentation.