### PR TITLE
Fixed issue with adding columns to existing tables in mssql.

### DIFF
--- a/src/driver/sqlserver/SqlServerQueryRunner.ts
+++ b/src/driver/sqlserver/SqlServerQueryRunner.ts
@@ -654,7 +654,7 @@ export class SqlServerQueryRunner extends BaseQueryRunner implements QueryRunner
         const upQueries: Query[] = [];
         const downQueries: Query[] = [];
 
-        upQueries.push(new Query(`ALTER TABLE ${this.escapePath(table)} ADD ${this.buildCreateColumnSql(table, column, false, false)}`));
+        upQueries.push(new Query(`ALTER TABLE ${this.escapePath(table)} ADD ${this.buildCreateColumnSql(table, column, false, true)}`));
         downQueries.push(new Query(`ALTER TABLE ${this.escapePath(table)} DROP COLUMN "${column.name}"`));
 
         // create or update primary key constraint
@@ -693,10 +693,9 @@ export class SqlServerQueryRunner extends BaseQueryRunner implements QueryRunner
             downQueries.push(new Query(`ALTER TABLE ${this.escapePath(table)} DROP CONSTRAINT "${uniqueConstraint.name}"`));
         }
 
-        // create default constraint
+        // remove default constraint
         if (column.default !== null && column.default !== undefined) {
             const defaultName = this.connection.namingStrategy.defaultConstraintName(table.name, column.name);
-            upQueries.push(new Query(`ALTER TABLE ${this.escapePath(table)} ADD CONSTRAINT "${defaultName}" DEFAULT ${column.default} FOR "${column.name}"`));
             downQueries.push(new Query(`ALTER TABLE ${this.escapePath(table)} DROP CONSTRAINT "${defaultName}"`));
         }
 

--- a/test/other-issues/mssql-add-column-with-default-value/entity/Post-Fail.ts
+++ b/test/other-issues/mssql-add-column-with-default-value/entity/Post-Fail.ts
@@ -1,0 +1,15 @@
+import {Entity} from "../../../../src/decorator/entity/Entity";
+import {PrimaryGeneratedColumn} from "../../../../src/decorator/columns/PrimaryGeneratedColumn";
+import {Column} from "../../../../src/decorator/columns/Column";
+
+@Entity()
+export class Post {
+    @PrimaryGeneratedColumn()
+    id: number;
+
+    @Column()
+    title: string;
+
+    @Column()
+    addedField: string;
+}

--- a/test/other-issues/mssql-add-column-with-default-value/entity/Post-Succeed.ts
+++ b/test/other-issues/mssql-add-column-with-default-value/entity/Post-Succeed.ts
@@ -1,0 +1,15 @@
+import {Entity} from "../../../../src/decorator/entity/Entity";
+import {PrimaryGeneratedColumn} from "../../../../src/decorator/columns/PrimaryGeneratedColumn";
+import {Column} from "../../../../src/decorator/columns/Column";
+
+@Entity()
+export class Post {
+    @PrimaryGeneratedColumn()
+    id: number;
+
+    @Column()
+    title: string;
+
+    @Column({default: "Test"})
+    addedField: string;
+}

--- a/test/other-issues/mssql-add-column-with-default-value/entity/Post-Succeed.ts
+++ b/test/other-issues/mssql-add-column-with-default-value/entity/Post-Succeed.ts
@@ -10,6 +10,6 @@ export class Post {
     @Column()
     title: string;
 
-    @Column({default: "Test"})
+    @Column({default: "default value"})
     addedField: string;
 }

--- a/test/other-issues/mssql-add-column-with-default-value/entity/Post.ts
+++ b/test/other-issues/mssql-add-column-with-default-value/entity/Post.ts
@@ -1,0 +1,13 @@
+import {Entity} from "../../../../src/decorator/entity/Entity";
+import {PrimaryGeneratedColumn} from "../../../../src/decorator/columns/PrimaryGeneratedColumn";
+import {Column} from "../../../../src/decorator/columns/Column";
+
+@Entity()
+export class Post {
+    @PrimaryGeneratedColumn()
+    id: number;
+
+    @Column()
+    title: string;
+
+}

--- a/test/other-issues/mssql-add-column-with-default-value/mssql-add-column-with-default-value.ts
+++ b/test/other-issues/mssql-add-column-with-default-value/mssql-add-column-with-default-value.ts
@@ -1,6 +1,7 @@
 
 import {createTestingConnections} from "../../utils/test-utils";
 import {Connection} from "../../../src";
+import {Post} from "./entity/Post-Succeed";
 
 describe("mssql -> add column to existing table", () => {
     let connection: Connection;
@@ -12,7 +13,7 @@ describe("mssql -> add column to existing table", () => {
         }))[0];
 
         await connection.synchronize(true);
-        await connection.getRepository("Post").insert({id: 0, title: "test"});
+        await connection.getRepository("Post").insert({title: "test"});
         await connection.close();
     });
 
@@ -36,5 +37,13 @@ describe("mssql -> add column to existing table", () => {
         }))[0];
 
         await connection.synchronize().should.eventually.eq(undefined);
+        const post = await connection.getRepository<Post>("Post").findOne();
+        if (!post) {
+            throw "Post should exist";
+        }
+        post.should.exist;
+        post.id.should.be.eq(1);
+        post.title.should.be.eq("test");
+        post.addedField.should.be.eq("default value");
     });
 })

--- a/test/other-issues/mssql-add-column-with-default-value/mssql-add-column-with-default-value.ts
+++ b/test/other-issues/mssql-add-column-with-default-value/mssql-add-column-with-default-value.ts
@@ -1,0 +1,40 @@
+
+import {createTestingConnections} from "../../utils/test-utils";
+import {Connection} from "../../../src";
+
+describe("mssql -> add column to existing table", () => {
+    let connection: Connection;
+
+    beforeEach(async () => {
+        connection = (await createTestingConnections({
+            enabledDrivers: ["mssql"],
+            entities: [__dirname + "/entity/Post{.js,.ts}"]
+        }))[0];
+
+        await connection.synchronize(true);
+        await connection.getRepository("Post").insert({id: 0, title: "test"});
+        await connection.close();
+    });
+
+    afterEach(async () => {
+        await connection.close();
+    });
+
+    it("should fail to add column", async () => {
+        connection = (await createTestingConnections({
+            enabledDrivers: ["mssql"],
+            entities: [__dirname + "/entity/Post-Fail{.js,.ts}"]
+        }))[0];
+
+        await connection.synchronize().should.eventually.rejectedWith("Error: ALTER TABLE only allows columns to be added that can contain nulls, or have a DEFAULT definition specified, or the column being added is an identity or timestamp column, or alternatively if none of the previous conditions are satisfied the table must be empty to allow addition of this column. Column 'addedField' cannot be added to non-empty table 'post' because it does not satisfy these conditions.");
+    });
+
+    it("should succeed to add column", async () => {
+        connection = (await createTestingConnections({
+            enabledDrivers: ["mssql"],
+            entities: [__dirname + "/entity/Post-Succeed{.js,.ts}"]
+        }))[0];
+
+        await connection.synchronize().should.eventually.eq(undefined);
+    });
+})

--- a/test/other-issues/mssql-add-column-with-default-value/mssql-add-column-with-default-value.ts
+++ b/test/other-issues/mssql-add-column-with-default-value/mssql-add-column-with-default-value.ts
@@ -46,4 +46,4 @@ describe("mssql -> add column to existing table", () => {
         post.title.should.be.eq("test");
         post.addedField.should.be.eq("default value");
     });
-})
+});


### PR DESCRIPTION
If you try to add a non null column to an existing table, the query will fail on MS-SQL due to a restriction of non-null non-default columns being forbidden when the table already contains rows of data.

In order to work around this, you need to define a default value, but the driver does not add the default value until after the column is created. On MSSQL this causes you to not be able to ever add the column.

This simple patch fixes that.