### PR TITLE
fix: backport FindOperator return types

### DIFF
--- a/src/find-options/operator/Any.ts
+++ b/src/find-options/operator/Any.ts
@@ -4,6 +4,6 @@ import {FindOperator} from "../FindOperator";
  * Find Options Operator.
  * Example: { someField: Any([...]) }
  */
-export function Any<T>(value: T[]|FindOperator<T>) {
+export function Any<T>(value: T[]|FindOperator<T>): FindOperator<T> {
     return new FindOperator("any", value as any);
 }

--- a/src/find-options/operator/Between.ts
+++ b/src/find-options/operator/Between.ts
@@ -4,6 +4,6 @@ import {FindOperator} from "../FindOperator";
  * Find Options Operator.
  * Example: { someField: Between(x, y) }
  */
-export function Between<T>(from: T|FindOperator<T>, to: T|FindOperator<T>) {
+export function Between<T>(from: T|FindOperator<T>, to: T|FindOperator<T>): FindOperator<T> {
     return new FindOperator("between", [from, to] as any, true, true);
 }

--- a/src/find-options/operator/In.ts
+++ b/src/find-options/operator/In.ts
@@ -4,6 +4,6 @@ import {FindOperator} from "../FindOperator";
  * Find Options Operator.
  * Example: { someField: In([...]) }
  */
-export function In<T>(value: T[]|FindOperator<T>) {
+export function In<T>(value: T[]|FindOperator<T>): FindOperator<T> {
     return new FindOperator("in", value as any, true, true);
 }

--- a/src/find-options/operator/Raw.ts
+++ b/src/find-options/operator/Raw.ts
@@ -4,6 +4,6 @@ import {FindOperator} from "../FindOperator";
  * Find Options Operator.
  * Example: { someField: Raw([...]) }
  */
-export function Raw<T>(value: string|((columnAlias: string) => string)) {
+export function Raw<T>(value: string|((columnAlias: string) => string)): FindOperator<any> {
     return new FindOperator("raw", value as any, false);
 }


### PR DESCRIPTION
the `next` branch added return types to `FindOperator`s and
this backports that change