### PR TITLE
Handle null exports gracefully

### DIFF
--- a/src/util/DirectoryExportedClassesLoader.ts
+++ b/src/util/DirectoryExportedClassesLoader.ts
@@ -13,7 +13,7 @@ export function importClassesFromDirectories(directories: string[], formats = ["
         } else if (Array.isArray(exported)) {
             exported.forEach((i: any) => loadFileClasses(i, allLoaded));
 
-        } else if (typeof exported === "object") {
+        } else if (typeof exported === "object" && exported !== null) {
             Object.keys(exported).forEach(key => loadFileClasses(exported[key], allLoaded));
 
         }


### PR DESCRIPTION
Fixes https://github.com/typeorm/typeorm/issues/3405 by introducing a `null` check.