### PR TITLE
Change so that parameters from "url" connection option can be overridden by specific connection options

### DIFF
--- a/docs/connection-options.md
+++ b/docs/connection-options.md
@@ -103,7 +103,7 @@ Read more about caching [here](./caching.md).
 
 ## `mysql` / `mariadb` connection options
 
-* `url` - Connection url where perform connection to.
+* `url` - Connection url where perform connection to. Please note that other connection options will override parameters set from url.
 
 * `host` - Database host.
 
@@ -162,7 +162,7 @@ See [SSL options](https://github.com/mysqljs/mysql#ssl-options).
 
 ## `postgres` connection options
 
-* `url` - Connection url where perform connection to.
+* `url` - Connection url where perform connection to. Please note that other connection options will override parameters set from url.
 
 * `host` - Database host.
 
@@ -198,7 +198,7 @@ See [SSL options](https://github.com/mysqljs/mysql#ssl-options).
 
 ## `mssql` connection options
 
-* `url` - Connection url where perform connection to.
+* `url` - Connection url where perform connection to. Please note that other connection options will override parameters set from url.
 
 * `host` - Database host.
 
@@ -346,7 +346,7 @@ See [SSL options](https://github.com/mysqljs/mysql#ssl-options).
 
 ## `mongodb` connection options
 
-* `url` - Connection url where perform connection to.
+* `url` - Connection url where perform connection to. Please note that other connection options will override parameters set from url.
 
 * `host` - Database host.
 

--- a/src/driver/DriverUtils.ts
+++ b/src/driver/DriverUtils.ts
@@ -16,25 +16,24 @@ export class DriverUtils {
             const parsedUrl = this.parseConnectionUrl(options.url);
             if (buildOptions && buildOptions.useSid) {
                 const urlDriverOptions: any = {
-                    type: options.type,
-                    host: parsedUrl.host,
-                    username: parsedUrl.username,
-                    password: parsedUrl.password,
-                    port: parsedUrl.port,
-                    sid: parsedUrl.database
+                    type: options.type || parsedUrl.type,
+                    host: options.host || parsedUrl.host,
+                    username: options.username || parsedUrl.username,
+                    password: options.password || parsedUrl.password,
+                    port: options.port || parsedUrl.port,
+                    sid: options.sid || options.database || parsedUrl.database
                 };
-                return Object.assign(options, urlDriverOptions);
-
+                return Object.assign(urlDriverOptions, options);
             } else {
                 const urlDriverOptions: any = {
-                    type: options.type,
-                    host: parsedUrl.host,
-                    username: parsedUrl.username,
-                    password: parsedUrl.password,
-                    port: parsedUrl.port,
-                    database: parsedUrl.database
+                    type: options.type || parsedUrl.type,
+                    host: options.host || parsedUrl.host,
+                    username: options.username || parsedUrl.username,
+                    password: options.password || parsedUrl.password,
+                    port: options.port || parsedUrl.port,
+                    database: options.database || parsedUrl.database
                 };
-                return Object.assign(options, urlDriverOptions);
+                return Object.assign(urlDriverOptions, options);
             }
         }
         return Object.assign({}, options);
@@ -48,6 +47,7 @@ export class DriverUtils {
      * Extracts connection data from the connection url.
      */
     private static parseConnectionUrl(url: string) {
+        const type = url.split(':')[0];
         const firstSlashes = url.indexOf("//");
         const preBase = url.substr(firstSlashes + 2);
         const secondSlash = preBase.indexOf("/");
@@ -68,6 +68,7 @@ export class DriverUtils {
         const [host, port] = hostAndPort.split(":");
 
         return {
+            type: type,
             host: host,
             username: username,
             password: password,


### PR DESCRIPTION
Based on discussion in https://github.com/typeorm/typeorm/issues/3159, it would be desirable to allow users to override parameters set in *url* connection option (only in mysql/mariadb, postgres, mssql and mongodb).

The current implementation prioritises `url` over the other parameters.

For example...

```
const options = {
  url: 'postgres://localhost:5432',
  username: 'myuser',
  password: 'mypass',
  ...
};```

...would get initial options from url, and then set username and password as defined in options.