### PR TITLE
Update docs to recommend using npx instead of global docs

### DIFF
--- a/README-zh_CN.md
+++ b/README-zh_CN.md
@@ -213,16 +213,10 @@ await timber.remove();
 快速开始只有在NodeJS应用程序中使用TypeORM才可以使用。
 如果你正在使用其他平台，请看[分步指南](#分步指南)。
 
-首先全局安装TypeORM：
-
-```
-npm install typeorm -g
-```
-
 然后转到新项目的目录并运行该命令：
 
 ```
-typeorm init --name MyProject --database mysql
+npx typeorm init --name MyProject --database mysql
 ```
 
 `name`即项目的名称，`database`是你将使用的数据库。数据库可以是下列值之一：`mysql`、`mariadb`、`postgres`、`sqlite`、`mssql`、`oracle`、`mongodb`、`cordova`、`react-native`、`expo`。

--- a/README.md
+++ b/README.md
@@ -233,16 +233,10 @@ The quickest way to get started with TypeORM is to use its CLI commands to gener
 Quick start works only if you are using TypeORM in a NodeJS application.
 If you are using other platforms, proceed to the [step-by-step guide](#step-by-step-guide).
 
-First, install TypeORM globally:
+Go to the directory where you want to create a new project and run the command:
 
 ```
-npm install typeorm -g
-```
-
-Then go to the directory where you want to create a new project and run the command:
-
-```
-typeorm init --name MyProject --database mysql
+npx typeorm init --name MyProject --database mysql
 ```
 
 Where `name` is the name of your project and `database` is the database you'll use.


### PR DESCRIPTION
npx tool, installed by default in node will download the library and execute.
This will also prevent a global installation and ensure that the binary run is
always the latest stable version.