### PR TITLE
 Fixed the incorrect sql query for changing the column name in sql

### DIFF
--- a/docs/migrations.md
+++ b/docs/migrations.md
@@ -128,14 +128,12 @@ import {MigrationInterface, QueryRunner} from "typeorm";
 export class PostRefactoringTIMESTAMP implements MigrationInterface {
     
     async up(queryRunner: QueryRunner): Promise<any> {
-        await queryRunner.query(`ALTER TABLE "post" ALTER COLUMN "title" RENAME TO "name"`);
+        await queryRunner.query(`ALTER TABLE "post" RENAME COLUMN "title" TO "name"`);
     }
 
     async down(queryRunner: QueryRunner): Promise<any> { 
-        await queryRunner.query(`ALTER TABLE "post" ALTER COLUMN "name" RENAME TO "title"`); // reverts things made in "up" method
+        await queryRunner.query(`ALTER TABLE "post" RENAME COLUMN "name" TO "title"`); // reverts things made in "up" method
     }
-
-    
 }
 ```
 

--- a/docs/zh_CN/migrations.md
+++ b/docs/zh_CN/migrations.md
@@ -40,7 +40,7 @@ export class Post {
 你需要使用以下 sql 查询（postgres dialect）创建新的迁移：
 
 ```sql
-ALTER TABLE "post" ALTER COLUMN "title" RENAME TO "name";
+ALTER TABLE "post" RENAME COLUMN "title" TO "name";
 ```
 
 运行此 sql 查询后，你的数据库架构就可以使用新的代码库了。


### PR DESCRIPTION
 Fixed the incorrect sql query for changing the column name in sql, 
it has to be like this:

ALTER TABLE table_name RENAME COLUMN old_name to new_name;

But the docs give the wrong query. I keep failing of making the migration.

reference: 
[https://www.1keydata.com/sql/alter-table-rename-column.html](https://www.1keydata.com/sql/alter-table-rename-column.html)

[https://www.w3schools.com/sql/sql_alter.asp](https://www.w3schools.com/sql/sql_alter.asp)