### PR TITLE
fix: support ORDER BY json field with JOIN and pagination

### DIFF
--- a/src/query-builder/SelectQueryBuilder.ts
+++ b/src/query-builder/SelectQueryBuilder.ts
@@ -2051,10 +2051,17 @@ export class SelectQueryBuilder<Entity> extends QueryBuilder<Entity> implements 
                 if (orderCriteria.indexOf(".") !== -1) {
                     const criteriaParts = orderCriteria.split(".");
                     const aliasName = criteriaParts[0];
-                    const propertyPath = criteriaParts.slice(1).join(".");
+                    const fieldSpec = criteriaParts.slice(1).join(".");
+                    let propertyPath = fieldSpec;
+                    let rawFieldSpecs = "";
                     const alias = this.expressionMap.findAliasByName(aliasName);
-                    const column = alias.metadata.findColumnWithPropertyPath(propertyPath);
-                    return this.escape(parentAlias) + "." + this.escape(DriverUtils.buildAlias(this.connection.driver, aliasName, column!.databaseName));
+                    const spIdx = propertyPath.indexOf(" ");
+                    if (spIdx !== -1) {
+                        propertyPath = propertyPath.slice(0, spIdx);
+                        rawFieldSpecs = propertyPath.slice(spIdx);
+                    }
+                    const column = alias.metadata.findColumnWithPropertyName(propertyPath);
+                    return this.escape(parentAlias) + "." + this.escape(DriverUtils.buildAlias(this.connection.driver, aliasName, column!.databaseName)) + rawFieldSpecs;
                 } else {
                     if (this.expressionMap.selects.find(select => select.selection === orderCriteria || select.aliasName === orderCriteria))
                         return this.escape(parentAlias) + "." + orderCriteria;
@@ -2069,10 +2076,17 @@ export class SelectQueryBuilder<Entity> extends QueryBuilder<Entity> implements 
             if (orderCriteria.indexOf(".") !== -1) {
                 const criteriaParts = orderCriteria.split(".");
                 const aliasName = criteriaParts[0];
-                const propertyPath = criteriaParts.slice(1).join(".");
+                const fieldSpec = criteriaParts.slice(1).join(".");
+                let propertyPath = fieldSpec;
+                let rawFieldSpecs = "";
                 const alias = this.expressionMap.findAliasByName(aliasName);
+                const spIdx = propertyPath.indexOf(" ");
+                if (spIdx !== -1) {
+                    propertyPath = propertyPath.slice(0, spIdx);
+                    rawFieldSpecs = propertyPath.slice(spIdx);
+                }
                 const column = alias.metadata.findColumnWithPropertyPath(propertyPath);
-                orderByObject[this.escape(parentAlias) + "." + this.escape(DriverUtils.buildAlias(this.connection.driver, aliasName, column!.databaseName))] = orderBys[orderCriteria];
+                orderByObject[this.escape(parentAlias) + "." + this.escape(DriverUtils.buildAlias(this.connection.driver, aliasName, column!.databaseName)) + rawFieldSpecs] = orderBys[orderCriteria];
             } else {
                 if (this.expressionMap.selects.find(select => select.selection === orderCriteria || select.aliasName === orderCriteria)) {
                     orderByObject[this.escape(parentAlias) + "." + orderCriteria] = orderBys[orderCriteria];

--- a/test/github-issues/6640/entity/Form.ts
+++ b/test/github-issues/6640/entity/Form.ts
@@ -1,0 +1,28 @@
+import {Column, Entity, ManyToOne, PrimaryGeneratedColumn} from "../../../../src";
+import {FormTmpl} from "./FormTmpl";
+
+export class ExtraSetting {
+  someStr: string;
+  someNb: number;
+}
+
+@Entity()
+export class Form {
+  @PrimaryGeneratedColumn()
+  id: number;
+
+  @Column()
+  formTmplId: number;
+
+  @ManyToOne(() => FormTmpl, (formTmpl) => formTmpl.id, {
+    eager: true,
+  })
+  formTmpl: FormTmpl;
+
+  @Column()
+  settings: string;
+
+  // JSONB column
+  @Column("jsonb", {nullable: true})
+  extraSettings?: ExtraSetting;
+}

--- a/test/github-issues/6640/entity/FormTmpl.ts
+++ b/test/github-issues/6640/entity/FormTmpl.ts
@@ -1,0 +1,17 @@
+import {Column, Entity, OneToMany, PrimaryGeneratedColumn} from "../../../../src";
+import {Form} from "./Form";
+
+@Entity()
+export class FormTmpl {
+  @PrimaryGeneratedColumn()
+  id: number;
+
+  @Column()
+  origin: number;
+
+  @Column()
+  name: string;
+
+  @OneToMany(() => Form, (form) => form.id)
+  publicSettings: Form[];
+}

--- a/test/github-issues/6640/issue-6640.ts
+++ b/test/github-issues/6640/issue-6640.ts
@@ -1,0 +1,93 @@
+import "reflect-metadata";
+import {closeTestingConnections, createTestingConnections, reloadTestingDatabases} from "../../utils/test-utils";
+import {Connection} from "../../../src/connection/Connection";
+import {Form} from "./entity/Form";
+import {FormTmpl} from "./entity/FormTmpl";
+import { expect } from "chai";
+
+
+
+describe("github issues > #6640 Cannot ORDER BY json field in query with JOIN and pagination", () => {
+
+    let connections: Connection[];
+    before(async () => connections = await createTestingConnections({
+        entities: [__dirname + "/entity/*{.js,.ts}"],
+        enabledDrivers: ["postgres"]
+    }));
+    beforeEach(() => reloadTestingDatabases(connections));
+    after(() => closeTestingConnections(connections));
+
+    it("should correctly run query with join, order by json field and pagination", () => Promise.all(connections.map(async connection => {
+
+      const formTmpls: FormTmpl[] = [
+        {
+          id: 1,
+          origin: 1,
+          name: "form1",
+          publicSettings: [],
+        },
+        {
+          id: 2,
+          origin: 2,
+          name: "form2",
+          publicSettings: [],
+        },
+      ];
+      await connection.getRepository(FormTmpl).save(formTmpls);
+
+      const repo = connection.getRepository(Form);
+      const form1 = new Form();
+      form1.formTmplId = 1;
+      form1.settings = "setting1";
+      form1.extraSettings = {
+        someNb: 7,
+        someStr: "extra1",
+      };
+      await repo.save(form1);
+
+      const form2 = new Form();
+      form2.formTmplId = 2;
+      form2.settings = "setting2";
+      form2.extraSettings = {
+        someNb: 21,
+        someStr: "extra2",
+      };
+      await repo.save(form2);
+
+      const form3 = new Form();
+      form3.formTmplId = 1;
+      form3.settings = "setting3";
+      form3.extraSettings = {
+        someNb: 5,
+        someStr: "extra3",
+      };
+      await repo.save(form3);
+
+      const form4 = new Form();
+      form4.formTmplId = 1;
+      form4.settings = "setting4";
+      form4.extraSettings = {
+        someNb: 40,
+        someStr: "extra4",
+      };
+      await repo.save(form4);
+
+      const orig = 1;
+      const qb = connection.createQueryBuilder(Form, "form")
+        .innerJoinAndSelect("form.formTmpl", "formTmpls", "formTmpls.origin = :orig", { orig })
+        .orderBy({
+          "form.extraSettings ->'someNb'": {
+              order: "DESC",
+              nulls: "NULLS LAST",
+            }
+        })
+        .take(2);
+
+      const [result, total] = await qb.getManyAndCount();
+
+      expect(total).eq(3);
+      expect(result.length).eq(2);
+      expect(result[0].extraSettings!.someNb).eq(40);
+    })));
+
+});


### PR DESCRIPTION
Closes: #6640 

Allow specifying jsonb fields (`property ->'field'` in Postgres) in a GROUP BY, even for the case the query has JOIN and uses pagination. 