### PR TITLE
Issue 1738 advanced console formatted

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "typeorm",
-  "version": "0.2.6",
+  "version": "0.2.7",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -492,7 +492,6 @@
       "version": "6.26.0",
       "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.26.0.tgz",
       "integrity": "sha1-llxwWGaOgrVde/4E/yM3vItWR/4=",
-      "dev": true,
       "requires": {
         "core-js": "2.5.4",
         "regenerator-runtime": "0.11.1"
@@ -1160,8 +1159,7 @@
     "core-js": {
       "version": "2.5.4",
       "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.5.4.tgz",
-      "integrity": "sha1-8si/GB8qgLkvNgEhQpzmOi8K6uA=",
-      "dev": true
+      "integrity": "sha1-8si/GB8qgLkvNgEhQpzmOi8K6uA="
     },
     "core-util-is": {
       "version": "1.0.2",
@@ -6094,8 +6092,7 @@
     "regenerator-runtime": {
       "version": "0.11.1",
       "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.11.1.tgz",
-      "integrity": "sha512-MguG95oij0fC3QV3URf4V2SDYGJhJnJGqvIIgdECeODCT98wSWDAJ94SSuVpYQUoTcGUIL6L4yNB7j1DFFHSBg==",
-      "dev": true
+      "integrity": "sha512-MguG95oij0fC3QV3URf4V2SDYGJhJnJGqvIIgdECeODCT98wSWDAJ94SSuVpYQUoTcGUIL6L4yNB7j1DFFHSBg=="
     },
     "regex-cache": {
       "version": "0.4.4",
@@ -6832,6 +6829,22 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
       "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw="
+    },
+    "sql-formatter": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/sql-formatter/-/sql-formatter-2.3.0.tgz",
+      "integrity": "sha1-huEb36LJG7D2Sp73tw2k3M9Ws8Y=",
+      "requires": {
+        "babel-runtime": "6.26.0",
+        "lodash": "4.17.5"
+      },
+      "dependencies": {
+        "lodash": {
+          "version": "4.17.5",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.5.tgz",
+          "integrity": "sha512-svL3uiZf1RwhH+cWrfZn3A4+U58wbP0tGVTLQPbjplZxZ8ROD9VLuNgsRniTlLe7OlSqR79RUehXgpBW/s0IQw=="
+        }
+      }
     },
     "sql.js": {
       "version": "0.5.0",

--- a/package.json
+++ b/package.json
@@ -87,6 +87,7 @@
     "js-yaml": "^3.11.0",
     "mkdirp": "^0.5.1",
     "reflect-metadata": "^0.1.12",
+    "sql-formatter": "^2.3.0",
     "xml2js": "^0.4.17",
     "yargonaut": "^1.1.2",
     "yargs": "^11.1.0"

--- a/src/index.ts
+++ b/src/index.ts
@@ -90,6 +90,7 @@ export * from "./find-options/JoinOptions";
 export * from "./find-options/OrderByCondition";
 export * from "./logger/Logger";
 export * from "./logger/AdvancedConsoleLogger";
+export * from "./logger/AdvancedConsoleFormattedLogger";
 export * from "./logger/SimpleConsoleLogger";
 export * from "./logger/FileLogger";
 export * from "./metadata/EntityMetadata";

--- a/src/logger/AdvancedConsoleFormattedLogger.ts
+++ b/src/logger/AdvancedConsoleFormattedLogger.ts
@@ -1,0 +1,24 @@
+import {LoggerOptions} from "./LoggerOptions";
+import {QueryRunner} from "../query-runner/QueryRunner";
+import {Logger} from "./Logger";
+import { AdvancedConsoleLogger } from "./AdvancedConsoleLogger";
+const sqlFormatter  = require("sql-formatter"); // use require because there"s no type definition
+
+/**
+ * Performs logging of the events in TypeORM.
+ * This version of logger uses console to log events and use syntax highlighting.
+ */
+export class AdvancedConsoleFormattedLogger extends AdvancedConsoleLogger implements Logger {
+
+    // -------------------------------------------------------------------------
+    // Constructor
+    // -------------------------------------------------------------------------
+
+    constructor(options?: LoggerOptions) {
+        super(options);
+    }
+
+    public logQuery(query: string, parameters?: any[], queryRunner?: QueryRunner) {
+        super.logQuery("\n" + sqlFormatter.format(query) + "\n\n", parameters, queryRunner);
+    }
+}

--- a/src/logger/LoggerFactory.ts
+++ b/src/logger/LoggerFactory.ts
@@ -2,6 +2,7 @@ import {Logger} from "./Logger";
 import {LoggerOptions} from "./LoggerOptions";
 import {SimpleConsoleLogger} from "./SimpleConsoleLogger";
 import {AdvancedConsoleLogger} from "./AdvancedConsoleLogger";
+import {AdvancedConsoleFormattedLogger} from "./AdvancedConsoleFormattedLogger";
 import {FileLogger} from "./FileLogger";
 import {DebugLogger} from "./DebugLogger";
 
@@ -28,12 +29,15 @@ export class LoggerFactory {
                 case "advanced-console":
                     return new AdvancedConsoleLogger(options);
 
+                case "advanced-console-formatted":
+                    return new AdvancedConsoleFormattedLogger(options);
+
                 case "debug":
                     return new DebugLogger();
             }
         }
 
-        return new AdvancedConsoleLogger(options);
+        return new AdvancedConsoleFormattedLogger(options);
     }
 
 }

--- a/test/github-issues/1738/issue-1738-advanced-console-formatted.ts
+++ b/test/github-issues/1738/issue-1738-advanced-console-formatted.ts
@@ -1,0 +1,31 @@
+import "reflect-metadata";
+const sqlFormatter  = require("sql-formatter"); // use require because there"s no type definition
+import * as sinon from "sinon";
+import { AdvancedConsoleFormattedLogger } from "../../../src/logger/AdvancedConsoleFormattedLogger";
+import { AdvancedConsoleLogger } from "../../../src/logger/AdvancedConsoleLogger";
+
+describe("github issues > #1738 formatted advanced console debugger feature", () => {
+
+    // Testing an SQL based driver.  If needed more tests could be made for other
+    // specific drivers
+    it("AdvancedConsoleFormattedLogger - logQuery - called with formatted Sql", () => {
+
+        // spy on AdvancedConsoleLogger (super) calls
+        const superLogQuerySpy = sinon.stub(AdvancedConsoleLogger.prototype, "logQuery");
+
+        // setup logger and SQL
+        const logger = new AdvancedConsoleFormattedLogger(true);
+        const sql = "SELECT user.*, photo.* FROM users user JOIN photos photo ON photo.user = user.id AND .isRemoved = FALSE user.name = 'Timber'";
+
+        // spy on AdvancedConsoleFormattedLogger
+        const logQuerySpy = sinon.spy(logger, "logQuery");
+
+        logger.logQuery(sql);
+
+        sinon.assert.calledOnce(logQuerySpy);
+        sinon.assert.calledOnce(superLogQuerySpy);
+        sinon.assert.calledWith(logQuerySpy, sql);
+        sinon.assert.calledWith(superLogQuerySpy, "\n" + sqlFormatter.format(sql) + "\n\n");
+    });
+
+});


### PR DESCRIPTION
I've put this off for a while just because I've had stuff working locally and haven't had a need for it.

This is a pretty simple addition, but could easily be tweaked going forward if need be.  For now I've just extended AdvancedConsoleLogger and just added in the bits we'd need to format SQL for logQuery calls.  I'm completely open to reworking this if another method is preferred (i.e. build this into it's own standalone logger).

One thing I did notice on one comment a while back, someone was complaining about extra packages included for the debug/loggers.  I'm wondering if it would be worthwhile to just add this as a separate package, something like `@typeorm/advanced-console-formatted` and then people can import and use it as they see fit.

Anyways, apologies again for not following through on this sooner. Let me know if/how this needs to be reworked.  Right now I just want to get this out there to discuss and see what, if anything, fails in the pipeline.  Thanks!