### PR TITLE
Remove an unused import in the Data Mapper example

### DIFF
--- a/docs/active-record-data-mapper.md
+++ b/docs/active-record-data-mapper.md
@@ -111,7 +111,7 @@ You can read more about data mapper on [Wikipedia](https://en.wikipedia.org/wiki
 Example:
 
 ```typescript
-import {BaseEntity, Entity, PrimaryGeneratedColumn, Column} from "typeorm";
+import {Entity, PrimaryGeneratedColumn, Column} from "typeorm";
 
 @Entity()
 export class User {


### PR DESCRIPTION
My guess is that it was accidentally copied over from the Active Record example.