### PR TITLE
add missing parentheses in the bracket example

### DIFF
--- a/docs/select-query-builder.md
+++ b/docs/select-query-builder.md
@@ -325,6 +325,7 @@ createQueryBuilder("user")
     .andWhere(new Brackets(qb => {
         qb.where("user.firstName = :firstName", { firstName: "Timber" })
           .orWhere("user.lastName = :lastName", { lastName: "Saw" })
+    }))
 ```
 
 Which will produce the following SQL query:


### PR DESCRIPTION
Closing parentheses were missing in the bracket example on select-query-builder.md.

Thus, I added following parentheses on the example.