### PR TITLE
Fix for error in mongodb embed field @BeforeInsert. 

### DIFF
--- a/src/metadata/EntityListenerMetadata.ts
+++ b/src/metadata/EntityListenerMetadata.ts
@@ -85,7 +85,7 @@ export class EntityListenerMetadata {
         if (!propertyPath)
             return;
 
-        if (propertyPaths.length === 0) {
+        if (propertyPaths.length === 0 && entity[propertyPath][this.propertyName]) {
             entity[propertyPath][this.propertyName]();
         } else {
             if (entity[propertyPath])


### PR DESCRIPTION
Using mongodb drive, my entities are:
```
@Entity('teams')
export class TeamEntity {
  @ObjectIdColumn()
  public id: ObjectID;

  @Column()
  public title: string;

  @Column(type => TeamPlayerEntity)
  public players: TeamPlayerEntity[];
}

@Entity()
export class TeamPlayerEntity {
  @ObjectIdColumn()
  public id?: ObjectID;

  @Column()
  public user: ObjectID;

  @Column()
  public status?: TeamPlayerStatus;

  @Column()
  public updated?: Date;

  @BeforeInsert()
  public async beforeInsert() {
    this.status = TeamPlayerStatus.CREATED;
    this.updated = new Date();
  }
}
```

When the following code is executed:
```
let team = this.teamRepository.create({ title: 'test'});
team.players = [ this.teamPlayerRepository.create({ user: user.id }) ];
await this.teamRepository.save(team);
```

I recieve:
```
 UnhandledPromiseRejectionWarning: TypeError: entity[propertyPath][this.propertyName] is not a function
    at EntityListenerMetadata.callEntityEmbeddedMethod (/Users/danilmihajlovic/WebstormProjects/cups-backend/src/metadata/EntityListenerMetadata.ts:90:16)
    at EntityListenerMetadata.execute (/Users/danilmihajlovic/WebstormProjects/cups-backend/src/metadata/EntityListenerMetadata.ts:74:6)
    ...
```