### PR TITLE
[Feature Request] Add new connection option to sqlite for SQLCipher #…

### DIFF
--- a/src/driver/sqlite/SqliteConnectionOptions.ts
+++ b/src/driver/sqlite/SqliteConnectionOptions.ts
@@ -15,4 +15,9 @@ export interface SqliteConnectionOptions extends BaseConnectionOptions {
      */
     readonly database: string;
 
+    /**
+     * Encryption key for for SQLCipher.
+     */
+    readonly key?: string;
+
 }

--- a/src/driver/sqlite/SqliteDriver.ts
+++ b/src/driver/sqlite/SqliteDriver.ts
@@ -97,6 +97,14 @@ export class SqliteDriver extends AbstractSqliteDriver {
                     if (err) return fail(err);
                     ok(databaseConnection);
                 });
+
+                // in the options, if encryption key for for SQLCipher is setted.
+                if (this.options.key) {
+                  databaseConnection.run(`PRAGMA key = ${this.options.key};`, (err: any, result: any) => {
+                    if (err) return fail(err);
+                    ok(databaseConnection);
+                  });
+                }
             });
         });
     }


### PR DESCRIPTION
Hello Umed,

I tried to make a test case but basically it's not impossible to test a connection if a target sqlite database is not encrypted by SQLCipher extension. The extension is not default for sqlite. We need to apply it manually by building from source code like this link(https://github.com/mapbox/node-sqlite3#building-for-sqlcipher).

If you have a good idea to make a test case for this feature, please let me know.

Thanks,
JJ