### PR TITLE
feat(RelationDecorators): allow to pass string instead of typeFunction

### DIFF
--- a/src/decorator/relations/ManyToMany.ts
+++ b/src/decorator/relations/ManyToMany.ts
@@ -6,14 +6,15 @@ import {RelationMetadataArgs} from "../../metadata-args/RelationMetadataArgs";
  * multiple instances of Entity1. To achieve it, this type of relation creates a junction table, where it storage
  * entity1 and entity2 ids. This is owner side of the relationship.
  */
-export function ManyToMany<T>(typeFunction: (type?: any) => ObjectType<T>, options?: RelationOptions): Function;
+export function ManyToMany<T>(typeFunctionOrTarget: string|((type?: any) => ObjectType<T>), 
+                              options?: RelationOptions): Function;
 
 /**
  * Many-to-many is a type of relationship when Entity1 can have multiple instances of Entity2, and Entity2 can have
  * multiple instances of Entity1. To achieve it, this type of relation creates a junction table, where it storage
  * entity1 and entity2 ids. This is owner side of the relationship.
  */
-export function ManyToMany<T>(typeFunction: (type?: any) => ObjectType<T>,
+export function ManyToMany<T>(typeFunctionOrTarget: string|((type?: any) => ObjectType<T>),
                               inverseSide?: string|((object: T) => any),
                               options?: RelationOptions): Function;
 
@@ -22,7 +23,7 @@ export function ManyToMany<T>(typeFunction: (type?: any) => ObjectType<T>,
  * multiple instances of Entity1. To achieve it, this type of relation creates a junction table, where it storage
  * entity1 and entity2 ids. This is owner side of the relationship.
  */
-export function ManyToMany<T>(typeFunction: (type?: any) => ObjectType<T>,
+export function ManyToMany<T>(typeFunctionOrTarget: string|((type?: any) => ObjectType<T>),
                               inverseSideOrOptions?: string|((object: T) => any)|RelationOptions,
                               options?: RelationOptions): Function {
 
@@ -51,7 +52,7 @@ export function ManyToMany<T>(typeFunction: (type?: any) => ObjectType<T>,
             // propertyType: reflectedType,
             relationType: "many-to-many",
             isLazy: isLazy,
-            type: typeFunction,
+            type: typeFunctionOrTarget,
             inverseSideProperty: inverseSideProperty,
             options: options
         } as RelationMetadataArgs);

--- a/src/decorator/relations/ManyToOne.ts
+++ b/src/decorator/relations/ManyToOne.ts
@@ -6,14 +6,14 @@ import {RelationMetadataArgs} from "../../metadata-args/RelationMetadataArgs";
  * Entity2 can have a multiple instances of Entity1. Entity1 is an owner of the relationship, and storages Entity2 id
  * on its own side.
  */
-export function ManyToOne<T>(typeFunction: (type?: any) => ObjectType<T>, options?: RelationOptions): Function;
+export function ManyToOne<T>(typeFunctionOrTarget: string|((type?: any) => ObjectType<T>), options?: RelationOptions): Function;
 
 /**
  * Many-to-one relation allows to create type of relation when Entity1 can have single instance of Entity2, but
  * Entity2 can have a multiple instances of Entity1. Entity1 is an owner of the relationship, and storages Entity2 id
  * on its own side.
  */
-export function ManyToOne<T>(typeFunction: (type?: any) => ObjectType<T>,
+export function ManyToOne<T>(typeFunctionOrTarget: string|((type?: any) => ObjectType<T>),
                              inverseSide?: string|((object: T) => any),
                              options?: RelationOptions): Function;
 
@@ -22,7 +22,7 @@ export function ManyToOne<T>(typeFunction: (type?: any) => ObjectType<T>,
  * Entity2 can have a multiple instances of Entity1. Entity1 is an owner of the relationship, and storages Entity2 id
  * on its own side.
  */
-export function ManyToOne<T>(typeFunction: (type?: any) => ObjectType<T>,
+export function ManyToOne<T>(typeFunctionOrTarget: string|((type?: any) => ObjectType<T>),
                              inverseSideOrOptions?: string|((object: T) => any)|RelationOptions,
                              options?: RelationOptions): Function {
 
@@ -51,7 +51,7 @@ export function ManyToOne<T>(typeFunction: (type?: any) => ObjectType<T>,
             // propertyType: reflectedType,
             relationType: "many-to-one",
             isLazy: isLazy,
-            type: typeFunction,
+            type: typeFunctionOrTarget,
             inverseSideProperty: inverseSideProperty,
             options: options
         } as RelationMetadataArgs);

--- a/src/decorator/relations/OneToMany.ts
+++ b/src/decorator/relations/OneToMany.ts
@@ -5,7 +5,7 @@ import {RelationMetadataArgs} from "../../metadata-args/RelationMetadataArgs";
  * One-to-many relation allows to create type of relation when Entity2 can have multiple instances of Entity1.
  * Entity1 have only one Entity2. Entity1 is an owner of the relationship, and storages Entity2 id on its own side.
  */
-export function OneToMany<T>(typeFunction: (type?: any) => ObjectType<T>, inverseSide: string|((object: T) => any), options?: RelationOptions): Function {
+export function OneToMany<T>(typeFunctionOrTarget: string|((type?: any) => ObjectType<T>), inverseSide: string|((object: T) => any), options?: RelationOptions): Function {
     return function (object: Object, propertyName: string) {
         if (!options) options = {} as RelationOptions;
 
@@ -23,7 +23,7 @@ export function OneToMany<T>(typeFunction: (type?: any) => ObjectType<T>, invers
             // propertyType: reflectedType,
             isLazy: isLazy,
             relationType: "one-to-many",
-            type: typeFunction,
+            type: typeFunctionOrTarget,
             inverseSideProperty: inverseSide,
             options: options
         } as RelationMetadataArgs);

--- a/src/decorator/relations/OneToOne.ts
+++ b/src/decorator/relations/OneToOne.ts
@@ -5,13 +5,14 @@ import {RelationMetadataArgs} from "../../metadata-args/RelationMetadataArgs";
  * One-to-one relation allows to create direct relation between two entities. Entity1 have only one Entity2.
  * Entity1 is an owner of the relationship, and storages Entity1 id on its own side.
  */
-export function OneToOne<T>(typeFunction: (type?: any) => ObjectType<T>, options?: RelationOptions): Function;
+export function OneToOne<T>(typeFunctionOrTarget: string|((type?: any) => ObjectType<T>), 
+                            options?: RelationOptions): Function;
 
 /**
  * One-to-one relation allows to create direct relation between two entities. Entity1 have only one Entity2.
  * Entity1 is an owner of the relationship, and storages Entity1 id on its own side.
  */
-export function OneToOne<T>(typeFunction: (type?: any) => ObjectType<T>,
+export function OneToOne<T>(typeFunctionOrTarget: string|((type?: any) => ObjectType<T>),
                             inverseSide?: string|((object: T) => any),
                             options?: RelationOptions): Function;
 
@@ -19,7 +20,7 @@ export function OneToOne<T>(typeFunction: (type?: any) => ObjectType<T>,
  * One-to-one relation allows to create direct relation between two entities. Entity1 have only one Entity2.
  * Entity1 is an owner of the relationship, and storages Entity1 id on its own side.
  */
-export function OneToOne<T>(typeFunction: (type?: any) => ObjectType<T>,
+export function OneToOne<T>(typeFunctionOrTarget: string|((type?: any) => ObjectType<T>),
                             inverseSideOrOptions?: string|((object: T) => any)|RelationOptions,
                             options?: RelationOptions): Function {
 
@@ -48,7 +49,7 @@ export function OneToOne<T>(typeFunction: (type?: any) => ObjectType<T>,
             // propertyType: reflectedType,
             isLazy: isLazy,
             relationType: "one-to-one",
-            type: typeFunction,
+            type: typeFunctionOrTarget,
             inverseSideProperty: inverseSideProperty,
             options: options
         } as RelationMetadataArgs);

--- a/test/github-issues/4190/entity/Category.ts
+++ b/test/github-issues/4190/entity/Category.ts
@@ -1,0 +1,12 @@
+import {Entity, PrimaryGeneratedColumn, Column} from "../../../../src";
+
+@Entity()
+export class Category {
+
+    @PrimaryGeneratedColumn()
+    id: number;
+
+    @Column()
+    name: string;
+
+}

--- a/test/github-issues/4190/entity/Photo.ts
+++ b/test/github-issues/4190/entity/Photo.ts
@@ -1,0 +1,16 @@
+import {Entity, PrimaryGeneratedColumn, Column, ManyToOne} from "../../../../src";
+import {User} from "./User";
+
+@Entity()
+export class Photo {
+
+    @PrimaryGeneratedColumn()
+    id: number;
+
+    @Column()
+    url: string;
+
+    @ManyToOne("User", "photos")
+    user: User;
+
+}

--- a/test/github-issues/4190/entity/Profile.ts
+++ b/test/github-issues/4190/entity/Profile.ts
@@ -1,0 +1,15 @@
+import {Entity, PrimaryGeneratedColumn, Column} from "../../../../src";
+
+@Entity()
+export class Profile {
+
+    @PrimaryGeneratedColumn()
+    id: number;
+
+    @Column()
+    gender: string;
+
+    @Column()
+    photo: string;
+
+}

--- a/test/github-issues/4190/entity/Question.ts
+++ b/test/github-issues/4190/entity/Question.ts
@@ -1,0 +1,14 @@
+import {Entity, PrimaryGeneratedColumn, ManyToMany, JoinTable} from "../../../../src";
+import {Category} from "./Category";
+
+@Entity()
+export class Question {
+
+    @PrimaryGeneratedColumn()
+    id: number;
+
+    @ManyToMany("Category")
+    @JoinTable()
+    categories: Category[];
+
+}

--- a/test/github-issues/4190/entity/User.ts
+++ b/test/github-issues/4190/entity/User.ts
@@ -1,0 +1,21 @@
+import {Entity, PrimaryGeneratedColumn, Column, OneToMany, OneToOne, JoinColumn} from "../../../../src";
+import {Photo} from "./Photo";
+import {Profile} from "./Profile";
+
+@Entity()
+export class User {
+
+    @PrimaryGeneratedColumn()
+    id: number;
+
+    @Column()
+    name: string;
+
+    @OneToMany("Photo", "user")
+    photos: Photo[];
+
+    @OneToOne("Profile")
+    @JoinColumn()
+    profile: Profile;
+
+}

--- a/test/github-issues/4190/issue-4190.ts
+++ b/test/github-issues/4190/issue-4190.ts
@@ -1,0 +1,129 @@
+import "reflect-metadata";
+import {createTestingConnections, closeTestingConnections, reloadTestingDatabases} from "../../utils/test-utils";
+import {Connection} from "../../../src/connection/Connection";
+
+import {Photo} from "./entity/Photo";
+import {User} from "./entity/User";
+import {Profile} from "./entity/Profile";
+import {Category} from "./entity/Category";
+import {Question} from "./entity/Question";
+
+describe("github issues > #4190 Relation decorators: allow to pass string instead of typeFunction", () => {
+
+    let connections: Connection[];
+    before(async () => connections = await createTestingConnections({
+        entities: [__dirname + "/entity/*{.js,.ts}"],
+        schemaCreate: true,
+        dropSchema: true,
+    }));
+    beforeEach(() => reloadTestingDatabases(connections));
+    after(() => closeTestingConnections(connections));
+
+    it("should work with one-to-one relations", () => Promise.all(connections.map(async connection => {
+
+        const profile = new Profile();
+        profile.gender = "male";
+        profile.photo = "me.jpg";
+        await connection.manager.save(profile);
+        
+        const user = new User();
+        user.name = "Joe Smith";
+        user.profile = profile;
+        await connection.manager.save(user);
+
+        const users = await connection.manager.find(User, { relations: ["profile"] });
+
+        users.should.eql([{
+            id: 1,
+            name: "Joe Smith",
+            profile: {
+                id: 1,
+                gender: "male",
+                photo: "me.jpg"
+            }
+        }]);
+
+    })));
+    
+    it("should work with many-to-one/one-to-many relations", () => Promise.all(connections.map(async connection => {
+
+        const photo1 = new Photo();
+        photo1.url = "me.jpg";
+        await connection.manager.save(photo1);
+        
+        const photo2 = new Photo();
+        photo2.url = "me-and-bears.jpg";
+        await connection.manager.save(photo2);
+        
+        const user = new User();
+        user.name = "John";
+        user.photos = [photo1, photo2];
+        await connection.manager.save(user);
+
+        const users = await connection.manager.find(User, { relations: ["photos"] });
+        const photos = await connection.manager.find(Photo, { relations: ["user"] });
+
+        // Check one-to-many
+        users[0].photos.should.have.deep.members([
+            {
+                id: 1,
+                url: "me.jpg"
+            },
+            {
+                id: 2,
+                url: "me-and-bears.jpg"
+            }
+        ]);
+
+        // Check many-to-one
+        photos.should.have.deep.members([
+            {
+                id: 1,
+                url: "me.jpg",
+                user: {
+                    id: 1,
+                    name: "John"
+                }
+            },
+            {
+                id: 2,
+                url: "me-and-bears.jpg",
+                user: {
+                    id: 1,
+                    name: "John"
+                }
+            }
+        ]);
+
+    })));
+
+    it("should work with many-to-many relations", () => Promise.all(connections.map(async connection => {
+
+        const category1 = new Category();
+        category1.name = "animals";
+        await connection.manager.save(category1);
+        
+        const category2 = new Category();
+        category2.name = "zoo";
+        await connection.manager.save(category2);
+        
+        const question = new Question();
+        question.categories = [category1, category2];
+        await connection.manager.save(question);
+
+        const questions = await connection.manager.find(Question, { relations: ["categories"] });
+
+        questions[0].categories.should.have.deep.members([
+            {
+                id: 1,
+                name: "animals"
+            },
+            {
+                id: 2,
+                name: "zoo"
+            }
+        ]);
+
+    })));
+
+});


### PR DESCRIPTION
Closes #4190

In addition to
```ts
@OneToOne(type => Profile)
@ManyToOne(type => User, user => user.photos)
@ManyToMany(type => Category)
```
now it's also possible to write:
```ts
@OneToOne('Profile')
@ManyToOne('User','photos')
@ManyToMany('Category')
```

Using this approach can prevent circular dependency issues when TypeORM is used within a frontend/browser application (e.g. when running through Angular CLI).

