### PR TITLE
Add NotImplementedError for driver functions that do nothing

### DIFF
--- a/src/driver/aurora-data-api/AuroraDataApiQueryRunner.ts
+++ b/src/driver/aurora-data-api/AuroraDataApiQueryRunner.ts
@@ -2,6 +2,7 @@ import {QueryRunner} from "../../query-runner/QueryRunner";
 import {ObjectLiteral} from "../../common/ObjectLiteral";
 import {TransactionAlreadyStartedError} from "../../error/TransactionAlreadyStartedError";
 import {TransactionNotStartedError} from "../../error/TransactionNotStartedError";
+import {NotImplementedError} from "../../error/NotImplementedError";
 import {TableColumn} from "../../schema-builder/table/TableColumn";
 import {Table} from "../../schema-builder/table/Table";
 import {TableForeignKey} from "../../schema-builder/table/TableForeignKey";
@@ -155,7 +156,7 @@ export class AuroraDataApiQueryRunner extends BaseQueryRunner implements QueryRu
      * Returns all available database names including system databases.
      */
     async getDatabases(): Promise<string[]> {
-        return Promise.resolve([]);
+        throw new NotImplementedError();
     }
 
     /**

--- a/src/driver/cockroachdb/CockroachQueryRunner.ts
+++ b/src/driver/cockroachdb/CockroachQueryRunner.ts
@@ -2,6 +2,7 @@ import {QueryRunner} from "../../query-runner/QueryRunner";
 import {ObjectLiteral} from "../../common/ObjectLiteral";
 import {TransactionAlreadyStartedError} from "../../error/TransactionAlreadyStartedError";
 import {TransactionNotStartedError} from "../../error/TransactionNotStartedError";
+import {NotImplementedError} from "../../error/NotImplementedError";
 import {TableColumn} from "../../schema-builder/table/TableColumn";
 import {Table} from "../../schema-builder/table/Table";
 import {TableIndex} from "../../schema-builder/table/TableIndex";
@@ -251,7 +252,7 @@ export class CockroachQueryRunner extends BaseQueryRunner implements QueryRunner
      * Returns all available database names including system databases.
      */
     async getDatabases(): Promise<string[]> {
-        return Promise.resolve([]);
+        throw new NotImplementedError();
     }
 
     /**
@@ -259,7 +260,7 @@ export class CockroachQueryRunner extends BaseQueryRunner implements QueryRunner
      * If database parameter specified, returns schemas of that database.
      */
     async getSchemas(database?: string): Promise<string[]> {
-        return Promise.resolve([]);
+        throw new NotImplementedError();
     }
 
     /**

--- a/src/driver/mysql/MysqlQueryRunner.ts
+++ b/src/driver/mysql/MysqlQueryRunner.ts
@@ -2,6 +2,7 @@ import {QueryRunner} from "../../query-runner/QueryRunner";
 import {ObjectLiteral} from "../../common/ObjectLiteral";
 import {TransactionAlreadyStartedError} from "../../error/TransactionAlreadyStartedError";
 import {TransactionNotStartedError} from "../../error/TransactionNotStartedError";
+import {NotImplementedError} from "../../error/NotImplementedError";
 import {TableColumn} from "../../schema-builder/table/TableColumn";
 import {Table} from "../../schema-builder/table/Table";
 import {TableForeignKey} from "../../schema-builder/table/TableForeignKey";
@@ -202,7 +203,7 @@ export class MysqlQueryRunner extends BaseQueryRunner implements QueryRunner {
      * Returns all available database names including system databases.
      */
     async getDatabases(): Promise<string[]> {
-        return Promise.resolve([]);
+        throw new NotImplementedError();
     }
 
     /**

--- a/src/driver/oracle/OracleQueryRunner.ts
+++ b/src/driver/oracle/OracleQueryRunner.ts
@@ -2,6 +2,7 @@ import {QueryRunner} from "../../query-runner/QueryRunner";
 import {ObjectLiteral} from "../../common/ObjectLiteral";
 import {TransactionAlreadyStartedError} from "../../error/TransactionAlreadyStartedError";
 import {TransactionNotStartedError} from "../../error/TransactionNotStartedError";
+import {NotImplementedError} from "../../error/NotImplementedError";
 import {TableColumn} from "../../schema-builder/table/TableColumn";
 import {Table} from "../../schema-builder/table/Table";
 import {TableForeignKey} from "../../schema-builder/table/TableForeignKey";
@@ -201,7 +202,7 @@ export class OracleQueryRunner extends BaseQueryRunner implements QueryRunner {
      * Returns all available database names including system databases.
      */
     async getDatabases(): Promise<string[]> {
-        return Promise.resolve([]);
+        throw new NotImplementedError();
     }
 
     /**
@@ -209,21 +210,21 @@ export class OracleQueryRunner extends BaseQueryRunner implements QueryRunner {
      * If database parameter specified, returns schemas of that database.
      */
     async getSchemas(database?: string): Promise<string[]> {
-        return Promise.resolve([]);
+        throw new NotImplementedError();
     }
 
     /**
      * Checks if database with the given name exist.
      */
     async hasDatabase(database: string): Promise<boolean> {
-        return Promise.resolve(false);
+        throw new NotImplementedError();
     }
 
     /**
      * Checks if schema with the given name exist.
      */
     async hasSchema(schema: string): Promise<boolean> {
-        return Promise.resolve(false);
+        throw new NotImplementedError();
     }
 
     /**
@@ -257,7 +258,7 @@ export class OracleQueryRunner extends BaseQueryRunner implements QueryRunner {
      * Drops database.
      */
     async dropDatabase(database: string, ifExist?: boolean): Promise<void> {
-        return Promise.resolve();
+        throw new NotImplementedError();
     }
 
     /**

--- a/src/driver/postgres/PostgresQueryRunner.ts
+++ b/src/driver/postgres/PostgresQueryRunner.ts
@@ -4,6 +4,7 @@ import {QueryFailedError} from "../../error/QueryFailedError";
 import {QueryRunnerAlreadyReleasedError} from "../../error/QueryRunnerAlreadyReleasedError";
 import {TransactionAlreadyStartedError} from "../../error/TransactionAlreadyStartedError";
 import {TransactionNotStartedError} from "../../error/TransactionNotStartedError";
+import {NotImplementedError} from "../../error/NotImplementedError";
 import {ColumnType} from "../../index";
 import {ReadStream} from "../../platform/PlatformTools";
 import {BaseQueryRunner} from "../../query-runner/BaseQueryRunner";
@@ -222,7 +223,7 @@ export class PostgresQueryRunner extends BaseQueryRunner implements QueryRunner 
      * Returns all available database names including system databases.
      */
     async getDatabases(): Promise<string[]> {
-        return Promise.resolve([]);
+        throw new NotImplementedError();
     }
 
     /**
@@ -230,14 +231,14 @@ export class PostgresQueryRunner extends BaseQueryRunner implements QueryRunner 
      * If database parameter specified, returns schemas of that database.
      */
     async getSchemas(database?: string): Promise<string[]> {
-        return Promise.resolve([]);
+        throw new NotImplementedError();
     }
 
     /**
      * Checks if database with the given name exist.
      */
     async hasDatabase(database: string): Promise<boolean> {
-        return Promise.resolve(false);
+        throw new NotImplementedError();
     }
 
     /**
@@ -273,7 +274,7 @@ export class PostgresQueryRunner extends BaseQueryRunner implements QueryRunner 
      * Postgres does not supports database creation inside a transaction block.
      */
     async createDatabase(database: string, ifNotExist?: boolean): Promise<void> {
-        await Promise.resolve();
+        throw new NotImplementedError();
     }
 
     /**
@@ -281,7 +282,7 @@ export class PostgresQueryRunner extends BaseQueryRunner implements QueryRunner 
      * Postgres does not supports database drop inside a transaction block.
      */
     async dropDatabase(database: string, ifExist?: boolean): Promise<void> {
-        return Promise.resolve();
+        throw new NotImplementedError();
     }
 
     /**

--- a/src/driver/sqlite-abstract/AbstractSqliteQueryRunner.ts
+++ b/src/driver/sqlite-abstract/AbstractSqliteQueryRunner.ts
@@ -2,6 +2,7 @@ import {QueryRunner} from "../../query-runner/QueryRunner";
 import {ObjectLiteral} from "../../common/ObjectLiteral";
 import {TransactionAlreadyStartedError} from "../../error/TransactionAlreadyStartedError";
 import {TransactionNotStartedError} from "../../error/TransactionNotStartedError";
+import {NotImplementedError} from "../../error/NotImplementedError";
 import {TableColumn} from "../../schema-builder/table/TableColumn";
 import {ColumnMetadata} from "../../metadata/ColumnMetadata";
 import {Table} from "../../schema-builder/table/Table";
@@ -138,7 +139,7 @@ export abstract class AbstractSqliteQueryRunner extends BaseQueryRunner implemen
      * Returns all available database names including system databases.
      */
     async getDatabases(): Promise<string[]> {
-        return Promise.resolve([]);
+        throw new NotImplementedError();
     }
 
     /**
@@ -146,14 +147,14 @@ export abstract class AbstractSqliteQueryRunner extends BaseQueryRunner implemen
      * If database parameter specified, returns schemas of that database.
      */
     async getSchemas(database?: string): Promise<string[]> {
-        return Promise.resolve([]);
+        throw new NotImplementedError();
     }
 
     /**
      * Checks if database with the given name exist.
      */
     async hasDatabase(database: string): Promise<boolean> {
-        return Promise.resolve(false);
+        throw new NotImplementedError();
     }
 
     /**

--- a/src/driver/sqlserver/SqlServerQueryRunner.ts
+++ b/src/driver/sqlserver/SqlServerQueryRunner.ts
@@ -3,6 +3,7 @@ import {QueryFailedError} from "../../error/QueryFailedError";
 import {QueryRunnerAlreadyReleasedError} from "../../error/QueryRunnerAlreadyReleasedError";
 import {TransactionAlreadyStartedError} from "../../error/TransactionAlreadyStartedError";
 import {TransactionNotStartedError} from "../../error/TransactionNotStartedError";
+import {NotImplementedError} from "../../error/NotImplementedError";
 import {ColumnType, PromiseUtils} from "../../index";
 import {ReadStream} from "../../platform/PlatformTools";
 import {BaseQueryRunner} from "../../query-runner/BaseQueryRunner";
@@ -71,7 +72,7 @@ export class SqlServerQueryRunner extends BaseQueryRunner implements QueryRunner
      * Returns obtained database connection.
      */
     connect(): Promise<void> {
-        return Promise.resolve();
+        throw new NotImplementedError();
     }
 
     /**

--- a/src/error/NotImplementedError.ts
+++ b/src/error/NotImplementedError.ts
@@ -1,0 +1,12 @@
+/**
+ * Thrown when the interface is not implemented for the given adapter.
+ */
+export class NotImplementedError extends Error {
+    name = "NotImplementedError";
+
+    constructor() {
+        super();
+        Object.setPrototypeOf(this, NotImplementedError.prototype);
+        this.message = "Function not implemented.";
+    }
+}

--- a/test/functional/schema-builder/custom-db-and-schema-sync.ts
+++ b/test/functional/schema-builder/custom-db-and-schema-sync.ts
@@ -97,7 +97,9 @@ describe("schema builder > custom-db-and-schema-sync", () => {
         await queryRunner.dropTable(albumMetadata.tablePath, true, false);
 
         // drop created database
-        await queryRunner.dropDatabase("secondDB", true);
+        if (!(connection.driver instanceof PostgresDriver)) {
+            await queryRunner.dropDatabase("secondDB", true);
+        }
 
         await queryRunner.release();
 


### PR DESCRIPTION
This is very minor, but recently bitten by this. I don't see any reason why unimplemented functions should return silently doing nothing.