### PR TITLE
Fix CreateDateColumn and UpdateDateColumn defaults

### DIFF
--- a/src/driver/mysql/MysqlDriver.ts
+++ b/src/driver/mysql/MysqlDriver.ts
@@ -232,10 +232,10 @@ export class MysqlDriver implements Driver {
     mappedDataTypes: MappedColumnTypes = {
         createDate: "datetime",
         createDatePrecision: 6,
-        createDateDefault: "CURRENT_TIMESTAMP(6)",
+        createDateDefault: "current_timestamp(6)",
         updateDate: "datetime",
         updateDatePrecision: 6,
-        updateDateDefault: "CURRENT_TIMESTAMP(6)",
+        updateDateDefault: "current_timestamp(6)",
         version: "int",
         treeLevel: "int",
         migrationId: "int",


### PR DESCRIPTION
This fixes an issue where the default for columns using CreateDateColumn and UpdateDateColumn are considered as changed because the database server reports the default for these columns with the CURRENT_TIMESTAMP function in lowercase.