### PR TITLE
`this.migrationsTableName` was used before assigned

### DIFF
--- a/src/migration/MigrationExecutor.ts
+++ b/src/migration/MigrationExecutor.ts
@@ -29,8 +29,8 @@ export class MigrationExecutor {
                 protected queryRunner?: QueryRunner) {
 
         const options = <SqlServerConnectionOptions|PostgresConnectionOptions>this.connection.driver.options;
-        this.migrationsTable = this.connection.driver.buildTableName(this.migrationsTableName, options.schema, options.database);
         this.migrationsTableName = "migrations" || connection.options.migrationsTableName;
+        this.migrationsTable = this.connection.driver.buildTableName(this.migrationsTableName, options.schema, options.database);
     }
 
     // -------------------------------------------------------------------------


### PR DESCRIPTION
Hi, I'm testing actual `next` version, but I cannot run migrations because of wrong ordering in the constructor.