### PR TITLE
Add a unit test for issue #3125

### DIFF
--- a/src/persistence/EntityPersistExecutor.ts
+++ b/src/persistence/EntityPersistExecutor.ts
@@ -94,9 +94,9 @@ export class EntityPersistExecutor {
 
                     // load database entities for all subjects we have
                     // next step is to load database entities for all operate subjects
-                    // console.time("loading...");
+                    console.time("loading...");
                     await new SubjectDatabaseEntityLoader(queryRunner, subjects).load(this.mode);
-                    // console.timeEnd("loading...");
+                    console.timeEnd("loading...");
 
                     // console.time("other subjects...");
                     // build all related subjects and change maps

--- a/test/github-issues/3125/entity/Country.ts
+++ b/test/github-issues/3125/entity/Country.ts
@@ -1,0 +1,15 @@
+import {CreateDateColumn, Entity, PrimaryColumn, Column} from "../../../../src";
+
+@Entity()
+export class Country {
+
+    @PrimaryColumn()
+    code: string;
+
+    @Column()
+    name: string;
+
+    @CreateDateColumn()
+    createdAt: Date;
+
+}

--- a/test/github-issues/3125/issue-3125.ts
+++ b/test/github-issues/3125/issue-3125.ts
@@ -1,0 +1,34 @@
+import "reflect-metadata";
+import {Connection} from "../../../src/connection/Connection";
+import {closeTestingConnections, createTestingConnections} from "../../utils/test-utils";
+import {Country} from "./entity/Country";
+import {QueryFailedError} from "../../../src/error/QueryFailedError";
+
+describe("github issues > #3125 Saving a record with the same primary key doesn't throw if the primary key isn't auto-generated", () => {
+
+    let connections: Connection[];
+    before(async () => {
+        connections = await createTestingConnections({
+            entities: [__dirname + "/entity/*{.js,.ts}"],
+            enabledDrivers: ["mysql"],
+            schemaCreate: true,
+            dropSchema: true,
+        });
+    });
+    after(() => closeTestingConnections(connections));
+
+    it("should fail when inserting a record with the same primary key", () => Promise.all(connections.map(async connection => {
+
+        const country1 = new Country();
+        country1.code = "TO";
+        country1.name = "TypeORM";
+        await connection.manager.save(country1);
+
+        const country2 = new Country();
+        country2.code = "TO";
+        country2.name = "TypeORM";
+        await connection.manager.save(country2).should.be.rejectedWith(QueryFailedError);
+
+    })));
+
+});


### PR DESCRIPTION
Here is a unit test for issue #3125

1. The primary key is not autogenerated but an identifier exists because it's set manually in the entity.
2. `SubjectDatabaseEntityLoader` catches this manually set identifier and loads the entity.
3. Now that the identity is loaded the `save` method thinks nothing changed and doesn't really do anything.

I've tried to see how I can get around this, but I'm afraid that there's a lot going on. Maybe we just need an auto-generated strategy called 'manual' or something unless there's a more elegant way to sort this issue out.

Help appreciated.