### PR TITLE
[WIP] Add new mode to wrap each migration in transaction

### DIFF
--- a/src/commands/MigrationRevertCommand.ts
+++ b/src/commands/MigrationRevertCommand.ts
@@ -44,9 +44,26 @@ export class MigrationRevertCommand {
                 logging: ["query", "error", "schema"]
             });
             connection = await createConnection(connectionOptions);
+
             const options = {
-                transaction: argv["t"] === "false" ? false : true
+                transactionMode: "all" as "all" | "none" | "each",
             };
+
+            switch (argv["t"]) {
+                case "all":
+                    options.transactionMode = "all";
+                    break;
+                case "none":
+                case "false":
+                    options.transactionMode = "none";
+                    break;
+                case "each":
+                    options.transactionMode = "each";
+                    break;
+                default:
+                    // noop
+            }
+
             await connection.undoLastMigration(options);
             await connection.close();
 

--- a/src/commands/MigrationRunCommand.ts
+++ b/src/commands/MigrationRunCommand.ts
@@ -47,8 +47,24 @@ export class MigrationRunCommand {
             connection = await createConnection(connectionOptions);
 
             const options = {
-                transaction: argv["t"] === "false" ? false : true
+                transactionMode: "all" as "all" | "none" | "each",
             };
+
+            switch (argv["t"]) {
+                case "all":
+                    options.transactionMode = "all";
+                    break;
+                case "none":
+                case "false":
+                    options.transactionMode = "none";
+                    break;
+                case "each":
+                    options.transactionMode = "each";
+                    break;
+                default:
+                    // noop
+            }
+
             await connection.runMigrations(options);
             await connection.close();
             // exit process if no errors

--- a/src/connection/Connection.ts
+++ b/src/connection/Connection.ts
@@ -272,12 +272,12 @@ export class Connection {
      * Runs all pending migrations.
      * Can be used only after connection to the database is established.
      */
-    async runMigrations(options?: { transactionMode?: 'all' | 'none' | 'each' }): Promise<Migration[]> {
+    async runMigrations(options?: { transactionMode?: "all" | "none" | "each" }): Promise<Migration[]> {
         if (!this.isConnected)
             throw new CannotExecuteNotConnectedError(this.name);
 
         const migrationExecutor = new MigrationExecutor(this);
-        migrationExecutor.transactionMode = (options && options.transactionMode) || 'all';
+        migrationExecutor.transactionMode = (options && options.transactionMode) || "all";
 
         const successMigrations = await migrationExecutor.executePendingMigrations();
         return successMigrations;
@@ -287,13 +287,13 @@ export class Connection {
      * Reverts last executed migration.
      * Can be used only after connection to the database is established.
      */
-    async undoLastMigration(options?: { transactionMode?: 'all' | 'none' | 'each' }): Promise<void> {
+    async undoLastMigration(options?: { transactionMode?: "all" | "none" | "each" }): Promise<void> {
 
         if (!this.isConnected)
             throw new CannotExecuteNotConnectedError(this.name);
 
         const migrationExecutor = new MigrationExecutor(this);
-        migrationExecutor.transactionMode = (options && options.transactionMode) || 'all';
+        migrationExecutor.transactionMode = (options && options.transactionMode) || "all";
 
         await migrationExecutor.undoLastMigration();
     }

--- a/src/connection/Connection.ts
+++ b/src/connection/Connection.ts
@@ -272,14 +272,13 @@ export class Connection {
      * Runs all pending migrations.
      * Can be used only after connection to the database is established.
      */
-    async runMigrations(options?: { transaction?: boolean }): Promise<Migration[]> {
+    async runMigrations(options?: { transactionMode?: 'all' | 'none' | 'each' }): Promise<Migration[]> {
         if (!this.isConnected)
             throw new CannotExecuteNotConnectedError(this.name);
 
         const migrationExecutor = new MigrationExecutor(this);
-        if (options && options.transaction === false) {
-            migrationExecutor.transaction = false;
-        }
+        migrationExecutor.transactionMode = (options && options.transactionMode) || 'all';
+
         const successMigrations = await migrationExecutor.executePendingMigrations();
         return successMigrations;
     }
@@ -288,15 +287,14 @@ export class Connection {
      * Reverts last executed migration.
      * Can be used only after connection to the database is established.
      */
-    async undoLastMigration(options?: { transaction?: boolean }): Promise<void> {
+    async undoLastMigration(options?: { transactionMode?: 'all' | 'none' | 'each' }): Promise<void> {
 
         if (!this.isConnected)
             throw new CannotExecuteNotConnectedError(this.name);
 
         const migrationExecutor = new MigrationExecutor(this);
-        if (options && options.transaction === false) {
-            migrationExecutor.transaction = false;
-        }
+        migrationExecutor.transactionMode = (options && options.transactionMode) || 'all';
+
         await migrationExecutor.undoLastMigration();
     }
 

--- a/src/migration/MigrationExecutor.ts
+++ b/src/migration/MigrationExecutor.ts
@@ -19,9 +19,12 @@ export class MigrationExecutor {
     // -------------------------------------------------------------------------
 
     /**
-     * Indicates if migrations must be executed in a transaction.
+     * Indicates how migrations should be run in transactions.
+     *   all: all migrations are run in a single transaction
+     *   none: all migrations are run without a transaction
+     *   each: each migration is run in a separate transaction
      */
-    transaction: boolean = true;
+    transactionMode: 'all' | 'none' | 'each' = 'all';
 
     // -------------------------------------------------------------------------
     // Private Properties
@@ -66,9 +69,6 @@ export class MigrationExecutor {
         // get all user's migrations in the source code
         const allMigrations = this.getMigrations();
 
-        // variable to store all migrations we did successefuly
-        const successMigrations: Migration[] = [];
-
         // find all migrations that needs to be executed
         const pendingMigrations = allMigrations.filter(migration => {
             // check if we already have executed migration
@@ -100,47 +100,14 @@ export class MigrationExecutor {
             this.connection.logger.logSchemaBuild(`${lastTimeExecutedMigration.name} is the last executed migration. It was executed on ${new Date(lastTimeExecutedMigration.timestamp).toString()}.`);
         this.connection.logger.logSchemaBuild(`${pendingMigrations.length} migrations are new migrations that needs to be executed.`);
 
-        // start transaction if its not started yet
-        let transactionStartedByUs = false;
-        if (this.transaction && !queryRunner.isTransactionActive) {
-            await queryRunner.startTransaction();
-            transactionStartedByUs = true;
+        switch (this.transactionMode) {
+            case 'each':
+                return this.runEachMigrationInSeparateTransaction(queryRunner, pendingMigrations);
+            case 'all':
+                return this.runAllMigrationsInSingleTransaction(queryRunner, pendingMigrations);
+            case 'none':
+                return this.runAllMigrationsWithoutTransaction(queryRunner, pendingMigrations);
         }
-
-        // run all pending migrations in a sequence
-        try {
-            await PromiseUtils.runInSequence(pendingMigrations, migration => {
-                return migration.instance!.up(queryRunner)
-                    .then(() => { // now when migration is executed we need to insert record about it into the database
-                        return this.insertExecutedMigration(queryRunner, migration);
-                    })
-                    .then(() => { // informative log about migration success
-                        successMigrations.push(migration);
-                        this.connection.logger.logSchemaBuild(`Migration ${migration.name} has been executed successfully.`);
-                    });
-            });
-
-            // commit transaction if we started it
-            if (transactionStartedByUs)
-                await queryRunner.commitTransaction();
-
-        } catch (err) { // rollback transaction if we started it
-            if (transactionStartedByUs) {
-                try { // we throw original error even if rollback thrown an error
-                    await queryRunner.rollbackTransaction();
-                } catch (rollbackError) { }
-            }
-
-            throw err;
-
-        } finally {
-
-            // if query runner was created by us then release it
-            if (!this.queryRunner)
-                await queryRunner.release();
-        }
-        return successMigrations;
-
     }
 
     /**
@@ -182,7 +149,7 @@ export class MigrationExecutor {
 
         // start transaction if its not started yet
         let transactionStartedByUs = false;
-        if (this.transaction && !queryRunner.isTransactionActive) {
+        if ((this.transactionMode !== 'none') && !queryRunner.isTransactionActive) {
             await queryRunner.startTransaction();
             transactionStartedByUs = true;
         }
@@ -341,6 +308,117 @@ export class MigrationExecutor {
             .andWhere(`${qb.escape("name")} = :name`)
             .setParameters(conditions)
             .execute();
+    }
+
+    protected async runEachMigrationInSeparateTransaction(queryRunner: QueryRunner, pendingMigrations: Migration[]) {
+        // variable to store all migrations we did successefuly
+        const successMigrations: Migration[] = [];
+
+        if (queryRunner.isTransactionActive) {
+            throw new Error('Trying to run each migration in separate transaction, but already in one. Try changing this option and run migrations again.');
+        }
+
+        // run all pending migrations in a sequence
+        try {
+            await PromiseUtils.runInSequence(pendingMigrations, async migration => {
+                await queryRunner.startTransaction();
+                return migration.instance!.up(queryRunner)
+                    .then(async () => { // now when migration is executed we need to insert record about it into the database
+                        await this.insertExecutedMigration(queryRunner, migration);
+                        await queryRunner.commitTransaction();
+                    })
+                    .then(() => { // informative log about migration success
+                        successMigrations.push(migration);
+                        this.connection.logger.logSchemaBuild(`Migration ${migration.name} has been executed successfully.`);
+                    });
+            });
+
+        } catch (err) { // rollback transaction if we started it
+            try { // we throw original error even if rollback thrown an error
+                if (queryRunner.isTransactionActive) {
+                    await queryRunner.rollbackTransaction();
+                }
+            } catch (rollbackError) { }
+
+            throw err;
+
+        } finally {
+            // if query runner was created by us then release it
+            if (!this.queryRunner)
+                await queryRunner.release();
+        }
+        return successMigrations;
+    }
+
+    protected async runAllMigrationsInSingleTransaction(queryRunner: QueryRunner, pendingMigrations: Migration[]) {
+        // variable to store all migrations we did successefuly
+        const successMigrations: Migration[] = [];
+
+        // start transaction if its not started yet
+        let transactionStartedByUs = false;
+        if (!queryRunner.isTransactionActive) {
+            await queryRunner.startTransaction();
+            transactionStartedByUs = true;
+        }
+
+        // run all pending migrations in a sequence
+        try {
+            await PromiseUtils.runInSequence(pendingMigrations, migration => {
+                return migration.instance!.up(queryRunner)
+                    .then(() => { // now when migration is executed we need to insert record about it into the database
+                        return this.insertExecutedMigration(queryRunner, migration);
+                    })
+                    .then(() => { // informative log about migration success
+                        successMigrations.push(migration);
+                        this.connection.logger.logSchemaBuild(`Migration ${migration.name} has been executed successfully.`);
+                    });
+            });
+
+            // commit transaction if we started it
+            if (transactionStartedByUs)
+                await queryRunner.commitTransaction();
+
+        } catch (err) { // rollback transaction if we started it
+            if (transactionStartedByUs) {
+                try { // we throw original error even if rollback thrown an error
+                    await queryRunner.rollbackTransaction();
+                } catch (rollbackError) { }
+            }
+
+            throw err;
+
+        } finally {
+
+            // if query runner was created by us then release it
+            if (!this.queryRunner)
+                await queryRunner.release();
+        }
+        return successMigrations;
+    }
+
+    protected async runAllMigrationsWithoutTransaction(queryRunner: QueryRunner, pendingMigrations: Migration[]) {
+        // variable to store all migrations we did successefuly
+        const successMigrations: Migration[] = [];
+
+        // run all pending migrations in a sequence
+        try {
+            await PromiseUtils.runInSequence(pendingMigrations, migration => {
+                return migration.instance!.up(queryRunner)
+                    .then(() => { // now when migration is executed we need to insert record about it into the database
+                        return this.insertExecutedMigration(queryRunner, migration);
+                    })
+                    .then(() => { // informative log about migration success
+                        successMigrations.push(migration);
+                        this.connection.logger.logSchemaBuild(`Migration ${migration.name} has been executed successfully.`);
+                    });
+            });
+        } finally {
+
+            // if query runner was created by us then release it
+            if (!this.queryRunner)
+                await queryRunner.release();
+        }
+        return successMigrations;
     }
 
 }

--- a/src/migration/MigrationExecutor.ts
+++ b/src/migration/MigrationExecutor.ts
@@ -24,7 +24,7 @@ export class MigrationExecutor {
      *   none: all migrations are run without a transaction
      *   each: each migration is run in a separate transaction
      */
-    transactionMode: 'all' | 'none' | 'each' = 'all';
+    transactionMode: "all" | "none" | "each" = "all";
 
     // -------------------------------------------------------------------------
     // Private Properties
@@ -101,11 +101,11 @@ export class MigrationExecutor {
         this.connection.logger.logSchemaBuild(`${pendingMigrations.length} migrations are new migrations that needs to be executed.`);
 
         switch (this.transactionMode) {
-            case 'each':
+            case "each":
                 return this.runEachMigrationInSeparateTransaction(queryRunner, pendingMigrations);
-            case 'all':
+            case "all":
                 return this.runAllMigrationsInSingleTransaction(queryRunner, pendingMigrations);
-            case 'none':
+            case "none":
                 return this.runAllMigrationsWithoutTransaction(queryRunner, pendingMigrations);
         }
     }
@@ -149,7 +149,7 @@ export class MigrationExecutor {
 
         // start transaction if its not started yet
         let transactionStartedByUs = false;
-        if ((this.transactionMode !== 'none') && !queryRunner.isTransactionActive) {
+        if ((this.transactionMode !== "none") && !queryRunner.isTransactionActive) {
             await queryRunner.startTransaction();
             transactionStartedByUs = true;
         }
@@ -315,7 +315,7 @@ export class MigrationExecutor {
         const successMigrations: Migration[] = [];
 
         if (queryRunner.isTransactionActive) {
-            throw new Error('Trying to run each migration in separate transaction, but already in one. Try changing this option and run migrations again.');
+            throw new Error("Trying to run each migration in separate transaction, but already in one. Try changing this option and run migrations again.");
         }
 
         // run all pending migrations in a sequence

--- a/test/github-issues/2693/issue-2693.ts
+++ b/test/github-issues/2693/issue-2693.ts
@@ -1,0 +1,28 @@
+import "reflect-metadata";
+import {createTestingConnections, closeTestingConnections, reloadTestingDatabases} from "../../utils/test-utils";
+import {Connection} from "../../../src/connection/Connection";
+import {Migration} from "../../../src/migration/Migration";
+
+describe("github issues > #2875 Option to run migrations in 1-transaction-per-migration mode", () => {
+    let connections: Connection[];
+    before(async () => connections = await createTestingConnections({
+        migrations: [__dirname + "/migration/*.js"],
+        enabledDrivers: ["postgres"]
+    }));
+    beforeEach(() => reloadTestingDatabases(connections));
+    after(() => closeTestingConnections(connections));
+
+    it("should fail to run all necessary migrations when transactionMode is all", () => Promise.all(connections.map(async connection => {
+        const mymigr: Migration[] = await connection.runMigrations({ transactionMode: "all" });
+    
+        mymigr.length.should.be.equal(0);
+    })));
+
+    it("should be able to run all necessary migrations when transactionMode is each", () => Promise.all(connections.map(async connection => {
+        const mymigr: Migration[] = await connection.runMigrations({ transactionMode: "each" });
+    
+        mymigr.length.should.be.equal(2);
+        mymigr[0].name.should.be.equal("CreateUuidExtension1544044606093");
+        mymigr[1].name.should.be.equal("CreateUsers1543965157399");
+    })));
+ });

--- a/test/github-issues/2693/migration/1543844606093-CreateUuidExtension.ts
+++ b/test/github-issues/2693/migration/1543844606093-CreateUuidExtension.ts
@@ -1,0 +1,12 @@
+import { MigrationInterface } from "../../../../src/migration/MigrationInterface";
+import { QueryRunner } from "../../../../src/query-runner/QueryRunner";
+
+export class CreateUuidExtension1544044606093 implements MigrationInterface {
+    public up(queryRunner: QueryRunner): Promise<any> {
+        return queryRunner.query(`CREATE EXTENSION IF NOT EXISTS "uuid-ossp";`);
+    }
+
+    public down(queryRunner: QueryRunner): Promise<any> {
+        return queryRunner.query("DROP EXTENSION \"uuid-ossp\"");
+    }
+}

--- a/test/github-issues/2693/migration/1543965157399-CreateUsers.ts
+++ b/test/github-issues/2693/migration/1543965157399-CreateUsers.ts
@@ -1,0 +1,20 @@
+import { MigrationInterface } from "../../../../src/migration/MigrationInterface";
+import { QueryRunner } from "../../../../src/query-runner/QueryRunner";
+import { Table } from "../../../../src/schema-builder/table/Table";
+
+export class CreateUsers1543965157399 implements MigrationInterface {
+    public up(queryRunner: QueryRunner): Promise<any> {
+        return queryRunner.createTable(
+        new Table({
+            name: "users",
+            columns: [
+            { name: "id", type: "uuid", isPrimary: true, default: "uuid_generate_v4()" },
+            ]
+        })
+        );
+    }
+
+    public down(queryRunner: QueryRunner): Promise<any> {
+        return queryRunner.dropTable("users");
+    }
+}


### PR DESCRIPTION
Addresses https://github.com/typeorm/typeorm/issues/2693

Creates a new, backwards compatible mode for running migrations each in their own transaction. This behaviour is what I think most expect as default from an ORM, so running all migrations in a single transaction seems odd. Using a single transaction also does not allow you to do certain things (in Postgres at least) if you expect to be able to run all migrations at once.

For example, if you have the following two migrations, you can **never** run all of from scratch.

```ts
import { MigrationInterface, QueryRunner } from "typeorm";

export class CreateUuidExtension1544044606093 implements MigrationInterface {
  public up(queryRunner: QueryRunner): Promise<any> {
    return queryRunner.query(`CREATE EXTENSION IF NOT EXISTS "uuid-ossp";`);
  }

  public down(queryRunner: QueryRunner): Promise<any> {
    return queryRunner.query('DROP EXTENSION "uuid-ossp"');
  }
}
```

```ts
import { MigrationInterface, QueryRunner, Table } from "typeorm";

export class CreateUsers1543965157399 implements MigrationInterface {
  public up(queryRunner: QueryRunner): Promise<any> {
    return queryRunner.createTable(
      new Table({
        name: "users",
        columns: [
          { name: "id", type: "uuid", isPrimary: true, default: "uuid_generate_v4()" },
        ]
      })
    );
  }

  public down(queryRunner: QueryRunner): Promise<any> {
    return queryRunner.dropTable("users");
  }
}
```

The error is `function uuid_generate_v4() does not exist` because extensions cannot be referenced from the same transaction which they are created.

Changes to the `-t` flag to accept: `all` (run all migrations in a single transaction), `each` (run each migration in a separate transaction), `none` (run all migrations without transactions) or `false` (same as none).

TODO:
- [x] Add new tests for 'each' mode
- [ ] Clean up code