### PR TITLE
Allow sql expression to all columns in postgres

### DIFF
--- a/src/driver/postgres/PostgresDriver.ts
+++ b/src/driver/postgres/PostgresDriver.ts
@@ -290,6 +290,10 @@ export class PostgresDriver implements Driver {
         if (value === null || value === undefined)
             return value;
 
+        // SQL expressions
+        if (value instanceof Function)
+            return value;
+
         if (columnMetadata.type === Boolean) {
             return value === true ? 1 : 0;
 


### PR DESCRIPTION
This probably isn't as much of a PR as it is a issue report with line of code identified.

This is a follow up to https://github.com/typeorm/typeorm/commit/c5edd3956a5ab0f82d269ed6b2e8bc9922327af5

Right now if a column type is say `jsonb`, then this type of expression won't work

```ts
        await connection.createQueryBuilder()
            .update(User)
            .set({ jsonbColumn: () => `jsonbColumn || '{"mykey": "myvalue"}'`
            .where("id = :id", { id })
            .execute();
```

the parameter `_updated_jsonbColumn` will actually be undefined because it will be `JSON.stringify`'ed as a function.