### PR TITLE
docs: fix entities broken link

### DIFF
--- a/docs/entities.md
+++ b/docs/entities.md
@@ -98,7 +98,7 @@ If you want to set a base prefix for all database tables in your application you
 
 When using an entity constructor its arguments **must be optional**. Since ORM creates instances of entity classes when loading from the database, therefore it is not aware of your constructor arguments.
 
-Learn more about parameters @Entity in [Decorators reference](decorator-reference.md).
+Learn more about parameters `@Entity` in [Decorators reference](decorator-reference.md).
 
 ## Entity columns
 


### PR DESCRIPTION
The `decorator-reference` link is broken. I believe this will fix it
see: https://typeorm.io/#/entities