### PR TITLE
Handle SQLite in-memory db in ConnectionOptionsReader

### DIFF
--- a/src/connection/ConnectionOptionsReader.ts
+++ b/src/connection/ConnectionOptionsReader.ts
@@ -144,7 +144,7 @@ export class ConnectionOptionsReader {
 
             // make database path file in sqlite relative to package.json
             if (options.type === "sqlite") {
-                if (typeof options.database === "string" && options.database.substr(0, 1) !== "/") {
+                if (typeof options.database === "string" && options.database.substr(0, 1) !== "/" && options.database !== ":memory:") {
                     Object.assign(options, {
                         database: this.baseDirectory + "/" + options.database
                     });

--- a/test/functional/connection-options-reader/configs/sqlite-memory.ts
+++ b/test/functional/connection-options-reader/configs/sqlite-memory.ts
@@ -1,0 +1,9 @@
+module.exports = [{
+  type: "sqlite",
+  name: "file",
+  database: "test"
+}, {
+  type: "sqlite",
+  name: "memory",
+  database: ":memory:",
+}];

--- a/test/functional/connection-options-reader/connection-options-reader.ts
+++ b/test/functional/connection-options-reader/connection-options-reader.ts
@@ -2,7 +2,7 @@ import {expect} from "chai";
 import {ConnectionOptions} from "../../../src/connection/ConnectionOptions";
 import {ConnectionOptionsReader} from "../../../src/connection/ConnectionOptionsReader";
 
-describe("ConnectionOptionsReader", () => {
+describe.only("ConnectionOptionsReader", () => {
   it("properly loads config with entities specified", async () => {
     type EntititesList = Function[] | string[];
     const connectionOptionsReader = new ConnectionOptionsReader({ root: __dirname, configName: "configs/class-entities" });
@@ -11,4 +11,14 @@ describe("ConnectionOptionsReader", () => {
     const entities: EntititesList = options.entities as EntititesList;
     expect(entities.length).to.equal(1);
   });
+
+  it("properly loads sqlite in-memory/path config", async () => {
+    const connectionOptionsReader = new ConnectionOptionsReader({ root: __dirname, configName: "configs/sqlite-memory" });
+    const inmemoryOptions: ConnectionOptions = await connectionOptionsReader.get("memory");
+    expect(inmemoryOptions.database).to.equal(":memory:");
+    const fileOptions: ConnectionOptions = await connectionOptionsReader.get("file");
+    expect(fileOptions.database).to.have.string("/test");
+  });
+
+
 });

--- a/test/functional/connection-options-reader/connection-options-reader.ts
+++ b/test/functional/connection-options-reader/connection-options-reader.ts
@@ -2,7 +2,7 @@ import {expect} from "chai";
 import {ConnectionOptions} from "../../../src/connection/ConnectionOptions";
 import {ConnectionOptionsReader} from "../../../src/connection/ConnectionOptionsReader";
 
-describe.only("ConnectionOptionsReader", () => {
+describe("ConnectionOptionsReader", () => {
   it("properly loads config with entities specified", async () => {
     type EntititesList = Function[] | string[];
     const connectionOptionsReader = new ConnectionOptionsReader({ root: __dirname, configName: "configs/class-entities" });
@@ -19,6 +19,5 @@ describe.only("ConnectionOptionsReader", () => {
     const fileOptions: ConnectionOptions = await connectionOptionsReader.get("file");
     expect(fileOptions.database).to.have.string("/test");
   });
-
 
 });


### PR DESCRIPTION
Fixed an issue where `ConnectionOptionsReader` could not handle `:memory:` database properly.
Fixes #1604.