### PR TITLE
Add failing test for issue #1505

### DIFF
--- a/test/github-issues/1505/entity/Category.ts
+++ b/test/github-issues/1505/entity/Category.ts
@@ -1,0 +1,16 @@
+import {Entity} from "../../../../src/decorator/entity/Entity";
+import {PrimaryGeneratedColumn} from "../../../../src/decorator/columns/PrimaryGeneratedColumn";
+import {Column} from "../../../../src/decorator/columns/Column";
+
+@Entity()
+export class Category {
+
+    @PrimaryGeneratedColumn()
+    id: number;
+
+    @Column()
+    name: string;
+
+    @Column()
+    title: string;
+}

--- a/test/github-issues/1505/issue-1505.ts
+++ b/test/github-issues/1505/issue-1505.ts
@@ -1,0 +1,45 @@
+import "reflect-metadata";
+import {closeTestingConnections, createTestingConnections, reloadTestingDatabases} from "../../utils/test-utils";
+import {Connection} from "../../../src/connection/Connection";
+import {expect} from "chai";
+import {Category} from "./entity/Category";
+import { CategoryRepository } from "./repository/CategoryRepository";
+
+describe("github issues > #1505 nested transactions", () => {
+
+    let connections: Connection[];
+    before(async () => connections = await createTestingConnections({
+        entities: [__dirname + "/entity/*{.js,.ts}"],
+        enabledDrivers: ["postgres"]
+    }));
+    beforeEach(() => reloadTestingDatabases(connections));
+    after(() => closeTestingConnections(connections));
+
+    it("should rollback the outer transaction and save nothing into the database", () => Promise.all(connections.map(async connection => {
+        const repo = connection.getCustomRepository(CategoryRepository);
+        const category = new Category();
+
+        try {
+            await repo.triggerNestedTransactionError(category); // Should fail
+            throw new Error();
+        } catch {
+            // Check that the post information was not saved.
+            const categories = await connection.createQueryBuilder(Category, "category").getMany();
+            expect(categories, "Nested transaction: Outer transaction failed to rollback. Inner transaction already committed the changes.").to.length(0);
+        }
+    })));
+
+    it("should detect that a transaction is already running and use savepoints", () => Promise.all(connections.map(async connection => {
+        const repo = connection.getCustomRepository(CategoryRepository);
+        const category = new Category();
+
+        connection.query("START TRANSACTION;");
+        await repo.triggerTransactionSuccess(category);
+        connection.query("ROLLBACK;");
+
+        // Check that the post information was not saved.
+        const categories = await connection.createQueryBuilder(Category, "category").getMany();
+        expect(categories, "Nested transaction: Outer transaction failed to rollback. Inner transaction already committed the changes.").to.length(0);
+    })));
+
+});

--- a/test/github-issues/1505/repository/CategoryRepository.ts
+++ b/test/github-issues/1505/repository/CategoryRepository.ts
@@ -1,0 +1,31 @@
+import { Category } from "../entity/Category";
+import {EntityRepository} from "../../../../src/decorator/EntityRepository";
+import { Transaction, Repository, EntityManager, TransactionManager } from "../../../../src";
+
+@EntityRepository(Category)
+export class CategoryRepository extends Repository<Category> {
+
+    constructor(public manager: EntityManager) {
+        super();
+    }
+
+    @Transaction("postgres")
+    async triggerNestedTransactionError(category: Category, @TransactionManager() entityManager?: EntityManager) {
+        category.name = "new name";
+        await this.triggerTransactionSuccess(category);
+        throw new Error("COULD NOT SAVE THE CATEGORY");
+    }
+
+    @Transaction("postgres")
+    async triggerTransactionError(category: Category, @TransactionManager() entityManager?: EntityManager) {
+        category.name = "new name";
+        throw new Error("COULD NOT SAVE THE CATEGORY");
+    }
+
+    @Transaction("postgres")
+    triggerTransactionSuccess(category: Category, @TransactionManager() entityManager?: EntityManager) {
+        category.name = "new name";
+        category.title = "new title";
+        return entityManager!.save(category);
+    }
+}


### PR DESCRIPTION
See #1505.

The 1st test case is concerned with calling transactional methods inside another transaction. The 2nd test case (closer to what I need) is related to detect if there's a transaction already running in the current connection. In both test cases, the solution would be that Typeorm somehow detects that the transaction is open and switch over to savepoint/commit savepoint approach.