### PR TITLE
Correct the comment of OneToMany decorator

### DIFF
--- a/src/decorator/relations/OneToMany.ts
+++ b/src/decorator/relations/OneToMany.ts
@@ -2,8 +2,8 @@ import {getMetadataArgsStorage, ObjectType, RelationOptions} from "../../";
 import {RelationMetadataArgs} from "../../metadata-args/RelationMetadataArgs";
 
 /**
- * One-to-many relation allows to create type of relation when Entity2 can have multiple instances of Entity1.
- * Entity1 have only one Entity2. Entity1 is an owner of the relationship, and storages Entity2 id on its own side.
+ * One-to-many relation allows to create type of relation when Entity1 can have multiple instances of Entity2.
+ * Entity2 have only one Entity1. Entity2 is an owner of the relationship, and storages Entity1 id on its own side.
  */
 export function OneToMany<T>(typeFunctionOrTarget: string|((type?: any) => ObjectType<T>), inverseSide: string|((object: T) => any), options?: RelationOptions): PropertyDecorator {
     return function (object: Object, propertyName: string) {


### PR DESCRIPTION
Hi, seems like there's an error in the description of the `OneToMany` decorator type (displayed e.g. in editors and IDEs when hovering over the decorator). The comment states that

> One-to-many relation allows to create type of relation when Entity2 can have multiple instances of Entity1. Entity1 have only one Entity2. Entity1 is an owner of the relationship, and storages Entity2 id on its own side.

I think there has to be a mistake since this seems to describe the same side of the relation as the comment on `ManyToOne`

> Many-to-one relation allows to create type of relation when Entity1 can have single instance of Entity2, but Entity2 can have a multiple instances of Entity1. Entity1 is an owner of the relationship, and storages Entity2 id on its own side.

If I'm not mistaken, this PR should correct the description of the relation.