### PR TITLE
Implement deferrable foreign keys for SAP HANA

### DIFF
--- a/src/driver/sap/SapQueryRunner.ts
+++ b/src/driver/sap/SapQueryRunner.ts
@@ -466,7 +466,7 @@ export class SapQueryRunner extends BaseQueryRunner implements QueryRunner {
                     referencedColumnNames: foreignKeys.map(dbFk => dbFk["REFERENCED_COLUMN_NAME"]),
                     onDelete: dbForeignKey["DELETE_RULE"] === "RESTRICT" ? "NO ACTION" : dbForeignKey["DELETE_RULE"],
                     onUpdate: dbForeignKey["UPDATE_RULE"] === "RESTRICT" ? "NO ACTION" : dbForeignKey["UPDATE_RULE"],
-                    deferrable: dbForeignKey["CHECK_TIME"].replace('_', ' '), // "CHECK_TIME" is "INITIALLY_IMMEDIATE" or "INITIALLY DEFERRED"
+                    deferrable: dbForeignKey["CHECK_TIME"].replace("_", " "), // "CHECK_TIME" is "INITIALLY_IMMEDIATE" or "INITIALLY DEFERRED"
                 });
             });
 
@@ -572,7 +572,7 @@ export class SapQueryRunner extends BaseQueryRunner implements QueryRunner {
                             referencedColumnNames: foreignKeys.map(dbFk => dbFk["REFERENCED_COLUMN_NAME"]),
                             onDelete: dbForeignKey["DELETE_RULE"] === "RESTRICT" ? "NO ACTION" : dbForeignKey["DELETE_RULE"],
                             onUpdate: dbForeignKey["UPDATE_RULE"] === "RESTRICT" ? "NO ACTION" : dbForeignKey["UPDATE_RULE"],
-                            deferrable: dbForeignKey["CHECK_TIME"].replace('_', ' '),
+                            deferrable: dbForeignKey["CHECK_TIME"].replace("_", " "),
                         });
                     });
 
@@ -908,7 +908,7 @@ export class SapQueryRunner extends BaseQueryRunner implements QueryRunner {
                         referencedColumnNames: foreignKeys.map(dbFk => dbFk["REFERENCED_COLUMN_NAME"]),
                         onDelete: dbForeignKey["DELETE_RULE"] === "RESTRICT" ? "NO ACTION" : dbForeignKey["DELETE_RULE"],
                         onUpdate: dbForeignKey["UPDATE_RULE"] === "RESTRICT" ? "NO ACTION" : dbForeignKey["UPDATE_RULE"],
-                        deferrable: dbForeignKey["CHECK_TIME"].replace('_', ' '),
+                        deferrable: dbForeignKey["CHECK_TIME"].replace("_", " "),
                     });
                 });
 
@@ -1044,7 +1044,7 @@ export class SapQueryRunner extends BaseQueryRunner implements QueryRunner {
                     referencedColumnNames: foreignKeys.map(dbFk => dbFk["REFERENCED_COLUMN_NAME"]),
                     onDelete: dbForeignKey["DELETE_RULE"] === "RESTRICT" ? "NO ACTION" : dbForeignKey["DELETE_RULE"],
                     onUpdate: dbForeignKey["UPDATE_RULE"] === "RESTRICT" ? "NO ACTION" : dbForeignKey["UPDATE_RULE"],
-                    deferrable: dbForeignKey["CHECK_TIME"].replace('_', ' '),
+                    deferrable: dbForeignKey["CHECK_TIME"].replace("_", " "),
                 });
             });
 
@@ -1113,7 +1113,7 @@ export class SapQueryRunner extends BaseQueryRunner implements QueryRunner {
                     referencedColumnNames: foreignKeys.map(dbFk => dbFk["REFERENCED_COLUMN_NAME"]),
                     onDelete: dbForeignKey["DELETE_RULE"] === "RESTRICT" ? "NO ACTION" : dbForeignKey["DELETE_RULE"],
                     onUpdate: dbForeignKey["UPDATE_RULE"] === "RESTRICT" ? "NO ACTION" : dbForeignKey["UPDATE_RULE"],
-                    deferrable: dbForeignKey["CHECK_TIME"].replace('_', ' '),
+                    deferrable: dbForeignKey["CHECK_TIME"].replace("_", " "),
                 });
             });
 
@@ -1632,7 +1632,7 @@ export class SapQueryRunner extends BaseQueryRunner implements QueryRunner {
                     referencedColumnNames: foreignKeys.map(dbFk => dbFk["REFERENCED_COLUMN_NAME"]),
                     onDelete: dbForeignKey["DELETE_RULE"] === "RESTRICT" ? "NO ACTION" : dbForeignKey["DELETE_RULE"],
                     onUpdate: dbForeignKey["UPDATE_RULE"] === "RESTRICT" ? "NO ACTION" : dbForeignKey["UPDATE_RULE"],
-                    deferrable: dbForeignKey["CHECK_TIME"].replace('_', ' '),
+                    deferrable: dbForeignKey["CHECK_TIME"].replace("_", " "),
                 });
             });
 

--- a/src/driver/sap/SapQueryRunner.ts
+++ b/src/driver/sap/SapQueryRunner.ts
@@ -91,7 +91,7 @@ export class SapQueryRunner extends BaseQueryRunner implements QueryRunner {
             return this.driver.master.release(this.databaseConnection);
         }
 
-        return Promise.resolve();        
+        return Promise.resolve();
     }
 
     /**
@@ -466,6 +466,7 @@ export class SapQueryRunner extends BaseQueryRunner implements QueryRunner {
                     referencedColumnNames: foreignKeys.map(dbFk => dbFk["REFERENCED_COLUMN_NAME"]),
                     onDelete: dbForeignKey["DELETE_RULE"] === "RESTRICT" ? "NO ACTION" : dbForeignKey["DELETE_RULE"],
                     onUpdate: dbForeignKey["UPDATE_RULE"] === "RESTRICT" ? "NO ACTION" : dbForeignKey["UPDATE_RULE"],
+                    deferrable: dbForeignKey["CHECK_TIME"].replace('_', ' '), // "CHECK_TIME" is "INITIALLY_IMMEDIATE" or "INITIALLY DEFERRED"
                 });
             });
 
@@ -571,6 +572,7 @@ export class SapQueryRunner extends BaseQueryRunner implements QueryRunner {
                             referencedColumnNames: foreignKeys.map(dbFk => dbFk["REFERENCED_COLUMN_NAME"]),
                             onDelete: dbForeignKey["DELETE_RULE"] === "RESTRICT" ? "NO ACTION" : dbForeignKey["DELETE_RULE"],
                             onUpdate: dbForeignKey["UPDATE_RULE"] === "RESTRICT" ? "NO ACTION" : dbForeignKey["UPDATE_RULE"],
+                            deferrable: dbForeignKey["CHECK_TIME"].replace('_', ' '),
                         });
                     });
 
@@ -906,6 +908,7 @@ export class SapQueryRunner extends BaseQueryRunner implements QueryRunner {
                         referencedColumnNames: foreignKeys.map(dbFk => dbFk["REFERENCED_COLUMN_NAME"]),
                         onDelete: dbForeignKey["DELETE_RULE"] === "RESTRICT" ? "NO ACTION" : dbForeignKey["DELETE_RULE"],
                         onUpdate: dbForeignKey["UPDATE_RULE"] === "RESTRICT" ? "NO ACTION" : dbForeignKey["UPDATE_RULE"],
+                        deferrable: dbForeignKey["CHECK_TIME"].replace('_', ' '),
                     });
                 });
 
@@ -1041,6 +1044,7 @@ export class SapQueryRunner extends BaseQueryRunner implements QueryRunner {
                     referencedColumnNames: foreignKeys.map(dbFk => dbFk["REFERENCED_COLUMN_NAME"]),
                     onDelete: dbForeignKey["DELETE_RULE"] === "RESTRICT" ? "NO ACTION" : dbForeignKey["DELETE_RULE"],
                     onUpdate: dbForeignKey["UPDATE_RULE"] === "RESTRICT" ? "NO ACTION" : dbForeignKey["UPDATE_RULE"],
+                    deferrable: dbForeignKey["CHECK_TIME"].replace('_', ' '),
                 });
             });
 
@@ -1109,6 +1113,7 @@ export class SapQueryRunner extends BaseQueryRunner implements QueryRunner {
                     referencedColumnNames: foreignKeys.map(dbFk => dbFk["REFERENCED_COLUMN_NAME"]),
                     onDelete: dbForeignKey["DELETE_RULE"] === "RESTRICT" ? "NO ACTION" : dbForeignKey["DELETE_RULE"],
                     onUpdate: dbForeignKey["UPDATE_RULE"] === "RESTRICT" ? "NO ACTION" : dbForeignKey["UPDATE_RULE"],
+                    deferrable: dbForeignKey["CHECK_TIME"].replace('_', ' '),
                 });
             });
 
@@ -1627,6 +1632,7 @@ export class SapQueryRunner extends BaseQueryRunner implements QueryRunner {
                     referencedColumnNames: foreignKeys.map(dbFk => dbFk["REFERENCED_COLUMN_NAME"]),
                     onDelete: dbForeignKey["DELETE_RULE"] === "RESTRICT" ? "NO ACTION" : dbForeignKey["DELETE_RULE"],
                     onUpdate: dbForeignKey["UPDATE_RULE"] === "RESTRICT" ? "NO ACTION" : dbForeignKey["UPDATE_RULE"],
+                    deferrable: dbForeignKey["CHECK_TIME"].replace('_', ' '),
                 });
             });
 
@@ -1719,6 +1725,9 @@ export class SapQueryRunner extends BaseQueryRunner implements QueryRunner {
                 if (fk.onUpdate) {
                     const onUpdate = fk.onUpdate === "NO ACTION" ? "RESTRICT" : fk.onUpdate;
                     constraint += ` ON UPDATE ${onUpdate}`;
+                }
+                if (fk.deferrable) {
+                    constraint += ` ${fk.deferrable}`;
                 }
 
                 return constraint;
@@ -1823,7 +1832,7 @@ export class SapQueryRunner extends BaseQueryRunner implements QueryRunner {
         let indexType = "";
         if (index.isUnique) {
             indexType += "UNIQUE ";
-        } 
+        }
         if (index.isFulltext) {
             indexType += "FULLTEXT ";
         }
@@ -1894,6 +1903,10 @@ export class SapQueryRunner extends BaseQueryRunner implements QueryRunner {
         if (foreignKey.onUpdate) {
             const onUpdate = foreignKey.onUpdate === "NO ACTION" ? "RESTRICT" : foreignKey.onUpdate;
             sql += ` ON UPDATE ${onUpdate}`;
+        }
+
+        if (foreignKey.deferrable) {
+            sql += ` ${foreignKey.deferrable}`;
         }
 
         return new Query(sql);


### PR DESCRIPTION
Related feature request: #6098, #2191.

I've added deferrable (check time) options for foreign keys on SAP HANA. See `<references_specification>` in the [CREATE TABLE](https://help.sap.com/viewer/4fe29514fd584807ac9f2a04f6754767/2.0.04/en-US/20d58a5f75191014b2fe92141b7df228.html#loio20d58a5f75191014b2fe92141b7df228__create_table_references_specification) and [ALTER TABLE](https://help.sap.com/viewer/4fe29514fd584807ac9f2a04f6754767/2.0.04/en-US/20d329a6751910149d5fdbc4800f92ff.html#loio20d329a6751910149d5fdbc4800f92ff__references_specification) specification:
```EBNF
<references_specification> ::= 
  REFERENCES <referenced_table> [ ( <referenced_column_name_list> ) ]
  [ <referential_triggered_action> ]
  [ <constraint_enforcement> ]
  [ <constraint_check_time> ]
<constraint_check_time> ::= INITIALLY { IMMEDIATE | DEFERRED }
```
as well as the [REFERENTIAL_CONSTRAINTS](https://help.sap.com/viewer/4fe29514fd584807ac9f2a04f6754767/2.0.03/en-US/20ccc0a175191014901b88e6bc175c44.html) system table in their official documentation:
| Column name | Data type | Description                                                                         |
|-------------|-----------|-------------------------------------------------------------------------------------|
| `CHECK_TIME`  | `STRING`    | The time when the constraint is checked: `INITIALLY_IMMEDIATE` or `INITIALLY DEFERRED`. |

**Notes:**
- The implementation is using the already defined `deferrable` attribute in `RelationOptions`, that has the possible values `INITIALLY IMMEDIATE` and `INITIALLY DEFERRED`, same as the specification for the `REFERENCES` SQL expression.
- In the `REFERENTIAL_CONSTRAINTS` table, the possible values are `INITIALLY_IMMEDIATE` (with underscore) and `INITIALLY DEFERRED` (with space).