### PR TITLE
feat: hash aliases to avoid conflicts

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "typeorm",
-  "version": "0.2.20",
+  "version": "0.2.21",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/src/driver/DriverUtils.ts
+++ b/src/driver/DriverUtils.ts
@@ -1,5 +1,5 @@
 import { Driver } from "./Driver";
-import { shorten } from "../util/StringUtils";
+import { hash } from "../util/StringUtils";
 
     /**
  * Common driver utility functions.
@@ -34,10 +34,11 @@ export class DriverUtils {
     }
 
     /**
-     * Builds column alias from given alias name and column name,
+     * Builds column alias from given alias name and column name.
+     * 
      * If alias length is greater than the limit (if any) allowed by the current
-     * driver, abbreviates the longest part (alias or column name) in the resulting
-     * alias.
+     * driver, replaces either the alias or both the alias and the column name
+     * with hashed strings.
      *
      * @param driver Current `Driver`.
      * @param alias Alias part.
@@ -48,10 +49,16 @@ export class DriverUtils {
     static buildColumnAlias({ maxAliasLength }: Driver, alias: string, column: string): string {
         const columnAliasName = alias + "_" + column;
 
-        if (maxAliasLength && maxAliasLength > 0 && columnAliasName.length > maxAliasLength)
-            return alias.length > column.length
-                ? `${shorten(alias)}_${column}`
-                : `${alias}_${shorten(column)}`;
+        if (maxAliasLength && maxAliasLength > 0 && columnAliasName.length > maxAliasLength) {
+            const hashedAlias = hash(alias, { length: 8 });
+            const hashedColumnAliasName = hashedAlias + "_" + column;
+
+            if (hashedColumnAliasName.length > maxAliasLength) {
+                return hashedAlias + "_" + hash(column, { length: 8 });
+            }
+
+            return hashedColumnAliasName;
+        }
 
         return columnAliasName;
     }

--- a/src/driver/DriverUtils.ts
+++ b/src/driver/DriverUtils.ts
@@ -37,8 +37,7 @@ export class DriverUtils {
      * Builds column alias from given alias name and column name.
      * 
      * If alias length is greater than the limit (if any) allowed by the current
-     * driver, replaces either the alias or both the alias and the column name
-     * with hashed strings.
+     * driver, replaces it with a hashed string.
      *
      * @param driver Current `Driver`.
      * @param alias Alias part.
@@ -50,14 +49,7 @@ export class DriverUtils {
         const columnAliasName = alias + "_" + column;
 
         if (maxAliasLength && maxAliasLength > 0 && columnAliasName.length > maxAliasLength) {
-            const hashedAlias = hash(alias, { length: 8 });
-            const hashedColumnAliasName = hashedAlias + "_" + column;
-
-            if (hashedColumnAliasName.length > maxAliasLength) {
-                return hashedAlias + "_" + hash(column, { length: 8 });
-            }
-
-            return hashedColumnAliasName;
+            return hash(columnAliasName, { length: maxAliasLength });
         }
 
         return columnAliasName;

--- a/src/util/StringUtils.ts
+++ b/src/util/StringUtils.ts
@@ -1,4 +1,4 @@
-import * as crypto from 'crypto';
+import * as crypto from "crypto";
 
 /**
  * Converts string into camelCase.
@@ -92,7 +92,7 @@ export interface IShortenOptions {
   }
 
 interface IHashOptions {
-    length?: number
+    length?: number;
 }
 
 /**
@@ -102,11 +102,11 @@ interface IHashOptions {
  * @param options.length Optionally, shorten the output to desired length.
  */
 export function hash(input: string, options: IHashOptions = {}): string {
-    const hashFunction = crypto.createHash('sha256');
+    const hashFunction = crypto.createHash("sha256");
 
-    hashFunction.update(input, 'utf8');
+    hashFunction.update(input, "utf8");
 
-    const hashedInput = hashFunction.digest('hex');
+    const hashedInput = hashFunction.digest("hex");
 
     if (options.length) {
         return hashedInput.slice(0, options.length);

--- a/src/util/StringUtils.ts
+++ b/src/util/StringUtils.ts
@@ -1,3 +1,5 @@
+import * as crypto from 'crypto';
+
 /**
  * Converts string into camelCase.
  *
@@ -87,4 +89,28 @@ export interface IShortenOptions {
     }, []);
 
     return shortSegments.join(separator);
+  }
+
+interface IHashOptions {
+    length?: number
+}
+
+/**
+ * Returns a hashed input.
+ *
+ * @param input String to be hashed.
+ * @param options.length Optionally, shorten the output to desired length.
+ */
+export function hash(input: string, options: IHashOptions = {}): string {
+    const hashFunction = crypto.createHash('sha256');
+
+    hashFunction.update(input, 'utf8');
+
+    const hashedInput = hashFunction.digest('hex');
+
+    if (options.length) {
+        return hashedInput.slice(0, options.length);
+    }
+
+    return hashedInput;
   }


### PR DESCRIPTION
When selecting relations (e.g. in `find` methods), if a generated alias is longer than the maximum identifier length allowed by the current driver, it would get shortened: for example "Something_somethingElse" would become "Some_soEl" etc.

However, if multiple relations have similar enough aliases, their shortened versions might end up identical. This would lead to conflicts that cause the query to fail.

This commit hashes aliases that are too long, instead. This way there is still a theoretical possibility of a collision, but it's astronomically low. In practice, alias conflicts should disappear.

One drawback of this solution is that it leads to more vague aliases. This may make queries less inspectable. For what it's worth, though, `Some_soEl` doesn't grant a lot of clarity about what it represents, either.

BREAKING CHANGE: aliases for very long relation names may be replaced with hashed strings

---

This change only affects one place where identifiers are `shorten`ed. This solves the problem that I encountered personally. Perhaps it doesn't solve all problems from this category, but I don't understand the TypeORM codebase enough to want to change anything more than what I know is necessary.

I didn't open this PR in response to a specific ticket, but instead based on my own problem. But it appears like it might solve https://github.com/typeorm/typeorm/issues/3721 and https://github.com/typeorm/typeorm/issues/1969, maybe others as well.