### PR TITLE
fix: support multiple `JoinColumn`s in EntitySchema

### DIFF
--- a/src/entity-schema/EntitySchemaRelationOptions.ts
+++ b/src/entity-schema/EntitySchemaRelationOptions.ts
@@ -55,7 +55,7 @@ export interface EntitySchemaRelationOptions {
     /**
      * Join column options of this column. If set to true then it simply means that it has a join column.
      */
-    joinColumn?: boolean|JoinColumnOptions;
+    joinColumn?: boolean|JoinColumnOptions|JoinColumnOptions[];
 
     /**
      * Indicates if this is a parent (can be only many-to-one relation) relation in the tree tables.

--- a/src/entity-schema/EntitySchemaTransformer.ts
+++ b/src/entity-schema/EntitySchemaTransformer.ts
@@ -151,13 +151,17 @@ export class EntitySchemaTransformer {
                             };
                             metadataArgsStorage.joinColumns.push(joinColumn);
                         } else {
-                            const joinColumn: JoinColumnMetadataArgs = {
-                                target: options.target || options.name,
-                                propertyName: relationName,
-                                name: relationSchema.joinColumn.name,
-                                referencedColumnName: relationSchema.joinColumn.referencedColumnName
-                            };
-                            metadataArgsStorage.joinColumns.push(joinColumn);
+                            const joinColumnsOptions = Array.isArray(relationSchema.joinColumn) ? relationSchema.joinColumn : [relationSchema.joinColumn];
+
+                            for (const joinColumnOption of joinColumnsOptions) {
+                                const joinColumn: JoinColumnMetadataArgs = {
+                                    target: options.target || options.name,
+                                    propertyName: relationName,
+                                    name: joinColumnOption.name,
+                                    referencedColumnName: joinColumnOption.referencedColumnName
+                                };
+                                metadataArgsStorage.joinColumns.push(joinColumn);
+                            }
                         }
                     }
 

--- a/test/github-issues/5444/entity/Author.ts
+++ b/test/github-issues/5444/entity/Author.ts
@@ -1,0 +1,41 @@
+import {EntitySchemaOptions} from "../../../../src/entity-schema/EntitySchemaOptions";
+import {Post} from "./Post";
+
+export class Author {
+    id: number;
+
+    publisherId: number;
+
+    name: string;
+
+    posts: Post[];
+}
+
+export const AuthorSchema: EntitySchemaOptions<Author> = {
+    name: "Author",
+
+    target: Author,
+
+    columns: {
+        id: {
+            primary: true,
+            type: Number
+        },
+
+        publisherId: {
+            primary: true,
+            type: Number
+        },
+
+        name: {
+            type: "varchar"
+        }
+    },
+
+    relations: {
+        posts: {
+            target: () => Post,
+            type: "one-to-many"
+        }
+    }
+};

--- a/test/github-issues/5444/entity/Post.ts
+++ b/test/github-issues/5444/entity/Post.ts
@@ -1,0 +1,53 @@
+import {EntitySchemaOptions} from "../../../../src/entity-schema/EntitySchemaOptions";
+import {Author} from "./Author";
+
+export class Post {
+    authorPublisherId: number;
+
+    authorId: number;
+
+    id: number;
+
+    title: string;
+
+    author: Author;
+}
+
+export const PostSchema: EntitySchemaOptions<Post> = {
+    name: "Post",
+
+    target: Post,
+
+    columns: {
+        authorPublisherId: {
+            primary: true,
+            type: Number
+        },
+
+        authorId: {
+            primary: true,
+            type: Number
+        },
+
+        id: {
+            primary: true,
+            type: Number
+        },
+
+        title: {
+            type: "varchar"
+        }
+    },
+
+    relations: {
+        author: {
+            target: () => Author,
+            type: "many-to-one",
+            eager: true,
+            joinColumn: [
+                { name: "authorPublisherId", referencedColumnName: "publisherId" },
+                { name: "authorId", referencedColumnName: "id" },
+            ]
+        }
+    }
+};

--- a/test/github-issues/5444/issue-5444.ts
+++ b/test/github-issues/5444/issue-5444.ts
@@ -1,0 +1,40 @@
+import { EntitySchemaTransformer } from "../../../src/entity-schema/EntitySchemaTransformer";
+
+import {expect} from "chai";
+
+import { Post, PostSchema } from "./entity/Post";
+import { Author, AuthorSchema } from "./entity/Author";
+import {EntitySchema} from "../../../src";
+
+
+describe("github issues > #5444 EntitySchema missing support for multiple joinColumns in relations", () => {
+  it("Update query returns the number of affected rows", async () => {
+      const transformer = new EntitySchemaTransformer();
+
+      const actual = transformer.transform(
+        [
+          new EntitySchema<Author>(AuthorSchema),
+          new EntitySchema<Post>(PostSchema)
+        ]
+      );
+
+      const joinColumns = actual.joinColumns;
+
+      expect(joinColumns.length).to.eq(2);
+      expect(joinColumns).to.deep.eq([
+          {
+              target: Post,
+              propertyName: "author",
+              name: "authorPublisherId",
+              referencedColumnName: "publisherId"
+          },
+          {
+              target: Post,
+              propertyName: "author",
+              name: "authorId",
+              referencedColumnName: "id"
+          },
+
+      ]);
+  });
+});


### PR DESCRIPTION
update type definition and schema transformer
so that - like the decorator - the EntitySchema can define
composite `JoinColumn` definitions

Closes: #5444