### PR TITLE
test: remove hardcoded test from github issue tst 2096

### DIFF
--- a/test/github-issues/114/issue-114.ts
+++ b/test/github-issues/114/issue-114.ts
@@ -7,7 +7,7 @@ describe.skip("github issues > #114 Can not be parsed correctly the URL of pg.",
 
     let connection: Connection;
     before(() => {
-        connection = new Connection({
+        connection = new Connection({ // Dummy Connection, won't be established
             type: "postgres",
             url: "postgres://test:test@localhost:5432/test",
         });

--- a/test/github-issues/2096/issue-2096.ts
+++ b/test/github-issues/2096/issue-2096.ts
@@ -2,6 +2,7 @@ import "reflect-metadata";
 import { expect } from "chai";
 import { createConnection } from "../../../src";
 import { getTypeOrmConfig } from "../../utils/test-utils";
+import {MysqlConnectionOptions} from "../../../src/driver/mysql/MysqlConnectionOptions";
 
 describe("github issues > #2096 [mysql] Database name isn't read from url", () => {
     it("should be possible to define a database by connection url for mysql", async () => {
@@ -9,10 +10,22 @@ describe("github issues > #2096 [mysql] Database name isn't read from url", () =
 
         // it is important to synchronize here, to trigger EntityMetadataValidator.validate
         // that previously threw the error where the database on the driver object was undefined
-        if (config.find(c => c.name === "mysql" && !c.skip)) {
+        const mysqlConfig: MysqlConnectionOptions = config.find(c => c.name === "mysql" && !c.skip) as MysqlConnectionOptions;
+
+        if (mysqlConfig) {
+            const {
+                username,
+                password,
+                host,
+                port,
+                database
+            } = mysqlConfig;
+
+            const url = `mysql://${username}:${password}@${host}:${port}/${database}`
+
             const connection = await createConnection({
                 name: "#2096",
-                url: "mysql://root:admin@localhost:3306/test",
+                url,
                 entities: [__dirname + "/entity/*{.js,.ts}"],
                 synchronize: true,
                 type: "mysql"


### PR DESCRIPTION
the test had assumed the username, password, host, and port of
the mysql server

this update changes that so the test instead uses the config properly
while still checking that the test works as expected