### PR TITLE
Fix "Hstore injection" & properly handle NULL, empty string, backslashes & quotes in hstore key/value pairs

### DIFF
--- a/test/github-issues/4719/entity/Post.ts
+++ b/test/github-issues/4719/entity/Post.ts
@@ -1,0 +1,12 @@
+import {Column, Entity, PrimaryGeneratedColumn, ObjectLiteral} from "../../../../src/index";
+
+@Entity()
+export class Post {
+
+    @PrimaryGeneratedColumn()
+    id: number;
+
+    @Column("hstore", { hstoreType: "object" })
+    hstoreObj: ObjectLiteral;
+
+}

--- a/test/github-issues/4719/issue-4719.ts
+++ b/test/github-issues/4719/issue-4719.ts
@@ -4,7 +4,6 @@ import {Connection} from "../../../src/connection/Connection";
 import {Post} from "./entity/Post";
 
 describe("github issues > #4719 HStore with empty string values", () => {
-
     let connections: Connection[];
     before(async () => connections = await createTestingConnections({
         entities: [__dirname + "/entity/*{.js,.ts}"],
@@ -24,6 +23,19 @@ describe("github issues > #4719 HStore with empty string values", () => {
       const loadedPost = await postRepository.findOneOrFail(id);
       loadedPost.hstoreObj.should.be.deep.equal(
         { name: "Alice", surname: "A", age: "25", blank: "", "": "blank-key", "\"": "\"", foo: null });
+      await queryRunner.release();
+    })));
+
+    it("should not allow 'hstore injection'", () => Promise.all(connections.map(async connection => {
+      const queryRunner = connection.createQueryRunner();
+      const postRepository = connection.getRepository(Post);
+
+      const post = new Post();
+      post.hstoreObj = { username: `", admin=>"1`, admin: "0" };
+      const {id} = await postRepository.save(post);
+
+      const loadedPost = await postRepository.findOneOrFail(id);
+      loadedPost.hstoreObj.should.be.deep.equal({ username: `", admin=>"1`, admin: "0" });
       await queryRunner.release();
     })));
 });

--- a/test/github-issues/4719/issue-4719.ts
+++ b/test/github-issues/4719/issue-4719.ts
@@ -1,0 +1,29 @@
+import "reflect-metadata";
+import {closeTestingConnections, createTestingConnections, reloadTestingDatabases} from "../../utils/test-utils";
+import {Connection} from "../../../src/connection/Connection";
+import {Post} from "./entity/Post";
+
+describe("github issues > #4719 HStore with empty string values", () => {
+
+    let connections: Connection[];
+    before(async () => connections = await createTestingConnections({
+        entities: [__dirname + "/entity/*{.js,.ts}"],
+        enabledDrivers: ["postgres"]
+    }));
+    beforeEach(() => reloadTestingDatabases(connections));
+    after(() => closeTestingConnections(connections));
+
+    it("should handle HStore with empty string keys or values", () => Promise.all(connections.map(async connection => {
+      const queryRunner = connection.createQueryRunner();
+      const postRepository = connection.getRepository(Post);
+
+      const post = new Post();
+      post.hstoreObj = {name: "Alice", surname: "A", age: 25, blank: "", "": "blank-key", "\"": "\"", foo: null};
+      const {id} = await postRepository.save(post);
+
+      const loadedPost = await postRepository.findOneOrFail(id);
+      loadedPost.hstoreObj.should.be.deep.equal(
+        { name: "Alice", surname: "A", age: "25", blank: "", "": "blank-key", "\"": "\"", foo: null });
+      await queryRunner.release();
+    })));
+});


### PR DESCRIPTION
Closes https://github.com/typeorm/typeorm/issues/4719

Add support for empty string keys/values, NULL values, and properly escape key/values.