### PR TITLE
Fix: change CURRENT_TIMESTAMP to DEFAULT so that time precision is pr…

### DIFF
--- a/src/query-builder/UpdateQueryBuilder.ts
+++ b/src/query-builder/UpdateQueryBuilder.ts
@@ -427,7 +427,7 @@ export class UpdateQueryBuilder<Entity> extends QueryBuilder<Entity> implements 
             if (metadata.versionColumn)
                 updateColumnAndValues.push(this.escape(metadata.versionColumn.databaseName) + " = " + this.escape(metadata.versionColumn.databaseName) + " + 1");
             if (metadata.updateDateColumn)
-                updateColumnAndValues.push(this.escape(metadata.updateDateColumn.databaseName) + " = CURRENT_TIMESTAMP"); // todo: fix issue with CURRENT_TIMESTAMP(6) being used, can "DEFAULT" be used?!
+                updateColumnAndValues.push(this.escape(metadata.updateDateColumn.databaseName) + " = DEFAULT"); // todo: fix issue with CURRENT_TIMESTAMP(6) being used, can "DEFAULT" be used?!
 
         } else {
             Object.keys(valuesSet).map(key => {

--- a/src/query-builder/UpdateQueryBuilder.ts
+++ b/src/query-builder/UpdateQueryBuilder.ts
@@ -426,8 +426,13 @@ export class UpdateQueryBuilder<Entity> extends QueryBuilder<Entity> implements 
 
             if (metadata.versionColumn)
                 updateColumnAndValues.push(this.escape(metadata.versionColumn.databaseName) + " = " + this.escape(metadata.versionColumn.databaseName) + " + 1");
-            if (metadata.updateDateColumn)
-                updateColumnAndValues.push(this.escape(metadata.updateDateColumn.databaseName) + " = DEFAULT"); // todo: fix issue with CURRENT_TIMESTAMP(6) being used, can "DEFAULT" be used?!
+            if (metadata.updateDateColumn) {
+                if (this.connection.driver instanceof MysqlDriver) {
+                    updateColumnAndValues.push(this.escape(metadata.updateDateColumn.databaseName) + " = DEFAULT");
+                } else {
+                    updateColumnAndValues.push(this.escape(metadata.updateDateColumn.databaseName) + " = CURRENT_TIMESTAMP");
+                }
+            }
 
         } else {
             Object.keys(valuesSet).map(key => {


### PR DESCRIPTION
…eserved when updating entities

Currently date-time precision is lost on updates for the UpdateDateColumn.

![image](https://user-images.githubusercontent.com/471800/59529350-a0c44780-8e95-11e9-88a9-2c4f5e960db4.png)

When setting up the entity, a precision of 6 was configured, but as it can be seen in the above query, entities having **version > 1** will lose 3 decimal places of precision.

Found this problem because when running local tests that have fast inserts, some updated entities will fall into the same seconds for UpdateDateColumn, which causes inconsistencies when sorting them by time, the order of updates cannot be distinguished within the same second.

Looking at the original comment, for performance issues CURRENT_TIMESTAMP(6) was not used anymore. But if tables have default `updatedDate datetime(6) DEFAULT CURRENT_TIMESTAMP(6)` then we should be okay to use DEFAULT, which will preserve precision in the cases of `updatedDate datetime(3) DEFAULT CURRENT_TIMESTAMP(3)`.