### PR TITLE
cli: removed "s" from some migration commands

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -61,7 +61,7 @@ This fixed various issues on how real arrays must work
 composite unique constraint, on table level. E.g. `@Unique("uq_id_name", ["id", "name"])`
 * fixed `Oracle` issues, now it will be maintained as other drivers 
 * implemented migrations functionality in all drivers
-* CLI commands changed from `migrations:create`, `migrations:generate` and `migrations:revert` to `migration:create`, `migration:generate` and `migration:revert`
+* CLI commands changed from `migrations:create`, `migrations:generate`, `migrations:revert` and `migrations:run` to `migration:create`, `migration:generate`, `migration:revert` and `migration:run`
 
 ## 0.1.13
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -61,6 +61,7 @@ This fixed various issues on how real arrays must work
 composite unique constraint, on table level. E.g. `@Unique("uq_id_name", ["id", "name"])`
 * fixed `Oracle` issues, now it will be maintained as other drivers 
 * implemented migrations functionality in all drivers
+* CLI commands changed from `migrations:create`, `migrations:generate` and `migrations:revert` to `migration:create`, `migration:generate` and `migration:revert`
 
 ## 0.1.13
 

--- a/docs/migrations.md
+++ b/docs/migrations.md
@@ -141,7 +141,7 @@ export class PostRefactoringTIMESTAMP implements MigrationInterface {
 Once you have a migration to run on production, you can run them using a CLI command:
 
 ```
-typeorm migrations:run
+typeorm migration:run
 ```
 
 This command will execute all pending migrations and run them in a sequence ordered by their timestamps.

--- a/docs/migrations.md
+++ b/docs/migrations.md
@@ -77,7 +77,7 @@ Here we setup two options:
 Once you setup connection options you can create a new migration using CLI:
 
 ```
-typeorm migrations:create -n PostRefactoring
+typeorm migration:create -n PostRefactoring
 ```
 
 To use CLI commands, you need to install typeorm globally (`npm i typeorm -g`).
@@ -151,7 +151,7 @@ That's all! Now you have your database schema up-to-date.
 If for some reason you want to revert the changes, you can run:
 
 ```
-typeorm migrations:revert
+typeorm migration:revert
 ```
 
 This command will execute `down` in the latest executed migration. 
@@ -165,7 +165,7 @@ Let's say you have a `Post` entity with a `title` column, and you have changed t
 You can run following command:
 
 ```
-typeorm migrations:generate -n PostRefactoring
+typeorm migration:generate -n PostRefactoring
 ```
 
 And it will generate a new migration called `{TIMESTAMP}-PostRefactoring.ts` with the following content:

--- a/docs/using-cli.md
+++ b/docs/using-cli.md
@@ -181,10 +181,10 @@ Learn more about [Migrations](./migrations.md).
 
 ## Revert migrations
 
-To revert the last executed migration use the following command:
+To revert the most recently executed migration use the following command:
 
 ```
-typeorm migrations:revert
+typeorm migration:revert
 ```
 
 This command will undo only the last executed migration.

--- a/docs/using-cli.md
+++ b/docs/using-cli.md
@@ -174,7 +174,7 @@ Learn more about [Migrations](./migrations.md).
 To execute all pending migrations use following command:
 
 ```
-typeorm migrations:run
+typeorm migration:run
 ```
 
 Learn more about [Migrations](./migrations.md).

--- a/src/commands/MigrationCreateCommand.ts
+++ b/src/commands/MigrationCreateCommand.ts
@@ -7,7 +7,7 @@ const chalk = require("chalk");
  */
 export class MigrationCreateCommand {
 
-    command = "migrations:create";
+    command = "migration:create";
     describe = "Creates a new migration file.";
 
     builder(yargs: any) {

--- a/src/commands/MigrationGenerateCommand.ts
+++ b/src/commands/MigrationGenerateCommand.ts
@@ -11,7 +11,7 @@ const chalk = require("chalk");
  */
 export class MigrationGenerateCommand {
 
-    command = "migrations:generate";
+    command = "migration:generate";
     describe = "Generates a new migration file with sql needs to be executed to update schema.";
 
     builder(yargs: any) {

--- a/src/commands/MigrationRevertCommand.ts
+++ b/src/commands/MigrationRevertCommand.ts
@@ -8,7 +8,7 @@ const chalk = require("chalk");
  */
 export class MigrationRevertCommand {
 
-    command = "migrations:revert";
+    command = "migration:revert";
     describe = "Reverts last executed migration.";
 
     builder(yargs: any) {

--- a/src/commands/MigrationRunCommand.ts
+++ b/src/commands/MigrationRunCommand.ts
@@ -10,7 +10,7 @@ const chalk = require("chalk");
  */
 export class MigrationRunCommand {
 
-    command = "migrations:run";
+    command = "migration:run";
     describe = "Runs all pending migrations.";
 
     builder(yargs: any) {


### PR DESCRIPTION
* `migrations:create` becomes `migration:create`
* `migrations:generate` becomes `migration:generate`
* `migrations:revert` becomes `migration:revert`

**BUT** `migrations:run` stays `migrations:run`

fixed #1281