### PR TITLE
refactor: update changelog with isolation level feature

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ however since API is already quite stable we don't expect too much breaking chan
 If we missed a note on some change or you have a questions on migrating from old version, 
 feel free to ask us and community.
 
+## 0.2.8
+
+* added support for specifying isolation levels in transactions
+
 ## 0.2.7
 
 * added support for rowversion type for mssql (#2198)

--- a/docs/transactions.md
+++ b/docs/transactions.md
@@ -1,10 +1,9 @@
 # Transactions
 
-- [Transactions](#transactions)
-    - [Creating and using transactions](#creating-and-using-transactions)
-        - [Specifying Isolation Levels](#specifying-isolation-levels)
-    - [Transaction decorators](#transaction-decorators)
-    - [Using `QueryRunner` to create and control state of single database connection](#using-queryrunner-to-create-and-control-state-of-single-database-connection)
+- [Creating and using transactions](#creating-and-using-transactions)
+	- [Specifying Isolation Levels](#specifying-isolation-levels)
+- [Transaction decorators](#transaction-decorators)
+- [Using `QueryRunner` to create and control state of single database connection](#using-queryrunner-to-create-and-control-state-of-single-database-connection)
 
 ## Creating and using transactions
 


### PR DESCRIPTION
I realized my change to the `transactions.md` file were not actually committed in the original PR, this was due to a plugin I was using that auto-creates and formats the table of contents in markdown files, so I went ahead and added that change to this PR in addition to the changelog update.