### PR TITLE
Use most specific matching relation type

### DIFF
--- a/src/metadata-args/MetadataArgsStorage.ts
+++ b/src/metadata-args/MetadataArgsStorage.ts
@@ -87,7 +87,7 @@ export class MetadataArgsStorage {
     filterRelations(target: Function|string): RelationMetadataArgs[];
     filterRelations(target: (Function|string)[]): RelationMetadataArgs[];
     filterRelations(target: (Function|string)|(Function|string)[]): RelationMetadataArgs[] {
-        return this.filterByTargetAndWithoutDuplicateProperties(this.relations, target);
+        return this.filterByTargetAndWithoutDuplicateRelationProperties(this.relations, target);
     }
 
     filterRelationIds(target: Function|string): RelationIdMetadataArgs[];
@@ -216,6 +216,27 @@ export class MetadataArgsStorage {
             if (sameTarget) {
                 if (!newArray.find(newItem => newItem.propertyName === item.propertyName))
                     newArray.push(item);
+            }
+        });
+        return newArray;
+    }
+
+    /**
+     * Filters given array by a given target or targets and prevents duplicate relation property names.
+     */
+    protected filterByTargetAndWithoutDuplicateRelationProperties<T extends RelationMetadataArgs>(array: T[], target: (Function|string)|(Function|string)[]): T[] {
+        const newArray: T[] = [];
+        array.forEach(item => {
+            const sameTarget = target instanceof Array ? target.indexOf(item.target) !== -1 : item.target === target;
+            if (sameTarget) {
+                const existingIndex = newArray.findIndex(newItem => newItem.propertyName === item.propertyName);
+                if (target instanceof Array && existingIndex !== -1 && target.indexOf(item.target) < target.indexOf(newArray[existingIndex].target)) {
+                    const clone = Object.create(newArray[existingIndex]);
+                    clone.type = item.type;
+                    newArray[existingIndex] = clone;
+                } else if (existingIndex === -1) {
+                    newArray.push(item);
+                }
             }
         });
         return newArray;

--- a/src/metadata-builder/EntityMetadataBuilder.ts
+++ b/src/metadata-builder/EntityMetadataBuilder.ts
@@ -415,8 +415,17 @@ export class EntityMetadataBuilder {
         entityMetadata.ownRelations = this.metadataArgsStorage.filterRelations(entityMetadata.inheritanceTree).map(args => {
 
             // for single table children we reuse relations created for their parents
-            if (entityMetadata.tableType === "entity-child")
-                return entityMetadata.parentEntityMetadata.ownRelations.find(relation => relation.propertyName === args.propertyName)!;
+            if (entityMetadata.tableType === "entity-child") {
+                const parentRelation = entityMetadata.parentEntityMetadata.ownRelations.find(relation => relation.propertyName === args.propertyName)!;
+                const type = args.type instanceof Function ? (args.type as () => any)() : args.type;
+                if (parentRelation.type !== type) {
+                    const clone = Object.create(parentRelation);
+                    clone.type = type;
+                    return clone;
+                }
+
+                return parentRelation;
+            }
 
             return new RelationMetadata({ entityMetadata, args });
         });

--- a/test/functional/table-inheritance/single-table/no-type-column/entity/Author.ts
+++ b/test/functional/table-inheritance/single-table/no-type-column/entity/Author.ts
@@ -1,0 +1,10 @@
+import * as TypeOrm from "../../../../../../src";
+import {Person} from "./Person";
+
+@TypeOrm.Entity({name: "person"})
+export class Author extends Person {
+
+    @TypeOrm.Column({default: null})
+    public authorName: string;
+
+}

--- a/test/functional/table-inheritance/single-table/no-type-column/entity/Employee.ts
+++ b/test/functional/table-inheritance/single-table/no-type-column/entity/Employee.ts
@@ -1,0 +1,10 @@
+import * as TypeOrm from "../../../../../../src";
+import {Person} from "./Person";
+
+@TypeOrm.Entity({name: "person"})
+export class Employee extends Person {
+
+    @TypeOrm.Column({default: null})
+    public employeeName: string;
+
+}

--- a/test/functional/table-inheritance/single-table/no-type-column/entity/Note.ts
+++ b/test/functional/table-inheritance/single-table/no-type-column/entity/Note.ts
@@ -1,0 +1,17 @@
+import * as TypeOrm from "../../../../../../src";
+import {Person} from "./Person";
+
+@TypeOrm.Entity()
+@TypeOrm.TableInheritance({column: {type: "varchar", name: "type"}})
+export class Note {
+
+    @TypeOrm.PrimaryGeneratedColumn()
+    public id: number;
+
+    @TypeOrm.Column({default: null})
+    public label?: string;
+
+    @TypeOrm.ManyToOne(() => Person)
+    public owner: Person;
+
+}

--- a/test/functional/table-inheritance/single-table/no-type-column/entity/Person.ts
+++ b/test/functional/table-inheritance/single-table/no-type-column/entity/Person.ts
@@ -1,0 +1,16 @@
+import * as TypeOrm from "../../../../../../src";
+import {Note} from "./Note";
+
+@TypeOrm.Entity({name: "person"})
+export class Person {
+
+    @TypeOrm.PrimaryGeneratedColumn()
+    public id: number;
+
+    @TypeOrm.Column()
+    public name: string;
+
+    @TypeOrm.OneToMany(() => Note, note => note.owner)
+    public notes: Note[];
+
+}

--- a/test/functional/table-inheritance/single-table/no-type-column/entity/PostItNote.ts
+++ b/test/functional/table-inheritance/single-table/no-type-column/entity/PostItNote.ts
@@ -1,0 +1,14 @@
+import * as TypeOrm from "../../../../../../src";
+import {Note} from "./Note";
+import {Employee} from "./Employee";
+
+@TypeOrm.ChildEntity()
+export class PostItNote extends Note {
+
+    @TypeOrm.Column()
+    public postItNoteLabel: string;
+
+    @TypeOrm.ManyToOne(() => Employee, person => person.notes)
+    public owner: Employee;
+
+}

--- a/test/functional/table-inheritance/single-table/no-type-column/entity/StickyNote.ts
+++ b/test/functional/table-inheritance/single-table/no-type-column/entity/StickyNote.ts
@@ -1,0 +1,14 @@
+import * as TypeOrm from "../../../../../../src";
+import {Note} from "./Note";
+import {Author} from "./Author";
+
+@TypeOrm.ChildEntity()
+export class StickyNote extends Note {
+
+    @TypeOrm.Column()
+    public stickyNoteLabel: string;
+
+    @TypeOrm.ManyToOne(() => Author, author => author.notes)
+    public owner: Author;
+
+}

--- a/test/functional/table-inheritance/single-table/no-type-column/no-type-column.ts
+++ b/test/functional/table-inheritance/single-table/no-type-column/no-type-column.ts
@@ -1,0 +1,58 @@
+import "reflect-metadata";
+import {closeTestingConnections, createTestingConnections, reloadTestingDatabases} from "../../../../utils/test-utils";
+import {Connection} from "../../../../../src";
+import {Author} from "./entity/Author";
+import {Employee} from "./entity/Employee";
+import {PostItNote} from "./entity/PostItNote";
+import {StickyNote} from "./entity/StickyNote";
+
+describe("table-inheritance > single-table > no-type-column", () => {
+
+    let connections: Connection[];
+    before(async () => connections = await createTestingConnections({
+        entities: [__dirname + "/entity/*{.js,.ts}"]
+    }));
+    beforeEach(() => reloadTestingDatabases(connections));
+    after(() => closeTestingConnections(connections));
+
+    it("should return subclass in relations", () => Promise.all(connections.map(async connection => {
+
+        const postItRepo = connection.getRepository(PostItNote);
+        const stickyRepo = connection.getRepository(StickyNote);
+
+        // -------------------------------------------------------------------------
+        // Create
+        // -------------------------------------------------------------------------
+
+        const employee = new Employee();
+        employee.name = "alicefoo";
+        employee.employeeName = "Alice Foo";
+        await connection.getRepository(Employee).save(employee);
+
+        const author = new Author();
+        author.name = "bobbar";
+        author.authorName = "Bob Bar";
+        await connection.getRepository(Author).save(author);
+
+        await postItRepo.insert({ postItNoteLabel: "A post-it note", owner: employee } as PostItNote);
+        await stickyRepo.insert({ stickyNoteLabel: "A sticky note", owner: author } as StickyNote);
+
+        // -------------------------------------------------------------------------
+        // Select
+        // -------------------------------------------------------------------------
+
+        const postIt = await postItRepo.findOne({ relations: [ "owner" ] }) as PostItNote;
+
+        postIt.owner.should.be.an.instanceOf(Employee);
+        postIt.owner.name.should.be.equal("alicefoo");
+        postIt.owner.employeeName.should.be.equal("Alice Foo");
+
+        const sticky = await stickyRepo.findOne({ relations: [ "owner" ] }) as StickyNote;
+
+        sticky.owner.should.be.an.instanceOf(Author);
+        sticky.owner.name.should.be.equal("bobbar");
+        sticky.owner.authorName.should.be.equal("Bob Bar");
+
+    })));
+
+});


### PR DESCRIPTION
This allows using a single table for multiple entities without using a
type column. Some databases infer the type from the context of how/where
the row is loaded.