### PR TITLE
Aurora Data API - Add AWS configurationOptions to aurora-data-api-pg connector

### DIFF
--- a/ormconfig.json.dist
+++ b/ormconfig.json.dist
@@ -103,5 +103,18 @@
       "maxRetries": 3
     },
     "logging": false
+  },
+  {
+    "skip": true,
+    "name": "aurora-data-api-pg",
+    "type": "aurora-data-api-pg",
+    "region": "us-east-1",
+    "secretArn": "mysecret",
+    "resourceArn": "app-dbcluster",
+    "database": "app-dbcluster-mine",
+    "serviceConfigOptions": {
+      "maxRetries": 3
+    },
+    "logging": false
   }
 ]

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "typeorm",
-  "version": "0.2.24",
+  "version": "0.2.25",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -1861,8 +1861,8 @@
       }
     },
     "data-api-client": {
-      "version": "github:ArsenyYankovsky/data-api-client#42a4a26b5d7de0939b748d6d22a67022a9955a6f",
-      "from": "github:ArsenyYankovsky/data-api-client#support-date",
+      "version": "github:ArsenyYankovsky/data-api-client#043f3320f8d665c21250d615101e7b3bc8f1d298",
+      "from": "github:ArsenyYankovsky/data-api-client#support-postgres",
       "dev": true,
       "requires": {
         "sqlstring": "^2.3.1"
@@ -2753,8 +2753,7 @@
           "version": "2.1.1",
           "resolved": false,
           "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -2778,15 +2777,13 @@
           "version": "1.0.0",
           "resolved": false,
           "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "resolved": false,
           "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
           "dev": true,
-          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -2796,22 +2793,19 @@
           "version": "1.1.0",
           "resolved": false,
           "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "concat-map": {
           "version": "0.0.1",
           "resolved": false,
           "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "resolved": false,
           "integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4=",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -2932,8 +2926,7 @@
           "version": "2.0.3",
           "resolved": false,
           "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "ini": {
           "version": "1.3.5",
@@ -2947,7 +2940,6 @@
           "resolved": false,
           "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
           "dev": true,
-          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -2964,7 +2956,6 @@
           "resolved": false,
           "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
           "dev": true,
-          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -2973,15 +2964,13 @@
           "version": "0.0.8",
           "resolved": false,
           "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "mkdirp": {
           "version": "0.5.1",
           "resolved": false,
           "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
           "dev": true,
-          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -3070,8 +3059,7 @@
           "version": "1.0.1",
           "resolved": false,
           "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -3085,7 +3073,6 @@
           "resolved": false,
           "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
           "dev": true,
-          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -3181,8 +3168,7 @@
           "version": "5.1.1",
           "resolved": false,
           "integrity": "sha512-kKvNJn6Mm93gAczWVJg7wH+wGYWNrDHdWvpUmHyEsgCtIwwo3bqPtV4tR5tuPaUhTOo/kvhVwd8XwwOllGYkbg==",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -3224,7 +3210,6 @@
           "resolved": false,
           "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
           "dev": true,
-          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -3246,7 +3231,6 @@
           "resolved": false,
           "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
           "dev": true,
-          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -3304,8 +3288,7 @@
           "version": "1.0.2",
           "resolved": false,
           "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "yallist": {
           "version": "3.0.3",
@@ -8560,12 +8543,12 @@
       "dev": true
     },
     "typeorm-aurora-data-api-driver": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/typeorm-aurora-data-api-driver/-/typeorm-aurora-data-api-driver-1.2.0.tgz",
-      "integrity": "sha512-PT/y49qFk0Kub+HWITgtJ2oOQCEET9UYcpZ3LA7kgFvnrGrrbiCsDwbuJpFCXt1boqca5nkGsVCUcbzLcCaO9w==",
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/typeorm-aurora-data-api-driver/-/typeorm-aurora-data-api-driver-1.3.0.tgz",
+      "integrity": "sha512-9U5/zAcRgXixbMt4Hf6VkO94657WpR+Sq/SPKKEGDh+UxI1DHpkXLquvpOAdq76/LiMpmyAIRw51Yhjk8/lxpA==",
       "dev": true,
       "requires": {
-        "data-api-client": "github:ArsenyYankovsky/data-api-client#support-date"
+        "data-api-client": "github:ArsenyYankovsky/data-api-client#043f3320f8d665c21250d615101e7b3bc8f1d298"
       }
     },
     "typescript": {

--- a/package.json
+++ b/package.json
@@ -91,7 +91,7 @@
     "sqlite3": "^4.0.9",
     "ts-node": "^8.0.2",
     "tslint": "^5.13.1",
-    "typeorm-aurora-data-api-driver": "^1.2.0",
+    "typeorm-aurora-data-api-driver": "^1.3.0",
     "typescript": "^3.3.3333"
   },
   "dependencies": {

--- a/src/driver/aurora-data-api-pg/AuroraDataApiPostgresConnectionOptions.ts
+++ b/src/driver/aurora-data-api-pg/AuroraDataApiPostgresConnectionOptions.ts
@@ -31,4 +31,6 @@ export interface AuroraDataApiPostgresConnectionOptions extends BaseConnectionOp
     * Defaults to logging error with `warn` level.
      */
     readonly poolErrorHandler?: (err: any) => any;
+
+    readonly serviceConfigOptions?: { [key: string]: any };
 }

--- a/src/driver/postgres/PostgresDriver.ts
+++ b/src/driver/postgres/PostgresDriver.ts
@@ -1039,6 +1039,7 @@ export class AuroraDataApiPostgresDriver extends PostgresWrapper {
             this.options.resourceArn,
             this.options.database,
             (query: string, parameters?: any[]) => this.connection.logger.logQuery(query, parameters),
+            this.options.serviceConfigOptions
         );
     }
 

--- a/test/functional/connection-manager/connection-manager.ts
+++ b/test/functional/connection-manager/connection-manager.ts
@@ -10,6 +10,8 @@ import {Entity} from "../../../src/decorator/entity/Entity";
 // Uncomment when testing the aurora data API driver
 // import {AuroraDataApiDriver} from "../../../src/driver/aurora-data-api/AuroraDataApiDriver";
 // import {AuroraDataApiConnectionOptions} from "../../../src/driver/aurora-data-api/AuroraDataApiConnectionOptions";
+// import {AuroraDataApiPostgresDriver} from "../../../src/driver/postgres/PostgresDriver";
+// import {AuroraDataApiPostgresConnectionOptions} from "../../../src/driver/aurora-data-api-pg/AuroraDataApiPostgresConnectionOptions";
 
 describe("ConnectionManager", () => {
 
@@ -87,6 +89,24 @@ describe("ConnectionManager", () => {
             connection.driver.should.be.instanceOf(AuroraDataApiDriver);
             connection.isConnected.should.be.true;
             const serviceConfigOptions = (connection.options as AuroraDataApiConnectionOptions).serviceConfigOptions;
+            expect(serviceConfigOptions).to.include({ maxRetries: 3, region: "us-east-1" });
+            await connection.close();
+        });
+
+        it("should create a aurora connection when aurora-data-api-pg driver is specified", async () => {
+            const options = setupSingleTestingConnection("aurora-data-api-pg", {
+                name: "aurora-data-api-pg",
+                dropSchema: false,
+                schemaCreate: false,
+                enabledDrivers: ["aurora-data-api-pg"]
+            });
+            const connectionManager = new ConnectionManager();
+            const connection = connectionManager.create(options!);
+            await connection.connect();
+            connection.name.should.contain("aurora-data-api-pg");
+            connection.driver.should.be.instanceOf(AuroraDataApiPostgresDriver);
+            connection.isConnected.should.be.true;
+            const serviceConfigOptions = (connection.options as AuroraDataApiPostgresConnectionOptions).serviceConfigOptions;
             expect(serviceConfigOptions).to.include({ maxRetries: 3, region: "us-east-1" });
             await connection.close();
         });


### PR DESCRIPTION
With the merge of #5651 typeorm supports aurora data api with postgres, but typeorm has a version missmatch in devDepencies it needs version 1.3.0, pr [here](https://github.com/ArsenyYankovsky/typeorm-aurora-data-api-driver/pull/35).

Like in #5754 pr, the typeorm-aurora-data-api-driver allows passing configuration to underlying awsClient, changes in this PR allows users to pass the values (same code from #5754 but in AuroraDataApiPostgresDriver class).