### PR TITLE
chore: update node versions tested on travis

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,1 +1,0 @@
-@sap:registry=https://npm.sap.com

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,8 @@
 language: node_js
 node_js:
+  - 13
   - 12
   - 10
-  - 8
 
 services:
   - docker

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "typeorm",
-  "version": "0.2.21",
+  "version": "0.2.22",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -118,174 +118,6 @@
       "dev": true,
       "requires": {
         "any-observable": "^0.3.0"
-      }
-    },
-    "@sap/hdbext": {
-      "version": "6.1.1",
-      "resolved": "https://npm.sap.com/@sap/hdbext/-/hdbext-6.1.1.tgz",
-      "integrity": "sha512-M+VmMghNPVuGOvZnIJUfb8usYqj3HoEIjdcBaDzSHpSLXxUXGaWgWZ0pGgdDV4BTjWPHkbb7ZiBrp4k4heOoSg==",
-      "dev": true,
-      "requires": {
-        "@sap/e2e-trace": "^2.0.0",
-        "@sap/hana-client": "2.4.167",
-        "accept-language": "2.0.16",
-        "async": "2.4.1",
-        "debug": "3.1.0",
-        "lodash": "4.17.13",
-        "verror": "1.10.0"
-      },
-      "dependencies": {
-        "@sap/e2e-trace": {
-          "version": "2.0.0",
-          "resolved": "https://npm.sap.com/@sap/e2e-trace/-/e2e-trace-2.0.0.tgz",
-          "integrity": "sha512-iAAd+U8W+c5Yk4f3PSCL68oAjpCG6NUtmh67MD+hifCjM+LIG8R9oDtVgefQ68jImAtsiInBwEFisRkYHBjztw==",
-          "dev": true,
-          "requires": {
-            "request-stats": "3.0.0"
-          },
-          "dependencies": {
-            "http-headers": {
-              "version": "3.0.2",
-              "resolved": "https://registry.npmjs.org/http-headers/-/http-headers-3.0.2.tgz",
-              "integrity": "sha512-87E1I+2Wg4dxxz4rcxElo3dxO/w1ZtgL1yA0Sb6vH3qU16vRKq1NjWQv9SCY3ly2OQROcoxHZOUpmelS+k6wOw==",
-              "dev": true,
-              "requires": {
-                "next-line": "^1.1.0"
-              }
-            },
-            "next-line": {
-              "version": "1.1.0",
-              "resolved": "https://registry.npmjs.org/next-line/-/next-line-1.1.0.tgz",
-              "integrity": "sha1-/K5XhTBStqm66CCOQN19PC0wRgM=",
-              "dev": true
-            },
-            "once": {
-              "version": "1.4.0",
-              "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
-              "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
-              "dev": true,
-              "requires": {
-                "wrappy": "1"
-              }
-            },
-            "request-stats": {
-              "version": "3.0.0",
-              "resolved": "https://registry.npmjs.org/request-stats/-/request-stats-3.0.0.tgz",
-              "integrity": "sha1-dpFV3Il0141KHLh7vxTqq5ha/iU=",
-              "dev": true,
-              "requires": {
-                "http-headers": "^3.0.1",
-                "once": "^1.4.0"
-              }
-            },
-            "wrappy": {
-              "version": "1.0.2",
-              "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-              "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
-              "dev": true
-            }
-          }
-        },
-        "@sap/hana-client": {
-          "version": "2.4.167",
-          "resolved": "https://npm.sap.com/@sap/hana-client/-/hana-client-2.4.167.tgz",
-          "integrity": "sha512-nUIOcuNa6xhUPr49RR497Pg+UYB/Lb/X2SM2woQGaCeY23mkaQy5w/+TVAgqmW0i0WQhRC1BJ8tXOR2TmLYzmg==",
-          "dev": true,
-          "requires": {
-            "debug": "3.1.0"
-          },
-          "dependencies": {
-            "debug": {
-              "version": "3.1.0",
-              "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
-              "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
-              "dev": true,
-              "requires": {
-                "ms": "2.0.0"
-              }
-            },
-            "ms": {
-              "version": "2.0.0",
-              "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-              "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
-              "dev": true
-            }
-          }
-        },
-        "accept-language": {
-          "version": "2.0.16",
-          "resolved": "https://registry.npmjs.org/accept-language/-/accept-language-2.0.16.tgz",
-          "integrity": "sha1-uefScQd0rWCfJHbzz+GkkrVgYb4=",
-          "dev": true,
-          "requires": {
-            "bcp47": "^1.1.2"
-          }
-        },
-        "assert-plus": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
-          "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
-          "dev": true
-        },
-        "async": {
-          "version": "2.4.1",
-          "resolved": "https://registry.npmjs.org/async/-/async-2.4.1.tgz",
-          "integrity": "sha1-YqVrJ5yYoR0JhwlqAcw+6463u9c=",
-          "dev": true,
-          "requires": {
-            "lodash": "^4.14.0"
-          }
-        },
-        "bcp47": {
-          "version": "1.1.2",
-          "resolved": "https://registry.npmjs.org/bcp47/-/bcp47-1.1.2.tgz",
-          "integrity": "sha1-NUvjMH/9CEM6ePXh4glYRfifx/4=",
-          "dev": true
-        },
-        "core-util-is": {
-          "version": "1.0.2",
-          "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
-          "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
-          "dev": true
-        },
-        "debug": {
-          "version": "3.1.0",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
-          "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
-          "dev": true,
-          "requires": {
-            "ms": "2.0.0"
-          }
-        },
-        "extsprintf": {
-          "version": "1.4.0",
-          "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.4.0.tgz",
-          "integrity": "sha1-4mifjzVvrWLMplo6kcXfX5VRaS8=",
-          "dev": true
-        },
-        "lodash": {
-          "version": "4.17.13",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.13.tgz",
-          "integrity": "sha512-vm3/XWXfWtRua0FkUyEHBZy8kCPjErNBT9fJx8Zvs+U6zjqPbTUOpkaoum3O5uiA8sm+yNMHXfYkTUHFoMxFNA==",
-          "dev": true
-        },
-        "ms": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
-          "dev": true
-        },
-        "verror": {
-          "version": "1.10.0",
-          "resolved": "https://registry.npmjs.org/verror/-/verror-1.10.0.tgz",
-          "integrity": "sha1-OhBcoXBTr1XW4nDB+CiGguGNpAA=",
-          "dev": true,
-          "requires": {
-            "assert-plus": "^1.0.0",
-            "core-util-is": "1.0.2",
-            "extsprintf": "^1.2.0"
-          }
-        }
       }
     },
     "@sinonjs/commons": {
@@ -2913,7 +2745,8 @@
           "version": "2.1.1",
           "resolved": false,
           "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -2937,13 +2770,15 @@
           "version": "1.0.0",
           "resolved": false,
           "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "resolved": false,
           "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
           "dev": true,
+          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -2953,19 +2788,22 @@
           "version": "1.1.0",
           "resolved": false,
           "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "concat-map": {
           "version": "0.0.1",
           "resolved": false,
           "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "resolved": false,
           "integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4=",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -3086,7 +2924,8 @@
           "version": "2.0.3",
           "resolved": false,
           "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "ini": {
           "version": "1.3.5",
@@ -3100,6 +2939,7 @@
           "resolved": false,
           "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
           "dev": true,
+          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -3116,6 +2956,7 @@
           "resolved": false,
           "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
           "dev": true,
+          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -3124,13 +2965,15 @@
           "version": "0.0.8",
           "resolved": false,
           "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "mkdirp": {
           "version": "0.5.1",
           "resolved": false,
           "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
           "dev": true,
+          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -3219,7 +3062,8 @@
           "version": "1.0.1",
           "resolved": false,
           "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -3233,6 +3077,7 @@
           "resolved": false,
           "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
           "dev": true,
+          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -3328,7 +3173,8 @@
           "version": "5.1.1",
           "resolved": false,
           "integrity": "sha512-kKvNJn6Mm93gAczWVJg7wH+wGYWNrDHdWvpUmHyEsgCtIwwo3bqPtV4tR5tuPaUhTOo/kvhVwd8XwwOllGYkbg==",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -3370,6 +3216,7 @@
           "resolved": false,
           "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
           "dev": true,
+          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -3391,6 +3238,7 @@
           "resolved": false,
           "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
           "dev": true,
+          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -3448,7 +3296,8 @@
           "version": "1.0.2",
           "resolved": false,
           "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "yallist": {
           "version": "3.0.3",

--- a/package.json
+++ b/package.json
@@ -47,7 +47,6 @@
     "oracle-orm"
   ],
   "devDependencies": {
-    "@sap/hdbext": "^6.1.1",
     "@types/chai": "^4.1.2",
     "@types/chai-as-promised": "7.1.0",
     "@types/debug": "4.1.2",


### PR DESCRIPTION
Update node.js versions tested on travis:
- removed nodejs 8.x - EOL
- added 13.x - current
- removed @sap/hdbext from dev dependencies

Looks like @sap/hdbext is not compatible with node 13. I think we should deal with this same way we're currently handling oracledb. It doesn't work in every environment(32 bit), so developer need to install it manually if he wants to use it.