### PR TITLE
Change return type of generated migrations up/down

### DIFF
--- a/src/commands/MigrationGenerateCommand.ts
+++ b/src/commands/MigrationGenerateCommand.ts
@@ -135,12 +135,12 @@ export class MigrationGenerateCommand implements yargs.CommandModule {
 export class ${migrationName} implements MigrationInterface {
     name = '${migrationName}'
 
-    public async up(queryRunner: QueryRunner): Promise<any> {
+    public async up(queryRunner: QueryRunner): Promise<void> {
 ${upSqls.join(`
 `)}
     }
 
-    public async down(queryRunner: QueryRunner): Promise<any> {
+    public async down(queryRunner: QueryRunner): Promise<void> {
 ${downSqls.join(`
 `)}
     }


### PR DESCRIPTION
Convert from `Promise<any>` to `Promise<void>`

This fixes projects that frown upon the use of `any` type