### PR TITLE
chore: remove uneccessary cockroachdriver calls in view-entity tests

### DIFF
--- a/test/functional/view-entity/mssql/view-entity-mssql.ts
+++ b/test/functional/view-entity/mssql/view-entity-mssql.ts
@@ -1,6 +1,5 @@
 import {expect} from "chai";
 import "reflect-metadata";
-import {CockroachDriver} from "../../../../src/driver/cockroachdb/CockroachDriver";
 import {Category} from "./entity/Category";
 import {Connection} from "../../../../src";
 import {closeTestingConnections, createTestingConnections, reloadTestingDatabases} from "../../../utils/test-utils";
@@ -49,13 +48,11 @@ describe("view entity > mssql", () => {
         const postCategories = await connection.manager.find(PostCategory);
         postCategories.length.should.be.equal(2);
 
-        const postId1 = connection.driver instanceof CockroachDriver ? "1" : 1;
-        postCategories[0].id.should.be.equal(postId1);
+        postCategories[0].id.should.be.equal(1);
         postCategories[0].postName.should.be.equal("About BMW");
         postCategories[0].categoryName.should.be.equal("Cars");
 
-        const postId2 = connection.driver instanceof CockroachDriver ? "2" : 2;
-        postCategories[1].id.should.be.equal(postId2);
+        postCategories[1].id.should.be.equal(2);
         postCategories[1].postName.should.be.equal("About Boeing");
         postCategories[1].categoryName.should.be.equal("Airplanes");
 

--- a/test/functional/view-entity/mysql/view-entity-mysql.ts
+++ b/test/functional/view-entity/mysql/view-entity-mysql.ts
@@ -1,6 +1,5 @@
 import {expect} from "chai";
 import "reflect-metadata";
-import {CockroachDriver} from "../../../../src/driver/cockroachdb/CockroachDriver";
 import {Category} from "./entity/Category";
 import {Connection} from "../../../../src";
 import {closeTestingConnections, createTestingConnections, reloadTestingDatabases} from "../../../utils/test-utils";
@@ -49,13 +48,11 @@ describe("view entity > mysql", () => {
         const postCategories = await connection.manager.find(PostCategory);
         postCategories.length.should.be.equal(2);
 
-        const postId1 = connection.driver instanceof CockroachDriver ? "1" : 1;
-        postCategories[0].id.should.be.equal(postId1);
+        postCategories[0].id.should.be.equal(1);
         postCategories[0].postName.should.be.equal("About BMW");
         postCategories[0].categoryName.should.be.equal("Cars");
 
-        const postId2 = connection.driver instanceof CockroachDriver ? "2" : 2;
-        postCategories[1].id.should.be.equal(postId2);
+        postCategories[1].id.should.be.equal(2);
         postCategories[1].postName.should.be.equal("About Boeing");
         postCategories[1].categoryName.should.be.equal("Airplanes");
 

--- a/test/functional/view-entity/oracle/view-entity-oracle.ts
+++ b/test/functional/view-entity/oracle/view-entity-oracle.ts
@@ -1,6 +1,5 @@
 import {expect} from "chai";
 import "reflect-metadata";
-import {CockroachDriver} from "../../../../src/driver/cockroachdb/CockroachDriver";
 import {Category} from "./entity/Category";
 import {Connection} from "../../../../src";
 import {closeTestingConnections, createTestingConnections, reloadTestingDatabases} from "../../../utils/test-utils";
@@ -49,13 +48,11 @@ describe("view entity > oracle", () => {
         const postCategories = await connection.manager.find(PostCategory);
         postCategories.length.should.be.equal(2);
 
-        const postId1 = connection.driver instanceof CockroachDriver ? "1" : 1;
-        postCategories[0].id.should.be.equal(postId1);
+        postCategories[0].id.should.be.equal(1);
         postCategories[0].postName.should.be.equal("About BMW");
         postCategories[0].categoryName.should.be.equal("Cars");
 
-        const postId2 = connection.driver instanceof CockroachDriver ? "2" : 2;
-        postCategories[1].id.should.be.equal(postId2);
+        postCategories[1].id.should.be.equal(2);
         postCategories[1].postName.should.be.equal("About Boeing");
         postCategories[1].categoryName.should.be.equal("Airplanes");
 

--- a/test/functional/view-entity/postgres/view-entity-postgres.ts
+++ b/test/functional/view-entity/postgres/view-entity-postgres.ts
@@ -1,6 +1,5 @@
 import {expect} from "chai";
 import "reflect-metadata";
-import {CockroachDriver} from "../../../../src/driver/cockroachdb/CockroachDriver";
 import {Category} from "./entity/Category";
 import {Connection} from "../../../../src";
 import {closeTestingConnections, createTestingConnections, reloadTestingDatabases} from "../../../utils/test-utils";
@@ -75,13 +74,11 @@ describe("view entity > postgres", () => {
         const postCategories = await connection.manager.find(PostCategory);
         postCategories.length.should.be.equal(2);
 
-        const postId1 = connection.driver instanceof CockroachDriver ? "1" : 1;
-        postCategories[0].id.should.be.equal(postId1);
+        postCategories[0].id.should.be.equal(1);
         postCategories[0].postName.should.be.equal("About BMW");
         postCategories[0].categoryName.should.be.equal("Cars");
 
-        const postId2 = connection.driver instanceof CockroachDriver ? "2" : 2;
-        postCategories[1].id.should.be.equal(postId2);
+        postCategories[1].id.should.be.equal(2);
         postCategories[1].postName.should.be.equal("About Boeing");
         postCategories[1].categoryName.should.be.equal("Airplanes");
 

--- a/test/functional/view-entity/sqlite/view-entity-sqlite.ts
+++ b/test/functional/view-entity/sqlite/view-entity-sqlite.ts
@@ -1,6 +1,5 @@
 import {expect} from "chai";
 import "reflect-metadata";
-import {CockroachDriver} from "../../../../src/driver/cockroachdb/CockroachDriver";
 import {Category} from "./entity/Category";
 import {Connection} from "../../../../src";
 import {closeTestingConnections, createTestingConnections, reloadTestingDatabases} from "../../../utils/test-utils";
@@ -49,13 +48,11 @@ describe("view entity > sqlite", () => {
         const postCategories = await connection.manager.find(PostCategory);
         postCategories.length.should.be.equal(2);
 
-        const postId1 = connection.driver instanceof CockroachDriver ? "1" : 1;
-        postCategories[0].id.should.be.equal(postId1);
+        postCategories[0].id.should.be.equal(1);
         postCategories[0].postName.should.be.equal("About BMW");
         postCategories[0].categoryName.should.be.equal("Cars");
 
-        const postId2 = connection.driver instanceof CockroachDriver ? "2" : 2;
-        postCategories[1].id.should.be.equal(postId2);
+        postCategories[1].id.should.be.equal(2);
         postCategories[1].postName.should.be.equal("About Boeing");
         postCategories[1].categoryName.should.be.equal("Airplanes");
 


### PR DESCRIPTION
this is a backport of changes from the `next` branch