### PR TITLE
Expo driver

### DIFF
--- a/ISSUE_TEMPLATE.md
+++ b/ISSUE_TEMPLATE.md
@@ -16,6 +16,7 @@
 [ ] `sqlite`
 [ ] `sqljs`
 [ ] `react-native`
+[ ] `expo`
 
 **TypeORM version:**
 

--- a/README-zh_CN.md
+++ b/README-zh_CN.md
@@ -20,7 +20,7 @@
   <br>
 </div>
 
-TypeORM是一个[ORM](https://en.wikipedia.org/wiki/Object-relational_mapping)框架，它可以运行在NodeJS、浏览器、Cordova、PhoneGap、Ionic、React Native和Electron平台上，可以与TypeScript和JavaScript (ES5, ES6, ES7)一起使用。
+TypeORM是一个[ORM](https://en.wikipedia.org/wiki/Object-relational_mapping)框架，它可以运行在NodeJS、浏览器、Cordova、PhoneGap、Ionic、React Native、Expo和Electron平台上，可以与TypeScript和JavaScript (ES5, ES6, ES7)一起使用。
 它的目标是始终支持最新的JavaScript特性并提供额外的特性以帮助你开发任何使用数据库的应用程序 —— 不管是只有几张表的小型应用还是拥有多数据库的大型企业应用。
 
 不同于现有的所有其他JavaScript ORM框架，TypeORM支持Active Record和Data Mapper模式，这意味着你用最有效的方法编写高质量的、松耦合的、可扩展的、可维护的应用程序。
@@ -59,7 +59,7 @@ TypeORM 的一些特性：
 - json / xml / yml / env格式的连接配置
 - 支持 MySQL / MariaDB / Postgres / SQLite / Microsoft SQL Server / Oracle / sql.js
 - 支持 MongoDB NoSQL 数据库
-- 在NodeJS / 浏览器 / Ionic / Cordova / React Native / Electron平台上工作
+- 在NodeJS / 浏览器 / Ionic / Cordova / React Native / Expo / Electron平台上工作
 - 支持 TypeScript 和 JavaScript
 - 产生出高性能、灵活、清晰和可维护的代码
 - 遵循所有可能的最佳实践
@@ -228,7 +228,7 @@ npm install typeorm -g
 typeorm init --name MyProject --database mysql
 ```
 
-`name`即项目的名称，`database`是你将使用的数据库。数据库可以是下列值之一：`mysql`、`mariadb`、`postgres`、`sqlite`、`mssql`、`oracle`、`mongodb`、`cordova`、`react-native`。
+`name`即项目的名称，`database`是你将使用的数据库。数据库可以是下列值之一：`mysql`、`mariadb`、`postgres`、`sqlite`、`mssql`、`oracle`、`mongodb`、`cordova`、`react-native`、`expo`。
 
 该命令将在`MyProject`目录中生成一个新项目，其中包含以下文件：
 
@@ -511,7 +511,7 @@ createConnection({
 }).catch(error => console.log(error));
 ```
 
-在例子里使用的是mysql，你也可以选择其他数据库，只需要简单修改driver选项里的数据库的类型就可以了，比如：mysql、mariadb、postgres、sqlite、mssql、oracle、cordova、react-native或mongodb
+在例子里使用的是mysql，你也可以选择其他数据库，只需要简单修改driver选项里的数据库的类型就可以了，比如：mysql、mariadb、postgres、sqlite、mssql、oracle、cordova、react-native、expo或mongodb
 同样可以修改host, port, username, password 以及database等设置。
 
 把Photo实体加到数据连接的实体列表中，所有需要在这个连接下使用的实体都必须加到这个列表中。

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@
 </div>
 
 TypeORM is an [ORM](https://en.wikipedia.org/wiki/Object-relational_mapping) 
-that can run in NodeJS, Browser, Cordova, PhoneGap, Ionic, React Native and Electron platforms
+that can run in NodeJS, Browser, Cordova, PhoneGap, Ionic, React Native, Expo, and Electron platforms
 and can be used with TypeScript and JavaScript (ES5, ES6, ES7, ES8).
 Its goal is to always support the latest JavaScript features and provide additional features
 that help you to develop any kind of application that uses databases - from
@@ -69,7 +69,7 @@ Some TypeORM features:
 * connection configuration in json / xml / yml / env formats
 * supports MySQL / MariaDB / Postgres / SQLite / Microsoft SQL Server / Oracle / sql.js
 * supports MongoDB NoSQL database
-* works in NodeJS / Browser / Ionic / Cordova / React Native / Electron platforms
+* works in NodeJS / Browser / Ionic / Cordova / React Native / Expo / Electron platforms
 * TypeScript and JavaScript support
 * produced code is performant, flexible, clean and maintainable
 * follows all possible best practices
@@ -240,7 +240,8 @@ typeorm init --name MyProject --database mysql
 ```
 
 Where `name` is the name of your project and `database` is the database you'll use.
-Database can be one of the following values: `mysql`, `mariadb`, `postgres`, `sqlite`, `mssql`, `oracle`, `mongodb`, `cordova`, `react-native`.
+Database can be one of the following values: `mysql`, `mariadb`, `postgres`, `sqlite`, `mssql`, `oracle`, `mongodb`,
+`cordova`, `react-native`, `expo`.
 
 This command will generate a new project in the `MyProject` directory with the following files:
 
@@ -535,7 +536,7 @@ createConnection({
 
 We are using MySQL in this example, but you can use any other supported database. 
 To use another database, simply change the `type` in the options to the database type you are using: 
-mysql, mariadb, postgres, sqlite, mssql, oracle, cordova, react-native or mongodb.
+mysql, mariadb, postgres, sqlite, mssql, oracle, cordova, react-native, expo, or mongodb.
 Also make sure to use your own host, port, username, password and database settings.
 
 We added our Photo entity to the list of entities for this connection. 

--- a/docs/connection-options.md
+++ b/docs/connection-options.md
@@ -10,6 +10,7 @@
 * [`mssql` connection options](#mssql-connection-options)
 * [`mongodb` connection options](#mongodb-connection-options)
 * [`sql.js` connection options](#sqljs-connection-options)
+* [`expo` connection options](#expo-connection-options)
 * [Connection options example](#connection-options-example)
     
 ## What is `ConnectionOptions`
@@ -456,6 +457,10 @@ See [SSL options](https://github.com/mysqljs/mysql#ssl-options).
 * `autoSaveCallback`: A function that get's called when changes to the database are made and `autoSave` is enabled. The function gets a `UInt8Array` that represents the database.
 
 * `location`: The file location to load and save the database to.
+
+## `expo` connection options
+
+* `database` - Name of the database. For example "mydb".
 
 ## Connection options example
 

--- a/docs/entities.md
+++ b/docs/entities.md
@@ -8,7 +8,7 @@
 * [Column types](#column-types)
   * [Column types for `mysql` / `mariadb`](#column-types-for-mysql--mariadb)
   * [Column types for `postgres`](#column-types-for-postgres)
-  * [Column types for `sqlite` / `cordova` / `react-native`](#column-types-for-sqlite--cordova--react-native)
+  * [Column types for `sqlite` / `cordova` / `react-native` / `expo`](#column-types-for-sqlite--cordova--react-native--expo)
   * [Column types for `mssql`](#column-types-for-mssql)
   * [`simple-array` column type](#simple-array-column-type)
   * [`simple-json` column type](#simple-json-column-type)
@@ -305,7 +305,7 @@ or
 `tsvector`, `tsquery`, `uuid`, `xml`, `json`, `jsonb`, `int4range`, `int8range`, `numrange`,
 `tsrange`, `tstzrange`, `daterange`, `geometry`, `geography`
 
-### Column types for `sqlite` / `cordova` / `react-native`
+### Column types for `sqlite` / `cordova` / `react-native` / `expo`
 
 `int`, `int2`, `int8`, `integer`, `tinyint`, `smallint`, `mediumint`, `bigint`, `decimal`,
 `numeric`, `float`, `double`, `real`, `double precision`, `datetime`, `varying character`,

--- a/docs/supported-platforms.md
+++ b/docs/supported-platforms.md
@@ -3,6 +3,8 @@
 * [NodeJS](#nodejs)
 * [Browser](#browser)
 * [Cordova / PhoneGap / Ionic apps](#cordova--phonegap--ionic-apps)
+* [React Native](#react-native)
+* [Expo](#expo)
 * [NativeScript](#nativescript)
 
 ## NodeJS
@@ -58,6 +60,10 @@ For an example how to use TypeORM in Cordova see [typeorm/cordova-example](https
 
 ## React Native
 TypeORM is able to on React Native apps using the [react-native-sqlite-storage](https://github.com/andpor/react-native-sqlite-storage) plugin. For an example see [typeom/react-native-example](https://github.com/typeorm/react-native-example).
+
+# Expo
+
+TypeORM is able to run on Expo apps using the [Expo SQLite API](https://docs.expo.io/versions/latest/sdk/sqlite.html).
 
 ## NativeScript
 

--- a/src/connection/ConnectionOptions.ts
+++ b/src/connection/ConnectionOptions.ts
@@ -7,6 +7,7 @@ import {MongoConnectionOptions} from "../driver/mongodb/MongoConnectionOptions";
 import {CordovaConnectionOptions} from "../driver/cordova/CordovaConnectionOptions";
 import {SqljsConnectionOptions} from "../driver/sqljs/SqljsConnectionOptions";
 import {ReactNativeConnectionOptions} from "../driver/react-native/ReactNativeConnectionOptions";
+import {ExpoConnectionOptions} from "../driver/expo/ExpoConnectionOptions";
 
 /**
  * ConnectionOptions is an interface with settings and options for specific connection.
@@ -22,4 +23,5 @@ export type ConnectionOptions =
     CordovaConnectionOptions|
     ReactNativeConnectionOptions|
     SqljsConnectionOptions|
-    MongoConnectionOptions;
+    MongoConnectionOptions|
+    ExpoConnectionOptions;

--- a/src/driver/DriverFactory.ts
+++ b/src/driver/DriverFactory.ts
@@ -8,6 +8,7 @@ import {ReactNativeDriver} from "./react-native/ReactNativeDriver";
 import {SqljsDriver} from "./sqljs/SqljsDriver";
 import {MysqlDriver} from "./mysql/MysqlDriver";
 import {PostgresDriver} from "./postgres/PostgresDriver";
+import {ExpoDriver} from "./expo/ExpoDriver";
 import {Driver} from "./Driver";
 import {Connection} from "../connection/Connection";
 
@@ -42,6 +43,8 @@ export class DriverFactory {
                 return new SqlServerDriver(connection);
             case "mongodb":
                 return new MongoDriver(connection);
+            case "expo":
+                return new ExpoDriver(connection);
             default:
                 throw new MissingDriverError(type);
         }

--- a/src/driver/expo/ExpoConnectionOptions.ts
+++ b/src/driver/expo/ExpoConnectionOptions.ts
@@ -1,0 +1,17 @@
+import {BaseConnectionOptions} from "../../connection/BaseConnectionOptions";
+
+/**
+ * Sqlite-specific connection options.
+ */
+export interface ExpoConnectionOptions extends BaseConnectionOptions {
+
+    /**
+     * Database type.
+     */
+    readonly type: "expo";
+
+    /**
+     * Database name.
+     */
+    readonly database: string;
+}

--- a/src/driver/expo/ExpoDriver.ts
+++ b/src/driver/expo/ExpoDriver.ts
@@ -1,0 +1,105 @@
+import {AbstractSqliteDriver} from "../sqlite-abstract/AbstractSqliteDriver";
+import {ExpoConnectionOptions} from "./ExpoConnectionOptions";
+import {ExpoQueryRunner} from "./ExpoQueryRunner";
+import {QueryRunner} from "../../query-runner/QueryRunner";
+import {Connection} from "../../connection/Connection";
+import {DriverOptionNotSetError} from "../../error/DriverOptionNotSetError";
+import {DriverPackageNotInstalledError} from "../../error/DriverPackageNotInstalledError";
+
+// needed for typescript compiler
+interface Window {
+    Expo: any;
+}
+declare const window: Window;
+
+export class ExpoDriver extends AbstractSqliteDriver {
+    options: ExpoConnectionOptions;
+    
+    // -------------------------------------------------------------------------
+    // Constructor
+    // -------------------------------------------------------------------------
+
+    constructor(connection: Connection) {
+        super(connection);
+
+        this.database = this.options.database;
+
+        // validate options to make sure everything is set
+        if (!this.options.database)
+            throw new DriverOptionNotSetError("database");
+
+        // load sqlite package
+        this.loadDependencies();
+    }
+    
+
+    // -------------------------------------------------------------------------
+    // Public Methods
+    // -------------------------------------------------------------------------
+
+    /**
+     * Closes connection with database.
+     */
+    async disconnect(): Promise<void> {
+        return new Promise<void>((ok, fail) => {
+            try {
+                this.queryRunner = undefined;
+                this.databaseConnection = undefined;
+                ok();
+            } catch (error) {
+                fail(error);
+            }
+        });
+    }
+    
+    /**
+     * Creates a query runner used to execute database queries.
+     */
+    createQueryRunner(mode: "master"|"slave" = "master"): QueryRunner {
+        if (!this.queryRunner)
+            this.queryRunner = new ExpoQueryRunner(this);
+
+        return this.queryRunner;
+    }
+    
+    // -------------------------------------------------------------------------
+    // Protected Methods
+    // -------------------------------------------------------------------------
+
+    /**
+     * Creates connection with the database.
+     */
+    protected createDatabaseConnection() {
+        return new Promise<void>((ok, fail) => {
+            try {
+                const databaseConnection = this.sqlite.openDatabase(this.options.database);
+                /*
+                // we need to enable foreign keys in sqlite to make sure all foreign key related features
+                // working properly. this also makes onDelete work with sqlite.
+                */
+                databaseConnection.transaction((tsx: any) => {
+                    tsx.executeSql(`PRAGMA foreign_keys = ON;`, [], (t: any, result: any) => {
+                        ok(databaseConnection);
+                    }, (t: any, err: any) => {
+                        fail({transaction: t, error: err});
+                    });
+                }, (err: any) => {
+                    fail(err);
+                });
+            } catch (error) {
+                fail(error);
+            }
+        });
+    }
+
+    /**
+     * If driver dependency is not given explicitly, then try to load it via "require".
+     */
+    protected loadDependencies(): void {
+        try {
+            this.sqlite = window.Expo.SQLite;
+        } catch (e) {
+            throw new DriverPackageNotInstalledError("Expo", "expo");
+        }
+    }
+}

--- a/src/driver/expo/ExpoQueryRunner.ts
+++ b/src/driver/expo/ExpoQueryRunner.ts
@@ -1,0 +1,136 @@
+import {QueryRunnerAlreadyReleasedError} from "../../error/QueryRunnerAlreadyReleasedError";
+import {QueryFailedError} from "../../error/QueryFailedError";
+import {AbstractSqliteQueryRunner} from "../sqlite-abstract/AbstractSqliteQueryRunner";
+import {TransactionAlreadyStartedError} from "../../error/TransactionAlreadyStartedError";
+import {TransactionNotStartedError} from "../../error/TransactionNotStartedError";
+import {ExpoDriver} from "./ExpoDriver";
+import {Broadcaster} from "../../subscriber/Broadcaster";
+
+// Needed to satisfy the Typescript compiler
+interface IResultSet {
+    insertId: number | undefined;
+    rowsAffected: number;
+    rows: {
+        length: number;
+        item: (idx: number) => any;
+        _array: any[];
+    }
+}
+interface ITransaction {
+    executeSql: (
+        sql: string,
+        args: any[] | undefined,
+        ok: (tsx: ITransaction, resultSet: IResultSet) => void,
+        fail: (tsx: ITransaction, err: any) => void
+    ) => void;
+}
+
+/**
+ * Runs queries on a single sqlite database connection.
+ */
+export class ExpoQueryRunner extends AbstractSqliteQueryRunner {
+    
+    /**
+     * Database driver used by connection.
+     */
+    driver: ExpoDriver;
+
+    /**
+     * Database transaction object
+     */
+    private transaction?: ITransaction;
+    
+    // -------------------------------------------------------------------------
+    // Constructor
+    // -------------------------------------------------------------------------
+
+    constructor(driver: ExpoDriver) {
+        super();
+        this.driver = driver;
+        this.connection = driver.connection;
+        this.broadcaster = new Broadcaster(this);
+    }
+
+    /**
+     * Starts transaction.
+     */
+    async startTransaction(): Promise<void> {
+        if (this.isTransactionActive && typeof this.transaction !== "undefined")
+            throw new TransactionAlreadyStartedError();
+
+        this.isTransactionActive = true;
+    }
+
+    /**
+     * Commits transaction.
+     * Error will be thrown if transaction was not started.
+     */
+    async commitTransaction(): Promise<void> {
+        if (!this.isTransactionActive && typeof this.transaction === "undefined")
+            throw new TransactionNotStartedError();
+
+        this.isTransactionActive = false;
+        this.transaction = undefined;
+    }
+
+    /**
+     * Rollbacks transaction.
+     * Error will be thrown if transaction was not started.
+     */
+    async rollbackTransaction(): Promise<void> {
+        if (!this.isTransactionActive && typeof this.transaction === "undefined")
+            throw new TransactionNotStartedError();
+
+        this.isTransactionActive = false;
+        this.transaction = undefined;
+    }
+
+    /**
+     * Executes a given SQL query.
+     */
+    query(query: string, parameters?: any[]): Promise<any> {
+        if (this.isReleased)
+            throw new QueryRunnerAlreadyReleasedError();
+
+        return new Promise<any>(async (ok, fail) => {
+            const databaseConnection = await this.connect();
+            this.driver.connection.logger.logQuery(query, parameters, this);
+            const queryStartTime = +new Date();
+            databaseConnection.transaction((transaction: ITransaction) => {
+                if (typeof this.transaction === "undefined") {
+                    this.startTransaction();
+                    this.transaction = transaction;
+                }
+                this.transaction.executeSql(query, parameters, (t: ITransaction, result: IResultSet) => {
+                    // log slow queries if maxQueryExecution time is set
+                    const maxQueryExecutionTime = this.driver.connection.options.maxQueryExecutionTime;
+                    const queryEndTime = +new Date();
+                    const queryExecutionTime = queryEndTime - queryStartTime;
+                    if (maxQueryExecutionTime && queryExecutionTime > maxQueryExecutionTime) {
+                        this.driver.connection.logger.logQuerySlow(queryExecutionTime, query, parameters, this);
+                    }
+    
+                    // return id of inserted row, if query was insert statement.
+                    if (query.substr(0, 11) === "INSERT INTO") {
+                        ok(result.insertId);
+                    }
+                    else {
+                        let resultSet = [];
+                        for (let i = 0; i < result.rows.length; i++) {
+                            resultSet.push(result.rows.item(i));
+                        }
+                        ok(resultSet);
+                    }
+                }, (t: ITransaction, err: any) => {
+                    this.driver.connection.logger.logQueryError(err, query, parameters, this);
+                    fail(new QueryFailedError(query, parameters, err));
+                });
+            }, (err: any) => {
+                this.rollbackTransaction();
+            }, () => {
+                this.isTransactionActive = false;
+                this.transaction = undefined;
+            });
+        });
+    }
+}

--- a/src/driver/types/DatabaseType.ts
+++ b/src/driver/types/DatabaseType.ts
@@ -11,4 +11,5 @@ export type DatabaseType =
     "sqljs"|
     "oracle"|
     "mssql"|
-    "mongodb";
+    "mongodb"|
+    "expo";

--- a/src/error/MissingDriverError.ts
+++ b/src/error/MissingDriverError.ts
@@ -7,7 +7,7 @@ export class MissingDriverError extends Error {
     constructor(driverType: string) {
         super();
         Object.setPrototypeOf(this, MissingDriverError.prototype);
-        this.message = `Wrong driver: "${driverType}" given. Supported drivers are: "cordova", "mariadb", "mongodb", "mssql", "mysql", "oracle", "postgres", "sqlite", "sqljs", "react-native".`;
+        this.message = `Wrong driver: "${driverType}" given. Supported drivers are: "cordova", "expo", "mariadb", "mongodb", "mssql", "mysql", "oracle", "postgres", "sqlite", "sqljs", "react-native".`;
     }
 
 }


### PR DESCRIPTION
Add a driver to support the [Expo](https://expo.io/) platform. In particular it is using the [Expo SQLite API](https://docs.expo.io/versions/latest/sdk/sqlite.html) that ships with Expo.

A few things to note about this pull request:
- Expo apps still need to install `react-native-sqlite-storage` as a dependency. The issue is that the Expo packager still attempts to include this dependency (even though it doesn't need it) because of the `this.sqlite = require("react-native-sqlite-storage");` line in `src/driver/react-native/ReactNativeDriver.ts`. If someone knows how to make the Expo packager ignore this line, I'm all ears! Still, needing to install  `react-native-sqlite-storage` isn't such a big deal. No linking or ejecting of the Expo app is required.
- Expo has an odd way of handling transactions: basically every query to the database is in a transaction context. In fact, running a `BEGIN TRANSACTION` query throws a `Transaction already started` error. As a result, I needed to override the `startTransaction`, `commitTransaction`, and `rollbackTransaction` methods on the `AbstractSqliteQueryRunner` class to account for the weird behavior. Besides this, the Expo driver is almost identical to how React Native is being handled.

I have a working Expo example at [https://github.com/cuibonobo/expo-example](https://github.com/cuibonobo/expo-example). To try it, download the Expo app from the App Store or Google Play Store, then `cd` into the `expo-example` directory and run:

```bash
npm install
npm start
```

If your phone is on the same network as your development machine, scanning the generated QR code will automatically open the Expo app and run the example.

---
Fixes #2183.