### PR TITLE
fix(postgres): Fixed migration issue with postgres numeric enum type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ feel free to ask us and community.
 
 ### Bug fixes
 
+* fixed migration issue with postgres numeric enum type - change queries are not generated if enum is not modified ([#3587](https://github.com/typeorm/typeorm/issues/3587))
 * fixed mongodb entity listeners in optional embeddeds ([#3450](https://github.com/typeorm/typeorm/issues/3450))
 * fixes returning invalid delete result
 

--- a/src/decorator/options/ColumnOptions.ts
+++ b/src/decorator/options/ColumnOptions.ts
@@ -110,7 +110,7 @@ export interface ColumnOptions extends ColumnCommonOptions {
     /**
      * Array of possible enumerated values.
      */
-    enum?: any[]|Object;
+    enum?: (string|number)[]|Object;
 
     /**
      * Generated column expression. Supports only in MySQL.

--- a/src/driver/postgres/PostgresDriver.ts
+++ b/src/driver/postgres/PostgresDriver.ts
@@ -741,7 +741,7 @@ export class PostgresDriver implements Driver {
             if (!tableColumn)
                 return false; // we don't need new columns, we only need exist and changed
 
-            return  tableColumn.name !== columnMetadata.databaseName
+            return tableColumn.name !== columnMetadata.databaseName
                 || tableColumn.type !== this.normalizeType(columnMetadata)
                 || tableColumn.length !== columnMetadata.length
                 || tableColumn.precision !== columnMetadata.precision
@@ -751,7 +751,15 @@ export class PostgresDriver implements Driver {
                 || tableColumn.isPrimary !== columnMetadata.isPrimary
                 || tableColumn.isNullable !== columnMetadata.isNullable
                 || tableColumn.isUnique !== this.normalizeIsUnique(columnMetadata)
-                || (tableColumn.enum && columnMetadata.enum && !OrmUtils.isArraysEqual(tableColumn.enum, columnMetadata.enum))
+                || (
+                    tableColumn.enum
+                    && columnMetadata.enum
+                    // enums in postgres are always strings
+                    && !OrmUtils.isArraysEqual(
+                        tableColumn.enum,
+                        columnMetadata.enum.map(val => val + "")
+                    )
+                )
                 || tableColumn.isGenerated !== columnMetadata.isGenerated
                 || (tableColumn.spatialFeatureType || "").toLowerCase() !== (columnMetadata.spatialFeatureType || "").toLowerCase()
                 || tableColumn.srid !== columnMetadata.srid;

--- a/src/metadata/ColumnMetadata.ts
+++ b/src/metadata/ColumnMetadata.ts
@@ -146,8 +146,11 @@ export class ColumnMetadata {
 
     /**
      * Array of possible enumerated values.
+     *
+     * `postgres` and `mysql` store enum values as strings but we want to keep support
+     * for numeric and heterogeneous based typescript enums, so we need (string|number)[]
      */
-    enum?: any[];
+    enum?: (string|number)[];
 
     /**
      * Generated column expression. Supports only in MySQL.

--- a/src/schema-builder/options/TableColumnOptions.ts
+++ b/src/schema-builder/options/TableColumnOptions.ts
@@ -111,7 +111,7 @@ export interface TableColumnOptions {
     /**
      * Array of possible enumerated values.
      */
-    enum?: any[];
+    enum?: string[];
 
     /**
      * Generated column expression. Supports only in MySQL.

--- a/src/schema-builder/table/TableColumn.ts
+++ b/src/schema-builder/table/TableColumn.ts
@@ -112,7 +112,7 @@ export class TableColumn {
     /**
      * Array of possible enumerated values.
      */
-    enum?: any[];
+    enum?: string[];
 
     /**
      * Generated column expression. Supports only in MySQL.

--- a/src/schema-builder/util/TableUtils.ts
+++ b/src/schema-builder/util/TableUtils.ts
@@ -27,7 +27,7 @@ export class TableUtils {
             isPrimary: columnMetadata.isPrimary,
             isUnique: driver.normalizeIsUnique(columnMetadata),
             isArray: columnMetadata.isArray || false,
-            enum: columnMetadata.enum,
+            enum: columnMetadata.enum ? columnMetadata.enum.map(val => val + "") : columnMetadata.enum,
             spatialFeatureType: columnMetadata.spatialFeatureType,
             srid: columnMetadata.srid
         };

--- a/test/github-issues/3587/entity/EquipmentModel.ts
+++ b/test/github-issues/3587/entity/EquipmentModel.ts
@@ -1,0 +1,17 @@
+import { Entity, PrimaryGeneratedColumn, Column } from "../../../../src";
+
+export enum EquipmentModelType {
+    Thing1 = 1,
+    Thing2 = 4,
+    Thing3 = 3,
+    Thing4 = 2
+}
+
+@Entity("equipmentmodels")
+export class EquipmentModel {
+    @PrimaryGeneratedColumn("uuid")
+    id: string;
+
+    @Column("enum", { enum: EquipmentModelType })
+    type: EquipmentModelType;
+}

--- a/test/github-issues/3587/issue-3587.ts
+++ b/test/github-issues/3587/issue-3587.ts
@@ -1,0 +1,28 @@
+import "reflect-metadata";
+import { closeTestingConnections, createTestingConnections, reloadTestingDatabases } from "../../utils/test-utils";
+import { Connection } from "../../../src/connection/Connection";
+import { EquipmentModel } from "./entity/EquipmentModel";
+import { expect } from "chai";
+
+
+describe("github issues > #3587 do not generate change queries for number based enum types every time", () => {
+
+    let connections: Connection[];
+    before(async () => connections = await createTestingConnections({
+        entities: [EquipmentModel],
+        enabledDrivers: ["postgres"]
+    }));
+    beforeEach(() => reloadTestingDatabases(connections));
+    after(() => closeTestingConnections(connections));
+
+    it("should NOT generate change queries in case enum is not changed", () => Promise.all(connections.map(async function (connection) {
+
+        await connection.synchronize(true);
+
+        const sqlInMemory = await connection.driver.createSchemaBuilder().log();
+
+        expect(sqlInMemory.downQueries).to.be.empty;
+        expect(sqlInMemory.upQueries).to.be.empty;
+    })));
+
+});


### PR DESCRIPTION
Postgres store enum type as string and we support now numeric TS enum so we have to compare array of possible values and values in DB schema as strings.

Fixes https://github.com/typeorm/typeorm/issues/3587