### PR TITLE
Fix for #3640: Setting Null values in query rather than passing them as query parameters for AbstractSqliteDriver

### DIFF
--- a/src/query-builder/UpdateQueryBuilder.ts
+++ b/src/query-builder/UpdateQueryBuilder.ts
@@ -388,6 +388,10 @@ export class UpdateQueryBuilder<Entity> extends QueryBuilder<Entity> implements 
                     // todo: duplication zone
                     if (value instanceof Function) { // support for SQL expressions in update query
                         updateColumnAndValues.push(this.escape(column.databaseName) + " = " + value());
+                    } else if ( (value === undefined || value === null) && this.connection.driver instanceof AbstractSqliteDriver ) {
+                        // If value is null and we are working with SQLite simply set the null value directly into the query instead of passing it on the paramters.
+                        // This is to avoid underlying drivers to complain avout null params. See  https://github.com/typeorm/typeorm/issues/3640
+                        updateColumnAndValues.push(this.escape(column.databaseName) + " = NULL");
                     } else {
                         if (this.connection.driver instanceof SqlServerDriver) {
                             value = this.connection.driver.parametrizeValue(column, value);
@@ -434,6 +438,10 @@ export class UpdateQueryBuilder<Entity> extends QueryBuilder<Entity> implements 
                 // todo: duplication zone
                 if (value instanceof Function) { // support for SQL expressions in update query
                     updateColumnAndValues.push(this.escape(key) + " = " + value());
+                } else if ( (value === undefined || value === null) && this.connection.driver instanceof AbstractSqliteDriver ) {
+                    // If value is null and we are working with SQLite simply set the null value directly into the query instead of passing it on the paramters.
+                    // This is to avoid underlying drivers to complain avout null params. See  https://github.com/typeorm/typeorm/issues/3640
+                    updateColumnAndValues.push(this.escape(key) + " = NULL");
                 } else {
 
                     // we need to store array values in a special class to make sure parameter replacement will work correctly

--- a/test/github-issues/3640/entity/User.ts
+++ b/test/github-issues/3640/entity/User.ts
@@ -1,0 +1,15 @@
+import {Column, Entity, PrimaryColumn} from "../../../../src";
+
+@Entity()
+export class User {
+
+    @PrimaryColumn()
+    id: number;
+
+    @Column({nullable:true})
+    name:string
+    
+    @Column({nullable:true})
+    status:string
+
+}

--- a/test/github-issues/3640/entity/User.ts
+++ b/test/github-issues/3640/entity/User.ts
@@ -6,10 +6,10 @@ export class User {
     @PrimaryColumn()
     id: number;
 
-    @Column({nullable:true})
-    name:string
+    @Column({nullable: true})
+    name: string;
     
-    @Column({nullable:true})
-    status:string
+    @Column({nullable: true})
+    status: string;
 
 }

--- a/test/github-issues/3640/issue-3640.ts
+++ b/test/github-issues/3640/issue-3640.ts
@@ -8,7 +8,6 @@ describe("github issues > #3640 Updating column values to NULL should be done in
     let connections: Connection[];
     before(async () => connections = await createTestingConnections({
         entities: [__dirname + "/entity/*{.js,.ts}"],
-        logging: true,
         enabledDrivers: ["sqlite"]
     }));
     beforeEach(() => reloadTestingDatabases(connections));

--- a/test/github-issues/3640/issue-3640.ts
+++ b/test/github-issues/3640/issue-3640.ts
@@ -1,0 +1,37 @@
+import {Connection} from "../../../src";
+import {closeTestingConnections, createTestingConnections, reloadTestingDatabases} from "../../utils/test-utils";
+import {User} from "./entity/User";
+import {expect} from "chai";
+
+describe("github issues > #3640 Updating column values to NULL should be done in SET clasue rather than passing as query paramters for SQLite. Specially when using typeorm on mobile apps for Android as Android requires query params to not be null", () => {
+
+    let connections: Connection[];
+    before(async () => connections = await createTestingConnections({
+        entities: [__dirname + "/entity/*{.js,.ts}"],
+        logging: true,
+        enabledDrivers: ["sqlite"]
+    }));
+    beforeEach(() => reloadTestingDatabases(connections));
+    after(() => closeTestingConnections(connections));
+
+    it("should be able to update an existing record column with a null value", () => Promise.all(connections.map(async connection => {
+        const user = new User();
+        user.id = 1
+        user.name = "Test user"
+        user.status = "active"
+        // This should insert the new user
+        await connection.manager.save(user);
+        // Updating same user with id 1 and setting status to null. Doing it this way as strictNullChecks is set to true
+        const sameUser = {
+            id: 1,
+            name: "Same Test user udpated name",
+            status:null
+        };
+        // this should update the existing user with id=1 and set stauts to null.
+        await connection.manager.save('User',sameUser);
+        let loadedUser = await connection.manager.findOne(User, 1)
+        expect(loadedUser).not.to.be.undefined;
+        expect(loadedUser!.status).to.be.null;
+    })));
+
+});

--- a/test/github-issues/3640/issue-3640.ts
+++ b/test/github-issues/3640/issue-3640.ts
@@ -15,20 +15,20 @@ describe("github issues > #3640 Updating column values to NULL should be done in
 
     it("should be able to update an existing record column with a null value", () => Promise.all(connections.map(async connection => {
         const user = new User();
-        user.id = 1
-        user.name = "Test user"
-        user.status = "active"
+        user.id = 1;
+        user.name = "Test user";
+        user.status = "active";
         // This should insert the new user
         await connection.manager.save(user);
         // Updating same user with id 1 and setting status to null. Doing it this way as strictNullChecks is set to true
         const sameUser = {
             id: 1,
             name: "Same Test user udpated name",
-            status:null
+            status: null
         };
         // this should update the existing user with id=1 and set stauts to null.
-        await connection.manager.save('User',sameUser);
-        let loadedUser = await connection.manager.findOne(User, 1)
+        await connection.manager.save("User", sameUser);
+        let loadedUser = await connection.manager.findOne(User, 1);
         expect(loadedUser).not.to.be.undefined;
         expect(loadedUser!.status).to.be.null;
     })));


### PR DESCRIPTION
This fixes issues with typeorm when using with NativeScript in Android platform. Underlying sqlite driver for Android requires all query parameter not to be null, so when updating an existing column value with null typeorm should set it directly into the query rather than passing null as one of the query parameters.

https://github.com/typeorm/typeorm/issues/3640