### PR TITLE
New npm script to run specific test

### DIFF
--- a/DEVELOPER.md
+++ b/DEVELOPER.md
@@ -140,6 +140,18 @@ All the tests are executed on our Continuous Integration infrastructure and a PR
 describe.only('your describe test', ....)
 ```
 
+>**Hint:** you can use the `test-fast-single` npm script to only execute tests contained within a specific file or directory tree.
+>
+> Example: to only execute tests related to github issue #363:
+>```shell
+>npm run test-fast-single build/compiled/test/github-issues/363
+>```
+>
+> Example: To only execute tests related to schema-builder:
+>```shell
+>npm run test-fast-single build/compiled/test/functional/schema-builder
+>```
+
 >**Hint:** you can use the `--grep` flag to pass a Regex to `gulp-mocha`. Only the tests have have `describe`/`it`
 >statements that match the Regex will be run. For example:
 >

--- a/package.json
+++ b/package.json
@@ -114,6 +114,7 @@
     "test-ci": "gulp ci-tests",
     "test": "rimraf ./build && tsc && mocha --file ./build/compiled/test/utils/test-setup.js --bail --recursive --timeout 60000 ./build/compiled/test",
     "test-fast": "mocha --file ./build/compiled/test/utils/test-setup.js --bail --recursive --timeout 60000 ./build/compiled/test",
+    "test-fast-single": "mocha --file ./build/compiled/test/utils/test-setup.js --bail --recursive --timeout 60000",
     "compile": "rimraf ./build && tsc",
     "package": "gulp package",
     "lint": "tslint -p ."


### PR DESCRIPTION
Integrated a new `test-fast-single` npm script in package.json enabling developpers to execute specific tests by targeting the directory where the tests are located.

Thus the command below will only execute the tests located within the specified directory (and by extension in all its sub-directories):

`npm run test-fast-single build/compiled/test/functional/schema-builder`

It is just another way of doing than using the  `--grep` option that requires a regular expression to be written.

This method here might be more intuitive than having to write a regular expression to target the subset of tests we want to execute.