### PR TITLE
Fix misspelled column type

### DIFF
--- a/src/persistence/SubjectChangedColumnsComputer.ts
+++ b/src/persistence/SubjectChangedColumnsComputer.ts
@@ -82,7 +82,7 @@ export class SubjectChangedColumnsComputer {
                         if (databaseValue !== null && databaseValue !== undefined)
                             databaseValue = JSON.stringify(databaseValue);
 
-                    } else if (column.type === "sample-array") {
+                    } else if (column.type === "simple-array") {
                         normalizedValue = DateUtils.simpleArrayToString(entityValue);
                         databaseValue = DateUtils.simpleArrayToString(databaseValue);
                     }


### PR DESCRIPTION
Fix misspelled column type.

This causes the following problem: if you have a `simple-array` column, when doing a save on the entity, because the diff algorithm has this column type name misspelled, the column will be always marked for update, even though the value didn't change.