### PR TITLE
style: migrate from slave/master terms to primary/replica

### DIFF
--- a/docs/multiple-connections.md
+++ b/docs/multiple-connections.md
@@ -36,7 +36,7 @@ const connections = await createConnections([{
 }]);
 ```
 
-This approach allows you to connect to any number of databases you have 
+This approach allows you to connect to any number of databases you have
 and each database will have its own configuration, own entities and overall ORM scope and settings.
 
 For each connection a new `Connection` instance will be created.
@@ -71,11 +71,11 @@ const db2Connection = getConnection("db2Connection");
 
 Benefit of using this approach is that you can configure multiple connections with different login credentials,
 host, port and even database type itself.
-Downside for might be that you'll need to manage and work with multiple connection instances. 
+Downside for might be that you'll need to manage and work with multiple connection instances.
 
 ## Using multiple databases in a single connection
 
-If you don't want to create multiple connections, 
+If you don't want to create multiple connections,
 but want to use multiple databases in a single connection,
 you can specify database name per-entity you use:
 
@@ -130,7 +130,7 @@ const users = await connection
 This code will produce following sql query (depend on database type):
 
 ```sql
-SELECT * FROM "secondDB"."user" "user", "thirdDB"."photo" "photo" 
+SELECT * FROM "secondDB"."user" "user", "thirdDB"."photo" "photo"
     WHERE "photo"."userId" = "user"."id"
 ```
 
@@ -203,7 +203,7 @@ const users = await connection
 This code will produce following sql query (depend on database type):
 
 ```sql
-SELECT * FROM "secondSchema"."question" "question", "thirdSchema"."photo" "photo" 
+SELECT * FROM "secondSchema"."question" "question", "thirdSchema"."photo" "photo"
     WHERE "photo"."userId" = "user"."id"
 ```
 
@@ -250,14 +250,14 @@ Example of replication connection settings:
   type: "mysql",
   logging: true,
   replication: {
-    master: {
+    primary: {
       host: "server1",
       port: 3306,
       username: "test",
       password: "test",
       database: "test"
     },
-    slaves: [{
+    replicas: [{
       host: "server2",
       port: 3306,
       username: "test",
@@ -274,21 +274,21 @@ Example of replication connection settings:
 }
 ```
 
-All schema update and write operations are performed using `master` server.
-All simple queries performed by find methods or select query builder are using a random `slave` instance. 
+All schema update and write operations are performed using `primary` server.
+All simple queries performed by find methods or select query builder are using a random `replica` instance.
 
-If you want to explicitly use master in SELECT created by query builder, you can use the following code:
+If you want to explicitly use primary in SELECT created by query builder, you can use the following code:
 
 ```typescript
-const masterQueryRunner = connection.createQueryRunner("master");
+const primaryQueryRunner = connection.createQueryRunner("primary");
 try {
-    const postsFromMaster = await connection.createQueryBuilder(Post, "post")
-        .setQueryRunner(masterQueryRunner)
+    const postsFromPrimary = await connection.createQueryBuilder(Post, "post")
+        .setQueryRunner(primaryQueryRunner)
         .getMany();
 } finally {
-      await masterQueryRunner.release();
+      await primaryQueryRunner.release();
 }
-        
+
 ```
 
 Note that connection created by a `QueryRunner` need to be explicitly released.
@@ -300,14 +300,14 @@ Mysql supports deep configuration:
 ```typescript
 {
   replication: {
-    master: {
+    primary: {
       host: "server1",
       port: 3306,
       username: "test",
       password: "test",
       database: "test"
     },
-    slaves: [{
+    replicas: [{
       host: "server2",
       port: 3306,
       username: "test",
@@ -320,7 +320,7 @@ Mysql supports deep configuration:
       password: "test",
       database: "test"
     }],
-    
+
     /**
     * If true, PoolCluster will attempt to reconnect when connection fails. (Default: true)
     */

--- a/docs/zh_CN/multiple-connections.md
+++ b/docs/zh_CN/multiple-connections.md
@@ -126,7 +126,7 @@ const users = await connection
 此代码将生成以下sql查询（取决于数据库类型）：
 
 ```sql
-SELECT * FROM "secondDB"."question" "question", "thirdDB"."photo" "photo" 
+SELECT * FROM "secondDB"."question" "question", "thirdDB"."photo" "photo"
     WHERE "photo"."userId" = "user"."id"
 ```
 
@@ -199,7 +199,7 @@ const users = await connection
 此代码将生成以下sql查询（取决于数据库类型）：
 
 ```sql
-SELECT * FROM "secondSchema"."question" "question", "thirdSchema"."photo" "photo" 
+SELECT * FROM "secondSchema"."question" "question", "thirdSchema"."photo" "photo"
     WHERE "photo"."userId" = "user"."id"
 ```
 
@@ -248,14 +248,14 @@ export class User {
   type: "mysql",
   logging: true,
   replication: {
-    master: {
+    primary: {
       host: "server1",
       port: 3306,
       username: "test",
       password: "test",
       database: "test"
     },
-    slaves: [{
+    replicas: [{
       host: "server2",
       port: 3306,
       username: "test",
@@ -272,19 +272,19 @@ export class User {
 }
 ```
 
-所有模式更新和写入操作都使用`master`服务器执行。
-find方法或select query builder执行的所有简单查询都使用随机的`slave`实例。
+所有模式更新和写入操作都使用`primary`服务器执行。
+find方法或select query builder执行的所有简单查询都使用随机的`replica`实例。
 
-如果要在查询构建器创建的SELECT中显式使用master，可以使用以下代码：
+如果要在查询构建器创建的SELECT中显式使用primary，可以使用以下代码：
 
 ```typescript
-const masterQueryRunner = connection.createQueryRunner("master");
+const primaryQueryRunner = connection.createQueryRunner("primary");
 try {
-    const postsFromMaster = await connection.createQueryBuilder(Post, "post")
-        .setQueryRunner(masterQueryRunner)
+    const postsFromPrimary = await connection.createQueryBuilder(Post, "post")
+        .setQueryRunner(primaryQueryRunner)
         .getMany();
 } finally {
-      await masterQueryRunner.release();
+      await primaryQueryRunner.release();
 }
 ```
 请注意，需要显式释放由`QueryRunner`创建的连接。
@@ -296,14 +296,14 @@ Mysql支持深度配置：
 ```typescript
 {
   replication: {
-    master: {
+    primary: {
       host: "server1",
       port: 3306,
       username: "test",
       password: "test",
       database: "test"
     },
-    slaves: [{
+    replicas: [{
       host: "server2",
       port: 3306,
       username: "test",
@@ -316,7 +316,7 @@ Mysql支持深度配置：
       password: "test",
       database: "test"
     }],
-    
+
     /**
     * 如果为true，则PoolCluster将在连接失败时尝试重新连接。 （默认值：true）
     */

--- a/src/cache/DbQueryResultCache.ts
+++ b/src/cache/DbQueryResultCache.ts
@@ -229,7 +229,7 @@ export class DbQueryResultCache implements QueryResultCache {
         if (queryRunner)
             return queryRunner;
 
-        return this.connection.createQueryRunner("master");
+        return this.connection.createQueryRunner("primary");
     }
 
 }

--- a/src/commands/QueryCommand.ts
+++ b/src/commands/QueryCommand.ts
@@ -48,7 +48,7 @@ export class QueryCommand implements yargs.CommandModule {
             connection = await createConnection(connectionOptions);
 
             // create a query runner and execute query using it
-            queryRunner = connection.createQueryRunner("master");
+            queryRunner = connection.createQueryRunner("primary");
             console.log(chalk.green("Running query: ") + PlatformTools.highlightSql(args._[1]));
             const queryResult = await queryRunner.query(args._[1]);
             console.log(chalk.green("Query has been executed. Result: "));

--- a/src/driver/Driver.ts
+++ b/src/driver/Driver.ts
@@ -20,7 +20,7 @@ export interface Driver {
     options: BaseConnectionOptions;
 
     /**
-     * Master database used to perform all write queries.
+     * Primary database used to perform all write queries.
      *
      * todo: probably move into query runner.
      */
@@ -102,7 +102,7 @@ export interface Driver {
     /**
      * Creates a query runner used for common queries.
      */
-    createQueryRunner(mode: "master"|"slave"): QueryRunner;
+    createQueryRunner(mode: "master"|"slave"|"primary"|"replica"): QueryRunner;
 
     /**
      * Replaces parameters in the given sql with special escaping character
@@ -159,18 +159,38 @@ export interface Driver {
     createFullType(column: TableColumn): string;
 
     /**
-     * Obtains a new database connection to a master server.
+     * Obtains a new database connection to a primary server.
      * Used for replication.
      * If replication is not setup then returns default connection's database connection.
+     *
+     * @deprecated
+     * @see obtainPrimaryConnection
      */
     obtainMasterConnection(): Promise<any>;
 
     /**
-     * Obtains a new database connection to a slave server.
+     * Obtains a new database connection to a replica server.
      * Used for replication.
-     * If replication is not setup then returns master (default) connection's database connection.
+     * If replication is not setup then returns primary (default) connection's database connection.
+     *
+     * @deprecated
+     * @see obtainReplicaConnection
      */
     obtainSlaveConnection(): Promise<any>;
+
+    /**
+     * Obtains a new database connection to a primary server.
+     * Used for replication.
+     * If replication is not setup then returns default connection's database connection.
+     */
+    obtainPrimaryConnection(): Promise<any>;
+
+    /**
+     * Obtains a new database connection to a replica server.
+     * Used for replication.
+     * If replication is not setup then returns primary (default) connection's database connection.
+     */
+    obtainReplicaConnection(): Promise<any>;
 
     /**
      * Creates generated map of values generated or returned by database after INSERT query.

--- a/src/driver/aurora-data-api/AuroraDataApiConnection.ts
+++ b/src/driver/aurora-data-api/AuroraDataApiConnection.ts
@@ -13,7 +13,7 @@ export class AuroraDataApiConnection extends Connection {
         this.queryRunnter = queryRunner;
     }
 
-    public createQueryRunner(mode: "master" | "slave" = "master"): QueryRunner {
+    public createQueryRunner(mode: "master" | "slave" | "primary" | "replica" = "primary"): QueryRunner {
         return this.queryRunnter;
     }
 

--- a/src/driver/cockroachdb/CockroachConnectionOptions.ts
+++ b/src/driver/cockroachdb/CockroachConnectionOptions.ts
@@ -22,14 +22,32 @@ export interface CockroachConnectionOptions extends BaseConnectionOptions, Cockr
     readonly replication?: {
 
         /**
-         * Master server used by orm to perform writes.
+         * Primary server used by orm to perform writes.
+         *
+         * @deprecated
+         * @see primary
          */
         readonly master: CockroachConnectionCredentialsOptions;
 
         /**
-         * List of read-from severs (slaves).
+         * List of read-from severs (replicas).
+         *
+         * @deprecated
+         * @see replicas
          */
         readonly slaves: CockroachConnectionCredentialsOptions[];
+
+    }|{
+
+        /**
+         * Primary server used by orm to perform writes.
+         */
+        readonly primary: CockroachConnectionCredentialsOptions;
+
+        /**
+         * List of read-from severs (replicas).
+         */
+        readonly replicas: CockroachConnectionCredentialsOptions[];
 
     };
 

--- a/src/driver/cordova/CordovaDriver.ts
+++ b/src/driver/cordova/CordovaDriver.ts
@@ -15,7 +15,7 @@ declare var window: Window;
 
 export class CordovaDriver extends AbstractSqliteDriver {
     options: CordovaConnectionOptions;
-    
+
     // -------------------------------------------------------------------------
     // Constructor
     // -------------------------------------------------------------------------
@@ -37,7 +37,7 @@ export class CordovaDriver extends AbstractSqliteDriver {
         // load sqlite package
         this.loadDependencies();
     }
-    
+
 
     // -------------------------------------------------------------------------
     // Public Methods
@@ -52,17 +52,17 @@ export class CordovaDriver extends AbstractSqliteDriver {
             this.databaseConnection.close(ok, fail);
         });
     }
-    
+
     /**
      * Creates a query runner used to execute database queries.
      */
-    createQueryRunner(mode: "master"|"slave" = "master"): QueryRunner {
+    createQueryRunner(mode: "master"|"slave"|"primary"|"replica" = "primary"): QueryRunner {
         if (!this.queryRunner)
             this.queryRunner = new CordovaQueryRunner(this);
 
         return this.queryRunner;
     }
-    
+
     // -------------------------------------------------------------------------
     // Protected Methods
     // -------------------------------------------------------------------------

--- a/src/driver/expo/ExpoDriver.ts
+++ b/src/driver/expo/ExpoDriver.ts
@@ -7,7 +7,7 @@ import {DriverOptionNotSetError} from "../../error/DriverOptionNotSetError";
 
 export class ExpoDriver extends AbstractSqliteDriver {
     options: ExpoConnectionOptions;
-    
+
     // -------------------------------------------------------------------------
     // Constructor
     // -------------------------------------------------------------------------
@@ -20,14 +20,14 @@ export class ExpoDriver extends AbstractSqliteDriver {
         // validate options to make sure everything is set
         if (!this.options.database)
             throw new DriverOptionNotSetError("database");
-        
+
         if (!this.options.driver)
             throw new DriverOptionNotSetError("driver");
 
         // load sqlite package
         this.sqlite = this.options.driver;
     }
-    
+
 
     // -------------------------------------------------------------------------
     // Public Methods
@@ -48,17 +48,17 @@ export class ExpoDriver extends AbstractSqliteDriver {
             }
         });
     }
-    
+
     /**
      * Creates a query runner used to execute database queries.
      */
-    createQueryRunner(mode: "master"|"slave" = "master"): QueryRunner {
+    createQueryRunner(mode: "master"|"slave"|"primary"|"replica" = "primary"): QueryRunner {
         if (!this.queryRunner)
             this.queryRunner = new ExpoQueryRunner(this);
 
         return this.queryRunner;
     }
-    
+
     // -------------------------------------------------------------------------
     // Protected Methods
     // -------------------------------------------------------------------------

--- a/src/driver/mongodb/MongoDriver.ts
+++ b/src/driver/mongodb/MongoDriver.ts
@@ -47,7 +47,7 @@ export class MongoDriver implements Driver {
     options: MongoConnectionOptions;
 
     /**
-     * Master database used to perform all write queries.
+     * Primary database used to perform all write queries.
      */
     database?: string;
 
@@ -262,7 +262,7 @@ export class MongoDriver implements Driver {
     /**
      * Creates a query runner used to execute database queries.
      */
-    createQueryRunner(mode: "master"|"slave" = "master") {
+    createQueryRunner(mode: "master"|"slave"|"primary"|"replica" = "primary") {
         return this.queryRunner!;
     }
 
@@ -343,20 +343,44 @@ export class MongoDriver implements Driver {
     }
 
     /**
-     * Obtains a new database connection to a master server.
+     * Obtains a new database connection to a primary server.
+     * Used for replication.
+     * If replication is not setup then returns default connection's database connection.
+     *
+     * @deprecated
+     * @see obtainPrimaryConnection
+     */
+    obtainMasterConnection(): Promise<any> {
+        return this.obtainPrimaryConnection();
+    }
+
+    /**
+     * Obtains a new database connection to a replica server.
+     * Used for replication.
+     * If replication is not setup then returns primary (default) connection's database connection.
+     *
+     * @deprecated
+     * @see obtainReplicaConnection
+     */
+    obtainSlaveConnection(): Promise<any> {
+        return this.obtainReplicaConnection();
+    }
+
+    /**
+     * Obtains a new database connection to a primary server.
      * Used for replication.
      * If replication is not setup then returns default connection's database connection.
      */
-    obtainMasterConnection(): Promise<any> {
+    obtainPrimaryConnection(): Promise<any> {
         return Promise.resolve();
     }
 
     /**
-     * Obtains a new database connection to a slave server.
+     * Obtains a new database connection to a replica server.
      * Used for replication.
-     * If replication is not setup then returns master (default) connection's database connection.
+     * If replication is not setup then returns primary (default) connection's database connection.
      */
-    obtainSlaveConnection(): Promise<any> {
+    obtainReplicaConnection(): Promise<any> {
         return Promise.resolve();
     }
 

--- a/src/driver/mysql/MysqlConnectionOptions.ts
+++ b/src/driver/mysql/MysqlConnectionOptions.ts
@@ -36,7 +36,7 @@ export interface MysqlConnectionOptions extends BaseConnectionOptions, MysqlConn
      * The milliseconds before a timeout occurs during the initial connection to the MySQL server. (Default: 10000)
      * This difference between connectTimeout and acquireTimeout is subtle and is described in the mysqljs/mysql docs
      * https://github.com/mysqljs/mysql/tree/master#pool-options
-     */ 
+     */
     readonly acquireTimeout?: number;
 
     /**
@@ -100,12 +100,18 @@ export interface MysqlConnectionOptions extends BaseConnectionOptions, MysqlConn
     readonly replication?: {
 
         /**
-         * Master server used by orm to perform writes.
+         * Primary server used by orm to perform writes.
+         *
+         * @deprecated
+         * @see primary
          */
         readonly master: MysqlConnectionCredentialsOptions;
 
         /**
-         * List of read-from severs (slaves).
+         * List of read-from severs (replicas).
+         *
+         * @deprecated
+         * @see replicas
          */
         readonly slaves: MysqlConnectionCredentialsOptions[];
 
@@ -127,7 +133,44 @@ export interface MysqlConnectionOptions extends BaseConnectionOptions, MysqlConn
         readonly restoreNodeTimeout?: number;
 
         /**
-         * Determines how slaves are selected:
+         * Determines how replicas are selected:
+         * RR: Select one alternately (Round-Robin).
+         * RANDOM: Select the node by random function.
+         * ORDER: Select the first node available unconditionally.
+         */
+        readonly selector?: "RR"|"RANDOM"|"ORDER";
+
+    }|{
+
+        /**
+         * Primary server used by orm to perform writes.
+         */
+        readonly primary: MysqlConnectionCredentialsOptions;
+
+        /**
+         * List of read-from severs (replicas).
+         */
+        readonly replicas: MysqlConnectionCredentialsOptions[];
+
+        /**
+         * If true, PoolCluster will attempt to reconnect when connection fails. (Default: true)
+         */
+        readonly canRetry?: boolean;
+
+        /**
+         * If connection fails, node's errorCount increases.
+         * When errorCount is greater than removeNodeErrorCount, remove a node in the PoolCluster. (Default: 5)
+         */
+        readonly removeNodeErrorCount?: number;
+
+        /**
+         * If connection fails, specifies the number of milliseconds before another connection attempt will be made.
+         * If set to 0, then node will be removed instead and never re-used. (Default: 0)
+         */
+        readonly restoreNodeTimeout?: number;
+
+        /**
+         * Determines how replicas are selected:
          * RR: Select one alternately (Round-Robin).
          * RANDOM: Select the node by random function.
          * ORDER: Select the first node available unconditionally.

--- a/src/driver/mysql/MysqlQueryRunner.ts
+++ b/src/driver/mysql/MysqlQueryRunner.ts
@@ -50,7 +50,7 @@ export class MysqlQueryRunner extends BaseQueryRunner implements QueryRunner {
     // Constructor
     // -------------------------------------------------------------------------
 
-    constructor(driver: MysqlDriver, mode: "master"|"slave" = "master") {
+    constructor(driver: MysqlDriver, mode: "master"|"slave"|"primary"|"replica" = "primary") {
         super();
         this.driver = driver;
         this.connection = driver.connection;
@@ -73,15 +73,15 @@ export class MysqlQueryRunner extends BaseQueryRunner implements QueryRunner {
         if (this.databaseConnectionPromise)
             return this.databaseConnectionPromise;
 
-        if (this.mode === "slave" && this.driver.isReplicated) {
+        if ((this.mode === "replica" || this.mode === "slave") && this.driver.isReplicated) {
 
             this.databaseConnectionPromise = this.driver.obtainSlaveConnection().then(connection => {
                 this.databaseConnection = connection;
                 return this.databaseConnection;
             });
 
-        } else { // master
-            this.databaseConnectionPromise = this.driver.obtainMasterConnection().then(connection => {
+        } else { // primary
+            this.databaseConnectionPromise = this.driver.obtainPrimaryConnection().then(connection => {
                 this.databaseConnection = connection;
                 return this.databaseConnection;
             });

--- a/src/driver/nativescript/NativescriptDriver.ts
+++ b/src/driver/nativescript/NativescriptDriver.ts
@@ -66,7 +66,7 @@ export class NativescriptDriver extends AbstractSqliteDriver {
     /**
      * Creates a query runner used to execute database queries.
      */
-    createQueryRunner(mode: "master"|"slave" = "master"): QueryRunner {
+    createQueryRunner(mode: "master"|"slave"|"primary"|"replica" = "primary"): QueryRunner {
         if (!this.queryRunner) {
             this.queryRunner = new NativescriptQueryRunner(this);
         }

--- a/src/driver/oracle/OracleConnectionOptions.ts
+++ b/src/driver/oracle/OracleConnectionOptions.ts
@@ -22,14 +22,32 @@ export interface OracleConnectionOptions extends BaseConnectionOptions, OracleCo
     readonly replication?: {
 
         /**
-         * Master server used by orm to perform writes.
+         * Primary server used by orm to perform writes.
+         *
+         * @deprecated
+         * @see primary
          */
         readonly master: OracleConnectionCredentialsOptions;
 
         /**
-         * List of read-from severs (slaves).
+         * List of read-from severs (replicas).
+         *
+         * @deprecated
+         * @see replicas
          */
         readonly slaves: OracleConnectionCredentialsOptions[];
+
+    }|{
+
+        /**
+         * Primary server used by orm to perform writes.
+         */
+        readonly primary: OracleConnectionCredentialsOptions;
+
+        /**
+         * List of read-from severs (replicas).
+         */
+        readonly replicas: OracleConnectionCredentialsOptions[];
 
     };
 

--- a/src/driver/oracle/OracleQueryRunner.ts
+++ b/src/driver/oracle/OracleQueryRunner.ts
@@ -48,7 +48,7 @@ export class OracleQueryRunner extends BaseQueryRunner implements QueryRunner {
     // Constructor
     // -------------------------------------------------------------------------
 
-    constructor(driver: OracleDriver, mode: "master"|"slave" = "master") {
+    constructor(driver: OracleDriver, mode: "master"|"slave"|"primary"|"replica" = "primary") {
         super();
         this.driver = driver;
         this.connection = driver.connection;
@@ -71,14 +71,14 @@ export class OracleQueryRunner extends BaseQueryRunner implements QueryRunner {
         if (this.databaseConnectionPromise)
             return this.databaseConnectionPromise;
 
-        if (this.mode === "slave" && this.driver.isReplicated) {
-            this.databaseConnectionPromise = this.driver.obtainSlaveConnection().then(connection => {
+        if ((this.mode === "replica" || this.mode === "slave") && this.driver.isReplicated) {
+            this.databaseConnectionPromise = this.driver.obtainReplicaConnection().then(connection => {
                 this.databaseConnection = connection;
                 return this.databaseConnection;
             });
 
-        } else { // master
-            this.databaseConnectionPromise = this.driver.obtainMasterConnection().then(connection => {
+        } else { // primary
+            this.databaseConnectionPromise = this.driver.obtainPrimaryConnection().then(connection => {
                 this.databaseConnection = connection;
                 return this.databaseConnection;
             });

--- a/src/driver/postgres/PostgresConnectionOptions.ts
+++ b/src/driver/postgres/PostgresConnectionOptions.ts
@@ -22,15 +22,32 @@ export interface PostgresConnectionOptions extends BaseConnectionOptions, Postgr
     readonly replication?: {
 
         /**
-         * Master server used by orm to perform writes.
+         * Primary server used by orm to perform writes.
+         *
+         * @deprecated
+         * @see primary
          */
         readonly master: PostgresConnectionCredentialsOptions;
 
         /**
-         * List of read-from severs (slaves).
+         * List of read-from severs (replicas).
+         *
+         * @deprecated
+         * @see replicas
          */
         readonly slaves: PostgresConnectionCredentialsOptions[];
 
+    }|{
+
+        /**
+         * Primary server used by orm to perform writes.
+         */
+        readonly primary: PostgresConnectionCredentialsOptions;
+
+        /**
+         * List of read-from severs (replicas).
+         */
+        readonly replicas: PostgresConnectionCredentialsOptions[];
     };
 
     /**

--- a/src/driver/postgres/PostgresDriver.ts
+++ b/src/driver/postgres/PostgresDriver.ts
@@ -42,15 +42,34 @@ export class PostgresDriver implements Driver {
     postgres: any;
 
     /**
-     * Pool for master database.
+     * Pool for primary database.
+     *
+     * @deprecated
+     * @see primary
      */
-    master: any;
+    get master(): any { return this.primary; }
+    set master(value: any) { this.primary = value; }
 
     /**
-     * Pool for slave databases.
+     * Pool for replica databases.
+     * Used in replication.
+     *
+     * @deprecated
+     * @see replicas
+     */
+    get slaves(): any[] { return this.replicas; }
+    set slaves(value: any[]) { this.replicas = value; }
+
+    /**
+     * Pool for primary database.
+     */
+    primary: any;
+
+    /**
+     * Pool for replica databases.
      * Used in replication.
      */
-    slaves: any[] = [];
+    replicas: any[] = [];
 
     /**
      * We store all created query runners because we need to release them.
@@ -67,7 +86,7 @@ export class PostgresDriver implements Driver {
     options: PostgresConnectionOptions;
 
     /**
-     * Master database used to perform all write queries.
+     * Primary database used to perform all write queries.
      */
     database?: string;
 
@@ -285,14 +304,18 @@ export class PostgresDriver implements Driver {
     async connect(): Promise<void> {
 
         if (this.options.replication) {
-            this.slaves = await Promise.all(this.options.replication.slaves.map(slave => {
-                return this.createPool(this.options, slave);
+            const replication = this.options.replication;
+            const primary = "primary" in replication ? replication.primary : replication.master;
+            const replicas = "replicas" in replication ? replication.replicas : replication.slaves;
+
+            this.replicas = await Promise.all(replicas.map(replica => {
+                return this.createPool(this.options, replica);
             }));
-            this.master = await this.createPool(this.options, this.options.replication.master);
-            this.database = this.options.replication.master.database;
+            this.primary = await this.createPool(this.options, primary);
+            this.database = primary.database;
 
         } else {
-            this.master = await this.createPool(this.options, this.options);
+            this.primary = await this.createPool(this.options, this.options);
             this.database = this.options.database;
         }
     }
@@ -320,7 +343,7 @@ export class PostgresDriver implements Driver {
             return metadata.exclusions.length > 0;
         });
         if (hasUuidColumns || hasCitextColumns || hasHstoreColumns || hasGeometryColumns || hasCubeColumns || hasExclusionConstraints) {
-            await Promise.all([this.master, ...this.slaves].map(pool => {
+            await Promise.all([this.primary, ...this.replicas].map(pool => {
                 return new Promise((ok, fail) => {
                     pool.connect(async (err: any, connection: any, release: Function) => {
                         const { logger } = this.connection;
@@ -376,13 +399,13 @@ export class PostgresDriver implements Driver {
      * Closes connection with database.
      */
     async disconnect(): Promise<void> {
-        if (!this.master)
+        if (!this.primary)
             return Promise.reject(new ConnectionIsNotSetError("postgres"));
 
-        await this.closePool(this.master);
-        await Promise.all(this.slaves.map(slave => this.closePool(slave)));
-        this.master = undefined;
-        this.slaves = [];
+        await this.closePool(this.primary);
+        await Promise.all(this.replicas.map(replica => this.closePool(replica)));
+        this.primary = undefined;
+        this.replicas = [];
     }
 
     /**
@@ -395,7 +418,7 @@ export class PostgresDriver implements Driver {
     /**
      * Creates a query runner used to execute database queries.
      */
-    createQueryRunner(mode: "master"|"slave" = "master") {
+    createQueryRunner(mode: "master"|"slave"|"primary"|"replica" = "primary") {
         return new PostgresQueryRunner(this, mode);
     }
 
@@ -771,34 +794,60 @@ export class PostgresDriver implements Driver {
     }
 
     /**
-     * Obtains a new database connection to a master server.
+     * Obtains a new database connection to a primary server.
+     * Used for replication.
+     * If replication is not setup then returns default connection's database connection.
+     *
+     * @deprecated
+     * @see obtainPrimaryConnection
+     */
+    obtainMasterConnection(): Promise<any> {
+        return this.obtainPrimaryConnection();
+    }
+
+    /**
+     * Obtains a new database connection to a replica server.
+     * Used for replication.
+     * If replication is not setup then returns primary (default) connection's database connection.
+     *
+     * @deprecated
+     * @see obtainReplicaConnection
+     */
+    obtainSlaveConnection(): Promise<any> {
+        return this.obtainReplicaConnection();
+    }
+
+    /**
+     * Obtains a new database connection to a primary server.
      * Used for replication.
      * If replication is not setup then returns default connection's database connection.
      */
-    obtainMasterConnection(): Promise<any> {
+    obtainPrimaryConnection(): Promise<any> {
         return new Promise((ok, fail) => {
-            this.master.connect((err: any, connection: any, release: any) => {
+            this.primary.connect((err: any, connection: any, release: any) => {
                 err ? fail(err) : ok([connection, release]);
             });
         });
     }
 
     /**
-     * Obtains a new database connection to a slave server.
+     * Obtains a new database connection to a replica server.
      * Used for replication.
-     * If replication is not setup then returns master (default) connection's database connection.
+     * If replication is not setup then returns primary (default) connection's database connection.
      */
-    obtainSlaveConnection(): Promise<any> {
-        if (!this.slaves.length)
-            return this.obtainMasterConnection();
+    obtainReplicaConnection(): Promise<any> {
+        if (!this.replicas.length)
+            return this.obtainPrimaryConnection();
 
         return new Promise((ok, fail) => {
-            const random = Math.floor(Math.random() * this.slaves.length);
-            this.slaves[random].connect((err: any, connection: any, release: any) => {
+            const random = Math.floor(Math.random() * this.replicas.length);
+            this.replicas[random].connect((err: any, connection: any, release: any) => {
                 err ? fail(err) : ok([connection, release]);
             });
         });
     }
+
+
 
     /**
      * Creates generated map of values generated or returned by database after INSERT query.
@@ -984,7 +1033,7 @@ export class PostgresDriver implements Driver {
 abstract class PostgresWrapper extends PostgresDriver {
     options: any;
 
-    abstract createQueryRunner(mode: "master"|"slave"): any;
+    abstract createQueryRunner(mode: "master"|"slave"|"primary"|"replica"): any;
 }
 
 /**
@@ -1018,7 +1067,7 @@ export class AuroraDataApiPostgresDriver extends PostgresWrapper {
     options: AuroraDataApiPostgresConnectionOptions;
 
     /**
-     * Master database used to perform all write queries.
+     * Primary database used to perform all write queries.
      */
     database?: string;
 
@@ -1066,7 +1115,7 @@ export class AuroraDataApiPostgresDriver extends PostgresWrapper {
     /**
      * Creates a query runner used to execute database queries.
      */
-    createQueryRunner(mode: "master"|"slave" = "master") {
+    createQueryRunner(mode: "master"|"slave"|"primary"|"replica" = "primary") {
         return new AuroraDataApiPostgresQueryRunner(this, mode);
     }
 

--- a/src/driver/react-native/ReactNativeDriver.ts
+++ b/src/driver/react-native/ReactNativeDriver.ts
@@ -8,7 +8,7 @@ import {DriverPackageNotInstalledError} from "../../error/DriverPackageNotInstal
 
 export class ReactNativeDriver extends AbstractSqliteDriver {
     options: ReactNativeConnectionOptions;
-    
+
     // -------------------------------------------------------------------------
     // Constructor
     // -------------------------------------------------------------------------
@@ -28,7 +28,7 @@ export class ReactNativeDriver extends AbstractSqliteDriver {
         // load sqlite package
         this.loadDependencies();
     }
-    
+
 
     // -------------------------------------------------------------------------
     // Public Methods
@@ -43,17 +43,17 @@ export class ReactNativeDriver extends AbstractSqliteDriver {
             this.databaseConnection.close(ok, fail);
         });
     }
-    
+
     /**
      * Creates a query runner used to execute database queries.
      */
-    createQueryRunner(mode: "master"|"slave" = "master"): QueryRunner {
+    createQueryRunner(mode: "master"|"slave"|"primary"|"replica" = "primary"): QueryRunner {
         if (!this.queryRunner)
             this.queryRunner = new ReactNativeQueryRunner(this);
 
         return this.queryRunner;
     }
-    
+
     // -------------------------------------------------------------------------
     // Protected Methods
     // -------------------------------------------------------------------------

--- a/src/driver/sap/SapQueryRunner.ts
+++ b/src/driver/sap/SapQueryRunner.ts
@@ -55,7 +55,7 @@ export class SapQueryRunner extends BaseQueryRunner implements QueryRunner {
     // Constructor
     // -------------------------------------------------------------------------
 
-    constructor(driver: SapDriver, mode: "master"|"slave" = "master") {
+    constructor(driver: SapDriver, mode: "master"|"slave"|"primary"|"replica" = "primary") {
         super();
         this.driver = driver;
         this.connection = driver.connection;
@@ -75,7 +75,7 @@ export class SapQueryRunner extends BaseQueryRunner implements QueryRunner {
         if (this.databaseConnection)
             return this.databaseConnection;
 
-        this.databaseConnection = await this.driver.obtainMasterConnection();
+        this.databaseConnection = await this.driver.obtainPrimaryConnection();
 
         return this.databaseConnection;
     }
@@ -88,10 +88,10 @@ export class SapQueryRunner extends BaseQueryRunner implements QueryRunner {
         this.isReleased = true;
 
         if (this.databaseConnection) {
-            return this.driver.master.release(this.databaseConnection);
+            return this.driver.primary.release(this.databaseConnection);
         }
 
-        return Promise.resolve();        
+        return Promise.resolve();
     }
 
     /**
@@ -1823,7 +1823,7 @@ export class SapQueryRunner extends BaseQueryRunner implements QueryRunner {
         let indexType = "";
         if (index.isUnique) {
             indexType += "UNIQUE ";
-        } 
+        }
         if (index.isFulltext) {
             indexType += "FULLTEXT ";
         }

--- a/src/driver/sqlite-abstract/AbstractSqliteDriver.ts
+++ b/src/driver/sqlite-abstract/AbstractSqliteDriver.ts
@@ -48,7 +48,7 @@ export abstract class AbstractSqliteDriver implements Driver {
     options: BaseConnectionOptions;
 
     /**
-     * Master database used to perform all write queries.
+     * Primary database used to perform all write queries.
      */
     database?: string;
 
@@ -195,7 +195,7 @@ export abstract class AbstractSqliteDriver implements Driver {
     /**
      * Creates a query runner used to execute database queries.
      */
-    abstract createQueryRunner(mode: "master"|"slave"): QueryRunner;
+    abstract createQueryRunner(mode: "master"|"slave"|"primary"|"replica"): QueryRunner;
 
     // -------------------------------------------------------------------------
     // Public Methods
@@ -487,20 +487,44 @@ export abstract class AbstractSqliteDriver implements Driver {
     }
 
     /**
-     * Obtains a new database connection to a master server.
+     * Obtains a new database connection to a primary server.
+     * Used for replication.
+     * If replication is not setup then returns default connection's database connection.
+     *
+     * @deprecated
+     * @see obtainPrimaryConnection
+     */
+    obtainMasterConnection(): Promise<any> {
+        return this.obtainPrimaryConnection();
+    }
+
+    /**
+     * Obtains a new database connection to a replica server.
+     * Used for replication.
+     * If replication is not setup then returns primary (default) connection's database connection.
+     *
+     * @deprecated
+     * @see obtainReplicaConnection
+     */
+    obtainSlaveConnection(): Promise<any> {
+        return this.obtainReplicaConnection();
+    }
+
+    /**
+     * Obtains a new database connection to a primary server.
      * Used for replication.
      * If replication is not setup then returns default connection's database connection.
      */
-    obtainMasterConnection(): Promise<any> {
+    obtainPrimaryConnection(): Promise<any> {
         return Promise.resolve();
     }
 
     /**
-     * Obtains a new database connection to a slave server.
+     * Obtains a new database connection to a replica server.
      * Used for replication.
-     * If replication is not setup then returns master (default) connection's database connection.
+     * If replication is not setup then returns primary (default) connection's database connection.
      */
-    obtainSlaveConnection(): Promise<any> {
+    obtainReplicaConnection(): Promise<any> {
         return Promise.resolve();
     }
 

--- a/src/driver/sqlite/SqliteDriver.ts
+++ b/src/driver/sqlite/SqliteDriver.ts
@@ -63,7 +63,7 @@ export class SqliteDriver extends AbstractSqliteDriver {
     /**
      * Creates a query runner used to execute database queries.
      */
-    createQueryRunner(mode: "master" | "slave" = "master"): QueryRunner {
+    createQueryRunner(mode: "master"|"slave"|"primary"|"replica" = "primary"): QueryRunner {
         if (!this.queryRunner)
             this.queryRunner = new SqliteQueryRunner(this);
 

--- a/src/driver/sqljs/SqljsDriver.ts
+++ b/src/driver/sqljs/SqljsDriver.ts
@@ -69,7 +69,7 @@ export class SqljsDriver extends AbstractSqliteDriver {
     /**
      * Creates a query runner used to execute database queries.
      */
-    createQueryRunner(mode: "master" | "slave" = "master"): QueryRunner {
+    createQueryRunner(mode: "master"|"slave"|"primary"|"replica" = "primary"): QueryRunner {
         if (!this.queryRunner)
             this.queryRunner = new SqljsQueryRunner(this);
 

--- a/src/driver/sqlserver/SqlServerConnectionOptions.ts
+++ b/src/driver/sqlserver/SqlServerConnectionOptions.ts
@@ -271,14 +271,32 @@ export interface SqlServerConnectionOptions extends BaseConnectionOptions, SqlSe
     readonly replication?: {
 
         /**
-         * Master server used by orm to perform writes.
+         * Primary server used by orm to perform writes.
+         *
+         * @deprecated
+         * @see primary
          */
         readonly master: SqlServerConnectionCredentialsOptions;
 
         /**
-         * List of read-from severs (slaves).
+         * List of read-from severs (replicas).
+         *
+         * @deprecated
+         * @see replicas
          */
         readonly slaves: SqlServerConnectionCredentialsOptions[];
+
+    }|{
+
+        /**
+         * Primary server used by orm to perform writes.
+         */
+        readonly primary: SqlServerConnectionCredentialsOptions;
+
+        /**
+         * List of read-from severs (replicas).
+         */
+        readonly replicas: SqlServerConnectionCredentialsOptions[];
 
     };
 

--- a/src/entity-manager/EntityManager.ts
+++ b/src/entity-manager/EntityManager.ts
@@ -127,7 +127,7 @@ export class EntityManager {
 
         // if query runner is already defined in this class, it means this entity manager was already created for a single connection
         // if its not defined we create a new query runner - single connection where we'll execute all our operations
-        const queryRunner = this.queryRunner || this.connection.createQueryRunner("master");
+        const queryRunner = this.queryRunner || this.connection.createQueryRunner("primary");
 
         try {
             if (isolation) {
@@ -1117,7 +1117,7 @@ export class EntityManager {
      */
     async clear<Entity>(entityClass: ObjectType<Entity>|EntitySchema<Entity>|string): Promise<void> {
         const metadata = this.connection.getMetadata(entityClass);
-        const queryRunner = this.queryRunner || this.connection.createQueryRunner("master");
+        const queryRunner = this.queryRunner || this.connection.createQueryRunner("primary");
         try {
             return await queryRunner.clearTable(metadata.tablePath); // await is needed here because we are using finally
 

--- a/src/migration/MigrationExecutor.ts
+++ b/src/migration/MigrationExecutor.ts
@@ -129,7 +129,7 @@ export class MigrationExecutor {
      */
     async showMigrations(): Promise<boolean> {
         let hasUnappliedMigrations = false;
-        const queryRunner = this.queryRunner || this.connection.createQueryRunner("master");
+        const queryRunner = this.queryRunner || this.connection.createQueryRunner("primary");
         // create migrations table if its not created yet
         await this.createMigrationsTableIfNotExist(queryRunner);
         // get all migrations that are executed and saved in the database
@@ -163,7 +163,7 @@ export class MigrationExecutor {
      */
     async executePendingMigrations(): Promise<Migration[]> {
 
-        const queryRunner = this.queryRunner || this.connection.createQueryRunner("master");
+        const queryRunner = this.queryRunner || this.connection.createQueryRunner("primary");
         // create migrations table if its not created yet
         await this.createMigrationsTableIfNotExist(queryRunner);
         // get all migrations that are executed and saved in the database
@@ -265,7 +265,7 @@ export class MigrationExecutor {
      */
     async undoLastMigration(): Promise<void> {
 
-        const queryRunner = this.queryRunner || this.connection.createQueryRunner("master");
+        const queryRunner = this.queryRunner || this.connection.createQueryRunner("primary");
 
         // create migrations table if its not created yet
         await this.createMigrationsTableIfNotExist(queryRunner);
@@ -496,7 +496,7 @@ export class MigrationExecutor {
     }
 
     protected async withQueryRunner<T extends any>(callback: (queryRunner: QueryRunner) => T) {
-        const queryRunner = this.queryRunner || this.connection.createQueryRunner("master");
+        const queryRunner = this.queryRunner || this.connection.createQueryRunner("primary");
 
         try {
             return callback(queryRunner);

--- a/src/persistence/EntityPersistExecutor.ts
+++ b/src/persistence/EntityPersistExecutor.ts
@@ -50,7 +50,7 @@ export class EntityPersistExecutor {
 
             // if query runner is already defined in this class, it means this entity manager was already created for a single connection
             // if its not defined we create a new query runner - single connection where we'll execute all our operations
-            const queryRunner = this.queryRunner || this.connection.createQueryRunner("master");
+            const queryRunner = this.queryRunner || this.connection.createQueryRunner("primary");
 
             // save data in the query runner - this is useful functionality to share data from outside of the world
             // with third classes - like subscribers and listener methods

--- a/src/query-builder/QueryBuilder.ts
+++ b/src/query-builder/QueryBuilder.ts
@@ -858,7 +858,7 @@ export abstract class QueryBuilder<Entity> {
      * Creates a query builder used to execute sql queries inside this query builder.
      */
     protected obtainQueryRunner() {
-        return this.queryRunner || this.connection.createQueryRunner("master");
+        return this.queryRunner || this.connection.createQueryRunner("primary");
     }
 
 }

--- a/src/query-builder/SelectQueryBuilder.ts
+++ b/src/query-builder/SelectQueryBuilder.ts
@@ -2024,7 +2024,7 @@ export class SelectQueryBuilder<Entity> extends QueryBuilder<Entity> implements 
      * Creates a query builder used to execute sql queries inside this query builder.
      */
     protected obtainQueryRunner() {
-        return this.queryRunner || this.connection.createQueryRunner("slave");
+        return this.queryRunner || this.connection.createQueryRunner("replica");
     }
 
 }

--- a/src/query-runner/BaseQueryRunner.ts
+++ b/src/query-runner/BaseQueryRunner.ts
@@ -82,7 +82,7 @@ export abstract class BaseQueryRunner {
      * Used for replication.
      * If replication is not setup its value is ignored.
      */
-    protected mode: "master"|"slave";
+    protected mode: "master"|"slave"|"primary"|"replica";
 
     // -------------------------------------------------------------------------
     // Public Abstract Methods

--- a/src/schema-builder/RdbmsSchemaBuilder.ts
+++ b/src/schema-builder/RdbmsSchemaBuilder.ts
@@ -65,7 +65,7 @@ export class RdbmsSchemaBuilder implements SchemaBuilder {
      * Creates complete schemas for the given entity metadatas.
      */
     async build(): Promise<void> {
-        this.queryRunner = this.connection.createQueryRunner("master");
+        this.queryRunner = this.connection.createQueryRunner("primary");
         // CockroachDB implements asynchronous schema sync operations which can not been executed in transaction.
         // E.g. if you try to DROP column and ADD it again in the same transaction, crdb throws error.
         if (!(this.connection.driver instanceof CockroachDriver))
@@ -104,7 +104,7 @@ export class RdbmsSchemaBuilder implements SchemaBuilder {
      * Returns sql queries to be executed by schema builder.
      */
     async log(): Promise<SqlInMemory> {
-        this.queryRunner = this.connection.createQueryRunner("master");
+        this.queryRunner = this.connection.createQueryRunner("primary");
         try {
             const tablePaths = this.entityToSyncMetadatas.map(metadata => metadata.tablePath);
             // TODO: typeorm_metadata table needs only for Views for now.

--- a/test/functional/cache/provider/MockQueryResultCache.ts
+++ b/test/functional/cache/provider/MockQueryResultCache.ts
@@ -229,7 +229,7 @@ export class MockQueryResultCache implements QueryResultCache {
         if (queryRunner)
             return queryRunner;
 
-        return this.connection.createQueryRunner("master");
+        return this.connection.createQueryRunner("primary");
     }
 
 }

--- a/test/github-issues/2067/issue-2067.ts
+++ b/test/github-issues/2067/issue-2067.ts
@@ -21,8 +21,8 @@ describe("github issues > #2067 Unhandled promise rejection warning on postgres 
         const connectionFailureMessage = "Test error to simulate a connection error";
 
         if (connection.driver instanceof PostgresDriver) {
-          connection.driver.obtainMasterConnection = () => Promise.reject<any>(new Error(connectionFailureMessage));
-          connection.driver.obtainSlaveConnection = () => Promise.reject<any>(new Error(connectionFailureMessage));
+          connection.driver.obtainPrimaryConnection = () => Promise.reject<any>(new Error(connectionFailureMessage));
+          connection.driver.obtainReplicaConnection = () => Promise.reject<any>(new Error(connectionFailureMessage));
         }
 
         const repository = connection.getRepository(User);

--- a/test/github-issues/4753/issue-4753.ts
+++ b/test/github-issues/4753/issue-4753.ts
@@ -11,12 +11,12 @@ describe("github issues > #4753 MySQL Replication Config broken", () => {
         const connection = getConnectionManager().create({
             type: "mysql",
             replication: {
-                master: {
+                primary: {
                     username: "test",
                     password: "test",
                     database: "test"
                 },
-                slaves: [
+                replicas: [
                     {
                         username: "test",
                         password: "test",


### PR DESCRIPTION
this change updates terminology to "primary"/"replica"

more inclusive terminology can lead to a more inclusive project

the terminology master/slave is considered non-inclusive by many
and most databases that this project uses are also migrating away
from the terminology.

this leaves the original "master" and "slave" terminology in place
but marks them as deprecated & points them at the primary/replica
terminology.  at the next breaking change branch these can be removed
with a warning about the breaking change in the changelog