### PR TITLE
Allow subscriber listenTo() to return also a String

### DIFF
--- a/src/subscriber/EntitySubscriberInterface.ts
+++ b/src/subscriber/EntitySubscriberInterface.ts
@@ -11,7 +11,7 @@ export interface EntitySubscriberInterface<Entity = any> {
      * Returns the class of the entity to which events will listen.
      * If this method is omitted, then subscriber will listen to events of all entities.
      */
-    listenTo?(): Function;
+    listenTo?(): Function|string;
 
     /**
      * Called after entity is loaded from the database.


### PR DESCRIPTION
Hi, thanks for your hard work on TypeORM.

I just improved the subscriber listenTo() signature, because it allows previously only that you return the Entity itself (the constructor). The new version allows us also to return strings which was required if you want use schema files without Entity classes.

In my project for example I just use TS interface definitions and schemas, which works already fine with the Subscriber interface. Expect of the TS compile error/warning.

The `Broadcaster` `isAllowedSubscriber` method already supports schema files (and strings as argument). See the target definition and line 330:

https://github.com/typeorm/typeorm/blob/0a46810a026e147e6cac80d9a5ee16ea3b4bfe67/src/subscriber/Broadcaster.ts#L326-L332

This allow the user of the Subscriber interface to implement listenTo with a static schema references. For example:

```typescript
interface MyEntry {
  id?: number
  timestamp: Date
  // ...
}

const MySchema = new EntitySchema<MyEntry>({
  name: 'my_entry',
  columns: {
    id: {
      type: Number,
      primary: true,
      generated: true,
    },
    timestamp: {
      type: Date,
    },
    // ...
  },
})

class MyListener implements EntitySubscriberInterface<MyEntry> {
  listenTo() {
    // This was previously not possible!
    return MySchema.options.name
  }

  // ...
}
```