### PR TITLE
Support specifying full config file path in cli using -f option

### DIFF
--- a/src/connection/ConnectionOptionsReader.ts
+++ b/src/connection/ConnectionOptionsReader.ts
@@ -83,7 +83,7 @@ export class ConnectionOptionsReader {
         const fileFormats = ["env", "js", "ts", "json", "yml", "yaml", "xml"];
 
         // Detect if baseFilePath contains file extension
-        const possibleExtension = this.baseFilePath.substr(this.baseFilePath.indexOf("."));
+        const possibleExtension = this.baseFilePath.substr(this.baseFilePath.lastIndexOf("."));
         const fileExtension = fileFormats.find(extension => `.${extension}` === possibleExtension);
 
         // try to find any of following configuration formats

--- a/src/connection/ConnectionOptionsReader.ts
+++ b/src/connection/ConnectionOptionsReader.ts
@@ -78,9 +78,16 @@ export class ConnectionOptionsReader {
      * todo: get in count NODE_ENV somehow
      */
     protected async load(): Promise<ConnectionOptions[]|undefined> {
+        let connectionOptions: ConnectionOptions|ConnectionOptions[]|undefined = undefined;
+
+        const fileFormats = ["env", "js", "ts", "json", "yml", "yaml", "xml"];
+
+        // Detect if baseFilePath contains file extension
+        const possibleExtension = this.baseFilePath.substr(this.baseFilePath.indexOf("."));
+        const fileExtension = fileFormats.find(extension => `.${extension}` === possibleExtension);
 
         // try to find any of following configuration formats
-        const foundFileFormat = ["env", "js", "ts", "json", "yml", "yaml", "xml"].find(format => {
+        const foundFileFormat = fileExtension || fileFormats.find(format => {
             return PlatformTools.fileExist(this.baseFilePath + "." + format);
         });
 
@@ -93,28 +100,30 @@ export class ConnectionOptionsReader {
             dotenv.config({ path: ".env" });
         }
 
+        // Determine config file name
+        const configFile = fileExtension ? this.baseFilePath : this.baseFilePath + "." + foundFileFormat;
+
         // try to find connection options from any of available sources of configuration
-        let connectionOptions: ConnectionOptions|ConnectionOptions[]|undefined = undefined;
         if (PlatformTools.getEnvVariable("TYPEORM_CONNECTION")) {
             connectionOptions = new ConnectionOptionsEnvReader().read();
 
         } else if (foundFileFormat === "js") {
-            connectionOptions = PlatformTools.load(this.baseFilePath + ".js");
+            connectionOptions = PlatformTools.load(configFile);
 
         } else if (foundFileFormat === "ts") {
-            connectionOptions = PlatformTools.load(this.baseFilePath + ".ts");
+            connectionOptions = PlatformTools.load(configFile);
 
         } else if (foundFileFormat === "json") {
-            connectionOptions = PlatformTools.load(this.baseFilePath + ".json");
+            connectionOptions = PlatformTools.load(configFile);
 
         } else if (foundFileFormat === "yml") {
-            connectionOptions = new ConnectionOptionsYmlReader().read(this.baseFilePath + ".yml");
+            connectionOptions = new ConnectionOptionsYmlReader().read(configFile);
 
         } else if (foundFileFormat === "yaml") {
-            connectionOptions = new ConnectionOptionsYmlReader().read(this.baseFilePath + ".yaml");
+            connectionOptions = new ConnectionOptionsYmlReader().read(configFile);
 
         } else if (foundFileFormat === "xml") {
-            connectionOptions = await new ConnectionOptionsXmlReader().read(this.baseFilePath + ".xml");
+            connectionOptions = await new ConnectionOptionsXmlReader().read(configFile);
         }
 
         // normalize and return connection options
@@ -133,11 +142,10 @@ export class ConnectionOptionsReader {
             connectionOptions = [connectionOptions];
 
         connectionOptions.forEach(options => {
-
             if (options.entities) {
                 const entities = (options.entities as any[]).map(entity => {
                     if (typeof entity === "string" && entity.substr(0, 1) !== "/")
-                        return this.baseFilePath + "/" + entity;
+                        return this.baseDirectory + "/" + entity;
 
                     return entity;
                 });
@@ -146,7 +154,7 @@ export class ConnectionOptionsReader {
             if (options.subscribers) {
                 const subscribers = (options.subscribers as any[]).map(subscriber => {
                     if (typeof subscriber === "string" && subscriber.substr(0, 1) !== "/")
-                        return this.baseFilePath + "/" + subscriber;
+                        return this.baseDirectory + "/" + subscriber;
 
                     return subscriber;
                 });
@@ -155,7 +163,7 @@ export class ConnectionOptionsReader {
             if (options.migrations) {
                 const migrations = (options.migrations as any[]).map(migration => {
                     if (typeof migration === "string" && migration.substr(0, 1) !== "/")
-                        return this.baseFilePath + "/" + migration;
+                        return this.baseDirectory + "/" + migration;
 
                     return migration;
                 });
@@ -179,7 +187,7 @@ export class ConnectionOptionsReader {
     }
 
     /**
-     * Gets directory where configuration file should be located and configuration file name without extension.
+     * Gets directory where configuration file should be located and configuration file name.
      */
     protected get baseFilePath(): string {
         return this.baseDirectory + "/" + this.baseConfigName;

--- a/test/functional/connection-options-reader/configs/test-path-config.js
+++ b/test/functional/connection-options-reader/configs/test-path-config.js
@@ -1,0 +1,5 @@
+module.exports = [{
+  type: "sqlite",
+  name: "file",
+  database: "test-js"
+}];

--- a/test/functional/connection-options-reader/connection-options-reader.ts
+++ b/test/functional/connection-options-reader/connection-options-reader.ts
@@ -20,4 +20,10 @@ describe("ConnectionOptionsReader", () => {
     expect(fileOptions.database).to.have.string("/test");
   });
 
+  it("properly loads config with specified file path", async () => {
+    const connectionOptionsReader = new ConnectionOptionsReader({ root: __dirname, configName: "configs/test-path-config.js" });
+    const fileOptions: ConnectionOptions = await connectionOptionsReader.get("file");
+    expect(fileOptions.database).to.have.string("/test-js");
+  });
+
 });


### PR DESCRIPTION
Support specification of a full file path with extension using the `-f` option in the cli.

Omitting a file extension will retain the current behavior of looping over possible file extensions for support.

I also updated `normalizeConnectionOptions` to use `baseDirectory` since this seemed more correct, but please let me know if that's not desirable.

Resolves #2339 