### PR TITLE
fix for reading custom env files (for e.g. ormconfig.env)

### DIFF
--- a/src/connection/ConnectionOptionsReader.ts
+++ b/src/connection/ConnectionOptionsReader.ts
@@ -94,7 +94,7 @@ export class ConnectionOptionsReader {
         // if .env file found then load all its variables into process.env using dotenv package
         if (foundFileFormat === "env") {
             const dotenv = PlatformTools.load("dotenv");
-            dotenv.config({ path: this.baseFilePath });
+            dotenv.config({ path: `${this.baseFilePath}.env` });
         } else if (PlatformTools.fileExist(".env")) {
             const dotenv = PlatformTools.load("dotenv");
             dotenv.config({ path: ".env" });


### PR DESCRIPTION
Added missing extension when reading <custom_name>.env file

Tested on TypeORM  v0.2.11