### PR TITLE
Improve Repository.save() return type

### DIFF
--- a/src/repository/Repository.ts
+++ b/src/repository/Repository.ts
@@ -123,13 +123,15 @@ export class Repository<Entity extends ObjectLiteral> {
      * Saves all given entities in the database.
      * If entities do not exist in the database then inserts, otherwise updates.
      */
-    save<T extends DeepPartial<Entity>>(entities: T[], options?: SaveOptions): Promise<T[]>;
+    save<T extends DeepPartial<Entity>>(entities: T[], options: SaveOptions & { reload: false }): Promise<T[]>;
+    save<T extends DeepPartial<Entity>>(entities: T[], options?: SaveOptions): Promise<(T & Entity)[]>;
 
     /**
      * Saves a given entity in the database.
      * If entity does not exist in the database then inserts, otherwise updates.
      */
-    save<T extends DeepPartial<Entity>>(entity: T, options?: SaveOptions): Promise<T>;
+    save<T extends DeepPartial<Entity>>(entity: T, options: SaveOptions & { reload: false }): Promise<T>;
+    save<T extends DeepPartial<Entity>>(entity: T, options?: SaveOptions): Promise<T & Entity>;
 
     /**
      * Saves one or many given entities.


### PR DESCRIPTION
When saving a new entity with `repository.save(fields)`, the current type definition fails to return to me the right fields types for the generated columns, for example:

```typescript
@Entity()
export default class User {
    @PrimaryGeneratedColumn('uuid') id: string
    @Column() name: string
    @Column({ nullable: true }) address?: string
}

// ...

const user = { name: 'John Doe', address: 'Somewhere' }
const createdUser = await this.repository.save(user)

console.log(createdUser.name) // okay 
console.log(createdUser.address) // okay
console.log(createdUser.id) // compilation error: Property 'id' does not exist on type ...
```
This seems to only make sense when `reload: false` is sent, which is not the case. 
This little change fixes that, while overriding the optional type when the values are present.

I'm not sure if this breaks some special case, maybe some maintainer could look into this :sweat_smile: 