### PR TITLE
[sqljs] Provide a default empty array for parameters.

### DIFF
--- a/src/driver/sqljs/SqljsQueryRunner.ts
+++ b/src/driver/sqljs/SqljsQueryRunner.ts
@@ -41,7 +41,7 @@ export class SqljsQueryRunner extends AbstractSqliteQueryRunner {
     /**
      * Executes a given SQL query.
      */
-    query(query: string, parameters?: any[]): Promise<any> {
+    query(query: string, parameters: any[] = []): Promise<any> {
         if (this.isReleased)
             throw new QueryRunnerAlreadyReleasedError();
 


### PR DESCRIPTION
The statement bind method in sqljs assumes that either an object or an array has been provided.