### PR TITLE
docs: clarify how cascade option works

### DIFF
--- a/README.md
+++ b/README.md
@@ -1046,6 +1046,8 @@ createConnection(options).then(async connection => {
 }).catch(error => console.log(error));
 ```
 
+Notice that we now set the photo's `metadata` property, instead of the metadata's `photo` property as before. The `cascade` feature only works if you connect the photo to its metadata from the photo's side. If you set the metadata's side, the metadata would not be saved automatically.
+
 ### Creating a many-to-one / one-to-many relation
 
 Let's create a many-to-one / one-to-many relation.


### PR DESCRIPTION
I was trying to use the following, which does not work with `cascade` as described in the README.

```typescript
metadata.photo = photo; // this way we connect them
```

The code in the README is correct, but the change was not called out.
```typescript
photo.metadata = metadata; // this way we connect them
```