### PR TITLE
Fix query builder crashing when using object in .where inside Brackets

### DIFF
--- a/test/github-issues/3685/entity/User.ts
+++ b/test/github-issues/3685/entity/User.ts
@@ -1,0 +1,14 @@
+import { Column, Entity, PrimaryGeneratedColumn } from "../../../../src";
+
+@Entity()
+export class User {
+
+    @PrimaryGeneratedColumn()
+    id: number;
+
+    @Column()
+    firstName: string;
+
+    @Column()
+    lastName: string;
+}

--- a/test/github-issues/3685/issue-3685.ts
+++ b/test/github-issues/3685/issue-3685.ts
@@ -1,0 +1,62 @@
+import { expect } from "chai";
+import { Brackets, Connection } from "../../../src";
+import { closeTestingConnections, createTestingConnections, reloadTestingDatabases } from "../../utils/test-utils";
+import { User } from "./entity/User";
+
+describe("github issues > #3685 Brackets syntax should not fail when used with object literal", () => {
+
+    let connections: Connection[];
+    before(async () => connections = await createTestingConnections({
+        entities: [__dirname + "/entity/*{.js,.ts}"],
+        schemaCreate: true,
+        dropSchema: true,
+    }));
+    beforeEach(() => reloadTestingDatabases(connections));
+    after(() => connections && closeTestingConnections(connections));
+
+    it("should accept objects in .where method (github issue #3685)", () => Promise.all(connections.map(async connection => {
+
+        await Promise.all([
+            connection.manager.save(Object.assign(new User(), {
+                firstName: "Jean",
+                lastName: "Doe",
+            })),
+
+            connection.manager.save(Object.assign(new User(), {
+                firstName: "John",
+                lastName: "Doe",
+            })),
+
+            connection.manager.save(Object.assign(new User(), {
+                firstName: "John",
+                lastName: "Dupont",
+            })),
+
+            connection.manager.save(Object.assign(new User(), {
+                firstName: "Fred",
+                lastName: "Doe",
+            }))
+        ]);
+
+        const qb = connection.createQueryBuilder(User, "u")
+            .where(new Brackets(qb => {
+                qb.where({ firstName: "John" })
+                    .orWhere("u.firstName = :firstName", { firstName: "Jean" });
+            }))
+            .andWhere("u.lastName = :lastName", { lastName: "Doe" })
+            .orderBy({
+                "u.firstName": "ASC",
+                "u.lastName": "ASC",
+            });
+
+        const results = await qb.getMany();
+
+        expect(results.length).to.equal(2);
+
+        expect(results[0].firstName).to.equal("Jean");
+        expect(results[0].lastName).to.equal("Doe");
+
+        expect(results[1].firstName).to.equal("John");
+        expect(results[1].lastName).to.equal("Doe");
+    })));
+});


### PR DESCRIPTION
This is an attempt at fixing #3685 where the following piece of code

```typescript
const generatedSql = entityManager
    .createQueryBuilder()
    .from(Product, 'Product')
    .where(new Brackets(qb => qb.where({ id: 1 })))
```

would crash because the QueryBuilder could not determine the alias to use for `id`