### PR TITLE
Enchancement - Add support for ioredis Cluster object initialization

### DIFF
--- a/src/cache/QueryResultCacheFactory.ts
+++ b/src/cache/QueryResultCacheFactory.ts
@@ -32,8 +32,10 @@ export class QueryResultCacheFactory {
         if ((this.connection.options.cache as any).type === "ioredis")
             return new RedisQueryResultCache(this.connection, "ioredis");
 
+        if ((this.connection.options.cache as any).type === "ioredis/cluster")
+            return new RedisQueryResultCache(this.connection, "ioredis/cluster");
+
         return new DbQueryResultCache(this.connection);
     }
-
 
 }

--- a/src/cache/RedisQueryResultCache.ts
+++ b/src/cache/RedisQueryResultCache.ts
@@ -26,13 +26,13 @@ export class RedisQueryResultCache implements QueryResultCache {
     /**
      * Type of the Redis Client (redis or ioredis).
      */
-    protected clientType: "redis" | "ioredis";
+    protected clientType: "redis" | "ioredis" | "ioredis/cluster";
 
     // -------------------------------------------------------------------------
     // Constructor
     // -------------------------------------------------------------------------
 
-    constructor(protected connection: Connection, clientType: "redis" | "ioredis") {
+    constructor(protected connection: Connection, clientType: "redis" | "ioredis" | "ioredis/cluster") {
         this.clientType = clientType;
         this.redis = this.loadRedis();
     }
@@ -59,6 +59,13 @@ export class RedisQueryResultCache implements QueryResultCache {
                 this.client = new this.redis(cacheOptions.options);
             } else {
                 this.client = new this.redis();
+            }
+
+        } else if (this.clientType === "ioredis/cluster") {
+            if (cacheOptions && cacheOptions.options) {
+                this.client = new this.redis.Cluster(cacheOptions.options);
+            } else {
+                throw new Error(`Options required for ${this.clientType}.`);
             }
 
         }

--- a/src/connection/BaseConnectionOptions.ts
+++ b/src/connection/BaseConnectionOptions.ts
@@ -114,7 +114,7 @@ export interface BaseConnectionOptions {
          * - "database" means cached values will be stored in the separate table in database. This is default value.
          * - "redis" means cached values will be stored inside redis. You must provide redis connection options.
          */
-        readonly type?: "database"|"redis"; // todo: add mongodb and other cache providers as well in the future
+        readonly type?: "database" | "redis" | "ioredis" | "ioredis/cluster"; // todo: add mongodb and other cache providers as well in the future
 
         /**
          * Used to provide redis connection options.

--- a/src/platform/PlatformTools.ts
+++ b/src/platform/PlatformTools.ts
@@ -83,6 +83,7 @@ export class PlatformTools {
                  * ioredis
                  */
                 case "ioredis":
+                case "ioredis/cluster":
                     return require("ioredis");
 
                 /**


### PR DESCRIPTION
As a continuation to:

https://github.com/typeorm/typeorm/pull/3289

and my comment about Ioredis cluster object I submit the following tweaks which allow to initialize a Ioredis cluster object as a caching option.

https://github.com/luin/ioredis/blob/master/API.md#Cluster

