### PR TITLE
Fix deepMerge to keep object protoype

### DIFF
--- a/src/util/OrmUtils.ts
+++ b/src/util/OrmUtils.ts
@@ -86,7 +86,7 @@ export class OrmUtils {
                     && !(source[propertyKey] instanceof Set)
                     && !(source[propertyKey] instanceof Date)
                     && !(source[propertyKey] instanceof Buffer)) {
-                    if (!target[key]) Object.assign(target, { [key]: {} });
+                    if (!target[key]) Object.assign(target, { [key]: Object.create(Object.getPrototypeOf(source[propertyKey])) });
                     this.mergeDeep(target[key], source[propertyKey]);
                 } else {
                     Object.assign(target, { [key]: source[propertyKey] });

--- a/test/github-issues/2557/entity/dummy.ts
+++ b/test/github-issues/2557/entity/dummy.ts
@@ -1,0 +1,13 @@
+import {Column} from "../../../../src/decorator/columns/Column";
+import {PrimaryGeneratedColumn} from "../../../../src/decorator/columns/PrimaryGeneratedColumn";
+import {Entity} from "../../../../src/decorator/entity/Entity";
+import {WrappedNumber, transformer} from "../transformer";
+
+@Entity()
+export class Dummy {
+    @PrimaryGeneratedColumn()
+    id: number;
+
+    @Column('int', {transformer})
+    num: WrappedNumber;
+}

--- a/test/github-issues/2557/issue-2557.ts
+++ b/test/github-issues/2557/issue-2557.ts
@@ -1,0 +1,31 @@
+import "reflect-metadata";
+import {createTestingConnections, closeTestingConnections, reloadTestingDatabases} from "../../utils/test-utils";
+import {Connection} from "../../../src/connection/Connection";
+import {expect} from "chai";
+import {Dummy} from "./entity/dummy";
+import {transformer, WrappedNumber} from "./transformer";
+
+describe("github issues > #2557 object looses its prototype before transformer.to()", () => {
+
+    let connections: Connection[];
+    before(async () => connections = await createTestingConnections({
+        entities: [__dirname + "/entity/*{.js,.ts}"],
+        schemaCreate: true,
+        dropSchema: true,
+    }));
+    beforeEach(() => reloadTestingDatabases(connections));
+    after(() => closeTestingConnections(connections));
+
+    it("should give correct object in transformer.to", () => Promise.all(connections.map(async connection => {
+        const dummy = new Dummy();
+        dummy.id = 1;
+        dummy.num = new WrappedNumber(3);
+
+        await connection.getRepository(Dummy).save(dummy);
+
+        expect(transformer.lastValue).to.be.instanceOf(WrappedNumber);
+    })));
+
+    // you can add additional tests if needed
+
+});

--- a/test/github-issues/2557/transformer.ts
+++ b/test/github-issues/2557/transformer.ts
@@ -1,0 +1,18 @@
+export class WrappedNumber {
+    constructor (private wrapped: number) {}
+
+    getWrapped() : number {
+        return this.wrapped;
+    }
+}
+
+export const transformer = {
+    lastValue : undefined as any,
+    from(val : number) {
+        return new WrappedNumber(val);
+    },
+    to(w : WrappedNumber) {
+        transformer.lastValue = w;
+        return w.getWrapped();
+    }
+};


### PR DESCRIPTION
In #2557 and maybe also in #2280, luxon DateTime prototype is lost during `save()` before applying the transformer. luxon then sees the DateTime as invalid.

I've added a test with a custom wrapping object to avoid a dependency on luxon only for tests.