### PR TITLE
fix: Transform properties when creating or updating entities

### DIFF
--- a/src/persistence/SubjectExecutor.ts
+++ b/src/persistence/SubjectExecutor.ts
@@ -328,6 +328,13 @@ export class SubjectExecutor {
             }
 
             subjects.forEach(subject => {
+                if (subject.diffColumns) {
+                    subject.diffColumns.forEach(column => {
+                        const value = column.getEntityValue(subject.entity!);
+                        const preparedValue = this.queryRunner.connection.driver.prepareHydratedValue(value, column);
+                        column.setEntityValue(subject.entity!, preparedValue);
+                    });
+                }
                 if (subject.generatedMap) {
                     subject.metadata.columns.forEach(column => {
                         const value = column.getEntityValue(subject.generatedMap!);
@@ -393,6 +400,13 @@ export class SubjectExecutor {
                 }
 
                 const updateResult = await updateQueryBuilder.execute();
+                if (subject.diffColumns) {
+                    subject.diffColumns.forEach(column => {
+                        const value = column.getEntityValue(subject.entity!);
+                        const preparedValue = this.queryRunner.connection.driver.prepareHydratedValue(value, column);
+                        column.setEntityValue(subject.entity!, preparedValue);
+                    });
+                }
                 subject.generatedMap = updateResult.generatedMaps[0];
                 if (subject.generatedMap) {
                     subject.metadata.columns.forEach(column => {

--- a/test/github-issues/4293/entity/Example.ts
+++ b/test/github-issues/4293/entity/Example.ts
@@ -1,0 +1,16 @@
+import {Entity, PrimaryGeneratedColumn, Column, CreateDateColumn} from "../../../../src";
+
+@Entity()
+export class Example {
+    @PrimaryGeneratedColumn()
+    id: number;
+
+    @Column({ transformer: {
+        to: value => value,
+        from: (value: string) => value.toUpperCase(),
+    }})
+    name: string;
+
+    @CreateDateColumn()
+    created: Date;
+}

--- a/test/github-issues/4293/issue-4293.ts
+++ b/test/github-issues/4293/issue-4293.ts
@@ -3,7 +3,7 @@ import {Connection} from "../../../src";
 import {closeTestingConnections, createTestingConnections, reloadTestingDatabases} from "../../utils/test-utils";
 import {Example} from "./entity/Example";
 
-describe.only("github issues > #4293 Transformer value not returned on save", () => {
+describe("github issues > #4293 Transformer value not returned on save", () => {
     let connections: Connection[];
     before(async () => connections = await createTestingConnections({
         entities: [Example],

--- a/test/github-issues/4293/issue-4293.ts
+++ b/test/github-issues/4293/issue-4293.ts
@@ -1,0 +1,63 @@
+import {expect} from "chai";
+import {Connection} from "../../../src";
+import {closeTestingConnections, createTestingConnections, reloadTestingDatabases} from "../../utils/test-utils";
+import {Example} from "./entity/Example";
+
+describe.only("github issues > #4293 Transformer value not returned on save", () => {
+    let connections: Connection[];
+    before(async () => connections = await createTestingConnections({
+        entities: [Example],
+        enabledDrivers: ["mysql", "postgres"]
+    }));
+    beforeEach(() => reloadTestingDatabases(connections));
+    after(() => closeTestingConnections(connections));
+
+    it("Still transforms value on retrieval as expected", async () => Promise.all(connections.map(async connection => {
+        const entity = await connection.manager.save(Object.assign(new Example(), {name: "test"}));
+
+        const loadedEntity = await connection.manager.findOne(Example, entity.id);
+        expect(loadedEntity!.name).to.be.eql("TEST");
+    })));
+
+    it("Transforms value on entity returned from save", async () => Promise.all(connections.map(async connection => {
+        const entity = await connection.manager.save(Object.assign(new Example(), {name: "test"}));
+
+        expect(entity.name).to.be.eql("TEST");
+    })));
+
+    it("Transforms value on multiple entities returned from save", async () => Promise.all(connections.map(async connection => {
+        const [foo, bar] = await connection.manager.save([
+            Object.assign(new Example(), {name: "foo"}),
+            Object.assign(new Example(), {name: "bar"}),
+        ]);
+
+        expect(foo.name).to.be.eql("FOO");
+        expect(bar.name).to.be.eql("BAR");
+    })));
+
+    it("Transforms value on single updated entity", async () => Promise.all(connections.map(async connection => {
+        const entity = await connection.manager.save(Object.assign(new Example(), {name: "test"}));
+        expect(entity.name).to.be.eql("TEST");
+
+        entity.name = "foo";
+        await connection.manager.save(entity);
+
+        expect(entity.name).to.be.eql("FOO");
+    })));
+
+    it("Transforms value on multiple updated entities", async () => Promise.all(connections.map(async connection => {
+        const [foo, bar] = await connection.manager.save([
+            Object.assign(new Example(), {name: "test"}),
+            Object.assign(new Example(), {name: "test"}),
+        ]);
+        expect(foo.name).to.be.eql("TEST");
+        expect(bar.name).to.be.eql("TEST");
+
+        foo.name = "foo";
+        bar.name = "bar";
+        await connection.manager.save([foo, bar]);
+
+        expect(foo.name).to.be.eql("FOO");
+        expect(bar.name).to.be.eql("BAR");
+    })));
+});


### PR DESCRIPTION
Fixes #4293. Entities no longer need to be retrieved after being saved to have transformed properties.

Updates `SubjectExecutor` to check `diffColumns` and transform the values if columns were changed as the result of a `save`.

During testing, I found columns in the `generatedMap` were specifically not included in `diffColumns` and vice-versa, so there shouldn't be columns being transformed twice.

Added in a `@CreateDateColumn` in the test to demonstrate that generated columns are not affected.