### PR TITLE
Clean directories before compile

### DIFF
--- a/package.json
+++ b/package.json
@@ -99,8 +99,8 @@
   },
   "scripts": {
     "test-ci": "gulp ci-tests",
-    "test": "tsc && mocha --file ./build/compiled/test/utils/test-setup.js --bail --recursive --timeout 30000  ./build/compiled/test",
-    "compile": "tsc",
+    "test": "rimraf ./build && tsc && mocha --file ./build/compiled/test/utils/test-setup.js --bail --recursive --timeout 30000  ./build/compiled/test",
+    "compile": "rimraf ./build && tsc",
     "package": "gulp package"
   },
   "bin": {


### PR DESCRIPTION
Use  rimraf module to delete build directory before each build.