### PR TITLE
Resolve warning declaration Connection class: Initializers are not allowed in ambient contexts.

### DIFF
--- a/src/connection/Connection.ts
+++ b/src/connection/Connection.ts
@@ -62,7 +62,7 @@ export class Connection {
     /**
      * Indicates if connection is initialized or not.
      */
-    readonly isConnected = false;
+    readonly isConnected: boolean;
 
     /**
      * Database driver used by this connection.
@@ -128,6 +128,7 @@ export class Connection {
         this.queryResultCache = options.cache ? new QueryResultCacheFactory(this).create() : undefined;
         this.relationLoader = new RelationLoader(this);
         this.relationIdLoader = new RelationIdLoader(this);
+        this.isConnected = false;
     }
 
     // -------------------------------------------------------------------------


### PR DESCRIPTION
I got this warning when using Webpack compile typeorm.

```
node_modules/typeorm/connection/Connection.d.ts (40,28): Initializers are not allowed in ambient contexts.
```
Maybe relate to this issue:
https://github.com/typeorm/typeorm/issues/3823