### PR TITLE
Config SSL parameter in .env

### DIFF
--- a/src/connection/options-reader/ConnectionOptionsEnvReader.ts
+++ b/src/connection/options-reader/ConnectionOptionsEnvReader.ts
@@ -19,6 +19,7 @@ export class ConnectionOptionsEnvReader {
     read(): ConnectionOptions {
         return {
             type: PlatformTools.getEnvVariable("TYPEORM_CONNECTION") || (PlatformTools.getEnvVariable("TYPEORM_URL") ? PlatformTools.getEnvVariable("TYPEORM_URL").split("://")[0] : undefined),
+            ssl: PlatformTools.getEnvVariable("TYPEORM_SSL") === "true",
             url: PlatformTools.getEnvVariable("TYPEORM_URL"),
             host: PlatformTools.getEnvVariable("TYPEORM_HOST"),
             port: PlatformTools.getEnvVariable("TYPEORM_PORT"),


### PR DESCRIPTION
I noticed that i cannot add the SSL parameter when configuring through .env, so this allows that, where anything except the input "true" defaults to false.

This is useful for me since I am on Heroku postgres and it by default only accepts ssl connections.

~~TODO: add test case~~ after looking at existing tests for this, they seem entirely threadbare; so i guess not high pri https://github.com/osdiab/typeorm/tree/osdiab/config-ssl-in-env/test/functional/connection-options-reader