### PR TITLE
 exit process on migrations:run command complete

### DIFF
--- a/src/commands/MigrationRunCommand.ts
+++ b/src/commands/MigrationRunCommand.ts
@@ -44,6 +44,8 @@ export class MigrationRunCommand {
 
             await connection.runMigrations();
             await connection.close();
+            // exit process if no errors
+            process.exit(0);
 
         } catch (err) {
             if (connection) await (connection as Connection).close();


### PR DESCRIPTION
I was trying to automate migrations on heroku but the build phase hangs because the migrations:run does not exit process