### PR TITLE
Use correct typings for the result of `getUpsertedIds()`

### DIFF
--- a/src/driver/mongodb/typings.ts
+++ b/src/driver/mongodb/typings.ts
@@ -4271,7 +4271,7 @@ export interface BulkWriteResult {
     /**
      * Return an array of upserted ids.
      */
-    getUpsertedIds(): Array<Object>;
+    getUpsertedIds(): Array<{ _id: string, index: number }>;
 
     /**
      * Retrieve the write concern error if any.


### PR DESCRIPTION
This method returns an object with `_id` and `index` properties, according to [the description of `BulkWriteResult`](https://docs.mongodb.com/manual/reference/method/BulkWriteResult/#BulkWriteResult.upserted).

Without this change, TypeScript complains when trying to access the `_id` property.