### PR TITLE
fix(3981): update typescript deps in cli generated project

### DIFF
--- a/src/commands/InitCommand.ts
+++ b/src/commands/InitCommand.ts
@@ -525,7 +525,7 @@ Steps to run this project:
         Object.assign(packageJson.devDependencies, {
             "ts-node": "3.3.0",
             "@types/node": "^8.0.29",
-            "typescript": "2.5.2"
+            "typescript": "3.3.3333"
         });
 
         if (!packageJson.dependencies) packageJson.dependencies = {};


### PR DESCRIPTION
**Problem:**
Newly cli generated projects are not compilable. 

**Solution:**
This PR update typescript version for cli generated projects to version 3.3.3333.

Close https://github.com/typeorm/typeorm/issues/3981