### PR TITLE
Performance of hydration

### DIFF
--- a/src/query-builder/JoinAttribute.ts
+++ b/src/query-builder/JoinAttribute.ts
@@ -68,19 +68,30 @@ export class JoinAttribute {
         return false;
     }
 
+    
+    isSelectedCache: boolean;
+    isSelectedEvalueated: boolean = false;
     /**
      * Indicates if this join is selected.
      */
     get isSelected(): boolean {
-        for (const select of this.queryExpressionMap.selects) {
-            if (select.selection === this.alias.name)
-                return true;
+        if (!this.isSelectedEvalueated) {
+            let getValue = () => {
+                for (const select of this.queryExpressionMap.selects) {
+                    if (select.selection === this.alias.name)
+                        return true;
 
-            if (this.metadata && !!this.metadata.columns.find(column => select.selection === this.alias.name + "." + column.propertyPath))
-                return true;
+                    if (this.metadata && !!this.metadata.columns.find(column => select.selection === this.alias.name + "." + column.propertyPath))
+                        return true;
+                }
+
+                return false;
+            };
+            this.isSelectedCache = getValue();
+            this.isSelectedEvalueated = true;
         }
+        return this.isSelectedCache;
 
-        return false;
     }
 
     /**
@@ -117,31 +128,40 @@ export class JoinAttribute {
         return this.entityOrProperty.substr(this.entityOrProperty.indexOf(".") + 1);
     }
 
+    relationCache: RelationMetadata|undefined;
+    relationEvalueated: boolean = false;
     /**
      * Relation of the parent.
      * This is used to understand what is joined.
      * This is available when join was made using "post.category" syntax.
      * Relation can be undefined if entityOrProperty is regular entity or custom table.
      */
-    get relation(): RelationMetadata|undefined {
-        if (!QueryBuilderUtils.isAliasProperty(this.entityOrProperty))
-            return undefined;
+    get relation(): RelationMetadata | undefined {
+        if (!this.relationEvalueated) {
+            let getValue = () => {
+                if (!QueryBuilderUtils.isAliasProperty(this.entityOrProperty))
+                    return undefined;
 
-        const relationOwnerSelection = this.queryExpressionMap.findAliasByName(this.parentAlias!);
-        let relation = relationOwnerSelection.metadata.findRelationWithPropertyPath(this.relationPropertyPath!);
-        
-        if (relation) {
-            return relation;
+                const relationOwnerSelection = this.queryExpressionMap.findAliasByName(this.parentAlias!);
+                let relation = relationOwnerSelection.metadata.findRelationWithPropertyPath(this.relationPropertyPath!);
+
+                if (relation) {
+                    return relation;
+                }
+
+                if (relationOwnerSelection.metadata.parentEntityMetadata) {
+                    relation = relationOwnerSelection.metadata.parentEntityMetadata.findRelationWithPropertyPath(this.relationPropertyPath!);
+                    if (relation) {
+                        return relation;
+                    }
+                }
+
+                throw new Error(`Relation with property path ${this.relationPropertyPath} in entity was not found.`);
+            };
+            this.relationCache = getValue.bind(this)();
+            this.relationEvalueated = true;
         }
-
-        if (relationOwnerSelection.metadata.parentEntityMetadata) {
-            relation = relationOwnerSelection.metadata.parentEntityMetadata.findRelationWithPropertyPath(this.relationPropertyPath!);
-            if (relation) {
-                return relation;
-            }
-        }
-
-        throw new Error(`Relation with property path ${this.relationPropertyPath} in entity was not found.`);  
+        return this.relationCache;
     }
 
     /**


### PR DESCRIPTION
#2381 
I don't like the way I implemented it but I don't have a concept how to do it better. Decorators won't be of help here because they work when object is being created. Using generic class just for caching would require changing how it is used  - we can't have a getter to property of type Cache<T> which returns type T, so instead of `obj.relation` we would have to use `obj.relation.value` or something similar.

I hope community will come up with some nicer solution. On problem reproduction repo https://github.com/stelltec/typeorm_testcase1 cached version works ~15x faster with 10240 rows returned.