### PR TITLE
Fix #1833: Add only one error listener to MySQL connections

### DIFF
--- a/src/driver/mysql/MysqlDriver.ts
+++ b/src/driver/mysql/MysqlDriver.ts
@@ -570,7 +570,9 @@ export class MysqlDriver implements Driver {
           Attaching an error handler to connection errors is essential, as, otherwise, errors raised will go unhandled and
           cause the hosting app to crash.
          */
-        connection.on("error", (error: any) => logger.log("warn", `MySQL connection raised an error. ${error}`));
+        if (connection.listeners("error").length === 0) {
+            connection.on("error", (error: any) => logger.log("warn", `MySQL connection raised an error. ${error}`));
+        }
         return connection;
     }
 


### PR DESCRIPTION
Check if there are any listeners attached to the database connection already. If not, add one.

This solves an event listener overflow issue as described in #1833 

I haven't figured out a way to write tests for this yet because the raw connection seems to be a protected property. Working on it, but opening a PR for feedback now.