### PR TITLE
Fix sha.js import

### DIFF
--- a/src/util/StringUtils.ts
+++ b/src/util/StringUtils.ts
@@ -1,4 +1,4 @@
-import * as shajs from "sha.js";
+import shajs from "sha.js";
 
 /**
  * Converts string into camelCase.

--- a/test/github-issues/799/issue-799.ts
+++ b/test/github-issues/799/issue-799.ts
@@ -1,7 +1,7 @@
 import "reflect-metadata";
 import * as assert from "assert";
 import {createConnection} from "../../../src/index";
-import * as rimraf from "rimraf";
+import rimraf from "rimraf";
 import {dirname} from "path";
 import {Connection} from "../../../src/connection/Connection";
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -4,7 +4,7 @@
         "lib": ["es5", "es6"],
         "outDir": "build/compiled",
         "allowSyntheticDefaultImports": true,
-	"esModuleInterop": true,
+	      "esModuleInterop": true,
         "target": "es5",
         "module": "commonjs",
         "moduleResolution": "node",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -3,6 +3,7 @@
     "compilerOptions": {
         "lib": ["es5", "es6"],
         "outDir": "build/compiled",
+        "allowSyntheticDefaultImports": true,
         "target": "es5",
         "module": "commonjs",
         "moduleResolution": "node",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -4,6 +4,7 @@
         "lib": ["es5", "es6"],
         "outDir": "build/compiled",
         "allowSyntheticDefaultImports": true,
+	"esModuleInterop": true,
         "target": "es5",
         "module": "commonjs",
         "moduleResolution": "node",


### PR DESCRIPTION
When using this pattern in the browser it will throw because namespace objects can never be functions, which also throws in Rollup even if it might work in other build tools.

Using the default import form ensures the instance is the exact `module.exports` instance provided by sha.js.