### PR TITLE
postgres: return whole result on updates and deletes

### DIFF
--- a/src/driver/postgres/PostgresQueryRunner.ts
+++ b/src/driver/postgres/PostgresQueryRunner.ts
@@ -174,7 +174,8 @@ export class PostgresQueryRunner extends BaseQueryRunner implements QueryRunner 
                         this.driver.connection.logger.logQueryError(err, query, parameters, this);
                         fail(new QueryFailedError(query, parameters, err));
                     } else {
-                        ok(result.rows);
+                        const wholeResult = result.command === "DELETE" || result.command === "UPDATE";
+                        ok(wholeResult ? result : result.rows);
                     }
                 });
 

--- a/src/query-builder/ReturningResultsEntityUpdator.ts
+++ b/src/query-builder/ReturningResultsEntityUpdator.ts
@@ -40,7 +40,14 @@ export class ReturningResultsEntityUpdator {
                         return newRaw;
                     }, {} as ObjectLiteral);
                 }
-                const result = updateResult.raw instanceof Array ? updateResult.raw[entityIndex] : updateResult.raw;
+                let result;
+                if (updateResult.raw instanceof Array) {
+                    result = updateResult.raw[entityIndex];
+                } else if (updateResult.raw.rows) {
+                    result = updateResult.raw.rows[entityIndex];
+                } else {
+                    result = updateResult.raw;
+                }
                 const returningColumns = this.queryRunner.connection.driver.createGeneratedMap(metadata, result);
                 if (returningColumns) {
                     this.queryRunner.manager.merge(metadata.target, entity, returningColumns);


### PR DESCRIPTION
Currently on updates and deletes nothing useful is returned to the caller. By returning the whole result from the postgres driver we can know how many rows were altered, etc.

Addresses: #2415, #1308, #2578 