### PR TITLE
See if we can run ci tests in parallel, one DB at a time

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,11 +17,21 @@ before_script:
   - sudo service mysql stop
   - sudo service postgresql stop
   - docker-compose up -d
-  - cp ormconfig.travis.json ormconfig.json
   - npm install sqlite3 --build-from-source
+
+env:
+  - TEST_DB=mariadb
+  - TEST_DB=mongodb
+  - TEST_DB=mssql
+  - TEST_DB=mysql
+  - TEST_DB=oracle
+  - TEST_DB=postgres
+  - TEST_DB=sqlite
+  - TEST_DB=sqljs
 
 script:
   - npm run lint
+  - cp ormconfigs/ormconfig.$TEST_DB.json ormconfig.json
   - npm test
 
 after_success:

--- a/ormconfigs/ormconfig.mariadb.json
+++ b/ormconfigs/ormconfig.mariadb.json
@@ -1,0 +1,13 @@
+[
+    {
+        "skip": true,
+        "name": "mariadb",
+        "type": "mariadb",
+        "host": "localhost",
+        "port": 3307,
+        "username": "test",
+        "password": "test",
+        "database": "test",
+        "logging": false
+      }
+]

--- a/ormconfigs/ormconfig.mongodb.json
+++ b/ormconfigs/ormconfig.mongodb.json
@@ -1,0 +1,10 @@
+[
+    {
+        "skip": false,
+        "disabledIfNotEnabledImplicitly": true,
+        "name": "mongodb",
+        "type": "mongodb",
+        "database": "test",
+        "logging": false
+      }
+]

--- a/ormconfigs/ormconfig.mssql.json
+++ b/ormconfigs/ormconfig.mssql.json
@@ -1,0 +1,12 @@
+[
+    {
+        "skip": true,
+        "name": "mssql",
+        "type": "mssql",
+        "host": "localhost",
+        "username": "sa",
+        "password": "Admin12345",
+        "database": "tempdb",
+        "logging": false
+      }
+]

--- a/ormconfigs/ormconfig.mysql.json
+++ b/ormconfigs/ormconfig.mysql.json
@@ -1,0 +1,13 @@
+[
+    {
+        "skip": false,
+        "name": "mysql",
+        "type": "mysql",
+        "host": "localhost",
+        "port": 3306,
+        "username": "test",
+        "password": "test",
+        "database": "test",
+        "logging": false
+      }
+]

--- a/ormconfigs/ormconfig.oracle.json
+++ b/ormconfigs/ormconfig.oracle.json
@@ -1,0 +1,13 @@
+[
+    {
+        "skip": true,
+        "name": "oracle",
+        "type": "oracle",
+        "host": "localhost",
+        "username": "system",
+        "password": "oracle",
+        "port": 1521,
+        "sid": "xe.oracle.docker",
+        "logging": false
+      }
+]

--- a/ormconfigs/ormconfig.postgres.json
+++ b/ormconfigs/ormconfig.postgres.json
@@ -1,0 +1,13 @@
+[
+    {
+        "skip": false,
+        "name": "postgres",
+        "type": "postgres",
+        "host": "localhost",
+        "port": 5432,
+        "username": "test",
+        "password": "test",
+        "database": "test",
+        "logging": false
+      }
+]

--- a/ormconfigs/ormconfig.sqlite.json
+++ b/ormconfigs/ormconfig.sqlite.json
@@ -1,0 +1,9 @@
+[
+    {
+        "skip": false,
+        "name": "sqlite",
+        "type": "sqlite",
+        "database": "temp/sqlitedb.db",
+        "logging": false
+    }
+]

--- a/ormconfigs/ormconfig.sqljs.json
+++ b/ormconfigs/ormconfig.sqljs.json
@@ -1,0 +1,8 @@
+[
+    {
+        "skip": true,
+        "name": "sqljs",
+        "type": "sqljs",
+        "logging": false
+      }
+]


### PR DESCRIPTION
I don't mean for this PR to be accepted as is, I just wanted to open a discussion about an approach like this.

While working on stuff, I was getting frustrated at how the CI tests fail due to an issue with one DB that isn't present on the others. I took a stab at seeing if we could change the mocha `describe` and `it` usage to indicate which DB failed, but I didn't come up with anything good.

So, I figured maybe we could try running all the tests for each DB separately, that way we get a better sense of what is failing. This change would cause Travis to run `npm test` with a config unique to each DB so that only a single DB is tested. It then runs all of the DBs in parallel (it appears 5 at a time).

Right now I think it is a bit slower than the current approach, because it has to spin up, `npm install`, etc. for each test. We use CircleCI, so I know how I'd make it work more efficiently there, but I'm not too familiar with Travis.

Anyone have thoughts on how to speed this up? I think it would be really nice to know if my changes cause a break for multiple DBs or just a single DB.