### PR TITLE
feat: support options that can be used when clearing/truncating tables

### DIFF
--- a/src/driver/BaseClearOptions.ts
+++ b/src/driver/BaseClearOptions.ts
@@ -1,0 +1,12 @@
+import {DatabaseType} from "./types/DatabaseType";
+
+/**
+ * BaseClearOptions is set of options shared by all database types.
+ */
+export interface BaseClearOptions {
+
+    /**
+     * Database type. This value is required.
+     */
+    readonly type: DatabaseType;
+}

--- a/src/driver/postgres/PostgresClearOptions.ts
+++ b/src/driver/postgres/PostgresClearOptions.ts
@@ -1,0 +1,17 @@
+import {BaseClearOptions} from "../BaseClearOptions";
+
+/**
+ * Postgres-specific connection options.
+ */
+export interface PostgresClearOptions extends BaseClearOptions {
+
+    /**
+     * Database type.
+     */
+    readonly type: "postgres";
+
+    /**
+     * Cascade when truncating.
+     */
+    readonly cascade?: boolean;
+}

--- a/src/driver/postgres/PostgresQueryRunner.ts
+++ b/src/driver/postgres/PostgresQueryRunner.ts
@@ -22,6 +22,7 @@ import {OrmUtils} from "../../util/OrmUtils";
 import {Query} from "../Query";
 import {IsolationLevel} from "../types/IsolationLevel";
 import {PostgresDriver} from "./PostgresDriver";
+import {PostgresClearOptions} from "./PostgresClearOptions";
 
 /**
  * Runs queries on a single postgres database connection.
@@ -1260,8 +1261,8 @@ export class PostgresQueryRunner extends BaseQueryRunner implements QueryRunner 
      * Clears all table contents.
      * Note: this operation uses SQL's TRUNCATE query which cannot be reverted in transactions.
      */
-    async clearTable(tableName: string): Promise<void> {
-        await this.query(`TRUNCATE TABLE ${this.escapePath(tableName)}`);
+    async clearTable(tableName: string, options?: PostgresClearOptions): Promise<void> {
+        await this.query(`TRUNCATE TABLE ${this.escapePath(tableName)} ${options && options.cascade ? "CASCADE" : ""}`);
     }
 
     /**

--- a/src/entity-manager/EntityManager.ts
+++ b/src/entity-manager/EntityManager.ts
@@ -35,6 +35,7 @@ import {OracleDriver} from "../driver/oracle/OracleDriver";
 import {FindConditions} from "../find-options/FindConditions";
 import {IsolationLevel} from "../driver/types/IsolationLevel";
 import {ObjectUtils} from "../util/ObjectUtils";
+import {ClearOptions} from "../repository/ClearOptions";
 
 /**
  * Entity manager supposed to work with any entity, automatically find its repository and call its methods,
@@ -919,11 +920,11 @@ export class EntityManager {
      * Note: this method uses TRUNCATE and may not work as you expect in transactions on some platforms.
      * @see https://stackoverflow.com/a/5972738/925151
      */
-    async clear<Entity>(entityClass: ObjectType<Entity>|EntitySchema<Entity>|string): Promise<void> {
+    async clear<Entity>(entityClass: ObjectType<Entity>|EntitySchema<Entity>|string, options?: ClearOptions): Promise<void> {
         const metadata = this.connection.getMetadata(entityClass);
         const queryRunner = this.queryRunner || this.connection.createQueryRunner("master");
         try {
-            return await queryRunner.clearTable(metadata.tablePath); // await is needed here because we are using finally
+            return await queryRunner.clearTable(metadata.tablePath, options); // await is needed here because we are using finally
 
         } finally {
             if (!this.queryRunner)

--- a/src/query-runner/QueryRunner.ts
+++ b/src/query-runner/QueryRunner.ts
@@ -13,6 +13,7 @@ import {Broadcaster} from "../subscriber/Broadcaster";
 import {TableCheck} from "../schema-builder/table/TableCheck";
 import {IsolationLevel} from "../driver/types/IsolationLevel";
 import {TableExclusion} from "../schema-builder/table/TableExclusion";
+import {ClearOptions} from "../repository/ClearOptions";
 
 /**
  * Runs queries on a single database connection.
@@ -362,7 +363,7 @@ export interface QueryRunner {
      * Clears all table contents.
      * Note: this operation uses SQL's TRUNCATE query which cannot be reverted in transactions.
      */
-    clearTable(tableName: string): Promise<void>;
+    clearTable(tableName: string, options?: ClearOptions): Promise<void>;
 
     /**
      * Enables special query runner mode in which sql queries won't be executed,

--- a/src/repository/ClearOptions.ts
+++ b/src/repository/ClearOptions.ts
@@ -1,0 +1,8 @@
+/**
+ * Special options passed to Repository#clear
+ */
+import {PostgresClearOptions} from "../driver/postgres/PostgresClearOptions";
+
+// todo as we add support for other driver truncat options (e.g. oracle) we would extend here
+export type ClearOptions =
+    PostgresClearOptions;

--- a/src/repository/Repository.ts
+++ b/src/repository/Repository.ts
@@ -14,6 +14,7 @@ import {InsertResult} from "../query-builder/result/InsertResult";
 import {QueryDeepPartialEntity} from "../query-builder/QueryPartialEntity";
 import {ObjectID} from "../driver/mongodb/typings";
 import {FindConditions} from "../find-options/FindConditions";
+import {ClearOptions} from "./ClearOptions";
 
 /**
  * Repository is supposed to work with your entity objects. Find entities, insert, update, delete, etc.
@@ -332,8 +333,8 @@ export class Repository<Entity extends ObjectLiteral> {
      * Note: this method uses TRUNCATE and may not work as you expect in transactions on some platforms.
      * @see https://stackoverflow.com/a/5972738/925151
      */
-    clear(): Promise<void> {
-        return this.manager.clear(this.metadata.target);
+    clear(options?: ClearOptions): Promise<void> {
+        return this.manager.clear(this.metadata.target, options);
     }
 
     /**


### PR DESCRIPTION
current change only affects the downstream Postgres QueryRunner, which supports cascading when truncating

Closes #2978