### PR TITLE
added in memory caching option

### DIFF
--- a/src/cache/InMemoryQueryResultCache.ts
+++ b/src/cache/InMemoryQueryResultCache.ts
@@ -1,6 +1,6 @@
 import {QueryResultCache} from "./QueryResultCache";
-import { QueryResultCacheOptions } from './QueryResultCacheOptions';
-import { QueryRunner } from '..';
+import { QueryResultCacheOptions } from "./QueryResultCacheOptions";
+import { QueryRunner } from "..";
 
 /**
  * Caches query result into simple in-memory map.
@@ -14,7 +14,7 @@ export class InMemoryQueryResultCache implements QueryResultCache {
     /**
      * Map to store cached values.
      */
-    protected cache: Record<string, QueryResultCacheOptions>
+    protected cache: Record<string, QueryResultCacheOptions>;
 
     // -------------------------------------------------------------------------
     // Constructor
@@ -89,9 +89,9 @@ export class InMemoryQueryResultCache implements QueryResultCache {
     remove(identifiers: string[], queryRunner?: QueryRunner | undefined): Promise<void> {
         identifiers.forEach(identifier => {
             if (this.cache[identifier]) {
-                delete this.cache[identifier]
+                delete this.cache[identifier];
             } 
-        })
+        });
         return Promise.resolve();
     }
 }

--- a/src/cache/InMemoryQueryResultCache.ts
+++ b/src/cache/InMemoryQueryResultCache.ts
@@ -16,6 +16,12 @@ export class InMemoryQueryResultCache implements QueryResultCache {
      */
     protected cache: Record<string, QueryResultCacheOptions>;
 
+    /**
+     * Singleton instance of the cache.
+     */
+    protected static instance: InMemoryQueryResultCache;
+
+
     // -------------------------------------------------------------------------
     // Constructor
     // -------------------------------------------------------------------------
@@ -93,5 +99,15 @@ export class InMemoryQueryResultCache implements QueryResultCache {
             } 
         });
         return Promise.resolve();
+    }
+
+    /**
+     * Get the singleton instance of the cache.
+     */
+    static getInstance(): InMemoryQueryResultCache {
+        if (!InMemoryQueryResultCache.instance) {
+            InMemoryQueryResultCache.instance = new InMemoryQueryResultCache();
+        }
+        return InMemoryQueryResultCache.instance;
     }
 }

--- a/src/cache/InMemoryQueryResultCache.ts
+++ b/src/cache/InMemoryQueryResultCache.ts
@@ -1,0 +1,97 @@
+import {QueryResultCache} from "./QueryResultCache";
+import { QueryResultCacheOptions } from './QueryResultCacheOptions';
+import { QueryRunner } from '..';
+
+/**
+ * Caches query result into simple in-memory map.
+ */
+export class InMemoryQueryResultCache implements QueryResultCache {
+
+    // -------------------------------------------------------------------------
+    // Protected Properties
+    // -------------------------------------------------------------------------
+
+    /**
+     * Map to store cached values.
+     */
+    protected cache: Record<string, QueryResultCacheOptions>
+
+    // -------------------------------------------------------------------------
+    // Constructor
+    // -------------------------------------------------------------------------
+
+    constructor() {
+        this.cache = {};
+    }
+
+    // -------------------------------------------------------------------------
+    // Public Methods
+    // -------------------------------------------------------------------------
+
+    /**
+     * Creates a connection with given cache provider.
+     */
+    connect(): Promise<void> {
+        return Promise.resolve();
+    } 
+    
+    /**
+     * Disconnects the connection
+     */
+    disconnect(): Promise<void> {
+        return Promise.resolve();
+    }
+
+    /**
+     * Creates table for storing cache if it does not exist yet.
+     */
+    synchronize(queryRunner?: import("..").QueryRunner | undefined): Promise<void> {
+        return Promise.resolve();
+    }
+
+    /**
+     * Caches given query result.
+     * Returns cache result if found.
+     * Returns undefined if result is not cached.
+     */
+    getFromCache(options: QueryResultCacheOptions, queryRunner?: QueryRunner | undefined): Promise<QueryResultCacheOptions | undefined> {
+        const result = this.cache[options.identifier];
+        return Promise.resolve(result);
+    }
+
+    /**
+     * Stores given query result in the cache.
+     */
+    storeInCache(options: QueryResultCacheOptions, savedCache: QueryResultCacheOptions | undefined, queryRunner?: QueryRunner | undefined): Promise<void> {
+        this.cache[options.identifier] = options;
+        return Promise.resolve();
+    }
+
+    /**
+     * Checks if cache is expired or not.
+     */
+    isExpired(savedCache: QueryResultCacheOptions): boolean {
+        const duration = typeof savedCache.duration === "string" ? parseInt(savedCache.duration) : savedCache.duration;
+        return ((typeof savedCache.time === "string" ? parseInt(savedCache.time as any) : savedCache.time)! + duration) < new Date().getTime();
+    }
+
+    /**
+     * Clears everything stored in the cache.
+     */
+    clear(queryRunner?: QueryRunner | undefined): Promise<void> {
+        this.cache = {};
+        return Promise.resolve();
+    }
+
+    /**
+     * Removes all cached results by given identifiers from cache.
+     */
+    remove(identifiers: string[], queryRunner?: QueryRunner | undefined): Promise<void> {
+        identifiers.forEach(identifier => {
+            if (this.cache[identifier]) {
+                delete this.cache[identifier]
+            } 
+        })
+        return Promise.resolve();
+    }
+}

--- a/src/cache/QueryResultCacheFactory.ts
+++ b/src/cache/QueryResultCacheFactory.ts
@@ -1,5 +1,6 @@
 import {RedisQueryResultCache} from "./RedisQueryResultCache";
 import {DbQueryResultCache} from "./DbQueryResultCache";
+import {InMemoryQueryResultCache} from "./InMemoryQueryResultCache";
 import {QueryResultCache} from "./QueryResultCache";
 import {Connection} from "../connection/Connection";
 
@@ -34,6 +35,9 @@ export class QueryResultCacheFactory {
 
         if ((this.connection.options.cache as any).type === "ioredis/cluster")
             return new RedisQueryResultCache(this.connection, "ioredis/cluster");
+        
+            if ((this.connection.options.cache as any).type === "memory")
+                return new InMemoryQueryResultCache();
 
         return new DbQueryResultCache(this.connection);
     }

--- a/src/cache/QueryResultCacheFactory.ts
+++ b/src/cache/QueryResultCacheFactory.ts
@@ -37,7 +37,7 @@ export class QueryResultCacheFactory {
             return new RedisQueryResultCache(this.connection, "ioredis/cluster");
         
             if ((this.connection.options.cache as any).type === "memory")
-                return new InMemoryQueryResultCache();
+                return InMemoryQueryResultCache.getInstance();
 
         return new DbQueryResultCache(this.connection);
     }


### PR DESCRIPTION
For testing or in cases when Redis is unsuitable/ not wanted, I think an in-memory cache option is a nice feature. Also, I don't quite see the utility of a db based cache which is the current default setting. This will allow caching without the need to hit db or implement Redis.