### PR TITLE
fix: resolve issues ora-00972:identifier is too long

### DIFF
--- a/src/driver/oracle/OracleDriver.ts
+++ b/src/driver/oracle/OracleDriver.ts
@@ -635,7 +635,7 @@ export class OracleDriver implements Driver {
      * Creates an escaped parameter.
      */
     createParameter(parameterName: string, index: number): string {
-        return ":" + parameterName;
+        return ":" + (index + 1);
     }
 
     /**

--- a/test/github-issues/5067/issue-5067.ts
+++ b/test/github-issues/5067/issue-5067.ts
@@ -4,10 +4,11 @@ import {Connection} from "../../../src";
 import {closeTestingConnections, createTestingConnections} from "../../utils/test-utils";
 import {OracleDriver} from "../../../src/driver/oracle/OracleDriver";
 
-describe.only("github issues > #5067 ORA-00972: identifier is too long", () => {
+describe("github issues > #5067 ORA-00972: identifier is too long", () => {
     let connections: Connection[];
     before(async () => connections = await createTestingConnections({
-        entities: [__dirname + "/entity/*{.js,.ts}"]
+        entities: [__dirname + "/entity/*{.js,.ts}"],
+        enabledDrivers: ["oracle"]
     }));
     after(() => closeTestingConnections(connections));
 

--- a/test/github-issues/5067/issue-5067.ts
+++ b/test/github-issues/5067/issue-5067.ts
@@ -2,28 +2,19 @@ import "reflect-metadata";
 import {expect} from "chai";
 import {Connection} from "../../../src";
 import {closeTestingConnections, createTestingConnections} from "../../utils/test-utils";
-import {OracleDriver} from "../../../src/driver/oracle/OracleDriver";
 
 describe("github issues > #5067 ORA-00972: identifier is too long", () => {
     let connections: Connection[];
     before(async () => connections = await createTestingConnections({
-        entities: [__dirname + "/entity/*{.js,.ts}"],
         enabledDrivers: ["oracle"]
     }));
     after(() => closeTestingConnections(connections));
 
-    it("generated parameter name returns index instead of parameter name", () => Promise.all(connections.map(async connection => {
-        if (connection.driver instanceof OracleDriver)
-        {
-            const paramName = "output_";
-            const parametersCount = 0;
-            const createdParameter = await connection.driver.createParameter(paramName, parametersCount);
+    it("generated parameter name is within the size constraints", () => Promise.all(connections.map(async connection => {
+        const paramName = "output_that_is_really_long_and_must_be_truncated_in_this_driver";
+        const createdParameter = await connection.driver.createParameter(paramName, 0);
 
-            expect(createdParameter).to.be.not.undefined;
-            expect(createdParameter).to.be.not.null;
-            expect(createdParameter).to.be.an("String");
-            expect(createdParameter).to.not.match(/(?:output_)/);
-            expect(await connection.driver.createParameter(paramName, 2)).to.equal(":" + 3);
-        }
+        expect(createdParameter).to.be.an("String");
+        expect(createdParameter.length).to.be.lessThan(30);
     })));
 });

--- a/test/github-issues/5067/issue-5067.ts
+++ b/test/github-issues/5067/issue-5067.ts
@@ -2,6 +2,7 @@ import "reflect-metadata";
 import {expect} from "chai";
 import {Connection} from "../../../src";
 import {closeTestingConnections, createTestingConnections} from "../../utils/test-utils";
+import {OracleDriver} from "../../../src/driver/oracle/OracleDriver";
 
 describe.only("github issues > #5067 ORA-00972: identifier is too long", () => {
     let connections: Connection[];
@@ -11,14 +12,17 @@ describe.only("github issues > #5067 ORA-00972: identifier is too long", () => {
     after(() => closeTestingConnections(connections));
 
     it("generated parameter name returns index instead of parameter name", () => Promise.all(connections.map(async connection => {
-        const paramName = "output_";
-        const parametersCount = 0;
-        const createdParameter = await connection.driver.createParameter(paramName, parametersCount);
+        if (connection.driver instanceof OracleDriver)
+        {
+            const paramName = "output_";
+            const parametersCount = 0;
+            const createdParameter = await connection.driver.createParameter(paramName, parametersCount);
 
-        expect(createdParameter).to.be.not.undefined;
-        expect(createdParameter).to.be.not.null;
-        expect(createdParameter).to.be.an("String");
-        expect(createdParameter).to.not.match(/(?:output_)/);
-        expect(await connection.driver.createParameter(paramName, 2)).to.equal(":" + 3);
+            expect(createdParameter).to.be.not.undefined;
+            expect(createdParameter).to.be.not.null;
+            expect(createdParameter).to.be.an("String");
+            expect(createdParameter).to.not.match(/(?:output_)/);
+            expect(await connection.driver.createParameter(paramName, 2)).to.equal(":" + 3);
+        }
     })));
 });

--- a/test/github-issues/5067/issue-5067.ts
+++ b/test/github-issues/5067/issue-5067.ts
@@ -1,0 +1,24 @@
+import "reflect-metadata";
+import {expect} from "chai";
+import {Connection} from "../../../src";
+import {closeTestingConnections, createTestingConnections} from "../../utils/test-utils";
+
+describe.only("github issues > #5067 ORA-00972: identifier is too long", () => {
+    let connections: Connection[];
+    before(async () => connections = await createTestingConnections({
+        entities: [__dirname + "/entity/*{.js,.ts}"]
+    }));
+    after(() => closeTestingConnections(connections));
+
+    it("generated parameter name returns index instead of parameter name", () => Promise.all(connections.map(async connection => {
+        const paramName = "output_";
+        const parametersCount = 0;
+        const createdParameter = await connection.driver.createParameter(paramName, parametersCount);
+
+        expect(createdParameter).to.be.not.undefined;
+        expect(createdParameter).to.be.not.null;
+        expect(createdParameter).to.be.an("String");
+        expect(createdParameter).to.not.match(/(?:output_)/);
+        expect(await connection.driver.createParameter(paramName, 2)).to.equal(":" + 3);
+    })));
+});


### PR DESCRIPTION
Use index instead of parameter name for make it shorter alias name.

Closes #6591
Fixes #5067