### PR TITLE
Always lowercase the enum type name

### DIFF
--- a/src/driver/postgres/PostgresQueryRunner.ts
+++ b/src/driver/postgres/PostgresQueryRunner.ts
@@ -1725,7 +1725,7 @@ export class PostgresQueryRunner extends BaseQueryRunner implements QueryRunner 
             enumName = enumName + "_old";
         return enumName.split(".").map(i => {
             return disableEscape ? i : `"${i}"`;
-        }).join(".");
+        }).join(".").toLocaleLowerCase();
     }
 
     /**


### PR DESCRIPTION
### Aye there!
***
Sending this PR to resolve a not so edge case. Here is the issue:

```sql
select 
     *,   "udt_name"::"regtype" AS "regtype"
FROM "information_schema"."columns"
WHERE ("table_schema" = 'public' AND "table_name" = 'MyTable')
```

TypeORM runs a query like this when booting and query the database for schema and a weird problem arrise here, if the table name contains any upper case character the regtype for enum will be named as
**MyTable_fieldname_enum** and the udt_name will run into an error, seems like if you name your type with upper case characters the PostgreSQL will not be able to resolve the regtype.

The error looks like this:

```
ERROR:  type "mytable_fieldname_enum" does not exist
```

How to reproduce:
 - Create a table with any UpperCase letter in its name.
 - Sync the schema into the database.
 - Trigger a schema query.

***
This is only a fixing the enum, maybe this issue effects more type queries, but sadly only had time to fix this one.

Cheers guys, keep up this good work!