### PR TITLE
FindConditions instead of any for EntityManager.delete()

### DIFF
--- a/src/entity-manager/EntityManager.ts
+++ b/src/entity-manager/EntityManager.ts
@@ -533,7 +533,7 @@ export class EntityManager {
      * Does not check if entity exist in the database.
      * Condition(s) cannot be empty.
      */
-    delete<Entity>(targetOrEntity: ObjectType<Entity>|EntitySchema<Entity>|string, criteria: string|string[]|number|number[]|Date|Date[]|ObjectID|ObjectID[]|any): Promise<DeleteResult> {
+    delete<Entity>(targetOrEntity: ObjectType<Entity>|EntitySchema<Entity>|string, criteria: string|string[]|number|number[]|Date|Date[]|ObjectID|ObjectID[]|FindConditions<Entity>): Promise<DeleteResult> {
 
         // if user passed empty criteria or empty list of criterias, then throw an error
         if (criteria === undefined ||


### PR DESCRIPTION
Context is in #4608 . I'm not 100% sure if this is correct for using `delete` properly (it passes the code directly to a `QueryBuilder.where()` clause, which I think can take `FindConditions`? But I'm not totally sure if that's how `QueryBuilder` works.

Having something like this would save my team and probably other's from blowing up their own dbs.