### PR TITLE
optimizing CI build times

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -23,12 +23,12 @@ jobs:
           POSTGRES_PASSWORD: "test"
           POSTGRES_DB: "test"
       - image: circleci/mongo:3.4.18
-      - image: mcr.microsoft.com/mssql/server:2017-GA-ubuntu
-        environment:
-          SA_PASSWORD: "Admin12345"
-          ACCEPT_EULA: "Y"
-      - image: cockroachdb/cockroach-unstable:latest
-        command: start --insecure
+      # - image: mcr.microsoft.com/mssql/server:2017-GA-ubuntu
+      #   environment:
+      #     SA_PASSWORD: "Admin12345"
+      #     ACCEPT_EULA: "Y"
+      # - image: cockroachdb/cockroach-unstable:latest
+      #   command: start --insecure
 
     steps:
       - checkout
@@ -43,7 +43,6 @@ jobs:
           - v1-dependencies-
 
       - run: npm install
-      - run: npm install sqlite3 --build-from-source
 
       - save_cache:
           paths:
@@ -51,7 +50,7 @@ jobs:
           key: v1-dependencies-{{ checksum "package.json" }}
 
       # - run: docker-compose up -d
-        
+
       # run tests
       - run: npm run lint
       - run: npm test

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,7 +18,6 @@ before_script:
   - sudo service postgresql stop
   - docker-compose up -d
   - cp ormconfig.travis.json ormconfig.json
-  - npm install sqlite3 --build-from-source
 
 script:
   - npm run lint


### PR DESCRIPTION
Removed steps no longer used from CI configs.

Right now circle CI test takes about [3 mins](https://circleci.com/gh/Kononnable/typeorm/18?utm_campaign=vcs-integration-link&utm_medium=referral&utm_source=github-build-link). We could enable mssql there, but it would double the time(so I'm not sure if we need it there). TravisCI still takes it time, but it tests each driver we currently test on CI.