### PR TITLE
Fix getPendingMigrations

### DIFF
--- a/src/migration/MigrationExecutor.ts
+++ b/src/migration/MigrationExecutor.ts
@@ -90,7 +90,7 @@ export class MigrationExecutor {
         const executedMigrations = await this.getExecutedMigrations();
 
         return allMigrations.filter(migration =>
-            executedMigrations.find(
+            !executedMigrations.find(
                 executedMigration =>
                     executedMigration.name === migration.name
             )


### PR DESCRIPTION
getPendingMigrations currently returns the executed migrations instead of the non-executed ones.