### PR TITLE
unbreak release: externalise nativescript

### DIFF
--- a/docs/supported-platforms.md
+++ b/docs/supported-platforms.md
@@ -69,6 +69,20 @@ TypeORM is able to run on Expo apps using the [Expo SQLite API](https://docs.exp
 
 1. `tns install webpack` (read below why webpack is required)
 2. `tns plugin add nativescript-sqlite`
+3. Create Database connetion in your app's entry point
+    ```typescript
+    import driver from 'nativescript-sqlite'
+
+    const connection = await createConnection({
+        database: 'test.db',
+        type: 'nativescript',
+        driver,
+        entities: [
+            Todo //... whatver entities you have
+        ],
+        logging: true
+    })
+    ```
 
 Note: This works only with NativeScript 4.x and above
 

--- a/src/driver/nativescript/NativescriptConnectionOptions.ts
+++ b/src/driver/nativescript/NativescriptConnectionOptions.ts
@@ -15,4 +15,10 @@ export interface NativescriptConnectionOptions extends BaseConnectionOptions {
      */
     readonly database: string;
 
+    /**
+     * The driver object
+     * you should pass `require('nativescript-sqlite') here
+     */
+    readonly driver: any;
+
 }

--- a/src/driver/nativescript/NativescriptDriver.ts
+++ b/src/driver/nativescript/NativescriptDriver.ts
@@ -8,89 +8,96 @@ import {DriverPackageNotInstalledError} from "../../error/DriverPackageNotInstal
 import {ColumnType} from "../types/ColumnTypes";
 
 /**
- * Organizes communication with sqlite DBMS within Nativescript.
- */
+* Organizes communication with sqlite DBMS within Nativescript.
+*/
 export class NativescriptDriver extends AbstractSqliteDriver {
     // -------------------------------------------------------------------------
     // Public Properties
     // -------------------------------------------------------------------------
-
+    
     /**
-     * Connection options.
-     */
+    * Connection options.
+    */
     options: NativescriptConnectionOptions;
-
+    
+    /**
+    * Nativescript driver module
+    * this is most likely `nativescript-sqlite`
+    * but user can pass his own
+    */
+    driver: any;
+    
     // -------------------------------------------------------------------------
     // Constructor
     // -------------------------------------------------------------------------
-
+    
     constructor(connection: Connection) {
         super(connection);
-
+        
         this.connection = connection;
         this.options = connection.options as NativescriptConnectionOptions;
         this.database = this.options.database;
-
+        
         // validate options to make sure everything is set
         if (!this.options.database)
-            throw new DriverOptionNotSetError("database");
-
+        throw new DriverOptionNotSetError("database");
+        
         // load sqlite package
         this.loadDependencies();
     }
-
-
+    
+    
     // -------------------------------------------------------------------------
     // Public Methods
     // -------------------------------------------------------------------------
-
+    
     /**
-     * Closes connection with database.
-     */
+    * Closes connection with database.
+    */
     async disconnect(): Promise<void> {
         return new Promise<void>((ok, fail) => {
             this.queryRunner = undefined;
             this.databaseConnection.close().then(ok).catch(fail);
         });
     }
-
+    
     /**
-     * Creates a query runner used to execute database queries.
-     */
+    * Creates a query runner used to execute database queries.
+    */
     createQueryRunner(mode: "master"|"slave" = "master"): QueryRunner {
         if (!this.queryRunner)
-            this.queryRunner = new NativescriptQueryRunner(this);
-
+        this.queryRunner = new NativescriptQueryRunner(this);
+        
         return this.queryRunner;
     }
-
+    
     normalizeType(column: { type?: ColumnType, length?: number | string, precision?: number|null, scale?: number }): string {
         if ((column.type as any) === Buffer) {
             return "blob";
         }
-
+        
         return super.normalizeType(column);
     }
     // -------------------------------------------------------------------------
     // Protected Methods
     // -------------------------------------------------------------------------
-
+    
     /**
-     * Creates connection with the database.
-     */
+    * Creates connection with the database.
+    */
     protected createDatabaseConnection() {
         return new Promise<void>((ok, fail) => {
             const options = Object.assign({}, {
                 name: this.options.database,
             }, this.options.extra || {});
-
+            
             new this.sqlite(options.name, (err: Error, db: any): any => {
                 if (err) return fail(err);
-
+                
                 // use object mode to work with TypeORM
                 db.resultType(this.sqlite.RESULTSASOBJECT);
-
-
+                
+                
                 // we need to enable foreign keys in sqlite to make sure all foreign key related features
                 // working properly. this also makes onDelete work with sqlite.
                 db.execSQL(`PRAGMA foreign_keys = ON;`, [], (err: Error, result: any): any => {
@@ -101,15 +108,13 @@ export class NativescriptDriver extends AbstractSqliteDriver {
             });
         });
     }
-
+    
     /**
      * If driver dependency is not given explicitly, then try to load it via "require".
      */
     protected loadDependencies(): void {
-        try {
-            this.sqlite = require("nativescript-sqlite");
-
-        } catch (e) {
+        this.driver = this.options.driver
+        if (!this.driver) {
             throw new DriverPackageNotInstalledError("Nativescript", "nativescript-sqlite");
         }
     }

--- a/src/driver/nativescript/NativescriptDriver.ts
+++ b/src/driver/nativescript/NativescriptDriver.ts
@@ -37,6 +37,7 @@ export class NativescriptDriver extends AbstractSqliteDriver {
         this.connection = connection;
         this.options = connection.options as NativescriptConnectionOptions;
         this.database = this.options.database;
+        this.driver = this.options.driver;
 
         // validate options to make sure everything is set
         if (!this.options.database) {
@@ -115,7 +116,7 @@ export class NativescriptDriver extends AbstractSqliteDriver {
      * If driver dependency is not given explicitly, then try to load it via "require".
      */
     protected loadDependencies(): void {
-        this.driver = this.options.driver
+        this.sqlite = this.driver
         if (!this.driver) {
             throw new DriverPackageNotInstalledError("Nativescript", "nativescript-sqlite");
         }

--- a/src/driver/nativescript/NativescriptDriver.ts
+++ b/src/driver/nativescript/NativescriptDriver.ts
@@ -8,96 +8,98 @@ import {DriverPackageNotInstalledError} from "../../error/DriverPackageNotInstal
 import {ColumnType} from "../types/ColumnTypes";
 
 /**
-* Organizes communication with sqlite DBMS within Nativescript.
-*/
+ * Organizes communication with sqlite DBMS within Nativescript.
+ */
 export class NativescriptDriver extends AbstractSqliteDriver {
     // -------------------------------------------------------------------------
     // Public Properties
     // -------------------------------------------------------------------------
-    
+
     /**
-    * Connection options.
-    */
+     * Connection options.
+     */
     options: NativescriptConnectionOptions;
-    
+
     /**
-    * Nativescript driver module
-    * this is most likely `nativescript-sqlite`
-    * but user can pass his own
-    */
+     * Nativescript driver module
+     * this is most likely `nativescript-sqlite`
+     * but user can pass his own
+     */
     driver: any;
-    
+
     // -------------------------------------------------------------------------
     // Constructor
     // -------------------------------------------------------------------------
-    
+
     constructor(connection: Connection) {
         super(connection);
-        
+
         this.connection = connection;
         this.options = connection.options as NativescriptConnectionOptions;
         this.database = this.options.database;
-        
+
         // validate options to make sure everything is set
-        if (!this.options.database)
-        throw new DriverOptionNotSetError("database");
-        
+        if (!this.options.database) {
+            throw new DriverOptionNotSetError("database");
+        }
+
         // load sqlite package
         this.loadDependencies();
     }
-    
-    
+
+
     // -------------------------------------------------------------------------
     // Public Methods
     // -------------------------------------------------------------------------
-    
+
     /**
-    * Closes connection with database.
-    */
+     * Closes connection with database.
+     */
     async disconnect(): Promise<void> {
         return new Promise<void>((ok, fail) => {
             this.queryRunner = undefined;
             this.databaseConnection.close().then(ok).catch(fail);
         });
     }
-    
+
     /**
-    * Creates a query runner used to execute database queries.
-    */
+     * Creates a query runner used to execute database queries.
+     */
     createQueryRunner(mode: "master"|"slave" = "master"): QueryRunner {
-        if (!this.queryRunner)
-        this.queryRunner = new NativescriptQueryRunner(this);
-        
+        if (!this.queryRunner) {
+            this.queryRunner = new NativescriptQueryRunner(this);
+        }
+
         return this.queryRunner;
     }
-    
+
     normalizeType(column: { type?: ColumnType, length?: number | string, precision?: number|null, scale?: number }): string {
         if ((column.type as any) === Buffer) {
             return "blob";
         }
-        
+
         return super.normalizeType(column);
     }
     // -------------------------------------------------------------------------
     // Protected Methods
     // -------------------------------------------------------------------------
-    
+
     /**
-    * Creates connection with the database.
-    */
+     * Creates connection with the database.
+     */
     protected createDatabaseConnection() {
         return new Promise<void>((ok, fail) => {
             const options = Object.assign({}, {
                 name: this.options.database,
             }, this.options.extra || {});
-            
+
             new this.sqlite(options.name, (err: Error, db: any): any => {
                 if (err) return fail(err);
-                
+
                 // use object mode to work with TypeORM
                 db.resultType(this.sqlite.RESULTSASOBJECT);
-                
-                
+
+
                 // we need to enable foreign keys in sqlite to make sure all foreign key related features
                 // working properly. this also makes onDelete work with sqlite.
                 db.execSQL(`PRAGMA foreign_keys = ON;`, [], (err: Error, result: any): any => {
@@ -108,7 +110,7 @@ export class NativescriptDriver extends AbstractSqliteDriver {
             });
         });
     }
-    
+
     /**
      * If driver dependency is not given explicitly, then try to load it via "require".
      */


### PR DESCRIPTION
Going into the future drivers should come from the userland
or other packages of @typeorm/driver-xxxx

But for now we need to unbreak the 0.2.x release cycle
and only NativeScript broke it

Signed-off-by: Arnav Gupta <arnav@codingblocks.com>