### PR TITLE
fix: do not clear group by on subquery

### DIFF
--- a/src/query-builder/SelectQueryBuilder.ts
+++ b/src/query-builder/SelectQueryBuilder.ts
@@ -1992,8 +1992,7 @@ export class SelectQueryBuilder<Entity> extends QueryBuilder<Entity> implements 
                 //     options: this.findOptions.options,
                 //     where: this.findOptions.where
                 // })
-                .orderBy()
-                .groupBy();
+                .orderBy();
 
             rawResults = await new SelectQueryBuilder(this.connection, queryRunner)
                 .select(`DISTINCT ${querySelects.join(", ")}`)


### PR DESCRIPTION
This enables queries which compute select values to work properly.

In my case I have the following query generated:

```sql
SELECT
    DISTINCT "distinctAlias"."event_id" AS "ids_event_id",
    "distinctAlias".event_applications
FROM (
    SELECT
        "event"."id" AS "event_id",
        "event"."createdAt" AS "event_createdAt",
        "event"."updatedAt" AS "event_updatedAt",
        "event"."label" AS "event_label",
        "event"."description" AS "event_description",
        "event"."capacity" AS "event_capacity",
        "event"."credits" AS "event_credits",
        "event"."organiserId" AS "event_organiserId",
        "event"."processId" AS "event_processId",
        COUNT(DISTINCT ("applications"."id")) AS "event_applications"
    FROM
        "event" "event"
    LEFT JOIN "application" "applications" ON "applications"."eventId" = "event"."id"
WHERE
    event. "processId" = '52fdf293-2d3f-4e6a-9a0d-59c7a27e6edb'
) "distinctAlias"
ORDER BY
    "distinctAlias".event_applications DESC,
    "event_id" ASC
LIMIT 10
```

Which will fail because TypeORM clears GROUP BY on the subquery for paginated results. In my case I need it because of the computed "event_applications" property. Not clearing GROUP BY results in this query:

```sql
SELECT
    DISTINCT "distinctAlias"."event_id" AS "ids_event_id",
    "distinctAlias".event_applications
FROM (
    SELECT
        "event"."id" AS "event_id",
        "event"."createdAt" AS "event_createdAt",
        "event"."updatedAt" AS "event_updatedAt",
        "event"."label" AS "event_label",
        "event"."description" AS "event_description",
        "event"."capacity" AS "event_capacity",
        "event"."credits" AS "event_credits",
        "event"."organiserId" AS "event_organiserId",
        "event"."processId" AS "event_processId",
        COUNT(DISTINCT ("applications"."id")) AS "event_applications"
    FROM
        "event" "event"
    LEFT JOIN "application" "applications" ON "applications"."eventId" = "event"."id"
WHERE
    event. "processId" = '52fdf293-2d3f-4e6a-9a0d-59c7a27e6edb'
GROUP BY
    "event"."id") "distinctAlias"
ORDER BY
    "distinctAlias".event_applications DESC,
    "event_id" ASC
LIMIT 10
```

which executes properly. If there are any issues that will arise due to removing the clear, please point them out. In my case this doesn't seem to break anything. This behavior exists also on master so I guess if this PR is accepted we should remove the clear on master as well.