### PR TITLE
Fix duplicate unique index removal in mysql

### DIFF
--- a/src/schema-builder/table/Table.ts
+++ b/src/schema-builder/table/Table.ts
@@ -222,7 +222,7 @@ export class Table {
             if (index.columnNames.length === 1 && index.isUnique && isMysql) {
                 const column = this.columns.find(c => c.name === index.columnNames[0]);
                 if (column)
-                    column.isUnique = false;
+                    column.isUnique = this.indices.some(ind => ind.columnNames.length === 1 && ind.columnNames[0] === column.name && !!index.isUnique);
             }
         }
     }


### PR DESCRIPTION
With https://github.com/typeorm/typeorm/issues/1686#issuecomment-382204047 at some point, you get 3 indices on uuid : `FK_`, `REL_` and `IDX_`. `IDX_` is a duplicate of `REL_` and should be removed.

When the schema builder tries to remove `IDX_`, it resets `tableColumn.isUnique` to false even if the `REL_` index keeps it unique. The column is then seen as changed and thus foreign key is dropped and recreated and `IDX_` is also recreated.

I've changed `Table.removeIndex()` to check for other unique indices.

I'm not sure how to add tests.
And `Table.removeUniqueConstraint()` should maybe be changed the same way for other dbms.