### PR TITLE
Fix Postgres synchronisation unnecessarily dropping "float" columns

### DIFF
--- a/src/driver/postgres/PostgresDriver.ts
+++ b/src/driver/postgres/PostgresDriver.ts
@@ -563,7 +563,7 @@ export class PostgresDriver implements Driver {
         } else if (column.type === "decimal") {
             return "numeric";
 
-        } else if (column.type === "float8") {
+        } else if (column.type === "float8" || column.type === "float") {
             return "double precision";
 
         } else if (column.type === "float4") {


### PR DESCRIPTION
As suggested by @mattb-prg. Hopefully fixes #2210