### PR TITLE
fix(3953): add missing spatial options in entity schema column definition

### DIFF
--- a/src/entity-schema/EntitySchemaColumnOptions.ts
+++ b/src/entity-schema/EntitySchemaColumnOptions.ts
@@ -1,7 +1,8 @@
 import {ColumnType} from "../driver/types/ColumnTypes";
 import {ValueTransformer} from "../decorator/options/ValueTransformer";
+import { SpatialColumnOptions } from "../decorator/options/SpatialColumnOptions";
 
-export interface EntitySchemaColumnOptions {
+export interface EntitySchemaColumnOptions extends SpatialColumnOptions {
 
     /**
      * Indicates if this column is a primary column.

--- a/src/entity-schema/EntitySchemaTransformer.ts
+++ b/src/entity-schema/EntitySchemaTransformer.ts
@@ -91,7 +91,9 @@ export class EntitySchemaTransformer {
                         generatedType: column.generatedType,
                         hstoreType: column.hstoreType,
                         array: column.array,
-                        transformer: column.transformer
+                        transformer: column.transformer,
+                        spatialFeatureType: column.spatialFeatureType,
+                        srid: column.srid
                     }
                 };
                 metadataArgsStorage.columns.push(columnAgrs);


### PR DESCRIPTION
Adding `spatialFeatureType` and `srid` into `EntitySchemaColumnOptions`.

Fix https://github.com/typeorm/typeorm/issues/3953