### PR TITLE
fix: better mergeDeep implementation and tests

### DIFF
--- a/src/persistence/SubjectExecutor.ts
+++ b/src/persistence/SubjectExecutor.ts
@@ -352,7 +352,7 @@ export class SubjectExecutor {
 
             // for mongodb we have a bit different updation logic
             if (this.queryRunner instanceof MongoQueryRunner) {
-                const partialEntity = OrmUtils.mergeDeep({}, subject.entity!);
+                const partialEntity = OrmUtils.mergeDeep({}, { ...subject.entity! });
                 if (subject.metadata.objectIdColumn && subject.metadata.objectIdColumn.propertyName) {
                     delete partialEntity[subject.metadata.objectIdColumn.propertyName];
                 }

--- a/src/util/OrmUtils.ts
+++ b/src/util/OrmUtils.ts
@@ -70,11 +70,10 @@ export class OrmUtils {
         // Filters out Buffer and custom instances of classes
         const prototype = Object.getPrototypeOf(item);
         return prototype === null || prototype === Object.getPrototypeOf({});
-
     }
 
     /**
-     * Deep Object.assign.
+     * Deep Object.assign for simple objects.
      *
      * @see http://stackoverflow.com/a/34749873
      */

--- a/test/functional/columns/value-transformer/entity/Post.ts
+++ b/test/functional/columns/value-transformer/entity/Post.ts
@@ -15,6 +15,38 @@ class TagTransformer implements ValueTransformer {
 
 }
 
+export class Complex {
+    x: number;
+    y: number;
+    circularReferenceToMySelf: {
+        complex: Complex
+    };
+
+    constructor(from: String) {
+        this.circularReferenceToMySelf = { complex: this };
+        const [x, y] = from.split(" ");
+        this.x = +x;
+        this.y = +y;
+    }
+
+    toString() {
+        return `${this.x} ${this.y}`;
+    }
+}
+
+class ComplexTransformer implements ValueTransformer {
+
+    to (value: Complex | null): string | null {
+        if (value == null) { return value; }
+        return value.toString();
+    }
+
+    from (value: string | null): Complex | null {
+        if (value == null) { return value; }
+        return new Complex(value);
+    }
+}
+
 @Entity()
 export class Post {
 
@@ -27,4 +59,6 @@ export class Post {
     @Column({ type: String, transformer: new TagTransformer() })
     tags: string[];
 
+    @Column({ type: String, transformer: new ComplexTransformer(), nullable: true })
+    complex: Complex | null;
 }

--- a/test/functional/columns/value-transformer/value-transformer.ts
+++ b/test/functional/columns/value-transformer/value-transformer.ts
@@ -96,7 +96,7 @@ describe("columns > value-transformer functionality", () => {
 
     })));
 
-    it.only("should marshal data using a complex value-transformer", () => Promise.all(connections.map(async connection => {
+    it("should marshal data using a complex value-transformer", () => Promise.all(connections.map(async connection => {
 
         const postRepository = connection.getRepository(Post);
 

--- a/test/functional/columns/value-transformer/value-transformer.ts
+++ b/test/functional/columns/value-transformer/value-transformer.ts
@@ -4,7 +4,7 @@ import {closeTestingConnections, createTestingConnections, reloadTestingDatabase
 
 import {Connection} from "../../../../src/connection/Connection";
 import {PhoneBook} from "./entity/PhoneBook";
-import {Post} from "./entity/Post";
+import {Complex, Post} from "./entity/Post";
 import {User} from "./entity/User";
 import {Category} from "./entity/Category";
 import {View} from "./entity/View";
@@ -94,5 +94,61 @@ describe("columns > value-transformer functionality", () => {
         const dbView = await viewRepository.findOne();
         dbView && dbView.title.should.be.eql(title);
 
+    })));
+
+    it.only("should marshal data using a complex value-transformer", () => Promise.all(connections.map(async connection => {
+
+        const postRepository = connection.getRepository(Post);
+
+        // create and save a post first
+        const post = new Post();
+        post.title = "Complex transformers!";
+        post.tags = ["complex", "transformer"];
+        await postRepository.save(post);
+
+        let loadedPost = await postRepository.findOne(post.id);
+        expect(loadedPost!.complex).to.eq(null);
+
+        // then update all its properties and save again
+        post.title = "Complex transformers2!";
+        post.tags = ["very", "complex", "actually"];
+        post.complex = new Complex("3 2.5");
+        await postRepository.save(post);
+
+        // check if all columns are updated except for readonly columns
+        loadedPost = await postRepository.findOne(post.id);
+        expect(loadedPost!.title).to.be.equal("Complex transformers2!");
+        expect(loadedPost!.tags).to.deep.eq(["very", "complex", "actually"]);
+        expect(loadedPost!.complex!.x).to.eq(3);
+        expect(loadedPost!.complex!.y).to.eq(2.5);
+
+        // then update all its properties and save again
+        post.title = "Complex transformers3!";
+        post.tags = ["very", "lacking", "actually"];
+        post.complex = null;
+        await postRepository.save(post);
+
+        loadedPost = await postRepository.findOne(post.id);
+        expect(loadedPost!.complex).to.eq(null);
+
+        // then update all its properties and save again
+        post.title = "Complex transformers4!";
+        post.tags = ["very", "here", "again!"];
+        post.complex = new Complex("0.5 0.5");
+        await postRepository.save(post);
+
+        loadedPost = await postRepository.findOne(post.id);
+        expect(loadedPost!.complex!.x).to.eq(0.5);
+        expect(loadedPost!.complex!.y).to.eq(0.5);
+
+        // then update all its properties and save again
+        post.title = "Complex transformers5!";
+        post.tags = ["now", "really", "lacking!"];
+        post.complex = new Complex("1.05 2.3");
+        await postRepository.save(post);
+
+        loadedPost = await postRepository.findOne(post.id);
+        expect(loadedPost!.complex!.x).to.eq(1.05);
+        expect(loadedPost!.complex!.y).to.eq(2.3);
     })));
 });

--- a/test/functional/mongodb/basic/repository-actions/entity/Counters.ts
+++ b/test/functional/mongodb/basic/repository-actions/entity/Counters.ts
@@ -1,0 +1,19 @@
+import {Column} from "../../../../../../src/decorator/columns/Column";
+import {Entity} from "../../../../../../src/decorator/entity/Entity";
+import {User} from "./User";
+
+@Entity()
+export class Counters {
+
+    @Column({ name: "_likes" })
+    likes: number;
+
+    @Column({ name: "_comments" })
+    comments: number;
+
+    @Column({ name: "_favorites" })
+    favorites: number;
+
+    @Column(() => User)
+    viewer: User;
+}

--- a/test/functional/mongodb/basic/repository-actions/entity/Post.ts
+++ b/test/functional/mongodb/basic/repository-actions/entity/Post.ts
@@ -1,4 +1,5 @@
 import {Entity} from "../../../../../../src/decorator/entity/Entity";
+import {Counters} from "./Counters";
 import {Column} from "../../../../../../src/decorator/columns/Column";
 import {ObjectIdColumn} from "../../../../../../src/decorator/columns/ObjectIdColumn";
 import {ObjectID} from "../../../../../../src/driver/mongodb/typings";
@@ -18,7 +19,6 @@ export class Post {
     @Column()
     index: number;
 
-    // @Column(() => Counters)
-    // counters: Counters;
-
+    @Column(() => Counters)
+    counters: Counters;
 }

--- a/test/functional/mongodb/basic/repository-actions/entity/User.ts
+++ b/test/functional/mongodb/basic/repository-actions/entity/User.ts
@@ -1,0 +1,9 @@
+import {Column} from "../../../../../../src/decorator/columns/Column";
+import {Entity} from "../../../../../../src/decorator/entity/Entity";
+
+@Entity()
+export class User {
+
+    @Column()
+    name: string;
+}

--- a/test/functional/mongodb/basic/repository-actions/mongodb-repository-actions.ts
+++ b/test/functional/mongodb/basic/repository-actions/mongodb-repository-actions.ts
@@ -3,6 +3,8 @@ import {expect} from "chai";
 import {Connection} from "../../../../../src/connection/Connection";
 import {closeTestingConnections, createTestingConnections, reloadTestingDatabases} from "../../../../utils/test-utils";
 import {Post} from "./entity/Post";
+import {Counters} from "./entity/Counters";
+import {User} from "./entity/User";
 
 describe("mongodb > basic repository actions", () => {
 
@@ -44,6 +46,32 @@ describe("mongodb > basic repository actions", () => {
         mergedPost.should.be.equal(post);
         mergedPost.title.should.be.equal("This is updated post");
         mergedPost.text.should.be.equal("And its text is updated as well");
+    })));
+
+    it("merge should merge all given recursive partial objects into given source entity", () => Promise.all(connections.map(async connection => {
+        const postRepository = connection.getRepository(Post);
+        const counter1 = new Counters();
+        counter1.likes = 5;
+        const counter2 = new Counters();
+        counter2.likes = 2;
+        counter2.viewer = new User();
+        counter2.viewer.name = "Hello World";
+        const post = postRepository.create({
+            title: "This is created post",
+            text: "All about this post",
+            counters: counter1
+        });
+        const mergedPost = postRepository.merge(post,
+            { title: "This is updated post" },
+            { text: "And its text is updated as well" },
+            { counters: counter2 }
+        );
+        mergedPost.should.be.instanceOf(Post);
+        mergedPost.should.be.equal(post);
+        mergedPost.title.should.be.equal("This is updated post");
+        mergedPost.text.should.be.equal("And its text is updated as well");
+        mergedPost.counters.likes.should.be.equal(2);
+        mergedPost.counters.viewer.name.should.be.equal("Hello World");
     })));
 
     it("target should be valid", () => Promise.all(connections.map(async connection => {

--- a/test/functional/util/OrmUtils.ts
+++ b/test/functional/util/OrmUtils.ts
@@ -1,0 +1,106 @@
+import { expect } from "chai";
+import { OrmUtils } from "../../../src/util/OrmUtils";
+
+describe("OrmUtils.isPlainObject", () => {
+    const isPlainObject = OrmUtils.isPlainObject.bind(OrmUtils);
+
+    it("should return `true` if the Object is made by Object.create(null), {} or new Object().", () => {
+        class Foo {}
+
+        expect(isPlainObject(new Object())).to.be.true;
+        expect(isPlainObject(Object.create(null))).to.be.true;
+        expect(isPlainObject(Object.create(Object.prototype))).to.be.true;
+        expect(isPlainObject({ foo: "bar" })).to.be.true;
+        expect(isPlainObject({ constructor: "foo" })).to.be.true;
+        expect(isPlainObject({ constructor: Foo })).to.be.true;
+        expect(isPlainObject({}));
+    });
+
+    it("should return `false` if the Object is not made by Object.create(null), {} or new Object().", () => {
+        class Foo {}
+
+        expect(isPlainObject(Object.create({}))).to.be.false;
+        expect(isPlainObject(Object.create(Object))).to.be.false;
+        expect(isPlainObject(/foo/)).to.be.false;
+        expect(isPlainObject(function() {})).to.be.false;
+        expect(isPlainObject(() => {})).to.be.false;
+        expect(isPlainObject(["foo", "bar"])).to.be.false;
+        expect(isPlainObject([])).to.be.false;
+        expect(isPlainObject(new Foo())).to.be.false;
+        expect(isPlainObject(null)).to.be.false;
+        expect(isPlainObject(Math)).to.be.false;
+        expect(isPlainObject(Error)).to.be.false;
+        expect(isPlainObject(0)).to.be.false;
+        expect(isPlainObject(false)).to.be.false;
+        expect(isPlainObject(NaN)).to.be.false;
+    });
+ });
+
+describe("OrmUtils.mergeDeep", () => {
+    const mergeDeep = OrmUtils.mergeDeep.bind(OrmUtils);
+
+    it("should handle simple values.", () => {
+        expect(mergeDeep(1, 2)).to.equal(1);
+        expect(mergeDeep(2, 1)).to.equal(2);
+        expect(mergeDeep(2, 1, 1)).to.equal(2);
+        expect(mergeDeep(1, 2, 1)).to.equal(1);
+        expect(mergeDeep(1, 1, 2)).to.equal(1);
+        expect(mergeDeep(2, 1, 2)).to.equal(2);
+    });
+
+    it("should handle ordering and indempotence.", () => {
+        const a = { a: 1 };
+        const b = { a: 2 };
+        expect(mergeDeep(a, b)).to.deep.equal(b);
+        expect(mergeDeep(b, a)).to.deep.equal(a);
+        expect(mergeDeep(b, a, a)).to.deep.equal(a);
+        expect(mergeDeep(a, b, a)).to.deep.equal(a);
+        expect(mergeDeep(a, a, b)).to.deep.equal(b);
+        expect(mergeDeep(b, a, b)).to.deep.equal(b);
+        const c = { a: 3 };
+        expect(mergeDeep(a, b, c)).to.deep.equal(c);
+        expect(mergeDeep(b, c, b)).to.deep.equal(b);
+        expect(mergeDeep(c, a, a)).to.deep.equal(a);
+        expect(mergeDeep(c, b, a)).to.deep.equal(a);
+        expect(mergeDeep(a, c, b)).to.deep.equal(b);
+        expect(mergeDeep(b, a, c)).to.deep.equal(c);
+    });
+
+    it("should skip nested promises in sources.", () => {
+        expect(mergeDeep({}, { p: Promise.resolve() })).to.deep.equal({});
+        expect(mergeDeep({}, { p: { p: Promise.resolve() }})).to.deep.equal({ p: {} });
+        const a = { p: Promise.resolve(0) };
+        const b = { p: Promise.resolve(1) };
+        expect(mergeDeep(a, {})).to.deep.equal(a);
+        expect(mergeDeep(a, b)).to.deep.equal(a);
+        expect(mergeDeep(b, a)).to.deep.equal(b);
+        expect(mergeDeep(b, {})).to.deep.equal(b);
+    });
+
+    it("should merge moderately deep objects correctly.", () => {
+        const a = { a: { b: { c: { d: { e: 123, h: { i: 23 } } } } }, g: 19 };
+        const b = { a: { b: { c: { d: { f: 99 } }, f: 31 } } };
+        const c = { a: { b: { c: { d: { e: 123, f: 99, h: { i: 23 } } }, f: 31 } }, g: 19 };
+        expect(mergeDeep(a, b)).to.deep.equal(c);
+        expect(mergeDeep(b, a)).to.deep.equal(c);
+        expect(mergeDeep(b, a, a)).to.deep.equal(c);
+        expect(mergeDeep(a, b, a)).to.deep.equal(c);
+        expect(mergeDeep(a, a, b)).to.deep.equal(c);
+        expect(mergeDeep(b, a, b)).to.deep.equal(c);
+    });
+
+    it("should reference copy complex instances of classes.", () => {
+        class Foo {
+            recursive: Foo;
+
+            constructor() {
+                this.recursive = this;
+            }
+        }
+
+        const foo = new Foo();
+        const result = mergeDeep({}, { foo });
+        expect(result).to.have.property("foo");
+        expect(result.foo).to.equal(foo);
+    });
+ });


### PR DESCRIPTION
The current mergeDeep implementation tries to recursively copy complex objects like class instances. So, a new implementation of `mergeDeep` and `isPlainObject` (previously `isObject`) is given. This fixes #5096, which demonstrates the problem.

As a bonus, this creates tests for these methods which weren't tested before.