### PR TITLE
docs: fix missing async

### DIFF
--- a/docs/transactions.md
+++ b/docs/transactions.md
@@ -23,7 +23,7 @@ or
 ```typescript
 import {getManager} from "typeorm";
 
-await getManager().transaction(transactionalEntityManager => {
+await getManager().transaction(async transactionalEntityManager => {
     
 });
 ```

--- a/docs/transactions.md
+++ b/docs/transactions.md
@@ -13,7 +13,7 @@ Examples:
 ```typescript
 import {getConnection} from "typeorm";
 
-await getConnection().transaction(transactionalEntityManager => {
+await getConnection().transaction(async transactionalEntityManager => {
     
 });
 ```


### PR DESCRIPTION
In the second example the lambda is correctly started with an `async`. It is missing in the first example.