### PR TITLE
Fix circular dependency error message

### DIFF
--- a/src/error/CircularRelationsError.ts
+++ b/src/error/CircularRelationsError.ts
@@ -7,7 +7,7 @@ export class CircularRelationsError extends Error {
     constructor(path: string) {
         super();
         Object.setPrototypeOf(this, CircularRelationsError.prototype);
-        this.message = `Circular relations detected: ${path}. To resolve this issue you need to set nullable: false somewhere in this dependency structure.`;
+        this.message = `Circular relations detected: ${path}. To resolve this issue you need to set nullable: true somewhere in this dependency structure.`;
     }
 
 }


### PR DESCRIPTION
I believe this should say `nullable: true`. You only have an impossible circular dependency if both relations are `NOT NULL`.