### PR TITLE
fix: pass queryrunner to migrationexecutor

### DIFF
--- a/src/connection/Connection.ts
+++ b/src/connection/Connection.ts
@@ -279,11 +279,11 @@ export class Connection {
      * Runs all pending migrations.
      * Can be used only after connection to the database is established.
      */
-    async runMigrations(options?: { transaction?: "all" | "none" | "each" }): Promise<Migration[]> {
+    async runMigrations(options?: { transaction?: "all" | "none" | "each", queryRunner?: QueryRunner }): Promise<Migration[]> {
         if (!this.isConnected)
             throw new CannotExecuteNotConnectedError(this.name);
 
-        const migrationExecutor = new MigrationExecutor(this);
+        const migrationExecutor = new MigrationExecutor(this, (options && options.queryRunner) || undefined);
         migrationExecutor.transaction = (options && options.transaction) || "all";
 
         const successMigrations = await migrationExecutor.executePendingMigrations();
@@ -294,12 +294,11 @@ export class Connection {
      * Reverts last executed migration.
      * Can be used only after connection to the database is established.
      */
-    async undoLastMigration(options?: { transaction?: "all" | "none" | "each" }): Promise<void> {
+    async undoLastMigration(options?: { transaction?: "all" | "none" | "each", queryRunner?: QueryRunner }): Promise<void> {
 
         if (!this.isConnected)
             throw new CannotExecuteNotConnectedError(this.name);
-
-        const migrationExecutor = new MigrationExecutor(this);
+        const migrationExecutor = new MigrationExecutor(this, (options && options.queryRunner) || undefined);
         migrationExecutor.transaction = (options && options.transaction) || "all";
 
         await migrationExecutor.undoLastMigration();
@@ -309,11 +308,11 @@ export class Connection {
      * Lists all migrations and whether they have been run.
      * Returns true if there are pending migrations
      */
-    async showMigrations(): Promise<boolean> {
+    async showMigrations(options?: {queryRunner?: QueryRunner}): Promise<boolean> {
         if (!this.isConnected) {
             throw new CannotExecuteNotConnectedError(this.name);
         }
-        const migrationExecutor = new MigrationExecutor(this);
+        const migrationExecutor = new MigrationExecutor(this, (options && options.queryRunner) || undefined);
         return await migrationExecutor.showMigrations();
     }
 


### PR DESCRIPTION
So the `MigrationExecutor` has the option to pass in a `QueryRunner` in the constructor, but the methods `runMigrations`, `undoLastMigration` and `showMigrations`, all of which create a `MigrationExecutor` do not have the same possibility.

This Pull Request will allow for a `QueryRunner` to be provided in the options parameter.

Our particular use case/requirement for this is as follows:

We have a particular setup for permissions inside of Postgres. This setup involves having 3 roles, we'll call them `admin_role`, `writer_role` and `reader_role` for this. `admin_role` is given ownership of the `public` schema, and the other roles are given permissions **from** the admin role. This allows `writer_role` and `reader_role` to have access to any object owned by `admin_role` and nothing else.

In Postgres when a user (a role with the `LOGIN` flag) creates a resource, ownership of that resource is given to that user. Here's how this effects how we use TypeORM.

Scenario A: TypeORM is configured to use `admin_user` as their login, which is a member of `admin_role`. TypeORM runs migrations and creates tables. Ownership of all of these tables are set to `admin_user` rather than `admin_role`. A user, `writer_user` with the role `writer_role` logs in and attempts to query a table. **Access denied**.

We can sort of fix this by executing `SET ROLE admin_role` inside of each migration. This leads to the following behavior:

Scenario B: TypeORM is configured to use `admin_user` as their login, which is a member of `admin_role`. TypeORM runs migrations and creates tables. These migrations execute `SET ROLE admin_role`. The first migration **fails** because the connection session is set to the role `admin_role` and ownership of the table `migrations` created by TypeORM is `admin_user` and it cannot insert the new migration into the table. However, a user, `writer_user` with the role `writer_role` logs in and attempts to query a table. **Access Granted** but this would **fail** in CI/CD

This fixes our problem around the tables created by TypeORM **during** a migration working with our permissions structure as expected, and we can fix the issue around not being able to insert into the `migrations` table by executing `RESET ROLE` after a migration. However, this requires us to add additional lines of boilerplate to each migration, making each one look like this:

```
SET ROLE admin_role
... migration code...
RESET ROLE
```

An additional issue is that we cannot properly rotate passwords and expect migrations to run properly, as we would create a new user `admin_user2` for our application, deploy it out with the new credentials, and then reset the original user `admin_user`. We'd just swap the next time we need to rotate credentials. However, since ownership of the `migrations` table is assigned to the original `admin_user`, we are unable to read or insert into the `migrations` table with `admin_user2`.

After doing some digging and not finding a way to effectively `SET ROLE` for creation of the `migrations` table, and wanting to solve this problem not just for this application, but for all of our future applications (as we will have a large number of services to maintain), we began looking at what a minimal code change could be to enable this. 

We eventually found that `MigrationExecutor` will accept a `QueryRunner` as a parameter, and found that `MigrationExecutor`  was being constructed in the `runMigrations` method of a `Connection`. Additionally, `MigrationExecutor` was fetching a new `QueryRunner` if not provided. This has the potential of getting a new underlying database connection from the connection pool, which means if we executed `SET ROLE` on the `Connection` instance in the past (via `query(...)`, the migrations could possibly run on a separate underlying database connection which didn't have `SET ROLE` executed. 

By allowing us to provide a `QueryRunner` instance, we can override `connect` which will allow us to execute `SET ROLE` on the **current** database session, and upon `release` of the `QueryRunner` execute `RESET ROLE` which will put it back to what it was before.

Not only does this allow us to create the `migrations` table and all of our own resources as `admin_role`, it also allows us to make sure we're not running afoul of any connection pool allocations. Additionally, this allows us to standardize how migrations are executed, not requiring our engineers to include boilerplate code into each migration, or alter ownership after migrations have been executed to prevent issues with the `migrations` table in the future.

We believe the changes we've landed on are as minimal as they could be, and is really just completing some wiring that already existed in the first place.

Thank you for your time! Let me know if there are any concerns or additional comments.