### PR TITLE
fixed `sql` to `query` in the last example

### DIFF
--- a/docs/logging.md
+++ b/docs/logging.md
@@ -162,6 +162,6 @@ postRepository.save(post, { data: { request: request } });
 // in logger you can access it this way:
 logQuery(query: string, parameters?: any[], queryRunner?: QueryRunner) {
     const requestUrl = queryRunner && queryRunner.data["request"] ? "(" + queryRunner.data["request"].url + ") " : "";
-    console.log(requestUrl + "executing query: " + sql);
+    console.log(requestUrl + "executing query: " + query);
 }
 ```


### PR DESCRIPTION
there was no `sql` tag in the example, and `query` made the most sense.