### PR TITLE
Added handling of synchronous errors from .connect() methods

### DIFF
--- a/src/driver/cockroachdb/CockroachDriver.ts
+++ b/src/driver/cockroachdb/CockroachDriver.ts
@@ -534,7 +534,7 @@ export class CockroachDriver implements Driver {
      * Used for replication.
      * If replication is not setup then returns default connection's database connection.
      */
-    obtainMasterConnection(): Promise<any> {
+    async obtainMasterConnection(): Promise<any> {
         return new Promise((ok, fail) => {
             this.master.connect((err: any, connection: any, release: any) => {
                 err ? fail(err) : ok([connection, release]);

--- a/src/driver/mysql/MysqlDriver.ts
+++ b/src/driver/mysql/MysqlDriver.ts
@@ -641,7 +641,7 @@ export class MysqlDriver implements Driver {
      * Used for replication.
      * If replication is not setup then returns default connection's database connection.
      */
-    obtainMasterConnection(): Promise<any> {
+    async obtainMasterConnection(): Promise<any> {
         return new Promise<any>((ok, fail) => {
             if (this.poolCluster) {
                 this.poolCluster.getConnection("MASTER", (err: any, dbConnection: any) => {

--- a/src/driver/oracle/OracleDriver.ts
+++ b/src/driver/oracle/OracleDriver.ts
@@ -532,7 +532,7 @@ export class OracleDriver implements Driver {
      * Used for replication.
      * If replication is not setup then returns default connection's database connection.
      */
-    obtainMasterConnection(): Promise<any> {
+    async obtainMasterConnection(): Promise<any> {
         return new Promise<any>((ok, fail) => {
             this.master.getConnection((err: any, connection: any, release: Function) => {
                 if (err) return fail(err);

--- a/src/driver/postgres/PostgresDriver.ts
+++ b/src/driver/postgres/PostgresDriver.ts
@@ -709,7 +709,7 @@ export class PostgresDriver implements Driver {
      * Used for replication.
      * If replication is not setup then returns default connection's database connection.
      */
-    obtainMasterConnection(): Promise<any> {
+    async obtainMasterConnection(): Promise<any> {
         return new Promise((ok, fail) => {
             this.master.connect((err: any, connection: any, release: any) => {
                 err ? fail(err) : ok([connection, release]);
@@ -722,7 +722,7 @@ export class PostgresDriver implements Driver {
      * Used for replication.
      * If replication is not setup then returns master (default) connection's database connection.
      */
-    obtainSlaveConnection(): Promise<any> {
+    async obtainSlaveConnection(): Promise<any> {
         if (!this.slaves.length)
             return this.obtainMasterConnection();
 


### PR DESCRIPTION
This is workaround for issue that we have found:
* Sometimes `this.master` is `undefined` in PostgresDriver.ts - we are not sure why this happened, because our code never calls `.disconnect`.
* Errors thrown from `.connect` method synchronously (present in eg. `pg-pool`) can propagate as synchronous errors - leaving users surprised (end if this occurs in callback, it can kill your process).

After this PR, these errors will still occur, but users can handle them as rejected promises.