### PR TITLE
feat: Virtual column

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,9 +18,10 @@ before_script:
   - sudo service postgresql stop
   - docker-compose up -d
   - cp ormconfig.travis.json ormconfig.json
-  - npm install sqlite3
+  - npm install sqlite3 --build-from-source
 
 script:
+  - npm run lint
   - npm test
 
 after_success:

--- a/package.json
+++ b/package.json
@@ -113,7 +113,7 @@
   },
   "scripts": {
     "test-ci": "gulp ci-tests",
-    "test": "rimraf ./build && tsc && mocha --file ./build/compiled/test/utils/test-setup.js --bail --timeout 60000 ./build/compiled/test/functional/repository/virtual-column",
+    "test": "rimraf ./build && tsc && mocha --file ./build/compiled/test/utils/test-setup.js --bail --recursive --timeout 60000 ./build/compiled/test",
     "compile": "rimraf ./build && tsc",
     "package": "gulp package",
     "lint": "tslint -p ."

--- a/src/decorator/columns/Column.ts
+++ b/src/decorator/columns/Column.ts
@@ -147,3 +147,7 @@ export function Column(typeOrOptions?: ((type?: any) => Function)|ColumnType|(Co
         }
     };
 }
+
+export type ColumnName<M> = {
+    [P in keyof M]: string
+};

--- a/src/decorator/options/ColumnOptions.ts
+++ b/src/decorator/options/ColumnOptions.ts
@@ -1,6 +1,7 @@
 import {ColumnType} from "../../driver/types/ColumnTypes";
 import {ValueTransformer} from "./ValueTransformer";
 import { ColumnCommonOptions } from "./ColumnCommonOptions";
+import { DatabaseType } from "../..";
 
 /**
  * Describes all column's options.
@@ -118,6 +119,11 @@ export interface ColumnOptions extends ColumnCommonOptions {
     asExpression?: string;
 
     /**
+     * Like asExpression, but support all database in typeorm.
+     */
+    asVirtual?: (names: {[col: string]: string }, type: DatabaseType) => string;
+
+    /**
      * Generated column type. Supports only in MySQL.
      */
     generatedType?: "VIRTUAL"|"STORED";
@@ -150,4 +156,7 @@ export interface ColumnOptions extends ColumnCommonOptions {
      * SRID (Spatial Reference ID (EPSG code))
      */
     srid?: number;
+
 }
+
+

--- a/src/driver/mysql/MysqlQueryRunner.ts
+++ b/src/driver/mysql/MysqlQueryRunner.ts
@@ -1333,7 +1333,8 @@ export class MysqlQueryRunner extends BaseQueryRunner implements QueryRunner {
      * Builds create table sql
      */
     protected createTableSql(table: Table, createForeignKeys?: boolean): string {
-        const columnDefinitions = table.columns.map(column => this.buildCreateColumnSql(column, true)).join(", ");
+        const columnDefinitions = table.columns.filter( c => !c.asVirtual)
+            .map(column => this.buildCreateColumnSql(column, true)).join(", ");
         let sql = `CREATE TABLE ${this.escapeTableName(table)} (${columnDefinitions}`;
 
         // we create unique indexes instead of unique constraints, because MySql does not have unique constraints.

--- a/src/driver/oracle/OracleQueryRunner.ts
+++ b/src/driver/oracle/OracleQueryRunner.ts
@@ -1259,7 +1259,8 @@ export class OracleQueryRunner extends BaseQueryRunner implements QueryRunner {
      * Builds and returns SQL for create table.
      */
     protected createTableSql(table: Table, createForeignKeys?: boolean): string {
-        const columnDefinitions = table.columns.map(column => this.buildCreateColumnSql(column)).join(", ");
+        const columnDefinitions = table.columns.filter(c => !c.asVirtual)
+            .map(column => this.buildCreateColumnSql(column)).join(", ");
         let sql = `CREATE TABLE "${table.name}" (${columnDefinitions}`;
 
         table.columns

--- a/src/driver/postgres/PostgresQueryRunner.ts
+++ b/src/driver/postgres/PostgresQueryRunner.ts
@@ -1577,7 +1577,8 @@ export class PostgresQueryRunner extends BaseQueryRunner implements QueryRunner 
      * Builds create table sql.
      */
     protected createTableSql(table: Table, createForeignKeys?: boolean): string {
-        const columnDefinitions = table.columns.map(column => this.buildCreateColumnSql(table, column)).join(", ");
+        const columnDefinitions = table.columns.filter( c => !c.asVirtual)
+            .map(column => this.buildCreateColumnSql(table, column)).join(", ");
         let sql = `CREATE TABLE ${this.escapeTableName(table)} (${columnDefinitions}`;
 
         table.columns

--- a/src/driver/sqlite-abstract/AbstractSqliteQueryRunner.ts
+++ b/src/driver/sqlite-abstract/AbstractSqliteQueryRunner.ts
@@ -874,7 +874,8 @@ export abstract class AbstractSqliteQueryRunner extends BaseQueryRunner implemen
         if (skipPrimary && hasAutoIncrement)
             throw new Error(`Sqlite does not support AUTOINCREMENT on composite primary key`);
 
-        const columnDefinitions = table.columns.map(column => this.buildCreateColumnSql(column, skipPrimary)).join(", ");
+        const columnDefinitions = table.columns.filter(c => !c.asVirtual)
+            .map(column => this.buildCreateColumnSql(column, skipPrimary)).join(", ");
         let sql = `CREATE TABLE "${table.name}" (${columnDefinitions}`;
 
         // need for `addColumn()` method, because it recreates table.

--- a/src/driver/sqlserver/SqlServerQueryRunner.ts
+++ b/src/driver/sqlserver/SqlServerQueryRunner.ts
@@ -1655,7 +1655,8 @@ export class SqlServerQueryRunner extends BaseQueryRunner implements QueryRunner
      * Builds and returns SQL for create table.
      */
     protected createTableSql(table: Table, createForeignKeys?: boolean): string {
-        const columnDefinitions = table.columns.map(column => this.buildCreateColumnSql(table, column, false, true)).join(", ");
+        const columnDefinitions = table.columns.filter( c => c.asVirtual)
+            .map(column => this.buildCreateColumnSql(table, column, false, true)).join(", ");
         let sql = `CREATE TABLE ${this.escapeTableName(table)} (${columnDefinitions}`;
 
         table.columns

--- a/src/driver/sqlserver/SqlServerQueryRunner.ts
+++ b/src/driver/sqlserver/SqlServerQueryRunner.ts
@@ -1655,7 +1655,7 @@ export class SqlServerQueryRunner extends BaseQueryRunner implements QueryRunner
      * Builds and returns SQL for create table.
      */
     protected createTableSql(table: Table, createForeignKeys?: boolean): string {
-        const columnDefinitions = table.columns.filter( c => c.asVirtual)
+        const columnDefinitions = table.columns.filter( c => !c.asVirtual)
             .map(column => this.buildCreateColumnSql(table, column, false, true)).join(", ");
         let sql = `CREATE TABLE ${this.escapeTableName(table)} (${columnDefinitions}`;
 

--- a/src/entity-schema/EntitySchemaColumnOptions.ts
+++ b/src/entity-schema/EntitySchemaColumnOptions.ts
@@ -1,5 +1,6 @@
 import {ColumnType} from "../driver/types/ColumnTypes";
 import {ValueTransformer} from "../decorator/options/ValueTransformer";
+import { DatabaseType } from "..";
 
 export interface EntitySchemaColumnOptions {
 
@@ -152,6 +153,11 @@ export interface EntitySchemaColumnOptions {
      * Generated column expression. Supports only in MySQL.
      */
     asExpression?: string;
+
+    /**
+     * Like asExpression, but support all database in typeorm.
+     */
+    asVirtual?: (names: {[col: string]: string }, type: DatabaseType) => string;
 
     /**
      * Generated column type. Supports only in MySQL.

--- a/src/entity-schema/EntitySchemaTransformer.ts
+++ b/src/entity-schema/EntitySchemaTransformer.ts
@@ -87,6 +87,7 @@ export class EntitySchemaTransformer {
                         collation: column.collation,
                         enum: column.enum,
                         asExpression: column.asExpression,
+                        asVirtual: column.asVirtual,
                         generatedType: column.generatedType,
                         hstoreType: column.hstoreType,
                         array: column.array,

--- a/src/metadata/ColumnMetadata.ts
+++ b/src/metadata/ColumnMetadata.ts
@@ -10,6 +10,7 @@ import {ValueTransformer} from "../decorator/options/ValueTransformer";
 import {MongoDriver} from "../driver/mongodb/MongoDriver";
 import {PromiseUtils} from "../util/PromiseUtils";
 import {FindOperator} from "../find-options/FindOperator";
+import { DatabaseType } from "..";
 
 /**
  * This metadata contains all information about entity's column.
@@ -155,8 +156,14 @@ export class ColumnMetadata {
     asExpression?: string;
 
     /**
+     * Like asExpression, but support all database in typeorm.
+     */
+    asVirtual?: (names: {[col: string]: string }, type: DatabaseType) => string;
+
+    /**
      * Generated column type. Supports only in MySQL.
      */
+
     generatedType?: "VIRTUAL"|"STORED";
 
     /**
@@ -361,6 +368,9 @@ export class ColumnMetadata {
         if (options.args.options.asExpression) {
             this.asExpression = options.args.options.asExpression;
             this.generatedType = options.args.options.generatedType ? options.args.options.generatedType : "VIRTUAL";
+        }
+        if (options.args.options.asVirtual) {
+            this.asVirtual = options.args.options.asVirtual;
         }
         if (options.args.options.hstoreType)
             this.hstoreType = options.args.options.hstoreType;

--- a/src/query-builder/InsertQueryBuilder.ts
+++ b/src/query-builder/InsertQueryBuilder.ts
@@ -336,6 +336,10 @@ export class InsertQueryBuilder<Entity> extends QueryBuilder<Entity> {
             if (this.expressionMap.insertColumns.length)
                 return this.expressionMap.insertColumns.indexOf(column.propertyPath) !== -1;
 
+            if (column.asVirtual) {
+                return false;
+            }
+
             // if user did not specified such list then return all columns except auto-increment one
             // for Oracle we return auto-increment column as well because Oracle does not support DEFAULT VALUES expression
             if (column.isGenerated && column.generationStrategy === "increment" && !(this.connection.driver instanceof OracleDriver) && !(this.connection.driver instanceof MysqlDriver))

--- a/src/schema-builder/options/TableColumnOptions.ts
+++ b/src/schema-builder/options/TableColumnOptions.ts
@@ -1,3 +1,4 @@
+import { DatabaseType } from "../..";
 
 /**
  * Table's column options.
@@ -117,6 +118,11 @@ export interface TableColumnOptions {
      * Generated column expression. Supports only in MySQL.
      */
     asExpression?: string;
+
+    /**
+     * Like asExpression, but support all database in typeorm.
+     */
+    asVirtual?: (names: {[col: string]: string }, type: DatabaseType) => string;
 
     /**
      * Generated column type. Supports only in MySQL.

--- a/src/schema-builder/table/TableColumn.ts
+++ b/src/schema-builder/table/TableColumn.ts
@@ -1,4 +1,5 @@
 import {TableColumnOptions} from "../options/TableColumnOptions";
+import { DatabaseType } from "../..";
 
 /**
  * Table's columns in the database represented in this class.
@@ -120,6 +121,11 @@ export class TableColumn {
     asExpression?: string;
 
     /**
+     * Like asExpression, but support all database in typeorm.
+     */
+    asVirtual?: (names: {[col: string]: string }, type: DatabaseType) => string;
+
+    /**
      * Generated column type. Supports only in MySQL.
      */
     generatedType?: "VIRTUAL"|"STORED";
@@ -161,6 +167,7 @@ export class TableColumn {
             this.comment = options.comment;
             this.enum = options.enum;
             this.asExpression = options.asExpression;
+            this.asVirtual = options.asVirtual;
             this.generatedType = options.generatedType;
             this.spatialFeatureType = options.spatialFeatureType;
             this.srid = options.srid;
@@ -188,6 +195,7 @@ export class TableColumn {
             unsigned: this.unsigned,
             enum: this.enum,
             asExpression: this.asExpression,
+            asVirtual: this.asVirtual,
             generatedType: this.generatedType,
             default: this.default,
             onUpdate: this.onUpdate,

--- a/src/schema-builder/util/TableUtils.ts
+++ b/src/schema-builder/util/TableUtils.ts
@@ -16,6 +16,7 @@ export class TableUtils {
             zerofill: columnMetadata.zerofill,
             unsigned: columnMetadata.unsigned,
             asExpression: columnMetadata.asExpression,
+            asVirtual: columnMetadata.asVirtual,
             generatedType: columnMetadata.generatedType,
             default: driver.normalizeDefault(columnMetadata),
             onUpdate: columnMetadata.onUpdate,

--- a/test/functional/connection/connection.ts
+++ b/test/functional/connection/connection.ts
@@ -23,7 +23,6 @@ describe("Connection", () => {
     // const resourceDir = __dirname + "/../../../../../test/functional/connection/";
 
     describe("before connection is established", function() {
-
         let connection: Connection;
         before(async () => {
             connection = getConnectionManager().create(setupSingleTestingConnection("mysql", {

--- a/test/functional/repository/virtual-column/entity/Post.ts
+++ b/test/functional/repository/virtual-column/entity/Post.ts
@@ -1,0 +1,26 @@
+import { Entity } from "../../../../../src/decorator/entity/Entity";
+import { Column, ColumnName, PrimaryGeneratedColumn } from "../../../../../src";
+import { summary } from "./utils";
+
+
+@Entity()
+export class Post {
+    @PrimaryGeneratedColumn()
+    id: number;
+
+    @Column({
+        nullable: true,
+        asVirtual: (names: ColumnName<Post>, type) => {
+            try {
+                return summary(type, names.body, 10);
+            } catch {
+                return "'not implement!'";
+            }
+        }
+    })
+    summary: string;
+
+
+    @Column()
+    body: string;
+}

--- a/test/functional/repository/virtual-column/entity/Post.ts
+++ b/test/functional/repository/virtual-column/entity/Post.ts
@@ -14,7 +14,7 @@ export class Post {
             try {
                 return summary(type, names.body, 10);
             } catch {
-                return "'not implement!'";
+                return "'not implemented!'";
             }
         }
     })

--- a/test/functional/repository/virtual-column/entity/Post.ts
+++ b/test/functional/repository/virtual-column/entity/Post.ts
@@ -9,7 +9,6 @@ export class Post {
     id: number;
 
     @Column({
-        nullable: true,
         asVirtual: (names: ColumnName<Post>, type) => {
             try {
                 return summary(type, names.body, 10);

--- a/test/functional/repository/virtual-column/entity/User.ts
+++ b/test/functional/repository/virtual-column/entity/User.ts
@@ -1,0 +1,28 @@
+import { Entity } from "../../../../../src/decorator/entity/Entity";
+import { Column, ColumnName, PrimaryGeneratedColumn } from "../../../../../src";
+import { concat } from "./utils";
+
+
+@Entity()
+export class User {
+    @PrimaryGeneratedColumn()
+    id: number;
+
+    @Column({
+        nullable: true,
+        asVirtual: (names: ColumnName<User>, type) => {
+            try {
+                return concat(type, names.firstName, "'-'", names.lastName);
+            } catch {
+                return "'not implemented!'";
+            }
+        }
+    })
+    fullName: string;
+
+    @Column()
+    firstName: string;
+
+    @Column()
+    lastName: string;
+}

--- a/test/functional/repository/virtual-column/entity/User.ts
+++ b/test/functional/repository/virtual-column/entity/User.ts
@@ -9,7 +9,6 @@ export class User {
     id: number;
 
     @Column({
-        nullable: true,
         asVirtual: (names: ColumnName<User>, type) => {
             try {
                 return concat(type, names.firstName, "'-'", names.lastName);

--- a/test/functional/repository/virtual-column/entity/utils.ts
+++ b/test/functional/repository/virtual-column/entity/utils.ts
@@ -16,13 +16,13 @@ export function concat(type: DatabaseType, ...strings: string[]) {
 
 export function summary(type: DatabaseType, body: string, max_length: number) {
     switch (type) {
-        //case "oracle":
+        // case "oracle":
         case "sqlite":
-        //case "mysql":
-        //case "mariadb":
+        // case "mysql":
+        // case "mariadb":
             return concat(type, `substr(${body}, 0, ${max_length})`, "'...'");
         case "postgres":
-            //return concat(type, `substring(${body}, 0, ${max_length})`, "'...'");
+            return concat(type, `substring(${body}, 0, ${max_length})`, "'...'");
         default:
             throw new Error(`dialect '${type}' still not implement 'summary()'`);
     }

--- a/test/functional/repository/virtual-column/entity/utils.ts
+++ b/test/functional/repository/virtual-column/entity/utils.ts
@@ -1,0 +1,30 @@
+import { DatabaseType } from "../../../../../src";
+
+export function concat(type: DatabaseType, ...strings: string[]) {
+    switch (type) {
+        case "postgres":
+        case "oracle":
+        case "sqlite":
+            return strings.join("||");
+        case "mysql":
+        case "mariadb":
+            return "concat(" + strings.join(",") + ")";
+        default:
+            throw new Error(`dialect '${type}' still not implement 'concat()'`);
+    }
+}
+
+export function summary(type: DatabaseType, body: string, max_length: number) {
+    switch (type) {
+        //case "oracle":
+        case "sqlite":
+        //case "mysql":
+        //case "mariadb":
+            return concat(type, `substr(${body}, 0, ${max_length})`, "'...'");
+        case "postgres":
+            //return concat(type, `substring(${body}, 0, ${max_length})`, "'...'");
+        default:
+            throw new Error(`dialect '${type}' still not implement 'summary()'`);
+    }
+}
+

--- a/test/functional/repository/virtual-column/repository-virtual-column.ts
+++ b/test/functional/repository/virtual-column/repository-virtual-column.ts
@@ -1,0 +1,69 @@
+import "reflect-metadata";
+import {expect} from "chai";
+import {Connection} from "../../../../src/connection/Connection";
+import {User} from "./entity/User";
+import {Post} from "./entity/Post";
+import {closeTestingConnections, createTestingConnections, reloadTestingDatabases} from "../../../utils/test-utils";
+
+describe("repository > virtual-column", function() {
+
+    // -------------------------------------------------------------------------
+    // Configuration
+    // -------------------------------------------------------------------------
+
+    let connections: Connection[];
+    before(async () => connections = await createTestingConnections({
+        entities: [__dirname + "/entity/*{.js,.ts}"],
+    }));
+    beforeEach(() => reloadTestingDatabases(connections));
+    after(() => closeTestingConnections(connections));
+
+    // -------------------------------------------------------------------------
+    // Specifications
+    // -------------------------------------------------------------------------
+
+    it("fullName should be compluted correctly.", () => Promise.all(connections.map(async connection => {
+        const userRepository = connection.getRepository(User);
+
+        const newUser = userRepository.create();
+        newUser.firstName = "chen";
+        newUser.lastName = "fei";
+
+        await Promise.all([
+            userRepository.save(newUser),
+            /*
+            userRepository.insert({
+                firstName: "chen",
+                lastName: "fei"
+            })
+            */
+        ]);
+
+        const loadedUsers = await userRepository.find();
+
+        expect(loadedUsers.map(v => v.fullName)[0])
+            .oneOf(["not implemented!", "chen-fei"]);
+    })));
+
+    it("summary should be compluted correctly", () => Promise.all(connections.map(async connection => {
+        const postRepository = connection.getRepository(Post);
+
+        const newPost = postRepository.create();
+        newPost.body = "ORM for TypeScript and JavaScript (ES7, ES6, ES5). ";
+        await Promise.all([
+            postRepository.save(newPost),
+            /*
+            postRepository.insert({
+                body :"ORM for TypeScript and JavaScript (ES7, ES6, ES5). "
+            })
+            */
+        ]);
+
+        const loadedPosts = await postRepository.find();
+
+        expect(loadedPosts.map(v => v.summary)[0])
+            .oneOf(["not implemented!", newPost.body.substr(0, 9) + "..."]);
+
+    })));
+
+});

--- a/test/functional/repository/virtual-column/repository-virtual-column.ts
+++ b/test/functional/repository/virtual-column/repository-virtual-column.ts
@@ -35,6 +35,7 @@ describe("repository > virtual-column", function() {
 
         const loadedUsers = await userRepository.find();
 
+
         expect(loadedUsers.map(v => v.fullName)[0])
             .oneOf(["not implemented!", "chen-fei"]);
     })));

--- a/test/functional/repository/virtual-column/repository-virtual-column.ts
+++ b/test/functional/repository/virtual-column/repository-virtual-column.ts
@@ -35,7 +35,6 @@ describe("repository > virtual-column", function() {
 
         const loadedUsers = await userRepository.find();
 
-
         expect(loadedUsers.map(v => v.fullName)[0])
             .oneOf(["not implemented!", "chen-fei"]);
     })));

--- a/test/functional/repository/virtual-column/repository-virtual-column.ts
+++ b/test/functional/repository/virtual-column/repository-virtual-column.ts
@@ -31,12 +31,6 @@ describe("repository > virtual-column", function() {
 
         await Promise.all([
             userRepository.save(newUser),
-            /*
-            userRepository.insert({
-                firstName: "chen",
-                lastName: "fei"
-            })
-            */
         ]);
 
         const loadedUsers = await userRepository.find();
@@ -52,11 +46,6 @@ describe("repository > virtual-column", function() {
         newPost.body = "ORM for TypeScript and JavaScript (ES7, ES6, ES5). ";
         await Promise.all([
             postRepository.save(newPost),
-            /*
-            postRepository.insert({
-                body :"ORM for TypeScript and JavaScript (ES7, ES6, ES5). "
-            })
-            */
         ]);
 
         const loadedPosts = await postRepository.find();
@@ -65,5 +54,4 @@ describe("repository > virtual-column", function() {
             .oneOf(["not implemented!", newPost.body.substr(0, 9) + "..."]);
 
     })));
-
 });

--- a/test/functional/repository/virtual-column/run_test.sh
+++ b/test/functional/repository/virtual-column/run_test.sh
@@ -1,0 +1,2 @@
+npx mocha --require ts-node/register repository-virtual-column.ts
+rm -rf temp


### PR DESCRIPTION
Support virtual column, that add new option `asVirtual` for `Column`, like `asExpression`, but support more database. 


Usage in [test cases](https://github.com/s97712/typeorm/tree/virtual-column/test/functional/repository/virtual-column)

Related issue: #2498