### PR TITLE
Use ConnectionOptionsEnvReader to read configuration if TYPEORM_URL is set

### DIFF
--- a/src/connection/ConnectionOptionsReader.ts
+++ b/src/connection/ConnectionOptionsReader.ts
@@ -104,7 +104,7 @@ export class ConnectionOptionsReader {
         const configFile = fileExtension ? this.baseFilePath : this.baseFilePath + "." + foundFileFormat;
 
         // try to find connection options from any of available sources of configuration
-        if (PlatformTools.getEnvVariable("TYPEORM_CONNECTION")) {
+        if (PlatformTools.getEnvVariable("TYPEORM_CONNECTION") || PlatformTools.getEnvVariable("TYPEORM_URL")) {
             connectionOptions = new ConnectionOptionsEnvReader().read();
 
         } else if (foundFileFormat === "js") {


### PR DESCRIPTION
This fixes the use of typeorm (cli), mentioned in issue https://github.com/typeorm/typeorm/issues/2738.

Basically the change is just that besides `TYPEORM_CONNECTION` environment variables, optionally also `TYPEORM_URL` will trigger the use of ConnectionOptionsEnvReader to load configuration. Therefore one can use only `TYPEORM_URL` to load configuration.