### PR TITLE
chore: explicitly pull in typescript 3.9

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -254,8 +254,7 @@
     "@sqltools/formatter": {
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/@sqltools/formatter/-/formatter-1.2.2.tgz",
-      "integrity": "sha512-/5O7Fq6Vnv8L6ucmPjaWbVG1XkP4FO+w5glqfkIsq3Xw4oyNAdJddbnYodNDAfjVUvo/rrSCTom4kAND7T1o5Q==",
-      "dev": true
+      "integrity": "sha512-/5O7Fq6Vnv8L6ucmPjaWbVG1XkP4FO+w5glqfkIsq3Xw4oyNAdJddbnYodNDAfjVUvo/rrSCTom4kAND7T1o5Q=="
     },
     "@types/app-root-path": {
       "version": "1.2.4",

--- a/package.json
+++ b/package.json
@@ -101,7 +101,7 @@
     "sqlite3": "^5.0.0",
     "ts-node": "^9.0.0",
     "typeorm-aurora-data-api-driver": "^1.4.0",
-    "typescript": "^3.3.3333"
+    "typescript": "^3.9.7"
   },
   "dependencies": {
     "@sqltools/formatter": "1.2.2",


### PR DESCRIPTION
this bumps the version of typescript accepted to >=3.9.7,<4.0
we were implicitly pulling in that version (per the package-lock.json)
so this just codifies it in the package.json as well