### PR TITLE
sqlite date hydration is susceptible to corruption #3949

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ feel free to ask us and community.
 * revert changes from [#3814](https://github.com/typeorm/typeorm/pull/3814) ([#3828](https://github.com/typeorm/typeorm/pull/3828))
 * fix performance issue when inserting into raw tables with QueryBuilder
   ([#3931](https://github.com/typeorm/typeorm/issues/3931))
+* sqlite date hydration is susceptible to corruption ([#3949](https://github.com/typeorm/typeorm/issues/3949))
 
 ### Features
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "typeorm",
-  "version": "0.2.15",
+  "version": "0.2.16",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/src/driver/sqlite-abstract/AbstractSqliteDriver.ts
+++ b/src/driver/sqlite-abstract/AbstractSqliteDriver.ts
@@ -286,7 +286,18 @@ export abstract class AbstractSqliteDriver implements Driver {
              * https://www.w3.org/TR/NOTE-datetime
              */
             if (value && typeof value === "string") {
-                value = value.replace(" ", "T") + "Z";
+                // There are various valid time string formats a sqlite time string might have:
+                // https://www.sqlite.org/lang_datefunc.html
+                // There are two separate fixes we may need to do:
+                //   1) Add 'T' separator if space is used instead
+                //   2) Add 'Z' UTC suffix if no timezone or offset specified
+
+                if (/^\d\d\d\d-\d\d-\d\d \d\d:\d\d/.test(value)) {
+                    value = value.replace(" ", "T");
+                }
+                if (/^\d\d\d\d-\d\d-\d\dT\d\d:\d\d(:\d\d(\.\d\d\d)?)?$/.test(value)) {
+                    value += "Z";
+                }
             }
 
             value = DateUtils.normalizeHydratedDate(value);

--- a/test/github-issues/3949/entity/Post.ts
+++ b/test/github-issues/3949/entity/Post.ts
@@ -1,0 +1,14 @@
+import {Entity} from "../../../../src/decorator/entity/Entity";
+import {Column} from "../../../../src/decorator/columns/Column";
+import {PrimaryColumn} from "../../../../src/decorator/columns/PrimaryColumn";
+
+@Entity()
+export class Post {
+
+    @PrimaryColumn()
+    id: number;
+
+    @Column()
+    date!: Date;
+
+}

--- a/test/github-issues/3949/issue-3949.ts
+++ b/test/github-issues/3949/issue-3949.ts
@@ -1,0 +1,39 @@
+import "reflect-metadata";
+import {Connection} from "../../../src/connection/Connection";
+import {closeTestingConnections, createTestingConnections, reloadTestingDatabases} from "../../utils/test-utils";
+import {Post} from "./entity/Post";
+
+describe("github issues > #3949 sqlite date hydration is susceptible to corruption", () => {
+
+    let connections: Connection[];
+    before(async () => {
+        connections = await createTestingConnections({
+            entities: [__dirname + "/entity/*{.js,.ts}"],
+            schemaCreate: true,
+            dropSchema: true,
+            enabledDrivers: ["sqlite", "sqljs"],
+        });
+    });
+    beforeEach(() => reloadTestingDatabases(connections));
+    after(() => closeTestingConnections(connections));
+
+    const testDateString = (sqlDateString: string, jsDateString: string) => async (connection: Connection) => {
+        const queryRunner = connection.createQueryRunner();
+        const repo = connection.getRepository(Post);
+
+        await queryRunner.query(`INSERT INTO "POST"("id", "date") VALUES (?, ?)`, [1, sqlDateString]);
+
+        const post = await repo.findOne(1);
+
+        post!.date.should.eql(new Date(jsDateString));
+    };
+
+    it("should correctly read date column that was inserted raw in canonical format", () =>
+        // Append UTC to javascript date string, because while sqlite assumes naive date strings are UTC,
+        // javascript assumes they are in local system time.
+        Promise.all(connections.map(testDateString("2018-03-14 02:33:33.906", "2018-03-14T02:33:33.906Z"))));
+
+    it("should correctly read date column that was inserted raw in iso 8601 format", () =>
+        Promise.all(connections.map(testDateString("2018-03-14T02:33:33.906+00:00", "2018-03-14T02:33:33.906Z"))));
+
+});


### PR DESCRIPTION
`AbstractSqliteDriver:prepareHydratedValue` should check for expected time string format before applying safari fixes.