### PR TITLE
Fix compare2Objects handling of null.

### DIFF
--- a/src/util/OrmUtils.ts
+++ b/src/util/OrmUtils.ts
@@ -177,8 +177,9 @@ export class OrmUtils {
         if (x === y)
             return true;
 
-        // Unequal, but either is null or undefined.
-        if (x == null || y == null)
+        // Unequal, but either is null or undefined (use case: jsonb comparasion)
+        // PR #3776, todo: add tests
+        if (x === null || y === null || x === undefined || y === undefined)
           return false;
 
         // Fix the buffer compare bug.

--- a/src/util/OrmUtils.ts
+++ b/src/util/OrmUtils.ts
@@ -177,6 +177,10 @@ export class OrmUtils {
         if (x === y)
             return true;
 
+        // Unequal, but either is null or undefined.
+        if (x == null || y == null)
+          return false;
+
         // Fix the buffer compare bug.
         // See: https://github.com/typeorm/typeorm/issues/3654
         if ((typeof x.equals === "function" || x.equals instanceof Function) && x.equals(y))


### PR DESCRIPTION
If you try to save a JSONB column with a null value in an object,
you get this error:

TypeError: Cannot read property 'equals' of null