### PR TITLE
feat: Add pool error handler

### DIFF
--- a/src/driver/cockroachdb/CockroachConnectionOptions.ts
+++ b/src/driver/cockroachdb/CockroachConnectionOptions.ts
@@ -33,4 +33,11 @@ export interface CockroachConnectionOptions extends BaseConnectionOptions, Cockr
 
     };
 
+
+    /*
+    * Function handling errors thrown by drivers pool.
+    * Defaults to logging error with `warn` level.
+     */
+    readonly poolErrorHandler?: (err: any) => any;
+
 }

--- a/src/driver/cockroachdb/CockroachDriver.ts
+++ b/src/driver/cockroachdb/CockroachDriver.ts
@@ -710,11 +710,14 @@ export class CockroachDriver implements Driver {
         // create a connection pool
         const pool = new this.postgres.Pool(connectionOptions);
         const { logger } = this.connection;
+
+        const poolErrorHandler = options.poolErrorHandler || ((error: any) => logger.log("warn", `Postgres pool raised an error. ${error}`));
+
         /*
           Attaching an error handler to pool errors is essential, as, otherwise, errors raised will go unhandled and
           cause the hosting app to crash.
          */
-        pool.on("error", (error: any) => logger.log("warn", `Postgres pool raised an error. ${error}`));
+        pool.on("error", poolErrorHandler);
 
         return new Promise((ok, fail) => {
             pool.connect((err: any, connection: any, release: Function) => {

--- a/src/driver/postgres/PostgresConnectionOptions.ts
+++ b/src/driver/postgres/PostgresConnectionOptions.ts
@@ -39,4 +39,11 @@ export interface PostgresConnectionOptions extends BaseConnectionOptions, Postgr
      * If uuid-ossp is selected, TypeORM will use the uuid_generate_v4() function from this extension.
      */
     readonly uuidExtension?: "pgcrypto" | "uuid-ossp";
+
+
+    /*
+    * Function handling errors thrown by drivers pool.
+    * Defaults to logging error with `warn` level.
+     */
+    readonly poolErrorHandler?: (err: any) => any;
 }

--- a/src/driver/postgres/PostgresDriver.ts
+++ b/src/driver/postgres/PostgresDriver.ts
@@ -878,11 +878,14 @@ export class PostgresDriver implements Driver {
         // create a connection pool
         const pool = new this.postgres.Pool(connectionOptions);
         const { logger } = this.connection;
+
+        const poolErrorHandler = options.poolErrorHandler || ((error: any) => logger.log("warn", `Postgres pool raised an error. ${error}`));
+
         /*
           Attaching an error handler to pool errors is essential, as, otherwise, errors raised will go unhandled and
           cause the hosting app to crash.
          */
-        pool.on("error", (error: any) => logger.log("warn", `Postgres pool raised an error. ${error}`));
+        pool.on("error", poolErrorHandler);
 
         return new Promise((ok, fail) => {
             pool.connect((err: any, connection: any, release: Function) => {

--- a/src/driver/sqlserver/SqlServerConnectionOptions.ts
+++ b/src/driver/sqlserver/SqlServerConnectionOptions.ts
@@ -271,4 +271,10 @@ export interface SqlServerConnectionOptions extends BaseConnectionOptions, SqlSe
 
     };
 
+    /*
+    * Function handling errors thrown by drivers pool.
+    * Defaults to logging error with `warn` level.
+     */
+    readonly poolErrorHandler?: (err: any) => any;
+
 }

--- a/src/driver/sqlserver/SqlServerDriver.ts
+++ b/src/driver/sqlserver/SqlServerDriver.ts
@@ -749,11 +749,13 @@ export class SqlServerDriver implements Driver {
             const pool = new this.mssql.ConnectionPool(connectionOptions);
 
             const { logger } = this.connection;
+
+            const poolErrorHandler = options.poolErrorHandler || ((error: any) => logger.log("warn", `MSSQL pool raised an error. ${error}`));
             /*
               Attaching an error handler to pool errors is essential, as, otherwise, errors raised will go unhandled and
               cause the hosting app to crash.
              */
-            pool.on("error", (error: any) => logger.log("warn", `MSSQL pool raised an error. ${error}`));
+            pool.on("error", poolErrorHandler);
 
             const connection = pool.connect((err: any) => {
                 if (err) return fail(err);


### PR DESCRIPTION
Add option to customize pool error handling. Users can decide to log these errors with higher level (eg. error), crash application or reconnect.