### PR TITLE
fix: remove unnecessary optionality from Raw operator's columnAlias argument

### DIFF
--- a/src/find-options/operator/Raw.ts
+++ b/src/find-options/operator/Raw.ts
@@ -4,6 +4,6 @@ import {FindOperator} from "../FindOperator";
  * Find Options Operator.
  * Example: { someField: Raw([...]) }
  */
-export function Raw<T>(value: string|((columnAlias?: string) => string)) {
+export function Raw<T>(value: string|((columnAlias: string) => string)) {
     return new FindOperator("raw", value as any, false);
 }


### PR DESCRIPTION
I believe it will be called with alias argument at https://github.com/typeorm/typeorm/blob/0.2.25/src/find-options/FindOperator.ts#L121

Unnecessary optional sign causes confusing and extra handling.

[@typescript-eslint/restrict-template-expressions](https://github.com/typescript-eslint/typescript-eslint/blob/v3.4.0/packages/eslint-plugin/docs/rules/restrict-template-expressions.md), which is [recommended since v3](https://github.com/typescript-eslint/typescript-eslint/issues/1423), warns `Invalid type "string | undefined" of template literal expression` for  `` Raw(alias =>`${alias} > NOW()`) ``