### PR TITLE
feat: add mysql check constraints

### DIFF
--- a/src/schema-builder/RdbmsSchemaBuilder.ts
+++ b/src/schema-builder/RdbmsSchemaBuilder.ts
@@ -575,8 +575,8 @@ export class RdbmsSchemaBuilder implements SchemaBuilder {
     }
 
     protected async createNewChecks(): Promise<void> {
-        // Mysql does not support check constraints
-        if (this.connection.driver instanceof MysqlDriver || this.connection.driver instanceof AuroraDataApiDriver)
+        // Mysql supports check constraints since v8.0.16
+        if (this.connection.driver instanceof AuroraDataApiDriver)
             return;
 
         for (const metadata of this.entityToSyncMetadatas) {

--- a/test/github-issues/4148/entity/Book.ts
+++ b/test/github-issues/4148/entity/Book.ts
@@ -1,0 +1,20 @@
+import { Column, Entity, PrimaryGeneratedColumn } from "../../../../src";
+import { Check } from "../../../../src/decorator/Check";
+
+@Entity("book")
+@Check("NR_OF_PAGES", "`nrOfPages` > 80")
+export class Book {
+
+    @PrimaryGeneratedColumn()
+    id: number;
+
+    @Column()
+    name: string;
+
+    @Column()
+    nrOfPages: number;
+
+    @Column()
+    @Check("VOLUME", "`volume` > 0")
+    volume: number;
+}

--- a/test/github-issues/4148/issue-4148.ts
+++ b/test/github-issues/4148/issue-4148.ts
@@ -1,0 +1,72 @@
+import { Connection } from "../../../src";
+import { closeTestingConnections, createTestingConnections, reloadTestingDatabases } from "../../utils/test-utils";
+import { Book } from "./entity/Book";
+import { expect } from "chai";
+
+describe("github issues > #4148 MySQL 8.0.16: Now supports CHECK-Constraints", () => {
+    let connections: Connection[];
+    before(
+        async () =>
+            (connections = await createTestingConnections({
+                entities: [Book],
+                dropSchema: true,
+                enabledDrivers: ["mysql"],
+            }))
+    );
+    beforeEach(() => reloadTestingDatabases(connections));
+    after(() => closeTestingConnections(connections));
+
+    it("should throw Volume checkConstraint if it's not satisfied", () => {
+        return Promise.all(connections.map(async connection => {
+
+            const qb = connection.manager
+                .createQueryBuilder("Book", "book");
+
+            await qb.insert()
+                .into(Book)
+                .values([
+                    { name: "book1", nrOfPages: 600, volume: 0 }
+                ])
+                .execute()
+                .catch(e => {
+                    expect(e.toString()).to.contain("Check constraint 'VOLUME' is violated");
+                });
+        }));
+    });
+
+    it("should throw NrOfPages checkConstraint if it's not satisfied", () => {
+        return Promise.all(connections.map(async connection => {
+            const qb = connection.manager
+                .createQueryBuilder("Book", "book");
+
+            await qb.insert()
+                .into(Book)
+                .values([
+                    { name: "book1", nrOfPages: 3, volume: 1 }
+                ])
+                .execute()
+                .catch(e => {
+                    expect(e.toString()).to.contain("Check constraint 'NR_OF_PAGES' is violated");
+                });
+        }));
+    });
+
+    it("should persist in DB if constraint is satisfied", () => {
+        return Promise.all(connections.map(async connection => {
+            const qb = connection.manager
+                .createQueryBuilder("Book", "book");
+
+            const bookRepository = connection.getRepository(Book);
+
+            await qb.insert()
+                .into(Book)
+                .values([
+                    { name: "book1", nrOfPages: 100, volume: 1 }
+                ])
+                .execute();
+
+            const result = await bookRepository.find();
+            expect(result).to.eql([{id: 1, name: "book1", nrOfPages: 100, volume: 1 }]);
+        }));
+    });
+});


### PR DESCRIPTION
Adds support for creating mysql check constraints on entities with @Check decorator.
MySQL supports check constraints from v8.0.16 

Closes -  https://github.com/typeorm/typeorm/issues/4148