### PR TITLE
fixing count performance issue

### DIFF
--- a/src/query-builder/SelectQueryBuilder.ts
+++ b/src/query-builder/SelectQueryBuilder.ts
@@ -1702,39 +1702,23 @@ export class SelectQueryBuilder<Entity> extends QueryBuilder<Entity> implements 
         const mainAlias = this.expressionMap.mainAlias!.name; // todo: will this work with "fromTableName"?
         const metadata = this.expressionMap.mainAlias!.metadata;
 
-        const distinctAlias = this.escape(mainAlias);
-        let countSql: string = "";
-        if (metadata.hasMultiplePrimaryKeys) {
-            if (this.connection.driver instanceof AbstractSqliteDriver) {
-                countSql = `COUNT(DISTINCT(` + metadata.primaryColumns.map((primaryColumn, index) => {
-                    const propertyName = this.escape(primaryColumn.databaseName);
-                    return `${distinctAlias}.${propertyName}`;
-                }).join(" || ") + ")) as \"cnt\"";
+        const querySelects = metadata.primaryColumns.map(primaryColumn => {
+            const distinctAlias = this.escape("distinctAlias");
+            const columnAlias = this.escape(DriverUtils.buildColumnAlias(this.connection.driver, mainAlias, primaryColumn.databaseName));
+            return `${distinctAlias}.${columnAlias} as "ids_${columnAlias}"`;
+        });
 
-            } else {
-                countSql = `COUNT(DISTINCT(CONCAT(` + metadata.primaryColumns.map((primaryColumn, index) => {
-                    const propertyName = this.escape(primaryColumn.databaseName);
-                    return `${distinctAlias}.${propertyName}`;
-                }).join(", ") + "))) as \"cnt\"";
-            }
+        const distinctQuery = new SelectQueryBuilder(this.connection, queryRunner)
+            .select(`DISTINCT ${querySelects.join(", ")}`)
+            .from(`(${this.clone().orderBy().limit().offset().skip().take().getQuery()})`, "distinctAlias");
 
-        } else {
-            countSql = `COUNT(DISTINCT(` + metadata.primaryColumns.map((primaryColumn, index) => {
-                const propertyName = this.escape(primaryColumn.databaseName);
-                return `${distinctAlias}.${propertyName}`;
-            }).join(", ") + ")) as \"cnt\"";
-        }
-
-        const results = await this.clone()
-            .orderBy()
-            .groupBy()
-            .offset(undefined)
-            .limit(undefined)
-            .skip(undefined)
-            .take(undefined)
-            .select(countSql)
-            .setOption("disable-global-order")
-            .loadRawResults(queryRunner);
+        const results = await new SelectQueryBuilder(this.connection, queryRunner)
+            .select("COUNT(1) as cnt")
+            .from(`(${distinctQuery.getSql()})`, "count")
+            .setParameters(this.getParameters())
+            .setNativeParameters(this.expressionMap.nativeParameters)
+            .cache(this.expressionMap.cache ? this.expressionMap.cache : this.expressionMap.cacheId, this.expressionMap.cacheDuration)
+            .getRawMany();
 
         if (!results || !results[0] || !results[0]["cnt"])
             return 0;


### PR DESCRIPTION
Counting joined results is never a easy task, however we can use an old technique, which is to recreate the query with an count and distinct, and typeorm uses this technique as other super popular orms like doctrine, sqlalchemy and hibernate does. However, it isn't doing it the right way, when it uses SELECT COUNT(DICTINCT(`table`.`id`)) FROM table -- the database will ignore indexes and will perform a full table scan and degrade performance (it is happening on my project, when counting results on a 50000+ registries, its taking from 6 to 15 seconds on my staging machine) .
To solve that problem, i changed it to the counting style that is used on the older and traditional orms like hibernate, doctrine and entities framework, they use count on a parent query encapsulating the current query as a subquery with distinct, that way the database engine doesn't ignore the indexes of the primary key, heres an example: "SELECT COUNT(1) cnt FROM (SELECT DISTINCT table.id FROM table) as result".
Thanks