### PR TITLE
Allow passing the acquireTimeout connection option to MySQL

### DIFF
--- a/docs/connection-options.md
+++ b/docs/connection-options.md
@@ -124,6 +124,8 @@ values to JavaScript Date object and vice versa. This can be `local`, `Z`, or an
 
 * `connectTimeout` - The milliseconds before a timeout occurs during the initial connection to the MySQL server.
  (Default: `10000`)
+
+* `acquireTimeout` - The milliseconds before a timeout occurs during the initial connection to the MySql server. It differs from `connectTimeout` as it governs the TCP connection timeout where as connectTimeout does not. (default: `10000`)
  
 * `insecureAuth` - Allow connecting to MySQL instances that ask for the old (insecure) authentication method. 
 (Default: `false`)

--- a/src/driver/mysql/MysqlConnectionOptions.ts
+++ b/src/driver/mysql/MysqlConnectionOptions.ts
@@ -33,6 +33,13 @@ export interface MysqlConnectionOptions extends BaseConnectionOptions, MysqlConn
     readonly connectTimeout?: number;
 
     /**
+     * The milliseconds before a timeout doccurs during the initial connection to the MySQL server. (Default: 10000)
+     * This difference between connectTimeout and acquireTimeout is subtle and is described in the mysqljs/mysql docs
+     * https://github.com/mysqljs/mysql/tree/master#pool-options
+     */ 
+    readonly acquireTimeout?: number;
+
+    /**
      * Allow connecting to MySQL instances that ask for the old (insecure) authentication method. (Default: false)
      */
     readonly insecureAuth?: boolean;

--- a/src/driver/mysql/MysqlDriver.ts
+++ b/src/driver/mysql/MysqlDriver.ts
@@ -719,6 +719,7 @@ export class MysqlDriver implements Driver {
         return Object.assign({}, {
             charset: options.charset,
             timezone: options.timezone,
+            acquireTimeout: options.acquireTimeout,
             connectTimeout: options.connectTimeout,
             insecureAuth: options.insecureAuth,
             supportBigNumbers: options.supportBigNumbers !== undefined ? options.supportBigNumbers : true,


### PR DESCRIPTION
Reporting: Bug

Hi there,

👍 for TypeORM - I really like working with it.

On AWS when connecting to Aurora Serverless if the instance is asleep it can take approximately 30 seconds for the TCP connection to be accepted. That results in the following handshake error, you can see the Timeout is being reported as 10,000ms. I have set connectionTimeout to 120,000ms on the connection.

```
Error: Handshake inactivity timeout
    at Handshake.<anonymous> (/var/task/src/sqs.js:244:837498)
    at emitNone (events.js:106:13)
    at Handshake.emit (events.js:208:7)
    at Handshake.Sequence._onTimeout (/var/task/src/sqs.js:19:140794)
    at Timer._onTimeout (/var/task/src/sqs.js:244:994425)
    at ontimeout (timers.js:482:11)
    at tryOnTimeout (timers.js:317:5)
    at Timer.listOnTimeout (timers.js:277:5)
    --------------------
    at Protocol._enqueue (/var/task/src/sqs.js:244:837180)
    at Protocol.handshake (/var/task/src/sqs.js:244:835505)
    at PoolConnection.Connection.connect (/var/task/src/sqs.js:19:437441)
    at Pool.getConnection (/var/task/src/sqs.js:147:2573233)
    at /var/task/src/sqs.js:19:124215
    at new Promise (<anonymous>)
    at MysqlDriver.createPool (/var/task/src/sqs.js:19:124180)
    at MysqlDriver.<anonymous> (/var/task/src/sqs.js:19:115354)
    at /var/task/src/sqs.js:19:112272
    at Object.next (/var/task/src/sqs.js:19:112388)
    at /var/task/src/sqs.js:19:111266
    at new Promise (<anonymous>)
    at __awaiter (/var/task/src/sqs.js:19:110879)
    at MysqlDriver.connect (/var/task/src/sqs.js:19:114829)
    at Connection.<anonymous> (/var/task/src/sqs.js:147:2413840)
    at /var/task/src/sqs.js:147:2411053
  code: 'PROTOCOL_SEQUENCE_TIMEOUT',
  fatal: true,
  timeout: 10000
```

As described in the [mysql docs](https://github.com/mysqljs/mysql#pool-options) there is an option to pass acquireTimeout, which is passed to the underlying socket and instructs it to wait N-ms until theres a TCP connection.

This PR allows this to be passed in through to `createConnectionOptions` by updating the MysqlDriver and MysqlConnectionOptions.

## Thoughts

* It's not immediately obvious to me how to write a good test for this given the current testing infrastructure. I'm happy to do so after some advice.
* not entirely sure how to better differentiate the two connection types, I can see it being confusing to folks aren't too familiar with the difference between the two states.