### PR TITLE
fix(pgsql): alter type of array enum cols

### DIFF
--- a/src/driver/postgres/PostgresQueryRunner.ts
+++ b/src/driver/postgres/PostgresQueryRunner.ts
@@ -670,6 +670,7 @@ export class PostgresQueryRunner extends BaseQueryRunner implements QueryRunner 
             if (newColumn.type === "enum" && oldColumn.type === "enum" && !OrmUtils.isArraysEqual(newColumn.enum!, oldColumn.enum!)) {
                 const enumName = this.buildEnumName(table, newColumn);
                 const enumNameWithoutSchema = this.buildEnumName(table, newColumn, false);
+                const arraySuffix = newColumn.isArray ? "[]" : "";
                 const oldEnumName = this.buildEnumName(table, newColumn, true, false, true);
                 const oldEnumNameWithoutSchema = this.buildEnumName(table, newColumn, false, false, true);
 
@@ -688,8 +689,8 @@ export class PostgresQueryRunner extends BaseQueryRunner implements QueryRunner 
                 }
 
                 // build column types
-                const upType = `${enumNameWithoutSchema} USING "${newColumn.name}"::"text"::${enumNameWithoutSchema}`;
-                const downType = `${oldEnumNameWithoutSchema} USING "${newColumn.name}"::"text"::${oldEnumNameWithoutSchema}`;
+                const upType = `${enumNameWithoutSchema}${arraySuffix} USING "${newColumn.name}"::"text"::${enumNameWithoutSchema}${arraySuffix}`;
+                const downType = `${oldEnumNameWithoutSchema}${arraySuffix} USING "${newColumn.name}"::"text"::${oldEnumNameWithoutSchema}${arraySuffix}`;
 
                 // update column to use new type
                 upQueries.push(`ALTER TABLE ${this.escapeTableName(table)} ALTER COLUMN "${newColumn.name}" TYPE ${upType}`);


### PR DESCRIPTION
Hi,

A quickfix for PostgreSQL databases running with tables composed of columns of type array+enum.

**Current query**:

```sql
ALTER TABLE "my_table" ALTER COLUMN "my_column" TYPE "my_table_my_column_enum" USING "my_column"::"text"::"my_table_my_column_enum"
```

**Valid query**:

```sql
ALTER TABLE "my_table" ALTER COLUMN "my_column" TYPE "my_table_my_column_enum"[] USING "my_column"::"text"::"my_table_my_column_enum"[]
```

In order to avoid **this error**:
>  invalid input value for enum my_table_my_column_enum: "{1,2}"

Where the column is decorated with:

```typescript
@Column({ name: 'my_column', type: 'enum', enum: MyEnum, array: true, nullable: true })
myColumn: MyEnum[];
```

Let me know if any extra modification is required :smile: 

Thanks for your work.