### PR TITLE
fix: add missing schema for OracleDriver

### DIFF
--- a/src/metadata/EntityMetadata.ts
+++ b/src/metadata/EntityMetadata.ts
@@ -6,6 +6,7 @@ import {PostgresDriver} from "../driver/postgres/PostgresDriver";
 import {SapDriver} from "../driver/sap/SapDriver";
 import {SqlServerConnectionOptions} from "../driver/sqlserver/SqlServerConnectionOptions";
 import {SqlServerDriver} from "../driver/sqlserver/SqlServerDriver";
+import {OracleDriver} from "../driver/oracle/OracleDriver";
 import {CannotCreateEntityIdMapError} from "../error/CannotCreateEntityIdMapError";
 import {OrderByCondition} from "../find-options/OrderByCondition";
 import {TableMetadataArgs} from "../metadata-args/TableMetadataArgs";
@@ -709,7 +710,7 @@ export class EntityMetadata {
     }
 
     private getInverseEntityMetadata(value: any, relation: RelationMetadata): EntityMetadata {
-        const childEntityMetadata = relation.inverseEntityMetadata.childEntityMetadatas.find(metadata => 
+        const childEntityMetadata = relation.inverseEntityMetadata.childEntityMetadatas.find(metadata =>
             metadata.target === value.constructor
         );
         return childEntityMetadata ? childEntityMetadata : relation.inverseEntityMetadata;
@@ -848,7 +849,7 @@ export class EntityMetadata {
      */
     protected buildTablePath(): string {
         let tablePath = this.tableName;
-        if (this.schema && ((this.connection.driver instanceof PostgresDriver) || (this.connection.driver instanceof SqlServerDriver) || (this.connection.driver instanceof SapDriver))) {
+        if (this.schema && ((this.connection.driver instanceof OracleDriver) || (this.connection.driver instanceof PostgresDriver) || (this.connection.driver instanceof SqlServerDriver) || (this.connection.driver instanceof SapDriver))) {
             tablePath = this.schema + "." + tablePath;
         }
 


### PR DESCRIPTION
Defining an Entity for Oracle connection does not recognise the schema value. This fixes that by adding it to the EntityMetadata class