### PR TITLE
Fix #3009 use newer extension for postgress UUID gen.

### DIFF
--- a/src/driver/postgres/PostgresDriver.ts
+++ b/src/driver/postgres/PostgresDriver.ts
@@ -299,9 +299,9 @@ export class PostgresDriver implements Driver {
                         if (err) return fail(err);
                         if (hasUuidColumns)
                             try {
-                                await this.executeQuery(connection, `CREATE EXTENSION IF NOT EXISTS "uuid-ossp"`);
+                                await this.executeQuery(connection, `CREATE EXTENSION IF NOT EXISTS "pgcrypto"`);
                             } catch (_) {
-                                logger.log("warn", "At least one of the entities has uuid column, but the 'uuid-ossp' extension cannot be installed automatically. Please install it manually using superuser rights");
+                                logger.log("warn", "At least one of the entities has uuid column, but the 'pgcrypto' extension cannot be installed automatically. Please install it manually using superuser rights");
                             }
                         if (hasCitextColumns)
                             try {

--- a/src/driver/postgres/PostgresQueryRunner.ts
+++ b/src/driver/postgres/PostgresQueryRunner.ts
@@ -1421,7 +1421,7 @@ export class PostgresQueryRunner extends BaseQueryRunner implements QueryRunner 
                             tableColumn.isGenerated = true;
                             tableColumn.generationStrategy = "increment";
 
-                        } else if (/^uuid_generate_v\d\(\)/.test(dbColumn["column_default"])) {
+                        } else if (/^gen_random_uuid\(\)/.test(dbColumn["column_default"])) {
                             tableColumn.isGenerated = true;
                             tableColumn.generationStrategy = "uuid";
 
@@ -1826,7 +1826,7 @@ export class PostgresQueryRunner extends BaseQueryRunner implements QueryRunner 
         if (column.default !== undefined && column.default !== null)
             c += " DEFAULT " + column.default;
         if (column.isGenerated && column.generationStrategy === "uuid" && !column.default)
-            c += " DEFAULT uuid_generate_v4()";
+            c += " DEFAULT gen_random_uuid()";
 
         return c;
     }

--- a/test/functional/schema-builder/change-column.ts
+++ b/test/functional/schema-builder/change-column.ts
@@ -150,7 +150,7 @@ describe("schema builder > change column", () => {
         const queryRunner = connection.createQueryRunner();
 
         if (connection.driver instanceof PostgresDriver)
-            await queryRunner.query(`CREATE EXTENSION IF NOT EXISTS "uuid-ossp"`);
+            await queryRunner.query(`CREATE EXTENSION IF NOT EXISTS "pgcrypto"`);
 
         const postMetadata = connection.getMetadata(Post);
         const idColumn = postMetadata.findColumnWithPropertyName("id")!;


### PR DESCRIPTION
Attention! New extension does not support Old postgres versions: 9.2 / 9.1 / 9.0 / 8.4 / 8.3