### PR TITLE
[README.md] Update the TS compiler version to 3.3 or greater

### DIFF
--- a/README.md
+++ b/README.md
@@ -220,7 +220,7 @@ await timber.remove();
 
 ##### TypeScript configuration
 
-Also, make sure you are using TypeScript compiler version **2.3** or greater,
+Also, make sure you are using TypeScript compiler version **3.3** or greater,
 and you have enabled the following settings in `tsconfig.json`:
 
 ```json


### PR DESCRIPTION
v0.2.15 requires to use the version 3.3 or greater of the TypeScript compiler. This PR updates the documentation with this new version.

Related issue: #3823 