### PR TITLE
fix(test): rowversion type is presented as timestamp type in SQL server

### DIFF
--- a/test/functional/database-schema/column-types/mssql/column-types-mssql.ts
+++ b/test/functional/database-schema/column-types/mssql/column-types-mssql.ts
@@ -137,7 +137,8 @@ describe("database schema > column types > mssql", () => { // https://github.com
         table!.findColumnByName("binary")!.type.should.be.equal("binary");
         table!.findColumnByName("varbinary")!.type.should.be.equal("varbinary");
         table!.findColumnByName("image")!.type.should.be.equal("image");
-        table!.findColumnByName("rowversion")!.type.should.be.equal("rowversion");
+        // the rowversion type's name in SQL server metadata is timestamp
+        table!.findColumnByName("rowversion")!.type.should.be.equal("timestamp");
         table!.findColumnByName("date")!.type.should.be.equal("date");
         table!.findColumnByName("dateObj")!.type.should.be.equal("date");
         table!.findColumnByName("datetime")!.type.should.be.equal("datetime");


### PR DESCRIPTION
In MSSQL rowversion is represented as timestamp column data type. This PR just fix test with type checking rowversion.

I think this is last puzzle to solve issue  https://github.com/typeorm/typeorm/issues/3169. I think we can also enable mssql tests on travis and will see if it is more stable now.