### PR TITLE
fix a bug that loadEagerRelations not working

### DIFF
--- a/src/find-options/FindOptionsUtils.ts
+++ b/src/find-options/FindOptionsUtils.ts
@@ -30,7 +30,8 @@ export class FindOptionsUtils {
                     typeof possibleOptions.cache === "boolean" ||
                     typeof possibleOptions.cache === "number" ||
                     possibleOptions.loadRelationIds instanceof Object ||
-                    typeof possibleOptions.loadRelationIds === "boolean"
+                    typeof possibleOptions.loadRelationIds === "boolean" ||
+                    typeof possibleOptions.loadEagerRelations === "boolean"
                 );
     }
 


### PR DESCRIPTION
```
someRepository.findOne("anyId", {
 loadEagerRelations: false
});
```

in case of the above code, FindOptionsUtils.isFindOneOptions returns false and we need to check one more option(typeof loadEagerRelations).

please check this out. :D