### PR TITLE
docs: fix incorrect "chunk" description

### DIFF
--- a/src/repository/SaveOptions.ts
+++ b/src/repository/SaveOptions.ts
@@ -22,7 +22,7 @@ export interface SaveOptions {
     transaction?: boolean;
 
     /**
-     * Breaks save execution into given number of chunks.
+     * Breaks save execution into chunks of a given size.
      * For example, if you want to save 100,000 objects but you have issues with saving them,
      * you can break them into 10 groups of 10,000 objects (by setting { chunk: 10000 }) and save each group separately.
      * This option is needed to perform very big insertions when you have issues with underlying driver parameter number limitation.


### PR DESCRIPTION
The number to pass into "chunk" is *not* the number of chunks you desire, it is the desired size of each chunk.

I lost a fair bit of time to this, because I only read the first line of the comment, and didn't realize it conflicted with the example presented later in the comment.