### PR TITLE
techdebt: create EntityTarget and use instead of EntitySchema / ObjectType / etc

### DIFF
--- a/src/common/EntityTarget.ts
+++ b/src/common/EntityTarget.ts
@@ -1,0 +1,11 @@
+import {ObjectType} from "./ObjectType";
+import {EntitySchema} from "..";
+
+/**
+ * Entity target.
+ */
+export type EntityTarget<Entity> =
+    | ObjectType<Entity>
+    | EntitySchema<Entity>
+    | string
+    | { type: Entity, name: string };

--- a/src/connection/Connection.ts
+++ b/src/connection/Connection.ts
@@ -1,6 +1,7 @@
 import {Driver} from "../driver/Driver";
 import {Repository} from "../repository/Repository";
 import {EntitySubscriberInterface} from "../subscriber/EntitySubscriberInterface";
+import {EntityTarget} from "../common/EntityTarget";
 import {ObjectType} from "../common/ObjectType";
 import {EntityManager} from "../entity-manager/EntityManager";
 import {DefaultNamingStrategy} from "../naming-strategy/DefaultNamingStrategy";
@@ -320,14 +321,14 @@ export class Connection {
     /**
      * Checks if entity metadata exist for the given entity class, target name or table name.
      */
-    hasMetadata(target: Function|EntitySchema<any>|string): boolean {
+    hasMetadata(target: EntityTarget<any>): boolean {
         return !!this.findMetadata(target);
     }
 
     /**
      * Gets entity metadata for the given entity class or schema name.
      */
-    getMetadata(target: Function|EntitySchema<any>|string): EntityMetadata {
+    getMetadata(target: EntityTarget<any>): EntityMetadata {
         const metadata = this.findMetadata(target);
         if (!metadata)
             throw new EntityMetadataNotFoundError(target);
@@ -338,7 +339,7 @@ export class Connection {
     /**
      * Gets repository for the given entity.
      */
-    getRepository<Entity>(target: ObjectType<Entity>|EntitySchema<Entity>|string): Repository<Entity> {
+    getRepository<Entity>(target: EntityTarget<Entity>): Repository<Entity> {
         return this.manager.getRepository(target);
     }
 
@@ -346,7 +347,7 @@ export class Connection {
      * Gets tree repository for the given entity class or name.
      * Only tree-type entities can have a TreeRepository, like ones decorated with @Tree decorator.
      */
-    getTreeRepository<Entity>(target: ObjectType<Entity>|EntitySchema<Entity>|string): TreeRepository<Entity> {
+    getTreeRepository<Entity>(target: EntityTarget<Entity>): TreeRepository<Entity> {
         return this.manager.getTreeRepository(target);
     }
 
@@ -354,7 +355,7 @@ export class Connection {
      * Gets mongodb-specific repository for the given entity class or name.
      * Works only if connection is mongodb-specific.
      */
-    getMongoRepository<Entity>(target: ObjectType<Entity>|EntitySchema<Entity>|string): MongoRepository<Entity> {
+    getMongoRepository<Entity>(target: EntityTarget<Entity>): MongoRepository<Entity> {
         if (!(this.driver instanceof MongoDriver))
             throw new Error(`You can use getMongoRepository only for MongoDB connections.`);
 
@@ -408,7 +409,7 @@ export class Connection {
     /**
      * Creates a new query builder that can be used to build a sql query.
      */
-    createQueryBuilder<Entity>(entityClass: ObjectType<Entity>|EntitySchema<Entity>|Function|string, alias: string, queryRunner?: QueryRunner): SelectQueryBuilder<Entity>;
+    createQueryBuilder<Entity>(entityClass: EntityTarget<Entity>, alias: string, queryRunner?: QueryRunner): SelectQueryBuilder<Entity>;
 
     /**
      * Creates a new query builder that can be used to build a sql query.
@@ -418,12 +419,12 @@ export class Connection {
     /**
      * Creates a new query builder that can be used to build a sql query.
      */
-    createQueryBuilder<Entity>(entityOrRunner?: ObjectType<Entity>|EntitySchema<Entity>|Function|string|QueryRunner, alias?: string, queryRunner?: QueryRunner): SelectQueryBuilder<Entity> {
+    createQueryBuilder<Entity>(entityOrRunner?: EntityTarget<Entity>|QueryRunner, alias?: string, queryRunner?: QueryRunner): SelectQueryBuilder<Entity> {
         if (this instanceof MongoEntityManager)
             throw new Error(`Query Builder is not supported by MongoDB.`);
 
         if (alias) {
-            const metadata = this.getMetadata(entityOrRunner as Function|EntitySchema<Entity>|string);
+            const metadata = this.getMetadata(entityOrRunner as EntityTarget<Entity>);
             return new SelectQueryBuilder(this, queryRunner)
                 .select(alias)
                 .from(metadata.target, alias);
@@ -453,7 +454,7 @@ export class Connection {
     /**
      * Gets entity metadata of the junction table (many-to-many table).
      */
-    getManyToManyMetadata(entityTarget: Function|string, relationPropertyPath: string) {
+    getManyToManyMetadata(entityTarget: EntityTarget<any>, relationPropertyPath: string) {
         const relationMetadata = this.getMetadata(entityTarget).findRelationWithPropertyPath(relationPropertyPath);
         if (!relationMetadata)
             throw new Error(`Relation "${relationPropertyPath}" was not found in ${entityTarget} entity.`);
@@ -478,7 +479,7 @@ export class Connection {
     /**
      * Finds exist entity metadata by the given entity class, target name or table name.
      */
-    protected findMetadata(target: Function|EntitySchema<any>|string): EntityMetadata|undefined {
+    protected findMetadata(target: EntityTarget<any>): EntityMetadata|undefined {
         return this.entityMetadatas.find(metadata => {
             if (metadata.target === target)
                 return true;

--- a/src/entity-manager/MongoEntityManager.ts
+++ b/src/entity-manager/MongoEntityManager.ts
@@ -1,6 +1,6 @@
 import { Connection } from "../connection/Connection";
 import { EntityManager } from "./EntityManager";
-import { ObjectType } from "../common/ObjectType";
+import { EntityTarget } from "../common/EntityTarget";
 import {
     AggregationCursor,
     BulkWriteOpResultObject,
@@ -51,7 +51,7 @@ import { InsertResult } from "../query-builder/result/InsertResult";
 import { UpdateResult } from "../query-builder/result/UpdateResult";
 import { DeleteResult } from "../query-builder/result/DeleteResult";
 import { EntityMetadata } from "../metadata/EntityMetadata";
-import { EntitySchema, FindConditions } from "../index";
+import { FindConditions } from "../index";
 import { BroadcasterResult } from "../subscriber/BroadcasterResult";
 
 /**
@@ -88,7 +88,7 @@ export class MongoEntityManager extends EntityManager {
     /**
      * Finds entities that match given find options or conditions.
      */
-    async find<Entity>(entityClassOrName: ObjectType<Entity> | EntitySchema<Entity> | string, optionsOrConditions?: FindManyOptions<Entity> | Partial<Entity>): Promise<Entity[]> {
+    async find<Entity>(entityClassOrName: EntityTarget<Entity>, optionsOrConditions?: FindManyOptions<Entity> | Partial<Entity>): Promise<Entity[]> {
         const query = this.convertFindManyOptionsOrConditionsToMongodbQuery(optionsOrConditions);
         const cursor = await this.createEntityCursor(entityClassOrName, query);
         if (FindOptionsUtils.isFindManyOptions(optionsOrConditions)) {
@@ -109,7 +109,7 @@ export class MongoEntityManager extends EntityManager {
      * Also counts all entities that match given conditions,
      * but ignores pagination settings (from and take options).
      */
-    async findAndCount<Entity>(entityClassOrName: ObjectType<Entity> | EntitySchema<Entity> | string, optionsOrConditions?: FindManyOptions<Entity> | Partial<Entity>): Promise<[Entity[], number]> {
+    async findAndCount<Entity>(entityClassOrName: EntityTarget<Entity>, optionsOrConditions?: FindManyOptions<Entity> | Partial<Entity>): Promise<[Entity[], number]> {
         const query = this.convertFindManyOptionsOrConditionsToMongodbQuery(optionsOrConditions);
         const cursor = await this.createEntityCursor(entityClassOrName, query);
         if (FindOptionsUtils.isFindManyOptions(optionsOrConditions)) {
@@ -134,7 +134,7 @@ export class MongoEntityManager extends EntityManager {
      * Finds entities by ids.
      * Optionally find options can be applied.
      */
-    async findByIds<Entity>(entityClassOrName: ObjectType<Entity> | EntitySchema<Entity> | string, ids: any[], optionsOrConditions?: FindManyOptions<Entity> | Partial<Entity>): Promise<Entity[]> {
+    async findByIds<Entity>(entityClassOrName: EntityTarget<Entity>, ids: any[], optionsOrConditions?: FindManyOptions<Entity> | Partial<Entity>): Promise<Entity[]> {
         const metadata = this.connection.getMetadata(entityClassOrName);
         const query = this.convertFindManyOptionsOrConditionsToMongodbQuery(optionsOrConditions) || {};
         const objectIdInstance = PlatformTools.load("mongodb").ObjectID;
@@ -164,7 +164,7 @@ export class MongoEntityManager extends EntityManager {
     /**
      * Finds first entity that matches given conditions and/or find options.
      */
-    async findOne<Entity>(entityClassOrName: ObjectType<Entity> | EntitySchema<Entity> | string,
+    async findOne<Entity>(entityClassOrName: EntityTarget<Entity>,
                           optionsOrConditions?: string | string[] | number | number[] | Date | Date[] | ObjectID | ObjectID[] | FindOneOptions<Entity> | DeepPartial<Entity>,
                           maybeOptions?: FindOneOptions<Entity>): Promise<Entity | undefined> {
         const objectIdInstance = PlatformTools.load("mongodb").ObjectID;
@@ -194,7 +194,7 @@ export class MongoEntityManager extends EntityManager {
      * Does not check if entity exist in the database, so query will fail if duplicate entity is being inserted.
      * You can execute bulk inserts using this method.
      */
-    async insert<Entity>(target: ObjectType<Entity> | EntitySchema<Entity> | string, entity: QueryDeepPartialEntity<Entity> | QueryDeepPartialEntity<Entity>[]): Promise<InsertResult> {
+    async insert<Entity>(target: EntityTarget<Entity>, entity: QueryDeepPartialEntity<Entity> | QueryDeepPartialEntity<Entity>[]): Promise<InsertResult> {
         // todo: convert entity to its database name
         const result = new InsertResult();
         if (Array.isArray(entity)) {
@@ -220,7 +220,7 @@ export class MongoEntityManager extends EntityManager {
      * Executes fast and efficient UPDATE query.
      * Does not check if entity exist in the database.
      */
-    async update<Entity>(target: ObjectType<Entity> | EntitySchema<Entity> | string, criteria: string | string[] | number | number[] | Date | Date[] | ObjectID | ObjectID[] | FindConditions<Entity>, partialEntity: QueryDeepPartialEntity<Entity>): Promise<UpdateResult> {
+    async update<Entity>(target: EntityTarget<Entity>, criteria: string | string[] | number | number[] | Date | Date[] | ObjectID | ObjectID[] | FindConditions<Entity>, partialEntity: QueryDeepPartialEntity<Entity>): Promise<UpdateResult> {
         if (Array.isArray(criteria)) {
             await Promise.all((criteria as any[]).map(criteriaItem => {
                 return this.update(target, criteriaItem, partialEntity);
@@ -240,7 +240,7 @@ export class MongoEntityManager extends EntityManager {
      * Executes fast and efficient DELETE query.
      * Does not check if entity exist in the database.
      */
-    async delete<Entity>(target: ObjectType<Entity> | EntitySchema<Entity> | string, criteria: string | string[] | number | number[] | Date | Date[] | ObjectID | ObjectID[] | FindConditions<Entity>): Promise<DeleteResult> {
+    async delete<Entity>(target: EntityTarget<Entity>, criteria: string | string[] | number | number[] | Date | Date[] | ObjectID | ObjectID[] | FindConditions<Entity>): Promise<DeleteResult> {
         if (Array.isArray(criteria)) {
             await Promise.all((criteria as any[]).map(criteriaItem => {
                 return this.delete(target, criteriaItem);
@@ -260,7 +260,7 @@ export class MongoEntityManager extends EntityManager {
     /**
      * Creates a cursor for a query that can be used to iterate over results from MongoDB.
      */
-    createCursor<Entity, T = any>(entityClassOrName: ObjectType<Entity> | EntitySchema<Entity> | string, query?: ObjectLiteral): Cursor<T> {
+    createCursor<Entity, T = any>(entityClassOrName: EntityTarget<Entity>, query?: ObjectLiteral): Cursor<T> {
         const metadata = this.connection.getMetadata(entityClassOrName);
         return this.queryRunner.cursor(metadata.tableName, query);
     }
@@ -269,7 +269,7 @@ export class MongoEntityManager extends EntityManager {
      * Creates a cursor for a query that can be used to iterate over results from MongoDB.
      * This returns modified version of cursor that transforms each result into Entity model.
      */
-    createEntityCursor<Entity>(entityClassOrName: ObjectType<Entity> | EntitySchema<Entity> | string, query?: ObjectLiteral): Cursor<Entity> {
+    createEntityCursor<Entity>(entityClassOrName: EntityTarget<Entity>, query?: ObjectLiteral): Cursor<Entity> {
         const metadata = this.connection.getMetadata(entityClassOrName);
         const cursor = this.createCursor(entityClassOrName, query);
         this.applyEntityTransformationToCursor(metadata, cursor);
@@ -279,7 +279,7 @@ export class MongoEntityManager extends EntityManager {
     /**
      * Execute an aggregation framework pipeline against the collection.
      */
-    aggregate<Entity, R = any>(entityClassOrName: ObjectType<Entity> | EntitySchema<Entity> | string, pipeline: ObjectLiteral[], options?: CollectionAggregationOptions): AggregationCursor<R> {
+    aggregate<Entity, R = any>(entityClassOrName: EntityTarget<Entity>, pipeline: ObjectLiteral[], options?: CollectionAggregationOptions): AggregationCursor<R> {
         const metadata = this.connection.getMetadata(entityClassOrName);
         return this.queryRunner.aggregate(metadata.tableName, pipeline, options);
     }
@@ -288,7 +288,7 @@ export class MongoEntityManager extends EntityManager {
      * Execute an aggregation framework pipeline against the collection.
      * This returns modified version of cursor that transforms each result into Entity model.
      */
-    aggregateEntity<Entity>(entityClassOrName: ObjectType<Entity> | EntitySchema<Entity> | string, pipeline: ObjectLiteral[], options?: CollectionAggregationOptions): AggregationCursor<Entity> {
+    aggregateEntity<Entity>(entityClassOrName: EntityTarget<Entity>, pipeline: ObjectLiteral[], options?: CollectionAggregationOptions): AggregationCursor<Entity> {
         const metadata = this.connection.getMetadata(entityClassOrName);
         const cursor = this.queryRunner.aggregate(metadata.tableName, pipeline, options);
         this.applyEntityTransformationToCursor(metadata, cursor);
@@ -298,7 +298,7 @@ export class MongoEntityManager extends EntityManager {
     /**
      * Perform a bulkWrite operation without a fluent API.
      */
-    bulkWrite<Entity>(entityClassOrName: ObjectType<Entity> | EntitySchema<Entity> | string, operations: ObjectLiteral[], options?: CollectionBulkWriteOptions): Promise<BulkWriteOpResultObject> {
+    bulkWrite<Entity>(entityClassOrName: EntityTarget<Entity>, operations: ObjectLiteral[], options?: CollectionBulkWriteOptions): Promise<BulkWriteOpResultObject> {
         const metadata = this.connection.getMetadata(entityClassOrName);
         return this.queryRunner.bulkWrite(metadata.tableName, operations, options);
     }
@@ -306,7 +306,7 @@ export class MongoEntityManager extends EntityManager {
     /**
      * Count number of matching documents in the db to a query.
      */
-    count<Entity>(entityClassOrName: ObjectType<Entity> | EntitySchema<Entity> | string, query?: ObjectLiteral, options?: MongoCountPreferences): Promise<number> {
+    count<Entity>(entityClassOrName: EntityTarget<Entity>, query?: ObjectLiteral, options?: MongoCountPreferences): Promise<number> {
         const metadata = this.connection.getMetadata(entityClassOrName);
         return this.queryRunner.count(metadata.tableName, query, options);
     }
@@ -314,7 +314,7 @@ export class MongoEntityManager extends EntityManager {
     /**
      * Creates an index on the db and collection.
      */
-    createCollectionIndex<Entity>(entityClassOrName: ObjectType<Entity> | EntitySchema<Entity> | string, fieldOrSpec: string | any, options?: MongodbIndexOptions): Promise<string> {
+    createCollectionIndex<Entity>(entityClassOrName: EntityTarget<Entity>, fieldOrSpec: string | any, options?: MongodbIndexOptions): Promise<string> {
         const metadata = this.connection.getMetadata(entityClassOrName);
         return this.queryRunner.createCollectionIndex(metadata.tableName, fieldOrSpec, options);
     }
@@ -324,7 +324,7 @@ export class MongoEntityManager extends EntityManager {
      * Earlier version of MongoDB will throw a command not supported error.
      * Index specifications are defined at http://docs.mongodb.org/manual/reference/command/createIndexes/.
      */
-    createCollectionIndexes<Entity>(entityClassOrName: ObjectType<Entity> | EntitySchema<Entity> | string, indexSpecs: ObjectLiteral[]): Promise<void> {
+    createCollectionIndexes<Entity>(entityClassOrName: EntityTarget<Entity>, indexSpecs: ObjectLiteral[]): Promise<void> {
         const metadata = this.connection.getMetadata(entityClassOrName);
         return this.queryRunner.createCollectionIndexes(metadata.tableName, indexSpecs);
     }
@@ -332,7 +332,7 @@ export class MongoEntityManager extends EntityManager {
     /**
      * Delete multiple documents on MongoDB.
      */
-    deleteMany<Entity>(entityClassOrName: ObjectType<Entity> | EntitySchema<Entity> | string, query: ObjectLiteral, options?: CollectionOptions): Promise<DeleteWriteOpResultObject> {
+    deleteMany<Entity>(entityClassOrName: EntityTarget<Entity>, query: ObjectLiteral, options?: CollectionOptions): Promise<DeleteWriteOpResultObject> {
         const metadata = this.connection.getMetadata(entityClassOrName);
         return this.queryRunner.deleteMany(metadata.tableName, query, options);
     }
@@ -340,7 +340,7 @@ export class MongoEntityManager extends EntityManager {
     /**
      * Delete a document on MongoDB.
      */
-    deleteOne<Entity>(entityClassOrName: ObjectType<Entity> | EntitySchema<Entity> | string, query: ObjectLiteral, options?: CollectionOptions): Promise<DeleteWriteOpResultObject> {
+    deleteOne<Entity>(entityClassOrName: EntityTarget<Entity>, query: ObjectLiteral, options?: CollectionOptions): Promise<DeleteWriteOpResultObject> {
         const metadata = this.connection.getMetadata(entityClassOrName);
         return this.queryRunner.deleteOne(metadata.tableName, query, options);
     }
@@ -348,7 +348,7 @@ export class MongoEntityManager extends EntityManager {
     /**
      * The distinct command returns returns a list of distinct values for the given key across a collection.
      */
-    distinct<Entity>(entityClassOrName: ObjectType<Entity> | EntitySchema<Entity> | string, key: string, query: ObjectLiteral, options?: { readPreference?: ReadPreference | string }): Promise<any> {
+    distinct<Entity>(entityClassOrName: EntityTarget<Entity>, key: string, query: ObjectLiteral, options?: { readPreference?: ReadPreference | string }): Promise<any> {
         const metadata = this.connection.getMetadata(entityClassOrName);
         return this.queryRunner.distinct(metadata.tableName, key, query, options);
     }
@@ -356,7 +356,7 @@ export class MongoEntityManager extends EntityManager {
     /**
      * Drops an index from this collection.
      */
-    dropCollectionIndex<Entity>(entityClassOrName: ObjectType<Entity> | EntitySchema<Entity> | string, indexName: string, options?: CollectionOptions): Promise<any> {
+    dropCollectionIndex<Entity>(entityClassOrName: EntityTarget<Entity>, indexName: string, options?: CollectionOptions): Promise<any> {
         const metadata = this.connection.getMetadata(entityClassOrName);
         return this.queryRunner.dropCollectionIndex(metadata.tableName, indexName, options);
     }
@@ -364,7 +364,7 @@ export class MongoEntityManager extends EntityManager {
     /**
      * Drops all indexes from the collection.
      */
-    dropCollectionIndexes<Entity>(entityClassOrName: ObjectType<Entity> | EntitySchema<Entity> | string): Promise<any> {
+    dropCollectionIndexes<Entity>(entityClassOrName: EntityTarget<Entity>): Promise<any> {
         const metadata = this.connection.getMetadata(entityClassOrName);
         return this.queryRunner.dropCollectionIndexes(metadata.tableName);
     }
@@ -372,7 +372,7 @@ export class MongoEntityManager extends EntityManager {
     /**
      * Find a document and delete it in one atomic operation, requires a write lock for the duration of the operation.
      */
-    findOneAndDelete<Entity>(entityClassOrName: ObjectType<Entity> | EntitySchema<Entity> | string, query: ObjectLiteral, options?: { projection?: Object, sort?: Object, maxTimeMS?: number }): Promise<FindAndModifyWriteOpResultObject> {
+    findOneAndDelete<Entity>(entityClassOrName: EntityTarget<Entity>, query: ObjectLiteral, options?: { projection?: Object, sort?: Object, maxTimeMS?: number }): Promise<FindAndModifyWriteOpResultObject> {
         const metadata = this.connection.getMetadata(entityClassOrName);
         return this.queryRunner.findOneAndDelete(metadata.tableName, query, options);
     }
@@ -380,7 +380,7 @@ export class MongoEntityManager extends EntityManager {
     /**
      * Find a document and replace it in one atomic operation, requires a write lock for the duration of the operation.
      */
-    findOneAndReplace<Entity>(entityClassOrName: ObjectType<Entity> | EntitySchema<Entity> | string, query: ObjectLiteral, replacement: Object, options?: FindOneAndReplaceOption): Promise<FindAndModifyWriteOpResultObject> {
+    findOneAndReplace<Entity>(entityClassOrName: EntityTarget<Entity>, query: ObjectLiteral, replacement: Object, options?: FindOneAndReplaceOption): Promise<FindAndModifyWriteOpResultObject> {
         const metadata = this.connection.getMetadata(entityClassOrName);
         return this.queryRunner.findOneAndReplace(metadata.tableName, query, replacement, options);
     }
@@ -388,7 +388,7 @@ export class MongoEntityManager extends EntityManager {
     /**
      * Find a document and update it in one atomic operation, requires a write lock for the duration of the operation.
      */
-    findOneAndUpdate<Entity>(entityClassOrName: ObjectType<Entity> | EntitySchema<Entity> | string, query: ObjectLiteral, update: Object, options?: FindOneAndReplaceOption): Promise<FindAndModifyWriteOpResultObject> {
+    findOneAndUpdate<Entity>(entityClassOrName: EntityTarget<Entity>, query: ObjectLiteral, update: Object, options?: FindOneAndReplaceOption): Promise<FindAndModifyWriteOpResultObject> {
         const metadata = this.connection.getMetadata(entityClassOrName);
         return this.queryRunner.findOneAndUpdate(metadata.tableName, query, update, options);
     }
@@ -396,7 +396,7 @@ export class MongoEntityManager extends EntityManager {
     /**
      * Execute a geo search using a geo haystack index on a collection.
      */
-    geoHaystackSearch<Entity>(entityClassOrName: ObjectType<Entity> | EntitySchema<Entity> | string, x: number, y: number, options?: GeoHaystackSearchOptions): Promise<any> {
+    geoHaystackSearch<Entity>(entityClassOrName: EntityTarget<Entity>, x: number, y: number, options?: GeoHaystackSearchOptions): Promise<any> {
         const metadata = this.connection.getMetadata(entityClassOrName);
         return this.queryRunner.geoHaystackSearch(metadata.tableName, x, y, options);
     }
@@ -404,7 +404,7 @@ export class MongoEntityManager extends EntityManager {
     /**
      * Execute the geoNear command to search for items in the collection.
      */
-    geoNear<Entity>(entityClassOrName: ObjectType<Entity> | EntitySchema<Entity> | string, x: number, y: number, options?: GeoNearOptions): Promise<any> {
+    geoNear<Entity>(entityClassOrName: EntityTarget<Entity>, x: number, y: number, options?: GeoNearOptions): Promise<any> {
         const metadata = this.connection.getMetadata(entityClassOrName);
         return this.queryRunner.geoNear(metadata.tableName, x, y, options);
     }
@@ -412,7 +412,7 @@ export class MongoEntityManager extends EntityManager {
     /**
      * Run a group command across a collection.
      */
-    group<Entity>(entityClassOrName: ObjectType<Entity> | EntitySchema<Entity> | string, keys: Object | Array<any> | Function | Code, condition: Object, initial: Object, reduce: Function | Code, finalize: Function | Code, command: boolean, options?: { readPreference?: ReadPreference | string }): Promise<any> {
+    group<Entity>(entityClassOrName: EntityTarget<Entity>, keys: Object | Array<any> | Function | Code, condition: Object, initial: Object, reduce: Function | Code, finalize: Function | Code, command: boolean, options?: { readPreference?: ReadPreference | string }): Promise<any> {
         const metadata = this.connection.getMetadata(entityClassOrName);
         return this.queryRunner.group(metadata.tableName, keys, condition, initial, reduce, finalize, command, options);
     }
@@ -420,7 +420,7 @@ export class MongoEntityManager extends EntityManager {
     /**
      * Retrieve all the indexes on the collection.
      */
-    collectionIndexes<Entity>(entityClassOrName: ObjectType<Entity> | EntitySchema<Entity> | string): Promise<any> {
+    collectionIndexes<Entity>(entityClassOrName: EntityTarget<Entity>): Promise<any> {
         const metadata = this.connection.getMetadata(entityClassOrName);
         return this.queryRunner.collectionIndexes(metadata.tableName);
     }
@@ -428,7 +428,7 @@ export class MongoEntityManager extends EntityManager {
     /**
      * Retrieve all the indexes on the collection.
      */
-    collectionIndexExists<Entity>(entityClassOrName: ObjectType<Entity> | EntitySchema<Entity> | string, indexes: string | string[]): Promise<boolean> {
+    collectionIndexExists<Entity>(entityClassOrName: EntityTarget<Entity>, indexes: string | string[]): Promise<boolean> {
         const metadata = this.connection.getMetadata(entityClassOrName);
         return this.queryRunner.collectionIndexExists(metadata.tableName, indexes);
     }
@@ -436,7 +436,7 @@ export class MongoEntityManager extends EntityManager {
     /**
      * Retrieves this collections index info.
      */
-    collectionIndexInformation<Entity>(entityClassOrName: ObjectType<Entity> | EntitySchema<Entity> | string, options?: { full: boolean }): Promise<any> {
+    collectionIndexInformation<Entity>(entityClassOrName: EntityTarget<Entity>, options?: { full: boolean }): Promise<any> {
         const metadata = this.connection.getMetadata(entityClassOrName);
         return this.queryRunner.collectionIndexInformation(metadata.tableName, options);
     }
@@ -444,7 +444,7 @@ export class MongoEntityManager extends EntityManager {
     /**
      * Initiate an In order bulk write operation, operations will be serially executed in the order they are added, creating a new operation for each switch in types.
      */
-    initializeOrderedBulkOp<Entity>(entityClassOrName: ObjectType<Entity> | EntitySchema<Entity> | string, options?: CollectionOptions): OrderedBulkOperation {
+    initializeOrderedBulkOp<Entity>(entityClassOrName: EntityTarget<Entity>, options?: CollectionOptions): OrderedBulkOperation {
         const metadata = this.connection.getMetadata(entityClassOrName);
         return this.queryRunner.initializeOrderedBulkOp(metadata.tableName, options);
     }
@@ -452,7 +452,7 @@ export class MongoEntityManager extends EntityManager {
     /**
      * Initiate a Out of order batch write operation. All operations will be buffered into insert/update/remove commands executed out of order.
      */
-    initializeUnorderedBulkOp<Entity>(entityClassOrName: ObjectType<Entity> | EntitySchema<Entity> | string, options?: CollectionOptions): UnorderedBulkOperation {
+    initializeUnorderedBulkOp<Entity>(entityClassOrName: EntityTarget<Entity>, options?: CollectionOptions): UnorderedBulkOperation {
         const metadata = this.connection.getMetadata(entityClassOrName);
         return this.queryRunner.initializeUnorderedBulkOp(metadata.tableName, options);
     }
@@ -460,7 +460,7 @@ export class MongoEntityManager extends EntityManager {
     /**
      * Inserts an array of documents into MongoDB.
      */
-    insertMany<Entity>(entityClassOrName: ObjectType<Entity> | EntitySchema<Entity> | string, docs: ObjectLiteral[], options?: CollectionInsertManyOptions): Promise<InsertWriteOpResult> {
+    insertMany<Entity>(entityClassOrName: EntityTarget<Entity>, docs: ObjectLiteral[], options?: CollectionInsertManyOptions): Promise<InsertWriteOpResult> {
         const metadata = this.connection.getMetadata(entityClassOrName);
         return this.queryRunner.insertMany(metadata.tableName, docs, options);
     }
@@ -468,7 +468,7 @@ export class MongoEntityManager extends EntityManager {
     /**
      * Inserts a single document into MongoDB.
      */
-    insertOne<Entity>(entityClassOrName: ObjectType<Entity> | EntitySchema<Entity> | string, doc: ObjectLiteral, options?: CollectionInsertOneOptions): Promise<InsertOneWriteOpResult> {
+    insertOne<Entity>(entityClassOrName: EntityTarget<Entity>, doc: ObjectLiteral, options?: CollectionInsertOneOptions): Promise<InsertOneWriteOpResult> {
         const metadata = this.connection.getMetadata(entityClassOrName);
         return this.queryRunner.insertOne(metadata.tableName, doc, options);
     }
@@ -476,7 +476,7 @@ export class MongoEntityManager extends EntityManager {
     /**
      * Returns if the collection is a capped collection.
      */
-    isCapped<Entity>(entityClassOrName: ObjectType<Entity> | EntitySchema<Entity> | string): Promise<any> {
+    isCapped<Entity>(entityClassOrName: EntityTarget<Entity>): Promise<any> {
         const metadata = this.connection.getMetadata(entityClassOrName);
         return this.queryRunner.isCapped(metadata.tableName);
     }
@@ -484,7 +484,7 @@ export class MongoEntityManager extends EntityManager {
     /**
      * Get the list of all indexes information for the collection.
      */
-    listCollectionIndexes<Entity>(entityClassOrName: ObjectType<Entity> | EntitySchema<Entity> | string, options?: { batchSize?: number, readPreference?: ReadPreference | string }): CommandCursor {
+    listCollectionIndexes<Entity>(entityClassOrName: EntityTarget<Entity>, options?: { batchSize?: number, readPreference?: ReadPreference | string }): CommandCursor {
         const metadata = this.connection.getMetadata(entityClassOrName);
         return this.queryRunner.listCollectionIndexes(metadata.tableName, options);
     }
@@ -492,7 +492,7 @@ export class MongoEntityManager extends EntityManager {
     /**
      * Run Map Reduce across a collection. Be aware that the inline option for out will return an array of results not a collection.
      */
-    mapReduce<Entity>(entityClassOrName: ObjectType<Entity> | EntitySchema<Entity> | string, map: Function | string, reduce: Function | string, options?: MapReduceOptions): Promise<any> {
+    mapReduce<Entity>(entityClassOrName: EntityTarget<Entity>, map: Function | string, reduce: Function | string, options?: MapReduceOptions): Promise<any> {
         const metadata = this.connection.getMetadata(entityClassOrName);
         return this.queryRunner.mapReduce(metadata.tableName, map, reduce, options);
     }
@@ -501,7 +501,7 @@ export class MongoEntityManager extends EntityManager {
      * Return N number of parallel cursors for a collection allowing parallel reading of entire collection.
      * There are no ordering guarantees for returned results.
      */
-    parallelCollectionScan<Entity>(entityClassOrName: ObjectType<Entity> | EntitySchema<Entity> | string, options?: ParallelCollectionScanOptions): Promise<Cursor<Entity>[]> {
+    parallelCollectionScan<Entity>(entityClassOrName: EntityTarget<Entity>, options?: ParallelCollectionScanOptions): Promise<Cursor<Entity>[]> {
         const metadata = this.connection.getMetadata(entityClassOrName);
         return this.queryRunner.parallelCollectionScan(metadata.tableName, options);
     }
@@ -509,7 +509,7 @@ export class MongoEntityManager extends EntityManager {
     /**
      * Reindex all indexes on the collection Warning: reIndex is a blocking operation (indexes are rebuilt in the foreground) and will be slow for large collections.
      */
-    reIndex<Entity>(entityClassOrName: ObjectType<Entity> | EntitySchema<Entity> | string): Promise<any> {
+    reIndex<Entity>(entityClassOrName: EntityTarget<Entity>): Promise<any> {
         const metadata = this.connection.getMetadata(entityClassOrName);
         return this.queryRunner.reIndex(metadata.tableName);
     }
@@ -517,7 +517,7 @@ export class MongoEntityManager extends EntityManager {
     /**
      * Reindex all indexes on the collection Warning: reIndex is a blocking operation (indexes are rebuilt in the foreground) and will be slow for large collections.
      */
-    rename<Entity>(entityClassOrName: ObjectType<Entity> | EntitySchema<Entity> | string, newName: string, options?: { dropTarget?: boolean }): Promise<Collection<any>> {
+    rename<Entity>(entityClassOrName: EntityTarget<Entity>, newName: string, options?: { dropTarget?: boolean }): Promise<Collection<any>> {
         const metadata = this.connection.getMetadata(entityClassOrName);
         return this.queryRunner.rename(metadata.tableName, newName, options);
     }
@@ -525,7 +525,7 @@ export class MongoEntityManager extends EntityManager {
     /**
      * Replace a document on MongoDB.
      */
-    replaceOne<Entity>(entityClassOrName: ObjectType<Entity> | EntitySchema<Entity> | string, query: ObjectLiteral, doc: ObjectLiteral, options?: ReplaceOneOptions): Promise<UpdateWriteOpResult> {
+    replaceOne<Entity>(entityClassOrName: EntityTarget<Entity>, query: ObjectLiteral, doc: ObjectLiteral, options?: ReplaceOneOptions): Promise<UpdateWriteOpResult> {
         const metadata = this.connection.getMetadata(entityClassOrName);
         return this.queryRunner.replaceOne(metadata.tableName, query, doc, options);
     }
@@ -533,12 +533,12 @@ export class MongoEntityManager extends EntityManager {
     /**
      * Get all the collection statistics.
      */
-    stats<Entity>(entityClassOrName: ObjectType<Entity> | EntitySchema<Entity> | string, options?: { scale: number }): Promise<CollStats> {
+    stats<Entity>(entityClassOrName: EntityTarget<Entity>, options?: { scale: number }): Promise<CollStats> {
         const metadata = this.connection.getMetadata(entityClassOrName);
         return this.queryRunner.stats(metadata.tableName, options);
     }
 
-    watch<Entity>(entityClassOrName: ObjectType<Entity> | EntitySchema<Entity> | string, pipeline?: Object[], options?: ChangeStreamOptions): ChangeStream {
+    watch<Entity>(entityClassOrName: EntityTarget<Entity>, pipeline?: Object[], options?: ChangeStreamOptions): ChangeStream {
         const metadata = this.connection.getMetadata(entityClassOrName);
         return this.queryRunner.watch(metadata.tableName, pipeline, options);
     }
@@ -546,7 +546,7 @@ export class MongoEntityManager extends EntityManager {
     /**
      * Update multiple documents on MongoDB.
      */
-    updateMany<Entity>(entityClassOrName: ObjectType<Entity> | EntitySchema<Entity> | string, query: ObjectLiteral, update: ObjectLiteral, options?: { upsert?: boolean, w?: any, wtimeout?: number, j?: boolean }): Promise<UpdateWriteOpResult> {
+    updateMany<Entity>(entityClassOrName: EntityTarget<Entity>, query: ObjectLiteral, update: ObjectLiteral, options?: { upsert?: boolean, w?: any, wtimeout?: number, j?: boolean }): Promise<UpdateWriteOpResult> {
         const metadata = this.connection.getMetadata(entityClassOrName);
         return this.queryRunner.updateMany(metadata.tableName, query, update, options);
     }
@@ -554,7 +554,7 @@ export class MongoEntityManager extends EntityManager {
     /**
      * Update a single document on MongoDB.
      */
-    updateOne<Entity>(entityClassOrName: ObjectType<Entity> | EntitySchema<Entity> | string, query: ObjectLiteral, update: ObjectLiteral, options?: ReplaceOneOptions): Promise<UpdateWriteOpResult> {
+    updateOne<Entity>(entityClassOrName: EntityTarget<Entity>, query: ObjectLiteral, update: ObjectLiteral, options?: ReplaceOneOptions): Promise<UpdateWriteOpResult> {
         const metadata = this.connection.getMetadata(entityClassOrName);
         return this.queryRunner.updateOne(metadata.tableName, query, update, options);
     }

--- a/src/error/EntityMetadataNotFoundError.ts
+++ b/src/error/EntityMetadataNotFoundError.ts
@@ -1,3 +1,4 @@
+import {EntityTarget} from "../common/EntityTarget";
 import {EntitySchema} from "../index";
 
 /**
@@ -5,13 +6,15 @@ import {EntitySchema} from "../index";
 export class EntityMetadataNotFoundError extends Error {
     name = "EntityMetadataNotFound";
 
-    constructor(target: Function|EntitySchema<any>|string) {
+    constructor(target: EntityTarget<any>) {
         super();
         Object.setPrototypeOf(this, EntityMetadataNotFoundError.prototype);
         let targetName: string;
         if (target instanceof EntitySchema) {
             targetName = target.options.name;
         } else if (typeof target === "function") {
+            targetName = target.name;
+        } else if (typeof target === "object" && "name" in target) {
             targetName = target.name;
         } else {
             targetName = target;

--- a/src/error/EntityNotFoundError.ts
+++ b/src/error/EntityNotFoundError.ts
@@ -1,4 +1,4 @@
-import {ObjectType} from "../common/ObjectType";
+import {EntityTarget} from "../common/EntityTarget";
 import {EntitySchema} from "../index";
 
 /**
@@ -7,13 +7,15 @@ import {EntitySchema} from "../index";
 export class EntityNotFoundError extends Error {
     name = "EntityNotFound";
 
-    constructor(entityClass: ObjectType<any>|EntitySchema<any>|string, criteria: any) {
+    constructor(entityClass: EntityTarget<any>, criteria: any) {
         super();
         Object.setPrototypeOf(this, EntityNotFoundError.prototype);
         let targetName: string;
         if (entityClass instanceof EntitySchema) {
             targetName = entityClass.options.name;
         } else if (typeof entityClass === "function") {
+            targetName = entityClass.name;
+        } else if (typeof entityClass === "object" && "name" in entityClass) {
             targetName = entityClass.name;
         } else {
             targetName = entityClass;

--- a/src/error/RepositoryNotFoundError.ts
+++ b/src/error/RepositoryNotFoundError.ts
@@ -1,3 +1,4 @@
+import {EntityTarget} from "../common/EntityTarget";
 import {EntitySchema} from "../index";
 
 /**
@@ -6,13 +7,15 @@ import {EntitySchema} from "../index";
 export class RepositoryNotFoundError extends Error {
     name = "RepositoryNotFoundError";
 
-    constructor(connectionName: string, entityClass: Function|EntitySchema<any>|string) {
+    constructor(connectionName: string, entityClass: EntityTarget<any>) {
         super();
         Object.setPrototypeOf(this, RepositoryNotFoundError.prototype);
         let targetName: string;
         if (entityClass instanceof EntitySchema) {
             targetName = entityClass.options.name;
         } else if (typeof entityClass === "function") {
+            targetName = entityClass.name;
+        } else if (typeof entityClass === "object" && "name" in entityClass) {
             targetName = entityClass.name;
         } else {
             targetName = entityClass;

--- a/src/error/RepositoryNotTreeError.ts
+++ b/src/error/RepositoryNotTreeError.ts
@@ -1,3 +1,4 @@
+import {EntityTarget} from "../common/EntityTarget";
 import {EntitySchema} from "../index";
 
 /**
@@ -6,16 +7,18 @@ import {EntitySchema} from "../index";
 export class RepositoryNotTreeError extends Error {
     name = "RepositoryNotTreeError";
 
-    constructor(target: Function|EntitySchema<any>|string) {
+    constructor(entityClass: EntityTarget<any>) {
         super();
         Object.setPrototypeOf(this, RepositoryNotTreeError.prototype);
         let targetName: string;
-        if (target instanceof EntitySchema) {
-            targetName = target.options.name;
-        } else if (typeof target === "function") {
-            targetName = target.name;
+        if (entityClass instanceof EntitySchema) {
+            targetName = entityClass.options.name;
+        } else if (typeof entityClass === "function") {
+            targetName = entityClass.name;
+        } else if (typeof entityClass === "object" && "name" in entityClass) {
+            targetName = entityClass.name;
         } else {
-            targetName = target;
+            targetName = entityClass;
         }
         this.message = `Repository of the "${targetName}" class is not a TreeRepository. Try to apply @Tree decorator on your entity.`;
     }

--- a/src/index.ts
+++ b/src/index.ts
@@ -17,13 +17,14 @@ import {PromiseUtils} from "./util/PromiseUtils";
 import {MongoEntityManager} from "./entity-manager/MongoEntityManager";
 import {SqljsEntityManager} from "./entity-manager/SqljsEntityManager";
 import {SelectQueryBuilder} from "./query-builder/SelectQueryBuilder";
-import {EntitySchema} from "./entity-schema/EntitySchema";
+import {EntityTarget} from "./common/EntityTarget";
 
 // -------------------------------------------------------------------------
 // Commonly Used exports
 // -------------------------------------------------------------------------
 
 export * from "./container";
+export * from "./common/EntityTarget";
 export * from "./common/ObjectType";
 export * from "./common/ObjectLiteral";
 export * from "./common/DeepPartial";
@@ -283,14 +284,14 @@ export function getSqljsManager(connectionName: string = "default"): SqljsEntity
 /**
  * Gets repository for the given entity class.
  */
-export function getRepository<Entity>(entityClass: ObjectType<Entity>|EntitySchema<Entity>|string, connectionName: string = "default"): Repository<Entity> {
+export function getRepository<Entity>(entityClass: EntityTarget<Entity>, connectionName: string = "default"): Repository<Entity> {
     return getConnectionManager().get(connectionName).getRepository<Entity>(entityClass);
 }
 
 /**
  * Gets tree repository for the given entity class.
  */
-export function getTreeRepository<Entity>(entityClass: ObjectType<Entity>|string, connectionName: string = "default"): TreeRepository<Entity> {
+export function getTreeRepository<Entity>(entityClass: EntityTarget<Entity>, connectionName: string = "default"): TreeRepository<Entity> {
     return getConnectionManager().get(connectionName).getTreeRepository<Entity>(entityClass);
 }
 
@@ -304,14 +305,14 @@ export function getCustomRepository<T>(customRepository: ObjectType<T>, connecti
 /**
  * Gets mongodb repository for the given entity class or name.
  */
-export function getMongoRepository<Entity>(entityClass: ObjectType<Entity>|string, connectionName: string = "default"): MongoRepository<Entity> {
+export function getMongoRepository<Entity>(entityClass: EntityTarget<Entity>, connectionName: string = "default"): MongoRepository<Entity> {
     return getConnectionManager().get(connectionName).getMongoRepository<Entity>(entityClass);
 }
 
 /**
  * Creates a new query builder.
  */
-export function createQueryBuilder<Entity>(entityClass?: ObjectType<Entity>|string, alias?: string, connectionName: string = "default"): SelectQueryBuilder<Entity> {
+export function createQueryBuilder<Entity>(entityClass?: EntityTarget<Entity>, alias?: string, connectionName: string = "default"): SelectQueryBuilder<Entity> {
     if (entityClass) {
         return getRepository(entityClass, connectionName).createQueryBuilder(alias);
     }

--- a/src/metadata-args/EntityRepositoryMetadataArgs.ts
+++ b/src/metadata-args/EntityRepositoryMetadataArgs.ts
@@ -1,4 +1,4 @@
-import { EntitySchema } from "../entity-schema/EntitySchema";
+import { EntityTarget } from "../common/EntityTarget";
 
 /**
  * Arguments for EntityRepositoryMetadata class, helps to construct an EntityRepositoryMetadata object.
@@ -13,6 +13,6 @@ export interface EntityRepositoryMetadataArgs {
     /**
      * Entity managed by this custom repository.
      */
-    readonly entity?: Function|string|EntitySchema<any>;
+    readonly entity?: EntityTarget<any>;
 
 }

--- a/src/query-builder/DeleteQueryBuilder.ts
+++ b/src/query-builder/DeleteQueryBuilder.ts
@@ -2,7 +2,7 @@ import {CockroachDriver} from "../driver/cockroachdb/CockroachDriver";
 import {OracleDriver} from "../driver/oracle/OracleDriver";
 import {QueryBuilder} from "./QueryBuilder";
 import {ObjectLiteral} from "../common/ObjectLiteral";
-import {ObjectType} from "../common/ObjectType";
+import {EntityTarget} from "../common/EntityTarget";
 import {Connection} from "../connection/Connection";
 import {QueryRunner} from "../query-runner/QueryRunner";
 import {SqlServerDriver} from "../driver/sqlserver/SqlServerDriver";
@@ -133,7 +133,7 @@ export class DeleteQueryBuilder<Entity> extends QueryBuilder<Entity> implements 
      * Specifies FROM which entity's table select/update/delete will be executed.
      * Also sets a main string alias of the selection data.
      */
-    from<T>(entityTarget: ObjectType<T>|EntitySchema<T>|string, aliasName?: string): DeleteQueryBuilder<T> {
+    from<T>(entityTarget: EntityTarget<T>, aliasName?: string): DeleteQueryBuilder<T> {
         entityTarget = entityTarget instanceof EntitySchema ? entityTarget.options.name : entityTarget;
         const mainAlias = this.createFromAlias(entityTarget, aliasName);
         this.expressionMap.setMainAlias(mainAlias);

--- a/src/query-builder/InsertQueryBuilder.ts
+++ b/src/query-builder/InsertQueryBuilder.ts
@@ -2,7 +2,7 @@ import {CockroachDriver} from "../driver/cockroachdb/CockroachDriver";
 import {SapDriver} from "../driver/sap/SapDriver";
 import {QueryBuilder} from "./QueryBuilder";
 import {ObjectLiteral} from "../common/ObjectLiteral";
-import {ObjectType} from "../common/ObjectType";
+import {EntityTarget} from "../common/EntityTarget";
 import {QueryDeepPartialEntity} from "./QueryPartialEntity";
 import {SqlServerDriver} from "../driver/sqlserver/SqlServerDriver";
 import {PostgresDriver} from "../driver/postgres/PostgresDriver";
@@ -164,7 +164,7 @@ export class InsertQueryBuilder<Entity> extends QueryBuilder<Entity> {
     /**
      * Specifies INTO which entity's table insertion will be executed.
      */
-    into<T>(entityTarget: ObjectType<T>|EntitySchema<T>|string, columns?: string[]): InsertQueryBuilder<T> {
+    into<T>(entityTarget: EntityTarget<T>, columns?: string[]): InsertQueryBuilder<T> {
         entityTarget = entityTarget instanceof EntitySchema ? entityTarget.options.name : entityTarget;
         const mainAlias = this.createFromAlias(entityTarget);
         this.expressionMap.setMainAlias(mainAlias);

--- a/src/query-builder/QueryBuilder.ts
+++ b/src/query-builder/QueryBuilder.ts
@@ -8,7 +8,7 @@ import {DeleteQueryBuilder} from "./DeleteQueryBuilder";
 import {SoftDeleteQueryBuilder} from "./SoftDeleteQueryBuilder";
 import {InsertQueryBuilder} from "./InsertQueryBuilder";
 import {RelationQueryBuilder} from "./RelationQueryBuilder";
-import {ObjectType} from "../common/ObjectType";
+import {EntityTarget} from "../common/EntityTarget";
 import {Alias} from "./Alias";
 import {Brackets} from "./Brackets";
 import {QueryDeepPartialEntity} from "./QueryPartialEntity";
@@ -187,17 +187,7 @@ export abstract class QueryBuilder<Entity> {
     /**
      * Creates UPDATE query for the given entity and applies given update values.
      */
-    update<T>(entity: ObjectType<T>, updateSet?: QueryDeepPartialEntity<T>): UpdateQueryBuilder<T>;
-
-    /**
-     * Creates UPDATE query for the given entity and applies given update values.
-     */
-    update<T>(entity: EntitySchema<T>, updateSet?: QueryDeepPartialEntity<T>): UpdateQueryBuilder<T>;
-
-    /**
-     * Creates UPDATE query for the given entity and applies given update values.
-     */
-    update(entity: Function|EntitySchema<Entity>|string, updateSet?: QueryDeepPartialEntity<Entity>): UpdateQueryBuilder<Entity>;
+    update<Entity>(entity: EntityTarget<Entity>, updateSet?: QueryDeepPartialEntity<Entity>): UpdateQueryBuilder<Entity>;
 
     /**
      * Creates UPDATE query for the given table name and applies given update values.
@@ -207,7 +197,7 @@ export abstract class QueryBuilder<Entity> {
     /**
      * Creates UPDATE query and applies given update values.
      */
-    update(entityOrTableNameUpdateSet?: string|Function|EntitySchema<any>|ObjectLiteral, maybeUpdateSet?: ObjectLiteral): UpdateQueryBuilder<any> {
+    update(entityOrTableNameUpdateSet?: EntityTarget<any>|ObjectLiteral, maybeUpdateSet?: ObjectLiteral): UpdateQueryBuilder<any> {
         const updateSet = maybeUpdateSet ? maybeUpdateSet : entityOrTableNameUpdateSet as ObjectLiteral|undefined;
         entityOrTableNameUpdateSet = entityOrTableNameUpdateSet instanceof EntitySchema ? entityOrTableNameUpdateSet.options.name : entityOrTableNameUpdateSet;
 
@@ -271,7 +261,7 @@ export abstract class QueryBuilder<Entity> {
     /**
      * Sets entity's relation with which this query builder gonna work.
      */
-    relation<T>(entityTarget: ObjectType<T>|string, propertyPath: string): RelationQueryBuilder<T>;
+    relation<T>(entityTarget: EntityTarget<T>, propertyPath: string): RelationQueryBuilder<T>;
 
     /**
      * Sets entity's relation with which this query builder gonna work.
@@ -303,7 +293,7 @@ export abstract class QueryBuilder<Entity> {
      *
      * todo: move this method to manager? or create a shortcut?
      */
-    hasRelation<T>(target: ObjectType<T>|string, relation: string): boolean;
+    hasRelation<T>(target: EntityTarget<T>, relation: string): boolean;
 
     /**
      * Checks if given relations exist in the entity.
@@ -311,7 +301,7 @@ export abstract class QueryBuilder<Entity> {
      *
      * todo: move this method to manager? or create a shortcut?
      */
-    hasRelation<T>(target: ObjectType<T>|string, relation: string[]): boolean;
+    hasRelation<T>(target: EntityTarget<T>, relation: string[]): boolean;
 
     /**
      * Checks if given relation or relations exist in the entity.
@@ -319,7 +309,7 @@ export abstract class QueryBuilder<Entity> {
      *
      * todo: move this method to manager? or create a shortcut?
      */
-    hasRelation<T>(target: ObjectType<T>|string, relation: string|string[]): boolean {
+    hasRelation<T>(target: EntityTarget<T>, relation: string|string[]): boolean {
         const entityMetadata = this.connection.getMetadata(target);
         const relations = Array.isArray(relation) ? relation : [relation];
         return relations.every(relation => {
@@ -532,7 +522,7 @@ export abstract class QueryBuilder<Entity> {
      * Specifies FROM which entity's table select/update/delete will be executed.
      * Also sets a main string alias of the selection data.
      */
-    protected createFromAlias(entityTarget: Function|string|((qb: SelectQueryBuilder<any>) => SelectQueryBuilder<any>), aliasName?: string): Alias {
+    protected createFromAlias(entityTarget: EntityTarget<any>|((qb: SelectQueryBuilder<any>) => SelectQueryBuilder<any>), aliasName?: string): Alias {
 
         // if table has a metadata then find it to properly escape its properties
         // const metadata = this.connection.entityMetadatas.find(metadata => metadata.tableName === tableName);
@@ -547,21 +537,25 @@ export abstract class QueryBuilder<Entity> {
             });
 
         } else {
-            let subQuery: string = "";
-            if (entityTarget instanceof Function) {
-                const subQueryBuilder: SelectQueryBuilder<any> = (entityTarget as any)(((this as any) as SelectQueryBuilder<any>).subQuery());
-                this.setParameters(subQueryBuilder.getParameters());
-                subQuery = subQueryBuilder.getQuery();
+            if (typeof entityTarget === "string") {
+                const isSubquery = entityTarget.substr(0, 1) === "(" && entityTarget.substr(-1) === ")";
 
-            } else {
-                subQuery = entityTarget;
+                return this.expressionMap.createAlias({
+                    type: "from",
+                    name: aliasName,
+                    tablePath: !isSubquery ? entityTarget as string : undefined,
+                    subQuery: isSubquery ? entityTarget : undefined,
+                });
             }
-            const isSubQuery = entityTarget instanceof Function || entityTarget.substr(0, 1) === "(" && entityTarget.substr(-1) === ")";
+
+            const subQueryBuilder: SelectQueryBuilder<any> = (entityTarget as any)(((this as any) as SelectQueryBuilder<any>).subQuery());
+            this.setParameters(subQueryBuilder.getParameters());
+            const subquery = subQueryBuilder.getQuery();
+
             return this.expressionMap.createAlias({
                 type: "from",
                 name: aliasName,
-                tablePath: isSubQuery === false ? entityTarget as string : undefined,
-                subQuery: isSubQuery === true ? subQuery : undefined,
+                subQuery: subquery
             });
         }
     }

--- a/src/query-builder/SelectQueryBuilder.ts
+++ b/src/query-builder/SelectQueryBuilder.ts
@@ -24,7 +24,7 @@ import {EntityMetadata} from "../metadata/EntityMetadata";
 import {ColumnMetadata} from "../metadata/ColumnMetadata";
 import {OrderByCondition} from "../find-options/OrderByCondition";
 import {QueryExpressionMap} from "./QueryExpressionMap";
-import {ObjectType} from "../common/ObjectType";
+import {EntityTarget} from "../common/EntityTarget";
 import {QueryRunner} from "../query-runner/QueryRunner";
 import {WhereExpression} from "./WhereExpression";
 import {Brackets} from "./Brackets";
@@ -188,14 +188,14 @@ export class SelectQueryBuilder<Entity> extends QueryBuilder<Entity> implements 
      * Also sets a main string alias of the selection data.
      * Removes all previously set from-s.
      */
-    from<T>(entityTarget: ObjectType<T>|string, aliasName: string): SelectQueryBuilder<T>;
+    from<T>(entityTarget: EntityTarget<T>, aliasName: string): SelectQueryBuilder<T>;
 
     /**
      * Specifies FROM which entity's table select/update/delete will be executed.
      * Also sets a main string alias of the selection data.
      * Removes all previously set from-s.
      */
-    from<T>(entityTarget: ObjectType<T>|string|((qb: SelectQueryBuilder<any>) => SelectQueryBuilder<any>), aliasName: string): SelectQueryBuilder<T> {
+    from<T>(entityTarget: EntityTarget<T>|((qb: SelectQueryBuilder<any>) => SelectQueryBuilder<any>), aliasName: string): SelectQueryBuilder<T> {
         const mainAlias = this.createFromAlias(entityTarget, aliasName);
         this.expressionMap.setMainAlias(mainAlias);
         return (this as any) as SelectQueryBuilder<T>;
@@ -211,13 +211,13 @@ export class SelectQueryBuilder<Entity> extends QueryBuilder<Entity> implements 
      * Specifies FROM which entity's table select/update/delete will be executed.
      * Also sets a main string alias of the selection data.
      */
-    addFrom<T>(entityTarget: ObjectType<T>|string, aliasName: string): SelectQueryBuilder<T>;
+    addFrom<T>(entityTarget: EntityTarget<T>, aliasName: string): SelectQueryBuilder<T>;
 
     /**
      * Specifies FROM which entity's table select/update/delete will be executed.
      * Also sets a main string alias of the selection data.
      */
-    addFrom<T>(entityTarget: ObjectType<T>|string|((qb: SelectQueryBuilder<any>) => SelectQueryBuilder<any>), aliasName: string): SelectQueryBuilder<T> {
+    addFrom<T>(entityTarget: EntityTarget<T>|((qb: SelectQueryBuilder<any>) => SelectQueryBuilder<any>), aliasName: string): SelectQueryBuilder<T> {
         const alias = this.createFromAlias(entityTarget, aliasName);
         if (!this.expressionMap.mainAlias)
             this.expressionMap.setMainAlias(alias);

--- a/src/query-builder/SoftDeleteQueryBuilder.ts
+++ b/src/query-builder/SoftDeleteQueryBuilder.ts
@@ -1,7 +1,7 @@
 import {CockroachDriver} from "../driver/cockroachdb/CockroachDriver";
 import {QueryBuilder} from "./QueryBuilder";
 import {ObjectLiteral} from "../common/ObjectLiteral";
-import {ObjectType} from "../common/ObjectType";
+import {EntityTarget} from "../common/EntityTarget";
 import {Connection} from "../connection/Connection";
 import {QueryRunner} from "../query-runner/QueryRunner";
 import {SqlServerDriver} from "../driver/sqlserver/SqlServerDriver";
@@ -142,7 +142,7 @@ export class SoftDeleteQueryBuilder<Entity> extends QueryBuilder<Entity> impleme
      * Specifies FROM which entity's table select/update/delete/soft-delete will be executed.
      * Also sets a main string alias of the selection data.
      */
-    from<T>(entityTarget: ObjectType<T>|EntitySchema<T>|string, aliasName?: string): SoftDeleteQueryBuilder<T> {
+    from<T>(entityTarget: EntityTarget<T>, aliasName?: string): SoftDeleteQueryBuilder<T> {
         entityTarget = entityTarget instanceof EntitySchema ? entityTarget.options.name : entityTarget;
         const mainAlias = this.createFromAlias(entityTarget, aliasName);
         this.expressionMap.setMainAlias(mainAlias);

--- a/src/repository/AbstractRepository.ts
+++ b/src/repository/AbstractRepository.ts
@@ -2,12 +2,12 @@ import {ObjectLiteral} from "../common/ObjectLiteral";
 import {EntityManager} from "../entity-manager/EntityManager";
 import {Repository} from "./Repository";
 import {TreeRepository} from "./TreeRepository";
+import {EntityTarget} from "../common/EntityTarget";
 import {ObjectType} from "../common/ObjectType";
 import {CustomRepositoryDoesNotHaveEntityError} from "../error/CustomRepositoryDoesNotHaveEntityError";
 import {getMetadataArgsStorage} from "../index";
 import {CustomRepositoryNotFoundError} from "../error/CustomRepositoryNotFoundError";
 import {SelectQueryBuilder} from "../query-builder/SelectQueryBuilder";
-import { EntitySchema } from "../entity-schema/EntitySchema";
 
 /**
  * Provides abstract class for custom repositories that do not inherit from original orm Repository.
@@ -100,7 +100,7 @@ export class AbstractRepository<Entity extends ObjectLiteral> {
      * Gets custom repository's managed entity.
      * If given custom repository does not manage any entity then undefined will be returned.
      */
-    private getCustomRepositoryTarget(customRepository: any): Function|string|EntitySchema<any>|undefined {
+    private getCustomRepositoryTarget(customRepository: any): EntityTarget<any>|undefined {
         const entityRepositoryMetadataArgs = getMetadataArgsStorage().entityRepositories.find(repository => {
             return repository.target === (customRepository instanceof Function ? customRepository : (customRepository as any).constructor);
         });

--- a/src/repository/Repository.ts
+++ b/src/repository/Repository.ts
@@ -147,7 +147,7 @@ export class Repository<Entity extends ObjectLiteral> {
      * Saves one or many given entities.
      */
     save<T extends DeepPartial<Entity>>(entityOrEntities: T|T[], options?: SaveOptions): Promise<T|T[]> {
-        return this.manager.save<T>(this.metadata.target as any, entityOrEntities as any, options);
+        return this.manager.save<Entity, T>(this.metadata.target as any, entityOrEntities as any, options);
     }
 
     /**
@@ -191,7 +191,7 @@ export class Repository<Entity extends ObjectLiteral> {
      * Records the delete date of one or many given entities.
      */
     softRemove<T extends DeepPartial<Entity>>(entityOrEntities: T|T[], options?: SaveOptions): Promise<T|T[]> {
-        return this.manager.softRemove<T>(this.metadata.target as any, entityOrEntities as any, options);
+        return this.manager.softRemove<Entity, T>(this.metadata.target as any, entityOrEntities as any, options);
     }
 
     /**
@@ -218,7 +218,7 @@ export class Repository<Entity extends ObjectLiteral> {
      * Recovers one or many given entities.
      */
     recover<T extends DeepPartial<Entity>>(entityOrEntities: T|T[], options?: SaveOptions): Promise<T|T[]> {
-        return this.manager.recover<T>(this.metadata.target as any, entityOrEntities as any, options);
+        return this.manager.recover<Entity, T>(this.metadata.target as any, entityOrEntities as any, options);
     }
 
     /**


### PR DESCRIPTION
This backports the `EntityTarget` type from the `@next` branch and uses it instead of the bunches of `ObjectType`/`EntitySchema`/`string` union types.