### PR TITLE
Fix wrong ES version in docs for async/await

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@
 
 TypeORM is an [ORM](https://en.wikipedia.org/wiki/Object-relational_mapping) 
 that can run in NodeJS, Browser, Cordova, PhoneGap, Ionic, React Native and Electron platforms
-and can be used with TypeScript and JavaScript (ES5, ES6, ES7).
+and can be used with TypeScript and JavaScript (ES5, ES6, ES7, ES8).
 Its goal is to always support the latest JavaScript features and provide additional features
 that help you to develop any kind of application that uses databases - from
 small applications with a few tables to large scale enterprise applications
@@ -624,7 +624,7 @@ It's not a new copy of the object, it modifies its "id" and returns it.
   
 ### Using async/await syntax
 
-Let's take advantage of the latest ES7 features and use async/await syntax instead:
+Let's take advantage of the latest ES8 (ES2017) features and use async/await syntax instead:
 
 ```typescript
 import {createConnection} from "typeorm";


### PR DESCRIPTION
Async/await have been standardized in ES2017 (aka ES8) not ES7