### PR TITLE
add skipLibCheck: true

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -18,7 +18,8 @@
         "pretty": true,
         "strictNullChecks": true,
         "noUnusedLocals": true,
-        "downlevelIteration": true
+        "downlevelIteration": true,
+        "skipLibCheck": true
     },
     "exclude": [
         "tmp",


### PR DESCRIPTION
This mostly just reduces noise during `gulp package`. There's 1000+ library errors that are emitted during the build, but are ignored (they don't fail the build). Might as well silence them?