### PR TITLE
test: disable logging for test 1960

### DIFF
--- a/test/github-issues/1960/issue-1960.ts
+++ b/test/github-issues/1960/issue-1960.ts
@@ -8,8 +8,7 @@ describe.skip("github issues > #1960 Migration generator produces duplicated cha
     let connections: Connection[];
     before(async () => connections = await createTestingConnections({
         entities: [__dirname + "/entity/*{.js,.ts}"],
-        enabledDrivers: ["mysql"],
-        logging: true
+        enabledDrivers: ["mysql"]
     }));
     beforeEach(() => reloadTestingDatabases(connections));
     after(() => closeTestingConnections(connections));


### PR DESCRIPTION
this test was emitting logs for no real reason so this removes the
`logging: true` when creating the testing connection