### PR TITLE
ts-node migration example does not work on windows

### DIFF
--- a/docs/migrations.md
+++ b/docs/migrations.md
@@ -151,7 +151,7 @@ typeorm migration:run
 
 Example with `ts-node`:
 ```
-ts-node ./node_modules/.bin/typeorm migration:run
+ts-node ./node_modules/typeorm/cli.js migration:run
 ```
 
 This command will execute all pending migrations and run them in a sequence ordered by their timestamps.


### PR DESCRIPTION
`ts-node ./node_modules/.bin/typeorm migration:run` does not work on windows
`ts-node ./node_modules/typeorm/cli.js migration:run` works on windows and on linux