### PR TITLE
update foreign keys when table name changes

### DIFF
--- a/src/schema-builder/RdbmsSchemaBuilder.ts
+++ b/src/schema-builder/RdbmsSchemaBuilder.ts
@@ -23,7 +23,7 @@ import {TableCheck} from "./table/TableCheck";
 import {TableExclusion} from "./table/TableExclusion";
 import {View} from "./view/View";
 import {AuroraDataApiDriver} from "../driver/aurora-data-api/AuroraDataApiDriver";
-import { ForeignKeyMetadata } from '../metadata/ForeignKeyMetadata';
+import { ForeignKeyMetadata } from "../metadata/ForeignKeyMetadata";
 
 /**
  * Creates complete tables schemas in the database based on the entity metadatas.

--- a/src/schema-builder/RdbmsSchemaBuilder.ts
+++ b/src/schema-builder/RdbmsSchemaBuilder.ts
@@ -23,6 +23,7 @@ import {TableCheck} from "./table/TableCheck";
 import {TableExclusion} from "./table/TableExclusion";
 import {View} from "./view/View";
 import {AuroraDataApiDriver} from "../driver/aurora-data-api/AuroraDataApiDriver";
+import { ForeignKeyMetadata } from '../metadata/ForeignKeyMetadata';
 
 /**
  * Creates complete tables schemas in the database based on the entity metadatas.
@@ -186,7 +187,7 @@ export class RdbmsSchemaBuilder implements SchemaBuilder {
 
             // find foreign keys that exist in the schemas but does not exist in the entity metadata
             const tableForeignKeysToDrop = table.foreignKeys.filter(tableForeignKey => {
-                const metadataFK = metadata.foreignKeys.find(metadataForeignKey => metadataForeignKey.name === tableForeignKey.name);
+                const metadataFK = metadata.foreignKeys.find(metadataForeignKey => foreignKeysMatch(tableForeignKey, metadataForeignKey));
                 return !metadataFK
                     || (metadataFK.onDelete && metadataFK.onDelete !== tableForeignKey.onDelete)
                     || (metadataFK.onUpdate && metadataFK.onUpdate !== tableForeignKey.onUpdate);
@@ -647,7 +648,7 @@ export class RdbmsSchemaBuilder implements SchemaBuilder {
                 return;
 
             const newKeys = metadata.foreignKeys.filter(foreignKey => {
-                return !table.foreignKeys.find(dbForeignKey => dbForeignKey.name === foreignKey.name);
+                return !table.foreignKeys.find(dbForeignKey => foreignKeysMatch(dbForeignKey, foreignKey));
             });
             if (newKeys.length === 0)
                 return;
@@ -781,4 +782,11 @@ export class RdbmsSchemaBuilder implements SchemaBuilder {
         ), true);
     }
 
+}
+
+function foreignKeysMatch(
+    tableForeignKey: TableForeignKey, metadataForeignKey: ForeignKeyMetadata
+): boolean {
+    return (tableForeignKey.name === metadataForeignKey.name)
+        && (tableForeignKey.referencedTableName === metadataForeignKey.referencedTablePath);
 }

--- a/test/github-issues/5119/entity/v1/Post.ts
+++ b/test/github-issues/5119/entity/v1/Post.ts
@@ -1,0 +1,22 @@
+import {
+    Column,
+    Entity,
+    ManyToOne,
+    PrimaryGeneratedColumn
+} from "../../../../../src/index";
+import { User } from "./User";
+
+@Entity()
+export class Post {
+    @PrimaryGeneratedColumn()
+    id: number;
+
+    @Column()
+    title: string;
+
+    @Column()
+    text: string;
+
+    @ManyToOne(type => User)
+    owner: User;
+}

--- a/test/github-issues/5119/entity/v1/User.ts
+++ b/test/github-issues/5119/entity/v1/User.ts
@@ -1,0 +1,14 @@
+import {
+    Column,
+    Entity,
+    PrimaryGeneratedColumn
+} from "../../../../../src/index";
+
+@Entity()
+export class User {
+    @PrimaryGeneratedColumn()
+    id: number;
+
+    @Column()
+    name: string;
+}

--- a/test/github-issues/5119/entity/v2/Account.ts
+++ b/test/github-issues/5119/entity/v2/Account.ts
@@ -1,0 +1,15 @@
+import {
+    Entity,
+    PrimaryGeneratedColumn,
+    ManyToOne
+} from "../../../../../src/index";
+import { User } from "./User";
+
+@Entity()
+export class Account {
+    @PrimaryGeneratedColumn()
+    id: number;
+
+    @ManyToOne(type => User)
+    user: User;
+}

--- a/test/github-issues/5119/entity/v2/Post.ts
+++ b/test/github-issues/5119/entity/v2/Post.ts
@@ -1,0 +1,22 @@
+import {
+    Column,
+    Entity,
+    ManyToOne,
+    PrimaryGeneratedColumn
+} from "../../../../../src/index";
+import { Account } from "./Account";
+
+@Entity()
+export class Post {
+    @PrimaryGeneratedColumn()
+    id: number;
+
+    @Column()
+    title: string;
+
+    @Column()
+    text: string;
+
+    @ManyToOne(type => Account)
+    owner: Account;
+}

--- a/test/github-issues/5119/entity/v2/User.ts
+++ b/test/github-issues/5119/entity/v2/User.ts
@@ -1,0 +1,14 @@
+import {
+    Column,
+    Entity,
+    PrimaryGeneratedColumn
+} from "../../../../../src/index";
+
+@Entity()
+export class User {
+    @PrimaryGeneratedColumn()
+    id: number;
+
+    @Column()
+    name: string;
+}

--- a/test/github-issues/5119/issue-5119.ts
+++ b/test/github-issues/5119/issue-5119.ts
@@ -8,7 +8,7 @@ import {
 import { Connection, createConnection } from "../../../src";
 import { fail } from "assert";
 
-describe("migration with foreign key that changes target", () => {
+describe("github issues > #5119 migration with foreign key that changes target", () => {
     let connections: Connection[];
     before(
         async () =>

--- a/test/github-issues/5119/issue-5119.ts
+++ b/test/github-issues/5119/issue-5119.ts
@@ -15,7 +15,6 @@ describe("github issues > #5119 migration with foreign key that changes target",
             (connections = await createTestingConnections({
                 entities: [__dirname + "/entity/v1/*{.js,.ts}"],
                 enabledDrivers: ["postgres"],
-                logging: true
             }))
     );
     beforeEach(() => reloadTestingDatabases(connections));
@@ -29,7 +28,6 @@ describe("github issues > #5119 migration with foreign key that changes target",
                     {
                         name: `${_connection.name}-v2`,
                         entities: [__dirname + "/entity/v2/*{.js,.ts}"],
-                        logging: true,
                         dropSchema: false,
                         schemaCreate: false
                     }
@@ -51,16 +49,16 @@ describe("github issues > #5119 migration with foreign key that changes target",
                         query => query.query
                     );
                     upQueries.should.eql([
-                        'ALTER TABLE "post" DROP CONSTRAINT "FK_4490d00e1925ca046a1f52ddf04"',
-                        'CREATE TABLE "account" ("id" SERIAL NOT NULL, "userId" integer, CONSTRAINT "PK_54115ee388cdb6d86bb4bf5b2ea" PRIMARY KEY ("id"))',
-                        'ALTER TABLE "account" ADD CONSTRAINT "FK_60328bf27019ff5498c4b977421" FOREIGN KEY ("userId") REFERENCES "user"("id") ON DELETE NO ACTION ON UPDATE NO ACTION',
-                        'ALTER TABLE "post" ADD CONSTRAINT "FK_4490d00e1925ca046a1f52ddf04" FOREIGN KEY ("ownerId") REFERENCES "account"("id") ON DELETE NO ACTION ON UPDATE NO ACTION'
+                        `ALTER TABLE "post" DROP CONSTRAINT "FK_4490d00e1925ca046a1f52ddf04"`,
+                        `CREATE TABLE "account" ("id" SERIAL NOT NULL, "userId" integer, CONSTRAINT "PK_54115ee388cdb6d86bb4bf5b2ea" PRIMARY KEY ("id"))`,
+                        `ALTER TABLE "account" ADD CONSTRAINT "FK_60328bf27019ff5498c4b977421" FOREIGN KEY ("userId") REFERENCES "user"("id") ON DELETE NO ACTION ON UPDATE NO ACTION`,
+                        `ALTER TABLE "post" ADD CONSTRAINT "FK_4490d00e1925ca046a1f52ddf04" FOREIGN KEY ("ownerId") REFERENCES "account"("id") ON DELETE NO ACTION ON UPDATE NO ACTION`
                     ]);
                     downQueries.should.eql([
-                        'ALTER TABLE "post" ADD CONSTRAINT "FK_4490d00e1925ca046a1f52ddf04" FOREIGN KEY ("ownerId") REFERENCES "user"("id") ON DELETE NO ACTION ON UPDATE NO ACTION',
-                        'DROP TABLE "account"',
-                        'ALTER TABLE "account" DROP CONSTRAINT "FK_60328bf27019ff5498c4b977421"',
-                        'ALTER TABLE "post" DROP CONSTRAINT "FK_4490d00e1925ca046a1f52ddf04"'
+                        `ALTER TABLE "post" ADD CONSTRAINT "FK_4490d00e1925ca046a1f52ddf04" FOREIGN KEY ("ownerId") REFERENCES "user"("id") ON DELETE NO ACTION ON UPDATE NO ACTION`,
+                        `DROP TABLE "account"`,
+                        `ALTER TABLE "account" DROP CONSTRAINT "FK_60328bf27019ff5498c4b977421"`,
+                        `ALTER TABLE "post" DROP CONSTRAINT "FK_4490d00e1925ca046a1f52ddf04"`
                     ]);
                 } finally {
                     connection.close();

--- a/test/github-issues/5119/migration-updates-foreign-keys.ts
+++ b/test/github-issues/5119/migration-updates-foreign-keys.ts
@@ -1,0 +1,90 @@
+import "reflect-metadata";
+import {
+    closeTestingConnections,
+    createTestingConnections,
+    reloadTestingDatabases,
+    setupSingleTestingConnection
+} from "../../utils/test-utils";
+import { Connection, createConnection } from "../../../src";
+import { fail } from "assert";
+
+describe("migration with foreign key that changes target", () => {
+    let connections: Connection[];
+    before(
+        async () =>
+            (connections = await createTestingConnections({
+                entities: [__dirname + "/entity/v1/*{.js,.ts}"],
+                enabledDrivers: ["postgres"],
+                logging: true
+            }))
+    );
+    beforeEach(() => reloadTestingDatabases(connections));
+    after(() => closeTestingConnections([...connections]));
+
+    it("should generate a drop and create step", async () => {
+        // v2Connections = await createTestingConnections({
+        //     entities: [__dirname + "/entity/v2/*{.js,.ts}"],
+        //     enabledDrivers: ["postgres"],
+        //     logging: true,
+        //     dropSchema: false,
+        //     schemaCreate: false
+        // });
+        console.log(`connections length: ${connections.length}`);
+        return Promise.all(
+            connections.map(async function(_connection) {
+                console.log("creating options");
+                const options = setupSingleTestingConnection(
+                    _connection.options.type,
+                    {
+                        name: `${_connection.name}-v2`,
+                        entities: [__dirname + "/entity/v2/*{.js,.ts}"],
+                        logging: true,
+                        dropSchema: false,
+                        schemaCreate: false
+                    }
+                );
+                console.log("created options");
+                if (!options) {
+                    fail();
+                    return Promise.resolve();
+                }
+                console.log("creating connection");
+                const connection = await createConnection(options);
+                console.log("created connection");
+                try {
+                    console.log("in test");
+                    const sqlInMemory = await connection.driver
+                        .createSchemaBuilder()
+                        .log();
+                    console.log("UP:");
+                    console.log(sqlInMemory.upQueries);
+                    console.log("DOWN:");
+                    console.log(sqlInMemory.downQueries);
+
+                    const downQueries = sqlInMemory.downQueries.map(
+                        query => query.query
+                    );
+                    const upQueries = sqlInMemory.downQueries.map(
+                        query => query.query
+                    );
+
+                    upQueries.should.equal([
+                        `CREATE TABLE "account" ("id" SERIAL NOT NULL, "userId" integer, CONSTRAINT "PK_54115ee388cdb6d86bb4bf5b2ea" PRIMARY KEY ("id"))`,
+                        `ALTER TABLE "account" ADD CONSTRAINT "FK_60328bf27019ff5498c4b977421" FOREIGN KEY ("userId") REFERENCES "user"("id") ON DELETE NO ACTION ON UPDATE NO ACTION`,
+                        `TODO alter table to drop FK from post to user`,
+                        `TODO alter tale to create FK from post to account`
+                    ]);
+
+                    downQueries.should.equal([
+                        `DROP TABLE "account"`,
+                        `ALTER TABLE "account" DROP CONSTRAINT "FK_60328bf27019ff5498c4b977421"`,
+                        `TODO alter table to drop FK from post to account`,
+                        `TODO alter table to create FK from post to user`
+                    ]);
+                } finally {
+                    connection.close();
+                }
+            })
+        );
+    });
+});


### PR DESCRIPTION
Closes #5119 , based on #5120 

Includes a check for the correct table name when checking for equality of foreign keys, to decide if they should be dropped and made fresh