### PR TITLE
Prevent errors when synchronizing Sqlite or MSSql DBs with `simple-enum` types

### DIFF
--- a/src/driver/sqlite-abstract/AbstractSqliteQueryRunner.ts
+++ b/src/driver/sqlite-abstract/AbstractSqliteQueryRunner.ts
@@ -815,16 +815,6 @@ export abstract class AbstractSqliteQueryRunner extends BaseQueryRunner implemen
                     tableColumn.generationStrategy = "increment";
                 }
 
-                if (tableColumn.type === "varchar") {
-                    // Check if this is an enum
-                    const enumMatch = sql.match(new RegExp("\"(" + tableColumn.name + ")\" varchar CHECK\\s*\\(\\s*\\1\\s+IN\\s*\\(('[^']+'(?:\\s*,\\s*'[^']+')+)\\s*\\)\\s*\\)"));
-                    if (enumMatch) {
-                        // This is an enum
-                        tableColumn.type = "simple-enum";
-                        tableColumn.enum = enumMatch[2].substr(1, enumMatch[2].length - 2).split("','");
-                    }
-                }
-
                 // parse datatype and attempt to retrieve length
                 let pos = tableColumn.type.indexOf("(");
                 if (pos !== -1) {

--- a/src/driver/sqlserver/SqlServerQueryRunner.ts
+++ b/src/driver/sqlserver/SqlServerQueryRunner.ts
@@ -1651,28 +1651,6 @@ export class SqlServerQueryRunner extends BaseQueryRunner implements QueryRunner
                             tableColumn.scale = dbColumn["NUMERIC_SCALE"];
                     }
 
-                    if (tableColumn.type === "nvarchar") {
-                        // Check if this is an enum
-                        const columnCheckConstraints = columnConstraints.filter(constraint => constraint["CONSTRAINT_TYPE"] === "CHECK");
-                        if (columnCheckConstraints.length) {
-                            const isEnumRegexp = new RegExp("^\\(\\[" + tableColumn.name + "\\]='[^']+'(?: OR \\[" + tableColumn.name + "\\]='[^']+')*\\)$");
-                            for (const checkConstraint of columnCheckConstraints) {
-                                if (isEnumRegexp.test(checkConstraint["definition"])) {
-                                    // This is an enum constraint, make column into an enum
-                                    tableColumn.type = "simple-enum";
-                                    tableColumn.enum = [];
-                                    const enumValueRegexp = new RegExp("\\[" + tableColumn.name + "\\]='([^']+)'", "g");
-                                    let result;
-                                    while ((result = enumValueRegexp.exec(checkConstraint["definition"])) !== null) {
-                                        tableColumn.enum.unshift(result[1]);
-                                    }
-                                    // Skip other column constraints
-                                    break;
-                                }
-                            }
-                        }
-                    }
-
                     tableColumn.default = dbColumn["COLUMN_DEFAULT"] !== null && dbColumn["COLUMN_DEFAULT"] !== undefined
                         ? this.removeParenthesisFromDefault(dbColumn["COLUMN_DEFAULT"])
                         : undefined;

--- a/test/functional/database-schema/column-types/mssql/column-types-mssql.ts
+++ b/test/functional/database-schema/column-types/mssql/column-types-mssql.ts
@@ -155,11 +155,11 @@ describe("database schema > column types > mssql", () => { // https://github.com
         table!.findColumnByName("geometry1")!.type.should.be.equal("geometry");
         table!.findColumnByName("simpleArray")!.type.should.be.equal("ntext");
         table!.findColumnByName("simpleJson")!.type.should.be.equal("ntext");
-        table!.findColumnByName("simpleEnum")!.type.should.be.equal("simple-enum");
+        table!.findColumnByName("simpleEnum")!.type.should.be.equal("nvarchar");
         table!.findColumnByName("simpleEnum")!.enum![0].should.be.equal("A");
         table!.findColumnByName("simpleEnum")!.enum![1].should.be.equal("B");
         table!.findColumnByName("simpleEnum")!.enum![2].should.be.equal("C");
-        table!.findColumnByName("simpleClassEnum1")!.type.should.be.equal("simple-enum");
+        table!.findColumnByName("simpleClassEnum1")!.type.should.be.equal("nvarchar");
         table!.findColumnByName("simpleClassEnum1")!.enum![0].should.be.equal("apple");
         table!.findColumnByName("simpleClassEnum1")!.enum![1].should.be.equal("pineapple");
         table!.findColumnByName("simpleClassEnum1")!.enum![2].should.be.equal("banana");

--- a/test/functional/database-schema/column-types/mssql/column-types-mssql.ts
+++ b/test/functional/database-schema/column-types/mssql/column-types-mssql.ts
@@ -156,13 +156,7 @@ describe("database schema > column types > mssql", () => { // https://github.com
         table!.findColumnByName("simpleArray")!.type.should.be.equal("ntext");
         table!.findColumnByName("simpleJson")!.type.should.be.equal("ntext");
         table!.findColumnByName("simpleEnum")!.type.should.be.equal("nvarchar");
-        table!.findColumnByName("simpleEnum")!.enum![0].should.be.equal("A");
-        table!.findColumnByName("simpleEnum")!.enum![1].should.be.equal("B");
-        table!.findColumnByName("simpleEnum")!.enum![2].should.be.equal("C");
         table!.findColumnByName("simpleClassEnum1")!.type.should.be.equal("nvarchar");
-        table!.findColumnByName("simpleClassEnum1")!.enum![0].should.be.equal("apple");
-        table!.findColumnByName("simpleClassEnum1")!.enum![1].should.be.equal("pineapple");
-        table!.findColumnByName("simpleClassEnum1")!.enum![2].should.be.equal("banana");
 
     })));
 

--- a/test/functional/database-schema/column-types/sqlite/column-types-sqlite.ts
+++ b/test/functional/database-schema/column-types/sqlite/column-types-sqlite.ts
@@ -128,11 +128,11 @@ describe("database schema > column types > sqlite", () => {
         table!.findColumnByName("datetime")!.type.should.be.equal("datetime");
         table!.findColumnByName("simpleArray")!.type.should.be.equal("text");
         table!.findColumnByName("simpleJson")!.type.should.be.equal("text");
-        table!.findColumnByName("simpleEnum")!.type.should.be.equal("simple-enum");
+        table!.findColumnByName("simpleEnum")!.type.should.be.equal("varchar");
         table!.findColumnByName("simpleEnum")!.enum![0].should.be.equal("A");
         table!.findColumnByName("simpleEnum")!.enum![1].should.be.equal("B");
         table!.findColumnByName("simpleEnum")!.enum![2].should.be.equal("C");
-        table!.findColumnByName("simpleClassEnum1")!.type.should.be.equal("simple-enum");
+        table!.findColumnByName("simpleClassEnum1")!.type.should.be.equal("varchar");
         table!.findColumnByName("simpleClassEnum1")!.enum![0].should.be.equal("apple");
         table!.findColumnByName("simpleClassEnum1")!.enum![1].should.be.equal("pineapple");
         table!.findColumnByName("simpleClassEnum1")!.enum![2].should.be.equal("banana");

--- a/test/functional/database-schema/column-types/sqlite/column-types-sqlite.ts
+++ b/test/functional/database-schema/column-types/sqlite/column-types-sqlite.ts
@@ -129,13 +129,7 @@ describe("database schema > column types > sqlite", () => {
         table!.findColumnByName("simpleArray")!.type.should.be.equal("text");
         table!.findColumnByName("simpleJson")!.type.should.be.equal("text");
         table!.findColumnByName("simpleEnum")!.type.should.be.equal("varchar");
-        table!.findColumnByName("simpleEnum")!.enum![0].should.be.equal("A");
-        table!.findColumnByName("simpleEnum")!.enum![1].should.be.equal("B");
-        table!.findColumnByName("simpleEnum")!.enum![2].should.be.equal("C");
         table!.findColumnByName("simpleClassEnum1")!.type.should.be.equal("varchar");
-        table!.findColumnByName("simpleClassEnum1")!.enum![0].should.be.equal("apple");
-        table!.findColumnByName("simpleClassEnum1")!.enum![1].should.be.equal("pineapple");
-        table!.findColumnByName("simpleClassEnum1")!.enum![2].should.be.equal("banana");
 
     })));
 


### PR DESCRIPTION
**Issue type:**

[ ] question
[x] bug report
[ ] feature request
[ ] documentation issue

**Database system/driver:**

[ ] `cordova`
[ ] `mongodb`
[ ] `mssql`
[ ] `mysql` / `mariadb`
[ ] `oracle`
[ ] `postgres`
[ ] `cockroachdb`
[x] `sqlite`
[ ] `sqljs`
[ ] `react-native`
[ ] `expo`

**TypeORM version:**

[x] `latest`
[ ] `@next`
[ ] `0.x.x` (or put your version here)

**Steps to reproduce:**

I tried to use the new (and **undocumented**) `simple-enum` type with sqlite. I'm surprised to see that Typeorm is able to synchronize only once when the table hasn't been created yet. Once the table has been created, synchronizing throws with the following error message:
```
{ QueryFailedError: SQLITE_ERROR: near "-": syntax error
    at new QueryFailedError (/home/louisremi/Workspace/monbelappart/src/error/QueryFailedError.ts:9:9)
    at handler (/home/louisremi/Workspace/monbelappart/src/driver/sqlite/SqliteQueryRunner.ts:53:26)
    at replacement (/home/louisremi/Workspace/monbelappart/node_modules/sqlite3/lib/trace.js:19:31)
    at Statement.errBack (/home/louisremi/Workspace/monbelappart/node_modules/sqlite3/lib/sqlite3.js:16:21)
  message: 'SQLITE_ERROR: near "-": syntax error',
  errno: 1,
  code: 'SQLITE_ERROR',
  name: 'QueryFailedError',
  query: 'CREATE TABLE "temporary_room" ("id" varchar PRIMARY KEY NOT NULL, "reference" varchar NOT NULL, "name" varchar NOT NULL, "floorArea" integer NOT NULL, "status" simple-enum CHECK( status IN (\'draft\',\'active\',\'maintenance\',\'archived\',\'deleted\') ) NOT NULL DEFAULT (\'draft\'), "createdAt" datetime NOT NULL DEFAULT (datetime(\'now\')), "updatedAt" datetime NOT NULL DEFAULT (datetime(\'now\')), CONSTRAINT "UQ_8c1de74045cb8a30adbb6614f7c" UNIQUE ("reference"))',
  parameters: [] }
```
I am a complete noob with Typeorm, but from poking around the source code, here's what I'm guessing is going wrong:
- at some point [`loadTables`](https://github.com/typeorm/typeorm/blob/63d993b1ef9f68a6e12bd535ac8ca8be39702502/src/driver/sqlite-abstract/AbstractSqliteQueryRunner.ts#L754) is executed to detect a difference between the entity and the actual Table layout.
- for some reason, the person who added simple-enum support wanted `loadTables()` to return `simple-enum` instead of the actual `varchar` type that was used when creating the table in sqlite, see https://github.com/typeorm/typeorm/blob/63d993b1ef9f68a6e12bd535ac8ca8be39702502/src/driver/sqlite-abstract/AbstractSqliteQueryRunner.ts#L818 This code block is troubling because there is no such "inverse conversion" for other `simple-*` types such as `simple-json` and `simple-array`
- because of this, two problems happen: Typeorm incorrectly detects a difference between the entity and the table layout, so it tries to recreate the table… and this time uses `simple-enum` as the column type in the query, which causes the above error.

I removed the "inverse conversion" code blocks in both Sqlite and MSSql query runners, and I removed the tests that were expecting `findColumnByName` to return the entity definition instead of the actual table layout. Again, the reason I did this is because the implementation and tests of `simple-array` and `simple-json` don't have this behavior and assertions… and also because using `simple-enum` only appears to work in sqlite when I remove this code.

I'm willing to add documentation for simple-enum to this PR if you are OK with the proposed changes.