### PR TITLE
Correct error in decorator reference in documentation example for One to Many/ Many to One.

### DIFF
--- a/docs/many-to-one-one-to-many-relations.md
+++ b/docs/many-to-one-one-to-many-relations.md
@@ -42,7 +42,7 @@ export class User {
 }
 ```
 
-Here we added `@ManyToOne` to the `photos` property and specified the target relation type to be `Photo`.
+Here we added `@OneToMany` to the `photos` property and specified the target relation type to be `Photo`.
 You can omit `@JoinColumn` in a `@ManyToOne` / `@OneToMany` relation.
 `@OneToMany` cannot exist without `@ManyToOne`.
 If you want to use `@OneToMany`, `@ManyToOne` is required.


### PR DESCRIPTION
The documentation for OneToMany and ManyToOne has an error in reference to the decorator applied to photos property in the User entity. This commit rectifies this by switching the ManyToOne reference to the correct OneToMany decorator used in the example.

It fixes issue https://github.com/typeorm/typeorm/issues/4188