### PR TITLE
fix(3536): fix sync schema issue with postgres enum in case capital letters in entity name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,8 @@ feel free to ask us and community.
 * fixed "deep relations" not loaded/mapped due to the built-in max length of Postgres ([#3118](https://github.com/typeorm/typeorm/issues/3118))
 * updated all dependencies
 * fixed types issue from [#3725](https://github.com/typeorm/typeorm/issues/3725)
-* removed sql-function-support (`() => ` syntax) in parameters to prevent security considerations 
+* removed sql-function-support (`() => ` syntax) in parameters to prevent security considerations
+* fix sync schema issue with postgres enum in case capital letters in entity name ([#3536](https://github.com/typeorm/typeorm/issues/3536))
 
 ### Features
 

--- a/src/driver/postgres/PostgresQueryRunner.ts
+++ b/src/driver/postgres/PostgresQueryRunner.ts
@@ -1846,12 +1846,12 @@ export class PostgresQueryRunner extends BaseQueryRunner implements QueryRunner 
         const columnName = columnOrName instanceof TableColumn ? columnOrName.name : columnOrName;
         const schema = table.name.indexOf(".") === -1 ? this.driver.options.schema : table.name.split(".")[0];
         const tableName = table.name.indexOf(".") === -1 ? table.name : table.name.split(".")[1];
-        let enumName = schema && withSchema ? `${schema}.${tableName}_${columnName.toLowerCase()}_enum` : `${tableName}_${columnName.toLowerCase()}_enum`;
+        let enumName = schema && withSchema ? `${schema}.${tableName}_${columnName}_enum` : `${tableName}_${columnName}_enum`;
         if (toOld)
             enumName = enumName + "_old";
         return enumName.split(".").map(i => {
             return disableEscape ? i : `"${i}"`;
-        }).join(".");
+        }).join(".").toLowerCase();
     }
 
     /**

--- a/test/github-issues/3536/entity/Roles.ts
+++ b/test/github-issues/3536/entity/Roles.ts
@@ -1,0 +1,18 @@
+import { Entity, PrimaryGeneratedColumn, Column } from "../../../../src";
+
+export enum AccountPermission {
+    Thing1 = 1,
+    Thing2 = 4,
+    Thing3 = 3,
+    Thing4 = 2
+}
+
+@Entity("Roles")
+export class Roles {
+
+    @PrimaryGeneratedColumn()
+    id: string;
+
+    @Column("enum", { enum: AccountPermission, array: true, default: "{}" })
+    accountPermission: AccountPermission[];
+}

--- a/test/github-issues/3536/issue-3536.ts
+++ b/test/github-issues/3536/issue-3536.ts
@@ -1,0 +1,25 @@
+import "reflect-metadata";
+import { Connection } from "../../../src/connection/Connection";
+import { closeTestingConnections, createTestingConnections } from "../../utils/test-utils";
+import { PromiseUtils } from "../../../src";
+import { Roles } from "./entity/Roles";
+
+describe("github issues > #3536 Sync only works once for enums on entities with capital letters in entity name", () => {
+
+    let connections: Connection[];
+    before(async () => {
+        connections = await createTestingConnections({
+            entities: [
+                Roles
+            ],
+            enabledDrivers: ["postgres"],
+            dropSchema: true,
+        });
+    });
+    after(() => closeTestingConnections(connections));
+
+    it("should run without throw error", () => PromiseUtils.runInSequence(connections, async connection => {
+        await connection.synchronize();
+        await connection.synchronize();
+    }));
+});


### PR DESCRIPTION
Using uppercase letters in enum names seems to be problem in postgres. This PR convert whole enum name into lowercase (not only column name part).

Fixes https://github.com/typeorm/typeorm/issues/3536 https://github.com/typeorm/typeorm/issues/2724
Close https://github.com/typeorm/typeorm/pull/1978 in favour of this PR with tests for inactivity of original PR author.