### PR TITLE
fix: transform relations for aggregate $lookup

### DIFF
--- a/src/query-builder/transformer/DocumentToEntityTransformer.ts
+++ b/src/query-builder/transformer/DocumentToEntityTransformer.ts
@@ -116,6 +116,20 @@ export class DocumentToEntityTransformer {
         addEmbeddedValuesRecursively(entity, document, metadata.embeddeds);
 
         // if relation is loaded then go into it recursively and transform its values too
+        metadata.relations.forEach(relation => {
+            const isResultArray = relation.isManyToMany || relation.isOneToMany;
+            const relatedEntities = document[relation.propertyName];
+
+            if (relatedEntities) {
+                const result = this.transformAll(relatedEntities, relation.inverseEntityMetadata);
+
+                entity[relation.propertyName] = !isResultArray ? result[0] : result;
+
+                if (!isResultArray || result.length > 0)
+                    hasData = true;
+            }
+        });        
+        
         /*metadata.relations.forEach(relation => {
             const relationAlias = this.selectionMap.findSelectionByParent(alias.name, relation.propertyName);
             if (relationAlias) {


### PR DESCRIPTION
$lookup aggregation support is lacking and I haven't seen much movement.  I am not very familiar with the library, but didn't want to just log another issue on this topic.  Please provide feedback and let me know how I can improve to get this supported in typeorm.

I've tested this with aggregateEntity queries, but have not fully tested for saves -- this probably needs work.  I will continue to run my own tests and add more commits, but I wanted to get eyes on this.

Resolves https://github.com/typeorm/typeorm/issues/655

User.ts
```ts
@Entity({ name: 'users' })
export class User implements IUser {
  @PrimaryGeneratedColumn()
  id: number;

  @Column()
  name: string;
}
```

Photo.ts
```ts
@Entity({ name: 'photos' })
export class Photo implements IPhoto {
  @PrimaryGeneratedColumn()
  id: number;

  @Column()
  url: string;

  @RelationId((photo: Photo) => photo.user)
  userId: number;

  @ManyToOne((type) => User)
  user: IUser;
}
```

photo.service.ts
```ts
  async findById(id: number) {
    const cursor = await this.repository.aggregateEntity([
      {
        $match: { id },
      },
      {
        $lookup: {
          from: 'users',
          localField: 'userId',
          foreignField: 'id',
          as: 'user',
        },
      }
    ]);

    const result = await cursor.limit(1).toArray();

    return result.length > 0 ? result[0] : undefined;
  }
```