### PR TITLE
fix: mssql change column default value

### DIFF
--- a/test/functional/schema-builder/change-column.ts
+++ b/test/functional/schema-builder/change-column.ts
@@ -97,6 +97,24 @@ describe("schema builder > change column", () => {
         postVersionColumn.type = "varchar";
     }));
 
+    it("should correctly change column default value", () => PromiseUtils.runInSequence(connections, async connection => {
+
+        const postMetadata = connection.getMetadata(Post);
+        const nameColumn = postMetadata.findColumnWithPropertyName("name")!;
+
+        nameColumn.default = "My awesome post";
+        nameColumn.build(connection);
+
+        await connection.synchronize(false);
+
+        const queryRunner = connection.createQueryRunner();
+        const postTable = await queryRunner.getTable("post");
+        await queryRunner.release();
+
+        postTable!.findColumnByName("name")!.default.should.be.equal("'My awesome post'");
+
+    }));
+
     it("should correctly make column primary and generated", () => PromiseUtils.runInSequence(connections, async connection => {
         // CockroachDB does not allow changing PK
         if (connection.driver instanceof CockroachDriver)


### PR DESCRIPTION
Hello, 
I m using typeorm with mssql and I stumble upon a problem when I tried to change the default value of a column and then synchronize. 
The problem was that the default column was being added again and not dropped first, resulting to an sql error. 
I looked into the code and made a fix and added the corresponding unit test into functional directory. This should also fix migration issues.

I believe this test is mandatory regardless of the database.


