### PR TITLE
docs: delete single quote from "'age' +1"

### DIFF
--- a/docs/update-query-builder.md
+++ b/docs/update-query-builder.md
@@ -30,7 +30,7 @@ await getConnection()
     .set({ 
         firstName: "Timber", 
         lastName: "Saw",
-        age: () => "'age' + 1"
+        age: () => "age + 1"
     })
     .where("id = :id", { id: 1 })
     .execute();


### PR DESCRIPTION
single quotes make error called ER_TRUNCATED_WRONG_VALUE: Truncated incorrect DOUBLE value.
It is working without single quotes.