### PR TITLE
Reuse preloaded null values for lazy loads

### DIFF
--- a/src/query-builder/RelationLoader.ts
+++ b/src/query-builder/RelationLoader.ts
@@ -191,7 +191,7 @@ export class RelationLoader {
 
         Object.defineProperty(entity, relation.propertyName, {
             get: function() {
-                if (this[resolveIndex] === true || this[dataIndex]) // if related data already was loaded then simply return it
+                if (this[resolveIndex] === true || this[dataIndex] !== undefined) // if related data already was loaded then simply return it
                     return Promise.resolve(this[dataIndex]);
 
                 if (this[promiseIndex]) // if related data is loading then return a promise relationLoader loads it


### PR DESCRIPTION
The lazy load getter checks to see if the relation was already loaded by checking to see if the data for the relation is stored on the `dataIndex` key of the entity (i.e. `post.author` will check for `post.__author__` and reuse it if present).

Previously, it checked for a truthy value (just a simple `if (post.__author__)`). However, if the data for that relation was previously loaded, and that relation is empty, then `post.__author__` will be `null`. The simple truthy check will fail, and it will query the DB to attempt to load the relation.

This PR changes the check to explicitly check for `undefined`, rather than any falsey value. That way, preloaded `null` relations can reuse the preloaded value.