### PR TITLE
Increment parameter index after relation condition

### DIFF
--- a/src/query-builder/SelectQueryBuilder.ts
+++ b/src/query-builder/SelectQueryBuilder.ts
@@ -2569,8 +2569,10 @@ export class SelectQueryBuilder<Entity> extends QueryBuilder<Entity> implements 
                         }
 
                         const condition = this.buildWhere(where[key], relation.inverseEntityMetadata, joinAlias);
-                        if (condition)
+                        if (condition) {
                             andConditions.push(condition);
+                            parameterIndex = Object.keys(this.expressionMap.nativeParameters).length;
+                        }
                     }
                 }
             }

--- a/test/github-issues/5809/entity/Role.ts
+++ b/test/github-issues/5809/entity/Role.ts
@@ -1,0 +1,14 @@
+import {Entity} from "../../../../src/decorator/entity/Entity";
+import {PrimaryColumn, OneToMany} from "../../../../src";
+import {User} from "./User";
+
+@Entity()
+export class Role {
+
+  @PrimaryColumn()
+  id: string;
+
+  @OneToMany(_ => User, user => user.role, { cascade: true })
+  users: User[];
+
+}

--- a/test/github-issues/5809/entity/User.ts
+++ b/test/github-issues/5809/entity/User.ts
@@ -1,0 +1,14 @@
+import {Entity} from "../../../../src/decorator/entity/Entity";
+import {PrimaryColumn, ManyToOne} from "../../../../src";
+import {Role} from "./Role";
+
+@Entity()
+export class User {
+
+  @PrimaryColumn()
+  id: number;
+
+  @ManyToOne(_ => Role, role => role.users)
+  role: Role;
+
+}

--- a/test/github-issues/5809/issue-5809.ts
+++ b/test/github-issues/5809/issue-5809.ts
@@ -1,0 +1,43 @@
+import "reflect-metadata";
+import {expect} from "chai";
+import {Connection} from "../../../src";
+import {User} from "./entity/User";
+import {Role} from "./entity/Role";
+import {createTestingConnections, reloadTestingDatabases, closeTestingConnections} from "../../utils/test-utils";
+
+describe("github issues > #5809 Increment parameter index after relation condition", () => {
+
+    let connections: Connection[];
+
+    before(async () => {
+        connections = await createTestingConnections({
+            entities: [User, Role],
+            schemaCreate: true,
+            dropSchema: true
+        });
+    });
+    beforeEach(() => reloadTestingDatabases(connections));
+    after(() => closeTestingConnections(connections));
+
+    it("should increment parameter index after relation condition", () =>
+    Promise.all(connections.map(async (connection) => {
+        const roleRepository = connection.getRepository(Role);
+        const userRepository = connection.getRepository(User);
+
+        await roleRepository.save([
+            { id: "a", users: [{ id: 1 }] },
+        ]);
+
+        const results = await userRepository.createQueryBuilder("user")
+            .where({
+                role: { id: "a" },
+                id: 1,
+            })
+            .getMany();
+
+        expect(results).to.be.deep.equal([
+            { id: 1 },
+        ]);
+    })));
+
+});


### PR DESCRIPTION
There's a small bug (for at least Postgres) when you make a query like the following one:

```typescript
qb.select("post.name")
  .where({
    category: {id: 1},
    title: "foo",
  })
```

This will result in both parameters being listed as `$1` in the resulting query. This PR fixes this by resetting the `parameterIndex` in `buildWhere()` to the new value after relation conditions have been applied.

Current workaround for this issue is to list properties of the parent in the find conditions first and the relations last.

I was initially writing a test for that, but ran into another bug, which is pretty hard for me to solve due to the architecture, so I hope a maintainer can have a look at that:

When calling `getSql()`, findOptions are not being applied, this is only done when calling query methods like `getOne()` on the SelectQueryBuilder. Adding `applyFindOptions()` to `getQuery()` in the SelectQueryBuilder is not an option though, since in that case the find options would be applied twice when e.g. calling `getOne()`.