### PR TITLE
fixed breaking caused by PR #1389

### DIFF
--- a/src/driver/mysql/MysqlQueryRunner.ts
+++ b/src/driver/mysql/MysqlQueryRunner.ts
@@ -847,7 +847,7 @@ export class MysqlQueryRunner implements QueryRunner {
         if (column.isNullable !== true)
             c += " NOT NULL";
         if (column.isNullable === true)
-            c += " NULL";
+            c += (column.isPrimary && !skipPrimary) ? " NOT NULL" : " NULL";
         if (column.isUnique === true)
             c += " UNIQUE";
         if (column.isGenerated && column.isPrimary && !skipPrimary)


### PR DESCRIPTION
PR prevents to set PRIMARY KEY column as NULL in table creation.
[#1389](https://github.com/typeorm/typeorm/commit/9b59503f69ab7e1d90343f1a88b9d08d488e4b79) 
[CI error log](https://travis-ci.org/typeorm/typeorm/builds/322071205?utm_source=github_status&utm_medium=notification)
