### PR TITLE
Fix "current_timestamp(6)" !== "CURRENT_TIMESTAMP(6)" for MariaDB >= 10.2

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -27,7 +27,7 @@ services:
 
   # mariadb
   mariadb:
-    image: "mariadb:10.1.37"
+    image: "mariadb:10.4.8"
     container_name: "typeorm-mariadb"
     ports:
       - "3307:3306"

--- a/src/util/VersionUtils.ts
+++ b/src/util/VersionUtils.ts
@@ -1,0 +1,20 @@
+export type Version = [number, number, number];
+
+export class VersionUtils {
+    static isGreaterOrEqual(version: string, targetVersion: string): boolean {
+        const v1 = parseVersion(version);
+        const v2 = parseVersion(targetVersion);
+
+        return v1[0] > v2[0] ||
+            v1[0] === v2[0] && v1[1] > v2[1] ||
+            v1[0] === v2[0] && v1[1] === v2[1] && v1[2] >= v2[2];
+    }
+}
+
+function parseVersion(version: string = ""): Version {
+    const v: Version = [0, 0, 0];
+
+    version.split(".").forEach((value, i) => v[i] = parseInt(value, 10));
+
+    return v;
+}

--- a/test/github-issues/4782/entity/Item.ts
+++ b/test/github-issues/4782/entity/Item.ts
@@ -1,0 +1,12 @@
+import { CreateDateColumn } from "../../../../src";
+import { PrimaryGeneratedColumn } from "../../../../src/decorator/columns/PrimaryGeneratedColumn";
+import { Entity } from "../../../../src/decorator/entity/Entity";
+
+@Entity()
+export class Item {
+    @PrimaryGeneratedColumn()
+    id: number;
+
+    @CreateDateColumn()
+    date: Date;
+}

--- a/test/github-issues/4782/issue-4782.ts
+++ b/test/github-issues/4782/issue-4782.ts
@@ -1,0 +1,56 @@
+import "reflect-metadata";
+import {closeTestingConnections, createTestingConnections, reloadTestingDatabases} from "../../utils/test-utils";
+import {Connection} from "../../../src/connection/Connection";
+import {expect} from "chai";
+import { VersionUtils } from "../../../src/util/VersionUtils";
+
+describe("github issues > 4782 mariadb driver wants to recreate create/update date columns CURRENT_TIMESTAMP(6) === current_timestamp(6)", () => {
+
+    let connections: Connection[];
+    before(async () => connections = await createTestingConnections({
+        // logging: true,
+        entities: [__dirname + "/entity/*{.js,.ts}"],
+        enabledDrivers: ["mysql", "mariadb"]
+    }));
+    beforeEach(() => reloadTestingDatabases(connections));
+    after(() => closeTestingConnections(connections));
+
+    it("should not want to execute migrations twice", () => Promise.all(connections.map(async connection => {
+        const sql1 = await connection.driver.createSchemaBuilder().log();
+        expect(sql1.upQueries).to.eql([]);
+    })));
+
+    describe("VersionUtils", () => {
+        describe("isGreaterOrEqual", () => {
+            it("should return false when comparing invalid versions", () => {
+                expect(VersionUtils.isGreaterOrEqual("", "")).to.equal(false);
+            });
+
+            it("should return false when targetVersion is larger", () => {
+                expect(VersionUtils.isGreaterOrEqual("1.2.3", "1.2.4")).to.equal(false);
+                expect(VersionUtils.isGreaterOrEqual("1.2.3", "1.4.3")).to.equal(false);
+                expect(VersionUtils.isGreaterOrEqual("1.2.3", "2.2.3")).to.equal(false);
+                expect(VersionUtils.isGreaterOrEqual("1.2", "1.3")).to.equal(false);
+                expect(VersionUtils.isGreaterOrEqual("1", "2")).to.equal(false);
+                expect(VersionUtils.isGreaterOrEqual(undefined as unknown as string, "0.0.1")).to.equal(false);
+            });
+
+            it("should return true when targetVersion is smaller", () => {
+
+                expect(VersionUtils.isGreaterOrEqual("1.2.3", "1.2.2")).to.equal(true);
+                expect(VersionUtils.isGreaterOrEqual("1.2.3", "1.1.3")).to.equal(true);
+                expect(VersionUtils.isGreaterOrEqual("1.2.3", "0.2.3")).to.equal(true);
+                expect(VersionUtils.isGreaterOrEqual("1.2", "1.2")).to.equal(true);
+                expect(VersionUtils.isGreaterOrEqual("1", "1")).to.equal(true);
+            });
+
+            it("should work with mariadb-style versions", () => {
+                const dbVersion = "10.4.8-MariaDB-1:10.4.8+maria~bionic";
+                expect(VersionUtils.isGreaterOrEqual("10.4.9", dbVersion)).to.equal(true);
+                expect(VersionUtils.isGreaterOrEqual("10.4.8", dbVersion)).to.equal(true);
+                expect(VersionUtils.isGreaterOrEqual("10.4.7", dbVersion)).to.equal(false);
+            });
+        });
+    });
+
+});


### PR DESCRIPTION
Fixes #4782. I've explained the issue in great detail there.

- Fixed a check for `CURRENT_TIMESTAMP`, and made it more generic to cover cases like `CURRENT_TIMESTAMP`, `CURRENT_TIMESTAMP()` and `CURRENT_TIMESTAMP(6)`, ignoring the case.
- Fixed a test failure in `test/functional/query-builder/add-column.ts` due to double-quoting:
https://github.com/typeorm/typeorm/blob/13ac22242ad1e2a46cc3aa6af870f4b1cfae1af3/test/functional/query-runner/add-column.ts#L73
- Added `semver` dependency to make it easy to check the version of MariaDB.

