### PR TITLE
Fix STI types on children in joins

### DIFF
--- a/src/metadata-args/MetadataArgsStorage.ts
+++ b/src/metadata-args/MetadataArgsStorage.ts
@@ -89,7 +89,7 @@ export class MetadataArgsStorage {
     filterRelations(target: Function|string): RelationMetadataArgs[];
     filterRelations(target: (Function|string)[]): RelationMetadataArgs[];
     filterRelations(target: (Function|string)|(Function|string)[]): RelationMetadataArgs[] {
-        return this.filterByTargetAndWithoutDuplicateProperties(this.relations, target);
+        return this.filterByTargetAndWithoutDuplicateRelationProperties(this.relations, target);
     }
 
     filterRelationIds(target: Function|string): RelationIdMetadataArgs[];
@@ -226,6 +226,27 @@ export class MetadataArgsStorage {
             if (sameTarget) {
                 if (!newArray.find(newItem => newItem.propertyName === item.propertyName))
                     newArray.push(item);
+            }
+        });
+        return newArray;
+    }
+
+    /**
+     * Filters given array by a given target or targets and prevents duplicate relation property names.
+     */
+    protected filterByTargetAndWithoutDuplicateRelationProperties<T extends RelationMetadataArgs>(array: T[], target: (Function|string)|(Function|string)[]): T[] {
+        const newArray: T[] = [];
+        array.forEach(item => {
+            const sameTarget = target instanceof Array ? target.indexOf(item.target) !== -1 : item.target === target;
+            if (sameTarget) {
+                const existingIndex = newArray.findIndex(newItem => newItem.propertyName === item.propertyName);
+                if (target instanceof Array && existingIndex !== -1 && target.indexOf(item.target) < target.indexOf(newArray[existingIndex].target)) {
+                    const clone = Object.create(newArray[existingIndex]);
+                    clone.type = item.type;
+                    newArray[existingIndex] = clone;
+                } else if (existingIndex === -1) {
+                    newArray.push(item);
+                }
             }
         });
         return newArray;

--- a/src/metadata-builder/EntityMetadataBuilder.ts
+++ b/src/metadata-builder/EntityMetadataBuilder.ts
@@ -422,8 +422,17 @@ export class EntityMetadataBuilder {
         entityMetadata.ownRelations = this.metadataArgsStorage.filterRelations(entityMetadata.inheritanceTree).map(args => {
 
             // for single table children we reuse relations created for their parents
-            if (entityMetadata.tableType === "entity-child")
-                return entityMetadata.parentEntityMetadata.ownRelations.find(relation => relation.propertyName === args.propertyName)!;
+            if (entityMetadata.tableType === "entity-child") {
+                const parentRelation = entityMetadata.parentEntityMetadata.ownRelations.find(relation => relation.propertyName === args.propertyName)!;
+                const type = args.type instanceof Function ? (args.type as () => any)() : args.type;
+                if (parentRelation.type !== type) {
+                    const clone = Object.create(parentRelation);
+                    clone.type = type;
+                    return clone;
+                }
+
+                return parentRelation;
+            }
 
             return new RelationMetadata({ entityMetadata, args });
         });

--- a/src/query-builder/transformer/RawSqlResultsToEntityTransformer.ts
+++ b/src/query-builder/transformer/RawSqlResultsToEntityTransformer.ts
@@ -157,8 +157,15 @@ export class RawSqlResultsToEntityTransformer {
 
             // this check need to avoid setting properties than not belong to entity when single table inheritance used. (todo: check if we still need it)
             // const metadata = metadata.childEntityMetadatas.find(childEntityMetadata => discriminatorValue === childEntityMetadata.discriminatorValue);
-            if (join.relation && !metadata.relations.find(relation => relation === join.relation))
-                return;
+            if (join.relation) {
+                const relation = metadata.relations.find(relation => relation.propertyPath === join.relation!.propertyPath);
+                if (!relation)
+                    return;
+
+                // Use current entity's type metadata, join might be from an STI parent with a different type
+                if (relation.inverseEntityMetadata)
+                    join.alias.metadata = relation.inverseEntityMetadata;
+            }
 
             // some checks to make sure this join is for current alias
             if (join.mapToProperty) {

--- a/test/functional/table-inheritance/single-table/no-type-column/entity/Author.ts
+++ b/test/functional/table-inheritance/single-table/no-type-column/entity/Author.ts
@@ -1,0 +1,10 @@
+import * as TypeOrm from "../../../../../../src";
+import {Person} from "./Person";
+
+@TypeOrm.Entity({name: "person"})
+export class Author extends Person {
+
+    @TypeOrm.Column({default: null})
+    public authorName: string;
+
+}

--- a/test/functional/table-inheritance/single-table/no-type-column/entity/Employee.ts
+++ b/test/functional/table-inheritance/single-table/no-type-column/entity/Employee.ts
@@ -1,0 +1,10 @@
+import * as TypeOrm from "../../../../../../src";
+import {Person} from "./Person";
+
+@TypeOrm.Entity({name: "person"})
+export class Employee extends Person {
+
+    @TypeOrm.Column({default: null})
+    public employeeName: string;
+
+}

--- a/test/functional/table-inheritance/single-table/no-type-column/entity/Note.ts
+++ b/test/functional/table-inheritance/single-table/no-type-column/entity/Note.ts
@@ -1,0 +1,17 @@
+import * as TypeOrm from "../../../../../../src";
+import {Person} from "./Person";
+
+@TypeOrm.Entity()
+@TypeOrm.TableInheritance({column: {type: "varchar", name: "type"}})
+export class Note {
+
+    @TypeOrm.PrimaryGeneratedColumn()
+    public id: number;
+
+    @TypeOrm.Column({default: null})
+    public label?: string;
+
+    @TypeOrm.ManyToOne(() => Person)
+    public owner: Person;
+
+}

--- a/test/functional/table-inheritance/single-table/no-type-column/entity/Person.ts
+++ b/test/functional/table-inheritance/single-table/no-type-column/entity/Person.ts
@@ -1,0 +1,16 @@
+import * as TypeOrm from "../../../../../../src";
+import {Note} from "./Note";
+
+@TypeOrm.Entity({name: "person"})
+export class Person {
+
+    @TypeOrm.PrimaryGeneratedColumn()
+    public id: number;
+
+    @TypeOrm.Column()
+    public name: string;
+
+    @TypeOrm.OneToMany(() => Note, note => note.owner)
+    public notes: Note[];
+
+}

--- a/test/functional/table-inheritance/single-table/no-type-column/entity/PostItNote.ts
+++ b/test/functional/table-inheritance/single-table/no-type-column/entity/PostItNote.ts
@@ -1,0 +1,14 @@
+import * as TypeOrm from "../../../../../../src";
+import {Note} from "./Note";
+import {Employee} from "./Employee";
+
+@TypeOrm.ChildEntity()
+export class PostItNote extends Note {
+
+    @TypeOrm.Column()
+    public postItNoteLabel: string;
+
+    @TypeOrm.ManyToOne(() => Employee, person => person.notes)
+    public owner: Employee;
+
+}

--- a/test/functional/table-inheritance/single-table/no-type-column/entity/StickyNote.ts
+++ b/test/functional/table-inheritance/single-table/no-type-column/entity/StickyNote.ts
@@ -1,0 +1,14 @@
+import * as TypeOrm from "../../../../../../src";
+import {Note} from "./Note";
+import {Author} from "./Author";
+
+@TypeOrm.ChildEntity()
+export class StickyNote extends Note {
+
+    @TypeOrm.Column()
+    public stickyNoteLabel: string;
+
+    @TypeOrm.ManyToOne(() => Author, author => author.notes)
+    public owner: Author;
+
+}

--- a/test/functional/table-inheritance/single-table/no-type-column/no-type-column.ts
+++ b/test/functional/table-inheritance/single-table/no-type-column/no-type-column.ts
@@ -1,0 +1,58 @@
+import "reflect-metadata";
+import {closeTestingConnections, createTestingConnections, reloadTestingDatabases} from "../../../../utils/test-utils";
+import {Connection} from "../../../../../src";
+import {Author} from "./entity/Author";
+import {Employee} from "./entity/Employee";
+import {PostItNote} from "./entity/PostItNote";
+import {StickyNote} from "./entity/StickyNote";
+
+describe("table-inheritance > single-table > no-type-column", () => {
+
+    let connections: Connection[];
+    before(async () => connections = await createTestingConnections({
+        entities: [__dirname + "/entity/*{.js,.ts}"]
+    }));
+    beforeEach(() => reloadTestingDatabases(connections));
+    after(() => closeTestingConnections(connections));
+
+    it("should return subclass in relations", () => Promise.all(connections.map(async connection => {
+
+        const postItRepo = connection.getRepository(PostItNote);
+        const stickyRepo = connection.getRepository(StickyNote);
+
+        // -------------------------------------------------------------------------
+        // Create
+        // -------------------------------------------------------------------------
+
+        const employee = new Employee();
+        employee.name = "alicefoo";
+        employee.employeeName = "Alice Foo";
+        await connection.getRepository(Employee).save(employee);
+
+        const author = new Author();
+        author.name = "bobbar";
+        author.authorName = "Bob Bar";
+        await connection.getRepository(Author).save(author);
+
+        await postItRepo.insert({ postItNoteLabel: "A post-it note", owner: employee } as PostItNote);
+        await stickyRepo.insert({ stickyNoteLabel: "A sticky note", owner: author } as StickyNote);
+
+        // -------------------------------------------------------------------------
+        // Select
+        // -------------------------------------------------------------------------
+
+        const postIt = await postItRepo.findOne({ relations: [ "owner" ] }) as PostItNote;
+
+        postIt.owner.should.be.an.instanceOf(Employee);
+        postIt.owner.name.should.be.equal("alicefoo");
+        postIt.owner.employeeName.should.be.equal("Alice Foo");
+
+        const sticky = await stickyRepo.findOne({ relations: [ "owner" ] }) as StickyNote;
+
+        sticky.owner.should.be.an.instanceOf(Author);
+        sticky.owner.name.should.be.equal("bobbar");
+        sticky.owner.authorName.should.be.equal("Bob Bar");
+
+    })));
+
+});

--- a/test/functional/table-inheritance/single-table/relations/child-relation-type/child-relation-type.ts
+++ b/test/functional/table-inheritance/single-table/relations/child-relation-type/child-relation-type.ts
@@ -1,0 +1,114 @@
+import "reflect-metadata";
+import {
+    closeTestingConnections,
+    createTestingConnections,
+    reloadTestingDatabases
+} from "../../../../../utils/test-utils";
+import {Connection} from "../../../../../../src";
+import {Teacher} from "./entity/Teacher";
+import {Accountant} from "./entity/Accountant";
+import {Person} from "./entity/Person";
+import {Specialization} from "./entity/Specialization";
+import {Department} from "./entity/Department";
+
+describe("table-inheritance > single-table > relations > child-relation-type", () => {
+
+    let connections: Connection[];
+    before(async () => connections = await createTestingConnections({
+        entities: [__dirname + "/entity/*{.js,.ts}"]
+    }));
+    beforeEach(() => reloadTestingDatabases(connections));
+    after(() => closeTestingConnections(connections));
+
+    it("should work correctly with OneToMany relations", () => Promise.all(connections.map(async connection => {
+
+        // -------------------------------------------------------------------------
+        // Create
+        // -------------------------------------------------------------------------
+
+        const specialization1 = new Specialization();
+        specialization1.name = "Geography";
+        await connection.getRepository(Specialization).save(specialization1);
+
+        const specialization2 = new Specialization();
+        specialization2.name = "Economist";
+        await connection.getRepository(Specialization).save(specialization2);
+
+        const teacher = new Teacher();
+        teacher.name = "Mr. Garrison";
+        teacher.data = [specialization1, specialization2];
+        await connection.getRepository(Teacher).save(teacher);
+
+        const department1 = new Department();
+        department1.name = "Bookkeeping";
+        await connection.getRepository(Department).save(department1);
+
+        const department2 = new Department();
+        department2.name = "HR";
+        await connection.getRepository(Department).save(department2);
+
+        const accountant = new Accountant();
+        accountant.name = "Mr. Burns";
+        accountant.data = [department1, department2];
+        await connection.getRepository(Accountant).save(accountant);
+
+        // -------------------------------------------------------------------------
+        // Select
+        // -------------------------------------------------------------------------
+
+        let loadedTeacher = await connection.manager
+            .createQueryBuilder(Teacher, "teacher")
+                .leftJoinAndSelect("teacher.data", "data")
+                .where("teacher.name = :name", { name: "Mr. Garrison" })
+                .orderBy("teacher.id, data.id")
+                .getOne();
+
+        loadedTeacher!.should.have.all.keys("id", "name", "data");
+        loadedTeacher!.id.should.equal(1);
+        loadedTeacher!.name.should.equal("Mr. Garrison");
+        loadedTeacher!.data.length.should.equal(2);
+        loadedTeacher!.data[0].should.be.instanceOf(Specialization);
+        loadedTeacher!.data[0].name.should.be.equal("Geography");
+        loadedTeacher!.data[1].name.should.be.equal("Economist");
+
+        let loadedAccountant = await connection.manager
+            .createQueryBuilder(Accountant, "accountant")
+            .leftJoinAndSelect("accountant.data", "data")
+            .where("accountant.name = :name", { name: "Mr. Burns" })
+            .orderBy("accountant.id, data.id")
+            .getOne();
+
+        loadedAccountant!.should.have.all.keys("id", "name", "data");
+        loadedAccountant!.id.should.equal(2);
+        loadedAccountant!.name.should.equal("Mr. Burns");
+        loadedAccountant!.data.length.should.equal(2);
+        loadedAccountant!.data[0].should.be.instanceOf(Department);
+        loadedAccountant!.data[0].name.should.be.equal("Bookkeeping");
+        loadedAccountant!.data[1].name.should.be.equal("HR");
+
+        const loadedPersons = await connection.manager
+            .createQueryBuilder(Person, "person")
+            .leftJoinAndSelect("person.data", "data")
+            .orderBy("person.id, data.id")
+            .getMany();
+
+        loadedPersons[0].should.have.all.keys("id", "name", "data");
+        loadedPersons[0].should.be.instanceof(Teacher);
+        loadedPersons[0].id.should.equal(1);
+        loadedPersons[0].name.should.equal("Mr. Garrison");
+        loadedPersons[0].data[0].should.be.instanceOf(Specialization);
+        (loadedPersons[0] as Teacher).data.length.should.equal(2);
+        (loadedPersons[0] as Teacher).data[0].name.should.be.equal("Geography");
+        (loadedPersons[0] as Teacher).data[1].name.should.be.equal("Economist");
+        loadedPersons[1].should.have.all.keys("id", "name", "data");
+        loadedPersons[1].should.be.instanceof(Accountant);
+        loadedPersons[1].id.should.equal(2);
+        loadedPersons[1].name.should.equal("Mr. Burns");
+        loadedPersons[1].data[0].should.be.instanceOf(Department);
+        (loadedPersons[1] as Accountant).data.length.should.equal(2);
+        (loadedPersons[1] as Accountant).data[0].name.should.be.equal("Bookkeeping");
+        (loadedPersons[1] as Accountant).data[1].name.should.be.equal("HR");
+
+    })));
+
+});

--- a/test/functional/table-inheritance/single-table/relations/child-relation-type/entity/Accountant.ts
+++ b/test/functional/table-inheritance/single-table/relations/child-relation-type/entity/Accountant.ts
@@ -1,0 +1,11 @@
+import {ChildEntity, OneToMany} from "../../../../../../../src";
+import {Department} from "./Department";
+import {Person} from "./Person";
+
+@ChildEntity()
+export class Accountant extends Person {
+
+    @OneToMany(() => Department, department => department.person)
+    data: Department[];
+
+}

--- a/test/functional/table-inheritance/single-table/relations/child-relation-type/entity/Data.ts
+++ b/test/functional/table-inheritance/single-table/relations/child-relation-type/entity/Data.ts
@@ -1,0 +1,16 @@
+import {Column, Entity, ManyToOne, PrimaryGeneratedColumn} from "../../../../../../../src";
+import {Person} from "./Person";
+
+@Entity("data")
+export abstract class Data {
+
+    @PrimaryGeneratedColumn()
+    id: number;
+
+    @Column()
+    name: string;
+
+    @ManyToOne(() => Person, person => person.data)
+    person: Person;
+
+}

--- a/test/functional/table-inheritance/single-table/relations/child-relation-type/entity/Department.ts
+++ b/test/functional/table-inheritance/single-table/relations/child-relation-type/entity/Department.ts
@@ -1,0 +1,11 @@
+import {Entity, ManyToOne} from "../../../../../../../src";
+import {Accountant} from "./Accountant";
+import {Data} from "./Data";
+
+@Entity("data")
+export class Department extends Data {
+
+    @ManyToOne(() => Accountant, accountant => accountant.data)
+    person: Accountant;
+
+}

--- a/test/functional/table-inheritance/single-table/relations/child-relation-type/entity/Person.ts
+++ b/test/functional/table-inheritance/single-table/relations/child-relation-type/entity/Person.ts
@@ -1,0 +1,17 @@
+import {Column, Entity, OneToMany, PrimaryGeneratedColumn, TableInheritance} from "../../../../../../../src";
+import {Data} from "./Data";
+
+@Entity()
+@TableInheritance({column: {name: "type", type: "varchar"}})
+export class Person {
+
+    @PrimaryGeneratedColumn()
+    id: number;
+
+    @Column()
+    name: string;
+
+    @OneToMany(() => Data, data => data.person)
+    data: Data[];
+
+}

--- a/test/functional/table-inheritance/single-table/relations/child-relation-type/entity/Specialization.ts
+++ b/test/functional/table-inheritance/single-table/relations/child-relation-type/entity/Specialization.ts
@@ -1,0 +1,11 @@
+import {Entity, ManyToOne} from "../../../../../../../src";
+import {Teacher} from "./Teacher";
+import {Data} from "./Data";
+
+@Entity("data")
+export class Specialization extends Data {
+
+    @ManyToOne(() => Teacher, teacher => teacher.data)
+    person: Teacher;
+
+}

--- a/test/functional/table-inheritance/single-table/relations/child-relation-type/entity/Teacher.ts
+++ b/test/functional/table-inheritance/single-table/relations/child-relation-type/entity/Teacher.ts
@@ -1,0 +1,11 @@
+import {ChildEntity, OneToMany} from "../../../../../../../src";
+import {Specialization} from "./Specialization";
+import {Person} from "./Person";
+
+@ChildEntity()
+export class Teacher extends Person {
+
+    @OneToMany(() => Specialization, specialization => specialization.person)
+    data: Specialization[];
+
+}


### PR DESCRIPTION
Note: This requires (and includes the commit from) PR #2967 otherwise you don't get the right type in the child's relation anyway.

If an STI child overrides a parent property and uses a different type doing a query on the parent type will skip the relation. This happens because the query's join is built using the parent relation but when mapping to an entity the child's relation is fetched so they don't match. Instead, we now use the relation's `propertyPath` to allow using relations that reference the same property. We also copy the child's relation type into the join to ensure we get the right type in the child as well.