### PR TITLE
Fix date conversion issue

### DIFF
--- a/src/util/DateUtils.ts
+++ b/src/util/DateUtils.ts
@@ -14,7 +14,16 @@ export class DateUtils {
         if (!mixedDate)
             return mixedDate;
 
-        const date = typeof mixedDate === "string" ? new Date(mixedDate) : mixedDate as Date;
+        /**
+         * Fix date conversion issue
+         * 
+         * If the format of the date string is "2018-03-14 02:33:33.906", Safari (and iOS WKWebView) will convert it to an invalid date object.
+         * We need to modify the date string to "2018-03-14T02:33:33.906Z" and Safari will convert it correctly.
+         *
+         * ISO 8601
+         * https://www.w3.org/TR/NOTE-datetime
+         */
+        const date = typeof mixedDate === "string" ? (!isNaN(new Date(mixedDate).getTime()) ? new Date(mixedDate) : new Date(mixedDate.replace(" ", "T") + "Z")) : mixedDate as Date;
         // if (!storedInLocal) {
 
         // else if it was not stored in local timezone, means it was stored in UTC


### PR DESCRIPTION
I'm working on a Ionic project, I have a problem that the date always display as "Invalid Date".

After some research, I found:

If the format of the date string is "2018-03-14 02:33:33.906", Safari (and iOS WKWebView) will convert it to an invalid date object.
We need to modify the date string to "2018-03-14T02:33:33.906Z" and Safari will convert it correctly.

ISO 8601
https://www.w3.org/TR/NOTE-datetime

![untitled2](https://user-images.githubusercontent.com/3059450/37398718-5f15bae6-27ba-11e8-973e-85a1eae5cc2e.png)