### PR TITLE
fix: transform nested embedded array column overwritten undefined (mongodb)

### DIFF
--- a/src/query-builder/transformer/DocumentToEntityTransformer.ts
+++ b/src/query-builder/transformer/DocumentToEntityTransformer.ts
@@ -89,7 +89,10 @@ export class DocumentToEntityTransformer {
                     entity[embedded.propertyName] = (document[embedded.prefix] as any[]).map((subValue: any, index: number) => {
                         const newItem = embedded.create();
                         embedded.columns.forEach(column => {
-                            newItem[column.propertyName] = subValue[column.databaseNameWithoutPrefixes];
+                            const value = subValue[column.databaseNameWithoutPrefixes];
+                            if (value === undefined) return;
+
+                            newItem[column.propertyName] = value;
                         });
                         addEmbeddedValuesRecursively(newItem, document[embedded.prefix][index], embedded.embeddeds);
                         return newItem;

--- a/test/functional/mongodb/basic/array-columns/entity/Counters.ts
+++ b/test/functional/mongodb/basic/array-columns/entity/Counters.ts
@@ -8,9 +8,13 @@ export class Counters {
     @Column()
     text: string;
 
-    constructor(likes: number, text: string) {
+    @Column()
+    tags: string[];
+
+    constructor(likes: number, text: string = "default text") {
         this.likes = likes;
         this.text = text;
+        this.tags = [];
     }
 
 }


### PR DESCRIPTION
**Issue type:**

[ ] question
[x] bug report
[ ] feature request
[ ] documentation issue

**Database system/driver:**

[ ] `cordova`
[x] `mongodb`
[ ] `mssql`
[ ] `mysql` / `mariadb`
[ ] `oracle`
[ ] `postgres`
[ ] `cockroachdb`
[ ] `sqlite`
[ ] `sqljs`
[ ] `react-native`
[ ] `expo`

**TypeORM version:**

[x] `latest`
[ ] `@next`
[ ] `0.x.x` (or put your version here)

**Steps to reproduce or a small repository showing the problem:**

```typescript
export class Post {
  @Column()
  title: string

  @Column()
  comments: Comment[]
}

export class Comment {
  @Column()
  text: string

  @Column(type => Attachment)
  attachments: Attachment[]  // new column added

  constructor() {
    this.attachments = [] // added
  }
}

export class Attachment {
  @Column()
  subject: string
}
...
const oldPost = new Post()
oldPost.title = 'title'
const comment  = new Comment()
comment.text = 'hello'
oldPost.comments = [comments]
await repo.save(oldPost); // before attachments column is added

// Add attachments to Comment

const [post] = await repo.find();
post.comments[0].attachments  // is undefined, empty array expected
```

For example, adding new column to a collection, existtant documents have no columns in DB.
I want to set the column default value in the constructor and then I can handle it without whether its value is null or not.

I think that skipping the assignment of columns that has no value should be implemented in the commit (https://github.com/typeorm/typeorm/commit/0ae68e49aab371cd56dd253e8ddbf13f3e1a57bb#diff-5ca83022308e329a128f5a2bf58ba6c8).

