### PR TITLE
fix: Improve simple-enum handling in migrations

### DIFF
--- a/src/schema-builder/RdbmsSchemaBuilder.ts
+++ b/src/schema-builder/RdbmsSchemaBuilder.ts
@@ -307,8 +307,11 @@ export class RdbmsSchemaBuilder implements SchemaBuilder {
             if (!table)
                 return;
 
+						// Checks created for simple-enum types are NOT metadata checks
+						// Do not consider simple-enum check constraints
+						// (indicated by ENUM prefix, see buildCreateColumnSql in simple-enum-compatible query runners)
             const oldChecks = table.checks.filter(tableCheck => {
-                return !metadata.checks.find(checkMetadata => checkMetadata.name === tableCheck.name);
+                return (tableCheck.name && tableCheck.name.startsWith("ENUM")) ? false : !metadata.checks.find(checkMetadata => checkMetadata.name === tableCheck.name);
             });
 
             if (oldChecks.length === 0)


### PR DESCRIPTION
Use an explicit name when creating simple-enum CHECK constraints so that
they can be ignored when finding old (to be deleted) CHECK constraints.
Additionally, update query runners for simple-enum-compatible types to
maintain true DB type ('varchar'/'nvarchar') as tableColumn.type, as opposed
to setting it to 'simple-enum' in `loadTables`. This fixes broken
`findChangedColumn` in simple-enum-compatible drivers, which check
tableColumn.type against normalized columnMetadata.type. According to
in-line documentation, `normalizeType` creates a DB type from a metadata
type, implying that tableColumn.type is expected to be a true DB type,
not a metadata type like 'simple-enum'.