### PR TITLE
Implemented entity factory to create entities

### DIFF
--- a/src/connection/BaseConnectionOptions.ts
+++ b/src/connection/BaseConnectionOptions.ts
@@ -3,6 +3,7 @@ import {LoggerOptions} from "../logger/LoggerOptions";
 import {NamingStrategyInterface} from "../naming-strategy/NamingStrategyInterface";
 import {DatabaseType} from "../driver/types/DatabaseType";
 import {Logger} from "../logger/Logger";
+import { EntityFactoryInterface } from '../entity-factory/EntityFactoryInterface';
 
 /**
  * BaseConnectionOptions is set of connection options shared by all database types.
@@ -51,6 +52,12 @@ export interface BaseConnectionOptions {
      * Naming strategy to be used to name tables and columns in the database.
      */
     readonly namingStrategy?: NamingStrategyInterface;
+
+    /**
+     * Entity factory to be used for this connection.
+     * If this options is set, TypeOrm will use the provided factory to create instance of entities.
+     */
+    readonly entityFactory?: EntityFactoryInterface;
 
     /**
      * Logging options.

--- a/src/connection/Connection.ts
+++ b/src/connection/Connection.ts
@@ -38,6 +38,8 @@ import {MysqlDriver} from "../driver/mysql/MysqlDriver";
 import {ObjectUtils} from "../util/ObjectUtils";
 import {PromiseUtils} from "../";
 import {IsolationLevel} from "../driver/types/IsolationLevel";
+import { EntityFactoryInterface } from '../entity-factory/EntityFactoryInterface';
+import { DefaultEntityFactory } from '../entity-factory/DefaultEntityFactory';
 
 /**
  * Connection is a single database ORM connection to a specific database.
@@ -96,6 +98,11 @@ export class Connection {
     readonly subscribers: EntitySubscriberInterface<any>[] = [];
 
     /**
+     * Entity factory used to instantiate entities objects
+     */
+    readonly entityFactory: EntityFactoryInterface;
+
+    /**
      * Observers observing queries.
      */
     readonly observers: QueryObserver[] = [];
@@ -131,6 +138,7 @@ export class Connection {
         this.driver = new DriverFactory().create(this);
         this.manager = this.createEntityManager();
         this.namingStrategy = options.namingStrategy || new DefaultNamingStrategy();
+        this.entityFactory = options.entityFactory || new DefaultEntityFactory();
         this.queryResultCache = options.cache ? new QueryResultCacheFactory(this).create() : undefined;
         this.relationLoader = new RelationLoader(this);
         this.relationIdLoader = new RelationIdLoader(this);

--- a/src/entity-factory/DefaultEntityFactory.ts
+++ b/src/entity-factory/DefaultEntityFactory.ts
@@ -1,0 +1,16 @@
+import { EntityFactoryInterface } from './EntityFactoryInterface';
+
+export class DefaultEntityFactory implements EntityFactoryInterface {
+
+    /**
+     * Returns an entity object
+     */
+    createEntity(target: Function): Object {
+
+        let ret: any = {};
+        Reflect.setPrototypeOf(ret, target.prototype);
+        return ret;
+
+    }
+
+}

--- a/src/entity-factory/EntityFactoryInterface.ts
+++ b/src/entity-factory/EntityFactoryInterface.ts
@@ -1,0 +1,12 @@
+/**
+ * Class that implements this interface is en entity factory used by the orm to 
+ * create entity objects.
+ */
+export interface EntityFactoryInterface {
+
+    /**
+     * Returns an entity object
+     */
+    createEntity(target: Function): Object;
+
+}

--- a/src/metadata/EntityMetadata.ts
+++ b/src/metadata/EntityMetadata.ts
@@ -502,8 +502,7 @@ export class EntityMetadata {
         // if target is set to a function (e.g. class) that can be created then create it
         let ret: any;
         if (this.target instanceof Function) {
-            ret = {};
-            Reflect.setPrototypeOf(ret, this.target.prototype);
+            ret = this.connection.entityFactory.createEntity(this.target)
             this.lazyRelations.forEach(relation => this.connection.relationLoader.enableLazyLoad(relation, ret, queryRunner));
             return ret;
         }

--- a/test/functional/entity-factory/custom-entity-factory.ts
+++ b/test/functional/entity-factory/custom-entity-factory.ts
@@ -1,0 +1,44 @@
+import "reflect-metadata";
+import {expect} from "chai";
+import {closeTestingConnections, createTestingConnections, reloadTestingDatabases} from "../../utils/test-utils";
+import {Connection} from "../../../src/connection/Connection";
+import {Post} from "./entity/Post";
+
+describe("entity-factory > custom entity factory", () => {
+    
+    let connections: Connection[];
+    before(async () => connections = await createTestingConnections({
+        entities: [Post],
+        /**
+         * Defining a custom entity factory that initializes entity by
+         * calling its constructor.
+         */
+        entityFactory: {
+            createEntity(target: Function) {
+                let entity = new (<any> target)();
+                return entity;
+            }
+        },
+        dropSchema: true
+    }));
+    beforeEach(() => reloadTestingDatabases(connections));
+    after(() => closeTestingConnections(connections));
+
+    it("should call the constructor", () => Promise.all(connections.map(async connection => {
+        
+        const postRepository = connection.getRepository(Post);
+
+        // create and save a post first and check entity is initialized
+        const post = new Post("About columns");
+        await postRepository.save(post);
+
+        expect(post.initialized).to.be.true;
+
+        // check if entity loaded from database is initialized by constructor
+        const loadedPost = await postRepository.findOne(1);
+        expect(loadedPost).to.be.instanceof(Post);
+        expect(loadedPost!.initialized).to.be.true;
+        
+    })));
+
+});

--- a/test/functional/entity-factory/custom-proxifying-entity-factory.ts
+++ b/test/functional/entity-factory/custom-proxifying-entity-factory.ts
@@ -1,0 +1,64 @@
+import "reflect-metadata";
+import { expect } from "chai";
+import { closeTestingConnections, createTestingConnections, reloadTestingDatabases } from "../../utils/test-utils";
+import { Connection } from "../../../src/connection/Connection";
+import { Post } from "./entity/Post";
+
+describe("entity-factory > custom proxifying entity factory", () => {
+
+    let connections: Connection[];
+    before(async () => connections = await createTestingConnections({
+        entities: [Post],
+        entityFactory: {
+            createEntity(target: Function) {
+                // Creating an entity not initialized by constructor
+                // (Same as default behavior)
+                let entity: any = {};
+                Reflect.setPrototypeOf(entity, target.prototype);
+
+                // Proxifying the entity to intercept method calls
+                return new Proxy(
+                    entity,
+                    {
+                        get(target, propKey, receiver) {
+        
+                            const property = target[propKey];
+                            
+                            if (property instanceof Function) {
+                                return function (...args:any[]) {
+                                    const result = property.apply(this, args);
+                                    return result + " !!!";
+                                };
+                            }
+                            
+                            return property;
+                        }
+                    }
+                )
+            }
+        },
+        dropSchema: true
+    }));
+    beforeEach(() => reloadTestingDatabases(connections));
+    after(() => closeTestingConnections(connections));
+
+    it("should proxify the entity", () => Promise.all(connections.map(async connection => {
+
+        const postRepository = connection.getRepository(Post);
+
+        // create and save a post first and check entity is initialized
+        const post = new Post("About columns");
+        await postRepository.save(post);
+
+        expect(post.initialized).to.be.true;
+
+        // check if entity loaded from database is not initialized by constructor
+        // and is proxified
+        const loadedPost = await postRepository.findOne(1);
+        expect(loadedPost).to.be.instanceof(Post);
+        expect(loadedPost!.initialized).to.be.undefined;
+        expect(loadedPost!.getTitle()).to.be.equal("About columns !!!")
+
+    })));
+
+});

--- a/test/functional/entity-factory/default-entity-factory.ts
+++ b/test/functional/entity-factory/default-entity-factory.ts
@@ -1,0 +1,34 @@
+import "reflect-metadata";
+import {expect} from "chai";
+import {closeTestingConnections, createTestingConnections, reloadTestingDatabases} from "../../utils/test-utils";
+import {Connection} from "../../../src/connection/Connection";
+import {Post} from "./entity/Post";
+
+describe("entity-factory > default entity factory", () => {
+    
+    let connections: Connection[];
+    before(async () => connections = await createTestingConnections({
+        entities: [Post],
+        dropSchema: true
+    }));
+    beforeEach(() => reloadTestingDatabases(connections));
+    after(() => closeTestingConnections(connections));
+
+    it("should not call the constructor", () => Promise.all(connections.map(async connection => {
+        
+        const postRepository = connection.getRepository(Post);
+
+        // create and save a post first and check entity is initialized
+        const post = new Post("About columns");
+        await postRepository.save(post);
+
+        expect(post.initialized).to.be.true;
+
+        // check if entity loaded from database is not initialized by constructor
+        const loadedPost = await postRepository.findOne(1);
+        expect(loadedPost).to.be.instanceof(Post);
+        expect(loadedPost!.initialized).to.be.undefined;
+        
+    })));
+
+});

--- a/test/functional/entity-factory/entity/Post.ts
+++ b/test/functional/entity-factory/entity/Post.ts
@@ -1,0 +1,24 @@
+import {Entity} from "../../../../src/decorator/entity/Entity";
+import {Column} from "../../../../src/decorator/columns/Column";
+import {PrimaryGeneratedColumn} from "../../../../src/decorator/columns/PrimaryGeneratedColumn";
+
+@Entity()
+export class Post {
+    @PrimaryGeneratedColumn()
+    id: number;
+
+    @Column()
+    private title: string;
+
+    initialized?: true;
+
+    constructor(title: string) {
+        this.title = title;
+        this.initialized = true;
+    }
+
+    public getTitle(): string {
+        return this.title;
+    }
+}
+

--- a/test/utils/test-utils.ts
+++ b/test/utils/test-utils.ts
@@ -7,6 +7,7 @@ import {EntitySchema} from "../../src/entity-schema/EntitySchema";
 import {createConnections} from "../../src/index";
 import {NamingStrategyInterface} from "../../src/naming-strategy/NamingStrategyInterface";
 import {PromiseUtils} from "../../src/util/PromiseUtils";
+import { EntityFactoryInterface } from '../../src/entity-factory/EntityFactoryInterface';
 
 /**
  * Interface in which data is stored in ormconfig.json of the project.
@@ -62,6 +63,11 @@ export interface TestingOptions {
      * Subscribers needs to be included in the connection for the given test suite.
      */
     subscribers?: string[]|Function[];
+
+    /**
+     * Entity factory needs to be included in the connection for the given test suite.
+     */
+    entityFactory?: EntityFactoryInterface;
 
     /**
      * Indicates if schema sync should be performed or not.
@@ -219,6 +225,8 @@ export function setupTestingConnections(options?: TestingOptions): ConnectionOpt
                 newOptions.migrations = [options.__dirname + "/migration/*{.js,.ts}"];
             if (options && options.namingStrategy)
                 newOptions.namingStrategy = options.namingStrategy;
+            if (options && options.entityFactory)
+                newOptions.entityFactory = options.entityFactory;
             return newOptions;
         });
 }


### PR DESCRIPTION
Following PR #3845 

1) Refactored the code to use an EntityFactory to create the entities
2) Added optional "entityFactory" configuration option: this gives full flexibility to end-user to fine-tune how the entities are created by the ORM (for example he might want to stay with previous behaviour when entities are creating by calling the constructor). Default behaviour stays the one implemented in PR #3845 (skipping constructor).

Also using a custom entity factory, end-user can now use ES6 Proxy API to profile the entities created by the ORM.

See examples implemented as tests in the PR.
