### PR TITLE
Fix typo in closure table section of entities.md

### DIFF
--- a/docs/entities.md
+++ b/docs/entities.md
@@ -623,7 +623,7 @@ export class Category {
     description: string;
 
     @TreeChildren()
-    children: Category;
+    children: Category[];
 
     @TreeParent()
     parent: Category;


### PR DESCRIPTION
This now matches the example in http://typeorm.io/#/tree-entities (that one doesn't show `@TreeLevelColumn`, despite importing it, but I'm not sure if that's intentional or not).