### PR TITLE
Add support to Mysql / Postgres for duplicate entry update or ignore

### DIFF
--- a/src/query-builder/InsertQueryBuilder.ts
+++ b/src/query-builder/InsertQueryBuilder.ts
@@ -226,6 +226,29 @@ export class InsertQueryBuilder<Entity> extends QueryBuilder<Entity> {
         return this;
     }
 
+    /**
+     * Adds additional ignore statement supported in databases.
+     */
+    orIgnore(statement: string | boolean = true): this {
+        this.expressionMap.onIgnore = statement;
+        return this;
+    }
+
+    /**
+     * Adds additional update statement supported in databases.
+     */
+    orUpdate(statement?: { columns?: string[], conflict_target?: string | string[] }): this {
+      this.expressionMap.onUpdate = {};
+      if (statement && statement.conflict_target instanceof Array)
+          this.expressionMap.onUpdate.conflict = ` ( ${statement.conflict_target.join(", ")} ) `;
+      if (statement && typeof statement.conflict_target === "string")
+          this.expressionMap.onUpdate.conflict = ` ON CONSTRAINT ${statement.conflict_target} `;
+      if (statement && statement.columns instanceof Array)
+          this.expressionMap.onUpdate.columns = statement.columns.map(column => `${column} = :${column}`).join(", ");
+      return this;
+  }
+
+
     // -------------------------------------------------------------------------
     // Protected Methods
     // -------------------------------------------------------------------------
@@ -234,14 +257,17 @@ export class InsertQueryBuilder<Entity> extends QueryBuilder<Entity> {
      * Creates INSERT express used to perform insert query.
      */
     protected createInsertExpression() {
-
         const tableName = this.getTableName(this.getMainTableName());
         const valuesExpression = this.createValuesExpression(); // its important to get values before returning expression because oracle rely on native parameters and ordering of them is important
         const returningExpression = this.createReturningExpression();
         const columnsExpression = this.createColumnNamesExpression();
+        let query = "INSERT "
 
-        // generate INSERT query
-        let query = `INSERT INTO ${tableName}`;
+        if(this.connection.driver instanceof MysqlDriver) {
+          query+= `${this.expressionMap.onIgnore ? " IGNORE " : ""}`
+        }
+
+        query += `INTO ${tableName}`;
 
         // add columns expression
         if (columnsExpression) {
@@ -266,9 +292,12 @@ export class InsertQueryBuilder<Entity> extends QueryBuilder<Entity> {
                 query += ` DEFAULT VALUES`;
             }
         }
-
-        if (this.expressionMap.onConflict && this.connection.driver instanceof PostgresDriver) {
-            query += ` ON CONFLICT ` + this.expressionMap.onConflict;
+        if (this.connection.driver instanceof PostgresDriver) {
+            query += `${this.expressionMap.onIgnore ? " ON CONFLICT DO NOTHING " : ""}`
+            query += `${this.expressionMap.onUpdate ? " ON CONFLICT " + this.expressionMap.onUpdate.conflict + " DO UPDATE SET " + this.expressionMap.onUpdate.columns : ""}`
+            query += `${this.expressionMap.onConflict ? " ON CONFLICT " + this.expressionMap.onConflict : ""}`
+        } else if (this.connection.driver instanceof MysqlDriver) {
+            query+= `${this.expressionMap.onUpdate ? " ON DUPLICATE KEY UPDATE " + this.expressionMap.onUpdate.columns : ""}`;
         }
 
         // add RETURNING expression

--- a/src/query-builder/QueryExpressionMap.ts
+++ b/src/query-builder/QueryExpressionMap.ts
@@ -73,6 +73,16 @@ export class QueryExpressionMap {
     onConflict: string = "";
 
     /**
+     * Optional on ignore statement used in insertion query in databases.
+     */
+    onIgnore: string | boolean = false;
+
+    /**
+     * Optional on update statement used in insertion query in databases.
+     */
+    onUpdate: { columns?: string, conflict?: string };
+
+    /**
      * JOIN queries.
      */
     joinAttributes: JoinAttribute[] = [];
@@ -368,6 +378,8 @@ export class QueryExpressionMap {
         map.valuesSet = this.valuesSet;
         map.returning = this.returning;
         map.onConflict = this.onConflict;
+        map.onIgnore = this.onIgnore;
+        map.onUpdate = this.onUpdate;
         map.joinAttributes = this.joinAttributes.map(join => new JoinAttribute(this.connection, this, join));
         map.relationIdAttributes = this.relationIdAttributes.map(relationId => new RelationIdAttribute(this, relationId));
         map.relationCountAttributes = this.relationCountAttributes.map(relationCount => new RelationCountAttribute(this, relationCount));

--- a/test/github-issues/1780/entity/User.ts
+++ b/test/github-issues/1780/entity/User.ts
@@ -1,0 +1,16 @@
+import {Entity} from "../../../../src/decorator/entity/Entity";
+import {Column} from "../../../../src/decorator/columns/Column";
+import {PrimaryGeneratedColumn} from "../../../../src/decorator/columns/PrimaryGeneratedColumn";
+import {Index} from "../../../../src/decorator/Index";
+ @Entity()
+@Index("unique_idx", ["first_name", "last_name"], { unique: true })
+export class User {
+     @PrimaryGeneratedColumn()
+    id: number;
+     @Column({ type: "varchar", length: 100 })
+    first_name: string;
+     @Column({ type: "varchar", length: 100 })
+    last_name: string;
+     @Column({ type: "varchar", length: 100 })
+    is_updated: string;
+ }

--- a/test/github-issues/1780/issue-1780.ts
+++ b/test/github-issues/1780/issue-1780.ts
@@ -1,0 +1,160 @@
+import "reflect-metadata";
+import {createTestingConnections, closeTestingConnections, reloadTestingDatabases} from "../../utils/test-utils";
+import {Connection} from "../../../src/connection/Connection";
+import {expect} from "chai";
+import {User} from "./entity/User";
+import {MysqlDriver} from "../../../src/driver/mysql/MysqlDriver";
+import {PostgresDriver} from "../../../src/driver/postgres/PostgresDriver";
+describe("github issues > #1780 Support for insertion ignore on duplicate error", () => {
+     let connections: Connection[];
+    before(async () => connections = await createTestingConnections({
+        entities: [User],
+        schemaCreate: true,
+        dropSchema: true,
+    }));
+    beforeEach(() => reloadTestingDatabases(connections));
+    after(() => closeTestingConnections(connections));
+     let user1 = new User();
+    user1.first_name = "John";
+    user1.last_name = "Lenon";
+    user1.is_updated = "no";
+     let user2 = new User();
+    user2.first_name = "John";
+    user2.last_name = "Lenon";
+    user2.is_updated = "yes";
+     // let data = [user1, user2];
+    // Bulk insertion with duplicated data through same query with duplicate error exception is not supported in PostgreSQL
+    // https://doxygen.postgresql.org/nodeModifyTable_8c_source.html : Line 1356
+     it("should save one row without duplicate error in MySQL/MariaDB", () => Promise.all(connections.map(async connection => {
+      try {
+         if (connection.driver instanceof MysqlDriver) {
+             const UserRepository = connection.manager.getRepository(User);
+             // ignore while insertion duplicated row
+            await UserRepository
+                .createQueryBuilder()
+                .insert()
+                .orIgnore()
+                .into(User)
+                .values(user1)
+                .execute();
+             await UserRepository
+                .createQueryBuilder()
+                .insert()
+                .orIgnore()
+                .into(User)
+                .values(user2)
+                .execute();
+             let loadedUser_1 = await UserRepository.find();
+            expect(loadedUser_1).not.to.be.empty;
+            loadedUser_1.length.should.be.equal(1);
+             // remove all rows
+            await UserRepository.remove(loadedUser_1);
+             let loadedUser_2 = await UserRepository.find();
+            expect(loadedUser_2).to.be.empty;
+             // update while insertion duplicated row
+            await UserRepository
+                .createQueryBuilder()
+                .insert()
+                .orUpdate({ columns: [ "is_updated" ] })
+                .setParameter("is_updated", user1.is_updated)
+                .into(User)
+                .values(user1)
+                .execute();
+             await UserRepository
+                .createQueryBuilder()
+                .insert()
+                .orUpdate({ columns: [ "is_updated" ] })
+                .setParameter("is_updated", user2.is_updated)
+                .into(User)
+                .values(user2)
+                .execute();
+             let loadedUser_3 = await UserRepository.find();
+            expect(loadedUser_3).not.to.be.empty;
+            loadedUser_3.length.should.be.equal(1);
+            expect(loadedUser_3[0]).to.include({ first_name: "John", last_name: "Lenon", is_updated: "yes" });
+        }
+       } catch (err) {
+           throw new Error(err);
+      }
+     })));
+     it("should save one row without duplicate error in PostgreSQL", () => Promise.all(connections.map(async connection => {
+         try {
+            if (connection.driver instanceof PostgresDriver) {
+
+                const UserRepository = connection.manager.getRepository(User);
+                 // ignore while insertion duplicated row
+                await UserRepository
+                    .createQueryBuilder()
+                    .insert()
+                    .orIgnore()
+                    .into(User)
+                    .values(user1)
+                    .execute();
+                 await UserRepository
+                    .createQueryBuilder()
+                    .insert()
+                    .orIgnore()
+                    .into(User)
+                    .values(user2)
+                    .execute();
+                 let loadedUser_1 = await UserRepository.find();
+                expect(loadedUser_1).not.to.be.empty;
+                loadedUser_1.length.should.be.equal(1);
+                 // remove all rows
+                await UserRepository.remove(loadedUser_1);
+                 let loadedUser_2 = await UserRepository.find();
+                expect(loadedUser_2).to.be.empty;
+                 // update while insertion duplicated row via unique columns
+                await UserRepository
+                    .createQueryBuilder()
+                    .insert()
+                    .orUpdate({ columns: [ "is_updated" ], conflict_target: [ "first_name", "last_name" ] })
+                    .setParameter("is_updated", user1.is_updated)
+                    .into(User)
+                    .values(user1)
+                    .execute();
+                 await UserRepository
+                    .createQueryBuilder()
+                    .insert()
+                    .orUpdate({ columns: [ "is_updated" ], conflict_target: [ "first_name", "last_name" ] })
+                    .setParameter("is_updated", user2.is_updated)
+                    .into(User)
+                    .values(user2)
+                    .execute();
+                 let loadedUser_3 = await UserRepository.find();
+                expect(loadedUser_3).not.to.be.empty;
+                loadedUser_3.length.should.be.equal(1);
+                expect(loadedUser_3[0]).to.include({ first_name: "John", last_name: "Lenon", is_updated: "yes" });
+                 // create unique constraint
+                await connection.manager.query("ALTER TABLE \"user\" ADD CONSTRAINT constraint_unique_idx UNIQUE USING INDEX unique_idx;");
+                 await UserRepository.remove(loadedUser_3);
+                 let loadedUser_4 = await UserRepository.find();
+                expect(loadedUser_4).to.be.empty;
+                 // update while insertion duplicated row via unique's constraint name
+                await UserRepository
+                    .createQueryBuilder()
+                    .insert()
+                    .orUpdate({ columns: [ "is_updated" ], conflict_target: "constraint_unique_idx" })
+                    .setParameter("is_updated", user1.is_updated)
+                    .into(User)
+                    .values(user1)
+                    .execute();
+                 await UserRepository
+                    .createQueryBuilder()
+                    .insert()
+                    .orUpdate({ columns: [ "is_updated" ], conflict_target: "constraint_unique_idx" })
+                    .setParameter("is_updated", user2.is_updated)
+                    .into(User)
+                    .values(user2)
+                    .execute();
+                 let loadedUser_5 = await UserRepository.find();
+                expect(loadedUser_5).not.to.be.empty;
+                loadedUser_5.length.should.be.equal(1);
+                expect(loadedUser_3[0]).to.include({ first_name: "John", last_name: "Lenon", is_updated: "yes" });
+            }
+        }
+        catch (err) {
+           throw new Error(err);
+        }
+    })));
+ });


### PR DESCRIPTION
Hello, starting from issue #1780 and its relative PR #1793 I've updated the code of #1793 which now is based on the current master.
This solves #1780, support is provided only for MySql and Postgres at the moment.