### PR TITLE
feat: support spatial functions of MySQL 8+

### DIFF
--- a/docs/connection-options.md
+++ b/docs/connection-options.md
@@ -154,6 +154,8 @@ Slight performance penalty for most calls. (Default: `true`)
 * `multipleStatements` - Allow multiple mysql statements per query. Be careful with this, it could increase the scope 
 of SQL injection attacks. (Default: `false`)
 
+* `legacySpatialSupport` - Use spatial functions like GeomFromText and AsText which are removed in MySQL 8. (Default: true)
+
 * `flags` - List of connection flags to use other than the default ones. It is also possible to blacklist default ones.
  For more information, check [Connection Flags](https://github.com/mysqljs/mysql#connection-flags).
  

--- a/docs/zh_CN/connection-options.md
+++ b/docs/zh_CN/connection-options.md
@@ -98,6 +98,8 @@
 
 - `multipleStatements` - 每个查询允许多个 mysql 语句。请注意，它可能会增加 SQL 注入攻击的范围。 （默认值：`false`）
 
+- `legacySpatialSupport` - Use spatial functions like GeomFromText and AsText which are removed in MySQL 8. (Default: true)
+
 - `flags` - 使用非默认连接标志的连接标志列表。也可以将默认值列入黑名单。有关更多信息，请查看[Connection Flags](https://github.com/mysqljs/mysql#connection-flags)。
 
 - `ssl` - 带有 ssl 参数的对象或包含 ssl 配置文件名称的字符串。请参阅[SSL 选项](https://github.com/mysqljs/mysql#ssl-options)。

--- a/src/driver/aurora-data-api/AuroraDataApiConnectionOptions.ts
+++ b/src/driver/aurora-data-api/AuroraDataApiConnectionOptions.ts
@@ -20,4 +20,10 @@ export interface AuroraDataApiConnectionOptions extends BaseConnectionOptions, A
     readonly resourceArn: string;
 
     readonly database: string;
+
+    /**
+     * Use spatial functions like GeomFromText and AsText which are removed in MySQL 8.
+     * (Default: true)
+     */
+    readonly legacySpatialSupport?: boolean;
 }

--- a/src/driver/mysql/MysqlConnectionOptions.ts
+++ b/src/driver/mysql/MysqlConnectionOptions.ts
@@ -83,6 +83,12 @@ export interface MysqlConnectionOptions extends BaseConnectionOptions, MysqlConn
     readonly multipleStatements?: boolean;
 
     /**
+     * Use spatial functions like GeomFromText and AsText which are removed in MySQL 8.
+     * (Default: true)
+     */
+    readonly legacySpatialSupport?: boolean;
+
+    /**
      * List of connection flags to use other than the default ones. It is also possible to blacklist default ones.
      * For more information, check https://github.com/mysqljs/mysql#connection-flags.
      */

--- a/src/driver/mysql/MysqlDriver.ts
+++ b/src/driver/mysql/MysqlDriver.ts
@@ -297,7 +297,10 @@ export class MysqlDriver implements Driver {
 
     constructor(connection: Connection) {
         this.connection = connection;
-        this.options = connection.options as MysqlConnectionOptions;
+        this.options = {
+            legacySpatialSupport: true,
+            ...connection.options
+        } as MysqlConnectionOptions;
         this.isReplicated = this.options.replication ? true : false;
 
         // load mysql package

--- a/src/query-builder/InsertQueryBuilder.ts
+++ b/src/query-builder/InsertQueryBuilder.ts
@@ -470,7 +470,13 @@ export class InsertQueryBuilder<Entity> extends QueryBuilder<Entity> {
 
                         this.expressionMap.nativeParameters[paramName] = value;
                         if ((this.connection.driver instanceof MysqlDriver || this.connection.driver instanceof AuroraDataApiDriver) && this.connection.driver.spatialTypes.indexOf(column.type) !== -1) {
-                            expression += `GeomFromText(${this.connection.driver.createParameter(paramName, parametersCount)})`;
+                            const useLegacy = this.connection.driver.options.legacySpatialSupport;
+                            const geomFromText = useLegacy ? "GeomFromText" : "ST_GeomFromText";
+                            if (column.srid != null) {
+                                expression += `${geomFromText}(${this.connection.driver.createParameter(paramName, parametersCount)}, ${column.srid})`;
+                            } else {
+                                expression += `${geomFromText}(${this.connection.driver.createParameter(paramName, parametersCount)})`;
+                            }
                         } else if (this.connection.driver instanceof PostgresDriver && this.connection.driver.spatialTypes.indexOf(column.type) !== -1) {
                             if (column.srid != null) {
                               expression += `ST_SetSRID(ST_GeomFromGeoJSON(${this.connection.driver.createParameter(paramName, parametersCount)}), ${column.srid})::${column.type}`;

--- a/src/query-builder/SelectQueryBuilder.ts
+++ b/src/query-builder/SelectQueryBuilder.ts
@@ -1681,8 +1681,11 @@ export class SelectQueryBuilder<Entity> extends QueryBuilder<Entity> implements 
             const selection = this.expressionMap.selects.find(select => select.selection === aliasName + "." + column.propertyPath);
             let selectionPath = this.escape(aliasName) + "." + this.escape(column.databaseName);
             if (this.connection.driver.spatialTypes.indexOf(column.type) !== -1) {
-                if (this.connection.driver instanceof MysqlDriver || this.connection.driver instanceof AuroraDataApiDriver)
-                    selectionPath = `AsText(${selectionPath})`;
+                if (this.connection.driver instanceof MysqlDriver || this.connection.driver instanceof AuroraDataApiDriver) {
+                    const useLegacy = this.connection.driver.options.legacySpatialSupport;
+                    const asText = useLegacy ? "AsText" : "ST_AsText";
+                    selectionPath = `${asText}(${selectionPath})`;
+                }
 
                 if (this.connection.driver instanceof PostgresDriver)
                     // cast to JSON to trigger parsing in the driver

--- a/src/query-builder/UpdateQueryBuilder.ts
+++ b/src/query-builder/UpdateQueryBuilder.ts
@@ -420,7 +420,13 @@ export class UpdateQueryBuilder<Entity> extends QueryBuilder<Entity> implements 
 
                         let expression = null;
                         if ((this.connection.driver instanceof MysqlDriver || this.connection.driver instanceof AuroraDataApiDriver) && this.connection.driver.spatialTypes.indexOf(column.type) !== -1) {
-                            expression = `GeomFromText(${this.connection.driver.createParameter(paramName, parametersCount)})`;
+                            const useLegacy = this.connection.driver.options.legacySpatialSupport;
+                            const geomFromText = useLegacy ? "GeomFromText" : "ST_GeomFromText";
+                            if (column.srid != null) {
+                                expression = `${geomFromText}(${this.connection.driver.createParameter(paramName, parametersCount)}, ${column.srid})`;
+                            } else {
+                                expression = `${geomFromText}(${this.connection.driver.createParameter(paramName, parametersCount)})`;
+                            }
                         } else if (this.connection.driver instanceof PostgresDriver && this.connection.driver.spatialTypes.indexOf(column.type) !== -1) {
                             if (column.srid != null) {
                               expression = `ST_SetSRID(ST_GeomFromGeoJSON(${this.connection.driver.createParameter(paramName, parametersCount)}), ${column.srid})::${column.type}`;

--- a/test/github-issues/3702/entity/LetterBox.ts
+++ b/test/github-issues/3702/entity/LetterBox.ts
@@ -1,0 +1,13 @@
+import {Entity, PrimaryGeneratedColumn} from "../../../../src";
+import {Column} from "../../../../src/decorator/columns/Column";
+
+@Entity()
+export class LetterBox {
+
+    @PrimaryGeneratedColumn()
+    id: number;
+
+    @Column({ type: "point", srid: 4326 })
+    coord: string;
+
+}

--- a/test/github-issues/3702/issue-3702.ts
+++ b/test/github-issues/3702/issue-3702.ts
@@ -1,0 +1,104 @@
+import "reflect-metadata";
+import {createTestingConnections, closeTestingConnections} from "../../utils/test-utils";
+import {Connection} from "../../../src/connection/Connection";
+import {expect} from "chai";
+import {LetterBox} from "./entity/LetterBox";
+
+// Another related path: test/functional/spatial
+describe("github issues > #3702 MySQL Spatial Type Support : GeomFromText function is not supported", () => {
+
+    describe("when legacySpatialSupport: true", () => {
+        let connections: Connection[];
+
+        before(async () => connections = await createTestingConnections({
+            entities: [__dirname + "/entity/*{.js,.ts}"],
+            enabledDrivers: ["mysql"],
+            dropSchema: true,
+            schemaCreate: true,
+            driverSpecific: {
+                // it's default
+                // legacySpatialSupport: true,
+            },
+        }));
+        after(() => closeTestingConnections(connections));
+
+        it("should use GeomFromText", () => Promise.all(connections.map(async connection => {
+            let queryBuilder = connection.createQueryBuilder().insert();
+            queryBuilder.into(LetterBox).values({ coord: "POINT(20 30)" });
+            const sql = queryBuilder.getSql();
+
+            expect(sql).includes("GeomFromText");
+            expect(sql).not.includes("ST_GeomFromText");
+
+            await queryBuilder.execute();
+        })));
+
+
+        it("should provide SRID", () => Promise.all(connections.map(async connection => {
+            let queryBuilder = connection.createQueryBuilder().insert();
+            queryBuilder.into(LetterBox).values({ coord: "POINT(25 100)" });
+            const sql = queryBuilder.getSql();
+
+            expect(sql).includes("4326");
+
+            await queryBuilder.execute();
+        })));
+
+        it("should use AsText", () => Promise.all(connections.map(async connection => {
+            const repository = connection.getRepository(LetterBox);
+            let queryBuilder = repository.createQueryBuilder("letterBox").select(["letterBox"]);
+            const sql = queryBuilder.getSql();
+
+            expect(sql).includes("AsText");
+            expect(sql).not.includes("ST_AsText");
+
+            await queryBuilder.getMany();
+        })));
+    });
+
+
+    describe("when legacySpatialSupport: false", () => {
+        let connections: Connection[];
+
+        before(async () => connections = await createTestingConnections({
+            entities: [__dirname + "/entity/*{.js,.ts}"],
+            enabledDrivers: ["mysql"],
+            dropSchema: true,
+            schemaCreate: true,
+            driverSpecific: {
+                legacySpatialSupport: false,
+            }
+        }));
+        after(() => closeTestingConnections(connections));
+
+        it("should use ST_GeomFromText", () => Promise.all(connections.map(async connection => {
+            let queryBuilder = connection.createQueryBuilder().insert();
+            queryBuilder.into(LetterBox).values({ coord: "POINT(20 30)" });
+            const sql = queryBuilder.getSql();
+
+            expect(sql).includes("ST_GeomFromText");
+
+            await queryBuilder.execute();
+        })));
+
+        it("should provide SRID", () => Promise.all(connections.map(async connection => {
+            let queryBuilder = connection.createQueryBuilder().insert();
+            queryBuilder.into(LetterBox).values({ coord: "POINT(25 100)" });
+            const sql = queryBuilder.getSql();
+
+            expect(sql).includes("4326");
+
+            await queryBuilder.execute();
+        })));
+
+        it("should use ST_AsText", () => Promise.all(connections.map(async connection => {
+            const repository = connection.getRepository(LetterBox);
+            let queryBuilder = repository.createQueryBuilder("letterBox").select(["letterBox"]);
+            const sql = queryBuilder.getSql();
+
+            expect(sql).includes("ST_AsText");
+
+            await queryBuilder.getMany();
+        })));
+    });
+});


### PR DESCRIPTION
* Add `legacySpatialSupport` option for replacing
  dropped functions to new ones

* Use srid column option like PostgreSQL

Implemented the OP's suggestion naively.
Close #3702