### PR TITLE
chore: instead of require, import chalk from chalk

### DIFF
--- a/src/commands/CacheClearCommand.ts
+++ b/src/commands/CacheClearCommand.ts
@@ -2,7 +2,7 @@ import {createConnection} from "../index";
 import {ConnectionOptionsReader} from "../connection/ConnectionOptionsReader";
 import {Connection} from "../connection/Connection";
 import * as yargs from "yargs";
-const chalk = require("chalk");
+import chalk from "chalk";
 
 /**
  * Clear cache command.

--- a/src/commands/EntityCreateCommand.ts
+++ b/src/commands/EntityCreateCommand.ts
@@ -1,7 +1,7 @@
 import {ConnectionOptionsReader} from "../connection/ConnectionOptionsReader";
 import {CommandUtils} from "./CommandUtils";
 import * as yargs from "yargs";
-const chalk = require("chalk");
+import chalk from "chalk";
 
 /**
  * Generates a new entity.

--- a/src/commands/InitCommand.ts
+++ b/src/commands/InitCommand.ts
@@ -2,7 +2,7 @@ import {CommandUtils} from "./CommandUtils";
 import {ObjectLiteral} from "../common/ObjectLiteral";
 import * as path from "path";
 import * as yargs from "yargs";
-const chalk = require("chalk");
+import chalk from "chalk";
 
 /**
  * Generates a new project with TypeORM.

--- a/src/commands/MigrationCreateCommand.ts
+++ b/src/commands/MigrationCreateCommand.ts
@@ -2,7 +2,7 @@ import {ConnectionOptionsReader} from "../connection/ConnectionOptionsReader";
 import {CommandUtils} from "./CommandUtils";
 import {camelCase} from "../util/StringUtils";
 import * as yargs from "yargs";
-const chalk = require("chalk");
+import chalk from "chalk";
 
 /**
  * Creates a new migration file.

--- a/src/commands/MigrationGenerateCommand.ts
+++ b/src/commands/MigrationGenerateCommand.ts
@@ -6,7 +6,7 @@ import {MysqlDriver} from "../driver/mysql/MysqlDriver";
 import {camelCase} from "../util/StringUtils";
 import * as yargs from "yargs";
 import {AuroraDataApiDriver} from "../driver/aurora-data-api/AuroraDataApiDriver";
-const chalk = require("chalk");
+import chalk from "chalk";
 
 /**
  * Generates a new migration file with sql needs to be executed to update schema.

--- a/src/commands/MigrationRevertCommand.ts
+++ b/src/commands/MigrationRevertCommand.ts
@@ -2,7 +2,7 @@ import {createConnection} from "../index";
 import {ConnectionOptionsReader} from "../connection/ConnectionOptionsReader";
 import {Connection} from "../connection/Connection";
 import * as yargs from "yargs";
-const chalk = require("chalk");
+import chalk from "chalk";
 
 /**
  * Reverts last migration command.

--- a/src/commands/MigrationRunCommand.ts
+++ b/src/commands/MigrationRunCommand.ts
@@ -3,7 +3,7 @@ import {ConnectionOptionsReader} from "../connection/ConnectionOptionsReader";
 import {Connection} from "../connection/Connection";
 import * as process from "process";
 import * as yargs from "yargs";
-const chalk = require("chalk");
+import chalk from "chalk";
 
 /**
  * Runs migration command.

--- a/src/commands/MigrationShowCommand.ts
+++ b/src/commands/MigrationShowCommand.ts
@@ -3,7 +3,7 @@ import {ConnectionOptionsReader} from "../connection/ConnectionOptionsReader";
 import {Connection} from "../connection/Connection";
 import * as process from "process";
 import * as yargs from "yargs";
-const chalk = require("chalk");
+import chalk from "chalk";
 
 /**
  * Runs migration command.

--- a/src/commands/QueryCommand.ts
+++ b/src/commands/QueryCommand.ts
@@ -4,7 +4,7 @@ import {ConnectionOptionsReader} from "../connection/ConnectionOptionsReader";
 import {Connection} from "../connection/Connection";
 import {PlatformTools} from "../platform/PlatformTools";
 import * as yargs from "yargs";
-const chalk = require("chalk");
+import chalk from "chalk";
 
 /**
  * Executes an sql query on the given connection.

--- a/src/commands/SchemaDropCommand.ts
+++ b/src/commands/SchemaDropCommand.ts
@@ -2,7 +2,7 @@ import {createConnection} from "../index";
 import {Connection} from "../connection/Connection";
 import {ConnectionOptionsReader} from "../connection/ConnectionOptionsReader";
 import * as yargs from "yargs";
-const chalk = require("chalk");
+import chalk from "chalk";
 
 /**
  * Drops all tables of the database from the given connection.

--- a/src/commands/SchemaLogCommand.ts
+++ b/src/commands/SchemaLogCommand.ts
@@ -3,8 +3,7 @@ import {Connection} from "../connection/Connection";
 import {ConnectionOptionsReader} from "../connection/ConnectionOptionsReader";
 import {highlight} from "cli-highlight";
 import * as yargs from "yargs";
-
-const chalk = require("chalk");
+import chalk from "chalk";
 
 /**
  * Shows sql to be executed by schema:sync command.
@@ -53,7 +52,7 @@ export class SchemaLogCommand implements yargs.CommandModule {
             } else {
                 const lengthSeparators = String(sqlInMemory.upQueries.length).split("").map(char => "-").join("");
                 console.log(chalk.yellow("---------------------------------------------------------------" + lengthSeparators));
-                console.log(chalk.yellow.bold(`-- Schema syncronization will execute following sql queries (${chalk.white(sqlInMemory.upQueries.length)}):`));
+                console.log(chalk.yellow.bold(`-- Schema syncronization will execute following sql queries (${chalk.white(sqlInMemory.upQueries.length.toString())}):`));
                 console.log(chalk.yellow("---------------------------------------------------------------" + lengthSeparators));
 
                 sqlInMemory.upQueries.forEach(upQuery => {

--- a/src/commands/SchemaSyncCommand.ts
+++ b/src/commands/SchemaSyncCommand.ts
@@ -2,7 +2,7 @@ import {createConnection} from "../index";
 import {Connection} from "../connection/Connection";
 import {ConnectionOptionsReader} from "../connection/ConnectionOptionsReader";
 import * as yargs from "yargs";
-const chalk = require("chalk");
+import chalk from "chalk";
 
 /**
  * Synchronizes database schema with entities.

--- a/src/commands/SubscriberCreateCommand.ts
+++ b/src/commands/SubscriberCreateCommand.ts
@@ -1,7 +1,7 @@
 import {ConnectionOptionsReader} from "../connection/ConnectionOptionsReader";
 import {CommandUtils} from "./CommandUtils";
 import * as yargs from "yargs";
-const chalk = require("chalk");
+import chalk from "chalk";
 
 /**
  * Generates a new subscriber.

--- a/src/commands/VersionCommand.ts
+++ b/src/commands/VersionCommand.ts
@@ -1,5 +1,5 @@
 import * as yargs from "yargs";
-const exec = require("child_process").exec;
+import {exec} from "child_process";
 
 /**
  * Shows typeorm version.

--- a/src/platform/PlatformTools.ts
+++ b/src/platform/PlatformTools.ts
@@ -1,11 +1,10 @@
 import * as path from "path";
 import * as fs from "fs";
+import chalk from "chalk";
 import {highlight, Theme} from "cli-highlight";
 export {ReadStream} from "fs";
 export {EventEmitter} from "events";
 export {Readable, Writable} from "stream";
-
-const chalk = require("chalk");
 
 /**
  * Platform-specific tools.


### PR DESCRIPTION
There's not much point to require `chalk` in the way it's been done - so use `import` instead.

This allows us to use the type definitions for chalk which we weren't before - `require` makes it `any` instead of the `chalk` types