### PR TITLE
fix: add SaveOptions and RemoveOptions into ActiveRecord

### DIFF
--- a/src/repository/BaseEntity.ts
+++ b/src/repository/BaseEntity.ts
@@ -53,8 +53,8 @@ export class BaseEntity {
     /**
      * Removes current entity from the database.
      */
-    remove(): Promise<this> {
-        return (this.constructor as any).getRepository().remove(this);
+    remove(options?: RemoveOptions): Promise<this> {
+        return (this.constructor as any).getRepository().remove(this, options);
     }
 
     /**

--- a/src/repository/BaseEntity.ts
+++ b/src/repository/BaseEntity.ts
@@ -46,8 +46,8 @@ export class BaseEntity {
      * Saves current entity in the database.
      * If entity does not exist in the database then inserts, otherwise updates.
      */
-    save(): Promise<this> {
-        return (this.constructor as any).getRepository().save(this);
+    save(options?: SaveOptions): Promise<this> {
+        return (this.constructor as any).getRepository().save(this, options);
     }
 
     /**


### PR DESCRIPTION
This brings SaveOptions and RemoveOptions to BaseEntity inherited models methods `remove`and `save` when using ActiveRecord pattern.