### PR TITLE
Updated the hidden column to reflect the query

### DIFF
--- a/docs/select-query-builder.md
+++ b/docs/select-query-builder.md
@@ -932,7 +932,7 @@ export class User {
     name: string;
 
     @Column({select: false})
-    name: string;
+    password: string;
 }
 ```
 


### PR DESCRIPTION
I noticed this while browsing the docs. There were two columns with the name `name`. The example query builder to fetch that column was selecting `password`. So updated the column to reflect that