### PR TITLE
fix: length limit for eager join table alias in FindOptions

### DIFF
--- a/src/naming-strategy/DefaultNamingStrategy.ts
+++ b/src/naming-strategy/DefaultNamingStrategy.ts
@@ -1,6 +1,6 @@
 import {NamingStrategyInterface} from "./NamingStrategyInterface";
 import {RandomGenerator} from "../util/RandomGenerator";
-import {camelCase, snakeCase, titleCase} from "../util/StringUtils";
+import {camelCase, shorten, snakeCase, titleCase} from "../util/StringUtils";
 import {Table} from "../schema-builder/table/Table";
 
 /**
@@ -148,7 +148,13 @@ export class DefaultNamingStrategy implements NamingStrategyInterface {
         return prefix + tableName;
     }
 
-    eagerJoinRelationAlias(alias: string, propertyPath: string): string {
-        return alias + "_" + propertyPath.replace(".", "_");
+    joinRelationAlias(alias: string, relation: string, maxAliasLength?: number): string {
+        const relationAlias = alias + "__" + relation;
+        return maxAliasLength && relationAlias.length > maxAliasLength ? shorten(relationAlias) : relationAlias;
+    }
+
+    eagerJoinRelationAlias(alias: string, propertyPath: string, maxAliasLength?: number): string {
+        const relationAlias = alias + "__" + propertyPath.replace(".", "__");
+        return maxAliasLength && relationAlias.length > maxAliasLength ? shorten(relationAlias) : relationAlias;
     }
 }

--- a/src/naming-strategy/NamingStrategyInterface.ts
+++ b/src/naming-strategy/NamingStrategyInterface.ts
@@ -120,5 +120,10 @@ export interface NamingStrategyInterface {
     /**
      * Gets the name of the alias used for relation joins.
      */
-    eagerJoinRelationAlias(alias: string, propertyPath: string): string;
+    joinRelationAlias(alias: string, propertyPath: string, maxAliasLength?: number): string;
+
+    /**
+     * Gets the name of the alias used for eager relation joins.
+     */
+    eagerJoinRelationAlias(alias: string, propertyPath: string, maxAliasLength?: number): string;
 }


### PR DESCRIPTION
Hello!

### Context

This is a follow-up of the PR https://github.com/typeorm/typeorm/pull/4182 which itself was a follow-up of the PR https://github.com/typeorm/typeorm/pull/3514.

The issue is still the same except it's happening in join alias from relations defined as `eager` instead of join alias (defined in FindOption `relations` array) resulting in a `ERROR:  table name "CategoryWithVeryLongName__postsWithVeryLongName__authorWithVery" specified more than once` due to the fact names are truncated.

### Solution

The way I've implemented a fix is similar to what I did in the previous PR, i.e. by re-using @VinceOPS `shorten()`. This time I noticed the eager alias were generated from the --not-released-- NamingStrategy class, I added a method so both type of relations would be handled there.

### Tests

I did not write a test about it, I guess updating the previous one to add an eager relation would do the trick. I only tested it on Postgres but considering it's re-using existing Driver's option `maxAliasLength` it should be safe.

### Comments

Let me know if there is anything else I should do in order to get the PR merged.  
We are currently maintaining a fork of TypeORM with this fix on our apps until it's being reviewed and merged.

PS: In the previous PR I commented about updating manually the changelog, since then I noticed that conventional commit was adopted. Since my commits are respecting it, should I still update it manually or all commits will be picked-up automatically ?