### PR TITLE
chore: discourage questions as issues

### DIFF
--- a/ISSUE_TEMPLATE.md
+++ b/ISSUE_TEMPLATE.md
@@ -1,6 +1,12 @@
 **Issue type:**
 
-[ ] question
+<!--
+     Have a question?
+     Check the "Support" Documentation on the best places to ask questions!
+     ---
+     https://github.com/typeorm/typeorm/blob/master/docs/support.md
+-->
+
 [ ] bug report
 [ ] feature request
 [ ] documentation issue

--- a/docs/support.md
+++ b/docs/support.md
@@ -6,7 +6,7 @@ If you found a bug, issue, or you just want to propose a new feature, create [an
 
 ### Have a question?
 
-If you have a question, you can ask it on [StackOverflow](https://stackoverflow.com/questions/tagged/typeorm).
+If you have a question, you can ask it on [StackOverflow](https://stackoverflow.com/questions/tagged/typeorm) or other community support channels.
 
 ### Want community support?
 


### PR DESCRIPTION
Update the issue template to discourage asking questions through issues and instead direct users to check out the support documentation.

Questions are very often not answered and end up filling up the issues backlog with non-issues - just misconceptions.  If there's a problem with documentation that's one thing, but there are currently 603 open questions that make it much harder to find actual issues with TypeORM.