### PR TITLE
Documentation: Fix example using numeric type with length type parameter

### DIFF
--- a/docs/entities.md
+++ b/docs/entities.md
@@ -283,7 +283,7 @@ For example:
 or
 
 ```typescript
-@Column({ type: "int", length: 200 })
+@Column({ type: "int", width: 200 })
 ```
 
 ### Column types for `mysql` / `mariadb`


### PR DESCRIPTION
The following example from the documentation doesn't work:

```ts
@Column({ type: "int", length: 200 })
```

When I try doing something similar I get the error:

```
Error: Column foo of Entity Bar does not support length property.
```

Per #1872 it appears that the API was changed and that one should now use `width` together with numeric types. This PR changes the documentation accordingly.