### PR TITLE
Add reference to 'is not null' expression

### DIFF
--- a/docs/find-options.md
+++ b/docs/find-options.md
@@ -325,6 +325,7 @@ const loadedPosts = await connection.getRepository(Post).find({
     title: IsNull()
 });
 ```
+Note: if you want execute expression where value not equal to `null` - follow the note in this section https://typeorm.io/#/select-query-builder/adding-where-expression
 
 will execute following query: 
 


### PR DESCRIPTION
It's confusing when you write about `IsNull()` function to compare that value is equal to `null`, but never wrote about how to get value which `is not null`.