### PR TITLE
added `lock` option in FindOptions;

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ feel free to ask us and community.
 
 ### Features
 
+* added `lock` option in `FindOptions`
+
 ## 0.2.15 (2019-03-14)
 
 ### Bug fixes

--- a/docs/find-options.md
+++ b/docs/find-options.md
@@ -114,6 +114,23 @@ userRepository.find({
 })
 ```
 
+* `lock` - Enables locking mechanism for query. Can be used only in `findOne` method. `lock` is an object which can be defined as:
+```ts
+{ mode: "optimistic", version: number|Date }
+```
+or
+```ts
+{ mode: "pessimistic_read"|"pessimistic_write" }
+```
+
+for example:
+
+```typescript
+userRepository.findOne(1, {
+    lock: { mode: "optimistic", version: 1 }
+})
+```
+
 Complete example of find options:
 
 ```typescript

--- a/src/find-options/FindOneOptions.ts
+++ b/src/find-options/FindOneOptions.ts
@@ -38,6 +38,11 @@ export interface FindOneOptions<Entity = any> {
     cache?: boolean | number | { id: any, milliseconds: number };
 
     /**
+     * Enables or disables query result caching.
+     */
+    lock?: { mode: "optimistic", version: number|Date } | { mode: "pessimistic_read"|"pessimistic_write" };
+
+    /**
      * If sets to true then loads all relation ids of the entity and maps them into relation values (not relation objects).
      * If array of strings is given then loads only relation ids of the given properties.
      */

--- a/src/find-options/FindOptionsUtils.ts
+++ b/src/find-options/FindOptionsUtils.ts
@@ -29,6 +29,7 @@ export class FindOptionsUtils {
                     possibleOptions.cache instanceof Object ||
                     typeof possibleOptions.cache === "boolean" ||
                     typeof possibleOptions.cache === "number" ||
+                    possibleOptions.lock instanceof Object ||
                     possibleOptions.loadRelationIds instanceof Object ||
                     typeof possibleOptions.loadRelationIds === "boolean" ||
                     typeof possibleOptions.loadEagerRelations === "boolean"
@@ -167,6 +168,14 @@ export class FindOptionsUtils {
                 qb.cache(cache.id, cache.milliseconds);
             } else {
                 qb.cache(options.cache);
+            }
+        }
+
+        if (options.lock) {
+            if (options.lock.mode === "optimistic") {
+                qb.setLock(options.lock.mode, options.lock.version as any);
+            } else if (options.lock.mode === "pessimistic_read" || options.lock.mode === "pessimistic_write") {
+                qb.setLock(options.lock.mode);
             }
         }
 

--- a/test/functional/repository/find-options-locking/entity/PostWithUpdateDate.ts
+++ b/test/functional/repository/find-options-locking/entity/PostWithUpdateDate.ts
@@ -1,0 +1,18 @@
+import {Entity} from "../../../../../src/decorator/entity/Entity";
+import {PrimaryGeneratedColumn} from "../../../../../src/decorator/columns/PrimaryGeneratedColumn";
+import {Column} from "../../../../../src/decorator/columns/Column";
+import {UpdateDateColumn} from "../../../../../src/decorator/columns/UpdateDateColumn";
+
+@Entity()
+export class PostWithUpdateDate {
+
+    @PrimaryGeneratedColumn()
+    id: number;
+
+    @Column()
+    title: string;
+
+    @UpdateDateColumn()
+    updateDate: Date;
+
+}

--- a/test/functional/repository/find-options-locking/entity/PostWithVersion.ts
+++ b/test/functional/repository/find-options-locking/entity/PostWithVersion.ts
@@ -1,0 +1,18 @@
+import {Entity} from "../../../../../src/decorator/entity/Entity";
+import {PrimaryGeneratedColumn} from "../../../../../src/decorator/columns/PrimaryGeneratedColumn";
+import {Column} from "../../../../../src/decorator/columns/Column";
+import {VersionColumn} from "../../../../../src/decorator/columns/VersionColumn";
+
+@Entity()
+export class PostWithVersion {
+
+    @PrimaryGeneratedColumn()
+    id: number;
+
+    @Column()
+    title: string;
+
+    @VersionColumn()
+    version: number;
+
+}

--- a/test/functional/repository/find-options-locking/entity/PostWithVersionAndUpdatedDate.ts
+++ b/test/functional/repository/find-options-locking/entity/PostWithVersionAndUpdatedDate.ts
@@ -1,0 +1,22 @@
+import {Entity} from "../../../../../src/decorator/entity/Entity";
+import {PrimaryGeneratedColumn} from "../../../../../src/decorator/columns/PrimaryGeneratedColumn";
+import {Column} from "../../../../../src/decorator/columns/Column";
+import {VersionColumn} from "../../../../../src/decorator/columns/VersionColumn";
+import {UpdateDateColumn} from "../../../../../src/decorator/columns/UpdateDateColumn";
+
+@Entity("post_with_v_ud")
+export class PostWithVersionAndUpdatedDate {
+
+    @PrimaryGeneratedColumn()
+    id: number;
+
+    @Column()
+    title: string;
+
+    @VersionColumn()
+    version: number;
+
+    @UpdateDateColumn()
+    updateDate: Date;
+
+}

--- a/test/functional/repository/find-options-locking/entity/PostWithoutVersionAndUpdateDate.ts
+++ b/test/functional/repository/find-options-locking/entity/PostWithoutVersionAndUpdateDate.ts
@@ -1,0 +1,14 @@
+import {Entity} from "../../../../../src/decorator/entity/Entity";
+import {PrimaryGeneratedColumn} from "../../../../../src/decorator/columns/PrimaryGeneratedColumn";
+import {Column} from "../../../../../src/decorator/columns/Column";
+
+@Entity("post_without_v_ud")
+export class PostWithoutVersionAndUpdateDate {
+
+    @PrimaryGeneratedColumn()
+    id: number;
+
+    @Column()
+    title: string;
+
+}

--- a/test/functional/repository/find-options-locking/find-options-locking.ts
+++ b/test/functional/repository/find-options-locking/find-options-locking.ts
@@ -1,0 +1,249 @@
+import "reflect-metadata";
+import {CockroachDriver} from "../../../../src/driver/cockroachdb/CockroachDriver";
+import {closeTestingConnections, createTestingConnections, reloadTestingDatabases} from "../../../utils/test-utils";
+import {Connection} from "../../../../src";
+import {PostWithVersion} from "./entity/PostWithVersion";
+import {expect} from "chai";
+import {PostWithoutVersionAndUpdateDate} from "./entity/PostWithoutVersionAndUpdateDate";
+import {PostWithUpdateDate} from "./entity/PostWithUpdateDate";
+import {PostWithVersionAndUpdatedDate} from "./entity/PostWithVersionAndUpdatedDate";
+import {OptimisticLockVersionMismatchError} from "../../../../src/error/OptimisticLockVersionMismatchError";
+import {OptimisticLockCanNotBeUsedError} from "../../../../src/error/OptimisticLockCanNotBeUsedError";
+import {NoVersionOrUpdateDateColumnError} from "../../../../src/error/NoVersionOrUpdateDateColumnError";
+import {PessimisticLockTransactionRequiredError} from "../../../../src/error/PessimisticLockTransactionRequiredError";
+import {MysqlDriver} from "../../../../src/driver/mysql/MysqlDriver";
+import {PostgresDriver} from "../../../../src/driver/postgres/PostgresDriver";
+import {SqlServerDriver} from "../../../../src/driver/sqlserver/SqlServerDriver";
+import {AbstractSqliteDriver} from "../../../../src/driver/sqlite-abstract/AbstractSqliteDriver";
+import {OracleDriver} from "../../../../src/driver/oracle/OracleDriver";
+import {LockNotSupportedOnGivenDriverError} from "../../../../src/error/LockNotSupportedOnGivenDriverError";
+
+describe("repository > find options > locking", () => {
+
+    let connections: Connection[];
+    before(async () => connections = await createTestingConnections({
+        entities: [__dirname + "/entity/*{.js,.ts}"],
+    }));
+    beforeEach(() => reloadTestingDatabases(connections));
+    after(() => closeTestingConnections(connections));
+
+    it("should throw error if pessimistic lock used without transaction", () => Promise.all(connections.map(async connection => {
+        if (connection.driver instanceof AbstractSqliteDriver || connection.driver instanceof CockroachDriver)
+            return;
+
+        return Promise.all([
+            connection
+                .getRepository(PostWithVersion)
+                .findOne(1, { lock: { mode: "pessimistic_read" } })
+                .should.be.rejectedWith(PessimisticLockTransactionRequiredError),
+
+            connection
+                .getRepository(PostWithVersion)
+                .findOne(1, { lock: { mode: "pessimistic_write" } })
+                .should.be.rejectedWith(PessimisticLockTransactionRequiredError),
+        ]);
+    })));
+
+    it("should not throw error if pessimistic lock used with transaction", () => Promise.all(connections.map(async connection => {
+        if (connection.driver instanceof AbstractSqliteDriver || connection.driver instanceof CockroachDriver)
+            return;
+
+        return connection.manager.transaction(entityManager => {
+            return Promise.all([
+                entityManager
+                    .getRepository(PostWithVersion)
+                    .findOne(1, { lock: { mode: "pessimistic_read" } })
+                    .should.not.be.rejected,
+
+                entityManager
+                    .getRepository(PostWithVersion)
+                    .findOne(1, { lock: { mode: "pessimistic_write" } })
+                    .should.not.be.rejected
+            ]);
+        });
+    })));
+
+    it("should attach pessimistic read lock statement on query if locking enabled", () => Promise.all(connections.map(async connection => {
+        if (connection.driver instanceof AbstractSqliteDriver || connection.driver instanceof CockroachDriver)
+            return;
+
+        const executedSql: string[] = [];
+
+        await connection.manager.transaction(entityManager => {
+            const originalQuery = entityManager.queryRunner!.query.bind(entityManager.queryRunner);
+            entityManager.queryRunner!.query = (...args) => {
+                executedSql.push(args[0]);
+                return originalQuery(...args);
+            };
+
+            return entityManager
+                .getRepository(PostWithVersion)
+                .findOne(1, {lock: {mode: "pessimistic_read"}});
+        });
+
+        if (connection.driver instanceof MysqlDriver) {
+            expect(executedSql[0].indexOf("LOCK IN SHARE MODE") !== -1).to.be.true;
+
+        } else if (connection.driver instanceof PostgresDriver) {
+            expect(executedSql[0].indexOf("FOR SHARE") !== -1).to.be.true;
+
+        } else if (connection.driver instanceof OracleDriver) {
+            expect(executedSql[0].indexOf("FOR UPDATE") !== -1).to.be.true;
+
+        } else if (connection.driver instanceof SqlServerDriver) {
+            expect(executedSql[0].indexOf("WITH (HOLDLOCK, ROWLOCK)") !== -1).to.be.true;
+        }
+
+    })));
+
+    it("should attach pessimistic write lock statement on query if locking enabled", () => Promise.all(connections.map(async connection => {
+        if (connection.driver instanceof AbstractSqliteDriver || connection.driver instanceof CockroachDriver)
+            return;
+
+        const executedSql: string[] = [];
+
+        await connection.manager.transaction(entityManager => {
+            const originalQuery = entityManager.queryRunner!.query.bind(entityManager.queryRunner);
+            entityManager.queryRunner!.query = (...args) => {
+                executedSql.push(args[0]);
+                return originalQuery(...args);
+            };
+
+            return entityManager
+                .getRepository(PostWithVersion)
+                .findOne(1, {lock: {mode: "pessimistic_write"}});
+        });
+
+        if (connection.driver instanceof MysqlDriver || connection.driver instanceof PostgresDriver || connection.driver instanceof OracleDriver) {
+            expect(executedSql[0].indexOf("FOR UPDATE") !== -1).to.be.true;
+
+        } else if (connection.driver instanceof SqlServerDriver) {
+            expect(executedSql[0].indexOf("WITH (UPDLOCK, ROWLOCK)") !== -1).to.be.true;
+        }
+
+    })));
+
+    it("should throw error if optimistic lock used with `find` method", () => Promise.all(connections.map(async connection => {
+       return connection
+           .getRepository(PostWithVersion)
+           .find({lock: {mode: "optimistic", version: 1}})
+           .should.be.rejectedWith(OptimisticLockCanNotBeUsedError);
+    })));
+
+    it("should not throw error if optimistic lock used with `findOne` method", () => Promise.all(connections.map(async connection => {
+        return connection
+            .getRepository(PostWithVersion)
+            .findOne(1, {lock: {mode: "optimistic", version: 1}})
+            .should.not.be.rejected;
+    })));
+
+    it("should throw error if entity does not have version and update date columns", () => Promise.all(connections.map(async connection => {
+
+        const post = new PostWithoutVersionAndUpdateDate();
+        post.title = "New post";
+        await connection.manager.save(post);
+
+        return connection
+            .getRepository(PostWithoutVersionAndUpdateDate)
+            .findOne(1, {lock: {mode: "optimistic", version: 1}})
+            .should.be.rejectedWith(NoVersionOrUpdateDateColumnError);
+    })));
+
+    it("should throw error if actual version does not equal expected version", () => Promise.all(connections.map(async connection => {
+
+        const post = new PostWithVersion();
+        post.title = "New post";
+        await connection.manager.save(post);
+
+        return connection
+            .getRepository(PostWithVersion)
+            .findOne(1, {lock: {mode: "optimistic", version: 2}})
+            .should.be.rejectedWith(OptimisticLockVersionMismatchError);
+    })));
+
+    it("should not throw error if actual version and expected versions are equal", () => Promise.all(connections.map(async connection => {
+
+        const post = new PostWithVersion();
+        post.title = "New post";
+        await connection.manager.save(post);
+
+        return connection
+            .getRepository(PostWithVersion)
+            .findOne(1, {lock: {mode: "optimistic", version: 1}})
+            .should.not.be.rejected;
+    })));
+
+    it("should throw error if actual updated date does not equal expected updated date", () => Promise.all(connections.map(async connection => {
+
+        // skipped because inserted milliseconds are not always equal to what we say it to insert, unskip when needed
+        if (connection.driver instanceof SqlServerDriver)
+            return;
+
+        const post = new PostWithUpdateDate();
+        post.title = "New post";
+        await connection.manager.save(post);
+
+        return connection
+            .getRepository(PostWithUpdateDate)
+            .findOne(1, {lock: {mode: "optimistic", version: new Date(2017, 1, 1)}})
+            .should.be.rejectedWith(OptimisticLockVersionMismatchError);
+    })));
+
+    it("should not throw error if actual updated date and expected updated date are equal", () => Promise.all(connections.map(async connection => {
+
+        // skipped because inserted milliseconds are not always equal to what we say it to insert, unskip when needed
+        if (connection.driver instanceof SqlServerDriver)
+            return;
+
+        const post = new PostWithUpdateDate();
+        post.title = "New post";
+        await connection.manager.save(post);
+
+        return connection
+            .getRepository(PostWithUpdateDate)
+            .findOne(1, {lock: {mode: "optimistic", version: post.updateDate}})
+            .should.not.be.rejected;
+    })));
+
+    it("should work if both version and update date columns applied", () => Promise.all(connections.map(async connection => {
+
+        // skipped because inserted milliseconds are not always equal to what we say it to insert, unskip when needed
+        if (connection.driver instanceof SqlServerDriver)
+            return;
+
+        const post = new PostWithVersionAndUpdatedDate();
+        post.title = "New post";
+        await connection.manager.save(post);
+
+        return Promise.all([
+            connection
+                .getRepository(PostWithVersionAndUpdatedDate)
+                .findOne(1, {lock: {mode: "optimistic", version: post.updateDate}})
+                .should.not.be.rejected,
+            connection
+                .getRepository(PostWithVersionAndUpdatedDate)
+                .findOne(1, {lock: {mode: "optimistic", version: 1}})
+                .should.not.be.rejected,
+        ]);
+    })));
+
+    it("should throw error if pessimistic locking not supported by given driver", () => Promise.all(connections.map(async connection => {
+        if (connection.driver instanceof AbstractSqliteDriver || connection.driver instanceof CockroachDriver)
+            return connection.manager.transaction(entityManager => {
+                return Promise.all([
+                    entityManager
+                        .getRepository(PostWithVersion)
+                        .findOne(1, { lock: { mode: "pessimistic_read" } })
+                        .should.be.rejectedWith(LockNotSupportedOnGivenDriverError),
+
+                    entityManager
+                        .getRepository(PostWithVersion)
+                        .findOne(1, { lock: { mode: "pessimistic_write" } })
+                        .should.be.rejectedWith(LockNotSupportedOnGivenDriverError),
+                ]);
+            });
+
+        return;
+    })));
+
+});


### PR DESCRIPTION
`lock` is an object which can be defined as:
```ts
{ mode: "optimistic", version: number|Date }
```
or
```ts
{ mode: "pessimistic_read"|"pessimistic_write" }
```

for example:

```typescript
userRepository.findOne(1, {
    lock: { mode: "optimistic", version: 1 }
})
```