### PR TITLE
Fix repo for app-root-path in lock file

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -457,8 +457,8 @@
     },
     "app-root-path": {
       "version": "3.0.0",
-      "resolved": "https://artifacts.daimler.com/artifactory/api/npm/switch-npm-virtual/app-root-path/-/app-root-path-3.0.0.tgz",
-      "integrity": "sha1-IQtvQ4cyJ+GKS4EKAyKDMRVV1a0="
+      "resolved": "https://registry.npmjs.org/app-root-path/-/app-root-path-3.0.0.tgz",
+      "integrity": "sha512-qMcx+Gy2UZynHjOHOIXPNvpf+9cjvk3cWrBBK7zg4gH9+clobJRb9NGzcT7mQTcV/6Gm/1WelUtqxVXnNlrwcw=="
     },
     "append-buffer": {
       "version": "1.0.2",


### PR DESCRIPTION
Missed some configurations on my side in the last PR.
See https://github.com/typeorm/typeorm/commit/7f87f0c9da6f74e14d167c3dfffdd351ca2d2f9f#diff-32607347f8126e6534ebc7ebaec4853dR460

Now reverted back to official npm repo for the `app-root-path` package