### PR TITLE
fix(postgres): postgres query runner to create materialized view

### DIFF
--- a/src/driver/oracle/OracleQueryRunner.ts
+++ b/src/driver/oracle/OracleQueryRunner.ts
@@ -1385,7 +1385,7 @@ export class OracleQueryRunner extends BaseQueryRunner implements QueryRunner {
     }
 
     protected createViewSql(view: View): Query {
-        const materializedClause = view.materialized ? "" : "MATERIALIZED ";
+        const materializedClause = view.materialized ? "MATERIALIZED " : "";
         if (typeof view.expression === "string") {
             return new Query(`CREATE ${materializedClause}VIEW "${view.name}" AS ${view.expression}`);
         } else {

--- a/src/driver/postgres/PostgresQueryRunner.ts
+++ b/src/driver/postgres/PostgresQueryRunner.ts
@@ -1739,10 +1739,13 @@ export class PostgresQueryRunner extends BaseQueryRunner implements QueryRunner 
     }
 
     protected createViewSql(view: View): Query {
+        const materializedClause = view.materialized ? "MATERIALIZED " : "";
+        const viewName = this.escapePath(view);
+
         if (typeof view.expression === "string") {
-            return new Query(`CREATE VIEW ${this.escapePath(view)} AS ${view.expression}`);
+            return new Query(`CREATE ${materializedClause}VIEW ${viewName} AS ${view.expression}`);
         } else {
-            return new Query(`CREATE VIEW ${this.escapePath(view)} AS ${view.expression(this.connection).getQuery()}`);
+            return new Query(`CREATE ${materializedClause}VIEW ${viewName} AS ${view.expression(this.connection).getQuery()}`);
         }
     }
 

--- a/src/schema-builder/view/View.ts
+++ b/src/schema-builder/view/View.ts
@@ -66,7 +66,7 @@ export class View {
         const options: ViewOptions = {
             name: driver.buildTableName(entityMetadata.tableName, entityMetadata.schema, entityMetadata.database),
             expression: entityMetadata.expression!,
-            materialized: false
+            materialized: entityMetadata.tableMetadataArgs.materialized
         };
 
         return new View(options);

--- a/test/functional/view-entity/postgres/entity/PostByCategory.ts
+++ b/test/functional/view-entity/postgres/entity/PostByCategory.ts
@@ -1,0 +1,24 @@
+import {Connection} from "../../../../../src";
+import {ViewColumn} from "../../../../../src/decorator/columns/ViewColumn";
+import {ViewEntity} from "../../../../../src/decorator/entity-view/ViewEntity";
+import {Category} from "./Category";
+import {Post} from "./Post";
+
+@ViewEntity({
+    materialized: true,
+    expression: (connection: Connection) => connection.createQueryBuilder()
+        .select("category.name", "categoryName")
+        .addSelect("COUNT(post.id)", "postCount")
+        .from(Post, "post")
+        .innerJoin(Category, "category", "category.id = post.categoryId")
+        .groupBy("category.name")
+})
+export class PostByCategory {
+
+    @ViewColumn()
+    categoryName: string;
+
+    @ViewColumn()
+    postCount: number;
+
+}


### PR DESCRIPTION
We've just started using a materialized view in our project (postgres DB) and noticed that the schema sync task during our tests was not creating a materialized version of the view when passing `{ materialized: true }` in the entity definition.

Looks like a few things were missed in https://github.com/typeorm/typeorm/pull/4478:

1. materialized SQL logic left out of `PostgresQueryRunner.ts`.
2. materialized condition logic was backwards and _always_ adding `MATERIALIZED` to the create view SQL
3. The `materialized` option in the entity definition was always being set to false due to not being passed through
4. [Materialized views are not supported in cockroachdb](https://marsettler.com/docs/v2.1/postgres-ddl-support.html#create-materialized-view) so I've disabled the cockroach driver for the postgres test (this was causing tests to fail without a meaningful reason). I'm happy to add some boilerplate tests for cockroach but I'm not experienced with it so I'm not certain how much value I could add to that suite.

We're using my fork internally in production and the new materialized views are working great. Would be awesome to have someone take a look at this :smile: 