### PR TITLE
require react native and nativescript drivers dynamically

### DIFF
--- a/src/driver/nativescript/NativescriptConnectionOptions.ts
+++ b/src/driver/nativescript/NativescriptConnectionOptions.ts
@@ -15,4 +15,9 @@ export interface NativescriptConnectionOptions extends BaseConnectionOptions {
      */
     readonly database: string;
 
+    /**
+     * (optional) driver module package name
+     */
+    readonly driverModule?: string;
+
 }

--- a/src/driver/nativescript/NativescriptDriver.ts
+++ b/src/driver/nativescript/NativescriptDriver.ts
@@ -11,6 +11,7 @@ import {ColumnType} from "../types/ColumnTypes";
  * Organizes communication with sqlite DBMS within Nativescript.
  */
 export class NativescriptDriver extends AbstractSqliteDriver {
+    static readonly DRIVER_MODULE_NAME = "nativescript-sqlite";
     // -------------------------------------------------------------------------
     // Public Properties
     // -------------------------------------------------------------------------
@@ -19,6 +20,11 @@ export class NativescriptDriver extends AbstractSqliteDriver {
      * Connection options.
      */
     options: NativescriptConnectionOptions;
+
+    /**
+     * package name of the driver module
+     */
+    driverModuleName: string;
 
     // -------------------------------------------------------------------------
     // Constructor
@@ -34,6 +40,12 @@ export class NativescriptDriver extends AbstractSqliteDriver {
         // validate options to make sure everything is set
         if (!this.options.database)
             throw new DriverOptionNotSetError("database");
+
+        if (this.options.driverModule) {
+            this.driverModuleName = this.options.driverModule;
+        } else {
+            this.driverModuleName = NativescriptDriver.DRIVER_MODULE_NAME;
+        }
 
         // load sqlite package
         this.loadDependencies();
@@ -107,10 +119,10 @@ export class NativescriptDriver extends AbstractSqliteDriver {
      */
     protected loadDependencies(): void {
         try {
-            this.sqlite = require("nativescript-sqlite");
+            this.sqlite = require(this.driverModuleName);
 
         } catch (e) {
-            throw new DriverPackageNotInstalledError("Nativescript", "nativescript-sqlite");
+            throw new DriverPackageNotInstalledError("Nativescript", this.driverModuleName);
         }
     }
 }

--- a/src/driver/react-native/ReactNativeConnectionOptions.ts
+++ b/src/driver/react-native/ReactNativeConnectionOptions.ts
@@ -19,4 +19,9 @@ export interface ReactNativeConnectionOptions extends BaseConnectionOptions {
      * Storage Location
      */
     readonly location: string;
+
+    /**
+     * (optional) driver module package name
+     */
+    readonly driverModule?: string;
 }

--- a/src/driver/react-native/ReactNativeDriver.ts
+++ b/src/driver/react-native/ReactNativeDriver.ts
@@ -7,7 +7,17 @@ import {DriverOptionNotSetError} from "../../error/DriverOptionNotSetError";
 import {DriverPackageNotInstalledError} from "../../error/DriverPackageNotInstalledError";
 
 export class ReactNativeDriver extends AbstractSqliteDriver {
+    static readonly DRIVER_MODULE_NAME = "react-native-sqlite-storage";
+
+    /**
+     * Connection options.
+     */
     options: ReactNativeConnectionOptions;
+
+    /**
+     * package name of the driver module
+     */
+    driverModuleName: string;
     
     // -------------------------------------------------------------------------
     // Constructor
@@ -24,6 +34,12 @@ export class ReactNativeDriver extends AbstractSqliteDriver {
 
         if (!this.options.location)
             throw new DriverOptionNotSetError("location");
+
+        if (this.options.driverModule) {
+            this.driverModuleName = this.options.driverModule;
+        } else {
+            this.driverModuleName = ReactNativeDriver.DRIVER_MODULE_NAME;
+        }
 
         // load sqlite package
         this.loadDependencies();
@@ -89,10 +105,10 @@ export class ReactNativeDriver extends AbstractSqliteDriver {
      */
     protected loadDependencies(): void {
         try {
-            this.sqlite = require("react-native-sqlite-storage");
+            this.sqlite = require(this.driverModuleName);
 
         } catch (e) {
-            throw new DriverPackageNotInstalledError("React-Native", "react-native-sqlite-storage");
+            throw new DriverPackageNotInstalledError("React-Native", this.driverModuleName);
         }
     }
 }


### PR DESCRIPTION
these require lines should not be resolved by Webpack, so using
runtime resolved variable here instead of constant strings.

Signed-off-by: Arnav Gupta <arnav@codingblocks.com>