### PR TITLE
fix: fix foreign key indexes not being created

### DIFF
--- a/src/metadata-builder/EntityMetadataBuilder.ts
+++ b/src/metadata-builder/EntityMetadataBuilder.ts
@@ -127,6 +127,7 @@ export class EntityMetadataBuilder {
                         relation.registerForeignKeys(foreignKey); // push it to the relation and thus register there a join column
                         entityMetadata.foreignKeys.push(foreignKey);
                     }
+
                     if (uniqueConstraint) {
                         if (this.connection.driver instanceof MysqlDriver || this.connection.driver instanceof SqlServerDriver) {
                             const index = new IndexMetadata({
@@ -163,7 +164,7 @@ export class EntityMetadataBuilder {
                         }
                     }
 
-                    if (foreignKey && this.connection.driver instanceof CockroachDriver) {
+                    if (foreignKey && !uniqueConstraint) {
                         const index = new IndexMetadata({
                             entityMetadata: relation.entityMetadata,
                             columns: foreignKey.columns,


### PR DESCRIPTION
Hello!

### Context

We recently experienced performance degradation in our stress test once the number of records were somewhat large.
At first I thought our queries were the issues (due to ~35 joins of tables sometimes containing up to 150k records), so I analyzed them (using `EXPLAIN ANALYSE`) and noticed a bunch of joins were done by Sequential Scan (`Seq Scan`).
I was quite surprised so I double checked our indexes and noticed none of our Relations but the `@OneToOne()` had their columns indexed.
Considering in the past I've noticed TypeORM was creating them correctly, I thought it was a regression. I inspected the source code, it was not that easy since I'm not really familiar with the whole synchronize system but I think I figured the issue :
- Basically there were no metadata related to those constraints in the table, so I inspected the `EntityMetadataBuilder`
- I figured that the regression is likely coming from changes between the Feb 11th and Feb 22th spread across multiple commits from @AlexMesser: https://github.com/typeorm/typeorm/commits/master/src/metadata-builder/EntityMetadataBuilder.ts.

### Solution

The way I've implemented a fix is pretty simple and may be subject to issues, especially for other drivers.
What I did is to not let index creation from foreign keys being created only for CockroachDB but for all drivers.
Also, I did not tested on CockroachDB but I wouldn't be surprised if there were a double index creation, one for the foreign key and another one for the unique constraint in the case of a `@OneToOne()` (since it's both a unique constraint and a foreign key). It should fix this issue as well.

### Tests

There is no test about this fix at this moment considering the scope of the change is quite big and I'm not sure what direction to take in order to provide a good coverage. Let me know what can I do on here.

### Comments

I would appreciate if @AlexMesser could comment about it and more importantly review it since it's mostly related to his changes and I'm not sure if my fix is not creating side effects elsewhere.

Also this bug is quite important (performance wise), I was surprised no one noticed it in ~4months, any application deployed during this time which doesn't have its schema synchronized will need to be notified about it in order to let the developers create a migration adding the missing indexes.
Not sure what you do usually @pleerock but I guess a special notice in changelog would be enough. (If people don't read the changelog when they update a package, then 🤷‍♂ )