### PR TITLE
docs: use remove instead of delete

### DIFF
--- a/docs/example-with-express.md
+++ b/docs/example-with-express.md
@@ -233,7 +233,7 @@ createConnection().then(connection => {
     });
 
     app.delete("/users/:id", async function(req: Request, res: Response) {
-        const results = await userRepository.remove(req.params.id);
+        const results = await userRepository.delete(req.params.id);
         return res.send(results);
     });
 


### PR DESCRIPTION
the `remove` method requires the entity itself as input. To remove a record based on it's id, you need to use `delete`