### PR TITLE
fix(transactions): remove session keyword from mysql transaction init…

### DIFF
--- a/src/driver/mysql/MysqlQueryRunner.ts
+++ b/src/driver/mysql/MysqlQueryRunner.ts
@@ -105,9 +105,11 @@ export class MysqlQueryRunner extends BaseQueryRunner implements QueryRunner {
             throw new TransactionAlreadyStartedError();
 
         this.isTransactionActive = true;
-        await this.query("START TRANSACTION");
         if (isolationLevel) {
-            await this.query("SET SESSION TRANSACTION ISOLATION LEVEL " + isolationLevel);
+            await this.query("SET TRANSACTION ISOLATION LEVEL " + isolationLevel);
+            await this.query("START TRANSACTION");
+        } else {
+            await this.query("START TRANSACTION");
         }
     }
 


### PR DESCRIPTION
In response to #2227  [comment](https://github.com/typeorm/typeorm/pull/2227#pullrequestreview-148154828)

For some reason I specified `SESSION` in the initiation of a transaction when an isolation level was provided for the MySQL runner, this removes that keyword.