### PR TITLE
feat: add distinct on() support for postgres

### DIFF
--- a/docs/select-query-builder.md
+++ b/docs/select-query-builder.md
@@ -27,7 +27,7 @@
 
 ## What is `QueryBuilder`
 
-`QueryBuilder` is one of the most powerful features of TypeORM - 
+`QueryBuilder` is one of the most powerful features of TypeORM -
 it allows you to build SQL queries using elegant and convenient syntax,
 execute them and get automatically transformed entities.
 
@@ -41,12 +41,12 @@ const firstUser = await connection
     .getOne();
 ```
 
-It builds the following SQL query: 
+It builds the following SQL query:
 
 ```sql
-SELECT 
-    user.id as userId, 
-    user.firstName as userFirstName, 
+SELECT
+    user.id as userId,
+    user.firstName as userFirstName,
     user.lastName as userLastName
 FROM users user
 WHERE user.id = 1
@@ -60,17 +60,17 @@ User {
     firstName: "Timber",
     lastName: "Saw"
 }
-``` 
+```
 
 ## How to create and use a `QueryBuilder`
 
 There are several ways how you can create a `Query Builder`:
 
 * Using connection:
-    
+
     ```typescript
     import {getConnection} from "typeorm";
-    
+
     const user = await getConnection()
         .createQueryBuilder()
         .select("user")
@@ -80,10 +80,10 @@ There are several ways how you can create a `Query Builder`:
     ```
 
 * Using entity manager:
-    
+
     ```typescript
     import {getManager} from "typeorm";
-    
+
     const user = await getManager()
         .createQueryBuilder(User, "user")
         .where("user.id = :id", { id: 1 })
@@ -91,10 +91,10 @@ There are several ways how you can create a `Query Builder`:
     ```
 
 * Using repository:
-    
+
     ```typescript
     import {getRepository} from "typeorm";
-    
+
     const user = await getRepository(User)
         .createQueryBuilder("user")
         .where("user.id = :id", { id: 1 })
@@ -107,7 +107,7 @@ There are 5 different `QueryBuilder` types available:
 
     ```typescript
     import {getConnection} from "typeorm";
-    
+
     const user = await getConnection()
         .createQueryBuilder()
         .select("user")
@@ -120,23 +120,23 @@ There are 5 different `QueryBuilder` types available:
 
     ```typescript
     import {getConnection} from "typeorm";
-    
+
     await getConnection()
         .createQueryBuilder()
         .insert()
         .into(User)
         .values([
-            { firstName: "Timber", lastName: "Saw" }, 
+            { firstName: "Timber", lastName: "Saw" },
             { firstName: "Phantom", lastName: "Lancer" }
          ])
         .execute();
     ```
 
 * `UpdateQueryBuilder` - used to build and execute `UPDATE` queries. Example:
-                          
+
     ```typescript
     import {getConnection} from "typeorm";
-    
+
     await getConnection()
         .createQueryBuilder()
         .update(User)
@@ -145,10 +145,10 @@ There are 5 different `QueryBuilder` types available:
         .execute();
     ```
 * `DeleteQueryBuilder` - used to build and execute `DELETE` queries. Example:
-                                                    
+
     ```typescript
     import {getConnection} from "typeorm";
-    
+
     await getConnection()
         .createQueryBuilder()
         .delete()
@@ -157,14 +157,14 @@ There are 5 different `QueryBuilder` types available:
         .execute();
     ```
 
-* `RelationQueryBuilder` - used to build and execute relation-specific operations [TBD]. 
+* `RelationQueryBuilder` - used to build and execute relation-specific operations [TBD].
 
 You can switch between different types of query builder within any of them,
 once you do, you will get a new instance of query builder (unlike all other methods).
 
 ## Getting values using `QueryBuilder`
 
-To get a single result from the database, 
+To get a single result from the database,
 for example to get a user by id or name, you must use `getOne`:
 
 ```typescript
@@ -172,9 +172,9 @@ const timber = await getRepository(User)
     .createQueryBuilder("user")
     .where("user.id = :id OR user.name = :name", { id: 1, name: "Timber" })
     .getOne();
-``` 
+```
 
-To get multiple results from the database, 
+To get multiple results from the database,
 for example, to get all users from the database, use `getMany`:
 
 ```typescript
@@ -184,9 +184,9 @@ const users = await getRepository(User)
 ```
 
 There are two types of results you can get using select query builder: **entities** or **raw results**.
-Most of the time, you need to select real entities from your database, for example, users. 
+Most of the time, you need to select real entities from your database, for example, users.
 For this purpose, you use `getOne` and `getMany`.
-But sometimes you need to select some specific data, let's say the *sum of all user photos*. 
+But sometimes you need to select some specific data, let's say the *sum of all user photos*.
 This data is not an entity, it's called raw data.
 To get raw data, you use `getRawOne` and `getRawMany`.
 Examples:
@@ -213,7 +213,7 @@ const photosSums = await getRepository(User)
 ## What are aliases for?
 
 We used `createQueryBuilder("user")`. But what is "user"?
-It's just a regular SQL alias. 
+It's just a regular SQL alias.
 We use aliases everywhere, except when we work with selected data.
 
 `createQueryBuilder("user")` is equivalent to:
@@ -250,15 +250,15 @@ See, we used the users table by using the `user` alias we assigned when we creat
 
 One query builder is not limited to one alias, they can have multiple aliases.
 Each select can have its own alias,
-you can select from multiple tables each with its own alias, 
+you can select from multiple tables each with its own alias,
 you can join multiple tables each with its own alias.
-You can use those aliases to access tables are you selecting (or data you are selecting). 
+You can use those aliases to access tables are you selecting (or data you are selecting).
 
 ## Using parameters to escape data
 
 We used `where("user.name = :name", { name: "Timber" })`.
 What does `{ name: "Timber" }` stand for? It's a parameter we used to prevent SQL injection.
-We could have written: `where("user.name = '" + name + "')`, 
+We could have written: `where("user.name = '" + name + "')`,
 however this is not safe, as it opens the code to SQL injections.
 The safe way is to use this special syntax: `where("user.name = :name", { name: "Timber" })`,
 where `:name` is a parameter name and the value is specified in an object: `{ name: "Timber" }`.
@@ -353,8 +353,8 @@ You can combine as many `AND` and `OR` expressions as you need.
 If you use `.where` more than once you'll override all previous `WHERE` expressions.
 
 Note: be careful with `orWhere` - if you use complex expressions with both `AND` and `OR` expressions,
-keep in mind that they are stacked without any pretences. 
-Sometimes you'll need to create a where string instead, and avoid using `orWhere`. 
+keep in mind that they are stacked without any pretences.
+Sometimes you'll need to create a where string instead, and avoid using `orWhere`.
 
 ## Adding `HAVING` expression
 
@@ -422,7 +422,7 @@ You can change the ordering direction from ascending to descending (or versa):
 ```typescript
 createQueryBuilder("user")
     .orderBy("user.id", "DESC")
-    
+
 createQueryBuilder("user")
     .orderBy("user.id", "ASC")
 ```
@@ -446,6 +446,24 @@ createQueryBuilder("user")
 ```
 
 If you use `.orderBy` more than once you'll override all previous `ORDER BY` expressions.
+
+## Adding `DISTINCT ON` expression (Postgres only)
+When using both distinct-on with an order-by expression, the distinct-on expression must match the leftmost order-by.
+The distinct-on expressions are interpreted using the same rules as order-by. Please note that, using distinct-on without an order-by expression means that the first row of each set is unpredictable.
+
+Adding a `DISTINCT ON` expression is easy as:
+
+```typescript
+createQueryBuilder("user")
+    .distinctOn(["user.id"])
+    .orderBy("user.id")
+```
+
+Which will produce:
+
+```sql
+SELECT DISTINCT ON (user.id) ... FROM users user ORDER BY user.id
+```
 
 ## Adding `GROUP BY` expression
 
@@ -519,13 +537,13 @@ import {Photo} from "./Photo";
 
 @Entity()
 export class User {
-    
+
     @PrimaryGeneratedColumn()
     id: number;
-    
+
     @Column()
     name: string;
-    
+
     @OneToMany(type => Photo, photo => photo.user)
     photos: Photo[];
 }
@@ -537,13 +555,13 @@ import {User} from "./User";
 
 @Entity()
 export class Photo {
-    
+
     @PrimaryGeneratedColumn()
     id: number;
-    
+
     @Column()
     url: string;
-    
+
     @ManyToOne(type => User, user => user.photos)
     user: User;
 }
@@ -590,7 +608,7 @@ const user = await createQueryBuilder("user")
 This will generate following sql query:
 
 ```sql
-SELECT user.*, photo.* FROM users user 
+SELECT user.*, photo.* FROM users user
     LEFT JOIN photos photo ON photo.user = user.id
     WHERE user.name = 'Timber' AND photo.isRemoved = FALSE
 ```
@@ -607,7 +625,7 @@ const user = await createQueryBuilder("user")
 This will generate the following sql query:
 
 ```sql
-SELECT user.*, photo.* FROM users user 
+SELECT user.*, photo.* FROM users user
     LEFT JOIN photos photo ON photo.user = user.id AND photo.isRemoved = FALSE
     WHERE user.name = 'Timber'
 ```
@@ -626,7 +644,7 @@ const user = await createQueryBuilder("user")
 This will generate:
 
 ```sql
-SELECT user.*, photo.* FROM users user 
+SELECT user.*, photo.* FROM users user
     INNER JOIN photos photo ON photo.user = user.id AND photo.isRemoved = FALSE
     WHERE user.name = 'Timber'
 ```
@@ -650,12 +668,12 @@ const user = await createQueryBuilder("user")
 This will generate:
 
 ```sql
-SELECT user.* FROM users user 
+SELECT user.* FROM users user
     INNER JOIN photos photo ON photo.user = user.id
     WHERE user.name = 'Timber'
 ```
 
-This will select Timber if he has photos, but won't return his photos. 
+This will select Timber if he has photos, but won't return his photos.
 
 ## Joining any entity or table
 
@@ -682,7 +700,7 @@ Add `profilePhoto` to `User` entity and you can map any data into that property 
 export class User {    
     /// ...
     profilePhoto: Photo;
-    
+
 }
 ```
 
@@ -724,9 +742,9 @@ This query will return users and print the used sql statement to the console.
 ## Getting raw results
 
 There are two types of results you can get using select query builder: **entities** and **raw results**.
-Most of the time, you need to select real entities from your database, for example, users. 
+Most of the time, you need to select real entities from your database, for example, users.
 For this purpose, you use `getOne` and `getMany`.
-However, sometimes you need to select specific data, like the *sum of all user photos*. 
+However, sometimes you need to select specific data, like the *sum of all user photos*.
 Such data is not a entity, it's called raw data.
 To get raw data, you use `getRawOne` and `getRawMany`.
 Examples:
@@ -965,10 +983,10 @@ import {Entity, PrimaryGeneratedColumn, Column} from "typeorm";
 
 @Entity()
 export class User {
-    
+
     @PrimaryGeneratedColumn()
     id: number;
-    
+
     @Column()
     name: string;
 

--- a/src/query-builder/QueryExpressionMap.ts
+++ b/src/query-builder/QueryExpressionMap.ts
@@ -52,6 +52,11 @@ export class QueryExpressionMap {
     selectDistinct: boolean = false;
 
     /**
+     * SELECT DISTINCT ON query (postgres).
+     */
+    selectDistinctOn: string[]|boolean = false;
+
+    /**
      * FROM-s to be selected.
      */
     // froms: { target: string, alias: string }[] = [];
@@ -80,7 +85,7 @@ export class QueryExpressionMap {
     /**
      * Optional on ignore statement used in insertion query in databases.
      */
-    onIgnore: string | boolean = false;
+    onIgnore: string|boolean = false;
 
     /**
      * Optional on update statement used in insertion query in databases.
@@ -379,6 +384,7 @@ export class QueryExpressionMap {
         map.queryType = this.queryType;
         map.selects = this.selects.map(select => select);
         map.selectDistinct = this.selectDistinct;
+        map.selectDistinctOn = this.selectDistinctOn;
         this.aliases.forEach(alias => map.aliases.push(new Alias(alias)));
         map.mainAlias = this.mainAlias;
         map.valuesSet = this.valuesSet;

--- a/src/query-builder/QueryExpressionMap.ts
+++ b/src/query-builder/QueryExpressionMap.ts
@@ -54,7 +54,7 @@ export class QueryExpressionMap {
     /**
      * SELECT DISTINCT ON query (postgres).
      */
-    selectDistinctOn: string[]|boolean = false;
+    selectDistinctOn: string[] = [];
 
     /**
      * FROM-s to be selected.

--- a/src/query-builder/SelectQueryBuilder.ts
+++ b/src/query-builder/SelectQueryBuilder.ts
@@ -171,8 +171,8 @@ export class SelectQueryBuilder<Entity> extends QueryBuilder<Entity> implements 
      * Sets the distinct on clause for Postgres.
      */
     distinctOn(distinctOn: string[]): this {
-      this.expressionMap.selectDistinctOn = distinctOn;
-      return this;
+        this.expressionMap.selectDistinctOn = distinctOn;
+        return this;
     }
 
     /**

--- a/src/query-builder/SelectQueryBuilder.ts
+++ b/src/query-builder/SelectQueryBuilder.ts
@@ -1409,9 +1409,33 @@ export class SelectQueryBuilder<Entity> extends QueryBuilder<Entity> implements 
 
                 return this.getTableName(alias.tablePath!) + " " + this.escape(alias.name);
             });
-        const select = "SELECT " + (this.expressionMap.selectDistinct ? "DISTINCT " : "");
+
+        // const select = "SELECT " + (this.expressionMap.selectDistinct ? "DISTINCT " : "");
+        const select = this.createSelectDistinctExpression();
         const selection = allSelects.map(select => select.selection + (select.aliasName ? " AS " + this.escape(select.aliasName) : "")).join(", ");
+
         return select + selection + " FROM " + froms.join(", ") + lock;
+    }
+
+    /**
+     * Create distinct part of SQL query.
+     */
+    protected createSelectDistinctExpression(): string {
+      const {selectDistinct, selectDistinctOn} = this.expressionMap;
+      const {driver} = this.connection;
+
+      let select = "SELECT ";
+      if (driver instanceof PostgresDriver && this.expressionMap.selectDistinctOn) {
+        console.log('POSTGRES');
+        const selectDistinctOnMap = selectDistinctOn.join(', ');
+
+        select = `SELECT DISTINCT ON(${selectDistinctOnMap})`;
+      } else if (this.expressionMap.selectDistinct) {
+        select = "SELECT DISTINCT ";
+      }
+
+      console.log(select);
+      return select;
     }
 
     /**

--- a/test/functional/query-builder/distinct-on/entity/Category.ts
+++ b/test/functional/query-builder/distinct-on/entity/Category.ts
@@ -1,0 +1,17 @@
+import {Entity} from "../../../../../src/decorator/entity/Entity";
+import {PrimaryGeneratedColumn} from "../../../../../src/decorator/columns/PrimaryGeneratedColumn";
+import {Column} from "../../../../../src/decorator/columns/Column";
+
+@Entity()
+export class Category {
+
+  @PrimaryGeneratedColumn()
+  id: number;
+
+  @Column()
+  title: string;
+
+  @Column()
+  author: string;
+
+}

--- a/test/functional/query-builder/distinct-on/entity/Post.ts
+++ b/test/functional/query-builder/distinct-on/entity/Post.ts
@@ -1,0 +1,20 @@
+import {Entity} from "../../../../../src/decorator/entity/Entity";
+import {PrimaryGeneratedColumn} from "../../../../../src/decorator/columns/PrimaryGeneratedColumn";
+import {Column} from "../../../../../src/decorator/columns/Column";
+
+@Entity()
+export class Post {
+
+  @PrimaryGeneratedColumn()
+  id: number;
+
+  @Column()
+  title: string;
+
+  @Column()
+  author: string;
+
+  @Column()
+  moderator: string;
+
+}

--- a/test/functional/query-builder/distinct-on/entity/User.ts
+++ b/test/functional/query-builder/distinct-on/entity/User.ts
@@ -1,0 +1,14 @@
+import {Entity} from "../../../../../src/decorator/entity/Entity";
+import {PrimaryGeneratedColumn} from "../../../../../src/decorator/columns/PrimaryGeneratedColumn";
+import {Column} from "../../../../../src/decorator/columns/Column";
+
+@Entity()
+export class User {
+
+  @PrimaryGeneratedColumn()
+  id: number;
+
+  @Column()
+  name: string;
+
+}

--- a/test/functional/query-builder/distinct-on/query-builder-distinct-on.ts
+++ b/test/functional/query-builder/distinct-on/query-builder-distinct-on.ts
@@ -1,0 +1,148 @@
+import "reflect-metadata";
+import {expect} from "chai";
+import {closeTestingConnections, createTestingConnections, reloadTestingDatabases} from "../../../utils/test-utils";
+import {Connection} from "../../../../src/connection/Connection";
+import {Category} from "./entity/Category";
+import {User} from "./entity/User";
+import {Post} from "./entity/Post";
+
+describe("query builder > distinct on", () => {
+    let connections: Connection[];
+
+    before(async () => connections = await createTestingConnections({
+        entities: [__dirname + "/entity/*{.js,.ts}"],
+        enabledDrivers: ["postgres"]
+    }));
+    beforeEach(() => reloadTestingDatabases(connections));
+    after(() => closeTestingConnections(connections));
+
+    async function prepareData(connection: Connection) {
+        const users = [
+          {
+            name: "Dion"
+          },
+          {
+            name: "Zelda"
+          },
+          {
+            name: "Sarah"
+          },
+          {
+            name: "Pablo"
+          }
+        ];
+        await connection.createQueryBuilder()
+          .insert()
+          .into(User)
+          .values(users)
+          .execute();
+
+        const categories = [
+          {
+            title: "Category One",
+            author: "Dion"
+          },
+          {
+            title: "Category Two",
+            author: "Dion"
+          },
+          {
+            title: "Category Three",
+            author: "Zelda"
+          },
+          {
+            title: "Category Four",
+            author: "Zelda"
+          },
+          {
+            title: "Category Five",
+            author: "Dion"
+          }
+        ];
+        await connection.createQueryBuilder()
+          .insert()
+          .into(Category)
+          .values(categories)
+          .execute();
+
+        const posts = [
+          {
+            title: "Post One",
+            author: "Dion",
+            moderator: "Dion"
+          },
+          {
+            title: "Post Two",
+            author: "Sarah",
+            moderator: "Dion"
+          },
+          {
+            title: "Post Three",
+            author: "Zelda",
+            moderator: "Dion"
+          },
+          {
+            title: "Post Four",
+            author: "Sarah",
+            moderator: "Dion"
+          },
+          {
+            title: "Post Five",
+            author: "Pablo",
+            moderator: "Sarah"
+          }
+        ];
+        await connection.createQueryBuilder()
+          .insert()
+          .into(Post)
+          .values(posts)
+          .execute();
+    }
+
+    it("should perform distinct on category authors", () => Promise.all(
+        connections.map(async connection => {
+            await prepareData(connection);
+
+            const result = await connection.manager.createQueryBuilder(Category, "category")
+              .distinctOn(["category.author"])
+              .getMany();
+
+            expect(result.map(({author}) => author)).to.have.members(
+                ["Dion", "Zelda"]
+            );
+        }
+    )));
+
+    it("should perform distinct on post authors and moderators combination", () => Promise.all(
+        connections.map(async connection => {
+            await prepareData(connection);
+
+            const result = await connection.manager.createQueryBuilder(Post, "post")
+              .distinctOn(["post.author", "post.moderator"])
+              .getMany();
+
+            expect(result.map(({moderator}) => moderator)).to.have.members(
+                ["Dion", "Sarah", "Dion", "Dion"]
+            ) &&
+            expect(result.map(({author}) => author)).to.have.members(
+                ["Dion", "Pablo", "Sarah", "Zelda"]
+            );
+        }
+    )));
+
+    it("should perform distinct on post and category authors", () => Promise.all(
+        connections.map(async connection => {
+            await prepareData(connection);
+
+            const result = await connection.manager.createQueryBuilder(Post, "post")
+              .leftJoinAndSelect(Category, "category", "category.author = post.author")
+              .distinctOn(["post.author", "category.author"])
+              .getMany();
+
+            expect(result.map(({author}) => author)).to.have.members(
+                ["Dion", "Pablo", "Sarah", "Zelda"]
+            );
+        }
+    )));
+
+});

--- a/test/functional/query-builder/select/query-builder-select.ts
+++ b/test/functional/query-builder/select/query-builder-select.ts
@@ -42,18 +42,6 @@ describe("query builder > select", () => {
             "FROM post post");
     })));
 
-    it("should perform distinct on selection", () => Promise.all(connections.map(async connection => {
-        const sql = connection.manager.createQueryBuilder(Post, "post")
-            .distinctOn(["post.version"])
-            .disableEscaping()
-            .getSql();
-
-        expect(sql).to.equal("SELECT DISTINCT ON (post.version) post.id AS post_id, " +
-            "post.title AS post_title, post.description AS post_description, " +
-            "post.rating AS post_rating, post.version AS post_version, " +
-            "post.categoryId AS post_categoryId FROM post post");
-    })));
-
     it("should append all entity mapped columns from both main selection and join selections to select statement", () => Promise.all(connections.map(async connection => {
         const sql = connection.createQueryBuilder(Post, "post")
             .leftJoinAndSelect("category", "category")

--- a/test/functional/query-builder/select/query-builder-select.ts
+++ b/test/functional/query-builder/select/query-builder-select.ts
@@ -42,6 +42,18 @@ describe("query builder > select", () => {
             "FROM post post");
     })));
 
+    it("should perform distinct on selection", () => Promise.all(connections.map(async connection => {
+        const sql = connection.manager.createQueryBuilder(Post, "post")
+            .distinctOn(["post.version"])
+            .disableEscaping()
+            .getSql();
+
+        expect(sql).to.equal("SELECT DISTINCT ON (post.version) post.id AS post_id, " +
+            "post.title AS post_title, post.description AS post_description, " +
+            "post.rating AS post_rating, post.version AS post_version, " +
+            "post.categoryId AS post_categoryId FROM post post");
+    })));
+
     it("should append all entity mapped columns from both main selection and join selections to select statement", () => Promise.all(connections.map(async connection => {
         const sql = connection.createQueryBuilder(Post, "post")
             .leftJoinAndSelect("category", "category")


### PR DESCRIPTION
Following on from #4109. This PR adds support for Postgres distinct on clause.

todo;
- [x] Update docs to cover distinct on clause use (orderBy etc)