### PR TITLE
docs: add example for the TYPEORM_DRIVER_EXTRA env variable

### DIFF
--- a/docs/using-ormconfig.md
+++ b/docs/using-ormconfig.md
@@ -140,6 +140,10 @@ On production you can set all these values in real ENVIRONMENT VARIABLES.
 You cannot define multiple connections using an `env` file or environment variables.
 If your app has multiple connections then use alternative configuration storage format.
 
+If you need to pass a driver-specific option, e.g. `charset` for MySQL, you could use the `TYPEORM_DRIVER_EXTRA` variable in JSON format, e.g.
+```
+TYPEORM_DRIVER_EXTRA='{"charset": "utf8mb4"}'`
+```
 ## Using `ormconfig.yml`
 
 Create `ormconfig.yml` in the project root (near `package.json`). It should have the following content:


### PR DESCRIPTION
It isn't clear that it's possible to pass any typeORM config variable with environment variables. For example [here](https://github.com/typeorm/typeorm/issues/2885)

English isn't my native language, so feel free to improve the text.