### PR TITLE
Fixes to Postgres, MySQL and MSSQL drivers propagating unhandled errors and crashing the hosting application

### DIFF
--- a/src/driver/postgres/PostgresDriver.ts
+++ b/src/driver/postgres/PostgresDriver.ts
@@ -639,6 +639,12 @@ export class PostgresDriver implements Driver {
 
         // create a connection pool
         const pool = new this.postgres.Pool(connectionOptions);
+        const { logger } = this.connection;
+        /*
+          Attaching an error handler to pool errors is essential, as, otherwise, errors raised will go unhandled and
+          cause the hosting app to crash.
+         */
+        pool.on("error", (error: any) => logger.log("warn", `Postgres pool raised an error. ${error}`));
 
         return new Promise((ok, fail) => {
             pool.connect((err: any, connection: any, release: Function) => {

--- a/src/driver/sqlserver/SqlServerDriver.ts
+++ b/src/driver/sqlserver/SqlServerDriver.ts
@@ -574,7 +574,16 @@ export class SqlServerDriver implements Driver {
         // pooling is enabled either when its set explicitly to true,
         // either when its not defined at all (e.g. enabled by default)
         return new Promise<void>((ok, fail) => {
-            const connection = new this.mssql.ConnectionPool(connectionOptions).connect((err: any) => {
+            const pool = new this.mssql.ConnectionPool(connectionOptions);
+
+            const { logger } = this.connection;
+            /*
+              Attaching an error handler to pool errors is essential, as, otherwise, errors raised will go unhandled and
+              cause the hosting app to crash.
+             */
+            pool.on("error", (error: any) => logger.log("warn", `MSSQL pool raised an error. ${error}`));
+
+            const connection = pool.connect((err: any) => {
                 if (err) return fail(err);
                 ok(connection);
             });


### PR DESCRIPTION
Fixes #1689 

This is the resolution to the connection drop-out issues for all drivers:

Postgres - Originated the issue. Fixed in this PR
MongoDB - `autoReconnect` flag is the way to go. TypeORM already defaults this to `true`.
MySQL - Similar issue to Postgres. The error handler is on the connection object ([see docs](https://github.com/mysqljs/mysql#error-handling)). Fixed locally.
sqlite - Nothing in [documentation](https://github.com/mapbox/node-sqlite3/wiki/API#new-sqlite3databasefilename-mode-callback). I imagine this doesn't apply due to the nature of the database.
sqljs - Not applicable.
mssql - Same issue as Postgres. Fixed by attaching an error handler to the pool.
websql - Not applicable.

As discussed in the issue, I couldn't see a way to forcefully drop a database connection as part of the tests in order to automate testing of this. @pleerock, you mentioned this was ok as long as there were comments explaining the changes. Comments were added as requested.