### PR TITLE
add default value note for unique @Column option

### DIFF
--- a/docs/decorator-reference.md
+++ b/docs/decorator-reference.md
@@ -178,7 +178,7 @@ Default value is `true`.
 * `select: boolean` - Defines whether or not to hide this column by default when making queries. When set to `false`, the column data will not show with a standard query. By default column is `select: true`
 * `default: string` - Adds database-level column's `DEFAULT` value.
 * `primary: boolean` - Marks column as primary. Same as using  `@PrimaryColumn`.
-* `unique: boolean` - Marks column as unique column (creates unique constraint).
+* `unique: boolean` - Marks column as unique column (creates unique constraint). Default value is false.
 * `comment: string` - Database's column comment. Not supported by all database types.
 * `precision: number` - The precision for a decimal (exact numeric) column (applies only for decimal column), which is the maximum
  number of digits that are stored for the values. Used in some column types.


### PR DESCRIPTION
adds note about the "default" value of the unique option of the `@Column` decorator

I'm pretty sure this is true. Feel free to just close this PR if not. I just noticed some explicit `unique: false`'s in our project and wanted to make this clear in the docs