### PR TITLE
fix: oracle table escaping

### DIFF
--- a/docs/decorator-reference.md
+++ b/docs/decorator-reference.md
@@ -60,6 +60,7 @@ You can also specify some additional entity options:
 * `engine` - database engine to be set during table creation (works only in some databases).
 * `synchronize` - entities marked with `false` are skipped from schema updates.
 * `orderBy` - specifies default ordering for entities when using `find` operations and `QueryBuilder`.
+* `exact` - determines if the `name` should not be modified and used exactly as it is specified
 
 Example:
 
@@ -169,7 +170,7 @@ By default the column name is generated from the name of the property.
 You can change it by specifying your own name.
 * `length: string|number` - Column type's length. For example, if you want to create `varchar(150)` type
 you specify column type and length options.
-* `width: number` - column type's display width. Used only for [MySQL integer types](https://dev.mysql.com/doc/refman/5.7/en/integer-types.html)
+* `width: number` - column type's display width. Used only for [MySQL integer types](https://dev.mysql.com/doc/refman/5.7/en/integer-types.html).
 * `onUpdate: string` - `ON UPDATE` trigger. Used only in [MySQL](https://dev.mysql.com/doc/refman/5.7/en/timestamp-initialization.html).
 * `nullable: boolean` - Makes column `NULL` or `NOT NULL` in the database.
 By default column is `nullable: false`.

--- a/docs/decorator-reference.md
+++ b/docs/decorator-reference.md
@@ -60,7 +60,7 @@ You can also specify some additional entity options:
 * `engine` - database engine to be set during table creation (works only in some databases).
 * `synchronize` - entities marked with `false` are skipped from schema updates.
 * `orderBy` - specifies default ordering for entities when using `find` operations and `QueryBuilder`.
-* `exact` - determines if the `name` should not be modified and used exactly as it is specified
+* `exact` - determines if the `name` should not be modified and used exactly as it is provided. This is optional
 
 Example:
 

--- a/ormconfig.circleci-common.json
+++ b/ormconfig.circleci-common.json
@@ -106,7 +106,7 @@
     "sid": "XE",
     "username": "system",
     "password": "oracle",
-    "logging": false,
+    "logging": true,
     "extra": {
       "connectString": "typeorm-oracle:1521/XE"
     }

--- a/src/decorator/options/EntityOptions.ts
+++ b/src/decorator/options/EntityOptions.ts
@@ -43,8 +43,15 @@ export interface EntityOptions {
 
     /**
      * If set to 'true' this option disables Sqlite's default behaviour of secretly creating
-     * an integer primary key column named 'rowid' on table creation. 
-     * @see https://www.sqlite.org/withoutrowid.html. 
+     * an integer primary key column named 'rowid' on table creation.
+     * @see https://www.sqlite.org/withoutrowid.html.
      */
     withoutRowid?: boolean;
+
+    /**
+     * If set to `true`, the name of the table will NOT be changed in anyway. This is
+     * to counteract the truncation of the table by underscore delimiter and leaving a
+     * malformed table name when the full name is to remain as-is.
+     */
+    exact? : boolean;
 }

--- a/src/driver/oracle/OracleDriver.ts
+++ b/src/driver/oracle/OracleDriver.ts
@@ -101,6 +101,7 @@ export class OracleDriver implements Driver {
         "timestamp",
         "timestamp with time zone",
         "timestamp with local time zone",
+        "sysdate",
         "interval year to month",
         "interval day to second",
         "bfile",
@@ -151,9 +152,9 @@ export class OracleDriver implements Driver {
      * Column types are driver dependant.
      */
     mappedDataTypes: MappedColumnTypes = {
-        createDate: "timestamp",
+        createDate: "sysdate",
         createDateDefault: "CURRENT_TIMESTAMP",
-        updateDate: "timestamp",
+        updateDate: "sysdate",
         updateDateDefault: "CURRENT_TIMESTAMP",
         deleteDate: "timestamp",
         deleteDateNullable: true,

--- a/src/driver/oracle/OracleDriver.ts
+++ b/src/driver/oracle/OracleDriver.ts
@@ -339,7 +339,7 @@ export class OracleDriver implements Driver {
      * Escapes a column name.
      */
     escape(columnName: string): string {
-        return `"${columnName}"`;
+        return columnName.toUpperCase();
     }
 
     /**
@@ -347,7 +347,7 @@ export class OracleDriver implements Driver {
      * Oracle does not support table schemas. One user can have only one schema.
      */
     buildTableName(tableName: string, schema?: string, database?: string): string {
-        return tableName;
+        return tableName.toUpperCase();
     }
 
     /**

--- a/src/driver/oracle/OracleQueryRunner.ts
+++ b/src/driver/oracle/OracleQueryRunner.ts
@@ -1496,7 +1496,7 @@ export class OracleQueryRunner extends BaseQueryRunner implements QueryRunner {
      * Builds create foreign key sql.
      */
     protected createForeignKeySql(table: Table, foreignKey: TableForeignKey): Query {
-        const columnNames = foreignKey.columnNames.map(column => `'${column}'`).join(", ");
+        const columnNames = foreignKey.columnNames.map(column => `${column}`).join(", ");
         const referencedColumnNames = foreignKey.referencedColumnNames.map(column => column).join(",");
         let sql = `ALTER TABLE ${table.name} ADD CONSTRAINT ${foreignKey.name} FOREIGN KEY (${columnNames}) ` +
             `REFERENCES ${foreignKey.referencedTableName} (${referencedColumnNames})`;

--- a/src/driver/oracle/OracleQueryRunner.ts
+++ b/src/driver/oracle/OracleQueryRunner.ts
@@ -386,8 +386,8 @@ export class OracleQueryRunner extends BaseQueryRunner implements QueryRunner {
         }
 
         // rename table
-        upQueries.push(new Query(`ALTER TABLE "${oldTable.name}" RENAME TO "${newTable.name}"`));
-        downQueries.push(new Query(`ALTER TABLE "${newTable.name}" RENAME TO "${oldTable.name}"`));
+        upQueries.push(new Query(`ALTER TABLE ${oldTable.name}" RENAME TO "${newTable.name}"`));
+        downQueries.push(new Query(`ALTER TABLE ${newTable.name}" RENAME TO "${oldTable.name}"`));
 
         // rename primary key constraint
         if (newTable.primaryColumns.length > 0) {
@@ -397,8 +397,8 @@ export class OracleQueryRunner extends BaseQueryRunner implements QueryRunner {
             const newPkName = this.connection.namingStrategy.primaryKeyName(newTable, columnNames);
 
             // build queries
-            upQueries.push(new Query(`ALTER TABLE "${newTable.name}" RENAME CONSTRAINT "${oldPkName}" TO "${newPkName}"`));
-            downQueries.push(new Query(`ALTER TABLE "${newTable.name}" RENAME CONSTRAINT "${newPkName}" TO "${oldPkName}"`));
+            upQueries.push(new Query(`ALTER TABLE ${newTable.name}" RENAME CONSTRAINT "${oldPkName}" TO "${newPkName}"`));
+            downQueries.push(new Query(`ALTER TABLE ${newTable.name}" RENAME CONSTRAINT "${newPkName}" TO "${oldPkName}"`));
         }
 
         // rename unique constraints
@@ -407,8 +407,8 @@ export class OracleQueryRunner extends BaseQueryRunner implements QueryRunner {
             const newUniqueName = this.connection.namingStrategy.uniqueConstraintName(newTable, unique.columnNames);
 
             // build queries
-            upQueries.push(new Query(`ALTER TABLE "${newTable.name}" RENAME CONSTRAINT "${unique.name}" TO "${newUniqueName}"`));
-            downQueries.push(new Query(`ALTER TABLE "${newTable.name}" RENAME CONSTRAINT "${newUniqueName}" TO "${unique.name}"`));
+            upQueries.push(new Query(`ALTER TABLE ${newTable.name}" RENAME CONSTRAINT "${unique.name}" TO "${newUniqueName}"`));
+            downQueries.push(new Query(`ALTER TABLE ${newTable.name}" RENAME CONSTRAINT "${newUniqueName}" TO "${unique.name}"`));
 
             // replace constraint name
             unique.name = newUniqueName;
@@ -433,8 +433,8 @@ export class OracleQueryRunner extends BaseQueryRunner implements QueryRunner {
             const newForeignKeyName = this.connection.namingStrategy.foreignKeyName(newTable, foreignKey.columnNames, foreignKey.referencedTableName, foreignKey.referencedColumnNames);
 
             // build queries
-            upQueries.push(new Query(`ALTER TABLE "${newTable.name}" RENAME CONSTRAINT "${foreignKey.name}" TO "${newForeignKeyName}"`));
-            downQueries.push(new Query(`ALTER TABLE "${newTable.name}" RENAME CONSTRAINT "${newForeignKeyName}" TO "${foreignKey.name}"`));
+            upQueries.push(new Query(`ALTER TABLE ${newTable.name}" RENAME CONSTRAINT "${foreignKey.name}" TO "${newForeignKeyName}"`));
+            downQueries.push(new Query(`ALTER TABLE ${newTable.name}" RENAME CONSTRAINT "${newForeignKeyName}" TO "${foreignKey.name}"`));
 
             // replace constraint name
             foreignKey.name = newForeignKeyName;
@@ -456,8 +456,8 @@ export class OracleQueryRunner extends BaseQueryRunner implements QueryRunner {
         const upQueries: Query[] = [];
         const downQueries: Query[] = [];
 
-        upQueries.push(new Query(`ALTER TABLE "${table.name}" ADD ${this.buildCreateColumnSql(column)}`));
-        downQueries.push(new Query(`ALTER TABLE "${table.name}" DROP COLUMN "${column.name}"`));
+        upQueries.push(new Query(`ALTER TABLE ${table.name}" ADD ${this.buildCreateColumnSql(column)}`));
+        downQueries.push(new Query(`ALTER TABLE ${table.name}" DROP COLUMN "${column.name}"`));
 
         // create or update primary key constraint
         if (column.isPrimary) {
@@ -466,15 +466,15 @@ export class OracleQueryRunner extends BaseQueryRunner implements QueryRunner {
             if (primaryColumns.length > 0) {
                 const pkName = this.connection.namingStrategy.primaryKeyName(clonedTable.name, primaryColumns.map(column => column.name));
                 const columnNames = primaryColumns.map(column => `"${column.name}"`).join(", ");
-                upQueries.push(new Query(`ALTER TABLE "${table.name}" DROP CONSTRAINT "${pkName}"`));
-                downQueries.push(new Query(`ALTER TABLE "${table.name}" ADD CONSTRAINT "${pkName}" PRIMARY KEY (${columnNames})`));
+                upQueries.push(new Query(`ALTER TABLE ${table.name}" DROP CONSTRAINT "${pkName}"`));
+                downQueries.push(new Query(`ALTER TABLE ${table.name}" ADD CONSTRAINT "${pkName}" PRIMARY KEY (${columnNames})`));
             }
 
             primaryColumns.push(column);
             const pkName = this.connection.namingStrategy.primaryKeyName(clonedTable.name, primaryColumns.map(column => column.name));
             const columnNames = primaryColumns.map(column => `"${column.name}"`).join(", ");
-            upQueries.push(new Query(`ALTER TABLE "${table.name}" ADD CONSTRAINT "${pkName}" PRIMARY KEY (${columnNames})`));
-            downQueries.push(new Query(`ALTER TABLE "${table.name}" DROP CONSTRAINT "${pkName}"`));
+            upQueries.push(new Query(`ALTER TABLE ${table.name}" ADD CONSTRAINT "${pkName}" PRIMARY KEY (${columnNames})`));
+            downQueries.push(new Query(`ALTER TABLE ${table.name}" DROP CONSTRAINT "${pkName}"`));
         }
 
         // create column index
@@ -492,8 +492,8 @@ export class OracleQueryRunner extends BaseQueryRunner implements QueryRunner {
                 columnNames: [column.name]
             });
             clonedTable.uniques.push(uniqueConstraint);
-            upQueries.push(new Query(`ALTER TABLE "${table.name}" ADD CONSTRAINT "${uniqueConstraint.name}" UNIQUE ("${column.name}")`));
-            downQueries.push(new Query(`ALTER TABLE "${table.name}" DROP CONSTRAINT "${uniqueConstraint.name}"`));
+            upQueries.push(new Query(`ALTER TABLE ${table.name}" ADD CONSTRAINT "${uniqueConstraint.name}" UNIQUE ("${column.name}")`));
+            downQueries.push(new Query(`ALTER TABLE ${table.name}" DROP CONSTRAINT "${uniqueConstraint.name}"`));
         }
 
         await this.executeQueries(upQueries, downQueries);
@@ -556,8 +556,8 @@ export class OracleQueryRunner extends BaseQueryRunner implements QueryRunner {
         } else {
             if (newColumn.name !== oldColumn.name) {
                 // rename column
-                upQueries.push(new Query(`ALTER TABLE "${table.name}" RENAME COLUMN "${oldColumn.name}" TO "${newColumn.name}"`));
-                downQueries.push(new Query(`ALTER TABLE "${table.name}" RENAME COLUMN "${newColumn.name}" TO "${oldColumn.name}"`));
+                upQueries.push(new Query(`ALTER TABLE ${table.name}" RENAME COLUMN "${oldColumn.name}" TO "${newColumn.name}"`));
+                downQueries.push(new Query(`ALTER TABLE ${table.name}" RENAME COLUMN "${newColumn.name}" TO "${oldColumn.name}"`));
 
                 // rename column primary key constraint
                 if (oldColumn.isPrimary === true) {
@@ -574,8 +574,8 @@ export class OracleQueryRunner extends BaseQueryRunner implements QueryRunner {
                     // build new primary constraint name
                     const newPkName = this.connection.namingStrategy.primaryKeyName(clonedTable, columnNames);
 
-                    upQueries.push(new Query(`ALTER TABLE "${table.name}" RENAME CONSTRAINT "${oldPkName}" TO "${newPkName}"`));
-                    downQueries.push(new Query(`ALTER TABLE "${table.name}" RENAME CONSTRAINT "${newPkName}" TO "${oldPkName}"`));
+                    upQueries.push(new Query(`ALTER TABLE ${table.name}" RENAME CONSTRAINT "${oldPkName}" TO "${newPkName}"`));
+                    downQueries.push(new Query(`ALTER TABLE ${table.name}" RENAME CONSTRAINT "${newPkName}" TO "${oldPkName}"`));
                 }
 
                 // rename unique constraints
@@ -586,8 +586,8 @@ export class OracleQueryRunner extends BaseQueryRunner implements QueryRunner {
                     const newUniqueName = this.connection.namingStrategy.uniqueConstraintName(clonedTable, unique.columnNames);
 
                     // build queries
-                    upQueries.push(new Query(`ALTER TABLE "${table.name}" RENAME CONSTRAINT "${unique.name}" TO "${newUniqueName}"`));
-                    downQueries.push(new Query(`ALTER TABLE "${table.name}" RENAME CONSTRAINT "${newUniqueName}" TO "${unique.name}"`));
+                    upQueries.push(new Query(`ALTER TABLE ${table.name}" RENAME CONSTRAINT "${unique.name}" TO "${newUniqueName}"`));
+                    downQueries.push(new Query(`ALTER TABLE ${table.name}" RENAME CONSTRAINT "${newUniqueName}" TO "${unique.name}"`));
 
                     // replace constraint name
                     unique.name = newUniqueName;
@@ -616,8 +616,8 @@ export class OracleQueryRunner extends BaseQueryRunner implements QueryRunner {
                     const newForeignKeyName = this.connection.namingStrategy.foreignKeyName(clonedTable, foreignKey.columnNames, foreignKey.referencedTableName, foreignKey.referencedColumnNames);
 
                     // build queries
-                    upQueries.push(new Query(`ALTER TABLE "${table.name}" RENAME CONSTRAINT "${foreignKey.name}" TO "${newForeignKeyName}"`));
-                    downQueries.push(new Query(`ALTER TABLE "${table.name}" RENAME CONSTRAINT "${newForeignKeyName}" TO "${foreignKey.name}"`));
+                    upQueries.push(new Query(`ALTER TABLE ${table.name}" RENAME CONSTRAINT "${foreignKey.name}" TO "${newForeignKeyName}"`));
+                    downQueries.push(new Query(`ALTER TABLE ${table.name}" RENAME CONSTRAINT "${newForeignKeyName}" TO "${foreignKey.name}"`));
 
                     // replace constraint name
                     foreignKey.name = newForeignKeyName;
@@ -661,8 +661,8 @@ export class OracleQueryRunner extends BaseQueryRunner implements QueryRunner {
                     }
                 }
 
-                upQueries.push(new Query(`ALTER TABLE "${table.name}" MODIFY "${oldColumn.name}" ${this.connection.driver.createFullType(newColumn)} ${defaultUp} ${nullableUp}`));
-                downQueries.push(new Query(`ALTER TABLE "${table.name}" MODIFY "${oldColumn.name}" ${this.connection.driver.createFullType(oldColumn)} ${defaultDown} ${nullableDown}`));
+                upQueries.push(new Query(`ALTER TABLE ${table.name}" MODIFY "${oldColumn.name}" ${this.connection.driver.createFullType(newColumn)} ${defaultUp} ${nullableUp}`));
+                downQueries.push(new Query(`ALTER TABLE ${table.name}" MODIFY "${oldColumn.name}" ${this.connection.driver.createFullType(oldColumn)} ${defaultDown} ${nullableDown}`));
             }
 
             if (newColumn.isPrimary !== oldColumn.isPrimary) {
@@ -672,8 +672,8 @@ export class OracleQueryRunner extends BaseQueryRunner implements QueryRunner {
                 if (primaryColumns.length > 0) {
                     const pkName = this.connection.namingStrategy.primaryKeyName(clonedTable.name, primaryColumns.map(column => column.name));
                     const columnNames = primaryColumns.map(column => `"${column.name}"`).join(", ");
-                    upQueries.push(new Query(`ALTER TABLE "${table.name}" DROP CONSTRAINT "${pkName}"`));
-                    downQueries.push(new Query(`ALTER TABLE "${table.name}" ADD CONSTRAINT "${pkName}" PRIMARY KEY (${columnNames})`));
+                    upQueries.push(new Query(`ALTER TABLE ${table.name}" DROP CONSTRAINT "${pkName}"`));
+                    downQueries.push(new Query(`ALTER TABLE ${table.name}" ADD CONSTRAINT "${pkName}" PRIMARY KEY (${columnNames})`));
                 }
 
                 if (newColumn.isPrimary === true) {
@@ -683,8 +683,8 @@ export class OracleQueryRunner extends BaseQueryRunner implements QueryRunner {
                     column!.isPrimary = true;
                     const pkName = this.connection.namingStrategy.primaryKeyName(clonedTable.name, primaryColumns.map(column => column.name));
                     const columnNames = primaryColumns.map(column => `"${column.name}"`).join(", ");
-                    upQueries.push(new Query(`ALTER TABLE "${table.name}" ADD CONSTRAINT "${pkName}" PRIMARY KEY (${columnNames})`));
-                    downQueries.push(new Query(`ALTER TABLE "${table.name}" DROP CONSTRAINT "${pkName}"`));
+                    upQueries.push(new Query(`ALTER TABLE ${table.name}" ADD CONSTRAINT "${pkName}" PRIMARY KEY (${columnNames})`));
+                    downQueries.push(new Query(`ALTER TABLE ${table.name}" DROP CONSTRAINT "${pkName}"`));
 
                 } else {
                     const primaryColumn = primaryColumns.find(c => c.name === newColumn.name);
@@ -698,8 +698,8 @@ export class OracleQueryRunner extends BaseQueryRunner implements QueryRunner {
                     if (primaryColumns.length > 0) {
                         const pkName = this.connection.namingStrategy.primaryKeyName(clonedTable.name, primaryColumns.map(column => column.name));
                         const columnNames = primaryColumns.map(column => `"${column.name}"`).join(", ");
-                        upQueries.push(new Query(`ALTER TABLE "${table.name}" ADD CONSTRAINT "${pkName}" PRIMARY KEY (${columnNames})`));
-                        downQueries.push(new Query(`ALTER TABLE "${table.name}" DROP CONSTRAINT "${pkName}"`));
+                        upQueries.push(new Query(`ALTER TABLE ${table.name}" ADD CONSTRAINT "${pkName}" PRIMARY KEY (${columnNames})`));
+                        downQueries.push(new Query(`ALTER TABLE ${table.name}" DROP CONSTRAINT "${pkName}"`));
                     }
                 }
             }
@@ -711,16 +711,16 @@ export class OracleQueryRunner extends BaseQueryRunner implements QueryRunner {
                         columnNames: [newColumn.name]
                     });
                     clonedTable.uniques.push(uniqueConstraint);
-                    upQueries.push(new Query(`ALTER TABLE "${table.name}" ADD CONSTRAINT "${uniqueConstraint.name}" UNIQUE ("${newColumn.name}")`));
-                    downQueries.push(new Query(`ALTER TABLE "${table.name}" DROP CONSTRAINT "${uniqueConstraint.name}"`));
+                    upQueries.push(new Query(`ALTER TABLE ${table.name}" ADD CONSTRAINT "${uniqueConstraint.name}" UNIQUE ("${newColumn.name}")`));
+                    downQueries.push(new Query(`ALTER TABLE ${table.name}" DROP CONSTRAINT "${uniqueConstraint.name}"`));
 
                 } else {
                     const uniqueConstraint = clonedTable.uniques.find(unique => {
                         return unique.columnNames.length === 1 && !!unique.columnNames.find(columnName => columnName === newColumn.name);
                     });
                     clonedTable.uniques.splice(clonedTable.uniques.indexOf(uniqueConstraint!), 1);
-                    upQueries.push(new Query(`ALTER TABLE "${table.name}" DROP CONSTRAINT "${uniqueConstraint!.name}"`));
-                    downQueries.push(new Query(`ALTER TABLE "${table.name}" ADD CONSTRAINT "${uniqueConstraint!.name}" UNIQUE ("${newColumn.name}")`));
+                    upQueries.push(new Query(`ALTER TABLE ${table.name}" DROP CONSTRAINT "${uniqueConstraint!.name}"`));
+                    downQueries.push(new Query(`ALTER TABLE ${table.name}" ADD CONSTRAINT "${uniqueConstraint!.name}" UNIQUE ("${newColumn.name}")`));
                 }
             }
 
@@ -753,8 +753,8 @@ export class OracleQueryRunner extends BaseQueryRunner implements QueryRunner {
         if (column.isPrimary) {
             const pkName = this.connection.namingStrategy.primaryKeyName(clonedTable.name, clonedTable.primaryColumns.map(column => column.name));
             const columnNames = clonedTable.primaryColumns.map(primaryColumn => `"${primaryColumn.name}"`).join(", ");
-            upQueries.push(new Query(`ALTER TABLE "${clonedTable.name}" DROP CONSTRAINT "${pkName}"`));
-            downQueries.push(new Query(`ALTER TABLE "${clonedTable.name}" ADD CONSTRAINT "${pkName}" PRIMARY KEY (${columnNames})`));
+            upQueries.push(new Query(`ALTER TABLE ${clonedTable.name}" DROP CONSTRAINT "${pkName}"`));
+            downQueries.push(new Query(`ALTER TABLE ${clonedTable.name}" ADD CONSTRAINT "${pkName}" PRIMARY KEY (${columnNames})`));
 
             // update column in table
             const tableColumn = clonedTable.findColumnByName(column.name);
@@ -764,8 +764,8 @@ export class OracleQueryRunner extends BaseQueryRunner implements QueryRunner {
             if (clonedTable.primaryColumns.length > 0) {
                 const pkName = this.connection.namingStrategy.primaryKeyName(clonedTable.name, clonedTable.primaryColumns.map(column => column.name));
                 const columnNames = clonedTable.primaryColumns.map(primaryColumn => `"${primaryColumn.name}"`).join(", ");
-                upQueries.push(new Query(`ALTER TABLE "${clonedTable.name}" ADD CONSTRAINT "${pkName}" PRIMARY KEY (${columnNames})`));
-                downQueries.push(new Query(`ALTER TABLE "${clonedTable.name}" DROP CONSTRAINT "${pkName}"`));
+                upQueries.push(new Query(`ALTER TABLE ${clonedTable.name}" ADD CONSTRAINT "${pkName}" PRIMARY KEY (${columnNames})`));
+                downQueries.push(new Query(`ALTER TABLE ${clonedTable.name}" DROP CONSTRAINT "${pkName}"`));
             }
         }
 
@@ -792,8 +792,8 @@ export class OracleQueryRunner extends BaseQueryRunner implements QueryRunner {
             downQueries.push(this.createUniqueConstraintSql(table, columnUnique));
         }
 
-        upQueries.push(new Query(`ALTER TABLE "${table.name}" DROP COLUMN "${column.name}"`));
-        downQueries.push(new Query(`ALTER TABLE "${table.name}" ADD ${this.buildCreateColumnSql(column)}`));
+        upQueries.push(new Query(`ALTER TABLE ${table.name}" DROP COLUMN "${column.name}"`));
+        downQueries.push(new Query(`ALTER TABLE ${table.name}" ADD ${this.buildCreateColumnSql(column)}`));
 
         await this.executeQueries(upQueries, downQueries);
 
@@ -843,8 +843,8 @@ export class OracleQueryRunner extends BaseQueryRunner implements QueryRunner {
         if (primaryColumns.length > 0) {
             const pkName = this.connection.namingStrategy.primaryKeyName(clonedTable.name, primaryColumns.map(column => column.name));
             const columnNamesString = primaryColumns.map(column => `"${column.name}"`).join(", ");
-            upQueries.push(new Query(`ALTER TABLE "${table.name}" DROP CONSTRAINT "${pkName}"`));
-            downQueries.push(new Query(`ALTER TABLE "${table.name}" ADD CONSTRAINT "${pkName}" PRIMARY KEY (${columnNamesString})`));
+            upQueries.push(new Query(`ALTER TABLE ${table.name}" DROP CONSTRAINT "${pkName}"`));
+            downQueries.push(new Query(`ALTER TABLE ${table.name}" ADD CONSTRAINT "${pkName}" PRIMARY KEY (${columnNamesString})`));
         }
 
         // update columns in table.
@@ -854,8 +854,8 @@ export class OracleQueryRunner extends BaseQueryRunner implements QueryRunner {
 
         const pkName = this.connection.namingStrategy.primaryKeyName(clonedTable.name, columnNames);
         const columnNamesString = columnNames.map(columnName => `"${columnName}"`).join(", ");
-        upQueries.push(new Query(`ALTER TABLE "${table.name}" ADD CONSTRAINT "${pkName}" PRIMARY KEY (${columnNamesString})`));
-        downQueries.push(new Query(`ALTER TABLE "${table.name}" DROP CONSTRAINT "${pkName}"`));
+        upQueries.push(new Query(`ALTER TABLE ${table.name}" ADD CONSTRAINT "${pkName}" PRIMARY KEY (${columnNamesString})`));
+        downQueries.push(new Query(`ALTER TABLE ${table.name}" DROP CONSTRAINT "${pkName}"`));
 
         await this.executeQueries(upQueries, downQueries);
         this.replaceCachedTable(table, clonedTable);
@@ -1380,7 +1380,7 @@ export class OracleQueryRunner extends BaseQueryRunner implements QueryRunner {
      */
     protected dropTableSql(tableOrName: Table|string, ifExist?: boolean): Query {
         const tableName = tableOrName instanceof Table ? tableOrName.name : tableOrName;
-        const query = ifExist ? `DROP TABLE IF EXISTS "${tableName}"` : `DROP TABLE "${tableName}"`;
+        const query = ifExist ? `DROP TABLE IF EXISTS ${tableName}` : `DROP TABLE ${tableName}`;
         return new Query(query);
     }
 
@@ -1409,7 +1409,7 @@ export class OracleQueryRunner extends BaseQueryRunner implements QueryRunner {
      */
     protected dropViewSql(viewOrPath: View|string): Query {
         const viewName = viewOrPath instanceof View ? viewOrPath.name : viewOrPath;
-        return new Query(`DROP VIEW "${viewName}"`);
+        return new Query(`DROP VIEW ${viewName}`);
     }
 
     /**
@@ -1449,7 +1449,7 @@ export class OracleQueryRunner extends BaseQueryRunner implements QueryRunner {
     protected createPrimaryKeySql(table: Table, columnNames: string[]): Query {
         const primaryKeyName = this.connection.namingStrategy.primaryKeyName(table.name, columnNames);
         const columnNamesString = columnNames.map(columnName => `"${columnName}"`).join(", ");
-        return new Query(`ALTER TABLE "${table.name}" ADD CONSTRAINT "${primaryKeyName}" PRIMARY KEY (${columnNamesString})`);
+        return new Query(`ALTER TABLE ${table.name} ADD CONSTRAINT "${primaryKeyName}" PRIMARY KEY (${columnNamesString})`);
     }
 
     /**
@@ -1458,7 +1458,7 @@ export class OracleQueryRunner extends BaseQueryRunner implements QueryRunner {
     protected dropPrimaryKeySql(table: Table): Query {
         const columnNames = table.primaryColumns.map(column => column.name);
         const primaryKeyName = this.connection.namingStrategy.primaryKeyName(table.name, columnNames);
-        return new Query(`ALTER TABLE "${table.name}" DROP CONSTRAINT "${primaryKeyName}"`);
+        return new Query(`ALTER TABLE ${table.name} DROP CONSTRAINT "${primaryKeyName}"`);
     }
 
     /**
@@ -1466,7 +1466,7 @@ export class OracleQueryRunner extends BaseQueryRunner implements QueryRunner {
      */
     protected createUniqueConstraintSql(table: Table, uniqueConstraint: TableUnique): Query {
         const columnNames = uniqueConstraint.columnNames.map(column => `"` + column + `"`).join(", ");
-        return new Query(`ALTER TABLE "${table.name}" ADD CONSTRAINT "${uniqueConstraint.name}" UNIQUE (${columnNames})`);
+        return new Query(`ALTER TABLE ${table.name} ADD CONSTRAINT "${uniqueConstraint.name}" UNIQUE (${columnNames})`);
     }
 
     /**
@@ -1474,14 +1474,14 @@ export class OracleQueryRunner extends BaseQueryRunner implements QueryRunner {
      */
     protected dropUniqueConstraintSql(table: Table, uniqueOrName: TableUnique|string): Query {
         const uniqueName = uniqueOrName instanceof TableUnique ? uniqueOrName.name : uniqueOrName;
-        return new Query(`ALTER TABLE "${table.name}" DROP CONSTRAINT "${uniqueName}"`);
+        return new Query(`ALTER TABLE ${table.name} DROP CONSTRAINT "${uniqueName}"`);
     }
 
     /**
      * Builds create check constraint sql.
      */
     protected createCheckConstraintSql(table: Table, checkConstraint: TableCheck): Query {
-        return new Query(`ALTER TABLE "${table.name}" ADD CONSTRAINT "${checkConstraint.name}" CHECK (${checkConstraint.expression})`);
+        return new Query(`ALTER TABLE ${table.name} ADD CONSTRAINT "${checkConstraint.name}" CHECK (${checkConstraint.expression})`);
     }
 
     /**
@@ -1489,7 +1489,7 @@ export class OracleQueryRunner extends BaseQueryRunner implements QueryRunner {
      */
     protected dropCheckConstraintSql(table: Table, checkOrName: TableCheck|string): Query {
         const checkName = checkOrName instanceof TableCheck ? checkOrName.name : checkOrName;
-        return new Query(`ALTER TABLE "${table.name}" DROP CONSTRAINT "${checkName}"`);
+        return new Query(`ALTER TABLE ${table.name} DROP CONSTRAINT "${checkName}"`);
     }
 
     /**
@@ -1498,7 +1498,7 @@ export class OracleQueryRunner extends BaseQueryRunner implements QueryRunner {
     protected createForeignKeySql(table: Table, foreignKey: TableForeignKey): Query {
         const columnNames = foreignKey.columnNames.map(column => `"` + column + `"`).join(", ");
         const referencedColumnNames = foreignKey.referencedColumnNames.map(column => `"` + column + `"`).join(",");
-        let sql = `ALTER TABLE "${table.name}" ADD CONSTRAINT "${foreignKey.name}" FOREIGN KEY (${columnNames}) ` +
+        let sql = `ALTER TABLE ${table.name} ADD CONSTRAINT "${foreignKey.name}" FOREIGN KEY (${columnNames}) ` +
             `REFERENCES "${foreignKey.referencedTableName}" (${referencedColumnNames})`;
         // Oracle does not support NO ACTION, but we set NO ACTION by default in EntityMetadata
         if (foreignKey.onDelete && foreignKey.onDelete !== "NO ACTION")
@@ -1512,7 +1512,7 @@ export class OracleQueryRunner extends BaseQueryRunner implements QueryRunner {
      */
     protected dropForeignKeySql(table: Table, foreignKeyOrName: TableForeignKey|string): Query {
         const foreignKeyName = foreignKeyOrName instanceof TableForeignKey ? foreignKeyOrName.name : foreignKeyOrName;
-        return new Query(`ALTER TABLE "${table.name}" DROP CONSTRAINT "${foreignKeyName}"`);
+        return new Query(`ALTER TABLE ${table.name} DROP CONSTRAINT "${foreignKeyName}"`);
     }
 
     /**

--- a/src/driver/oracle/OracleQueryRunner.ts
+++ b/src/driver/oracle/OracleQueryRunner.ts
@@ -671,7 +671,7 @@ export class OracleQueryRunner extends BaseQueryRunner implements QueryRunner {
                 // if primary column state changed, we must always drop existed constraint.
                 if (primaryColumns.length > 0) {
                     const pkName = this.connection.namingStrategy.primaryKeyName(clonedTable.name, primaryColumns.map(column => column.name));
-                    const columnNames = primaryColumns.map(column => `${column.name}`).join(", ");
+                    const columnNames = primaryColumns.map(column => `${column.name.toUpperCase()}`).join(", ");
                     upQueries.push(new Query(`ALTER TABLE ${table.name} DROP CONSTRAINT ${pkName}`));
                     downQueries.push(new Query(`ALTER TABLE ${table.name} ADD CONSTRAINT ${pkName} PRIMARY KEY (${columnNames})`));
                 }
@@ -681,7 +681,7 @@ export class OracleQueryRunner extends BaseQueryRunner implements QueryRunner {
                     // update column in table
                     const column = clonedTable.columns.find(column => column.name === newColumn.name);
                     column!.isPrimary = true;
-                    const pkName = this.connection.namingStrategy.primaryKeyName(clonedTable.name, primaryColumns.map(column => column.name));
+                    const pkName = this.connection.namingStrategy.primaryKeyName(clonedTable.name, primaryColumns.map(column => column.name.toUpperCase()));
                     const columnNames = primaryColumns.map(column => `${column.name}`).join(", ");
                     upQueries.push(new Query(`ALTER TABLE ${table.name} ADD CONSTRAINT ${pkName} PRIMARY KEY (${columnNames})`));
                     downQueries.push(new Query(`ALTER TABLE ${table.name} DROP CONSTRAINT ${pkName}`));
@@ -696,8 +696,8 @@ export class OracleQueryRunner extends BaseQueryRunner implements QueryRunner {
 
                     // if we have another primary keys, we must recreate constraint.
                     if (primaryColumns.length > 0) {
-                        const pkName = this.connection.namingStrategy.primaryKeyName(clonedTable.name, primaryColumns.map(column => column.name));
-                        const columnNames = primaryColumns.map(column => `${column.name}`).join(", ");
+                        const pkName = this.connection.namingStrategy.primaryKeyName(clonedTable.name, primaryColumns.map(column => column.name.toUpperCase()));
+                        const columnNames = primaryColumns.map(column => `${column.name.toUpperCase()}`).join(", ");
                         upQueries.push(new Query(`ALTER TABLE ${table.name} ADD CONSTRAINT ${pkName} PRIMARY KEY (${columnNames})`));
                         downQueries.push(new Query(`ALTER TABLE ${table.name} DROP CONSTRAINT ${pkName}`));
                     }
@@ -752,7 +752,7 @@ export class OracleQueryRunner extends BaseQueryRunner implements QueryRunner {
         // drop primary key constraint
         if (column.isPrimary) {
             const pkName = this.connection.namingStrategy.primaryKeyName(clonedTable.name, clonedTable.primaryColumns.map(column => column.name));
-            const columnNames = clonedTable.primaryColumns.map(primaryColumn => `${primaryColumn.name}`).join(", ");
+            const columnNames = clonedTable.primaryColumns.map(primaryColumn => `${primaryColumn.name.toUpperCase()}`).join(", ");
             upQueries.push(new Query(`ALTER TABLE ${clonedTable.name} DROP CONSTRAINT ${pkName}`));
             downQueries.push(new Query(`ALTER TABLE ${clonedTable.name} ADD CONSTRAINT ${pkName} PRIMARY KEY (${columnNames})`));
 
@@ -762,8 +762,8 @@ export class OracleQueryRunner extends BaseQueryRunner implements QueryRunner {
 
             // if primary key have multiple columns, we must recreate it without dropped column
             if (clonedTable.primaryColumns.length > 0) {
-                const pkName = this.connection.namingStrategy.primaryKeyName(clonedTable.name, clonedTable.primaryColumns.map(column => column.name));
-                const columnNames = clonedTable.primaryColumns.map(primaryColumn => `${primaryColumn.name}`).join(", ");
+                const pkName = this.connection.namingStrategy.primaryKeyName(clonedTable.name, clonedTable.primaryColumns.map(column => column.name.toUpperCase()));
+                const columnNames = clonedTable.primaryColumns.map(primaryColumn => `${primaryColumn.name.toUpperCase()}`).join(", ");
                 upQueries.push(new Query(`ALTER TABLE ${clonedTable.name} ADD CONSTRAINT ${pkName} PRIMARY KEY (${columnNames})`));
                 downQueries.push(new Query(`ALTER TABLE ${clonedTable.name} DROP CONSTRAINT ${pkName}`));
             }
@@ -833,7 +833,7 @@ export class OracleQueryRunner extends BaseQueryRunner implements QueryRunner {
      */
     async updatePrimaryKeys(tableOrName: Table|string, columns: TableColumn[]): Promise<void> {
         const table = tableOrName instanceof Table ? tableOrName : await this.getCachedTable(tableOrName);
-        const columnNames = columns.map(column => column.name);
+        const columnNames = columns.map(column => column.name.toUpperCase());
         const clonedTable = table.clone();
         const upQueries: Query[] = [];
         const downQueries: Query[] = [];
@@ -842,7 +842,7 @@ export class OracleQueryRunner extends BaseQueryRunner implements QueryRunner {
         const primaryColumns = clonedTable.primaryColumns;
         if (primaryColumns.length > 0) {
             const pkName = this.connection.namingStrategy.primaryKeyName(clonedTable.name, primaryColumns.map(column => column.name));
-            const columnNamesString = primaryColumns.map(column => `'${column.name}'`).join(", ");
+            const columnNamesString = primaryColumns.map(column => `'${column.name.toUpperCase()}'`).join(", ");
             upQueries.push(new Query(`ALTER TABLE ${table.name} DROP CONSTRAINT ${pkName}`));
             downQueries.push(new Query(`ALTER TABLE ${table.name} ADD CONSTRAINT ${pkName} PRIMARY KEY (${columnNamesString})`));
         }
@@ -1131,7 +1131,7 @@ export class OracleQueryRunner extends BaseQueryRunner implements QueryRunner {
         if (!hasTable)
             return Promise.resolve([]);
 
-        const viewNamesString = viewNames.map(name => `'${name}'`).join(", ");
+        const viewNamesString = viewNames.map(name => `'${name.toUpperCase()}'`).join(", ");
         let query = `SELECT T.* FROM ${this.getTypeormMetadataTableName()} T INNER JOIN USER_VIEWS V ON V.VIEW_NAME = T.name WHERE T.type = 'VIEW'`;
         if (viewNamesString.length > 0)
             query += ` AND T.name IN (${viewNamesString})`;
@@ -1154,7 +1154,7 @@ export class OracleQueryRunner extends BaseQueryRunner implements QueryRunner {
             return [];
 
         // load tables, columns, indices and foreign keys
-        const tableNamesString = tableNames.map(name => `'${name}'`).join(", ");
+        const tableNamesString = tableNames.map(name => `'${name.toUpperCase()}'`).join(", ");
         const tablesSql = `SELECT * FROM USER_TABLES WHERE TABLE_NAME IN (${tableNamesString})`;
         const columnsSql = `SELECT * FROM USER_TAB_COLS WHERE TABLE_NAME IN (${tableNamesString})`;
 
@@ -1314,7 +1314,7 @@ export class OracleQueryRunner extends BaseQueryRunner implements QueryRunner {
      * Builds and returns SQL for create table.
      */
     protected createTableSql(table: Table, createForeignKeys?: boolean): Query {
-        const columnDefinitions = table.columns.map(column => this.buildCreateColumnSql(column)).join(", ");
+        const columnDefinitions = table.columns.map(column => this.buildCreateColumnSql(column)).join(", ").toUpperCase();
         let sql = `CREATE TABLE ${table.name} (${columnDefinitions}`;
 
         table.columns
@@ -1331,7 +1331,7 @@ export class OracleQueryRunner extends BaseQueryRunner implements QueryRunner {
         if (table.uniques.length > 0) {
             const uniquesSql = table.uniques.map(unique => {
                 const uniqueName = unique.name ? unique.name : this.connection.namingStrategy.uniqueConstraintName(table.name, unique.columnNames);
-                const columnNames = unique.columnNames.map(columnName => `${columnName}`).join(", ");
+                const columnNames = unique.columnNames.map(columnName => `${columnName.toUpperCase()}`).join(", ");
                 return `CONSTRAINT ${uniqueName} UNIQUE (${columnNames})`;
             }).join(", ");
 
@@ -1349,10 +1349,10 @@ export class OracleQueryRunner extends BaseQueryRunner implements QueryRunner {
 
         if (table.foreignKeys.length > 0 && createForeignKeys) {
             const foreignKeysSql = table.foreignKeys.map(fk => {
-                const columnNames = fk.columnNames.map(columnName => `${columnName}`).join(", ");
+                const columnNames = fk.columnNames.map(columnName => `${columnName.toUpperCase()}`).join(", ");
                 if (!fk.name)
                     fk.name = this.connection.namingStrategy.foreignKeyName(table.name, fk.columnNames, fk.referencedTableName, fk.referencedColumnNames);
-                const referencedColumnNames = fk.referencedColumnNames.map(columnName => `${columnName}`).join(", ");
+                const referencedColumnNames = fk.referencedColumnNames.map(columnName => `${columnName.toUpperCase()}`).join(", ");
                 let constraint = `CONSTRAINT ${fk.name} FOREIGN KEY (${columnNames}) REFERENCES ${fk.referencedTableName} (${referencedColumnNames})`;
                 if (fk.onDelete && fk.onDelete !== "NO ACTION") // Oracle does not support NO ACTION, but we set NO ACTION by default in EntityMetadata
                     constraint += ` ON DELETE ${fk.onDelete}`;
@@ -1365,8 +1365,8 @@ export class OracleQueryRunner extends BaseQueryRunner implements QueryRunner {
 
         const primaryColumns = table.columns.filter(column => column.isPrimary);
         if (primaryColumns.length > 0) {
-            const primaryKeyName = this.connection.namingStrategy.primaryKeyName(table.name, primaryColumns.map(column => column.name));
-            const columnNames = primaryColumns.map(column => `${column.name}`).join(", ");
+            const primaryKeyName = this.connection.namingStrategy.primaryKeyName(table.name, primaryColumns.map(column => column.name.toUpperCase()));
+            const columnNames = primaryColumns.map(column => `${column.name.toUpperCase()}`).join(", ");
             sql += `, CONSTRAINT ${primaryKeyName} PRIMARY KEY (${columnNames})`;
         }
 
@@ -1380,7 +1380,7 @@ export class OracleQueryRunner extends BaseQueryRunner implements QueryRunner {
      */
     protected dropTableSql(tableOrName: Table|string, ifExist?: boolean): Query {
         const tableName = tableOrName instanceof Table ? tableOrName.name : tableOrName;
-        const query = ifExist ? `DROP TABLE IF EXISTS ${tableName}` : `DROP TABLE ${tableName}`;
+        const query = ifExist ? `DROP TABLE IF EXISTS ${tableName.toUpperCase()}` : `DROP TABLE ${tableName.toUpperCase()}`;
         return new Query(query);
     }
 
@@ -1431,7 +1431,7 @@ export class OracleQueryRunner extends BaseQueryRunner implements QueryRunner {
      * Builds create index sql.
      */
     protected createIndexSql(table: Table, index: TableIndex): Query {
-        const columns = index.columnNames.map(columnName => `${columnName}`).join(", ");
+        const columns = index.columnNames.map(columnName => `${columnName.toUpperCase()}`).join(", ");
         return new Query(`CREATE ${index.isUnique ? "UNIQUE " : ""}INDEX ${index.name} ON ${table.name} (${columns})`);
     }
 
@@ -1448,7 +1448,7 @@ export class OracleQueryRunner extends BaseQueryRunner implements QueryRunner {
      */
     protected createPrimaryKeySql(table: Table, columnNames: string[]): Query {
         const primaryKeyName = this.connection.namingStrategy.primaryKeyName(table.name, columnNames);
-        const columnNamesString = columnNames.map(columnName => `'${columnName}'`).join(", ");
+        const columnNamesString = columnNames.map(columnName => `'${columnName.toUpperCase()}'`).join(", ");
         return new Query(`ALTER TABLE ${table.name} ADD CONSTRAINT ${primaryKeyName} PRIMARY KEY (${columnNamesString})`);
     }
 
@@ -1456,7 +1456,7 @@ export class OracleQueryRunner extends BaseQueryRunner implements QueryRunner {
      * Builds drop primary key sql.
      */
     protected dropPrimaryKeySql(table: Table): Query {
-        const columnNames = table.primaryColumns.map(column => column.name);
+        const columnNames = table.primaryColumns.map(column => column.name.toUpperCase());
         const primaryKeyName = this.connection.namingStrategy.primaryKeyName(table.name, columnNames);
         return new Query(`ALTER TABLE ${table.name} DROP CONSTRAINT ${primaryKeyName}`);
     }
@@ -1496,7 +1496,7 @@ export class OracleQueryRunner extends BaseQueryRunner implements QueryRunner {
      * Builds create foreign key sql.
      */
     protected createForeignKeySql(table: Table, foreignKey: TableForeignKey): Query {
-        const columnNames = foreignKey.columnNames.map(column => `${column}`).join(", ");
+        const columnNames = foreignKey.columnNames.map(column => `${column.toUpperCase()}`).join(", ");
         const referencedColumnNames = foreignKey.referencedColumnNames.map(column => column).join(",");
         let sql = `ALTER TABLE ${table.name} ADD CONSTRAINT ${foreignKey.name} FOREIGN KEY (${columnNames}) ` +
             `REFERENCES ${foreignKey.referencedTableName} (${referencedColumnNames})`;

--- a/src/driver/oracle/OracleQueryRunner.ts
+++ b/src/driver/oracle/OracleQueryRunner.ts
@@ -1132,7 +1132,7 @@ export class OracleQueryRunner extends BaseQueryRunner implements QueryRunner {
             return Promise.resolve([]);
 
         const viewNamesString = viewNames.map(name => `'${name.toUpperCase()}'`).join(", ");
-        let query = `SELECT T.* FROM ${this.getTypeormMetadataTableName()} T INNER JOIN USER_VIEWS V ON V.VIEW_NAME = T.name WHERE T.type = 'VIEW'`;
+        let query = `SELECT T.* FROM ${this.getTypeormMetadataTableName().toUpperCase()} T INNER JOIN USER_VIEWS V ON V.VIEW_NAME = T.name WHERE T.type = 'VIEW'`;
         if (viewNamesString.length > 0)
             query += ` AND T.name IN (${viewNamesString})`;
         const dbViews = await this.query(query);

--- a/src/driver/oracle/OracleQueryRunner.ts
+++ b/src/driver/oracle/OracleQueryRunner.ts
@@ -842,7 +842,7 @@ export class OracleQueryRunner extends BaseQueryRunner implements QueryRunner {
         const primaryColumns = clonedTable.primaryColumns;
         if (primaryColumns.length > 0) {
             const pkName = this.connection.namingStrategy.primaryKeyName(clonedTable.name, primaryColumns.map(column => column.name));
-            const columnNamesString = primaryColumns.map(column => `${column.name}`).join(", ");
+            const columnNamesString = primaryColumns.map(column => `'${column.name}'`).join(", ");
             upQueries.push(new Query(`ALTER TABLE ${table.name} DROP CONSTRAINT ${pkName}`));
             downQueries.push(new Query(`ALTER TABLE ${table.name} ADD CONSTRAINT ${pkName} PRIMARY KEY (${columnNamesString})`));
         }
@@ -853,7 +853,7 @@ export class OracleQueryRunner extends BaseQueryRunner implements QueryRunner {
             .forEach(column => column.isPrimary = true);
 
         const pkName = this.connection.namingStrategy.primaryKeyName(clonedTable.name, columnNames);
-        const columnNamesString = columnNames.map(columnName => `${columnName}`).join(", ");
+        const columnNamesString = columnNames.map(columnName => `'${columnName}'`).join(", ");
         upQueries.push(new Query(`ALTER TABLE ${table.name} ADD CONSTRAINT ${pkName} PRIMARY KEY (${columnNamesString})`));
         downQueries.push(new Query(`ALTER TABLE ${table.name} DROP CONSTRAINT ${pkName}`));
 
@@ -1131,7 +1131,7 @@ export class OracleQueryRunner extends BaseQueryRunner implements QueryRunner {
         if (!hasTable)
             return Promise.resolve([]);
 
-        const viewNamesString = viewNames.map(name => "'" + name + "'").join(", ");
+        const viewNamesString = viewNames.map(name => `'${name}'`).join(", ");
         let query = `SELECT T.* FROM ${this.getTypeormMetadataTableName()} T INNER JOIN USER_VIEWS V ON V.VIEW_NAME = T.name WHERE T.type = 'VIEW'`;
         if (viewNamesString.length > 0)
             query += ` AND T.name IN (${viewNamesString})`;
@@ -1154,7 +1154,7 @@ export class OracleQueryRunner extends BaseQueryRunner implements QueryRunner {
             return [];
 
         // load tables, columns, indices and foreign keys
-        const tableNamesString = tableNames.map(name => name).join(", ");
+        const tableNamesString = tableNames.map(name => `'${name}'`).join(", ");
         const tablesSql = `SELECT * FROM USER_TABLES WHERE TABLE_NAME IN (${tableNamesString})`;
         const columnsSql = `SELECT * FROM USER_TAB_COLS WHERE TABLE_NAME IN (${tableNamesString})`;
 
@@ -1448,7 +1448,7 @@ export class OracleQueryRunner extends BaseQueryRunner implements QueryRunner {
      */
     protected createPrimaryKeySql(table: Table, columnNames: string[]): Query {
         const primaryKeyName = this.connection.namingStrategy.primaryKeyName(table.name, columnNames);
-        const columnNamesString = columnNames.map(columnName => `${columnName}`).join(", ");
+        const columnNamesString = columnNames.map(columnName => `'${columnName}'`).join(", ");
         return new Query(`ALTER TABLE ${table.name} ADD CONSTRAINT ${primaryKeyName} PRIMARY KEY (${columnNamesString})`);
     }
 
@@ -1465,7 +1465,7 @@ export class OracleQueryRunner extends BaseQueryRunner implements QueryRunner {
      * Builds create unique constraint sql.
      */
     protected createUniqueConstraintSql(table: Table, uniqueConstraint: TableUnique): Query {
-        const columnNames = uniqueConstraint.columnNames.map(column => column).join(", ");
+        const columnNames = uniqueConstraint.columnNames.map(column => `'${column}'`).join(", ");
         return new Query(`ALTER TABLE ${table.name} ADD CONSTRAINT ${uniqueConstraint.name} UNIQUE (${columnNames})`);
     }
 
@@ -1496,7 +1496,7 @@ export class OracleQueryRunner extends BaseQueryRunner implements QueryRunner {
      * Builds create foreign key sql.
      */
     protected createForeignKeySql(table: Table, foreignKey: TableForeignKey): Query {
-        const columnNames = foreignKey.columnNames.map(column => column).join(", ");
+        const columnNames = foreignKey.columnNames.map(column => `'${column}'`).join(", ");
         const referencedColumnNames = foreignKey.referencedColumnNames.map(column => column).join(",");
         let sql = `ALTER TABLE ${table.name} ADD CONSTRAINT ${foreignKey.name} FOREIGN KEY (${columnNames}) ` +
             `REFERENCES ${foreignKey.referencedTableName} (${referencedColumnNames})`;

--- a/src/driver/oracle/OracleQueryRunner.ts
+++ b/src/driver/oracle/OracleQueryRunner.ts
@@ -386,8 +386,8 @@ export class OracleQueryRunner extends BaseQueryRunner implements QueryRunner {
         }
 
         // rename table
-        upQueries.push(new Query(`ALTER TABLE ${oldTable.name}" RENAME TO "${newTable.name}"`));
-        downQueries.push(new Query(`ALTER TABLE ${newTable.name}" RENAME TO "${oldTable.name}"`));
+        upQueries.push(new Query(`ALTER TABLE ${oldTable.name} RENAME TO "${newTable.name}"`));
+        downQueries.push(new Query(`ALTER TABLE ${newTable.name} RENAME TO "${oldTable.name}"`));
 
         // rename primary key constraint
         if (newTable.primaryColumns.length > 0) {
@@ -397,8 +397,8 @@ export class OracleQueryRunner extends BaseQueryRunner implements QueryRunner {
             const newPkName = this.connection.namingStrategy.primaryKeyName(newTable, columnNames);
 
             // build queries
-            upQueries.push(new Query(`ALTER TABLE ${newTable.name}" RENAME CONSTRAINT "${oldPkName}" TO "${newPkName}"`));
-            downQueries.push(new Query(`ALTER TABLE ${newTable.name}" RENAME CONSTRAINT "${newPkName}" TO "${oldPkName}"`));
+            upQueries.push(new Query(`ALTER TABLE ${newTable.name} RENAME CONSTRAINT "${oldPkName}" TO "${newPkName}"`));
+            downQueries.push(new Query(`ALTER TABLE ${newTable.name} RENAME CONSTRAINT "${newPkName}" TO "${oldPkName}"`));
         }
 
         // rename unique constraints
@@ -407,8 +407,8 @@ export class OracleQueryRunner extends BaseQueryRunner implements QueryRunner {
             const newUniqueName = this.connection.namingStrategy.uniqueConstraintName(newTable, unique.columnNames);
 
             // build queries
-            upQueries.push(new Query(`ALTER TABLE ${newTable.name}" RENAME CONSTRAINT "${unique.name}" TO "${newUniqueName}"`));
-            downQueries.push(new Query(`ALTER TABLE ${newTable.name}" RENAME CONSTRAINT "${newUniqueName}" TO "${unique.name}"`));
+            upQueries.push(new Query(`ALTER TABLE ${newTable.name} RENAME CONSTRAINT "${unique.name}" TO "${newUniqueName}"`));
+            downQueries.push(new Query(`ALTER TABLE ${newTable.name} RENAME CONSTRAINT "${newUniqueName}" TO "${unique.name}"`));
 
             // replace constraint name
             unique.name = newUniqueName;

--- a/src/driver/oracle/OracleQueryRunner.ts
+++ b/src/driver/oracle/OracleQueryRunner.ts
@@ -1315,7 +1315,7 @@ export class OracleQueryRunner extends BaseQueryRunner implements QueryRunner {
      */
     protected createTableSql(table: Table, createForeignKeys?: boolean): Query {
         const columnDefinitions = table.columns.map(column => this.buildCreateColumnSql(column)).join(", ");
-        let sql = `CREATE TABLE "${table.name}" (${columnDefinitions}`;
+        let sql = `CREATE TABLE ${table.name} (${columnDefinitions}`;
 
         table.columns
             .filter(column => column.isUnique)

--- a/src/driver/oracle/OracleQueryRunner.ts
+++ b/src/driver/oracle/OracleQueryRunner.ts
@@ -1497,7 +1497,7 @@ export class OracleQueryRunner extends BaseQueryRunner implements QueryRunner {
      */
     protected createForeignKeySql(table: Table, foreignKey: TableForeignKey): Query {
         const columnNames = foreignKey.columnNames.map(column => `${column.toUpperCase()}`).join(", ");
-        const referencedColumnNames = foreignKey.referencedColumnNames.map(column => column).join(",");
+        const referencedColumnNames = foreignKey.referencedColumnNames.map(column => column.toUpperCase()).join(",");
         let sql = `ALTER TABLE ${table.name} ADD CONSTRAINT ${foreignKey.name} FOREIGN KEY (${columnNames}) ` +
             `REFERENCES ${foreignKey.referencedTableName} (${referencedColumnNames})`;
         // Oracle does not support NO ACTION, but we set NO ACTION by default in EntityMetadata
@@ -1511,7 +1511,7 @@ export class OracleQueryRunner extends BaseQueryRunner implements QueryRunner {
      * Builds drop foreign key sql.
      */
     protected dropForeignKeySql(table: Table, foreignKeyOrName: TableForeignKey|string): Query {
-        const foreignKeyName = foreignKeyOrName instanceof TableForeignKey ? foreignKeyOrName.name : foreignKeyOrName;
+        const foreignKeyName = foreignKeyOrName instanceof TableForeignKey ? foreignKeyOrName.name?.toUpperCase() : foreignKeyOrName.toUpperCase();
         return new Query(`ALTER TABLE ${table.name} DROP CONSTRAINT ${foreignKeyName}`);
     }
 
@@ -1519,7 +1519,7 @@ export class OracleQueryRunner extends BaseQueryRunner implements QueryRunner {
      * Builds a query for create column.
      */
     protected buildCreateColumnSql(column: TableColumn) {
-        let c = `${column.name} ` + this.connection.driver.createFullType(column);
+        let c = `${column.name} ` + this.connection.driver.createFullType(column).toUpperCase();
         if (column.charset)
             c += " CHARACTER SET " + column.charset;
         if (column.collation)

--- a/src/driver/oracle/OracleQueryRunner.ts
+++ b/src/driver/oracle/OracleQueryRunner.ts
@@ -1511,7 +1511,7 @@ export class OracleQueryRunner extends BaseQueryRunner implements QueryRunner {
      * Builds drop foreign key sql.
      */
     protected dropForeignKeySql(table: Table, foreignKeyOrName: TableForeignKey|string): Query {
-        const foreignKeyName = foreignKeyOrName instanceof TableForeignKey ? foreignKeyOrName.name?.toUpperCase() : foreignKeyOrName.toUpperCase();
+        const foreignKeyName = foreignKeyOrName instanceof TableForeignKey ? foreignKeyOrName.name : foreignKeyOrName;
         return new Query(`ALTER TABLE ${table.name} DROP CONSTRAINT ${foreignKeyName}`);
     }
 

--- a/src/driver/oracle/OracleQueryRunner.ts
+++ b/src/driver/oracle/OracleQueryRunner.ts
@@ -231,7 +231,7 @@ export class OracleQueryRunner extends BaseQueryRunner implements QueryRunner {
      */
     async hasTable(tableOrName: Table|string): Promise<boolean> {
         const tableName = tableOrName instanceof Table ? tableOrName.name : tableOrName;
-        const sql = `SELECT TABLE_NAME FROM USER_TABLES WHERE TABLE_NAME = '${tableName}'`;
+        const sql = `SELECT TABLE_NAME FROM USER_TABLES WHERE TABLE_NAME = '${tableName.toUpperCase()}'`;
         const result = await this.query(sql);
         return result.length ? true : false;
     }

--- a/src/driver/oracle/OracleQueryRunner.ts
+++ b/src/driver/oracle/OracleQueryRunner.ts
@@ -1104,11 +1104,11 @@ export class OracleQueryRunner extends BaseQueryRunner implements QueryRunner {
     async clearDatabase(): Promise<void> {
         await this.startTransaction();
         try {
-            const dropViewsQuery = `SELECT 'DROP VIEW ' || VIEW_NAME || ' AS query FROM USER_VIEWS`;
+            const dropViewsQuery = `SELECT 'DROP VIEW "' || VIEW_NAME || '"' AS "query" FROM "USER_VIEWS"`;
             const dropViewQueries: ObjectLiteral[] = await this.query(dropViewsQuery);
             await Promise.all(dropViewQueries.map(query => this.query(query["query"])));
 
-            const dropTablesQuery = `SELECT 'DROP TABLE ' || TABLE_NAME || ' CASCADE CONSTRAINTS' AS query FROM USER_TABLES`;
+            const dropTablesQuery = `SELECT 'DROP TABLE "' || TABLE_NAME || '" CASCADE CONSTRAINTS' AS "query" FROM "USER_TABLES"`;
             const dropTableQueries: ObjectLiteral[] = await this.query(dropTablesQuery);
             await Promise.all(dropTableQueries.map(query => this.query(query["query"])));
             await this.commitTransaction();

--- a/src/driver/oracle/OracleQueryRunner.ts
+++ b/src/driver/oracle/OracleQueryRunner.ts
@@ -241,7 +241,7 @@ export class OracleQueryRunner extends BaseQueryRunner implements QueryRunner {
      */
     async hasColumn(tableOrName: Table|string, columnName: string): Promise<boolean> {
         const tableName = tableOrName instanceof Table ? tableOrName.name : tableOrName;
-        const sql = `SELECT COLUMN_NAME FROM USER_TAB_COLS WHERE TABLE_NAME = '${tableName}' AND COLUMN_NAME = '${columnName}'`;
+        const sql = `SELECT COLUMN_NAME FROM USER_TAB_COLS WHERE TABLE_NAME = '${tableName.toUpperCase()}' AND COLUMN_NAME = '${columnName.toUpperCase()}'`;
         const result = await this.query(sql);
         return result.length ? true : false;
     }

--- a/src/driver/types/ColumnTypes.ts
+++ b/src/driver/types/ColumnTypes.ts
@@ -48,7 +48,8 @@ export type WithPrecisionColumnType = "float" // mysql, mssql, oracle, sqlite
     |"timestamp" // mysql, postgres, mssql, oracle, cockroachdb
     |"timestamp without time zone" // postgres, cockroachdb
     |"timestamp with time zone" // postgres, oracle, cockroachdb
-    |"timestamp with local time zone"; // oracle
+    |"timestamp with local time zone" // oracle
+    |"sysdate"; //oracle
 
 /**
  * Column types where column length is used.

--- a/src/metadata-args/TableMetadataArgs.ts
+++ b/src/metadata-args/TableMetadataArgs.ts
@@ -61,9 +61,16 @@ export interface TableMetadataArgs {
      */
     materialized?: boolean;
 
-     /**
+    /**
      * If set to 'true' this option disables Sqlite's default behaviour of secretly creating
-     * an integer primary key column named 'rowid' on table creation. 
+     * an integer primary key column named 'rowid' on table creation.
      */
-    withoutRowid?: boolean;   
+    withoutRowid?: boolean;
+
+    /**
+     * If set to `true`, the name of the table will NOT be changed in anyway. This is
+     * to counteract the truncation of the table by underscore delimiter and leaving a
+     * malformed table name when the full name is to remain as-is.
+     */
+    exact?: boolean;
 }

--- a/src/metadata/EntityMetadata.ts
+++ b/src/metadata/EntityMetadata.ts
@@ -786,7 +786,7 @@ export class EntityMetadata {
             this.schema = (this.connection.options as PostgresConnectionOptions|SqlServerConnectionOptions).schema;
         }
         this.givenTableName = this.tableMetadataArgs.type === "entity-child" && this.parentEntityMetadata ? this.parentEntityMetadata.givenTableName : this.tableMetadataArgs.name;
-        this.synchronize = this.tableMetadataArgs.synchronize === false ? false : true;
+        this.synchronize = this.tableMetadataArgs.synchronize !== false;
         this.targetName = this.tableMetadataArgs.target instanceof Function ? (this.tableMetadataArgs.target as any).name : this.tableMetadataArgs.target;
         if (this.tableMetadataArgs.type === "closure-junction") {
             this.tableNameWithoutPrefix = namingStrategy.closureJunctionTableName(this.givenTableName!);
@@ -795,7 +795,7 @@ export class EntityMetadata {
         } else {
             this.tableNameWithoutPrefix = namingStrategy.tableName(this.targetName, this.givenTableName);
 
-            if (this.connection.driver.maxAliasLength && this.connection.driver.maxAliasLength > 0 && this.tableNameWithoutPrefix.length > this.connection.driver.maxAliasLength) {
+            if (!this.tableMetadataArgs.exact && (this.connection.driver.maxAliasLength && this.connection.driver.maxAliasLength > 0 && this.tableNameWithoutPrefix.length > this.connection.driver.maxAliasLength)) {
                 this.tableNameWithoutPrefix = shorten(this.tableNameWithoutPrefix, { separator: "_", segmentLength: 3 });
             }
         }
@@ -803,7 +803,7 @@ export class EntityMetadata {
         this.target = this.target ? this.target : this.tableName;
         this.name = this.targetName ? this.targetName : this.tableName;
         this.expression = this.tableMetadataArgs.expression;
-        this.withoutRowid = this.tableMetadataArgs.withoutRowid === true ? true : false;
+        this.withoutRowid = this.tableMetadataArgs.withoutRowid === true;
         this.tablePath = this.buildTablePath();
         this.schemaPath = this.buildSchemaPath();
         this.orderBy = (this.tableMetadataArgs.orderBy instanceof Function) ? this.tableMetadataArgs.orderBy(this.propertiesMap) : this.tableMetadataArgs.orderBy; // todo: is propertiesMap available here? Looks like its not

--- a/src/query-builder/QueryBuilder.ts
+++ b/src/query-builder/QueryBuilder.ts
@@ -506,13 +506,17 @@ export abstract class QueryBuilder<Entity> {
      * schema name, otherwise returns escaped table name.
      */
     protected getTableName(tablePath: string): string {
-        return tablePath.split(".")
-            .map(i => {
-                // this condition need because in SQL Server driver when custom database name was specified and schema name was not, we got `dbName..tableName` string, and doesn't need to escape middle empty string
-                if (i === "")
-                    return i;
-                return this.escape(i);
-            }).join(".");
+        if(this.connection.driver instanceof OracleDriver) {
+            return tablePath;
+        } else {
+            return tablePath.split(".")
+                .map(i => {
+                    // this condition need because in SQL Server driver when custom database name was specified and schema name was not, we got `dbName..tableName` string, and doesn't need to escape middle empty string
+                    if (i === "")
+                        return i;
+                    return this.escape(i);
+                }).join(".");
+        }
     }
 
     /**


### PR DESCRIPTION
The way the table name is made up in typeorm isn't always right. It can cause the table name to be escaped and truncated (based on underscores) and the inclusion of quotes around the table name means pipelined queries cannot be easily run. With this change, ther

A new option on @Entity decorator exists called `exact` and the purpose of this is to ensure that the name of the table does not get modified in anyway and is used as it. This aids where you need to call a function (within a package) pipelined but the length is greater than 30 characters.

Tests to follow