### PR TITLE
fix: enable explicitly inserting IDENTITY values into mssql

### DIFF
--- a/src/query-builder/InsertQueryBuilder.ts
+++ b/src/query-builder/InsertQueryBuilder.ts
@@ -347,6 +347,18 @@ export class InsertQueryBuilder<Entity> extends QueryBuilder<Entity> {
             query += ` RETURNING ${returningExpression}`;
         }
 
+
+        // Inserting a specific value for an auto-increment primary key in mssql requires enabling IDENTITY_INSERT
+        // IDENTITY_INSERT can only be enabled for tables where there is an IDENTITY column and only if there is a value to be inserted (i.e. supplying DEFAULT is prohibited if IDENTITY_INSERT is enabled)
+        if (this.connection.driver instanceof SqlServerDriver
+            && this.expressionMap.mainAlias!.hasMetadata
+            && this.expressionMap.mainAlias!.metadata.columns
+                .filter((column) => this.expressionMap.insertColumns.length > 0 ? this.expressionMap.insertColumns.indexOf(column.propertyPath) !== -1 : column.isInsert)
+                .some((column) => this.isOverridingAutoIncrementBehavior(column))
+        ) {
+            query = `SET IDENTITY_INSERT ${tableName} ON; ${query}; SET IDENTITY_INSERT ${tableName} OFF`;
+        }
+
         return query;
     }
 
@@ -372,7 +384,8 @@ export class InsertQueryBuilder<Entity> extends QueryBuilder<Entity> {
                 && !(this.connection.driver instanceof OracleDriver)
                 && !(this.connection.driver instanceof AbstractSqliteDriver)
                 && !(this.connection.driver instanceof MysqlDriver)
-                && !(this.connection.driver instanceof AuroraDataApiDriver))
+                && !(this.connection.driver instanceof AuroraDataApiDriver)
+                && !(this.connection.driver instanceof SqlServerDriver && this.isOverridingAutoIncrementBehavior(column)))
                 return false;
 
             return true;
@@ -598,6 +611,21 @@ export class InsertQueryBuilder<Entity> extends QueryBuilder<Entity> {
             return [this.expressionMap.valuesSet];
 
         throw new InsertValuesMissingError();
+    }
+
+    /**
+     * Checks if column is an auto-generated primary key, but the current insertion specifies a value for it.
+     * 
+     * @param column
+     */
+    protected isOverridingAutoIncrementBehavior(column: ColumnMetadata): boolean {
+        return column.isPrimary 
+                && column.isGenerated 
+                && column.generationStrategy === "increment"
+                && this.getValueSets().some((valueSet) => 
+                    column.getEntityValue(valueSet) !== undefined 
+                    && column.getEntityValue(valueSet) !== null
+                );
     }
 
 }


### PR DESCRIPTION
Allow explicit insertion of preset values for mssql IDENTITY columns. These are the equivalent to
auto-incrementing primary keys in MySQL, but require special conditional treatment.

Closes: #2199 for mssql