### PR TITLE
Skip constructor when entity is loaded from database

### DIFF
--- a/src/metadata/EntityMetadata.ts
+++ b/src/metadata/EntityMetadata.ts
@@ -502,7 +502,8 @@ export class EntityMetadata {
         // if target is set to a function (e.g. class) that can be created then create it
         let ret: any;
         if (this.target instanceof Function) {
-            ret = new (<any> this.target)();
+            ret = {};
+            Reflect.setPrototypeOf(ret, this.target.prototype);
             this.lazyRelations.forEach(relation => this.connection.relationLoader.enableLazyLoad(relation, ret, queryRunner));
             return ret;
         }

--- a/test/github-issues/1772/entity/Post.ts
+++ b/test/github-issues/1772/entity/Post.ts
@@ -1,0 +1,24 @@
+import {Entity} from "../../../../src/decorator/entity/Entity";
+import {Column} from "../../../../src/decorator/columns/Column";
+import {PrimaryGeneratedColumn} from "../../../../src/decorator/columns/PrimaryGeneratedColumn";
+
+@Entity()
+export class Post {
+    @PrimaryGeneratedColumn()
+    id: number;
+
+    @Column()
+    private title: string;
+
+    initialized?: true;
+
+    constructor(title: string) {
+        this.title = title;
+        this.initialized = true;
+    }
+
+    public getTitle(): string {
+        return this.title;
+    }
+}
+

--- a/test/github-issues/1772/issue-1772.ts
+++ b/test/github-issues/1772/issue-1772.ts
@@ -1,0 +1,30 @@
+import "reflect-metadata";
+import {expect} from "chai";
+import {closeTestingConnections, createTestingConnections, reloadTestingDatabases} from "../../utils/test-utils";
+import {Connection} from "../../../src/connection/Connection";
+import {Post} from "./entity/Post";
+
+describe("github issues > #1772 Skip the constructor when entity is loaded from the database", () => {
+    let connections: Connection[];
+    before(async () => connections = await createTestingConnections({
+        entities: [Post],
+        dropSchema: true
+    }));
+    beforeEach(() => reloadTestingDatabases(connections));
+    after(() => closeTestingConnections(connections));
+
+    it("should not call the constructor", () => Promise.all(connections.map(async connection => {
+        const postRepository = connection.getRepository(Post);
+
+        // create and save a post first and check entity is initialized
+        const post = new Post("About columns");
+        await postRepository.save(post);
+
+        expect(post.initialized).to.be.true;
+
+        // check if entity loaded from database is not initialized by constructor
+        const loadedPost = await postRepository.findOne(1);
+        expect(loadedPost).to.be.instanceof(Post);
+        expect(loadedPost!.initialized).to.be.undefined;
+    })));
+});


### PR DESCRIPTION
I basically copied the code submitted by @pepakriz  into a new branch created against `next`, only I used JS's `Reflect` instead of `ObjectInstantiator`).

Original PR: https://github.com/typeorm/typeorm/pull/1773