### PR TITLE
Removed .only from tests causing only 20 tests to run

### DIFF
--- a/test/functional/observers/observe-count/observers-count-insert.ts
+++ b/test/functional/observers/observe-count/observers-count-insert.ts
@@ -4,7 +4,7 @@ import {Connection} from "../../../../src";
 import {closeTestingConnections, createTestingConnections, reloadTestingDatabases} from "../../../utils/test-utils";
 import {Post} from "./entity/Post";
 
-describe.only("observers > count > on insert", function() {
+describe("observers > count > on insert", function() {
 
     let connections: Connection[];
     before(async () => {

--- a/test/functional/observers/observe-count/observers-count-remove.ts
+++ b/test/functional/observers/observe-count/observers-count-remove.ts
@@ -3,7 +3,7 @@ import {Connection, LessThan} from "../../../../src";
 import {closeTestingConnections, createTestingConnections, reloadTestingDatabases} from "../../../utils/test-utils";
 import {Post} from "./entity/Post";
 
-describe.only("observers > count > on remove", function() {
+describe("observers > count > on remove", function() {
 
     let connections: Connection[];
     before(async () => {

--- a/test/functional/observers/observe-count/observers-count-update.ts
+++ b/test/functional/observers/observe-count/observers-count-update.ts
@@ -3,7 +3,7 @@ import {Connection, LessThan} from "../../../../src";
 import {closeTestingConnections, createTestingConnections, reloadTestingDatabases} from "../../../utils/test-utils";
 import {Post} from "./entity/Post";
 
-describe.only("observers > count > on update", function() {
+describe("observers > count > on update", function() {
 
     let connections: Connection[];
     before(async () => {

--- a/test/functional/observers/observe-many-and-count/observers-many-and-count-insert.ts
+++ b/test/functional/observers/observe-many-and-count/observers-many-and-count-insert.ts
@@ -4,7 +4,7 @@ import {Connection} from "../../../../src";
 import {closeTestingConnections, createTestingConnections, reloadTestingDatabases} from "../../../utils/test-utils";
 import {Post} from "./entity/Post";
 
-describe.only("observers > many and count > on insert", function() {
+describe("observers > many and count > on insert", function() {
 
     let connections: Connection[];
     before(async () => {

--- a/test/functional/observers/observe-many-and-count/observers-many-and-count-remove.ts
+++ b/test/functional/observers/observe-many-and-count/observers-many-and-count-remove.ts
@@ -3,7 +3,7 @@ import {Connection, LessThan} from "../../../../src";
 import {closeTestingConnections, createTestingConnections, reloadTestingDatabases} from "../../../utils/test-utils";
 import {Post} from "./entity/Post";
 
-describe.only("observers > many and count > on remove", function() {
+describe("observers > many and count > on remove", function() {
 
     let connections: Connection[];
     before(async () => {

--- a/test/functional/observers/observe-many-and-count/observers-many-and-count-update.ts
+++ b/test/functional/observers/observe-many-and-count/observers-many-and-count-update.ts
@@ -3,7 +3,7 @@ import {Connection, LessThan, MoreThan} from "../../../../src";
 import {closeTestingConnections, createTestingConnections, reloadTestingDatabases} from "../../../utils/test-utils";
 import {Post} from "./entity/Post";
 
-describe.only("observers > many and count > on update", function() {
+describe("observers > many and count > on update", function() {
 
     let connections: Connection[];
     before(async () => {

--- a/test/functional/observers/observe-many/observers-many-insert.ts
+++ b/test/functional/observers/observe-many/observers-many-insert.ts
@@ -4,7 +4,7 @@ import {Connection} from "../../../../src";
 import {closeTestingConnections, createTestingConnections, reloadTestingDatabases} from "../../../utils/test-utils";
 import {Post} from "./entity/Post";
 
-describe.only("observers > many > on insert", function() {
+describe("observers > many > on insert", function() {
 
     let connections: Connection[];
     before(async () => {

--- a/test/functional/observers/observe-many/observers-many-remove.ts
+++ b/test/functional/observers/observe-many/observers-many-remove.ts
@@ -3,7 +3,7 @@ import {Connection, LessThan} from "../../../../src";
 import {closeTestingConnections, createTestingConnections, reloadTestingDatabases} from "../../../utils/test-utils";
 import {Post} from "./entity/Post";
 
-describe.only("observers > many > on remove", function() {
+describe("observers > many > on remove", function() {
 
     let connections: Connection[];
     before(async () => {

--- a/test/functional/observers/observe-many/observers-many-update.ts
+++ b/test/functional/observers/observe-many/observers-many-update.ts
@@ -3,7 +3,7 @@ import {Connection, LessThan, MoreThan} from "../../../../src";
 import {closeTestingConnections, createTestingConnections, reloadTestingDatabases} from "../../../utils/test-utils";
 import {Post} from "./entity/Post";
 
-describe.only("observers > many > on update", function() {
+describe("observers > many > on update", function() {
 
     let connections: Connection[];
     before(async () => {

--- a/test/functional/observers/observe-one/observers-one-insert.ts
+++ b/test/functional/observers/observe-one/observers-one-insert.ts
@@ -3,7 +3,7 @@ import {Connection} from "../../../../src";
 import {closeTestingConnections, createTestingConnections, reloadTestingDatabases} from "../../../utils/test-utils";
 import {Post} from "./entity/Post";
 
-describe.only("observers > one > on insert", function() {
+describe("observers > one > on insert", function() {
 
     let connections: Connection[];
     before(async () => {

--- a/test/functional/observers/observe-one/observers-one-remove.ts
+++ b/test/functional/observers/observe-one/observers-one-remove.ts
@@ -4,7 +4,7 @@ import {closeTestingConnections, createTestingConnections, reloadTestingDatabase
 import {Post} from "./entity/Post";
 import {expect} from "chai";
 
-describe.only("observers > one > on remove", function() {
+describe("observers > one > on remove", function() {
 
     let connections: Connection[];
     before(async () => {

--- a/test/functional/observers/observe-one/observers-one-update.ts
+++ b/test/functional/observers/observe-one/observers-one-update.ts
@@ -4,7 +4,7 @@ import {Connection} from "../../../../src";
 import {closeTestingConnections, createTestingConnections, reloadTestingDatabases} from "../../../utils/test-utils";
 import {Post} from "./entity/Post";
 
-describe.only("observers > one > on update", function() {
+describe("observers > one > on update", function() {
 
     let connections: Connection[];
     before(async () => {

--- a/test/other-issues/sqlite-bulk-save/sqlite-bulk-save.ts
+++ b/test/other-issues/sqlite-bulk-save/sqlite-bulk-save.ts
@@ -3,7 +3,7 @@ import {closeTestingConnections, createTestingConnections, reloadTestingDatabase
 import {Connection} from "../../../src/connection/Connection";
 import {Post} from "./entity/Post";
 
-describe.only("other issues > bulk save in sqlite", () => {
+describe("other issues > bulk save in sqlite", () => {
 
     let connections: Connection[];
     before(async () => connections = await createTestingConnections({


### PR DESCRIPTION
@pleerock @Kononnable It appears that only 20 tests are being run on the next branch build.

Take a look at the output of the vNext build vs master build.

vNext build: https://travis-ci.org/typeorm/typeorm/jobs/437460875
master build: https://travis-ci.org/typeorm/typeorm/jobs/437717744

It appears that some .only statements are causing a subset of the tests to run. In this PR I've removed those and you can see that more than 20 tests are now running:
https://travis-ci.org/csuich2/typeorm/jobs/437822569