### PR TITLE
chore: pin version of cockroach to a known good version 

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -108,7 +108,7 @@ jobs:
           POSTGRES_USER: "test"
           POSTGRES_PASSWORD: "test"
           POSTGRES_DB: "test"
-      - image: cockroachdb/cockroach:latest
+      - image: cockroachdb/cockroach:v19.2.9
         name: cockroachdb
         command: start --insecure
       - image: circleci/mongo:3.4.18

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -62,7 +62,7 @@ services:
 
   # cockroachdb
   cockroachdb:
-    image: "cockroachdb/cockroach-unstable:v19.1.0-rc.2"
+    image: "cockroachdb/cockroach:v19.2.9"
     container_name: "typeorm-cockroachdb"
     command: start --insecure
     ports:


### PR DESCRIPTION
for some reason, the CI build started OOM'ing with CockroachDB v20 every once in a while - this pins us on a stable v19 release.