### PR TITLE
fix: resolve sorting bug for several mongo vesions with typeorm migra

### DIFF
--- a/src/migration/MigrationExecutor.ts
+++ b/src/migration/MigrationExecutor.ts
@@ -311,7 +311,7 @@ export class MigrationExecutor {
             .db(this.connection.driver.database!)
             .collection(this.migrationsTableName)
             .find<Migration>()
-            .sort("_id", -1)
+            .sort({"_id": -1})
             .toArray();
         } else {
             const migrationsRaw: ObjectLiteral[] = await this.connection.manager


### PR DESCRIPTION
fix: resolve sorting bug for several mongo versions with typeorm migration

refactored the sort string-valued key parameter to an object in order to avoid the `MongoError: Can't canonicalize query: BadValue bad order array [2]` error when running migration

Closes #5115