### PR TITLE
refactor(cockroachdb): redundant executeQuery()

### DIFF
--- a/src/driver/cockroachdb/CockroachDriver.ts
+++ b/src/driver/cockroachdb/CockroachDriver.ts
@@ -735,16 +735,4 @@ export class CockroachDriver implements Driver {
         });
     }
 
-    /**
-     * Executes given query.
-     */
-    protected executeQuery(connection: any, query: string) {
-        return new Promise((ok, fail) => {
-            connection.query(query, (err: any, result: any) => {
-                if (err) return fail(err);
-                ok(result);
-            });
-        });
-    }
-
 }


### PR DESCRIPTION
`executeQuery` method is not used in `cockroachdb` driver

![redundant-executeQuery](https://user-images.githubusercontent.com/31797554/59614930-58718780-912a-11e9-94a6-897f94df83c2.png)
