### PR TITLE
Make children inherit database option from parent

### DIFF
--- a/src/metadata/EntityMetadata.ts
+++ b/src/metadata/EntityMetadata.ts
@@ -747,7 +747,7 @@ export class EntityMetadata {
         const namingStrategy = this.connection.namingStrategy;
         const entityPrefix = this.connection.options.entityPrefix;
         this.engine = this.tableMetadataArgs.engine;
-        this.database = this.tableMetadataArgs.database;
+        this.database = this.tableMetadataArgs.type === "entity-child" && this.parentEntityMetadata ? this.parentEntityMetadata.database : this.tableMetadataArgs.database;
         this.schema = this.tableMetadataArgs.schema || (this.connection.options as PostgresConnectionOptions|SqlServerConnectionOptions).schema;
         this.givenTableName = this.tableMetadataArgs.type === "entity-child" && this.parentEntityMetadata ? this.parentEntityMetadata.givenTableName : this.tableMetadataArgs.name;
         this.synchronize = this.tableMetadataArgs.synchronize === false ? false : true;

--- a/test/functional/table-inheritance/single-table/database-option-inherited/database-option-inherited.ts
+++ b/test/functional/table-inheritance/single-table/database-option-inherited/database-option-inherited.ts
@@ -1,0 +1,21 @@
+import "reflect-metadata";
+import {closeTestingConnections, createTestingConnections, reloadTestingDatabases} from "../../../../utils/test-utils";
+import {Connection} from "../../../../../src";
+
+describe("table-inheritance > single-table > database-option-inherited", () => {
+
+    let connections: Connection[];
+    before(async () => connections = await createTestingConnections({
+        entities: [__dirname + "/entity/*{.js,.ts}"]
+    }));
+    beforeEach(() => reloadTestingDatabases(connections));
+    after(() => closeTestingConnections(connections));
+
+    it("should correctly inherit database option", () => Promise.all(connections.map(async connection => {
+
+        connection.entityMetadatas.forEach(metadata =>
+            metadata.database!.should.equal("test"));
+
+    })));
+
+});

--- a/test/functional/table-inheritance/single-table/database-option-inherited/entity/Employee.ts
+++ b/test/functional/table-inheritance/single-table/database-option-inherited/entity/Employee.ts
@@ -1,0 +1,11 @@
+import {ChildEntity, Column} from "../../../../../../src";
+
+import {Person} from "./Person";
+
+@ChildEntity()
+export class Employee extends Person {
+
+    @Column()
+    salary: number;
+
+}

--- a/test/functional/table-inheritance/single-table/database-option-inherited/entity/Person.ts
+++ b/test/functional/table-inheritance/single-table/database-option-inherited/entity/Person.ts
@@ -1,0 +1,13 @@
+import {Column, Entity, PrimaryGeneratedColumn, TableInheritance} from "../../../../../../src";
+
+@Entity({database: "test"})
+@TableInheritance({column: {name: "type", type: "varchar"}})
+export class Person {
+
+    @PrimaryGeneratedColumn()
+    id: number;
+
+    @Column()
+    name: string;
+
+}


### PR DESCRIPTION
Without this children use the default database for the connection which may be undefined or not the same as the one on the parent entity.