### PR TITLE
fix: allow expireAfterSeconds 0 in Index decorator (close #5004)

### DIFF
--- a/src/decorator/Index.ts
+++ b/src/decorator/Index.ts
@@ -79,7 +79,7 @@ export function Index(nameOrFieldsOrOptions?: string|string[]|((object: any) => 
             fulltext: options && options.fulltext ? true : false,
             sparse: options && options.sparse ? true : false,
             background: options && options.background ? true : false,
-            expireAfterSeconds: options && options.expireAfterSeconds ? options.expireAfterSeconds : undefined
+            expireAfterSeconds: options ? options.expireAfterSeconds : undefined
         } as IndexMetadataArgs);
     };
 }

--- a/test/github-issues/5004/entity/Foo.ts
+++ b/test/github-issues/5004/entity/Foo.ts
@@ -1,0 +1,10 @@
+import {Column} from "../../../../src/decorator/columns/Column";
+import {Entity} from "../../../../src/decorator/entity/Entity";
+import {Index} from "../../../../src/decorator/Index";
+
+@Entity()
+export class Foo {
+  @Column("date")
+  @Index({ expireAfterSeconds: 0 })
+  expireAt: Date;
+}

--- a/test/github-issues/5004/issue-5004.ts
+++ b/test/github-issues/5004/issue-5004.ts
@@ -1,0 +1,18 @@
+import "reflect-metadata";
+import {expect} from "chai";
+import {getMetadataArgsStorage} from "../../../src";
+import {Foo} from "./entity/Foo";
+
+describe("github issues > #5004 expireAfterSeconds 0 can't be passed to Index decorator", () => {
+
+    it("should allow expireAfterSeconds 0 to be passed to Index decorator", () => {
+
+        const metadataArgsStorage = getMetadataArgsStorage();
+        const fooIndices = metadataArgsStorage.indices.filter(indice => indice.target === Foo);
+
+        expect(fooIndices.length).to.eql(1);
+        expect(fooIndices[0].expireAfterSeconds).to.eql(0);
+
+    });
+
+});


### PR DESCRIPTION
This PR allow `expireAfterSeconds: 0` to be passed to Index decorator.

Related issue: #5004 