### PR TITLE
fix(postgres): spatialFeatureType mapping

### DIFF
--- a/src/driver/postgres/PostgresQueryRunner.ts
+++ b/src/driver/postgres/PostgresQueryRunner.ts
@@ -1504,7 +1504,7 @@ export class PostgresQueryRunner extends BaseQueryRunner implements QueryRunner 
                       WHERE ${tablesCondition} AND "column_name" = '${tableColumn.name}'`;
 
                         const results: ObjectLiteral[] = await this.query(geometryColumnSql);
-                        tableColumn.spatialFeatureType = results[0].type;
+                        tableColumn.spatialFeatureType = results.filter(result => result.table_name === table.name && result.column_name === tableColumn.name)[0].type;
                         tableColumn.srid = results[0].srid;
                     }
 
@@ -1521,7 +1521,7 @@ export class PostgresQueryRunner extends BaseQueryRunner implements QueryRunner 
                       WHERE ${tablesCondition} AND "column_name" = '${tableColumn.name}'`;
 
                         const results: ObjectLiteral[] = await this.query(geographyColumnSql);
-                        tableColumn.spatialFeatureType = results[0].type;
+                        tableColumn.spatialFeatureType = results.filter(result => result.table_name === table.name && result.column_name === tableColumn.name)[0].type;
                         tableColumn.srid = results[0].srid;
                     }
 


### PR DESCRIPTION
Fixes incorrect spatial feature type mapping when there are multiple tables with different spatial types.

For example, when there are two tables `A` and `B` with columns `A.point` as `Point` and `B.polygon` ans `Polygon` type, both columns where recognized as `Point`.