### PR TITLE
Ensure we don't have duplicated columns in update (Fixes #2651)

### DIFF
--- a/src/query-builder/UpdateQueryBuilder.ts
+++ b/src/query-builder/UpdateQueryBuilder.ts
@@ -410,7 +410,10 @@ export class UpdateQueryBuilder<Entity> extends QueryBuilder<Entity> implements 
 
                 columns.forEach(column => {
                     if (!column.isUpdate) { return; }
-                    updatedColumns.push(column);
+
+                    if (-1 === updatedColumns.indexOf(column)) {
+                        updatedColumns.push(column);
+                    }
 
                     const paramName = "upd_" + column.databaseName;
 


### PR DESCRIPTION
Hi,

I noticed that an erroneous update query was being generated in my application (using the Postgres driver), similar to the error described in #2651:

```
ERROR:  multiple assignments to same column "column_id"
STATEMENT:  UPDATE "tasks" SET "column_id" = $2, "column_id" = $3, "task_position" = $4 WHERE "id" IN ($1)
```

I did a bit of digging and was able to narrow it down to this `updatedColumns` array not having a uniqueness check.

![image](https://user-images.githubusercontent.com/681426/89128172-fc1b2400-d4f3-11ea-85f3-d6b24d97b583.png)


I'm not sure exactly what it is about my entity structure that triggers this, but I added a sanity check anyway. Please let me know if there's anything I can do to help get this merged.

Cheers,
--Kieran