### PR TITLE
docs: adds note regarding dangerous findOne behavior

### DIFF
--- a/docs/repository-api.md
+++ b/docs/repository-api.md
@@ -212,6 +212,8 @@ const user = await repository.findOneOrFail(1);
 const timber = await repository.findOneOrFail({ firstName: "Timber" });
 ```
 
+>Note: It is strongly recommended to ensure that your `id` or `FindOptions` value is not `null` or `undefined` before calling `findOne` and `findOneOrFail`. When passed `null` or `undefined`, the query will match with every entity in the repository and return the first record.
+
 * `query` - Executes a raw SQL query.
 
 ```typescript


### PR DESCRIPTION
Calling `findOne(undefined)` or `findOne(null)` results in potentially unexpected and dangerous behavior.

Ref:
* https://github.com/typeorm/typeorm/issues/4687
* https://github.com/typeorm/typeorm/issues/2500
* https://github.com/typeorm/typeorm/issues/4448

Given the amount of issues opened regarding this behavior, I think it warrants a note in the docs.