### PR TITLE
Add TYPEORM_MSSQL_ENCRYPT config environment variable

### DIFF
--- a/docs/using-ormconfig.md
+++ b/docs/using-ormconfig.md
@@ -131,6 +131,7 @@ List of available env variables you can set:
 * TYPEORM_CACHE_OPTIONS
 * TYPEORM_CACHE_ALWAYS_ENABLED
 * TYPEORM_CACHE_DURATION
+* TYPEORM_MSSQL_ENCRYPT
 
 `TYPEORM_CACHE` should be boolean or string of cache type
 

--- a/src/connection/options-reader/ConnectionOptionsEnvReader.ts
+++ b/src/connection/options-reader/ConnectionOptionsEnvReader.ts
@@ -46,7 +46,10 @@ export class ConnectionOptionsEnvReader {
                 subscribersDir: PlatformTools.getEnvVariable("TYPEORM_SUBSCRIBERS_DIR"),
             },
             cache: this.transformCaching(),
-            uuidExtension: PlatformTools.getEnvVariable("TYPEORM_UUID_EXTENSION")
+            uuidExtension: PlatformTools.getEnvVariable("TYPEORM_UUID_EXTENSION"),
+            options: {
+                encrypt: OrmUtils.toBoolean(PlatformTools.getEnvVariable("TYPEORM_MSSQL_ENCRYPT"))
+            }
         };
     }
 


### PR DESCRIPTION
Add option to enable encryption using environment variables when connecting to MSSQL in Azure. 