### PR TITLE
docs: fix grammatical error (lets => let's)

### DIFF
--- a/docs/transactions.md
+++ b/docs/transactions.md
@@ -150,7 +150,7 @@ try {
     
 } catch (err) {
     
-    // since we have errors lets rollback changes we made
+    // since we have errors let's rollback changes we made
     await queryRunner.rollbackTransaction();
     
 } finally {


### PR DESCRIPTION
Change "lets" to "let's" in the sentence "since we have errors lets [sic] rollback changes we made".