### PR TITLE
Add zerofill and unsigned options to ColumnWithWidthOptions

### DIFF
--- a/src/decorator/options/ColumnWithWidthOptions.ts
+++ b/src/decorator/options/ColumnWithWidthOptions.ts
@@ -9,4 +9,15 @@ export interface ColumnWithWidthOptions {
      */
     width?: number;
 
+    /**
+     * Puts ZEROFILL attribute on to numeric column. Works only for MySQL.
+     * If you specify ZEROFILL for a numeric column, MySQL automatically adds the UNSIGNED attribute to this column
+     */
+    zerofill?: boolean;
+
+    /**
+     * Puts UNSIGNED attribute on to numeric column. Works only for MySQL.
+     */
+    unsigned?: boolean;
+
 }


### PR DESCRIPTION
# Current Behavior
`WithWidthColumnType` such as `tinyint` or `int` should have `zerofill` and `unsigned` options,  but currently it does not.

# Steps to reproduce
The code below cannot be compiled.
```
@Column('tinyint', { unsigned: true })
columnName?: number
```