### PR TITLE
docs: Decorator Reference Mistake | line 254

### DIFF
--- a/docs/decorator-reference.md
+++ b/docs/decorator-reference.md
@@ -251,7 +251,7 @@ Default generation strategy is `increment`, to change it to another strategy, si
 export class User {
 
     @PrimaryGeneratedColumn("uuid")
-    id: number;
+    id: string;
 
 }
 ```


### PR DESCRIPTION
Found a mistake at line 254.
The type of a _@PrimaryGeneratedColumn("uuid")_ must be a **string** and **not a number**.

![Annotation 2019-10-21 203403](https://user-images.githubusercontent.com/21266147/67232703-26f32a80-f442-11e9-8c33-16a20f3403b2.jpg)
