### PR TITLE
fix(column decorator): create generation strategy on generated columns

### DIFF
--- a/src/decorator/columns/Column.ts
+++ b/src/decorator/columns/Column.ts
@@ -14,6 +14,7 @@ import {EmbeddedMetadataArgs} from "../../metadata-args/EmbeddedMetadataArgs";
 import {ColumnTypeUndefinedError} from "../../error/ColumnTypeUndefinedError";
 import {ColumnHstoreOptions} from "../options/ColumnHstoreOptions";
 import {ColumnWithWidthOptions} from "../options/ColumnWithWidthOptions";
+import { GeneratedMetadataArgs } from "../../metadata-args/GeneratedMetadataArgs";
 
 /**
  * Column decorator is used to mark a specific class property as a table column. Only properties decorated with this
@@ -135,6 +136,14 @@ export function Column(typeOrOptions?: ((type?: any) => Function)|ColumnType|(Co
                 mode: "regular",
                 options: options
             } as ColumnMetadataArgs);
+
+            if (options.generated) {
+                getMetadataArgsStorage().generations.push({
+                    target: object.constructor,
+                    propertyName: propertyName,
+                    strategy: options.type === "uuid" ? "uuid" : "increment"
+                } as GeneratedMetadataArgs);
+            }
         }
     };
 }

--- a/src/decorator/columns/PrimaryColumn.ts
+++ b/src/decorator/columns/PrimaryColumn.ts
@@ -2,6 +2,7 @@ import {ColumnOptions, ColumnType, getMetadataArgsStorage} from "../../";
 import {ColumnTypeUndefinedError} from "../../error/ColumnTypeUndefinedError";
 import {PrimaryColumnCannotBeNullableError} from "../../error/PrimaryColumnCannotBeNullableError";
 import {ColumnMetadataArgs} from "../../metadata-args/ColumnMetadataArgs";
+import { GeneratedMetadataArgs } from "../../metadata-args/GeneratedMetadataArgs";
 
 /**
  * Column decorator is used to mark a specific class property as a table column.
@@ -61,6 +62,14 @@ export function PrimaryColumn(typeOrOptions?: ColumnType|ColumnOptions, options?
             mode: "regular",
             options: options
         } as ColumnMetadataArgs);
+
+        if (options.generated) {
+            getMetadataArgsStorage().generations.push({
+                target: object.constructor,
+                propertyName: propertyName,
+                strategy: options.type === "uuid" ? "uuid" : "increment"
+            } as GeneratedMetadataArgs);
+        }
     };
 }
 

--- a/src/decorator/options/ColumnOptions.ts
+++ b/src/decorator/options/ColumnOptions.ts
@@ -1,10 +1,11 @@
 import {ColumnType} from "../../driver/types/ColumnTypes";
 import {ValueTransformer} from "./ValueTransformer";
+import { ColumnCommonOptions } from "./ColumnCommonOptions";
 
 /**
  * Describes all column's options.
  */
-export interface ColumnOptions {
+export interface ColumnOptions extends ColumnCommonOptions {
 
     /**
      * Column type. Must be one of the value from the ColumnTypes class.

--- a/test/github-issues/2364/entity/dummy.ts
+++ b/test/github-issues/2364/entity/dummy.ts
@@ -1,0 +1,13 @@
+import {Column} from "../../../../src/decorator/columns/Column";
+import {Entity} from "../../../../src/decorator/entity/Entity";
+
+@Entity()
+export class Dummy {
+    @Column("integer", {
+        generated: true,
+        nullable: false,
+        primary: true,
+    })
+    id: number;
+}
+

--- a/test/github-issues/2364/entity/dummy2.ts
+++ b/test/github-issues/2364/entity/dummy2.ts
@@ -1,0 +1,13 @@
+import {Entity} from "../../../../src/decorator/entity/Entity";
+import { PrimaryColumn } from "../../../../src";
+
+@Entity()
+export class Dummy2 {
+    @PrimaryColumn("integer", {
+        generated: true,
+        nullable: false,
+        primary: true,
+    })
+    id: number;
+}
+

--- a/test/github-issues/2364/issue-2364.ts
+++ b/test/github-issues/2364/issue-2364.ts
@@ -1,0 +1,33 @@
+import "reflect-metadata";
+import { createTestingConnections, closeTestingConnections, reloadTestingDatabases } from "../../utils/test-utils";
+import { Connection } from "../../../src/connection/Connection";
+import { expect } from "chai";
+import { Dummy } from "./entity/dummy";
+import { Dummy2 } from "./entity/dummy2";
+
+describe("github issues > #2364 should generate id value if @Column generated:true is set", () => {
+
+    let connections: Connection[];
+
+
+    it("should generate id value", async () => {
+        connections = await createTestingConnections({
+            entities: [__dirname + "/entity/*{.js,.ts}"],
+            schemaCreate: true,
+            dropSchema: true,
+        });
+        await reloadTestingDatabases(connections);
+        await Promise.all(connections.map(async connection => {
+            const repository1 = connection.getRepository(Dummy);
+            const repository2 = connection.getRepository(Dummy2);
+            let dummyObj1 = new Dummy();
+            let dummyObj2 = new Dummy2();
+            await repository1.insert(dummyObj1);
+            await repository2.insert(dummyObj2);
+
+            expect(dummyObj1.id).to.not.be.eq(0);
+            expect(dummyObj2.id).to.not.be.eq(0);
+        }));
+        await closeTestingConnections(connections);
+    });
+});


### PR DESCRIPTION
close #2364 
Allows to use `@Column` and `@PrimaryColumn` decorators to create primary columns with generated values.