### PR TITLE
fix the description of SaveOption.chunk

### DIFF
--- a/src/repository/SaveOptions.ts
+++ b/src/repository/SaveOptions.ts
@@ -22,9 +22,9 @@ export interface SaveOptions {
     transaction?: boolean;
 
     /**
-     * Breaks save execution into given number of chunks.
-     * For example, if you want to save 100.000 objects but you have issues with saving them,
-     * you can break them into 10 groups of 10.000 objects (by setting { chunk: 10 }) and save each group separately.
+     * Breaks save execution into chunks with size of given number.
+     * For example, if you want to save 100,000 objects but you have issues with saving them,
+     * you can break them into 10 groups of 10,000 objects (by setting { chunk: 10000 }) and save each group separately.
      * This option is needed to perform very big insertions when you have issues with underlying driver parameter number limitation.
      */
     chunk?: number;


### PR DESCRIPTION
According to `OrmUtils.chunk`, `SaveOptions.chunk` is the size of each chunk, not the number of chunks.