### PR TITLE
Pass referencedColumn's databaseName instead of propertyName

### DIFF
--- a/src/metadata-builder/RelationJoinColumnBuilder.ts
+++ b/src/metadata-builder/RelationJoinColumnBuilder.ts
@@ -127,7 +127,7 @@ export class RelationJoinColumnBuilder {
                 return (!joinColumn.referencedColumnName || joinColumn.referencedColumnName === referencedColumn.propertyName) &&
                     !!joinColumn.name;
             });
-            const joinColumnName = joinColumnMetadataArg ? joinColumnMetadataArg.name : this.connection.namingStrategy.joinColumnName(relation.propertyName, referencedColumn.propertyName);
+            const joinColumnName = joinColumnMetadataArg ? joinColumnMetadataArg.name : this.connection.namingStrategy.joinColumnName(relation.propertyName, referencedColumn.databaseName);
 
             let relationalColumn = relation.entityMetadata.ownColumns.find(column => column.databaseName === joinColumnName);
             if (!relationalColumn) {


### PR DESCRIPTION
Pass referencedColumn's databaseName instead of propertyName while creating default joinColumnName

When I tried to define chained multiple keys relations like:

```typescript
@Entity()
export class Semester {

    @PrimaryColumn()
    year: number;

    @PrimaryColumn()
    season: string;

}

@Entity()
export class Lecture {

    @ManyToOne(type => Semester, { primary: true })
    semester: Semester;

    @PrimaryColumn()
    course: string;

}

@Entity()
export class Project {

    @ManyToOne(type => Lecture, { primary: true })
    lecture: Lecture;

    @PrimaryColumn()
    studentId: string;

}
```

It throws an error trying to create two `lectureSemester` columns on `project` table.

I expected the join columns for Project.lecture should be `lectureSemesterYear`, `lectureSemesterSeason`

This is caused by the logic creating the default joinColumnName with the referencedColumn's propertyName which can collides.
(https://github.com/typeorm/typeorm/blob/master/src/metadata-builder/RelationJoinColumnBuilder.ts#L130)
