### PR TITLE
QueryBuilder getCount() fails when counting projected dataset

### DIFF
--- a/test/functional/query-builder/count/entity/Image.ts
+++ b/test/functional/query-builder/count/entity/Image.ts
@@ -1,0 +1,15 @@
+import {Entity} from "../../../../../src/decorator/entity/Entity";
+import {PrimaryGeneratedColumn} from "../../../../../src/decorator/columns/PrimaryGeneratedColumn";
+import { ManyToOne } from "../../../../../src";
+
+import { User } from "./User";
+
+@Entity()
+export class Image {
+
+    @PrimaryGeneratedColumn()
+    id: number;
+
+    @ManyToOne(type => User)
+    user: User;
+}

--- a/test/functional/query-builder/count/entity/User.ts
+++ b/test/functional/query-builder/count/entity/User.ts
@@ -1,0 +1,15 @@
+import {Entity} from "../../../../../src/decorator/entity/Entity";
+import {PrimaryGeneratedColumn} from "../../../../../src/decorator/columns/PrimaryGeneratedColumn";
+import { OneToMany } from "../../../../../src";
+
+import { Image } from "./Image";
+
+@Entity()
+export class User {
+
+    @PrimaryGeneratedColumn()
+    id: number;
+
+    @OneToMany(type => Image, image => image.user)
+    images: Image[];
+}

--- a/test/functional/query-builder/count/query-builder-count.ts
+++ b/test/functional/query-builder/count/query-builder-count.ts
@@ -1,0 +1,66 @@
+import "reflect-metadata";
+import {expect} from "chai";
+import {closeTestingConnections, createTestingConnections, reloadTestingDatabases} from "../../../utils/test-utils";
+import {Connection} from "../../../../src/connection/Connection";
+import {Image} from "./entity/Image";
+import {User} from "./entity/User";
+
+describe("query builder > count", () => {
+    let connections: Connection[];
+    before(async () => {
+        connections = await createTestingConnections({
+            entities: [__dirname + "/entity/*{.js,.ts}"],
+        });
+
+        await Promise.all(connections.map(async connection => {
+            await reloadTestingDatabases(connections);
+
+            const user1 = new User();
+            await connection.manager.save(user1);
+
+            const user1Images = Array(5).fill(true).map(() => {
+                const image = new Image();
+                image.user = user1;
+                return image;
+            });
+            await connection.manager.save(user1Images);
+
+            const user2 = new User();
+            await connection.manager.save(user2);
+
+            const user2Images = Array(10).fill(true).map(() => {
+                const image = new Image();
+                image.user = user1;
+                return image;
+            });
+            await connection.manager.save(user2Images);
+        }));
+    });
+    after(() => closeTestingConnections(connections));
+
+    it("counts entities", () => Promise.all(connections.map(async connection => {
+        const count = await connection.manager.createQueryBuilder(Image, "image")
+            .getCount();
+
+        expect(count).to.eql(15);
+    })));
+
+    it("counts entities with a 'raw' query", () => Promise.all(connections.map(async connection => {
+        const escapedUserId = connection.driver.escape("userId");
+        const escapedImageCount = connection.driver.escape("imageCount");
+
+        const imageCountByUserQuery = connection.manager.createQueryBuilder(Image, "image")
+            .select(escapedUserId)
+            .addSelect(`count(*)`, `imageCount`)
+            .groupBy(escapedUserId);
+
+        const matchingUsersQuery = connection.manager.createQueryBuilder()
+            .select(`userId, imageCount`)
+            .from(`(${imageCountByUserQuery.getQuery()})`, "imageCounts")
+            .where(`${escapedImageCount} >= :minImageCount`, { minImageCount: 6 });
+
+        const count = await matchingUsersQuery.getCount();
+
+        expect(count).to.eql(1);
+    })));
+});


### PR DESCRIPTION
I run into this issue where I was attempting to do some aggregation in a subquery, then count the results based on a where condition. I found that QueryBuilder getCount() was requiring that the alias have metadata, which mine did not.

My solution is to check if the entity *has* metadata, and if not, use a simple `COUNT(*) as "cnt"` select.