### PR TITLE
fix(driver-utils): correctly parse connection URI with query params

### DIFF
--- a/src/driver/DriverUtils.ts
+++ b/src/driver/DriverUtils.ts
@@ -35,7 +35,7 @@ export class DriverUtils {
 
     /**
      * Builds column alias from given alias name and column name.
-     * 
+     *
      * If alias length is greater than the limit (if any) allowed by the current
      * driver, replaces it with a hashed string.
      *
@@ -68,7 +68,11 @@ export class DriverUtils {
         const preBase = url.substr(firstSlashes + 2);
         const secondSlash = preBase.indexOf("/");
         const base = (secondSlash !== -1) ? preBase.substr(0, secondSlash) : preBase;
-        const afterBase = (secondSlash !== -1) ? preBase.substr(secondSlash + 1) : undefined;
+        let afterBase = (secondSlash !== -1) ? preBase.substr(secondSlash + 1) : undefined;
+        // remove mongodb query params
+        if (afterBase && afterBase.indexOf("?") !== -1) {
+            afterBase = afterBase.substr(0, afterBase.indexOf("?"));
+        }
 
         const lastAtSign = base.lastIndexOf("@");
         const usernameAndPassword = base.substr(0, lastAtSign);

--- a/test/github-issues/6389/issue-6389.ts
+++ b/test/github-issues/6389/issue-6389.ts
@@ -1,0 +1,26 @@
+import { DriverUtils } from "../../../src/driver/DriverUtils";
+import { expect } from "chai";
+
+describe("github issues > #6389 MongoDB URI Connection string with query params", () => {
+    it("should parse correctly mongodb URI", () => {
+        const obj: any = {
+            type: "mongodb",
+            username: "user",
+            password: "password",
+            host: "host",
+            database: "database",
+            port: 27017,
+        };
+
+        const url = `${obj.type}://${obj.username}:${obj.password}@${obj.host}:${obj.port}/${obj.database}?readPreference=primary`;
+        const options = DriverUtils.buildDriverOptions({url});
+
+        expect(options.type).to.eql(obj.type);
+        expect(options.username).to.eql(obj.username);
+        expect(options.username).to.eql(obj.username);
+        expect(options.password).to.eql(obj.password);
+        expect(options.host).to.eql(obj.host);
+        expect(options.port).to.eql(obj.port);
+        expect(options.database).to.eql(obj.database);
+    });
+});


### PR DESCRIPTION
ref #6389

**BC?:**
No

In the future, it may be better to use this library
https://github.com/vitaly-t/connection-string