### PR TITLE
fix: respect database from connection urls

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "typeorm",
-  "version": "0.2.24",
+  "version": "0.2.22",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "typeorm",
-  "version": "0.2.22",
+  "version": "0.2.24",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/src/connection/Connection.ts
+++ b/src/connection/Connection.ts
@@ -38,6 +38,7 @@ import {ObjectUtils} from "../util/ObjectUtils";
 import {PromiseUtils} from "../";
 import {IsolationLevel} from "../driver/types/IsolationLevel";
 import {AuroraDataApiDriver} from "../driver/aurora-data-api/AuroraDataApiDriver";
+import {DriverUtils} from "../driver/DriverUtils";
 
 /**
  * Connection is a single database ORM connection to a specific database.
@@ -524,17 +525,17 @@ export class Connection {
 
     // This database name property is nested for replication configs.
     protected getDatabaseName(): string {
-    const options = this.options;
-    switch (options.type) {
-        case "mysql" :
-        case "mariadb" :
-        case "postgres":
-        case "cockroachdb":
-        case "mssql":
-        case "oracle":
-            return (options.replication ? options.replication.master.database : options.database) as string;
-        default:
-            return options.database as string;
+        const options = this.options;
+        switch (options.type) {
+            case "mysql" :
+            case "mariadb" :
+            case "postgres":
+            case "cockroachdb":
+            case "mssql":
+            case "oracle":
+                return DriverUtils.buildDriverOptions(options.replication ? options.replication.master : options).database;
+            default:
+                return DriverUtils.buildDriverOptions(options).database;
     }
 }
 

--- a/src/connection/Connection.ts
+++ b/src/connection/Connection.ts
@@ -518,7 +518,6 @@ export class Connection {
         ObjectUtils.assign(this, { migrations: migrations });
 
         this.driver.database = this.getDatabaseName();
-        console.log(this.driver.database);
 
         // validate all created entity metadatas to make sure user created entities are valid and correct
         entityMetadataValidator.validateMany(this.entityMetadatas.filter(metadata => metadata.tableType !== "view"), this.driver);

--- a/src/connection/Connection.ts
+++ b/src/connection/Connection.ts
@@ -518,6 +518,7 @@ export class Connection {
         ObjectUtils.assign(this, { migrations: migrations });
 
         this.driver.database = this.getDatabaseName();
+        console.log(this.driver.database);
 
         // validate all created entity metadatas to make sure user created entities are valid and correct
         entityMetadataValidator.validateMany(this.entityMetadatas.filter(metadata => metadata.tableType !== "view"), this.driver);

--- a/test/github-issues/2096/entity/TestEntity.ts
+++ b/test/github-issues/2096/entity/TestEntity.ts
@@ -1,0 +1,9 @@
+import {Entity, PrimaryGeneratedColumn} from "../../../../src";
+
+@Entity()
+export class TestEntity {
+
+    @PrimaryGeneratedColumn()
+    id: number;
+
+}

--- a/test/github-issues/2096/issue-2096.ts
+++ b/test/github-issues/2096/issue-2096.ts
@@ -1,19 +1,24 @@
 import "reflect-metadata";
-import {expect} from "chai";
-import {createConnection} from "../../../src";
+import { expect } from "chai";
+import { createConnection } from "../../../src";
+import { getTypeOrmConfig } from "../../utils/test-utils";
 
 describe("github issues > #2096 [mysql] Database name isn't read from url", () => {
     it("should be possible to define a database by connection url for mysql", async () => {
+        const config = getTypeOrmConfig();
+
         // it is important to synchronize here, to trigger EntityMetadataValidator.validate
         // that previously threw the error where the database on the driver object was undefined
-        const connection = await createConnection({
-            name: "#2096",
-            url: "mysql://root:admin@localhost:3306/test",
-            entities: [__dirname + "/entity/*{.js,.ts}"],
-            synchronize: true,
-            type: "mysql"
-        });
-        expect(connection.isConnected).to.eq(true);
-        await connection.close();
+        if (config.find(c => c.name === "mysql" && !c.skip)) {
+            const connection = await createConnection({
+                name: "#2096",
+                url: "mysql://root:admin@localhost:3306/test",
+                entities: [__dirname + "/entity/*{.js,.ts}"],
+                synchronize: true,
+                type: "mysql"
+            });
+            expect(connection.isConnected).to.eq(true);
+            await connection.close();
+        }
     });
 });

--- a/test/github-issues/2096/issue-2096.ts
+++ b/test/github-issues/2096/issue-2096.ts
@@ -1,23 +1,19 @@
 import "reflect-metadata";
-import { expect } from "chai";
-import { createConnection, getConnectionManager } from "../../../src";
+import {expect} from "chai";
+import {Connection} from "../../../src";
 
 describe("github issues > #2096 [mysql] Database name isn't read from url", () => {
     it("should be possible to define a database by connection url for mysql", async () => {
-        const connection = getConnectionManager().connections.find(
-            c => c.name.indexOf("mysql") > -1
-        );
-        if (connection && connection.isConnected) {
-            await connection.close();
-        }
         // it is important to synchronize here, to trigger EntityMetadataValidator.validate
         // that previously threw the error where the database on the driver object was undefined
-        const newConnection = await createConnection({
-            url: "mysql://test:test@localhost:3306/test",
+        const connection = new Connection({
+            name: "#2096",
+            url: "mysql://root:admin@localhost:3306/test",
             entities: [__dirname + "/entity/*{.js,.ts}"],
             synchronize: true,
             type: "mysql"
         });
-        expect(newConnection.isConnected).to.eq(true);
+        expect(connection.isConnected).to.eq(true);
+        await connection.close();
     });
 });

--- a/test/github-issues/2096/issue-2096.ts
+++ b/test/github-issues/2096/issue-2096.ts
@@ -1,13 +1,13 @@
 import "reflect-metadata";
-import {expect} from "chai";
-import {createConnection, getConnectionManager} from "../../../src";
+import { expect } from "chai";
+import { createConnection, getConnectionManager } from "../../../src";
 
 describe("github issues > #2096 [mysql] Database name isn't read from url", () => {
     it("should be possible to define a database by connection url for mysql", async () => {
         const connection = getConnectionManager().connections.find(
             c => c.name.indexOf("mysql") > -1
         );
-        if (connection) {
+        if (connection && connection.isConnected) {
             await connection.close();
         }
         // it is important to synchronize here, to trigger EntityMetadataValidator.validate

--- a/test/github-issues/2096/issue-2096.ts
+++ b/test/github-issues/2096/issue-2096.ts
@@ -1,12 +1,12 @@
 import "reflect-metadata";
 import {expect} from "chai";
-import {Connection} from "../../../src";
+import {createConnection} from "../../../src";
 
 describe("github issues > #2096 [mysql] Database name isn't read from url", () => {
     it("should be possible to define a database by connection url for mysql", async () => {
         // it is important to synchronize here, to trigger EntityMetadataValidator.validate
         // that previously threw the error where the database on the driver object was undefined
-        const connection = new Connection({
+        const connection = await createConnection({
             name: "#2096",
             url: "mysql://root:admin@localhost:3306/test",
             entities: [__dirname + "/entity/*{.js,.ts}"],

--- a/test/github-issues/2096/issue-2096.ts
+++ b/test/github-issues/2096/issue-2096.ts
@@ -1,0 +1,23 @@
+import "reflect-metadata";
+import {expect} from "chai";
+import {createConnection, getConnectionManager} from "../../../src";
+
+describe("github issues > #2096 [mysql] Database name isn't read from url", () => {
+    it("should be possible to define a database by connection url for mysql", async () => {
+        const connection = getConnectionManager().connections.find(
+            c => c.name.indexOf("mysql") > -1
+        );
+        if (connection) {
+            await connection.close();
+        }
+        // it is important to synchronize here, to trigger EntityMetadataValidator.validate
+        // that previously threw the error where the database on the driver object was undefined
+        const newConnection = await createConnection({
+            url: "mysql://test:test@localhost:3306/test",
+            entities: [__dirname + "/entity/*{.js,.ts}"],
+            synchronize: true,
+            type: "mysql"
+        });
+        expect(newConnection.isConnected).to.eq(true);
+    });
+});


### PR DESCRIPTION
Database names can be defined in the options object. Now also connection urls that contain a database can be used to have the database set in the drivers object.

Closes: #2096