### PR TITLE
Fix invalid SQL syntax when using distinct and addSelect on Postgresql

### DIFF
--- a/src/query-builder/SelectQuery.ts
+++ b/src/query-builder/SelectQuery.ts
@@ -1,5 +1,6 @@
 export interface SelectQuery {
     selection: string;
+    columnPath?: string;
     aliasName?: string;
     virtual?: boolean;
 }

--- a/test/github-issues/2641/entity/Bar.ts
+++ b/test/github-issues/2641/entity/Bar.ts
@@ -1,0 +1,18 @@
+import {Column, PrimaryGeneratedColumn, ManyToOne} from "../../../../src";
+import {Entity} from "../../../../src/decorator/entity/Entity";
+import {Foo} from "./Foo";
+
+@Entity()
+export class Bar {
+    @PrimaryGeneratedColumn()
+    id: number;
+
+    @Column()
+    name: string;
+
+    @Column()
+    description: string;
+
+    @ManyToOne(() => Foo, foo => foo.bar)
+    public foo: Foo;
+}

--- a/test/github-issues/2641/entity/Foo.ts
+++ b/test/github-issues/2641/entity/Foo.ts
@@ -1,0 +1,16 @@
+import {Column, PrimaryGeneratedColumn, OneToMany} from "../../../../src";
+import {Entity} from "../../../../src/decorator/entity/Entity";
+import {Bar} from "./Bar";
+
+@Entity("foo")
+export class Foo {
+
+    @PrimaryGeneratedColumn()
+    id: number;
+
+    @Column()
+    name: string;
+
+    @OneToMany(() => Bar, bar => bar.foo)
+    public bar: Bar;
+}

--- a/test/github-issues/2641/issue-2641.ts
+++ b/test/github-issues/2641/issue-2641.ts
@@ -1,0 +1,55 @@
+import "reflect-metadata";
+import {closeTestingConnections, createTestingConnections, reloadTestingDatabases} from "../../utils/test-utils";
+import {Connection} from "../../../src/connection/Connection";
+import {Foo} from "./entity/Foo";
+import {Bar} from "./entity/Bar";
+
+describe("github issues > #2641 - DISTINCT in query builder", () => {
+
+    let connections: Connection[];
+    before(async () => connections = await createTestingConnections({
+        entities: [__dirname + "/entity/*{.js,.ts}"],
+        enabledDrivers: ["postgres"]
+    }));
+
+    beforeEach(() => reloadTestingDatabases(connections));
+    after(() => closeTestingConnections(connections));
+
+    it("should not fail with DISTINCT or DISTINCT ON with addSelect", () => Promise.all(
+        connections.map(async connection => {
+
+        const foo: Foo = new Foo();
+        foo.name = "Foobar";
+
+        const bars: Bar[] = [1, 2].map((i) => {
+            const bar: Bar = new Bar();
+            bar.foo = foo;
+            bar.name = "bar";
+            bar.description = `Description ${1}`;
+            return bar;
+        });
+
+        await Promise.all([
+            connection.manager.save(foo),
+            connection.manager.save(bars)
+        ]);
+
+        const withDistinct = await connection.manager
+            .createQueryBuilder(Bar, "bar")
+            .select("DISTINCT(bar.name)", "name")
+            .addSelect("bar.description", "description")
+            .getRawMany();
+
+        const withDistinctOn = await connection.manager
+            .createQueryBuilder(Foo, "foo")
+            .select("DISTINCT ON (foo.id) foo.id", "id")
+            .addSelect("bars.description", "description")
+            .leftJoin("foo.bar", "bars")
+            .getRawMany();
+
+        withDistinct.length.should.equal(1);
+        withDistinctOn.length.should.equal(1);
+      }
+    )));
+
+});


### PR DESCRIPTION
Fixes this: https://github.com/typeorm/typeorm/issues/2641 for **Postgresql**

When using `distinct` with `addSelect`, the `distinct`-selection will be behind all the other `selects` in the resulting SQL.

So both this:
```javascript
createQueryBuilder(Bar, "bar")
    .select('DISTINCT(bar.name)', 'name')
    .addSelect('bar.description', 'description')
    .getRawMany();
```

and this:

```javascript
createQueryBuilder(Bar, "bar")
    .select('bar.description', 'description')
    .addSelect('DISTINCT(bar.name)', 'name')
    .getRawMany();
```

Will produce the same sql resulting to this error:
```
ERROR:  syntax error at or near "DISTINCT" at character 46
STATEMENT:  SELECT "bar"."description" AS "description", DISTINCT("bar"."name") AS "name" FROM "bar" "bar"
```
The same error is produced when using` DISTINCT ON (...)` with `addSelect`.
Valid syntax would be with the distinct selection before other selections:

`SELECT DISTINCT("bar"."name") AS "name", "bar"."description" AS "description" FROM "bar" "bar"`

This change ensures that `DISTINCT` / `DISTINCT ON (...)` selections are added to the front of the select clauses.