### PR TITLE
Added support for insertion ignore clause on duplicate error for MySQL/MariaDB, PostgreSQL, SQlite/Sqljs and Oracle databases

### DIFF
--- a/src/query-builder/QueryExpressionMap.ts
+++ b/src/query-builder/QueryExpressionMap.ts
@@ -67,6 +67,16 @@ export class QueryExpressionMap {
     onConflict: string = "";
 
     /**
+     * Optional on ignore statement used in insertion query in databases.
+     */
+    onIgnore: string | boolean = false;
+
+    /**
+     * Optional on update statement used in insertion query in databases.
+     */
+    onUpdate: { columns?: string, conflict?: string };
+
+    /**
      * JOIN queries.
      */
     joinAttributes: JoinAttribute[] = [];
@@ -335,6 +345,8 @@ export class QueryExpressionMap {
         map.valuesSet = this.valuesSet;
         map.returning = this.returning;
         map.onConflict = this.onConflict;
+        map.onIgnore = this.onIgnore;
+        map.onUpdate = this.onUpdate;
         map.joinAttributes = this.joinAttributes.map(join => new JoinAttribute(this.connection, this, join));
         map.relationIdAttributes = this.relationIdAttributes.map(relationId => new RelationIdAttribute(this, relationId));
         map.relationCountAttributes = this.relationCountAttributes.map(relationCount => new RelationCountAttribute(this, relationCount));

--- a/test/github-issues/1780/entity/User.ts
+++ b/test/github-issues/1780/entity/User.ts
@@ -1,0 +1,22 @@
+import {Entity} from "../../../../src/decorator/entity/Entity";
+import {Column} from "../../../../src/decorator/columns/Column";
+import {PrimaryGeneratedColumn} from "../../../../src/decorator/columns/PrimaryGeneratedColumn";
+import {Index} from "../../../../src/decorator/Index";
+
+@Entity()
+@Index("unique_idx", ["first_name", "last_name"], { unique: true })
+export class User {
+
+    @PrimaryGeneratedColumn()
+    id: number;
+
+    @Column({ type: "varchar", length: 100 })
+    first_name: string;
+
+    @Column({ type: "varchar", length: 100 })
+    last_name: string;
+
+    @Column({ type: "varchar", length: 100 })
+    is_updated: string;
+
+}

--- a/test/github-issues/1780/issue-1780.ts
+++ b/test/github-issues/1780/issue-1780.ts
@@ -1,0 +1,301 @@
+import "reflect-metadata";
+import {createTestingConnections, closeTestingConnections, reloadTestingDatabases} from "../../utils/test-utils";
+import {Connection} from "../../../src/connection/Connection";
+import {expect} from "chai";
+import {User} from "./entity/User";
+import {MysqlDriver} from "../../../src/driver/mysql/MysqlDriver";
+import {PostgresDriver} from "../../../src/driver/postgres/PostgresDriver";
+import {OracleDriver} from "../../../src/driver/oracle/OracleDriver";
+import {SqliteDriver} from "../../../src/driver/sqlite/SqliteDriver";
+import {SqljsDriver} from "../../../src/driver/sqljs/SqljsDriver";
+
+describe("github issues > #1780 Support for insertion ignore on duplicate error", () => {
+
+    let connections: Connection[];
+    before(async () => connections = await createTestingConnections({
+        entities: [User],
+        schemaCreate: true,
+        dropSchema: true,
+    }));
+    beforeEach(() => reloadTestingDatabases(connections));
+    after(() => closeTestingConnections(connections));
+
+    let user1 = new User();
+    user1.first_name = "John";
+    user1.last_name = "Lenon";
+    user1.is_updated = "no";
+
+    let user2 = new User();
+    user2.first_name = "John";
+    user2.last_name = "Lenon";
+    user2.is_updated = "yes";
+
+    // let data = [user1, user2];
+    // Bulk insertion with duplicated data through same query with duplicate error exception is not supported in PostgreSQL
+    // https://doxygen.postgresql.org/nodeModifyTable_8c_source.html : Line 1356
+
+    it("should save one row without duplicate error in MySQL/MariaDB", () => Promise.all(connections.map(async connection => {
+
+      try {
+
+        if (connection.driver instanceof MysqlDriver) {
+
+            const UserRepository = connection.manager.getRepository(User);
+
+            // ignore while insertion duplicated row
+            await UserRepository
+                .createQueryBuilder()
+                .insert()
+                .orIgnore()
+                .into(User)
+                .values(user1)
+                .execute();
+
+            await UserRepository
+                .createQueryBuilder()
+                .insert()
+                .orIgnore()
+                .into(User)
+                .values(user2)
+                .execute();
+
+            let loadedUser_1 = await UserRepository.find();
+            expect(loadedUser_1).not.to.be.empty;
+            loadedUser_1.length.should.be.equal(1);
+
+            // remove all rows
+            await UserRepository.remove(loadedUser_1);
+
+            let loadedUser_2 = await UserRepository.find();
+            expect(loadedUser_2).to.be.empty;
+
+            // update while insertion duplicated row
+            await UserRepository
+                .createQueryBuilder()
+                .insert()
+                .orUpdate({ columns: [ "is_updated" ] })
+                .setParameter("is_updated", user1.is_updated)
+                .into(User)
+                .values(user1)
+                .execute();
+
+            await UserRepository
+                .createQueryBuilder()
+                .insert()
+                .orUpdate({ columns: [ "is_updated" ] })
+                .setParameter("is_updated", user2.is_updated)
+                .into(User)
+                .values(user2)
+                .execute();
+
+            let loadedUser_3 = await UserRepository.find();
+            expect(loadedUser_3).not.to.be.empty;
+            loadedUser_3.length.should.be.equal(1);
+            expect(loadedUser_3[0]).to.include({ first_name: "John", last_name: "Lenon", is_updated: "yes" });
+        } 
+
+      } catch (err) {
+
+          throw new Error(err);
+      }
+
+    })));
+
+    it("should save one row without duplicate error in PostgreSQL", () => Promise.all(connections.map(async connection => {
+
+        try {
+            if (connection.driver instanceof PostgresDriver) {
+                
+                const UserRepository = connection.manager.getRepository(User);
+
+                // ignore while insertion duplicated row
+                await UserRepository
+                    .createQueryBuilder()
+                    .insert()
+                    .orIgnore()
+                    .into(User)
+                    .values(user1)
+                    .execute();
+
+                await UserRepository
+                    .createQueryBuilder()
+                    .insert()
+                    .orIgnore()
+                    .into(User)
+                    .values(user2)
+                    .execute();
+
+                let loadedUser_1 = await UserRepository.find();
+                expect(loadedUser_1).not.to.be.empty;
+                loadedUser_1.length.should.be.equal(1);
+
+                // remove all rows
+                await UserRepository.remove(loadedUser_1);
+
+                let loadedUser_2 = await UserRepository.find();
+                expect(loadedUser_2).to.be.empty;
+
+                // update while insertion duplicated row via unique columns
+                await UserRepository
+                    .createQueryBuilder()
+                    .insert()
+                    .orUpdate({ columns: [ "is_updated" ], conflict_target: [ "first_name", "last_name" ] })
+                    .setParameter("is_updated", user1.is_updated)
+                    .into(User)
+                    .values(user1)
+                    .execute();
+
+                await UserRepository
+                    .createQueryBuilder()
+                    .insert()
+                    .orUpdate({ columns: [ "is_updated" ], conflict_target: [ "first_name", "last_name" ] })
+                    .setParameter("is_updated", user2.is_updated)
+                    .into(User)
+                    .values(user2)
+                    .execute();
+
+                let loadedUser_3 = await UserRepository.find();
+                expect(loadedUser_3).not.to.be.empty;
+                loadedUser_3.length.should.be.equal(1);
+                expect(loadedUser_3[0]).to.include({ first_name: "John", last_name: "Lenon", is_updated: "yes" });
+
+                // create unique constraint
+                await connection.manager.query("ALTER TABLE \"user\" ADD CONSTRAINT constraint_unique_idx UNIQUE USING INDEX unique_idx;");
+
+                await UserRepository.remove(loadedUser_3);
+
+                let loadedUser_4 = await UserRepository.find();
+                expect(loadedUser_4).to.be.empty;
+
+                // update while insertion duplicated row via unique's constraint name
+                await UserRepository
+                    .createQueryBuilder()
+                    .insert()
+                    .orUpdate({ columns: [ "is_updated" ], conflict_target: "constraint_unique_idx" })
+                    .setParameter("is_updated", user1.is_updated)
+                    .into(User)
+                    .values(user1)
+                    .execute();
+
+                await UserRepository
+                    .createQueryBuilder()
+                    .insert()
+                    .orUpdate({ columns: [ "is_updated" ], conflict_target: "constraint_unique_idx" })
+                    .setParameter("is_updated", user2.is_updated)
+                    .into(User)
+                    .values(user2)
+                    .execute();
+
+                let loadedUser_5 = await UserRepository.find();
+                expect(loadedUser_5).not.to.be.empty;
+                loadedUser_5.length.should.be.equal(1);
+                expect(loadedUser_3[0]).to.include({ first_name: "John", last_name: "Lenon", is_updated: "yes" });
+            }
+        }
+        catch (err) {
+
+          throw new Error(err);
+        }
+    })));
+
+    it("should save one row without duplicate error in Oracle Database", () => Promise.all(connections.map(async connection => {
+
+        try {
+            if (connection.driver instanceof OracleDriver) {
+
+                const UserRepository = connection.manager.getRepository(User);
+                
+                // ignore while insertion duplicated row
+                await UserRepository
+                    .createQueryBuilder()
+                    .insert()
+                    .orIgnore("unique-idx")
+                    .into(User)
+                    .values(user1)
+                    .execute();
+
+                await UserRepository
+                    .createQueryBuilder()
+                    .insert()
+                    .orIgnore("unique-idx")
+                    .into(User)
+                    .values(user2)
+                    .execute();
+
+                let loadedUser_1 = await UserRepository.find();
+                expect(loadedUser_1).not.to.be.empty;
+                loadedUser_1.length.should.be.equal(1);
+                             
+            }
+        }
+        catch (err) {
+
+          throw new Error(err);
+        }
+    })));
+
+    it("should save one row without duplicate error in SQLite/Sqljs", () => Promise.all(connections.map(async connection => {
+
+        try {
+            if ([SqljsDriver, SqliteDriver].find(currentDriver => connection.driver instanceof currentDriver)) {
+
+                const UserRepository = connection.manager.getRepository(User);
+
+                // ignore while insertion duplicated row
+                await UserRepository
+                    .createQueryBuilder()
+                    .insert()
+                    .orIgnore()
+                    .into(User)
+                    .values(user1)
+                    .execute();
+
+                await UserRepository
+                    .createQueryBuilder()
+                    .insert()
+                    .orIgnore()
+                    .into(User)
+                    .values(user2)
+                    .execute();
+
+                let loadedUser_1 = await UserRepository.find();
+                expect(loadedUser_1).not.to.be.empty;
+                loadedUser_1.length.should.be.equal(1);
+
+                // remove all rows
+                await UserRepository.remove(loadedUser_1);
+
+                let loadedUser_2 = await UserRepository.find();
+                expect(loadedUser_2).to.be.empty;
+
+                // update while insertion duplicated row
+                await UserRepository
+                    .createQueryBuilder()
+                    .insert()
+                    .orUpdate()
+                    .into(User)
+                    .values(user1)
+                    .execute();
+
+                await UserRepository
+                    .createQueryBuilder()
+                    .insert()
+                    .orUpdate()
+                    .into(User)
+                    .values(user2)
+                    .execute();
+
+                let loadedUser_3 = await UserRepository.find();
+                expect(loadedUser_3).not.to.be.empty;
+                loadedUser_3.length.should.be.equal(1);
+                expect(loadedUser_3[0]).to.include({ first_name: "John", last_name: "Lenon", is_updated: "yes" });
+                             
+            }
+        }
+        catch (err) {
+
+          throw new Error(err);
+        }
+    })));
+
+});


### PR DESCRIPTION
See [#1780](https://github.com/typeorm/typeorm/issues/1780)