### PR TITLE
typeorm migration:show

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ feel free to ask us and community.
 
 ### Features
 
+* adds `typeorm migration:show` command ([#4173](https://github.com/typeorm/typeorm/pull/4173))
 * deprecate column `readonly` option in favor of `update` and `insert` options ([#4035](https://github.com/typeorm/typeorm/pull/4035))
 * support sql.js v1.0 ([#4104](https://github.com/typeorm/typeorm/issues/4104))
 * added support for `orUpdate` in SQLlite ([#4097](https://github.com/typeorm/typeorm/pull/4097))

--- a/docs/using-cli.md
+++ b/docs/using-cli.md
@@ -228,6 +228,10 @@ To show all migrations and whether they've been run or not use following command
 typeorm migration:show
 ```
 
+✅ = Migration has been ran
+
+⏳ = Migration is pending/unapplied
+
 This command also returns an error code if there are unapplied migrations.
 
 ## Sync database schema

--- a/docs/using-cli.md
+++ b/docs/using-cli.md
@@ -228,9 +228,9 @@ To show all migrations and whether they've been run or not use following command
 typeorm migration:show
 ```
 
-✅ = Migration has been ran
+[X] = Migration has been ran
 
-⏳ = Migration is pending/unapplied
+[ ] = Migration is pending/unapplied
 
 This command also returns an error code if there are unapplied migrations.
 

--- a/docs/using-cli.md
+++ b/docs/using-cli.md
@@ -8,6 +8,7 @@
 * [Generate a migration from exist table schema](#generate-a-migration-from-exist-table-schema)
 * [Run migrations](#run-migrations)
 * [Revert migrations](#revert-migrations)
+* [Show migrations](#show-migrations)
 * [Sync database schema](#sync-database-schema)
 * [Log sync database schema queries without actual running them](#log-sync-database-schema-queries-without-actual-running-them)
 * [Drop database schema](#drop-database-schema)
@@ -219,6 +220,15 @@ typeorm migration:revert
 This command will undo only the last executed migration.
 You can execute this command multiple times to revert multiple migrations.
 Learn more about [Migrations](./migrations.md).
+
+## Show migrations
+To show all migrations and whether they've been run or not use following command:
+
+```
+typeorm migration:show
+```
+
+This command also returns an error code if there are unapplied migrations.
 
 ## Sync database schema
 

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -8,6 +8,7 @@ import {EntityCreateCommand} from "./commands/EntityCreateCommand";
 import {MigrationCreateCommand} from "./commands/MigrationCreateCommand";
 import {MigrationRunCommand} from "./commands/MigrationRunCommand";
 import {MigrationRevertCommand} from "./commands/MigrationRevertCommand";
+import {MigrationShowCommand} from "./commands/MigrationShowCommand";
 import {SubscriberCreateCommand} from "./commands/SubscriberCreateCommand";
 import {SchemaLogCommand} from "./commands/SchemaLogCommand";
 import {MigrationGenerateCommand} from "./commands/MigrationGenerateCommand";
@@ -26,6 +27,7 @@ yargs
     .command(new MigrationCreateCommand())
     .command(new MigrationGenerateCommand())
     .command(new MigrationRunCommand())
+    .command(new MigrationShowCommand())
     .command(new MigrationRevertCommand())
     .command(new VersionCommand())
     .command(new CacheClearCommand())

--- a/src/commands/MigrationShowCommand.ts
+++ b/src/commands/MigrationShowCommand.ts
@@ -20,11 +20,6 @@ export class MigrationShowCommand implements yargs.CommandModule {
         default: "default",
         describe: "Name of the connection on which run a query."
       })
-      .option("transaction", {
-        alias: "t",
-        default: "default",
-        describe: "Indicates if transaction should be used or not for migration run. Enabled by default."
-      })
       .option("config", {
         alias: "f",
         default: "ormconfig",
@@ -48,11 +43,7 @@ export class MigrationShowCommand implements yargs.CommandModule {
         logging: ["query", "error", "schema"]
       });
       connection = await createConnection(connectionOptions);
-
-      const options = {
-        transaction: args["t"] === "false" ? false : true
-      };
-      const unappliedMigrations = await connection.showMigrations(options);
+      const unappliedMigrations = await connection.showMigrations();
       await connection.close();
 
       // return error code if there are unapplied migrations for CI

--- a/src/commands/MigrationShowCommand.ts
+++ b/src/commands/MigrationShowCommand.ts
@@ -1,0 +1,69 @@
+import {createConnection} from "../index";
+import {ConnectionOptionsReader} from "../connection/ConnectionOptionsReader";
+import {Connection} from "../connection/Connection";
+import * as process from "process";
+import * as yargs from "yargs";
+const chalk = require("chalk");
+
+/**
+ * Runs migration command.
+ */
+export class MigrationShowCommand implements yargs.CommandModule {
+
+  command = "migration:show";
+  describe = "Show all migrations and whether they have been run or not";
+
+  builder(args: yargs.Argv) {
+    return args
+      .option("connection", {
+        alias: "c",
+        default: "default",
+        describe: "Name of the connection on which run a query."
+      })
+      .option("transaction", {
+        alias: "t",
+        default: "default",
+        describe: "Indicates if transaction should be used or not for migration run. Enabled by default."
+      })
+      .option("config", {
+        alias: "f",
+        default: "ormconfig",
+        describe: "Name of the file with connection configuration."
+      });
+  }
+
+  async handler(args: yargs.Arguments) {
+    let connection: Connection|undefined = undefined;
+    try {
+      const connectionOptionsReader = new ConnectionOptionsReader({
+        root: process.cwd(),
+        configName: args.config as any
+      });
+      const connectionOptions = await connectionOptionsReader.get(args.connection as any);
+      Object.assign(connectionOptions, {
+        subscribers: [],
+        synchronize: false,
+        migrationsRun: false,
+        dropSchema: false,
+        logging: ["query", "error", "schema"]
+      });
+      connection = await createConnection(connectionOptions);
+
+      const options = {
+        transaction: args["t"] === "false" ? false : true
+      };
+      await connection.showMigrations(options);
+      await connection.close();
+      // exit process if no errors
+      process.exit(0);
+
+    } catch (err) {
+      if (connection) await (connection as Connection).close();
+
+      console.log(chalk.black.bgRed("Error during migration show:"));
+      console.error(err);
+      process.exit(1);
+    }
+  }
+
+}

--- a/src/commands/MigrationShowCommand.ts
+++ b/src/commands/MigrationShowCommand.ts
@@ -52,10 +52,11 @@ export class MigrationShowCommand implements yargs.CommandModule {
       const options = {
         transaction: args["t"] === "false" ? false : true
       };
-      await connection.showMigrations(options);
+      const unappliedMigrations = await connection.showMigrations(options);
       await connection.close();
-      // exit process if no errors
-      process.exit(0);
+
+      // return error code if there are unapplied migrations for CI
+      process.exit(unappliedMigrations ? 1 : 0);
 
     } catch (err) {
       if (connection) await (connection as Connection).close();

--- a/src/connection/Connection.ts
+++ b/src/connection/Connection.ts
@@ -307,8 +307,9 @@ export class Connection {
 
     /**
      * Runs all pending migrations.
+     * Returns true if there are no pending migrations
      */
-    async showMigrations(options?: { transaction?: boolean }): Promise<void> {
+    async showMigrations(options?: { transaction?: boolean }): Promise<boolean> {
         if (!this.isConnected) {
             throw new CannotExecuteNotConnectedError(this.name);
         }

--- a/src/connection/Connection.ts
+++ b/src/connection/Connection.ts
@@ -306,7 +306,7 @@ export class Connection {
     }
 
     /**
-     * Runs all pending migrations.
+     * Lists all migrations and whether they have been run.
      * Returns true if there are no pending migrations
      */
     async showMigrations(): Promise<boolean> {

--- a/src/connection/Connection.ts
+++ b/src/connection/Connection.ts
@@ -306,6 +306,20 @@ export class Connection {
     }
 
     /**
+     * Runs all pending migrations.
+     */
+    async showMigrations(options?: { transaction?: boolean }): Promise<void> {
+        if (!this.isConnected) {
+            throw new CannotExecuteNotConnectedError(this.name);
+        }
+        const migrationExecutor = new MigrationExecutor(this);
+        if (options && options.transaction === false) {
+            migrationExecutor.transaction = false;
+        }
+        return await migrationExecutor.showMigrations();
+    }
+
+    /**
      * Checks if entity metadata exist for the given entity class, target name or table name.
      */
     hasMetadata(target: Function|EntitySchema<any>|string): boolean {

--- a/src/connection/Connection.ts
+++ b/src/connection/Connection.ts
@@ -309,14 +309,11 @@ export class Connection {
      * Runs all pending migrations.
      * Returns true if there are no pending migrations
      */
-    async showMigrations(options?: { transaction?: boolean }): Promise<boolean> {
+    async showMigrations(): Promise<boolean> {
         if (!this.isConnected) {
             throw new CannotExecuteNotConnectedError(this.name);
         }
         const migrationExecutor = new MigrationExecutor(this);
-        if (options && options.transaction === false) {
-            migrationExecutor.transaction = false;
-        }
         return await migrationExecutor.showMigrations();
     }
 

--- a/src/migration/MigrationExecutor.ts
+++ b/src/migration/MigrationExecutor.ts
@@ -67,10 +67,10 @@ export class MigrationExecutor {
             const executedMigration = executedMigrations.find(executedMigration => executedMigration.name === migration.name);
 
             if (executedMigration) {
-                this.connection.logger.logSchemaBuild(` ✅ ${migration.name}`);
+                this.connection.logger.logSchemaBuild(` [X] ${migration.name}`);
             } else {
                 hasUnappliedMigrations = true;
-                this.connection.logger.logSchemaBuild(` ⏳ ${migration.name}`);
+                this.connection.logger.logSchemaBuild(` [ ] ${migration.name}`);
             }
         }
 

--- a/src/migration/MigrationExecutor.ts
+++ b/src/migration/MigrationExecutor.ts
@@ -50,8 +50,10 @@ export class MigrationExecutor {
 
     /**
      * Lists all migrations and whether they have been executed or not
+     * returns true if there are unapplied migrations
      */
-    async showMigrations(): Promise<void> {
+    async showMigrations(): Promise<boolean> {
+        let hasUnappliedMigrations = false;
         const queryRunner = this.queryRunner || this.connection.createQueryRunner("master");
         // create migrations table if its not created yet
         await this.createMigrationsTableIfNotExist(queryRunner);
@@ -67,6 +69,7 @@ export class MigrationExecutor {
             if (executedMigration) {
                 this.connection.logger.logSchemaBuild(` ✅ ${migration.name}`);
             } else {
+                hasUnappliedMigrations = true;
                 this.connection.logger.logSchemaBuild(` ⏳ ${migration.name}`);
             }
         }
@@ -75,6 +78,8 @@ export class MigrationExecutor {
         if (!this.queryRunner) {
             await queryRunner.release();
         }
+
+        return hasUnappliedMigrations;
     }
 
     /**

--- a/test/functional/migrations/show-command/command.ts
+++ b/test/functional/migrations/show-command/command.ts
@@ -1,0 +1,26 @@
+import "reflect-metadata";
+import {createTestingConnections, closeTestingConnections, reloadTestingDatabases} from "../../../utils/test-utils";
+import {Connection} from "../../../../src/connection/Connection";
+
+describe("migrations > show command", () => {
+    let connections: Connection[];
+    before(async () => connections = await createTestingConnections({
+        migrations: [__dirname + "/migration/*.js"],
+        enabledDrivers: ["postgres"],
+        schemaCreate: true,
+        dropSchema: true,
+    }));
+    beforeEach(() => reloadTestingDatabases(connections));
+    after(() => closeTestingConnections(connections));
+
+    it("can recognise pending migrations", () => Promise.all(connections.map(async connection => {
+        const migrations = await connection.showMigrations();
+        migrations.should.be.equal(true);
+    })));
+
+    it("can recognise no pending migrations", () => Promise.all(connections.map(async connection => {
+        await connection.runMigrations();
+        const migrations = await connection.showMigrations();
+        migrations.should.be.equal(false);
+    })));
+ });

--- a/test/functional/migrations/show-command/command.ts
+++ b/test/functional/migrations/show-command/command.ts
@@ -6,7 +6,7 @@ describe("migrations > show command", () => {
     let connections: Connection[];
     before(async () => connections = await createTestingConnections({
         migrations: [__dirname + "/migration/*.js"],
-        enabledDrivers: ["mysql", "mariadb", "oracle", "mssql", "sqljs", "sqlite", "postgres"],
+        enabledDrivers: ["postgres"],
         schemaCreate: true,
         dropSchema: true,
     }));

--- a/test/functional/migrations/show-command/command.ts
+++ b/test/functional/migrations/show-command/command.ts
@@ -6,7 +6,7 @@ describe("migrations > show command", () => {
     let connections: Connection[];
     before(async () => connections = await createTestingConnections({
         migrations: [__dirname + "/migration/*.js"],
-        enabledDrivers: ["postgres"],
+        enabledDrivers: ["mysql", "mariadb", "oracle", "mssql", "sqljs", "sqlite", "postgres"],
         schemaCreate: true,
         dropSchema: true,
     }));

--- a/test/functional/migrations/show-command/migration/1530542855524-ExampleMigration.ts
+++ b/test/functional/migrations/show-command/migration/1530542855524-ExampleMigration.ts
@@ -1,0 +1,9 @@
+import { MigrationInterface } from "../../../../../src/migration/MigrationInterface";
+import { QueryRunner } from "../../../../../src/query-runner/QueryRunner";
+
+export class ExampleMigration1530542855524 implements MigrationInterface {
+    public async up(queryRunner: QueryRunner): Promise<any> {
+    }
+    public async down(queryRunner: QueryRunner): Promise<any> {
+    }
+}

--- a/test/functional/migrations/show-command/migration/1530542855524-ExampleMigrationTwo.ts
+++ b/test/functional/migrations/show-command/migration/1530542855524-ExampleMigrationTwo.ts
@@ -1,0 +1,9 @@
+import { MigrationInterface } from "../../../../../src/migration/MigrationInterface";
+import { QueryRunner } from "../../../../../src/query-runner/QueryRunner";
+
+export class ExampleMigrationTwo1530542855524 implements MigrationInterface {
+    public async up(queryRunner: QueryRunner): Promise<any> {
+    }
+    public async down(queryRunner: QueryRunner): Promise<any> {
+    }
+}


### PR DESCRIPTION
As proposed here: https://github.com/typeorm/typeorm/issues/3954

This PR adds a new command `typeorm migration:show`

This lists all migrations and shows whether they are applied or pending.

The command also returns an error code if there are unapplied migrations, so that it can easily be used  in CI pipelines.