### PR TITLE
Fix: Apostrophe in Postgres enum strings breaks query

### DIFF
--- a/src/driver/mysql/MysqlQueryRunner.ts
+++ b/src/driver/mysql/MysqlQueryRunner.ts
@@ -1636,7 +1636,7 @@ export class MysqlQueryRunner extends BaseQueryRunner implements QueryRunner {
             c += " UNSIGNED";
         }
         if (column.enum)
-            c += ` (${column.enum.map(value => "'" + value + "'").join(", ")})`;
+            c += ` (${column.enum.map(value => "'" + value.replace("'", "''") + "'").join(", ")})`;
         if (column.charset)
             c += ` CHARACTER SET "${column.charset}"`;
         if (column.collation)

--- a/src/driver/postgres/PostgresQueryRunner.ts
+++ b/src/driver/postgres/PostgresQueryRunner.ts
@@ -1838,7 +1838,7 @@ export class PostgresQueryRunner extends BaseQueryRunner implements QueryRunner 
     protected createEnumTypeSql(table: Table, column: TableColumn, enumName?: string): Query {
         if (!enumName)
             enumName = this.buildEnumName(table, column);
-        const enumValues = column.enum!.map(value => `'${value}'`).join(", ");
+        const enumValues = column.enum!.map(value => `'${value.replace("'", "''")}'`).join(", ");
         return new Query(`CREATE TYPE ${enumName} AS ENUM(${enumValues})`);
     }
 

--- a/test/github-issues/4630/entity/User.ts
+++ b/test/github-issues/4630/entity/User.ts
@@ -1,0 +1,15 @@
+import { Entity, Column, PrimaryGeneratedColumn } from '../../../../src';
+
+export enum Realm {
+    Blackrock = "Blackrock",
+    KelThuzad = "Kel'Thuzad",
+}
+
+@Entity()
+export class User {
+    @PrimaryGeneratedColumn()
+    id: number;
+
+    @Column({ type: 'enum', enum: Realm })
+    realm: Realm;
+}

--- a/test/github-issues/4630/entity/User.ts
+++ b/test/github-issues/4630/entity/User.ts
@@ -1,4 +1,4 @@
-import { Entity, Column, PrimaryGeneratedColumn } from '../../../../src';
+import { Entity, Column, PrimaryGeneratedColumn } from "../../../../src";
 
 export enum Realm {
     Blackrock = "Blackrock",
@@ -10,6 +10,6 @@ export class User {
     @PrimaryGeneratedColumn()
     id: number;
 
-    @Column({ type: 'enum', enum: Realm })
+    @Column({ type: "enum", enum: Realm })
     realm: Realm;
 }

--- a/test/github-issues/4630/issue-4630.ts
+++ b/test/github-issues/4630/issue-4630.ts
@@ -1,0 +1,31 @@
+import "reflect-metadata";
+import {createTestingConnections, closeTestingConnections, reloadTestingDatabases} from "../../utils/test-utils";
+import {Connection} from "../../../src/connection/Connection";
+import { Realm } from './entity/User';
+import {User} from "./entity/User";
+
+describe("github issues > #4360 Enum string not escaping resulting in broken migrations.", () => {
+
+    let connections: Connection[];
+    before(async () => connections = await createTestingConnections({
+        entities: [__dirname + "/entity/*{.js,.ts}"],
+        schemaCreate: true,
+        dropSchema: true,
+    }));
+    beforeEach(() => reloadTestingDatabases(connections));
+    after(() => closeTestingConnections(connections));
+
+    it("should should allow postgres enums to have apostrophes in the values", () => Promise.all(connections.map(async connection => {
+        const user = new User()
+        user.realm = Realm.KelThuzad;
+
+        await connection.manager.save(user);
+
+        const users = await connection.manager.find(User);
+
+        users.should.eql([{
+            id: 1,
+            realm: "Kel'Thuzad"
+        }])
+    })));
+});

--- a/test/github-issues/4630/issue-4630.ts
+++ b/test/github-issues/4630/issue-4630.ts
@@ -1,7 +1,7 @@
 import "reflect-metadata";
 import {createTestingConnections, closeTestingConnections, reloadTestingDatabases} from "../../utils/test-utils";
 import {Connection} from "../../../src/connection/Connection";
-import { Realm } from './entity/User';
+import { Realm } from "./entity/User";
 import {User} from "./entity/User";
 
 describe("github issues > #4360 Enum string not escaping resulting in broken migrations.", () => {
@@ -16,7 +16,7 @@ describe("github issues > #4360 Enum string not escaping resulting in broken mig
     after(() => closeTestingConnections(connections));
 
     it("should should allow postgres enums to have apostrophes in the values", () => Promise.all(connections.map(async connection => {
-        const user = new User()
+        const user = new User();
         user.realm = Realm.KelThuzad;
 
         await connection.manager.save(user);
@@ -26,6 +26,6 @@ describe("github issues > #4360 Enum string not escaping resulting in broken mig
         users.should.eql([{
             id: 1,
             realm: "Kel'Thuzad"
-        }])
+        }]);
     })));
 });

--- a/test/github-issues/4630/issue-4630.ts
+++ b/test/github-issues/4630/issue-4630.ts
@@ -4,7 +4,7 @@ import {Connection} from "../../../src/connection/Connection";
 import { Realm } from "./entity/User";
 import {User} from "./entity/User";
 
-describe.only("github issues > #4630 Enum string not escaping resulting in broken migrations.", () => {
+describe("github issues > #4630 Enum string not escaping resulting in broken migrations.", () => {
 
     let connections: Connection[];
     before(async () => connections = await createTestingConnections({

--- a/test/github-issues/4630/issue-4630.ts
+++ b/test/github-issues/4630/issue-4630.ts
@@ -4,18 +4,19 @@ import {Connection} from "../../../src/connection/Connection";
 import { Realm } from "./entity/User";
 import {User} from "./entity/User";
 
-describe("github issues > #4360 Enum string not escaping resulting in broken migrations.", () => {
+describe.only("github issues > #4630 Enum string not escaping resulting in broken migrations.", () => {
 
     let connections: Connection[];
     before(async () => connections = await createTestingConnections({
         entities: [__dirname + "/entity/*{.js,.ts}"],
         schemaCreate: true,
         dropSchema: true,
+        enabledDrivers: ["mysql", "postgres"]
     }));
     beforeEach(() => reloadTestingDatabases(connections));
     after(() => closeTestingConnections(connections));
 
-    it("should should allow postgres enums to have apostrophes in the values", () => Promise.all(connections.map(async connection => {
+    it("should support enums of strings with apostrophes in them", () => Promise.all(connections.map(async connection => {
         const user = new User();
         user.realm = Realm.KelThuzad;
 


### PR DESCRIPTION
Patch for #4630

I'm not a SQL hero, but a simple way of escaping an apostrophe in this context is to simply use two apostrophes and this appears to work well for me. This is likely an issue in other drivers, but I am not familiar.