### PR TITLE
Edit database replication document

### DIFF
--- a/docs/multiple-connections.md
+++ b/docs/multiple-connections.md
@@ -265,9 +265,9 @@ All simple queries performed by find methods or select query builder are using a
 If you want to explicitly use master in SELECT created by query builder, you can use following code:
 
 ```typescript
-const postsQueryBuilder = connection.createQueryBuilder(Post, "post")
+const postsFromMaster = await connection.createQueryBuilder(Post, "post")
     .setQueryRunner(connection.createQueryRunner("master"));
-const postsFromMaster = await postsQueryBuilder.getMany();
+    .getMany();
 ```
 
 Replication is supported by mysql, postgres and sql server databases.

--- a/docs/multiple-connections.md
+++ b/docs/multiple-connections.md
@@ -265,9 +265,9 @@ All simple queries performed by find methods or select query builder are using a
 If you want to explicitly use master in SELECT created by query builder, you can use following code:
 
 ```typescript
-const postsFromMaster = await connection.createQueryBuilder(Post, "post")
-    .setQueryRunner(connection.createQueryRunner("master"))
-    .getMany();
+const postsQueryBuilder = connection.createQueryBuilder(Post, "post")
+    .setQueryRunner(connection.createQueryRunner("master"));
+const postsFromMaster = await postsQueryBuilder.getMany();
 ```
 
 Replication is supported by mysql, postgres and sql server databases.

--- a/docs/multiple-connections.md
+++ b/docs/multiple-connections.md
@@ -266,7 +266,7 @@ If you want to explicitly use master in SELECT created by query builder, you can
 
 ```typescript
 const postsFromMaster = await connection.createQueryBuilder(Post, "post")
-    .setQueryRunner(connection.createQueryRunner("master"));
+    .setQueryRunner(connection.createQueryRunner("master"))
     .getMany();
 ```
 

--- a/src/query-builder/QueryBuilder.ts
+++ b/src/query-builder/QueryBuilder.ts
@@ -410,8 +410,9 @@ export abstract class QueryBuilder<Entity> {
     /**
      * Sets or overrides query builder's QueryRunner.
      */
-    setQueryRunner(queryRunner: QueryRunner) {
+    setQueryRunner(queryRunner: QueryRunner): this {
         this.queryRunner = queryRunner;
+        return this;
     }
 
     // -------------------------------------------------------------------------


### PR DESCRIPTION
Hi
In database replication document, 
https://github.com/typeorm/typeorm/blob/master/docs/multiple-connections.md#replication
`setQueryRunner` returns `void`.

So, this document is wrong.