### PR TITLE
Migrate TSLint formatter to included stylish formatter

### DIFF
--- a/gulpfile.ts
+++ b/gulpfile.ts
@@ -2,7 +2,7 @@
 ///<reference path="node_modules/@types/chai/index.d.ts"/>
 ///<reference path="node_modules/@types/mocha/index.d.ts"/>
 
-import {Gulpclass, Task, SequenceTask, MergedTask} from "gulpclass";
+import { Gulpclass, Task, SequenceTask, MergedTask } from "gulpclass";
 
 const gulp = require("gulp");
 const del = require("del");
@@ -12,7 +12,6 @@ const rename = require("gulp-rename");
 const mocha = require("gulp-mocha");
 const chai = require("chai");
 const tslint = require("gulp-tslint");
-const stylish = require("tslint-stylish");
 const sourcemaps = require("gulp-sourcemaps");
 const istanbul = require("gulp-istanbul");
 const remapIstanbul = require("remap-istanbul/lib/gulpRemapIstanbul");
@@ -21,7 +20,6 @@ const args = require("yargs").argv;
 
 @Gulpclass()
 export class Gulpfile {
-
     // -------------------------------------------------------------------------
     // General tasks
     // -------------------------------------------------------------------------
@@ -47,7 +45,8 @@ export class Gulpfile {
      */
     @Task()
     compile() {
-        return gulp.src("package.json", { read: false })
+        return gulp
+            .src("package.json", { read: false })
             .pipe(shell(["npm run compile"]));
     }
 
@@ -60,15 +59,16 @@ export class Gulpfile {
      */
     @Task()
     browserCopySources() {
-        return gulp.src([
-            "./src/**/*.ts",
-            "!./src/commands/*.ts",
-            "!./src/cli.ts",
-            "!./src/typeorm.ts",
-            "!./src/typeorm-model-shim.ts",
-            "!./src/platform/PlatformTools.ts"
-        ])
-        .pipe(gulp.dest("./build/browser/src"));
+        return gulp
+            .src([
+                "./src/**/*.ts",
+                "!./src/commands/*.ts",
+                "!./src/cli.ts",
+                "!./src/typeorm.ts",
+                "!./src/typeorm-model-shim.ts",
+                "!./src/platform/PlatformTools.ts"
+            ])
+            .pipe(gulp.dest("./build/browser/src"));
     }
 
     /**
@@ -76,7 +76,8 @@ export class Gulpfile {
      */
     @Task()
     browserCopyPlatformTools() {
-        return gulp.src("./src/platform/BrowserPlatformTools.template")
+        return gulp
+            .src("./src/platform/BrowserPlatformTools.template")
             .pipe(rename("PlatformTools.ts"))
             .pipe(gulp.dest("./build/browser/src/platform"));
     }
@@ -86,7 +87,8 @@ export class Gulpfile {
      */
     @Task()
     browserCopyDisabledDriversDummy() {
-        return gulp.src("./src/platform/BrowserDisabledDriversDummy.template")
+        return gulp
+            .src("./src/platform/BrowserDisabledDriversDummy.template")
             .pipe(rename("BrowserDisabledDriversDummy.ts"))
             .pipe(gulp.dest("./build/browser/src/platform"));
     }
@@ -95,26 +97,34 @@ export class Gulpfile {
     browserCompile() {
         const tsProject = ts.createProject("tsconfig.json", {
             module: "es2015",
-            "lib": ["es5", "es6", "dom"],
+            lib: ["es5", "es6", "dom"],
             typescript: require("typescript")
         });
-        const tsResult = gulp.src(["./build/browser/src/**/*.ts", "./node_modules/reflect-metadata/**/*.d.ts", "./node_modules/@types/**/*.ts"])
+        const tsResult = gulp
+            .src([
+                "./build/browser/src/**/*.ts",
+                "./node_modules/reflect-metadata/**/*.d.ts",
+                "./node_modules/@types/**/*.ts"
+            ])
             .pipe(sourcemaps.init())
             .pipe(tsProject());
 
         return [
             tsResult.dts.pipe(gulp.dest("./build/package/browser")),
             tsResult.js
-                .pipe(sourcemaps.write(".", { sourceRoot: "", includeContent: true }))
+                .pipe(
+                    sourcemaps.write(".", {
+                        sourceRoot: "",
+                        includeContent: true
+                    })
+                )
                 .pipe(gulp.dest("./build/package/browser"))
         ];
     }
 
     @Task()
     browserClearPackageDirectory(cb: Function) {
-        return del([
-            "./build/browser/**"
-        ]);
+        return del(["./build/browser/**"]);
     }
 
     // -------------------------------------------------------------------------
@@ -126,10 +136,9 @@ export class Gulpfile {
      */
     @Task()
     packagePublish() {
-        return gulp.src("package.json", { read: false })
-            .pipe(shell([
-                "cd ./build/package && npm publish"
-            ]));
+        return gulp
+            .src("package.json", { read: false })
+            .pipe(shell(["cd ./build/package && npm publish"]));
     }
 
     /**
@@ -137,10 +146,9 @@ export class Gulpfile {
      */
     @Task()
     packagePublishNext() {
-        return gulp.src("package.json", { read: false })
-            .pipe(shell([
-                "cd ./build/package && npm publish --tag next"
-            ]));
+        return gulp
+            .src("package.json", { read: false })
+            .pipe(shell(["cd ./build/package && npm publish --tag next"]));
     }
 
     /**
@@ -148,15 +156,23 @@ export class Gulpfile {
      */
     @MergedTask()
     packageCompile() {
-        const tsProject = ts.createProject("tsconfig.json", { typescript: require("typescript") });
-        const tsResult = gulp.src(["./src/**/*.ts", "./node_modules/@types/**/*.ts"])
+        const tsProject = ts.createProject("tsconfig.json", {
+            typescript: require("typescript")
+        });
+        const tsResult = gulp
+            .src(["./src/**/*.ts", "./node_modules/@types/**/*.ts"])
             .pipe(sourcemaps.init())
             .pipe(tsProject());
 
         return [
             tsResult.dts.pipe(gulp.dest("./build/package")),
             tsResult.js
-                .pipe(sourcemaps.write(".", { sourceRoot: "", includeContent: true }))
+                .pipe(
+                    sourcemaps.write(".", {
+                        sourceRoot: "",
+                        includeContent: true
+                    })
+                )
                 .pipe(gulp.dest("./build/package"))
         ];
     }
@@ -166,7 +182,8 @@ export class Gulpfile {
      */
     @Task()
     packageMoveCompiledFiles() {
-        return gulp.src("./build/package/src/**/*")
+        return gulp
+            .src("./build/package/src/**/*")
             .pipe(gulp.dest("./build/package"));
     }
 
@@ -175,7 +192,8 @@ export class Gulpfile {
      */
     @Task()
     packageReplaceReferences() {
-        return gulp.src("./build/package/**/*.d.ts")
+        return gulp
+            .src("./build/package/**/*.d.ts")
             .pipe(replace(`/// <reference types="node" />`, ""))
             .pipe(replace(`/// <reference types="chai" />`, ""))
             .pipe(gulp.dest("./build/package"));
@@ -186,9 +204,7 @@ export class Gulpfile {
      */
     @Task()
     packageClearPackageDirectory(cb: Function) {
-        return del([
-            "build/package/src/**"
-        ], cb);
+        return del(["build/package/src/**"], cb);
     }
 
     /**
@@ -196,8 +212,9 @@ export class Gulpfile {
      */
     @Task()
     packagePreparePackageFile() {
-        return gulp.src("./package.json")
-            .pipe(replace("\"private\": true,", "\"private\": false,"))
+        return gulp
+            .src("./package.json")
+            .pipe(replace('"private": true,', '"private": false,'))
             .pipe(gulp.dest("./build/package"));
     }
 
@@ -206,7 +223,8 @@ export class Gulpfile {
      */
     @Task()
     packageCopyReadme() {
-        return gulp.src("./README.md")
+        return gulp
+            .src("./README.md")
             .pipe(replace(/```typescript([\s\S]*?)```/g, "```javascript$1```"))
             .pipe(gulp.dest("./build/package"));
     }
@@ -216,7 +234,11 @@ export class Gulpfile {
      */
     @Task()
     packageCopyShims() {
-        return gulp.src(["./extra/typeorm-model-shim.js", "./extra/typeorm-class-transformer-shim.js"])
+        return gulp
+            .src([
+                "./extra/typeorm-model-shim.js",
+                "./extra/typeorm-class-transformer-shim.js"
+            ])
             .pipe(gulp.dest("./build/package"));
     }
 
@@ -227,7 +249,11 @@ export class Gulpfile {
     package() {
         return [
             "clean",
-            ["browserCopySources", "browserCopyPlatformTools", "browserCopyDisabledDriversDummy"],
+            [
+                "browserCopySources",
+                "browserCopyPlatformTools",
+                "browserCopyDisabledDriversDummy"
+            ],
             ["packageCompile", "browserCompile"],
             "packageMoveCompiledFiles",
             [
@@ -237,7 +263,7 @@ export class Gulpfile {
                 "packagePreparePackageFile",
                 "packageCopyReadme",
                 "packageCopyShims"
-            ],
+            ]
         ];
     }
 
@@ -266,13 +292,20 @@ export class Gulpfile {
      */
     @Task()
     tslint() {
-        return gulp.src(["./src/**/*.ts", "./test/**/*.ts", "./sample/**/*.ts"])
-            .pipe(tslint())
-            .pipe(tslint.report(stylish, {
-                emitError: true,
-                sort: true,
-                bell: true
-            }));
+        return gulp
+            .src(["./src/**/*.ts", "./test/**/*.ts", "./sample/**/*.ts"])
+            .pipe(
+                tslint({
+                    formatter: "stylish"
+                })
+            )
+            .pipe(
+                tslint.report({
+                    emitError: true,
+                    sort: true,
+                    bell: true
+                })
+            );
     }
 
     /**
@@ -280,7 +313,8 @@ export class Gulpfile {
      */
     @Task()
     coveragePre() {
-        return gulp.src(["./build/compiled/src/**/*.js"])
+        return gulp
+            .src(["./build/compiled/src/**/*.js"])
             .pipe(istanbul())
             .pipe(istanbul.hookRequire());
     }
@@ -290,7 +324,8 @@ export class Gulpfile {
      */
     @Task()
     coveragePost() {
-        return gulp.src(["./build/compiled/test/**/*.js"])
+        return gulp
+            .src(["./build/compiled/test/**/*.js"])
             .pipe(istanbul.writeReports());
     }
 
@@ -303,17 +338,19 @@ export class Gulpfile {
         chai.use(require("sinon-chai"));
         chai.use(require("chai-as-promised"));
 
-        return gulp.src(["./build/compiled/test/**/*.js"])
-            .pipe(mocha({
+        return gulp.src(["./build/compiled/test/**/*.js"]).pipe(
+            mocha({
                 bail: true,
                 grep: !!args.grep ? new RegExp(args.grep) : undefined,
                 timeout: 15000
-            }));
+            })
+        );
     }
 
     @Task()
     coverageRemap() {
-        return gulp.src("./coverage/coverage-final.json")
+        return gulp
+            .src("./coverage/coverage-final.json")
             .pipe(remapIstanbul())
             .pipe(gulp.dest("./coverage"));
     }
@@ -355,9 +392,9 @@ export class Gulpfile {
 
     @Task()
     createTravisOrmConfig() {
-        return gulp.src("./ormconfig.travis.json")
+        return gulp
+            .src("./ormconfig.travis.json")
             .pipe(rename("ormconfig.json"))
             .pipe(gulp.dest("./"));
     }
-
 }

--- a/gulpfile.ts
+++ b/gulpfile.ts
@@ -2,7 +2,7 @@
 ///<reference path="node_modules/@types/chai/index.d.ts"/>
 ///<reference path="node_modules/@types/mocha/index.d.ts"/>
 
-import { Gulpclass, Task, SequenceTask, MergedTask } from "gulpclass";
+import {Gulpclass, Task, SequenceTask, MergedTask} from "gulpclass";
 
 const gulp = require("gulp");
 const del = require("del");
@@ -20,6 +20,7 @@ const args = require("yargs").argv;
 
 @Gulpclass()
 export class Gulpfile {
+
     // -------------------------------------------------------------------------
     // General tasks
     // -------------------------------------------------------------------------
@@ -45,8 +46,7 @@ export class Gulpfile {
      */
     @Task()
     compile() {
-        return gulp
-            .src("package.json", { read: false })
+        return gulp.src("package.json", { read: false })
             .pipe(shell(["npm run compile"]));
     }
 
@@ -59,16 +59,15 @@ export class Gulpfile {
      */
     @Task()
     browserCopySources() {
-        return gulp
-            .src([
-                "./src/**/*.ts",
-                "!./src/commands/*.ts",
-                "!./src/cli.ts",
-                "!./src/typeorm.ts",
-                "!./src/typeorm-model-shim.ts",
-                "!./src/platform/PlatformTools.ts"
-            ])
-            .pipe(gulp.dest("./build/browser/src"));
+        return gulp.src([
+            "./src/**/*.ts",
+            "!./src/commands/*.ts",
+            "!./src/cli.ts",
+            "!./src/typeorm.ts",
+            "!./src/typeorm-model-shim.ts",
+            "!./src/platform/PlatformTools.ts"
+        ])
+        .pipe(gulp.dest("./build/browser/src"));
     }
 
     /**
@@ -76,8 +75,7 @@ export class Gulpfile {
      */
     @Task()
     browserCopyPlatformTools() {
-        return gulp
-            .src("./src/platform/BrowserPlatformTools.template")
+        return gulp.src("./src/platform/BrowserPlatformTools.template")
             .pipe(rename("PlatformTools.ts"))
             .pipe(gulp.dest("./build/browser/src/platform"));
     }
@@ -87,8 +85,7 @@ export class Gulpfile {
      */
     @Task()
     browserCopyDisabledDriversDummy() {
-        return gulp
-            .src("./src/platform/BrowserDisabledDriversDummy.template")
+        return gulp.src("./src/platform/BrowserDisabledDriversDummy.template")
             .pipe(rename("BrowserDisabledDriversDummy.ts"))
             .pipe(gulp.dest("./build/browser/src/platform"));
     }
@@ -97,34 +94,26 @@ export class Gulpfile {
     browserCompile() {
         const tsProject = ts.createProject("tsconfig.json", {
             module: "es2015",
-            lib: ["es5", "es6", "dom"],
+            "lib": ["es5", "es6", "dom"],
             typescript: require("typescript")
         });
-        const tsResult = gulp
-            .src([
-                "./build/browser/src/**/*.ts",
-                "./node_modules/reflect-metadata/**/*.d.ts",
-                "./node_modules/@types/**/*.ts"
-            ])
+        const tsResult = gulp.src(["./build/browser/src/**/*.ts", "./node_modules/reflect-metadata/**/*.d.ts", "./node_modules/@types/**/*.ts"])
             .pipe(sourcemaps.init())
             .pipe(tsProject());
 
         return [
             tsResult.dts.pipe(gulp.dest("./build/package/browser")),
             tsResult.js
-                .pipe(
-                    sourcemaps.write(".", {
-                        sourceRoot: "",
-                        includeContent: true
-                    })
-                )
+                .pipe(sourcemaps.write(".", { sourceRoot: "", includeContent: true }))
                 .pipe(gulp.dest("./build/package/browser"))
         ];
     }
 
     @Task()
     browserClearPackageDirectory(cb: Function) {
-        return del(["./build/browser/**"]);
+        return del([
+            "./build/browser/**"
+        ]);
     }
 
     // -------------------------------------------------------------------------
@@ -136,9 +125,10 @@ export class Gulpfile {
      */
     @Task()
     packagePublish() {
-        return gulp
-            .src("package.json", { read: false })
-            .pipe(shell(["cd ./build/package && npm publish"]));
+        return gulp.src("package.json", { read: false })
+            .pipe(shell([
+                "cd ./build/package && npm publish"
+            ]));
     }
 
     /**
@@ -146,9 +136,10 @@ export class Gulpfile {
      */
     @Task()
     packagePublishNext() {
-        return gulp
-            .src("package.json", { read: false })
-            .pipe(shell(["cd ./build/package && npm publish --tag next"]));
+        return gulp.src("package.json", { read: false })
+            .pipe(shell([
+                "cd ./build/package && npm publish --tag next"
+            ]));
     }
 
     /**
@@ -156,23 +147,15 @@ export class Gulpfile {
      */
     @MergedTask()
     packageCompile() {
-        const tsProject = ts.createProject("tsconfig.json", {
-            typescript: require("typescript")
-        });
-        const tsResult = gulp
-            .src(["./src/**/*.ts", "./node_modules/@types/**/*.ts"])
+        const tsProject = ts.createProject("tsconfig.json", { typescript: require("typescript") });
+        const tsResult = gulp.src(["./src/**/*.ts", "./node_modules/@types/**/*.ts"])
             .pipe(sourcemaps.init())
             .pipe(tsProject());
 
         return [
             tsResult.dts.pipe(gulp.dest("./build/package")),
             tsResult.js
-                .pipe(
-                    sourcemaps.write(".", {
-                        sourceRoot: "",
-                        includeContent: true
-                    })
-                )
+                .pipe(sourcemaps.write(".", { sourceRoot: "", includeContent: true }))
                 .pipe(gulp.dest("./build/package"))
         ];
     }
@@ -182,8 +165,7 @@ export class Gulpfile {
      */
     @Task()
     packageMoveCompiledFiles() {
-        return gulp
-            .src("./build/package/src/**/*")
+        return gulp.src("./build/package/src/**/*")
             .pipe(gulp.dest("./build/package"));
     }
 
@@ -192,8 +174,7 @@ export class Gulpfile {
      */
     @Task()
     packageReplaceReferences() {
-        return gulp
-            .src("./build/package/**/*.d.ts")
+        return gulp.src("./build/package/**/*.d.ts")
             .pipe(replace(`/// <reference types="node" />`, ""))
             .pipe(replace(`/// <reference types="chai" />`, ""))
             .pipe(gulp.dest("./build/package"));
@@ -204,7 +185,9 @@ export class Gulpfile {
      */
     @Task()
     packageClearPackageDirectory(cb: Function) {
-        return del(["build/package/src/**"], cb);
+        return del([
+            "build/package/src/**"
+        ], cb);
     }
 
     /**
@@ -212,9 +195,8 @@ export class Gulpfile {
      */
     @Task()
     packagePreparePackageFile() {
-        return gulp
-            .src("./package.json")
-            .pipe(replace('"private": true,', '"private": false,'))
+        return gulp.src("./package.json")
+            .pipe(replace("\"private\": true,", "\"private\": false,"))
             .pipe(gulp.dest("./build/package"));
     }
 
@@ -223,8 +205,7 @@ export class Gulpfile {
      */
     @Task()
     packageCopyReadme() {
-        return gulp
-            .src("./README.md")
+        return gulp.src("./README.md")
             .pipe(replace(/```typescript([\s\S]*?)```/g, "```javascript$1```"))
             .pipe(gulp.dest("./build/package"));
     }
@@ -234,11 +215,7 @@ export class Gulpfile {
      */
     @Task()
     packageCopyShims() {
-        return gulp
-            .src([
-                "./extra/typeorm-model-shim.js",
-                "./extra/typeorm-class-transformer-shim.js"
-            ])
+        return gulp.src(["./extra/typeorm-model-shim.js", "./extra/typeorm-class-transformer-shim.js"])
             .pipe(gulp.dest("./build/package"));
     }
 
@@ -249,11 +226,7 @@ export class Gulpfile {
     package() {
         return [
             "clean",
-            [
-                "browserCopySources",
-                "browserCopyPlatformTools",
-                "browserCopyDisabledDriversDummy"
-            ],
+            ["browserCopySources", "browserCopyPlatformTools", "browserCopyDisabledDriversDummy"],
             ["packageCompile", "browserCompile"],
             "packageMoveCompiledFiles",
             [
@@ -263,7 +236,7 @@ export class Gulpfile {
                 "packagePreparePackageFile",
                 "packageCopyReadme",
                 "packageCopyShims"
-            ]
+            ],
         ];
     }
 
@@ -292,20 +265,17 @@ export class Gulpfile {
      */
     @Task()
     tslint() {
-        return gulp
-            .src(["./src/**/*.ts", "./test/**/*.ts", "./sample/**/*.ts"])
+        return gulp.src(["./src/**/*.ts", "./test/**/*.ts", "./sample/**/*.ts"])
             .pipe(
                 tslint({
                     formatter: "stylish"
                 })
             )
-            .pipe(
-                tslint.report({
-                    emitError: true,
-                    sort: true,
-                    bell: true
-                })
-            );
+            .pipe(tslint.report({
+                emitError: true,
+                sort: true,
+                bell: true
+            }));
     }
 
     /**
@@ -313,8 +283,7 @@ export class Gulpfile {
      */
     @Task()
     coveragePre() {
-        return gulp
-            .src(["./build/compiled/src/**/*.js"])
+        return gulp.src(["./build/compiled/src/**/*.js"])
             .pipe(istanbul())
             .pipe(istanbul.hookRequire());
     }
@@ -324,8 +293,7 @@ export class Gulpfile {
      */
     @Task()
     coveragePost() {
-        return gulp
-            .src(["./build/compiled/test/**/*.js"])
+        return gulp.src(["./build/compiled/test/**/*.js"])
             .pipe(istanbul.writeReports());
     }
 
@@ -338,19 +306,17 @@ export class Gulpfile {
         chai.use(require("sinon-chai"));
         chai.use(require("chai-as-promised"));
 
-        return gulp.src(["./build/compiled/test/**/*.js"]).pipe(
-            mocha({
+        return gulp.src(["./build/compiled/test/**/*.js"])
+            .pipe(mocha({
                 bail: true,
                 grep: !!args.grep ? new RegExp(args.grep) : undefined,
                 timeout: 15000
-            })
-        );
+            }));
     }
 
     @Task()
     coverageRemap() {
-        return gulp
-            .src("./coverage/coverage-final.json")
+        return gulp.src("./coverage/coverage-final.json")
             .pipe(remapIstanbul())
             .pipe(gulp.dest("./coverage"));
     }
@@ -392,9 +358,9 @@ export class Gulpfile {
 
     @Task()
     createTravisOrmConfig() {
-        return gulp
-            .src("./ormconfig.travis.json")
+        return gulp.src("./ormconfig.travis.json")
             .pipe(rename("ormconfig.json"))
             .pipe(gulp.dest("./"));
     }
+
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "typeorm",
-  "version": "0.2.13",
+  "version": "0.2.14",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -6714,12 +6714,6 @@
       "integrity": "sha1-45mpgiV6J22uQou5KEXLcb3CbRk=",
       "dev": true
     },
-    "text-table": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
-      "integrity": "sha1-f17oI66AUgfACvLfSoTsP8+lcLQ=",
-      "dev": true
-    },
     "textextensions": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/textextensions/-/textextensions-1.0.2.tgz",
@@ -6893,9 +6887,9 @@
       "integrity": "sha512-4krF8scpejhaOgqzBEcGM7yDIEfi0/8+8zDRZhNZZ2kjmHJ4hv3zCbQWxoJGz1iw5U0Jl0nma13xzHXcncMavQ=="
     },
     "tslint": {
-      "version": "5.11.0",
-      "resolved": "https://registry.npmjs.org/tslint/-/tslint-5.11.0.tgz",
-      "integrity": "sha1-mPMMAurjzecAYgHkwzywi0hYHu0=",
+      "version": "5.13.0",
+      "resolved": "https://registry.npmjs.org/tslint/-/tslint-5.13.0.tgz",
+      "integrity": "sha512-ECOOQRxXCYnUUePG5h/+Z1Zouobk3KFpIHA9aKBB/nnMxs97S1JJPDGt5J4cGm1y9U9VmVlfboOxA8n1kSNzGw==",
       "dev": true,
       "requires": {
         "babel-code-frame": "^6.22.0",
@@ -6906,121 +6900,11 @@
         "glob": "^7.1.1",
         "js-yaml": "^3.7.0",
         "minimatch": "^3.0.4",
+        "mkdirp": "^0.5.1",
         "resolve": "^1.3.2",
         "semver": "^5.3.0",
         "tslib": "^1.8.0",
         "tsutils": "^2.27.2"
-      }
-    },
-    "tslint-stylish": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/tslint-stylish/-/tslint-stylish-2.1.0.tgz",
-      "integrity": "sha1-jNo8OMnKtU57It989CuO8RXc2V8=",
-      "dev": true,
-      "requires": {
-        "chalk": "^1.1.1",
-        "lodash": "^3.10.1",
-        "log-symbols": "^1.0.2",
-        "text-table": "^0.2.0",
-        "tslint": "^2.5.0"
-      },
-      "dependencies": {
-        "ansi-regex": {
-          "version": "2.1.1",
-          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
-          "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
-          "dev": true
-        },
-        "ansi-styles": {
-          "version": "2.2.1",
-          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
-          "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
-          "dev": true
-        },
-        "chalk": {
-          "version": "1.1.3",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
-          "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
-          "dev": true,
-          "requires": {
-            "ansi-styles": "^2.2.1",
-            "escape-string-regexp": "^1.0.2",
-            "has-ansi": "^2.0.0",
-            "strip-ansi": "^3.0.0",
-            "supports-color": "^2.0.0"
-          }
-        },
-        "findup-sync": {
-          "version": "0.2.1",
-          "resolved": "https://registry.npmjs.org/findup-sync/-/findup-sync-0.2.1.tgz",
-          "integrity": "sha1-4KkKRQB1xJRm7lE3MgV1FLgeh4w=",
-          "dev": true,
-          "requires": {
-            "glob": "~4.3.0"
-          }
-        },
-        "glob": {
-          "version": "4.3.5",
-          "resolved": "https://registry.npmjs.org/glob/-/glob-4.3.5.tgz",
-          "integrity": "sha1-gPuwjKVA8jiszl0R0em8QedRc9M=",
-          "dev": true,
-          "requires": {
-            "inflight": "^1.0.4",
-            "inherits": "2",
-            "minimatch": "^2.0.1",
-            "once": "^1.3.0"
-          }
-        },
-        "lodash": {
-          "version": "3.10.1",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz",
-          "integrity": "sha1-W/Rejkm6QYnhfUgnid/RW9FAt7Y=",
-          "dev": true
-        },
-        "log-symbols": {
-          "version": "1.0.2",
-          "resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-1.0.2.tgz",
-          "integrity": "sha1-N2/3tY6jCGoPCfrMdGF+ylAeGhg=",
-          "dev": true,
-          "requires": {
-            "chalk": "^1.0.0"
-          }
-        },
-        "minimatch": {
-          "version": "2.0.10",
-          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.10.tgz",
-          "integrity": "sha1-jQh8OcazjAAbl/ynzm0OHoCvusc=",
-          "dev": true,
-          "requires": {
-            "brace-expansion": "^1.0.0"
-          }
-        },
-        "strip-ansi": {
-          "version": "3.0.1",
-          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
-          "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
-          "dev": true,
-          "requires": {
-            "ansi-regex": "^2.0.0"
-          }
-        },
-        "supports-color": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
-          "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
-          "dev": true
-        },
-        "tslint": {
-          "version": "2.5.1",
-          "resolved": "https://registry.npmjs.org/tslint/-/tslint-2.5.1.tgz",
-          "integrity": "sha1-veTJnpfNXRxvuzAz9kt9iX/UGpI=",
-          "dev": true,
-          "requires": {
-            "findup-sync": "~0.2.1",
-            "optimist": "~0.6.0",
-            "underscore.string": "~3.1.1"
-          }
-        }
       }
     },
     "tsutils": {
@@ -7098,12 +6982,6 @@
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/unc-path-regex/-/unc-path-regex-0.1.2.tgz",
       "integrity": "sha1-5z3T17DXxe2G+6xrCufYxqadUPo=",
-      "dev": true
-    },
-    "underscore.string": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/underscore.string/-/underscore.string-3.1.1.tgz",
-      "integrity": "sha1-DN1rytDARv12Y9MF2KeFtdoQ8zU=",
       "dev": true
     },
     "undertaker": {

--- a/package.json
+++ b/package.json
@@ -85,8 +85,7 @@
     "sql.js": "^0.5.0",
     "sqlite3": "^4.0.3",
     "ts-node": "^5.0.0",
-    "tslint": "^5.9.1",
-    "tslint-stylish": "^2.1.0",
+    "tslint": "^5.13.0",
     "typescript": "^2.8.1"
   },
   "dependencies": {


### PR DESCRIPTION
While doing an `npm audit` to verify that [this Issue](https://github.com/typeorm/typeorm/issues/3695) was resolved, I noticed that the package [tslint-stylish](https://github.com/adamfitzpatrick/tslint-stylish) was the only remaining dependency linking to the dangerous version of `minimatch`. It was also listed by its developer as deprecated in favor of one now included by @Palantir in the `tslint` core package.

To remove that last security issue from the codebase (even if it was only in dev), this PR updates the `tslint` version used by typeorm to latest, removes the dependency on `tslint-stylish`, and instead uses the `tslint` native stylish formatter for lint output.