### PR TITLE
joinEagerRelations for QueryBuilder

### DIFF
--- a/docs/eager-and-lazy-relations.md
+++ b/docs/eager-and-lazy-relations.md
@@ -60,7 +60,7 @@ const questions = await questionRepository.find();
 ```
 
 Eager relations only work when you use `find*` methods.
-If you use `QueryBuilder` eager relations are disabled and have to use `leftJoinAndSelect` to load the relation.
+If you use `QueryBuilder` eager relations are disabled and have to use `leftJoinAndSelect` or `joinEagerRelations` to load the relation.
 Eager relations can only be used on one side of the relationship,
 using `eager: true` on both sides of relationship is disallowed.
 

--- a/src/decorator/options/RelationOptions.ts
+++ b/src/decorator/options/RelationOptions.ts
@@ -50,8 +50,8 @@ export interface RelationOptions {
 
     /**
      * Set this relation to be eager.
-     * Eager relations are always loaded automatically when relation's owner entity is loaded using find* methods.
-     * Only using QueryBuilder prevents loading eager relations.
+     * Eager relations are always loaded automatically when relation's owner entity is loaded using find* methods
+     * and by `joinEagerRelations` when using queryBuilder.
      * Eager flag cannot be set from both sides of relation - you can eager load only one side of the relationship.
      */
     eager?: boolean;

--- a/src/query-builder/SelectQueryBuilder.ts
+++ b/src/query-builder/SelectQueryBuilder.ts
@@ -36,6 +36,7 @@ import {SelectQueryBuilderOption} from "./SelectQueryBuilderOption";
 import {ObjectUtils} from "../util/ObjectUtils";
 import {DriverUtils} from "../driver/DriverUtils";
 import {AuroraDataApiDriver} from "../driver/aurora-data-api/AuroraDataApiDriver";
+import {FindOptionsUtils} from "../find-options/FindOptionsUtils";
 
 /**
  * Allows to build complex sql queries in a fashion way and execute those queries.
@@ -586,6 +587,14 @@ export class SelectQueryBuilder<Entity> extends QueryBuilder<Entity> implements 
         this.join("LEFT", entityOrProperty, alias, condition, parameters, mapToProperty, false);
         return this;
     }
+
+    /**
+    * Recursively leftJoinAndSelect's entity's eager relations.
+    */
+    joinEagerRelations(): this {
+        FindOptionsUtils.joinEagerRelations(this, this.alias, this.expressionMap.mainAlias!.metadata);
+        return this;
+    };
 
     /**
      */


### PR DESCRIPTION
This commit adds method to `QueryBuilder` that automatically loads eager relations. This functionality is mirrored from `find*` methods. Discussion issue #5889 