### PR TITLE
fix(docs): Fixed many-to-many docs

### DIFF
--- a/docs/many-to-many-relations.md
+++ b/docs/many-to-many-relations.md
@@ -82,6 +82,8 @@ category2.name = "zoo";
 await connection.manager.save(category2);
 
 const question = new Question();
+question.title = "dogs";
+question.text = "who let the dogs out?";
 question.categories = [category1, category2];
 await connection.manager.save(question);
 ```


### PR DESCRIPTION
closes #4196

It's a minor documentation fix - should I provide a changelog update for this? I only see generic "update documentation" lines.