### PR TITLE
docs: fix typo in `zh_CN` logging chapter

### DIFF
--- a/docs/zh_CN/logging.md
+++ b/docs/zh_CN/logging.md
@@ -86,7 +86,7 @@ TypeORM 附带 4 种不同类型的记录器：
 
 - `advanced-console` - 默认记录器，它将使用颜色和 sql 语法高亮显示所有记录到控制台中的消息（使用[chalk](https://github.com/chalk/chalk)）。
 - `simple-console` - 简单的控制台记录器，与高级记录器完全相同，但它不使用任何颜色突出显示。
-  如果你又问题/或不喜欢彩色日志，可以使用此记录器。
+  如果你不喜欢/或者使用彩色日志有问题，可以使用此记录器。
 - `file` - 这个记录器将所有日志写入项目根文件夹中的`ormlogs.log`（靠近`package.json`和`ormconfig.json`）。
 - `debug` - 此记录器使用[debug package](https://github.com/visionmedia/debug)打开日志记录设置你的 env 变量`DEBUG = typeorm：*`（注意记录选项对此记录器没有影响）。
 


### PR DESCRIPTION
fix typo in `zh_CN` logging chapter
it should be `有` instead of `又`