### PR TITLE
Only check for discriminator conflicts on STI entities

### DIFF
--- a/src/metadata-builder/EntityMetadataValidator.ts
+++ b/src/metadata-builder/EntityMetadataValidator.ts
@@ -58,7 +58,7 @@ export class EntityMetadataValidator {
 
         // validate if table is using inheritance it has a discriminator
         // also validate if discriminator values are not empty and not repeated
-        if (entityMetadata.inheritancePattern === "STI") {
+        if (entityMetadata.inheritancePattern === "STI" || entityMetadata.tableType === "entity-child") {
             if (!entityMetadata.discriminatorColumn)
                 throw new Error(`Entity ${entityMetadata.name} using single-table inheritance, it should also have a discriminator column. Did you forget to put discriminator column options?`);
 
@@ -66,7 +66,10 @@ export class EntityMetadataValidator {
                 throw new Error(`Entity ${entityMetadata.name} has empty discriminator value. Discriminator value should not be empty.`);
 
             const sameDiscriminatorValueEntityMetadata = allEntityMetadatas.find(metadata => {
-                return metadata !== entityMetadata && metadata.inheritancePattern === "STI" && metadata.discriminatorValue === entityMetadata.discriminatorValue;
+                return metadata !== entityMetadata
+                    && (metadata.inheritancePattern === "STI" || metadata.tableType === "entity-child")
+                    && metadata.discriminatorValue === entityMetadata.discriminatorValue
+                    && metadata.inheritanceTree.some(parent => entityMetadata.inheritanceTree.indexOf(parent) !== -1);
             });
             if (sameDiscriminatorValueEntityMetadata)
                 throw new Error(`Entities ${entityMetadata.name} and ${sameDiscriminatorValueEntityMetadata.name} have the same discriminator values. Make sure they are different while using the @ChildEntity decorator.`);

--- a/src/metadata-builder/EntityMetadataValidator.ts
+++ b/src/metadata-builder/EntityMetadataValidator.ts
@@ -66,7 +66,7 @@ export class EntityMetadataValidator {
                 throw new Error(`Entity ${entityMetadata.name} has empty discriminator value. Discriminator value should not be empty.`);
 
             const sameDiscriminatorValueEntityMetadata = allEntityMetadatas.find(metadata => {
-                return metadata !== entityMetadata && metadata.discriminatorValue === entityMetadata.discriminatorValue;
+                return metadata !== entityMetadata && metadata.inheritancePattern === "STI" && metadata.discriminatorValue === entityMetadata.discriminatorValue;
             });
             if (sameDiscriminatorValueEntityMetadata)
                 throw new Error(`Entities ${entityMetadata.name} and ${sameDiscriminatorValueEntityMetadata.name} have the same discriminator values. Make sure they are different while using the @ChildEntity decorator.`);

--- a/test/github-issues/2984/entity/commit/note.ts
+++ b/test/github-issues/2984/entity/commit/note.ts
@@ -1,0 +1,9 @@
+import {Entity, PrimaryGeneratedColumn} from "../../../../../src";
+
+@Entity({name: "commitNote"})
+export class Note {
+
+    @PrimaryGeneratedColumn()
+    public id: number;
+
+}

--- a/test/github-issues/2984/entity/issue/note.ts
+++ b/test/github-issues/2984/entity/issue/note.ts
@@ -1,0 +1,10 @@
+import {Entity, PrimaryGeneratedColumn, TableInheritance} from "../../../../../src";
+
+@Entity({name: "issueNote"})
+@TableInheritance({column: {type: "varchar", name: "type"}})
+export class Note {
+
+    @PrimaryGeneratedColumn()
+    public id: number;
+
+}

--- a/test/github-issues/2984/entity/issue/ownernote.ts
+++ b/test/github-issues/2984/entity/issue/ownernote.ts
@@ -1,0 +1,10 @@
+import {ChildEntity, Column} from "../../../../../src";
+import {Note} from "./note";
+
+@ChildEntity()
+export class OwnerNote extends Note {
+
+    @Column()
+    public owner: string;
+
+}

--- a/test/github-issues/2984/entity/wiki/note.ts
+++ b/test/github-issues/2984/entity/wiki/note.ts
@@ -1,0 +1,10 @@
+import {Entity, PrimaryGeneratedColumn, TableInheritance} from "../../../../../src";
+
+@Entity({name: "wikiNote"})
+@TableInheritance({column: {type: "varchar", name: "type"}})
+export class Note {
+
+    @PrimaryGeneratedColumn()
+    public id: number;
+
+}

--- a/test/github-issues/2984/entity/wiki/ownernote.ts
+++ b/test/github-issues/2984/entity/wiki/ownernote.ts
@@ -1,0 +1,10 @@
+import {ChildEntity, Column} from "../../../../../src";
+import {Note} from "./note";
+
+@ChildEntity()
+export class OwnerNote extends Note {
+
+    @Column()
+    public owner: string;
+
+}

--- a/test/github-issues/2984/issue-2984.ts
+++ b/test/github-issues/2984/issue-2984.ts
@@ -1,25 +1,21 @@
 import "reflect-metadata";
 
-import {closeTestingConnections, reloadTestingDatabases, setupSingleTestingConnection} from "../../utils/test-utils";
-import {createConnection, Connection} from "../../../src";
+import {closeTestingConnections, createTestingConnections, reloadTestingDatabases} from "../../utils/test-utils";
+import {Connection} from "../../../src";
 
 describe("github issues > #2984 Discriminator conflict reported even for non-inherited tables", () => {
-    let connection: Connection;
 
-    before(async () => connection = await createConnection(setupSingleTestingConnection("postgres", {
+    let connections: Connection[];
+    before(async () => connections = await createTestingConnections({
         entities: [__dirname + "/entity/**/*{.js,.ts}"],
-        schemaCreate: true,
-        dropSchema: true,
-    })));
-    beforeEach(async () => {
-        await reloadTestingDatabases([connection]);
-    });
-    after(() => closeTestingConnections([connection]));
+    }));
+    beforeEach(() => reloadTestingDatabases(connections));
+    after(() => closeTestingConnections(connections));
 
-    it("should load entities even with the same discriminator", async () => {
+    it("should load entities even with the same discriminator", () => Promise.all(connections.map(async connection => {
         connection.entityMetadatas.should.have.length(2);
         connection.entityMetadatas.forEach(metadata =>
             metadata.discriminatorValue!.should.be.equal("Note"));
-    });
+    })));
 
 });

--- a/test/github-issues/2984/issue-2984.ts
+++ b/test/github-issues/2984/issue-2984.ts
@@ -13,9 +13,9 @@ describe("github issues > #2984 Discriminator conflict reported even for non-inh
     after(() => closeTestingConnections(connections));
 
     it("should load entities even with the same discriminator", () => Promise.all(connections.map(async connection => {
-        connection.entityMetadatas.should.have.length(2);
+        connection.entityMetadatas.should.have.length(5);
         connection.entityMetadatas.forEach(metadata =>
-            metadata.discriminatorValue!.should.be.equal("Note"));
+            metadata.discriminatorValue!.should.be.oneOf(["Note", "OwnerNote"]));
     })));
 
 });

--- a/test/github-issues/2984/issue-2984.ts
+++ b/test/github-issues/2984/issue-2984.ts
@@ -1,0 +1,25 @@
+import "reflect-metadata";
+
+import {closeTestingConnections, reloadTestingDatabases, setupSingleTestingConnection} from "../../utils/test-utils";
+import {createConnection, Connection} from "../../../src";
+
+describe("github issues > #2984 Discriminator conflict reported even for non-inherited tables", () => {
+    let connection: Connection;
+
+    before(async () => connection = await createConnection(setupSingleTestingConnection("postgres", {
+        entities: [__dirname + "/entity/**/*{.js,.ts}"],
+        schemaCreate: true,
+        dropSchema: true,
+    })));
+    beforeEach(async () => {
+        await reloadTestingDatabases([connection]);
+    });
+    after(() => closeTestingConnections([connection]));
+
+    it("should load entities even with the same discriminator", async () => {
+        connection.entityMetadatas.should.have.length(2);
+        connection.entityMetadatas.forEach(metadata =>
+            metadata.discriminatorValue!.should.be.equal("Note"));
+    });
+
+});


### PR DESCRIPTION
If an entity has the same discriminator value as one using
@TableInheritance this should be allowed as there is no way for them to
conflict. Fixes #2984.