### PR TITLE
Add failing test for issue #3828

### DIFF
--- a/test/github-issues/3828/entity/Entity.ts
+++ b/test/github-issues/3828/entity/Entity.ts
@@ -1,0 +1,15 @@
+import { Column, Entity, PrimaryGeneratedColumn } from "../../../../src";
+
+enum MyEntityEnum {
+    Something = 'SOMETHING',
+    SomethingElse = 'SOMETHING_ELSE'
+}
+
+@Entity({ name: 'MyEntity' })
+export class MyEntity {
+    @PrimaryGeneratedColumn("uuid")
+    id: number;
+
+    @Column('enum', { enum: MyEntityEnum })
+    myColumn: MyEntityEnum;
+}

--- a/test/github-issues/3828/issue-3828.ts
+++ b/test/github-issues/3828/issue-3828.ts
@@ -1,0 +1,31 @@
+import "reflect-metadata";
+import { createTestingConnections, closeTestingConnections, reloadTestingDatabases } from "../../utils/test-utils";
+import { Connection } from "../../../src/connection/Connection";
+import { MyEntity } from "./entity/Entity";
+
+describe("github issues > #3828 Conflicting PR to fix postgres schema:log with uppercase table names and enums", () => {
+
+    let connections: Connection[];
+
+    before(async () => {
+        connections = await createTestingConnections({
+            entities: [MyEntity],
+            enabledDrivers: ["postgres"],
+            schemaCreate: true,
+            dropSchema: true,
+            logging: true
+        });
+    });
+
+    beforeEach(() => reloadTestingDatabases(connections));
+    after(() => closeTestingConnections(connections));
+
+    it("should work on public schema and all lowercase", () => Promise.all(connections.map(async connection => {
+        // Rename type to what typeorm created <= 0.2.14
+        // @see https://github.com/typeorm/typeorm/commit/0338d5eedcaedfd9571a90ebe1975b9b07c8e07a
+        await connection.query(`ALTER TYPE "myentity_mycolumn_enum" RENAME TO "MyEntity_mycolumn_enum"`);
+
+        // Sync database, so that typeorm create the table and enum type
+        await connection.synchronize();
+    })));
+});


### PR DESCRIPTION
This test shows the crash that happens when trying to migrate tables with uppercase name containing at least one enum that were created with typeorm <= 0.2.14

See issue #3828