### PR TITLE
update FindOneOptions["where"] type

### DIFF
--- a/src/find-options/FindOneOptions.ts
+++ b/src/find-options/FindOneOptions.ts
@@ -15,7 +15,7 @@ export interface FindOneOptions<Entity = any> {
     /**
      * Simple condition that should be applied to match entities.
      */
-    where?: Array<FindConditions<Entity>>|FindConditions<Entity>|ObjectLiteral|string;
+    where?: FindConditions<Entity>[]|FindConditions<Entity>|ObjectLiteral|string;
 
     /**
      * Indicates what relations of entity should be loaded (simplified left join form).

--- a/src/find-options/FindOneOptions.ts
+++ b/src/find-options/FindOneOptions.ts
@@ -15,7 +15,7 @@ export interface FindOneOptions<Entity = any> {
     /**
      * Simple condition that should be applied to match entities.
      */
-    where?: FindConditions<Entity>|ObjectLiteral|string;
+    where?: Array<FindConditions<Entity>>|FindConditions<Entity>|ObjectLiteral|string;
 
     /**
      * Indicates what relations of entity should be loaded (simplified left join form).


### PR DESCRIPTION
according to docs (https://github.com/typeorm/typeorm/blob/0.2.13/docs/find-options.md) this type should also accept an array of find options

array of options was previously covered by `ObjectLiteral` type, should it be removed then?

#3644 