### PR TITLE
Fix #2770

### DIFF
--- a/src/driver/sqlserver/SqlServerDriver.ts
+++ b/src/driver/sqlserver/SqlServerDriver.ts
@@ -434,7 +434,8 @@ export class SqlServerDriver implements Driver {
             return "uniqueidentifier";
 
         } else if (column.type === "simple-array" || column.type === "simple-json") {
-            return "ntext";
+            column.length = "MAX";
+            return "nvarchar";
 
         } else if (column.type === "dec") {
             return "decimal";


### PR DESCRIPTION
Fix #2770
Modified simple-array and simple-json to use nvarchar(MAX) in mssql

https://docs.microsoft.com/en-us/sql/t-sql/data-types/ntext-text-and-image-transact-sql?view=sql-server-2017

> IMPORTANT! ntext, text, and image data types will be removed in a future version of SQL Server. Avoid using these data types in new development work, and plan to modify applications that currently use them. Use nvarchar(max), varchar(max), and varbinary(max) instead.

One more reason for using nvarchar(max) is STRING_SPLIT is applicable to nvarchar only. In the following example, Tags is a simple-array column.
```sql
SELECT ProductId, Name, Tags  
FROM Product  
WHERE EXISTS (SELECT *  
    FROM STRING_SPLIT(Tags, ',')  
    WHERE value IN ('clothing', 'road')); 
```

https://docs.microsoft.com/en-us/sql/t-sql/functions/string-split-transact-sql?view=sql-server-2017