### PR TITLE
Add array type to CockroachDB default parser

### DIFF
--- a/src/driver/cockroachdb/CockroachDriver.ts
+++ b/src/driver/cockroachdb/CockroachDriver.ts
@@ -479,7 +479,10 @@ export class CockroachDriver implements Driver {
         const defaultValue = columnMetadata.default;
         const arrayCast = columnMetadata.isArray ? `::${columnMetadata.type}[]` : "";
 
-        if (typeof defaultValue === "number") {
+        if (columnMetadata.isArray && Array.isArray(defaultValue)) {
+            return `'{${defaultValue.map((val: string) => `${val}`).join(",")}}'`;
+            
+        } else if (typeof defaultValue === "number") {
             return "" + defaultValue;
 
         } else if (typeof defaultValue === "boolean") {


### PR DESCRIPTION
This PR implements the following fix to the CockroachDB driver:

- The default array parser from the PostgresDriver has been copied over.

Previously, when the following column was provided:

```ts
@Column("varchar", { array: true, default: ["hello"] })
```

An error was thrown that the array type did not match, as arrays were not getting parsed. The alternative solution was to set the default to use PostgreSQL syntax:

```ts
@Column("varchar", { array: true, default: "{'hello'}" })
```