### PR TITLE
.synchronize() drops json column on mariadb

### DIFF
--- a/src/driver/mysql/MysqlDriver.ts
+++ b/src/driver/mysql/MysqlDriver.ts
@@ -537,6 +537,14 @@ export class MysqlDriver implements Driver {
         } else if (column.type === "uuid") {
             return "varchar";
 
+        } else if (column.type === "json" && this.options.type === "mariadb") {
+            /*
+             * MariaDB implements this as a LONGTEXT rather, as the JSON data type contradicts the SQL standard,
+             * and MariaDB's benchmarks indicate that performance is at least equivalent.
+             * @see https://mariadb.com/kb/en/json-data-type/
+             */
+            return "longtext";
+
         } else if (column.type === "simple-array" || column.type === "simple-json") {
             return "text";
 

--- a/src/driver/mysql/MysqlDriver.ts
+++ b/src/driver/mysql/MysqlDriver.ts
@@ -541,6 +541,7 @@ export class MysqlDriver implements Driver {
             /*
              * MariaDB implements this as a LONGTEXT rather, as the JSON data type contradicts the SQL standard,
              * and MariaDB's benchmarks indicate that performance is at least equivalent.
+             *
              * @see https://mariadb.com/kb/en/json-data-type/
              */
             return "longtext";

--- a/test/github-issues/3636/entity/Post.ts
+++ b/test/github-issues/3636/entity/Post.ts
@@ -10,7 +10,6 @@ export class Post {
 
     @Column({
         type: "json",
-        default: "{}"
     })
     data: any;
 

--- a/test/github-issues/3636/entity/Post.ts
+++ b/test/github-issues/3636/entity/Post.ts
@@ -1,0 +1,17 @@
+import {Column} from "../../../../src/decorator/columns/Column";
+import {PrimaryColumn} from "../../../../src/decorator/columns/PrimaryColumn";
+import {Entity} from "../../../../src/decorator/entity/Entity";
+
+@Entity()
+export class Post {
+
+    @PrimaryColumn()
+    id: number;
+
+    @Column({
+        type: "json",
+        default: "{}"
+    })
+    data: any;
+
+}

--- a/test/github-issues/3636/issue-3636.ts
+++ b/test/github-issues/3636/issue-3636.ts
@@ -1,0 +1,33 @@
+import "reflect-metadata";
+import {closeTestingConnections, createTestingConnections, reloadTestingDatabases} from "../../utils/test-utils";
+import {Connection} from "../../../src/connection/Connection";
+import {Post} from "./entity/Post";
+import {expect} from "chai";
+
+describe("github issues > #3636 synchronize drops (and then re-adds) json column in mariadb", () => {
+
+    let connections: Connection[];
+    before(async () => connections = await createTestingConnections({
+        entities: [__dirname + "/entity/*{.js,.ts}"],
+        subscribers: [__dirname + "/subscriber/*{.js,.ts}"],
+        enabledDrivers: ["mariadb"],
+    }));
+    beforeEach(() => reloadTestingDatabases(connections));
+    after(() => closeTestingConnections(connections));
+
+    it("should not drop json column", () => Promise.all(connections.map(async function(connection) {
+
+        const post = new Post();
+        post.id = 1;
+        post.data = {hello: "world"};
+        await connection.manager.save(post);
+
+        await connection.synchronize();
+
+        const loadedPost = await connection.manager.findOne(Post, 1);
+
+        expect(loadedPost).to.be.not.empty;
+        expect(loadedPost!.data.hello).to.be.eq("world");
+    })));
+
+});


### PR DESCRIPTION
Fixes #3636 

https://mariadb.com/kb/en/json-data-type/

The JSON column type is implemented using LONGTEXT in MariaDB, so every time a table with JOSN column gets synchronized will drop the column and add it again. 

This PR could fix the issue

