### PR TITLE
Dealt with numbers in change detection

### DIFF
--- a/src/driver/types/ColumnTypes.ts
+++ b/src/driver/types/ColumnTypes.ts
@@ -194,3 +194,33 @@ export type ColumnType = WithPrecisionColumnType
     |DateConstructor
     |NumberConstructor
     |StringConstructor;
+
+export const NumericTypes = [
+    "bigint", // mysql, postgres, mssql, sqlite, cockroachdb
+    "dec", // oracle, mssql
+    "dec", // oracle, mssql, mysql
+    "decimal", // mysql, postgres, mssql, sqlite
+    "decimal", // mysql, postgres, mssql, sqlite
+    "double precision", // postgres, oracle, sqlite, mysql, cockroachdb
+    "double", // mysql, sqlite
+    "fixed", // mysql
+    "fixed", // mysql
+    "float", // mysql, mssql, oracle, sqlite
+    "float4", // postgres, cockroachdb
+    "float8", // postgres, cockroachdb
+    "int", // mysql, mssql, oracle, sqlite
+    "int2", // postgres, sqlite, cockroachdb
+    "int4", // postgres, cockroachdb
+    "int8", // postgres, sqlite, cockroachdb
+    "integer", // postgres, oracle, sqlite, mysql, cockroachdb
+    "mediumint", // mysql, sqlite
+    "money", // postgres, mssql
+    "number", // oracle
+    "number", // oracle
+    "numeric", // postgres, mssql, sqlite
+    "numeric", // postgres, mssql, sqlite, mysql
+    "real", // mysql, postgres, mssql, oracle, sqlite, cockroachdb
+    "smallint", // mysql, postgres, mssql, oracle, sqlite, cockroachdb
+    "smallmoney", // mssql
+    "tinyint", // mysql, mssql, sqlite
+];

--- a/src/persistence/SubjectChangedColumnsComputer.ts
+++ b/src/persistence/SubjectChangedColumnsComputer.ts
@@ -1,3 +1,4 @@
+import {NumericTypes} from "../driver/types/ColumnTypes";
 import {Subject} from "./Subject";
 import {DateUtils} from "../util/DateUtils";
 import {ObjectLiteral} from "../common/ObjectLiteral";
@@ -78,6 +79,11 @@ export class SubjectChangedColumnsComputer {
 
                     } else if (column.type === "time") {
                         normalizedValue = DateUtils.mixedDateToTimeString(entityValue);
+
+                    } else if (NumericTypes.some(t => t === column.type)) {
+                        normalizedValue = column.precision != null
+                            ? normalizedValue.toPrecision(column.precision)
+                            : normalizedValue.toString();
 
                     } else if (column.type === "datetime" || column.type === Date) {
                         normalizedValue = DateUtils.mixedDateToUtcDatetimeString(entityValue);


### PR DESCRIPTION
Previously, number columns would always be marked as different and an update was executed. I changed the `SubjectChangedColumnsComputer.computeDiffColumns` to normalize numbers.