### PR TITLE
fix: postgresql connection URL can use an UNIX Socket

### DIFF
--- a/src/driver/postgres/PostgresDriver.ts
+++ b/src/driver/postgres/PostgresDriver.ts
@@ -2,7 +2,6 @@ import {Driver} from "../Driver";
 import {ConnectionIsNotSetError} from "../../error/ConnectionIsNotSetError";
 import {ObjectLiteral} from "../../common/ObjectLiteral";
 import {DriverPackageNotInstalledError} from "../../error/DriverPackageNotInstalledError";
-import {DriverUtils} from "../DriverUtils";
 import {ColumnMetadata} from "../../metadata/ColumnMetadata";
 import {PostgresQueryRunner} from "./PostgresQueryRunner";
 import {DateUtils} from "../../util/DateUtils";
@@ -922,11 +921,12 @@ export class PostgresDriver implements Driver {
      */
     protected async createPool(options: PostgresConnectionOptions, credentials: PostgresConnectionCredentialsOptions): Promise<any> {
 
-        credentials = Object.assign({}, credentials, DriverUtils.buildDriverOptions(credentials)); // todo: do it better way
+        credentials = Object.assign({}, credentials);
 
         // build connection options for the driver
         // See: https://github.com/brianc/node-postgres/tree/master/packages/pg-pool#create
         const connectionOptions = Object.assign({}, {
+            connectionString: credentials.url,
             host: credentials.host,
             user: credentials.username,
             password: credentials.password,


### PR DESCRIPTION
Solves https://github.com/typeorm/typeorm/issues/2614.
* Current behavior:
Users may provide an URL in the connection options which is parsed by a generic function to fill the following fields: host, port, username, password, database.
* Issue:
You can't give an UNIX socket as host with PostgreSQL.
* Corrected behavior:
Provide a `ConnectionUrlParser` class with different parser functions. The default parser function is left unchanged to prevent any regression with other database types. Concerning PostgreSQL a new function is provided which solves the issue. To prevent any regression, I tested myself the function with multiples strings against the default parser.
* Exemple of tested strings
`postgres://user:password@host:5432/database` (standard)
`postgres://user:password@/var/run/postgresql?dbname=database` (UNIX socket)
`postgres:///var/run/postgresql?dbname=database` (without username)
