### PR TITLE
doc: set User entity in the Repository decorator

### DIFF
--- a/docs/active-record-data-mapper.md
+++ b/docs/active-record-data-mapper.md
@@ -158,7 +158,7 @@ We can create such a function in a "custom repository".
 import {EntityRepository, Repository} from "typeorm";
 import {User} from "../entity/User";
 
-@EntityRepository()
+@EntityRepository(User)
 export class UserRepository extends Repository<User> {
        
     findByName(firstName: string, lastName: string) {


### PR DESCRIPTION
added to the EntityRepository decorator the parameter User, since it won't work without it and following the docs in: 
https://typeorm.io/#/custom-repository/
