### PR TITLE
escape columns in InsertQueryBuilder.orUpdate

### DIFF
--- a/src/query-builder/InsertQueryBuilder.ts
+++ b/src/query-builder/InsertQueryBuilder.ts
@@ -267,16 +267,16 @@ export class InsertQueryBuilder<Entity> extends QueryBuilder<Entity> {
     orUpdate(statement?: { columns?: string[], overwrite?: string[], conflict_target?: string | string[] }): this {
       this.expressionMap.onUpdate = {};
       if (statement && Array.isArray(statement.conflict_target))
-          this.expressionMap.onUpdate.conflict = ` ( ${statement.conflict_target.join(", ")} ) `;
+          this.expressionMap.onUpdate.conflict = ` ( ${statement.conflict_target.map((columnName) => this.escape(columnName)).join(", ")} ) `;
       if (statement && typeof statement.conflict_target === "string")
-          this.expressionMap.onUpdate.conflict = ` ON CONSTRAINT ${statement.conflict_target} `;
+          this.expressionMap.onUpdate.conflict = ` ON CONSTRAINT ${this.escape(statement.conflict_target)} `;
       if (statement && Array.isArray(statement.columns))
-          this.expressionMap.onUpdate.columns = statement.columns.map(column => `${column} = :${column}`).join(", ");
+          this.expressionMap.onUpdate.columns = statement.columns.map(column => `${this.escape(column)} = :${column}`).join(", ");
       if (statement && Array.isArray(statement.overwrite)) {
         if (this.connection.driver instanceof MysqlDriver || this.connection.driver instanceof AuroraDataApiDriver) {
           this.expressionMap.onUpdate.overwrite = statement.overwrite.map(column => `${column} = VALUES(${column})`).join(", ");
         } else if (this.connection.driver instanceof PostgresDriver || this.connection.driver instanceof AbstractSqliteDriver || this.connection.driver instanceof CockroachDriver) {
-          this.expressionMap.onUpdate.overwrite = statement.overwrite.map(column => `${column} = EXCLUDED.${column}`).join(", ");
+          this.expressionMap.onUpdate.overwrite = statement.overwrite.map(column => `${this.escape(column)} = EXCLUDED.${this.escape(column)}`).join(", ");
         }
       }
       return this;

--- a/test/functional/query-builder/insert-on-conflict/entity/Post.ts
+++ b/test/functional/query-builder/insert-on-conflict/entity/Post.ts
@@ -1,8 +1,10 @@
 import {Entity} from "../../../../../src/decorator/entity/Entity";
 import {Column} from "../../../../../src/decorator/columns/Column";
+import {Unique} from "../../../../../src/decorator/Unique";
 import {PrimaryColumn} from "../../../../../src/decorator/columns/PrimaryColumn";
 
 @Entity()
+@Unique(["date"])
 export class Post {
 
     @PrimaryColumn()
@@ -10,5 +12,8 @@ export class Post {
 
     @Column()
     title: string;
+
+    @Column()
+    date: Date;
 
 }

--- a/test/functional/query-builder/insert-on-conflict/query-builder-insert-on-conflict.ts
+++ b/test/functional/query-builder/insert-on-conflict/query-builder-insert-on-conflict.ts
@@ -13,11 +13,12 @@ describe("query builder > insertion > on conflict", () => {
     beforeEach(() => reloadTestingDatabases(connections));
     after(() => closeTestingConnections(connections));
 
-    it("should perform insertion correctly", () => Promise.all(connections.map(async connection => {
+    it("should perform insertion correctly using onConflict", () => Promise.all(connections.map(async connection => {
 
         const post1 = new Post();
         post1.id = "post#1";
         post1.title = "About post";
+        post1.date = new Date('06 Aug 2020 00:12:00 GMT');
 
         await connection.createQueryBuilder()
             .insert()
@@ -28,6 +29,7 @@ describe("query builder > insertion > on conflict", () => {
         const post2 = new Post();
         post2.id = "post#1";
         post2.title = "Again post";
+        post2.date = new Date('06 Aug 2020 00:12:00 GMT');
 
         await connection.createQueryBuilder()
             .insert()
@@ -38,7 +40,8 @@ describe("query builder > insertion > on conflict", () => {
 
         await connection.manager.findOne(Post, "post#1").should.eventually.be.eql({
             id: "post#1",
-            title: "About post"
+            title: "About post",
+            date: new Date('06 Aug 2020 00:12:00 GMT')
         });
 
         await connection.createQueryBuilder()
@@ -51,7 +54,76 @@ describe("query builder > insertion > on conflict", () => {
 
         await connection.manager.findOne(Post, "post#1").should.eventually.be.eql({
             id: "post#1",
-            title: "Again post"
+            title: "Again post",
+            date: new Date('06 Aug 2020 00:12:00 GMT')
+        });
+    })));
+
+    it("should perform insertion correctly using orIgnore", () => Promise.all(connections.map(async connection => {
+
+        const post1 = new Post();
+        post1.id = "post#1";
+        post1.title = "About post";
+        post1.date = new Date('06 Aug 2020 00:12:00 GMT');
+
+        await connection.createQueryBuilder()
+            .insert()
+            .into(Post)
+            .values(post1)
+            .execute();
+
+        const post2 = new Post();
+        post2.id = "post#1";
+        post2.title = "Again post";
+        post2.date = new Date('06 Aug 2020 00:12:00 GMT');
+
+        await connection.createQueryBuilder()
+            .insert()
+            .into(Post)
+            .values(post2)
+            .orIgnore('date')
+            .execute();
+
+        await connection.manager.findOne(Post, "post#1").should.eventually.be.eql({
+            id: "post#1",
+            title: "About post",
+            date: new Date('06 Aug 2020 00:12:00 GMT')
+        });
+    })));
+
+    it("should perform insertion correctly using orUpdate", () => Promise.all(connections.map(async connection => {
+
+        const post1 = new Post();
+        post1.id = "post#1";
+        post1.title = "About post";
+        post1.date = new Date('06 Aug 2020 00:12:00 GMT');
+
+        await connection.createQueryBuilder()
+            .insert()
+            .into(Post)
+            .values(post1)
+            .execute();
+
+        const post2 = new Post();
+        post2.id = "post#1";
+        post2.title = "Again post";
+        post2.date = new Date('06 Aug 2020 00:12:00 GMT');
+
+        await connection.createQueryBuilder()
+            .insert()
+            .into(Post)
+            .values(post2)
+            .orUpdate({
+                conflict_target: ['date'],
+                overwrite: ['title']
+            })
+            .setParameter("title", post2.title)
+            .execute();
+
+        await connection.manager.findOne(Post, "post#1").should.eventually.be.eql({
+            id: "post#1",
+            title: "Again post",
+            date: new Date('06 Aug 2020 00:12:00 GMT')
         });
     })));
 


### PR DESCRIPTION
Fixies this use-case

```typescript
await repository
        .createQueryBuilder()
        .insert()
        .values({
            name,
            code,
            createdAt: new Date(),
            updatedAt: new Date(),
        })
        .orUpdate({
            conflict_target: ['name'],
            overwrite: ['code', 'updatedAt'],
        })
        .execute();
```

because it generates:

```sql
INSERT INTO "my_table"("id", "name", "code", "createdAt", "updatedAt") VALUES (DEFAULT, $1, $2, $3, $4) ON CONFLICT  ( name )  DO UPDATE SET code = EXCLUDED.code, updatedAt = EXCLUDED.updatedAt
```

and it causes:

```
ERROR:  column excluded.updatedat does not exist
LINE 1: ...  DO UPDATE SET code = EXCLUDED.code, updatedAt = EXCLUDED.u...
                                                             ^
HINT:  Perhaps you meant to reference the column "excluded.updatedAt".
```

instead of:

```sql
INSERT INTO "my_table"("id", "name", "code", "createdAt", "updatedAt") VALUES (DEFAULT, $1, $2, $3, $4) ON CONFLICT  ( "name" )  DO UPDATE SET "code" = EXCLUDED."code", "updatedAt" = EXCLUDED."updatedAt"
```
