### PR TITLE
Fix docs description 

### DIFF
--- a/docs/connection-api.md
+++ b/docs/connection-api.md
@@ -183,7 +183,7 @@ await connection.close();
 ```
 
 * `synchronize` - Synchronizes database schema. When `synchronize: true` is set in connection options it calls this method. 
-Usually, you call this method when your application is shutting down.
+Usually, you call this method when your application is starting.
 
 ```typescript
 await connection.synchronize();


### PR DESCRIPTION
## This pull request fixes the description of `synchronize` method

I guess the `synchronize` method has the wrong description. I've changed the description to indicate that `synchronize` is usually used on application starting instead of application shut down.