### PR TITLE
feat: mysql8 geomcollection is synonymous to geometrycollection

### DIFF
--- a/src/driver/mysql/MysqlQueryRunner.ts
+++ b/src/driver/mysql/MysqlQueryRunner.ts
@@ -1372,6 +1372,12 @@ export class MysqlQueryRunner extends BaseQueryRunner implements QueryRunner {
                         tableColumn.precision = parseInt(dbColumn["DATETIME_PRECISION"]);
                     }
 
+                    if (tableColumn.type === "geomcollection" && !isMariaDb && VersionUtils.isGreaterOrEqual(dbVersion, "8.0.0")) {
+                        // MySQL 8 GeomCollection and GeometryCollection are synonymous, with GeomCollection the preferred type name.
+                        // See https://dev.mysql.com/doc/refman/8.0/en/gis-class-geometrycollection.html
+                        tableColumn.type = "geometrycollection";
+                    }
+
                     return tableColumn;
                 });
 


### PR DESCRIPTION
mysql reports `geomcollection` as column data_type. according to https://dev.mysql.com/doc/refman/8.0/en/gis-class-geometrycollection.html these two types are synonymous.

reporting column type as "geometrycollection" to keep backward compatibility.