### PR TITLE
Spatial support for PostgreSQL using PostGIS

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -39,7 +39,7 @@ services:
 
   # postgres
   postgres:
-    image: "postgres:9.6.1"
+    image: "mdillon/postgis:9.6"
     container_name: "typeorm-postgres"
     ports:
       - "5432:5432"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -39,6 +39,9 @@ services:
 
   # postgres
   postgres:
+    # mdillon/postgis is postgres + PostGIS (only). if you need additional
+    # extensions, it's probably time to create a purpose-built image with all
+    # necessary extensions. sorry, and thanks for adding support for them!
     image: "mdillon/postgis:9.6"
     container_name: "typeorm-postgres"
     ports:

--- a/docs/decorator-reference.md
+++ b/docs/decorator-reference.md
@@ -139,6 +139,8 @@ You can specify array of values or specify a enum class.
 * `hstoreType: "object"|"string"` - Return type of `HSTORE` column. Returns value as string or as object. Used only in [Postgres](https://www.postgresql.org/docs/9.6/static/hstore.html).
 * `array: boolean` - Used for postgres column types which can be array (for example int[]).
 * `transformer: ValueTransformer` - Specifies a value transformer that is to be used to (un)marshal this column when reading or writing to the database.
+* `spatialFeatureType: string` - Optional feature type (`Point`, `Polygon`, `LineString`, `Geometry`) used as a constraint on a spatial column. If not specified, it will behave as though `Geometry` was provided. Used only in PostgreSQL.
+* `srid: number` - Optional [Spatial Reference ID](https://postgis.net/docs/using_postgis_dbmanagement.html#spatial_ref_sys) used as a constraint on a spatial column. If not specified, it will default to `0`. Standard geographic coordinates (latitude/longitude in the WGS84 datum) correspond to [EPSG 4326](http://spatialreference.org/ref/epsg/wgs-84/). Used only in PostgreSQL.
 
 Learn more about [entity columns](entities.md#entity-columns).
 

--- a/docs/entities.md
+++ b/docs/entities.md
@@ -200,6 +200,59 @@ You don't need to set this column - it will be automatically set.
 each time you call `save` of entity manager or repository.
 You don't need to set this column - it will be automatically set.
 
+### Spatial columns
+
+MS SQL, MySQL / MariaDB, and PostgreSQL all support spatial columns. TypeORM's
+support for each varies slightly between databases, particularly as the column
+names vary between databases.
+
+MS SQL and MySQL / MariaDB's TypeORM support exposes (and expects) geometries to
+be provided as [well-known text
+(WKT)](https://en.wikipedia.org/wiki/Well-known_text), so geometry columns
+should be tagged with the `string` type.
+
+TypeORM's PostgreSQL support uses [GeoJSON](http://geojson.org/) as an
+interchange format, so geometry columns should be tagged either as `object` or
+`Geometry` (or subclasses, e.g. `Point`) after importing [`geojson`
+types](https://www.npmjs.com/package/@types/geojson).
+
+TypeORM tries to do the right thing, but it's not always possible to determine
+when a value being inserted or the result of a PostGIS function should be
+treated as a geometry. As a result, you may find yourself writing code similar
+to the following, where values are converted into PostGIS `geometry`s from
+GeoJSON and into GeoJSON as `json`:
+
+```typescript
+const origin = {
+  type: "Point",
+  coordinates: [0, 0]
+};
+
+await getManager()
+    .createQueryBuilder(Thing, "thing")
+    // convert stringified GeoJSON into a geometry with an SRID that matches the
+    // table specification
+    .where("ST_Distance(geom, ST_SetSRID(ST_GeomFromGeoJSON(:origin), ST_SRID(geom))) > 0")
+    .orderBy({
+        "ST_Distance(geom, ST_SetSRID(ST_GeomFromGeoJSON(:origin), ST_SRID(geom)))": {
+            order: "ASC"
+        }
+    })
+    .setParameters({
+      // stringify GeoJSON
+      origin: JSON.stringify(origin)
+    })
+    .getMany();
+
+await getManager()
+    .createQueryBuilder(Thing, "thing")
+    // convert geometry result into GeoJSON, treated as JSON (so that TypeORM
+    // will know to deserialize it)
+    .select("ST_AsGeoJSON(ST_Buffer(geom, 0.1))::json geom")
+    .from("thing")
+    .getMany();
+```
+
 
 ## Column types
 
@@ -249,7 +302,7 @@ or
 `date`, `time`, `time without time zone`, `time with time zone`, `interval`, `bool`, `boolean`,
 `enum`, `point`, `line`, `lseg`, `box`, `path`, `polygon`, `circle`, `cidr`, `inet`, `macaddr`,
 `tsvector`, `tsquery`, `uuid`, `xml`, `json`, `jsonb`, `int4range`, `int8range`, `numrange`,
-`tsrange`, `tstzrange`, `daterange`
+`tsrange`, `tstzrange`, `daterange`, `geometry`, `geography`
 
 ### Column types for `sqlite` / `cordova` / `react-native`
 

--- a/docs/entities.md
+++ b/docs/entities.md
@@ -4,6 +4,7 @@
 * [Entity columns](#entity-columns)
   * [Primary columns](#primary-columns)
   * [Special columns](#special-columns)
+  * [Spatial columns](#spatial-columns)
 * [Column types](#column-types)
   * [Column types for `mysql` / `mariadb`](#column-types-for-mysql--mariadb)
   * [Column types for `postgres`](#column-types-for-postgres)

--- a/docs/indices.md
+++ b/docs/indices.md
@@ -3,6 +3,8 @@
 * [Column indices](#column-indices)
 * [Unique indices](#unique-indices)
 * [Indices with multiple columns](#indices-with-multiple-columns)
+* [Spatial Indices](#spatial-indices)
+* [Disabling synchronization](#disabling-synchronization)
 
 ## Column indices
 

--- a/docs/indices.md
+++ b/docs/indices.md
@@ -98,7 +98,39 @@ export class User {
 
     @Column()
     lastName: string;
-    
+
+}
+```
+
+## Spatial Indices
+
+MySQL and PostgreSQL (when PostGIS is available) both support spatial indices.
+
+To create a spatial index on a column in MySQL, add an `Index` with `spatial:
+true` on a column that uses a spatial type (`geometry`, `point`, `linestring`,
+`polygon`, `multipoint`, `multilinestring`, `multipolygon`,
+`geometrycollection`):
+
+```typescript
+@Entity()
+export class Thing {
+    @Column("point")
+    @Index({ spatial: true })
+    point: string;
+}
+```
+
+To create a spatial index on a column in PostgreSQL, add an `Index` with `spatial: true` on a column that uses a spatial type (`geometry`, `geography`):
+
+```typescript
+@Entity()
+export class Thing {
+    @Column("geometry", {
+      spatialFeatureType: "Point",
+      srid: 4326
+    })
+    @Index({ spatial: true })
+    point: Geometry;
 }
 ```
 

--- a/src/decorator/columns/Column.ts
+++ b/src/decorator/columns/Column.ts
@@ -1,10 +1,11 @@
 import {ColumnOptions, getMetadataArgsStorage} from "../../";
 import {
-    ColumnType, SimpleColumnType, WithLengthColumnType,
+    ColumnType, SimpleColumnType, SpatialColumnType, WithLengthColumnType,
     WithPrecisionColumnType, WithWidthColumnType
 } from "../../driver/types/ColumnTypes";
 import {ColumnMetadataArgs} from "../../metadata-args/ColumnMetadataArgs";
 import {ColumnCommonOptions} from "../options/ColumnCommonOptions";
+import {SpatialColumnOptions} from "../options/SpatialColumnOptions";
 import {ColumnWithLengthOptions} from "../options/ColumnWithLengthOptions";
 import {ColumnNumericOptions} from "../options/ColumnNumericOptions";
 import {ColumnEnumOptions} from "../options/ColumnEnumOptions";
@@ -31,6 +32,12 @@ export function Column(options: ColumnOptions): Function;
  * Only properties decorated with this decorator will be persisted to the database when entity be saved.
  */
 export function Column(type: SimpleColumnType, options?: ColumnCommonOptions): Function;
+
+/**
+ * Column decorator is used to mark a specific class property as a table column.
+ * Only properties decorated with this decorator will be persisted to the database when entity be saved.
+ */
+export function Column(type: SpatialColumnType, options?: ColumnCommonOptions & SpatialColumnOptions): Function;
 
 /**
  * Column decorator is used to mark a specific class property as a table column.

--- a/src/decorator/options/ColumnOptions.ts
+++ b/src/decorator/options/ColumnOptions.ts
@@ -139,5 +139,14 @@ export interface ColumnOptions {
      * this column when reading or writing to the database.
      */
     transformer?: ValueTransformer;
-    
+
+    /**
+     * Spatial Feature Type (Geometry, Point, Polygon, etc.)
+     */
+    spatialFeatureType?: string;
+
+    /**
+     * SRID (Spatial Reference ID (EPSG code))
+     */
+    srid?: number;
 }

--- a/src/decorator/options/IndexOptions.ts
+++ b/src/decorator/options/IndexOptions.ts
@@ -10,7 +10,7 @@ export interface IndexOptions {
 
     /**
      * The SPATIAL modifier indexes the entire column and does not allow indexed columns to contain NULL values.
-     * Works only in MySQL.
+     * Works only in MySQL and PostgreSQL.
      */
     spatial?: boolean;
 

--- a/src/decorator/options/SpatialColumnOptions.ts
+++ b/src/decorator/options/SpatialColumnOptions.ts
@@ -1,0 +1,18 @@
+/**
+ * Options for spatial columns.
+ */
+export interface SpatialColumnOptions {
+
+    /**
+     * Column type's feature type.
+     * Geometry, Point, Polygon, etc.
+     */
+    spatialFeatureType?: string;
+
+    /**
+     * Column type's SRID.
+     * Spatial Reference ID or EPSG code.
+     */
+    srid?: number;
+
+}

--- a/src/driver/postgres/PostgresDriver.ts
+++ b/src/driver/postgres/PostgresDriver.ts
@@ -721,7 +721,9 @@ export class PostgresDriver implements Driver {
                 || tableColumn.isNullable !== columnMetadata.isNullable
                 || tableColumn.isUnique !== this.normalizeIsUnique(columnMetadata)
                 || (tableColumn.enum && columnMetadata.enum && !OrmUtils.isArraysEqual(tableColumn.enum, columnMetadata.enum))
-                || tableColumn.isGenerated !== columnMetadata.isGenerated;
+                || tableColumn.isGenerated !== columnMetadata.isGenerated
+                || (tableColumn.spatialFeatureType || "").toLowerCase() !== (columnMetadata.spatialFeatureType || "").toLowerCase()
+                || tableColumn.srid !== columnMetadata.srid;
         });
     }
 

--- a/src/driver/postgres/PostgresDriver.ts
+++ b/src/driver/postgres/PostgresDriver.ts
@@ -636,6 +636,14 @@ export class PostgresDriver implements Driver {
 
         } else if (column.type === "timestamp with time zone") {
             type = "TIMESTAMP" + (column.precision !== null && column.precision !== undefined ? "(" + column.precision + ")" : "") + " WITH TIME ZONE";
+        } else if (this.spatialTypes.indexOf(column.type as ColumnType) >= 0) {
+          if (column.spatialFeatureType != null && column.srid != null) {
+            type = `${column.type}(${column.spatialFeatureType},${column.srid})`;
+          } else if (column.spatialFeatureType != null) {
+            type = `${column.type}(${column.spatialFeatureType})`;
+          } else {
+            type = column.type;
+          }
         }
 
         if (column.isArray)

--- a/src/driver/postgres/PostgresDriver.ts
+++ b/src/driver/postgres/PostgresDriver.ts
@@ -384,7 +384,7 @@ export class PostgresDriver implements Driver {
             || columnMetadata.type === "timestamp without time zone") {
             return DateUtils.mixedDateToDate(value);
 
-        } else if (this.spatialTypes.concat(["json", "jsonb"]).indexOf(columnMetadata.type) >= 0) {
+        } else if (["json", "jsonb", ...this.spatialTypes].indexOf(columnMetadata.type) >= 0) {
             return JSON.stringify(value);
 
         } else if (columnMetadata.type === "hstore") {

--- a/src/driver/postgres/PostgresQueryRunner.ts
+++ b/src/driver/postgres/PostgresQueryRunner.ts
@@ -812,6 +812,12 @@ export class PostgresQueryRunner extends BaseQueryRunner implements QueryRunner 
                     downQueries.push(`ALTER TABLE ${this.escapeTableName(table)} ALTER COLUMN "${newColumn.name}" SET DEFAULT ${oldColumn.default}`);
                 }
             }
+
+            if (newColumn.spatialFeatureType !== oldColumn.spatialFeatureType || newColumn.srid !== oldColumn.srid) {
+                upQueries.push(`ALTER TABLE ${this.escapeTableName(table)} ALTER COLUMN "${newColumn.name}" TYPE ${this.driver.createFullType(newColumn)}`);
+                downQueries.push(`ALTER TABLE ${this.escapeTableName(table)} ALTER COLUMN "${newColumn.name}" TYPE ${this.driver.createFullType(oldColumn)}`);
+            }
+
         }
 
         await this.executeQueries(upQueries, downQueries);

--- a/src/driver/types/ColumnTypes.ts
+++ b/src/driver/types/ColumnTypes.ts
@@ -17,6 +17,12 @@ export type PrimaryGeneratedColumnType = "int" // mysql, mssql, oracle, sqlite
     |"number"; // oracle
 
 /**
+ * Column types where spatial properties are used.
+ */
+export type SpatialColumnType = "geometry" // postgres
+    |"geography"; // postgres
+
+/**
  * Column types where precision and scale properties are used.
  */
 export type WithPrecisionColumnType = "float" // mysql, mssql, oracle, sqlite
@@ -171,6 +177,7 @@ export type SimpleColumnType =
 export type ColumnType = WithPrecisionColumnType
     |WithLengthColumnType
     |WithWidthColumnType
+    |SpatialColumnType
     |SimpleColumnType
     |BooleanConstructor
     |DateConstructor

--- a/src/entity-schema/EntitySchemaIndexOptions.ts
+++ b/src/entity-schema/EntitySchemaIndexOptions.ts
@@ -29,7 +29,7 @@ export interface EntitySchemaIndexOptions {
 
     /**
      * The SPATIAL modifier indexes the entire column and does not allow indexed columns to contain NULL values.
-     * Works only in MySQL.
+     * Works only in MySQL and PostgreSQL.
      */
     spatial?: boolean;
 

--- a/src/metadata/ColumnMetadata.ts
+++ b/src/metadata/ColumnMetadata.ts
@@ -278,6 +278,11 @@ export class ColumnMetadata {
      */
     isMaterializedPath: boolean = false;
 
+    /**
+     * SRID (Spatial Reference ID (EPSG code))
+     */
+    srid?: number;
+
     // ---------------------------------------------------------------------
     // Constructor
     // ---------------------------------------------------------------------
@@ -366,6 +371,8 @@ export class ColumnMetadata {
         }
         if (options.args.options.transformer)
             this.transformer = options.args.options.transformer;
+        if (options.args.options.srid)
+            this.srid = options.args.options.srid;
         if (this.isTreeLevel)
             this.type = options.connection.driver.mappedDataTypes.treeLevel;
         if (this.isCreateDate) {

--- a/src/metadata/ColumnMetadata.ts
+++ b/src/metadata/ColumnMetadata.ts
@@ -279,6 +279,11 @@ export class ColumnMetadata {
     isMaterializedPath: boolean = false;
 
     /**
+     * Spatial Feature Type (Geometry, Point, Polygon, etc.)
+     */
+    spatialFeatureType?: string;
+
+    /**
      * SRID (Spatial Reference ID (EPSG code))
      */
     srid?: number;
@@ -371,6 +376,8 @@ export class ColumnMetadata {
         }
         if (options.args.options.transformer)
             this.transformer = options.args.options.transformer;
+        if (options.args.options.spatialFeatureType)
+            this.spatialFeatureType = options.args.options.spatialFeatureType;
         if (options.args.options.srid)
             this.srid = options.args.options.srid;
         if (this.isTreeLevel)

--- a/src/query-builder/InsertQueryBuilder.ts
+++ b/src/query-builder/InsertQueryBuilder.ts
@@ -418,6 +418,8 @@ export class InsertQueryBuilder<Entity> extends QueryBuilder<Entity> {
                         this.expressionMap.nativeParameters[paramName] = value;
                         if (this.connection.driver instanceof MysqlDriver && this.connection.driver.spatialTypes.indexOf(column.type) !== -1) {
                             expression += `GeomFromText(${this.connection.driver.createParameter(paramName, parametersCount)})`;
+                        } else if (this.connection.driver instanceof PostgresDriver && this.connection.driver.spatialTypes.indexOf(column.type) !== -1) {
+                            expression += `ST_GeomFromGeoJSON(${this.connection.driver.createParameter(paramName, parametersCount)})::${column.type}`;
                         } else {
                             expression += this.connection.driver.createParameter(paramName, parametersCount);
                         }

--- a/src/query-builder/InsertQueryBuilder.ts
+++ b/src/query-builder/InsertQueryBuilder.ts
@@ -419,7 +419,11 @@ export class InsertQueryBuilder<Entity> extends QueryBuilder<Entity> {
                         if (this.connection.driver instanceof MysqlDriver && this.connection.driver.spatialTypes.indexOf(column.type) !== -1) {
                             expression += `GeomFromText(${this.connection.driver.createParameter(paramName, parametersCount)})`;
                         } else if (this.connection.driver instanceof PostgresDriver && this.connection.driver.spatialTypes.indexOf(column.type) !== -1) {
-                            expression += `ST_GeomFromGeoJSON(${this.connection.driver.createParameter(paramName, parametersCount)})::${column.type}`;
+                            if (column.srid != null) {
+                              expression += `ST_SetSRID(ST_GeomFromGeoJSON(${this.connection.driver.createParameter(paramName, parametersCount)}), ${column.srid})::${column.type}`;
+                            } else {
+                              expression += `ST_GeomFromGeoJSON(${this.connection.driver.createParameter(paramName, parametersCount)})::${column.type}`;
+                            }
                         } else {
                             expression += this.connection.driver.createParameter(paramName, parametersCount);
                         }

--- a/src/query-builder/QueryBuilder.ts
+++ b/src/query-builder/QueryBuilder.ts
@@ -319,9 +319,7 @@ export abstract class QueryBuilder<Entity> {
         if (this.expressionMap.parentQueryBuilder)
             this.expressionMap.parentQueryBuilder.setParameters(parameters);
 
-        Object.keys(parameters).forEach(key => {
-            this.expressionMap.parameters[key] = parameters[key];
-        });
+        Object.keys(parameters).forEach(key => this.setParameter(key, parameters[key]));
         return this;
     }
 

--- a/src/query-builder/SelectQueryBuilder.ts
+++ b/src/query-builder/SelectQueryBuilder.ts
@@ -1661,6 +1661,10 @@ export class SelectQueryBuilder<Entity> extends QueryBuilder<Entity> implements 
                 if (this.connection.driver instanceof MysqlDriver)
                     selectionPath = `AsText(${selectionPath})`;
 
+                if (this.connection.driver instanceof PostgresDriver)
+                    // cast to JSON to trigger parsing in the driver
+                    selectionPath = `ST_AsGeoJSON(${selectionPath})::json`;
+
                 if (this.connection.driver instanceof SqlServerDriver)
                     selectionPath = `${selectionPath}.ToString()`;
             }

--- a/src/schema-builder/options/TableColumnOptions.ts
+++ b/src/schema-builder/options/TableColumnOptions.ts
@@ -122,4 +122,14 @@ export interface TableColumnOptions {
      * Generated column type. Supports only in MySQL.
      */
     generatedType?: "VIRTUAL"|"STORED";
+
+    /**
+     * Spatial Feature Type (Geometry, Point, Polygon, etc.)
+     */
+    spatialFeatureType?: string;
+
+    /**
+     * SRID (Spatial Reference ID (EPSG code))
+     */
+    srid?: number;
 }

--- a/src/schema-builder/table/TableColumn.ts
+++ b/src/schema-builder/table/TableColumn.ts
@@ -124,6 +124,16 @@ export class TableColumn {
      */
     generatedType?: "VIRTUAL"|"STORED";
 
+    /**
+     * Spatial Feature Type (Geometry, Point, Polygon, etc.)
+     */
+    spatialFeatureType?: string;
+
+    /**
+     * SRID (Spatial Reference ID (EPSG code))
+     */
+    srid?: number;
+
     // -------------------------------------------------------------------------
     // Constructor
     // -------------------------------------------------------------------------
@@ -152,6 +162,8 @@ export class TableColumn {
             this.enum = options.enum;
             this.asExpression = options.asExpression;
             this.generatedType = options.generatedType;
+            this.spatialFeatureType = options.spatialFeatureType;
+            this.srid = options.srid;
         }
     }
 
@@ -185,7 +197,9 @@ export class TableColumn {
             isPrimary: this.isPrimary,
             isUnique: this.isUnique,
             isArray: this.isArray,
-            comment: this.comment
+            comment: this.comment,
+            spatialFeatureType: this.spatialFeatureType,
+            srid: this.srid
         });
     }
 

--- a/src/schema-builder/util/TableUtils.ts
+++ b/src/schema-builder/util/TableUtils.ts
@@ -27,7 +27,9 @@ export class TableUtils {
             isPrimary: columnMetadata.isPrimary,
             isUnique: driver.normalizeIsUnique(columnMetadata),
             isArray: columnMetadata.isArray || false,
-            enum: columnMetadata.enum
+            enum: columnMetadata.enum,
+            spatialFeatureType: columnMetadata.spatialFeatureType,
+            srid: columnMetadata.srid
         };
     }
 

--- a/test/functional/query-builder/order-by/entity/Post.ts
+++ b/test/functional/query-builder/order-by/entity/Post.ts
@@ -1,6 +1,7 @@
 import {Entity} from "../../../../../src/decorator/entity/Entity";
 import {PrimaryGeneratedColumn} from "../../../../../src/decorator/columns/PrimaryGeneratedColumn";
 import {Column} from "../../../../../src/decorator/columns/Column";
+import {Index} from "../../../../../src";
 
 @Entity({
     orderBy: {
@@ -20,5 +21,9 @@ export class Post {
 
     @Column()
     num2: number = 1;
+
+    @Column({ type: "geometry" })
+    @Index({ spatial: true })
+    geom: object;
 
 }

--- a/test/functional/query-builder/order-by/entity/Post.ts
+++ b/test/functional/query-builder/order-by/entity/Post.ts
@@ -1,7 +1,6 @@
 import {Entity} from "../../../../../src/decorator/entity/Entity";
 import {PrimaryGeneratedColumn} from "../../../../../src/decorator/columns/PrimaryGeneratedColumn";
 import {Column} from "../../../../../src/decorator/columns/Column";
-import {Index} from "../../../../../src";
 
 @Entity({
     orderBy: {
@@ -21,9 +20,5 @@ export class Post {
 
     @Column()
     num2: number = 1;
-
-    @Column({ type: "geometry" })
-    @Index({ spatial: true })
-    geom: object;
 
 }

--- a/test/functional/spatial/postgres/entity/Post.ts
+++ b/test/functional/spatial/postgres/entity/Post.ts
@@ -1,0 +1,24 @@
+import {PrimaryGeneratedColumn} from "../../../../../src/decorator/columns/PrimaryGeneratedColumn";
+import {Entity} from "../../../../../src/decorator/entity/Entity";
+import {Column} from "../../../../../src/decorator/columns/Column";
+import {Index} from "../../../../../src/decorator/Index";
+
+@Entity()
+export class Post {
+
+    @PrimaryGeneratedColumn()
+    id: number;
+
+    @Column("geometry", {
+      nullable: true
+    })
+    @Index({
+      spatial: true
+    })
+    geom: object;
+
+    @Column("geography", {
+      nullable: true
+    })
+    geog: object;
+}

--- a/test/functional/spatial/postgres/entity/Post.ts
+++ b/test/functional/spatial/postgres/entity/Post.ts
@@ -17,6 +17,19 @@ export class Post {
     })
     geom: object;
 
+    @Column("geometry", {
+      nullable: true,
+      spatialFeatureType: "Point"
+    })
+    pointWithoutSRID: object;
+
+    @Column("geometry", {
+      nullable: true,
+      spatialFeatureType: "Point",
+      srid: 4326
+    })
+    point: object;
+
     @Column("geography", {
       nullable: true
     })

--- a/test/functional/spatial/postgres/spatial-postgres.ts
+++ b/test/functional/spatial/postgres/spatial-postgres.ts
@@ -1,0 +1,119 @@
+import "reflect-metadata";
+import { expect } from "chai";
+import { Connection } from "../../../../src/connection/Connection";
+import {
+  closeTestingConnections,
+  createTestingConnections,
+  reloadTestingDatabases
+} from "../../../utils/test-utils";
+import { Post } from "./entity/Post";
+
+describe("spatial-postgres", () => {
+  let connections: Connection[];
+  before(async () => {
+    connections = await createTestingConnections({
+      entities: [__dirname + "/entity/*{.js,.ts}"],
+      enabledDrivers: ["postgres"]
+    });
+  });
+  beforeEach(async () => {
+    try {
+      await reloadTestingDatabases(connections);
+    } catch (err) {
+      console.warn(err.stack);
+      throw err;
+    }
+  });
+  after(async () => {
+    try {
+      await closeTestingConnections(connections);
+    } catch (err) {
+      console.warn(err.stack);
+      throw err;
+    }
+  });
+
+  it("should create correct schema with Postgres' geometry type", () =>
+    Promise.all(
+      connections.map(async connection => {
+        const queryRunner = connection.createQueryRunner();
+        const schema = await queryRunner.getTable("post");
+        await queryRunner.release();
+        expect(schema).not.to.be.empty;
+        expect(
+          schema!.columns.find(
+            tableColumn =>
+              tableColumn.name === "geom" && tableColumn.type === "geometry"
+          )
+        ).to.not.be.empty;
+      })
+    ));
+
+  it("should create correct schema with Postgres' geography type", () =>
+    Promise.all(
+      connections.map(async connection => {
+        const queryRunner = connection.createQueryRunner();
+        const schema = await queryRunner.getTable("post");
+        await queryRunner.release();
+        expect(schema).not.to.be.empty;
+        expect(
+          schema!.columns.find(
+            tableColumn =>
+              tableColumn.name === "geog" && tableColumn.type === "geography"
+          )
+        ).to.not.be.empty;
+      })
+    ));
+
+  it("should create correct schema with Postgres' geometry indices", () =>
+    Promise.all(
+      connections.map(async connection => {
+        const queryRunner = connection.createQueryRunner();
+        const schema = await queryRunner.getTable("post");
+        await queryRunner.release();
+        expect(schema).not.to.be.empty;
+        expect(
+          schema!.indices.find(
+            tableIndex =>
+              tableIndex.isSpatial === true &&
+              tableIndex.columnNames.length === 1 &&
+              tableIndex.columnNames[0] === "geom"
+          )
+        ).to.not.be.empty;
+      })
+    ));
+
+  it("should persist geometry correctly", () =>
+    Promise.all(
+      connections.map(async connection => {
+        const geom = {
+          type: "Point",
+          coordinates: [0, 0]
+        };
+        const recordRepo = connection.getRepository(Post);
+        const post = new Post();
+        post.geom = geom;
+        const persistedPost = await recordRepo.save(post);
+        const foundPost = await recordRepo.findOne(persistedPost.id);
+        expect(foundPost).to.exist;
+        expect(foundPost!.geom).to.deep.equal(geom);
+      })
+    ));
+
+  it("should persist geography correctly", () =>
+    Promise.all(
+      connections.map(async connection => {
+        const geom = {
+          type: "Point",
+          coordinates: [0, 0]
+        };
+        const recordRepo = connection.getRepository(Post);
+        const post = new Post();
+        post.geog = geom;
+        const persistedPost = await recordRepo.save(post);
+        const foundPost = await recordRepo.findOne(persistedPost.id);
+        expect(foundPost).to.exist;
+        expect(foundPost!.geog).to.deep.equal(geom);
+      })
+    ));
+});

--- a/test/functional/spatial/postgres/spatial-postgres.ts
+++ b/test/functional/spatial/postgres/spatial-postgres.ts
@@ -40,12 +40,13 @@ describe("spatial-postgres", () => {
         const schema = await queryRunner.getTable("post");
         await queryRunner.release();
         expect(schema).not.to.be.empty;
-        expect(
-          schema!.columns.find(
+        const pointColumn = schema!.columns.find(
             tableColumn =>
-              tableColumn.name === "geom" && tableColumn.type === "geometry"
+              tableColumn.name === "point" && tableColumn.type === "geometry"
           )
-        ).to.not.be.empty;
+        expect(pointColumn).to.not.be.empty;
+        expect(pointColumn!.spatialFeatureType!.toLowerCase()).to.equal("point");
+        expect(pointColumn!.srid).to.equal(4326);
       })
     ));
 

--- a/test/functional/spatial/postgres/spatial-postgres.ts
+++ b/test/functional/spatial/postgres/spatial-postgres.ts
@@ -43,7 +43,7 @@ describe("spatial-postgres", () => {
         const pointColumn = schema!.columns.find(
             tableColumn =>
               tableColumn.name === "point" && tableColumn.type === "geometry"
-          )
+          );
         expect(pointColumn).to.not.be.empty;
         expect(pointColumn!.spatialFeatureType!.toLowerCase()).to.equal("point");
         expect(pointColumn!.srid).to.equal(4326);

--- a/test/functional/spatial/postgres/spatial-postgres.ts
+++ b/test/functional/spatial/postgres/spatial-postgres.ts
@@ -117,6 +117,59 @@ describe("spatial-postgres", () => {
       })
     ));
 
+  it("should update geometry correctly", () =>
+    Promise.all(
+      connections.map(async connection => {
+        const geom = {
+          type: "Point",
+          coordinates: [0, 0]
+        };
+        const geom2 = {
+          type: "Point",
+          coordinates: [45, 45]
+        };
+        const recordRepo = connection.getRepository(Post);
+        const post = new Post();
+        post.geom = geom;
+        const persistedPost = await recordRepo.save(post);
+
+        await recordRepo.update({
+          id: persistedPost.id
+        }, {
+          geom: geom2
+        });
+
+        const foundPost = await recordRepo.findOne(persistedPost.id);
+        expect(foundPost).to.exist;
+        expect(foundPost!.geom).to.deep.equal(geom2);
+      })
+    ));
+
+  it("should re-save geometry correctly", () =>
+    Promise.all(
+      connections.map(async connection => {
+        const geom = {
+          type: "Point",
+          coordinates: [0, 0]
+        };
+        const geom2 = {
+          type: "Point",
+          coordinates: [45, 45]
+        };
+        const recordRepo = connection.getRepository(Post);
+        const post = new Post();
+        post.geom = geom;
+        const persistedPost = await recordRepo.save(post);
+
+        persistedPost.geom = geom2;
+        await recordRepo.save(persistedPost);
+
+        const foundPost = await recordRepo.findOne(persistedPost.id);
+        expect(foundPost).to.exist;
+        expect(foundPost!.geom).to.deep.equal(geom2);
+      })
+    ));
+
     it("should be able to order geometries by distance", () => Promise.all(connections.map(async connection => {
 
         const geoJson1 = {


### PR DESCRIPTION
This includes support for both geometry and geography columns as well as GiST indices (used when passing the `spatial: true` option). Client representations use GeoJSON (existing MySQL and MS SQL drivers use WKT (well-known text)) for compatibility with geospatial libraries such as Turf, JSTS, etc.

Fixes #370 