### PR TITLE
fix the Excessive stack depth comparing types `FindConditions<?>` and…

### DIFF
--- a/src/find-options/FindConditions.ts
+++ b/src/find-options/FindConditions.ts
@@ -4,5 +4,5 @@ import {FindOperator} from "./FindOperator";
  * Used for find operations.
  */
 export type FindConditions<T> = {
-    [P in keyof T]?: FindConditions<T[P]>|FindOperator<FindConditions<T[P]>>;
+    [P in keyof T]?: T[P] extends never ? FindConditions<T[P]>|FindOperator<FindConditions<T[P]>> : FindConditions<T[P]>|FindOperator<FindConditions<T[P]>>;
 };


### PR DESCRIPTION
Fix the this error:

`error TS2321: Excessive stack depth comparing types 'FindConditions<?>' and 'FindConditions<?>'.`

Affected TypeScript versions: >=3.2.0

The fixing is according to this link: https://github.com/microsoft/TypeScript/issues/21592#issuecomment-496723647
