### PR TITLE
perf: Optimized version of EntityMetadata#compareIds() for the common case

### DIFF
--- a/src/metadata/EntityMetadata.ts
+++ b/src/metadata/EntityMetadata.ts
@@ -746,6 +746,16 @@ export class EntityMetadata {
         if (firstId === undefined || firstId === null || secondId === undefined || secondId === null)
             return false;
 
+        // Optimized version for the common case
+        if (
+          typeof firstId.id === "string" &&
+          typeof secondId.id === "string" &&
+          Object.keys(firstId).length === 1 &&
+          Object.keys(secondId).length === 1
+        ) {
+            return firstId.id === secondId.id;
+        }
+
         return OrmUtils.deepCompare(firstId, secondId);
     }
 

--- a/src/metadata/EntityMetadata.ts
+++ b/src/metadata/EntityMetadata.ts
@@ -613,7 +613,7 @@ export class EntityMetadata {
         const secondEntityIdMap = this.getEntityIdMap(secondEntity);
         if (!secondEntityIdMap) return false;
 
-        return EntityMetadata.compareIds(firstEntityIdMap, secondEntityIdMap);
+        return OrmUtils.compareIds(firstEntityIdMap, secondEntityIdMap);
     }
 
     /**
@@ -734,29 +734,8 @@ export class EntityMetadata {
      */
     static difference(firstIdMaps: ObjectLiteral[], secondIdMaps: ObjectLiteral[]): ObjectLiteral[] {
         return firstIdMaps.filter(firstIdMap => {
-            return !secondIdMaps.find(secondIdMap => OrmUtils.deepCompare(firstIdMap, secondIdMap));
+            return !secondIdMaps.find(secondIdMap => OrmUtils.compareIds(firstIdMap, secondIdMap));
         });
-    }
-
-    /**
-     * Compares ids of the two entities.
-     * Returns true if they match, false otherwise.
-     */
-    static compareIds(firstId: ObjectLiteral|undefined, secondId: ObjectLiteral|undefined): boolean {
-        if (firstId === undefined || firstId === null || secondId === undefined || secondId === null)
-            return false;
-
-        // Optimized version for the common case
-        if (
-          typeof firstId.id === "string" &&
-          typeof secondId.id === "string" &&
-          Object.keys(firstId).length === 1 &&
-          Object.keys(secondId).length === 1
-        ) {
-            return firstId.id === secondId.id;
-        }
-
-        return OrmUtils.deepCompare(firstId, secondId);
     }
 
     /**

--- a/src/persistence/SubjectChangedColumnsComputer.ts
+++ b/src/persistence/SubjectChangedColumnsComputer.ts
@@ -1,7 +1,6 @@
 import {Subject} from "./Subject";
 import {DateUtils} from "../util/DateUtils";
 import {ObjectLiteral} from "../common/ObjectLiteral";
-import {EntityMetadata} from "../metadata/EntityMetadata";
 import {OrmUtils} from "../util/OrmUtils";
 
 /**
@@ -167,7 +166,7 @@ export class SubjectChangedColumnsComputer {
                 const databaseRelatedEntityRelationIdMap = relation.getEntityValue(subject.databaseEntity);
 
                 // if relation ids are equal then we don't need to update anything
-                const areRelatedIdsEqual = EntityMetadata.compareIds(relatedEntityRelationIdMap, databaseRelatedEntityRelationIdMap);
+                const areRelatedIdsEqual = OrmUtils.compareIds(relatedEntityRelationIdMap, databaseRelatedEntityRelationIdMap);
                 if (areRelatedIdsEqual) {
                     return;
                 } else {

--- a/src/persistence/subject-builder/ManyToManySubjectBuilder.ts
+++ b/src/persistence/subject-builder/ManyToManySubjectBuilder.ts
@@ -2,7 +2,6 @@ import {Subject} from "../Subject";
 import {OrmUtils} from "../../util/OrmUtils";
 import {ObjectLiteral} from "../../common/ObjectLiteral";
 import {RelationMetadata} from "../../metadata/RelationMetadata";
-import {EntityMetadata} from "../../metadata/EntityMetadata";
 
 /**
  * Builds operations needs to be executed for many-to-many relations of the given subjects.
@@ -150,7 +149,7 @@ export class ManyToManySubjectBuilder {
             // try to find related entity in the database
             // by example: find post's category in the database post's categories
             const relatedEntityExistInDatabase = databaseRelatedEntityIds.find(databaseRelatedEntityRelationId => {
-                return EntityMetadata.compareIds(databaseRelatedEntityRelationId, relatedEntityRelationIdMap);
+                return OrmUtils.compareIds(databaseRelatedEntityRelationId, relatedEntityRelationIdMap);
             });
 
             // if entity is found then don't do anything - it means binding in junction table already exist, we don't need to add anything
@@ -207,7 +206,7 @@ export class ManyToManySubjectBuilder {
         // now from all entities in the persisted entity find only those which aren't found in the db
         const removedJunctionEntityIds = databaseRelatedEntityIds.filter(existRelationId => {
             return !changedInverseEntityRelationIds.find(changedRelationId => {
-                return EntityMetadata.compareIds(changedRelationId, existRelationId);
+                return OrmUtils.compareIds(changedRelationId, existRelationId);
             });
         });
 

--- a/src/persistence/subject-builder/OneToManySubjectBuilder.ts
+++ b/src/persistence/subject-builder/OneToManySubjectBuilder.ts
@@ -117,7 +117,7 @@ export class OneToManySubjectBuilder {
             // check if this binding really exist in the database
             // by example: find our category if its already bind in the database
             const relationIdInDatabaseSubjectRelation = relatedEntityDatabaseRelationIds.find(relatedDatabaseEntityRelationId => {
-                return OrmUtils.deepCompare(relationIdMap, relatedDatabaseEntityRelationId);
+                return OrmUtils.compareIds(relationIdMap, relatedDatabaseEntityRelationId);
             });
 
             // if relationIdMap DOES NOT exist in the subject's relation in the database it means its a new relation and we need to "bind" them

--- a/src/persistence/subject-builder/OneToOneInverseSideSubjectBuilder.ts
+++ b/src/persistence/subject-builder/OneToOneInverseSideSubjectBuilder.ts
@@ -139,7 +139,7 @@ export class OneToOneInverseSideSubjectBuilder {
 
         // check if this binding really exist in the database
         // by example: find our post if its already bind to category in the database and its not equal to what user tries to set
-        const areRelatedIdEqualWithDatabase = relatedEntityDatabaseRelationId && OrmUtils.deepCompare(relationIdMap, relatedEntityDatabaseRelationId);
+        const areRelatedIdEqualWithDatabase = relatedEntityDatabaseRelationId && OrmUtils.compareIds(relationIdMap, relatedEntityDatabaseRelationId);
 
         // if they aren't equal it means its a new relation and we need to "bind" them
         // by example: this will tell category to insert into its post relation our post we are working with

--- a/src/query-builder/transformer/RawSqlResultsToEntityTransformer.ts
+++ b/src/query-builder/transformer/RawSqlResultsToEntityTransformer.ts
@@ -214,7 +214,7 @@ export class RawSqlResultsToEntityTransformer {
 
             const idMaps = rawRelationIdResult.results.map(result => {
                 const entityPrimaryIds = this.extractEntityPrimaryIds(relation, result);
-                if (EntityMetadata.compareIds(entityPrimaryIds, valueMap) === false)
+                if (OrmUtils.compareIds(entityPrimaryIds, valueMap) === false)
                     return;
 
                 let columns: ColumnMetadata[];

--- a/src/util/OrmUtils.ts
+++ b/src/util/OrmUtils.ts
@@ -122,6 +122,26 @@ export class OrmUtils {
     }
 
     /**
+     * Check if two entity-id-maps are the same
+     */
+    static compareIds(firstId: ObjectLiteral|undefined, secondId: ObjectLiteral|undefined) {
+        if (firstId === undefined || firstId === null || secondId === undefined || secondId === null)
+            return false;
+
+        // Optimized version for the common case
+        if (
+            typeof firstId.id === "string" &&
+            typeof secondId.id === "string" &&
+            Object.keys(firstId).length === 1 &&
+            Object.keys(secondId).length === 1
+        ) {
+            return firstId.id === secondId.id;
+        }
+
+        return OrmUtils.deepCompare(firstId, secondId);
+    }
+
+    /**
      * Transforms given value into boolean value.
      */
     static toBoolean(value: any): boolean {

--- a/src/util/OrmUtils.ts
+++ b/src/util/OrmUtils.ts
@@ -130,8 +130,8 @@ export class OrmUtils {
 
         // Optimized version for the common case
         if (
-            typeof firstId.id === "string" &&
-            typeof secondId.id === "string" &&
+            (typeof firstId.id === "string" || typeof firstId.id === "number") &&
+            (typeof secondId.id === "string" || typeof secondId.id === "number") &&
             Object.keys(firstId).length === 1 &&
             Object.keys(secondId).length === 1
         ) {

--- a/src/util/OrmUtils.ts
+++ b/src/util/OrmUtils.ts
@@ -100,7 +100,7 @@ export class OrmUtils {
      *
      * @see http://stackoverflow.com/a/1144249
      */
-    static deepCompare(...args: any[]) {
+    static deepCompare(...args: any[]): boolean {
         let i: any, l: any, leftChain: any, rightChain: any;
 
         if (arguments.length < 1) {
@@ -124,7 +124,7 @@ export class OrmUtils {
     /**
      * Check if two entity-id-maps are the same
      */
-    static compareIds(firstId: ObjectLiteral|undefined, secondId: ObjectLiteral|undefined) {
+    static compareIds(firstId: ObjectLiteral|undefined, secondId: ObjectLiteral|undefined): boolean {
         if (firstId === undefined || firstId === null || secondId === undefined || secondId === null)
             return false;
 

--- a/src/util/OrmUtils.ts
+++ b/src/util/OrmUtils.ts
@@ -130,8 +130,8 @@ export class OrmUtils {
 
         // Optimized version for the common case
         if (
-            (typeof firstId.id === "string" || typeof firstId.id === "number") &&
-            (typeof secondId.id === "string" || typeof secondId.id === "number") &&
+            ((typeof firstId.id === "string" && typeof secondId.id === "string") ||
+            (typeof firstId.id === "number" && typeof secondId.id === "number")) &&
             Object.keys(firstId).length === 1 &&
             Object.keys(secondId).length === 1
         ) {


### PR DESCRIPTION
We've found a TypeORM-based application spending most CPU time in `OrmUtils.deepCompare()`, called from `compareIds()`.

This PR implements a faster code path for the common case when the ID object has the type `{id: string}`. Our application's overall response time has improved from 1.2s to 0.4s!


Before:  
![image](https://user-images.githubusercontent.com/360800/73140065-0fe15b80-4075-11ea-8157-99529713a5fa.png)

After:  
![image](https://user-images.githubusercontent.com/360800/73140071-1e2f7780-4075-11ea-9d45-0428deb3240e.png)

wdyt?

cc @fresswolf