### PR TITLE
feat: asynchronous ormconfig support

### DIFF
--- a/src/connection/ConnectionOptionsReader.ts
+++ b/src/connection/ConnectionOptionsReader.ts
@@ -108,10 +108,10 @@ export class ConnectionOptionsReader {
             connectionOptions = new ConnectionOptionsEnvReader().read();
 
         } else if (foundFileFormat === "js") {
-            connectionOptions = PlatformTools.load(configFile);
+            connectionOptions = await PlatformTools.load(configFile);
 
         } else if (foundFileFormat === "ts") {
-            connectionOptions = PlatformTools.load(configFile);
+            connectionOptions = await PlatformTools.load(configFile);
 
         } else if (foundFileFormat === "json") {
             connectionOptions = PlatformTools.load(configFile);

--- a/test/functional/connection-options-reader/configs/test-path-config-async.ts
+++ b/test/functional/connection-options-reader/configs/test-path-config-async.ts
@@ -1,0 +1,5 @@
+module.exports = Promise.resolve({
+  type: "sqlite",
+  name: "file",
+  database: "test-js-async"
+});

--- a/test/functional/connection-options-reader/connection-options-reader.ts
+++ b/test/functional/connection-options-reader/connection-options-reader.ts
@@ -31,6 +31,12 @@ describe("ConnectionOptionsReader", () => {
     expect(fileOptions.database).to.have.string("/test-js");
   });
 
+  it("properly loads asynchronous config with specified file path", async () => {
+    const connectionOptionsReader = new ConnectionOptionsReader({ root: __dirname, configName: "configs/test-path-config-async.js" });
+    const fileOptions: ConnectionOptions = await connectionOptionsReader.get("file");
+    expect(fileOptions.database).to.have.string("/test-js-async");
+  });
+
   // TODO This test requires the configs/.env file be moved to the matching directory in build/compiled
   it.skip("properly loads config from .env file", async () => {
     const connectionOptionsReader = new ConnectionOptionsReader({ root: __dirname, configName: "configs/.env" });


### PR DESCRIPTION
This allows a Promise to be returned from a js or ts ormconfig file.

Closes: #4149