### PR TITLE
Added pagination 'wrapper' function

### DIFF
--- a/src/entity-manager/EntityManager.ts
+++ b/src/entity-manager/EntityManager.ts
@@ -801,9 +801,13 @@ export class EntityManager {
         return this.queryRunner.release();
     }
 
-    async paginate<Entity>(entityClass: ObjectType<Entity>|EntitySchema<Entity>|string, options: PaginationOptions<Entity>): Promise<PaginationInterface> {
-        if (options.skip >= 1) options.skip--;
-        options.skip = options.skip * options.take;
+    async paginate<Entity>(entityClass: ObjectType<Entity>|EntitySchema<Entity>|string, PaginationOptions: PaginationOptions<Entity>): Promise<PaginationInterface> {
+        if (PaginationOptions.page >= 1) PaginationOptions.page--;
+        
+        const options = {
+            skip: PaginationOptions.page * PaginationOptions.limit,
+            take: PaginationOptions.limit,
+        };
 
         const [results, total] = await this.findAndCount(entityClass, options);
 

--- a/src/entity-manager/EntityManager.ts
+++ b/src/entity-manager/EntityManager.ts
@@ -810,7 +810,7 @@ export class EntityManager {
         return {
             items: results,
             total,
-            pages: Math.ceil(total/options.take),
+            pages: Math.ceil(total / options.take),
             count: results.length,
         };
     }

--- a/src/entity-manager/PaginationInterface.ts
+++ b/src/entity-manager/PaginationInterface.ts
@@ -1,0 +1,9 @@
+
+interface PaginationInterface {
+  total: number;
+  pages: number;
+  items: any[];
+  count: number;
+}
+
+export default PaginationInterface;

--- a/src/find-options/PaginationOptions.ts
+++ b/src/find-options/PaginationOptions.ts
@@ -6,13 +6,13 @@ import {FindOneOptions} from "./FindOneOptions";
 export interface PaginationOptions<Entity = any> extends FindOneOptions<Entity> {
 
   /**
-   * Offset (paginated) where from entities should be taken.
+   * Specify the offset starting from 0
    */
-  skip: number;
+  page: number;
 
   /**
    * Limit (paginated) - max number of entities should be taken.
    */
-  take: number;
+  limit: number;
 
 }

--- a/src/find-options/PaginationOptions.ts
+++ b/src/find-options/PaginationOptions.ts
@@ -1,0 +1,18 @@
+import {FindOneOptions} from "./FindOneOptions";
+
+/**
+ * Defines a special criteria to find specific entities.
+ */
+export interface PaginationOptions<Entity = any> extends FindOneOptions<Entity> {
+
+  /**
+   * Offset (paginated) where from entities should be taken.
+   */
+  skip: number;
+
+  /**
+   * Limit (paginated) - max number of entities should be taken.
+   */
+  take: number;
+
+}

--- a/src/repository/Repository.ts
+++ b/src/repository/Repository.ts
@@ -14,6 +14,8 @@ import {InsertResult} from "../query-builder/result/InsertResult";
 import {QueryPartialEntity} from "../query-builder/QueryPartialEntity";
 import {ObjectID} from "../driver/mongodb/typings";
 import {FindConditions} from "../find-options/FindConditions";
+import PaginationInterface from './../entity-manager/PaginationInterface';
+import { PaginationOptions } from "../find-options/PaginationOptions";
 
 /**
  * Repository is supposed to work with your entity objects. Find entities, insert, update, delete, etc.
@@ -338,4 +340,7 @@ export class Repository<Entity extends ObjectLiteral> {
         return this.manager.decrement(this.metadata.target, conditions, propertyPath, value);
     }
 
+    paginate(options: PaginationOptions): Promise<PaginationInterface> {
+        return this.manager.paginate(this.metadata.target, options);
+    }
 }

--- a/test/functional/repository/basic-methods/repository-basic-methods.ts
+++ b/test/functional/repository/basic-methods/repository-basic-methods.ts
@@ -43,7 +43,7 @@ describe("repository > basic methods", () => {
         }));
 
     });
-    
+
     describe("hasId", function() {
 
         it("should return true if entity has an id", () => connections.forEach(connection => {
@@ -221,7 +221,7 @@ describe("repository > basic methods", () => {
             blog.text = "Blog about good people";
             blog.categories = [category];
             await blogRepository.save(blog);
-            
+
             // and preload it
             const plainBlogWithId = { id: 1 };
             const preloadedBlog = await blogRepository.preload(plainBlogWithId);
@@ -246,7 +246,7 @@ describe("repository > basic methods", () => {
             blog.text = "Blog about good people";
             blog.categories = [category];
             await blogRepository.save(blog);
-            
+
             // and preload it
             const plainBlogWithId = { id: 1, categories: [{ id: 1 }] };
             const preloadedBlog = await blogRepository.preload(plainBlogWithId);
@@ -348,7 +348,7 @@ describe("repository > basic methods", () => {
             const saved = await postRepository.save(dbPost);
 
             saved.should.be.instanceOf(Post);
-            
+
             saved.id!.should.be.equal(1);
             saved.title.should.be.equal("New title");
             saved.dateAdded.should.be.instanceof(Date);
@@ -419,6 +419,29 @@ describe("repository > basic methods", () => {
             result[0].max.should.not.be.empty;
         })));
 
+    });
+
+    describe("paginate", function() {
+        it("Should return a pagination object", () => Promise.all(connections.map(async connection => {
+            const repository = connection.getRepository(Blog);
+            const promises: Promise<Blog>[] = [];
+            for (let i =0; i <= 25; i++) {
+                promises.push(repository.save(repository.create({
+                  title: 'test',
+                  text: 'test',
+                  counter: i,
+                })));
+            }
+            await Promise.all(promises);
+            const result = await repository.paginate({
+              skip: 2,
+              take: 10,
+            });
+            result.items.should.not.be.empty;
+            result.count.should.be.equal(10);
+            result.pages.should.be.equal(3);
+            result.total.should.be.equal(25);
+        })));
     });
 
     /*describe.skip("transaction", function() {

--- a/test/functional/repository/basic-methods/repository-basic-methods.ts
+++ b/test/functional/repository/basic-methods/repository-basic-methods.ts
@@ -437,8 +437,8 @@ describe("repository > basic methods", () => {
               order: {
                 id: "ASC",
               },
-              skip: 2,
-              take: 10,
+              page: 2,
+              limit: 10,
             });
 
             result.items.length.should.be.equal(10);

--- a/test/functional/repository/basic-methods/repository-basic-methods.ts
+++ b/test/functional/repository/basic-methods/repository-basic-methods.ts
@@ -425,18 +425,23 @@ describe("repository > basic methods", () => {
         it("Should return a pagination object", () => Promise.all(connections.map(async connection => {
             const repository = connection.getRepository(Blog);
             const promises: Promise<Blog>[] = [];
-            for (let i =0; i <= 25; i++) {
+            for (let i = 0; i < 25; i++) {
                 promises.push(repository.save(repository.create({
-                  title: 'test',
-                  text: 'test',
+                  title: "test",
+                  text: "test",
                   counter: i,
                 })));
             }
             await Promise.all(promises);
             const result = await repository.paginate({
+              order: {
+                id: "ASC",
+              },
               skip: 2,
               take: 10,
             });
+
+            result.items.length.should.be.equal(10);
             result.items.should.not.be.empty;
             result.count.should.be.equal(10);
             result.pages.should.be.equal(3);


### PR DESCRIPTION
Added a pagination wrapper around findAndCount to return an defined object. Example:

```javascript
{
    items: [
        {
            id: 1,
            ...
        },
        ...
    ],
    count: 10,
    pages: 2,
    total: 20,
}
```
The pagination interface accepts {page: 1, limit: 10} to avoid confusion with skip and take. Where skip is page times limit. 

To be used like: 

```javascript
const result = await blogRepository.paginate({
    page: 2,
    limit: 10,
});
```

I had to disable MSSQL during testing due to MSSQL throwing an exception on FETCH ROW which seems to be a known issue?