### PR TITLE
Run all tests, not just the one for #2800

### DIFF
--- a/test/github-issues/2800/issue-2800.ts
+++ b/test/github-issues/2800/issue-2800.ts
@@ -17,7 +17,7 @@ describe("github issues > #2800 - Can't override embedded entities in STI implem
 
     after(() => closeTestingConnections(connections));
 
-    it.only("should be able to save entity with embedded entities overriding", () => Promise.all(connections.map(async connection => {
+    it("should be able to save entity with embedded entities overriding", () => Promise.all(connections.map(async connection => {
         await connection.manager.save(Car, connection.manager.create(Car, {
             engine: {
                 horsePower: 42,


### PR DESCRIPTION
The fix for #2800 includes a new test but it uses `it.only()` to run the test which makes mocha skip the rest of them.