### PR TITLE
fix: mysql driver query streaming

### DIFF
--- a/src/driver/mysql/MysqlQueryRunner.ts
+++ b/src/driver/mysql/MysqlQueryRunner.ts
@@ -187,10 +187,10 @@ export class MysqlQueryRunner extends BaseQueryRunner implements QueryRunner {
             try {
                 const databaseConnection = await this.connect();
                 this.driver.connection.logger.logQuery(query, parameters, this);
-                const stream = databaseConnection.query(query, parameters);
-                if (onEnd) stream.on("end", onEnd);
-                if (onError) stream.on("error", onError);
-                ok(stream);
+                const databaseQuery = databaseConnection.query(query, parameters);
+                if (onEnd) databaseQuery.on("end", onEnd);
+                if (onError) databaseQuery.on("error", onError);
+                ok(databaseQuery.stream());
 
             } catch (err) {
                 fail(err);


### PR DESCRIPTION
Mysql driver's `connection.query()` returns `Query` object which is an EventEmitter but not a ReadableStream. In order to get a stream one needs to call `.stream()` on it.

Fixes #5035
