### PR TITLE
feat(test): Use ts-node with typechecking and timeout

### DIFF
--- a/package.json
+++ b/package.json
@@ -99,7 +99,7 @@
   },
   "scripts": {
     "test-ci": "gulp ci-tests",
-    "test": "tsc && mocha --file ./build/compiled/test/utils/test-setup.js --bail './build/compiled/test/**/*.js' --timeout 30000 --color",
+    "test": "mocha -r ts-node/register/type-check --typeCheck --file ./test/utils/test-setup.ts './test/**/*.ts' --timeout 30000 --color",
     "compile": "tsc",
     "setup:config": "gulp createTravisOrmConfig",
     "package": "gulp package"


### PR DESCRIPTION
@pleerock One more try with timeout flags and color output. It's important that first run might be long (more than 30s) as the cache is generated then. All subsequent calls will be fast thought. In comparison running single test with `ts-node` takes around 1-2s vs 30s with tsc compiling everything.