### PR TITLE
rename a sequence related to generated primary key when a table is renamed

### DIFF
--- a/src/driver/postgres/PostgresQueryRunner.ts
+++ b/src/driver/postgres/PostgresQueryRunner.ts
@@ -438,6 +438,20 @@ export class PostgresQueryRunner extends BaseQueryRunner implements QueryRunner 
             downQueries.push(new Query(`ALTER TABLE ${this.escapePath(newTable)} RENAME CONSTRAINT "${newPkName}" TO "${oldPkName}"`));
         }
 
+        // rename sequences
+        newTable.columns.map(col => {
+            if (col.isGenerated) {
+                const seqName = this.buildSequenceName(oldTable, col.name, undefined, true, true);
+                const newSeqName = this.buildSequenceName(newTable, col.name, undefined, true, true);
+
+                const up = schemaName ? `ALTER SEQUENCE "${schemaName}"."${seqName}" RENAME TO "${newSeqName}"` : `ALTER SEQUENCE "${seqName}" RENAME TO "${newSeqName}"`;
+                const down = schemaName ? `ALTER SEQUENCE "${schemaName}"."${newSeqName}" RENAME TO "${seqName}"` : `ALTER SEQUENCE "${newSeqName}" RENAME TO "${seqName}"`;
+
+                upQueries.push(new Query(up));
+                downQueries.push(new Query(down));
+            }
+        });
+
         // rename unique constraints
         newTable.uniques.forEach(unique => {
             // build new constraint name

--- a/src/driver/postgres/PostgresQueryRunner.ts
+++ b/src/driver/postgres/PostgresQueryRunner.ts
@@ -440,7 +440,7 @@ export class PostgresQueryRunner extends BaseQueryRunner implements QueryRunner 
 
         // rename sequences
         newTable.columns.map(col => {
-            if (col.isGenerated) {
+            if (col.isGenerated && col.generationStrategy === "increment") {
                 const seqName = this.buildSequenceName(oldTable, col.name, undefined, true, true);
                 const newSeqName = this.buildSequenceName(newTable, col.name, undefined, true, true);
 

--- a/test/functional/query-runner/rename-table.ts
+++ b/test/functional/query-runner/rename-table.ts
@@ -36,18 +36,18 @@ describe("query runner > rename table", () => {
         table = await queryRunner.getTable("question");
         table!.should.be.exist;
 
-        await queryRunner.renameTable("question", "user");
-        table = await queryRunner.getTable("user");
+        await queryRunner.renameTable("question", "answer");
+        table = await queryRunner.getTable("answer");
         table!.should.be.exist;
 
         if (connection.driver instanceof PostgresDriver) {
-            let result = await queryRunner.query(`SELECT COUNT(*) FROM "pg_class" "c" WHERE "c"."relkind" = 'S' and "c"."relname" = 'user_id_seq'`);
+            let result = await queryRunner.query(`SELECT COUNT(*) FROM "pg_class" "c" WHERE "c"."relkind" = 'S' and "c"."relname" = 'answer_id_seq'`);
             result[0].count.should.be.equal("1");
         }
 
         await queryRunner.executeMemoryDownSql();
 
-        table = await queryRunner.getTable("post");
+        table = await queryRunner.getTable("faculty");
         table!.should.be.exist;
 
         await queryRunner.release();

--- a/test/functional/query-runner/rename-table.ts
+++ b/test/functional/query-runner/rename-table.ts
@@ -8,8 +8,6 @@ import {Table} from "../../../src/schema-builder/table/Table";
 import {AbstractSqliteDriver} from "../../../src/driver/sqlite-abstract/AbstractSqliteDriver";
 import {PostgresDriver} from "../../../src/driver/postgres/PostgresDriver";
 import {MysqlDriver} from "../../../src/driver/mysql/MysqlDriver";
-// import { SequenceTask } from 'gulpclass';
-// import { PostgresQueryRunner } from '../../../src/driver/postgres/PostgresQueryRunner';
 
 describe("query runner > rename table", () => {
 
@@ -44,7 +42,7 @@ describe("query runner > rename table", () => {
 
         if (connection.driver instanceof PostgresDriver) {
             let result = await queryRunner.query(`SELECT COUNT(*) FROM "pg_class" "c" WHERE "c"."relkind" = 'S' and "c"."relname" = 'user_id_seq'`);
-            result[0].count.should.be.equal('1');
+            result[0].count.should.be.equal("1");
         }
 
         await queryRunner.executeMemoryDownSql();

--- a/test/functional/query-runner/rename-table.ts
+++ b/test/functional/query-runner/rename-table.ts
@@ -8,6 +8,8 @@ import {Table} from "../../../src/schema-builder/table/Table";
 import {AbstractSqliteDriver} from "../../../src/driver/sqlite-abstract/AbstractSqliteDriver";
 import {PostgresDriver} from "../../../src/driver/postgres/PostgresDriver";
 import {MysqlDriver} from "../../../src/driver/mysql/MysqlDriver";
+// import { SequenceTask } from 'gulpclass';
+// import { PostgresQueryRunner } from '../../../src/driver/postgres/PostgresQueryRunner';
 
 describe("query runner > rename table", () => {
 
@@ -30,7 +32,7 @@ describe("query runner > rename table", () => {
 
         const queryRunner = connection.createQueryRunner();
 
-        let table = await queryRunner.getTable("post");
+        let table = await queryRunner.getTable("faculty");
 
         await queryRunner.renameTable(table!, "question");
         table = await queryRunner.getTable("question");
@@ -39,6 +41,11 @@ describe("query runner > rename table", () => {
         await queryRunner.renameTable("question", "user");
         table = await queryRunner.getTable("user");
         table!.should.be.exist;
+
+        if (connection.driver instanceof PostgresDriver) {
+            let result = await queryRunner.query(`SELECT COUNT(*) FROM "pg_class" "c" WHERE "c"."relkind" = 'S' and "c"."relname" = 'user_id_seq'`);
+            result[0].count.should.be.equal('1');
+        }
 
         await queryRunner.executeMemoryDownSql();
 

--- a/test/functional/query-runner/rename-table.ts
+++ b/test/functional/query-runner/rename-table.ts
@@ -30,25 +30,50 @@ describe("query runner > rename table", () => {
 
         const queryRunner = connection.createQueryRunner();
 
+        // check if sequence "faculty_id_seq" exist
+        if (connection.driver instanceof PostgresDriver) {
+            const facultySeq = await queryRunner.query(`SELECT COUNT(*) FROM "pg_class" "c" WHERE "c"."relkind" = 'S' and "c"."relname" = 'faculty_id_seq'`);
+            facultySeq[0].count.should.be.equal("1");
+        }
+
         let table = await queryRunner.getTable("faculty");
 
         await queryRunner.renameTable(table!, "question");
         table = await queryRunner.getTable("question");
         table!.should.be.exist;
 
+        // check if sequence "faculty_id_seq" was renamed to "question_id_seq"
+        if (connection.driver instanceof PostgresDriver) {
+            const facultySeq = await queryRunner.query(`SELECT COUNT(*) FROM "pg_class" "c" WHERE "c"."relkind" = 'S' and "c"."relname" = 'faculty_id_seq'`);
+            const questionSeq = await queryRunner.query(`SELECT COUNT(*) FROM "pg_class" "c" WHERE "c"."relkind" = 'S' and "c"."relname" = 'question_id_seq'`);
+            facultySeq[0].count.should.be.equal("0");
+            questionSeq[0].count.should.be.equal("1");
+        }
+
         await queryRunner.renameTable("question", "answer");
         table = await queryRunner.getTable("answer");
         table!.should.be.exist;
 
+        // check if sequence "question_id_seq" was renamed to "answer_id_seq"
         if (connection.driver instanceof PostgresDriver) {
-            let result = await queryRunner.query(`SELECT COUNT(*) FROM "pg_class" "c" WHERE "c"."relkind" = 'S' and "c"."relname" = 'answer_id_seq'`);
-            result[0].count.should.be.equal("1");
+            const questionSeq = await queryRunner.query(`SELECT COUNT(*) FROM "pg_class" "c" WHERE "c"."relkind" = 'S' and "c"."relname" = 'question_id_seq'`);
+            const answerSeq = await queryRunner.query(`SELECT COUNT(*) FROM "pg_class" "c" WHERE "c"."relkind" = 'S' and "c"."relname" = 'answer_id_seq'`);
+            questionSeq[0].count.should.be.equal("0");
+            answerSeq[0].count.should.be.equal("1");
         }
 
         await queryRunner.executeMemoryDownSql();
 
         table = await queryRunner.getTable("faculty");
         table!.should.be.exist;
+
+        // check if sequence "answer_id_seq" was renamed to "faculty_id_seq"
+        if (connection.driver instanceof PostgresDriver) {
+            const answerSeq = await queryRunner.query(`SELECT COUNT(*) FROM "pg_class" "c" WHERE "c"."relkind" = 'S' and "c"."relname" = 'answer_id_seq'`);
+            const facultySeq = await queryRunner.query(`SELECT COUNT(*) FROM "pg_class" "c" WHERE "c"."relkind" = 'S' and "c"."relname" = 'faculty_id_seq'`);
+            answerSeq[0].count.should.be.equal("0");
+            facultySeq[0].count.should.be.equal("1");
+        }
 
         await queryRunner.release();
     })));


### PR DESCRIPTION
fixes #4937
