### PR TITLE
fix: fix MySQL query construction with mixed type placeholders

### DIFF
--- a/test/github-issues/4429/entity/Category.ts
+++ b/test/github-issues/4429/entity/Category.ts
@@ -1,0 +1,16 @@
+import {Entity, PrimaryGeneratedColumn, Column} from "../../../../src";
+import {ManyToMany} from "../../../../src/decorator/relations/ManyToMany";
+import {Post} from "./Post";
+
+@Entity()
+export class Category {
+
+    @PrimaryGeneratedColumn()
+    id: number;
+
+    @ManyToMany(() => Post, post => post.categories)
+    posts: Post[];
+
+    @Column()
+    date: Date;
+}

--- a/test/github-issues/4429/entity/Post.ts
+++ b/test/github-issues/4429/entity/Post.ts
@@ -1,0 +1,18 @@
+import {Entity, ManyToMany, PrimaryGeneratedColumn, Column} from "../../../../src";
+import {JoinTable} from "../../../../src/decorator/relations/JoinTable";
+import {Category} from "./Category";
+
+@Entity()
+export class Post {
+
+    @PrimaryGeneratedColumn()
+    id: string;
+    
+    @Column()
+    name: string;
+
+    @ManyToMany(() => Category, category => category.posts)
+    @JoinTable()
+    categories: Category[];
+
+}

--- a/test/github-issues/4429/issue-4429.ts
+++ b/test/github-issues/4429/issue-4429.ts
@@ -1,0 +1,43 @@
+import "reflect-metadata";
+import {Connection} from "../../../src/connection/Connection";
+import {closeTestingConnections, createTestingConnections} from "../../utils/test-utils";
+import { Category } from "./entity/Category";
+import { Post } from "./entity/Post";
+import { expect } from "chai";
+import { LessThan } from "../../../src/find-options/operator/LessThan";
+
+describe("github issues > #4429 Incorrect construction of query with innerJoin and where ", () => {
+
+    let connections: Connection[];
+    before(async () => {
+        connections = await createTestingConnections({
+            entities: [__dirname + "/entity/*{.js,.ts}"],
+            enabledDrivers: ["mysql"],
+            schemaCreate: true,
+            dropSchema: true,
+        });
+    });
+    after(() => closeTestingConnections(connections));
+
+    it("should correctly construct a query where named and unnamed parameters are mixed", () => Promise.all(connections.map(async connection => {
+        const postRepository = connection.getRepository(Post);
+        const categoryRepository = connection.getRepository(Category);
+        
+        const category = new Category();
+        category.date = new Date(1970, 1, 1, 0, 0, 0);
+        await categoryRepository.save(category);
+
+        const post = new Post();
+        post.name = "foo";
+        post.categories = [ category ];
+        await postRepository.save(post);
+
+        const matches = await connection.getRepository(Category)
+            .createQueryBuilder()
+            .where({ date: LessThan(new Date()) })
+            .innerJoin("Category.posts", "post", "post.name = :name", { name: "foo" })
+            .getCount();
+        expect(matches).to.be.equal(1);
+    })));
+
+});


### PR DESCRIPTION
This commit fixes construction and execution of query with mixed
(named and unnamed) placeholders for MySQL.

Closes: typeorm/typeorm#4429