### PR TITLE
Added columnAliasName to Naming strategy to customize the alias generation

### DIFF
--- a/src/naming-strategy/DefaultNamingStrategy.ts
+++ b/src/naming-strategy/DefaultNamingStrategy.ts
@@ -34,6 +34,10 @@ export class DefaultNamingStrategy implements NamingStrategyInterface {
         return customName ? customName : propertyName;
     }
 
+    columnAliasName(aliasName: string, columnName: string): string {
+      return aliasName + "_" + columnName;
+    }
+
     relationName(propertyName: string): string {
         return propertyName;
     }

--- a/src/naming-strategy/NamingStrategyInterface.ts
+++ b/src/naming-strategy/NamingStrategyInterface.ts
@@ -32,6 +32,11 @@ export interface NamingStrategyInterface {
     columnName(propertyName: string, customName: string|undefined, embeddedPrefixes: string[]): string;
 
     /**
+     * Builds column alias from given alias name and column name.
+     */
+    columnAliasName(aliasName: string, columnName: string): string;
+
+    /**
      * Gets the table's relation name from the given property name.
      */
     relationName(propertyName: string): string;

--- a/src/query-builder/SelectQueryBuilder.ts
+++ b/src/query-builder/SelectQueryBuilder.ts
@@ -1836,7 +1836,7 @@ export class SelectQueryBuilder<Entity> extends QueryBuilder<Entity> implements 
             // transform raw results into entities
             const rawRelationIdResults = await relationIdLoader.load(rawResults);
             const rawRelationCountResults = await relationCountLoader.load(rawResults);
-            const transformer = new RawSqlResultsToEntityTransformer(this.expressionMap, this.connection.driver, rawRelationIdResults, rawRelationCountResults, this.queryRunner);
+            const transformer = new RawSqlResultsToEntityTransformer(this.expressionMap, this.connection, rawRelationIdResults, rawRelationCountResults, this.queryRunner);
             entities = transformer.transform(rawResults, this.expressionMap.mainAlias!);
 
             // broadcast all "after load" events
@@ -1930,7 +1930,7 @@ export class SelectQueryBuilder<Entity> extends QueryBuilder<Entity> implements 
      * If alias length is more than 29, abbreviates column name.
      */
     protected buildColumnAlias(aliasName: string, columnName: string): string {
-        const columnAliasName = aliasName + "_" + columnName;
+        const columnAliasName = this.connection.namingStrategy.columnAliasName(aliasName, columnName);
         if (columnAliasName.length > 29 && this.connection.driver instanceof OracleDriver)
             return aliasName  + "_" + abbreviate(columnName, 2);
 

--- a/src/query-builder/relation-id/RelationIdLoader.ts
+++ b/src/query-builder/relation-id/RelationIdLoader.ts
@@ -185,7 +185,7 @@ export class RelationIdLoader {
      * If alias length is more than 29, abbreviates column name.
      */
     protected buildColumnAlias(aliasName: string, columnName: string): string {
-        const columnAliasName = aliasName + "_" + columnName;
+        const columnAliasName = this.connection.namingStrategy.columnAliasName(aliasName, columnName);
         if (columnAliasName.length > 29 && this.connection.driver instanceof OracleDriver)
             return aliasName  + "_" + abbreviate(columnName, 2);
 

--- a/src/query-builder/transformer/RawSqlResultsToEntityTransformer.ts
+++ b/src/query-builder/transformer/RawSqlResultsToEntityTransformer.ts
@@ -1,4 +1,4 @@
-import {Driver} from "../../driver/Driver";
+import { Connection } from "../../connection/Connection";
 import {RelationIdLoadResult} from "../relation-id/RelationIdLoadResult";
 import {ObjectLiteral} from "../../common/ObjectLiteral";
 import {ColumnMetadata} from "../../metadata/ColumnMetadata";
@@ -23,7 +23,7 @@ export class RawSqlResultsToEntityTransformer {
     // -------------------------------------------------------------------------
 
     constructor(protected expressionMap: QueryExpressionMap,
-                protected driver: Driver,
+                protected connection: Connection,
                 protected rawRelationIdResults: RelationIdLoadResult[],
                 protected rawRelationCountResults: RelationCountLoadResult[],
                 protected queryRunner?: QueryRunner) {
@@ -128,7 +128,7 @@ export class RawSqlResultsToEntityTransformer {
             if (!this.expressionMap.selects.find(select => select.selection === alias.name || select.selection === alias.name + "." + column.propertyPath))
                 return;
 
-            column.setEntityValue(entity, this.driver.prepareHydratedValue(value, column));
+            column.setEntityValue(entity, this.connection.driver.prepareHydratedValue(value, column));
             if (value !== null) // we don't mark it as has data because if we will have all nulls in our object - we don't need such object
                 hasData = true;
         });
@@ -309,8 +309,8 @@ export class RawSqlResultsToEntityTransformer {
      * If alias length is more than 29, abbreviates column name.
      */
     protected buildColumnAlias(aliasName: string, columnName: string): string {
-        const columnAliasName = aliasName + "_" + columnName;
-        if (columnAliasName.length > 29 && this.driver instanceof OracleDriver)
+        const columnAliasName = this.connection.namingStrategy.columnAliasName(aliasName, columnName);
+        if (columnAliasName.length > 29 && this.connection.driver instanceof OracleDriver)
             return aliasName  + "_" + abbreviate(columnName, 2);
 
         return columnAliasName;


### PR DESCRIPTION
Added a method to the naming strategy to make the generation of column aliases customizable.
`columnAliasName(aliasName: string, columnName: string): string;`