### PR TITLE
Map TYPEORM_CONNECT_STRING to the connectString ConnectionOption

### DIFF
--- a/src/connection/options-reader/ConnectionOptionsEnvReader.ts
+++ b/src/connection/options-reader/ConnectionOptionsEnvReader.ts
@@ -46,7 +46,8 @@ export class ConnectionOptionsEnvReader {
                 subscribersDir: PlatformTools.getEnvVariable("TYPEORM_SUBSCRIBERS_DIR"),
             },
             cache: this.transformCaching(),
-            uuidExtension: PlatformTools.getEnvVariable("TYPEORM_UUID_EXTENSION")
+            uuidExtension: PlatformTools.getEnvVariable("TYPEORM_UUID_EXTENSION"),
+            connectString: PlatformTools.getEnvVariable("TYPEORM_CONNECT_STRING")
         };
     }
 


### PR DESCRIPTION
In order for Oracle DB to connect over secure networking protocols, I need access to the connectString. I noticed that the connectString is configurable when specified as a JS object and an ormconfig.json file, but not from an environment variable. I mapped the appropriate environment variable to cover that gap.