### PR TITLE
fix: remove schema name from MySQL view migrations

### DIFF
--- a/src/driver/mysql/MysqlQueryRunner.ts
+++ b/src/driver/mysql/MysqlQueryRunner.ts
@@ -1632,7 +1632,7 @@ export class MysqlQueryRunner extends BaseQueryRunner implements QueryRunner {
      * Extracts the table name from a table path
      */
     protected extractTableName(tablePath: string): string {
-        const path = tablePath.split('.') 
+        const path = tablePath.split(".");
         return path[path.length - 1];
     }
 


### PR DESCRIPTION
Proposed fix for #4925 (limited to MySQL):
When generating migrations for views the currently configured schema name is added to the migrations. Trying to apply the migration to a database with a different schema name will throw an exception unless each schema reference in the migration script is updated for every database that's in use.

This PR removes the schema references the migration scripts and allows to use to run the migration on differently named databases. During the migration the schema name in the `typeorm_metadata` table is inserted dynamically, based on which database is currently in use.