### PR TITLE
feat: dynamic embedded entities

### DIFF
--- a/src/decorator/columns/Column.ts
+++ b/src/decorator/columns/Column.ts
@@ -90,13 +90,13 @@ export function Column(type: "hstore", options?: ColumnCommonOptions & ColumnHst
  * single table of the entity where Embedded is used. And on hydration all columns which supposed to be in the
  * embedded will be mapped to it from the single table.
  */
-export function Column(type: (type?: any) => Function, options?: ColumnEmbeddedOptions): PropertyDecorator;
+export function Column(type: (type?: any, target?: Function, propertyName?: string) => Function, options?: ColumnEmbeddedOptions): PropertyDecorator;
 
 /**
  * Column decorator is used to mark a specific class property as a table column.
  * Only properties decorated with this decorator will be persisted to the database when entity be saved.
  */
-export function Column(typeOrOptions?: ((type?: any) => Function)|ColumnType|(ColumnOptions&ColumnEmbeddedOptions), options?: (ColumnOptions&ColumnEmbeddedOptions)): PropertyDecorator {
+export function Column(typeOrOptions?: ((type?: any, target?: Function, propertyName?: string) => Function)|ColumnType|(ColumnOptions&ColumnEmbeddedOptions), options?: (ColumnOptions&ColumnEmbeddedOptions)): PropertyDecorator {
     return function (object: Object, propertyName: string) {
 
         // normalize parameters

--- a/src/metadata-args/EmbeddedMetadataArgs.ts
+++ b/src/metadata-args/EmbeddedMetadataArgs.ts
@@ -27,6 +27,6 @@ export interface EmbeddedMetadataArgs {
     /**
      * Type of the class to be embedded.
      */
-    type: ((type?: any) => Function);
+    type: ((type?: any, target?: Function, propertyName?: string) => Function);
 
 }

--- a/src/metadata/EmbeddedMetadata.ts
+++ b/src/metadata/EmbeddedMetadata.ts
@@ -176,7 +176,7 @@ export class EmbeddedMetadata {
         args: EmbeddedMetadataArgs,
     }) {
         this.entityMetadata = options.entityMetadata;
-        this.type = options.args.type();
+        this.type = options.args.type(undefined, options.args.target, options.args.propertyName);
         this.propertyName = options.args.propertyName;
         this.customPrefix = options.args.prefix;
         this.isArray = options.args.isArray;


### PR DESCRIPTION
Pass the target object and property name to embedded entity type function. Allows an entity to decide at runtime which entity it would like to embed depending on the target object.

This makes it possible to create generic entity types where an extending class can change it's embedded types by using a static property, or other class specific logic, without having to duplicate the column definition.

For example:

```typescript
export abstract class PlayerEntity<A> {
	@Column((type, target, propertyName) => target.attributesType()) attributes: A;
}

@Entity('players_2019')
export class Game2019PlayerEntity extends PlayerEntity<Game2019Attributes> {
	static attributesType = () => Game2019Attributes;
}

@Entity('players_2020')
export class Game2020PlayerEntity extends PlayerEntity<Game2020Attributes> {
	static attributesType = () => Game2020Attributes;
}
```