### PR TITLE
Add driver option to address Expo API change.

### DIFF
--- a/docs/connection-options.md
+++ b/docs/connection-options.md
@@ -479,7 +479,8 @@ See [SSL options](https://github.com/mysqljs/mysql#ssl-options).
 
 ## `expo` connection options
 
-* `database` - Name of the database. For example "mydb".
+* `database` - Name of the database. For example, "mydb".
+* `driver` - The Expo SQLite module. For example, `require('expo-sqlite')`.
 
 ## Connection options example
 

--- a/docs/zh_CN/connection-options.md
+++ b/docs/zh_CN/connection-options.md
@@ -387,6 +387,7 @@
 ## `expo`
 
 - `database` - 数据库名， 例如 "mydb".
+- `driver` - Expo SQLite 模块. 例如，`require('expo-sqlite')`.
 
 ## 连接选项示例
 

--- a/src/driver/expo/ExpoConnectionOptions.ts
+++ b/src/driver/expo/ExpoConnectionOptions.ts
@@ -14,4 +14,9 @@ export interface ExpoConnectionOptions extends BaseConnectionOptions {
      * Database name.
      */
     readonly database: string;
+
+    /**
+    * Driver module
+    */
+    readonly driver: any;
 }

--- a/src/driver/expo/ExpoDriver.ts
+++ b/src/driver/expo/ExpoDriver.ts
@@ -4,13 +4,6 @@ import {ExpoQueryRunner} from "./ExpoQueryRunner";
 import {QueryRunner} from "../../query-runner/QueryRunner";
 import {Connection} from "../../connection/Connection";
 import {DriverOptionNotSetError} from "../../error/DriverOptionNotSetError";
-import {DriverPackageNotInstalledError} from "../../error/DriverPackageNotInstalledError";
-
-// needed for typescript compiler
-interface Window {
-    Expo: any;
-}
-declare const window: Window;
 
 export class ExpoDriver extends AbstractSqliteDriver {
     options: ExpoConnectionOptions;
@@ -27,9 +20,12 @@ export class ExpoDriver extends AbstractSqliteDriver {
         // validate options to make sure everything is set
         if (!this.options.database)
             throw new DriverOptionNotSetError("database");
+        
+        if (!this.options.driver)
+            throw new DriverOptionNotSetError("driver");
 
         // load sqlite package
-        this.loadDependencies();
+        this.sqlite = this.options.driver;
     }
     
 
@@ -90,16 +86,5 @@ export class ExpoDriver extends AbstractSqliteDriver {
                 fail(error);
             }
         });
-    }
-
-    /**
-     * If driver dependency is not given explicitly, then try to load it via "require".
-     */
-    protected loadDependencies(): void {
-        try {
-            this.sqlite = window.Expo.SQLite;
-        } catch (e) {
-            throw new DriverPackageNotInstalledError("Expo", "expo");
-        }
     }
 }


### PR DESCRIPTION
This pull request adds a new driver option that allows the user to pass `require('expo-sqlite')` into the driver. The Expo SQLite API changed to use a new `expo-sqlite` module instead of having a `SQLite` object be available on `window`.

I did not want to put `require('expo-sqlite')` directly in the driver code base because [Metro bundler does not allow dynamic imports](https://github.com/facebook/metro/issues/52), which means that all `typeorm/browser` users would be forced to import `expo-sqlite` into their project. (A similar thing happens with `react-native-sqlite-storage` for the React Native driver.)

I have added documentation for the new option, but I would appreciate if someone could check the Chinese translation.

Fixes #4846 