### PR TITLE
use distinct discriminator_value for each child entity saved

### DIFF
--- a/src/query-builder/InsertQueryBuilder.ts
+++ b/src/query-builder/InsertQueryBuilder.ts
@@ -414,8 +414,8 @@ export class InsertQueryBuilder<Entity> extends QueryBuilder<Entity> {
                     //     expression += subQuery;
 
                     } else if (column.isDiscriminator) {
-                        this.expressionMap.nativeParameters["discriminator_value"] = this.expressionMap.mainAlias!.metadata.discriminatorValue;
-                        expression += this.connection.driver.createParameter("discriminator_value", parametersCount);
+                        this.expressionMap.nativeParameters["discriminator_value_" + parametersCount] = this.expressionMap.mainAlias!.metadata.discriminatorValue;
+                        expression += this.connection.driver.createParameter("discriminator_value_" + parametersCount, parametersCount);
                         parametersCount++;
                         // return "1";
 

--- a/test/github-issues/2253/entity/User.ts
+++ b/test/github-issues/2253/entity/User.ts
@@ -1,0 +1,17 @@
+import { ChildEntity, Column, Entity, PrimaryColumn, TableInheritance } from "../../../../src";
+
+@TableInheritance({ column: "type" })
+@Entity()
+export class User {
+  @PrimaryColumn()
+  id: number;
+
+  @Column()
+  type: string;
+}
+
+@ChildEntity("sub")
+export class SubUser extends User {
+  @Column()
+  anotherColumn: number;
+}

--- a/test/github-issues/2253/issue-2253.ts
+++ b/test/github-issues/2253/issue-2253.ts
@@ -1,0 +1,28 @@
+import {Connection} from "../../../src";
+import {closeTestingConnections, createTestingConnections, reloadTestingDatabases} from "../../utils/test-utils";
+import {SubUser} from "./entity/User";
+import {expect} from "chai";
+
+describe("github issues > #2253 - inserting multiple child entities fails", () => {
+
+    let connections: Connection[];
+
+    before(async () => connections = await createTestingConnections({
+        entities: [__dirname + "/entity/*{.js,.ts}"],
+        schemaCreate: true,
+        dropSchema: true
+    }));
+    beforeEach(() => reloadTestingDatabases(connections));
+    after(() => closeTestingConnections(connections));
+
+  it("should be able to save multiple child entities", () => Promise.all(connections.map(async connection => {
+    const user1 = new SubUser();
+    user1.id = 1;
+    const user2 = new SubUser();
+    user2.id = 2;
+    await connection.manager.save([user1, user2]);
+    const users = connection.getRepository(SubUser);
+    expect(await users.count()).to.eql(2);
+  })));
+});
+


### PR DESCRIPTION
Currently, saving multiple child entities together results in failure, due to a name collision between the parameter supplied to specify the entity type (`discriminator_value`).  This commit makes the parameter name unique (`discriminator_value_NNN`) in order to avoid that collision and allow insertion of multiple child entities to succeed.

See #2253 for examples of the problem.  Fixes #2253.
