### PR TITLE
fix: migrations run in reverse order for mongodb

### DIFF
--- a/test/github-issues/4697/entity/config.entity.ts
+++ b/test/github-issues/4697/entity/config.entity.ts
@@ -1,0 +1,16 @@
+import {Entity, ObjectIdColumn, ObjectID, Column} from "../../../../src";
+
+/**
+ * @deprecated use item config instead
+ */
+@Entity()
+export class Config {
+  @ObjectIdColumn()
+  _id: ObjectID;
+
+  @Column()
+  itemId: string;
+
+  @Column({ type: "json" })
+  data: any;
+}

--- a/test/github-issues/4697/entity/item.entity.ts
+++ b/test/github-issues/4697/entity/item.entity.ts
@@ -1,0 +1,19 @@
+import {Entity, ObjectIdColumn, ObjectID, Column} from "../../../../src";
+
+@Entity()
+export class Item {
+  @ObjectIdColumn()
+  public _id: ObjectID;
+
+  /**
+   * @deprecated use contacts instead
+   */
+  @Column()
+  public contact?: string;
+
+  @Column({ array: true })
+  public contacts: Array<string>;
+
+  @Column({ type: "json" })
+  config: any;
+}

--- a/test/github-issues/4697/issue-4697.ts
+++ b/test/github-issues/4697/issue-4697.ts
@@ -1,0 +1,28 @@
+import "reflect-metadata";
+import {createTestingConnections, closeTestingConnections, reloadTestingDatabases} from "../../utils/test-utils";
+import {Connection} from "../../../src/connection/Connection";
+
+describe("github issues > #4697 Revert migrations running in reverse order.", () => {
+
+    let connections: Connection[];
+    before(async () => connections = await createTestingConnections({
+        entities: [__dirname + "/entity/*{.js,.ts}"],
+        migrations: [__dirname + "/migration/*.js"],
+        enabledDrivers: ["mongodb"],
+        schemaCreate: true,
+        dropSchema: true,
+    }));
+    beforeEach(() => reloadTestingDatabases(connections));
+    after(() => closeTestingConnections(connections));
+
+    it("should revert migrations in the right order", () => Promise.all(connections.map(async connection => {
+        await connection.runMigrations();
+
+        await connection.undoLastMigration();
+
+        const [lastMigration] = await connection.runMigrations();
+
+        lastMigration.should.have.property("timestamp", 1567689639607);
+        lastMigration.should.have.property("name", "MergeConfigs1567689639607");
+    })));
+});

--- a/test/github-issues/4697/migration/1566560354098-UpdateContacts.ts
+++ b/test/github-issues/4697/migration/1566560354098-UpdateContacts.ts
@@ -1,0 +1,30 @@
+import {MigrationInterface, QueryRunner} from "../../../../src";
+import {Item} from "../entity/item.entity";
+
+export class UpdateContacts1566560354098 implements MigrationInterface {
+
+  public async up({connection}: QueryRunner): Promise<any> {
+    const repo = connection.getMongoRepository(Item);
+    const items: Array<Item> = await repo.find();
+
+    items.forEach((item) => {
+      if (!item.contacts) {
+        item.contacts = [item.contact || ""];
+      }
+    });
+
+    await repo.save(items);
+  }
+
+  public async down({connection}: QueryRunner): Promise<any> {
+    const repo = connection.getMongoRepository(Item);
+    const items: Array<Item> = await repo.find();
+
+    items.forEach((item) => {
+      item.contact = item.contacts[0];
+    });
+
+    await repo.save(items);
+  }
+
+}

--- a/test/github-issues/4697/migration/1567689639607-MergeConfigs.ts
+++ b/test/github-issues/4697/migration/1567689639607-MergeConfigs.ts
@@ -1,0 +1,44 @@
+import {MigrationInterface, QueryRunner} from "../../../../src";
+import {Item} from "../entity/item.entity";
+import {Config} from "../entity/config.entity";
+
+export class MergeConfigs1567689639607 implements MigrationInterface {
+
+    public async up({connection}: QueryRunner): Promise<any> {
+      const itemRepository = connection.getMongoRepository(Item);
+      const configRepository = connection.getMongoRepository(Config);
+
+      const configs = await configRepository.find();
+
+      await Promise.all(configs.map(async ({itemId, data}) => {
+        const item = await itemRepository.findOne(itemId);
+
+        if (item) {
+          item.config = data;
+
+          return itemRepository.save(item);
+        } else {
+          console.warn(`No item found with id: ${ itemId }. Ignoring.`);
+
+          return null;
+        }
+      }));
+    }
+
+    public async down({connection}: QueryRunner): Promise<any> {
+      const itemRepository = connection.getRepository(Item);
+      const configRepository = connection.getRepository(Config);
+
+      const items = await itemRepository.find();
+
+      await Promise.all(items.map((item) => {
+        const config = new Config();
+
+        config.itemId = item._id.toString();
+        config.data = item.config;
+
+        return configRepository.save(config);
+      }));
+    }
+
+}


### PR DESCRIPTION
* update `loadExecutedMigrations` to get migrations sorted by id from database
* add missing await statements when running mongodb migrations

Fixes #4697 