### PR TITLE
[Doc] Fix typeorm alias for TS

### DIFF
--- a/docs/using-cli.md
+++ b/docs/using-cli.md
@@ -37,9 +37,11 @@ Add typeorm command under scripts section in package.json
 ```
 "scripts" {
     ...
-    "typeorm": "ts-node -r tsconfig-paths/register ./node_modules/typeorm/cli.js"    
+    "typeorm": "node --require ts-node/register ./node_modules/typeorm/cli.js"    
 }
 ```
+
+If you want to load more modules like [module-alias](https://github.com/ilearnio/module-alias) you can add more `--require my-module-supporting-register`
 
 Then you may run the command like this:
 ```


### PR DESCRIPTION
Just did not work with actual version of ts-node and others modules