### PR TITLE
Support absolute paths in migrationsDir for the CLI

### DIFF
--- a/src/commands/MigrationCreateCommand.ts
+++ b/src/commands/MigrationCreateCommand.ts
@@ -59,7 +59,7 @@ export class MigrationCreateCommand implements yargs.CommandModule {
                 } catch (err) { }
             }
 
-            const path = process.cwd() + "/" + (directory ? (directory + "/") : "") + filename;
+            const path = (directory.startsWith("/") ? "" : process.cwd() + "/") + (directory ? (directory + "/") : "") + filename;
             await CommandUtils.createFile(path, fileContent);
             console.log(`Migration ${chalk.blue(path)} has been generated successfully.`);
 


### PR DESCRIPTION
Right now the CLI will ALWAYS prepend the CWD to `options.cli.migrationsDir`. 

This prevents us from using absolute paths there. 

How would we feel about changing that to support absolute paths (by only prepending CLI if the path DOES NOT start with "/")? If we're open to it, I'm happy to make the change for the other CLI commands as well.