### PR TITLE
Upgrade app-root-path

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "typeorm",
-  "version": "0.2.19",
+  "version": "0.2.20",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -456,9 +456,9 @@
       }
     },
     "app-root-path": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/app-root-path/-/app-root-path-2.1.0.tgz",
-      "integrity": "sha1-mL9lmTJ+zqGZMJhm6BQDaP0uZGo="
+      "version": "3.0.0",
+      "resolved": "https://artifacts.daimler.com/artifactory/api/npm/switch-npm-virtual/app-root-path/-/app-root-path-3.0.0.tgz",
+      "integrity": "sha1-IQtvQ4cyJ+GKS4EKAyKDMRVV1a0="
     },
     "append-buffer": {
       "version": "1.0.2",

--- a/package.json
+++ b/package.json
@@ -89,11 +89,11 @@
     "sqlite3": "^4.0.9",
     "ts-node": "^8.0.2",
     "tslint": "^5.13.1",
-    "typescript": "^3.3.3333",
-    "typeorm-aurora-data-api-driver": "^1.1.1"
+    "typeorm-aurora-data-api-driver": "^1.1.1",
+    "typescript": "^3.3.3333"
   },
   "dependencies": {
-    "app-root-path": "^2.0.1",
+    "app-root-path": "^3.0.0",
     "buffer": "^5.1.0",
     "chalk": "^2.4.2",
     "cli-highlight": "^2.0.0",


### PR DESCRIPTION
Fixes incompatbility with pnpm which couldn't find the `ormconfig.json` in the root path.