### PR TITLE
fix: use global promise name

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -181,6 +181,15 @@
         "@types/node": "*"
       }
     },
+    "@types/continuation-local-storage": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/@types/continuation-local-storage/-/continuation-local-storage-3.2.2.tgz",
+      "integrity": "sha512-aItm+aYPJ4rT1cHmAxO+OdWjSviQ9iB5UKb5f0Uvgln0N4hS2mcDodHtPiqicYBXViUYhqyBjhA5uyOcT+S34Q==",
+      "dev": true,
+      "requires": {
+        "@types/node": "*"
+      }
+    },
     "@types/debug": {
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/@types/debug/-/debug-4.1.2.tgz",
@@ -702,6 +711,16 @@
       "resolved": "https://registry.npmjs.org/async-each/-/async-each-1.0.1.tgz",
       "integrity": "sha1-GdOGodntxufByF04iu28xW0zYC0=",
       "dev": true
+    },
+    "async-listener": {
+      "version": "0.6.10",
+      "resolved": "https://registry.npmjs.org/async-listener/-/async-listener-0.6.10.tgz",
+      "integrity": "sha512-gpuo6xOyF4D5DE5WvyqZdPA3NGhiT6Qf07l7DCB0wwDEsLvDIbCr6j9S5aj5Ch96dLace5tXVzWBZkxU/c5ohw==",
+      "dev": true,
+      "requires": {
+        "semver": "^5.3.0",
+        "shimmer": "^1.1.0"
+      }
     },
     "async-settle": {
       "version": "1.0.0",
@@ -1414,6 +1433,16 @@
       "integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4=",
       "dev": true
     },
+    "continuation-local-storage": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/continuation-local-storage/-/continuation-local-storage-3.2.1.tgz",
+      "integrity": "sha512-jx44cconVqkCEEyLSKWwkvUXwO561jXMa3LPjTPsm5QR22PA0/mhe33FT4Xb5y74JDvt/Cq+5lm8S8rskLv9ZA==",
+      "dev": true,
+      "requires": {
+        "async-listener": "^0.6.0",
+        "emitter-listener": "^1.1.1"
+      }
+    },
     "conventional-changelog": {
       "version": "3.1.8",
       "resolved": "https://registry.npmjs.org/conventional-changelog/-/conventional-changelog-3.1.8.tgz",
@@ -2121,6 +2150,15 @@
       "resolved": "https://registry.npmjs.org/elegant-spinner/-/elegant-spinner-1.0.1.tgz",
       "integrity": "sha1-2wQ1IcldfjA/2PNFvtwzSc+wcp4=",
       "dev": true
+    },
+    "emitter-listener": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/emitter-listener/-/emitter-listener-1.1.2.tgz",
+      "integrity": "sha512-Bt1sBAGFHY9DKY+4/2cV6izcKJUf5T7/gkdmkxzX/qv9CcGH8xSwVRW5mtX03SWJtRTWSOpzCuWN9rBFYZepZQ==",
+      "dev": true,
+      "requires": {
+        "shimmer": "^1.2.0"
+      }
     },
     "emoji-regex": {
       "version": "7.0.3",
@@ -7599,6 +7637,12 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-1.0.0.tgz",
       "integrity": "sha1-2kL0l0DAtC2yypcoVxyxkMmO/qM="
+    },
+    "shimmer": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/shimmer/-/shimmer-1.2.1.tgz",
+      "integrity": "sha512-sQTKC1Re/rM6XyFM6fIAGHRPVGvyXfgzIDvzoq608vM+jeyVD0Tu1E6Np0Kc2zAIFWIj963V2800iF/9LPieQw==",
+      "dev": true
     },
     "signal-exit": {
       "version": "3.0.2",

--- a/package.json
+++ b/package.json
@@ -48,6 +48,7 @@
   "devDependencies": {
     "@types/chai": "^4.1.2",
     "@types/chai-as-promised": "7.1.0",
+    "@types/continuation-local-storage": "^3.2.2",
     "@types/debug": "4.1.2",
     "@types/mocha": "^5.2.6",
     "@types/node": "^9.6.0",
@@ -58,6 +59,7 @@
     "chai": "^4.2.0",
     "chai-as-promised": "^7.1.1",
     "class-transformer": "^0.2.3",
+    "continuation-local-storage": "^3.2.1",
     "conventional-changelog-angular": "^5.0.3",
     "conventional-changelog-cli": "^2.0.21",
     "del": "^3.0.0",
@@ -119,6 +121,7 @@
     "test": "rimraf ./build && tsc && mocha --file ./build/compiled/test/utils/test-setup.js --bail --recursive --timeout 60000 ./build/compiled/test",
     "test-fast": "mocha --file ./build/compiled/test/utils/test-setup.js --bail --recursive --timeout 60000 ./build/compiled/test",
     "compile": "rimraf ./build && tsc",
+    "tsc": "tsc -w",
     "package": "gulp package",
     "lint": "tslint -p .",
     "changelog": "conventional-changelog -p angular -i CHANGELOG.md -s -r 2"

--- a/src/decorator/relations/ManyToMany.ts
+++ b/src/decorator/relations/ManyToMany.ts
@@ -1,5 +1,6 @@
 import {getMetadataArgsStorage, ObjectType, RelationOptions} from "../../";
 import {RelationMetadataArgs} from "../../metadata-args/RelationMetadataArgs";
+import { PromiseUtils } from "../../util/PromiseUtils";
 
 /**
  * Many-to-many is a type of relationship when Entity1 can have multiple instances of Entity2, and Entity2 can have
@@ -42,7 +43,7 @@ export function ManyToMany<T>(typeFunctionOrTarget: string|((type?: any) => Obje
         let isLazy = options.lazy === true;
         if (!isLazy && Reflect && (Reflect as any).getMetadata) { // automatic determination
             const reflectedType = (Reflect as any).getMetadata("design:type", object, propertyName);
-            if (reflectedType && typeof reflectedType.name === "string" && reflectedType.name.toLowerCase() === "promise")
+            if (reflectedType && typeof reflectedType.name === "string" && reflectedType.name.toLowerCase() === PromiseUtils.getGlobalPromiseTypeName())
                 isLazy = true;
         }
 

--- a/src/decorator/relations/ManyToOne.ts
+++ b/src/decorator/relations/ManyToOne.ts
@@ -1,5 +1,6 @@
 import {getMetadataArgsStorage, ObjectType, RelationOptions} from "../../";
 import {RelationMetadataArgs} from "../../metadata-args/RelationMetadataArgs";
+import { PromiseUtils } from "../../util/PromiseUtils";
 
 /**
  * Many-to-one relation allows to create type of relation when Entity1 can have single instance of Entity2, but
@@ -41,7 +42,7 @@ export function ManyToOne<T>(typeFunctionOrTarget: string|((type?: any) => Objec
         let isLazy = options && options.lazy === true ? true : false;
         if (!isLazy && Reflect && (Reflect as any).getMetadata) { // automatic determination
             const reflectedType = (Reflect as any).getMetadata("design:type", object, propertyName);
-            if (reflectedType && typeof reflectedType.name === "string" && reflectedType.name.toLowerCase() === "promise")
+            if (reflectedType && typeof reflectedType.name === "string" && reflectedType.name.toLowerCase() === PromiseUtils.getGlobalPromiseTypeName())
                 isLazy = true;
         }
 

--- a/src/decorator/relations/OneToMany.ts
+++ b/src/decorator/relations/OneToMany.ts
@@ -1,5 +1,6 @@
 import {getMetadataArgsStorage, ObjectType, RelationOptions} from "../../";
 import {RelationMetadataArgs} from "../../metadata-args/RelationMetadataArgs";
+import { PromiseUtils } from "../../util/PromiseUtils";
 
 /**
  * One-to-many relation allows to create type of relation when Entity2 can have multiple instances of Entity1.
@@ -13,7 +14,7 @@ export function OneToMany<T>(typeFunctionOrTarget: string|((type?: any) => Objec
         let isLazy = options && options.lazy === true ? true : false;
         if (!isLazy && Reflect && (Reflect as any).getMetadata) { // automatic determination
             const reflectedType = (Reflect as any).getMetadata("design:type", object, propertyName);
-            if (reflectedType && typeof reflectedType.name === "string" && reflectedType.name.toLowerCase() === "promise")
+            if (reflectedType && typeof reflectedType.name === "string" && reflectedType.name.toLowerCase() === PromiseUtils.getGlobalPromiseTypeName())
                 isLazy = true;
         }
 

--- a/src/decorator/relations/OneToOne.ts
+++ b/src/decorator/relations/OneToOne.ts
@@ -1,5 +1,6 @@
 import {getMetadataArgsStorage, ObjectType, RelationOptions} from "../../";
 import {RelationMetadataArgs} from "../../metadata-args/RelationMetadataArgs";
+import { PromiseUtils } from "../../util/PromiseUtils";
 
 /**
  * One-to-one relation allows to create direct relation between two entities. Entity1 have only one Entity2.
@@ -39,7 +40,7 @@ export function OneToOne<T>(typeFunctionOrTarget: string|((type?: any) => Object
         let isLazy = options && options.lazy === true ? true : false;
         if (!isLazy && Reflect && (Reflect as any).getMetadata) { // automatic determination
             const reflectedType = (Reflect as any).getMetadata("design:type", object, propertyName);
-            if (reflectedType && typeof reflectedType.name === "string" && reflectedType.name.toLowerCase() === "promise")
+            if (reflectedType && typeof reflectedType.name === "string" && reflectedType.name.toLowerCase() === PromiseUtils.getGlobalPromiseTypeName())
                 isLazy = true;
         }
 

--- a/src/decorator/tree/TreeChildren.ts
+++ b/src/decorator/tree/TreeChildren.ts
@@ -1,5 +1,6 @@
 import {getMetadataArgsStorage, RelationOptions} from "../../";
 import {RelationMetadataArgs} from "../../metadata-args/RelationMetadataArgs";
+import { PromiseUtils } from "../../util/PromiseUtils";
 
 /**
  * Marks a entity property as a children of the tree.
@@ -11,7 +12,7 @@ export function TreeChildren(options?: { cascade?: boolean|("insert"|"update"|"r
 
         // now try to determine it its lazy relation
         const reflectedType = Reflect && (Reflect as any).getMetadata ? Reflect.getMetadata("design:type", object, propertyName) : undefined;
-        const isLazy = (reflectedType && typeof reflectedType.name === "string" && reflectedType.name.toLowerCase() === "promise") || false;
+        const isLazy = (reflectedType && typeof reflectedType.name === "string" && reflectedType.name.toLowerCase() === PromiseUtils.getGlobalPromiseTypeName()) || false;
 
         // add one-to-many relation for this 
         getMetadataArgsStorage().relations.push({

--- a/src/decorator/tree/TreeParent.ts
+++ b/src/decorator/tree/TreeParent.ts
@@ -1,5 +1,6 @@
 import {getMetadataArgsStorage} from "../../";
 import {RelationMetadataArgs} from "../../metadata-args/RelationMetadataArgs";
+import { PromiseUtils } from "../../util/PromiseUtils";
 
 /**
  * Marks a entity property as a parent of the tree.
@@ -10,7 +11,7 @@ export function TreeParent(): Function {
 
         // now try to determine it its lazy relation
         const reflectedType = Reflect && (Reflect as any).getMetadata ? Reflect.getMetadata("design:type", object, propertyName) : undefined;
-        const isLazy = (reflectedType && typeof reflectedType.name === "string" && reflectedType.name.toLowerCase() === "promise") || false;
+        const isLazy = (reflectedType && typeof reflectedType.name === "string" && reflectedType.name.toLowerCase() === PromiseUtils.getGlobalPromiseTypeName()) || false;
 
         getMetadataArgsStorage().relations.push({
             isTreeParent: true,

--- a/src/util/PromiseUtils.ts
+++ b/src/util/PromiseUtils.ts
@@ -12,6 +12,10 @@ export class PromiseUtils {
         return promise;
     }
 
+    static getGlobalPromiseTypeName() {
+        return global.Promise.name.toLowerCase();
+    }
+
     /**
      * If given value is a promise created by "create" method this method gets its value.
      * If given value is not a promise then given value is returned back.

--- a/test/github-issues/5156/entity/Bar.ts
+++ b/test/github-issues/5156/entity/Bar.ts
@@ -1,0 +1,12 @@
+import { Entity } from "../../../../src/decorator/entity/Entity";
+import { OneToMany } from "../../../../src";
+import { Foo } from "./Foo";
+
+@Entity()
+export class Bar {
+    @OneToMany(() => Foo, async ({ bar }) => bar)
+    public foos: Foo[];
+}
+
+
+

--- a/test/github-issues/5156/entity/Foo.ts
+++ b/test/github-issues/5156/entity/Foo.ts
@@ -1,0 +1,12 @@
+import * as cls from "continuation-local-storage";
+cls.createNamespace("foo");
+
+import { Entity } from "../../../../src/decorator/entity/Entity";
+import { ManyToOne } from "../../../../src";
+import { Bar } from "./Bar";
+
+@Entity()
+export class Foo {
+    @ManyToOne(() => Bar, ({ foos }) => foos)
+    public bar: Promise<Bar>;
+}

--- a/test/github-issues/5156/issue-5156.ts
+++ b/test/github-issues/5156/issue-5156.ts
@@ -1,0 +1,18 @@
+import "reflect-metadata";
+
+import { Foo } from "./entity/Foo";
+import { expect } from "chai";
+import { getMetadataArgsStorage } from "../../../src";
+
+
+describe("github issues > #5156 it identifies lazy load properties if the global Promise has been changed", () => {
+
+    it("Identifies promise by the current name of the global promise", () => {
+
+        const metadataArgsStorage = getMetadataArgsStorage();
+        const barRelation = metadataArgsStorage.relations.filter(relation => relation.target === Foo);
+
+        expect(barRelation.length).to.eql(1);
+        expect(barRelation[0].isLazy).to.eql(true);
+    });
+});


### PR DESCRIPTION
when checking if a property is lazy, use the name of the current global
Promise, this way if it has been changed lazy properties will still be
identified

Closes #5156