### PR TITLE
Return number of affected rows on delete

### DIFF
--- a/src/driver/postgres/PostgresQueryRunner.ts
+++ b/src/driver/postgres/PostgresQueryRunner.ts
@@ -174,7 +174,14 @@ export class PostgresQueryRunner extends BaseQueryRunner implements QueryRunner 
                         this.driver.connection.logger.logQueryError(err, query, parameters, this);
                         fail(new QueryFailedError(query, parameters, err));
                     } else {
-                        ok(result.rows);
+                        switch (result.command) {
+                            case "DELETE":
+                                // for DELETE query additionally return number of affected rows
+                                ok([result.rows, result.rowCount]);
+                                break;
+                            default:
+                                ok(result.rows);
+                        }
                     }
                 });
 

--- a/src/driver/sqlserver/SqlServerQueryRunner.ts
+++ b/src/driver/sqlserver/SqlServerQueryRunner.ts
@@ -220,7 +220,15 @@ export class SqlServerQueryRunner extends BaseQueryRunner implements QueryRunner
                         return fail(new QueryFailedError(query, parameters, err));
                     }
 
-                    ok(result.recordset);
+                    const queryType = query.slice(0, query.indexOf(" "));
+                    switch (queryType) {
+                        case "DELETE":
+                            // for DELETE query additionally return number of affected rows
+                            ok([result.recordset, result.rowsAffected[0]]);
+                            break;
+                        default:
+                            ok(result.recordset);
+                    }
                     resolveChain();
                 });
 

--- a/src/query-builder/DeleteQueryBuilder.ts
+++ b/src/query-builder/DeleteQueryBuilder.ts
@@ -64,9 +64,28 @@ export class DeleteQueryBuilder<Entity> extends QueryBuilder<Entity> implements 
 
             // execute query
             const deleteResult = new DeleteResult();
-            const [raw, affected] = await queryRunner.query(sql, parameters);
-            deleteResult.raw = raw;
-            deleteResult.affected = affected;
+            const result = await queryRunner.query(sql, parameters);
+
+            switch (queryRunner.connection.name) {
+                case "mysql":
+                case "mariadb": {
+                    deleteResult.raw = result;
+                    deleteResult.affected = result.affectedRows;
+                    break;
+                }
+                case "mssql":
+                case "postgres": {
+                    deleteResult.raw = result[0] ? result[0] : null;
+                    // don't return 0 because it could confuse. null means that we did not receive this value
+                    deleteResult.affected = typeof result[1] === "number" ? result[1] : null;
+                    break;
+                }
+                // sqlite & sqljs doesn't return anything
+                case "sqlite":
+                case "sqljs":
+                default:
+                    deleteResult.raw = result;
+            }
 
             // call after deletion methods in listeners and subscribers
             if (this.expressionMap.callListeners === true && this.expressionMap.mainAlias!.hasMetadata) {

--- a/src/query-builder/DeleteQueryBuilder.ts
+++ b/src/query-builder/DeleteQueryBuilder.ts
@@ -64,7 +64,9 @@ export class DeleteQueryBuilder<Entity> extends QueryBuilder<Entity> implements 
 
             // execute query
             const deleteResult = new DeleteResult();
-            deleteResult.raw = await queryRunner.query(sql, parameters);
+            const [raw, affected] = await queryRunner.query(sql, parameters);
+            deleteResult.raw = raw;
+            deleteResult.affected = affected;
 
             // call after deletion methods in listeners and subscribers
             if (this.expressionMap.callListeners === true && this.expressionMap.mainAlias!.hasMetadata) {

--- a/src/query-builder/result/DeleteResult.ts
+++ b/src/query-builder/result/DeleteResult.ts
@@ -9,6 +9,7 @@ export class DeleteResult {
 
     /**
      * Number of affected rows/documents
+     * Not all drivers support this
      */
-    affected: number;
+    affected?: number;
 }

--- a/src/query-builder/result/DeleteResult.ts
+++ b/src/query-builder/result/DeleteResult.ts
@@ -2,7 +2,13 @@
  * Result object returned by DeleteQueryBuilder execution.
  */
 export class DeleteResult {
-
+    /**
+     * Raw SQL result returned by executed query.
+     */
     raw: any;
 
+    /**
+     * Number of affected rows/documents
+     */
+    affected: number;
 }

--- a/test/github-issues/2499/entity/Foo.ts
+++ b/test/github-issues/2499/entity/Foo.ts
@@ -1,0 +1,12 @@
+import {Column, PrimaryGeneratedColumn} from "../../../../src";
+import {Entity} from "../../../../src/decorator/entity/Entity";
+
+@Entity("foo")
+export class Foo {
+
+    @PrimaryGeneratedColumn()
+    id: number;
+
+    @Column()
+    description: string;
+}

--- a/test/github-issues/2499/issue-2499.ts
+++ b/test/github-issues/2499/issue-2499.ts
@@ -15,7 +15,14 @@ describe("github issues > #2499 Postgres DELETE query result is useless", () => 
     beforeEach(() => reloadTestingDatabases(connections));
     after(() => closeTestingConnections(connections));
 
-    it("should return correct number of affected rows", () => Promise.all(connections.map(async connection => {
+    it("should return correct number of affected rows for mysql, mariadb, postgres", () => Promise.all(connections.map(async connection => {
+        // skip test for sqlite because sqlite doesn't return any data on delete
+        // sqljs -- the same
+        // mongodb requires another test and it is also doesn't return correct number
+        // of removed documents (possibly a bug with mongodb itself)
+        if (["mysql", "mariadb", "mssql", "postgres"].indexOf(connection.name) === -1) {
+            return;
+        }
         const repo = connection.getRepository(Foo);
 
         await repo.save({ id: 1, description: "test1" });

--- a/test/github-issues/2499/issue-2499.ts
+++ b/test/github-issues/2499/issue-2499.ts
@@ -1,0 +1,30 @@
+import "reflect-metadata";
+import {createTestingConnections, closeTestingConnections, reloadTestingDatabases} from "../../utils/test-utils";
+import {Connection} from "../../../src/connection/Connection";
+import {Foo} from "./entity/Foo";
+import {expect} from "chai";
+
+describe("github issues > #2499 Postgres DELETE query result is useless", () => {
+
+    let connections: Connection[];
+    before(async () => connections = await createTestingConnections({
+        entities: [__dirname + "/entity/*{.js,.ts}"],
+        schemaCreate: true,
+        dropSchema: true,
+    }));
+    beforeEach(() => reloadTestingDatabases(connections));
+    after(() => closeTestingConnections(connections));
+
+    it("should return correct number of affected rows", () => Promise.all(connections.map(async connection => {
+        const repo = connection.getRepository(Foo);
+
+        await repo.save({ id: 1, description: "test1" });
+        await repo.save({ id: 2, description: "test2" });
+        await repo.save({ id: 3, description: "test3" });
+
+        // number 4 doesn't exist
+        const result = await repo.delete([1, 2, 3, 4]);
+
+        expect(result.affected).to.eql(3);
+    })));
+});


### PR DESCRIPTION
Hi, this is related with #2499 
Here we additionally receive new variable `affected` which is [`rowCount`](https://github.com/brianc/node-postgres/blob/master/lib/result.js#L46-L49) from `pg`.

UPD:
Number of affected rows returns for `mysql`, `mariadb`, `mssql`, `postgres`

I was unable to run Oracle locally, so it is not covered. `sqlite` & `sqljs` seems requires additional queries to getting such information. Mongodb seems to have an internal bug. It is always returns `{ n: 0; ok: 1 }` for me and this is goes not from the nodejs `mongo-core` package, but from db itself, so I think db is bugged. at least for node.js. Mongo console operations works as expected.

Also I limited the launch of tests only for covered databases.
