### PR TITLE
docs: Remove "cascade remove" option from relations.md

### DIFF
--- a/docs/relations.md
+++ b/docs/relations.md
@@ -21,7 +21,7 @@ There are several types of relations:
 There are several options you can specify for relations:
 
 * `eager: boolean` - If set to true, the relation will always be loaded with the main entity when using `find*` methods or `QueryBuilder` on this entity
-* `cascade: boolean | ("insert" | "update" | "remove")[]` - If set to true, the related object will be inserted and updated in the database. You can also specify an array of [cascade options](#cascade-options).
+* `cascade: boolean | ("insert" | "update")[]` - If set to true, the related object will be inserted and updated in the database. You can also specify an array of [cascade options](#cascade-options).
 * `onDelete: "RESTRICT"|"CASCADE"|"SET NULL"` - specifies how foreign key should behave when referenced object is deleted
 * `primary: boolean` - Indicates whether this relation's column will be a primary column or not.
 * `nullable: boolean` - Indicates whether this relation's column is nullable or not. By default it is nullable.
@@ -96,7 +96,7 @@ Also, they provide a less explicit way of saving new objects into the database.
 
 ### Cascade Options
 
-The `cascade` option can be set as a `boolean` or an array of cascade options `("insert", "update", "remove")[]`.
+The `cascade` option can be set as a `boolean` or an array of cascade options `("insert", "update")[]`.
 
 It will default to `false`, meaning no cascades. Setting `cascade: true` will enable full cascades. You can also specify options by providing an array.
 


### PR DESCRIPTION
The relations.md still has "cascade remove" option.
But as far as I know, "cascade remove" option has been removed from version [0.2.0](https://github.com/typeorm/typeorm/blob/master/CHANGELOG.md#020).
So I remove this option because this could lead to confusion.