### PR TITLE
docs: clarify title of configuration sources

### DIFF
--- a/docs/using-ormconfig.md
+++ b/docs/using-ormconfig.md
@@ -1,4 +1,4 @@
-# ormconfig.json
+# Using Configuration Sources
 
   - [Creating a new connection from the configuration file](#creating-a-new-connection-from-the-configuration-file)
   - [Using `ormconfig.json`](#using-ormconfigjson)


### PR DESCRIPTION
Since many formats of configuration sources are supported, it makes sense to not have the title specific to `.json`