### PR TITLE
Fix Webpack compilation single bundle with sql.js (nodejs)

### DIFF
--- a/src/platform/PlatformTools.ts
+++ b/src/platform/PlatformTools.ts
@@ -86,6 +86,12 @@ export class PlatformTools {
                     return require("sqlite3");
 
                 /**
+                * sql.js
+                */
+                case "sql.js":
+                    return require("sql.js");
+                    
+                /**
                 * sqlserver
                 */
                 case "mssql":


### PR DESCRIPTION
Webpack can not compile a bundle with sql.js.
`require(<expression>) `
doesn't work without some hints like
`require('/some-dir' + <expression>)`