### PR TITLE
Added note about using CreateDateColumn and UpdateDateColumn decorators

### DIFF
--- a/docs/decorator-reference.md
+++ b/docs/decorator-reference.md
@@ -280,7 +280,8 @@ Learn more about [MongoDB](mongodb.md).
 #### `@CreateDateColumn`
 
 Special column that is automatically set to the entity's insertion time.
-You don't need to write a value into this column - it will be automatically set.
+You don't need to write a value into this column - it will be automatically set.<br>
+NOTE: this column must have a set default value, depending on the database system you are using. E.g, `now()` for PostgreSQL<br>
 Example:
 
 ```typescript
@@ -297,7 +298,9 @@ export class User {
 
 Special column that is automatically set to the entity's update time
 each time you call `save` from entity manager or repository.
-You don't need to write a value into this column - it will be automatically set.
+You don't need to write a value into this column - it will be automatically set.<br>
+NOTE: this column must have a set default value, depending on the database system you are using. E.g, `now()` for PostgreSQL<br>
+Example:
 
 ```typescript
 @Entity()


### PR DESCRIPTION
Motivation: it may not be obvious to beginners that `INSERT` script will use the DEFAULT value, and the default behavior must be set for the column either in the decorator options or directly in migration script.