### PR TITLE
Update typeorm-aurora-data-api-driver

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1861,9 +1861,8 @@
       }
     },
     "data-api-client": {
-      "version": "1.0.0-beta",
-      "resolved": "https://registry.npmjs.org/data-api-client/-/data-api-client-1.0.0-beta.tgz",
-      "integrity": "sha512-sBC6pGooj59FhKhND7aj24a+pI4qFd0K08WtF6X7ZtthMy5x5ezWC6VDuMUfwMrvA0qGXttFdT6/2U1JTgSN2g==",
+      "version": "github:ArsenyYankovsky/data-api-client#42a4a26b5d7de0939b748d6d22a67022a9955a6f",
+      "from": "github:ArsenyYankovsky/data-api-client#support-date",
       "dev": true,
       "requires": {
         "sqlstring": "^2.3.1"
@@ -8483,12 +8482,12 @@
       "dev": true
     },
     "typeorm-aurora-data-api-driver": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/typeorm-aurora-data-api-driver/-/typeorm-aurora-data-api-driver-1.1.1.tgz",
-      "integrity": "sha512-KqqMiwf/YrT0/YIPL0D97zEAt2TtRyxZGVo1UJusnO3o+3FoLbzFLp3x0Jg3KapOq8EyzYGeLRDsWVUSJQ6MkQ==",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/typeorm-aurora-data-api-driver/-/typeorm-aurora-data-api-driver-1.2.0.tgz",
+      "integrity": "sha512-PT/y49qFk0Kub+HWITgtJ2oOQCEET9UYcpZ3LA7kgFvnrGrrbiCsDwbuJpFCXt1boqca5nkGsVCUcbzLcCaO9w==",
       "dev": true,
       "requires": {
-        "data-api-client": "^1.0.0-beta"
+        "data-api-client": "github:ArsenyYankovsky/data-api-client#support-date"
       }
     },
     "typescript": {

--- a/package.json
+++ b/package.json
@@ -91,7 +91,7 @@
     "sqlite3": "^4.0.9",
     "ts-node": "^8.0.2",
     "tslint": "^5.13.1",
-    "typeorm-aurora-data-api-driver": "^1.1.1",
+    "typeorm-aurora-data-api-driver": "^1.2.0",
     "typescript": "^3.3.3333"
   },
   "dependencies": {

--- a/src/driver/aurora-data-api/AuroraDataApiConnectionOptions.ts
+++ b/src/driver/aurora-data-api/AuroraDataApiConnectionOptions.ts
@@ -21,6 +21,8 @@ export interface AuroraDataApiConnectionOptions extends BaseConnectionOptions, A
 
     readonly database: string;
 
+    readonly serviceConfigOptions?: any;
+
     /**
      * Use spatial functions like GeomFromText and AsText which are removed in MySQL 8.
      * (Default: true)

--- a/src/driver/aurora-data-api/AuroraDataApiDriver.ts
+++ b/src/driver/aurora-data-api/AuroraDataApiDriver.ts
@@ -306,6 +306,7 @@ export class AuroraDataApiDriver implements Driver {
             this.options.resourceArn,
             this.options.database,
             (query: string, parameters?: any[]) => this.connection.logger.logQuery(query, parameters),
+            this.options.serviceConfigOptions,
         );
 
         // validate options to make sure everything is set


### PR DESCRIPTION
Update `typeorm-aurora-data-api-driver` to 1.2.0 https://github.com/ArsenyYankovsky/typeorm-aurora-data-api-driver/releases/tag/v1.2.0