### PR TITLE
fix(3517): fixed undefined object id field in case property name is _id

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ feel free to ask us and community.
 ### Bug Fixes
 
 * fixed signatures of `update`/`insert` methods, some `find*` methods in repositories, entity managers, BaseEntity and QueryBuilders
+* fixed undefined object id field in case property name is `_id` ([3517](https://github.com/typeorm/typeorm/issues/3517))
 
 ### Features
 

--- a/src/persistence/SubjectExecutor.ts
+++ b/src/persistence/SubjectExecutor.ts
@@ -492,7 +492,10 @@ export class SubjectExecutor {
 
             // mongo _id remove
             if (this.queryRunner instanceof MongoQueryRunner) {
-                if (subject.metadata.objectIdColumn && subject.metadata.objectIdColumn.databaseName) {
+                if (subject.metadata.objectIdColumn
+                    && subject.metadata.objectIdColumn.databaseName
+                    && subject.metadata.objectIdColumn.databaseName !== subject.metadata.objectIdColumn.propertyName
+                ) {
                     delete subject.entity[subject.metadata.objectIdColumn.databaseName];
                 }
             }

--- a/test/functional/mongodb/basic/object-id/entity/PostWithUnderscoreId.ts
+++ b/test/functional/mongodb/basic/object-id/entity/PostWithUnderscoreId.ts
@@ -1,0 +1,14 @@
+import { Entity } from "../../../../../../src/decorator/entity/Entity";
+import { Column } from "../../../../../../src/decorator/columns/Column";
+import { ObjectIdColumn } from "../../../../../../src/decorator/columns/ObjectIdColumn";
+import { ObjectID } from "../../../../../../src/driver/mongodb/typings";
+
+@Entity()
+export class PostWithUnderscoreId {
+
+    @ObjectIdColumn()
+    _id: ObjectID;
+
+    @Column()
+    title: string;
+}


### PR DESCRIPTION
We are deleting `_id` property from entity to avoid duplication of object id columns. I did not realize case when `_id` is possible property name. Now we check if property name is not same as "column" name in db.
 
Fixed #3517 