### PR TITLE
Fix issue#1140

### DIFF
--- a/src/driver/postgres/PostgresDriver.ts
+++ b/src/driver/postgres/PostgresDriver.ts
@@ -324,7 +324,7 @@ export class PostgresDriver implements Driver {
      */
     prepareHydratedValue(value: any, columnMetadata: ColumnMetadata): any {
         if (columnMetadata.transformer)
-            value = columnMetadata.transformer.from(value);
+            return columnMetadata.transformer.from(value);
 
         if (value === null || value === undefined)
             return value;


### PR DESCRIPTION
This changes the postgres driver behaviour such that if a transform exists on a column, the driver doesn't try to do further manipulation of the value after the transform has run.