### PR TITLE
[Postgres] Query runner generates wrong PK name (with custom schema)

### DIFF
--- a/src/driver/postgres/PostgresQueryRunner.ts
+++ b/src/driver/postgres/PostgresQueryRunner.ts
@@ -175,10 +175,8 @@ export class PostgresQueryRunner extends BaseQueryRunner implements QueryRunner 
 
                     if (err) {
                         this.driver.connection.logger.logQueryError(err, query, parameters, this);
-                        console.log("[ERROR]", query);
                         fail(new QueryFailedError(query, parameters, err));
                     } else {
-                        // console.log("[OK]", query);
                         switch (result.command) {
                             case "DELETE":
                                 // for DELETE query additionally return number of affected rows

--- a/test/github-issues/4063/entity/Post.ts
+++ b/test/github-issues/4063/entity/Post.ts
@@ -1,0 +1,14 @@
+import {Entity} from "../../../../src/decorator/entity/Entity";
+import {Column} from "../../../../src/decorator/columns/Column";
+import {PrimaryColumn} from "../../../../src/decorator/columns/PrimaryColumn";
+
+@Entity()
+export class Post {
+
+    @PrimaryColumn()
+    id: number;
+
+    @Column()
+    date!: Date;
+
+}

--- a/test/github-issues/4063/issue-4063.ts
+++ b/test/github-issues/4063/issue-4063.ts
@@ -1,0 +1,42 @@
+import "reflect-metadata";
+import {createTestingConnections, closeTestingConnections, reloadTestingDatabases} from "../../utils/test-utils";
+import {expect} from "chai";
+import {Connection} from "../../../src/connection/Connection";
+
+describe("github issues > #4063 [Postgres] Query runner generates wrong PK name (with custom schema)", () => {
+    let connections: Connection[];
+    before(async () => connections = await createTestingConnections({
+        enabledDrivers: ["postgres"],
+        entities: [__dirname + "/entity/*{.js,.ts}"],
+        schema: "custom",
+        schemaCreate: true
+    }));
+    beforeEach(() => reloadTestingDatabases(connections));
+    after(() => closeTestingConnections(connections));
+
+    it("should generate correct PK name", () => Promise.all(connections.map(async connection => {
+        const queryRunner = connection.createQueryRunner();
+
+        let table = await queryRunner.getTable("post");
+        const textColumn = table!.findColumnByName("id")!;
+        table!.findColumnByName("id")!.isPrimary.should.be.true;
+
+        const renamedTextColumn = textColumn!.clone();
+        renamedTextColumn.name = "extId";
+
+        await queryRunner.renameColumn(table!, textColumn, renamedTextColumn);
+
+        table = await queryRunner.getTable("post");
+        expect(table!.findColumnByName("id")).to.be.undefined;
+        table!.findColumnByName("extId")!.should.be.exist;
+        table!.findColumnByName("extId")!.isPrimary.should.be.true;
+
+        await queryRunner.executeMemoryDownSql();
+
+        table = await queryRunner.getTable("post");
+        expect(table!.findColumnByName("extId")).to.be.undefined;
+
+        await queryRunner.release();
+    })));
+
+});


### PR DESCRIPTION
*BUG report:* if you use a custom schema name, you will be not able to drop / rename / change your PK constraint. `typeorm` (latest stable version and `next`) doesn’t include schema name inside `createTableSql` method when it creates PKs, but it includes it inside other methods.
*Question here:*
1) If we will fix it inside `createTableSql`, this will fix an issue for new tables, but not for old ones. (`table.name = this.driver.buildTableName(table.name, _this.driver.options.schema);)`)
2) or we will fix it inside other methods (change / delete / update), so we will not use `schema` name for PK namingStrategy (`this.connection.namingStrategy.primaryKeyName(table.name, columnNames);`)