### PR TITLE
Postgres: Allow providing a function for password

### DIFF
--- a/src/driver/postgres/PostgresConnectionCredentialsOptions.ts
+++ b/src/driver/postgres/PostgresConnectionCredentialsOptions.ts
@@ -28,7 +28,7 @@ export interface PostgresConnectionCredentialsOptions {
     /**
      * Database password.
      */
-    readonly password?: string;
+    readonly password?: string | (() => string) | (() => Promise<string>);
 
     /**
      * Database name to connect to.


### PR DESCRIPTION
This simple change allows providing a function (optionally async) as the password instead of only a string. This change is necessary in order to enable [this node-postgres PR](https://github.com/brianc/node-postgres/pull/1926) to function inside of TypeORM. Fixes #4724.