### PR TITLE
techdebt: create a ReplicationMode type and update function defs

### DIFF
--- a/src/cache/DbQueryResultCache.ts
+++ b/src/cache/DbQueryResultCache.ts
@@ -229,7 +229,7 @@ export class DbQueryResultCache implements QueryResultCache {
         if (queryRunner)
             return queryRunner;
 
-        return this.connection.createQueryRunner("master");
+        return this.connection.createQueryRunner();
     }
 
 }

--- a/src/commands/QueryCommand.ts
+++ b/src/commands/QueryCommand.ts
@@ -48,7 +48,7 @@ export class QueryCommand implements yargs.CommandModule {
             connection = await createConnection(connectionOptions);
 
             // create a query runner and execute query using it
-            queryRunner = connection.createQueryRunner("master");
+            queryRunner = connection.createQueryRunner();
             console.log(chalk.green("Running query: ") + PlatformTools.highlightSql(args._[1]));
             const queryResult = await queryRunner.query(args._[1]);
             console.log(chalk.green("Query has been executed. Result: "));

--- a/src/connection/Connection.ts
+++ b/src/connection/Connection.ts
@@ -40,6 +40,7 @@ import {PromiseUtils} from "../";
 import {IsolationLevel} from "../driver/types/IsolationLevel";
 import {AuroraDataApiDriver} from "../driver/aurora-data-api/AuroraDataApiDriver";
 import {DriverUtils} from "../driver/DriverUtils";
+import {ReplicationMode} from "../driver/types/ReplicationMode";
 
 /**
  * Connection is a single database ORM connection to a specific database.
@@ -259,7 +260,7 @@ export class Connection {
      */
     // TODO rename
     async dropDatabase(): Promise<void> {
-        const queryRunner = this.createQueryRunner("master");
+        const queryRunner = this.createQueryRunner();
         try {
             if (this.driver instanceof SqlServerDriver || this.driver instanceof MysqlDriver || this.driver instanceof AuroraDataApiDriver) {
                 const databases: string[] = this.driver.database ? [this.driver.database] : [];
@@ -395,7 +396,7 @@ export class Connection {
         if (queryRunner && queryRunner.isReleased)
             throw new QueryRunnerProviderAlreadyReleasedError();
 
-        const usedQueryRunner = queryRunner || this.createQueryRunner("master");
+        const usedQueryRunner = queryRunner || this.createQueryRunner();
 
         try {
             return await usedQueryRunner.query(query, parameters);  // await is needed here because we are using finally
@@ -444,7 +445,7 @@ export class Connection {
      * If you perform writes you must use master database,
      * if you perform reads you can use slave databases.
      */
-    createQueryRunner(mode: "master"|"slave" = "master"): QueryRunner {
+    createQueryRunner(mode: ReplicationMode = "master"): QueryRunner {
         const queryRunner = this.driver.createQueryRunner(mode);
         const manager = this.createEntityManager(queryRunner);
         Object.assign(queryRunner, { manager: manager });

--- a/src/driver/Driver.ts
+++ b/src/driver/Driver.ts
@@ -8,6 +8,7 @@ import {DataTypeDefaults} from "./types/DataTypeDefaults";
 import {BaseConnectionOptions} from "../connection/BaseConnectionOptions";
 import {TableColumn} from "../schema-builder/table/TableColumn";
 import {EntityMetadata} from "../metadata/EntityMetadata";
+import {ReplicationMode} from "./types/ReplicationMode";
 
 /**
  * Driver organizes TypeORM communication with specific database management system.
@@ -102,7 +103,7 @@ export interface Driver {
     /**
      * Creates a query runner used for common queries.
      */
-    createQueryRunner(mode: "master"|"slave"): QueryRunner;
+    createQueryRunner(mode: ReplicationMode): QueryRunner;
 
     /**
      * Replaces parameters in the given sql with special escaping character

--- a/src/driver/aurora-data-api-pg/AuroraDataApiPostgresQueryRunner.ts
+++ b/src/driver/aurora-data-api-pg/AuroraDataApiPostgresQueryRunner.ts
@@ -5,11 +5,12 @@ import {QueryRunner} from "../../query-runner/QueryRunner";
 import {IsolationLevel} from "../types/IsolationLevel";
 import {AuroraDataApiPostgresDriver} from "../postgres/PostgresDriver";
 import {PostgresQueryRunner} from "../postgres/PostgresQueryRunner";
+import {ReplicationMode} from "../types/ReplicationMode";
 
 class PostgresQueryRunnerWrapper extends PostgresQueryRunner {
     driver: any;
 
-    constructor(driver: any, mode: "master"|"slave") {
+    constructor(driver: any, mode: ReplicationMode) {
         super(driver, mode);
     }
 }
@@ -46,7 +47,7 @@ export class AuroraDataApiPostgresQueryRunner extends PostgresQueryRunnerWrapper
     // Constructor
     // -------------------------------------------------------------------------
 
-    constructor(driver: AuroraDataApiPostgresDriver, mode: "master"|"slave" = "master") {
+    constructor(driver: AuroraDataApiPostgresDriver, mode: ReplicationMode) {
         super(driver, mode);
     }
 

--- a/src/driver/aurora-data-api/AuroraDataApiConnection.ts
+++ b/src/driver/aurora-data-api/AuroraDataApiConnection.ts
@@ -1,6 +1,7 @@
 import {AuroraDataApiQueryRunner} from "./AuroraDataApiQueryRunner";
 import {Connection} from "../../connection/Connection";
 import {ConnectionOptions, QueryRunner} from "../..";
+import {ReplicationMode} from "../types/ReplicationMode";
 
 /**
  * Organizes communication with MySQL DBMS.
@@ -13,7 +14,7 @@ export class AuroraDataApiConnection extends Connection {
         this.queryRunnter = queryRunner;
     }
 
-    public createQueryRunner(mode: "master" | "slave" = "master"): QueryRunner {
+    public createQueryRunner(mode: ReplicationMode): QueryRunner {
         return this.queryRunnter;
     }
 

--- a/src/driver/aurora-data-api/AuroraDataApiDriver.ts
+++ b/src/driver/aurora-data-api/AuroraDataApiDriver.ts
@@ -16,6 +16,7 @@ import {AuroraDataApiConnectionCredentialsOptions} from "./AuroraDataApiConnecti
 import {EntityMetadata} from "../../metadata/EntityMetadata";
 import {OrmUtils} from "../../util/OrmUtils";
 import {ApplyValueTransformers} from "../../util/ApplyValueTransformers";
+import {ReplicationMode} from "../types/ReplicationMode";
 
 /**
  * Organizes communication with MySQL DBMS.
@@ -355,7 +356,7 @@ export class AuroraDataApiDriver implements Driver {
     /**
      * Creates a query runner used to execute database queries.
      */
-    createQueryRunner(mode: "master"|"slave" = "master") {
+    createQueryRunner(mode: ReplicationMode) {
         return new AuroraDataApiQueryRunner(this);
     }
 

--- a/src/driver/better-sqlite3/BetterSqlite3Driver.ts
+++ b/src/driver/better-sqlite3/BetterSqlite3Driver.ts
@@ -9,6 +9,7 @@ import { QueryRunner } from "../../query-runner/QueryRunner";
 import { AbstractSqliteDriver } from "../sqlite-abstract/AbstractSqliteDriver";
 import { BetterSqlite3ConnectionOptions } from "./BetterSqlite3ConnectionOptions";
 import { BetterSqlite3QueryRunner } from "./BetterSqlite3QueryRunner";
+import {ReplicationMode} from "../types/ReplicationMode";
 
 /**
  * Organizes communication with sqlite DBMS.
@@ -63,7 +64,7 @@ export class BetterSqlite3Driver extends AbstractSqliteDriver {
     /**
      * Creates a query runner used to execute database queries.
      */
-    createQueryRunner(mode: "master" | "slave" = "master"): QueryRunner {
+    createQueryRunner(mode: ReplicationMode): QueryRunner {
         if (!this.queryRunner)
             this.queryRunner = new BetterSqlite3QueryRunner(this);
 

--- a/src/driver/cockroachdb/CockroachDriver.ts
+++ b/src/driver/cockroachdb/CockroachDriver.ts
@@ -19,6 +19,7 @@ import {EntityMetadata} from "../../metadata/EntityMetadata";
 import {OrmUtils} from "../../util/OrmUtils";
 import {CockroachQueryRunner} from "./CockroachQueryRunner";
 import {ApplyValueTransformers} from "../../util/ApplyValueTransformers";
+import {ReplicationMode} from "../types/ReplicationMode";
 
 /**
  * Organizes communication with Cockroach DBMS.
@@ -284,7 +285,7 @@ export class CockroachDriver implements Driver {
     /**
      * Creates a query runner used to execute database queries.
      */
-    createQueryRunner(mode: "master"|"slave" = "master") {
+    createQueryRunner(mode: ReplicationMode) {
         return new CockroachQueryRunner(this, mode);
     }
 

--- a/src/driver/cockroachdb/CockroachQueryRunner.ts
+++ b/src/driver/cockroachdb/CockroachQueryRunner.ts
@@ -22,6 +22,7 @@ import {TableCheck} from "../../schema-builder/table/TableCheck";
 import {ColumnType} from "../../index";
 import {IsolationLevel} from "../types/IsolationLevel";
 import {TableExclusion} from "../../schema-builder/table/TableExclusion";
+import {ReplicationMode} from "../types/ReplicationMode";
 
 /**
  * Runs queries on a single postgres database connection.
@@ -65,7 +66,7 @@ export class CockroachQueryRunner extends BaseQueryRunner implements QueryRunner
     // Constructor
     // -------------------------------------------------------------------------
 
-    constructor(driver: CockroachDriver, mode: "master"|"slave" = "master") {
+    constructor(driver: CockroachDriver, mode: ReplicationMode) {
         super();
         this.driver = driver;
         this.connection = driver.connection;

--- a/src/driver/cordova/CordovaDriver.ts
+++ b/src/driver/cordova/CordovaDriver.ts
@@ -5,6 +5,7 @@ import {QueryRunner} from "../../query-runner/QueryRunner";
 import {Connection} from "../../connection/Connection";
 import {DriverOptionNotSetError} from "../../error/DriverOptionNotSetError";
 import {DriverPackageNotInstalledError} from "../../error/DriverPackageNotInstalledError";
+import {ReplicationMode} from "../types/ReplicationMode";
 
 // needed for typescript compiler
 interface Window {
@@ -15,7 +16,7 @@ declare var window: Window;
 
 export class CordovaDriver extends AbstractSqliteDriver {
     options: CordovaConnectionOptions;
-    
+
     // -------------------------------------------------------------------------
     // Constructor
     // -------------------------------------------------------------------------
@@ -37,7 +38,7 @@ export class CordovaDriver extends AbstractSqliteDriver {
         // load sqlite package
         this.loadDependencies();
     }
-    
+
 
     // -------------------------------------------------------------------------
     // Public Methods
@@ -52,17 +53,17 @@ export class CordovaDriver extends AbstractSqliteDriver {
             this.databaseConnection.close(ok, fail);
         });
     }
-    
+
     /**
      * Creates a query runner used to execute database queries.
      */
-    createQueryRunner(mode: "master"|"slave" = "master"): QueryRunner {
+    createQueryRunner(mode: ReplicationMode): QueryRunner {
         if (!this.queryRunner)
             this.queryRunner = new CordovaQueryRunner(this);
 
         return this.queryRunner;
     }
-    
+
     // -------------------------------------------------------------------------
     // Protected Methods
     // -------------------------------------------------------------------------

--- a/src/driver/expo/ExpoDriver.ts
+++ b/src/driver/expo/ExpoDriver.ts
@@ -4,10 +4,11 @@ import {ExpoQueryRunner} from "./ExpoQueryRunner";
 import {QueryRunner} from "../../query-runner/QueryRunner";
 import {Connection} from "../../connection/Connection";
 import {DriverOptionNotSetError} from "../../error/DriverOptionNotSetError";
+import {ReplicationMode} from "../types/ReplicationMode";
 
 export class ExpoDriver extends AbstractSqliteDriver {
     options: ExpoConnectionOptions;
-    
+
     // -------------------------------------------------------------------------
     // Constructor
     // -------------------------------------------------------------------------
@@ -20,14 +21,14 @@ export class ExpoDriver extends AbstractSqliteDriver {
         // validate options to make sure everything is set
         if (!this.options.database)
             throw new DriverOptionNotSetError("database");
-        
+
         if (!this.options.driver)
             throw new DriverOptionNotSetError("driver");
 
         // load sqlite package
         this.sqlite = this.options.driver;
     }
-    
+
 
     // -------------------------------------------------------------------------
     // Public Methods
@@ -48,17 +49,17 @@ export class ExpoDriver extends AbstractSqliteDriver {
             }
         });
     }
-    
+
     /**
      * Creates a query runner used to execute database queries.
      */
-    createQueryRunner(mode: "master"|"slave" = "master"): QueryRunner {
+    createQueryRunner(mode: ReplicationMode): QueryRunner {
         if (!this.queryRunner)
             this.queryRunner = new ExpoQueryRunner(this);
 
         return this.queryRunner;
     }
-    
+
     // -------------------------------------------------------------------------
     // Protected Methods
     // -------------------------------------------------------------------------

--- a/src/driver/mongodb/MongoDriver.ts
+++ b/src/driver/mongodb/MongoDriver.ts
@@ -16,6 +16,7 @@ import {ConnectionOptions} from "../../connection/ConnectionOptions";
 import {EntityMetadata} from "../../metadata/EntityMetadata";
 import {ObjectUtils} from "../../util/ObjectUtils";
 import {ApplyValueTransformers} from "../../util/ApplyValueTransformers";
+import {ReplicationMode} from "../types/ReplicationMode";
 
 /**
  * Organizes communication with MongoDB.
@@ -262,7 +263,7 @@ export class MongoDriver implements Driver {
     /**
      * Creates a query runner used to execute database queries.
      */
-    createQueryRunner(mode: "master"|"slave" = "master") {
+    createQueryRunner(mode: ReplicationMode) {
         return this.queryRunner!;
     }
 

--- a/src/driver/mysql/MysqlDriver.ts
+++ b/src/driver/mysql/MysqlDriver.ts
@@ -18,6 +18,7 @@ import {MysqlConnectionCredentialsOptions} from "./MysqlConnectionCredentialsOpt
 import {EntityMetadata} from "../../metadata/EntityMetadata";
 import {OrmUtils} from "../../util/OrmUtils";
 import {ApplyValueTransformers} from "../../util/ApplyValueTransformers";
+import {ReplicationMode} from "../types/ReplicationMode";
 
 /**
  * Organizes communication with MySQL DBMS.
@@ -385,7 +386,7 @@ export class MysqlDriver implements Driver {
     /**
      * Creates a query runner used to execute database queries.
      */
-    createQueryRunner(mode: "master"|"slave" = "master") {
+    createQueryRunner(mode: ReplicationMode) {
         return new MysqlQueryRunner(this, mode);
     }
 

--- a/src/driver/mysql/MysqlQueryRunner.ts
+++ b/src/driver/mysql/MysqlQueryRunner.ts
@@ -22,6 +22,7 @@ import {TableCheck} from "../../schema-builder/table/TableCheck";
 import {IsolationLevel} from "../types/IsolationLevel";
 import {TableExclusion} from "../../schema-builder/table/TableExclusion";
 import {VersionUtils} from "../../util/VersionUtils";
+import {ReplicationMode} from "../types/ReplicationMode";
 
 /**
  * Runs queries on a single mysql database connection.
@@ -50,7 +51,7 @@ export class MysqlQueryRunner extends BaseQueryRunner implements QueryRunner {
     // Constructor
     // -------------------------------------------------------------------------
 
-    constructor(driver: MysqlDriver, mode: "master"|"slave" = "master") {
+    constructor(driver: MysqlDriver, mode: ReplicationMode) {
         super();
         this.driver = driver;
         this.connection = driver.connection;

--- a/src/driver/nativescript/NativescriptDriver.ts
+++ b/src/driver/nativescript/NativescriptDriver.ts
@@ -6,6 +6,7 @@ import {Connection} from "../../connection/Connection";
 import {DriverOptionNotSetError} from "../../error/DriverOptionNotSetError";
 import {DriverPackageNotInstalledError} from "../../error/DriverPackageNotInstalledError";
 import {ColumnType} from "../types/ColumnTypes";
+import {ReplicationMode} from "../types/ReplicationMode";
 
 /**
  * Organizes communication with sqlite DBMS within Nativescript.
@@ -66,7 +67,7 @@ export class NativescriptDriver extends AbstractSqliteDriver {
     /**
      * Creates a query runner used to execute database queries.
      */
-    createQueryRunner(mode: "master"|"slave" = "master"): QueryRunner {
+    createQueryRunner(mode: ReplicationMode): QueryRunner {
         if (!this.queryRunner) {
             this.queryRunner = new NativescriptQueryRunner(this);
         }

--- a/src/driver/oracle/OracleDriver.ts
+++ b/src/driver/oracle/OracleDriver.ts
@@ -18,6 +18,7 @@ import {DriverUtils} from "../DriverUtils";
 import {EntityMetadata} from "../../metadata/EntityMetadata";
 import {OrmUtils} from "../../util/OrmUtils";
 import {ApplyValueTransformers} from "../../util/ApplyValueTransformers";
+import {ReplicationMode} from "../types/ReplicationMode";
 
 /**
  * Organizes communication with Oracle RDBMS.
@@ -287,7 +288,7 @@ export class OracleDriver implements Driver {
     /**
      * Creates a query runner used to execute database queries.
      */
-    createQueryRunner(mode: "master"|"slave" = "master") {
+    createQueryRunner(mode: ReplicationMode) {
         return new OracleQueryRunner(this, mode);
     }
 

--- a/src/driver/oracle/OracleQueryRunner.ts
+++ b/src/driver/oracle/OracleQueryRunner.ts
@@ -20,6 +20,7 @@ import {TableCheck} from "../../schema-builder/table/TableCheck";
 import {ColumnType, PromiseUtils} from "../../index";
 import {IsolationLevel} from "../types/IsolationLevel";
 import {TableExclusion} from "../../schema-builder/table/TableExclusion";
+import {ReplicationMode} from "../types/ReplicationMode";
 
 /**
  * Runs queries on a single oracle database connection.
@@ -48,7 +49,7 @@ export class OracleQueryRunner extends BaseQueryRunner implements QueryRunner {
     // Constructor
     // -------------------------------------------------------------------------
 
-    constructor(driver: OracleDriver, mode: "master"|"slave" = "master") {
+    constructor(driver: OracleDriver, mode: ReplicationMode) {
         super();
         this.driver = driver;
         this.connection = driver.connection;

--- a/src/driver/postgres/PostgresDriver.ts
+++ b/src/driver/postgres/PostgresDriver.ts
@@ -21,6 +21,7 @@ import {OrmUtils} from "../../util/OrmUtils";
 import {ApplyValueTransformers} from "../../util/ApplyValueTransformers";
 import {AuroraDataApiPostgresConnectionOptions} from "../aurora-data-api-pg/AuroraDataApiPostgresConnectionOptions";
 import {AuroraDataApiPostgresQueryRunner} from "../aurora-data-api-pg/AuroraDataApiPostgresQueryRunner";
+import {ReplicationMode} from "../types/ReplicationMode";
 
 /**
  * Organizes communication with PostgreSQL DBMS.
@@ -436,7 +437,7 @@ export class PostgresDriver implements Driver {
     /**
      * Creates a query runner used to execute database queries.
      */
-    createQueryRunner(mode: "master"|"slave" = "master"): QueryRunner {
+    createQueryRunner(mode: ReplicationMode): QueryRunner {
         return new PostgresQueryRunner(this, mode);
     }
 
@@ -1043,7 +1044,7 @@ export class PostgresDriver implements Driver {
 abstract class PostgresWrapper extends PostgresDriver {
     options: any;
 
-    abstract createQueryRunner(mode: "master"|"slave"): any;
+    abstract createQueryRunner(mode: ReplicationMode): any;
 }
 
 export class AuroraDataApiPostgresDriver extends PostgresWrapper {
@@ -1123,7 +1124,7 @@ export class AuroraDataApiPostgresDriver extends PostgresWrapper {
     /**
      * Creates a query runner used to execute database queries.
      */
-    createQueryRunner(mode: "master"|"slave" = "master") {
+    createQueryRunner(mode: ReplicationMode) {
         return new AuroraDataApiPostgresQueryRunner(this, mode);
     }
 

--- a/src/driver/postgres/PostgresQueryRunner.ts
+++ b/src/driver/postgres/PostgresQueryRunner.ts
@@ -22,6 +22,7 @@ import {OrmUtils} from "../../util/OrmUtils";
 import {Query} from "../Query";
 import {IsolationLevel} from "../types/IsolationLevel";
 import {PostgresDriver} from "./PostgresDriver";
+import {ReplicationMode} from "../types/ReplicationMode";
 
 /**
  * Runs queries on a single postgres database connection.
@@ -55,7 +56,7 @@ export class PostgresQueryRunner extends BaseQueryRunner implements QueryRunner 
     // Constructor
     // -------------------------------------------------------------------------
 
-    constructor(driver: PostgresDriver, mode: "master"|"slave" = "master") {
+    constructor(driver: PostgresDriver, mode: ReplicationMode) {
         super();
         this.driver = driver;
         this.connection = driver.connection;

--- a/src/driver/react-native/ReactNativeDriver.ts
+++ b/src/driver/react-native/ReactNativeDriver.ts
@@ -6,10 +6,11 @@ import {Connection} from "../../connection/Connection";
 import {DriverOptionNotSetError} from "../../error/DriverOptionNotSetError";
 import {DriverPackageNotInstalledError} from "../../error/DriverPackageNotInstalledError";
 import {PlatformTools} from "../../platform/PlatformTools";
+import {ReplicationMode} from "../types/ReplicationMode";
 
 export class ReactNativeDriver extends AbstractSqliteDriver {
     options: ReactNativeConnectionOptions;
-    
+
     // -------------------------------------------------------------------------
     // Constructor
     // -------------------------------------------------------------------------
@@ -29,7 +30,7 @@ export class ReactNativeDriver extends AbstractSqliteDriver {
         // load sqlite package
         this.loadDependencies();
     }
-    
+
 
     // -------------------------------------------------------------------------
     // Public Methods
@@ -44,17 +45,17 @@ export class ReactNativeDriver extends AbstractSqliteDriver {
             this.databaseConnection.close(ok, fail);
         });
     }
-    
+
     /**
      * Creates a query runner used to execute database queries.
      */
-    createQueryRunner(mode: "master"|"slave" = "master"): QueryRunner {
+    createQueryRunner(mode: ReplicationMode): QueryRunner {
         if (!this.queryRunner)
             this.queryRunner = new ReactNativeQueryRunner(this);
 
         return this.queryRunner;
     }
-    
+
     // -------------------------------------------------------------------------
     // Protected Methods
     // -------------------------------------------------------------------------

--- a/src/driver/sap/SapDriver.ts
+++ b/src/driver/sap/SapDriver.ts
@@ -11,6 +11,7 @@ import {DataTypeDefaults} from "../types/DataTypeDefaults";
 import {MappedColumnTypes} from "../types/MappedColumnTypes";
 import {SapConnectionOptions} from "./SapConnectionOptions";
 import {SapQueryRunner} from "./SapQueryRunner";
+import {ReplicationMode} from "../types/ReplicationMode";
 
 /**
  * Organizes communication with SAP Hana DBMS.
@@ -273,7 +274,7 @@ export class SapDriver implements Driver {
     /**
      * Creates a query runner used to execute database queries.
      */
-    createQueryRunner(mode: "master"|"slave" = "master") {
+    createQueryRunner(mode: ReplicationMode) {
         return new SapQueryRunner(this, mode);
     }
 

--- a/src/driver/sap/SapQueryRunner.ts
+++ b/src/driver/sap/SapQueryRunner.ts
@@ -20,6 +20,7 @@ import {OrmUtils} from "../../util/OrmUtils";
 import {Query} from "../Query";
 import {IsolationLevel} from "../types/IsolationLevel";
 import {SapDriver} from "./SapDriver";
+import {ReplicationMode} from "../types/ReplicationMode";
 
 /**
  * Runs queries on a single SQL Server database connection.
@@ -55,7 +56,7 @@ export class SapQueryRunner extends BaseQueryRunner implements QueryRunner {
     // Constructor
     // -------------------------------------------------------------------------
 
-    constructor(driver: SapDriver, mode: "master"|"slave" = "master") {
+    constructor(driver: SapDriver, mode: ReplicationMode) {
         super();
         this.driver = driver;
         this.connection = driver.connection;
@@ -91,7 +92,7 @@ export class SapQueryRunner extends BaseQueryRunner implements QueryRunner {
             return this.driver.master.release(this.databaseConnection);
         }
 
-        return Promise.resolve();        
+        return Promise.resolve();
     }
 
     /**
@@ -1823,7 +1824,7 @@ export class SapQueryRunner extends BaseQueryRunner implements QueryRunner {
         let indexType = "";
         if (index.isUnique) {
             indexType += "UNIQUE ";
-        } 
+        }
         if (index.isFulltext) {
             indexType += "FULLTEXT ";
         }

--- a/src/driver/sqlite-abstract/AbstractSqliteDriver.ts
+++ b/src/driver/sqlite-abstract/AbstractSqliteDriver.ts
@@ -13,6 +13,7 @@ import {BaseConnectionOptions} from "../../connection/BaseConnectionOptions";
 import {EntityMetadata} from "../../metadata/EntityMetadata";
 import {OrmUtils} from "../../util/OrmUtils";
 import {ApplyValueTransformers} from "../../util/ApplyValueTransformers";
+import {ReplicationMode} from "../types/ReplicationMode";
 
 /**
  * Organizes communication with sqlite DBMS.
@@ -214,7 +215,7 @@ export abstract class AbstractSqliteDriver implements Driver {
     /**
      * Creates a query runner used to execute database queries.
      */
-    abstract createQueryRunner(mode: "master"|"slave"): QueryRunner;
+    abstract createQueryRunner(mode: ReplicationMode): QueryRunner;
 
     // -------------------------------------------------------------------------
     // Public Methods

--- a/src/driver/sqlite/SqliteDriver.ts
+++ b/src/driver/sqlite/SqliteDriver.ts
@@ -9,6 +9,7 @@ import { SqliteConnectionOptions } from "./SqliteConnectionOptions";
 import { ColumnType } from "../types/ColumnTypes";
 import { QueryRunner } from "../../query-runner/QueryRunner";
 import { AbstractSqliteDriver } from "../sqlite-abstract/AbstractSqliteDriver";
+import {ReplicationMode} from "../types/ReplicationMode";
 
 /**
  * Organizes communication with sqlite DBMS.
@@ -65,7 +66,7 @@ export class SqliteDriver extends AbstractSqliteDriver {
     /**
      * Creates a query runner used to execute database queries.
      */
-    createQueryRunner(mode: "master" | "slave" = "master"): QueryRunner {
+    createQueryRunner(mode: ReplicationMode): QueryRunner {
         if (!this.queryRunner)
             this.queryRunner = new SqliteQueryRunner(this);
 

--- a/src/driver/sqljs/SqljsDriver.ts
+++ b/src/driver/sqljs/SqljsDriver.ts
@@ -9,6 +9,7 @@ import {PlatformTools} from "../../platform/PlatformTools";
 import {EntityMetadata} from "../../metadata/EntityMetadata";
 import {OrmUtils} from "../../util/OrmUtils";
 import {ObjectLiteral} from "../../common/ObjectLiteral";
+import {ReplicationMode} from "../types/ReplicationMode";
 
 // This is needed to satisfy the typescript compiler.
 interface Window {
@@ -69,7 +70,7 @@ export class SqljsDriver extends AbstractSqliteDriver {
     /**
      * Creates a query runner used to execute database queries.
      */
-    createQueryRunner(mode: "master" | "slave" = "master"): QueryRunner {
+    createQueryRunner(mode: ReplicationMode): QueryRunner {
         if (!this.queryRunner)
             this.queryRunner = new SqljsQueryRunner(this);
 

--- a/src/driver/sqlserver/SqlServerDriver.ts
+++ b/src/driver/sqlserver/SqlServerDriver.ts
@@ -19,6 +19,7 @@ import {SqlServerConnectionCredentialsOptions} from "./SqlServerConnectionCreden
 import {EntityMetadata} from "../../metadata/EntityMetadata";
 import {OrmUtils} from "../../util/OrmUtils";
 import {ApplyValueTransformers} from "../../util/ApplyValueTransformers";
+import {ReplicationMode} from "../types/ReplicationMode";
 
 /**
  * Organizes communication with SQL Server DBMS.
@@ -296,7 +297,7 @@ export class SqlServerDriver implements Driver {
     /**
      * Creates a query runner used to execute database queries.
      */
-    createQueryRunner(mode: "master"|"slave" = "master") {
+    createQueryRunner(mode: ReplicationMode) {
         return new SqlServerQueryRunner(this, mode);
     }
 

--- a/src/driver/sqlserver/SqlServerQueryRunner.ts
+++ b/src/driver/sqlserver/SqlServerQueryRunner.ts
@@ -22,6 +22,7 @@ import {Query} from "../Query";
 import {IsolationLevel} from "../types/IsolationLevel";
 import {MssqlParameter} from "./MssqlParameter";
 import {SqlServerDriver} from "./SqlServerDriver";
+import {ReplicationMode} from "../types/ReplicationMode";
 
 /**
  * Runs queries on a single SQL Server database connection.
@@ -54,7 +55,7 @@ export class SqlServerQueryRunner extends BaseQueryRunner implements QueryRunner
     // Constructor
     // -------------------------------------------------------------------------
 
-    constructor(driver: SqlServerDriver, mode: "master"|"slave" = "master") {
+    constructor(driver: SqlServerDriver, mode: ReplicationMode) {
         super();
         this.driver = driver;
         this.connection = driver.connection;

--- a/src/driver/types/ReplicationMode.ts
+++ b/src/driver/types/ReplicationMode.ts
@@ -1,0 +1,1 @@
+export type ReplicationMode = "master" | "slave";

--- a/src/entity-manager/EntityManager.ts
+++ b/src/entity-manager/EntityManager.ts
@@ -128,7 +128,7 @@ export class EntityManager {
 
         // if query runner is already defined in this class, it means this entity manager was already created for a single connection
         // if its not defined we create a new query runner - single connection where we'll execute all our operations
-        const queryRunner = this.queryRunner || this.connection.createQueryRunner("master");
+        const queryRunner = this.queryRunner || this.connection.createQueryRunner();
 
         try {
             if (isolation) {
@@ -832,7 +832,7 @@ export class EntityManager {
      */
     async clear<Entity>(entityClass: EntityTarget<Entity>): Promise<void> {
         const metadata = this.connection.getMetadata(entityClass);
-        const queryRunner = this.queryRunner || this.connection.createQueryRunner("master");
+        const queryRunner = this.queryRunner || this.connection.createQueryRunner();
         try {
             return await queryRunner.clearTable(metadata.tablePath); // await is needed here because we are using finally
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -120,6 +120,7 @@ export * from "./schema-builder/table/TableUnique";
 export * from "./schema-builder/table/Table";
 export * from "./driver/mongodb/typings";
 export * from "./driver/types/DatabaseType";
+export * from "./driver/types/ReplicationMode";
 export * from "./driver/sqlserver/MssqlParameter";
 
 export {ConnectionOptionsReader} from "./connection/ConnectionOptionsReader";

--- a/src/migration/MigrationExecutor.ts
+++ b/src/migration/MigrationExecutor.ts
@@ -129,7 +129,7 @@ export class MigrationExecutor {
      */
     async showMigrations(): Promise<boolean> {
         let hasUnappliedMigrations = false;
-        const queryRunner = this.queryRunner || this.connection.createQueryRunner("master");
+        const queryRunner = this.queryRunner || this.connection.createQueryRunner();
         // create migrations table if its not created yet
         await this.createMigrationsTableIfNotExist(queryRunner);
         // get all migrations that are executed and saved in the database
@@ -163,7 +163,7 @@ export class MigrationExecutor {
      */
     async executePendingMigrations(): Promise<Migration[]> {
 
-        const queryRunner = this.queryRunner || this.connection.createQueryRunner("master");
+        const queryRunner = this.queryRunner || this.connection.createQueryRunner();
         // create migrations table if its not created yet
         await this.createMigrationsTableIfNotExist(queryRunner);
         // get all migrations that are executed and saved in the database
@@ -265,7 +265,7 @@ export class MigrationExecutor {
      */
     async undoLastMigration(): Promise<void> {
 
-        const queryRunner = this.queryRunner || this.connection.createQueryRunner("master");
+        const queryRunner = this.queryRunner || this.connection.createQueryRunner();
 
         // create migrations table if its not created yet
         await this.createMigrationsTableIfNotExist(queryRunner);
@@ -496,7 +496,7 @@ export class MigrationExecutor {
     }
 
     protected async withQueryRunner<T extends any>(callback: (queryRunner: QueryRunner) => T) {
-        const queryRunner = this.queryRunner || this.connection.createQueryRunner("master");
+        const queryRunner = this.queryRunner || this.connection.createQueryRunner();
 
         try {
             return callback(queryRunner);

--- a/src/persistence/EntityPersistExecutor.ts
+++ b/src/persistence/EntityPersistExecutor.ts
@@ -50,7 +50,7 @@ export class EntityPersistExecutor {
 
             // if query runner is already defined in this class, it means this entity manager was already created for a single connection
             // if its not defined we create a new query runner - single connection where we'll execute all our operations
-            const queryRunner = this.queryRunner || this.connection.createQueryRunner("master");
+            const queryRunner = this.queryRunner || this.connection.createQueryRunner();
 
             // save data in the query runner - this is useful functionality to share data from outside of the world
             // with third classes - like subscribers and listener methods

--- a/src/query-builder/QueryBuilder.ts
+++ b/src/query-builder/QueryBuilder.ts
@@ -860,7 +860,7 @@ export abstract class QueryBuilder<Entity> {
      * Creates a query builder used to execute sql queries inside this query builder.
      */
     protected obtainQueryRunner() {
-        return this.queryRunner || this.connection.createQueryRunner("master");
+        return this.queryRunner || this.connection.createQueryRunner();
     }
 
 }

--- a/src/query-runner/BaseQueryRunner.ts
+++ b/src/query-runner/BaseQueryRunner.ts
@@ -9,6 +9,7 @@ import {Table} from "../schema-builder/table/Table";
 import {EntityManager} from "../entity-manager/EntityManager";
 import {TableColumn} from "../schema-builder/table/TableColumn";
 import {Broadcaster} from "../subscriber/Broadcaster";
+import {ReplicationMode} from "../driver/types/ReplicationMode";
 
 export abstract class BaseQueryRunner {
 
@@ -82,7 +83,7 @@ export abstract class BaseQueryRunner {
      * Used for replication.
      * If replication is not setup its value is ignored.
      */
-    protected mode: "master"|"slave";
+    protected mode: ReplicationMode;
 
     // -------------------------------------------------------------------------
     // Public Abstract Methods

--- a/src/schema-builder/MongoSchemaBuilder.ts
+++ b/src/schema-builder/MongoSchemaBuilder.ts
@@ -1,6 +1,6 @@
 import {Connection} from "../connection/Connection";
 import {SchemaBuilder} from "./SchemaBuilder";
-import {MongoDriver} from "../driver/mongodb/MongoDriver";
+import {MongoQueryRunner} from "../driver/mongodb/MongoQueryRunner";
 import {SqlInMemory} from "../driver/SqlInMemory";
 import {MongodbIndexOptions} from "../driver/mongodb/typings";
 
@@ -35,7 +35,7 @@ export class MongoSchemaBuilder implements SchemaBuilder {
      * Creates complete schemas for the given entity metadatas.
      */
     async build(): Promise<void> {
-        const queryRunner = (this.connection.driver as MongoDriver).createQueryRunner();
+        const queryRunner = this.connection.createQueryRunner() as MongoQueryRunner;
         const promises: Promise<any>[] = [];
         this.connection.entityMetadatas.forEach(metadata => {
             metadata.indices.forEach(index => {

--- a/src/schema-builder/RdbmsSchemaBuilder.ts
+++ b/src/schema-builder/RdbmsSchemaBuilder.ts
@@ -65,7 +65,7 @@ export class RdbmsSchemaBuilder implements SchemaBuilder {
      * Creates complete schemas for the given entity metadatas.
      */
     async build(): Promise<void> {
-        this.queryRunner = this.connection.createQueryRunner("master");
+        this.queryRunner = this.connection.createQueryRunner();
         // CockroachDB implements asynchronous schema sync operations which can not been executed in transaction.
         // E.g. if you try to DROP column and ADD it again in the same transaction, crdb throws error.
         if (!(this.connection.driver instanceof CockroachDriver))
@@ -104,7 +104,7 @@ export class RdbmsSchemaBuilder implements SchemaBuilder {
      * Returns sql queries to be executed by schema builder.
      */
     async log(): Promise<SqlInMemory> {
-        this.queryRunner = this.connection.createQueryRunner("master");
+        this.queryRunner = this.connection.createQueryRunner();
         try {
             const tablePaths = this.entityToSyncMetadatas.map(metadata => metadata.tablePath);
             // TODO: typeorm_metadata table needs only for Views for now.

--- a/test/functional/cache/provider/MockQueryResultCache.ts
+++ b/test/functional/cache/provider/MockQueryResultCache.ts
@@ -229,7 +229,7 @@ export class MockQueryResultCache implements QueryResultCache {
         if (queryRunner)
             return queryRunner;
 
-        return this.connection.createQueryRunner("master");
+        return this.connection.createQueryRunner();
     }
 
 }


### PR DESCRIPTION
create a type to track ReplicationMode instead of writing out
`"master"|"slave"` everywhere.

update to drop the default from the QueryRunner constructor
as they will always receive the mode from the driver when
it's part of the QueryRunner

also drop the default from Driver.createQueryRunner in the
implementations - the interface mandates the mode to be defined
so it will never be omitted anyway

also drop the explict "master" from any connection.createQueryRunner
calls so we leave it either the default or `slave` when needed

all of this makes it easier to eventually migrate to
other naming convetions for the replication mode
should it be deemed the right path to go down