### PR TITLE
Fix DriverUtils.buildDriverOptions

### DIFF
--- a/src/driver/DriverUtils.ts
+++ b/src/driver/DriverUtils.ts
@@ -1,4 +1,4 @@
-/**
+    /**
  * Common driver utility functions.
  */
 export class DriverUtils {
@@ -14,27 +14,18 @@ export class DriverUtils {
     static buildDriverOptions(options: any, buildOptions?: { useSid: boolean }): any {
         if (options.url) {
             const parsedUrl = this.parseConnectionUrl(options.url);
+            let urlDriverOptions: any = {
+                type: parsedUrl.type,
+                host: parsedUrl.host,
+                username: parsedUrl.username,
+                password: parsedUrl.password,
+                port: parsedUrl.port,
+                database: parsedUrl.database
+            };
             if (buildOptions && buildOptions.useSid) {
-                const urlDriverOptions: any = {
-                    type: options.type || parsedUrl.type,
-                    host: options.host || parsedUrl.host,
-                    username: options.username || parsedUrl.username,
-                    password: options.password || parsedUrl.password,
-                    port: options.port || parsedUrl.port,
-                    sid: options.sid || options.database || parsedUrl.database
-                };
-                return Object.assign(urlDriverOptions, options);
-            } else {
-                const urlDriverOptions: any = {
-                    type: options.type || parsedUrl.type,
-                    host: options.host || parsedUrl.host,
-                    username: options.username || parsedUrl.username,
-                    password: options.password || parsedUrl.password,
-                    port: options.port || parsedUrl.port,
-                    database: options.database || parsedUrl.database
-                };
-                return Object.assign(urlDriverOptions, options);
+                urlDriverOptions.sid = parsedUrl.database;
             }
+            return Object.assign({}, options, urlDriverOptions);
         }
         return Object.assign({}, options);
     }


### PR DESCRIPTION
Fix DriverUtils.buildDriverOptions static method to actually assign TYPEORM_URL originated parameters. There has been couple of past PR's for this, so now it's better to make it simpler with only one way to get the parameters.

The new logic assigns parameters by default from the options values, and secondly from parsed TYPEORM_URL originated parameters. Finally the parsed parameters are assigned on top of options.