### PR TITLE
Feature: Refactor FindOperator to be extendable

### DIFF
--- a/docs/find-options.md
+++ b/docs/find-options.md
@@ -23,7 +23,7 @@ userRepository.find({ relations: ["profile", "photos", "videos", "videos.video_a
 * `join` - joins needs to be performed for the entity. Extended version of "relations".
 
 ```typescript
-userRepository.find({ 
+userRepository.find({
     join: {
         alias: "user",
         leftJoinAndSelect: {
@@ -40,7 +40,7 @@ userRepository.find({
 ```typescript
 userRepository.find({ where: { firstName: "Timber", lastName: "Saw" } });
 ```
-Querying a column from an embedded entity should be done with respect to the hierarchy in which it was defined. Example: 
+Querying a column from an embedded entity should be done with respect to the hierarchy in which it was defined. Example:
 
 ```typescript
 userRepository.find({ where: { name: { first: "Timber", last: "Saw" } } });
@@ -57,7 +57,7 @@ userRepository.find({
 });
 ```
 
-will execute following query: 
+will execute following query:
 
 ```sql
 SELECT * FROM "user" WHERE ("firstName" = 'Timber' AND "lastName" = 'Saw') OR ("firstName" = 'Stan' AND "lastName" = 'Lee')
@@ -66,7 +66,7 @@ SELECT * FROM "user" WHERE ("firstName" = 'Timber' AND "lastName" = 'Saw') OR ("
 * `order` - selection order.
 
 ```typescript
-userRepository.find({ 
+userRepository.find({
     order: {
         name: "ASC",
         id: "DESC"
@@ -79,7 +79,7 @@ userRepository.find({
 * `skip` - offset (paginated) from where entities should be taken.
 
 ```typescript
-userRepository.find({ 
+userRepository.find({
     skip: 5
 });
 ```
@@ -87,7 +87,7 @@ userRepository.find({
 * `take` - limit (paginated) - max number of entities that should be taken.
 
 ```typescript
-userRepository.find({ 
+userRepository.find({
     take: 10
 });
 ```
@@ -95,12 +95,12 @@ userRepository.find({
 ** If you are using typeorm with MSSQL, and want to use `take` or `limit`, you need to use order as well or you will receive the following error:   `'Invalid usage of the option NEXT in the FETCH statement.'`
 
 ```typescript
-userRepository.find({ 
-    order: { 
-        columnName: 'ASC' 
-        }, 
-    skip: 0, 
-    take: 10 
+userRepository.find({
+    order: {
+        columnName: 'ASC'
+        },
+    skip: 0,
+    take: 10
 })
 ```
 
@@ -134,12 +134,12 @@ userRepository.findOne(1, {
 Complete example of find options:
 
 ```typescript
-userRepository.find({ 
+userRepository.find({
     select: ["firstName", "lastName"],
     relations: ["profile", "photos", "videos"],
-    where: { 
-        firstName: "Timber", 
-        lastName: "Saw" 
+    where: {
+        firstName: "Timber",
+        lastName: "Saw"
     },
     order: {
         name: "ASC",
@@ -166,7 +166,7 @@ const loadedPosts = await connection.getRepository(Post).find({
 })
 ```
 
-will execute following query: 
+will execute following query:
 
 ```sql
 SELECT * FROM "post" WHERE "title" != 'About #1'
@@ -182,7 +182,7 @@ const loadedPosts = await connection.getRepository(Post).find({
 });
 ```
 
-will execute following query: 
+will execute following query:
 
 ```sql
 SELECT * FROM "post" WHERE "likes" < 10
@@ -198,7 +198,7 @@ const loadedPosts = await connection.getRepository(Post).find({
 });
 ```
 
-will execute following query: 
+will execute following query:
 
 ```sql
 SELECT * FROM "post" WHERE "likes" <= 10
@@ -214,7 +214,7 @@ const loadedPosts = await connection.getRepository(Post).find({
 });
 ```
 
-will execute following query: 
+will execute following query:
 
 ```sql
 SELECT * FROM "post" WHERE "likes" > 10
@@ -230,7 +230,7 @@ const loadedPosts = await connection.getRepository(Post).find({
 });
 ```
 
-will execute following query: 
+will execute following query:
 
 ```sql
 SELECT * FROM "post" WHERE "likes" >= 10
@@ -246,7 +246,7 @@ const loadedPosts = await connection.getRepository(Post).find({
 });
 ```
 
-will execute following query: 
+will execute following query:
 
 ```sql
 SELECT * FROM "post" WHERE "title" = 'About #2'
@@ -262,7 +262,7 @@ const loadedPosts = await connection.getRepository(Post).find({
 });
 ```
 
-will execute following query: 
+will execute following query:
 
 ```sql
 SELECT * FROM "post" WHERE "title" LIKE '%out #%'
@@ -278,7 +278,7 @@ const loadedPosts = await connection.getRepository(Post).find({
 });
 ```
 
-will execute following query: 
+will execute following query:
 
 ```sql
 SELECT * FROM "post" WHERE "likes" BETWEEN 1 AND 10
@@ -294,7 +294,7 @@ const loadedPosts = await connection.getRepository(Post).find({
 });
 ```
 
-will execute following query: 
+will execute following query:
 
 ```sql
 SELECT * FROM "post" WHERE "title" IN ('About #2','About #3')
@@ -310,7 +310,7 @@ const loadedPosts = await connection.getRepository(Post).find({
 });
 ```
 
-will execute following query (Postgres notation): 
+will execute following query (Postgres notation):
 
 ```sql
 SELECT * FROM "post" WHERE "title" = ANY(['About #2','About #3'])
@@ -326,7 +326,7 @@ const loadedPosts = await connection.getRepository(Post).find({
 });
 ```
 
-will execute following query: 
+will execute following query:
 
 ```sql
 SELECT * FROM "post" WHERE "title" IS NULL
@@ -342,7 +342,7 @@ const loadedPosts = await connection.getRepository(Post).find({
 });
 ```
 
-will execute following query: 
+will execute following query:
 
 ```sql
 SELECT * FROM "post" WHERE "likes" = "dislikes" - 4
@@ -359,7 +359,7 @@ const loadedPosts = await connection.getRepository(Post).find({
 });
 ```
 
-will execute following query: 
+will execute following query:
 
 ```sql
 SELECT * FROM "post" WHERE "currentDate" > NOW()
@@ -379,8 +379,28 @@ const loadedPosts = await connection.getRepository(Post).find({
 });
 ```
 
-will execute following query: 
+
+will execute following query:
 
 ```sql
 SELECT * FROM "post" WHERE NOT("likes" > 10) AND NOT("title" = 'About #2')
+```
+
+### Custom Operators
+
+If the standard operators don't cover the cases you need, you can create your own custom find operators by extending the `FindOperator` class.
+
+```ts
+class JsonbContainsOperator extends FindOperator {
+    constructor(value: {[key: string]: any}) {
+        super(value);
+    }
+
+    toSql(connection: Connection, aliasPath: string, parameters: string[]): string {
+        return `${aliasPath} @> ${JSON.stringify(parameters[0])}`;
+
+    }
+}
+
+export const JsonbContains = (value: {[key: string]: any}) => new JsonbContainsOperator(value);
 ```

--- a/src/find-options/FindOperator.ts
+++ b/src/find-options/FindOperator.ts
@@ -3,7 +3,7 @@ import {Connection} from "../";
 /**
  * Find Operator used in Find Conditions.
  */
-export abstract class FindOperator<T> {
+export abstract class FindOperator<T = any> {
     // -------------------------------------------------------------------------
     // Private Properties
     // -------------------------------------------------------------------------
@@ -11,17 +11,17 @@ export abstract class FindOperator<T> {
     /**
      * Parameter value.
      */
-    private _value: T | FindOperator<T>;
+    protected _value: T | FindOperator<T>;
 
     /**
      * Indicates if parameter is used or not for this operator.
      */
-    private _useParameter: boolean;
+    protected _useParameter: boolean;
 
     /**
      * Indicates if multiple parameters must be used for this operator.
      */
-    private _multipleParameters: boolean;
+    protected _multipleParameters: boolean;
 
     // -------------------------------------------------------------------------
     // Constructor
@@ -91,42 +91,3 @@ export abstract class FindOperator<T> {
      */
     abstract toSql(connection: Connection, aliasPath: string, parameters: string[]): string;
 }
-
-/*
-switch (this._type) {
-            case "not":
-                if (this._value instanceof FindOperator) {
-                    return `NOT(${this._value.toSql(
-                        connection,
-                        aliasPath,
-                        parameters
-                    )})`;
-                } else {
-                    return `${aliasPath} != ${parameters[0]}`;
-                }
-            case "lessThan":
-                return `${aliasPath} < ${parameters[0]}`;
-            case "lessThanOrEqual":
-                return `${aliasPath} <= ${parameters[0]}`;
-            case "moreThan":
-                return `${aliasPath} > ${parameters[0]}`;
-            case "moreThanOrEqual":
-                return `${aliasPath} >= ${parameters[0]}`;
-            case "like":
-                return `${aliasPath} LIKE ${parameters[0]}`;
-            case "in":
-                return `${aliasPath} IN (${parameters.join(", ")})`;
-            case "any":
-                return `${aliasPath} = ANY(${parameters[0]})`;
-            case "isNull":
-                return `${aliasPath} IS NULL`;
-            case "raw":
-                if (this.value instanceof Function) {
-                    return this.value(aliasPath);
-                } else {
-                    return `${aliasPath} = ${this.value}`;
-                }
-        }
-
-        return "";
- */

--- a/src/find-options/FindOperator.ts
+++ b/src/find-options/FindOperator.ts
@@ -91,3 +91,42 @@ export abstract class FindOperator<T> {
      */
     abstract toSql(connection: Connection, aliasPath: string, parameters: string[]): string;
 }
+
+/*
+switch (this._type) {
+            case "not":
+                if (this._value instanceof FindOperator) {
+                    return `NOT(${this._value.toSql(
+                        connection,
+                        aliasPath,
+                        parameters
+                    )})`;
+                } else {
+                    return `${aliasPath} != ${parameters[0]}`;
+                }
+            case "lessThan":
+                return `${aliasPath} < ${parameters[0]}`;
+            case "lessThanOrEqual":
+                return `${aliasPath} <= ${parameters[0]}`;
+            case "moreThan":
+                return `${aliasPath} > ${parameters[0]}`;
+            case "moreThanOrEqual":
+                return `${aliasPath} >= ${parameters[0]}`;
+            case "like":
+                return `${aliasPath} LIKE ${parameters[0]}`;
+            case "in":
+                return `${aliasPath} IN (${parameters.join(", ")})`;
+            case "any":
+                return `${aliasPath} = ANY(${parameters[0]})`;
+            case "isNull":
+                return `${aliasPath} IS NULL`;
+            case "raw":
+                if (this.value instanceof Function) {
+                    return this.value(aliasPath);
+                } else {
+                    return `${aliasPath} = ${this.value}`;
+                }
+        }
+
+        return "";
+ */

--- a/src/find-options/FindOperatorType.ts
+++ b/src/find-options/FindOperatorType.ts
@@ -1,5 +1,6 @@
 /**
  * List of types that FindOperator can be.
+ * @deprecated No longer required
  */
 export type FindOperatorType = "not"
     | "lessThan"

--- a/src/find-options/operator/Any.ts
+++ b/src/find-options/operator/Any.ts
@@ -1,9 +1,20 @@
 import {FindOperator} from "../FindOperator";
+import {Connection} from "../..";
 
 /**
  * Find Options Operator.
  * Example: { someField: Any([...]) }
  */
-export function Any<T>(value: T[]|FindOperator<T>) {
-    return new FindOperator("any", value as any);
+
+class AnyOperator<T> extends FindOperator<T> {
+
+    constructor(value: FindOperator<T> | T) {
+        super(value);
+    }
+
+    toSql(connection: Connection, aliasPath: string, parameters: string[]): string {
+        return `${aliasPath} = ANY(${parameters[0]})`;
+    }
 }
+
+export const Any = <T>(value: T[]|FindOperator<T>) => new AnyOperator<T>(value as any);

--- a/src/find-options/operator/Between.ts
+++ b/src/find-options/operator/Between.ts
@@ -1,9 +1,20 @@
 import {FindOperator} from "../FindOperator";
+import {Connection} from "../..";
 
 /**
  * Find Options Operator.
  * Example: { someField: Between(x, y) }
  */
-export function Between<T>(from: T|FindOperator<T>, to: T|FindOperator<T>) {
-    return new FindOperator("between", [from, to] as any, true, true);
+
+class BetweenOperator<T> extends FindOperator<T> {
+    constructor(value: FindOperator<T> | T) {
+        super(value, true, true);
+    }
+
+    toSql(connection: Connection, aliasPath: string, parameters: string[]): string {
+        return `${aliasPath} BETWEEN ${parameters[0]} AND ${parameters[1]}`;
+    }
+
 }
+
+export const Between = <T>(from: T | FindOperator<T>, to: T | FindOperator<T>) => new BetweenOperator<T>([from, to] as any);

--- a/src/find-options/operator/Equal.ts
+++ b/src/find-options/operator/Equal.ts
@@ -1,9 +1,18 @@
 import {FindOperator} from "../FindOperator";
+import {Connection} from "../..";
 
 /**
  * Find Options Operator.
  * Example: { someField: Equal("value") }
  */
-export function Equal<T>(value: T|FindOperator<T>) {
-    return new FindOperator("equal", value);
+class EqualOperator<T> extends FindOperator<T> {
+    constructor(value: FindOperator<T> | T) {
+        super(value);
+    }
+
+    toSql(connection: Connection, aliasPath: string, parameters: string[]): string {
+        return `${aliasPath} = ${parameters[0]}`;
+    }
 }
+
+export const Equal = <T>(value: T|FindOperator<T>): EqualOperator<T> => new EqualOperator<T>(value);

--- a/src/find-options/operator/In.ts
+++ b/src/find-options/operator/In.ts
@@ -1,9 +1,18 @@
 import {FindOperator} from "../FindOperator";
+import {Connection} from "../..";
 
 /**
  * Find Options Operator.
  * Example: { someField: In([...]) }
  */
-export function In<T>(value: T[]|FindOperator<T>) {
-    return new FindOperator("in", value as any, true, true);
+class InOperator<T> extends FindOperator<T> {
+    constructor(value: FindOperator<T> | T) {
+        super(value, true, true);
+    }
+
+    toSql(connection: Connection, aliasPath: string, parameters: string[]): string {
+        return `${aliasPath} IN (${parameters.join(", ")})`;
+    }
 }
+
+export const In = <T>(value: T[] | FindOperator<T>) => new InOperator<T>(value as any);

--- a/src/find-options/operator/IsNull.ts
+++ b/src/find-options/operator/IsNull.ts
@@ -1,9 +1,19 @@
 import {FindOperator} from "../FindOperator";
+import {Connection} from "../..";
 
 /**
  * Find Options Operator.
  * Example: { someField: IsNull() }
  */
-export function IsNull() {
-    return new FindOperator("isNull", undefined as any, false);
+class IsNullOperator<T> extends FindOperator<T> {
+    constructor() {
+        super(undefined as any);
+    }
+
+    toSql(connection: Connection, aliasPath: string, parameters: string[]): string {
+        return `${aliasPath} IS NULL`;
+    }
 }
+
+
+export const IsNull = () => new IsNullOperator();

--- a/src/find-options/operator/IsNull.ts
+++ b/src/find-options/operator/IsNull.ts
@@ -5,7 +5,7 @@ import {Connection} from "../..";
  * Find Options Operator.
  * Example: { someField: IsNull() }
  */
-class IsNullOperator<T> extends FindOperator<T> {
+class IsNullOperator extends FindOperator {
     constructor() {
         super(undefined as any);
     }

--- a/src/find-options/operator/IsNull.ts
+++ b/src/find-options/operator/IsNull.ts
@@ -7,7 +7,7 @@ import {Connection} from "../..";
  */
 class IsNullOperator extends FindOperator {
     constructor() {
-        super(undefined as any);
+        super(undefined as any, false, false);
     }
 
     toSql(connection: Connection, aliasPath: string, parameters: string[]): string {

--- a/src/find-options/operator/LessThan.ts
+++ b/src/find-options/operator/LessThan.ts
@@ -1,9 +1,19 @@
 import {FindOperator} from "../FindOperator";
+import {Connection} from "../..";
 
 /**
  * Find Options Operator.
  * Example: { someField: LessThan(10) }
  */
-export function LessThan<T>(value: T|FindOperator<T>) {
-    return new FindOperator("lessThan", value);
+class LessThanOperator<T> extends FindOperator<T> {
+    constructor(value: FindOperator<T> | T) {
+        super(value);
+    }
+
+    toSql(connection: Connection, aliasPath: string, parameters: string[]): string {
+        return `${aliasPath} < ${parameters[0]}`;
+
+    }
 }
+
+export const LessThan = <T>(value: T | FindOperator<T>) => new LessThanOperator<T>(value);

--- a/src/find-options/operator/LessThanOrEqual.ts
+++ b/src/find-options/operator/LessThanOrEqual.ts
@@ -1,9 +1,19 @@
 import {FindOperator} from "../FindOperator";
+import {Connection} from "../..";
 
 /**
  * Find Options Operator.
  * Example: { someField: LessThanOrEqual(10) }
  */
-export function LessThanOrEqual<T>(value: T|FindOperator<T>) {
-    return new FindOperator("lessThanOrEqual", value);
+class LessThanOrEqualOperator<T> extends FindOperator<T> {
+    constructor(value: FindOperator<T> | T) {
+        super(value);
+    }
+
+    toSql(connection: Connection, aliasPath: string, parameters: string[]): string {
+        return `${aliasPath} <= ${parameters[0]}`;
+    }
 }
+
+
+export const LessThanOrEqual = <T>(value: T | FindOperator<T>) => new LessThanOrEqualOperator<T>(value);

--- a/src/find-options/operator/Like.ts
+++ b/src/find-options/operator/Like.ts
@@ -1,9 +1,19 @@
 import {FindOperator} from "../FindOperator";
+import {Connection} from "../..";
 
 /**
  * Find Options Operator.
  * Example: { someField: Like("%some sting%") }
  */
-export function Like<T>(value: T|FindOperator<T>) {
-    return new FindOperator("like", value);
+class LikeOperator<T> extends FindOperator<T> {
+    constructor(value: FindOperator<T> | T) {
+        super(value);
+    }
+
+    toSql(connection: Connection, aliasPath: string, parameters: string[]): string {
+        return `${aliasPath} LIKE ${parameters[0]}`;
+
+    }
 }
+
+export const Like = <T>(value: T | FindOperator<T>) => new LikeOperator<T>(value);

--- a/src/find-options/operator/MoreThan.ts
+++ b/src/find-options/operator/MoreThan.ts
@@ -1,9 +1,19 @@
 import {FindOperator} from "../FindOperator";
+import {Connection} from "../..";
 
 /**
  * Find Options Operator.
  * Example: { someField: MoreThan(10) }
  */
-export function MoreThan<T>(value: T|FindOperator<T>) {
-    return new FindOperator("moreThan", value);
+class MoreThanOperator<T> extends FindOperator<T> {
+    constructor(value: FindOperator<T> | T) {
+        super(value);
+    }
+
+    toSql(connection: Connection, aliasPath: string, parameters: string[]): string {
+        return `${aliasPath} > ${parameters[0]}`;
+
+    }
 }
+
+export const MoreThan = <T>(value: T | FindOperator<T>) => new MoreThanOperator<T>(value);

--- a/src/find-options/operator/MoreThanOrEqual.ts
+++ b/src/find-options/operator/MoreThanOrEqual.ts
@@ -1,9 +1,19 @@
 import {FindOperator} from "../FindOperator";
+import {Connection} from "../..";
 
 /**
  * Find Options Operator.
  * Example: { someField: MoreThanOrEqual(10) }
  */
-export function MoreThanOrEqual<T>(value: T|FindOperator<T>) {
-    return new FindOperator("moreThanOrEqual", value);
+class MoreThanOrEqualOperator<T> extends FindOperator<T> {
+    constructor(value: FindOperator<T> | T) {
+        super(value);
+    }
+
+    toSql(connection: Connection, aliasPath: string, parameters: string[]): string {
+        return `${aliasPath} >= ${parameters[0]}`;
+
+    }
 }
+
+export const MoreThanOrEqual = <T>(value: T | FindOperator<T>) => new MoreThanOrEqualOperator<T>(value);

--- a/src/find-options/operator/Not.ts
+++ b/src/find-options/operator/Not.ts
@@ -1,10 +1,24 @@
 import {FindOperator} from "../FindOperator";
+import {Connection} from "../..";
 
 /**
  * Find Options Operator.
  * Used to negotiate expression.
  * Example: { title: not("hello") } will return entities where title not equal to "hello".
  */
-export function Not<T>(value: T|FindOperator<T>) {
-    return new FindOperator("not", value);
+class NotOperator<T> extends FindOperator<T> {
+    constructor(value: FindOperator<T> | T) {
+        super(value);
+    }
+
+    toSql(connection: Connection, aliasPath: string, parameters: string[]): string {
+        if (this._value instanceof FindOperator) {
+            return `NOT(${this._value.toSql(connection, aliasPath, parameters)})`;
+        } else {
+            return `${aliasPath} != ${parameters[0]}`;
+        }
+    }
 }
+
+
+export const Not = <T>(value: T | FindOperator<T>) => new NotOperator<T>(value);

--- a/src/find-options/operator/Raw.ts
+++ b/src/find-options/operator/Raw.ts
@@ -7,7 +7,7 @@ type RawOperatorArgs = string|((columnAlias?: string) => string);
  * Find Options Operator.
  * Example: { someField: Raw([...]) }
  */
-class RawOperator extends FindOperator<any> {
+class RawOperator extends FindOperator {
 
     constructor(value: RawOperatorArgs) {
         super(value);

--- a/src/find-options/operator/Raw.ts
+++ b/src/find-options/operator/Raw.ts
@@ -1,9 +1,28 @@
 import {FindOperator} from "../FindOperator";
+import {Connection} from "../..";
+
+type RawOperatorArgs = string|((columnAlias?: string) => string);
 
 /**
  * Find Options Operator.
  * Example: { someField: Raw([...]) }
  */
-export function Raw<T>(value: string|((columnAlias?: string) => string)) {
-    return new FindOperator("raw", value as any, false);
+class RawOperator extends FindOperator<any> {
+
+    constructor(value: RawOperatorArgs) {
+        super(value);
+    }
+
+    toSql(connection: Connection, aliasPath: string, parameters: string[]): string {
+        if (this.value instanceof Function) {
+            return this.value(aliasPath);
+        } else {
+            return `${aliasPath} = ${this.value}`;
+        }
+    }
+}
+
+
+export function Raw(value: RawOperatorArgs): FindOperator {
+    return new RawOperator(value);
 }

--- a/src/find-options/operator/Raw.ts
+++ b/src/find-options/operator/Raw.ts
@@ -10,7 +10,7 @@ type RawOperatorArgs = string|((columnAlias?: string) => string);
 class RawOperator extends FindOperator {
 
     constructor(value: RawOperatorArgs) {
-        super(value);
+        super(value, false);
     }
 
     toSql(connection: Connection, aliasPath: string, parameters: string[]): string {

--- a/test/functional/repository/find-options-operators/entity/Numeric.ts
+++ b/test/functional/repository/find-options-operators/entity/Numeric.ts
@@ -1,0 +1,10 @@
+import {PrimaryGeneratedColumn, Column, Entity} from "../../../../../src";
+
+@Entity()
+export class Numeric {
+    @PrimaryGeneratedColumn()
+    id: number;
+
+    @Column()
+    value: number;
+}

--- a/test/functional/repository/find-options-operators/repository-find-operators.ts
+++ b/test/functional/repository/find-options-operators/repository-find-operators.ts
@@ -5,6 +5,7 @@ import {
     Between,
     Connection,
     Equal,
+    FindOperator,
     In,
     IsNull,
     LessThan,
@@ -13,16 +14,20 @@ import {
     MoreThan,
     MoreThanOrEqual,
     Not,
-    PromiseUtils
+    PromiseUtils,
+    Raw
 } from "../../../../src";
 import {Post} from "./entity/Post";
 import {PostgresDriver} from "../../../../src/driver/postgres/PostgresDriver";
-import {Raw} from "../../../../src/find-options/operator/Raw";
+import * as chai from "chai";
 import {PersonAR} from "./entity/PersonAR";
-import {expect} from "chai";
+import {Numeric} from "./entity/Numeric";
+
+const {expect} = chai;
 
 describe("repository > find options > operators", () => {
 
+    chai.should();
     let connections: Connection[];
     before(async () => connections = await createTestingConnections({
         entities: [__dirname + "/entity/*{.js,.ts}"],
@@ -30,523 +35,616 @@ describe("repository > find options > operators", () => {
     beforeEach(() => reloadTestingDatabases(connections));
     after(() => closeTestingConnections(connections));
 
-    it("not", () => Promise.all(connections.map(async connection => {
-
-        // insert some fake data
-        const post1 = new Post();
-        post1.title = "About #1";
-        post1.likes = 12;
-        await connection.manager.save(post1);
-        const post2 = new Post();
-        post2.title = "About #2";
-        post2.likes = 3;
-        await connection.manager.save(post2);
-
-        // check operator
-        const loadedPosts = await connection.getRepository(Post).find({
-            title: Not("About #1")
-        });
-        loadedPosts.should.be.eql([{ id: 2, likes: 3, title: "About #2" }]);
-
-    })));
-
-    it("lessThan", () => Promise.all(connections.map(async connection => {
-
-        // insert some fake data
-        const post1 = new Post();
-        post1.title = "About #1";
-        post1.likes = 12;
-        await connection.manager.save(post1);
-        const post2 = new Post();
-        post2.title = "About #2";
-        post2.likes = 3;
-        await connection.manager.save(post2);
-
-        // check operator
-        const loadedPosts = await connection.getRepository(Post).find({
-            likes: LessThan(10)
-        });
-        loadedPosts.should.be.eql([{ id: 2, likes: 3, title: "About #2" }]);
-
-    })));
-
-    it("lessThanOrEqual", () => Promise.all(connections.map(async connection => {
-
-        // insert some fake data
-        const post1 = new Post();
-        post1.title = "About #1";
-        post1.likes = 12;
-        await connection.manager.save(post1);
-        const post2 = new Post();
-        post2.title = "About #2";
-        post2.likes = 3;
-        await connection.manager.save(post2);
-        const post3 = new Post();
-        post3.title = "About #3";
-        post3.likes = 13;
-        await connection.manager.save(post3);
-
-        // check operator
-        const loadedPosts = await connection.getRepository(Post).find({
-            likes: LessThanOrEqual(12)
-        });
-        loadedPosts.should.be.eql([
-            { id: 1, likes: 12, title: "About #1" },
-            { id: 2, likes: 3, title: "About #2" }
-        ]);
-
-    })));
-
-    it("not(lessThan)", () => Promise.all(connections.map(async connection => {
-
-        // insert some fake data
-        const post1 = new Post();
-        post1.title = "About #1";
-        post1.likes = 12;
-        await connection.manager.save(post1);
-        const post2 = new Post();
-        post2.title = "About #2";
-        post2.likes = 3;
-        await connection.manager.save(post2);
-
-        // check operator
-        const loadedPosts = await connection.getRepository(Post).find({
-            likes: Not(LessThan(10))
-        });
-        loadedPosts.should.be.eql([{ id: 1, likes: 12, title: "About #1" }]);
-
-    })));
-
-    it("not(lessThanOrEqual)", () => Promise.all(connections.map(async connection => {
-
-        // insert some fake data
-        const post1 = new Post();
-        post1.title = "About #1";
-        post1.likes = 12;
-        await connection.manager.save(post1);
-        const post2 = new Post();
-        post2.title = "About #2";
-        post2.likes = 3;
-        await connection.manager.save(post2);
-        const post3 = new Post();
-        post3.title = "About #3";
-        post3.likes = 13;
-        await connection.manager.save(post3);
-
-        // check operator
-        const loadedPosts = await connection.getRepository(Post).find({
-            likes: Not(LessThanOrEqual(12))
-        });
-        loadedPosts.should.be.eql([{ id: 3, likes: 13, title: "About #3" }]);
-
-    })));
-
-    it("moreThan", () => Promise.all(connections.map(async connection => {
-
-        // insert some fake data
-        const post1 = new Post();
-        post1.title = "About #1";
-        post1.likes = 12;
-        await connection.manager.save(post1);
-        const post2 = new Post();
-        post2.title = "About #2";
-        post2.likes = 3;
-        await connection.manager.save(post2);
-
-        // check operator
-        const loadedPosts = await connection.getRepository(Post).find({
-            likes: MoreThan(10)
-        });
-        loadedPosts.should.be.eql([{ id: 1, likes: 12, title: "About #1" }]);
-
-    })));
-
-    it("moreThanOrEqual", () => Promise.all(connections.map(async connection => {
-
-        // insert some fake data
-        const post1 = new Post();
-        post1.title = "About #1";
-        post1.likes = 12;
-        await connection.manager.save(post1);
-        const post2 = new Post();
-        post2.title = "About #2";
-        post2.likes = 3;
-        await connection.manager.save(post2);
-        const post3 = new Post();
-        post3.title = "About #3";
-        post3.likes = 13;
-        await connection.manager.save(post3);
-
-        // check operator
-        const loadedPosts = await connection.getRepository(Post).find({
-            likes: MoreThanOrEqual(12)
-        });
-        loadedPosts.should.be.eql([
-            { id: 1, likes: 12, title: "About #1" },
-            { id: 3, likes: 13, title: "About #3" }
-        ]);
-
-    })));
-
-    it("not(moreThan)", () => Promise.all(connections.map(async connection => {
-
-        // insert some fake data
-        const post1 = new Post();
-        post1.title = "About #1";
-        post1.likes = 12;
-        await connection.manager.save(post1);
-        const post2 = new Post();
-        post2.title = "About #2";
-        post2.likes = 3;
-        await connection.manager.save(post2);
-
-        // check operator
-        const loadedPosts = await connection.getRepository(Post).find({
-            likes: Not(MoreThan(10))
-        });
-        loadedPosts.should.be.eql([{ id: 2, likes: 3, title: "About #2" }]);
-
-    })));
-
-    it("not(moreThanOrEqual)", () => Promise.all(connections.map(async connection => {
-
-        // insert some fake data
-        const post1 = new Post();
-        post1.title = "About #1";
-        post1.likes = 12;
-        await connection.manager.save(post1);
-        const post2 = new Post();
-        post2.title = "About #2";
-        post2.likes = 3;
-        await connection.manager.save(post2);
-        const post3 = new Post();
-        post3.title = "About #3";
-        post3.likes = 13;
-        await connection.manager.save(post3);
-
-        // check operator
-        const loadedPosts = await connection.getRepository(Post).find({
-            likes: Not(MoreThanOrEqual(12))
-        });
-        loadedPosts.should.be.eql([{ id: 2, likes: 3, title: "About #2" }]);
-
-    })));
-
-    it("equal", () => Promise.all(connections.map(async connection => {
-
-        // insert some fake data
-        const post1 = new Post();
-        post1.title = "About #1";
-        post1.likes = 12;
-        await connection.manager.save(post1);
-        const post2 = new Post();
-        post2.title = "About #2";
-        post2.likes = 3;
-        await connection.manager.save(post2);
-
-        // check operator
-        const loadedPosts = await connection.getRepository(Post).find({
-            title: Equal("About #2")
-        });
-        loadedPosts.should.be.eql([{ id: 2, likes: 3, title: "About #2" }]);
-
-    })));
-
-    it("not(equal)", () => Promise.all(connections.map(async connection => {
-
-        // insert some fake data
-        const post1 = new Post();
-        post1.title = "About #1";
-        post1.likes = 12;
-        await connection.manager.save(post1);
-        const post2 = new Post();
-        post2.title = "About #2";
-        post2.likes = 3;
-        await connection.manager.save(post2);
-
-        // check operator
-        const loadedPosts = await connection.getRepository(Post).find({
-            title: Not(Equal("About #2"))
-        });
-        loadedPosts.should.be.eql([{ id: 1, likes: 12, title: "About #1" }]);
-
-    })));
-
-    it("like", () => Promise.all(connections.map(async connection => {
-
-        // insert some fake data
-        const post1 = new Post();
-        post1.title = "About #1";
-        post1.likes = 12;
-        await connection.manager.save(post1);
-        const post2 = new Post();
-        post2.title = "About #2";
-        post2.likes = 3;
-        await connection.manager.save(post2);
-
-        // check operator
-        const loadedPosts = await connection.getRepository(Post).find({
-            title: Like("%out #%")
-        });
-        loadedPosts.should.be.eql([{ id: 1, likes: 12, title: "About #1" }, { id: 2, likes: 3, title: "About #2" }]);
-
-    })));
-
-    it("not(like)", () => Promise.all(connections.map(async connection => {
-
-        // insert some fake data
-        const post1 = new Post();
-        post1.title = "About #1";
-        post1.likes = 12;
-        await connection.manager.save(post1);
-        const post2 = new Post();
-        post2.title = "About #2";
-        post2.likes = 3;
-        await connection.manager.save(post2);
-
-        // check operator
-        const loadedPosts = await connection.getRepository(Post).find({
-            title: Not(Like("%out #1"))
-        });
-        loadedPosts.should.be.eql([{ id: 2, likes: 3, title: "About #2" }]);
-
-    })));
-
-    it("between", () => Promise.all(connections.map(async connection => {
-
-        // insert some fake data
-        const post1 = new Post();
-        post1.title = "About #1";
-        post1.likes = 12;
-        await connection.manager.save(post1);
-        const post2 = new Post();
-        post2.title = "About #2";
-        post2.likes = 3;
-        await connection.manager.save(post2);
-
-        // check operator
-        const loadedPosts1 = await connection.getRepository(Post).find({
-            likes: Between(1, 10)
-        });
-        loadedPosts1.should.be.eql([{ id: 2, likes: 3, title: "About #2" }]);
-
-        const loadedPosts2 = await connection.getRepository(Post).find({
-            likes: Between(10, 13)
-        });
-        loadedPosts2.should.be.eql([{ id: 1, likes: 12, title: "About #1" }]);
-
-        const loadedPosts3 = await connection.getRepository(Post).find({
-            likes: Between(1, 20)
-        });
-        loadedPosts3.should.be.eql([{ id: 1, likes: 12, title: "About #1" }, { id: 2, likes: 3, title: "About #2" }]);
-
-    })));
-
-    it("not(between)", () => Promise.all(connections.map(async connection => {
-
-        // insert some fake data
-        const post1 = new Post();
-        post1.title = "About #1";
-        post1.likes = 12;
-        await connection.manager.save(post1);
-        const post2 = new Post();
-        post2.title = "About #2";
-        post2.likes = 3;
-        await connection.manager.save(post2);
-
-        // check operator
-        const loadedPosts1 = await connection.getRepository(Post).find({
-            likes: Not(Between(1, 10))
-        });
-        loadedPosts1.should.be.eql([{ id: 1, likes: 12, title: "About #1" }]);
-
-        const loadedPosts2 = await connection.getRepository(Post).find({
-            likes: Not(Between(10, 13))
-        });
-        loadedPosts2.should.be.eql([{ id: 2, likes: 3, title: "About #2" }]);
-
-        const loadedPosts3 = await connection.getRepository(Post).find({
-            likes: Not(Between(1, 20))
-        });
-        loadedPosts3.should.be.eql([]);
-    })));
-
-    it("in", () => Promise.all(connections.map(async connection => {
-
-        // insert some fake data
-        const post1 = new Post();
-        post1.title = "About #1";
-        post1.likes = 12;
-        await connection.manager.save(post1);
-        const post2 = new Post();
-        post2.title = "About #2";
-        post2.likes = 3;
-        await connection.manager.save(post2);
-
-        // check operator
-        const loadedPosts = await connection.getRepository(Post).find({
-            title: In(["About #2", "About #3"])
-        });
-        loadedPosts.should.be.eql([{ id: 2, likes: 3, title: "About #2" }]);
-
-    })));
-
-    it("not(in)", () => Promise.all(connections.map(async connection => {
-
-        // insert some fake data
-        const post1 = new Post();
-        post1.title = "About #1";
-        post1.likes = 12;
-        await connection.manager.save(post1);
-        const post2 = new Post();
-        post2.title = "About #2";
-        post2.likes = 3;
-        await connection.manager.save(post2);
-
-        // check operator
-        const loadedPosts = await connection.getRepository(Post).find({
-            title: Not(In(["About #1", "About #3"]))
-        });
-        loadedPosts.should.be.eql([{ id: 2, likes: 3, title: "About #2" }]);
-
-    })));
-
-    it("any", () => Promise.all(connections.map(async connection => {
-        if (!(connection.driver instanceof PostgresDriver))
-            return;
-
-        // insert some fake data
-        const post1 = new Post();
-        post1.title = "About #1";
-        post1.likes = 12;
-        await connection.manager.save(post1);
-        const post2 = new Post();
-        post2.title = "About #2";
-        post2.likes = 3;
-        await connection.manager.save(post2);
-
-        // check operator
-        const loadedPosts = await connection.getRepository(Post).find({
-            title: Any(["About #2", "About #3"])
-        });
-        loadedPosts.should.be.eql([{ id: 2, likes: 3, title: "About #2" }]);
-
-    })));
-
-    it("not(any)", () => Promise.all(connections.map(async connection => {
-        if (!(connection.driver instanceof PostgresDriver))
-            return;
-
-        // insert some fake data
-        const post1 = new Post();
-        post1.title = "About #1";
-        post1.likes = 12;
-        await connection.manager.save(post1);
-        const post2 = new Post();
-        post2.title = "About #2";
-        post2.likes = 3;
-        await connection.manager.save(post2);
-
-        // check operator
-        const loadedPosts = await connection.getRepository(Post).find({
-            title: Not(Any(["About #2", "About #3"]))
-        });
-        loadedPosts.should.be.eql([{ id: 1, likes: 12, title: "About #1" }]);
-
-    })));
-
-    it("isNull", () => Promise.all(connections.map(async connection => {
-
-        // insert some fake data
-        const post1 = new Post();
-        post1.title = "About #1";
-        post1.likes = 12;
-        await connection.manager.save(post1);
-        const post2 = new Post();
-        post2.title = null as any;
-        post2.likes = 3;
-        await connection.manager.save(post2);
-
-        // check operator
-        const loadedPosts = await connection.getRepository(Post).find({
-            title: IsNull()
-        });
-        loadedPosts.should.be.eql([{ id: 2, likes: 3, title: null }]);
-
-    })));
-
-    it("not(isNull)", () => Promise.all(connections.map(async connection => {
-
-        // insert some fake data
-        const post1 = new Post();
-        post1.title = "About #1";
-        post1.likes = 12;
-        await connection.manager.save(post1);
-        const post2 = new Post();
-        post2.title = null as any;
-        post2.likes = 3;
-        await connection.manager.save(post2);
-
-        // check operator
-        const loadedPosts = await connection.getRepository(Post).find({
-            title: Not(IsNull())
-        });
-        loadedPosts.should.be.eql([{ id: 1, likes: 12, title: "About #1" }]);
-
-    })));
-
-    it("raw", () => Promise.all(connections.map(async connection => {
-
-        // insert some fake data
-        const post1 = new Post();
-        post1.title = "About #1";
-        post1.likes = 12;
-        await connection.manager.save(post1);
-        const post2 = new Post();
-        post2.title = "About #2";
-        post2.likes = 3;
-        await connection.manager.save(post2);
-
-        // check operator
-        const loadedPosts = await connection.getRepository(Post).find({
-            likes: Raw("12")
-        });
-        loadedPosts.should.be.eql([{ id: 1, likes: 12, title: "About #1" }]);
-
-    })));
-
-    it("raw (function)", () => Promise.all(connections.map(async connection => {
-
-        // insert some fake data
-        const post1 = new Post();
-        post1.title = "About #1";
-        post1.likes = 12;
-        await connection.manager.save(post1);
-        const post2 = new Post();
-        post2.title = "About #2";
-        post2.likes = 3;
-        await connection.manager.save(post2);
-
-        // check operator
-        const loadedPosts = await connection.getRepository(Post).find({
-            likes: Raw(columnAlias => "1 + " + columnAlias + " = 4")
-        });
-        loadedPosts.should.be.eql([{ id: 2, likes: 3, title: "About #2" }]);
-
-    })));
-
-    it("should work with ActiveRecord model", () => PromiseUtils.runInSequence(connections, async connection => {
-        PersonAR.useConnection(connection);
-
-        const person = new PersonAR();
-        person.name = "Timber";
-        await connection.manager.save(person);
-
-        const loadedPeople = await PersonAR.find({
-            name: In(["Timber"])
-        });
-        expect(loadedPeople[0].name).to.be.equal("Timber");
-
-    }));
+
+    describe("find operator", () => {
+
+        class TestStatementFormatOperator extends FindOperator {
+            constructor(value: any) {
+                super(value, true, false);
+            }
+
+            toSql(connection: Connection, aliasPath: string, parameters: string[]): string {
+                return `${aliasPath} <::> ${parameters[0]}`;
+            }
+        }
+
+        class TestBetweenNumeriClosedRange extends FindOperator {
+            constructor(value: [number, number]) {
+                super(value, true, true);
+            }
+
+            toSql(connection: Connection, aliasPath: string, parameters: string[]): string {
+                return `${parameters[0]} < ${aliasPath} AND ${aliasPath} < ${parameters[1]}`;
+            }
+        }
+
+        class TestNumericRangeWithOptionsOperator extends FindOperator {
+            private readonly isInclusive: boolean = false;
+
+            constructor(readonly payload: { value: [number, number], inclusive?: boolean }) {
+                super(payload.value, true, true);
+                this.isInclusive = payload.inclusive === true;
+            }
+
+            toSql(connection: Connection, aliasPath: string, parameters: string[]): string {
+                const op = this.isInclusive ? "=" : "";
+                return `${parameters[0]} <${op} ${aliasPath} AND ${aliasPath} <${op} ${parameters[1]}`;
+            }
+        }
+
+
+        it("should produce correctly formatted sql", () => Promise.all(connections.map(async connection => {
+            const operator = new TestStatementFormatOperator("TEST");
+            expect(operator.toSql(connection, "ALIAS", [":value"])).to.equal("ALIAS <::> :value");
+        })));
+
+        it("should be able execute a custom operator's sql", () => Promise.all(connections.map(async connection => {
+            const repository = connection.getRepository(Numeric);
+            await repository.save(Array.from({length: 10}, (_, i) => repository.create({value: i + 1})));
+            const numbersBetweenClosedRange = await repository.find({
+                where: {
+                    value: new TestBetweenNumeriClosedRange([1, 10]),
+                }
+            });
+            expect(numbersBetweenClosedRange.map(item => +item.value)).to.be.deep.equal([2, 3, 4, 5, 6, 7, 8, 9]);
+        })));
+
+
+        it("should allow for more complex constructors", () => Promise.all(connections.map(async connection => {
+            const repository = connection.getRepository(Numeric);
+            await repository.save(Array.from({length: 10}, (_, i) => repository.create({value: i + 1})));
+            const numbersBetweenClosedRange = await repository.find({
+                where: {
+                    value: new TestNumericRangeWithOptionsOperator({value: [1, 10]})
+                }
+            });
+            expect(numbersBetweenClosedRange.map(item => +item.value)).to.be.deep.equal([2, 3, 4, 5, 6, 7, 8, 9]);
+
+            const numbersBetweenOpenRange = await repository.find({
+                where: {
+                    value: new TestNumericRangeWithOptionsOperator({value: [1, 10], inclusive: true})
+                }
+            });
+            expect(numbersBetweenOpenRange.map(item => +item.value)).to.be.deep.equal([1, 2, 3, 4, 5, 6, 7, 8, 9, 10]);
+        })));
+
+        it("should allow for nested find operators", () => Promise.all(connections.map(async connection => {
+            const repository = connection.getRepository(Numeric);
+            await repository.save(Array.from({length: 10}, (_, i) => repository.create({value: i + 1})));
+
+            const numbersNotBetween = await repository.find({
+                where: {
+                    value: Not(new TestNumericRangeWithOptionsOperator({value: [1, 10]}))
+                }
+            });
+
+            expect(numbersNotBetween.map(item => +item.value)).to.be.deep.equal([1, 10]);
+        })));
+
+
+        it("should work with ActiveRecord model", () => PromiseUtils.runInSequence(connections, async connection => {
+            PersonAR.useConnection(connection);
+
+            const person = new PersonAR();
+            person.name = "Timber";
+            await connection.manager.save(person);
+
+            const loadedPeople = await PersonAR.find({
+                name: In(["Timber"])
+            });
+            expect(loadedPeople[0].name).to.be.equal("Timber");
+
+        }));
+    });
+
+    describe("built in operators", () => {
+
+        it("not", () => Promise.all(connections.map(async connection => {
+
+            // insert some fake data
+            const post1 = new Post();
+            post1.title = "About #1";
+            post1.likes = 12;
+            await connection.manager.save(post1);
+            const post2 = new Post();
+            post2.title = "About #2";
+            post2.likes = 3;
+            await connection.manager.save(post2);
+
+            // check operator
+            const loadedPosts = await connection.getRepository(Post).find({
+                title: Not("About #1")
+            });
+
+            console.log({loadedPosts});
+            loadedPosts.should.be.eql([{id: 2, likes: 3, title: "About #2"}]);
+
+        })));
+
+        it("lessThan", () => Promise.all(connections.map(async connection => {
+
+            // insert some fake data
+            const post1 = new Post();
+            post1.title = "About #1";
+            post1.likes = 12;
+            await connection.manager.save(post1);
+            const post2 = new Post();
+            post2.title = "About #2";
+            post2.likes = 3;
+            await connection.manager.save(post2);
+
+            // check operator
+            const loadedPosts = await connection.getRepository(Post).find({
+                likes: LessThan(10)
+            });
+            loadedPosts.should.be.eql([{id: 2, likes: 3, title: "About #2"}]);
+
+        })));
+
+        it("lessThanOrEqual", () => Promise.all(connections.map(async connection => {
+
+            // insert some fake data
+            const post1 = new Post();
+            post1.title = "About #1";
+            post1.likes = 12;
+            await connection.manager.save(post1);
+            const post2 = new Post();
+            post2.title = "About #2";
+            post2.likes = 3;
+            await connection.manager.save(post2);
+            const post3 = new Post();
+            post3.title = "About #3";
+            post3.likes = 13;
+            await connection.manager.save(post3);
+
+            // check operator
+            const loadedPosts = await connection.getRepository(Post).find({
+                likes: LessThanOrEqual(12)
+            });
+            loadedPosts.should.be.eql([
+                {id: 1, likes: 12, title: "About #1"},
+                {id: 2, likes: 3, title: "About #2"}
+            ]);
+
+        })));
+
+        it("not(lessThan)", () => Promise.all(connections.map(async connection => {
+
+            // insert some fake data
+            const post1 = new Post();
+            post1.title = "About #1";
+            post1.likes = 12;
+            await connection.manager.save(post1);
+            const post2 = new Post();
+            post2.title = "About #2";
+            post2.likes = 3;
+            await connection.manager.save(post2);
+
+            // check operator
+            const loadedPosts = await connection.getRepository(Post).find({
+                likes: Not(LessThan(10))
+            });
+            loadedPosts.should.be.eql([{id: 1, likes: 12, title: "About #1"}]);
+
+        })));
+
+        it("not(lessThanOrEqual)", () => Promise.all(connections.map(async connection => {
+
+            // insert some fake data
+            const post1 = new Post();
+            post1.title = "About #1";
+            post1.likes = 12;
+            await connection.manager.save(post1);
+            const post2 = new Post();
+            post2.title = "About #2";
+            post2.likes = 3;
+            await connection.manager.save(post2);
+            const post3 = new Post();
+            post3.title = "About #3";
+            post3.likes = 13;
+            await connection.manager.save(post3);
+
+            // check operator
+            const loadedPosts = await connection.getRepository(Post).find({
+                likes: Not(LessThanOrEqual(12))
+            });
+            loadedPosts.should.be.eql([{id: 3, likes: 13, title: "About #3"}]);
+
+        })));
+
+        it("moreThan", () => Promise.all(connections.map(async connection => {
+
+            // insert some fake data
+            const post1 = new Post();
+            post1.title = "About #1";
+            post1.likes = 12;
+            await connection.manager.save(post1);
+            const post2 = new Post();
+            post2.title = "About #2";
+            post2.likes = 3;
+            await connection.manager.save(post2);
+
+            // check operator
+            const loadedPosts = await connection.getRepository(Post).find({
+                likes: MoreThan(10)
+            });
+            loadedPosts.should.be.eql([{id: 1, likes: 12, title: "About #1"}]);
+
+        })));
+
+        it("moreThanOrEqual", () => Promise.all(connections.map(async connection => {
+
+            // insert some fake data
+            const post1 = new Post();
+            post1.title = "About #1";
+            post1.likes = 12;
+            await connection.manager.save(post1);
+            const post2 = new Post();
+            post2.title = "About #2";
+            post2.likes = 3;
+            await connection.manager.save(post2);
+            const post3 = new Post();
+            post3.title = "About #3";
+            post3.likes = 13;
+            await connection.manager.save(post3);
+
+            // check operator
+            const loadedPosts = await connection.getRepository(Post).find({
+                likes: MoreThanOrEqual(12)
+            });
+            loadedPosts.should.be.eql([
+                {id: 1, likes: 12, title: "About #1"},
+                {id: 3, likes: 13, title: "About #3"}
+            ]);
+
+        })));
+
+        it("not(moreThan)", () => Promise.all(connections.map(async connection => {
+
+            // insert some fake data
+            const post1 = new Post();
+            post1.title = "About #1";
+            post1.likes = 12;
+            await connection.manager.save(post1);
+            const post2 = new Post();
+            post2.title = "About #2";
+            post2.likes = 3;
+            await connection.manager.save(post2);
+
+            // check operator
+            const loadedPosts = await connection.getRepository(Post).find({
+                likes: Not(MoreThan(10))
+            });
+            loadedPosts.should.be.eql([{id: 2, likes: 3, title: "About #2"}]);
+
+        })));
+
+        it("not(moreThanOrEqual)", () => Promise.all(connections.map(async connection => {
+
+            // insert some fake data
+            const post1 = new Post();
+            post1.title = "About #1";
+            post1.likes = 12;
+            await connection.manager.save(post1);
+            const post2 = new Post();
+            post2.title = "About #2";
+            post2.likes = 3;
+            await connection.manager.save(post2);
+            const post3 = new Post();
+            post3.title = "About #3";
+            post3.likes = 13;
+            await connection.manager.save(post3);
+
+            // check operator
+            const loadedPosts = await connection.getRepository(Post).find({
+                likes: Not(MoreThanOrEqual(12))
+            });
+            loadedPosts.should.be.eql([{id: 2, likes: 3, title: "About #2"}]);
+
+        })));
+
+        it("equal", () => Promise.all(connections.map(async connection => {
+
+            // insert some fake data
+            const post1 = new Post();
+            post1.title = "About #1";
+            post1.likes = 12;
+            await connection.manager.save(post1);
+            const post2 = new Post();
+            post2.title = "About #2";
+            post2.likes = 3;
+            await connection.manager.save(post2);
+
+            // check operator
+            const loadedPosts = await connection.getRepository(Post).find({
+                title: Equal("About #2")
+            });
+            loadedPosts.should.be.eql([{id: 2, likes: 3, title: "About #2"}]);
+
+        })));
+
+        it("not(equal)", () => Promise.all(connections.map(async connection => {
+
+            // insert some fake data
+            const post1 = new Post();
+            post1.title = "About #1";
+            post1.likes = 12;
+            await connection.manager.save(post1);
+            const post2 = new Post();
+            post2.title = "About #2";
+            post2.likes = 3;
+            await connection.manager.save(post2);
+
+            // check operator
+            const loadedPosts = await connection.getRepository(Post).find({
+                title: Not(Equal("About #2"))
+            });
+            loadedPosts.should.be.eql([{id: 1, likes: 12, title: "About #1"}]);
+
+        })));
+
+        it("like", () => Promise.all(connections.map(async connection => {
+
+            // insert some fake data
+            const post1 = new Post();
+            post1.title = "About #1";
+            post1.likes = 12;
+            await connection.manager.save(post1);
+            const post2 = new Post();
+            post2.title = "About #2";
+            post2.likes = 3;
+            await connection.manager.save(post2);
+
+            // check operator
+            const loadedPosts = await connection.getRepository(Post).find({
+                title: Like("%out #%")
+            });
+            loadedPosts.should.be.eql([{id: 1, likes: 12, title: "About #1"}, {id: 2, likes: 3, title: "About #2"}]);
+
+        })));
+
+        it("not(like)", () => Promise.all(connections.map(async connection => {
+
+            // insert some fake data
+            const post1 = new Post();
+            post1.title = "About #1";
+            post1.likes = 12;
+            await connection.manager.save(post1);
+            const post2 = new Post();
+            post2.title = "About #2";
+            post2.likes = 3;
+            await connection.manager.save(post2);
+
+            // check operator
+            const loadedPosts = await connection.getRepository(Post).find({
+                title: Not(Like("%out #1"))
+            });
+            loadedPosts.should.be.eql([{id: 2, likes: 3, title: "About #2"}]);
+
+        })));
+
+        it("between", () => Promise.all(connections.map(async connection => {
+
+            // insert some fake data
+            const post1 = new Post();
+            post1.title = "About #1";
+            post1.likes = 12;
+            await connection.manager.save(post1);
+            const post2 = new Post();
+            post2.title = "About #2";
+            post2.likes = 3;
+            await connection.manager.save(post2);
+
+            // check operator
+            const loadedPosts1 = await connection.getRepository(Post).find({
+                likes: Between(1, 10)
+            });
+            loadedPosts1.should.be.eql([{id: 2, likes: 3, title: "About #2"}]);
+
+            const loadedPosts2 = await connection.getRepository(Post).find({
+                likes: Between(10, 13)
+            });
+            loadedPosts2.should.be.eql([{id: 1, likes: 12, title: "About #1"}]);
+
+            const loadedPosts3 = await connection.getRepository(Post).find({
+                likes: Between(1, 20)
+            });
+            loadedPosts3.should.be.eql([{id: 1, likes: 12, title: "About #1"}, {id: 2, likes: 3, title: "About #2"}]);
+
+        })));
+
+        it("not(between)", () => Promise.all(connections.map(async connection => {
+
+            // insert some fake data
+            const post1 = new Post();
+            post1.title = "About #1";
+            post1.likes = 12;
+            await connection.manager.save(post1);
+            const post2 = new Post();
+            post2.title = "About #2";
+            post2.likes = 3;
+            await connection.manager.save(post2);
+
+            // check operator
+            const loadedPosts1 = await connection.getRepository(Post).find({
+                likes: Not(Between(1, 10))
+            });
+            loadedPosts1.should.be.eql([{id: 1, likes: 12, title: "About #1"}]);
+
+            const loadedPosts2 = await connection.getRepository(Post).find({
+                likes: Not(Between(10, 13))
+            });
+            loadedPosts2.should.be.eql([{id: 2, likes: 3, title: "About #2"}]);
+
+            const loadedPosts3 = await connection.getRepository(Post).find({
+                likes: Not(Between(1, 20))
+            });
+            loadedPosts3.should.be.eql([]);
+        })));
+
+        it("in", () => Promise.all(connections.map(async connection => {
+
+            // insert some fake data
+            const post1 = new Post();
+            post1.title = "About #1";
+            post1.likes = 12;
+            await connection.manager.save(post1);
+            const post2 = new Post();
+            post2.title = "About #2";
+            post2.likes = 3;
+            await connection.manager.save(post2);
+
+            // check operator
+            const loadedPosts = await connection.getRepository(Post).find({
+                title: In(["About #2", "About #3"])
+            });
+            loadedPosts.should.be.eql([{id: 2, likes: 3, title: "About #2"}]);
+
+        })));
+
+        it("not(in)", () => Promise.all(connections.map(async connection => {
+
+            // insert some fake data
+            const post1 = new Post();
+            post1.title = "About #1";
+            post1.likes = 12;
+            await connection.manager.save(post1);
+            const post2 = new Post();
+            post2.title = "About #2";
+            post2.likes = 3;
+            await connection.manager.save(post2);
+
+            // check operator
+            const loadedPosts = await connection.getRepository(Post).find({
+                title: Not(In(["About #1", "About #3"]))
+            });
+            loadedPosts.should.be.eql([{id: 2, likes: 3, title: "About #2"}]);
+
+        })));
+
+        it("any", () => Promise.all(connections.map(async connection => {
+            if (!(connection.driver instanceof PostgresDriver))
+                return;
+
+            // insert some fake data
+            const post1 = new Post();
+            post1.title = "About #1";
+            post1.likes = 12;
+            await connection.manager.save(post1);
+            const post2 = new Post();
+            post2.title = "About #2";
+            post2.likes = 3;
+            await connection.manager.save(post2);
+
+            // check operator
+            const loadedPosts = await connection.getRepository(Post).find({
+                title: Any(["About #2", "About #3"])
+            });
+            loadedPosts.should.be.eql([{id: 2, likes: 3, title: "About #2"}]);
+
+        })));
+
+        it("not(any)", () => Promise.all(connections.map(async connection => {
+            if (!(connection.driver instanceof PostgresDriver))
+                return;
+
+            // insert some fake data
+            const post1 = new Post();
+            post1.title = "About #1";
+            post1.likes = 12;
+            await connection.manager.save(post1);
+            const post2 = new Post();
+            post2.title = "About #2";
+            post2.likes = 3;
+            await connection.manager.save(post2);
+
+            // check operator
+            const loadedPosts = await connection.getRepository(Post).find({
+                title: Not(Any(["About #2", "About #3"]))
+            });
+            loadedPosts.should.be.eql([{id: 1, likes: 12, title: "About #1"}]);
+
+        })));
+
+        it("isNull", () => Promise.all(connections.map(async connection => {
+
+            // insert some fake data
+            const post1 = new Post();
+            post1.title = "About #1";
+            post1.likes = 12;
+            await connection.manager.save(post1);
+            const post2 = new Post();
+            post2.title = null as any;
+            post2.likes = 3;
+            await connection.manager.save(post2);
+
+            // check operator
+            const loadedPosts = await connection.getRepository(Post).find({
+                title: IsNull()
+            });
+            loadedPosts.should.be.eql([{id: 2, likes: 3, title: null}]);
+
+        })));
+
+        it("not(isNull)", () => Promise.all(connections.map(async connection => {
+
+            // insert some fake data
+            const post1 = new Post();
+            post1.title = "About #1";
+            post1.likes = 12;
+            await connection.manager.save(post1);
+            const post2 = new Post();
+            post2.title = null as any;
+            post2.likes = 3;
+            await connection.manager.save(post2);
+
+            // check operator
+            const loadedPosts = await connection.getRepository(Post).find({
+                title: Not(IsNull())
+            });
+            loadedPosts.should.be.eql([{id: 1, likes: 12, title: "About #1"}]);
+
+        })));
+
+        it("raw", () => Promise.all(connections.map(async connection => {
+
+            // insert some fake data
+            const post1 = new Post();
+            post1.title = "About #1";
+            post1.likes = 12;
+            await connection.manager.save(post1);
+            const post2 = new Post();
+            post2.title = "About #2";
+            post2.likes = 3;
+            await connection.manager.save(post2);
+
+            // check operator
+            const loadedPosts = await connection.getRepository(Post).find({
+                likes: Raw("12")
+            });
+            loadedPosts.should.be.eql([{id: 1, likes: 12, title: "About #1"}]);
+
+        })));
+
+        it("raw (function)", () => Promise.all(connections.map(async connection => {
+
+            // insert some fake data
+            const post1 = new Post();
+            post1.title = "About #1";
+            post1.likes = 12;
+            await connection.manager.save(post1);
+            const post2 = new Post();
+            post2.title = "About #2";
+            post2.likes = 3;
+            await connection.manager.save(post2);
+
+            // check operator
+            const loadedPosts = await connection.getRepository(Post).find({
+                likes: Raw(columnAlias => "1 + " + columnAlias + " = 4")
+            });
+            loadedPosts.should.be.eql([{id: 2, likes: 3, title: "About #2"}]);
+
+        })));
+    });
 
 });

--- a/test/functional/repository/find-options-operators/repository-find-operators.ts
+++ b/test/functional/repository/find-options-operators/repository-find-operators.ts
@@ -156,7 +156,6 @@ describe("repository > find options > operators", () => {
                 title: Not("About #1")
             });
 
-            console.log({loadedPosts});
             loadedPosts.should.be.eql([{id: 2, likes: 3, title: "About #2"}]);
 
         })));


### PR DESCRIPTION
Inspired by this issue: https://github.com/typeorm/typeorm/issues/4418

Currently the only way (I can see) to add custom where operators is to extend the base FindOperator class, but the class isn't made very extendable, all the potential operators are handled by a switch statement inside it.

With this refactor, each operator is in charge of creating and providing its own SQL statement, so now writing a new operator is very simple, and the constructor can be locked down to restrict types at compile time.

Alternatively if the class based approach is not a route you want to take with the code base, we can just add another parameter to the FindOperator constructor which is `statement` and pass it in. 