### PR TITLE
Code coverage

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -54,6 +54,3 @@ jobs:
       # run tests
       - run: npm run lint
       - run: npm test
-
-      # run code coverage
-      - run: curl -s https://codecov.io/bash

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+.nyc_output/
 .DS_Store
 .vscode/
 .idea/

--- a/.travis.yml
+++ b/.travis.yml
@@ -23,5 +23,4 @@ script:
   - npx nyc npm test
 
 after_success:
-  - npx nyc report --reporter=json > coverage/coverage.json
   - bash <(curl -s https://codecov.io/bash)

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,3 @@
-sudo: required
 language: node_js
 node_js:
 #  - stable
@@ -21,7 +20,8 @@ before_script:
 
 script:
   - npm run lint
-  - npm test
+  - npx nyc npm test
 
 after_success:
+  - npx nyc report --reporter=json > coverage/coverage.json
   - bash <(curl -s https://codecov.io/bash)

--- a/package.json
+++ b/package.json
@@ -129,12 +129,16 @@
   "nyc": {
     "all": true,
     "cache": false,
+    "exclude": [
+      "**/*.d.ts"
+    ],
     "extension": [
       ".ts"
     ],
     "include": [
-      "src/**/*"
+      "build/compiled/src/**",
+      "src/**"
     ],
-    "reporter": "json"
+    "reporter":"json"
   }
 }

--- a/package.json
+++ b/package.json
@@ -125,5 +125,18 @@
     "type": "opencollective",
     "url": "https://opencollective.com/typeorm",
     "logo": "https://opencollective.com/opencollective/logo.txt"
+  },
+  "nyc": {
+    "extension": [
+      ".ts",
+      ".tsx"
+    ],
+    "exclude": [
+      "**/*.d.ts"
+    ],
+    "include": [
+      "src/**/*.ts"
+    ],
+    "all": true
   }
 }

--- a/package.json
+++ b/package.json
@@ -127,16 +127,14 @@
     "logo": "https://opencollective.com/opencollective/logo.txt"
   },
   "nyc": {
+    "all": true,
+    "cache": false,
     "extension": [
-      ".ts",
-      ".tsx"
-    ],
-    "exclude": [
-      "**/*.d.ts"
+      ".ts"
     ],
     "include": [
-      "src/**/*.ts"
+      "src/**/*"
     ],
-    "all": true
+    "reporter": "json"
   }
 }


### PR DESCRIPTION
Right now we've got coverage badge in readme, but it shows coverage status from quite some time ago. I've enabled code coverage only for TravisCI - no need to slow down CircleCI builds since it's not testing all of the drivers.
