### PR TITLE
Fix column option readonly

### DIFF
--- a/src/persistence/Subject.ts
+++ b/src/persistence/Subject.ts
@@ -193,7 +193,7 @@ export class Subject {
             if (this.metadata.isJunction && changeMap.column) {
                 valueMap = changeMap.column.createValueMap(changeMap.column.referencedColumn!.getEntityValue(value));
 
-            } else if (changeMap.column) {
+            } else if (changeMap.column && (!changeMap.column.isReadonly || !this.databaseEntity)) {
                 valueMap = changeMap.column.createValueMap(value);
 
             } else if (changeMap.relation) {

--- a/src/query-builder/UpdateQueryBuilder.ts
+++ b/src/query-builder/UpdateQueryBuilder.ts
@@ -367,7 +367,10 @@ export class UpdateQueryBuilder<Entity> extends QueryBuilder<Entity> implements 
                 columns.forEach(column => {
                     const paramName = "upd_" + column.databaseName;
 
-                    //
+                    if (column.isReadonly) {
+                        return;
+                    }
+
                     let value = column.getEntityValue(valuesSet);
                     if (column.referencedColumn && value instanceof Object) {
                         value = column.referencedColumn.getEntityValue(value);

--- a/test/functional/columns/readonly/columns-readonly.ts
+++ b/test/functional/columns/readonly/columns-readonly.ts
@@ -34,7 +34,7 @@ describe("columns > readonly functionality", () => {
         const loadedPost = await postRepository.findOne(1);
         expect(loadedPost!.title).to.be.equal("About columns1");
         expect(loadedPost!.text).to.be.equal("Some text about columns1");
-        expect(loadedPost!.authorName).to.be.equal("Umed1");
+        expect(loadedPost!.authorName).to.be.equal("Umed");
 
     })));
 

--- a/test/functional/columns/readonly/columns-readonly.ts
+++ b/test/functional/columns/readonly/columns-readonly.ts
@@ -36,7 +36,18 @@ describe("columns > readonly functionality", () => {
         expect(loadedPost!.text).to.be.equal("Some text about columns1");
         expect(loadedPost!.authorName).to.be.equal("Umed");
 
+
+        // then update all its properties and save again
+        post.title = "About columns1";
+        post.text = "Some text about columns1";
+        post.authorName = "Umed1";
+        await postRepository.update(post.id, post);
+
+        // check if all columns are updated except for readonly columns
+        const loadedPost2 = await postRepository.findOne(1);
+        expect(loadedPost2!.title).to.be.equal("About columns1");
+        expect(loadedPost2!.text).to.be.equal("Some text about columns1");
+        expect(loadedPost2!.authorName).to.be.equal("Umed");
+
     })));
-
-
 });


### PR DESCRIPTION
As described in issue #2041 and issue #2221 the readonly option is not working correctly.

I have fixed and updated de testcase to use `.save` and `.update` and fixed the code accordingly.