### PR TITLE
Fix query-builder error for pessimistic_write locks with left joins

### DIFF
--- a/src/query-builder/QueryExpressionMap.ts
+++ b/src/query-builder/QueryExpressionMap.ts
@@ -158,6 +158,11 @@ export class QueryExpressionMap {
     lockVersion?: number|Date;
 
     /**
+     * Table alias to apply pessimistic_write lock
+     */
+    tableName?: string;
+
+    /**
      * Parameters used to be escaped in final query.
      */
     parameters: ObjectLiteral = {};
@@ -405,6 +410,7 @@ export class QueryExpressionMap {
         map.take = this.take;
         map.lockMode = this.lockMode;
         map.lockVersion = this.lockVersion;
+        map.tableName = this.tableName;
         map.parameters = Object.assign({}, this.parameters);
         map.disableEscaping = this.disableEscaping;
         map.enableRelationIdValues = this.enableRelationIdValues;


### PR DESCRIPTION
Fix for problem described here: https://github.com/typeorm/typeorm/issues/4084
Usage: 
```
.createQueryBuilder(User, 'user')
  .setLock('pessimistic_write', 'user')
  .leftJoinAndSelect('user.someAnotherTable', 'someAnotherTable')
  .where('email LIKE :email', { email: 'email@mail.com' })
  .getOne();```