### PR TITLE
Webpack, browser, warnings fix: Module not found

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,6 +9,18 @@
     "name": "Umed Khudoiberdiev",
     "email": "pleerock.me@gmail.com"
   },
+  "browser": {
+    "redis": false,
+    "pg-query-stream": false,
+    "pg-native": false,
+    "pg": false,
+    "oracledb": false,
+    "mysql2": false,
+    "mysql": false,
+    "mssql": false,
+    "mongodb": false,
+    "sqlite3": false
+  },
   "repository": {
     "type": "git",
     "url": "https://github.com/typeorm/typeorm.git"


### PR DESCRIPTION
Fix for webpack (browser build) warning: Module not found. This will fix all webpack errors if you are build for example angular 5 app.

WARNING in ../node_modules/typeorm/platform/PlatformTools.js
Module not found: Error: Can't resolve '**database module name**' in '/Users/dariusz/ProjectsMac/npm/tsc-npm-project/projects/workspace/node_modules/typeorm/platform'
resolve 'redis' in '/Users/dariusz/ProjectsMac/npm/tsc-npm-project/projects/workspace/node_modules/typeorm/platform'
  Parsed request is a module