### PR TITLE
fixing query builder regression #2103

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,10 @@ feel free to ask us and community.
 
 ## 0.2.12
 
+* queries are simplified in `findByIds` and `whereInIds` for simple entities with single primary key
 * fixed broken findOne method with custom join column name
 * fixed issue with uuid in mysql
+* fixed issue with logical operator precedence in `QueryBuilder` `whereInIds` (#2103)
 
 ## 0.2.11
 

--- a/src/query-builder/QueryBuilder.ts
+++ b/src/query-builder/QueryBuilder.ts
@@ -733,7 +733,9 @@ export abstract class QueryBuilder<Entity> {
             return whereSubStrings.join(" AND ");
         });
 
-        return whereStrings.length > 1 ? whereStrings.map(whereString => "(" + whereString + ")").join(" OR ") : whereStrings[0];
+        return whereStrings.length > 1
+            ? "(" + whereStrings.map(whereString => "(" + whereString + ")").join(" OR ") + ")"
+            : whereStrings[0];
     }
 
     /**

--- a/src/query-builder/SelectQueryBuilder.ts
+++ b/src/query-builder/SelectQueryBuilder.ts
@@ -736,7 +736,7 @@ export class SelectQueryBuilder<Entity> extends QueryBuilder<Entity> implements 
      * for example [{ firstId: 1, secondId: 2 }, { firstId: 2, secondId: 3 }, ...]
      */
     andWhereInIds(ids: any|any[]): this {
-        return this.andWhere("(" + this.createWhereIdsExpression(ids) + ")");
+        return this.andWhere(this.createWhereIdsExpression(ids));
     }
 
     /**
@@ -748,7 +748,7 @@ export class SelectQueryBuilder<Entity> extends QueryBuilder<Entity> implements 
      * for example [{ firstId: 1, secondId: 2 }, { firstId: 2, secondId: 3 }, ...]
      */
     orWhereInIds(ids: any|any[]): this {
-        return this.orWhere("(" + this.createWhereIdsExpression(ids) + ")");
+        return this.orWhere(this.createWhereIdsExpression(ids));
     }
 
     /**

--- a/test/github-issues/2103/entity/Complex.ts
+++ b/test/github-issues/2103/entity/Complex.ts
@@ -1,0 +1,15 @@
+import {Entity, Column, PrimaryColumn} from "../../../../src";
+
+@Entity()
+export class Complex {
+
+    @PrimaryColumn()
+    id: number;
+
+    @PrimaryColumn()
+    code: number;
+
+    @Column()
+    x: number;
+
+}

--- a/test/github-issues/2103/entity/Simple.ts
+++ b/test/github-issues/2103/entity/Simple.ts
@@ -1,0 +1,12 @@
+import {Entity, Column, PrimaryGeneratedColumn} from "../../../../src";
+
+@Entity()
+export class Simple {
+
+    @PrimaryGeneratedColumn()
+    id: number;
+
+    @Column()
+    x: number;
+
+}

--- a/test/github-issues/2103/issue-2103.ts
+++ b/test/github-issues/2103/issue-2103.ts
@@ -1,0 +1,73 @@
+import "reflect-metadata";
+import {createTestingConnections, closeTestingConnections, reloadTestingDatabases} from "../../utils/test-utils";
+import {Connection} from "../../../src";
+import {Simple} from "./entity/Simple";
+import {Complex} from "./entity/Complex";
+
+describe("github issues > #2103 query builder regression", () => {
+
+    let connections: Connection[];
+    before(async () => connections = await createTestingConnections({
+        entities: [__dirname + "/entity/*{.js,.ts}"],
+        schemaCreate: true,
+        dropSchema: true,
+    }));
+    beforeEach(() => reloadTestingDatabases(connections));
+    after(() => closeTestingConnections(connections));
+
+    it("whereInIds should respect logical operator precedence > single simple primary key (in is used)", () => Promise.all(connections.map(async connection => {
+        const repository = connection.getRepository(Simple);
+
+        const savedEntities = await repository.save([
+            repository.create({ x: 1 }),
+            repository.create({ x: 2 }),
+            repository.create({ x: 1 }),
+            repository.create({ x: 3 })
+        ]);
+
+        savedEntities.length.should.be.equal(4); // check if they all are saved
+
+        const ids = savedEntities.map(entity => entity.id);
+
+        const entities = await repository.createQueryBuilder("s")
+            .whereInIds(ids)
+            .andWhere("x = 1")
+            .getMany();
+
+        entities.map(entity => entity.id).should.be.eql(
+            savedEntities
+                .filter(entity => entity.x === 1)
+                .map(entity => entity.id)
+        );
+    })));
+
+    it("whereInIds should respect logical operator precedence > multiple primary keys", () => Promise.all(connections.map(async connection => {
+        const repository = connection.getRepository(Complex);
+
+        // sqlite does not support autoincrement for composite primary key, so we pass ids by ourselves here
+        const savedEntities = await repository.save([
+            repository.create({ id: 1, code: 1, x: 1 }),
+            repository.create({ id: 2, code: 1, x: 2 }),
+            repository.create({ id: 3, code: 1, x: 1 }),
+            repository.create({ id: 4, code: 1, x: 3 })
+        ]);
+
+        savedEntities.length.should.be.equal(4); // check if they all are saved
+
+        const ids = savedEntities.map(entity => entity.id);
+
+        const entities = await repository.createQueryBuilder("s")
+            .whereInIds(ids.map(id => {
+                return { id, code: 1 };
+            }))
+            .andWhere("x = 1")
+            .getMany();
+
+        entities.map(entity => entity.id).should.be.eql(
+            savedEntities
+                .filter(entity => entity.x === 1)
+                .map(entity => entity.id)
+        );
+    })));
+
+});


### PR DESCRIPTION
respecting logical operators precedence in `whereInIds` (using brackets for multiple `OR` operators)