### PR TITLE
better entity values comparison on save

### DIFF
--- a/src/persistence/SubjectChangedColumnsComputer.ts
+++ b/src/persistence/SubjectChangedColumnsComputer.ts
@@ -73,28 +73,50 @@ export class SubjectChangedColumnsComputer {
                 let normalizedValue = entityValue;
                 // normalize special values to make proper comparision
                 if (entityValue !== null) {
-                    if (column.type === "date") {
-                        normalizedValue = DateUtils.mixedDateToDateString(entityValue);
+                    switch (column.type) {
+                        case "date":
+                            normalizedValue = DateUtils.mixedDateToDateString(entityValue);
+                            break;
 
-                    } else if (column.type === "time") {
-                        normalizedValue = DateUtils.mixedDateToTimeString(entityValue);
+                        case "time":
+                        case "time with time zone":
+                        case "time without time zone":
+                        case "timetz":
+                            normalizedValue = DateUtils.mixedDateToTimeString(entityValue);
+                            break;
 
-                    } else if (column.type === "datetime" || column.type === Date) {
-                        normalizedValue = DateUtils.mixedDateToUtcDatetimeString(entityValue);
-                        databaseValue = DateUtils.mixedDateToUtcDatetimeString(databaseValue);
+                        case "datetime":
+                        case "datetime2":
+                        case Date:
+                        case "timestamp":
+                        case "timestamp without time zone":
+                        case "timestamp with time zone":
+                        case "timestamp with local time zone":
+                        case "timestamptz":
+                            normalizedValue = DateUtils.mixedDateToUtcDatetimeString(entityValue);
+                            databaseValue = DateUtils.mixedDateToUtcDatetimeString(databaseValue);
+                            break;
 
-                    } else if (column.type === "json" || column.type === "jsonb") {
-                        // JSON.stringify doesn't work because postgresql sorts jsonb before save.
-                        // If you try to save json '[{"messages": "", "attribute Key": "", "level":""}] ' as jsonb,
-                        // then postgresql will save it as '[{"level": "", "message":"", "attributeKey": ""}]'
-                        if (OrmUtils.deepCompare(entityValue, databaseValue)) return;
+                        case "json":
+                        case "jsonb":
+                            // JSON.stringify doesn't work because postgresql sorts jsonb before save.
+                            // If you try to save json '[{"messages": "", "attribute Key": "", "level":""}] ' as jsonb,
+                            // then postgresql will save it as '[{"level": "", "message":"", "attributeKey": ""}]'
+                            if (OrmUtils.deepCompare(entityValue, databaseValue)) return;
+                            break;
 
-                    } else if (column.type === "simple-array") {
-                        normalizedValue = DateUtils.simpleArrayToString(entityValue);
-                        databaseValue = DateUtils.simpleArrayToString(databaseValue);
-                    } else if (column.type === "simple-enum") {
-                        normalizedValue = DateUtils.simpleEnumToString(entityValue);
-                        databaseValue = DateUtils.simpleEnumToString(databaseValue);
+                        case "simple-array":
+                            normalizedValue = DateUtils.simpleArrayToString(entityValue);
+                            databaseValue = DateUtils.simpleArrayToString(databaseValue);
+                            break;
+                        case "simple-enum":
+                            normalizedValue = DateUtils.simpleEnumToString(entityValue);
+                            databaseValue = DateUtils.simpleEnumToString(databaseValue);
+                            break;
+                        case "simple-json":
+                            normalizedValue = DateUtils.simpleJsonToString(entityValue);
+                            databaseValue = DateUtils.simpleJsonToString(databaseValue);
+                            break;
                     }
                 }
 

--- a/src/util/DateUtils.ts
+++ b/src/util/DateUtils.ts
@@ -118,7 +118,7 @@ export class DateUtils {
     }
 
     /**
-     * Converts given value into utc datetime string in a "YYYY-MM-DD HH-mm-ss" format.
+     * Converts given value into utc datetime string in a "YYYY-MM-DD HH-mm-ss.sss" format.
      */
     static mixedDateToUtcDatetimeString(value: Date|any): string|any {
         if (typeof value === "string") {


### PR DESCRIPTION
```typescript
@Entity()
export class Post {
    @PrimaryGeneratedColumn()
    id: number;
    @Column({ name: "dt", type: "timestamp with time zone" })  // <-- type is important here
    date: Date;
}

const post = new Post();
post.id = 1;
post.date = new Date();
await postRepository.save(post);       // <-- first save, it is ok

const loadedPost = await postRepository.findOneOrFail(1);
await postRepository.save(loadedPost); // <-- was not changed, 
                                       // but typeorm will update the record with the same date
```

Entity property with column type "timestamp with time zone" value is always different for TypeORM on save.

Seems like you forget to normalize these values on value comparison function.