### PR TITLE
test(mongodb): time comparing is stable

### DIFF
--- a/test/functional/mongodb/basic/timestampable-columns/timestampable-columns.ts
+++ b/test/functional/mongodb/basic/timestampable-columns/timestampable-columns.ts
@@ -32,7 +32,8 @@ describe("mongodb > timestampable columns", () => {
         post.updatedAt.should.be.instanceof(Date);
         const updatedAt = post.updatedAt;
 
-        expect(post.createdAt.getTime()).to.equal(post.updatedAt.getTime());
+        // test has +/- delta range of 5 milliseconds, because earlier this test fell due to the difference of 1 millisecond
+        expect(post.updatedAt.getTime() - post.createdAt.getTime()).to.be.closeTo(0, 5);
 
         // update
         const date = new Date();


### PR DESCRIPTION
Test has `+/-` delta range of 5 milliseconds, because earlier this test fell due to the difference of 1 millisecond.

It fixes issue #4285