### PR TITLE
bugfix: pass `ids_` to alias builder to prevent length overflow

### DIFF
--- a/src/query-builder/SelectQueryBuilder.ts
+++ b/src/query-builder/SelectQueryBuilder.ts
@@ -1861,7 +1861,14 @@ export class SelectQueryBuilder<Entity> extends QueryBuilder<Entity> implements 
                 const columnAlias = this.escape(DriverUtils.buildColumnAlias(this.connection.driver, mainAliasName, primaryColumn.databaseName));
                 if (!orderBys[columnAlias]) // make sure we aren't overriding user-defined order in inverse direction
                     orderBys[columnAlias] = "ASC";
-                return `${distinctAlias}.${columnAlias} as "ids_${DriverUtils.buildColumnAlias(this.connection.driver, mainAliasName, primaryColumn.databaseName)}"`;
+
+                const alias = DriverUtils.buildColumnAlias(
+                    this.connection.driver,
+                    "ids_" + mainAliasName,
+                    primaryColumn.databaseName
+                );
+
+                return `${distinctAlias}.${columnAlias} as "${alias}"`;
             });
 
             rawResults = await new SelectQueryBuilder(this.connection, queryRunner)
@@ -1888,7 +1895,13 @@ export class SelectQueryBuilder<Entity> extends QueryBuilder<Entity> implements 
                         }).join(" AND ");
                     }).join(" OR ");
                 } else {
-                    const ids = rawResults.map(result => result["ids_" + DriverUtils.buildColumnAlias(this.connection.driver, mainAliasName, metadata.primaryColumns[0].databaseName)]);
+                    const alias = DriverUtils.buildColumnAlias(
+                        this.connection.driver,
+                        "ids_" + mainAliasName,
+                        metadata.primaryColumns[0].databaseName
+                    );
+
+                    const ids = rawResults.map(result => result[alias]);
                     const areAllNumbers = ids.every((id: any) => typeof id === "number");
                     if (areAllNumbers) {
                         // fixes #190. if all numbers then its safe to perform query without parameter


### PR DESCRIPTION
When creating the query for the `distinctAlias` - Instead of prepending `ids_` to the built alias name we include `ids_` as a prefix.

This means that the generated column alias could potentially be 4 characters longer than the maximum allowed column length defined by the driver.  In the case of Oracle, with its hilariously short identifier length, this comes up very frequently and causes the `ORA-00972` error code to emit.

