### PR TITLE
MsSql: stringy port exception

### DIFF
--- a/src/connection/options-reader/ConnectionOptionsEnvReader.ts
+++ b/src/connection/options-reader/ConnectionOptionsEnvReader.ts
@@ -21,7 +21,7 @@ export class ConnectionOptionsEnvReader {
             type: PlatformTools.getEnvVariable("TYPEORM_CONNECTION") || (PlatformTools.getEnvVariable("TYPEORM_URL") ? PlatformTools.getEnvVariable("TYPEORM_URL").split("://")[0] : undefined),
             url: PlatformTools.getEnvVariable("TYPEORM_URL"),
             host: PlatformTools.getEnvVariable("TYPEORM_HOST"),
-            port: Number(PlatformTools.getEnvVariable("TYPEORM_PORT")),
+            port: PlatformTools.getEnvVariable("TYPEORM_PORT") && !isNaN(PlatformTools.getEnvVariable("TYPEORM_PORT")) ? Number(PlatformTools.getEnvVariable("TYPEORM_PORT")) : undefined,
             username: PlatformTools.getEnvVariable("TYPEORM_USERNAME"),
             password: PlatformTools.getEnvVariable("TYPEORM_PASSWORD"),
             database: PlatformTools.getEnvVariable("TYPEORM_DATABASE"),

--- a/src/connection/options-reader/ConnectionOptionsEnvReader.ts
+++ b/src/connection/options-reader/ConnectionOptionsEnvReader.ts
@@ -21,7 +21,7 @@ export class ConnectionOptionsEnvReader {
             type: PlatformTools.getEnvVariable("TYPEORM_CONNECTION") || (PlatformTools.getEnvVariable("TYPEORM_URL") ? PlatformTools.getEnvVariable("TYPEORM_URL").split("://")[0] : undefined),
             url: PlatformTools.getEnvVariable("TYPEORM_URL"),
             host: PlatformTools.getEnvVariable("TYPEORM_HOST"),
-            port: PlatformTools.getEnvVariable("TYPEORM_PORT"),
+            port: +PlatformTools.getEnvVariable("TYPEORM_PORT"),
             username: PlatformTools.getEnvVariable("TYPEORM_USERNAME"),
             password: PlatformTools.getEnvVariable("TYPEORM_PASSWORD"),
             database: PlatformTools.getEnvVariable("TYPEORM_DATABASE"),

--- a/src/connection/options-reader/ConnectionOptionsEnvReader.ts
+++ b/src/connection/options-reader/ConnectionOptionsEnvReader.ts
@@ -21,7 +21,7 @@ export class ConnectionOptionsEnvReader {
             type: PlatformTools.getEnvVariable("TYPEORM_CONNECTION") || (PlatformTools.getEnvVariable("TYPEORM_URL") ? PlatformTools.getEnvVariable("TYPEORM_URL").split("://")[0] : undefined),
             url: PlatformTools.getEnvVariable("TYPEORM_URL"),
             host: PlatformTools.getEnvVariable("TYPEORM_HOST"),
-            port: +PlatformTools.getEnvVariable("TYPEORM_PORT"),
+            port: Number(PlatformTools.getEnvVariable("TYPEORM_PORT")),
             username: PlatformTools.getEnvVariable("TYPEORM_USERNAME"),
             password: PlatformTools.getEnvVariable("TYPEORM_PASSWORD"),
             database: PlatformTools.getEnvVariable("TYPEORM_DATABASE"),


### PR DESCRIPTION
There was a problem with MsSql driver - [tedious](https://github.com/tediousjs/tedious), when getting DB connection parameters from environment. There was [a type checking of number](https://github.com/tediousjs/tedious/blob/master/src/connection.js#L534), but port, passed from TypeORM was a stringy number, so it throws an error.

Solution: convert port to number.