### PR TITLE
Update links to Active Record and Data Mapper doc

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,17 +31,20 @@ that help you to develop any kind of application that uses databases - from
 small applications with a few tables to large scale enterprise applications
 with multiple databases.
 
-TypeORM supports both [Active Record](docs/active-record-data-mapper.md#what-is-the-active-record-pattern) and [Data Mapper](docs/active-record-data-mapper.md#what-is-the-data-mapper-pattern) patterns,
+TypeORM supports both [Active Record][] and [Data Mapper][] patterns,
 unlike all other JavaScript ORMs currently in existence,
 which means you can write high quality, loosely coupled, scalable,
 maintainable applications the most productive way.
+
+[Active Record]: docs/active-record-data-mapper.md#what-is-the-active-record-pattern
+[Data Mapper]: docs/active-record-data-mapper.md#what-is-the-data-mapper-pattern
 
 TypeORM is highly influenced by other ORMs, such as [Hibernate](http://hibernate.org/orm/),
  [Doctrine](http://www.doctrine-project.org/) and [Entity Framework](https://www.asp.net/entity-framework).
 
 Some TypeORM features:
 
-* supports both [DataMapper](active-record-data-mapper.md#what-is-the-data-mapper-pattern) and [ActiveRecord](active-record-data-mapper.md#what-is-the-active-record-pattern) (your choice)
+* supports both [Data Mapper][] and [Active Record][] (your choice)
 * entities and columns
 * database-specific column types
 * entity manager


### PR DESCRIPTION
Follow-up of e42091e1506148ba761737d7977331b5c1d60307 and #4928

This is probably duplicate of #5065. Still, this commit shows a way to define links without having to put the URLs inline.