### PR TITLE
revert: "fix: connection Reuse is broken in a Lambda environment: (#4804)"

### DIFF
--- a/src/connection/Connection.ts
+++ b/src/connection/Connection.ts
@@ -479,12 +479,8 @@ export class Connection {
      */
     protected findMetadata(target: Function|EntitySchema<any>|string): EntityMetadata|undefined {
         return this.entityMetadatas.find(metadata => {
-            if (typeof metadata.target === "function" && typeof target === "function" && metadata.target.name === target.name) {
+            if (metadata.target === target)
                 return true;
-            }
-            if (metadata.target === target) {
-                return true;
-            }
             if (target instanceof EntitySchema) {
                 return metadata.name === target.options.name;
             }


### PR DESCRIPTION
This reverts commit 7962036be3c009f8de3030e83002be0346e35d48 

The original PR came about from this issue: https://github.com/typeorm/typeorm/issues/3427.
The author of the original issue has since realized the root problem they were facing was unrelated: https://github.com/typeorm/typeorm/issues/3427#issuecomment-549770047

It seems this "monkeypatch" is causing more problems than any workaround it might have provided is worth. The conditional `metadata.target.name === target.name` in the `findMetadata` function is not a thorough-enough comparison. Function names are often the same in large codebases and especially in minified code (as @Benjamin-Dobell points out https://github.com/typeorm/typeorm/pull/4804#issuecomment-580075220). This results in false positives returned from `this.entityMetadatas.find()` depending on the order of the `EntityMetadata` in the array.

Closes:
https://github.com/typeorm/typeorm/issues/4958 TypeORM 0.2.20 getRepository returns results from another Repo.
https://github.com/typeorm/typeorm/issues/4967 0.2.20 release breaks entity repo resolving mechanism