### PR TITLE
Extend afterLoad() subscriber interface to take LoadEvent

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ feel free to ask us and community.
 * support sql.js v1.0 ([#4104](https://github.com/typeorm/typeorm/issues/4104))
 * added support for `orUpdate` in SQLlite ([#4097](https://github.com/typeorm/typeorm/pull/4097))
 * added support for `dirty_read` (NOLOCK) in SQLServer ([#4133](https://github.com/typeorm/typeorm/pull/4133))
+* extend afterLoad() subscriber interface to take LoadEvent ([issue #4185](https://github.com/typeorm/typeorm/issues/4185))
 
 ## 0.2.17 (2019-05-01)
 

--- a/src/subscriber/Broadcaster.ts
+++ b/src/subscriber/Broadcaster.ts
@@ -305,7 +305,13 @@ export class Broadcaster {
             if (this.queryRunner.connection.subscribers.length) {
                 this.queryRunner.connection.subscribers.forEach(subscriber => {
                     if (this.isAllowedSubscriber(subscriber, metadata.target) && subscriber.afterLoad) {
-                        const executionResult = subscriber.afterLoad!(entity);
+                        const executionResult = subscriber.afterLoad!(entity, {
+                            connection: this.queryRunner.connection,
+                            queryRunner: this.queryRunner,
+                            manager: this.queryRunner.manager,
+                            entity: entity,
+                            metadata: metadata
+                        });
                         if (executionResult instanceof Promise)
                             result.promises.push(executionResult);
                         result.count++;

--- a/src/subscriber/EntitySubscriberInterface.ts
+++ b/src/subscriber/EntitySubscriberInterface.ts
@@ -1,6 +1,7 @@
 import {UpdateEvent} from "./event/UpdateEvent";
 import {RemoveEvent} from "./event/RemoveEvent";
 import {InsertEvent} from "./event/InsertEvent";
+import {LoadEvent} from "./event/LoadEvent";
 
 /**
  * Classes that implement this interface are subscribers that subscribe for the specific events in the ORM.
@@ -15,8 +16,13 @@ export interface EntitySubscriberInterface<Entity = any> {
 
     /**
      * Called after entity is loaded from the database.
+     *
+     * For backward compatibility this signature is slightly different from the
+     * others.  `event` was added later but is always provided (it is only
+     * optional in the signature so that its introduction does not break
+     * compilation for existing subscribers).
      */
-    afterLoad?(entity: Entity): Promise<any>|void;
+    afterLoad?(entity: Entity, event?: LoadEvent<Entity>): Promise<any>|void;
 
     /**
      * Called before entity is inserted to the database.

--- a/src/subscriber/event/LoadEvent.ts
+++ b/src/subscriber/event/LoadEvent.ts
@@ -1,0 +1,38 @@
+import {EntityManager} from "../../entity-manager/EntityManager";
+import {Connection} from "../../connection/Connection";
+import {QueryRunner} from "../../query-runner/QueryRunner";
+import {EntityMetadata} from "../../metadata/EntityMetadata";
+
+/**
+ * LoadEvent is an object that broadcaster sends to the entity subscriber when an entity is loaded from the database.
+ */
+export interface LoadEvent<Entity> {
+
+    /**
+     * Connection used in the event.
+     */
+    connection: Connection;
+
+    /**
+     * QueryRunner used in the event transaction.
+     * All database operations in the subscribed event listener should be performed using this query runner instance.
+     */
+    queryRunner: QueryRunner;
+
+    /**
+     * EntityManager used in the event transaction.
+     * All database operations in the subscribed event listener should be performed using this entity manager instance.
+     */
+    manager: EntityManager;
+
+    /**
+     * Loaded entity.
+     */
+    entity: Entity;
+
+    /**
+     * Metadata of the entity.
+     */
+    metadata: EntityMetadata;
+
+}

--- a/test/github-issues/4185/entity/Post.ts
+++ b/test/github-issues/4185/entity/Post.ts
@@ -1,0 +1,12 @@
+import {PrimaryColumn} from "../../../../src/decorator/columns/PrimaryColumn";
+import {Entity} from "../../../../src/decorator/entity/Entity";
+import {LoadEvent} from "../../../../src/subscriber/event/LoadEvent";
+
+@Entity()
+export class Post {
+    @PrimaryColumn()
+    id: number;
+
+    simpleSubscriberSaw?: boolean;
+    extendedSubscriberSaw?: LoadEvent<Post>;
+}

--- a/test/github-issues/4185/issue-4185.ts
+++ b/test/github-issues/4185/issue-4185.ts
@@ -1,0 +1,41 @@
+import "reflect-metadata";
+import {closeTestingConnections, createTestingConnections, reloadTestingDatabases} from "../../utils/test-utils";
+import {Connection} from "../../../src/connection/Connection";
+import {Post} from "./entity/Post";
+import {assert} from "chai";
+
+describe("github issues > #4185 afterLoad() subscriber interface missing additional info available on other events", () => {
+
+    let connections: Connection[];
+    before(async () => connections = await createTestingConnections({
+        entities: [__dirname + "/entity/*{.js,.ts}"],
+        subscribers: [__dirname + "/subscriber/*{.js,.ts}"],
+        schemaCreate: true,
+        dropSchema: true
+    }));
+    beforeEach(() => reloadTestingDatabases(connections));
+    after(() => closeTestingConnections(connections));
+
+    it("should invoke afterLoad() with LoadEvent", () => Promise.all(connections.map(async connection => {
+        const post1 = new Post();
+        post1.id = 1;
+        const post2 = new Post();
+        post2.id = 2;
+        await connection.manager.save([post1, post2]);
+
+        const entities = await connection.manager
+            .getRepository(Post)
+            .find();
+        assert.strictEqual(entities.length, 2);
+        for (const entity of entities) {
+            assert.isDefined(entity.simpleSubscriberSaw);
+            const event = entity.extendedSubscriberSaw;
+            assert.isDefined(event);
+            assert.strictEqual(event!.connection, connection);
+            assert.isDefined(event!.queryRunner);
+            assert.isDefined(event!.manager);
+            assert.strictEqual(event!.entity, entity);
+            assert.isDefined(event!.metadata);
+        }
+    })));
+});

--- a/test/github-issues/4185/subscriber/ExtendedAfterLoadSubscriber.ts
+++ b/test/github-issues/4185/subscriber/ExtendedAfterLoadSubscriber.ts
@@ -1,0 +1,15 @@
+import {Post} from "../entity/Post";
+import {EntitySubscriberInterface, EventSubscriber} from "../../../../src";
+import {LoadEvent} from "../../../../src/subscriber/event/LoadEvent";
+
+@EventSubscriber()
+export class ExtendedAfterLoadSubscriber
+    implements EntitySubscriberInterface<Post> {
+    listenTo() {
+        return Post;
+    }
+
+    async afterLoad(entity: Post, event: LoadEvent<Post>) {
+        entity.extendedSubscriberSaw = event;
+    }
+}

--- a/test/github-issues/4185/subscriber/SimpleAfterLoadSubscriber.ts
+++ b/test/github-issues/4185/subscriber/SimpleAfterLoadSubscriber.ts
@@ -1,0 +1,16 @@
+import {Post} from "../entity/Post";
+import {EntitySubscriberInterface, EventSubscriber} from "../../../../src";
+
+// "Old" subscribers which only take one parameter should still compile and work
+
+@EventSubscriber()
+export class SimpleAfterLoadSubscriber
+    implements EntitySubscriberInterface<Post> {
+    listenTo() {
+        return Post;
+    }
+
+    async afterLoad(entity: Post) {
+        entity.simpleSubscriberSaw = true;
+    }
+}


### PR DESCRIPTION
This brings it in line with the other events which already have the Connection, EntityManager, QueryRunner etc available.

Test Plan: npm test, and more specifically npm test -- --grep='github issues > #4185'