### PR TITLE
Names of extra columns for specific tree types moved to NamingStrategy

### DIFF
--- a/src/metadata-builder/EntityMetadataBuilder.ts
+++ b/src/metadata-builder/EntityMetadataBuilder.ts
@@ -403,6 +403,8 @@ export class EntityMetadataBuilder {
             }
         }
 
+        const { namingStrategy } = this.connection;
+
         // check if tree is used then we need to add extra columns for specific tree types
         if (entityMetadata.treeType === "materialized-path") {
             entityMetadata.ownColumns.push(new ColumnMetadata({
@@ -414,7 +416,7 @@ export class EntityMetadataBuilder {
                     mode: "virtual",
                     propertyName: "mpath",
                     options: /*tree.column || */ {
-                        name: "mpath",
+                        name: namingStrategy.materializedPathColumnName,
                         type: "varchar",
                         nullable: true,
                         default: ""
@@ -423,6 +425,7 @@ export class EntityMetadataBuilder {
             }));
 
         } else if (entityMetadata.treeType === "nested-set") {
+            const { left, right } = namingStrategy.nestedSetColumnNames;
             entityMetadata.ownColumns.push(new ColumnMetadata({
                 connection: this.connection,
                 entityMetadata: entityMetadata,
@@ -430,9 +433,9 @@ export class EntityMetadataBuilder {
                 args: {
                     target: entityMetadata.target,
                     mode: "virtual",
-                    propertyName: "nsleft",
+                    propertyName: left,
                     options: /*tree.column || */ {
-                        name: "nsleft",
+                        name: left,
                         type: "integer",
                         nullable: false,
                         default: 1
@@ -446,9 +449,9 @@ export class EntityMetadataBuilder {
                 args: {
                     target: entityMetadata.target,
                     mode: "virtual",
-                    propertyName: "nsright",
+                    propertyName: right,
                     options: /*tree.column || */ {
-                        name: "nsright",
+                        name: right,
                         type: "integer",
                         nullable: false,
                         default: 2

--- a/src/naming-strategy/DefaultNamingStrategy.ts
+++ b/src/naming-strategy/DefaultNamingStrategy.ts
@@ -153,4 +153,7 @@ export class DefaultNamingStrategy implements NamingStrategyInterface {
     eagerJoinRelationAlias(alias: string, propertyPath: string): string {
         return alias + "_" + propertyPath.replace(".", "_");
     }
+
+    nestedSetColumnNames = { left: "nsleft", right: "nsright" };
+    materializedPathColumnName = "mpath";
 }

--- a/src/naming-strategy/NamingStrategyInterface.ts
+++ b/src/naming-strategy/NamingStrategyInterface.ts
@@ -121,4 +121,14 @@ export interface NamingStrategyInterface {
      * Gets the name of the alias used for relation joins.
      */
     eagerJoinRelationAlias(alias: string, propertyPath: string): string;
+
+    /**
+     * Column names for nested sets.
+     */
+    nestedSetColumnNames: { left: string, right: string };
+
+    /**
+     * Column name for materialized paths.
+     */
+    materializedPathColumnName: string;
 }


### PR DESCRIPTION
This change makes column names used by the nested set and materialized path tree types configurable through the naming strategy, keeping the ones already in use as defaults.

The rationale is that some of us have to work with legacy databases accessed by other tools as well, in which case altering column names is off the table.