### PR TITLE
SQLite: add integer primary keys to primary key list

### DIFF
--- a/src/driver/sqlite-abstract/AbstractSqliteQueryRunner.ts
+++ b/src/driver/sqlite-abstract/AbstractSqliteQueryRunner.ts
@@ -272,6 +272,12 @@ export class AbstractSqliteQueryRunner implements QueryRunner {
                 if (tableColumn.isGenerated) {
                     tableColumn.generationStrategy = "increment";
                 }
+                // According to the SQlite docs, integer primary keys don't have an index.
+                // Therefore the primary key has to be added seperately.
+                // https://www.sqlite.org/lang_createtable.html#rowid
+                if (tableColumn.isPrimary && tableColumn.type === "integer") {
+                    table.addPrimaryKeys([new TablePrimaryKey(tableColumn.name, tableColumn.name)]);
+                }
 
                 // parse datatype and attempt to retrieve length
                 let pos = tableColumn.type.indexOf("(");
@@ -285,6 +291,7 @@ export class AbstractSqliteQueryRunner implements QueryRunner {
                         }
                     }
                 }
+
                 const columnForeignKeys = dbForeignKeys
                     .filter(foreignKey => foreignKey["from"] === dbColumn["name"])
                     .map(foreignKey => {

--- a/src/driver/sqlite/SqliteQueryRunner.ts
+++ b/src/driver/sqlite/SqliteQueryRunner.ts
@@ -36,6 +36,11 @@ export class SqliteQueryRunner extends AbstractSqliteQueryRunner {
         if (this.isReleased)
             throw new QueryRunnerAlreadyReleasedError();
 
+        if (this.sqlMemoryMode === true) {
+            this.sqlsInMemory.push(query);
+            return Promise.resolve();
+        }
+
         return new Promise<any[]>(async (ok, fail) => {
             const databaseConnection = await this.connect();
             this.driver.connection.logger.logQuery(query, parameters, this);

--- a/src/driver/sqljs/SqljsQueryRunner.ts
+++ b/src/driver/sqljs/SqljsQueryRunner.ts
@@ -48,6 +48,11 @@ export class SqljsQueryRunner extends AbstractSqliteQueryRunner {
         if (this.isReleased)
             throw new QueryRunnerAlreadyReleasedError();
 
+        if (this.sqlMemoryMode === true) {
+            this.sqlsInMemory.push(query);
+            return Promise.resolve();
+        }
+
         return new Promise<any[]>(async (ok, fail) => {
             const databaseConnection = await this.connect();
             this.driver.connection.logger.logQuery(query, parameters, this);

--- a/test/functional/database-schema/synchronize/entities/User.ts
+++ b/test/functional/database-schema/synchronize/entities/User.ts
@@ -1,0 +1,12 @@
+import {Entity} from "../../../../../src/decorator/entity/Entity";
+import {PrimaryGeneratedColumn} from "../../../../../src/decorator/columns/PrimaryGeneratedColumn";
+import {Column} from "../../../../../src/decorator/columns/Column";
+
+@Entity()
+export class User {
+    @PrimaryGeneratedColumn()
+    id: number;
+
+    @Column()
+    name: string;
+}

--- a/test/functional/database-schema/synchronize/entities/User2.ts
+++ b/test/functional/database-schema/synchronize/entities/User2.ts
@@ -1,0 +1,12 @@
+import {Entity} from "../../../../../src/decorator/entity/Entity";
+import {PrimaryColumn} from "../../../../../src/decorator/columns/PrimaryColumn";
+import {Column} from "../../../../../src/decorator/columns/Column";
+
+@Entity()
+export class User2 {
+    @PrimaryColumn()
+    id: string;
+
+    @Column()
+    name: string;
+}

--- a/test/functional/database-schema/synchronize/synchronize.ts
+++ b/test/functional/database-schema/synchronize/synchronize.ts
@@ -1,0 +1,30 @@
+import "reflect-metadata";
+import {closeTestingConnections, createTestingConnections, reloadTestingDatabases} from "../../../utils/test-utils";
+import {Connection} from "../../../../src/connection/Connection";
+import {expect} from "chai";
+
+import {User} from "./entities/User";
+import {User2} from "./entities/User2";
+
+describe("synchronize sqlite", () => {
+
+    let connections: Connection[];
+    before(async () => connections = await createTestingConnections({
+        entities: [User, User2],
+        schemaCreate: true,
+        dropSchema: true
+    }));
+    beforeEach(() => reloadTestingDatabases(connections));
+    after(() => closeTestingConnections(connections));
+
+    it("should not report changes without a change in the model", () => Promise.all(connections.map(async connection => {
+        await connection.synchronize();
+        
+        const schemaBuilder = connection.driver.createSchemaBuilder();
+        const queries = await schemaBuilder.log();
+
+        expect(queries.length).to.be.equal(0);
+
+    })));
+        
+});


### PR DESCRIPTION
I discovered, that SQLite doesn't create primary columns that are specified as `integer` but rather creates an alias to an internal column called `rowid` which is created for every table. When the primary key column is not an integer the column and an index is created. Before this fix, the primary key was only added to the list if the index existed. This is why SQLite based drivers tried to add primary keys that already existed when an `integer` was used.
This fixed the first of the two problems I mentioned in #1530. For the second one a special method would be needed that can be called `RdbmsSchemaBuilder::build()` to disable and enable foreign key constraints for database systems that don't support `ALTER TABLE` statements. Or is there a better way/place to enable and disable them?