### PR TITLE
Fix undefined `repository` variable on docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,6 +106,8 @@ export class User {
 And your domain logic looks like this:
 
 ```typescript
+const repository = connection.getRepository(User);
+
 const user = new User();
 user.firstName = "Timber";
 user.lastName = "Saw";


### PR DESCRIPTION
The `repository` variable is not defined in the first Data Mapper pattern example