### PR TITLE
Add flag to enable ON CONFLICT support for Sqlite.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,6 +17,7 @@ before_script:
   - sudo service postgresql stop
   - docker-compose up -d
   - cp ormconfig.travis.json ormconfig.json
+  - npm install sqlite3 --build-from-source
 
 script:
   - npm test

--- a/src/query-builder/InsertQueryBuilder.ts
+++ b/src/query-builder/InsertQueryBuilder.ts
@@ -16,6 +16,7 @@ import {SqljsDriver} from "../driver/sqljs/SqljsDriver";
 import {BroadcasterResult} from "../subscriber/BroadcasterResult";
 import {EntitySchema} from "../";
 import {OracleDriver} from "../driver/oracle/OracleDriver";
+import {SqliteDriver} from "../driver/sqlite/SqliteDriver";
 
 /**
  * Allows to build complex sql queries in a fashion way and execute those queries.
@@ -299,7 +300,7 @@ export class InsertQueryBuilder<Entity> extends QueryBuilder<Entity> {
                 query += ` DEFAULT VALUES`;
             }
         }
-        if (this.connection.driver instanceof PostgresDriver) {
+        if (this.connection.driver instanceof PostgresDriver || (this.connection.driver instanceof SqliteDriver)) {
           query += `${this.expressionMap.onIgnore ? " ON CONFLICT DO NOTHING " : ""}`;
           query += `${this.expressionMap.onConflict ? " ON CONFLICT " + this.expressionMap.onConflict : ""}`;
           if (this.expressionMap.onUpdate) {

--- a/test/functional/query-builder/insert-on-conflict/query-builder-insert-on-conflict.ts
+++ b/test/functional/query-builder/insert-on-conflict/query-builder-insert-on-conflict.ts
@@ -4,11 +4,11 @@ import {Connection} from "../../../../src/connection/Connection";
 import {Post} from "./entity/Post";
 
 describe("query builder > insertion > on conflict", () => {
-    
+
     let connections: Connection[];
     before(async () => connections = await createTestingConnections({
         entities: [__dirname + "/entity/*{.js,.ts}"],
-        enabledDrivers: ["postgres"] // since on conflict statement is only supported in postgres
+        enabledDrivers: ["postgres", "sqlite"] // since on conflict statement is only supported in postgres and sqlite >= 3.24.0
     }));
     beforeEach(() => reloadTestingDatabases(connections));
     after(() => closeTestingConnections(connections));


### PR DESCRIPTION
Sqlite `ON CONFLICT` clause is supported since `sqlite` `3.24.0`. This PR adds a flag to enable explicit support for it, to avoid breaking changes, and preserves the current behavior otherwise.

It might be necessary to build `sqlite3` from source since precompiled binaries from npm apparently are not build with a recent enough `sqlite` lib.

Tests were added for the driver option and `ON CONFLICT` functionality.