### PR TITLE
entity property name helper for propertyPath on increment/decrement

### DIFF
--- a/src/entity-manager/EntityManager.ts
+++ b/src/entity-manager/EntityManager.ts
@@ -937,17 +937,17 @@ export class EntityManager {
     async increment<Entity>(entityClass: ObjectType<Entity>|EntitySchema<Entity>|string,
                             conditions: any,
                             propertyPath: Extract<keyof Entity, string> | string,
-                            value: number | string): Promise<UpdateResult> {
+                            value: number | string = 1): Promise<UpdateResult> {
+
+        if (isNaN(Number(value)))
+            throw new Error(`Value "${value}" is not a number.`);
 
         const metadata = this.connection.getMetadata(entityClass);
         const column = metadata.findColumnWithPropertyPath(propertyPath);
         if (!column)
             throw new Error(`Column ${propertyPath} was not found in ${metadata.targetName} entity.`);
 
-        if (isNaN(Number(value)))
-            throw new Error(`Value "${value}" is not a number.`);
-
-        // convert possible embeded path "social.likes" into object { social: { like: () => value } }
+        // convert possible embedded path "social.likes" into object { social: { like: () => value } }
         const values: QueryDeepPartialEntity<Entity> = propertyPath
             .split(".")
             .reduceRight(
@@ -969,17 +969,17 @@ export class EntityManager {
     async decrement<Entity>(entityClass: ObjectType<Entity>|EntitySchema<Entity>|string,
                             conditions: any,
                             propertyPath: Extract<keyof Entity, string> | string,
-                            value: number | string): Promise<UpdateResult> {
+                            value: number | string = 1): Promise<UpdateResult> {
+
+        if (isNaN(Number(value)))
+            throw new Error(`Value "${value}" is not a number.`);
 
         const metadata = this.connection.getMetadata(entityClass);
         const column = metadata.findColumnWithPropertyPath(propertyPath);
         if (!column)
             throw new Error(`Column ${propertyPath} was not found in ${metadata.targetName} entity.`);
 
-        if (isNaN(Number(value)))
-            throw new Error(`Value "${value}" is not a number.`);
-
-        // convert possible embeded path "social.likes" into object { social: { like: () => value } }
+        // convert possible embedded path "social.likes" into object { social: { like: () => value } }
         const values: QueryDeepPartialEntity<Entity> = propertyPath
             .split(".")
             .reduceRight(

--- a/src/entity-manager/EntityManager.ts
+++ b/src/entity-manager/EntityManager.ts
@@ -936,7 +936,7 @@ export class EntityManager {
      */
     async increment<Entity>(entityClass: ObjectType<Entity>|EntitySchema<Entity>|string,
                             conditions: any,
-                            propertyPath: string,
+                            propertyPath: Extract<keyof Entity, string> | string,
                             value: number | string): Promise<UpdateResult> {
 
         const metadata = this.connection.getMetadata(entityClass);
@@ -968,7 +968,7 @@ export class EntityManager {
      */
     async decrement<Entity>(entityClass: ObjectType<Entity>|EntitySchema<Entity>|string,
                             conditions: any,
-                            propertyPath: string,
+                            propertyPath: Extract<keyof Entity, string> | string,
                             value: number | string): Promise<UpdateResult> {
 
         const metadata = this.connection.getMetadata(entityClass);

--- a/src/repository/Repository.ts
+++ b/src/repository/Repository.ts
@@ -339,14 +339,14 @@ export class Repository<Entity extends ObjectLiteral> {
     /**
      * Increments some column by provided value of the entities matched given conditions.
      */
-    increment(conditions: FindConditions<Entity>, propertyPath: Extract<keyof Entity, string> | string, value: number | string): Promise<UpdateResult> {
+    increment(conditions: FindConditions<Entity>, propertyPath: Extract<keyof Entity, string> | string, value: number | string = 1): Promise<UpdateResult> {
         return this.manager.increment(this.metadata.target, conditions, propertyPath, value);
     }
 
     /**
      * Decrements some column by provided value of the entities matched given conditions.
      */
-    decrement(conditions: FindConditions<Entity>, propertyPath: Extract<keyof Entity, string> | string, value: number | string): Promise<UpdateResult> {
+    decrement(conditions: FindConditions<Entity>, propertyPath: Extract<keyof Entity, string> | string, value: number | string = 1): Promise<UpdateResult> {
         return this.manager.decrement(this.metadata.target, conditions, propertyPath, value);
     }
 

--- a/src/repository/Repository.ts
+++ b/src/repository/Repository.ts
@@ -339,14 +339,14 @@ export class Repository<Entity extends ObjectLiteral> {
     /**
      * Increments some column by provided value of the entities matched given conditions.
      */
-    increment(conditions: FindConditions<Entity>, propertyPath: string, value: number | string): Promise<UpdateResult> {
+    increment(conditions: FindConditions<Entity>, propertyPath: Extract<keyof Entity, string> | string, value: number | string): Promise<UpdateResult> {
         return this.manager.increment(this.metadata.target, conditions, propertyPath, value);
     }
 
     /**
      * Decrements some column by provided value of the entities matched given conditions.
      */
-    decrement(conditions: FindConditions<Entity>, propertyPath: string, value: number | string): Promise<UpdateResult> {
+    decrement(conditions: FindConditions<Entity>, propertyPath: Extract<keyof Entity, string> | string, value: number | string): Promise<UpdateResult> {
         return this.manager.decrement(this.metadata.target, conditions, propertyPath, value);
     }
 

--- a/test/functional/repository/increment/repository-increment.ts
+++ b/test/functional/repository/increment/repository-increment.ts
@@ -33,7 +33,7 @@ describe("repository > increment method", () => {
             // increment counter of post 1
             await connection
                 .getRepository(Post)
-                .increment({ id: 1 }, "counter", 1);
+                .increment({ id: 1 }, "counter");
 
             // increment counter of post 2
             await connection
@@ -113,7 +113,7 @@ describe("repository > increment method", () => {
             // increment counter of post 1
             await connection
                 .getRepository(Post)
-                .increment({ id: 1 }, "unknownProperty", 1)
+                .increment({ id: 1 }, "unknownProperty")
                 .should.be.rejected;
 
         })));


### PR DESCRIPTION
`propertyPath` argument in `increment`/`decrement` methods of `manager` as a simple string is not really safe way to pass the field name and it is so abstract just to support embedded fields.

Here is a helper for current entity property names, just to help developer pass valid name in simple cases.

Also it will be great to have a default value in this methods.

<img width="691" alt="Screen Shot 2019-10-03 at 14 04 10" src="https://user-images.githubusercontent.com/166803/66121926-0b38f900-e5e7-11e9-83ad-c00ffe401cd9.png">
