### PR TITLE
Mentions url attribute that can be used for connecting

### DIFF
--- a/docs/connection.md
+++ b/docs/connection.md
@@ -38,6 +38,13 @@ const connection = await createConnection({
     database: "test"
 });
 ```
+A single `url` attribute, plus the `type` attribute, will work too.
+
+```js
+createConnection({
+    type: 'postgres',
+    url: 'postgres://test:test@localhost/test'
+})
 
 `createConnections` creates multiple connections:
 


### PR DESCRIPTION
I find this much easier and more compatible with PaaS software. Heroku and Dokku, I believe the most popular, give DB add-ons a single URL environment variable. These URLs can change, too. So manually deconstructing the URL is a bad solution. But come to think of it, `new URL(process.env.DATABASE_URL)` but make parts of that easier. Anyhow, I think `url` should be documented.