### PR TITLE
Update select-query-builder.md

### DIFF
--- a/docs/select-query-builder.md
+++ b/docs/select-query-builder.md
@@ -342,7 +342,7 @@ createQueryBuilder("user")
 Which will produce the following SQL query:
 
 ```sql
-SELECT ... FROM users user WHERE user.firstName IN (1, 2, 3, 4)
+SELECT ... FROM users user WHERE user.id IN (1, 2, 3, 4)
 ```
 
 


### PR DESCRIPTION
Found a typo on the "**Adding WHERE expression**" section: ```user.firstName``` is used in one of the SQL snippets, but you were previously referring to ```user.id``` for that example.