### PR TITLE
feat: SelectQueryBuilder.clearSelection()

### DIFF
--- a/src/query-builder/SelectQueryBuilder.ts
+++ b/src/query-builder/SelectQueryBuilder.ts
@@ -123,6 +123,14 @@ export class SelectQueryBuilder<Entity> extends QueryBuilder<Entity> implements 
     }
 
     /**
+     * Removes all previous selections if they exist
+     */
+    clearSelection(): this {
+        this.expressionMap.selects = [];
+        return this;
+    }
+
+    /**
      * Adds new selection to the SELECT query.
      */
     addSelect(selection: (qb: SelectQueryBuilder<any>) => SelectQueryBuilder<any>, selectionAliasName?: string): this;

--- a/test/functional/query-builder/select/query-builder-select.ts
+++ b/test/functional/query-builder/select/query-builder-select.ts
@@ -110,4 +110,13 @@ describe("query builder > select", () => {
         expect(sql).to.equal("SELECT post.name FROM post post");
     })));
 
+    it("should clear selections", () => Promise.all(connections.map(async connection => {
+        const sql = connection.createQueryBuilder(Post, "post")
+            .clearSelection()
+            .addSelect('1')
+            .getSql();
+
+        expect(sql).to.equal("SELECT 1 FROM post post");
+    })));
+
 });


### PR DESCRIPTION
Adds new method .clearSelection() to SelectQueryBuilder.

This is useful when adding you to avoid default "select all" behaviour.