### PR TITLE
fix(3182): fixed increment/decrement values of embeded entity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ feel free to ask us and community.
 
 ### Bug Fixes
 
+* fixed increment/decrement value of embedded entity ([#3182](https://github.com/typeorm/typeorm/issues/3182))
 * fixed signatures of `update`/`insert` methods, some `find*` methods in repositories, entity managers, BaseEntity and QueryBuilders
 * handle embedded documents through multiple levels in mongodb ([#3551](https://github.com/typeorm/typeorm/issues/3551))
 

--- a/src/entity-manager/EntityManager.ts
+++ b/src/entity-manager/EntityManager.ts
@@ -681,12 +681,18 @@ export class EntityManager {
         if (isNaN(Number(value)))
             throw new Error(`Value "${value}" is not a number.`);
 
+        // convert possible embeded path "social.likes" into object { social: { like: () => value } }
+        const values: QueryDeepPartialEntity<Entity> = propertyPath
+            .split(".")
+            .reduceRight(
+                (value, key) => ({ [key]: value }) as any,
+                () => this.connection.driver.escape(column.databaseName) + " + " + value
+            );
+
         return this
             .createQueryBuilder(entityClass, "entity")
             .update(entityClass)
-            .set({
-                [propertyPath]: () => this.connection.driver.escape(column.databaseName) + " + " + value
-            } as QueryDeepPartialEntity<Entity>)
+            .set(values)
             .where(conditions)
             .execute();
     }
@@ -707,12 +713,18 @@ export class EntityManager {
         if (isNaN(Number(value)))
             throw new Error(`Value "${value}" is not a number.`);
 
+        // convert possible embeded path "social.likes" into object { social: { like: () => value } }
+        const values: QueryDeepPartialEntity<Entity> = propertyPath
+            .split(".")
+            .reduceRight(
+                (value, key) => ({ [key]: value }) as any,
+                () => this.connection.driver.escape(column.databaseName) + " - " + value
+            );
+
         return this
             .createQueryBuilder(entityClass, "entity")
             .update(entityClass)
-            .set({
-                [propertyPath]: () => this.connection.driver.escape(column.databaseName) + " - " + value
-            } as QueryDeepPartialEntity<Entity>)
+            .set(values)
             .where(conditions)
             .execute();
     }

--- a/test/functional/repository/decrement/entity/UserWithEmbededEntity.ts
+++ b/test/functional/repository/decrement/entity/UserWithEmbededEntity.ts
@@ -1,0 +1,22 @@
+import { Column, Entity, PrimaryColumn } from "../../../../../src";
+
+class FriendStats {
+    @Column("int", { default: 0 })
+    count: number;
+
+    @Column("int", { default: 0 })
+    sent: number;
+
+    @Column("int", { default: 0 })
+    received: number;
+}
+
+@Entity()
+export class UserWithEmbededEntity {
+
+    @PrimaryColumn()
+    id: number;
+
+    @Column(type => FriendStats)
+    friend: FriendStats;
+}

--- a/test/functional/repository/decrement/repository-decrement.ts
+++ b/test/functional/repository/decrement/repository-decrement.ts
@@ -4,6 +4,7 @@ import { Connection } from "../../../../src/connection/Connection";
 import { UpdateResult } from "../../../../src";
 import { Post } from "./entity/Post";
 import { PostBigInt } from "./entity/PostBigInt";
+import { UserWithEmbededEntity } from "./entity/UserWithEmbededEntity";
 
 describe("repository > decrement method", () => {
 
@@ -180,6 +181,33 @@ describe("repository > decrement method", () => {
 
             const loadedPost2 = await connection.manager.findOne(PostBigInt, 2);
             loadedPost2!.counter.should.be.equal("2");
+
+        })));
+
+    });
+
+
+    describe("embeded entities", () => {
+
+        let connections: Connection[];
+        before(async () => connections = await createTestingConnections({
+            entities: [UserWithEmbededEntity],
+        }));
+        beforeEach(() => reloadTestingDatabases(connections));
+        after(() => closeTestingConnections(connections));
+
+        it("should decrement value", () => Promise.all(connections.map(async connection => {
+
+            const userWithEmbededEntity = new UserWithEmbededEntity();
+            userWithEmbededEntity.id = 1;
+            await connection.manager.save([userWithEmbededEntity]);
+
+            await connection
+                .getRepository(UserWithEmbededEntity)
+                .decrement({ id: 1 }, "friend.sent", 15);
+
+            const loadedUser = await connection.manager.findOne(UserWithEmbededEntity, 1);
+            loadedUser!.friend.sent.should.be.equal(-15);
 
         })));
 

--- a/test/functional/repository/increment/entity/UserWithEmbededEntity.ts
+++ b/test/functional/repository/increment/entity/UserWithEmbededEntity.ts
@@ -1,0 +1,22 @@
+import { Column, Entity, PrimaryColumn } from "../../../../../src";
+
+class FriendStats {
+    @Column("int", { default: 0 })
+    count: number;
+
+    @Column("int", { default: 0 })
+    sent: number;
+
+    @Column("int", { default: 0 })
+    received: number;
+}
+
+@Entity()
+export class UserWithEmbededEntity {
+
+    @PrimaryColumn()
+    id: number;
+
+    @Column(type => FriendStats)
+    friend: FriendStats;
+}

--- a/test/functional/repository/increment/repository-increment.ts
+++ b/test/functional/repository/increment/repository-increment.ts
@@ -4,6 +4,7 @@ import { Connection } from "../../../../src/connection/Connection";
 import { UpdateResult } from "../../../../src";
 import { Post } from "./entity/Post";
 import { PostBigInt } from "./entity/PostBigInt";
+import { UserWithEmbededEntity } from "./entity/UserWithEmbededEntity";
 
 describe("repository > increment method", () => {
 
@@ -180,6 +181,33 @@ describe("repository > increment method", () => {
 
             const loadedPost2 = await connection.manager.findOne(PostBigInt, 2);
             loadedPost2!.counter.should.be.equal("9000000000000000002");
+
+        })));
+
+    });
+
+
+    describe("embeded entities", () => {
+
+        let connections: Connection[];
+        before(async () => connections = await createTestingConnections({
+            entities: [UserWithEmbededEntity],
+        }));
+        beforeEach(() => reloadTestingDatabases(connections));
+        after(() => closeTestingConnections(connections));
+
+        it("should increment value", () => Promise.all(connections.map(async connection => {
+
+            const userWithEmbededEntity = new UserWithEmbededEntity();
+            userWithEmbededEntity.id = 1;
+            await connection.manager.save([userWithEmbededEntity]);
+
+            await connection
+                .getRepository(UserWithEmbededEntity)
+                .increment({ id: 1 }, "friend.sent", 5);
+
+            const loadedUser = await connection.manager.findOne(UserWithEmbededEntity, 1);
+            loadedUser!.friend.sent.should.be.equal(5);
 
         })));
 


### PR DESCRIPTION
**Root of problem:**
Current implementation of increment/decrement method for embedded property define values to update like this:
```typescript
// ...
.set({
    "embedded.property": () => ...
})
// ...
```
But update query builder do not support define key as string with "dot notation path".

**Solution:**
Convert:
```typescript
.set({
    "embedded.property": () => ...
})
```
to: 
```typescript
.set({
    embedded: {
         property: () => ...
    }
})
```

*Note: Sure we can add support of "dot notation path" into `set()` method but right now `set()` method accept strongly typed argument and I think it is better keep this functionality and just update increment/decrement function as it is presented in this PR.*

Fixes https://github.com/typeorm/typeorm/issues/3182
