### PR TITLE
 Fix transform embeddeds with no columns but with nested embeddeds (mongodb)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,10 @@ feel free to ask us and community.
 * support sql.js v1.0 ([#4104](https://github.com/typeorm/typeorm/issues/4104))
 * added support for `orUpdate` in SQLlite ([#4097](https://github.com/typeorm/typeorm/pull/4097))
 
+### Bug fixes
+
+* fixed transform embeddeds with no columns but with nested embeddeds (mongodb)
+
 ## 0.2.17 (2019-05-01)
 
 ### Bug fixes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@ feel free to ask us and community.
 
 ### Bug fixes
 
-* fixed transform embeddeds with no columns but with nested embeddeds (mongodb)
+* fixed transform embeddeds with no columns but with nested embeddeds (mongodb) ([#4131](https://github.com/typeorm/typeorm/pull/44131))
 
 ## 0.2.17 (2019-05-01)
 

--- a/src/query-builder/transformer/DocumentToEntityTransformer.ts
+++ b/src/query-builder/transformer/DocumentToEntityTransformer.ts
@@ -96,6 +96,9 @@ export class DocumentToEntityTransformer {
                     });
 
                 } else {
+                    if (embedded.embeddeds.length && !entity[embedded.propertyName]) 
+                        entity[embedded.propertyName] = embedded.create();
+                    
                     embedded.columns.forEach(column => {
                         const value = document[embedded.prefix][column.databaseNameWithoutPrefixes];
                         if (value === undefined) return;

--- a/test/functional/mongodb/basic/embedded-columns/entity/Counters.ts
+++ b/test/functional/mongodb/basic/embedded-columns/entity/Counters.ts
@@ -1,5 +1,6 @@
 import {Column} from "../../../../../../src/decorator/columns/Column";
 import {Information} from "./Information";
+import {ExtraInformation} from "./ExtraInformation";
 
 export class Counters {
 
@@ -15,4 +16,6 @@ export class Counters {
     @Column(type => Information)
     information: Information;
 
+    @Column(type => ExtraInformation)
+    extraInformation: ExtraInformation;
 }

--- a/test/functional/mongodb/basic/embedded-columns/entity/EditHistory.ts
+++ b/test/functional/mongodb/basic/embedded-columns/entity/EditHistory.ts
@@ -1,0 +1,11 @@
+import {Column} from "../../../../../../src/decorator/columns/Column";
+
+export class EditHistory {
+
+    @Column()
+    title: string;
+
+    @Column()
+    text: string;
+
+}

--- a/test/functional/mongodb/basic/embedded-columns/entity/ExtraInformation.ts
+++ b/test/functional/mongodb/basic/embedded-columns/entity/ExtraInformation.ts
@@ -1,0 +1,9 @@
+import {Column} from "../../../../../../src/decorator/columns/Column";
+import {EditHistory} from "./EditHistory";
+
+export class ExtraInformation {
+
+    @Column(type => EditHistory)
+    lastEdit: EditHistory;
+
+}


### PR DESCRIPTION
**Issue type:**

[ ] question
[x] bug report
[ ] feature request
[ ] documentation issue

**Database system/driver:**

[ ] `cordova`
[x] `mongodb`
[ ] `mssql`
[ ] `mysql` / `mariadb`
[ ] `oracle`
[ ] `postgres`
[ ] `cockroachdb`
[ ] `sqlite`
[ ] `sqljs`
[ ] `react-native`
[ ] `expo`

**TypeORM version:**

[x] `latest`
[ ] `@next`
[ ] `0.2.17` (or put your version here)

**Steps to reproduce or a small repository showing the problem:**

```
export class Post {
  @Column()
  title: string

  @Column(type => ExtraInfo)
  extraInfo: ExtraInfo
}
export class ExtraInfo {
  @Column(type => EditHistory)
  lastEdit: EditHistory
}
export class EditHistory {
  @Column()
  message: string
}
...
await repo.save(somePost);
const [post] = await repo.find();

// UnhandledPromiseRejectionWarning: TypeError: Cannot read property 'lastEdit' of undefined
at \src\query-builder\transformer\DocumentToEntityTransformer.ts
at addEmbeddedValuesRecursively

// extraInfo is not created!
```
After hours of trial without looking at the source code, I got a workaround.
```
export class ExtraInfo {
  @Column(type => EditHistory)
  lastEdit: EditHistory

  @Column()
   justNothing: number = 1
}
// clear the collection, insert another post with that additional field
await repo.save(anotherPost);
const [post] = await repo.find();
// works perfectly
```
This workaround does not make any sense it should not be an intentional design so it might be a bug indeed...

In `addEmbeddedValuesRecursively`, I discovered that the field may not be created if `embedded.columns` is empty array.\
Then, when the foreach clause is skipped and it tries the enter into next recursion of `addEmbeddedValuesRecursively` the first argument may be `undefined`,\
which cause the entity in that recursion to be `undefined`,\
eventually causing unexpected error as we still got some columns deep deep inside.

Here I suggest to fix it by an extra check, so that it won't break any existing behavior.