### PR TITLE
Clarify example

### DIFF
--- a/docs/find-options.md
+++ b/docs/find-options.md
@@ -68,8 +68,8 @@ SELECT * FROM "user" WHERE ("firstName" = 'Timber' AND "lastName" = 'Saw') OR ("
 ```typescript
 userRepository.find({ 
     order: {
-        name: "ASC",
-        id: "DESC"
+        columnName: "ASC",
+        otherColumnName: "DESC"
     }
 });
 ```


### PR DESCRIPTION
`name` and `id` are often reserved keys, so the example should be made less ambiguous.