### PR TITLE
change mongodb ObjectID to ObjectId

### DIFF
--- a/docs/decorator-reference.md
+++ b/docs/decorator-reference.md
@@ -260,9 +260,9 @@ Learn more about [entity columns](entities.md#entity-columns).
 
 #### `@ObjectIdColumn`
 
-Marks a property in your entity as ObjectID.
+Marks a property in your entity as ObjectId.
 This decorator is only used in MongoDB.
-Every entity in MongoDB must have a ObjectID column.
+Every entity in MongoDB must have a ObjectId column.
 Example:
 
 ```typescript
@@ -270,7 +270,7 @@ Example:
 export class User {
 
     @ObjectIdColumn()
-    id: ObjectID;
+    id: ObjectId;
 
 }
 ```

--- a/docs/mongodb.md
+++ b/docs/mongodb.md
@@ -20,13 +20,13 @@ instead of `@PrimaryColumn` or `@PrimaryGeneratedColumn`.
 Simple entity example:
 
 ```typescript
-import {Entity, ObjectID, ObjectIdColumn, Column} from "typeorm";
+import {Entity, ObjectId, ObjectIdColumn, Column} from "typeorm";
 
 @Entity()
 export class User {
     
     @ObjectIdColumn()
-    id: ObjectID;
+    id: ObjectId;
     
     @Column()
     firstName: string;
@@ -56,7 +56,7 @@ Since MongoDB stores objects and objects inside objects (or documents inside doc
 you can do the same in TypeORM:
 
 ```typescript
-import {Entity, ObjectID, ObjectIdColumn, Column} from "typeorm";
+import {Entity, ObjectId, ObjectIdColumn, Column} from "typeorm";
 
 export class Profile {
     
@@ -73,7 +73,7 @@ export class Profile {
 ```
 
 ```typescript
-import {Entity, ObjectID, ObjectIdColumn, Column} from "typeorm";
+import {Entity, ObjectId, ObjectIdColumn, Column} from "typeorm";
 
 export class Photo {
     
@@ -96,13 +96,13 @@ export class Photo {
 ```
 
 ```typescript
-import {Entity, ObjectID, ObjectIdColumn, Column} from "typeorm";
+import {Entity, ObjectId, ObjectIdColumn, Column} from "typeorm";
 
 @Entity()
 export class User {
     
     @ObjectIdColumn()
-    id: ObjectID;
+    id: ObjectId;
     
     @Column()
     firstName: string;

--- a/docs/zh_CN/decorator-reference.md
+++ b/docs/zh_CN/decorator-reference.md
@@ -244,16 +244,16 @@ export class User {
 
 #### `@ObjectIdColumn`
 
-将实体中的属性标记为 ObjectID。
+将实体中的属性标记为 ObjectId。
 此装饰器仅用于 MongoDB。
-MongoDB 中的每个实体都必须具有 ObjectID 列。
+MongoDB 中的每个实体都必须具有 ObjectId 列。
 例如：
 
 ```typescript
 @Entity()
 export class User {
     @ObjectIdColumn()
-    id: ObjectID;
+    id: ObjectId;
 }
 ```
 

--- a/docs/zh_CN/mongodb.md
+++ b/docs/zh_CN/mongodb.md
@@ -18,12 +18,12 @@ TypeORM 大多数功能都是特定于 RDBMS 的，
 简单实体示例：
 
 ```typescript
-import { Entity, ObjectID, ObjectIdColumn, Column } from "typeorm";
+import { Entity, ObjectId, ObjectIdColumn, Column } from "typeorm";
 
 @Entity()
 export class User {
   @ObjectIdColumn()
-  id: ObjectID;
+  id: ObjectId;
 
   @Column()
   firstName: string;
@@ -51,7 +51,7 @@ const connection: Connection = await createConnection({
 由于 MongoDB 存储对象和对象内的对象（或文档内的文档），因此你可以在 TypeORM 中执行相同的操作：
 
 ```typescript
-import { Entity, ObjectID, ObjectIdColumn, Column } from "typeorm";
+import { Entity, ObjectId, ObjectIdColumn, Column } from "typeorm";
 
 export class Profile {
   @Column()
@@ -66,7 +66,7 @@ export class Profile {
 ```
 
 ```typescript
-import { Entity, ObjectID, ObjectIdColumn, Column } from "typeorm";
+import { Entity, ObjectId, ObjectIdColumn, Column } from "typeorm";
 
 export class Photo {
   @Column()
@@ -87,12 +87,12 @@ export class Photo {
 ```
 
 ```typescript
-import { Entity, ObjectID, ObjectIdColumn, Column } from "typeorm";
+import { Entity, ObjectId, ObjectIdColumn, Column } from "typeorm";
 
 @Entity()
 export class User {
   @ObjectIdColumn()
-  id: ObjectID;
+  id: ObjectId;
 
   @Column()
   firstName: string;

--- a/sample/sample34-mongodb/entity/Post.ts
+++ b/sample/sample34-mongodb/entity/Post.ts
@@ -1,12 +1,12 @@
 import {Column, Entity} from "../../../src/index";
 import {ObjectIdColumn} from "../../../src/decorator/columns/ObjectIdColumn";
-import {ObjectID} from "../../../src/driver/mongodb/typings";
+import {ObjectId} from "../../../src/driver/mongodb/typings";
 
 @Entity("sample34_post")
 export class Post {
 
     @ObjectIdColumn()
-    id: ObjectID;
+    id: ObjectId;
 
     @Column()
     title: string;

--- a/src/commands/InitCommand.ts
+++ b/src/commands/InitCommand.ts
@@ -215,13 +215,13 @@ temp/`;
      * Gets contents of the user entity.
      */
     protected static getUserEntityTemplate(database: string): string {
-        return `import {Entity, ${ database === "mongodb" ? "ObjectIdColumn, ObjectID" : "PrimaryGeneratedColumn" }, Column} from "typeorm";
+        return `import {Entity, ${ database === "mongodb" ? "ObjectIdColumn, ObjectId" : "PrimaryGeneratedColumn" }, Column} from "typeorm";
 
 @Entity()
 export class User {
 
     ${ database === "mongodb" ? "@ObjectIdColumn()" : "@PrimaryGeneratedColumn()" }
-    id: ${ database === "mongodb" ? "ObjectID" : "number" };
+    id: ${ database === "mongodb" ? "ObjectId" : "number" };
 
     @Column()
     firstName: string;

--- a/src/driver/mongodb/typings.ts
+++ b/src/driver/mongodb/typings.ts
@@ -1877,59 +1877,65 @@ export interface FindOneAndDeleteOptions {
 }
 
 /**
- * Create a new ObjectID instance.
- *
- * @see http://mongodb.github.io/node-mongodb-native/2.1/api/ObjectID.html
+ * Create a new ObjectId instance.
  */
-export declare class ObjectID {
-    constructor(s?: string | number);
-
+export declare class ObjectId {
     /**
-     * The generation time of this ObjectId instance.
+     * Create a new ObjectId instance
+     * @param {(string|number|ObjectId)} id Can be a 24 byte hex string, 12 byte binary string or a Number.
      */
+    constructor(id?: string | number | ObjectId);
+    /** The generation time of this ObjectId instance */
     generationTime: number;
-
+    /** If true cache the hex string representation of ObjectId */
+    static cacheHexString?: boolean;
     /**
-     * Creates an ObjectID from a hex string representation of an ObjectID.
+     * Creates an ObjectId from a hex string representation of an ObjectId.
+     * @param {string} hexString create a ObjectId from a passed in 24 byte hexstring.
+     * @return {ObjectId} return the created ObjectId
      */
-    static createFromHexString(hexString: string): ObjectID;
-
+    static createFromHexString(hexString: string): ObjectId;
     /**
-     * Creates an ObjectID from a second based number, with the rest of the ObjectID zeroed out. Used for comparisons or sorting the ObjectID.
+     * Creates an ObjectId from a second based number, with the rest of the ObjectId zeroed out. Used for comparisons or sorting the ObjectId.
+     * @param {number} time an integer number representing a number of seconds.
+     * @return {ObjectId} return the created ObjectId
      */
-    static createFromTime(time: number): ObjectID;
-
+    static createFromTime(time: number): ObjectId;
     /**
-     * Checks if a value is a valid bson ObjectId.
+     * Checks if a value is a valid bson ObjectId
+     *
+     * @return {boolean} return true if the value is a valid bson ObjectId, return false otherwise.
      */
-    static isValid(id: any): boolean;
-
+    static isValid(id: string | number | ObjectId): boolean;
     /**
-     * Compares the equality of this ObjectID with otherID.
+     * Compares the equality of this ObjectId with `otherID`.
+     * @param {ObjectId|string} otherID ObjectId instance to compare against.
+     * @return {boolean} the result of comparing two ObjectId's
      */
-    equals(otherID: ObjectID): boolean;
-
+    equals(otherID: ObjectId | string): boolean;
     /**
-     * Generate a 12 byte id buffer used in ObjectID's.
+     * Generate a 12 byte id string used in ObjectId's
+     * @param {number} time optional parameter allowing to pass in a second based timestamp.
+     * @return {string} return the 12 byte id binary string.
      */
-    generate(time?: number): string;
-
+    static generate(time?: number): Buffer;
     /**
      * Returns the generation date (accurate up to the second) that this ID was generated.
-     *
+     * @return {Date} the generation date
      */
     getTimestamp(): Date;
-
     /**
-     * Return the ObjectID id as a 24 byte hex string representation.
+     * Return the ObjectId id as a 24 byte hex string representation
+     * @return {string} return the 24 byte hex string representation.
      */
     toHexString(): string;
-
-    /**
-     * Get the timestamp and validate correctness.
-     */
-    toString(): string;
 }
+
+/**
+ * ObjectID (with capital "D") is deprecated. Use ObjectId (lowercase "d") instead.
+ * @deprecated
+ */
+export { ObjectId as ObjectID };
 
 /**
  * A class representation of the BSON Binary type.
@@ -2562,7 +2568,7 @@ export interface CollectionDistinctOptions {
 }
 
 /**
- * Create a new ObjectID instance.
+ * Create a new ObjectId instance.
  *
  * @see http://mongodb.github.io/node-mongodb-native/2.1/api/Collection.html
  */
@@ -4603,7 +4609,7 @@ export interface InsertWriteOpResult {
     /**
      * All the generated _id's for the inserted documents.
      */
-    insertedIds: Array<ObjectID>;
+    insertedIds: Array<ObjectId>;
 
     /**
      * The connection object used for the operation.
@@ -4677,7 +4683,7 @@ export interface InsertOneWriteOpResult {
     /**
      * The driver generated ObjectId for the insert operation.
      */
-    insertedId: ObjectID;
+    insertedId: ObjectId;
 
     /**
      * The connection object used for the operation.
@@ -4793,7 +4799,7 @@ export interface UpdateWriteOpResult {
      * The upserted id.
      * @param _id The upserted _id returned from the server.
      */
-    upsertedId: { _id: ObjectID };
+    upsertedId: { _id: ObjectId };
 }
 
 /**
@@ -5883,7 +5889,7 @@ export declare class GridFSBucket {
      * @param callback The result callback
      * @see http://mongodb.github.io/node-mongodb-native/2.1/api/GridFSBucket.html#delete
      */
-    delete(id: ObjectID, callback?: GridFSBucketErrorCallback): void;
+    delete(id: ObjectId, callback?: GridFSBucketErrorCallback): void;
 
     /**
      * Removes this bucket's files collection, followed by its chunks collection.
@@ -5903,7 +5909,7 @@ export declare class GridFSBucket {
      * @param options Optional settings
      * @see http://mongodb.github.io/node-mongodb-native/2.1/api/GridFSBucket.html#openDownloadStream
      */
-    openDownloadStream(id: ObjectID, options?: { start: number, end: number }): GridFSBucketReadStream;
+    openDownloadStream(id: ObjectId, options?: { start: number, end: number }): GridFSBucketReadStream;
 
     /**
      * Returns a readable stream (GridFSBucketReadStream) for streaming file
@@ -5940,7 +5946,7 @@ export declare class GridFSBucket {
      * @param callback The result callback
      * @see http://mongodb.github.io/node-mongodb-native/2.1/api/GridFSBucket.html#rename
      */
-    rename(id: ObjectID, filename: string, callback?: GridFSBucketErrorCallback): void;
+    rename(id: ObjectId, filename: string, callback?: GridFSBucketErrorCallback): void;
 }
 
 /**

--- a/src/entity-manager/EntityManager.ts
+++ b/src/entity-manager/EntityManager.ts
@@ -27,7 +27,7 @@ import {RepositoryFactory} from "../repository/RepositoryFactory";
 import {TreeRepositoryNotSupportedError} from "../error/TreeRepositoryNotSupportedError";
 import {QueryDeepPartialEntity} from "../query-builder/QueryPartialEntity";
 import {EntityPersistExecutor} from "../persistence/EntityPersistExecutor";
-import {ObjectID} from "../driver/mongodb/typings";
+import {ObjectId} from "../driver/mongodb/typings";
 import {InsertResult} from "../query-builder/result/InsertResult";
 import {UpdateResult} from "../query-builder/result/UpdateResult";
 import {DeleteResult} from "../query-builder/result/DeleteResult";
@@ -495,7 +495,7 @@ export class EntityManager {
      * Does not check if entity exist in the database.
      * Condition(s) cannot be empty.
      */
-    update<Entity>(target: ObjectType<Entity>|EntitySchema<Entity>|string, criteria: string|string[]|number|number[]|Date|Date[]|ObjectID|ObjectID[]|any, partialEntity: QueryDeepPartialEntity<Entity>): Promise<UpdateResult> {
+    update<Entity>(target: ObjectType<Entity>|EntitySchema<Entity>|string, criteria: string|string[]|number|number[]|Date|Date[]|ObjectId|ObjectId[]|any, partialEntity: QueryDeepPartialEntity<Entity>): Promise<UpdateResult> {
 
         // if user passed empty criteria or empty list of criterias, then throw an error
         if (criteria === undefined ||
@@ -533,7 +533,7 @@ export class EntityManager {
      * Does not check if entity exist in the database.
      * Condition(s) cannot be empty.
      */
-    delete<Entity>(targetOrEntity: ObjectType<Entity>|EntitySchema<Entity>|string, criteria: string|string[]|number|number[]|Date|Date[]|ObjectID|ObjectID[]|any): Promise<DeleteResult> {
+    delete<Entity>(targetOrEntity: ObjectType<Entity>|EntitySchema<Entity>|string, criteria: string|string[]|number|number[]|Date|Date[]|ObjectId|ObjectId[]|any): Promise<DeleteResult> {
 
         // if user passed empty criteria or empty list of criterias, then throw an error
         if (criteria === undefined ||
@@ -768,17 +768,17 @@ export class EntityManager {
     /**
      * Finds first entity that matches given find options.
      */
-    findOne<Entity>(entityClass: ObjectType<Entity>, id?: string|number|Date|ObjectID, options?: FindOneOptions<Entity>): Promise<Entity|undefined>;
+    findOne<Entity>(entityClass: ObjectType<Entity>, id?: string|number|Date|ObjectId, options?: FindOneOptions<Entity>): Promise<Entity|undefined>;
 
     /**
      * Finds first entity that matches given find options.
      */
-    findOne<Entity>(entityClass: EntitySchema<Entity>, id?: string|number|Date|ObjectID, options?: FindOneOptions<Entity>): Promise<Entity|undefined>;
+    findOne<Entity>(entityClass: EntitySchema<Entity>, id?: string|number|Date|ObjectId, options?: FindOneOptions<Entity>): Promise<Entity|undefined>;
 
     /**
      * Finds first entity that matches given find options.
      */
-    findOne<Entity>(entityClass: string, id?: string|number|Date|ObjectID, options?: FindOneOptions<Entity>): Promise<Entity|undefined>;
+    findOne<Entity>(entityClass: string, id?: string|number|Date|ObjectId, options?: FindOneOptions<Entity>): Promise<Entity|undefined>;
 
     /**
      * Finds first entity that matches given find options.
@@ -813,7 +813,7 @@ export class EntityManager {
     /**
      * Finds first entity that matches given conditions.
      */
-    async findOne<Entity>(entityClass: ObjectType<Entity>|EntitySchema<Entity>|string, idOrOptionsOrConditions?: string|string[]|number|number[]|Date|Date[]|ObjectID|ObjectID[]|FindOneOptions<Entity>|any, maybeOptions?: FindOneOptions<Entity>): Promise<Entity|undefined> {
+    async findOne<Entity>(entityClass: ObjectType<Entity>|EntitySchema<Entity>|string, idOrOptionsOrConditions?: string|string[]|number|number[]|Date|Date[]|ObjectId|ObjectId[]|FindOneOptions<Entity>|any, maybeOptions?: FindOneOptions<Entity>): Promise<Entity|undefined> {
 
         let findOptions: FindManyOptions<any>|FindOneOptions<any>|undefined = undefined;
         if (FindOptionsUtils.isFindOneOptions(idOrOptionsOrConditions)) {
@@ -859,17 +859,17 @@ export class EntityManager {
     /**
      * Finds first entity that matches given find options or rejects the returned promise on error.
      */
-    findOneOrFail<Entity>(entityClass: ObjectType<Entity>, id?: string|number|Date|ObjectID, options?: FindOneOptions<Entity>): Promise<Entity>;
+    findOneOrFail<Entity>(entityClass: ObjectType<Entity>, id?: string|number|Date|ObjectId, options?: FindOneOptions<Entity>): Promise<Entity>;
 
     /**
      * Finds first entity that matches given find options or rejects the returned promise on error.
      */
-    findOneOrFail<Entity>(entityClass: EntitySchema<Entity>, id?: string|number|Date|ObjectID, options?: FindOneOptions<Entity>): Promise<Entity>;
+    findOneOrFail<Entity>(entityClass: EntitySchema<Entity>, id?: string|number|Date|ObjectId, options?: FindOneOptions<Entity>): Promise<Entity>;
 
     /**
      * Finds first entity that matches given find options or rejects the returned promise on error.
      */
-    findOneOrFail<Entity>(entityClass: string, id?: string|number|Date|ObjectID, options?: FindOneOptions<Entity>): Promise<Entity>;
+    findOneOrFail<Entity>(entityClass: string, id?: string|number|Date|ObjectId, options?: FindOneOptions<Entity>): Promise<Entity>;
 
     /**
      * Finds first entity that matches given find options or rejects the returned promise on error.
@@ -904,7 +904,7 @@ export class EntityManager {
     /**
      * Finds first entity that matches given conditions or rejects the returned promise on error.
      */
-    async findOneOrFail<Entity>(entityClass: ObjectType<Entity>|EntitySchema<Entity>|string, idOrOptionsOrConditions?: string|string[]|number|number[]|Date|Date[]|ObjectID|ObjectID[]|FindOneOptions<Entity>|any, maybeOptions?: FindOneOptions<Entity>): Promise<Entity> {
+    async findOneOrFail<Entity>(entityClass: ObjectType<Entity>|EntitySchema<Entity>|string, idOrOptionsOrConditions?: string|string[]|number|number[]|Date|Date[]|ObjectId|ObjectId[]|FindOneOptions<Entity>|any, maybeOptions?: FindOneOptions<Entity>): Promise<Entity> {
         return this.findOne<Entity>(entityClass as any, idOrOptionsOrConditions as any, maybeOptions).then((value) => {
             if (value === undefined) {
                 return Promise.reject(new EntityNotFoundError(entityClass, idOrOptionsOrConditions));

--- a/src/entity-manager/MongoEntityManager.ts
+++ b/src/entity-manager/MongoEntityManager.ts
@@ -29,7 +29,7 @@ import {
     MongoCountPreferences,
     MongodbIndexOptions,
     MongoError,
-    ObjectID,
+    ObjectId,
     OrderedBulkOperation,
     ParallelCollectionScanOptions,
     ReadPreference,
@@ -137,7 +137,8 @@ export class MongoEntityManager extends EntityManager {
     async findByIds<Entity>(entityClassOrName: ObjectType<Entity> | EntitySchema<Entity> | string, ids: any[], optionsOrConditions?: FindManyOptions<Entity> | Partial<Entity>): Promise<Entity[]> {
         const metadata = this.connection.getMetadata(entityClassOrName);
         const query = this.convertFindManyOptionsOrConditionsToMongodbQuery(optionsOrConditions) || {};
-        const objectIdInstance = PlatformTools.load("mongodb").ObjectID;
+        const mongodb = PlatformTools.load("mongodb");
+        const objectIdInstance = mongodb.ObjectId || mongodb.ObjectID;
         query["_id"] = {
             $in: ids.map(id => {
                 if (id instanceof objectIdInstance)
@@ -165,9 +166,10 @@ export class MongoEntityManager extends EntityManager {
      * Finds first entity that matches given conditions and/or find options.
      */
     async findOne<Entity>(entityClassOrName: ObjectType<Entity> | EntitySchema<Entity> | string,
-                          optionsOrConditions?: string | string[] | number | number[] | Date | Date[] | ObjectID | ObjectID[] | FindOneOptions<Entity> | DeepPartial<Entity>,
+                          optionsOrConditions?: string | string[] | number | number[] | Date | Date[] | ObjectId | ObjectId[] | FindOneOptions<Entity> | DeepPartial<Entity>,
                           maybeOptions?: FindOneOptions<Entity>): Promise<Entity | undefined> {
-        const objectIdInstance = PlatformTools.load("mongodb").ObjectID;
+        const mongodb = PlatformTools.load("mongodb");
+        const objectIdInstance = mongodb.ObjectId || mongodb.ObjectID;
         const id = (optionsOrConditions instanceof objectIdInstance) || typeof optionsOrConditions === "string" ? optionsOrConditions : undefined;
         const findOneOptionsOrConditions = (id ? maybeOptions : optionsOrConditions) as any;
         const query = this.convertFindOneOptionsOrConditionsToMongodbQuery(findOneOptionsOrConditions) || {};
@@ -220,7 +222,7 @@ export class MongoEntityManager extends EntityManager {
      * Executes fast and efficient UPDATE query.
      * Does not check if entity exist in the database.
      */
-    async update<Entity>(target: ObjectType<Entity> | EntitySchema<Entity> | string, criteria: string | string[] | number | number[] | Date | Date[] | ObjectID | ObjectID[] | FindConditions<Entity>, partialEntity: QueryDeepPartialEntity<Entity>): Promise<UpdateResult> {
+    async update<Entity>(target: ObjectType<Entity> | EntitySchema<Entity> | string, criteria: string | string[] | number | number[] | Date | Date[] | ObjectId | ObjectId[] | FindConditions<Entity>, partialEntity: QueryDeepPartialEntity<Entity>): Promise<UpdateResult> {
         if (criteria instanceof Array) {
             await Promise.all((criteria as any[]).map(criteriaItem => {
                 return this.update(target, criteriaItem, partialEntity);
@@ -240,7 +242,7 @@ export class MongoEntityManager extends EntityManager {
      * Executes fast and efficient DELETE query.
      * Does not check if entity exist in the database.
      */
-    async delete<Entity>(target: ObjectType<Entity> | EntitySchema<Entity> | string, criteria: string | string[] | number | number[] | Date | Date[] | ObjectID | ObjectID[] | FindConditions<Entity>): Promise<DeleteResult> {
+    async delete<Entity>(target: ObjectType<Entity> | EntitySchema<Entity> | string, criteria: string | string[] | number | number[] | Date | Date[] | ObjectId | ObjectId[] | FindConditions<Entity>): Promise<DeleteResult> {
         if (criteria instanceof Array) {
             await Promise.all((criteria as any[]).map(criteriaItem => {
                 return this.delete(target, criteriaItem);
@@ -640,7 +642,8 @@ export class MongoEntityManager extends EntityManager {
         }
 
         // means idMap is just object id
-        const objectIdInstance = PlatformTools.load("mongodb").ObjectID;
+        const mongodb = PlatformTools.load("mongodb");
+        const objectIdInstance = mongodb.ObjectId || mongodb.ObjectID;
         return {
             "_id": (idMap instanceof objectIdInstance) ? idMap : new objectIdInstance(idMap)
         };

--- a/src/entity-schema/EntitySchemaColumnOptions.ts
+++ b/src/entity-schema/EntitySchemaColumnOptions.ts
@@ -10,7 +10,7 @@ export interface EntitySchemaColumnOptions extends SpatialColumnOptions {
     primary?: boolean;
 
     /**
-     * Indicates if this column is of type ObjectID
+     * Indicates if this column is of type ObjectId
      */
     objectId?: boolean;
 

--- a/src/repository/BaseEntity.ts
+++ b/src/repository/BaseEntity.ts
@@ -11,7 +11,7 @@ import {SelectQueryBuilder} from "../query-builder/SelectQueryBuilder";
 import {InsertResult} from "../query-builder/result/InsertResult";
 import {UpdateResult} from "../query-builder/result/UpdateResult";
 import {DeleteResult} from "../query-builder/result/DeleteResult";
-import {ObjectID} from "../driver/mongodb/typings";
+import {ObjectId} from "../driver/mongodb/typings";
 import {ObjectUtils} from "../util/ObjectUtils";
 import {QueryDeepPartialEntity} from "../query-builder/QueryPartialEntity";
 
@@ -213,7 +213,7 @@ export class BaseEntity {
      * Executes fast and efficient UPDATE query.
      * Does not check if entity exist in the database.
      */
-    static update<T extends BaseEntity>(this: ObjectType<T>, criteria: string|string[]|number|number[]|Date|Date[]|ObjectID|ObjectID[]|FindConditions<T>, partialEntity: QueryDeepPartialEntity<T>, options?: SaveOptions): Promise<UpdateResult> {
+    static update<T extends BaseEntity>(this: ObjectType<T>, criteria: string|string[]|number|number[]|Date|Date[]|ObjectId|ObjectId[]|FindConditions<T>, partialEntity: QueryDeepPartialEntity<T>, options?: SaveOptions): Promise<UpdateResult> {
         return (this as any).getRepository().update(criteria, partialEntity, options);
     }
 
@@ -223,7 +223,7 @@ export class BaseEntity {
      * Executes fast and efficient DELETE query.
      * Does not check if entity exist in the database.
      */
-    static delete<T extends BaseEntity>(this: ObjectType<T>, criteria: string|string[]|number|number[]|Date|Date[]|ObjectID|ObjectID[]|FindConditions<T>, options?: RemoveOptions): Promise<DeleteResult> {
+    static delete<T extends BaseEntity>(this: ObjectType<T>, criteria: string|string[]|number|number[]|Date|Date[]|ObjectId|ObjectId[]|FindConditions<T>, options?: RemoveOptions): Promise<DeleteResult> {
         return (this as any).getRepository().delete(criteria, options);
     }
 
@@ -307,7 +307,7 @@ export class BaseEntity {
     /**
      * Finds first entity that matches given options.
      */
-    static findOne<T extends BaseEntity>(this: ObjectType<T>, id?: string|number|Date|ObjectID, options?: FindOneOptions<T>): Promise<T|undefined>;
+    static findOne<T extends BaseEntity>(this: ObjectType<T>, id?: string|number|Date|ObjectId, options?: FindOneOptions<T>): Promise<T|undefined>;
 
     /**
      * Finds first entity that matches given options.
@@ -322,14 +322,14 @@ export class BaseEntity {
     /**
      * Finds first entity that matches given conditions.
      */
-    static findOne<T extends BaseEntity>(this: ObjectType<T>, optionsOrConditions?: string|number|Date|ObjectID|FindOneOptions<T>|FindConditions<T>, maybeOptions?: FindOneOptions<T>): Promise<T|undefined> {
+    static findOne<T extends BaseEntity>(this: ObjectType<T>, optionsOrConditions?: string|number|Date|ObjectId|FindOneOptions<T>|FindConditions<T>, maybeOptions?: FindOneOptions<T>): Promise<T|undefined> {
         return (this as any).getRepository().findOne(optionsOrConditions as any, maybeOptions);
     }
 
     /**
      * Finds first entity that matches given options.
      */
-    static findOneOrFail<T extends BaseEntity>(this: ObjectType<T>, id?: string|number|Date|ObjectID, options?: FindOneOptions<T>): Promise<T>;
+    static findOneOrFail<T extends BaseEntity>(this: ObjectType<T>, id?: string|number|Date|ObjectId, options?: FindOneOptions<T>): Promise<T>;
 
     /**
      * Finds first entity that matches given options.
@@ -344,7 +344,7 @@ export class BaseEntity {
     /**
      * Finds first entity that matches given conditions.
      */
-    static findOneOrFail<T extends BaseEntity>(this: ObjectType<T>, optionsOrConditions?: string|number|Date|ObjectID|FindOneOptions<T>|FindConditions<T>, maybeOptions?: FindOneOptions<T>): Promise<T> {
+    static findOneOrFail<T extends BaseEntity>(this: ObjectType<T>, optionsOrConditions?: string|number|Date|ObjectId|FindOneOptions<T>|FindConditions<T>, maybeOptions?: FindOneOptions<T>): Promise<T> {
         return (this as any).getRepository().findOneOrFail(optionsOrConditions as any, maybeOptions);
     }
 

--- a/src/repository/EntityId.ts
+++ b/src/repository/EntityId.ts
@@ -1,3 +1,3 @@
-import {ObjectID} from "../driver/mongodb/typings";
+import {ObjectId} from "../driver/mongodb/typings";
 
-export type EntityId = string|number|Date|ObjectID;
+export type EntityId = string|number|Date|ObjectId;

--- a/src/repository/MongoRepository.ts
+++ b/src/repository/MongoRepository.ts
@@ -24,7 +24,7 @@ import {
     InsertWriteOpResult,
     MapReduceOptions,
     MongoCountPreferences,
-    MongodbIndexOptions, ObjectID,
+    MongodbIndexOptions, ObjectId,
     OrderedBulkOperation,
     ParallelCollectionScanOptions,
     ReadPreference,
@@ -97,7 +97,7 @@ export class MongoRepository<Entity extends ObjectLiteral> extends Repository<En
     /**
      * Finds first entity that matches given conditions and/or find options.
      */
-    findOne(optionsOrConditions?: string|number|Date|ObjectID|FindOneOptions<Entity>|Partial<Entity>, maybeOptions?: FindOneOptions<Entity>): Promise<Entity|undefined> {
+    findOne(optionsOrConditions?: string|number|Date|ObjectId|FindOneOptions<Entity>|Partial<Entity>, maybeOptions?: FindOneOptions<Entity>): Promise<Entity|undefined> {
         return this.manager.findOne(this.metadata.target, optionsOrConditions as any, maybeOptions as any);
     }
 

--- a/src/repository/Repository.ts
+++ b/src/repository/Repository.ts
@@ -12,7 +12,7 @@ import {DeleteResult} from "../query-builder/result/DeleteResult";
 import {UpdateResult} from "../query-builder/result/UpdateResult";
 import {InsertResult} from "../query-builder/result/InsertResult";
 import {QueryDeepPartialEntity} from "../query-builder/QueryPartialEntity";
-import {ObjectID} from "../driver/mongodb/typings";
+import {ObjectId} from "../driver/mongodb/typings";
 import {FindConditions} from "../find-options/FindConditions";
 
 /**
@@ -183,7 +183,7 @@ export class Repository<Entity extends ObjectLiteral> {
      * Executes fast and efficient UPDATE query.
      * Does not check if entity exist in the database.
      */
-    update(criteria: string|string[]|number|number[]|Date|Date[]|ObjectID|ObjectID[]|FindConditions<Entity>, partialEntity: QueryDeepPartialEntity<Entity>): Promise<UpdateResult> {
+    update(criteria: string|string[]|number|number[]|Date|Date[]|ObjectId|ObjectId[]|FindConditions<Entity>, partialEntity: QueryDeepPartialEntity<Entity>): Promise<UpdateResult> {
         return this.manager.update(this.metadata.target as any, criteria as any, partialEntity);
     }
 
@@ -193,7 +193,7 @@ export class Repository<Entity extends ObjectLiteral> {
      * Executes fast and efficient DELETE query.
      * Does not check if entity exist in the database.
      */
-    delete(criteria: string|string[]|number|number[]|Date|Date[]|ObjectID|ObjectID[]|FindConditions<Entity>): Promise<DeleteResult> {
+    delete(criteria: string|string[]|number|number[]|Date|Date[]|ObjectId|ObjectId[]|FindConditions<Entity>): Promise<DeleteResult> {
         return this.manager.delete(this.metadata.target as any, criteria as any);
     }
 
@@ -277,7 +277,7 @@ export class Repository<Entity extends ObjectLiteral> {
     /**
      * Finds first entity that matches given options.
      */
-    findOne(id?: string|number|Date|ObjectID, options?: FindOneOptions<Entity>): Promise<Entity|undefined>;
+    findOne(id?: string|number|Date|ObjectId, options?: FindOneOptions<Entity>): Promise<Entity|undefined>;
 
     /**
      * Finds first entity that matches given options.
@@ -292,14 +292,14 @@ export class Repository<Entity extends ObjectLiteral> {
     /**
      * Finds first entity that matches given conditions.
      */
-    findOne(optionsOrConditions?: string|number|Date|ObjectID|FindOneOptions<Entity>|FindConditions<Entity>, maybeOptions?: FindOneOptions<Entity>): Promise<Entity|undefined> {
+    findOne(optionsOrConditions?: string|number|Date|ObjectId|FindOneOptions<Entity>|FindConditions<Entity>, maybeOptions?: FindOneOptions<Entity>): Promise<Entity|undefined> {
         return this.manager.findOne(this.metadata.target as any, optionsOrConditions as any, maybeOptions);
     }
 
     /**
      * Finds first entity that matches given options.
      */
-    findOneOrFail(id?: string|number|Date|ObjectID, options?: FindOneOptions<Entity>): Promise<Entity>;
+    findOneOrFail(id?: string|number|Date|ObjectId, options?: FindOneOptions<Entity>): Promise<Entity>;
 
     /**
      * Finds first entity that matches given options.
@@ -314,7 +314,7 @@ export class Repository<Entity extends ObjectLiteral> {
     /**
      * Finds first entity that matches given conditions.
      */
-    findOneOrFail(optionsOrConditions?: string|number|Date|ObjectID|FindOneOptions<Entity>|FindConditions<Entity>, maybeOptions?: FindOneOptions<Entity>): Promise<Entity> {
+    findOneOrFail(optionsOrConditions?: string|number|Date|ObjectId|FindOneOptions<Entity>|FindConditions<Entity>, maybeOptions?: FindOneOptions<Entity>): Promise<Entity> {
         return this.manager.findOneOrFail(this.metadata.target as any, optionsOrConditions as any, maybeOptions);
     }
 

--- a/test/functional/mongodb/basic/array-columns/entity/Post.ts
+++ b/test/functional/mongodb/basic/array-columns/entity/Post.ts
@@ -2,13 +2,13 @@ import {Entity} from "../../../../../../src/decorator/entity/Entity";
 import {Column} from "../../../../../../src/decorator/columns/Column";
 import {ObjectIdColumn} from "../../../../../../src/decorator/columns/ObjectIdColumn";
 import {Counters} from "./Counters";
-import {ObjectID} from "../../../../../../src/driver/mongodb/typings";
+import {ObjectId} from "../../../../../../src/driver/mongodb/typings";
 
 @Entity()
 export class Post {
 
     @ObjectIdColumn()
-    id: ObjectID;
+    id: ObjectId;
 
     @Column()
     title: string;

--- a/test/functional/mongodb/basic/embedded-columns-listeners/entity/Post.ts
+++ b/test/functional/mongodb/basic/embedded-columns-listeners/entity/Post.ts
@@ -2,13 +2,13 @@ import {Entity} from "../../../../../../src/decorator/entity/Entity";
 import {Column} from "../../../../../../src/decorator/columns/Column";
 import {ObjectIdColumn} from "../../../../../../src/decorator/columns/ObjectIdColumn";
 import {Counters} from "./Counters";
-import {ObjectID} from "../../../../../../src/driver/mongodb/typings";
+import {ObjectId} from "../../../../../../src/driver/mongodb/typings";
 
 @Entity()
 export class Post {
 
     @ObjectIdColumn()
-    id: ObjectID;
+    id: ObjectId;
 
     @Column()
     title: string;

--- a/test/functional/mongodb/basic/embedded-columns/entity/Post.ts
+++ b/test/functional/mongodb/basic/embedded-columns/entity/Post.ts
@@ -2,13 +2,13 @@ import {Entity} from "../../../../../../src/decorator/entity/Entity";
 import {Column} from "../../../../../../src/decorator/columns/Column";
 import {ObjectIdColumn} from "../../../../../../src/decorator/columns/ObjectIdColumn";
 import {Counters} from "./Counters";
-import {ObjectID} from "../../../../../../src/driver/mongodb/typings";
+import {ObjectId} from "../../../../../../src/driver/mongodb/typings";
 
 @Entity()
 export class Post {
 
     @ObjectIdColumn()
-    id: ObjectID;
+    id: ObjectId;
 
     @Column()
     title: string;

--- a/test/functional/mongodb/basic/mongo-embeddeds-index/entity/Post.ts
+++ b/test/functional/mongodb/basic/mongo-embeddeds-index/entity/Post.ts
@@ -2,7 +2,7 @@ import {Entity} from "../../../../../../src/decorator/entity/Entity";
 import {Column} from "../../../../../../src/decorator/columns/Column";
 import {ObjectIdColumn} from "../../../../../../src/decorator/columns/ObjectIdColumn";
 import {Index} from "../../../../../../src/decorator/Index";
-import {ObjectID} from "../../../../../../src/driver/mongodb/typings";
+import {ObjectId} from "../../../../../../src/driver/mongodb/typings";
 import {Information} from "./Information";
 
 @Entity()
@@ -10,7 +10,7 @@ import {Information} from "./Information";
 export class Post {
 
     @ObjectIdColumn()
-    id: ObjectID;
+    id: ObjectId;
 
     @Column()
     title: string;

--- a/test/functional/mongodb/basic/mongo-index/entity/Post.ts
+++ b/test/functional/mongodb/basic/mongo-index/entity/Post.ts
@@ -2,7 +2,7 @@ import {Entity} from "../../../../../../src/decorator/entity/Entity";
 import {Column} from "../../../../../../src/decorator/columns/Column";
 import {ObjectIdColumn} from "../../../../../../src/decorator/columns/ObjectIdColumn";
 import {Index} from "../../../../../../src/decorator/Index";
-import {ObjectID} from "../../../../../../src/driver/mongodb/typings";
+import {ObjectId} from "../../../../../../src/driver/mongodb/typings";
 
 @Entity()
 @Index(["title", "name"])
@@ -14,7 +14,7 @@ import {ObjectID} from "../../../../../../src/driver/mongodb/typings";
 export class Post {
 
     @ObjectIdColumn()
-    id: ObjectID;
+    id: ObjectId;
 
     @Column()
     @Index()

--- a/test/functional/mongodb/basic/mongo-repository/entity/Post.ts
+++ b/test/functional/mongodb/basic/mongo-repository/entity/Post.ts
@@ -1,13 +1,13 @@
 import {Entity} from "../../../../../../src/decorator/entity/Entity";
 import {Column} from "../../../../../../src/decorator/columns/Column";
 import {ObjectIdColumn} from "../../../../../../src/decorator/columns/ObjectIdColumn";
-import {ObjectID} from "../../../../../../src/driver/mongodb/typings";
+import {ObjectId} from "../../../../../../src/driver/mongodb/typings";
 
 @Entity()
 export class Post {
 
     @ObjectIdColumn()
-    id: ObjectID;
+    id: ObjectId;
 
     @Column()
     title: string;

--- a/test/functional/mongodb/basic/object-id/entity/Post.ts
+++ b/test/functional/mongodb/basic/object-id/entity/Post.ts
@@ -1,13 +1,13 @@
 import { Entity } from "../../../../../../src/decorator/entity/Entity";
 import { Column } from "../../../../../../src/decorator/columns/Column";
 import { ObjectIdColumn } from "../../../../../../src/decorator/columns/ObjectIdColumn";
-import { ObjectID } from "../../../../../../src/driver/mongodb/typings";
+import { ObjectId } from "../../../../../../src/driver/mongodb/typings";
 
 @Entity()
 export class Post {
 
     @ObjectIdColumn()
-    nonIdNameOfObjectId: ObjectID;
+    nonIdNameOfObjectId: ObjectId;
 
     @Column()
     title: string;

--- a/test/functional/mongodb/basic/object-id/entity/PostWithUnderscoreId.ts
+++ b/test/functional/mongodb/basic/object-id/entity/PostWithUnderscoreId.ts
@@ -1,13 +1,13 @@
 import { Entity } from "../../../../../../src/decorator/entity/Entity";
 import { Column } from "../../../../../../src/decorator/columns/Column";
 import { ObjectIdColumn } from "../../../../../../src/decorator/columns/ObjectIdColumn";
-import { ObjectID } from "../../../../../../src/driver/mongodb/typings";
+import { ObjectId } from "../../../../../../src/driver/mongodb/typings";
 
 @Entity()
 export class PostWithUnderscoreId {
 
     @ObjectIdColumn()
-    _id: ObjectID;
+    _id: ObjectId;
 
     @Column()
     title: string;

--- a/test/functional/mongodb/basic/repository-actions/entity/Post.ts
+++ b/test/functional/mongodb/basic/repository-actions/entity/Post.ts
@@ -1,13 +1,13 @@
 import {Entity} from "../../../../../../src/decorator/entity/Entity";
 import {Column} from "../../../../../../src/decorator/columns/Column";
 import {ObjectIdColumn} from "../../../../../../src/decorator/columns/ObjectIdColumn";
-import {ObjectID} from "../../../../../../src/driver/mongodb/typings";
+import {ObjectId} from "../../../../../../src/driver/mongodb/typings";
 
 @Entity()
 export class Post {
 
     @ObjectIdColumn()
-    id: ObjectID;
+    id: ObjectId;
 
     @Column()
     title: string;

--- a/test/functional/mongodb/basic/timestampable-columns/entity/Post.ts
+++ b/test/functional/mongodb/basic/timestampable-columns/entity/Post.ts
@@ -1,7 +1,7 @@
 import { Entity } from "../../../../../../src/decorator/entity/Entity";
 import { Column } from "../../../../../../src/decorator/columns/Column";
 import { ObjectIdColumn } from "../../../../../../src/decorator/columns/ObjectIdColumn";
-import { ObjectID } from "../../../../../../src/driver/mongodb/typings";
+import { ObjectId } from "../../../../../../src/driver/mongodb/typings";
 import { CreateDateColumn } from "../../../../../../src/decorator/columns/CreateDateColumn";
 import { UpdateDateColumn } from "../../../../../../src/decorator/columns/UpdateDateColumn";
 
@@ -9,7 +9,7 @@ import { UpdateDateColumn } from "../../../../../../src/decorator/columns/Update
 export class Post {
 
     @ObjectIdColumn()
-    id: ObjectID;
+    id: ObjectId;
 
     @Column()
     message: string;

--- a/test/github-issues/1210/entity/Event.ts
+++ b/test/github-issues/1210/entity/Event.ts
@@ -1,4 +1,4 @@
-import {ObjectID} from "../../../../src/driver/mongodb/typings";
+import {ObjectId} from "../../../../src/driver/mongodb/typings";
 import {Entity} from "../../../../src/decorator/entity/Entity";
 import {ObjectIdColumn} from "../../../../src/decorator/columns/ObjectIdColumn";
 import {Column} from "../../../../src/decorator/columns/Column";
@@ -7,7 +7,7 @@ import {Column} from "../../../../src/decorator/columns/Column";
 export class Event {
 
     @ObjectIdColumn()
-    id: ObjectID;
+    id: ObjectId;
 
     @Column()
     name: string;

--- a/test/github-issues/1210/entity/User.ts
+++ b/test/github-issues/1210/entity/User.ts
@@ -1,14 +1,14 @@
 import {Entity} from "../../../../src/decorator/entity/Entity";
 import {ObjectIdColumn} from "../../../../src/decorator/columns/ObjectIdColumn";
 import {Column} from "../../../../src/decorator/columns/Column";
-import {ObjectID} from "../../../../src/driver/mongodb/typings";
+import {ObjectId} from "../../../../src/driver/mongodb/typings";
 import {Event} from "./Event";
 
 @Entity()
 export class User {
 
     @ObjectIdColumn()
-    id: ObjectID;
+    id: ObjectId;
 
     @Column()
     firstName: string;

--- a/test/github-issues/1510/issue-1510.ts
+++ b/test/github-issues/1510/issue-1510.ts
@@ -22,8 +22,8 @@ describe("github issues > #1510 entity schema does not support mode=objectId", (
         }
     });
 
-    const UserWithoutObjectIDEntity = new EntitySchema<any>({
-        name: "UserWithoutObjectID",
+    const UserWithoutObjectIdEntity = new EntitySchema<any>({
+        name: "UserWithoutObjectId",
         tableName: "test_1510_users2",
         columns: {
             _id: {
@@ -40,7 +40,7 @@ describe("github issues > #1510 entity schema does not support mode=objectId", (
     let connections: Connection[];
     before(async () => {
         return connections = await createTestingConnections({
-            entities: [__dirname + "/entity/*{.js,.ts}", UserEntity, UserWithoutObjectIDEntity],
+            entities: [__dirname + "/entity/*{.js,.ts}", UserEntity, UserWithoutObjectIdEntity],
             enabledDrivers: ["mongodb"]
         });
     });
@@ -48,7 +48,7 @@ describe("github issues > #1510 entity schema does not support mode=objectId", (
     after(() => closeTestingConnections(connections));
 
     it("throws an error because there is no object id defined", () => Promise.all(connections.map(async connection => {
-        const repo = connection.getRepository("UserWithoutObjectID");
+        const repo = connection.getRepository("UserWithoutObjectId");
 
         try {
             await repo.insert({

--- a/test/github-issues/1584/entity/User.ts
+++ b/test/github-issues/1584/entity/User.ts
@@ -1,13 +1,13 @@
 import {Entity} from "../../../../src/decorator/entity/Entity";
 import {ObjectIdColumn} from "../../../../src/decorator/columns/ObjectIdColumn";
 import {Column} from "../../../../src/decorator/columns/Column";
-import {ObjectID} from "../../../../src/driver/mongodb/typings";
+import {ObjectId} from "../../../../src/driver/mongodb/typings";
 
 @Entity()
 export class User {
 
     @ObjectIdColumn()
-    id: ObjectID;
+    id: ObjectId;
 
     @Column()
     name: string;

--- a/test/github-issues/1929/entity/Product.ts
+++ b/test/github-issues/1929/entity/Product.ts
@@ -1,4 +1,4 @@
-import {Column, Entity, ObjectID, ObjectIdColumn} from "../../../../src";
+import {Column, Entity, ObjectId, ObjectIdColumn} from "../../../../src";
 
 @Entity()
 export class Product {
@@ -11,7 +11,7 @@ export class Product {
     }
 
     @ObjectIdColumn()
-    id: ObjectID;
+    id: ObjectId;
 
     @Column()
     name: string;

--- a/test/github-issues/3551/entity/Book.ts
+++ b/test/github-issues/3551/entity/Book.ts
@@ -1,4 +1,4 @@
-import { Entity, ObjectIdColumn, Column, ObjectID } from "../../../../src";
+import { Entity, ObjectIdColumn, Column, ObjectId } from "../../../../src";
 
 export class Page {
     @Column()
@@ -16,7 +16,7 @@ export class Chapter {
 @Entity()
 export class Book {
     @ObjectIdColumn()
-    id: ObjectID;
+    id: ObjectId;
 
     @Column()
     title: string;

--- a/test/github-issues/970/entity/Post.ts
+++ b/test/github-issues/970/entity/Post.ts
@@ -1,13 +1,13 @@
 import {Entity} from "../../../../src/decorator/entity/Entity";
 import {ObjectIdColumn} from "../../../../src/decorator/columns/ObjectIdColumn";
-import {ObjectID} from "../../../../src/driver/mongodb/typings";
+import {ObjectId} from "../../../../src/driver/mongodb/typings";
 import {Column} from "../../../../src/decorator/columns/Column";
 
 @Entity()
 export class Post {
 
     @ObjectIdColumn()
-    id: ObjectID;
+    id: ObjectId;
 
     @Column()
     title: string;

--- a/test/other-issues/mongodb-entity-change-in-subscribers/entity/Post.ts
+++ b/test/other-issues/mongodb-entity-change-in-subscribers/entity/Post.ts
@@ -1,13 +1,13 @@
 import {Entity} from "../../../../src/decorator/entity/Entity";
 import {Column} from "../../../../src/decorator/columns/Column";
 import {UpdateDateColumn} from "../../../../src/decorator/columns/UpdateDateColumn";
-import {ObjectID, ObjectIdColumn} from "../../../../src";
+import {ObjectId, ObjectIdColumn} from "../../../../src";
 
 @Entity()
 export class Post {
 
     @ObjectIdColumn()
-    id: ObjectID;
+    id: ObjectId;
 
     @Column()
     title: string;


### PR DESCRIPTION
issue #4241

bson lib types
https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/bson/index.d.ts#L352

A little *BC* 
from `ObjectID`
```typescript
generate(time?: number): string;
```
to `ObjectId`
```typescript
static generate(time?: number): Buffer;
```

Old `ObjectID` will still be supported, but deprecated
https://github.com/typeorm/typeorm/commit/9c8fa67c02b163fd737eec8299a0cf3887553680#diff-859ccae412ed029cdf257edd7258b283R1934-R1939