### PR TITLE
fix(pgsql): empty array enum cols

### DIFF
--- a/src/driver/postgres/PostgresDriver.ts
+++ b/src/driver/postgres/PostgresDriver.ts
@@ -453,7 +453,7 @@ export class PostgresDriver implements Driver {
 
         // manually convert enum array to array of values (pg does not support, see https://github.com/brianc/node-pg-types/issues/56)
         if (columnMetadata.enum && columnMetadata.isArray)
-            value = (value as string).substr(1).substr(0, (value as string).length - 2).split(",");
+            value = value !== "{}" ? (value as string).substr(1, (value as string).length - 2).split(",") : [];
 
         if (columnMetadata.transformer)
             value = columnMetadata.transformer.from(value);

--- a/test/github-issues/2871/documentEnum.ts
+++ b/test/github-issues/2871/documentEnum.ts
@@ -1,0 +1,7 @@
+export enum DocumentEnum {
+  NONE = "",
+  DOCUMENT_A = "DOCUMENT_A",
+  DOCUMENT_B = "DOCUMENT_B",
+  DOCUMENT_C = "DOCUMENT_C",
+  DOCUMENT_D = "DOCUMENT_D",
+}

--- a/test/github-issues/2871/entity/Bar.ts
+++ b/test/github-issues/2871/entity/Bar.ts
@@ -1,0 +1,18 @@
+import { BaseEntity, Column, PrimaryGeneratedColumn } from "../../../../src";
+
+import { Entity } from "../../../../src/decorator/entity/Entity";
+
+import {DocumentEnum} from "../documentEnum";
+import {getEnumValues} from "../enumTools";
+
+@Entity()
+export class Bar extends BaseEntity {
+  @PrimaryGeneratedColumn() barId: number;
+
+  @Column({
+    type: "enum",
+    enum: getEnumValues(DocumentEnum),
+    array: true,
+  })
+  documents: DocumentEnum[];
+}

--- a/test/github-issues/2871/enumTools.ts
+++ b/test/github-issues/2871/enumTools.ts
@@ -1,0 +1,22 @@
+/**
+ * Returns available values of an enum
+ *
+ * @example
+ * ```
+ *  enum LambdaEnum {
+ *    NONE = 0,
+ *    A = 1,
+ *    B = 2,
+ * }
+ * // become => { "0": "NONE", "1": "A", "2": "B", "NONE": 0, "A": 1, "B": 2}
+ *
+ * const values = getEnumValues(LambdaEnum); // returns [ 0, 1, 2 ]
+ * ```
+ * @param enumObj
+ * @returns The values of the enum
+ */
+export function getEnumValues<T>(enumObj: T): Array<T[keyof T]> {
+  return Object.keys(enumObj)
+      .filter(key => isNaN(parseInt(key, 10)))
+      .map(key => (enumObj as any)[key]);
+}

--- a/test/github-issues/2871/issue-2871.ts
+++ b/test/github-issues/2871/issue-2871.ts
@@ -1,0 +1,53 @@
+import "reflect-metadata";
+import {expect} from "chai";
+
+import {closeTestingConnections, reloadTestingDatabases, setupSingleTestingConnection} from "../../utils/test-utils";
+import {Connection} from "../../../src/connection/Connection";
+import {createConnection, Repository} from "../../../src";
+
+import {Bar} from "./entity/Bar";
+import {DocumentEnum} from "./documentEnum";
+
+describe("github issues > #2871 Empty enum array is returned as array with single empty string", () => {
+  let connection: Connection;
+  let repository: Repository<Bar>;
+
+  before(async () => connection = await createConnection(setupSingleTestingConnection("postgres", {
+    entities: [__dirname + "/entity/*{.js,.ts}"],
+    schemaCreate: true,
+    dropSchema: true,
+  })));
+  beforeEach(async () => {
+    await reloadTestingDatabases([connection]);
+    repository = connection.getRepository(Bar);
+  });
+  after(() => closeTestingConnections([connection]));
+
+  it("should extract array with values from enum array values from 'postgres'", async () => {
+    const documents: DocumentEnum[] = [DocumentEnum.DOCUMENT_A, DocumentEnum.DOCUMENT_B, DocumentEnum.DOCUMENT_C];
+
+    const barSaved = await repository.save({documents}) as Bar;
+    const barFromDb = await repository.findOne(barSaved.barId) as Bar;
+
+    expect(barFromDb.documents).to.eql(documents);
+  });
+
+  it("should extract array with one value from enum array with one value from 'postgres'", async () => {
+    const documents: DocumentEnum[] = [DocumentEnum.DOCUMENT_D];
+
+    const barSaved = await repository.save({documents}) as Bar;
+    const barFromDb = await repository.findOne(barSaved.barId) as Bar;
+
+    expect(barFromDb.documents).to.eql(documents);
+  });
+
+  // This `it` test that issue #2871 is fixed
+  it("should extract empty array from empty enum array from 'postgres'", async () => {
+    const documents: DocumentEnum[] = [];
+
+    const barSaved = await repository.save({documents}) as Bar;
+    const barFromDb = await repository.findOne(barSaved.barId) as Bar;
+
+    expect(barFromDb.documents).to.eql(documents);
+  });
+});


### PR DESCRIPTION
Hi,

Closes to this issue: https://github.com/typeorm/typeorm/issues/2871, it's a quickfix to handle the case when an array of enum is empty within PostgreSQL database.

Current result:
```typescript
    const documents: DocumentEnum[] = [];

    const barSaved = await repository.save({documents}) as Bar;
    const barFromDb = await repository.findOne(barSaved.barId) as Bar;

    expect(barFromDb.documents).to.eql(documents);
    // AssertionError: expected [ '' ] to deeply equal []
```

But, the expected result is that `barFromDb.documents` to be equal `documents`.

Let me know if I can do anything to or if you have any questions.

Many thanks for your work on this amazing project 😃 