### PR TITLE
[Docs] Fix typo in connection-options

### DIFF
--- a/docs/connection-options.md
+++ b/docs/connection-options.md
@@ -87,7 +87,7 @@ This option is useful during debug and development.
  Instead, it syncs just by creating indices.
 
 * `migrationsRun` - Indicates if migrations should be auto run on every application launch.
-As an alternative, you can use CLI and run migrations:run command.
+As an alternative, you can use CLI and run migration:run command.
 
 * `migrationsTableName` - Name of the table in the database which is going to contain information about executed migrations.
 By default this table is called "migrations".


### PR DESCRIPTION
Fixes a small typo in the migration command on the [connection-options](http://typeorm.io/#/connection-options) page.