### PR TITLE
Fix update of geospatial type column with mysql driver in UpdateQueryBuilder.ts

### DIFF
--- a/src/query-builder/UpdateQueryBuilder.ts
+++ b/src/query-builder/UpdateQueryBuilder.ts
@@ -393,7 +393,12 @@ export class UpdateQueryBuilder<Entity> extends QueryBuilder<Entity> implements 
                             this.expressionMap.nativeParameters[paramName] = value;
                         }
 
-                        updateColumnAndValues.push(this.escape(column.databaseName) + " = " + this.connection.driver.createParameter(paramName, parametersCount));
+                        if (this.connection.driver instanceof MysqlDriver && this.connection.driver.spatialTypes.indexOf(column.type) !== -1) {
+                            updateColumnAndValues.push(this.escape(column.databaseName) + " = GeomFromText(" + this.connection.driver.createParameter(paramName, parametersCount) + ")");
+                        } else {
+                            updateColumnAndValues.push(this.escape(column.databaseName) + " = " + this.connection.driver.createParameter(paramName, parametersCount));
+                        }
+
                         parametersCount++;
                     }
                 });


### PR DESCRIPTION
In InsertQueryBuilder the geospatial types are addressed with GeomFromText() function passed to MySQL/MariaDB so we replicated the same behaviour on UpdateQuerBuilder.
We faced this reported issue: https://github.com/typeorm/typeorm/issues/2329 and needed a quick fix to continue working.
