### PR TITLE
fix: calling EntityManager.insert() with an empty array of entities

### DIFF
--- a/test/github-issues/5734/entity/Post.ts
+++ b/test/github-issues/5734/entity/Post.ts
@@ -1,0 +1,12 @@
+import {PrimaryColumn} from "../../../../src/decorator/columns/PrimaryColumn";
+import {Entity} from "../../../../src/decorator/entity/Entity";
+
+@Entity()
+export class Post {
+    @PrimaryColumn()
+    id: number;
+
+    constructor(id: number) {
+        this.id = id;
+    }
+}

--- a/test/github-issues/5734/issue-5734.ts
+++ b/test/github-issues/5734/issue-5734.ts
@@ -1,0 +1,28 @@
+import "reflect-metadata";
+import {closeTestingConnections, createTestingConnections, reloadTestingDatabases} from "../../utils/test-utils";
+import {Connection} from "../../../src/connection/Connection";
+import {Post} from "./entity/Post";
+
+describe("github issues > #5734 insert([]) should not crash", () => {
+
+    let connections: Connection[];
+    before(async () => connections = await createTestingConnections({
+        entities: [__dirname + "/entity/*{.js,.ts}"],
+        subscribers: [__dirname + "/subscriber/*{.js,.ts}"],
+        schemaCreate: true,
+        dropSchema: true
+    }));
+    beforeEach(() => reloadTestingDatabases(connections));
+    after(() => closeTestingConnections(connections));
+
+    it("should not crash on insert([])", () => Promise.all(connections.map(async connection => {
+        const repository = connection.getRepository(Post);
+        await repository.insert([]);
+    })));
+
+    it("should still work with a nonempty array", () => Promise.all(connections.map(async connection => {
+        const repository = connection.getRepository(Post);
+        await repository.insert([new Post(1)]);
+        await repository.findOneOrFail({where: {id: 1}});
+    })));
+});

--- a/test/github-issues/5734/subscriber/CheckValidEntitySubscriber.ts
+++ b/test/github-issues/5734/subscriber/CheckValidEntitySubscriber.ts
@@ -1,0 +1,22 @@
+import {Post} from "../entity/Post";
+import {EntitySubscriberInterface, EventSubscriber, InsertEvent} from "../../../../src";
+
+/**
+ * Subscriber which checks the validity of the entity passed to beforeInsert().
+ * Tests the fix for issue #5734 in which we saw an empty array leak into
+ * beforeInsert().
+ */
+@EventSubscriber()
+export class ValidEntityCheckSubscriber
+    implements EntitySubscriberInterface<Post> {
+    listenTo() {
+        return Post;
+    }
+
+    beforeInsert(event: InsertEvent<Post>) {
+        const entity = event.entity;
+        if (Array.isArray(entity) || !entity.id) {
+            throw new Error(`Subscriber saw invalid entity: ${JSON.stringify(entity)}`);
+        }
+    }
+}


### PR DESCRIPTION
As described in issue #5734, the current behaviour seems like an oversight and inconsistent with save() and remove() which already have this handled as a special case.

Test Plan: npm test, and more specifically npm test -- --grep='#5734'

Closes: #5734