### PR TITLE
Assign name in one to one example

### DIFF
--- a/docs/one-to-one-relations.md
+++ b/docs/one-to-one-relations.md
@@ -77,6 +77,7 @@ profile.photo = "me.jpg";
 await connection.manager.save(profile);
 
 const user = new User();
+user.name = 'Joe Smith';
 user.profile = profile;
 await connection.manager.save(user);
 ```


### PR DESCRIPTION
If you don't assign name, you get this error:

```
UnhandledPromiseRejectionWarning: QueryFailedError: ER_NO_DEFAULT_FOR_FIELD: Field 'name' doesn't have a default value
```