### PR TITLE
feat: add long and medium simple-array and simple-json

### DIFF
--- a/src/driver/mysql/MysqlDriver.ts
+++ b/src/driver/mysql/MysqlDriver.ts
@@ -458,10 +458,12 @@ export class MysqlDriver implements Driver {
         } else if (columnMetadata.type === "timestamp" || columnMetadata.type === "datetime" || columnMetadata.type === Date) {
             return DateUtils.mixedDateToDate(value);
 
-        } else if (columnMetadata.type === "simple-array") {
+        } else if (columnMetadata.type === "simple-array" || columnMetadata.type === "medium-simple-array"
+            || columnMetadata.type === "long-simple-array") {
             return DateUtils.simpleArrayToString(value);
 
-        } else if (columnMetadata.type === "simple-json") {
+        } else if (columnMetadata.type === "simple-json" || columnMetadata.type === "medium-simple-json"
+            || columnMetadata.type === "long-simple-json") {
             return DateUtils.simpleJsonToString(value);
 
         } else if (columnMetadata.type === "enum" || columnMetadata.type === "simple-enum") {
@@ -496,10 +498,12 @@ export class MysqlDriver implements Driver {
         } else if (columnMetadata.type === "time") {
             value = DateUtils.mixedTimeToString(value);
 
-        } else if (columnMetadata.type === "simple-array") {
+        } else if (columnMetadata.type === "simple-array" || columnMetadata.type === "medium-simple-array"
+            || columnMetadata.type === "long-simple-array") {
             value = DateUtils.stringToSimpleArray(value);
 
-        } else if (columnMetadata.type === "simple-json") {
+        } else if (columnMetadata.type === "simple-json" || columnMetadata.type === "medium-simple-json"
+            || columnMetadata.type === "long-simple-json") {
             value = DateUtils.stringToSimpleJson(value);
 
         } else if ((columnMetadata.type === "enum" || columnMetadata.type === "simple-enum")
@@ -551,6 +555,12 @@ export class MysqlDriver implements Driver {
 
         } else if (column.type === "simple-array" || column.type === "simple-json") {
             return "text";
+
+        } else if (column.type === "medium-simple-array" || column.type === "medium-simple-json") {
+            return "mediumtext";
+
+        } else if (column.type === "long-simple-array" || column.type === "long-simple-json") {
+            return "longtext";
 
         } else if (column.type === "simple-enum") {
             return "enum";

--- a/src/driver/types/ColumnTypes.ts
+++ b/src/driver/types/ColumnTypes.ts
@@ -85,9 +85,13 @@ export type WithWidthColumnType = "tinyint" // mysql
 export type SimpleColumnType =
 
     "simple-array" // typeorm-specific, automatically mapped to string
+    |"medium-simple-array" //  mysql, typeorm-specific, automatically mapped to mediumtext string
+    |"long-simple-array" //  mysql, typeorm-specific, automatically mapped to longtext string
     // |"string" // typeorm-specific, automatically mapped to varchar depend on platform
 
     |"simple-json" // typeorm-specific, automatically mapped to string
+    |"medium-simple-json" //  mysql, typeorm-specific, automatically mapped to mediumtext string
+    |"long-simple-json" //  mysql, typeorm-specific, automatically mapped to longtext string
 
     |"simple-enum" // typeorm-specific, automatically mapped to string
 

--- a/test/functional/database-schema/column-types/mysql/column-types-mysql.ts
+++ b/test/functional/database-schema/column-types/mysql/column-types-mysql.ts
@@ -79,7 +79,11 @@ describe("database schema > column types > mysql", () => {
         post.classEnum1 = FruitEnum.Apple;
         post.json = { id: 1, name: "Post" };
         post.simpleArray = ["A", "B", "C"];
+        post.mediumSimpleArray = ["D", "E", "F"];
+        post.longSimpleArray = ["G", "H", "I"];
         post.simpleJson = { param: "VALUE" };
+        post.mediumSimpleJson = { param: "MEDIUM_VALUE" };
+        post.longSimpleJson = { param: "LONG_VALUE" };
         post.simpleEnum = "A";
         post.simpleClassEnum1 = FruitEnum.Apple;
         await postRepository.save(post);
@@ -137,7 +141,15 @@ describe("database schema > column types > mysql", () => {
         loadedPost.simpleArray[0].should.be.equal(post.simpleArray[0]);
         loadedPost.simpleArray[1].should.be.equal(post.simpleArray[1]);
         loadedPost.simpleArray[2].should.be.equal(post.simpleArray[2]);
+        loadedPost.mediumSimpleArray[0].should.be.equal(post.mediumSimpleArray[0]);
+        loadedPost.mediumSimpleArray[1].should.be.equal(post.mediumSimpleArray[1]);
+        loadedPost.mediumSimpleArray[2].should.be.equal(post.mediumSimpleArray[2]);
+        loadedPost.longSimpleArray[0].should.be.equal(post.longSimpleArray[0]);
+        loadedPost.longSimpleArray[1].should.be.equal(post.longSimpleArray[1]);
+        loadedPost.longSimpleArray[2].should.be.equal(post.longSimpleArray[2]);
         loadedPost.simpleJson.param.should.be.equal(post.simpleJson.param);
+        loadedPost.mediumSimpleJson.param.should.be.equal(post.mediumSimpleJson.param);
+        loadedPost.longSimpleJson.param.should.be.equal(post.longSimpleJson.param);
         loadedPost.simpleEnum.should.be.equal(post.simpleEnum);
         loadedPost.simpleClassEnum1.should.be.equal(post.simpleClassEnum1);
 
@@ -199,6 +211,7 @@ describe("database schema > column types > mysql", () => {
         table!.findColumnByName("json")!.type.should.be.equal("json");
         table!.findColumnByName("simpleArray")!.type.should.be.equal("text");
         table!.findColumnByName("simpleJson")!.type.should.be.equal("text");
+        table!.findColumnByName("longSimpleJson")!.type.should.be.equal("longtext");
         table!.findColumnByName("simpleEnum")!.type.should.be.equal("enum");
         table!.findColumnByName("simpleEnum")!.enum![0].should.be.equal("A");
         table!.findColumnByName("simpleEnum")!.enum![1].should.be.equal("B");

--- a/test/functional/database-schema/column-types/mysql/entity/Post.ts
+++ b/test/functional/database-schema/column-types/mysql/entity/Post.ts
@@ -190,8 +190,20 @@ export class Post {
     @Column("simple-array")
     simpleArray: string[];
 
+    @Column("medium-simple-array")
+    mediumSimpleArray: string[];
+
+    @Column("long-simple-array")
+    longSimpleArray: string[];
+
     @Column("simple-json")
     simpleJson: { param: string };
+
+    @Column("medium-simple-json")
+    mediumSimpleJson: { param: string };
+
+    @Column("long-simple-json")
+    longSimpleJson: { param: string };
 
     @Column("simple-enum", { enum: ["A", "B", "C"] })
     simpleEnum: string;


### PR DESCRIPTION
Support larger data objects for entities using simple-array and simple-json in mysql. Add two new types for simple columns, medium-simple-* and long-simple-* using mysql column types, mediumtext and longtext respectively.

Closes #6017