### PR TITLE
fix: prevent multiple `release` listeners in PostgresQueryRunner

### DIFF
--- a/test/github-issues/6699/issue-6699.ts
+++ b/test/github-issues/6699/issue-6699.ts
@@ -1,0 +1,30 @@
+import {closeTestingConnections, createTestingConnections, reloadTestingDatabases} from "../../utils/test-utils";
+import {Connection} from "../../../src/connection/Connection";
+import {expect} from 'chai';
+
+describe("github issues > #6699 MaxListenersExceededWarning occurs on Postgres", () => {
+
+    let connections: Connection[];
+    before(async () => connections = await createTestingConnections({
+        entities: [],
+        enabledDrivers: ["postgres"]
+    }));
+    beforeEach(() => reloadTestingDatabases(connections));
+    after(() => closeTestingConnections(connections));
+
+    it("queries in a transaction do not cause an EventEmitter memory leak", () => Promise.all(connections.map(async connection => {
+        await connection.transaction(async manager => {
+            const queryPromises = [...Array(10)].map(
+                () => manager.query('SELECT pg_sleep(0.0001)')
+            );
+
+            const pgConnection = await manager.queryRunner!.connect();
+
+            expect(pgConnection.listenerCount('error')).to.equal(1);
+
+            // Wait for all of the queries to finish and drain the backlog
+            await Promise.all(queryPromises);
+        });
+    })));
+
+});


### PR DESCRIPTION
move on-error-release code to the queryRunner connect function
so we only need to have one listener per query runner on each
connection - cutting down the number of listeners total &
preventing a problem with too many listeners

this edge case becomes a real problem within transactions where
the queries may be fired off on the same connection long before
they will eventually execute their callbacks

closes #6699

This is related to #6262 - it's a bit of a refactor of that code to handle
the case of transactions