### PR TITLE
Fix MySQL Foreign Key schema query

### DIFF
--- a/src/driver/mysql/MysqlQueryRunner.ts
+++ b/src/driver/mysql/MysqlQueryRunner.ts
@@ -1232,7 +1232,7 @@ export class MysqlQueryRunner extends BaseQueryRunner implements QueryRunner {
         const foreignKeysSql = `SELECT \`kcu\`.\`TABLE_SCHEMA\`, \`kcu\`.\`TABLE_NAME\`, \`kcu\`.\`CONSTRAINT_NAME\`, \`kcu\`.\`COLUMN_NAME\`, \`kcu\`.\`REFERENCED_TABLE_SCHEMA\`, ` +
             `\`kcu\`.\`REFERENCED_TABLE_NAME\`, \`kcu\`.\`REFERENCED_COLUMN_NAME\`, \`rc\`.\`DELETE_RULE\` \`ON_DELETE\`, \`rc\`.\`UPDATE_RULE\` \`ON_UPDATE\` ` +
             `FROM \`INFORMATION_SCHEMA\`.\`KEY_COLUMN_USAGE\` \`kcu\` ` +
-            `INNER JOIN \`INFORMATION_SCHEMA\`.\`REFERENTIAL_CONSTRAINTS\` \`rc\` ON \`rc\`.\`constraint_name\` = \`kcu\`.\`constraint_name\` ` +
+            `INNER JOIN \`INFORMATION_SCHEMA\`.\`REFERENTIAL_CONSTRAINTS\` \`rc\` ON \`rc\`.\`constraint_name\` = \`kcu\`.\`constraint_name\` AND \`rc\`.\`constraint_schema\` = \`kcu\`.\`constraint_schema\` ` +
             `WHERE ` + foreignKeysCondition;
         const [dbTables, dbColumns, dbPrimaryKeys, dbCollations, dbIndices, dbForeignKeys]: ObjectLiteral[][] = await Promise.all([
             this.query(tablesSql),

--- a/test/github-issues/6168/entity/User.ts
+++ b/test/github-issues/6168/entity/User.ts
@@ -1,0 +1,11 @@
+import {Entity, PrimaryGeneratedColumn, ManyToOne} from "../../../../src";
+import { UserType } from "./UserType";
+
+@Entity({ name: "user", database: "test" })
+export class User {
+    @PrimaryGeneratedColumn()
+    id: number;
+
+    @ManyToOne(() => UserType, { onUpdate: "CASCADE", onDelete: "CASCADE" })
+    type: UserType;
+}

--- a/test/github-issues/6168/entity/UserType.ts
+++ b/test/github-issues/6168/entity/UserType.ts
@@ -1,0 +1,7 @@
+import {Entity, PrimaryGeneratedColumn} from "../../../../src";
+
+@Entity({ name: "user_type", database: "test" })
+export class UserType {
+    @PrimaryGeneratedColumn()
+    id: number;
+}

--- a/test/github-issues/6168/issue-6168.ts
+++ b/test/github-issues/6168/issue-6168.ts
@@ -1,0 +1,25 @@
+import "reflect-metadata";
+import {closeTestingConnections, createTestingConnections, reloadTestingDatabases} from "../../utils/test-utils";
+import {Connection} from "../../../src";
+import {User} from "./entity/User";
+import {UserType} from "./entity/UserType";
+import {expect} from "chai";
+
+describe("github issues > #6168 wrong foreign key information loaded from schema in mysql", () => {
+    let connections: Connection[];
+    before(async () => connections = await createTestingConnections({
+                entities: [User, UserType ],
+                enabledDrivers: ["mysql", "mariadb"],
+                dropSchema: true,
+            })
+    );
+    beforeEach(() => reloadTestingDatabases(connections));
+    after(() => closeTestingConnections(connections));
+
+    it("should have equal foreign keys from schema and entities", () => Promise.all(connections.map(async connection => {
+        const queryRunner = connection.createQueryRunner("master");
+        const metadataFromSchema = await queryRunner.connection.getMetadata(User);
+        const metadataFromEntities = connection.getMetadata(User);
+        return expect(metadataFromSchema).to.be.deep.equal(metadataFromEntities);
+    })));
+});


### PR DESCRIPTION
Add a new clause for the join with `INFORMATION_SCHEMA.REFERENTIAL_CONSTRAINTS` to prevent errors when there is more than one database in the server with foreign keys with same name.

Closes #6168 