### PR TITLE
Add optional name to MigrationInterface (fixes #3933)

### DIFF
--- a/src/commands/MigrationGenerateCommand.ts
+++ b/src/commands/MigrationGenerateCommand.ts
@@ -128,9 +128,12 @@ export class MigrationGenerateCommand implements yargs.CommandModule {
      * Gets contents of the migration file.
      */
     protected static getTemplate(name: string, timestamp: number, upSqls: string[], downSqls: string[]): string {
+        const migrationName = `${camelCase(name, true)}${timestamp}`;
+
         return `import {MigrationInterface, QueryRunner} from "typeorm";
 
-export class ${camelCase(name, true)}${timestamp} implements MigrationInterface {
+export class ${migrationName} implements MigrationInterface {
+    name = '${migrationName}'
 
     public async up(queryRunner: QueryRunner): Promise<any> {
 ${upSqls.join(`

--- a/src/migration/MigrationExecutor.ts
+++ b/src/migration/MigrationExecutor.ts
@@ -314,7 +314,7 @@ export class MigrationExecutor {
      */
     protected getMigrations(): Migration[] {
         const migrations = this.connection.migrations.map(migration => {
-            const migrationClassName = (migration.constructor as any).name;
+            const migrationClassName = migration.name || (migration.constructor as any).name;
             const migrationTimestamp = parseInt(migrationClassName.substr(-13));
             if (!migrationTimestamp)
                 throw new Error(`${migrationClassName} migration name is wrong. Migration class name should have a JavaScript timestamp appended.`);

--- a/src/migration/MigrationInterface.ts
+++ b/src/migration/MigrationInterface.ts
@@ -4,6 +4,10 @@ import {QueryRunner} from "../query-runner/QueryRunner";
  * Migrations should implement this interface and all its methods.
  */
 export interface MigrationInterface {
+    /**
+     * Optional migration name, defaults to class name.
+     */
+    name?: string;
 
     /**
      * Run the migrations.


### PR DESCRIPTION
This fixes a problem when after minification process, migrations cannot be loaded because their name is changed to some random value, this happens mostly when using react-native/expo.

There are several topics about this issue in facebook/metro and typeorm repositories, but I couldn't find any pull request for it. It could be fixed by changing the default minifier, but that can break other stuff.

There are also a few steps before merging this PR:

- [x] If this field sould be called 'migrationName'? Other options could be 'displayName' or simply 'name'.

- [x] Should migrations generated with the CLI contain this attribute by default?

**EDIT**

Created a babel-plugin to automatically add name property:

```js
module.exports = function({ types: t }, options) {
  return {
    visitor: {
      ClassDeclaration(path) {
        const migrationName = t.stringLiteral(path.node.id.name)
        const migrationTimestamp = parseInt(migrationName.value.substr(-13), 10)

        if (!isNaN(migrationTimestamp)) {
          const prop = t.classProperty(t.identifier(options.property), migrationName, null, null)

          path.node.body.body.push(prop)
        }
      },
    },
  }
}
```

```js
{
  presets: ['module:metro-react-native-babel-preset'],
  plugins: [
    ['babel-plugin-typeorm-migration-name', { property: 'migrationName' }]
  ],
}
```