### PR TITLE
Fix migrations being generated for FK even if there are no changes

### DIFF
--- a/src/driver/postgres/PostgresQueryRunner.ts
+++ b/src/driver/postgres/PostgresQueryRunner.ts
@@ -1432,7 +1432,7 @@ export class PostgresQueryRunner extends BaseQueryRunner implements QueryRunner 
         return Promise.all(dbTables.map(async dbTable => {
             const table = new Table();
 
-            const getSchemaFromKey = (dbObject:any, key:string) => dbObject[key] === currentSchema && !this.driver.options.schema ? undefined : dbObject[key];
+            const getSchemaFromKey = (dbObject: any, key: string) => dbObject[key] === currentSchema && !this.driver.options.schema ? undefined : dbObject[key];
             // We do not need to join schema name, when database is by default.
             // In this case we need local variable `tableFullName` for below comparision.
             const schema = getSchemaFromKey(dbTable, "table_schema");

--- a/src/driver/postgres/PostgresQueryRunner.ts
+++ b/src/driver/postgres/PostgresQueryRunner.ts
@@ -1424,7 +1424,6 @@ export class PostgresQueryRunner extends BaseQueryRunner implements QueryRunner 
             this.query(indicesSql),
             this.query(foreignKeysSql),
         ]);
-
         // if tables were not found in the db, no need to proceed
         if (!dbTables.length)
             return [];
@@ -1433,9 +1432,10 @@ export class PostgresQueryRunner extends BaseQueryRunner implements QueryRunner 
         return Promise.all(dbTables.map(async dbTable => {
             const table = new Table();
 
+            const getSchemaFromKey = (dbObject:any, key:string) => dbObject[key] === currentSchema && !this.driver.options.schema ? undefined : dbObject[key];
             // We do not need to join schema name, when database is by default.
             // In this case we need local variable `tableFullName` for below comparision.
-            const schema = dbTable["table_schema"] === currentSchema && !this.driver.options.schema ? undefined : dbTable["table_schema"];
+            const schema = getSchemaFromKey(dbTable, "table_schema");
             table.name = this.driver.buildTableName(dbTable["table_name"], schema);
             const tableFullName = this.driver.buildTableName(dbTable["table_name"], dbTable["table_schema"]);
 
@@ -1612,7 +1612,7 @@ export class PostgresQueryRunner extends BaseQueryRunner implements QueryRunner 
                 const foreignKeys = dbForeignKeys.filter(dbFk => dbFk["constraint_name"] === dbForeignKey["constraint_name"]);
 
                 // if referenced table located in currently used schema, we don't need to concat schema name to table name.
-                const schema = dbForeignKey["referenced_table_schema"] === currentSchema ? undefined : dbForeignKey["referenced_table_schema"];
+                const schema = getSchemaFromKey(dbForeignKey, "referenced_table_schema");
                 const referencedTableName = this.driver.buildTableName(dbForeignKey["referenced_table_name"], schema);
 
                 return new TableForeignKey({

--- a/test/functional/migrations/generate-command/command.ts
+++ b/test/functional/migrations/generate-command/command.ts
@@ -1,0 +1,36 @@
+import "reflect-metadata";
+import {createTestingConnections, closeTestingConnections, /*reloadTestingDatabases*/} from "../../../utils/test-utils";
+import {Connection} from "../../../../src/connection/Connection";
+import { Category, Post } from "./entity";
+
+describe("migrations > generate command", () => {
+    let connections: Connection[];
+    before(async () => connections = await createTestingConnections({
+        migrations: [],
+        enabledDrivers: ["postgres"],
+        schemaCreate: false,
+        dropSchema: true,
+        entities: [Post, Category],
+        logging: true,
+        schema: "public",
+    }));
+    // beforeEach(() => reloadTestingDatabases(connections));
+    after(() => closeTestingConnections(connections));
+
+    it("can recognize model changes", () => Promise.all(connections.map(async connection => {
+        const sqlInMemory = await connection.driver.createSchemaBuilder().log();
+        sqlInMemory.upQueries.length.should.be.greaterThan(0);
+        sqlInMemory.downQueries.length.should.be.greaterThan(0);
+    })));
+
+    it("does not generate when no model changes", () => Promise.all(connections.map(async connection => {
+        await connection.driver.createSchemaBuilder().build();
+
+        const sqlInMemory = await connection.driver.createSchemaBuilder().log();
+
+        console.log(sqlInMemory.upQueries)
+        sqlInMemory.upQueries.length.should.be.equal(0);
+        sqlInMemory.downQueries.length.should.be.equal(0);
+
+    })));
+ });

--- a/test/functional/migrations/generate-command/command.ts
+++ b/test/functional/migrations/generate-command/command.ts
@@ -28,7 +28,7 @@ describe("migrations > generate command", () => {
 
         const sqlInMemory = await connection.driver.createSchemaBuilder().log();
 
-        console.log(sqlInMemory.upQueries)
+        console.log(sqlInMemory.upQueries);
         sqlInMemory.upQueries.length.should.be.equal(0);
         sqlInMemory.downQueries.length.should.be.equal(0);
 

--- a/test/functional/migrations/generate-command/entity/category.entity.ts
+++ b/test/functional/migrations/generate-command/entity/category.entity.ts
@@ -1,0 +1,15 @@
+import {PrimaryColumn} from "../../../../../src/decorator/columns/PrimaryColumn";
+import {Entity} from "../../../../../src/decorator/entity/Entity";
+import {BaseEntity} from "../../../../../src/repository/BaseEntity";
+import {Column} from "../../../../../src/decorator/columns/Column";
+
+@Entity("category_test", { schema: "public" })
+export class Category  extends BaseEntity {
+
+    @PrimaryColumn()
+    id: number;
+
+    @Column()
+    name: string;
+
+}

--- a/test/functional/migrations/generate-command/entity/index.ts
+++ b/test/functional/migrations/generate-command/entity/index.ts
@@ -1,3 +1,3 @@
-export {Post} from './post.entity'
-export {Category} from './category.entity';
-export {Tag} from './tag.entity';
+export {Post} from "./post.entity";
+export {Category} from "./category.entity";
+export {Tag} from "./tag.entity";

--- a/test/functional/migrations/generate-command/entity/index.ts
+++ b/test/functional/migrations/generate-command/entity/index.ts
@@ -1,0 +1,3 @@
+export {Post} from './post.entity'
+export {Category} from './category.entity';
+export {Tag} from './tag.entity';

--- a/test/functional/migrations/generate-command/entity/post.entity.ts
+++ b/test/functional/migrations/generate-command/entity/post.entity.ts
@@ -1,0 +1,26 @@
+import {Entity} from "../../../../../src/decorator/entity/Entity";
+import {BaseEntity} from "../../../../../src/repository/BaseEntity";
+import {PrimaryGeneratedColumn} from "../../../../../src/decorator/columns/PrimaryGeneratedColumn";
+import {Column} from "../../../../../src/decorator/columns/Column";
+import {ManyToMany, JoinTable} from "../../../../../src";
+import {Category} from "./category.entity";
+
+@Entity("post_test", { schema: "public" })
+export class Post extends BaseEntity {
+
+    @PrimaryGeneratedColumn()
+    id: number;
+
+    @Column()
+    title: string;
+
+    @Column({
+        default: "This is default text."
+    })
+    text: string;
+
+    @ManyToMany(type => Category)
+    @JoinTable()
+    categories: Category[];
+
+}

--- a/test/functional/migrations/generate-command/entity/tag.entity.ts
+++ b/test/functional/migrations/generate-command/entity/tag.entity.ts
@@ -1,0 +1,21 @@
+import {PrimaryColumn} from "../../../../../src/decorator/columns/PrimaryColumn";
+import {ManyToOne} from "../../../../../src/decorator/relations/ManyToOne";
+import {JoinColumn} from "../../../../../src/decorator/relations/JoinColumn";
+import {Entity} from "../../../../../src/decorator/entity/Entity";
+import {BaseEntity} from "../../../../../src/repository/BaseEntity";
+import {Column} from "../../../../../src/decorator/columns/Column";
+import {Post} from "./post.entity";
+
+@Entity("tag_test", { schema: "public" })
+export class Tag  extends BaseEntity {
+
+    @PrimaryColumn()
+    id: number;
+
+    @Column()
+    name: string;
+
+    @ManyToOne(() => Post)
+    @JoinColumn({ name: "tag_to_post" })
+    posts: Post | null;
+}


### PR DESCRIPTION
This is related to #3280 

We are using 0.2.22 with postrgres, but upgrading to 0.2.24 is impossible for us at that point, since migration:generate always generates bunch of FK recreations.
The deleted and the newly created FK are exactly  the same.

In the end I managed to trace this down to the fact that we are explicitly specifying the schema for each entity (we have entities in multiple schema).

So here is a fix. Metadata was building correctly the full table name for table changes, but this wasn't the case for  the FK definitions.
