### PR TITLE
Fix #6424 mysql migration: make sure the indices sql which left-join …

### DIFF
--- a/src/driver/mysql/MysqlQueryRunner.ts
+++ b/src/driver/mysql/MysqlQueryRunner.ts
@@ -1218,7 +1218,7 @@ export class MysqlQueryRunner extends BaseQueryRunner implements QueryRunner {
             return `(\`s\`.\`TABLE_SCHEMA\` = '${database}' AND \`s\`.\`TABLE_NAME\` = '${name}')`;
         }).join(" OR ");
         const indicesSql = `SELECT \`s\`.* FROM \`INFORMATION_SCHEMA\`.\`STATISTICS\` \`s\` ` +
-            `LEFT JOIN \`INFORMATION_SCHEMA\`.\`REFERENTIAL_CONSTRAINTS\` \`rc\` ON \`s\`.\`INDEX_NAME\` = \`rc\`.\`CONSTRAINT_NAME\` ` +
+            `LEFT JOIN \`INFORMATION_SCHEMA\`.\`REFERENTIAL_CONSTRAINTS\` \`rc\` ON \`s\`.\`INDEX_NAME\` = \`rc\`.\`CONSTRAINT_NAME\` AND \`s\`.\`TABLE_SCHEMA\` = \`rc\`.\`CONSTRAINT_SCHEMA\`` +
             `WHERE (${indicesCondition}) AND \`s\`.\`INDEX_NAME\` != 'PRIMARY' AND \`rc\`.\`CONSTRAINT_NAME\` IS NULL`;
 
         const foreignKeysCondition = tableNames.map(tableName => {


### PR DESCRIPTION
### Mysql migration generate issue for indices sql

### Current

```
SELECT `s`.*
FROM `INFORMATION_SCHEMA`.`STATISTICS` `s`
         LEFT JOIN `INFORMATION_SCHEMA`.`REFERENTIAL_CONSTRAINTS` `rc`
                   ON `s`.`INDEX_NAME` = `rc`.`CONSTRAINT_NAME`
```

### Should be

```
SELECT `s`.*
FROM `INFORMATION_SCHEMA`.`STATISTICS` `s`
         LEFT JOIN `INFORMATION_SCHEMA`.`REFERENTIAL_CONSTRAINTS` `rc`
                   ON `s`.`INDEX_NAME` = `rc`.`CONSTRAINT_NAME`
                   AND `s`.`TABLE_SCHEMA` = `rc`.`CONSTRAINT_SCHEMA`. # --- new condition
```

close #6424