### PR TITLE
Prevents the In operator from crashing when called with empty parameters

### DIFF
--- a/src/find-options/FindOperator.ts
+++ b/src/find-options/FindOperator.ts
@@ -107,7 +107,7 @@ export class FindOperator<T> {
             case "between":
                 return `${aliasPath} BETWEEN ${parameters[0]} AND ${parameters[1]}`;
             case "in":
-                return parameters.length > 0 ? `${aliasPath} IN (${parameters.join(", ")})` : "";
+                return parameters.length > 0 ? `${aliasPath} IN (${parameters.join(", ")})` : "1 != 1";
             case "any":
                 return `${aliasPath} = ANY(${parameters[0]})`;
             case "isNull":

--- a/src/find-options/FindOperator.ts
+++ b/src/find-options/FindOperator.ts
@@ -107,7 +107,7 @@ export class FindOperator<T> {
             case "between":
                 return `${aliasPath} BETWEEN ${parameters[0]} AND ${parameters[1]}`;
             case "in":
-                return `${aliasPath} IN (${parameters.join(", ")})`;
+                return parameters.length > 0 ? `${aliasPath} IN (${parameters.join(", ")})` : "";
             case "any":
                 return `${aliasPath} = ANY(${parameters[0]})`;
             case "isNull":

--- a/test/other-issues/find-operator-in-crashing-empty-parameters/entity/User.ts
+++ b/test/other-issues/find-operator-in-crashing-empty-parameters/entity/User.ts
@@ -1,0 +1,8 @@
+import {Entity} from "../../../../src/decorator/entity/Entity";
+import {PrimaryGeneratedColumn} from "../../../../src/decorator/columns/PrimaryGeneratedColumn";
+
+@Entity()
+export class User {
+  @PrimaryGeneratedColumn()
+  uuid: number;
+}

--- a/test/other-issues/find-operator-in-crashing-empty-parameters/find-operator-in-crashing-empty-parameters.ts
+++ b/test/other-issues/find-operator-in-crashing-empty-parameters/find-operator-in-crashing-empty-parameters.ts
@@ -1,0 +1,29 @@
+import "reflect-metadata";
+import {closeTestingConnections, createTestingConnections, reloadTestingDatabases} from "../../utils/test-utils";
+import {Connection} from "../../../src/connection/Connection";
+import {expect} from "chai";
+import {In} from "../../../src";
+import {User} from "./entity/User";
+
+describe("other issues > find operator in crashing when passed empty parameters", () => {
+    let connections: Connection[];
+    before(async () => connections = await createTestingConnections({
+        entities: [__dirname + "/entity/*{.js,.ts}"],
+    }));
+    beforeEach(() => reloadTestingDatabases(connections));
+    after(() => closeTestingConnections(connections));
+
+    it("should not crashed when passed empty parameters", () => Promise.all(connections.map(async function(connection) {
+        let error = null;
+        try {
+            await connection.getRepository(User).find({
+                where: {
+                    uuid: In([])
+                }
+            });
+        } catch (e) {
+            error = e;
+        }
+        expect(error).to.equal(null);
+    })));
+});

--- a/test/other-issues/find-operator-in-crashing-empty-parameters/find-operator-in-crashing-empty-parameters.ts
+++ b/test/other-issues/find-operator-in-crashing-empty-parameters/find-operator-in-crashing-empty-parameters.ts
@@ -26,4 +26,26 @@ describe("other issues > find operator in crashing when passed empty parameters"
         }
         expect(error).to.equal(null);
     })));
+
+    it("should return nothing if the array passed to the In operator is empty", () => () => Promise.all(connections.map(async function(connection) {
+        const repository = connection.getRepository(User)
+        const newUser = repository.create()
+        const user = await repository.save(newUser)
+
+        const users = await connection.getRepository(User).find({
+            where: {
+                uuid: In([user.uuid])
+            }
+        })
+
+        expect(users.length).to.equal(1)
+
+        const usersEmptyIn = await connection.getRepository(User).find({
+            where: {
+                uuid: In([])
+            }
+        })
+
+        expect(usersEmptyIn.length).to.equal(0);
+    })));
 });


### PR DESCRIPTION
The In() operator crashes if the array passed in parameters is empty, this makes it painful to work with dynamic data for the in operator.

This PR fixes that.