### PR TITLE
Allow find() to accept more complex where clauses

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ feel free to ask us and community.
 ### Features
 
 * deprecate column `readonly` option in favor of `update` and `insert` options ([#4035](https://github.com/typeorm/typeorm/pull/4035))
+* added `WhereFactory` which can be passed to `Repository#find` to facilitate constructing more complex queries.
 
 ## 0.2.17 (2019-05-01)
 

--- a/src/find-options/FindOneOptions.ts
+++ b/src/find-options/FindOneOptions.ts
@@ -1,6 +1,7 @@
 import {JoinOptions} from "./JoinOptions";
 import {ObjectLiteral} from "../common/ObjectLiteral";
 import {FindConditions} from "./FindConditions";
+import {WhereFactory} from "../query-builder/WhereFactory";
 
 /**
  * Defines a special criteria to find specific entity.
@@ -13,9 +14,9 @@ export interface FindOneOptions<Entity = any> {
     select?: (keyof Entity)[];
 
     /**
-     * Simple condition that should be applied to match entities.
+     * Where condition that should be applied to match entities.
      */
-    where?: FindConditions<Entity>[]|FindConditions<Entity>|ObjectLiteral|string;
+    where?: FindConditions<Entity>[]|FindConditions<Entity>|ObjectLiteral|string|WhereFactory;
 
     /**
      * Indicates what relations of entity should be loaded (simplified left join form).

--- a/src/index.ts
+++ b/src/index.ts
@@ -129,6 +129,7 @@ export {UpdateQueryBuilder} from "./query-builder/UpdateQueryBuilder";
 export {RelationQueryBuilder} from "./query-builder/RelationQueryBuilder";
 export {Brackets} from "./query-builder/Brackets";
 export {WhereExpression} from "./query-builder/WhereExpression";
+export {WhereFactory} from "./query-builder/WhereFactory";
 export {InsertResult} from "./query-builder/result/InsertResult";
 export {UpdateResult} from "./query-builder/result/UpdateResult";
 export {DeleteResult} from "./query-builder/result/DeleteResult";

--- a/src/query-builder/Brackets.ts
+++ b/src/query-builder/Brackets.ts
@@ -1,21 +1,8 @@
-import {WhereExpression} from "./WhereExpression";
+import {WhereFactory} from "./WhereFactory";
 
 /**
  * Syntax sugar.
  * Allows to use brackets in WHERE expressions for better syntax.
  */
-export class Brackets {
-
-    /**
-     * WHERE expression that will be taken into brackets.
-     */
-    whereFactory: (qb: WhereExpression) => any;
-
-    /**
-     * Given WHERE query builder that will build a WHERE expression that will be taken into brackets.
-     */
-    constructor(whereFactory: (qb: WhereExpression) => any) {
-        this.whereFactory = whereFactory;
-    }
-
+export class Brackets extends WhereFactory {
 }

--- a/src/query-builder/QueryBuilder.ts
+++ b/src/query-builder/QueryBuilder.ts
@@ -19,6 +19,7 @@ import {OracleDriver} from "../driver/oracle/OracleDriver";
 import {EntitySchema} from "../";
 import {FindOperator} from "../find-options/FindOperator";
 import {In} from "../find-options/operator/In";
+import {WhereFactory} from "./WhereFactory";
 
 // todo: completely cover query builder with tests
 // todo: entityOrProperty can be target name. implement proper behaviour if it is.
@@ -723,16 +724,16 @@ export abstract class QueryBuilder<Entity> {
     /**
      * Computes given where argument - transforms to a where string all forms it can take.
      */
-    protected computeWhereParameter(where: string|((qb: this) => string)|Brackets|ObjectLiteral|ObjectLiteral[]) {
+    protected computeWhereParameter(where: string|((qb: this) => string)|WhereFactory|ObjectLiteral|ObjectLiteral[]) {
         if (typeof where === "string")
             return where;
 
-        if (where instanceof Brackets) {
+        if (where instanceof WhereFactory) {
             const whereQueryBuilder = this.createQueryBuilder();
             where.whereFactory(whereQueryBuilder as any);
             const whereString = whereQueryBuilder.createWhereExpressionString();
             this.setParameters(whereQueryBuilder.getParameters());
-            return whereString ? "(" + whereString + ")" : "";
+            return whereString ? (where instanceof Brackets ? "(" + whereString + ")" : whereString) : "";
 
         } else if (where instanceof Function) {
             return where(this);

--- a/src/query-builder/SelectQueryBuilder.ts
+++ b/src/query-builder/SelectQueryBuilder.ts
@@ -26,7 +26,6 @@ import {QueryExpressionMap} from "./QueryExpressionMap";
 import {ObjectType} from "../common/ObjectType";
 import {QueryRunner} from "../query-runner/QueryRunner";
 import {WhereExpression} from "./WhereExpression";
-import {Brackets} from "./Brackets";
 import {AbstractSqliteDriver} from "../driver/sqlite-abstract/AbstractSqliteDriver";
 import {QueryResultCacheOptions} from "../cache/QueryResultCacheOptions";
 import {OffsetWithoutLimitNotSupportedError} from "../error/OffsetWithoutLimitNotSupportedError";
@@ -34,6 +33,7 @@ import {BroadcasterResult} from "../subscriber/BroadcasterResult";
 import {SelectQueryBuilderOption} from "./SelectQueryBuilderOption";
 import {ObjectUtils} from "../util/ObjectUtils";
 import {DriverUtils} from "../driver/DriverUtils";
+import {WhereFactory} from "./WhereFactory";
 
 /**
  * Allows to build complex sql queries in a fashion way and execute those queries.
@@ -685,7 +685,7 @@ export class SelectQueryBuilder<Entity> extends QueryBuilder<Entity> implements 
      * calling this function will override previously set WHERE conditions.
      * Additionally you can add parameters used in where expression.
      */
-    where(where: Brackets|string|((qb: this) => string)|ObjectLiteral|ObjectLiteral[], parameters?: ObjectLiteral): this {
+    where(where: WhereFactory|string|((qb: this) => string)|ObjectLiteral|ObjectLiteral[], parameters?: ObjectLiteral): this {
         this.expressionMap.wheres = []; // don't move this block below since computeWhereParameter can add where expressions
         const condition = this.computeWhereParameter(where);
         if (condition)
@@ -699,7 +699,7 @@ export class SelectQueryBuilder<Entity> extends QueryBuilder<Entity> implements 
      * Adds new AND WHERE condition in the query builder.
      * Additionally you can add parameters used in where expression.
      */
-    andWhere(where: string|Brackets|((qb: this) => string), parameters?: ObjectLiteral): this {
+    andWhere(where: string|WhereFactory|((qb: this) => string), parameters?: ObjectLiteral): this {
         this.expressionMap.wheres.push({ type: "and", condition: this.computeWhereParameter(where) });
         if (parameters) this.setParameters(parameters);
         return this;
@@ -709,7 +709,7 @@ export class SelectQueryBuilder<Entity> extends QueryBuilder<Entity> implements 
      * Adds new OR WHERE condition in the query builder.
      * Additionally you can add parameters used in where expression.
      */
-    orWhere(where: Brackets|string|((qb: this) => string), parameters?: ObjectLiteral): this {
+    orWhere(where: WhereFactory|string|((qb: this) => string), parameters?: ObjectLiteral): this {
         this.expressionMap.wheres.push({ type: "or", condition: this.computeWhereParameter(where) });
         if (parameters) this.setParameters(parameters);
         return this;

--- a/src/query-builder/UpdateQueryBuilder.ts
+++ b/src/query-builder/UpdateQueryBuilder.ts
@@ -6,7 +6,6 @@ import {QueryRunner} from "../query-runner/QueryRunner";
 import {SqlServerDriver} from "../driver/sqlserver/SqlServerDriver";
 import {PostgresDriver} from "../driver/postgres/PostgresDriver";
 import {WhereExpression} from "./WhereExpression";
-import {Brackets} from "./Brackets";
 import {EntityMetadata} from "../metadata/EntityMetadata";
 import {UpdateResult} from "./result/UpdateResult";
 import {ReturningStatementNotSupportedError} from "../error/ReturningStatementNotSupportedError";
@@ -21,6 +20,7 @@ import {OracleDriver} from "../driver/oracle/OracleDriver";
 import {UpdateValuesMissingError} from "../error/UpdateValuesMissingError";
 import {EntityColumnNotFound} from "../error/EntityColumnNotFound";
 import {QueryDeepPartialEntity} from "./QueryPartialEntity";
+import {WhereFactory} from "./WhereFactory";
 
 /**
  * Allows to build complex sql queries in a fashion way and execute those queries.
@@ -143,7 +143,7 @@ export class UpdateQueryBuilder<Entity> extends QueryBuilder<Entity> implements 
      * calling this function will override previously set WHERE conditions.
      * Additionally you can add parameters used in where expression.
      */
-    where(where: string|((qb: this) => string)|Brackets|ObjectLiteral|ObjectLiteral[], parameters?: ObjectLiteral): this {
+    where(where: string|((qb: this) => string)|WhereFactory|ObjectLiteral|ObjectLiteral[], parameters?: ObjectLiteral): this {
         this.expressionMap.wheres = []; // don't move this block below since computeWhereParameter can add where expressions
         const condition = this.computeWhereParameter(where);
         if (condition)
@@ -157,7 +157,7 @@ export class UpdateQueryBuilder<Entity> extends QueryBuilder<Entity> implements 
      * Adds new AND WHERE condition in the query builder.
      * Additionally you can add parameters used in where expression.
      */
-    andWhere(where: string|((qb: this) => string)|Brackets, parameters?: ObjectLiteral): this {
+    andWhere(where: string|((qb: this) => string)|WhereFactory, parameters?: ObjectLiteral): this {
         this.expressionMap.wheres.push({ type: "and", condition: this.computeWhereParameter(where) });
         if (parameters) this.setParameters(parameters);
         return this;
@@ -167,7 +167,7 @@ export class UpdateQueryBuilder<Entity> extends QueryBuilder<Entity> implements 
      * Adds new OR WHERE condition in the query builder.
      * Additionally you can add parameters used in where expression.
      */
-    orWhere(where: string|((qb: this) => string)|Brackets, parameters?: ObjectLiteral): this {
+    orWhere(where: string|((qb: this) => string)|WhereFactory, parameters?: ObjectLiteral): this {
         this.expressionMap.wheres.push({ type: "or", condition: this.computeWhereParameter(where) });
         if (parameters) this.setParameters(parameters);
         return this;

--- a/src/query-builder/WhereFactory.ts
+++ b/src/query-builder/WhereFactory.ts
@@ -1,0 +1,17 @@
+import {WhereExpression} from "./WhereExpression";
+
+export class WhereFactory {
+
+    /**
+     * Executed to allow the factory to build a WHERE expression with the provided query builder.
+     */
+    whereFactory: (qb: WhereExpression) => any;
+
+    /**
+     * Given a factory that can build a WHERE expression using a query builder.
+     */
+    constructor(whereFactory: (qb: WhereExpression) => any) {
+        this.whereFactory = whereFactory;
+    }
+
+}


### PR DESCRIPTION
# Description

I've introduced a new class called `WhereFactory` whose implementation is identical to that of the existing `Brackets`, it only varies in semantics i.e. `QueryBuilder` won't insert brackets around a `WHERE` clause generated by a `WhereFactory`.

`Brackets` now inherits from `WhereFactory` and defines no additional functionality of its own, it's purely semantic i.e. `QueryBuilder` _will_ put brackets around a `WHERE` clause generated by `Brackets`.

Any APIs that took `Brackets` now take `WhereFactory`, meaning they'll continue to accept `Brackets` in addition to `WhereFactory`, so the API changes are non-breaking / backward compatible.

# Motivation

Simply put, more elaborate `WHERE` clauses returning entities - not just for type safety, but also to leverage functionality like eager loading.

With this PR we now support (to my knowledge) _all_ possible `WHERE` conditions when using `find`; including brackets, sub-queries, combinations of string and object literal (property) conditions etc.

e.g. Here we load user entities, eager load in their posts, but restrict to:

* User's that _have posts_ (no users with zero posts).
* If the _current user_ isn't an admin, we chain (AND) in the condition:
   - Only consider public posts, OR,
   - Posts made by friends.

```typescript
function findAccessibleUserPosts(user : User): Promise<User[]> {
	return getRepository<User>(User).find({
		join: {
			alias: 'user',
			leftJoinAndSelect: {
				post: 'user.posts',
			}
		},
		where: new WhereFactory((qb: WhereExpression) => {
			qb.where("user.id = post.user_id")

			if (user.role !== Role.admin) {
				qb.andWhere(new Brackets(qb => {
						qb.where("post.public = true"})
							.orWhereInIds(user.friendIds)
					}
				))

			}
		}),
	})
}
```

which would spit out something _like_ the following:

`WHERE "user"."id" = post.user_id AND (post.public = true OR "user"."id" IN (?, ?, ?))` 