### PR TITLE
 fix: properly override database url properties

### DIFF
--- a/src/driver/DriverUtils.ts
+++ b/src/driver/DriverUtils.ts
@@ -28,7 +28,7 @@ export class DriverUtils {
             if (buildOptions && buildOptions.useSid) {
                 urlDriverOptions.sid = parsedUrl.database;
             }
-            return Object.assign({}, options, urlDriverOptions);
+            return Object.assign({}, urlDriverOptions, options);
         }
         return Object.assign({}, options);
     }

--- a/test/github-issues/4878/issue-4878.ts
+++ b/test/github-issues/4878/issue-4878.ts
@@ -1,0 +1,19 @@
+import { DriverUtils } from "../../../src/driver/DriverUtils";
+import { expect } from "chai";
+
+describe("github issues > #4878 URL Connection string not overridden by supplied options", () => {
+    it("should override url-built options with user-supplied options", () => {
+        const obj: any = {
+            username: "user",
+            password: "password",
+            host: "host",
+            database: "database",
+            port: 8888
+        };
+
+        const url = `postgres://url_user:${obj.password}@${obj.host}:${obj.port}/${obj.database}`;
+        obj.url = url;
+        const options = DriverUtils.buildDriverOptions(obj);
+        expect(options.username).to.eql(obj.username);
+    });
+});


### PR DESCRIPTION
As per the documentation, the url properties should be getting overridden by the specifically-passed configuration options. They currently are not because of the order of the `Object.assign` call.

This reverses the order of the assign to ensure that any properties which were already defined outside of the url are properly persisted in the final configuration.

There are various reasons for this PR. What drove me to make the change was CI/CD usage. In Gitlab, you are provided a DATABASE_URL, which can have a dynamic url and port due to the kubernetes setup. My typeorm connection kept connecting to the default user's database instead of the `test` database I was providing it, because the url property was overriding the provided `database`.

This PR fixes an issue opened October of last year! #4878