### PR TITLE
feat: add updateAllColumns to SaveOptions

### DIFF
--- a/src/persistence/SubjectExecutor.ts
+++ b/src/persistence/SubjectExecutor.ts
@@ -285,6 +285,7 @@ export class SubjectExecutor {
                         .into(subjects[0].metadata.target)
                         .values(bulkInsertMaps)
                         .updateEntity(this.options && this.options.reload === false ? false : true)
+                        .updateAllColumns(this.options && this.options.updateAllColumns === true ? true : false)
                         .callListeners(false)
                         .execute();
 
@@ -311,6 +312,7 @@ export class SubjectExecutor {
                             .into(subject.metadata.target)
                             .values(subject.insertedValueSet)
                             .updateEntity(this.options && this.options.reload === false ? false : true)
+                            .updateAllColumns(this.options && this.options.updateAllColumns === true ? true : false)
                             .callListeners(false)
                             .execute()
                             .then(insertResult => {
@@ -385,6 +387,7 @@ export class SubjectExecutor {
                     .update(subject.metadata.target)
                     .set(updateMap)
                     .updateEntity(this.options && this.options.reload === false ? false : true)
+                    .updateAllColumns(this.options && this.options.updateAllColumns === true ? true : false)
                     .callListeners(false);
 
                 if (subject.entity) {

--- a/src/query-builder/InsertQueryBuilder.ts
+++ b/src/query-builder/InsertQueryBuilder.ts
@@ -234,6 +234,17 @@ export class InsertQueryBuilder<Entity> extends QueryBuilder<Entity> {
     }
 
     /**
+     * Indicates if all columns of the entity must be updated.
+     * Only works if updateEntity is enabled.
+     *
+     * Disabled by default.
+     */
+    updateAllColumns(enabled: boolean): this {
+        this.expressionMap.updateAllColumns = enabled;
+        return this;
+    }
+
+    /**
      * Adds additional ON CONFLICT statement supported in postgres and cockroach.
      */
     onConflict(statement: string): this {

--- a/src/query-builder/QueryExpressionMap.ts
+++ b/src/query-builder/QueryExpressionMap.ts
@@ -250,6 +250,14 @@ export class QueryExpressionMap {
     updateEntity: boolean = true;
 
     /**
+     * Indicates if all columns of the entity must be updated.
+     * Only works if updateEntity is enabled.
+     *
+     * Disabled by default.
+     */
+    updateAllColumns: boolean = false;
+
+    /**
      * Indicates if listeners and subscribers must be called before and after query execution.
      */
     callListeners: boolean = true;

--- a/src/query-builder/ReturningResultsEntityUpdator.ts
+++ b/src/query-builder/ReturningResultsEntityUpdator.ts
@@ -156,6 +156,9 @@ export class ReturningResultsEntityUpdator {
         // for other databases we don't need to return id column since its returned by a driver already
         const needToCheckGenerated = this.queryRunner.connection.driver.isReturningSqlSupported();
 
+        // Do not filter if user wants all columns returned
+        if (this.expressionMap.updateAllColumns === true) return this.expressionMap.mainAlias!.metadata.columns;
+
         // filter out the columns of which we need database inserted values to update our entity
         return this.expressionMap.mainAlias!.metadata.columns.filter(column => {
             return  column.default !== undefined ||
@@ -170,6 +173,9 @@ export class ReturningResultsEntityUpdator {
      * Columns we need to be returned from the database when we update entity.
      */
     getUpdationReturningColumns(): ColumnMetadata[] {
+        // Do not filter if user wants all columns returned
+        if (this.expressionMap.updateAllColumns === true) return this.expressionMap.mainAlias!.metadata.columns;
+
         return this.expressionMap.mainAlias!.metadata.columns.filter(column => {
             return column.isUpdateDate || column.isVersion;
         });

--- a/src/query-builder/UpdateQueryBuilder.ts
+++ b/src/query-builder/UpdateQueryBuilder.ts
@@ -368,6 +368,17 @@ export class UpdateQueryBuilder<Entity> extends QueryBuilder<Entity> implements 
         return this;
     }
 
+    /**
+     * Indicates if all columns of the entity must be updated.
+     * Only works if updateEntity is enabled.
+     *
+     * Disabled by default.
+     */
+    updateAllColumns(enabled: boolean): this {
+        this.expressionMap.updateAllColumns = enabled;
+        return this;
+    }
+
     // -------------------------------------------------------------------------
     // Protected Methods
     // -------------------------------------------------------------------------

--- a/src/repository/SaveOptions.ts
+++ b/src/repository/SaveOptions.ts
@@ -2,7 +2,6 @@
  * Special options passed to Repository#save, Repository#insert and Repository#update methods.
  */
 export interface SaveOptions {
-
     /**
      * Additional data to be passed with persist method.
      * This data can be used in subscribers then.
@@ -38,4 +37,9 @@ export interface SaveOptions {
      */
     reload?: boolean;
 
+    /**
+     * Indicates if all columns should be updated (Depends on reload to work).
+     * Disabled by default.
+     */
+    updateAllColumns?: boolean;
 }

--- a/test/github-issues/3490/entity/Post.ts
+++ b/test/github-issues/3490/entity/Post.ts
@@ -1,0 +1,21 @@
+import {
+    Entity,
+    Column,
+    PrimaryGeneratedColumn,
+    BaseEntity
+} from "../../../../src";
+
+@Entity()
+export default class Post extends BaseEntity {
+    @PrimaryGeneratedColumn()
+    id: number;
+
+    @Column()
+    code: string;
+
+    @Column()
+    userId: number;
+
+    @Column()
+    content: string;
+}

--- a/test/github-issues/3490/entity/User.ts
+++ b/test/github-issues/3490/entity/User.ts
@@ -1,0 +1,19 @@
+import {
+    Entity,
+    Column,
+    PrimaryGeneratedColumn,
+    BaseEntity,
+    CreateDateColumn
+} from "../../../../src";
+
+@Entity()
+export default class User extends BaseEntity {
+    @PrimaryGeneratedColumn()
+    id: number;
+
+    @Column()
+    username: string;
+
+    @CreateDateColumn()
+    createdAt: Date;
+}

--- a/test/github-issues/3490/issue-3490.ts
+++ b/test/github-issues/3490/issue-3490.ts
@@ -1,0 +1,115 @@
+import {
+    closeTestingConnections,
+    createTestingConnections,
+    reloadTestingDatabases
+} from "../../utils/test-utils";
+import { Connection } from "../../../src/connection/Connection";
+import User from "./entity/User";
+import Post from "./entity/Post";
+import { EntityManager } from "../../../src/entity-manager/EntityManager";
+import { expect } from "chai";
+
+async function createTrigger(em: EntityManager) {
+    await em.query(
+        `
+        CREATE OR REPLACE FUNCTION post_code()
+        RETURNS TRIGGER
+        LANGUAGE plpgsql
+        AS $$
+        BEGIN
+            NEW.code = md5(random()::text);
+            RETURN NEW;
+        END $$;
+        `
+    );
+    await em.query(
+        `
+        CREATE TRIGGER trig_post
+        BEFORE INSERT ON post
+        FOR EACH ROW
+        EXECUTE PROCEDURE post_code();
+        `
+    );
+}
+
+describe("github issues > #3490 Method save does not return the entire model", () => {
+    let connections: Connection[];
+    before(async () => {
+        connections = await createTestingConnections({
+            entities: [User, Post],
+            dropSchema: true,
+            enabledDrivers: ["postgres"]
+        });
+    });
+    beforeEach(async () => await reloadTestingDatabases(connections));
+
+    it("should retrieve all columns after insert with flag enabled", async () => {
+        await Promise.all(
+            connections.map(async connection => {
+                const em = new EntityManager(connection);
+
+                await createTrigger(em);
+
+                const user = new User();
+                user.username = "John";
+                await em.save(user);
+
+                const post = new Post();
+                post.userId = user.id;
+                post.content = "Hello world";
+                await em.save(post, { updateAllColumns: true });
+
+                expect(post.code).to.exist;
+            })
+        );
+    });
+
+    it("should not retrieve additional columns by default", async () => {
+        await Promise.all(
+            connections.map(async connection => {
+                const em = new EntityManager(connection);
+
+                await createTrigger(em);
+
+                const user = new User();
+                user.username = "Anna";
+                await em.save(user);
+
+                const post = new Post();
+                post.userId = user.id;
+                post.content = "Happy holidays";
+                await em.save(post);
+
+                expect(post.code).to.not.exist;
+            })
+        );
+    });
+
+    it("should retrieve additional columns on update with flag enabled", async () => {
+        await Promise.all(
+            connections.map(async connection => {
+                const em = new EntityManager(connection);
+
+                const user = new User();
+                user.username = "Edward";
+                await em.save(user);
+
+                const updateUser1 = new User();
+                updateUser1.id = user.id;
+                updateUser1.username = "Emily";
+                await em.save(updateUser1);
+
+                expect(updateUser1.createdAt).to.not.exist;
+
+                const updateUser2 = new User();
+                updateUser2.id = user.id;
+                updateUser2.username = "Charles";
+                await em.save(updateUser2, { updateAllColumns: true });
+
+                expect(updateUser2.createdAt).to.exist;
+            })
+        );
+    });
+
+    after(async () => await closeTestingConnections(connections));
+});


### PR DESCRIPTION
Allows retrieving all columns with .save() on both insert and update within a single operation.

Fixes #3490