### PR TITLE
Deferrable options for foreign keys (postgres)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ feel free to ask us and community.
 
 ### Features
 
+* added deferrable options for foreign keys (postgres) ([#2191](https://github.com/typeorm/typeorm/issues/2191))
+
 ## 0.2.16 (2019-03-26)
 
 ### Bug fixes

--- a/src/decorator/options/RelationOptions.ts
+++ b/src/decorator/options/RelationOptions.ts
@@ -1,3 +1,4 @@
+import {DeferrableType} from "../../metadata/types/DeferrableType";
 import {OnDeleteType} from "../../metadata/types/OnDeleteType";
 import {OnUpdateType} from "../../metadata/types/OnUpdateType";
 
@@ -29,6 +30,11 @@ export interface RelationOptions {
      * Database cascade action on update.
      */
     onUpdate?: OnUpdateType;
+
+    /**
+     * Indicate if foreign key constraints can be deferred.
+     */
+    deferrable?: DeferrableType;
 
     /**
      * Indicates if this relation will be a primary key.

--- a/src/driver/postgres/PostgresQueryRunner.ts
+++ b/src/driver/postgres/PostgresQueryRunner.ts
@@ -1331,9 +1331,12 @@ export class PostgresQueryRunner extends BaseQueryRunner implements QueryRunner 
             return `("ns"."nspname" = '${schema}' AND "cl"."relname" = '${name}')`;
         }).join(" OR ");
         const foreignKeysSql = `SELECT "con"."conname" AS "constraint_name", "con"."nspname" AS "table_schema", "con"."relname" AS "table_name", "att2"."attname" AS "column_name", ` +
-            `"ns"."nspname" AS "referenced_table_schema", "cl"."relname" AS "referenced_table_name", "att"."attname" AS "referenced_column_name", "con"."confdeltype" AS "on_delete", "con"."confupdtype" AS "on_update" ` +
+            `"ns"."nspname" AS "referenced_table_schema", "cl"."relname" AS "referenced_table_name", "att"."attname" AS "referenced_column_name", "con"."confdeltype" AS "on_delete", ` +
+            `"con"."confupdtype" AS "on_update", "con"."condeferrable" AS "deferrable", "con"."condeferred" AS "deferred" ` +
             `FROM ( ` +
-            `SELECT UNNEST ("con1"."conkey") AS "parent", UNNEST ("con1"."confkey") AS "child", "con1"."confrelid", "con1"."conrelid", "con1"."conname", "con1"."contype", "ns"."nspname", "cl"."relname", ` +
+            `SELECT UNNEST ("con1"."conkey") AS "parent", UNNEST ("con1"."confkey") AS "child", "con1"."confrelid", "con1"."conrelid", "con1"."conname", "con1"."contype", "ns"."nspname", ` + 
+            `"cl"."relname", "con1"."condeferrable", ` + 
+            `CASE WHEN "con1"."condeferred" THEN 'INITIALLY DEFERRED' ELSE 'INITIALLY IMMEDIATE' END as condeferred, ` +
             `CASE "con1"."confdeltype" WHEN 'a' THEN 'NO ACTION' WHEN 'r' THEN 'RESTRICT' WHEN 'c' THEN 'CASCADE' WHEN 'n' THEN 'SET NULL' WHEN 'd' THEN 'SET DEFAULT' END as "confdeltype", ` +
             `CASE "con1"."confupdtype" WHEN 'a' THEN 'NO ACTION' WHEN 'r' THEN 'RESTRICT' WHEN 'c' THEN 'CASCADE' WHEN 'n' THEN 'SET NULL' WHEN 'd' THEN 'SET DEFAULT' END as "confupdtype" ` +
             `FROM "pg_class" "cl" ` +
@@ -1549,7 +1552,8 @@ export class PostgresQueryRunner extends BaseQueryRunner implements QueryRunner 
                     referencedTableName: referencedTableName,
                     referencedColumnNames: foreignKeys.map(dbFk => dbFk["referenced_column_name"]),
                     onDelete: dbForeignKey["on_delete"],
-                    onUpdate: dbForeignKey["on_update"]
+                    onUpdate: dbForeignKey["on_update"],
+                    deferrable: dbForeignKey["deferrable"] ? dbForeignKey["deferred"] : undefined,
                 });
             });
 
@@ -1637,6 +1641,8 @@ export class PostgresQueryRunner extends BaseQueryRunner implements QueryRunner 
                     constraint += ` ON DELETE ${fk.onDelete}`;
                 if (fk.onUpdate)
                     constraint += ` ON UPDATE ${fk.onUpdate}`;
+                if (fk.deferrable)
+                    constraint += ` DEFERRABLE ${fk.deferrable}`;
 
                 return constraint;
             }).join(", ");
@@ -1808,6 +1814,8 @@ export class PostgresQueryRunner extends BaseQueryRunner implements QueryRunner 
             sql += ` ON DELETE ${foreignKey.onDelete}`;
         if (foreignKey.onUpdate)
             sql += ` ON UPDATE ${foreignKey.onUpdate}`;
+        if (foreignKey.deferrable)
+            sql += ` DEFERRABLE ${foreignKey.deferrable}`;
 
         return sql;
     }

--- a/src/entity-schema/EntitySchemaRelationOptions.ts
+++ b/src/entity-schema/EntitySchemaRelationOptions.ts
@@ -1,6 +1,7 @@
 import {JoinColumnOptions} from "../decorator/options/JoinColumnOptions";
 import {RelationType} from "../metadata/types/RelationTypes";
 import {JoinTableMultipleColumnsOptions} from "../decorator/options/JoinTableMultipleColumnsOptions";
+import {DeferrableType} from "../metadata/types/DeferrableType";
 import {OnDeleteType} from "../metadata/types/OnDeleteType";
 import {OnUpdateType} from "../metadata/types/OnUpdateType";
 import {JoinTableOptions} from "../index";
@@ -91,5 +92,10 @@ export interface EntitySchemaRelationOptions {
      * Database cascade action on update.
      */
     onUpdate?: OnUpdateType;
+
+    /**
+     * Indicate if foreign key constraints can be deferred.
+     */
+    deferrable?: DeferrableType;
 
 }

--- a/src/entity-schema/EntitySchemaTransformer.ts
+++ b/src/entity-schema/EntitySchemaTransformer.ts
@@ -127,6 +127,7 @@ export class EntitySchemaTransformer {
                             nullable: relationSchema.nullable,
                             onDelete: relationSchema.onDelete,
                             onUpdate: relationSchema.onUpdate,
+                            deferrable: relationSchema.deferrable,
                             primary: relationSchema.primary,
                             persistence: relationSchema.persistence
                         }

--- a/src/metadata-builder/RelationJoinColumnBuilder.ts
+++ b/src/metadata-builder/RelationJoinColumnBuilder.ts
@@ -70,6 +70,7 @@ export class RelationJoinColumnBuilder {
             referencedColumns: referencedColumns,
             onDelete: relation.onDelete,
             onUpdate: relation.onUpdate,
+            deferrable: relation.deferrable,
         });
 
         // Oracle does not allow both primary and unique constraints on the same column

--- a/src/metadata/ForeignKeyMetadata.ts
+++ b/src/metadata/ForeignKeyMetadata.ts
@@ -1,6 +1,7 @@
 import {ColumnMetadata} from "./ColumnMetadata";
 import {EntityMetadata} from "./EntityMetadata";
 import {NamingStrategyInterface} from "../naming-strategy/NamingStrategyInterface";
+import {DeferrableType} from "./types/DeferrableType";
 import {OnDeleteType} from "./types/OnDeleteType";
 import {OnUpdateType} from "./types/OnUpdateType";
 
@@ -44,6 +45,11 @@ export class ForeignKeyMetadata {
     onUpdate?: OnUpdateType;
 
     /**
+     * When to check the constraints of a foreign key.
+     */
+    deferrable?: DeferrableType;
+
+    /**
      * Gets the table name to which this foreign key is referenced.
      */
     referencedTablePath: string;
@@ -74,7 +80,8 @@ export class ForeignKeyMetadata {
         columns: ColumnMetadata[],
         referencedColumns: ColumnMetadata[],
         onDelete?: OnDeleteType,
-        onUpdate?: OnUpdateType
+        onUpdate?: OnUpdateType,
+        deferrable?: DeferrableType,
     }) {
         this.entityMetadata = options.entityMetadata;
         this.referencedEntityMetadata = options.referencedEntityMetadata;
@@ -82,6 +89,7 @@ export class ForeignKeyMetadata {
         this.referencedColumns = options.referencedColumns;
         this.onDelete = options.onDelete || "NO ACTION";
         this.onUpdate = options.onUpdate || "NO ACTION";
+        this.deferrable = options.deferrable;
         if (options.namingStrategy)
             this.build(options.namingStrategy);
     }

--- a/src/metadata/RelationMetadata.ts
+++ b/src/metadata/RelationMetadata.ts
@@ -5,6 +5,7 @@ import {ObjectLiteral} from "../common/ObjectLiteral";
 import {ColumnMetadata} from "./ColumnMetadata";
 import {EmbeddedMetadata} from "./EmbeddedMetadata";
 import {RelationMetadataArgs} from "../metadata-args/RelationMetadataArgs";
+import {DeferrableType} from "./types/DeferrableType";
 import {OnUpdateType} from "./types/OnUpdateType";
 import {OnDeleteType} from "./types/OnDeleteType";
 import {PropertyTypeFactory} from "./types/PropertyTypeInFunction";
@@ -137,6 +138,11 @@ export class RelationMetadata {
      * What to do with a relation on update of the row containing a foreign key.
      */
     onUpdate?: OnUpdateType;
+
+    /**
+     * What to do with a relation on update of the row containing a foreign key.
+     */
+    deferrable?: DeferrableType;
 
     /**
      * Gets the property's type to which this relation is applied.
@@ -272,6 +278,7 @@ export class RelationMetadata {
         this.isNullable = args.options.nullable === false || this.isPrimary ? false : true;
         this.onDelete = args.options.onDelete;
         this.onUpdate = args.options.onUpdate;
+        this.deferrable = args.options.deferrable;
         this.isEager = args.options.eager || false;
         this.persistenceEnabled = args.options.persistence === false ? false : true;
         this.isTreeParent = args.isTreeParent || false;

--- a/src/metadata/types/DeferrableType.ts
+++ b/src/metadata/types/DeferrableType.ts
@@ -1,0 +1,5 @@
+
+/**
+ * DEFERRABLE type to be used to specify if foreign key constraints can be deferred.
+ */
+export type DeferrableType = "INITIALLY IMMEDIATE"|"INITIALLY DEFERRED";

--- a/src/schema-builder/options/TableForeignKeyOptions.ts
+++ b/src/schema-builder/options/TableForeignKeyOptions.ts
@@ -38,5 +38,10 @@ export interface TableForeignKeyOptions {
      * referenced stuff is being updated.
      */
     onUpdate?: string;
-
+    
+    /**
+     * Set this foreign key constraint as "DEFERRABLE" e.g. check constraints at start 
+     * or at the end of a transaction
+     */
+    deferrable?: string;
 }

--- a/src/schema-builder/table/TableForeignKey.ts
+++ b/src/schema-builder/table/TableForeignKey.ts
@@ -42,6 +42,12 @@ export class TableForeignKey {
      */
     onUpdate?: string;
 
+    /**
+     * Set this foreign key constraint as "DEFERRABLE" e.g. check constraints at start 
+     * or at the end of a transaction
+     */
+    deferrable?: string;
+
     // -------------------------------------------------------------------------
     // Constructor
     // -------------------------------------------------------------------------
@@ -53,6 +59,7 @@ export class TableForeignKey {
         this.referencedTableName = options.referencedTableName;
         this.onDelete = options.onDelete;
         this.onUpdate = options.onUpdate;
+        this.deferrable = options.deferrable;
     }
 
     // -------------------------------------------------------------------------
@@ -69,7 +76,8 @@ export class TableForeignKey {
             referencedColumnNames: [...this.referencedColumnNames],
             referencedTableName: this.referencedTableName,
             onDelete: this.onDelete,
-            onUpdate: this.onUpdate
+            onUpdate: this.onUpdate,
+            deferrable: this.deferrable,
         });
     }
 
@@ -87,7 +95,8 @@ export class TableForeignKey {
             referencedColumnNames: metadata.referencedColumnNames,
             referencedTableName: metadata.referencedTablePath,
             onDelete: metadata.onDelete,
-            onUpdate: metadata.onUpdate
+            onUpdate: metadata.onUpdate,
+            deferrable: metadata.deferrable,
         });
     }
 

--- a/test/functional/deferrable/deferrable.ts
+++ b/test/functional/deferrable/deferrable.ts
@@ -1,0 +1,95 @@
+import "reflect-metadata";
+import {closeTestingConnections, createTestingConnections, reloadTestingDatabases} from "../../utils/test-utils";
+import {Connection} from "../../../src/connection/Connection";
+import {Company} from "./entity/Company";
+import {Office} from "./entity/Office";
+import {User} from "./entity/User";
+import {expect} from "chai";
+
+describe("deferrable fk constraints should be check at the end of transaction (#2191)", () => {
+
+    let connections: Connection[];
+    before(async () => connections = await createTestingConnections({
+        entities: [__dirname + "/entity/*{.js,.ts}"],
+        enabledDrivers: ["postgres"]
+    }));
+    beforeEach(() => reloadTestingDatabases(connections));
+    after(() => closeTestingConnections(connections));
+
+    it("use initially deferred deferrable fk constraints", () => Promise.all(connections.map(async connection => {
+
+        await connection.manager.transaction(async entityManager => {
+            // first save user
+            const user = new User();
+            user.id = 1;
+            user.company = { id: 100 };
+            user.name = "Bob";
+
+            await entityManager.save(user);
+
+            // then save company
+            const company = new Company();
+            company.id = 100;
+            company.name = "Acme";
+
+            await entityManager.save(company);
+        });
+
+        // now check
+        const user = await connection.manager.findOne(User, {
+            relations: ["company"],
+            where: { id: 1 }
+        });
+
+        expect(user).not.to.be.undefined;
+
+        user!.should.be.eql({
+            id: 1,
+            name: "Bob",
+            company: {
+                id: 100,
+                name: "Acme",
+            }
+        });
+    })));
+
+    it("use initially immediated deferrable fk constraints", () => Promise.all(connections.map(async connection => {
+
+        await connection.manager.transaction(async entityManager => {
+            // first set constraints deferred manually
+            await entityManager.query("SET CONSTRAINTS ALL DEFERRED");
+
+            // now save office
+            const office = new Office();
+            office.id = 2;
+            office.company = { id: 200 };
+            office.name = "Barcelona";
+
+            await entityManager.save(office);
+
+            // then save company
+            const company = new Company();
+            company.id = 200;
+            company.name = "Emca";
+
+            await entityManager.save(company);
+        });
+
+        // now check
+        const office = await connection.manager.findOne(Office, {
+            relations: ["company"],
+            where: { id: 2 }
+        });
+
+        expect(office).not.to.be.undefined;
+
+        office!.should.be.eql({
+            id: 2,
+            name: "Barcelona",
+            company: {
+                id: 200,
+                name: "Emca",
+            }
+        });
+    })));
+});

--- a/test/functional/deferrable/entity/Company.ts
+++ b/test/functional/deferrable/entity/Company.ts
@@ -1,0 +1,14 @@
+import {Entity} from "../../../../src/decorator/entity/Entity";
+import {Column} from "../../../../src/decorator/columns/Column";
+import {PrimaryColumn} from "../../../../src/decorator/columns/PrimaryColumn";
+
+@Entity()
+export class Company {
+
+    @PrimaryColumn()
+    id: number;
+
+    @Column()
+    name?: string;
+
+}

--- a/test/functional/deferrable/entity/Office.ts
+++ b/test/functional/deferrable/entity/Office.ts
@@ -1,0 +1,21 @@
+import {Entity} from "../../../../src/decorator/entity/Entity";
+import {Column} from "../../../../src/decorator/columns/Column";
+import {ManyToOne} from "../../../../src/decorator/relations/ManyToOne";
+import {PrimaryColumn} from "../../../../src/decorator/columns/PrimaryColumn";
+import {Company} from "./Company";
+
+@Entity()
+export class Office {
+
+    @PrimaryColumn()
+    id: number;
+
+    @Column()
+    name: string;
+
+    @ManyToOne(type => Company, company => company.id, {
+        deferrable: "INITIALLY IMMEDIATE",
+    })
+    company: Company;
+}
+

--- a/test/functional/deferrable/entity/User.ts
+++ b/test/functional/deferrable/entity/User.ts
@@ -1,0 +1,21 @@
+import {Entity} from "../../../../src/decorator/entity/Entity";
+import {Column} from "../../../../src/decorator/columns/Column";
+import {ManyToOne} from "../../../../src/decorator/relations/ManyToOne";
+import {PrimaryColumn} from "../../../../src/decorator/columns/PrimaryColumn";
+import {Company} from "./Company";
+
+@Entity()
+export class User {
+
+    @PrimaryColumn()
+    id: number;
+
+    @Column()
+    name: string;
+
+    @ManyToOne(type => Company, company => company.id, {
+        deferrable: "INITIALLY DEFERRED",
+    })
+    company: Company;
+}
+


### PR DESCRIPTION
Related feature request: #2191

I've added deferrable options for foreign keys on Postgres, see `DEFERRABLE` on [CREATE TABLE](https://www.postgresql.org/docs/11/sql-createtable.html), or on [SET CONSTRAINTS](https://www.postgresql.org/docs/11/sql-set-constraints.html). Based on that documentation the following declarations are equivalent (at final of column or constraint definition):

- "" == "`NOT DEFERRABLE`"  (default)
- "`DEFERRABLE`" == "`DEFERRABLE INITIALLY IMMEDIATE`"
- "`DEFERRABLE INITIALLY DEFERRED`"

Thus, with a single property on foreign column options all three cases are covered (undefined means "`NOT DEFERRABLE`", default in postgres):
- `deferrable`: "`INITIALLY IMMEDIATE`" | "`INITIALLY DEFERRED`"

This configuration could be extensible to [sqlite](https://www.sqlite.org/foreignkeys.html#fk_deferred) later.