### PR TITLE
update cli migration up and down from any to void

### DIFF
--- a/docs/migrations.md
+++ b/docs/migrations.md
@@ -22,16 +22,16 @@ import { Entity, Column, PrimaryGeneratedColumn } from 'typeorm';
 
 @Entity()
 export class Post {
-    
+
     @PrimaryGeneratedColumn()
     id: number;
-    
+
     @Column()
     title: string;
-    
+
     @Column()
     text: string;
-    
+
 }
 ```
 
@@ -39,7 +39,7 @@ And your entity worked in production for months without any changes.
 You have thousands of posts in your database.
 
 Now you need to make a new release and rename `title` to `name`.
-What would you do? 
+What would you do?
 
 You need to create a new migration with the following sql query (postgres dialect):
 
@@ -96,16 +96,16 @@ You should see the following content inside your migration:
 import {MigrationInterface, QueryRunner} from "typeorm";
 
 export class PostRefactoringTIMESTAMP implements MigrationInterface {
-    
-    async up(queryRunner: QueryRunner): Promise<any> {
-        
+
+    async up(queryRunner: QueryRunner): Promise<void> {
+
     }
 
-    async down(queryRunner: QueryRunner): Promise<any> { 
-        
+    async down(queryRunner: QueryRunner): Promise<void> {
+
     }
 
-    
+
 }
 ```
 
@@ -124,12 +124,12 @@ Let's see what the migration looks like with our `Post` changes:
 import {MigrationInterface, QueryRunner} from "typeorm";
 
 export class PostRefactoringTIMESTAMP implements MigrationInterface {
-    
-    async up(queryRunner: QueryRunner): Promise<any> {
+
+    async up(queryRunner: QueryRunner): Promise<void> {
         await queryRunner.query(`ALTER TABLE "post" RENAME COLUMN "title" TO "name"`);
     }
 
-    async down(queryRunner: QueryRunner): Promise<any> { 
+    async down(queryRunner: QueryRunner): Promise<void> {
         await queryRunner.query(`ALTER TABLE "post" RENAME COLUMN "name" TO "title"`); // reverts things made in "up" method
     }
 }
@@ -180,20 +180,20 @@ And it will generate a new migration called `{TIMESTAMP}-PostRefactoring.ts` wit
 import {MigrationInterface, QueryRunner} from "typeorm";
 
 export class PostRefactoringTIMESTAMP implements MigrationInterface {
-    
-    async up(queryRunner: QueryRunner): Promise<any> {
+
+    async up(queryRunner: QueryRunner): Promise<void> {
         await queryRunner.query(`ALTER TABLE "post" ALTER COLUMN "title" RENAME TO "name"`);
     }
 
-    async down(queryRunner: QueryRunner): Promise<any> { 
+    async down(queryRunner: QueryRunner): Promise<void> {
         await queryRunner.query(`ALTER TABLE "post" ALTER COLUMN "name" RENAME TO "title"`);
     }
 
-    
+
 }
 ```
 
-See, you don't need to write the queries on your own. 
+See, you don't need to write the queries on your own.
 The rule of thumb for generating migrations is that you generate them after "each" change you made to your models.
 
 ## Using migration API to write migrations
@@ -206,8 +206,8 @@ Example:
 import {MigrationInterface, QueryRunner, Table, TableIndex, TableColumn, TableForeignKey } from "typeorm";
 
 export class QuestionRefactoringTIMESTAMP implements MigrationInterface {
-    
-    async up(queryRunner: QueryRunner): Promise<any> {
+
+    async up(queryRunner: QueryRunner): Promise<void> {
         await queryRunner.createTable(new Table({
             name: "question",
             columns: [
@@ -221,13 +221,13 @@ export class QuestionRefactoringTIMESTAMP implements MigrationInterface {
                     type: "varchar",
                 }
             ]
-        }), true)        
-        
+        }), true)
+
         await queryRunner.createIndex("question", new TableIndex({
             name: "IDX_QUESTION_NAME",
             columnNames: ["name"]
         }));
-        
+
         await queryRunner.createTable(new Table({
             name: "answer",
             columns: [
@@ -242,12 +242,12 @@ export class QuestionRefactoringTIMESTAMP implements MigrationInterface {
                 }
             ]
         }), true);
-        
+
         await queryRunner.addColumn("answer", new TableColumn({
-            name: "questionId", 
-            type: "int" 
+            name: "questionId",
+            type: "int"
         }));
-        
+
         await queryRunner.createForeignKey("answer", new TableForeignKey({
             columnNames: ["questionId"],
             referencedColumnNames: ["id"],
@@ -256,7 +256,7 @@ export class QuestionRefactoringTIMESTAMP implements MigrationInterface {
         }));
     }
 
-    async down(queryRunner: QueryRunner): Promise<any> {
+    async down(queryRunner: QueryRunner): Promise<void> {
         const table = await queryRunner.getTable("question");
         const foreignKey = table.foreignKeys.find(fk => fk.columnNames.indexOf("questionId") !== -1);
         await queryRunner.dropForeignKey("question", foreignKey);
@@ -265,64 +265,64 @@ export class QuestionRefactoringTIMESTAMP implements MigrationInterface {
         await queryRunner.dropIndex("question", "IDX_QUESTION_NAME");
         await queryRunner.dropTable("question");
     }
-    
+
 }
 ```
 
 ---
 
-```ts 
+```ts
 getDatabases(): Promise<string[]>
 ```
- 
+
 Returns all available database names including system databases.
 
 ---
 
-```ts 
+```ts
 getSchemas(database?: string): Promise<string[]>
 ```
- 
+
 - `database` - If database parameter specified, returns schemas of that database
 
 Returns all available schema names including system schemas. Useful for SQLServer and Postgres only.
 
 ---
 
-```ts 
+```ts
 getTable(tableName: string): Promise<Table|undefined>
 ```
- 
+
 - `tableName` - name of a table to be loaded
 
 Loads a table by a given name from the database.
 
 ---
 
-```ts 
+```ts
 getTables(tableNames: string[]): Promise<Table[]>
 ```
- 
+
 - `tableNames` - name of a tables to be loaded
 
 Loads a tables by a given names from the database.
 
 ---
 
-```ts 
+```ts
 hasDatabase(database: string): Promise<boolean>
 ```
- 
+
 - `database` - name of a database to be checked
 
 Checks if database with the given name exist.
 
 ---
 
-```ts 
+```ts
 hasSchema(schema: string): Promise<boolean>
 ```
- 
+
 - `schema` - name of a schema to be checked
 
 Checks if schema with the given name exist. Used only for SqlServer and Postgres.
@@ -332,17 +332,17 @@ Checks if schema with the given name exist. Used only for SqlServer and Postgres
 ```ts
 hasTable(table: Table|string): Promise<boolean>
 ```
- 
+
 - `table` - Table object or name
 
 Checks if table exist.
 
 ---
 
-```ts 
+```ts
 hasColumn(table: Table|string, columnName: string): Promise<boolean>
 ```
- 
+
 - `table` - Table object or name
 - `columnName` - name of a column to be checked
 
@@ -350,21 +350,21 @@ Checks if column exist in the table.
 
 ---
 
-```ts 
+```ts
 createDatabase(database: string, ifNotExist?: boolean): Promise<void>
 ```
- 
+
 - `database` - database name
 - `ifNotExist` - skips creation if `true`, otherwise throws error if database already exist
 
-Creates a new database. 
+Creates a new database.
 
 ---
 
-```ts 
+```ts
 dropDatabase(database: string, ifExist?: boolean): Promise<void>
 ```
- 
+
 - `database` - database name
 - `ifExist` - skips deletion if `true`, otherwise throws error if database was not found
 
@@ -372,10 +372,10 @@ Drops database.
 
 ---
 
-```ts 
+```ts
 createSchema(schemaPath: string, ifNotExist?: boolean): Promise<void>
 ```
- 
+
 - `schemaPath` - schema name. For SqlServer can accept schema path (e.g. 'dbName.schemaName') as parameter. 
 If schema path passed, it will create schema in specified database
 - `ifNotExist` - skips creation if `true`, otherwise throws error if schema already exist
@@ -384,10 +384,10 @@ Creates a new table schema.
 
 ---
 
-```ts 
+```ts
 dropSchema(schemaPath: string, ifExist?: boolean, isCascade?: boolean): Promise<void>
 ```
- 
+
 - `schemaPath` - schema name. For SqlServer can accept schema path (e.g. 'dbName.schemaName') as parameter. 
 If schema path passed, it will drop schema in specified database
 - `ifExist` - skips deletion if `true`, otherwise throws error if schema was not found
@@ -398,11 +398,11 @@ Drops a table schema.
 
 ---
 
-```ts 
+```ts
 createTable(table: Table, ifNotExist?: boolean, createForeignKeys?: boolean, createIndices?: boolean): Promise<void>
 ```
 
-- `table` - Table object. 
+- `table` - Table object.
 - `ifNotExist` - skips creation if `true`, otherwise throws error if table already exist. Default `false`
 - `createForeignKeys` - indicates whether foreign keys will be created on table creation. Default `true`
 - `createIndices` - indicates whether indices will be created on table creation. Default `true`
@@ -411,7 +411,7 @@ Creates a new table.
 
 ---
 
-```ts 
+```ts
 dropTable(table: Table|string, ifExist?: boolean, dropForeignKeys?: boolean, dropIndices?: boolean): Promise<void>
 ```
 
@@ -424,7 +424,7 @@ Drops a table.
 
 ---
 
-```ts 
+```ts
 renameTable(oldTableOrName: Table|string, newTableName: string): Promise<void>
 ```
 
@@ -435,7 +435,7 @@ Renames a table.
 
 ---
 
-```ts 
+```ts
 addColumn(table: Table|string, column: TableColumn): Promise<void>
 ```
 
@@ -446,7 +446,7 @@ Adds a new column.
 
 ---
 
-```ts 
+```ts
 addColumns(table: Table|string, columns: TableColumn[]): Promise<void>
 ```
 
@@ -457,7 +457,7 @@ Adds a new column.
 
 ---
 
-```ts 
+```ts
 renameColumn(table: Table|string, oldColumnOrName: TableColumn|string, newColumnOrName: TableColumn|string): Promise<void>
 ```
 
@@ -469,7 +469,7 @@ Renames a column.
 
 ---
 
-```ts 
+```ts
 changeColumn(table: Table|string, oldColumn: TableColumn|string, newColumn: TableColumn): Promise<void>
 ```
 
@@ -481,7 +481,7 @@ Changes a column in the table.
 
 ---
 
-```ts 
+```ts
 changeColumns(table: Table|string, changedColumns: { oldColumn: TableColumn, newColumn: TableColumn }[]): Promise<void>
 ```
 
@@ -494,7 +494,7 @@ Changes a columns in the table.
 
 ---
 
-```ts 
+```ts
 dropColumn(table: Table|string, column: TableColumn|string): Promise<void>
 ```
 
@@ -505,7 +505,7 @@ Drops a column in the table.
 
 ---
 
-```ts 
+```ts
 dropColumns(table: Table|string, columns: TableColumn[]): Promise<void>
 ```
 
@@ -516,7 +516,7 @@ Drops a columns in the table.
 
 ---
 
-```ts 
+```ts
 createPrimaryKey(table: Table|string, columnNames: string[]): Promise<void>
 ```
 
@@ -527,7 +527,7 @@ Creates a new primary key.
 
 ---
 
-```ts 
+```ts
 updatePrimaryKeys(table: Table|string, columns: TableColumn[]): Promise<void>
 ```
 
@@ -538,7 +538,7 @@ Updates composite primary keys.
 
 ---
 
-```ts 
+```ts
 dropPrimaryKey(table: Table|string): Promise<void>
 ```
 
@@ -548,7 +548,7 @@ Drops a primary key.
 
 ---
 
-```ts 
+```ts
 createUniqueConstraint(table: Table|string, uniqueConstraint: TableUnique): Promise<void>
 ```
 
@@ -561,7 +561,7 @@ Creates new unique constraint.
 
 ---
 
-```ts 
+```ts
 createUniqueConstraints(table: Table|string, uniqueConstraints: TableUnique[]): Promise<void>
 ```
 

--- a/docs/zh_CN/migrations.md
+++ b/docs/zh_CN/migrations.md
@@ -94,9 +94,9 @@ typeorm migration:create -n PostRefactoring
 import { MigrationInterface, QueryRunner } from "typeorm";
 
 export class PostRefactoringTIMESTAMP implements MigrationInterface {
-  async up(queryRunner: QueryRunner): Promise<any> {}
+  async up(queryRunner: QueryRunner): Promise<void> {}
 
-  async down(queryRunner: QueryRunner): Promise<any> {}
+  async down(queryRunner: QueryRunner): Promise<void> {}
 }
 ```
 
@@ -115,11 +115,11 @@ export class PostRefactoringTIMESTAMP implements MigrationInterface {
 import { MigrationInterface, QueryRunner } from "typeorm";
 
 export class PostRefactoringTIMESTAMP implements MigrationInterface {
-  async up(queryRunner: QueryRunner): Promise<any> {
+  async up(queryRunner: QueryRunner): Promise<void> {
     await queryRunner.query(`ALTER TABLE "post" ALTER COLUMN "title" RENAME TO "name"`);
   }
 
-  async down(queryRunner: QueryRunner): Promise<any> {
+  async down(queryRunner: QueryRunner): Promise<void> {
     await queryRunner.query(`ALTER TABLE "post" ALTER COLUMN "name" RENAME TO "title"`); // 恢复"up"方法所做的事情
   }
 }
@@ -171,11 +171,11 @@ typeorm migration:generate -n PostRefactoring
 import { MigrationInterface, QueryRunner } from "typeorm";
 
 export class PostRefactoringTIMESTAMP implements MigrationInterface {
-  async up(queryRunner: QueryRunner): Promise<any> {
+  async up(queryRunner: QueryRunner): Promise<void> {
     await queryRunner.query(`ALTER TABLE "post" ALTER COLUMN "title" RENAME TO "name"`);
   }
 
-  async down(queryRunner: QueryRunner): Promise<any> {
+  async down(queryRunner: QueryRunner): Promise<void> {
     await queryRunner.query(`ALTER TABLE "post" ALTER COLUMN "name" RENAME TO "title"`);
   }
 }
@@ -194,7 +194,7 @@ export class PostRefactoringTIMESTAMP implements MigrationInterface {
 import { MigrationInterface, QueryRunner, Table, TableIndex, TableColumn, TableForeignKey } from "typeorm";
 
 export class QuestionRefactoringTIMESTAMP implements MigrationInterface {
-  async up(queryRunner: QueryRunner): Promise<any> {
+  async up(queryRunner: QueryRunner): Promise<void> {
     await queryRunner.createTable(
       new Table({
         name: "question",
@@ -258,7 +258,7 @@ export class QuestionRefactoringTIMESTAMP implements MigrationInterface {
     );
   }
 
-  async down(queryRunner: QueryRunner): Promise<any> {
+  async down(queryRunner: QueryRunner): Promise<void> {
     const table = await queryRunner.getTable("question");
     const foreignKey = table.foreignKeys.find(fk => fk.columnNames.indexOf("questionId") !== -1);
     await queryRunner.dropForeignKey("question", foreignKey);

--- a/src/commands/MigrationCreateCommand.ts
+++ b/src/commands/MigrationCreateCommand.ts
@@ -82,10 +82,10 @@ export class MigrationCreateCommand implements yargs.CommandModule {
 
 export class ${camelCase(name, true)}${timestamp} implements MigrationInterface {
 
-    public async up(queryRunner: QueryRunner): Promise<any> {
+    public async up(queryRunner: QueryRunner): Promise<void> {
     }
 
-    public async down(queryRunner: QueryRunner): Promise<any> {
+    public async down(queryRunner: QueryRunner): Promise<void> {
     }
 
 }

--- a/test/functional/migrations/show-command/migration/1530542855524-ExampleMigration.ts
+++ b/test/functional/migrations/show-command/migration/1530542855524-ExampleMigration.ts
@@ -2,8 +2,8 @@ import { MigrationInterface } from "../../../../../src/migration/MigrationInterf
 import { QueryRunner } from "../../../../../src/query-runner/QueryRunner";
 
 export class ExampleMigration1530542855524 implements MigrationInterface {
-    public async up(queryRunner: QueryRunner): Promise<any> {
+    public async up(queryRunner: QueryRunner): Promise<void> {
     }
-    public async down(queryRunner: QueryRunner): Promise<any> {
+    public async down(queryRunner: QueryRunner): Promise<void> {
     }
 }

--- a/test/functional/migrations/show-command/migration/1530542855524-ExampleMigrationTwo.ts
+++ b/test/functional/migrations/show-command/migration/1530542855524-ExampleMigrationTwo.ts
@@ -2,8 +2,8 @@ import { MigrationInterface } from "../../../../../src/migration/MigrationInterf
 import { QueryRunner } from "../../../../../src/query-runner/QueryRunner";
 
 export class ExampleMigrationTwo1530542855524 implements MigrationInterface {
-    public async up(queryRunner: QueryRunner): Promise<any> {
+    public async up(queryRunner: QueryRunner): Promise<void> {
     }
-    public async down(queryRunner: QueryRunner): Promise<any> {
+    public async down(queryRunner: QueryRunner): Promise<void> {
     }
 }

--- a/test/github-issues/2875/migration/1530542855524-CreateUsersSeq.ts
+++ b/test/github-issues/2875/migration/1530542855524-CreateUsersSeq.ts
@@ -2,7 +2,7 @@ import { MigrationInterface } from "../../../../src/migration/MigrationInterface
 import { QueryRunner } from "../../../../src/query-runner/QueryRunner";
 
 export class InitUsers1530542855524 implements MigrationInterface {
-     public async up(queryRunner: QueryRunner): Promise<any> {
+     public async up(queryRunner: QueryRunner): Promise<void> {
         await queryRunner.query(`
             CREATE SEQUENCE users_id_seq INCREMENT 1 MINVALUE 1 MAXVALUE 9223372036854775807 START 1 CACHE 1
         `);
@@ -10,7 +10,7 @@ export class InitUsers1530542855524 implements MigrationInterface {
             DROP SEQUENCE IF EXISTS users_id_seq
         `);
     }
-     public async down(queryRunner: QueryRunner): Promise<any> {
+     public async down(queryRunner: QueryRunner): Promise<void> {
         await queryRunner.query(`
             DROP SEQUENCE IF EXISTS users_id_seq
         `);

--- a/test/github-issues/4701/migration/1567759789051-ExampleMigration.ts
+++ b/test/github-issues/4701/migration/1567759789051-ExampleMigration.ts
@@ -2,6 +2,6 @@ import { MigrationInterface } from "../../../../src/migration/MigrationInterface
 import { QueryRunner } from "../../../../src/query-runner/QueryRunner";
 
 export class ExampleMigrationOne1567759789051 implements MigrationInterface {
-    public async up(queryRunner: QueryRunner): Promise<any> {}
-    public async down(queryRunner: QueryRunner): Promise<any> {}
+    public async up(queryRunner: QueryRunner): Promise<void> {}
+    public async down(queryRunner: QueryRunner): Promise<void> {}
 }

--- a/test/github-issues/4701/migration/1567759832591-ExampleMigrationTwo.ts
+++ b/test/github-issues/4701/migration/1567759832591-ExampleMigrationTwo.ts
@@ -2,6 +2,6 @@ import { MigrationInterface } from "../../../../src/migration/MigrationInterface
 import { QueryRunner } from "../../../../src/query-runner/QueryRunner";
 
 export class ExampleMigrationOne1567759789051 implements MigrationInterface {
-    public async up(queryRunner: QueryRunner): Promise<any> {}
-    public async down(queryRunner: QueryRunner): Promise<any> {}
+    public async up(queryRunner: QueryRunner): Promise<void> {}
+    public async down(queryRunner: QueryRunner): Promise<void> {}
 }

--- a/test/github-issues/4701/migration/1571426391120-ExampleMigrationThree.ts
+++ b/test/github-issues/4701/migration/1571426391120-ExampleMigrationThree.ts
@@ -2,6 +2,6 @@ import { MigrationInterface } from "../../../../src/migration/MigrationInterface
 import { QueryRunner } from "../../../../src/query-runner/QueryRunner";
 
 export class ExampleMigrationThree1571426391120 implements MigrationInterface {
-    public async up(queryRunner: QueryRunner): Promise<any> {}
-    public async down(queryRunner: QueryRunner): Promise<any> {}
+    public async up(queryRunner: QueryRunner): Promise<void> {}
+    public async down(queryRunner: QueryRunner): Promise<void> {}
 }


### PR DESCRIPTION
Following the open issue https://github.com/typeorm/typeorm/issues/5629 I created a pull request.

I kept the `migration/MigrationInterface.d.ts` to `Promise<any>` so use-case like `test/github-issues/2693/migration/0000000000003-InsertUser.ts` still work.