### PR TITLE
[Fix] not to make typeorm generate alter query on geometry column when that column was not changed

### DIFF
--- a/src/driver/postgres/PostgresQueryRunner.ts
+++ b/src/driver/postgres/PostgresQueryRunner.ts
@@ -1501,7 +1501,7 @@ export class PostgresQueryRunner extends BaseQueryRunner implements QueryRunner 
                           "type"
                         FROM "geometry_columns"
                       ) AS _
-                      WHERE ${tablesCondition} AND "column_name" = '${tableColumn.name}'`;
+                      WHERE (${tablesCondition}) AND "column_name" = '${tableColumn.name}' AND "table_name" = '${table.name}'`;
 
                         const results: ObjectLiteral[] = await this.query(geometryColumnSql);
                         tableColumn.spatialFeatureType = results[0].type;
@@ -1518,7 +1518,7 @@ export class PostgresQueryRunner extends BaseQueryRunner implements QueryRunner 
                           "type"
                         FROM "geography_columns"
                       ) AS _
-                      WHERE ${tablesCondition} AND "column_name" = '${tableColumn.name}'`;
+                      WHERE (${tablesCondition}) AND "column_name" = '${tableColumn.name}' AND "table_name" = '${table.name}'`;
 
                         const results: ObjectLiteral[] = await this.query(geographyColumnSql);
                         tableColumn.spatialFeatureType = results[0].type;

--- a/src/metadata/ColumnMetadata.ts
+++ b/src/metadata/ColumnMetadata.ts
@@ -391,7 +391,7 @@ export class ColumnMetadata {
             this.transformer = options.args.options.transformer;
         if (options.args.options.spatialFeatureType)
             this.spatialFeatureType = options.args.options.spatialFeatureType;
-        if (options.args.options.srid)
+        if (options.args.options.srid !== undefined)
             this.srid = options.args.options.srid;
         if (this.isTreeLevel)
             this.type = options.connection.driver.mappedDataTypes.treeLevel;


### PR DESCRIPTION
## Problem

Let's assume the entity like this.
```
import { Point, Polygon } from 'geojson';

class SomeTable1 {
    ...
    @Column({type: 'geometry', srid: 4326, spatialFeatureType: 'Polygon'})
    my_polygon!: Polygon;
}

class SomeTable2 {
    ...
    @Column({type: 'geometry', srid: 4326, spatialFeatureType: 'Point'})
    my_place!: Point;
}

```

Typeorm always think the geometry field has been changed even though I did not change it.
If synchronize option is true, typeorm always run below query whenever server started.
```
query: ALTER TABLE "some_table2" ALTER COLUMN "my_place" TYPE geometry(Point,4326)
```
If synchronize option is false, when I execute `typeorm migration:generate`, it "always" make new migration file below even after I execute typeorm migration:run.
```
    public async up(queryRunner: QueryRunner): Promise<any> {
        await queryRunner.query('ALTER TABLE "some_table2" ALTER COLUMN "my_place" TYPE geometry(Point,4326)')
    }

    public async down(queryRunner: QueryRunner): Promise<any> {
        await queryRunner.query('ALTER TABLE "some_table2" ALTER COLUMN "my_place" TYPE geometry(POLYGON,4326)')
    }
```

When I run query below,
```
SELECT type 
FROM geometry_columns 
WHERE f_table_schema = 'public' 
AND f_table_name = 'some_table2 
and f_geometry_column = 'my_place';
```
it returns

|type|
|----------|
|POINT|

It means, `my_place` column's geometry type is `POINT` on postgresql which is correct, but as we can see in the result of `typeorm migration:generate`, typeorm think this column is not `POINT` but `POLYGON`.
Therefore, **typeorm keep trying to alter column's geometry type even though it set correctly.**
This is not a critical bug, but typeorm execute useless alter query if synchronize option is true. It is pretty annoying when execute `typeorm migration:generate` if synchronize option is false.


## Cause
Let's see the code of `loadTables` method in `PostgresQueryRunner.ts`.
```
if (tableColumn.type === "geometry") {
    const geometryColumnSql = `SELECT * FROM (
    SELECT
        "f_table_schema" "table_schema",
        "f_table_name" "table_name",
        "f_geometry_column" "column_name",
        "srid",
        "type"
        FROM "geometry_columns"
) AS _
    WHERE ${tablesCondition} AND "column_name" = '${tableColumn.name}'`;
        const results: ObjectLiteral[] = await this.query(geometryColumnSql);
        tableColumn.spatialFeatureType = results[0].type;
        tableColumn.srid = results[0].srid;
}
```

The `geometryColumnSql` execute the query like this.
```
SELECT * FROM (
    SELECT
    "f_table_schema" "table_schema",
    "f_table_name" "table_name",
    "f_geometry_column" "column_name",
    "srid",
    "type"
    FROM "geometry_columns"
    ) AS _
WHERE (blahblah) OR (blahblah) OR ... OR ("table_schema" = 'public' AND "table_name" = 'some_table1') OR ("table_schema" = 'public' AND "table_name" = 'some_table2') AND "column_name" = 'my_place'
```
The result is

|table_schema|table_name|column_name|srid|type|
|----------|----------|----------|----------|----------|
|public|some_table1|my_polygon|4326|POLYGON|
|public|some_table2|my_point|4326|POINT|

**This is the problem.**
Let's go back to the code. `results[0].type` is always `POLYGON`. Therefore even though the column `my_point`geometry type is `POINT`, typeorm always think it's type is `POLYGON`.

## Solution
First, we need to fix `WHERE` condition by wrapping OR condition in a parenthesis like this.
<pre>
WHERE
    <b>(</b>
        (blahblah) OR (blahblah) OR ... OR ("table_schema" = 'public' AND "table_name" = 'some_table1') OR ("table_schema" = 'public' AND "table_name" = 'some_table2')
    <b>)</b>
    AND "column_name" = 'my_place'
</pre>
Second, add table name on `WHERE` condition so that if we define same column name with different geometry type, the queryRunner can handle this properly.
<pre>
WHERE
    (
        (blahblah) OR (blahblah) OR ... OR ("table_schema" = 'public' AND "table_name" = 'some_table1') OR ("table_schema" = 'public' AND "table_name" = 'some_table2')
    )
    AND "column_name" = 'my_place' <b>AND "table_name" = 'some_table2'</b>
</pre>

Then, this query will always return only one correct column info.

|table_schema|table_name|column_name|srid|type|
|----------|----------|----------|----------|----------|
|public|some_table2|my_point|4326|POINT|



## Extra
The default postgis srid value is 0, which means, if you omit the `Column` option `srid` like this,
```
    @Column({type: 'geometry', spatialFeatureType: 'Point'})
    my_place!: Point;
```
postgis set this column's srid to 0.
However in `ColumnMetadata.ts`,
```
if (options.args.options.srid)
    this.srid = options.args.options.srid;
```
srid value zero can't pass this if statement, so that migration process think there are changes.
[Related issue](https://github.com/typeorm/typeorm/issues/4534)

By fixing the condition of if statements like this `options.args.options.srid !== undefined` we can solve this problem.