### PR TITLE
Add metadata to subscriber events

### DIFF
--- a/src/subscriber/Broadcaster.ts
+++ b/src/subscriber/Broadcaster.ts
@@ -50,7 +50,8 @@ export class Broadcaster {
                         connection: this.queryRunner.connection,
                         queryRunner: this.queryRunner,
                         manager: this.queryRunner.manager,
-                        entity: entity
+                        entity: entity,
+                        metadata: metadata
                     });
                     if (executionResult instanceof Promise)
                         result.promises.push(executionResult);
@@ -88,6 +89,7 @@ export class Broadcaster {
                         queryRunner: this.queryRunner,
                         manager: this.queryRunner.manager,
                         entity: entity,
+                        metadata: metadata,
                         databaseEntity: databaseEntity,
                         updatedColumns: updatedColumns || [],
                         updatedRelations: updatedRelations || []
@@ -128,6 +130,7 @@ export class Broadcaster {
                         queryRunner: this.queryRunner,
                         manager: this.queryRunner.manager,
                         entity: entity,
+                        metadata: metadata,
                         databaseEntity: databaseEntity,
                         entityId: metadata.getEntityIdMixedMap(databaseEntity)
                     });
@@ -167,7 +170,8 @@ export class Broadcaster {
                         connection: this.queryRunner.connection,
                         queryRunner: this.queryRunner,
                         manager: this.queryRunner.manager,
-                        entity: entity
+                        entity: entity,
+                        metadata: metadata
                     });
                     if (executionResult instanceof Promise)
                         result.promises.push(executionResult);
@@ -206,6 +210,7 @@ export class Broadcaster {
                         queryRunner: this.queryRunner,
                         manager: this.queryRunner.manager,
                         entity: entity,
+                        metadata: metadata,
                         databaseEntity: databaseEntity,
                         updatedColumns: updatedColumns || [],
                         updatedRelations: updatedRelations || []
@@ -247,6 +252,7 @@ export class Broadcaster {
                         queryRunner: this.queryRunner,
                         manager: this.queryRunner.manager,
                         entity: entity,
+                        metadata: metadata,
                         databaseEntity: databaseEntity,
                         entityId: metadata.getEntityIdMixedMap(databaseEntity)
                     });

--- a/src/subscriber/event/InsertEvent.ts
+++ b/src/subscriber/event/InsertEvent.ts
@@ -1,6 +1,7 @@
 import {EntityManager} from "../../entity-manager/EntityManager";
 import {Connection} from "../../connection/Connection";
 import {QueryRunner} from "../../query-runner/QueryRunner";
+import { EntityMetadata } from "../../metadata/EntityMetadata";
 
 /**
  * InsertEvent is an object that broadcaster sends to the entity subscriber when entity is inserted to the database.
@@ -28,5 +29,10 @@ export interface InsertEvent<Entity> {
      * Inserting event.
      */
     entity: Entity;
+
+    /**
+     * Metadata of the entity.
+     */
+    metadata: EntityMetadata;
 
 }

--- a/src/subscriber/event/RemoveEvent.ts
+++ b/src/subscriber/event/RemoveEvent.ts
@@ -1,6 +1,7 @@
 import {EntityManager} from "../../entity-manager/EntityManager";
 import {Connection} from "../../connection/Connection";
 import {QueryRunner} from "../../query-runner/QueryRunner";
+import { EntityMetadata } from "../../metadata/EntityMetadata";
 
 /**
  * RemoveEvent is an object that broadcaster sends to the entity subscriber when entity is being removed to the database.
@@ -29,6 +30,11 @@ export interface RemoveEvent<Entity> {
      * This may absent if entity is removed without being loaded (for examples by cascades).
      */
     entity?: Entity;
+
+    /**
+     * Metadata of the entity.
+     */
+    metadata: EntityMetadata;
 
     /**
      * Database representation of entity that is being removed.

--- a/src/subscriber/event/UpdateEvent.ts
+++ b/src/subscriber/event/UpdateEvent.ts
@@ -3,6 +3,7 @@ import {RelationMetadata} from "../../metadata/RelationMetadata";
 import {EntityManager} from "../../entity-manager/EntityManager";
 import {QueryRunner} from "../../query-runner/QueryRunner";
 import {Connection} from "../../connection/Connection";
+import { EntityMetadata } from "../../metadata/EntityMetadata";
 
 /**
  * UpdateEvent is an object that broadcaster sends to the entity subscriber when entity is being updated in the database.
@@ -30,6 +31,11 @@ export interface UpdateEvent<Entity> {
      * Updating entity.
      */
     entity: Entity;
+
+    /**
+     * Metadata of the entity.
+     */
+    metadata: EntityMetadata;
 
     /**
      * Updating entity in the database.


### PR DESCRIPTION
When creating a general subscriber, if prototype of an inserted object is not set, it is impossible to get metadata. Typeorm has this information from used repository, but doesn't pass it here. This pull request just passed down this information.