### PR TITLE
More accurate type for Postgres ssl parameters

### DIFF
--- a/src/driver/postgres/PostgresConnectionCredentialsOptions.ts
+++ b/src/driver/postgres/PostgresConnectionCredentialsOptions.ts
@@ -1,3 +1,5 @@
+import { TlsOptions } from "tls";
+
 /**
  * Postgres specific connection credential options.
  */
@@ -36,6 +38,6 @@ export interface PostgresConnectionCredentialsOptions {
     /**
      * Object with ssl parameters
      */
-    readonly ssl?: any;
+    readonly ssl?: boolean | TlsOptions;
 
 }


### PR DESCRIPTION
Reference to https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/pg/index.d.ts#L35