### PR TITLE
fix: handle hydration of uncommon datetime formats in sqlite

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ feel free to ask us and community.
 
 ## 0.2.18 (UNRELEASED)
 
+### Bug fixes
+
+* fixed Sqlite hydration of uncommon datetime formats ([#4114](https://github.com/typeorm/typeorm/pull/4114))
+
 ### Features
 
 * deprecate column `readonly` option in favor of `update` and `insert` options ([#4035](https://github.com/typeorm/typeorm/pull/4035))

--- a/src/driver/sqlite-abstract/AbstractSqliteDriver.ts
+++ b/src/driver/sqlite-abstract/AbstractSqliteDriver.ts
@@ -289,10 +289,15 @@ export abstract class AbstractSqliteDriver implements Driver {
             if (value && typeof value === "string") {
                 // There are various valid time string formats a sqlite time string might have:
                 // https://www.sqlite.org/lang_datefunc.html
-                // There are two separate fixes we may need to do:
-                //   1) Add 'T' separator if space is used instead
-                //   2) Add 'Z' UTC suffix if no timezone or offset specified
-
+                // There are three separate fixes we may need to do:
+                //   1) Remove spaces between the time and the timezone if any
+                //      (Sequelize serializes dates this way)
+                //   2) Add 'T' separator if space is used instead so that Safari
+                //      (and iOS WKWebView) is able to parse it
+                //   3) Add 'Z' UTC suffix if no timezone or offset specified
+                if (/ (Z|[+-]\d\d:\d\d)$/.test(value)) {
+                    value = value.replace(/ +(Z|[+-]\d\d:\d\d)$/, "$1");
+                }
                 if (/^\d\d\d\d-\d\d-\d\d \d\d:\d\d/.test(value)) {
                     value = value.replace(" ", "T");
                 }

--- a/test/functional/database-schema/column-types/sqlite/column-types-sqlite.ts
+++ b/test/functional/database-schema/column-types/sqlite/column-types-sqlite.ts
@@ -1,6 +1,5 @@
 import "reflect-metadata";
 import {Post} from "./entity/Post";
-import {getManager} from "../../../../../src";
 import {Connection} from "../../../../../src/connection/Connection";
 import {closeTestingConnections, createTestingConnections, reloadTestingDatabases} from "../../../../utils/test-utils";
 import {PostWithoutTypes} from "./entity/PostWithoutTypes";
@@ -172,11 +171,11 @@ describe("database schema > column types > sqlite", () => {
     })));
 
     it("unconventional datetime formats should be hydrated correctly", () => Promise.all(connections.map(async connection => {
-        const manager = getManager();
         const postRepository = connection.getRepository(Post);
+        const queryRunner = connection.createQueryRunner();
         const expectedDatetime = new Date("2001-02-03T04:45:56Z");
 
-        await manager.query(
+        await queryRunner.query(
             "INSERT INTO post(id, datetime) VALUES(?, ?), (?, ?)",
             [1, "2001-02-03 04:45:56", 2, "2001-02-03T05:45:56 +01:00"]
         );

--- a/test/functional/database-schema/column-types/sqlite/column-types-sqlite.ts
+++ b/test/functional/database-schema/column-types/sqlite/column-types-sqlite.ts
@@ -174,7 +174,7 @@ describe("database schema > column types > sqlite", () => {
     it("unconventional datetime formats should be hydrated correctly", () => Promise.all(connections.map(async connection => {
         const postRepository = connection.getRepository(PostWithDateOnly);
         const queryRunner = connection.createQueryRunner();
-        const expectedDatetime = new Date("2001-02-03T04:45:56Z");
+        const expectedDatetimeValue = new Date("2001-02-03T04:45:56Z").valueOf();
 
         await queryRunner.query(
             "INSERT INTO post_with_date_only(id, datetime) VALUES(?, ?), (?, ?)",
@@ -184,7 +184,7 @@ describe("database schema > column types > sqlite", () => {
         const loadedPost1 = (await postRepository.findOne(1))!;
         const loadedPost2 = (await postRepository.findOne(2))!;
 
-        loadedPost1.datetime.should.be.equal(expectedDatetime);
-        loadedPost2.datetime.should.be.equal(expectedDatetime);
+        loadedPost1.datetime.valueOf().should.be.equal(expectedDatetimeValue);
+        loadedPost2.datetime.valueOf().should.be.equal(expectedDatetimeValue);
     })));
 });

--- a/test/functional/database-schema/column-types/sqlite/column-types-sqlite.ts
+++ b/test/functional/database-schema/column-types/sqlite/column-types-sqlite.ts
@@ -1,8 +1,9 @@
 import "reflect-metadata";
-import {Post} from "./entity/Post";
 import {Connection} from "../../../../../src/connection/Connection";
 import {closeTestingConnections, createTestingConnections, reloadTestingDatabases} from "../../../../utils/test-utils";
+import {Post} from "./entity/Post";
 import {PostWithoutTypes} from "./entity/PostWithoutTypes";
+import {PostWithDateOnly} from "./entity/PostWithDateOnly";
 import {FruitEnum} from "./enum/FruitEnum";
 
 describe("database schema > column types > sqlite", () => {
@@ -171,7 +172,7 @@ describe("database schema > column types > sqlite", () => {
     })));
 
     it("unconventional datetime formats should be hydrated correctly", () => Promise.all(connections.map(async connection => {
-        const postRepository = connection.getRepository(Post);
+        const postRepository = connection.getRepository(PostWithDateOnly);
         const queryRunner = connection.createQueryRunner();
         const expectedDatetime = new Date("2001-02-03T04:45:56Z");
 

--- a/test/functional/database-schema/column-types/sqlite/column-types-sqlite.ts
+++ b/test/functional/database-schema/column-types/sqlite/column-types-sqlite.ts
@@ -177,7 +177,7 @@ describe("database schema > column types > sqlite", () => {
         const expectedDatetime = new Date("2001-02-03T04:45:56Z");
 
         await queryRunner.query(
-            "INSERT INTO post(id, datetime) VALUES(?, ?), (?, ?)",
+            "INSERT INTO post_with_date_only(id, datetime) VALUES(?, ?), (?, ?)",
             [1, "2001-02-03 04:45:56", 2, "2001-02-03T05:45:56 +01:00"]
         );
 

--- a/test/functional/database-schema/column-types/sqlite/column-types-sqlite.ts
+++ b/test/functional/database-schema/column-types/sqlite/column-types-sqlite.ts
@@ -186,5 +186,5 @@ describe("database schema > column types > sqlite", () => {
 
         loadedPost1.datetime.should.be.equal(expectedDatetime);
         loadedPost2.datetime.should.be.equal(expectedDatetime);
-    });
+    })));
 });

--- a/test/functional/database-schema/column-types/sqlite/entity/PostWithDateOnly.ts
+++ b/test/functional/database-schema/column-types/sqlite/entity/PostWithDateOnly.ts
@@ -1,0 +1,14 @@
+import {Entity} from "../../../../../../src/decorator/entity/Entity";
+import {PrimaryColumn} from "../../../../../../src/decorator/columns/PrimaryColumn";
+import {Column} from "../../../../../../src/decorator/columns/Column";
+
+@Entity()
+export class PostWithDateOnly {
+
+    @PrimaryColumn()
+    id: number;
+
+    @Column()
+    datetime: Date;
+
+}


### PR DESCRIPTION
Sequelize uses an uncommon format for datetime in Sqlite: `'YYYY-MM-DD HH:mm:ss.SSS Z'` (see [dataTypes.js](https://github.com/sequelize/sequelize/blob/7445423b9effc212e125d76d58e02713e808ffc6/lib/data-types.js#L467)). It's uncommon because it has a space instead of a T between the date and the time, and a space is inserted before the timezone. The change I am proposing allows properly hydrating those datetimes, instead of returning `Date { Invalid }` objects.

I also suggest removing the [comment block on line 280](https://github.com/monbelappart/typeorm/blob/fcfa5b91378005bada8b81d881931d7d6407c41f/src/driver/sqlite-abstract/AbstractSqliteDriver.ts#L280) as its content is mostly redundant with the comment section on line 290. Let me know if you agree and I will push that change as well.