### PR TITLE
fix: allow EntitySchema to be passed to EntityRepository

### DIFF
--- a/src/decorator/EntityRepository.ts
+++ b/src/decorator/EntityRepository.ts
@@ -1,12 +1,13 @@
-import {getMetadataArgsStorage} from "../";
-import {EntityRepositoryMetadataArgs} from "../metadata-args/EntityRepositoryMetadataArgs";
+import { getMetadataArgsStorage } from "../";
+import { EntityRepositoryMetadataArgs } from "../metadata-args/EntityRepositoryMetadataArgs";
+import { EntitySchema } from "../entity-schema/EntitySchema";
 
 /**
  * Used to declare a class as a custom repository.
  * Custom repository can manage some specific entity or just be generic.
  * Custom repository optionally can extend AbstractRepository, Repository or TreeRepository.
  */
-export function EntityRepository(entity?: Function): Function {
+export function EntityRepository(entity?: Function | EntitySchema<any>): Function {
     return function (target: Function) {
 
         getMetadataArgsStorage().entityRepositories.push({

--- a/src/metadata-args/EntityRepositoryMetadataArgs.ts
+++ b/src/metadata-args/EntityRepositoryMetadataArgs.ts
@@ -1,3 +1,5 @@
+import { EntitySchema } from "../entity-schema/EntitySchema";
+
 /**
  * Arguments for EntityRepositoryMetadata class, helps to construct an EntityRepositoryMetadata object.
  */
@@ -11,6 +13,6 @@ export interface EntityRepositoryMetadataArgs {
     /**
      * Entity managed by this custom repository.
      */
-    readonly entity?: Function|string;
+    readonly entity?: Function|string|EntitySchema<any>;
 
 }

--- a/src/repository/AbstractRepository.ts
+++ b/src/repository/AbstractRepository.ts
@@ -7,6 +7,7 @@ import {CustomRepositoryDoesNotHaveEntityError} from "../error/CustomRepositoryD
 import {getMetadataArgsStorage} from "../index";
 import {CustomRepositoryNotFoundError} from "../error/CustomRepositoryNotFoundError";
 import {SelectQueryBuilder} from "../query-builder/SelectQueryBuilder";
+import { EntitySchema } from "../entity-schema/EntitySchema";
 
 /**
  * Provides abstract class for custom repositories that do not inherit from original orm Repository.
@@ -99,7 +100,7 @@ export class AbstractRepository<Entity extends ObjectLiteral> {
      * Gets custom repository's managed entity.
      * If given custom repository does not manage any entity then undefined will be returned.
      */
-    private getCustomRepositoryTarget(customRepository: any): Function|string|undefined {
+    private getCustomRepositoryTarget(customRepository: any): Function|string|EntitySchema<any>|undefined {
         const entityRepositoryMetadataArgs = getMetadataArgsStorage().entityRepositories.find(repository => {
             return repository.target === (customRepository instanceof Function ? customRepository : (customRepository as any).constructor);
         });

--- a/src/subscriber/EntitySubscriberInterface.ts
+++ b/src/subscriber/EntitySubscriberInterface.ts
@@ -12,7 +12,7 @@ export interface EntitySubscriberInterface<Entity = any> {
      * Returns the class of the entity to which events will listen.
      * If this method is omitted, then subscriber will listen to events of all entities.
      */
-    listenTo?(): Function;
+    listenTo?(): Function | string;
 
     /**
      * Called after entity is loaded from the database.


### PR DESCRIPTION
Currently we cannot pass an `EntitySchema<T>` to the `@EntityRepository` decorator unless we cast it to `any`. But actually it works with an `EntitySchema`, just the types are missing. This PR adds the types.