### PR TITLE
Column options for postgres range types

### DIFF
--- a/src/driver/types/ColumnTypes.ts
+++ b/src/driver/types/ColumnTypes.ts
@@ -62,16 +62,6 @@ export type WithWidthColumnType = "tinyint" // mysql
     |"bigint"; // mysql
 
 /**
- * Range types
- */
-export type RangeColumnType = "int4range" // postgres
-    |"int8range" // postgres
-    |"numrange" // postgres
-    |"tsrange" // postgres
-    |"tstzrange" // postgres
-    |"daterange"; // postgres
-
-/**
  * All other regular column types.
  */
 export type SimpleColumnType =
@@ -186,5 +176,4 @@ export type ColumnType = WithPrecisionColumnType
     |BooleanConstructor
     |DateConstructor
     |NumberConstructor
-    |StringConstructor
-    |RangeColumnType;
+    |StringConstructor;

--- a/src/driver/types/ColumnTypes.ts
+++ b/src/driver/types/ColumnTypes.ts
@@ -145,6 +145,14 @@ export type SimpleColumnType =
     |"multipolygon" // mysql
     |"geometrycollection" // mysql
 
+    // range types
+    |"int4range" // postgres
+    |"int8range" // postgres
+    |"numrange" // postgres
+    |"tsrange" // postgres
+    |"tstzrange" // postgres
+    |"daterange" // postgres
+
     // other types
     |"enum" // mysql, postgres
     |"cidr" // postgres

--- a/test/functional/database-schema/column-types/postgres/column-types-postgres.ts
+++ b/test/functional/database-schema/column-types/postgres/column-types-postgres.ts
@@ -246,6 +246,7 @@ describe("database schema > column types > postgres", () => {
         post.timestampWithTimeZone = new Date();
         post.time = "15:30:13.278";
         post.timeWithTimeZone = "15:30:13.27801+05";
+        post.int4range = "[2,4)";
         await postRepository.save(post);
 
         const loadedPost = (await postRepository.findOne(1))!;
@@ -260,6 +261,7 @@ describe("database schema > column types > postgres", () => {
         // loadedPost.timestampWithTimeZone.valueOf().should.be.equal(post.timestampWithTimeZone.valueOf());
         loadedPost.time.valueOf().should.be.equal(post.time.valueOf());
         loadedPost.timeWithTimeZone.valueOf().should.be.equal(post.timeWithTimeZone.valueOf());
+        loadedPost.int4range.valueOf().should.be.equal(post.int4range.valueOf());
 
         table!.findColumnByName("id")!.type.should.be.equal("integer");
         table!.findColumnByName("numeric")!.type.should.be.equal("numeric");
@@ -284,6 +286,8 @@ describe("database schema > column types > postgres", () => {
         table!.findColumnByName("time")!.precision!.should.be.equal(3);
         table!.findColumnByName("timeWithTimeZone")!.type.should.be.equal("time with time zone");
         table!.findColumnByName("timeWithTimeZone")!.precision!.should.be.equal(5);
+        table!.findColumnByName("int4range")!.type.should.be.equal("int4range");
+        table!.findColumnByName("int4range")!.isNullable!.should.be.equal(true);
 
     })));
 

--- a/test/functional/database-schema/column-types/postgres/entity/PostWithOptions.ts
+++ b/test/functional/database-schema/column-types/postgres/entity/PostWithOptions.ts
@@ -50,4 +50,6 @@ export class PostWithOptions {
     @Column("time with time zone", { precision: 5 })
     timeWithTimeZone: string;
 
+    @Column("int4range", { nullable: true })
+    int4range: string;
 }


### PR DESCRIPTION
There was no way to declare common column options for postgres range types.