### PR TITLE
fix(mongodb): Do not duplicate ObjectIdColumn in DB and in entity

### DIFF
--- a/test/functional/mongodb/basic/object-id/entity/Post.ts
+++ b/test/functional/mongodb/basic/object-id/entity/Post.ts
@@ -1,0 +1,14 @@
+import { Entity } from "../../../../../../src/decorator/entity/Entity";
+import { Column } from "../../../../../../src/decorator/columns/Column";
+import { ObjectIdColumn } from "../../../../../../src/decorator/columns/ObjectIdColumn";
+import { ObjectID } from "../../../../../../src/driver/mongodb/typings";
+
+@Entity()
+export class Post {
+
+    @ObjectIdColumn()
+    nonIdNameOfObjectId: ObjectID;
+
+    @Column()
+    title: string;
+}

--- a/test/functional/mongodb/basic/object-id/mongodb-object-id.ts
+++ b/test/functional/mongodb/basic/object-id/mongodb-object-id.ts
@@ -1,0 +1,69 @@
+import "reflect-metadata";
+import { Connection } from "../../../../../src/connection/Connection";
+import { closeTestingConnections, createTestingConnections, reloadTestingDatabases } from "../../../../utils/test-utils";
+import { Post } from "./entity/Post";
+import { expect } from "chai";
+
+
+describe("mongodb > object id columns", () => {
+
+    let connections: Connection[];
+    before(async () => connections = await createTestingConnections({
+        entities: [Post],
+        enabledDrivers: ["mongodb"]
+    }));
+    beforeEach(() => reloadTestingDatabases(connections));
+    after(() => closeTestingConnections(connections));
+
+    it("should persist ObjectIdColumn property as _id to DB", () => Promise.all(connections.map(async connection => {
+        const postMongoRepository = connection.getMongoRepository(Post);
+
+        // save a post
+        const post = new Post();
+        post.title = "Post";
+        await postMongoRepository.save(post);
+
+        // little hack to get raw data from mongodb
+        const aggArr = await postMongoRepository.aggregate([]).toArray();
+
+        expect(aggArr[0]._id).to.be.not.undefined;
+        expect(aggArr[0].nonIdNameOfObjectId).to.be.undefined;
+    })));
+
+
+    it("should map _id to ObjectIdColumn property and remove BD _id property", () => Promise.all(connections.map(async connection => {
+        const postMongoRepository = connection.getMongoRepository(Post);
+
+        // save a post
+        const post = new Post();
+        post.title = "Post";
+        await postMongoRepository.save(post);
+
+        expect(post.nonIdNameOfObjectId).to.be.not.undefined;
+        expect((post as any)._id).to.be.undefined;
+    })));
+
+
+    it("should not persist entity ObjectIdColumn property in DB on update by save", () => Promise.all(connections.map(async connection => {
+        const postMongoRepository = connection.getMongoRepository(Post);
+
+        // save a post
+        const post = new Post();
+        post.title = "Post";
+        await postMongoRepository.save(post);
+
+        post.title = "Muhaha changed title";
+
+        await postMongoRepository.save(post);
+
+        expect(post.nonIdNameOfObjectId).to.be.not.undefined;
+        expect((post as any)._id).to.be.undefined;
+
+        // little hack to get raw data from mongodb
+        const aggArr = await postMongoRepository.aggregate([]).toArray();
+
+        expect(aggArr[0]._id).to.be.not.undefined;
+        expect(aggArr[0].nonIdNameOfObjectId).to.be.undefined;
+    })));
+
+});


### PR DESCRIPTION
Fix cases when `ObjectIdColumn` property has name different than `_id`
 - After first save - `_id` returned by mongo driver is now deleted from entity
 - Update by `save` method now do not cause duplicate `ObjectIdColumn` in DB. E.g. add `id` with duplicate value as presented in https://github.com/typeorm/typeorm/issues/3206

closes https://github.com/typeorm/typeorm/issues/3206
