### PR TITLE
add options to input init config for sql.js

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ feel free to ask us and community.
 * extend afterLoad() subscriber interface to take LoadEvent ([issue #4185](https://github.com/typeorm/typeorm/issues/4185))
 * relation decorators (e.g. `@OneToMany`) now also accept `string` instead of `typeFunction`, which prevents circular dependency issues in the frontend/browser ([issue #4190](https://github.com/typeorm/typeorm/issues/4190))
 * added support for metadata reflection in typeorm-class-transformer-shim.js ([issue #4219](https://github.com/typeorm/typeorm/issues/4219))
+* added `sqlJsConfig` to input config when initializing sql.js ([issue #4559](https://github.com/typeorm/typeorm/issues/4559))
 
 ## 0.2.17 (2019-05-01)
 

--- a/docs/connection-options.md
+++ b/docs/connection-options.md
@@ -461,6 +461,8 @@ See [SSL options](https://github.com/mysqljs/mysql#ssl-options).
 
 * `database`: The raw UInt8Array database that should be imported.
 
+* `sqlJsConfig`: Optional initialize config for sql.js.
+
 * `autoSave`: Whether or not autoSave should be disabled. If set to true the database will be saved to the given file location (Node.js) or LocalStorage element (browser) when a change happens and `location` is specified. Otherwise `autoSaveCallback` can be used.
 
 * `autoSaveCallback`: A function that get's called when changes to the database are made and `autoSave` is enabled. The function gets a `UInt8Array` that represents the database.

--- a/docs/zh_CN/connection-options.md
+++ b/docs/zh_CN/connection-options.md
@@ -372,6 +372,8 @@
 
 - `database`: 应导入的原始 UInt8Array 数据库。
 
+- `sqlJsConfig`: sql.js可选启动配置
+
 - `autoSave`: 是否应禁用 autoSave。如果设置为 true，则在发生更改并指定`location`时，数据库将保存到给定的文件位置（Node.js）或 LocalStorage（浏览器）。否则可以使用`autoSaveCallback`。
 
 - `autoSaveCallback`: 在对数据库进行更改并启用`autoSave`时调用的函数。该函数获取表示数据库的`UInt8Array`。

--- a/src/driver/sqljs/SqljsConnectionOptions.ts
+++ b/src/driver/sqljs/SqljsConnectionOptions.ts
@@ -16,6 +16,11 @@ export interface SqljsConnectionOptions extends BaseConnectionOptions {
     readonly database?: Uint8Array;
 
     /**
+     * Config that's used to initialize sql.js.
+     */
+    readonly sqlJsConfig?: any;
+
+    /**
      * Enables the autoSave mechanism which either saves to location
      * or calls autoSaveCallback every time a change to the database is made.
      */

--- a/src/driver/sqljs/SqljsDriver.ts
+++ b/src/driver/sqljs/SqljsDriver.ts
@@ -248,7 +248,7 @@ export class SqljsDriver extends AbstractSqliteDriver {
     protected async createDatabaseConnectionWithImport(database?: Uint8Array): Promise<any> {
         // sql.js < 1.0 exposes an object with a `Database` method.
         const isLegacyVersion = typeof this.sqlite.Database === "function";
-        const sqlite = isLegacyVersion ? this.sqlite : await this.sqlite(); 
+        const sqlite = isLegacyVersion ? this.sqlite : await this.sqlite(this.options.sqlJsConfig);
         if (database && database.length > 0) {
             this.databaseConnection = new sqlite.Database(database);
         }


### PR DESCRIPTION
Fixes https://github.com/typeorm/typeorm/issues/4559

added `sqlJsConfig` connection option for sql.js (v1.x) to inititialize.