### PR TITLE
docs: specify that columns using CreateDateColumn/UpdateDateColumn cannot be set manually

### DIFF
--- a/docs/decorator-reference.md
+++ b/docs/decorator-reference.md
@@ -93,7 +93,7 @@ View entity is a class that maps to a database view.
 `expression` can be string with properly escaped columns and tables, depend on database used (postgres in example):
 
 ```typescript
-@ViewEntity({ 
+@ViewEntity({
     expression: `
         SELECT "post"."id" "id", "post"."name" AS "name", "category"."name" AS "categoryName"
         FROM "post" "post"
@@ -106,7 +106,7 @@ export class PostCategory {
 or an instance of QueryBuilder
 
 ```typescript
-@ViewEntity({ 
+@ViewEntity({
     expression: (connection: Connection) => connection.createQueryBuilder()
         .select("post.id", "id")
         .addSelect("post.name", "name")
@@ -120,7 +120,7 @@ export class PostCategory {
 **Note:** parameter binding is not supported due to drivers limitations. Use the literal parameters instead.
 
 ```typescript
-@ViewEntity({ 
+@ViewEntity({
     expression: (connection: Connection) => connection.createQueryBuilder()
         .select("post.id", "id")
         .addSelect("post.name", "name")
@@ -240,7 +240,7 @@ There are two generation strategies:
 
 * `increment` - uses AUTO_INCREMENT / SERIAL / SEQUENCE (depend on database type) to generate incremental number.
 * `uuid` - generates unique `uuid` string.
-* `rowid` - only for [CockroachDB](https://www.cockroachlabs.com/docs/stable/serial.html). Value is automatically generated using the `unique_rowid()` 
+* `rowid` - only for [CockroachDB](https://www.cockroachlabs.com/docs/stable/serial.html). Value is automatically generated using the `unique_rowid()`
 function. This produces a 64-bit integer from the current timestamp and ID of the node executing the `INSERT` or `UPSERT` operation.
 > Note: property with a `rowid` generation strategy must be a `string` data type
 
@@ -279,32 +279,32 @@ Learn more about [MongoDB](mongodb.md).
 
 #### `@CreateDateColumn`
 
-Special column that is automatically set to the entity's insertion time.
-You don't need to write a value into this column - it will be automatically set.
-Example:
+Special column that sets a property to the entity's insertion time during
+insertion. The value is automatically set and you cannot change its value.
+manually.
 
 ```typescript
 @Entity()
 export class User {
 
     @CreateDateColumn()
-    createdDate: Date;
+    readonly createdDate: Date;
 
 }
 ```
 
 #### `@UpdateDateColumn`
 
-Special column that is automatically set to the entity's update time
-each time you call `save` from entity manager or repository.
-You don't need to write a value into this column - it will be automatically set.
+Special column that sets a property to the entity's update time each time you
+call `save` from entity manager or repository. The value is automatically set
+and you cannot change its value manually.
 
 ```typescript
 @Entity()
 export class User {
 
     @UpdateDateColumn()
-    updatedDate: Date;
+    readonly updatedDate: Date;
 
 }
 ```


### PR DESCRIPTION
Follows the discussion on #3365.

Columns using the decorators `@CreateDateColumn()` and `@UpdateDateColumn()` cannot have their values manually set. This behaviour is not documented in the docs.

This PR documents that behaviour.