### PR TITLE
WIP fix(query-builder): where conditions parameter

### DIFF
--- a/src/query-builder/SelectQueryBuilder.ts
+++ b/src/query-builder/SelectQueryBuilder.ts
@@ -2318,7 +2318,6 @@ export class SelectQueryBuilder<Entity> extends QueryBuilder<Entity> implements 
 
     protected buildWhere(where: any, metadata: EntityMetadata, alias: string, embedPrefix?: string): string {
         let condition: string = "";
-        let parameterIndex = Object.keys(this.expressionMap.nativeParameters).length;
         if (where instanceof Array) {
             condition = ("(" + where.map(whereItem => {
                 return this.buildWhere(whereItem, metadata, alias, embedPrefix);
@@ -2327,6 +2326,10 @@ export class SelectQueryBuilder<Entity> extends QueryBuilder<Entity> implements 
         } else {
             let andConditions: string[] = [];
             for (let key in where) {
+                // Earlier used to be at the very beginning of the buildWhere method, but should be in the loop
+                // Because when this loop call this.buildWhere() there are two separate `parameterIndex` variables
+                let parameterIndex = Object.keys(this.expressionMap.nativeParameters).length;
+
                 if (where[key] === undefined)
                     continue;
 

--- a/test/github-issues/3309/entity/Member.ts
+++ b/test/github-issues/3309/entity/Member.ts
@@ -1,0 +1,16 @@
+import {Column, Entity, OneToMany, PrimaryGeneratedColumn} from "../../../../src";
+import {Photo} from "./Photo";
+
+@Entity("member")
+export class Member {
+
+    @PrimaryGeneratedColumn()
+    id: number;
+
+    @Column()
+    name: string;
+
+    @OneToMany(_ => Photo, photo => photo.member)
+    photos: Photo[];
+
+}

--- a/test/github-issues/3309/entity/Photo.ts
+++ b/test/github-issues/3309/entity/Photo.ts
@@ -1,0 +1,16 @@
+import {Column, Entity, ManyToOne, PrimaryGeneratedColumn} from "../../../../src";
+import {Member} from "./Member";
+
+@Entity("photo")
+export class Photo {
+
+    @PrimaryGeneratedColumn()
+    id: number;
+
+    @Column()
+    type: string;
+
+    @ManyToOne(_ => Member, member => member.photos)
+    member: Member;
+
+}

--- a/test/github-issues/3309/issue-3309.ts
+++ b/test/github-issues/3309/issue-3309.ts
@@ -1,0 +1,63 @@
+import "reflect-metadata";
+import {closeTestingConnections, createTestingConnections, reloadTestingDatabases} from "../../utils/test-utils";
+import {Connection} from "../../../src/connection/Connection";
+import {Photo} from "./entity/Photo"
+import {Member} from "./entity/Member"
+import {expect} from "chai";
+
+describe.only("github issues > #3309 findOptions uses same parameter for different where options", () => {
+
+    let connections: Connection[];
+    before(async () => connections = await createTestingConnections({
+        entities: [__dirname + "/entity/*{.js,.ts}"],
+        enabledDrivers: ["postgres"],
+        dropSchema: true,
+        logging: true
+    }));
+    beforeEach(() => reloadTestingDatabases(connections));
+    after(() => closeTestingConnections(connections));
+
+    it("should not drop text column", () => Promise.all(connections.map(async connection => {
+        interface objInterface {
+            [key: string]: Photo
+        }
+        const obj:objInterface = {}
+
+        const array: string[] = ['old_type', 'new_type', 'old_type', 'new_type', 'new_type']
+        array.forEach(async (type: string, i: number) => {
+            const index = i + 1;
+            obj[`photo${index}`] = new Photo();
+            obj[`photo${index}`].type = type;
+            await connection.manager.save(obj[`photo${index}`]);
+        })
+
+        await connection.synchronize();
+        console.log({obj})
+
+        const member1 = new Member();
+        member1.name = "John";
+        member1.photos = [obj.photo1, obj.photo2];
+        await connection.manager.save(member1);
+
+        await connection.synchronize();
+
+        const member2 = new Member();
+        member2.name = "2ohn";
+        member2.photos = [obj.photo3, obj.photo4, obj.photo5];
+        await connection.manager.save(member2);
+
+        await connection.synchronize();
+
+        const result = await connection.manager.find(Photo, {
+            where: {
+                member: {
+                    id: 2
+                },
+                type: 'new_type'
+            }
+        });
+        expect([result[0].type, result[1].type]).to.be.eql(['new_type', 'new_type']);
+
+    })));
+
+});

--- a/test/github-issues/3309/issue-3309.ts
+++ b/test/github-issues/3309/issue-3309.ts
@@ -17,7 +17,7 @@ describe.only("github issues > #3309 findOptions uses same parameter for differe
     beforeEach(() => reloadTestingDatabases(connections));
     after(() => closeTestingConnections(connections));
 
-    it("should not drop text column", () => Promise.all(connections.map(async connection => {
+    it("should returns 2 object correctly", () => Promise.all(connections.map(async connection => {
         interface objInterface {
             [key: string]: Photo
         }
@@ -32,7 +32,6 @@ describe.only("github issues > #3309 findOptions uses same parameter for differe
         })
 
         await connection.synchronize();
-        console.log({obj})
 
         const member1 = new Member();
         member1.name = "John";

--- a/test/github-issues/3309/issue-3309.ts
+++ b/test/github-issues/3309/issue-3309.ts
@@ -1,35 +1,33 @@
 import "reflect-metadata";
 import {closeTestingConnections, createTestingConnections, reloadTestingDatabases} from "../../utils/test-utils";
 import {Connection} from "../../../src/connection/Connection";
-import {Photo} from "./entity/Photo"
-import {Member} from "./entity/Member"
+import {Photo} from "./entity/Photo";
+import {Member} from "./entity/Member";
 import {expect} from "chai";
 
-describe.only("github issues > #3309 findOptions uses same parameter for different where options", () => {
+describe("github issues > #3309 findOptions uses same parameter for different where options", () => {
 
     let connections: Connection[];
     before(async () => connections = await createTestingConnections({
         entities: [__dirname + "/entity/*{.js,.ts}"],
         enabledDrivers: ["postgres"],
         dropSchema: true,
-        logging: true
     }));
     beforeEach(() => reloadTestingDatabases(connections));
     after(() => closeTestingConnections(connections));
 
     it("should returns 2 object correctly", () => Promise.all(connections.map(async connection => {
-        interface objInterface {
-            [key: string]: Photo
+        interface ObjInterface {
+            [key: string]: Photo;
         }
-        const obj:objInterface = {}
-
-        const array: string[] = ['old_type', 'new_type', 'old_type', 'new_type', 'new_type']
+        const obj: ObjInterface = {};
+        const array: string[] = ["old_type", "new_type", "old_type", "new_type", "new_type"];
         array.forEach(async (type: string, i: number) => {
             const index = i + 1;
             obj[`photo${index}`] = new Photo();
             obj[`photo${index}`].type = type;
             await connection.manager.save(obj[`photo${index}`]);
-        })
+        });
 
         await connection.synchronize();
 
@@ -52,10 +50,10 @@ describe.only("github issues > #3309 findOptions uses same parameter for differe
                 member: {
                     id: 2
                 },
-                type: 'new_type'
+                type: "new_type"
             }
         });
-        expect([result[0].type, result[1].type]).to.be.eql(['new_type', 'new_type']);
+        expect([result[0].type, result[1].type]).to.be.eql(["new_type", "new_type"]);
 
     })));
 


### PR DESCRIPTION
TypeORM version **@next**

Fixes: #3309

Earlier `parameterIndex ` var was used at the very beginning of the `buildWhere` method, but should be in the loop
Because when this loop call `this.buildWhere()` there are two separate `parameterIndex` variables

But `parameterIndex` also used in this part of code:

```js
this.expressionMap.nativeParameters[parameterName + realParameterValueIndex] = realParameterValue;
parameterIndex++;
parameters.push(this.connection.driver.createParameter(parameterName + realParameterValueIndex, parameterIndex - 1));
```

Just want to run test by ci (my local machine is so weak) and recheck functionality one more time, I definitely write one more test for code above if it not exists

Also I have some questions:
1) Should I keep comment in the code or it looks messy?
2) Should I update `changelog`?