### PR TITLE
fix(base-entity): set create return type to T[]

### DIFF
--- a/src/repository/BaseEntity.ts
+++ b/src/repository/BaseEntity.ts
@@ -126,7 +126,7 @@ export class BaseEntity {
      * Creates a new entities and copies all entity properties from given objects into their new entities.
      * Note that it copies only properties that present in entity schema.
      */
-    static create<T extends BaseEntity>(this: ObjectType<T>, entityLikeArray: DeepPartial<T>[]): T;
+    static create<T extends BaseEntity>(this: ObjectType<T>, entityLikeArray: DeepPartial<T>[]): T[];
 
     /**
      * Creates a new entity instance and copies all entity properties from this object into a new entity.


### PR DESCRIPTION
**What's the problem this PR addresses?**

The version of `BaseEntity.create` that takes an array of `entityLike` objects returns an array of entities but the return type incorrectly specifies that it's a single entity.

**How did you fix it?**

Changed the return type from `T` to `T[]`