### PR TITLE
Add support to use current values in insert Mysql/Postgres

### DIFF
--- a/src/metadata/ColumnMetadata.ts
+++ b/src/metadata/ColumnMetadata.ts
@@ -532,7 +532,7 @@ export class ColumnMetadata {
      * If column is in embedded (or recursive embedded) it extracts its value from there.
      */
      getEntityValue(entity: ObjectLiteral, transform: boolean = false): any|undefined {
-        // if (entity === undefined || entity === null) return undefined; // uncomment if needed
+        if (entity === undefined || entity === null) return undefined;
 
         // extract column value from embeddeds of entity if column is in embedded
         let value: any = undefined;

--- a/src/metadata/RelationMetadata.ts
+++ b/src/metadata/RelationMetadata.ts
@@ -325,7 +325,7 @@ export class RelationMetadata {
      * If column is in embedded (or recursive embedded) it extracts its value from there.
      */
     getEntityValue(entity: ObjectLiteral, getLazyRelationsPromiseValue: boolean = false): any|undefined {
-
+        if (entity === null || entity === undefined) return undefined;
         // extract column value from embeddeds of entity if column is in embedded
         if (this.embeddedMetadata) {
 

--- a/src/query-builder/QueryExpressionMap.ts
+++ b/src/query-builder/QueryExpressionMap.ts
@@ -80,7 +80,7 @@ export class QueryExpressionMap {
     /**
      * Optional on update statement used in insertion query in databases.
      */
-    onUpdate: { columns?: string, conflict?: string };
+    onUpdate: { columns?: string, conflict?: string, overwrite?: string };
 
     /**
      * JOIN queries.

--- a/test/github-issues/3047/entity/User.ts
+++ b/test/github-issues/3047/entity/User.ts
@@ -1,0 +1,16 @@
+import {Entity} from "../../../../src/decorator/entity/Entity";
+import {Column} from "../../../../src/decorator/columns/Column";
+import {PrimaryGeneratedColumn} from "../../../../src/decorator/columns/PrimaryGeneratedColumn";
+import {Index} from "../../../../src/decorator/Index";
+@Entity()
+@Index("unique_idx", ["first_name", "last_name"], { unique: true })
+export class User {
+  @PrimaryGeneratedColumn()
+  id: number;
+  @Column({ type: "varchar", length: 100 })
+  first_name: string;
+  @Column({ type: "varchar", length: 100 })
+  last_name: string;
+  @Column({ type: "varchar", length: 100 })
+  is_updated: string;
+}

--- a/test/github-issues/3047/issue-3047.ts
+++ b/test/github-issues/3047/issue-3047.ts
@@ -1,0 +1,94 @@
+import "reflect-metadata";
+import {createTestingConnections, closeTestingConnections, reloadTestingDatabases} from "../../utils/test-utils";
+import {Connection} from "../../../src/connection/Connection";
+import {expect} from "chai";
+import {User} from "./entity/User";
+import {MysqlDriver} from "../../../src/driver/mysql/MysqlDriver";
+import {PostgresDriver} from "../../../src/driver/postgres/PostgresDriver";
+describe("github issues > #3047 Mysqsl on duplicate key update use current values", () => {
+    let connections: Connection[];
+
+    before(async () => connections = await createTestingConnections({
+        entities: [User],
+        schemaCreate: true,
+        dropSchema: true,
+    }));
+
+    beforeEach(() => reloadTestingDatabases(connections));
+
+    after(() => closeTestingConnections(connections));
+
+    let user1 = new User();
+    user1.first_name = "John";
+    user1.last_name = "Lenon";
+    user1.is_updated = "no";
+
+    let user2 = new User();
+    user2.first_name = "John";
+    user2.last_name = "Lenon";
+    user2.is_updated = "yes";
+
+    it("should overwrite using current value in MySQL/MariaDB", () => Promise.all(connections.map(async connection => {
+      try {
+         if (connection.driver instanceof MysqlDriver) {
+            const UserRepository = connection.manager.getRepository(User);
+
+            await UserRepository
+              .createQueryBuilder()
+              .insert()
+              .into(User)
+              .values(user1)
+              .execute();
+
+            await UserRepository
+              .createQueryBuilder()
+              .insert()
+              .into(User)
+              .values(user2)
+              .orUpdate({ overwrite: ["is_updated"]})
+              .execute();
+
+            let loadedUser = await UserRepository.find();
+            expect(loadedUser).not.to.be.empty;
+            expect(loadedUser).to.have.lengthOf(1);
+            expect(loadedUser[0]).to.includes({ is_updated: "yes" });
+        }
+      } catch (err) {
+        throw new Error(err);
+      }
+     })));
+
+    it("should overwrite using current value in PostgreSQL", () => Promise.all(connections.map(async connection => {
+      try {
+        if (connection.driver instanceof PostgresDriver) {
+
+          const UserRepository = connection.manager.getRepository(User);
+
+          await UserRepository
+            .createQueryBuilder()
+            .insert()
+            .into(User)
+            .values(user1)
+            .execute();
+
+          await UserRepository
+            .createQueryBuilder()
+            .insert()
+            .into(User)
+            .values(user2)
+            .orUpdate({
+              conflict_target: [ "first_name", "last_name" ],
+              overwrite: ["is_updated"],
+            })
+            .execute();
+
+          let loadedUser = await UserRepository.find();
+          expect(loadedUser).not.to.be.empty;
+          expect(loadedUser).to.have.lengthOf(1);
+          expect(loadedUser[0]).to.includes({ is_updated: "yes" });
+        }
+      } catch (err) {
+        throw new Error(err);
+      }
+    })));
+ });


### PR DESCRIPTION
In Mysql / Postgres add support to update record during INSERT on conflict / duplicate key using current values, implements, fixes #3047 