### PR TITLE
test: the column that has a default definition

### DIFF
--- a/test/github-issues/2756/entity/post.entity.ts
+++ b/test/github-issues/2756/entity/post.entity.ts
@@ -8,7 +8,11 @@ export class Post {
     @PrimaryGeneratedColumn()
     id: number;
 
-    @Column()
+    @Column({
+        name: 'incr',
+        nullable: true,
+        default: 10,
+    })
     incr: number;
 
     @Column()

--- a/test/github-issues/2756/entity/post.entity.ts
+++ b/test/github-issues/2756/entity/post.entity.ts
@@ -1,0 +1,17 @@
+import {Entity} from "../../../../src/decorator/entity/Entity";
+import {PrimaryGeneratedColumn} from "../../../../src/decorator/columns/PrimaryGeneratedColumn";
+import {Column} from "../../../../src/decorator/columns/Column";
+
+@Entity()
+export class Post {
+
+    @PrimaryGeneratedColumn()
+    id: number;
+
+    @Column()
+    incr: number;
+
+    @Column()
+    title: string;
+
+}

--- a/test/github-issues/2756/issue-2756.ts
+++ b/test/github-issues/2756/issue-2756.ts
@@ -18,7 +18,7 @@ describe("github issues > #2756 The field with a default value", () => {
     beforeEach(() => reloadTestingDatabases(connections));
     after(() => closeTestingConnections(connections));
 
-    it("should leave the default value unmodified", () => Promise.all(connections.map(async connection => {
+    it.only("should leave the default value unmodified", () => Promise.all(connections.map(async connection => {
         const [lastMigration] = await connection.runMigrations();
 
         lastMigration.should.have.property("timestamp", 1567689639608);
@@ -29,10 +29,10 @@ describe("github issues > #2756 The field with a default value", () => {
         const result = await connection.manager.save(post);
 
         expect(result).not.to.be.empty;
-        expect(result!.title).not.to.be.empty;
+        expect(result!.title).to.not.be.undefined;
         result!.title.should.be.equal("Super title");
 
-        expect(result!.incr, "incr field is present").not.to.be.empty;
+        expect(result!.incr, "incr field is present").to.not.be.undefined;
         expect(result!.incr).to.be.equal(10);
 
     })));

--- a/test/github-issues/2756/issue-2756.ts
+++ b/test/github-issues/2756/issue-2756.ts
@@ -1,0 +1,39 @@
+import "reflect-metadata";
+import {createTestingConnections, closeTestingConnections, reloadTestingDatabases} from "../../utils/test-utils";
+import {Connection} from "../../../src/connection/Connection";
+
+import {Post} from "./entity/post.entity";
+import {expect} from "chai";
+
+describe("github issues > #2756 The field with a default value", () => {
+
+    let connections: Connection[];
+    before(async () => connections = await createTestingConnections({
+        entities: [__dirname + "/entity/*{.js,.ts}"],
+        migrations: [__dirname + "/migration/*.js"],
+        enabledDrivers: ["postgres"],
+        schemaCreate: true,
+        dropSchema: true,
+    }));
+    beforeEach(() => reloadTestingDatabases(connections));
+    after(() => closeTestingConnections(connections));
+
+    it("should leave the default value unmodified", () => Promise.all(connections.map(async connection => {
+        const [lastMigration] = await connection.runMigrations();
+
+        lastMigration.should.have.property("timestamp", 1567689639608);
+        lastMigration.should.have.property("name", "DefaultValueAtColumn1567689639608");
+
+        const post = new Post();
+        post.title = "Super title";
+        const result = await connection.manager.save(post);
+
+        expect(result).not.to.be.empty;
+        expect(result!.title).not.to.be.empty;
+        result!.title.should.be.equal("Super title");
+
+        expect(result!.incr, "incr field is present").not.to.be.empty;
+        expect(result!.incr).to.be.equal(10);
+
+    })));
+});

--- a/test/github-issues/2756/migration/1567689639608-DefaultValueAtColumn.ts
+++ b/test/github-issues/2756/migration/1567689639608-DefaultValueAtColumn.ts
@@ -6,10 +6,9 @@ export class DefaultValueAtColumn1567689639608 implements MigrationInterface {
     await queryRunner.query(`
       CREATE TABLE IF NOT EXISTS "post"
         (
-          id serial NOT NULL,
+          id serial NOT NULL PRIMARY KEY,
           incr integer DEFAULT 10,
-          title character varying(255),
-          CONSTRAINT post_pkey PRIMARY KEY (id)
+          title character varying(255)
         );
     `);
   }

--- a/test/github-issues/2756/migration/1567689639608-DefaultValueAtColumn.ts
+++ b/test/github-issues/2756/migration/1567689639608-DefaultValueAtColumn.ts
@@ -1,0 +1,21 @@
+import {MigrationInterface, QueryRunner} from "../../../../src";
+
+export class DefaultValueAtColumn1567689639608 implements MigrationInterface {
+
+  public async up(queryRunner: QueryRunner): Promise<any> {
+    await queryRunner.query(`
+      CREATE TABLE IF NOT EXISTS "post"
+        (
+          id serial NOT NULL,
+          incr integer DEFAULT 10,
+          title character varying(255),
+          CONSTRAINT post_pkey PRIMARY KEY (id)
+        );
+    `);
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<any> {
+    await queryRunner.query(`DROP TABLE IF EXISTS "post";`);
+  }
+
+}


### PR DESCRIPTION
In order to expose this case, I modified the interface ```TestConnection``` in order to allow to run migrations.

After running the migrations, the following is to catch the case when a field that is defined to have a default value, must be present in the object returned by calling ```save```. That field should behave as behaves the field ```id```.

Related to #2756 