### PR TITLE
fix bug of OrmUtils.compare2Objects

### DIFF
--- a/src/util/OrmUtils.ts
+++ b/src/util/OrmUtils.ts
@@ -177,7 +177,9 @@ export class OrmUtils {
         if (x === y)
             return true;
 
-        if (x.equals instanceof Function && x.equals(y))
+        // Check if both argument is Buffer
+        // Buffer.equals Argument must be a Buffer
+        if (Buffer.isBuffer(x) && Buffer.isBuffer(y) && x.equals(y))
             return true;
 
         // Works in case when functions are created in constructor.

--- a/src/util/OrmUtils.ts
+++ b/src/util/OrmUtils.ts
@@ -179,7 +179,12 @@ export class OrmUtils {
 
         // Check if both argument is Buffer
         // Buffer.equals Argument must be a Buffer
-        if (Buffer.isBuffer(x) && Buffer.isBuffer(y) && x.equals(y))
+        if (Buffer.isBuffer(x) && Buffer.isBuffer(y))
+            return x.equals(y);
+        if (Buffer.isBuffer(x) || Buffer.isBuffer(y))
+            return false;
+
+        if (x.equals instanceof Function && x.equals(y))
             return true;
 
         // Works in case when functions are created in constructor.

--- a/test/functional/util/compare-objects.ts
+++ b/test/functional/util/compare-objects.ts
@@ -1,0 +1,51 @@
+import "reflect-metadata";
+import {closeTestingConnections, createTestingConnections, reloadTestingDatabases} from "../../utils/test-utils";
+import {Connection} from "../../../src/connection/Connection";
+import {Post} from "./entity/Post";
+import {Counters} from "./entity/Counters";
+
+describe("util > compare2Objects functionality", () => {
+
+    let connections: Connection[];
+    before(async () => connections = await createTestingConnections({
+        entities: [Post, Counters],
+        enabledDrivers: ["mysql"]
+    }));
+    beforeEach(() => reloadTestingDatabases(connections));
+    after(() => closeTestingConnections(connections));
+
+    it("should compare two binary objects correctly", () => Promise.all(connections.map(async connection => {
+
+        // create and save a post and a counters first
+        const post = new Post();
+        post.id = new Buffer([0]);
+        await connection.manager.save(post);
+        const counters = new Counters();
+        counters.id = new Buffer([0]);
+        await connection.manager.save(counters);
+
+        // then update its properties and save again
+        const loadedPost = await connection.getRepository(Post).findOne();
+        loadedPost!.counters = counters!;
+        await connection.manager.save(loadedPost!);
+
+    })));
+
+    it("should compare binary and null objects correctly", () => Promise.all(connections.map(async connection => {
+
+        // create and save a post and a counters first
+        const counters = new Counters();
+        counters.id = new Buffer([0]);
+        await connection.manager.save(counters);
+        const post = new Post();
+        post.id = new Buffer([0]);
+        post.counters = counters;
+        await connection.manager.save(post);
+
+        // then update its properties and save again
+        const loadedPost = await connection.getRepository(Post).findOne();
+        loadedPost!.counters = null!;
+        await connection.manager.save(loadedPost!);
+
+    })));
+});

--- a/test/functional/util/entity/Counters.ts
+++ b/test/functional/util/entity/Counters.ts
@@ -1,0 +1,12 @@
+import { Entity } from "../../../../src/decorator/entity/Entity";
+import { PrimaryColumn } from "../../../../src/decorator/columns/PrimaryColumn";
+
+@Entity()
+export class Counters {
+    
+    @PrimaryColumn("binary", {
+        length: 1
+    })
+    id: Buffer;
+
+}

--- a/test/functional/util/entity/Post.ts
+++ b/test/functional/util/entity/Post.ts
@@ -1,0 +1,19 @@
+import {Entity} from "../../../../src/decorator/entity/Entity";
+import {PrimaryColumn} from "../../../../src/decorator/columns/PrimaryColumn";
+import {ManyToOne} from "../../../../src/decorator/relations/ManyToOne";
+import {JoinColumn} from "../../../../src/decorator/relations/JoinColumn";
+import {Counters} from "./Counters";
+
+@Entity()
+export class Post {
+
+    @PrimaryColumn("binary", {
+        length: 1
+    })
+    id: Buffer;
+
+    @ManyToOne(type => Counters)
+    @JoinColumn()
+    counters: Counters | null;
+
+}


### PR DESCRIPTION
when id is binary and relation is nullable, compare2Objects raise error.

>TypeError: Argument must be a Buffer
>    at Buffer.equals (buffer.js:502:11)
>    at Function.OrmUtils.compare2Objects (../src/util/OrmUtils.ts:176:47)
>    at Function.OrmUtils.compare2Objects (../src/util/OrmUtils.ts:232:31)
>    at Function.OrmUtils.deepCompare (../src/util/OrmUtils.ts:114:23)
>    at Function.EntityMetadata.compareIds (../src/metadata/EntityMetadata.ts:723:25)
>    at ../src/persistence/SubjectChangedColumnsComputer.ts:150:13
>    at Array.forEach (native)
>    at SubjectChangedColumnsComputer.computeDiffRelationalColumns (../src/persistence/SubjectChangedColumnsComputer.ts:119:51)
>    at ../persistence/SubjectChangedColumnsComputer.ts:21:18
>    at Array.forEach (native)
>    at SubjectChangedColumnsComputer.compute (../src/persistence/SubjectChangedColumnsComputer.ts:19:18)
>    at SubjectExecutor.recompute (../src/persistence/SubjectExecutor.ts:167:45)
>    at new SubjectExecutor (../src/persistence/SubjectExecutor.ts:78:14)
>    at EntityPersistExecutor.<anonymous> (../src/persistence/EntityPersistExecutor.ts:119:28)
>    at step (../node_modules/typeorm/persistence/EntityPersistExecutor.js:32:23)
>    at Object.next (../node_modules/typeorm/persistence/EntityPersistExecutor.js:13:53)

this is an error case.

```TypeScript
class A {
  @ManyToOne(type => B, B => B.a, {})
  @JoinColumn({ name: "bId" })
  b: B | null;
}

class B {
  @Column("binary", {name: "id"})
  id: Buffer;

  @OneToMany(type => A, A => A.b)
  a: A[];
}
```

```TypeScript
const a = new A();
b.id = new Buffer([0]);
await a.save();

const b = new B();
await b.save();

a.b = b;
await a.save(); // this raise error
```