### PR TITLE
Fix error message for migration class naming

### DIFF
--- a/src/migration/MigrationExecutor.ts
+++ b/src/migration/MigrationExecutor.ts
@@ -270,7 +270,7 @@ export class MigrationExecutor {
             const migrationClassName = (migration.constructor as any).name;
             const migrationTimestamp = parseInt(migrationClassName.substr(-13));
             if (!migrationTimestamp)
-                throw new Error(`${migrationClassName} migration name is wrong. Migration class name should have a UNIX timestamp appended. `);
+                throw new Error(`${migrationClassName} migration name is wrong. Migration class name should have a JavaScript timestamp appended.`);
 
             return new Migration(undefined, migrationTimestamp, migrationClassName, migration);
         });


### PR DESCRIPTION
UNIX timestamps are measured in seconds, while JS timestamps are in milliseconds. So a UNIX timestamp = JS timestamp / 1000.