### PR TITLE
Fix some implicit dependencies not bundled by webpack

### DIFF
--- a/src/platform/PlatformTools.ts
+++ b/src/platform/PlatformTools.ts
@@ -128,6 +128,15 @@ export class PlatformTools {
                 case "glob":
                     return require("glob");
 
+                case "dotenv":
+                    return require("dotenv");
+
+                case "xml2js":
+                    return require("xml2js");
+
+                case "js-yaml":
+                    return require("js-yaml");
+
                 case "typeorm-aurora-data-api-driver":
                     return require("typeorm-aurora-data-api-driver");
                 /**


### PR DESCRIPTION
This PR adds some missing dependencies (dotenv, xml2js, js-yaml) into `PlatformTools.ts`, allowing webpack to bundle them.

Closes: #3152