### PR TITLE
Support orUpdate for SQLite

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ feel free to ask us and community.
 ### Features
 
 * deprecate column `readonly` option in favor of `update` and `insert` options ([#4035](https://github.com/typeorm/typeorm/pull/4035))
+* added support for `orUpdate` in SQLlite ([#4097](https://github.com/typeorm/typeorm/pull/4097))
 
 ## 0.2.17 (2019-05-01)
 

--- a/src/query-builder/InsertQueryBuilder.ts
+++ b/src/query-builder/InsertQueryBuilder.ts
@@ -249,7 +249,7 @@ export class InsertQueryBuilder<Entity> extends QueryBuilder<Entity> {
       if (statement && statement.overwrite instanceof Array) {
         if (this.connection.driver instanceof MysqlDriver) {
           this.expressionMap.onUpdate.overwrite = statement.overwrite.map(column => `${column} = VALUES(${column})`).join(", ");
-        } else if (this.connection.driver instanceof PostgresDriver) {
+        } else if (this.connection.driver instanceof PostgresDriver || this.connection.driver instanceof AbstractSqliteDriver) {
           this.expressionMap.onUpdate.overwrite = statement.overwrite.map(column => `${column} = EXCLUDED.${column}`).join(", ");
         }
       }

--- a/test/github-issues/4096/entity/User.ts
+++ b/test/github-issues/4096/entity/User.ts
@@ -1,0 +1,13 @@
+import { Entity, PrimaryColumn, Column } from "../../../../src";
+
+@Entity()
+export class User {
+  @PrimaryColumn()
+  email: string;
+
+  @PrimaryColumn()
+  username: string;
+
+  @Column()
+  bio: string;
+}

--- a/test/github-issues/4096/issue-4096.ts
+++ b/test/github-issues/4096/issue-4096.ts
@@ -1,0 +1,61 @@
+import "reflect-metadata";
+import {createTestingConnections, closeTestingConnections, reloadTestingDatabases} from "../../utils/test-utils";
+import {Connection} from "../../../src/connection/Connection";
+import {expect} from "chai";
+import {User} from "./entity/User";
+
+describe("github issues > #4096 SQLite support for orUpdate", () => {
+    let connections: Connection[];
+
+    before(async () => connections = await createTestingConnections({
+        entities: [User],
+        enabledDrivers: ["sqlite"],
+        schemaCreate: true,
+        dropSchema: true,
+    }));
+
+    beforeEach(() => reloadTestingDatabases(connections));
+
+    after(() => closeTestingConnections(connections));
+
+    const user1 = new User();
+    user1.email = "example@example.org";
+    user1.username = "example";
+    user1.bio = "My bio";
+
+    const user2 = new User();
+    user2.email = "example@example.org";
+    user2.username = "example";
+    user2.bio = "Updated bio";
+
+    it("should overwrite using current value in SQLite", () => Promise.all(connections.map(async connection => {
+      try {
+        const UserRepository = connection.manager.getRepository(User);
+
+        await UserRepository
+          .createQueryBuilder()
+          .insert()
+          .into(User)
+          .values(user1)
+          .execute();
+
+        await UserRepository
+          .createQueryBuilder()
+          .insert()
+          .into(User)
+          .values(user2)
+          .orUpdate({
+            conflict_target: [ "email", "username" ],
+            overwrite: ["bio"],
+          })
+          .execute();
+
+        const users = await UserRepository.find();
+        expect(users).not.to.be.undefined;
+        expect(users).to.have.lengthOf(1);
+        expect(users[0]).to.includes({ bio: "Updated bio" });
+      } catch (err) {
+        throw new Error(err);
+      }
+    })));
+ });

--- a/test/github-issues/4096/issue-4096.ts
+++ b/test/github-issues/4096/issue-4096.ts
@@ -18,18 +18,18 @@ describe("github issues > #4096 SQLite support for orUpdate", () => {
 
     after(() => closeTestingConnections(connections));
 
-    const user1 = new User();
-    user1.email = "example@example.org";
-    user1.username = "example";
-    user1.bio = "My bio";
-
-    const user2 = new User();
-    user2.email = "example@example.org";
-    user2.username = "example";
-    user2.bio = "Updated bio";
-
     it("should overwrite using current value in SQLite", () => Promise.all(connections.map(async connection => {
       try {
+        const user1 = new User();
+        user1.email = "example@example.org";
+        user1.username = "example";
+        user1.bio = "My bio";
+
+        const user2 = new User();
+        user2.email = "example@example.org";
+        user2.username = "example";
+        user2.bio = "Updated bio";
+
         const UserRepository = connection.manager.getRepository(User);
 
         await UserRepository

--- a/test/github-issues/4096/issue-4096.ts
+++ b/test/github-issues/4096/issue-4096.ts
@@ -19,43 +19,39 @@ describe("github issues > #4096 SQLite support for orUpdate", () => {
     after(() => closeTestingConnections(connections));
 
     it("should overwrite using current value in SQLite", () => Promise.all(connections.map(async connection => {
-      try {
-        const user1 = new User();
-        user1.email = "example@example.org";
-        user1.username = "example";
-        user1.bio = "My bio";
+      const user1 = new User();
+      user1.email = "example@example.org";
+      user1.username = "example";
+      user1.bio = "My bio";
 
-        const user2 = new User();
-        user2.email = "example@example.org";
-        user2.username = "example";
-        user2.bio = "Updated bio";
+      const user2 = new User();
+      user2.email = "example@example.org";
+      user2.username = "example";
+      user2.bio = "Updated bio";
 
-        const UserRepository = connection.manager.getRepository(User);
+      const UserRepository = connection.manager.getRepository(User);
 
-        await UserRepository
-          .createQueryBuilder()
-          .insert()
-          .into(User)
-          .values(user1)
-          .execute();
+      await UserRepository
+        .createQueryBuilder()
+        .insert()
+        .into(User)
+        .values(user1)
+        .execute();
 
-        await UserRepository
-          .createQueryBuilder()
-          .insert()
-          .into(User)
-          .values(user2)
-          .orUpdate({
-            conflict_target: [ "email", "username" ],
-            overwrite: ["bio"],
-          })
-          .execute();
+      await UserRepository
+        .createQueryBuilder()
+        .insert()
+        .into(User)
+        .values(user2)
+        .orUpdate({
+          conflict_target: [ "email", "username" ],
+          overwrite: ["bio"],
+        })
+        .execute();
 
-        const users = await UserRepository.find();
-        expect(users).not.to.be.undefined;
-        expect(users).to.have.lengthOf(1);
-        expect(users[0]).to.includes({ bio: "Updated bio" });
-      } catch (err) {
-        throw new Error(err);
-      }
+      const users = await UserRepository.find();
+      expect(users).not.to.be.undefined;
+      expect(users).to.have.lengthOf(1);
+      expect(users[0]).to.includes({ bio: "Updated bio" });
     })));
  });


### PR DESCRIPTION
#### Sumary

This PR adds support of `QueryBuilder`'s `orUpdate` for SQLite.

#### Issue

This closes issue #4096 


#### Background

In PR #3056, support for `ON CONFLICT` was added for MySQL and Postgres when using `orUpdate`, and in this PR #3190 support for Postgres `onConflict` was added for SQLite as they have the same syntax.


