### PR TITLE
chore: refactor mkdirp into native fs.mkdir with recursive

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -253,9 +253,9 @@
       "dev": true
     },
     "@types/node": {
-      "version": "9.6.42",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-9.6.42.tgz",
-      "integrity": "sha512-SpeVQJFekfnEaZZO1yl4je/36upII36L7gOT4DBx51B1GeAB45mmDb3a5OBQB+ZeFxVVOP37r8Owsl940G/fBg==",
+      "version": "10.17.20",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-10.17.20.tgz",
+      "integrity": "sha512-XgDgo6W10SeGEAM0k7FosJpvLCynOTYns4Xk3J5HGrA+UI/bKZ30PGMzOP5Lh2zs4259I71FSYLAtjnx3qhObw==",
       "dev": true
     },
     "@types/rimraf": {
@@ -5832,11 +5832,6 @@
           }
         }
       }
-    },
-    "mkdirp": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-1.0.3.tgz",
-      "integrity": "sha512-6uCP4Qc0sWsgMLy1EOqqS/3rjDHOEnsStVr/4vtAIK2Y5i2kA7lFFejYrpIyiN9w0pYf4ckeCYT9f1r1P9KX5g=="
     },
     "mocha": {
       "version": "6.1.4",

--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
     "@types/chai-as-promised": "7.1.0",
     "@types/debug": "4.1.2",
     "@types/mocha": "^5.2.6",
-    "@types/node": "^9.6.0",
+    "@types/node": "^10.17.20",
     "@types/rimraf": "^2.0.2",
     "@types/sha.js": "^2.4.0",
     "@types/sinon": "^7.0.8",
@@ -103,13 +103,15 @@
     "dotenv": "^6.2.0",
     "glob": "^7.1.2",
     "js-yaml": "^3.13.1",
-    "mkdirp": "^1.0.3",
     "reflect-metadata": "^0.1.13",
     "sha.js": "^2.4.11",
     "tslib": "^1.9.0",
     "xml2js": "^0.4.17",
     "yargonaut": "^1.1.2",
     "yargs": "^13.2.1"
+  },
+  "engines": {
+    "node": ">=10.12.0"
   },
   "lint-staged": {
     "*.ts": [

--- a/src/commands/CommandUtils.ts
+++ b/src/commands/CommandUtils.ts
@@ -1,6 +1,6 @@
 import * as fs from "fs";
 import * as path from "path";
-const mkdirp = require("mkdirp");
+import * as util from "util";
 
 /**
  * Command line utils functions.
@@ -11,7 +11,8 @@ export class CommandUtils {
      * Creates directories recursively.
      */
     static createDirectories(directory: string) {
-        return mkdirp(directory);
+        const mkdir = util.promisify(fs.mkdir);
+        return mkdir(directory, { recursive: true });
     }
 
     /**

--- a/src/driver/sqlite/SqliteDriver.ts
+++ b/src/driver/sqlite/SqliteDriver.ts
@@ -1,3 +1,5 @@
+import * as fs from "fs";
+import * as util from "util";
 import { DriverPackageNotInstalledError } from "../../error/DriverPackageNotInstalledError";
 import { SqliteQueryRunner } from "./SqliteQueryRunner";
 import { DriverOptionNotSetError } from "../../error/DriverOptionNotSetError";
@@ -133,9 +135,9 @@ export class SqliteDriver extends AbstractSqliteDriver {
      * Auto creates database directory if it does not exist.
      */
     protected createDatabaseDirectory(fullPath: string): Promise<void> {
-        const mkdirp = PlatformTools.load("mkdirp");
+        const mkdir = util.promisify(fs.mkdir);
         const path = PlatformTools.load("path");
-        return mkdirp(path.dirname(fullPath));
+        return mkdir(path.dirname(fullPath), { recursive: true });
     }
 
 }

--- a/src/platform/PlatformTools.ts
+++ b/src/platform/PlatformTools.ts
@@ -113,9 +113,6 @@ export class PlatformTools {
                 /**
                 * other modules
                 */
-                case "mkdirp":
-                    return require("mkdirp");
-
                 case "path":
                     return require("path");
 


### PR DESCRIPTION
use native mkdir with recursive option instead of mkdirp
(one less package to depend and audit)

fs.mkdir with recursive option is introduced in node 10.12 (which is oldest maintained version)