### PR TITLE
[docs] fix typo in supported_platforms.md page

### DIFF
--- a/docs/supported-platforms.md
+++ b/docs/supported-platforms.md
@@ -31,7 +31,7 @@ plugins: [
 ]
 ```
 
-and make sure (sql-wasm.wasm)[https://github.com/sql-js/sql.js/blob/master/README.md#downloadingusing] file exists in your public path.
+and make sure [sql-wasm.wasm file](https://github.com/sql-js/sql.js/blob/master/README.md#downloadingusing) exists in your public path.
 
 **Example of configuration**
 


### PR DESCRIPTION
Hello!

Just fix a small typo in supported platforms page

i also move the 'file' word to be part of the link text