### PR TITLE
build: use `npm install` to work around npm/cli#558

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -41,10 +41,15 @@ commands:
           name: Restore node_modules cache
           key: node_modules-<< parameters.cache-key >>-{{ checksum "package-lock.json" }}
       - run:
+          name: Verify `package.json` and `package-lock.json` are in sync
+          command: npx lock-verify
+      - run:
+          # This uses `npm install` instead of `npm ci`
+          # because of https://github.com/npm/cli/issues/558
           name: Install Node Packages
           command: |
             if [ ! -d node_modules ]; then
-              npm ci
+              npm install
             fi
       - save_cache:
           name: Save node_modules cache


### PR DESCRIPTION
the lockfile we use was generated on a mac & includes `fsevents` as a dependency. while this is optional for OSX it's not available for linux & this causes problems with the `npm ci` command.

npm v7 will correct this but until we're using that we should switch to using `npm install`