### PR TITLE
fix: load typeorm-aurora-data-api-driver correctly when using webpack

### DIFF
--- a/src/driver/aurora-data-api/AuroraDataApiDriver.ts
+++ b/src/driver/aurora-data-api/AuroraDataApiDriver.ts
@@ -761,6 +761,10 @@ export class AuroraDataApiDriver implements Driver {
      */
     protected loadDependencies(): void {
         this.DataApiDriver = PlatformTools.load("typeorm-aurora-data-api-driver");
+
+        // Driver uses rollup for publishing, which has issues when using typeorm in combination with webpack
+        // See https://github.com/webpack/webpack/issues/4742#issuecomment-295556787
+        this.DataApiDriver = this.DataApiDriver.default || this.DataApiDriver;
     }
 
     /**


### PR DESCRIPTION
TypeORM uses require() within PlatformTools to load driver packages.
The typeorm-aurora-data-api-driver is exported with export default and packaged with rollup, which, as per https://github.com/webpack/webpack/issues/4742,
causes the require'd module to be available via require('typeorm-aurora-data-api-driver').default property.

Fixes #4788