### PR TITLE
Fix #3549

### DIFF
--- a/src/query-builder/QueryBuilder.ts
+++ b/src/query-builder/QueryBuilder.ts
@@ -753,6 +753,7 @@ export abstract class QueryBuilder<Entity> {
                             const aliasPath = this.expressionMap.aliasNamePrefixingEnabled ? `${this.alias}.${propertyPath}` : column.propertyPath;
                             let parameterValue = column.getEntityValue(where, true);
                             const parameterName = "where_" + whereIndex + "_" + propertyIndex + "_" + columnIndex;
+                            const parameterBaseCount = Object.keys(this.expressionMap.nativeParameters).filter(x => x.startsWith(parameterName)).length;
 
                             if (parameterValue === null) {
                                 return `${aliasPath} IS NULL`;
@@ -762,9 +763,9 @@ export abstract class QueryBuilder<Entity> {
                                 if (parameterValue.useParameter) {
                                     const realParameterValues: any[] = parameterValue.multipleParameters ? parameterValue.value : [parameterValue.value];
                                     realParameterValues.forEach((realParameterValue, realParameterValueIndex) => {
-                                        this.expressionMap.nativeParameters[parameterName + realParameterValueIndex] = realParameterValue;
+                                        this.expressionMap.nativeParameters[parameterName + (parameterBaseCount + realParameterValueIndex)] = realParameterValue;
                                         parameterIndex++;
-                                        parameters.push(this.connection.driver.createParameter(parameterName + realParameterValueIndex, parameterIndex - 1));
+                                        parameters.push(this.connection.driver.createParameter(parameterName + (parameterBaseCount + realParameterValueIndex), parameterIndex - 1));
                                     });
                                 }
                                 return parameterValue.toSql(this.connection, aliasPath, parameters);

--- a/test/github-issues/3349/entity/Category.ts
+++ b/test/github-issues/3349/entity/Category.ts
@@ -1,0 +1,12 @@
+import {PrimaryColumn} from "../../../../src";
+import {Column} from "../../../../src";
+import {Entity} from "../../../../src";
+
+@Entity()
+export class Category {
+    @PrimaryColumn()
+    public id!: number;
+
+    @Column()
+    public myField!: number;
+}

--- a/test/github-issues/3349/issue-3349.ts
+++ b/test/github-issues/3349/issue-3349.ts
@@ -5,7 +5,7 @@ import { Category } from "./entity/Category";
 import { In } from "../../../src";
 import { expect } from "chai";
 
-describe.only("github issues > #3349 Multiple where conditions with parameters", () => {
+describe("github issues > #3349 Multiple where conditions with parameters", () => {
 
     let connections: Connection[];
     before(async () => connections = await createTestingConnections({

--- a/test/github-issues/3349/issue-3349.ts
+++ b/test/github-issues/3349/issue-3349.ts
@@ -1,0 +1,53 @@
+import "reflect-metadata";
+import { createTestingConnections, closeTestingConnections, reloadTestingDatabases } from "../../utils/test-utils";
+import { Connection } from "../../../src/connection/Connection";
+import { Category } from "./entity/Category";
+import { In } from "../../../src";
+import { expect } from "chai";
+
+describe.only("github issues > #3349 Multiple where conditions with parameters", () => {
+
+    let connections: Connection[];
+    before(async () => connections = await createTestingConnections({
+        entities: [__dirname + "/entity/*{.js,.ts}"],
+    }));
+    beforeEach(() => reloadTestingDatabases(connections));
+    after(() => closeTestingConnections(connections));
+
+    it("should work with query builder", () => Promise.all(connections.map(async connection => {
+
+        const repository = connection.getRepository(Category);
+        const category = new Category();
+        category.id = 1;
+        category.myField = 2;
+        await repository.save(category);
+
+        const result = await connection.createQueryBuilder()
+            .select("category")
+            .from(Category, "category")
+            .where("category.id = :ida", { ida: 1 })
+            .orWhereInIds([2])
+            .orWhereInIds([3])
+            .execute();
+
+        expect(result).lengthOf(1);
+    })));
+
+    it("should work with findOne", () => Promise.all(connections.map(async connection => {
+
+        const repository = connection.getRepository(Category);
+        const category = new Category();
+        category.id = 1;
+        category.myField = 2;
+        await repository.save(category);
+
+        const result = await repository.findOne(1, {
+            where: {
+                myField: In([2, 3]),
+            },
+        });
+
+        expect(result).to.not.be.null;
+    })));
+
+});


### PR DESCRIPTION
Fixes #3549

Tests were failing only on master. On next they were passing(before a fix) because next no longer use parameters in those generated queries. We've got a regression there unless it was done on purpose.