### PR TITLE
Inserting id (primary column) from code.

### DIFF
--- a/src/connection/BaseConnectionOptions.ts
+++ b/src/connection/BaseConnectionOptions.ts
@@ -104,6 +104,13 @@ export interface BaseConnectionOptions {
     readonly extra?: any;
 
     /**
+     * Allow to set values from code for generated columns for this connection.
+     * Use this only if you know what your are doing (e.g. inserting legacy data with pre-defined ids),
+     * and make sure the generated values will never collide with such a value from code.
+     */
+    readonly allowGeneratedValuesFromCode?: boolean;
+
+    /**
      * Allows to setup cache options.
      */
     readonly cache?: boolean|{

--- a/src/connection/Connection.ts
+++ b/src/connection/Connection.ts
@@ -111,6 +111,11 @@ export class Connection {
      */
     readonly relationIdLoader: RelationIdLoader;
 
+    /**
+     * Allow to set values from code for generated columns for this connection.
+     */
+    readonly allowGeneratedValuesFromCode: boolean;
+
     // -------------------------------------------------------------------------
     // Constructor
     // -------------------------------------------------------------------------
@@ -125,6 +130,7 @@ export class Connection {
         this.queryResultCache = options.cache ? new QueryResultCacheFactory(this).create() : undefined;
         this.relationLoader = new RelationLoader(this);
         this.relationIdLoader = new RelationIdLoader(this);
+        this.allowGeneratedValuesFromCode = options.allowGeneratedValuesFromCode || false;
     }
 
     // -------------------------------------------------------------------------

--- a/src/connection/options-reader/ConnectionOptionsEnvReader.ts
+++ b/src/connection/options-reader/ConnectionOptionsEnvReader.ts
@@ -38,6 +38,7 @@ export class ConnectionOptionsEnvReader {
             logger: PlatformTools.getEnvVariable("TYPEORM_LOGGER"),
             entityPrefix: PlatformTools.getEnvVariable("TYPEORM_ENTITY_PREFIX"),
             maxQueryExecutionTime: PlatformTools.getEnvVariable("TYPEORM_MAX_QUERY_EXECUTION_TIME"),
+            allowGeneratedValuesFromCode: OrmUtils.toBoolean(PlatformTools.getEnvVariable("TYPEORM_ALLOW_GENERATED_VALUES_FROM_CODE")),
             cli: {
                 entitiesDir: PlatformTools.getEnvVariable("TYPEORM_ENTITIES_DIR"),
                 migrationsDir: PlatformTools.getEnvVariable("TYPEORM_MIGRATIONS_DIR"),

--- a/src/connection/options-reader/ConnectionOptionsXmlReader.ts
+++ b/src/connection/options-reader/ConnectionOptionsXmlReader.ts
@@ -31,6 +31,7 @@ export class ConnectionOptionsXmlReader {
                 entities: connection.entities ? connection.entities[0].entity : [],
                 subscribers: connection.subscribers ? connection.subscribers[0].entity : [],
                 logging: connection.logging[0] ? connection.logging[0].split(",") : undefined,
+                allowGeneratedValuesFromCode: connection.allowGeneratedValuesFromCode ? connection.allowGeneratedValuesFromCode[0] : undefined,
             };
         });
     }

--- a/src/query-builder/InsertQueryBuilder.ts
+++ b/src/query-builder/InsertQueryBuilder.ts
@@ -294,7 +294,10 @@ export class InsertQueryBuilder<Entity> extends QueryBuilder<Entity> {
 
             // if user did not specified such list then return all columns except auto-increment one
             // for Oracle we return auto-increment column as well because Oracle does not support DEFAULT VALUES expression
-            if (column.isGenerated && column.generationStrategy === "increment" && !(this.connection.driver instanceof OracleDriver) && !(this.connection.driver instanceof MysqlDriver))
+            if (
+                column.isGenerated && column.generationStrategy === "increment" && !this.connection.allowGeneratedValuesFromCode &&
+                !(this.connection.driver instanceof OracleDriver) && !(this.connection.driver instanceof MysqlDriver)
+            )
                 return false;
 
             return true;

--- a/test/github-issues/2215/entity/Bar.ts
+++ b/test/github-issues/2215/entity/Bar.ts
@@ -1,0 +1,12 @@
+import { Column, PrimaryGeneratedColumn } from "../../../../src";
+import { Entity } from "../../../../src/decorator/entity/Entity";
+
+@Entity("bar")
+export class Bar {
+
+    @PrimaryGeneratedColumn()
+    id: number;
+
+    @Column()
+    description: string;
+}

--- a/test/github-issues/2215/issue-2225.ts
+++ b/test/github-issues/2215/issue-2225.ts
@@ -1,0 +1,64 @@
+import { expect } from "chai";
+import "reflect-metadata";
+import { Connection } from "../../../src/connection/Connection";
+import { MysqlDriver } from "../../../src/driver/mysql/MysqlDriver";
+import { OracleDriver } from "../../../src/driver/oracle/OracleDriver";
+import { closeTestingConnections, createTestingConnections, reloadTestingDatabases } from "../../utils/test-utils";
+import { Bar } from "./entity/Bar";
+
+describe("github issues > #2215 - Inserting id (primary column) from code", () => {
+
+    describe("connection with allowGeneratedValuesFromCode=true", () => {
+        let connections: Connection[];
+        before(async () => {
+            connections = await createTestingConnections({
+                entities: [__dirname + "/entity/*{.js,.ts}"],
+                schemaCreate: true,
+                dropSchema: true,
+                allowGeneratedValuesFromCode: true
+            });
+        });
+
+        beforeEach(() => reloadTestingDatabases(connections));
+        after(() => closeTestingConnections(connections));
+
+        it("should allow to explicitly insert primary key value with the flag allowGeneratedValuesFromCode=true", () => Promise.all(connections.map(async connection => {
+
+            const firstBarQuery =  connection.manager.create(Bar, {
+                id: 10,
+                description: "forced id value"
+            });
+            const firstBar = await connection.manager.save(firstBarQuery);
+            expect(firstBar.id).to.eql(10);
+        })));
+    });
+
+    describe("connection with allowGeneratedValuesFromCode not set", () => {
+        let connections: Connection[];
+        before(async () => {
+            connections = await createTestingConnections({
+                entities: [__dirname + "/entity/*{.js,.ts}"],
+                schemaCreate: true,
+                dropSchema: true
+            });
+        });
+
+        beforeEach(() => reloadTestingDatabases(connections));
+        after(() => closeTestingConnections(connections));
+
+        it("should not allow to explicitly insert primary key value with the flag allowGeneratedValuesFromCode not set", () => Promise.all(connections.map(async connection => {
+
+            const firstBarQuery =  connection.manager.create(Bar, {
+                id: 10,
+                description: "forced id value"
+            });
+            const firstBar = await connection.manager.save(firstBarQuery);
+            if (connection.driver instanceof OracleDriver || connection.driver instanceof MysqlDriver) {
+                expect(firstBar.id).to.eql(10);
+            } else {
+                expect(firstBar.id).not.to.eql(10);
+            }
+        })));
+    });
+
+});

--- a/test/utils/test-utils.ts
+++ b/test/utils/test-utils.ts
@@ -121,6 +121,11 @@ export interface TestingOptions {
      * They are passed down to the enabled drivers.
      */
     driverSpecific?: Object;
+
+    /**
+     * Allow to set values from code for generated columns for this connection.
+     */
+    allowGeneratedValuesFromCode?: boolean;
 }
 
 /**
@@ -138,7 +143,8 @@ export function setupSingleTestingConnection(driverType: DatabaseType, options: 
         enabledDrivers: [driverType],
         cache: options.cache,
         schema: options.schema ? options.schema : undefined,
-        namingStrategy: options.namingStrategy ? options.namingStrategy : undefined
+        namingStrategy: options.namingStrategy ? options.namingStrategy : undefined,
+        allowGeneratedValuesFromCode: options.allowGeneratedValuesFromCode
     });
     if (!testingConnections.length)
         throw new Error(`Unable to run tests because connection options for "${driverType}" are not set.`);
@@ -210,6 +216,8 @@ export function setupTestingConnections(options?: TestingOptions): ConnectionOpt
                 newOptions.entities = [options.__dirname + "/entity/*{.js,.ts}"];
             if (options && options.namingStrategy)
                 newOptions.namingStrategy = options.namingStrategy;
+            if (options)
+                newOptions.allowGeneratedValuesFromCode = options.allowGeneratedValuesFromCode;
             return newOptions;
         });
 }


### PR DESCRIPTION
Add flag allowGeneratedValuesFromCode to connection options to configure the behavior of values set from code for generated columns (#2215 )

It has to be discussed if the current exceptions should be kept in code or (at least MySql) could be removed and just this option is provided for transparent design.