### PR TITLE
fix issue 1981

### DIFF
--- a/src/driver/sqlite-abstract/AbstractSqliteDriver.ts
+++ b/src/driver/sqlite-abstract/AbstractSqliteDriver.ts
@@ -301,7 +301,15 @@ export abstract class AbstractSqliteDriver implements Driver {
      * and an array of parameter names to be passed to a query.
      */
     escapeQueryWithParameters(sql: string, parameters: ObjectLiteral, nativeParameters: ObjectLiteral): [string, any[]] {
-        const builtParameters: any[] = Object.keys(nativeParameters).map(key => nativeParameters[key]);
+        const builtParameters: any[] = Object.keys(nativeParameters).map(key => {
+            // Mapping boolean values to their numeric representation
+            if (typeof nativeParameters[key] === "boolean") {
+                return nativeParameters[key] === true ? 1 : 0;
+            }
+
+            return nativeParameters[key];
+        });
+
         if (!parameters || !Object.keys(parameters).length)
             return [sql, builtParameters];
 


### PR DESCRIPTION
This PR addresses issue #1981 where boolean values could not be used to `find` entities in a repository using `cordova`. This is because boolean values are represented as numeric values.  

This PR maps the boolean values to their corresponding numerical representation before submitting a query.