### PR TITLE
fix(sqlite): fixes simple-enum bug

### DIFF
--- a/src/driver/sqlite-abstract/AbstractSqliteDriver.ts
+++ b/src/driver/sqlite-abstract/AbstractSqliteDriver.ts
@@ -465,7 +465,9 @@ export abstract class AbstractSqliteDriver implements Driver {
      */
     createFullType(column: TableColumn): string {
         let type = column.type;
-
+        if (column.enum) {
+            return 'varchar'
+        }
         if (column.length) {
             type += "(" + column.length + ")";
 


### PR DESCRIPTION
I'm running into the same issue as @if1live here: https://github.com/typeorm/typeorm/issues/4147

```
CREATE TABLE "temporary_users" ("id" varchar PRIMARY KEY NOT NULL, "created_at" datetime NOT NULL DEFAULT (datetime('now')), "created_by_id" varchar NOT NULL, "updated_at" datetime DEFAULT (datetime('now')), "updated_by_id" varchar, "deleted_at" datetime, "deleted_by_id" varchar, "version" integer NOT NULL, "first_name" varchar(30) NOT NULL, "last_name" varchar(50), "email" varchar NOT NULL, "status" simple-enum CHECK( status IN ('ACTIVE','INACTIVE') ) NOT NULL, CONSTRAINT "UQ_97672ac88f789774dd47f7c8be3" UNIQUE ("email"))

error: [Error: SQLITE_ERROR: near "-": syntax error] {
  errno: 1,
  code: 'SQLITE_ERROR'
}
query: ROLLBACK

./src/error/QueryFailedError.ts:9
        super();
        ^
QueryFailedError: SQLITE_ERROR: near "-": syntax error
```

The issue seems to start in `buildCreateColumnSql`:

```
        if (column instanceof ColumnMetadata_1.ColumnMetadata) {
            c += " " + this.driver.normalizeType(column);
        }
        else {
            c += " " + this.connection.driver.createFullType(column);
        }
```

In the top code path, the correct type is generated.  When the bottom code path is hit, it doesn't handle enums properly