### PR TITLE
Support specifying .env as config

### DIFF
--- a/src/connection/ConnectionOptionsReader.ts
+++ b/src/connection/ConnectionOptionsReader.ts
@@ -94,7 +94,7 @@ export class ConnectionOptionsReader {
         // if .env file found then load all its variables into process.env using dotenv package
         if (foundFileFormat === "env") {
             const dotenv = PlatformTools.load("dotenv");
-            dotenv.config({ path: this.baseFilePath + ".env" });
+            dotenv.config({ path: this.baseFilePath });
         } else if (PlatformTools.fileExist(".env")) {
             const dotenv = PlatformTools.load("dotenv");
             dotenv.config({ path: ".env" });

--- a/test/functional/connection-options-reader/configs/.env
+++ b/test/functional/connection-options-reader/configs/.env
@@ -1,0 +1,2 @@
+TYPEORM_CONNECTION = mysql
+TYPEORM_DATABASE = test-js

--- a/test/functional/connection-options-reader/connection-options-reader.ts
+++ b/test/functional/connection-options-reader/connection-options-reader.ts
@@ -3,6 +3,11 @@ import {ConnectionOptions} from "../../../src/connection/ConnectionOptions";
 import {ConnectionOptionsReader} from "../../../src/connection/ConnectionOptionsReader";
 
 describe("ConnectionOptionsReader", () => {
+  after(() => {
+    delete process.env.TYPEORM_CONNECTION;
+    delete process.env.TYPEORM_DATABASE;
+  });
+
   it("properly loads config with entities specified", async () => {
     type EntititesList = Function[] | string[];
     const connectionOptionsReader = new ConnectionOptionsReader({ root: __dirname, configName: "configs/class-entities" });
@@ -20,10 +25,16 @@ describe("ConnectionOptionsReader", () => {
     expect(fileOptions.database).to.have.string("/test");
   });
 
-  it.skip("properly loads config with specified file path", async () => {
+  it("properly loads config with specified file path", async () => {
     const connectionOptionsReader = new ConnectionOptionsReader({ root: __dirname, configName: "configs/test-path-config.js" });
     const fileOptions: ConnectionOptions = await connectionOptionsReader.get("file");
     expect(fileOptions.database).to.have.string("/test-js");
   });
 
+  it("properly loads config from .env file", async () => {
+    const connectionOptionsReader = new ConnectionOptionsReader({ root: __dirname, configName: "configs/.env" });
+    const [ fileOptions ]: ConnectionOptions[] = await connectionOptionsReader.all();
+    expect(fileOptions.database).to.have.string("test-js");
+    expect(process.env.TYPEORM_DATABASE).to.equal("test-js");
+  });
 });


### PR DESCRIPTION
If `baseFilePath` was specified as `.env`, it would not properly load because `.env` was appended to the file path.

Reference typeorm/typeorm#3258