### PR TITLE
bugfix: sql.js v1.2+ don't support undefined parameters

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9149,9 +9149,9 @@
       "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw="
     },
     "sql.js": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/sql.js/-/sql.js-1.0.0.tgz",
-      "integrity": "sha512-fl/cQu8hDbu9bXNXTrmwwtS2wvHttWrXS9fzINVtedOBOJJWMjwSADR1aQ+DKmCdGNF4jrg/15AedJ5kcrWRJA==",
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/sql.js/-/sql.js-1.3.0.tgz",
+      "integrity": "sha512-bxrJ/9rqJ2SA6hpHnSodRjKBugZHewRvNTITTt74W1VZWmzODjdS68yQW0/J9oC0NWKylHEtV1ptkoTyOYO4Tw==",
       "dev": true
     },
     "sqlite3": {

--- a/package.json
+++ b/package.json
@@ -97,7 +97,7 @@
     "sinon": "^7.2.5",
     "sinon-chai": "^3.3.0",
     "source-map-support": "^0.5.10",
-    "sql.js": "^1.0.0",
+    "sql.js": "^1.3.0",
     "sqlite3": "^4.0.9",
     "ts-node": "^8.0.2",
     "typeorm-aurora-data-api-driver": "^1.3.0",

--- a/src/driver/sqljs/SqljsQueryRunner.ts
+++ b/src/driver/sqljs/SqljsQueryRunner.ts
@@ -53,6 +53,8 @@ export class SqljsQueryRunner extends AbstractSqliteQueryRunner {
             try {
                 statement = databaseConnection.prepare(query);
                 if (parameters) {
+                    parameters = parameters.map(p => typeof p !== 'undefined' ? p : null);
+
                     statement.bind(parameters);
                 }
                 


### PR DESCRIPTION
before sql.js 1.2 it seems undefined were treated as if they were null,
but as of 1.2 they cause a query error & fail to execute

this change swaps out any undefined parameters with `null`s

closes #5720