### PR TITLE
Bumped sqlite version in InitCommand to resolve cli init bug. 

### DIFF
--- a/src/commands/InitCommand.ts
+++ b/src/commands/InitCommand.ts
@@ -522,7 +522,7 @@ Steps to run this project:
                 packageJson.dependencies["pg"] = "^7.3.0";
                 break;
             case "sqlite":
-                packageJson.dependencies["sqlite3"] = "^3.1.10";
+                packageJson.dependencies["sqlite3"] = "^4.0.3";
                 break;
             case "oracle":
                 packageJson.dependencies["oracledb"] = "^1.13.1";


### PR DESCRIPTION
The version of sqlite3 (3.1.10) referenced by the cli init command is no longer available online for download during installation.  

That is, running 
```
typeorm init --name ormtest --database sqlite
cd ormtest
npm install
```

results in the following error: 
```
node-pre-gyp ERR! Tried to download(403): https://mapbox-node-binary.s3.amazonaws.com/sqlite3/v3.1.13/node-v64-win32-x64.tar.gz
node-pre-gyp ERR! Pre-built binaries not found for sqlite3@3.1.13 and node@10.15.0 (node-v64 ABI) (falling back to source compile with node-gyp)
node-pre-gyp ERR! Tried to download(undefined): https://mapbox-node-binary.s3.amazonaws.com/sqlite3/v3.1.13/node-v64-win32-x64.tar.gz
node-pre-gyp ERR! Pre-built binaries not found for sqlite3@3.1.13 and node@10.15.0 (node-v64 ABI) (falling back to source compile with node-gyp)
```

This is because the url used to download the installation files appears to be no longer active: [https://mapbox-node-binary.s3.amazonaws.com/sqlite3/v3.1.13/node-v64-win32-x64.tar.gz](https://mapbox-node-binary.s3.amazonaws.com/sqlite3/v3.1.13/node-v64-win32-x64.tar.gzl). 

Bumping the version to match the main project dependency (4.0.3) appears to resolve the issue; the sqlite3 install proceeds as expected thereafter. 
