### PR TITLE
revert(3814): Revert changes from PR#3814

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ feel free to ask us and community.
 ### Bug fixes
 
 * fixed transform embeddeds with boolean values (mongodb) ([#3900](https://github.com/typeorm/typeorm/pull/3900))
+* revert changes from [#3814](https://github.com/typeorm/typeorm/pull/3814) ([#3828](https://github.com/typeorm/typeorm/pull/3828))
 
 ### Features
 

--- a/src/driver/postgres/PostgresQueryRunner.ts
+++ b/src/driver/postgres/PostgresQueryRunner.ts
@@ -1985,12 +1985,12 @@ export class PostgresQueryRunner extends BaseQueryRunner implements QueryRunner 
         const columnName = columnOrName instanceof TableColumn ? columnOrName.name : columnOrName;
         const schema = table.name.indexOf(".") === -1 ? this.driver.options.schema : table.name.split(".")[0];
         const tableName = table.name.indexOf(".") === -1 ? table.name : table.name.split(".")[1];
-        let enumName = schema && withSchema ? `${schema}.${tableName}_${columnName}_enum` : `${tableName}_${columnName}_enum`;
+        let enumName = schema && withSchema ? `${schema}.${tableName}_${columnName.toLowerCase()}_enum` : `${tableName}_${columnName.toLowerCase()}_enum`;
         if (toOld)
             enumName = enumName + "_old";
         return enumName.split(".").map(i => {
             return disableEscape ? i : `"${i}"`;
-        }).join(".").toLowerCase();
+        }).join(".");
     }
 
     /**


### PR DESCRIPTION
As described in https://github.com/typeorm/typeorm/issues/3828 my PR https://github.com/typeorm/typeorm/pull/3814 cause conflicts with https://github.com/typeorm/typeorm/pull/3793. 

Because #3793 resolves root problem with non-lowercase enum type names this PR revert changes from  https://github.com/typeorm/typeorm/pull/3814 but leaves tests as they are.

Closes #3828 