### PR TITLE
feat: support Entity Listeners in EntitySchema

### DIFF
--- a/src/entity-schema/EntitySchemaListenerOptions.ts
+++ b/src/entity-schema/EntitySchemaListenerOptions.ts
@@ -1,0 +1,13 @@
+import {EventListenerType} from "../metadata/types/EventListenerTypes";
+
+export interface EntitySchemaListenerOptions {
+    /**
+     * Type of Event to Listen to
+     */
+    type: EventListenerType;
+
+    /**
+     * Entity's property name to which listener is applied.
+     */
+    propertyName: string;
+}

--- a/src/entity-schema/EntitySchemaOptions.ts
+++ b/src/entity-schema/EntitySchemaOptions.ts
@@ -7,6 +7,7 @@ import {TableType} from "../metadata/types/TableTypes";
 import {EntitySchemaUniqueOptions} from "./EntitySchemaUniqueOptions";
 import {EntitySchemaCheckOptions} from "./EntitySchemaCheckOptions";
 import {EntitySchemaExclusionOptions} from "./EntitySchemaExclusionOptions";
+import {EntitySchemaListenerOptions} from "./EntitySchemaListenerOptions";
 
 /**
  * Interface for entity metadata mappings stored inside "schemas" instead of models decorated by decorators.
@@ -86,6 +87,11 @@ export class EntitySchemaOptions<T> {
     * Entity exclusion options.
     */
     exclusions?: EntitySchemaExclusionOptions[];
+
+    /**
+     * Entity listener options.
+     */
+    listeners?: EntitySchemaListenerOptions[];
 
     /**
      * Indicates if schema synchronization is enabled or disabled for this entity.

--- a/src/entity-schema/EntitySchemaTransformer.ts
+++ b/src/entity-schema/EntitySchemaTransformer.ts
@@ -13,6 +13,7 @@ import {GeneratedMetadataArgs} from "../metadata-args/GeneratedMetadataArgs";
 import {UniqueMetadataArgs} from "../metadata-args/UniqueMetadataArgs";
 import {CheckMetadataArgs} from "../metadata-args/CheckMetadataArgs";
 import {ExclusionMetadataArgs} from "../metadata-args/ExclusionMetadataArgs";
+import {EntityListenerMetadataArgs} from "../metadata-args/EntityListenerMetadataArgs";
 
 /**
  * Transforms entity schema into metadata args storage.
@@ -237,6 +238,18 @@ export class EntitySchemaTransformer {
                         expression: exclusion.expression
                     };
                     metadataArgsStorage.exclusions.push(exclusionArgs);
+                });
+            }
+
+            // add listener metadata args from the schema
+            if (options.listeners) {
+                options.listeners.forEach(listener => {
+                    const listenerArgs: EntityListenerMetadataArgs = {
+                        target: options.target || options.name,
+                        propertyName: listener.propertyName,
+                        type: listener.type
+                    };
+                    metadataArgsStorage.entityListeners.push(listenerArgs);
                 });
             }
 

--- a/src/metadata-args/EntityListenerMetadataArgs.ts
+++ b/src/metadata-args/EntityListenerMetadataArgs.ts
@@ -8,7 +8,7 @@ export interface EntityListenerMetadataArgs {
     /**
      * Class to which listener is applied.
      */
-    readonly target: Function;
+    readonly target: Function|string;
 
     /**
      * Class's property name to which listener is applied.


### PR DESCRIPTION
Update the `EntitySchema` to add support for `listeners` - `EntityListeners` similar to the [decorator listeners](https://typeorm.io/#/listeners-and-subscribers/what-is-an-entity-listener).

Also update `EntityListenerMetadataArgs.target` to support `string` as well as `Function`.  This should be supported per [MetadataArgsStorage.filterListeners](https://github.com/typeorm/typeorm/blob/1e1595e4c561995c60eef60426ef4f198d8b48cb/src/metadata-args/MetadataArgsStorage.ts).


PARTIAL RESOLUTION for #2089 (Listener)