### PR TITLE
Allow Unique decorator to accept generic types

### DIFF
--- a/src/decorator/Unique.ts
+++ b/src/decorator/Unique.ts
@@ -4,28 +4,28 @@ import {UniqueMetadataArgs} from "../metadata-args/UniqueMetadataArgs";
 /**
  * Composite unique constraint must be set on entity classes and must specify entity's fields to be unique.
  */
-export function Unique(name: string, fields: string[]): Function;
+export function Unique<Entity>(name: string, fields: (keyof Entity)[]): Function;
 
 /**
  * Composite unique constraint must be set on entity classes and must specify entity's fields to be unique.
  */
-export function Unique(fields: string[]): Function;
+export function Unique<Entity>(fields: (keyof Entity)[]): Function;
 
 /**
  * Composite unique constraint must be set on entity classes and must specify entity's fields to be unique.
  */
-export function Unique(fields: (object?: any) => (any[]|{ [key: string]: number })): Function;
+export function Unique<Entity>(fields: (object?: any) => ((keyof Entity)[]|{ [key in keyof Entity]: number })): Function;
 
 /**
  * Composite unique constraint must be set on entity classes and must specify entity's fields to be unique.
  */
-export function Unique(name: string, fields: (object?: any) => (any[]|{ [key: string]: number })): Function;
+export function Unique<Entity>(name: string, fields: (object?: any) => ((keyof Entity)[]|{ [key: string]: number })): Function;
 
 /**
  * Composite unique constraint must be set on entity classes and must specify entity's fields to be unique.
  */
-export function Unique(nameOrFields?: string|string[]|((object: any) => (any[]|{ [key: string]: number })),
-                       maybeFields?: ((object?: any) => (any[]|{ [key: string]: number }))|string[]): Function {
+export function Unique<Entity>(nameOrFields?: string|(keyof Entity)[]|((object: any) => ((keyof Entity)[]|{ [key in keyof Entity]: number })),
+                       maybeFields?: ((object?: any) => ((keyof Entity)[]|{ [key in keyof Entity]: number }))|(keyof Entity)[]): Function {
     const name = typeof nameOrFields === "string" ? nameOrFields : undefined;
     const fields = typeof nameOrFields === "string" ? <((object?: any) => (any[]|{ [key: string]: number }))|string[]> maybeFields : nameOrFields as string[];
 

--- a/src/decorator/Unique.ts
+++ b/src/decorator/Unique.ts
@@ -14,7 +14,7 @@ export function Unique<Entity>(fields: (keyof Entity)[]): Function;
 /**
  * Composite unique constraint must be set on entity classes and must specify entity's fields to be unique.
  */
-export function Unique<Entity>(fields: (object?: any) => ((keyof Entity)[]|{ [key in keyof Entity]: number })): Function;
+export function Unique<Entity>(fields: (object?: any) => ((keyof Entity)[]|{ [key in keyof Entity]?: number })): Function;
 
 /**
  * Composite unique constraint must be set on entity classes and must specify entity's fields to be unique.
@@ -24,8 +24,8 @@ export function Unique<Entity>(name: string, fields: (object?: any) => ((keyof E
 /**
  * Composite unique constraint must be set on entity classes and must specify entity's fields to be unique.
  */
-export function Unique<Entity>(nameOrFields?: string|(keyof Entity)[]|((object: any) => ((keyof Entity)[]|{ [key in keyof Entity]: number })),
-                       maybeFields?: ((object?: any) => ((keyof Entity)[]|{ [key in keyof Entity]: number }))|(keyof Entity)[]): Function {
+export function Unique<Entity>(nameOrFields?: string|(keyof Entity)[]|((object: any) => ((keyof Entity)[]|{ [key in keyof Entity]?: number })),
+                       maybeFields?: ((object?: any) => ((keyof Entity)[]|{ [key in keyof Entity]?: number }))|(keyof Entity)[]): Function {
     const name = typeof nameOrFields === "string" ? nameOrFields : undefined;
     const fields = typeof nameOrFields === "string" ? <((object?: any) => (any[]|{ [key: string]: number }))|string[]> maybeFields : nameOrFields as string[];
 


### PR DESCRIPTION
It stricts `Unique` decorator array of column names to only be properties of the provided type.
Below example will print type error (User class doesn't have `idd` property).
```ts
@Entity
@Unique<User>('unique_key', ['idd'])
class User {
    id: number;
}
```

Works as usual when no type is provided (no type error):
```ts
@Entity
@Unique('unique_key', ['idd'])
class User {
    id: number;
}
```