### PR TITLE
[Add] FOR NO KEY UPDATE lock mode for postgresql

### DIFF
--- a/src/query-builder/QueryExpressionMap.ts
+++ b/src/query-builder/QueryExpressionMap.ts
@@ -150,7 +150,7 @@ export class QueryExpressionMap {
     /**
      * Locking mode.
      */
-    lockMode?: "optimistic"|"pessimistic_read"|"pessimistic_write"|"dirty_read";
+    lockMode?: "optimistic"|"pessimistic_read"|"pessimistic_write"|"dirty_read"|"for_no_key_update";
 
     /**
      * Current version of the entity, used for locking.

--- a/src/query-builder/SelectQueryBuilder.ts
+++ b/src/query-builder/SelectQueryBuilder.ts
@@ -967,12 +967,12 @@ export class SelectQueryBuilder<Entity> extends QueryBuilder<Entity> implements 
     /**
      * Sets locking mode.
      */
-    setLock(lockMode: "pessimistic_read"|"pessimistic_write"|"dirty_read"): this;
+    setLock(lockMode: "pessimistic_read"|"pessimistic_write"|"dirty_read"|"for_no_key_update"): this;
 
     /**
      * Sets locking mode.
      */
-    setLock(lockMode: "optimistic"|"pessimistic_read"|"pessimistic_write"|"dirty_read", lockVersion?: number|Date): this {
+    setLock(lockMode: "optimistic"|"pessimistic_read"|"pessimistic_write"|"dirty_read"|"for_no_key_update", lockVersion?: number|Date): this {
         this.expressionMap.lockMode = lockMode;
         this.expressionMap.lockVersion = lockVersion;
         return this;
@@ -1672,6 +1672,12 @@ export class SelectQueryBuilder<Entity> extends QueryBuilder<Entity> implements 
                 } else {
                     throw new LockNotSupportedOnGivenDriverError();
                 }
+            case "for_no_key_update":
+                if (driver instanceof PostgresDriver) {
+                    return " FOR NO KEY UPDATE"
+                } else {
+                    throw new LockNotSupportedOnGivenDriverError();
+                }
             default:
                 return "";
         }
@@ -1806,7 +1812,7 @@ export class SelectQueryBuilder<Entity> extends QueryBuilder<Entity> implements 
         if (!this.expressionMap.mainAlias)
             throw new Error(`Alias is not set. Use "from" method to set an alias.`);
 
-        if ((this.expressionMap.lockMode === "pessimistic_read" || this.expressionMap.lockMode === "pessimistic_write") && !queryRunner.isTransactionActive)
+        if ((this.expressionMap.lockMode === "pessimistic_read" || this.expressionMap.lockMode === "pessimistic_write" || this.expressionMap.lockMode === "for_no_key_update") && !queryRunner.isTransactionActive)
             throw new PessimisticLockTransactionRequiredError();
 
         if (this.expressionMap.lockMode === "optimistic") {

--- a/src/query-builder/SelectQueryBuilder.ts
+++ b/src/query-builder/SelectQueryBuilder.ts
@@ -1674,7 +1674,7 @@ export class SelectQueryBuilder<Entity> extends QueryBuilder<Entity> implements 
                 }
             case "for_no_key_update":
                 if (driver instanceof PostgresDriver) {
-                    return " FOR NO KEY UPDATE"
+                    return " FOR NO KEY UPDATE";
                 } else {
                     throw new LockNotSupportedOnGivenDriverError();
                 }

--- a/test/functional/query-builder/locking/query-builder-locking.ts
+++ b/test/functional/query-builder/locking/query-builder-locking.ts
@@ -82,19 +82,19 @@ describe("query builder > locking", () => {
             return connection.createQueryBuilder(PostWithVersion, "post")
                 .setLock("for_no_key_update")
                 .where("post.id = :id", { id: 1 })
-                .getOne().should.be.rejectedWith(PessimisticLockTransactionRequiredError)
+                .getOne().should.be.rejectedWith(PessimisticLockTransactionRequiredError);
         }
         return;
     })));
 
     it("should not throw error if for no key update lock used with transaction", () => Promise.all(connections.map(async connection => {
-        if(connection.driver instanceof PostgresDriver) {
+        if (connection.driver instanceof PostgresDriver) {
             return connection.manager.transaction(entityManager => {
                 return Promise.all([entityManager.createQueryBuilder(PostWithVersion, "post")
                     .setLock("for_no_key_update")
                     .where("post.id = :id", { id: 1})
                     .getOne().should.not.be.rejected]);
-            })
+            });
         }
         return;
     })));

--- a/test/functional/query-builder/locking/query-builder-locking.ts
+++ b/test/functional/query-builder/locking/query-builder-locking.ts
@@ -177,7 +177,7 @@ describe("query builder > locking", () => {
     it("should attach for no key update lock statement on query if locking enabled", () => Promise.all(connections.map(async connection => {
         if (connection.driver instanceof PostgresDriver) {
             const sql = connection.createQueryBuilder(PostWithVersion, "post")
-                .setLock("pessimistic_write")
+                .setLock("for_no_key_update")
                 .where("post.id = :id", { id: 1 })
                 .getSql();
 

--- a/test/functional/query-builder/locking/query-builder-locking.ts
+++ b/test/functional/query-builder/locking/query-builder-locking.ts
@@ -77,6 +77,28 @@ describe("query builder > locking", () => {
         });
     })));
 
+    it("should throw error if for no key update lock used without transaction", () => Promise.all(connections.map(async connection => {
+        if (connection.driver instanceof PostgresDriver) {
+            return connection.createQueryBuilder(PostWithVersion, "post")
+                .setLock("for_no_key_update")
+                .where("post.id = :id", { id: 1 })
+                .getOne().should.be.rejectedWith(PessimisticLockTransactionRequiredError)
+        }
+        return;
+    })));
+
+    it("should not throw error if for no key update lock used with transaction", () => Promise.all(connections.map(async connection => {
+        if(connection.driver instanceof PostgresDriver) {
+            return connection.manager.transaction(entityManager => {
+                return Promise.all([entityManager.createQueryBuilder(PostWithVersion, "post")
+                    .setLock("for_no_key_update")
+                    .where("post.id = :id", { id: 1})
+                    .getOne().should.not.be.rejected]);
+            })
+        }
+        return;
+    })));
+
     it("should attach pessimistic read lock statement on query if locking enabled", () => Promise.all(connections.map(async connection => {
         if (connection.driver instanceof AbstractSqliteDriver || connection.driver instanceof CockroachDriver || connection.driver instanceof SapDriver)
             return;
@@ -138,6 +160,30 @@ describe("query builder > locking", () => {
         } else if (connection.driver instanceof SqlServerDriver) {
             expect(sql.indexOf("WITH (UPDLOCK, ROWLOCK)") !== -1).to.be.true;
         }
+
+    })));
+
+    it("should not attach for no key update lock statement on query if locking is not used", () => Promise.all(connections.map(async connection => {
+        if (connection.driver instanceof PostgresDriver) {
+            const sql = connection.createQueryBuilder(PostWithVersion, "post")
+                .where("post.id = :id", { id: 1 })
+                .getSql();
+
+                expect(sql.indexOf("FOR NO KEY UPDATE") === -1).to.be.true;
+            }
+        return;
+    })));
+
+    it("should attach for no key update lock statement on query if locking enabled", () => Promise.all(connections.map(async connection => {
+        if (connection.driver instanceof PostgresDriver) {
+            const sql = connection.createQueryBuilder(PostWithVersion, "post")
+                .setLock("pessimistic_write")
+                .where("post.id = :id", { id: 1 })
+                .getSql();
+
+            expect(sql.indexOf("FOR NO KEY UPDATE") !== -1).to.be.true;
+        }
+        return;
 
     })));
 
@@ -287,6 +333,21 @@ describe("query builder > locking", () => {
                         .getOne().should.be.rejectedWith(LockNotSupportedOnGivenDriverError)
                 ]);
             });
+
+        return;
+    })));
+
+    it("should throw error if for no key update locking not supported by given driver", () => Promise.all(connections.map(async connection => {
+        if (!(connection.driver instanceof PostgresDriver)) {
+            return connection.manager.transaction(entityManager => {
+                return Promise.all([
+                    entityManager.createQueryBuilder(PostWithVersion, "post")
+                        .setLock("for_no_key_update")
+                        .where("post.id = :id", { id: 1 })
+                        .getOne().should.be.rejectedWith(LockNotSupportedOnGivenDriverError),
+                ]);
+            });
+        }
 
         return;
     })));


### PR DESCRIPTION
Support `FOR NO KEY UPDATE` lock mode on postgresql.
If you will not update primary key, then `FOR NO KEY UPDATE` is better then `FOR UPDATE`, becaues `FOR UPDATE` can make deadlock with `SELECT FOR KEY SHARE` query.
The main difference between `FOR NO KEY UPDATE` and `FOR UPDATE` is `FOR NO KEY UPDATE` will not block `SELECT FOR KEY SHARE`.
The detail is described [this article](https://dba.stackexchange.com/questions/188169/select-for-update-locking-other-tables-in-postgresql).