### PR TITLE
Allow join relation alias override from naming strategies

### DIFF
--- a/src/connection/BaseConnectionOptions.ts
+++ b/src/connection/BaseConnectionOptions.ts
@@ -3,7 +3,7 @@ import {LoggerOptions} from "../logger/LoggerOptions";
 import {NamingStrategyInterface} from "../naming-strategy/NamingStrategyInterface";
 import {DatabaseType} from "../driver/types/DatabaseType";
 import {Logger} from "../logger/Logger";
-import { EntityFactoryInterface } from '../entity-factory/EntityFactoryInterface';
+import { EntityFactoryInterface } from "../entity-factory/EntityFactoryInterface";
 
 /**
  * BaseConnectionOptions is set of connection options shared by all database types.

--- a/src/connection/Connection.ts
+++ b/src/connection/Connection.ts
@@ -38,8 +38,8 @@ import {MysqlDriver} from "../driver/mysql/MysqlDriver";
 import {ObjectUtils} from "../util/ObjectUtils";
 import {PromiseUtils} from "../";
 import {IsolationLevel} from "../driver/types/IsolationLevel";
-import { EntityFactoryInterface } from '../entity-factory/EntityFactoryInterface';
-import { DefaultEntityFactory } from '../entity-factory/DefaultEntityFactory';
+import { EntityFactoryInterface } from "../entity-factory/EntityFactoryInterface";
+import { DefaultEntityFactory } from "../entity-factory/DefaultEntityFactory";
 
 /**
  * Connection is a single database ORM connection to a specific database.

--- a/src/entity-factory/DefaultEntityFactory.ts
+++ b/src/entity-factory/DefaultEntityFactory.ts
@@ -1,4 +1,4 @@
-import { EntityFactoryInterface } from './EntityFactoryInterface';
+import { EntityFactoryInterface } from "./EntityFactoryInterface";
 
 export class DefaultEntityFactory implements EntityFactoryInterface {
 

--- a/src/entity-factory/EntityFactoryInterface.ts
+++ b/src/entity-factory/EntityFactoryInterface.ts
@@ -1,4 +1,4 @@
-import {EntityMetadata} from '../metadata/EntityMetadata';
+import {EntityMetadata} from "../metadata/EntityMetadata";
 
 /**
  * Class that implements this interface is en entity factory used by the orm to 

--- a/src/entity-factory/OldEntityFactory.ts
+++ b/src/entity-factory/OldEntityFactory.ts
@@ -1,4 +1,4 @@
-import { EntityFactoryInterface } from './EntityFactoryInterface';
+import { EntityFactoryInterface } from "./EntityFactoryInterface";
 
 export class OldEntityFactory implements EntityFactoryInterface {
 

--- a/src/metadata/EntityMetadata.ts
+++ b/src/metadata/EntityMetadata.ts
@@ -502,7 +502,7 @@ export class EntityMetadata {
         // if target is set to a function (e.g. class) that can be created then create it
         let ret: any;
         if (this.target instanceof Function) {
-            ret = this.connection.entityFactory.createEntity(this.target, this)
+            ret = this.connection.entityFactory.createEntity(this.target, this);
             this.lazyRelations.forEach(relation => this.connection.relationLoader.enableLazyLoad(relation, ret, queryRunner));
             return ret;
         }

--- a/src/naming-strategy/DefaultNamingStrategy.ts
+++ b/src/naming-strategy/DefaultNamingStrategy.ts
@@ -148,4 +148,7 @@ export class DefaultNamingStrategy implements NamingStrategyInterface {
         return prefix + tableName;
     }
 
+    eagerJoinRelationAlias(alias: string, propertyPath: string): string {
+        return alias + "_" + propertyPath.replace(".", "_");
+    }
 }

--- a/src/naming-strategy/NamingStrategyInterface.ts
+++ b/src/naming-strategy/NamingStrategyInterface.ts
@@ -117,4 +117,8 @@ export interface NamingStrategyInterface {
      */
     prefixTableName(prefix: string, tableName: string): string;
 
-}
+    /**
+     * Gets the name of the alias used for relation joins.
+     */
+    eagerJoinRelationAlias(alias: string, propertyPath: string): string;
+ }

--- a/src/query-builder/SelectQueryBuilder.ts
+++ b/src/query-builder/SelectQueryBuilder.ts
@@ -1868,7 +1868,7 @@ export class SelectQueryBuilder<Entity> extends QueryBuilder<Entity> implements 
                                                         .map(join => join.parentAlias + "." + join.relationPropertyPath);
                     const joinEagerRelations = (alias: string, metadata: EntityMetadata) => {
                         metadata.eagerRelations.forEach(relation => {
-                            const relationAlias = alias + "_" + relation.propertyPath.replace(".", "_");
+                            const relationAlias = this.connection.namingStrategy.eagerJoinRelationAlias(alias, relation.propertyPath);
                             const path = alias + "." + relation.propertyPath;
                             if (manuallyJoinedRelations.indexOf(path) === -1) {
                                 // This alias+propertyPath was already joined manually

--- a/test/functional/entity-factory/custom-complex-entity-factory.ts
+++ b/test/functional/entity-factory/custom-complex-entity-factory.ts
@@ -4,7 +4,7 @@ import { closeTestingConnections, createTestingConnections, reloadTestingDatabas
 import { Connection } from "../../../src/connection/Connection";
 import { Post } from "./entity/Post";
 import { PostVersioned } from "./entity/PostVersioned";
-import { EntityMetadata } from '../../../src';
+import { EntityMetadata } from "../../../src";
 
 describe("entity-factory > custom complex entity factory", () => {
 
@@ -31,7 +31,7 @@ describe("entity-factory > custom complex entity factory", () => {
                                 const property = target[propKey];
                                 
                                 if (property instanceof Function) {
-                                    return function (...args:any[]) {
+                                    return function (...args: any[]) {
                                         const result = property.apply(this, args);
                                         return result + " !!!";
                                     };
@@ -40,7 +40,7 @@ describe("entity-factory > custom complex entity factory", () => {
                                 return property;
                             }
                         }
-                    )
+                    );
                 }
 
                 return entity;

--- a/test/functional/entity-factory/entity/PostVersioned.ts
+++ b/test/functional/entity-factory/entity/PostVersioned.ts
@@ -1,7 +1,7 @@
 import {Entity} from "../../../../src/decorator/entity/Entity";
 import {Column} from "../../../../src/decorator/columns/Column";
 import {PrimaryGeneratedColumn} from "../../../../src/decorator/columns/PrimaryGeneratedColumn";
-import {VersionColumn} from '../../../../src/decorator/columns/VersionColumn';
+import {VersionColumn} from "../../../../src/decorator/columns/VersionColumn";
 
 @Entity()
 export class PostVersioned {

--- a/test/functional/entity-factory/old-entity-factory.ts
+++ b/test/functional/entity-factory/old-entity-factory.ts
@@ -3,7 +3,7 @@ import {expect} from "chai";
 import {closeTestingConnections, createTestingConnections, reloadTestingDatabases} from "../../utils/test-utils";
 import {Connection} from "../../../src/connection/Connection";
 import {Post} from "./entity/Post";
-import { OldEntityFactory } from '../../../src';
+import { OldEntityFactory } from "../../../src";
 
 describe("entity-factory > old entity factory", () => {
     

--- a/test/github-issues/2200/entity/Booking.ts
+++ b/test/github-issues/2200/entity/Booking.ts
@@ -1,0 +1,15 @@
+import {Entity, PrimaryGeneratedColumn, ManyToOne, JoinColumn} from "../../../../src/index";
+import { Contact } from "./Contact";
+
+@Entity()
+export class Booking {
+
+    @PrimaryGeneratedColumn()
+    id: number;
+
+    @ManyToOne(type => Contact, contact => contact.bookings, { eager: true })
+    @JoinColumn({
+      name: "contact_id",
+    })
+    contact: Contact;
+}

--- a/test/github-issues/2200/entity/Contact.ts
+++ b/test/github-issues/2200/entity/Contact.ts
@@ -1,0 +1,12 @@
+import {Entity, PrimaryGeneratedColumn, OneToMany} from "../../../../src/index";
+import { Booking } from "./Booking";
+
+@Entity()
+export class Contact {
+
+    @PrimaryGeneratedColumn()
+    id: number;
+
+    @OneToMany(type => Booking, booking => booking.contact)
+    bookings: Booking[];
+}

--- a/test/github-issues/2200/issue-2200.ts
+++ b/test/github-issues/2200/issue-2200.ts
@@ -1,0 +1,27 @@
+import "reflect-metadata";
+import {closeTestingConnections, createTestingConnections, reloadTestingDatabases} from "../../utils/test-utils";
+import {Connection} from "../../../src/connection/Connection";
+import {Booking} from "./entity/Booking";
+import {NamingStrategyUnderTest} from "./naming/NamingStrategyUnderTest";
+
+
+describe("github issue > #2200 Bug - Issue with snake_case naming strategy", () => {
+
+    let connections: Connection[];
+    let namingStrategy = new NamingStrategyUnderTest();
+
+    before(async () => connections = await createTestingConnections({
+        entities: [__dirname + "/entity/*{.js,.ts}"],
+        namingStrategy
+    }));
+    beforeEach(() => {
+        return reloadTestingDatabases(connections);
+    });
+    after(() => closeTestingConnections(connections));
+
+
+    it("Renammed alias allow to query correctly", () => Promise.all(connections.map(async connection => {
+        await connection.getRepository(Booking).find({take: 10});
+    })));
+
+});

--- a/test/github-issues/2200/naming/NamingStrategyUnderTest.ts
+++ b/test/github-issues/2200/naming/NamingStrategyUnderTest.ts
@@ -1,0 +1,7 @@
+import { DefaultNamingStrategy } from "../../../../src/naming-strategy/DefaultNamingStrategy";
+import { NamingStrategyInterface } from "../../../../src/naming-strategy/NamingStrategyInterface";
+
+export class NamingStrategyUnderTest extends DefaultNamingStrategy implements NamingStrategyInterface {
+  eagerJoinRelationAlias(alias: string, propertyPath: string): string {
+    return alias + "__" + propertyPath.replace(".", "_");
+}}

--- a/test/utils/test-utils.ts
+++ b/test/utils/test-utils.ts
@@ -7,7 +7,7 @@ import {EntitySchema} from "../../src/entity-schema/EntitySchema";
 import {createConnections} from "../../src/index";
 import {NamingStrategyInterface} from "../../src/naming-strategy/NamingStrategyInterface";
 import {PromiseUtils} from "../../src/util/PromiseUtils";
-import { EntityFactoryInterface } from '../../src/entity-factory/EntityFactoryInterface';
+import { EntityFactoryInterface } from "../../src/entity-factory/EntityFactoryInterface";
 
 /**
  * Interface in which data is stored in ormconfig.json of the project.


### PR DESCRIPTION
# Description

Current alias naming is causing issue with some naming strategy (snake case strategy at the very least). Issue was well described in #2200.

Master here #4124 

# Proposed solution

Added `eagerJoinRelationAlias` in NamingStrategyInterface and added current behaviour in DefaultNamingStrategy as to not change anything for current users.

This allow everyone to decide alias of joins, proposed solution for #2200 is to use the following (notice the double _):

```javascript
eagerJoinRelationAlias(alias: string, propertyPath: string): string {
    return alias + "__" + propertyPath.replace(".", "_")
}
```
