### PR TITLE
instanceof doesn't work as intended in typeorm for javascript

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -214,7 +214,7 @@ export async function createConnection(options: ConnectionOptions): Promise<Conn
  */
 export async function createConnection(optionsOrName?: any): Promise<Connection> {
     const connectionName = typeof optionsOrName === "string" ? optionsOrName : "default";
-    const options = optionsOrName instanceof Object ? optionsOrName : await getConnectionOptions(connectionName);
+    const options = typeof optionsOrName === "object" ? optionsOrName : await getConnectionOptions(connectionName);
     return getConnectionManager().create(options).connect();
 }
 


### PR DESCRIPTION
When using javascript with typeorm, `optionsOrName instanceof Object` returns `false`. So, typeorm tries to find a configuration file which is unnecessary when options are already submitted.