### PR TITLE
Missing semicolon on migrations.md

### DIFF
--- a/docs/migrations.md
+++ b/docs/migrations.md
@@ -255,7 +255,7 @@ export class QuestionRefactoringTIMESTAMP implements MigrationInterface {
 
     async down(queryRunner: QueryRunner): Promise<any> {
         const table = await queryRunner.getTable("question");
-        const foreignKey = table.foreignKeys.find(fk => fk.columnNames.indexOf("questionId") !== -1)
+        const foreignKey = table.foreignKeys.find(fk => fk.columnNames.indexOf("questionId") !== -1);
         await queryRunner.dropForeignKey("question", foreignKey);
         await queryRunner.dropColumn("question", "questionId");
         await queryRunner.dropTable("answer");


### PR DESCRIPTION
I copy and pasted the code and my linter picked up the missing semicolon ;)