### PR TITLE
support cjs extension for ormconfig

### DIFF
--- a/src/connection/ConnectionOptionsReader.ts
+++ b/src/connection/ConnectionOptionsReader.ts
@@ -80,7 +80,7 @@ export class ConnectionOptionsReader {
     protected async load(): Promise<ConnectionOptions[]|undefined> {
         let connectionOptions: ConnectionOptions|ConnectionOptions[]|undefined = undefined;
 
-        const fileFormats = ["env", "js", "ts", "json", "yml", "yaml", "xml"];
+        const fileFormats = ["env", "js", "cjs", "ts", "json", "yml", "yaml", "xml"];
 
         // Detect if baseFilePath contains file extension
         const possibleExtension = this.baseFilePath.substr(this.baseFilePath.lastIndexOf("."));
@@ -107,7 +107,7 @@ export class ConnectionOptionsReader {
         if (PlatformTools.getEnvVariable("TYPEORM_CONNECTION") || PlatformTools.getEnvVariable("TYPEORM_URL")) {
             connectionOptions = new ConnectionOptionsEnvReader().read();
 
-        } else if (foundFileFormat === "js") {
+        } else if (foundFileFormat === "js" || foundFileFormat === "cjs") {
             connectionOptions = await PlatformTools.load(configFile);
 
         } else if (foundFileFormat === "ts") {

--- a/src/util/DirectoryExportedClassesLoader.ts
+++ b/src/util/DirectoryExportedClassesLoader.ts
@@ -4,7 +4,7 @@ import {Logger} from "../logger/Logger";
 /**
  * Loads all exported classes from the given directory.
  */
-export function importClassesFromDirectories(logger: Logger, directories: string[], formats = [".js", ".ts"]): Function[] {
+export function importClassesFromDirectories(logger: Logger, directories: string[], formats = [".js", ".cjs", ".ts"]): Function[] {
 
     const logLevel = "info";
     const classesNotFoundMessage = "No classes were found using the provided glob pattern: ";

--- a/test/github-issues/6284/issue-6284.ts
+++ b/test/github-issues/6284/issue-6284.ts
@@ -1,14 +1,16 @@
 import {expect} from "chai";
 import { writeFileSync, unlinkSync } from "fs";
 import { ConnectionOptionsReader } from "../../../src/connection/ConnectionOptionsReader";
+import { importClassesFromDirectories } from "../../../src/util/DirectoryExportedClassesLoader";
+import { LoggerFactory } from "../../../src/logger/LoggerFactory";
 
 describe("cli support for cjs extension", () => {
     it("will load a cjs file", async  () => {
+        const cjsConfigPath = [__dirname, "ormconfig.cjs"].join("/");
         const databaseType = "postgres";
         const config = `module.exports = {"type": "${databaseType}"};`;
-        const cjsConfigPath = [__dirname, "ormconfig.cjs"].join("/");
-        writeFileSync(cjsConfigPath, config);
 
+        writeFileSync(cjsConfigPath, config);
         const reader = new ConnectionOptionsReader({root: __dirname });
 
         const results = await reader.all();
@@ -16,6 +18,19 @@ describe("cli support for cjs extension", () => {
         expect(results[0]).to.be.an("Object");
         expect(results[0].type).to.equal(databaseType);
 
+
         unlinkSync(cjsConfigPath);
+    });
+
+    it("loads cjs files via DirectoryExportedClassesloader", () => {
+        const klassPath = [__dirname, "klass.cjs"].join("/");
+        const klass = `module.exports.Widget = class Widget {};`;
+        writeFileSync(klassPath, klass);
+
+        const classes = importClassesFromDirectories(new LoggerFactory().create(), [`${__dirname}/*.cjs`]);
+        expect(classes).to.be.an("Array");
+        expect(classes.length).to.eq(1);
+
+        unlinkSync(klassPath);
     });
 });

--- a/test/github-issues/6284/issue-6284.ts
+++ b/test/github-issues/6284/issue-6284.ts
@@ -1,0 +1,21 @@
+import {expect} from "chai";
+import { writeFileSync, unlinkSync } from "fs";
+import { ConnectionOptionsReader } from "../../../src/connection/ConnectionOptionsReader";
+
+describe("cli support for cjs extension", () => {
+    it("will load a cjs file", async  () => {
+        const databaseType = "postgres";
+        const config = `module.exports = {"type": "${databaseType}"};`;
+        const cjsConfigPath = [__dirname, "ormconfig.cjs"].join("/")
+        writeFileSync(cjsConfigPath, config)
+
+        const reader = new ConnectionOptionsReader({root: __dirname });
+
+        const results = await reader.all();
+        expect(results).to.be.an("Array");
+        expect(results[0]).to.be.an("Object");
+        expect(results[0].type).to.equal(databaseType);
+
+        unlinkSync(cjsConfigPath);
+    });
+});

--- a/test/github-issues/6284/issue-6284.ts
+++ b/test/github-issues/6284/issue-6284.ts
@@ -6,8 +6,8 @@ describe("cli support for cjs extension", () => {
     it("will load a cjs file", async  () => {
         const databaseType = "postgres";
         const config = `module.exports = {"type": "${databaseType}"};`;
-        const cjsConfigPath = [__dirname, "ormconfig.cjs"].join("/")
-        writeFileSync(cjsConfigPath, config)
+        const cjsConfigPath = [__dirname, "ormconfig.cjs"].join("/");
+        writeFileSync(cjsConfigPath, config);
 
         const reader = new ConnectionOptionsReader({root: __dirname });
 


### PR DESCRIPTION
addresses #6284 - if you're running a NodeJS library that has ESM modules enabled, using a `cjs` extension for the `ormconfig` is required to express the configuration in commonjs.

This script allows me to run the CLI in a local environment and a test case is supplied.