### PR TITLE
Optional `prefix` cache option for the redis cache key 

### DIFF
--- a/src/cache/QueryResultCacheOptions.ts
+++ b/src/cache/QueryResultCacheOptions.ts
@@ -10,6 +10,12 @@ export interface QueryResultCacheOptions {
     identifier: string;
 
     /**
+     * Prefix to be applied to the cache identifer
+     *
+     */
+    prefix?: string;
+
+    /**
      * Time, when cache was created.
      */
     time?: number;
@@ -28,5 +34,4 @@ export interface QueryResultCacheOptions {
      * Query result that will be cached.
      */
     result?: any;
-
 }

--- a/src/cache/RedisQueryResultCache.ts
+++ b/src/cache/RedisQueryResultCache.ts
@@ -73,22 +73,18 @@ export class RedisQueryResultCache implements QueryResultCache {
      */
     getFromCache(options: QueryResultCacheOptions, queryRunner?: QueryRunner): Promise<QueryResultCacheOptions|undefined> {
         return new Promise((ok, fail) => {
-
-            if (options.identifier) {
-                this.client.get(options.identifier, (err: any, result: any) => {
-                    if (err) return fail(err);
-                    ok(JSON.parse(result));
-                });
-
-            } else if (options.query) {
-                this.client.get(options.query, (err: any, result: any) => {
-                    if (err) return fail(err);
-                    ok(JSON.parse(result));
-                });
-
-            } else {
+            let key = options.identifier || options.query;
+            if (!key) {
                 ok(undefined);
             }
+            if (options.prefix) {
+                key = `${options.prefix}~${key}`;
+            }
+
+            this.client.get(key, (err: any, result: any) => {
+                if (err) return fail(err);
+                ok(JSON.parse(result));
+            });
         });
     }
 
@@ -104,18 +100,19 @@ export class RedisQueryResultCache implements QueryResultCache {
      */
     async storeInCache(options: QueryResultCacheOptions, savedCache: QueryResultCacheOptions, queryRunner?: QueryRunner): Promise<void> {
         return new Promise<void>((ok, fail) => {
-            if (options.identifier) {
-                this.client.set(options.identifier, JSON.stringify(options), (err: any, result: any) => {
-                    if (err) return fail(err);
-                    ok();
-                });
+            let key = options.identifier || options.query;
 
-            } else if (options.query) {
-                this.client.set(options.query, JSON.stringify(options), (err: any, result: any) => {
-                    if (err) return fail(err);
-                    ok();
-                });
+            if (!key) {
+                ok(undefined);
             }
+            if (options.prefix) {
+                key = `${options.prefix}~${key}`;
+            }
+
+            this.client.set(key, JSON.stringify(options), (err: any, result: any) => {
+                if (err) return fail(err);
+                ok();
+            });
         });
     }
 

--- a/test/github-issues/1905/issue-1905.ts
+++ b/test/github-issues/1905/issue-1905.ts
@@ -1,0 +1,95 @@
+import "reflect-metadata";
+import {RedisQueryResultCache} from "../../../src/cache/RedisQueryResultCache";
+import {stub} from "sinon";
+import {expect} from "chai";
+
+let redisStub: any;
+
+class TestRedisQueryResultCache extends RedisQueryResultCache {
+    constructor() {
+        // Not testing anything related to the connection
+        super({} as any);
+        this.client = redisStub;
+    }
+    loadRedis() {
+        // overridden to set this.client as stub
+    }
+}
+
+describe("github issues > #1905 Use prefix for caching key when provided in cache options", () => {
+
+    beforeEach(() => {
+        redisStub = {
+            get: stub().callsArgWith(1, null, "{}"),
+            set: stub().callsArgWith(2, null, "{}")
+        };
+    });
+
+    describe("Uses the expected cache key for getting cached items", () => {
+        it("Should use the query as a key when identifier is not set", async () => {
+            const resultCache = new TestRedisQueryResultCache();
+            const options = { query: "query", identifier: "", duration: 0 };
+            return resultCache.getFromCache(options).then(() => {
+                expect(redisStub.get.firstCall.args[0]).to.be.equal("query");
+            });
+        });
+
+        it("Should use the identifier as a key when set", async () => {
+            const resultCache = new TestRedisQueryResultCache();
+            const options = { query: "query", identifier: "identifier", duration: 0 };
+            return resultCache.getFromCache(options).then(() => {
+                expect(redisStub.get.firstCall.args[0]).to.be.equal("identifier");
+            });
+        });
+
+        it("Should use prefix the query when prefix option is set", async () => {
+            const resultCache = new TestRedisQueryResultCache();
+            const options = { query: "query", identifier: "", prefix: "prefix", duration: 0 };
+            return resultCache.getFromCache(options).then(() => {
+            expect(redisStub.get.firstCall.args[0]).to.be.equal("prefix~query");
+            });
+        });
+
+        it("Should use prefix the identifier when prefix and identifier options are set", async () => {
+            const resultCache = new TestRedisQueryResultCache();
+            const options = { query: "query", identifier: "identifier", prefix: "prefix", duration: 0 };
+            return resultCache.getFromCache(options).then(() => {
+                expect(redisStub.get.firstCall.args[0]).to.be.equal("prefix~identifier");
+            });
+        });
+    });
+
+    describe("Uses the expected cache key for storing items in the cache", () => {
+        it("Should use the query as a key when identifier is not set", async () => {
+            const resultCache = new TestRedisQueryResultCache();
+            const options = { query: "query", identifier: "", duration: 0 };
+            return resultCache.storeInCache(options, options).then(() => {
+                expect(redisStub.set.firstCall.args[0]).to.be.equal("query");
+            });
+        });
+
+        it("Should use the identifier as a key when set", async () => {
+            const resultCache = new TestRedisQueryResultCache();
+            const options = { query: "query", identifier: "identifier", duration: 0 };
+            return resultCache.storeInCache(options, options).then(() => {
+                expect(redisStub.set.firstCall.args[0]).to.be.equal("identifier");
+            });
+        });
+
+        it("Should use prefix the query when prefix option is set", async () => {
+            const resultCache = new TestRedisQueryResultCache();
+            const options = { query: "query", identifier: "", prefix: "prefix", duration: 0 };
+            return resultCache.storeInCache(options, options).then(() => {
+            expect(redisStub.set.firstCall.args[0]).to.be.equal("prefix~query");
+            });
+        });
+
+        it("Should use prefix the identifier when prefix and identifier options are set", async () => {
+            const resultCache = new TestRedisQueryResultCache();
+            const options = { query: "query", identifier: "identifier", prefix: "prefix", duration: 0 };
+            return resultCache.storeInCache(options, options).then(() => {
+                expect(redisStub.set.firstCall.args[0]).to.be.equal("prefix~identifier");
+            });
+        });
+    });
+});


### PR DESCRIPTION
**Enhancement**

Add a new optional cache configuration option `prefix` that can be used to differentiate between identical statements in the query cache across connections that could point at different databases.

If the cache option `identifier` is also passed the `prefix` will be prepended to the identifier, otherwise it will be prepended to the serialised query.