### PR TITLE
Add UUID type for primary generated column

### DIFF
--- a/src/driver/types/ColumnTypes.ts
+++ b/src/driver/types/ColumnTypes.ts
@@ -14,7 +14,8 @@ export type PrimaryGeneratedColumnType = "int" // mysql, mssql, oracle, sqlite
     |"decimal" // mysql, postgres, mssql, sqlite
     |"fixed" // mysql
     |"numeric" // postgres, mssql, sqlite
-    |"number"; // oracle
+    |"number" // oracle
+    |"uuid"; // postgres
 
 /**
  * Column types where spatial properties are used.


### PR DESCRIPTION
#284 ensured TypeORM will support UUID primary generation; this PR adds `"uuid"` to the appropriate type