### PR TITLE
fix: entity object undefined in update subscriber

### DIFF
--- a/src/query-builder/UpdateQueryBuilder.ts
+++ b/src/query-builder/UpdateQueryBuilder.ts
@@ -70,7 +70,7 @@ export class UpdateQueryBuilder<Entity> extends QueryBuilder<Entity> implements 
             // call before updation methods in listeners and subscribers
             if (this.expressionMap.callListeners === true && this.expressionMap.mainAlias!.hasMetadata) {
                 const broadcastResult = new BroadcasterResult();
-                queryRunner.broadcaster.broadcastBeforeUpdateEvent(broadcastResult, this.expressionMap.mainAlias!.metadata);
+                queryRunner.broadcaster.broadcastBeforeUpdateEvent(broadcastResult, this.expressionMap.mainAlias!.metadata, this.expressionMap.valuesSet);
                 if (broadcastResult.promises.length > 0) await Promise.all(broadcastResult.promises);
             }
 

--- a/test/github-issues/4947/entity/Post.ts
+++ b/test/github-issues/4947/entity/Post.ts
@@ -1,7 +1,6 @@
 import {Entity} from "../../../../src/decorator/entity/Entity";
 import {PrimaryGeneratedColumn} from "../../../../src/decorator/columns/PrimaryGeneratedColumn";
 import {Column} from "../../../../src/decorator/columns/Column";
-import {UpdateDateColumn} from "../../../../src/decorator/columns/UpdateDateColumn";
 
 @Entity()
 export class Post {
@@ -12,9 +11,6 @@ export class Post {
     @Column({ nullable: true })
     title?: string;
 
-    @UpdateDateColumn()
-    updateDate: Date;
-
     @Column()
-    dateModified: Date;
+    colToUpdate: number = 0;
 }

--- a/test/github-issues/4947/entity/Post.ts
+++ b/test/github-issues/4947/entity/Post.ts
@@ -1,0 +1,20 @@
+import {Entity} from "../../../../src/decorator/entity/Entity";
+import {PrimaryGeneratedColumn} from "../../../../src/decorator/columns/PrimaryGeneratedColumn";
+import {Column} from "../../../../src/decorator/columns/Column";
+import {UpdateDateColumn} from "../../../../src/decorator/columns/UpdateDateColumn";
+
+@Entity()
+export class Post {
+
+    @PrimaryGeneratedColumn()
+    id: number;
+
+    @Column({ nullable: true })
+    title?: string;
+
+    @UpdateDateColumn()
+    updateDate: Date;
+
+    @Column()
+    dateModified: Date;
+}

--- a/test/github-issues/4947/issue-4947.ts
+++ b/test/github-issues/4947/issue-4947.ts
@@ -4,7 +4,7 @@ import {closeTestingConnections, createTestingConnections, reloadTestingDatabase
 import {Connection} from "../../../src/connection/Connection";
 import {Post} from "./entity/Post";
 
-describe.only("github issues > #4947 beforeUpdate subscriber entity argument is undefined", () => {
+describe("github issues > #4947 beforeUpdate subscriber entity argument is undefined", () => {
     let connections: Connection[];
     before(async () => connections = await createTestingConnections({
         entities: [__dirname + "/entity/*{.js,.ts}"],
@@ -26,9 +26,7 @@ describe.only("github issues > #4947 beforeUpdate subscriber entity argument is 
         expect(createdPost!.title).to.equal("set in subscriber when created");
 
         // change the entity
-        createdPost!.colToUpdate = 1;
-
-        await repo.update(createdPost!.id, createdPost!);
+        await repo.update(createdPost!.id, {colToUpdate: 1});
 
         const updatedPost = await repo.findOne();
 

--- a/test/github-issues/4947/issue-4947.ts
+++ b/test/github-issues/4947/issue-4947.ts
@@ -1,0 +1,39 @@
+import "reflect-metadata";
+import {expect} from "chai";
+import {closeTestingConnections, createTestingConnections, reloadTestingDatabases} from "../../utils/test-utils";
+import {Connection} from "../../../src/connection/Connection";
+import {Post} from "./entity/Post";
+
+describe("github issues > #4947 beforeUpdate subscriber entity argument is undefined", () => {
+    let connections: Connection[];
+    before(async () => connections = await createTestingConnections({
+        entities: [__dirname + "/entity/*{.js,.ts}"],
+        subscribers: [__dirname + "/subscriber/*{.js,.ts}"]
+    }));
+    beforeEach(() => reloadTestingDatabases(connections));
+    after(() => closeTestingConnections(connections));
+
+    it("if entity has been updated via repository update(), subscriber should get passed entity to change", () => Promise.all(connections.map(async function (connection) {
+
+        let repo = connection.getRepository(Post);
+
+        await repo.save(new Post());
+
+        const createdPost = await repo.findOne();
+
+        // test that the newly inserted post was touched by beforeInsert PostSubscriber event
+        expect(createdPost).not.to.be.undefined;
+        expect(createdPost!.title).to.equal("set in subscriber when created");
+
+        // change the entity
+        createdPost!.dateModified = new Date();
+
+        await repo.update(createdPost!.id, createdPost!);
+
+        const updatedPost = await repo.findOne();
+
+        // test that the updated post was touched by beforeUpdate PostSubscriber event
+        expect(updatedPost).not.to.be.undefined;
+        expect(updatedPost!.title).to.equal("set in subscriber when updated");
+    })));
+});

--- a/test/github-issues/4947/issue-4947.ts
+++ b/test/github-issues/4947/issue-4947.ts
@@ -4,7 +4,7 @@ import {closeTestingConnections, createTestingConnections, reloadTestingDatabase
 import {Connection} from "../../../src/connection/Connection";
 import {Post} from "./entity/Post";
 
-describe("github issues > #4947 beforeUpdate subscriber entity argument is undefined", () => {
+describe.only("github issues > #4947 beforeUpdate subscriber entity argument is undefined", () => {
     let connections: Connection[];
     before(async () => connections = await createTestingConnections({
         entities: [__dirname + "/entity/*{.js,.ts}"],
@@ -26,7 +26,7 @@ describe("github issues > #4947 beforeUpdate subscriber entity argument is undef
         expect(createdPost!.title).to.equal("set in subscriber when created");
 
         // change the entity
-        createdPost!.dateModified = new Date();
+        createdPost!.colToUpdate = 1;
 
         await repo.update(createdPost!.id, createdPost!);
 

--- a/test/github-issues/4947/subscriber/PostSubscriber.ts
+++ b/test/github-issues/4947/subscriber/PostSubscriber.ts
@@ -1,0 +1,23 @@
+import {Post} from "../entity/Post";
+import {EntitySubscriberInterface, EventSubscriber, UpdateEvent, InsertEvent} from "../../../../src";
+
+@EventSubscriber()
+export class PostSubscriber implements EntitySubscriberInterface<Post> {
+    listenTo() {
+        return Post;
+    }
+
+    beforeUpdate(event: UpdateEvent<Post>) {
+        if (event.entity) {
+            event.entity.dateModified = new Date();
+            event.entity.title = "set in subscriber when updated";
+        }
+    }
+
+    beforeInsert(event: InsertEvent<Post>) {
+        if (event.entity) {
+            event.entity.dateModified = new Date();
+            event.entity.title = "set in subscriber when created";
+        }
+    }
+}

--- a/test/github-issues/4947/subscriber/PostSubscriber.ts
+++ b/test/github-issues/4947/subscriber/PostSubscriber.ts
@@ -9,13 +9,13 @@ export class PostSubscriber implements EntitySubscriberInterface<Post> {
 
     beforeUpdate(event: UpdateEvent<Post>) {
         if (event.entity) {
-            event.entity.title = "set in subscriber when updated";
+            event.entity["title"] = "set in subscriber when updated";
         }
     }
 
     beforeInsert(event: InsertEvent<Post>) {
         if (event.entity) {
-            event.entity.title = "set in subscriber when created";
+            event.entity["title"]  = "set in subscriber when created";
         }
     }
 }

--- a/test/github-issues/4947/subscriber/PostSubscriber.ts
+++ b/test/github-issues/4947/subscriber/PostSubscriber.ts
@@ -9,14 +9,12 @@ export class PostSubscriber implements EntitySubscriberInterface<Post> {
 
     beforeUpdate(event: UpdateEvent<Post>) {
         if (event.entity) {
-            event.entity.dateModified = new Date();
             event.entity.title = "set in subscriber when updated";
         }
     }
 
     beforeInsert(event: InsertEvent<Post>) {
         if (event.entity) {
-            event.entity.dateModified = new Date();
             event.entity.title = "set in subscriber when created";
         }
     }


### PR DESCRIPTION
When defining a `beforeUpdate` implementation in a subscriber the entity object is undefined on the passed in `event.entity` property when calling `update` on a repository and passing a updated entity object.

Closes: #4947