### PR TITLE
Add env variable for the migrationsTableName conn option

### DIFF
--- a/docs/using-ormconfig.md
+++ b/docs/using-ormconfig.md
@@ -11,7 +11,7 @@
 ## Creating a new connection from the configuration file
 
 Most of the times you want to store your connection options in a separate configuration file.
-It makes it convenient and easy to manage. 
+It makes it convenient and easy to manage.
 TypeORM supports multiple configuration sources.
 You only need to create a `ormconfig.[format]` file in the root directory of your application (near `package.json`),
 put your configuration there and in your app call `createConnection()` without any configuration passed:
@@ -25,7 +25,7 @@ const connection = await createConnection();
 ```
 
 Supported ormconfig file formats are: `.json`, `.js`, `.env`, `.yml` and `.xml`.
- 
+
 ## Using `ormconfig.json`
 
 Create `ormconfig.json` in the project root (near `package.json`). It should have the following content:
@@ -115,6 +115,7 @@ List of available env variables you can set:
 * TYPEORM_MIGRATIONS_RUN
 * TYPEORM_ENTITIES
 * TYPEORM_MIGRATIONS
+* TYPEORM_MIGRATIONS_TABLE_NAME
 * TYPEORM_SUBSCRIBERS
 * TYPEORM_ENTITY_SCHEMAS
 * TYPEORM_LOGGING
@@ -144,7 +145,7 @@ default: # default connection
     username: "test"
     password: "test"
     database: "test"
-    
+
 second-connection: # other connection
     host: "localhost"
     port: 3306

--- a/src/connection/options-reader/ConnectionOptionsEnvReader.ts
+++ b/src/connection/options-reader/ConnectionOptionsEnvReader.ts
@@ -33,6 +33,7 @@ export class ConnectionOptionsEnvReader {
             migrationsRun: OrmUtils.toBoolean(PlatformTools.getEnvVariable("TYPEORM_MIGRATIONS_RUN")),
             entities: this.stringToArray(PlatformTools.getEnvVariable("TYPEORM_ENTITIES")),
             migrations: this.stringToArray(PlatformTools.getEnvVariable("TYPEORM_MIGRATIONS")),
+            migrationsTableName: PlatformTools.getEnvVariable("TYPEORM_MIGRATIONS_TABLE_NAME"),
             subscribers: this.stringToArray(PlatformTools.getEnvVariable("TYPEORM_SUBSCRIBERS")),
             logging: this.transformLogging(PlatformTools.getEnvVariable("TYPEORM_LOGGING")),
             logger: PlatformTools.getEnvVariable("TYPEORM_LOGGER"),


### PR DESCRIPTION
Add a new variable called `TYPEORM_MIGRATIONS_TABLE_NAME` as discussed here https://github.com/typeorm/typeorm/issues/3249

PR does not contain tests for this change as there are no tests for the other env variables