### PR TITLE
Add a link to TypeORM website

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -1,4 +1,4 @@
 # Documentation
 
 This directory contains all TypeORM documentation.
-This documentation is represented on a site.
+This documentation is [the TypeORM website](https://typeorm.io/)


### PR DESCRIPTION
Weirdly search sent me here, and it took a while to find the real TypeORM website.