### PR TITLE
fix: added support for selecting computed columns

### DIFF
--- a/src/query-builder/transformer/RawSqlResultsToEntityTransformer.ts
+++ b/src/query-builder/transformer/RawSqlResultsToEntityTransformer.ts
@@ -137,8 +137,15 @@ export class RawSqlResultsToEntityTransformer {
 
             // if user does not selected the whole entity or he used partial selection and does not select this particular column
             // then we don't add this column and its value into the entity
-            if (!this.expressionMap.selects.find(select => select.selection === alias.name || select.selection === alias.name + "." + column.propertyPath))
+            if (!this.expressionMap.selects.find(select => {
+                return !!(
+                    select.selection === alias.name
+                    || select.selection === alias.name + "." + column.propertyPath
+                    || (select.aliasName && select.aliasName === alias.name + "_" + column.propertyPath)
+                );
+            })) {
                 return;
+            }
 
             column.setEntityValue(entity, this.driver.prepareHydratedValue(value, column));
             if (value !== null) // we don't mark it as has data because if we will have all nulls in our object - we don't need such object

--- a/test/github-issues/296/entity/Post.ts
+++ b/test/github-issues/296/entity/Post.ts
@@ -1,0 +1,19 @@
+import {Entity} from "../../../../src/decorator/entity/Entity";
+import {PrimaryGeneratedColumn} from "../../../../src/decorator/columns/PrimaryGeneratedColumn";
+import {Column} from "../../../../src/decorator/columns/Column";
+
+@Entity()
+export class Post {
+
+    @PrimaryGeneratedColumn()
+    id: number;
+
+    @Column()
+    title: string;
+
+    @Column({ type: String, nullable: true })
+    text: string|null;
+
+    @Column({ nullable: true, insert: false, update: false, select: false })
+    textSize: number;
+}

--- a/test/github-issues/296/issue-296.ts
+++ b/test/github-issues/296/issue-296.ts
@@ -15,7 +15,7 @@ describe("github issues > #296 select additional computed columns", () => {
     after(() => closeTestingConnections(connections));
 
 
-    it("should correctly substring the text column and populate the entity property", () => Promise.all(connections.map(async connection => {
+    it("should correctly select computed size of text column and populate given entity property", () => Promise.all(connections.map(async connection => {
         const post = new Post();
         post.title = "hello post";
         post.text = "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiu";
@@ -33,6 +33,6 @@ describe("github issues > #296 select additional computed columns", () => {
         expect(loadedPost!.text).not.to.be.undefined;
         // Because some drivers return int's as strings's, so just to be sure we
         // cast both to string
-        expect("" + (loadedPost!.textSize)).to.be.equal("" + post.text.length);
+        expect("" + loadedPost!.textSize).to.be.equal("" + post.text.length);
     })));
 });

--- a/test/github-issues/296/issue-296.ts
+++ b/test/github-issues/296/issue-296.ts
@@ -1,0 +1,38 @@
+import "reflect-metadata";
+import {closeTestingConnections, createTestingConnections, reloadTestingDatabases} from "../../utils/test-utils";
+import {Connection} from "../../../src/connection/Connection";
+import {Post} from "./entity/Post";
+import {expect} from "chai";
+
+
+describe("github issues > #296 select additional computed columns", () => {
+
+    let connections: Connection[];
+    before(async () => connections = await createTestingConnections({
+        entities: [__dirname + "/entity/*{.js,.ts}"],
+    }));
+    beforeEach(() => reloadTestingDatabases(connections));
+    after(() => closeTestingConnections(connections));
+
+
+    it("should correctly substring the text column and populate the entity property", () => Promise.all(connections.map(async connection => {
+        const post = new Post();
+        post.title = "hello post";
+        post.text = "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiu";
+        await connection.manager.save(post);
+
+        const query = connection.manager
+            .createQueryBuilder(Post, "post");
+        const loadedPost = await query
+            .select("post.id")
+            .addSelect("post.text")
+            .addSelect("LENGTH(post.text)", `${query.alias}_textSize`)
+            .getOne();
+
+        expect(loadedPost).not.to.be.undefined;
+        expect(loadedPost!.text).not.to.be.undefined;
+        // Because some drivers return int's as strings's, so just to be sure we
+        // cast both to string
+        expect("" + (loadedPost!.textSize)).to.be.equal("" + post.text.length);
+    })));
+});

--- a/test/github-issues/296/issue-296.ts
+++ b/test/github-issues/296/issue-296.ts
@@ -14,25 +14,28 @@ describe("github issues > #296 select additional computed columns", () => {
     beforeEach(() => reloadTestingDatabases(connections));
     after(() => closeTestingConnections(connections));
 
+    it("should correctly select computed columns and populate given entity properties", () => Promise.all(connections.map(async connection => {
 
-    it("should correctly select computed size of text column and populate given entity property", () => Promise.all(connections.map(async connection => {
         const post = new Post();
         post.title = "hello post";
         post.text = "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiu";
         await connection.manager.save(post);
 
-        const query = connection.manager
-            .createQueryBuilder(Post, "post");
+        const lengthOperator = connection.driver.options.type === "mssql" ? "LEN" : "LENGTH";
+        const subStrOperation = ["sqljs", "sqlite"].indexOf(connection.driver.options.type) > -1 ? "SUBSTR" : "SUBSTRING";
+
+        const query = connection.manager.createQueryBuilder(Post, "post");
         const loadedPost = await query
             .select("post.id")
-            .addSelect("post.text")
-            .addSelect("LENGTH(post.text)", `${query.alias}_textSize`)
+            .addSelect(`${subStrOperation}(post.text, 1, 20)`, "post_text")
+            .addSelect(`${lengthOperator}(post.text)`, `${query.alias}_textSize`)
             .getOne();
 
         expect(loadedPost).not.to.be.undefined;
         expect(loadedPost!.text).not.to.be.undefined;
-        // Because some drivers return int's as strings's, so just to be sure we
-        // cast both to string
+        expect(loadedPost!.text!.length).to.be.equal(20);
+        // Some drivers return function int's as strings's, so just to be sure
+        // we cast both to string
         expect("" + loadedPost!.textSize).to.be.equal("" + post.text.length);
     })));
 });


### PR DESCRIPTION
This fixes some basic functionality to select computed columns discussed in issue #296 
```ts
@Entity()
export class Post {

    @PrimaryGeneratedColumn()
    id: number;

    @Column()
    title: string;

    @Column({ type: String, nullable: true })
    text: string|null;

    @Column({ nullable: true, insert: false, update: false, select: false })
    textSize: number;
}
```

```ts
const query = connection.manager.createQueryBuilder(Post, "post");
const loadedPost = await query
    .select("post.id")
    .addSelect("LENGTH(post.text)", `${query.alias}_textSize`)
    .addSelect("SUBSTRING(post.text, 1, 20)", "post_text")
    .getOne();
```