### PR TITLE
build: use docker-compose for database services

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -93,42 +93,72 @@ jobs:
     working_directory: ~/typeorm
     docker:
       - image: circleci/node:<< parameters.node-version >>
-      - image: mysql:5.7.24
-        environment:
-          MYSQL_ROOT_PASSWORD: "admin"
-          MYSQL_DATABASE: "test"
-      - image: mariadb:10.1.37
-        name: mariadb
-        environment:
-          MYSQL_ROOT_PASSWORD: "admin"
-          MYSQL_DATABASE: "test"
-      - image: circleci/postgres:9.6.11-postgis
-        name: postgres
-        environment:
-          POSTGRES_USER: "test"
-          POSTGRES_PASSWORD: "test"
-          POSTGRES_DB: "test"
-      - image: cockroachdb/cockroach:v19.2.9
-        name: cockroachdb
-        command: start --insecure
-      - image: circleci/mongo:3.4.18
-        name: mongodb
-      - image: mcr.microsoft.com/mssql/server:2017-latest
-        name: mssql
-        environment:
-          SA_PASSWORD: "Admin123"
-          ACCEPT_EULA: "Y"
-
     steps:
       - checkout
+      - setup_remote_docker
       - attach_workspace:
           at: ~/typeorm
       - create-typeorm-config:
           databases: << parameters.databases >>
-      # Download and cache dependencies
+      - run:
+          name: Start all Relevant Services
+          command: |
+            SERVICES=$(
+              npx js-yaml ./docker-compose.yml \
+                | jq -r '.services | keys | map(select(. | IN($ARGS.positional[]))) | join(" ")' --args << parameters.databases >>
+            )
+
+            docker-compose --project-name typeorm --no-ansi up --detach $SERVICES
       - install-packages:
-          cache-key: node<< parameters.node-version >>
-      - run: npx nyc npm run test-fast
+         cache-key: node<< parameters.node-version >>
+      - run:
+          name: Set up TypeORM Test Runner
+          command: |
+            docker run \
+              --volume /typeorm \
+              --name typeorm-code \
+              --workdir /typeorm \
+              circleci/node:<< parameters.node-version >> \
+              /bin/bash -c "sudo chmod 777 /typeorm && sudo chown circleci /typeorm"
+            docker cp ./ typeorm-code:/typeorm
+      - run:
+          name: Wait for Services to be Available
+          command: |
+            COMMANDS=$(
+                cat ormconfig.json \
+                  | jq -r '
+                    map(select(.skip == false)
+                      | select(.host)
+                      | select(.port)
+                      | "nc -z " + .host + " " + (.port|tostring) + " && echo " + .host + " " + (.port|tostring) + " is up")
+                      | join(" && ")
+                  '
+            )
+            echo "Running '$COMMANDS'"
+
+            docker run \
+              --network typeorm_default \
+              --tty \
+              ubuntu:trusty \
+              timeout 60 sh -c "until ($COMMANDS); do echo \"Waiting for Services to be Available ...\"; sleep 5; done"
+      # Download and cache dependencies
+      - run:
+          name: "Run Tests with Coverage"
+          command: |
+            docker run \
+              --env LD_LIBRARY_PATH='/typeorm/node_modules/oracledb/instantclient_19_8/:$LD_LIBRARY_PATH' \
+              --volumes-from typeorm-code \
+              --network typeorm_default \
+              --tty \
+              --workdir /typeorm \
+              --name typeorm-testrunner \
+              circleci/node:<< parameters.node-version >> \
+              npx nyc npm run test-fast
+
+            docker cp typeorm-testrunner:/typeorm/coverage/ ./
+      - run:
+          name: Stop all Relevant Services
+          command: docker-compose down
       - store_artifacts:
           path: coverage
       - codecov/upload
@@ -140,12 +170,12 @@ workflows:
       - lint
       - build
       - test:
-          name: test (mysql mariadb sqlite better-sqlite3 postgres sqljs mssql mongodb) - Node v<< matrix.node-version >>
+          name: test (mysql mariadb postgres mssql mongodb sqlite better-sqlite3 sqljs) - Node v<< matrix.node-version >>
           requires:
             - lint
             - build
+          databases: "mysql mariadb postgres mssql mongodb sqlite better-sqlite3 sqljs"
           matrix:
-            databases: "mysql mariadb sqlite better-sqlite3 postgres sqljs mssql mongodb"
             parameters:
               node-version:
                 - "10"

--- a/ormconfig.circleci-common.json
+++ b/ormconfig.circleci-common.json
@@ -1,78 +1,89 @@
 [
   {
-    "skip": false,
+    "skip": true,
     "name": "mysql",
     "type": "mysql",
-    "host": "localhost",
+    "host": "typeorm-mysql",
     "port": 3306,
     "username": "root",
     "password": "admin",
-    "database": "test"
+    "database": "test",
+    "logging": false
   },
   {
-    "skip": false,
+    "skip": true,
     "name": "mariadb",
     "type": "mariadb",
-    "host": "mariadb",
+    "host": "typeorm-mariadb",
     "port": 3306,
     "username": "root",
     "password": "admin",
-    "database": "test"
+    "database": "test",
+    "logging": false
   },
   {
-    "skip": false,
+    "skip": true,
     "name": "sqlite",
     "type": "sqlite",
-    "database": "temp/sqlitedb.db"
+    "database": "temp/sqlitedb.db",
+    "logging": false
   },
   {
-    "skip": false,
+    "skip": true,
     "name": "better-sqlite3",
     "type": "better-sqlite3",
-    "database": "temp/better-sqlite3db.db"
+    "database": "temp/better-sqlite3db.db",
+    "logging": false
   },
   {
-    "skip": false,
+    "skip": true,
     "name": "postgres",
     "type": "postgres",
-    "host": "postgres",
+    "host": "typeorm-postgres",
     "port": 5432,
     "username": "test",
     "password": "test",
-    "database": "test"
+    "database": "test",
+    "logging": false
   },
   {
     "skip": false,
     "name": "sqljs",
-    "type": "sqljs"
+    "type": "sqljs",
+    "logging": false
   },
+
   {
-    "skip": false,
+    "skip": true,
     "name": "mssql",
     "type": "mssql",
-    "host": "mssql",
+    "host": "typeorm-mssql",
+    "port": 1433,
     "username": "sa",
-    "password": "Admin123",
-    "database": "tempdb"
+    "password": "Admin12345",
+    "database": "tempdb",
+    "logging": false
   },
   {
     "skip": true,
     "name": "sap",
     "type": "sap",
-    "host": "sap",
+    "host": "typeorm-hana",
     "port": 39015,
     "username": "SYSTEM",
-    "password": "HXEHana1",
+    "password": "MySuperHanaPwd123!",
     "database": "HXE",
     "logging": false
   },
   {
-    "skip": false,
+    "skip": true,
     "disabledIfNotEnabledImplicitly": true,
     "name": "mongodb",
     "type": "mongodb",
-    "host": "mongodb",
+    "host": "typeorm-mongodb",
+    "port": 27017,
     "database": "test",
+    "logging": false,
     "useNewUrlParser": true,
     "useUnifiedTopology": true
   },
@@ -80,7 +91,7 @@
     "skip": true,
     "name": "cockroachdb",
     "type": "cockroachdb",
-    "host": "cockroachdb",
+    "host": "typeorm-cockroachdb",
     "port": 26257,
     "username": "root",
     "password": "",
@@ -90,10 +101,11 @@
     "skip": true,
     "name": "oracle",
     "type": "oracle",
-    "host": "oracle",
-    "username": "typeorm",
-    "password": "Passw0rd",
+    "host": "typeorm-oracle",
     "port": 1521,
-    "sid": "orclpdb1.localdomain"
+    "sid": "xe",
+    "username": "system",
+    "password": "oracle",
+    "logging": false
   }
 ]


### PR DESCRIPTION
This updates the CircleCI configuration to utilize `docker-compose` for running the dependent database services we run tests against.

This allows us to more easily deploy more varied and complex systems - such as databases that could normally run us out of memory (eg, CockroachDB) or databases that require authenticated login to fetch the images (eg, OracleDB & SAP Hana)

It also grants us access to a larger machine on the other end of the `docker-remote` - a system with 8GB of RAM instead of the 4GB the normal runner gets.

While the tests take a bit longer to run, there may be mechanisms we could employ to improve that down the line.