### PR TITLE
Add link to react-native-example to docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1248,6 +1248,7 @@ There are a few repositories which you can clone and start with:
 * [Example how to use TypeORM with MongoDB](https://github.com/typeorm/typeorm-typescript-mongo-example)
 * [Example how to use TypeORM in a Cordova/PhoneGap app](https://github.com/typeorm/cordova-example)
 * [Example how to use TypeORM with an Ionic app](https://github.com/typeorm/ionic-example)
+* [Example how to use TypeORM with React Native](https://github.com/typeorm/react-native-example)
 
 ## Extensions
 

--- a/docs/supported-platforms.md
+++ b/docs/supported-platforms.md
@@ -71,6 +71,9 @@ TypeORM is able to run on Cordova, PhoneGap, Ionic apps using the
 You have the option to choose between module loaders just like in browser package. 
 For an example how to use TypeORM in Cordova see [typeorm/cordova-example](https://github.com/typeorm/cordova-example) and for Ionic see [typeorm/ionic-example](https://github.com/typeorm/ionic-example). **Important**: For use with Ionic, a custom webpack config file is needed! Please checkout the example to see the needed changes.
 
+## React Native
+TypeORM is able to on React Native apps using the [react-native-sqlite-storage](https://github.com/andpor/react-native-sqlite-storage) plugin. For an example see [typeom/react-native-example](https://github.com/typeorm/react-native-example).
+
 ## NativeScript
 
 In the next releases we are planning to support NativeScript platform as well.


### PR DESCRIPTION
This adds the new example to the readme and the supported-platforms page.