### PR TITLE
Aurora Data API - Support for AWS configuration options through aurora driver

### DIFF
--- a/ormconfig.json.dist
+++ b/ormconfig.json.dist
@@ -92,7 +92,7 @@
     "useUnifiedTopology": true
   },
   {
-    "skip": false,
+    "skip": true,
     "name": "aurora-data-api",
     "type": "aurora-data-api",
     "region": "us-east-1",

--- a/ormconfig.json.dist
+++ b/ormconfig.json.dist
@@ -90,5 +90,18 @@
     "logging": false,
     "useNewUrlParser": true,
     "useUnifiedTopology": true
+  },
+  {
+    "skip": false,
+    "name": "aurora-data-api",
+    "type": "aurora-data-api",
+    "region": "us-east-1",
+    "secretArn": "mysecret",
+    "resourceArn": "app-dbcluster",
+    "database": "app-dbcluster-mine",
+    "serviceConfigOptions": {
+      "maxRetries": 3
+    },
+    "logging": false
   }
 ]

--- a/package-lock.json
+++ b/package-lock.json
@@ -1861,9 +1861,8 @@
       }
     },
     "data-api-client": {
-      "version": "1.0.0-beta",
-      "resolved": "https://registry.npmjs.org/data-api-client/-/data-api-client-1.0.0-beta.tgz",
-      "integrity": "sha512-sBC6pGooj59FhKhND7aj24a+pI4qFd0K08WtF6X7ZtthMy5x5ezWC6VDuMUfwMrvA0qGXttFdT6/2U1JTgSN2g==",
+      "version": "github:ArsenyYankovsky/data-api-client#42a4a26b5d7de0939b748d6d22a67022a9955a6f",
+      "from": "github:ArsenyYankovsky/data-api-client#support-date",
       "dev": true,
       "requires": {
         "sqlstring": "^2.3.1"
@@ -8483,12 +8482,12 @@
       "dev": true
     },
     "typeorm-aurora-data-api-driver": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/typeorm-aurora-data-api-driver/-/typeorm-aurora-data-api-driver-1.1.1.tgz",
-      "integrity": "sha512-KqqMiwf/YrT0/YIPL0D97zEAt2TtRyxZGVo1UJusnO3o+3FoLbzFLp3x0Jg3KapOq8EyzYGeLRDsWVUSJQ6MkQ==",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/typeorm-aurora-data-api-driver/-/typeorm-aurora-data-api-driver-1.2.0.tgz",
+      "integrity": "sha512-PT/y49qFk0Kub+HWITgtJ2oOQCEET9UYcpZ3LA7kgFvnrGrrbiCsDwbuJpFCXt1boqca5nkGsVCUcbzLcCaO9w==",
       "dev": true,
       "requires": {
-        "data-api-client": "^1.0.0-beta"
+        "data-api-client": "github:ArsenyYankovsky/data-api-client#support-date"
       }
     },
     "typescript": {

--- a/package.json
+++ b/package.json
@@ -91,7 +91,7 @@
     "sqlite3": "^4.0.9",
     "ts-node": "^8.0.2",
     "tslint": "^5.13.1",
-    "typeorm-aurora-data-api-driver": "^1.1.1",
+    "typeorm-aurora-data-api-driver": "^1.2.0",
     "typescript": "^3.3.3333"
   },
   "dependencies": {

--- a/src/driver/aurora-data-api/AuroraDataApiConnectionOptions.ts
+++ b/src/driver/aurora-data-api/AuroraDataApiConnectionOptions.ts
@@ -21,6 +21,8 @@ export interface AuroraDataApiConnectionOptions extends BaseConnectionOptions, A
 
     readonly database: string;
 
+    readonly serviceConfigOptions?: { [key: string]: any }; // pass optional AWS.ConfigurationOptions here
+
     /**
      * Use spatial functions like GeomFromText and AsText which are removed in MySQL 8.
      * (Default: true)

--- a/src/driver/aurora-data-api/AuroraDataApiDriver.ts
+++ b/src/driver/aurora-data-api/AuroraDataApiDriver.ts
@@ -306,6 +306,7 @@ export class AuroraDataApiDriver implements Driver {
             this.options.resourceArn,
             this.options.database,
             (query: string, parameters?: any[]) => this.connection.logger.logQuery(query, parameters),
+            this.options.serviceConfigOptions
         );
 
         // validate options to make sure everything is set

--- a/test/functional/connection-manager/connection-manager.ts
+++ b/test/functional/connection-manager/connection-manager.ts
@@ -7,6 +7,10 @@ import {PrimaryGeneratedColumn} from "../../../src/decorator/columns/PrimaryGene
 import {Column} from "../../../src/decorator/columns/Column";
 import {Entity} from "../../../src/decorator/entity/Entity";
 
+// Uncomment when testing the aurora data API driver
+// import {AuroraDataApiDriver} from "../../../src/driver/aurora-data-api/AuroraDataApiDriver";
+// import {AuroraDataApiConnectionOptions} from "../../../src/driver/aurora-data-api/AuroraDataApiConnectionOptions";
+
 describe("ConnectionManager", () => {
 
     @Entity()
@@ -67,6 +71,23 @@ describe("ConnectionManager", () => {
             connection.name.should.be.equal("default");
             connection.driver.should.be.instanceOf(MysqlDriver);
             connection.isConnected.should.be.true;
+            await connection.close();
+
+        it("should create a aurora connection when aurora-data-api driver is specified", async () => {
+            const options = setupSingleTestingConnection("aurora-data-api", {
+                name: "aurora-data-api",
+                dropSchema: false,
+                schemaCreate: false,
+                enabledDrivers: ["aurora-data-api"]
+            });
+            const connectionManager = new ConnectionManager();
+            const connection = connectionManager.create(options!);
+            await connection.connect();
+            connection.name.should.contain("aurora-data-api");
+            connection.driver.should.be.instanceOf(AuroraDataApiDriver);
+            connection.isConnected.should.be.true;
+            const serviceConfigOptions = (connection.options as AuroraDataApiConnectionOptions).serviceConfigOptions;
+            expect(serviceConfigOptions).to.include({ maxRetries: 3, region: "us-east-1" });
             await connection.close();
         });
 


### PR DESCRIPTION
The underlying AWS RDS database, accessible through the aurora-data-api driver supports configurations settings, also known as [AWS.ConfigurationOptions](https://docs.aws.amazon.com/AWSJavaScriptSDK/latest/AWS/RDSDataService.html#constructor-property). It allows you to pass options like max number of retries, Arn regions and impersonation secrets.

The [typeorm-aurora-data-api-driver](https://github.com/ArsenyYankovsky/typeorm-aurora-data-api-driver), which is referenced in this project has now added support for this, see pull request state [here](https://github.com/ArsenyYankovsky/typeorm-aurora-data-api-driver/pull/31). Minimum required version is 1.2.0. 

Changes included in this pull request  allows users of TypeORM to pass the values through AuroraDataApiConnectionOptions. Example:

```
createConnection({
    name,
    type: 'aurora-data-api',
    ...
    serviceConfigOptions: {
        credentials,
        maxRetries: 3,
        retryDelayOptions: {
           base: 5000,
        }
    }
  });
```

