### PR TITLE
fix: Child entities not being saved correctly with cascade actions

### DIFF
--- a/src/metadata/EntityMetadata.ts
+++ b/src/metadata/EntityMetadata.ts
@@ -700,12 +700,19 @@ export class EntityMetadata {
         relations.forEach(relation => {
             const value = relation.getEntityValue(entity);
             if (Array.isArray(value)) {
-                value.forEach(subValue => relationsAndValues.push([relation, subValue, relation.inverseEntityMetadata]));
+                value.forEach(subValue => relationsAndValues.push([relation, subValue, this.getInverseEntityMetadata(subValue, relation)]));
             } else if (value) {
-                relationsAndValues.push([relation, value, relation.inverseEntityMetadata]);
+                relationsAndValues.push([relation, value, this.getInverseEntityMetadata(value, relation)]);
             }
         });
         return relationsAndValues;
+    }
+
+    private getInverseEntityMetadata(value: any, relation: RelationMetadata): EntityMetadata {
+        const childEntityMetadata = relation.inverseEntityMetadata.childEntityMetadatas.find(metadata => 
+            metadata.target == value.constructor
+        )
+        return childEntityMetadata ? childEntityMetadata : relation.inverseEntityMetadata;
     }
 
     // -------------------------------------------------------------------------

--- a/src/metadata/EntityMetadata.ts
+++ b/src/metadata/EntityMetadata.ts
@@ -710,8 +710,8 @@ export class EntityMetadata {
 
     private getInverseEntityMetadata(value: any, relation: RelationMetadata): EntityMetadata {
         const childEntityMetadata = relation.inverseEntityMetadata.childEntityMetadatas.find(metadata => 
-            metadata.target == value.constructor
-        )
+            metadata.target === value.constructor
+        );
         return childEntityMetadata ? childEntityMetadata : relation.inverseEntityMetadata;
     }
 


### PR DESCRIPTION
`extractRelationValuesFromEntity` used `inverseEntityMetadata` which may contains abstract or base entity metadata which coursed child entity that we actually want to save to be treated as it's parent. This commit adds additional check for it.

Fixes: #2544 
