### PR TITLE
Fixes #3588 - Migration:generate issue with onUpdate using mysql 8.0

### DIFF
--- a/src/driver/mysql/MysqlQueryRunner.ts
+++ b/src/driver/mysql/MysqlQueryRunner.ts
@@ -1232,7 +1232,7 @@ export class MysqlQueryRunner extends BaseQueryRunner implements QueryRunner {
                     }
 
                     if (dbColumn["EXTRA"].indexOf("on update") !== -1) {
-                        tableColumn.onUpdate = dbColumn["EXTRA"].substring(10);
+                        tableColumn.onUpdate = dbColumn["EXTRA"].substring(dbColumn["EXTRA"].indexOf("on update") + 10);
                     }
 
                     if (dbColumn["GENERATION_EXPRESSION"]) {

--- a/test/github-issues/3588/entity/Session.ts
+++ b/test/github-issues/3588/entity/Session.ts
@@ -1,0 +1,17 @@
+import { Entity, PrimaryGeneratedColumn, Column } from "../../../../src";
+
+@Entity()
+export class Session {
+
+    @PrimaryGeneratedColumn()
+    id?: number;
+
+    @Column({
+        type: "timestamp",
+        precision: 3,
+        default: () => "CURRENT_TIMESTAMP(3)",
+        onUpdate: "CURRENT_TIMESTAMP(3)",
+      })
+    title: Date;
+
+}

--- a/test/github-issues/3588/entity/mysql.ts
+++ b/test/github-issues/3588/entity/mysql.ts
@@ -1,6 +1,6 @@
 import { Entity, PrimaryGeneratedColumn, Column } from "../../../../src";
 
-@Entity()
+@Entity({ name: "Session" })
 export class Session {
 
     @PrimaryGeneratedColumn()
@@ -11,7 +11,7 @@ export class Session {
         precision: 3,
         default: () => "CURRENT_TIMESTAMP(3)",
         onUpdate: "CURRENT_TIMESTAMP(3)",
-      })
-    title: Date;
+    })
+    ts: Date;
 
 }

--- a/test/github-issues/3588/issue-3588.ts
+++ b/test/github-issues/3588/issue-3588.ts
@@ -1,0 +1,21 @@
+import "reflect-metadata";
+import { createTestingConnections, closeTestingConnections, reloadTestingDatabases } from "../../utils/test-utils";
+import { Connection } from "../../../src/connection/Connection";
+import { expect } from "chai";
+it.only("github issues > #3588 Migration:generate issue with onUpdate using mysql 8.0", async () => {
+    let connections: Connection[];
+        connections = await createTestingConnections({
+            entities: [__dirname + "/entity/*{.js,.ts}"],
+            schemaCreate: true,
+            dropSchema: true,
+            enabledDrivers: ["mysql", "mariadb"],
+        });
+        await reloadTestingDatabases(connections);
+        await Promise.all(connections.map(async connection => {
+            const schemaBuilder = connection.driver.createSchemaBuilder();
+            const syncQueries = await schemaBuilder.log();
+            expect(syncQueries.downQueries).to.be.empty;
+            expect(syncQueries.upQueries).to.be.empty;
+        }));
+        await closeTestingConnections(connections);
+});

--- a/test/github-issues/3588/issue-3588.ts
+++ b/test/github-issues/3588/issue-3588.ts
@@ -2,13 +2,13 @@ import "reflect-metadata";
 import { createTestingConnections, closeTestingConnections, reloadTestingDatabases } from "../../utils/test-utils";
 import { Connection } from "../../../src/connection/Connection";
 import { expect } from "chai";
-it.only("github issues > #3588 Migration:generate issue with onUpdate using mysql 8.0", async () => {
+it("github issues > #3588 Migration:generate issue with onUpdate using mysql 8.0", async () => {
     let connections: Connection[];
         connections = await createTestingConnections({
             entities: [__dirname + "/entity/*{.js,.ts}"],
             schemaCreate: true,
             dropSchema: true,
-            enabledDrivers: ["mysql", "mariadb"],
+            enabledDrivers: ["mysql"],
         });
         await reloadTestingDatabases(connections);
         await Promise.all(connections.map(async connection => {


### PR DESCRIPTION
Changes to make syncing onUpdate work also on mysql 8.0.

Closes #3588