### PR TITLE
fix for issue when using order by with the fields database name when …

### DIFF
--- a/src/query-builder/SelectQueryBuilder.ts
+++ b/src/query-builder/SelectQueryBuilder.ts
@@ -1848,7 +1848,10 @@ export class SelectQueryBuilder<Entity> extends QueryBuilder<Entity> implements 
                 if (orderCriteria.indexOf(".") !== -1) {
                     const [aliasName, propertyPath] = orderCriteria.split(".");
                     const alias = this.expressionMap.findAliasByName(aliasName);
-                    const column = alias.metadata.findColumnWithPropertyName(propertyPath);
+                    let column = alias.metadata.findColumnWithPropertyName(propertyPath);
+                    if (!column) {
+                        column = alias.metadata.findColumnWithDatabaseName(propertyPath);
+                    }
                     return this.escape(parentAlias) + "." + this.escape(this.buildColumnAlias(aliasName, column!.databaseName));
                 } else {
                     if (this.expressionMap.selects.find(select => select.selection === orderCriteria || select.aliasName === orderCriteria))
@@ -1864,7 +1867,10 @@ export class SelectQueryBuilder<Entity> extends QueryBuilder<Entity> implements 
             if (orderCriteria.indexOf(".") !== -1) {
                 const [aliasName, propertyPath] = orderCriteria.split(".");
                 const alias = this.expressionMap.findAliasByName(aliasName);
-                const column = alias.metadata.findColumnWithPropertyName(propertyPath);
+                let column = alias.metadata.findColumnWithPropertyName(propertyPath);
+                if (!column) {
+                    column = alias.metadata.findColumnWithDatabaseName(propertyPath);
+                }
                 orderByObject[this.escape(parentAlias) + "." + this.escape(this.buildColumnAlias(aliasName, column!.databaseName))] = orderBys[orderCriteria];
             } else {
                 if (this.expressionMap.selects.find(select => select.selection === orderCriteria || select.aliasName === orderCriteria)) {

--- a/test/other-issues/take-order-by-property-name-different-to-database-name/entity/Category.ts
+++ b/test/other-issues/take-order-by-property-name-different-to-database-name/entity/Category.ts
@@ -1,0 +1,14 @@
+import {Entity} from "../../../../src/decorator/entity/Entity";
+import {PrimaryGeneratedColumn} from "../../../../src/decorator/columns/PrimaryGeneratedColumn";
+import {Column} from "../../../../src/decorator/columns/Column";
+
+@Entity()
+export class Category {
+
+    @PrimaryGeneratedColumn()
+    id: number;
+
+    @Column()
+    name: string;
+
+}

--- a/test/other-issues/take-order-by-property-name-different-to-database-name/entity/Post.ts
+++ b/test/other-issues/take-order-by-property-name-different-to-database-name/entity/Post.ts
@@ -1,0 +1,23 @@
+import {Entity} from "../../../../src/decorator/entity/Entity";
+import {PrimaryGeneratedColumn} from "../../../../src/decorator/columns/PrimaryGeneratedColumn";
+import {Column} from "../../../../src/decorator/columns/Column";
+import {Category} from "./Category";
+import {ManyToMany} from "../../../../src/decorator/relations/ManyToMany";
+import {JoinTable} from "../../../../src/decorator/relations/JoinTable";
+
+@Entity()
+export class Post {
+
+    @PrimaryGeneratedColumn()
+    id: number;
+
+    @Column({ name: "title" })
+    postTitle: string;
+
+    @ManyToMany(type => Category, {
+        cascade: ["insert"]
+    })
+    @JoinTable()
+    categories: Category[];
+
+}

--- a/test/other-issues/take-order-by-property-name-different-to-database-name/take-with-order-by-property-name-different-to-database-name.ts
+++ b/test/other-issues/take-order-by-property-name-different-to-database-name/take-with-order-by-property-name-different-to-database-name.ts
@@ -1,0 +1,57 @@
+import "reflect-metadata";
+import { createTestingConnections, reloadTestingDatabases, closeTestingConnections } from "../../utils/test-utils";
+import { Connection } from "../../../src/connection/Connection";
+import { Post } from "./entity/Post";
+import { expect } from "chai";
+import { Category } from "./entity/Category";
+
+describe("other issues > using limit in conjunction with order by", () => {
+
+    let connections: Connection[];
+    before(async () => connections = await createTestingConnections({
+        entities: [__dirname + "/entity/*{.js,.ts}"],
+    }));
+    beforeEach(() => reloadTestingDatabases(connections));
+    after(() => closeTestingConnections(connections));
+
+    it("should persist successfully and return persisted entity", () => Promise.all(connections.map(async function (connection) {
+
+        // generate bulk array of posts with categories
+        for (let i = 1; i <= 100; i++) {
+
+            const post = new Post();
+            post.postTitle = "Hello Post #" + i;
+            post.categories = [];
+
+            for (let i = 1; i <= 5; i++) {
+                const category = new Category();
+                category.name = "category #" + i;
+                post.categories.push(category);
+            }
+            await connection.manager.save(post);
+        }
+
+        // check if ordering by main object works correctly
+
+        const loadedPosts1 = await connection.manager
+            .createQueryBuilder(Post, "post")
+            .innerJoinAndSelect("post.categories", "categories")
+            .take(10)
+            .orderBy("post.title", "DESC")
+            .getMany();
+
+        expect(loadedPosts1).not.to.be.empty;
+        loadedPosts1.length.should.be.equal(10);
+        loadedPosts1[0].id.should.be.equal(99);
+        loadedPosts1[1].id.should.be.equal(98);
+        loadedPosts1[2].id.should.be.equal(97);
+        loadedPosts1[3].id.should.be.equal(96);
+        loadedPosts1[4].id.should.be.equal(95);
+        loadedPosts1[5].id.should.be.equal(94);
+        loadedPosts1[6].id.should.be.equal(93);
+        loadedPosts1[7].id.should.be.equal(92);
+        loadedPosts1[8].id.should.be.equal(91);
+        loadedPosts1[9].id.should.be.equal(90);
+    })));
+
+});


### PR DESCRIPTION
When using take or skip and attempting to run an order by you get a databaseName not found error if the orderby string contains the databaseName of the field and the databaseName and the propertry name in the model do not match.

This seems to be inconsistent with limit and offset which will build the query with the database name or the property name in the model.

I've added a test at test/other-issues/take-order-by-property-name-different-to-database-name

Which is passing with the change I've added. if you remove the two :

`if (!column) {
    column = alias.metadata.findColumnWithDatabaseName(propertyPath);
}`

 then you will see this test fails with the error mentioned above.

The fix could be cleaned up however I wanted to get an opinion on whether or not this is the right way to go to fix this problem.