### PR TITLE
fix #2502- TypeError: One of the sources for assign has an enumerable key on the prototype chain 

### DIFF
--- a/src/connection/Connection.ts
+++ b/src/connection/Connection.ts
@@ -33,6 +33,7 @@ import {RelationIdLoader} from "../query-builder/RelationIdLoader";
 import {EntitySchema} from "../";
 import {SqlServerDriver} from "../driver/sqlserver/SqlServerDriver";
 import {MysqlDriver} from "../driver/mysql/MysqlDriver";
+import {ObjectUtils} from "../util/ObjectUtils";
 import {PromiseUtils} from "../";
 
 /**
@@ -178,7 +179,7 @@ export class Connection {
             await this.queryResultCache.connect();
 
         // set connected status for the current connection
-        Object.assign(this, { isConnected: true });
+        ObjectUtils.assign(this, { isConnected: true });
 
         try {
 
@@ -224,7 +225,7 @@ export class Connection {
         if (this.queryResultCache)
             await this.queryResultCache.disconnect();
 
-        Object.assign(this, { isConnected: false });
+        ObjectUtils.assign(this, { isConnected: false });
     }
 
     /**
@@ -479,15 +480,15 @@ export class Connection {
 
         // create subscribers instances if they are not disallowed from high-level (for example they can disallowed from migrations run process)
         const subscribers = connectionMetadataBuilder.buildSubscribers(this.options.subscribers || []);
-        Object.assign(this, { subscribers: subscribers });
+        ObjectUtils.assign(this, { subscribers: subscribers });
 
         // build entity metadatas
         const entityMetadatas = connectionMetadataBuilder.buildEntityMetadatas(this.options.entities || []);
-        Object.assign(this, { entityMetadatas: entityMetadatas });
+        ObjectUtils.assign(this, { entityMetadatas: entityMetadatas });
 
         // create migration instances
         const migrations = connectionMetadataBuilder.buildMigrations(this.options.migrations || []);
-        Object.assign(this, { migrations: migrations });
+        ObjectUtils.assign(this, { migrations: migrations });
 
         // validate all created entity metadatas to make sure user created entities are valid and correct
         entityMetadataValidator.validateMany(this.entityMetadatas, this.driver);

--- a/src/driver/mongodb/MongoDriver.ts
+++ b/src/driver/mongodb/MongoDriver.ts
@@ -14,6 +14,7 @@ import {DataTypeDefaults} from "../types/DataTypeDefaults";
 import {TableColumn} from "../../schema-builder/table/TableColumn";
 import {ConnectionOptions} from "../../connection/ConnectionOptions";
 import {EntityMetadata} from "../../metadata/EntityMetadata";
+import {ObjectUtils} from "../../util/ObjectUtils";
 
 /**
  * Organizes communication with MongoDB.
@@ -184,7 +185,7 @@ export class MongoDriver implements Driver {
                 if (err) return fail(err);
 
                 this.queryRunner = new MongoQueryRunner(this.connection, client);
-                Object.assign(this.queryRunner, { manager: this.connection.manager });
+                ObjectUtils.assign(this.queryRunner, { manager: this.connection.manager });
                 ok();
             });
         });
@@ -290,7 +291,7 @@ export class MongoDriver implements Driver {
     getColumnLength(column: ColumnMetadata): string {
         throw new Error(`MongoDB is schema-less, not supported by this driver.`);
     }
-    
+
     /**
      * Normalizes "default" value of the column.
      */

--- a/src/driver/postgres/PostgresDriver.ts
+++ b/src/driver/postgres/PostgresDriver.ts
@@ -240,7 +240,7 @@ export class PostgresDriver implements Driver {
         // load postgres package
         this.loadDependencies();
 
-        // Object.assign(this.options, DriverUtils.buildDriverOptions(connection.options)); // todo: do it better way
+        // ObjectUtils.assign(this.options, DriverUtils.buildDriverOptions(connection.options)); // todo: do it better way
         // validate options to make sure everything is set
         // todo: revisit validation with replication in mind
         // if (!this.options.host)

--- a/src/entity-manager/EntityManager.ts
+++ b/src/entity-manager/EntityManager.ts
@@ -34,6 +34,7 @@ import {DeleteResult} from "../query-builder/result/DeleteResult";
 import {OracleDriver} from "../driver/oracle/OracleDriver";
 import {FindConditions} from "../find-options/FindConditions";
 import {IsolationLevel} from "../driver/types/IsolationLevel";
+import {ObjectUtils} from "../util/ObjectUtils";
 
 /**
  * Entity manager supposed to work with any entity, automatically find its repository and call its methods,
@@ -79,7 +80,7 @@ export class EntityManager {
         if (queryRunner) {
             this.queryRunner = queryRunner;
             // dynamic: this.queryRunner = manager;
-            Object.assign(this.queryRunner, { manager: this });
+            ObjectUtils.assign(this.queryRunner, { manager: this });
         }
     }
 
@@ -385,7 +386,7 @@ export class EntityManager {
      * Condition(s) cannot be empty.
      */
     update<Entity>(target: ObjectType<Entity>|EntitySchema<Entity>|string, criteria: string|string[]|number|number[]|Date|Date[]|ObjectID|ObjectID[]|FindConditions<Entity>, partialEntity: DeepPartial<Entity>, options?: SaveOptions): Promise<UpdateResult> {
-        
+
         // if user passed empty criteria or empty list of criterias, then throw an error
         if (criteria === undefined ||
             criteria === null ||
@@ -394,7 +395,7 @@ export class EntityManager {
 
             return Promise.reject(new Error(`Empty criteria(s) are not allowed for the update method.`));
         }
-        
+
         if (typeof criteria === "string" ||
             typeof criteria === "number" ||
             criteria instanceof Date ||
@@ -423,7 +424,7 @@ export class EntityManager {
      * Condition(s) cannot be empty.
      */
     delete<Entity>(targetOrEntity: ObjectType<Entity>|EntitySchema<Entity>|string, criteria: string|string[]|number|number[]|Date|Date[]|ObjectID|ObjectID[]|FindConditions<Entity>, options?: RemoveOptions): Promise<DeleteResult> {
-        
+
         // if user passed empty criteria or empty list of criterias, then throw an error
         if (criteria === undefined ||
             criteria === null ||
@@ -432,7 +433,7 @@ export class EntityManager {
 
             return Promise.reject(new Error(`Empty criteria(s) are not allowed for the delete method.`));
         }
-        
+
         if (typeof criteria === "string" ||
             typeof criteria === "number" ||
             criteria instanceof Date ||

--- a/src/error/QueryFailedError.ts
+++ b/src/error/QueryFailedError.ts
@@ -1,3 +1,5 @@
+import { ObjectUtils } from "../util/ObjectUtils";
+
 /**
  * Thrown when query execution has failed.
 */
@@ -10,7 +12,7 @@ export class QueryFailedError extends Error {
             .replace(/^error: /, "")
             .replace(/^Error: /, "")
             .replace(/^Request/, "");
-        Object.assign(this, {
+        ObjectUtils.assign(this, {
             ...driverError,
             name: "QueryFailedError",
             query: query,

--- a/src/query-builder/Alias.ts
+++ b/src/query-builder/Alias.ts
@@ -1,4 +1,5 @@
 import {EntityMetadata} from "../metadata/EntityMetadata";
+import { ObjectUtils } from "../util/ObjectUtils";
 
 /**
  */
@@ -20,7 +21,7 @@ export class Alias {
     subQuery?: string;
 
     constructor(alias?: Alias) {
-        Object.assign(this, alias || {});
+        ObjectUtils.assign(this, alias || {});
     }
 
     private _metadata?: EntityMetadata;

--- a/src/query-builder/JoinAttribute.ts
+++ b/src/query-builder/JoinAttribute.ts
@@ -4,6 +4,7 @@ import {RelationMetadata} from "../metadata/RelationMetadata";
 import {QueryBuilderUtils} from "./QueryBuilderUtils";
 import {QueryExpressionMap} from "./QueryExpressionMap";
 import {Alias} from "./Alias";
+import {ObjectUtils} from "../util/ObjectUtils";
 
 /**
  * Stores all join attributes which will be used to build a JOIN query.
@@ -51,7 +52,7 @@ export class JoinAttribute {
     constructor(private connection: Connection,
                 private queryExpressionMap: QueryExpressionMap,
                 joinAttribute?: JoinAttribute) {
-        Object.assign(this, joinAttribute || {});
+        ObjectUtils.assign(this, joinAttribute || {});
     }
 
     // -------------------------------------------------------------------------
@@ -129,7 +130,7 @@ export class JoinAttribute {
 
         const relationOwnerSelection = this.queryExpressionMap.findAliasByName(this.parentAlias!);
         let relation = relationOwnerSelection.metadata.findRelationWithPropertyPath(this.relationPropertyPath!);
-        
+
         if (relation) {
             return relation;
         }
@@ -141,7 +142,7 @@ export class JoinAttribute {
             }
         }
 
-        throw new Error(`Relation with property path ${this.relationPropertyPath} in entity was not found.`);  
+        throw new Error(`Relation with property path ${this.relationPropertyPath} in entity was not found.`);
     }
 
     /**

--- a/src/query-builder/SelectQueryBuilder.ts
+++ b/src/query-builder/SelectQueryBuilder.ts
@@ -33,6 +33,7 @@ import {OffsetWithoutLimitNotSupportedError} from "../error/OffsetWithoutLimitNo
 import {BroadcasterResult} from "../subscriber/BroadcasterResult";
 import {abbreviate} from "../util/StringUtils";
 import {SelectQueryBuilderOption} from "./SelectQueryBuilderOption";
+import {ObjectUtils} from "../util/ObjectUtils";
 
 /**
  * Allows to build complex sql queries in a fashion way and execute those queries.
@@ -1931,7 +1932,7 @@ export class SelectQueryBuilder<Entity> extends QueryBuilder<Entity> implements 
      * Merges into expression map given expression map properties.
      */
     protected mergeExpressionMap(expressionMap: Partial<QueryExpressionMap>): this {
-        Object.assign(this.expressionMap, expressionMap);
+        ObjectUtils.assign(this.expressionMap, expressionMap);
         return this;
     }
 

--- a/src/query-builder/relation-count/RelationCountAttribute.ts
+++ b/src/query-builder/relation-count/RelationCountAttribute.ts
@@ -3,6 +3,7 @@ import {QueryBuilderUtils} from "../QueryBuilderUtils";
 import {RelationMetadata} from "../../metadata/RelationMetadata";
 import {QueryExpressionMap} from "../QueryExpressionMap";
 import {SelectQueryBuilder} from "../SelectQueryBuilder";
+import {ObjectUtils} from "../../util/ObjectUtils";
 
 export class RelationCountAttribute {
 
@@ -32,7 +33,7 @@ export class RelationCountAttribute {
 
     constructor(private expressionMap: QueryExpressionMap,
                 relationCountAttribute?: Partial<RelationCountAttribute>) {
-        Object.assign(this, relationCountAttribute || {});
+        ObjectUtils.assign(this, relationCountAttribute || {});
     }
 
     // -------------------------------------------------------------------------

--- a/src/query-builder/relation-id/RelationIdAttribute.ts
+++ b/src/query-builder/relation-id/RelationIdAttribute.ts
@@ -3,6 +3,7 @@ import {QueryBuilderUtils} from "../QueryBuilderUtils";
 import {EntityMetadata} from "../../metadata/EntityMetadata";
 import {QueryExpressionMap} from "../QueryExpressionMap";
 import {SelectQueryBuilder} from "../SelectQueryBuilder";
+import {ObjectUtils} from "../../util/ObjectUtils";
 
 /**
  * Stores all join relation id attributes which will be used to build a JOIN query.
@@ -44,7 +45,7 @@ export class RelationIdAttribute {
 
     constructor(private queryExpressionMap: QueryExpressionMap,
                         relationIdAttribute?: Partial<RelationIdAttribute>) {
-        Object.assign(this, relationIdAttribute || {});
+        ObjectUtils.assign(this, relationIdAttribute || {});
     }
 
     // -------------------------------------------------------------------------

--- a/src/repository/BaseEntity.ts
+++ b/src/repository/BaseEntity.ts
@@ -12,6 +12,7 @@ import {InsertResult} from "../query-builder/result/InsertResult";
 import {UpdateResult} from "../query-builder/result/UpdateResult";
 import {DeleteResult} from "../query-builder/result/DeleteResult";
 import {ObjectID} from "../driver/mongodb/typings";
+import {ObjectUtils} from "../util/ObjectUtils";
 
 /**
  * Base abstract entity for all entities, used in ActiveRecord patterns.
@@ -62,7 +63,7 @@ export class BaseEntity {
         const base: any = this.constructor;
         const newestEntity: BaseEntity = await base.getRepository().findOneOrFail(base.getId(this));
 
-        Object.assign(this, newestEntity);
+        ObjectUtils.assign(this, newestEntity);
     }
 
     // -------------------------------------------------------------------------

--- a/src/util/ObjectUtils.ts
+++ b/src/util/ObjectUtils.ts
@@ -34,11 +34,8 @@ export class ObjectUtils {
    */
   static assign(target: object, ...sources: any[]): any {
     for (const source of sources) {
-      for (const prop in source) {
-        const descriptor = Object.getOwnPropertyDescriptor(source, prop);
-        if (descriptor === undefined || descriptor.writable) {
-            (target as any)[prop] = source[prop];
-        }
+      for (const prop of Object.getOwnPropertyNames(source)) {
+          (target as any)[prop] = source[prop];
       }
     }
   }

--- a/src/util/ObjectUtils.ts
+++ b/src/util/ObjectUtils.ts
@@ -1,0 +1,45 @@
+export class ObjectUtils {
+  /**
+   * Copy the values of all of the enumerable own properties from one or more source objects to a
+   * target object. Returns the target object.
+   * @param target The target object to copy to.
+   * @param source The source object from which to copy properties.
+   */
+  static assign<T, U>(target: T, source: U): T & U;
+
+  /**
+   * Copy the values of all of the enumerable own properties from one or more source objects to a
+   * target object. Returns the target object.
+   * @param target The target object to copy to.
+   * @param source1 The first source object from which to copy properties.
+   * @param source2 The second source object from which to copy properties.
+   */
+  static assign<T, U, V>(target: T, source1: U, source2: V): T & U & V;
+
+  /**
+   * Copy the values of all of the enumerable own properties from one or more source objects to a
+   * target object. Returns the target object.
+   * @param target The target object to copy to.
+   * @param source1 The first source object from which to copy properties.
+   * @param source2 The second source object from which to copy properties.
+   * @param source3 The third source object from which to copy properties.
+   */
+  static assign<T, U, V, W>(target: T, source1: U, source2: V, source3: W): T & U & V & W;
+
+  /**
+   * Copy the values of all of the enumerable own properties from one or more source objects to a
+   * target object. Returns the target object.
+   * @param target The target object to copy to.
+   * @param sources One or more source objects from which to copy properties
+   */
+  static assign(target: object, ...sources: any[]): any {
+    for (const source of sources) {
+      for (const prop in source) {
+        const descriptor = Object.getOwnPropertyDescriptor(source, prop);
+        if (descriptor === undefined || descriptor.writable) {
+            (target as any)[prop] = source[prop];
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
fix for https://github.com/typeorm/typeorm/issues/2502

I created a separate function ```ObjectUtils.assign``` to use instead of ```Object.assign``` that will only copy the properties returned by ```Object.getOwnPropertyNames```.