### PR TITLE
Updated to accept Oracle connectString for TNS based Host resolution

### DIFF
--- a/src/driver/oracle/OracleConnectionCredentialsOptions.ts
+++ b/src/driver/oracle/OracleConnectionCredentialsOptions.ts
@@ -37,5 +37,9 @@ export interface OracleConnectionCredentialsOptions {
      * Connection SID.
      */
     readonly sid?: string;
-
+    
+    /**
+     * Embedded TNS Connection String
+     */
+    readonly connectString?: string;
 }

--- a/src/driver/oracle/OracleDriver.ts
+++ b/src/driver/oracle/OracleDriver.ts
@@ -659,12 +659,12 @@ export class OracleDriver implements Driver {
     protected async createPool(options: OracleConnectionOptions, credentials: OracleConnectionCredentialsOptions): Promise<any> {
 
         credentials = Object.assign(credentials, DriverUtils.buildDriverOptions(credentials)); // todo: do it better way
-
+       
         // build connection options for the driver
         const connectionOptions = Object.assign({}, {
             user: credentials.username,
             password: credentials.password,
-            connectString: credentials.host + ":" + credentials.port + "/" + credentials.sid,
+            connectString: credentials.connectString ? credentials.connectString : credentials.host + ":" + credentials.port + "/" + credentials.sid,
         }, options.extra || {});
 
         // pooling is enabled either when its set explicitly to true,


### PR DESCRIPTION
Updated driver to accept Oracle connect string as specified in https://github.com/oracle/node-oracledb/blob/master/doc/api.md#-813-embedded-connection-strings since Oracle connections can also be made with TNS strings when connecting to a load-balanced service.