### PR TITLE
Fix expo sqlite driver disconnect()

### DIFF
--- a/src/driver/expo/ExpoDriver.ts
+++ b/src/driver/expo/ExpoDriver.ts
@@ -40,6 +40,7 @@ export class ExpoDriver extends AbstractSqliteDriver {
         return new Promise<void>((ok, fail) => {
             try {
                 this.queryRunner = undefined;
+                this.databaseConnection._db.close();
                 this.databaseConnection = undefined;
                 ok();
             } catch (error) {


### PR DESCRIPTION
Currently the disconnect() function does not perform a real call to databaseConnection close, it only sets the queryRunner and databaseConnection to undefined, this behavior may cause problems when you do something like this:

1 - await getConnection().close();
2 - Replace the database file
3 - Try to open connection createConnection(); and do some insert

more info:
https://github.com/expo/expo/issues/8109