### PR TITLE
feat: add a ttl to the redis key

### DIFF
--- a/src/cache/RedisQueryResultCache.ts
+++ b/src/cache/RedisQueryResultCache.ts
@@ -105,13 +105,13 @@ export class RedisQueryResultCache implements QueryResultCache {
     async storeInCache(options: QueryResultCacheOptions, savedCache: QueryResultCacheOptions, queryRunner?: QueryRunner): Promise<void> {
         return new Promise<void>((ok, fail) => {
             if (options.identifier) {
-                this.client.set(options.identifier, JSON.stringify(options), (err: any, result: any) => {
+                this.client.set(options.identifier, JSON.stringify(options), 'PX', options.duration, (err: any, result: any) => {
                     if (err) return fail(err);
                     ok();
                 });
 
             } else if (options.query) {
-                this.client.set(options.query, JSON.stringify(options), (err: any, result: any) => {
+                this.client.set(options.query, JSON.stringify(options), 'PX', options.duration, (err: any, result: any) => {
                     if (err) return fail(err);
                     ok();
                 });


### PR DESCRIPTION
On the next branch, the redis key doesn't have an expiry time.
I found this [PR](https://github.com/typeorm/typeorm/pull/2507) for `master`. But no information about why this was not done on `next`.
