### PR TITLE
Make subject entity’s properties enumerable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ feel free to ask us and community.
 
 * fixed mongodb entity listeners in optional embeddeds ([#3450](https://github.com/typeorm/typeorm/issues/3450))
 * fixes returning invalid delete result
+* fixed entities failing to save after lazy-loading their relations ([#3576](https://github.com/typeorm/typeorm/issues/3576))
 
 ### Features
 

--- a/src/persistence/Subject.ts
+++ b/src/persistence/Subject.ts
@@ -130,7 +130,7 @@ export class Subject {
         changeMaps?: SubjectChangeMap[]
     }) {
         this.metadata = options.metadata;
-        this.entity = options.entity;
+        this.entity = OrmUtils.makeEnumerable(options.entity);
         this.parentSubject = options.parentSubject;
         if (options.canBeInserted !== undefined)
             this.canBeInserted = options.canBeInserted;

--- a/src/query-builder/RelationLoader.ts
+++ b/src/query-builder/RelationLoader.ts
@@ -207,11 +207,13 @@ export class RelationLoader {
                         Object.defineProperty(this, dataIndex, {
                             value: result,
                             writable: true,
+                            configurable: true,
                         });
 
                         Object.defineProperty(this, resolveIndex, {
                             value: true,
                             writable: true,
+                            configurable: true,
                         });
 
                         delete this[promiseIndex];
@@ -228,11 +230,13 @@ export class RelationLoader {
                         Object.defineProperty(this, dataIndex, {
                             value: result,
                             writable: true,
+                            configurable: true,
                         });
 
                         Object.defineProperty(this, resolveIndex, {
                             value: true,
                             writable: true,
+                            configurable: true,
                         });
                     });
                 } else {
@@ -240,11 +244,13 @@ export class RelationLoader {
                     Object.defineProperty(this, dataIndex, {
                         value,
                         writable: true,
+                        configurable: true,
                     });
 
                     Object.defineProperty(this, resolveIndex, {
                         value: true,
                         writable: true,
+                        configurable: true,
                     });
                 }
             },

--- a/src/util/OrmUtils.ts
+++ b/src/util/OrmUtils.ts
@@ -63,6 +63,24 @@ export class OrmUtils {
     }
 
     /**
+     * Iterates over an object's own property names and ensures that all
+     * configurable properties are also enumerable.
+     */
+    static makeEnumerable(object: any) {
+        if (this.isObject(object)) {
+            Object.getOwnPropertyNames(object).forEach(property => {
+                const descriptor = Object.getOwnPropertyDescriptor(object, property);
+                if (descriptor && descriptor.configurable && !descriptor.enumerable) {
+                    descriptor.enumerable = true;
+                    Object.defineProperty(object, property, descriptor);
+                }
+            });
+        }
+
+        return object;
+    }
+
+    /**
      * Deep Object.assign.
      *
      * @see http://stackoverflow.com/a/34749873

--- a/test/github-issues/3576/entity/Book.ts
+++ b/test/github-issues/3576/entity/Book.ts
@@ -1,0 +1,14 @@
+import { Column, Entity, PrimaryGeneratedColumn, ManyToOne } from "../../../../src";
+import { User } from "./User";
+
+@Entity()
+export class Book {
+    @PrimaryGeneratedColumn("uuid")
+    id: string;
+
+    @Column()
+    title: string;
+
+    @ManyToOne(type => User, user => user.books, { lazy: true })
+    author: User;
+}

--- a/test/github-issues/3576/entity/User.ts
+++ b/test/github-issues/3576/entity/User.ts
@@ -1,0 +1,14 @@
+import { Column, Entity, OneToMany, PrimaryGeneratedColumn } from "../../../../src";
+import { Book } from "./Book";
+
+@Entity()
+export class User {
+    @PrimaryGeneratedColumn("uuid")
+    id: string;
+
+    @Column()
+    name: string;
+
+    @OneToMany(type => Book, book => book.author, { lazy: true })
+    books: Book[];
+}

--- a/test/github-issues/3576/issue-3576.ts
+++ b/test/github-issues/3576/issue-3576.ts
@@ -1,0 +1,48 @@
+import "reflect-metadata";
+
+import { expect } from "chai";
+
+import { Connection } from "../../../src/connection/Connection";
+import { closeTestingConnections, createTestingConnections } from "../../utils/test-utils";
+import { Book } from "./entity/Book";
+import { User } from "./entity/User";
+
+describe("github issues > #3576 Error when saving an entity after lazy loading its relations: TypeError: Cannot read property 'find' of undefined", () => {
+    let connections: Connection[];
+
+    before(async () => {
+        connections = await createTestingConnections({
+            schemaCreate: true,
+            entities: [__dirname + "/entity/*{.js,.ts}"],
+            enabledDrivers: ["postgres"],
+            dropSchema: true,
+        });
+    });
+
+    after(() => closeTestingConnections(connections));
+
+    it("shouldn't blow up when you try to save it after loading one of its relations", async () => {
+        const usersRepo = connections[0].getRepository(User);
+        const booksRepo = connections[0].getRepository(Book);
+
+        const author = new User();
+        author.name = "Vince Coppola";
+        await usersRepo.save(author);
+
+        const book1 = new Book();
+        book1.author = author;
+        book1.title = "This Better Work";
+        await booksRepo.save(book1);
+
+        const testAuthor = await usersRepo.findOneOrFail();
+
+        // Historically, this was the step that would cause the subsequent save
+        // operation to throw.
+        await testAuthor.books;
+
+        await usersRepo.save(testAuthor);
+
+        // If we made it this far, we're in the clear!
+        expect(true);
+    });
+});


### PR DESCRIPTION
Overview
-----
This PR fixes #3576 by making all configurable properties of `Subject.entity` enumerable again. This maintains the original intent of #3231 while fixing the underlying issue that it introduced.

**Note:** Unfortunately, I didn't noticed #3656 until just before opening this PR. That being said, I think that these changes are still worth proposing since they take a different approach and include tests.

-----

@pleerock Please let me know if the impact of these changes are larger than I'm anticipating. As far as I can tell, this makes the properties on `Subject.entity` the same as they were prior to #3231.