### PR TITLE
feat: add name option to view column

### DIFF
--- a/src/decorator/columns/ViewColumn.ts
+++ b/src/decorator/columns/ViewColumn.ts
@@ -1,16 +1,17 @@
 import {getMetadataArgsStorage} from "../../";
 import {ColumnMetadataArgs} from "../../metadata-args/ColumnMetadataArgs";
+import { ViewColumnOptions } from "../options/ViewColumnOptions";
 
 /**
  * ViewColumn decorator is used to mark a specific class property as a view column.
  */
-export function ViewColumn(): Function {
+export function ViewColumn(options?: ViewColumnOptions): Function {
     return function (object: Object, propertyName: string) {
         getMetadataArgsStorage().columns.push({
             target: object.constructor,
             propertyName: propertyName,
             mode: "regular",
-            options: {}
+            options: options || {}
         } as ColumnMetadataArgs);
     };
 }

--- a/src/decorator/options/ViewColumnOptions.ts
+++ b/src/decorator/options/ViewColumnOptions.ts
@@ -1,0 +1,9 @@
+/**
+ * Describes all view column's options.
+ */
+export interface ViewColumnOptions {
+    /**
+     * Column name in the database.
+     */
+    name?: string;
+}

--- a/test/functional/view-entity/general/entity/PhotoAlbumCategory.ts
+++ b/test/functional/view-entity/general/entity/PhotoAlbumCategory.ts
@@ -9,6 +9,7 @@ import {Photo} from "./Photo";
     expression: (connection: Connection) => connection.createQueryBuilder()
         .select("photo.id", "id")
         .addSelect("photo.name", "name")
+        .addSelect("photo.albumId", "albumId")
         .addSelect("category.name", "categoryName")
         .addSelect("album.name", "albumName")
         .from(Photo, "photo")
@@ -29,4 +30,7 @@ export class PhotoAlbumCategory {
 
     @ViewColumn()
     albumName: string;
+
+    @ViewColumn({ name: "albumId" })
+    photoAlbumId: number;
 }

--- a/test/functional/view-entity/general/view-entity-general.ts
+++ b/test/functional/view-entity/general/view-entity-general.ts
@@ -104,11 +104,13 @@ describe("view entity > general", () => {
         photoAlbumCategories[1].albumName.should.be.equal("BMW photos");
         photoAlbumCategories[1].categoryName.should.be.equal("Cars");
 
+        const albumId = connection.driver instanceof CockroachDriver ? "1" : 1;
         const photoAlbumCategory = await connection.manager.findOne(PhotoAlbumCategory, { id: 1 });
         photoAlbumCategory!.id.should.be.equal(photoId1);
         photoAlbumCategory!.name.should.be.equal("BMW E39");
         photoAlbumCategory!.albumName.should.be.equal("BMW photos");
         photoAlbumCategory!.categoryName.should.be.equal("Cars");
+        photoAlbumCategory!.photoAlbumId.should.be.equal(albumId);
 
     })));
 });

--- a/test/functional/view-entity/mssql/entity/PostCategory.ts
+++ b/test/functional/view-entity/mssql/entity/PostCategory.ts
@@ -11,8 +11,8 @@ export class PostCategory {
     @ViewColumn()
     id: number;
 
-    @ViewColumn()
-    name: string;
+    @ViewColumn({ name: "name" })
+    postName: string;
 
     @ViewColumn()
     categoryName: string;

--- a/test/functional/view-entity/mssql/view-entity-mssql.ts
+++ b/test/functional/view-entity/mssql/view-entity-mssql.ts
@@ -51,12 +51,12 @@ describe("view entity > mssql", () => {
 
         const postId1 = connection.driver instanceof CockroachDriver ? "1" : 1;
         postCategories[0].id.should.be.equal(postId1);
-        postCategories[0].name.should.be.equal("About BMW");
+        postCategories[0].postName.should.be.equal("About BMW");
         postCategories[0].categoryName.should.be.equal("Cars");
 
         const postId2 = connection.driver instanceof CockroachDriver ? "2" : 2;
         postCategories[1].id.should.be.equal(postId2);
-        postCategories[1].name.should.be.equal("About Boeing");
+        postCategories[1].postName.should.be.equal("About Boeing");
         postCategories[1].categoryName.should.be.equal("Airplanes");
 
     })));

--- a/test/functional/view-entity/mysql/entity/PostCategory.ts
+++ b/test/functional/view-entity/mysql/entity/PostCategory.ts
@@ -11,8 +11,8 @@ export class PostCategory {
     @ViewColumn()
     id: number;
 
-    @ViewColumn()
-    name: string;
+    @ViewColumn({ name: "name" })
+    postName: string;
 
     @ViewColumn()
     categoryName: string;

--- a/test/functional/view-entity/mysql/view-entity-mysql.ts
+++ b/test/functional/view-entity/mysql/view-entity-mysql.ts
@@ -51,12 +51,12 @@ describe("view entity > mysql", () => {
 
         const postId1 = connection.driver instanceof CockroachDriver ? "1" : 1;
         postCategories[0].id.should.be.equal(postId1);
-        postCategories[0].name.should.be.equal("About BMW");
+        postCategories[0].postName.should.be.equal("About BMW");
         postCategories[0].categoryName.should.be.equal("Cars");
 
         const postId2 = connection.driver instanceof CockroachDriver ? "2" : 2;
         postCategories[1].id.should.be.equal(postId2);
-        postCategories[1].name.should.be.equal("About Boeing");
+        postCategories[1].postName.should.be.equal("About Boeing");
         postCategories[1].categoryName.should.be.equal("Airplanes");
 
     })));

--- a/test/functional/view-entity/oracle/entity/PostCategory.ts
+++ b/test/functional/view-entity/oracle/entity/PostCategory.ts
@@ -11,8 +11,8 @@ export class PostCategory {
     @ViewColumn()
     id: number;
 
-    @ViewColumn()
-    name: string;
+    @ViewColumn({ name: "name" })
+    postName: string;
 
     @ViewColumn()
     categoryName: string;

--- a/test/functional/view-entity/oracle/view-entity-oracle.ts
+++ b/test/functional/view-entity/oracle/view-entity-oracle.ts
@@ -51,12 +51,12 @@ describe("view entity > oracle", () => {
 
         const postId1 = connection.driver instanceof CockroachDriver ? "1" : 1;
         postCategories[0].id.should.be.equal(postId1);
-        postCategories[0].name.should.be.equal("About BMW");
+        postCategories[0].postName.should.be.equal("About BMW");
         postCategories[0].categoryName.should.be.equal("Cars");
 
         const postId2 = connection.driver instanceof CockroachDriver ? "2" : 2;
         postCategories[1].id.should.be.equal(postId2);
-        postCategories[1].name.should.be.equal("About Boeing");
+        postCategories[1].postName.should.be.equal("About Boeing");
         postCategories[1].categoryName.should.be.equal("Airplanes");
 
     })));

--- a/test/functional/view-entity/postgres/entity/PostCategory.ts
+++ b/test/functional/view-entity/postgres/entity/PostCategory.ts
@@ -11,8 +11,8 @@ export class PostCategory {
     @ViewColumn()
     id: number;
 
-    @ViewColumn()
-    name: string;
+    @ViewColumn({ name: "name" })
+    postName: string;
 
     @ViewColumn()
     categoryName: string;

--- a/test/functional/view-entity/postgres/view-entity-postgres.ts
+++ b/test/functional/view-entity/postgres/view-entity-postgres.ts
@@ -77,12 +77,12 @@ describe("view entity > postgres", () => {
 
         const postId1 = connection.driver instanceof CockroachDriver ? "1" : 1;
         postCategories[0].id.should.be.equal(postId1);
-        postCategories[0].name.should.be.equal("About BMW");
+        postCategories[0].postName.should.be.equal("About BMW");
         postCategories[0].categoryName.should.be.equal("Cars");
 
         const postId2 = connection.driver instanceof CockroachDriver ? "2" : 2;
         postCategories[1].id.should.be.equal(postId2);
-        postCategories[1].name.should.be.equal("About Boeing");
+        postCategories[1].postName.should.be.equal("About Boeing");
         postCategories[1].categoryName.should.be.equal("Airplanes");
 
     })));

--- a/test/functional/view-entity/sqlite/entity/PostCategory.ts
+++ b/test/functional/view-entity/sqlite/entity/PostCategory.ts
@@ -11,8 +11,8 @@ export class PostCategory {
     @ViewColumn()
     id: number;
 
-    @ViewColumn()
-    name: string;
+    @ViewColumn({ name: "name" })
+    postName: string;
 
     @ViewColumn()
     categoryName: string;

--- a/test/functional/view-entity/sqlite/view-entity-sqlite.ts
+++ b/test/functional/view-entity/sqlite/view-entity-sqlite.ts
@@ -51,12 +51,12 @@ describe("view entity > sqlite", () => {
 
         const postId1 = connection.driver instanceof CockroachDriver ? "1" : 1;
         postCategories[0].id.should.be.equal(postId1);
-        postCategories[0].name.should.be.equal("About BMW");
+        postCategories[0].postName.should.be.equal("About BMW");
         postCategories[0].categoryName.should.be.equal("Cars");
 
         const postId2 = connection.driver instanceof CockroachDriver ? "2" : 2;
         postCategories[1].id.should.be.equal(postId2);
-        postCategories[1].name.should.be.equal("About Boeing");
+        postCategories[1].postName.should.be.equal("About Boeing");
         postCategories[1].categoryName.should.be.equal("Airplanes");
 
     })));


### PR DESCRIPTION
Add 'name' option to `@ViewColumn` to align with `@Column`
and allow a different property name for a column in a view.

This is required for views created without using the `sync` option.

Closes #5708 