### PR TITLE
Update query deep partial TypeScript definition

### DIFF
--- a/src/query-builder/QueryPartialEntity.ts
+++ b/src/query-builder/QueryPartialEntity.ts
@@ -11,7 +11,9 @@ export type QueryPartialEntity<T> = {
  */
 export type QueryDeepPartialEntity<T> = {
     [P in keyof T]?:
-        T[P] extends Array<infer U> ? Array<QueryDeepPartialEntity<U>> :
-        T[P] extends ReadonlyArray<infer U> ? ReadonlyArray<QueryDeepPartialEntity<U>> :
-        QueryDeepPartialEntity<T[P]> | (() => string);
+        (
+            T[P] extends Array<infer U> ? Array<QueryDeepPartialEntity<U>> :
+            T[P] extends ReadonlyArray<infer U> ? ReadonlyArray<QueryDeepPartialEntity<U>> :
+            QueryDeepPartialEntity<T[P]>
+        ) | (() => string);
 };


### PR DESCRIPTION
User should be able to pass function if field is an array, right now it is only enabled for single values.

Example:
```
await getConnection()
      .createQueryBuilder()
      .update(Entity)
      .set({
        arrayField: (() => 'some update query') as unknown as string[],
      })
      .where('1 = 1')
      .execute();
```

This is the workaround I've used so far to hack around TypeScript, with this fix merged, you can drop `as unknown as string[]` and it works as expected