### PR TITLE
Allow join relation alias override from naming strategies

### DIFF
--- a/src/find-options/FindOptionsUtils.ts
+++ b/src/find-options/FindOptionsUtils.ts
@@ -234,7 +234,7 @@ export class FindOptionsUtils {
 
     public static joinEagerRelations(qb: SelectQueryBuilder<any>, alias: string, metadata: EntityMetadata) {
         metadata.eagerRelations.forEach(relation => {
-            const relationAlias = alias + "_" + relation.propertyPath.replace(".", "_");
+            const relationAlias = qb.connection.namingStrategy.eagerJoinRelationAlias(alias, relation.propertyPath);
             qb.leftJoinAndSelect(alias + "." + relation.propertyPath, relationAlias);
             this.joinEagerRelations(qb, relationAlias, relation.inverseEntityMetadata);
         });

--- a/src/naming-strategy/DefaultNamingStrategy.ts
+++ b/src/naming-strategy/DefaultNamingStrategy.ts
@@ -148,4 +148,7 @@ export class DefaultNamingStrategy implements NamingStrategyInterface {
         return prefix + tableName;
     }
 
+    eagerJoinRelationAlias(alias: string, propertyPath: string): string {
+        return alias + "_" + propertyPath.replace(".", "_");
+    }
 }

--- a/src/naming-strategy/NamingStrategyInterface.ts
+++ b/src/naming-strategy/NamingStrategyInterface.ts
@@ -117,4 +117,8 @@ export interface NamingStrategyInterface {
      */
     prefixTableName(prefix: string, tableName: string): string;
 
+    /**
+     * Gets the name of the alias used for relation joins.
+     */
+    eagerJoinRelationAlias(alias: string, propertyPath: string): string;
 }

--- a/test/github-issues/2200/entity/Booking.ts
+++ b/test/github-issues/2200/entity/Booking.ts
@@ -1,0 +1,15 @@
+import {Entity, PrimaryGeneratedColumn, ManyToOne, JoinColumn} from "../../../../src/index";
+import { Contact } from "./Contact";
+
+@Entity()
+export class Booking {
+
+    @PrimaryGeneratedColumn()
+    id: number;
+
+    @ManyToOne(type => Contact, contact => contact.bookings, { eager: true })
+    @JoinColumn({
+      name: "contact_id",
+    })
+    contact: Contact;
+}

--- a/test/github-issues/2200/entity/Contact.ts
+++ b/test/github-issues/2200/entity/Contact.ts
@@ -1,0 +1,12 @@
+import {Entity, PrimaryGeneratedColumn, OneToMany} from "../../../../src/index";
+import { Booking } from "./Booking";
+
+@Entity()
+export class Contact {
+
+    @PrimaryGeneratedColumn()
+    id: number;
+
+    @OneToMany(type => Booking, booking => booking.contact)
+    bookings: Booking[];
+}

--- a/test/github-issues/2200/issue-2200.ts
+++ b/test/github-issues/2200/issue-2200.ts
@@ -1,0 +1,27 @@
+import "reflect-metadata";
+import {closeTestingConnections, createTestingConnections, reloadTestingDatabases} from "../../utils/test-utils";
+import {Connection} from "../../../src/connection/Connection";
+import {Booking} from "./entity/Booking";
+import {NamingStrategyUnderTest} from "./naming/NamingStrategyUnderTest";
+
+
+describe("github issue > #2200 Bug - Issue with snake_case naming strategy", () => {
+
+    let connections: Connection[];
+    let namingStrategy = new NamingStrategyUnderTest();
+
+    before(async () => connections = await createTestingConnections({
+        entities: [__dirname + "/entity/*{.js,.ts}"],
+        namingStrategy
+    }));
+    beforeEach(() => {
+        return reloadTestingDatabases(connections);
+    });
+    after(() => closeTestingConnections(connections));
+
+
+    it("Renammed alias allow to query correctly", () => Promise.all(connections.map(async connection => {
+        await connection.getRepository(Booking).find({take: 10});
+    })));
+
+});

--- a/test/github-issues/2200/naming/NamingStrategyUnderTest.ts
+++ b/test/github-issues/2200/naming/NamingStrategyUnderTest.ts
@@ -1,0 +1,7 @@
+import { DefaultNamingStrategy } from "../../../../src/naming-strategy/DefaultNamingStrategy";
+import { NamingStrategyInterface } from "../../../../src/naming-strategy/NamingStrategyInterface";
+
+export class NamingStrategyUnderTest extends DefaultNamingStrategy implements NamingStrategyInterface {
+  eagerJoinRelationAlias(alias: string, propertyPath: string): string {
+    return alias + "__" + propertyPath.replace(".", "_");
+}}


### PR DESCRIPTION
# Description

Current alias naming is causing issue with some naming strategy (snake case strategy at the very least). Issue was well described in #2200.

Next here #4125 

# Proposed solution

Added `eagerJoinRelationAlias` in NamingStrategyInterface and added current behaviour in DefaultNamingStrategy as to not change anything for current users.

This allow everyone to decide alias of joins, proposed solution for #2200 is to use the following (notice the double _):

```javascript
eagerJoinRelationAlias(alias: string, propertyPath: string): string {
    return alias + "__" + propertyPath.replace(".", "_")
}
```
