### PR TITLE
feat: add support for DISTINCT queries

### DIFF
--- a/src/query-builder/QueryExpressionMap.ts
+++ b/src/query-builder/QueryExpressionMap.ts
@@ -47,6 +47,11 @@ export class QueryExpressionMap {
     selects: SelectQuery[] = [];
 
     /**
+     * Whether SELECT is DISTINCT.
+     */
+    selectDistinct: boolean = false;
+
+    /**
      * FROM-s to be selected.
      */
     // froms: { target: string, alias: string }[] = [];

--- a/src/query-builder/SelectQueryBuilder.ts
+++ b/src/query-builder/SelectQueryBuilder.ts
@@ -159,6 +159,14 @@ export class SelectQueryBuilder<Entity> extends QueryBuilder<Entity> implements 
     }
 
     /**
+     * Sets whether the selection is DISTINCT.
+     */
+    distinct(distinct: boolean = true): this {
+        this.expressionMap.selectDistinct = distinct;
+        return this;
+    }
+
+    /**
      * Specifies FROM which entity's table select/update/delete will be executed.
      * Also sets a main string alias of the selection data.
      * Removes all previously set from-s.
@@ -1400,8 +1408,9 @@ export class SelectQueryBuilder<Entity> extends QueryBuilder<Entity> implements 
 
                 return this.getTableName(alias.tablePath!) + " " + this.escape(alias.name);
             });
+        const select = "SELECT " + (this.expressionMap.selectDistinct ? "DISTINCT " : "");
         const selection = allSelects.map(select => select.selection + (select.aliasName ? " AS " + this.escape(select.aliasName) : "")).join(", ");
-        return "SELECT " + selection + " FROM " + froms.join(", ") + lock;
+        return select + selection + " FROM " + froms.join(", ") + lock;
     }
 
     /**

--- a/test/functional/query-builder/select/query-builder-select.ts
+++ b/test/functional/query-builder/select/query-builder-select.ts
@@ -27,6 +27,21 @@ describe("query builder > select", () => {
             "FROM post post");
     })));
 
+    it("should append all entity mapped columns from main selection to SELECT DISTINCT statement", () => Promise.all(connections.map(async connection => {
+        const sql = connection.manager.createQueryBuilder(Post, "post")
+            .distinct()
+            .disableEscaping()
+            .getSql();
+
+        expect(sql).to.equal("SELECT DISTINCT post.id AS post_id, " +
+            "post.title AS post_title, " +
+            "post.description AS post_description, " +
+            "post.rating AS post_rating, " +
+            "post.version AS post_version, " +
+            "post.categoryId AS post_categoryId " +
+            "FROM post post");
+    })));
+
     it("should append all entity mapped columns from both main selection and join selections to select statement", () => Promise.all(connections.map(async connection => {
         const sql = connection.createQueryBuilder(Post, "post")
             .leftJoinAndSelect("category", "category")


### PR DESCRIPTION
# Description

A bare-bones `DISTINCT` implementation that just supports standard SQL row-level `SELECT DISTINCT`, nothing fancy like PSQL's `DISTINCT ON` specific columns.

I've added support to the `QueryBuilder`, and also to `Repository#find` (via `JoinOptions`).

# Relevant Issues

Closes #2641 - _However_, there are users who have posted in that issue wanting two separate things `DISTINCT` (i.e. this PR) and `DISTINCT ON`, which is a (very useful) non-standard SQL extension that is unfortunately not covered by this PR. If this merges, I'd suggest opening another issue specifically to track `DISTINCT ON`. 

# Use Cases

The use-cases for this functionality in `QueryBuilder` is immediately obvious. However, the benefit to `Repository#find` probably warrants an example. 

e.g. A forum (User + Post models) and you want to get all users who have at least 1 post, but not load in their posts. This can be achieved by  `leftJoin` _without_ selecting, we specify `distinct: true` to ensure we don't load into memory duplicate rows (one for each user's post):

```typescript
const users = getRepository<User>(User).find({
	join: {
		alias: 'user',
		distinct: true,
		leftJoin: {
			post: 'user.posts',
		}
	},
	where: "user.id = post.user_id",
})
```
