### PR TITLE
Update links in connection-api docs

### DIFF
--- a/docs/connection-api.md
+++ b/docs/connection-api.md
@@ -228,7 +228,7 @@ const userMetadata = connection.getMetadata(User);
 
 * `getRepository` - Gets `Repository` of the given entity.
 You can also specify a table name and if repository for given table is found it will be returned.
-Learn more about [Repositories](working-with-entity-manager.md).
+Learn more about [Repositories](working-with-repository.md).
 
 ```typescript
 const repository = connection.getRepository(User);
@@ -238,7 +238,7 @@ const users = await repository.findOne(1);
 
 * `getTreeRepository` - Gets `TreeRepository` of the given entity.
 You can also specify a table name and if repository for given table is found it will be returned.
-Learn more about [Repositories](working-with-entity-manager.md).
+Learn more about [Repositories](working-with-repository.md).
 
 ```typescript
 const repository = connection.getTreeRepository(Category);
@@ -259,7 +259,7 @@ const category2 = await categoryCursor.next();
 ```
 
 * `getCustomRepository` - Gets customly defined repository.
-Learn more about [custom repositories](working-with-entity-manager.md).
+Learn more about [custom repositories](custom-repository.md).
 
 ```typescript
 const userRepository = connection.getCustomRepository(UserRepository);


### PR DESCRIPTION
Fixes a few links in the **connection-api** docs to point towards more context appropriate pages. 

* "Learn more about Repositories" should navigate to `working-with-repository.md`. Currently links to `working-with-entity-manager.md`.
 
* "Learn more about custom repositories" should navigate to `custom-repository.md`. Currently also links to `working-with-entity-manager.md`.