### PR TITLE
docs: don't await .merge in example with express

### DIFF
--- a/docs/example-with-express.md
+++ b/docs/example-with-express.md
@@ -227,7 +227,7 @@ createConnection().then(connection => {
 
     app.put("/users/:id", async function(req: Request, res: Response) {
         const user = await userRepository.findOne(req.params.id);
-        await userRepository.merge(user, req.body);
+        userRepository.merge(user, req.body);
         const results = await userRepository.save(user);
         return res.send(results);
     });


### PR DESCRIPTION
In the [examples with express](https://typeorm.io/#/example-with-express/adding-typeorm-to-the-application) the PUT request awaits when it doesn't need to, since .merge doesn't return a promise.