### PR TITLE
Add localforage as alternative to local storage for sqljs driver

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,8 @@ feel free to ask us and community.
 
 ## 0.2.13 (2019-02-10)
 
+* added `useLocalforage` option to Sql.js connection options, which enables asynchronous load and save operations of the datatbase from the indexedDB ([#3554](https://github.com/typeorm/typeorm/issues/3554))
+
 ### Bug Fixes
 
 * fixed undefined object id field in case property name is `_id` ([3517](https://github.com/typeorm/typeorm/issues/3517))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,10 +15,9 @@ feel free to ask us and community.
 
 * added browser entry point to `package.json` ([3583](https://github.com/typeorm/typeorm/issues/3583))
 * replaced backend-only drivers by dummy driver in browser builds
+* added `useLocalForage` option to Sql.js connection options, which enables asynchronous load and save operations of the datatbase from the indexedDB ([#3554](https://github.com/typeorm/typeorm/issues/3554))
 
 ## 0.2.13 (2019-02-10)
-
-* added `useLocalforage` option to Sql.js connection options, which enables asynchronous load and save operations of the datatbase from the indexedDB ([#3554](https://github.com/typeorm/typeorm/issues/3554))
 
 ### Bug Fixes
 

--- a/docs/connection-options.md
+++ b/docs/connection-options.md
@@ -465,7 +465,7 @@ See [SSL options](https://github.com/mysqljs/mysql#ssl-options).
 
 * `location`: The file location to load and save the database to.
 
-* `useLocalforage`: Enables the usage of the localforage library (https://github.com/localForage/localForage) to save & load the database asynchronously from the indexedDB instead of using the synchron local storage methods in a browser environment. The localforage node module needs to be added to your project and the localforage.js should be imported in your page.
+* `useLocalForage`: Enables the usage of the localforage library (https://github.com/localForage/localForage) to save & load the database asynchronously from the indexedDB instead of using the synchron local storage methods in a browser environment. The localforage node module needs to be added to your project and the localforage.js should be imported in your page.
 
 ## `expo` connection options
 

--- a/docs/connection-options.md
+++ b/docs/connection-options.md
@@ -465,6 +465,8 @@ See [SSL options](https://github.com/mysqljs/mysql#ssl-options).
 
 * `location`: The file location to load and save the database to.
 
+* `useLocalforage`: Enables the usage of the localforage library (https://github.com/localForage/localForage) to save & load the database asynchronously from the indexedDB instead of using the synchron local storage methods in a browser environment. The localforage node module needs to be added to your project and the localforage.js should be imported in your page.
+
 ## `expo` connection options
 
 * `database` - Name of the database. For example "mydb".

--- a/src/driver/sqljs/SqljsConnectionOptions.ts
+++ b/src/driver/sqljs/SqljsConnectionOptions.ts
@@ -39,5 +39,5 @@ export interface SqljsConnectionOptions extends BaseConnectionOptions {
      * Enables the usage of the localforage library to save & load the database asynchronously from the
      * indexedDB instead of using the synchron local storage methods in a browser environment.
      */
-    readonly useLocalforage?: boolean;
+    readonly useLocalForage?: boolean;
 }

--- a/src/driver/sqljs/SqljsConnectionOptions.ts
+++ b/src/driver/sqljs/SqljsConnectionOptions.ts
@@ -34,4 +34,10 @@ export interface SqljsConnectionOptions extends BaseConnectionOptions {
      * location is used to automatically save the database.
      */
     readonly location?: string;
+
+    /**
+     * Enables the usage of the localforage library to save & load the database asynchronously from the
+     * indexedDB instead of using the synchron local storage methods in a browser environment.
+     */
+    readonly useLocalforage?: boolean;
 }

--- a/src/driver/sqljs/SqljsDriver.ts
+++ b/src/driver/sqljs/SqljsDriver.ts
@@ -104,7 +104,7 @@ export class SqljsDriver extends AbstractSqliteDriver {
                 // browser
                 // fileNameOrLocalStorageOrData should be a local storage / indexedDB key
                 let localStorageContent = null;
-                if (this.options.useLocalforage) {
+                if (this.options.useLocalForage) {
                     if (window.localforage) {
                         localStorageContent = await window.localforage.getItem(fileNameOrLocalStorageOrData);
                     } else {
@@ -136,7 +136,7 @@ export class SqljsDriver extends AbstractSqliteDriver {
 
     /**
      * Saved the current database to the given file (Node.js), local storage key (browser) or
-     * indexedDB key (browser with enabled useLocalforage option).
+     * indexedDB key (browser with enabled useLocalForage option).
      * If no location path is given, the location path in the options (if specified) will be used.
      */
     async save(location?: string) {
@@ -165,7 +165,7 @@ export class SqljsDriver extends AbstractSqliteDriver {
             const database: Uint8Array = this.databaseConnection.export();
             // convert Uint8Array to number array to improve local-storage storage
             const databaseArray = [].slice.call(database);
-            if (this.options.useLocalforage) {
+            if (this.options.useLocalForage) {
                 if (window.localforage) {
                     await window.localforage.setItem(path, JSON.stringify(databaseArray));
                 } else {
@@ -181,7 +181,7 @@ export class SqljsDriver extends AbstractSqliteDriver {
      * This gets called by the QueryRunner when a change to the database is made.
      * If a custom autoSaveCallback is specified, it get's called with the database as Uint8Array,
      * otherwise the save method is called which saves it to file (Node.js), local storage (browser)
-     * or indexedDB (browser with enabled useLocalforage option).
+     * or indexedDB (browser with enabled useLocalForage option).
      */
     async autoSave() {
         if (this.options.autoSave) {

--- a/src/driver/sqljs/SqljsDriver.ts
+++ b/src/driver/sqljs/SqljsDriver.ts
@@ -13,6 +13,7 @@ import {ObjectLiteral} from "../../common/ObjectLiteral";
 // This is needed to satisfy the typescript compiler.
 interface Window {
     SQL: any;
+    localforage: any;
 }
 declare var window: Window;
 
@@ -79,7 +80,7 @@ export class SqljsDriver extends AbstractSqliteDriver {
      * Loads a database from a given file (Node.js), local storage key (browser) or array.
      * This will delete the current database!
      */
-    load(fileNameOrLocalStorageOrData: string | Uint8Array, checkIfFileOrLocalStorageExists: boolean = true): Promise<any> {
+    async load(fileNameOrLocalStorageOrData: string | Uint8Array, checkIfFileOrLocalStorageExists: boolean = true): Promise<any> {
         if (typeof fileNameOrLocalStorageOrData === "string") {
             // content has to be loaded
             if (PlatformTools.type === "node") {
@@ -101,8 +102,17 @@ export class SqljsDriver extends AbstractSqliteDriver {
             } 
             else {
                 // browser
-                // fileNameOrLocalStorageOrData should be a local storage key
-                const localStorageContent = PlatformTools.getGlobalVariable().localStorage.getItem(fileNameOrLocalStorageOrData);
+                // fileNameOrLocalStorageOrData should be a local storage / indexedDB key
+                let localStorageContent = null;
+                if (this.options.useLocalforage) {
+                    if (window.localforage) {
+                        localStorageContent = await window.localforage.getItem(fileNameOrLocalStorageOrData);
+                    } else {
+                        throw new Error(`localforage is not defined - please import localforage.js into your site`);
+                    }
+                } else {
+                    localStorageContent = PlatformTools.getGlobalVariable().localStorage.getItem(fileNameOrLocalStorageOrData);
+                }
                 
                 if (localStorageContent != null) {
                     // localStorage value exists.
@@ -125,7 +135,8 @@ export class SqljsDriver extends AbstractSqliteDriver {
     }
 
     /**
-     * Saved the current database to the given file (Node.js) or local storage key (browser).
+     * Saved the current database to the given file (Node.js), local storage key (browser) or
+     * indexedDB key (browser with enabled useLocalforage option).
      * If no location path is given, the location path in the options (if specified) will be used.
      */
     async save(location?: string) {
@@ -154,14 +165,23 @@ export class SqljsDriver extends AbstractSqliteDriver {
             const database: Uint8Array = this.databaseConnection.export();
             // convert Uint8Array to number array to improve local-storage storage
             const databaseArray = [].slice.call(database);
-            PlatformTools.getGlobalVariable().localStorage.setItem(path, JSON.stringify(databaseArray));
+            if (this.options.useLocalforage) {
+                if (window.localforage) {
+                    await window.localforage.setItem(path, JSON.stringify(databaseArray));
+                } else {
+                    throw new Error(`localforage is not defined - please import localforage.js into your site`);
+                }
+            } else {
+                PlatformTools.getGlobalVariable().localStorage.setItem(path, JSON.stringify(databaseArray));
+            }
         }
     }
 
     /**
      * This gets called by the QueryRunner when a change to the database is made.
      * If a custom autoSaveCallback is specified, it get's called with the database as Uint8Array,
-     * otherwise the save method is called which saves it to file (Node.js) or localstorage (browser).
+     * otherwise the save method is called which saves it to file (Node.js), local storage (browser)
+     * or indexedDB (browser with enabled useLocalforage option).
      */
     async autoSave() {
         if (this.options.autoSave) {

--- a/src/entity-manager/SqljsEntityManager.ts
+++ b/src/entity-manager/SqljsEntityManager.ts
@@ -27,8 +27,8 @@ export class SqljsEntityManager extends EntityManager {
      * Loads either the definition from a file (Node.js) or localstorage (browser)
      * or uses the given definition to open a new database.
      */
-    loadDatabase(fileNameOrLocalStorageOrData: string | Uint8Array) {
-        this.driver.load(fileNameOrLocalStorageOrData);
+    async loadDatabase(fileNameOrLocalStorageOrData: string | Uint8Array): Promise<void> {
+        await this.driver.load(fileNameOrLocalStorageOrData);
     }
     
     /**

--- a/test/functional/sqljs/load.ts
+++ b/test/functional/sqljs/load.ts
@@ -38,10 +38,11 @@ describe("sqljs driver > load", () => {
 
     it("should throw an error if the file doesn't exist", () => Promise.all(connections.map(async connection => {
         const manager = getSqljsManager("sqljs");
-        const functionWithException = async () => {
+        try {
             await manager.loadDatabase("test/functional/sqljs/sqlite/test2.sqlite");
-        };
-
-        expect(await functionWithException).to.throw(/File .* does not exist/);
+            expect(true).to.be.false;
+        } catch (error) {
+            expect(error.message.match(/File .* does not exist/) !== null).to.equal(true, "Should throw: File does not exist");
+        }
     })));
 });

--- a/test/functional/sqljs/load.ts
+++ b/test/functional/sqljs/load.ts
@@ -20,7 +20,7 @@ describe("sqljs driver > load", () => {
 
     it("should load from a file", () => Promise.all(connections.map(async connection => {
         const manager = getSqljsManager("sqljs");
-        manager.loadDatabase("test/functional/sqljs/sqlite/test.sqlite");
+        await manager.loadDatabase("test/functional/sqljs/sqlite/test.sqlite");
 
         const repository = connection.getRepository(Post);
         const post = await repository.findOne({title: "A post"});
@@ -38,10 +38,10 @@ describe("sqljs driver > load", () => {
 
     it("should throw an error if the file doesn't exist", () => Promise.all(connections.map(async connection => {
         const manager = getSqljsManager("sqljs");
-        const functionWithException = () => {
-            manager.loadDatabase("test/functional/sqljs/sqlite/test2.sqlite");
+        const functionWithException = async () => {
+            await manager.loadDatabase("test/functional/sqljs/sqlite/test2.sqlite");
         };
 
-        expect(functionWithException).to.throw(/File .* does not exist/);
+        expect(await functionWithException).to.throw(/File .* does not exist/);
     })));
 });

--- a/test/functional/sqljs/save.ts
+++ b/test/functional/sqljs/save.ts
@@ -38,7 +38,7 @@ describe("sqljs driver > save", () => {
 
     it("should load a file that was saved", () => Promise.all(connections.map(async connection => {
         const manager = getSqljsManager("sqljs");
-        manager.loadDatabase(pathToSqlite);
+        await manager.loadDatabase(pathToSqlite);
 
         const repository = connection.getRepository(Post);
         const post = await repository.findOne({title: "The second title"});


### PR DESCRIPTION
For issue #3554.

I've added an option `useLocalforage` to the SqljsConnectionOptions to switch between the usage of the synchronous local storage (which could freeze the browser, when having lot's of data) and the async. indexedDB for the sql.js driver.

With using this flag, the localforage node module is needed and the localforage.js needs to be added to the page.

Having it enabled, the save & load operations are now asynchron, which means, those operations are not blocking the main thread of the browser anymore, which gives you the opportunity the display smooth loading screens. 

I've also created a small pre-realese, which allows us to use this version of typeorm in current angular projects: https://github.com/ApinautenGmbH/typeorm/releases  