### PR TITLE
Moves directory search to it's own function

### DIFF
--- a/src/util/DirectoryExportedClassesLoader.ts
+++ b/src/util/DirectoryExportedClassesLoader.ts
@@ -20,18 +20,41 @@ export function importClassesFromDirectories(directories: string[], formats = ["
         return allLoaded;
     }
 
-    const allFiles = directories.reduce((allDirs, dir) => {
-        return allDirs.concat(PlatformTools.load("glob").sync(PlatformTools.pathNormalize(dir)));
-    }, [] as string[]);
-
-    const dirs = allFiles
-        .filter(file => {
-            const dtsExtension = file.substring(file.length - 5, file.length);
-            return formats.indexOf(PlatformTools.pathExtname(file)) !== -1 && dtsExtension !== ".d.ts";
-        })
-        .map(file => PlatformTools.load(PlatformTools.pathResolve(file)));
+    const dirs = this.getAllDirs(directories, formats).map((file: string) => {
+        PlatformTools.load(PlatformTools.pathResolve(file));
+    });
 
     return loadFileClasses(dirs, []);
+}
+
+/**
+ * Gets all files for given directory mask
+ * @param directories array of directory path's
+ * @param formats file extensions to filter out
+ */
+export function getAllDirs(
+    directories: string[],
+    formats = [".js", ".ts"]
+): string[] {
+    const allFiles = directories.reduce(
+        (allDirs, dir) => {
+            return allDirs.concat(
+                PlatformTools.load("glob").sync(
+                    PlatformTools.pathNormalize(dir)
+                )
+            );
+        },
+        [] as string[]
+    );
+
+    return allFiles
+        .filter(file => {
+            const dtsExtension = file.substring(file.length - 5, file.length);
+            return (
+                formats.indexOf(PlatformTools.pathExtname(file)) !== -1 &&
+                dtsExtension !== ".d.ts"
+            );
+        });
 }
 
 /**


### PR DESCRIPTION
This small change allows to use TypeORM internal procedure of searching entity directories, outside ORM, by moving part of code to it's own exported function.