### PR TITLE
Change master query docs to not leak connections

### DIFF
--- a/docs/multiple-connections.md
+++ b/docs/multiple-connections.md
@@ -277,13 +277,21 @@ Example of replication connection settings:
 All schema update and write operations are performed using `master` server.
 All simple queries performed by find methods or select query builder are using a random `slave` instance. 
 
-If you want to explicitly use master in SELECT created by query builder, you can use following code:
+If you want to explicitly use master in SELECT created by query builder, you can use the following code:
 
 ```typescript
-const postsFromMaster = await connection.createQueryBuilder(Post, "post")
-    .setQueryRunner(connection.createQueryRunner("master"))
-    .getMany();
+const masterQueryRunner = connection.createQueryRunner("master");
+try {
+    const postsFromMaster = await connection.createQueryBuilder(Post, "post")
+        .setQueryRunner(masterQueryRunner)
+        .getMany();
+} finally {
+      await masterQueryRunner.release();
+}
+        
 ```
+
+Note that connection created by a `QueryRunner` need to be explicitly released.
 
 Replication is supported by mysql, postgres and sql server databases.
 


### PR DESCRIPTION
Example code that demonstrates querying master instead of a replica for select queries will leak connections.

This was biting us in production and took some time to troubleshoot because we weren't actually getting good errors (on my todolist as to why good errors weren't being thrown in the case, maybe I'll submit another PR when I figure that out), but I think the example code should not be leaking connections and we should mention that the query runner needs to be released manually.

Cheers!