### PR TITLE
Parse connection type from TYPEORM_URL

### DIFF
--- a/src/connection/options-reader/ConnectionOptionsEnvReader.ts
+++ b/src/connection/options-reader/ConnectionOptionsEnvReader.ts
@@ -18,7 +18,7 @@ export class ConnectionOptionsEnvReader {
      */
     read(): ConnectionOptions {
         return {
-            type: PlatformTools.getEnvVariable("TYPEORM_CONNECTION"),
+            type: PlatformTools.getEnvVariable("TYPEORM_CONNECTION") || PlatformTools.getEnvVariable("TYPEORM_URL").split("://")[0],
             url: PlatformTools.getEnvVariable("TYPEORM_URL"),
             host: PlatformTools.getEnvVariable("TYPEORM_HOST"),
             port: PlatformTools.getEnvVariable("TYPEORM_PORT"),

--- a/src/connection/options-reader/ConnectionOptionsEnvReader.ts
+++ b/src/connection/options-reader/ConnectionOptionsEnvReader.ts
@@ -18,7 +18,7 @@ export class ConnectionOptionsEnvReader {
      */
     read(): ConnectionOptions {
         return {
-            type: PlatformTools.getEnvVariable("TYPEORM_CONNECTION") || PlatformTools.getEnvVariable("TYPEORM_URL").split("://")[0],
+            type: PlatformTools.getEnvVariable("TYPEORM_CONNECTION") || (PlatformTools.getEnvVariable("TYPEORM_URL") ? PlatformTools.getEnvVariable("TYPEORM_URL").split("://")[0] : undefined),
             url: PlatformTools.getEnvVariable("TYPEORM_URL"),
             host: PlatformTools.getEnvVariable("TYPEORM_HOST"),
             port: PlatformTools.getEnvVariable("TYPEORM_PORT"),


### PR DESCRIPTION
This makes it possible just to provide `TYPEORM_URL`, instead of having to provide also `TYPEORM_CONNECTION`. Standard database URL contains already database connection type in protocol section (e.g. `postgres://hostname:5432/database`).