### PR TITLE
fix: add dummy for FileLogger, ConnectionOptionsReaders, and update gulpfile

### DIFF
--- a/gulpfile.ts
+++ b/gulpfile.ts
@@ -64,38 +64,18 @@ export class Gulpfile {
             "!./src/commands/*.ts",
             "!./src/cli.ts",
             "!./src/typeorm.ts",
-            "!./src/typeorm-model-shim.ts",
-            "!./src/platform/PlatformTools.ts"
+            "!./src/typeorm-model-shim.ts"
         ])
         .pipe(gulp.dest("./build/browser/src"));
     }
 
     /**
-     * Replaces PlatformTools with browser-specific implementation called BrowserPlatformTools.
+     * Copies templates for compilation
      */
     @Task()
-    browserCopyDirectoryExportedClassesLoader() {
-        return gulp.src("./src/platform/BrowserDirectoryExportedClassesLoader.template")
-            .pipe(rename("BrowserDirectoryExportedClassesLoader.ts"))
-            .pipe(gulp.dest("./build/browser/src/platform"));
-    }
-    /**
-     * Replaces PlatformTools with browser-specific implementation called BrowserPlatformTools.
-     */
-    @Task()
-    browserCopyPlatformTools() {
-        return gulp.src("./src/platform/BrowserPlatformTools.template")
-            .pipe(rename("PlatformTools.ts"))
-            .pipe(gulp.dest("./build/browser/src/platform"));
-    }
-
-    /**
-     * Adds dummy classes for disabled drivers (replacement is done via browser entry point in package.json)
-     */
-    @Task()
-    browserCopyDisabledDriversDummy() {
-        return gulp.src("./src/platform/BrowserDisabledDriversDummy.template")
-            .pipe(rename("BrowserDisabledDriversDummy.ts"))
+    browserCopyTemplates() {
+        return gulp.src("./src/platform/*.template")
+            .pipe(rename((p: any) => { p.extname = '.ts'; }))
             .pipe(gulp.dest("./build/browser/src/platform"));
     }
 
@@ -242,7 +222,7 @@ export class Gulpfile {
     package() {
         return [
             "clean",
-            ["browserCopySources", "browserCopyPlatformTools", "browserCopyDisabledDriversDummy", "browserCopyDirectoryExportedClassesLoader"],
+            ["browserCopySources", "browserCopyTemplates"],
             ["packageCompile", "browserCompile"],
             "packageMoveCompiledFiles",
             [

--- a/package.json
+++ b/package.json
@@ -25,6 +25,11 @@
     "./browser/driver/sqlite/SqliteDriver.js": "./browser/platform/BrowserDisabledDriversDummy.js",
     "./browser/driver/better-sqlite3/BetterSqlite3Driver.js": "./browser/platform/BrowserDisabledDriversDummy.js",
     "./browser/util/DirectoryExportedClassesLoader.js": "./browser/platform/BrowserDirectoryExportedClassesLoader.js",
+    "./browser/logger/FileLogger.js": "./browser/platform/BrowserFileLoggerDummy.js",
+    "./browser/connection/ConnectionOptionsReader.js": "./browser/platform/BrowserConnectionOptionsReaderDummy.js",
+    "./browser/connection/options-reader/ConnectionOptionsXmlReader.js": "./browser/platform/BrowserConnectionOptionsReaderDummy.js",
+    "./browser/connection/options-reader/ConnectionOptionsYmlReader.js": "./browser/platform/BrowserConnectionOptionsReaderDummy.js",
+    "./browser/platform/PlatformTools.js": "./browser/platform/BrowserPlatformTools.js",
     "./index.js": "./browser/index.js"
   },
   "repository": {

--- a/src/connection/ConnectionOptionsReader.ts
+++ b/src/connection/ConnectionOptionsReader.ts
@@ -103,8 +103,8 @@ export class ConnectionOptionsReader {
         const configFile = fileExtension ? this.baseFilePath : this.baseFilePath + "." + foundFileFormat;
 
         // try to find connection options from any of available sources of configuration
-        if (PlatformTools.getEnvVariable("TYPEORM_CONNECTION") || PlatformTools.getEnvVariable("TYPEORM_URL")) {
-            connectionOptions = new ConnectionOptionsEnvReader().read();
+        if (PlatformTools.getEnvVariable("TYPEORM_CONNECTION") || PlatformTools.getEnvVariable("TYPEORM_URL")) {
+            connectionOptions = await new ConnectionOptionsEnvReader().read();
 
         } else if (foundFileFormat === "js" || foundFileFormat === "cjs") {
             connectionOptions = await require(configFile);
@@ -116,10 +116,10 @@ export class ConnectionOptionsReader {
             connectionOptions = require(configFile);
 
         } else if (foundFileFormat === "yml") {
-            connectionOptions = new ConnectionOptionsYmlReader().read(configFile);
+            connectionOptions = await new ConnectionOptionsYmlReader().read(configFile);
 
         } else if (foundFileFormat === "yaml") {
-            connectionOptions = new ConnectionOptionsYmlReader().read(configFile);
+            connectionOptions = await new ConnectionOptionsYmlReader().read(configFile);
 
         } else if (foundFileFormat === "xml") {
             connectionOptions = await new ConnectionOptionsXmlReader().read(configFile);

--- a/src/connection/options-reader/ConnectionOptionsEnvReader.ts
+++ b/src/connection/options-reader/ConnectionOptionsEnvReader.ts
@@ -16,8 +16,8 @@ export class ConnectionOptionsEnvReader {
     /**
      * Reads connection options from environment variables.
      */
-    read(): ConnectionOptions {
-        return {
+    async read(): Promise<ConnectionOptions[]> {
+        return [{
             type: PlatformTools.getEnvVariable("TYPEORM_CONNECTION") || (PlatformTools.getEnvVariable("TYPEORM_URL") ? PlatformTools.getEnvVariable("TYPEORM_URL").split("://")[0] : undefined),
             url: PlatformTools.getEnvVariable("TYPEORM_URL"),
             host: PlatformTools.getEnvVariable("TYPEORM_HOST"),
@@ -47,7 +47,7 @@ export class ConnectionOptionsEnvReader {
             },
             cache: this.transformCaching(),
             uuidExtension: PlatformTools.getEnvVariable("TYPEORM_UUID_EXTENSION")
-        };
+        }];
     }
 
     // -------------------------------------------------------------------------

--- a/src/connection/options-reader/ConnectionOptionsYmlReader.ts
+++ b/src/connection/options-reader/ConnectionOptionsYmlReader.ts
@@ -14,7 +14,7 @@ export class ConnectionOptionsYmlReader {
     /**
      * Reads connection options from given yml file.
      */
-    read(path: string): ConnectionOptions[] {
+    async read(path: string): Promise<ConnectionOptions[]> {
         const contentsBuffer = PlatformTools.readFileSync(path);
         const contents = contentsBuffer.toString();
 

--- a/src/platform/BrowserConnectionOptionsReaderDummy.template
+++ b/src/platform/BrowserConnectionOptionsReaderDummy.template
@@ -1,0 +1,55 @@
+/**
+ * Dummy class for replacement via `package.json` in browser builds.
+ *
+ * If we don't include these functions typeorm will throw an error on runtime
+ * as well as during webpack builds.
+ */
+export class ConnectionOptionsEnvReader {
+    async read() {
+        throw new Error(`Cannot read connection options in a browser context.`);
+    }
+}
+
+/**
+ * Dummy class for replacement via `package.json` in browser builds.
+ *
+ * If we don't include these functions typeorm will throw an error on runtime
+ * as well as during webpack builds.
+ */
+export class ConnectionOptionsXmlReader {
+    async read(path: string) {
+        throw new Error(`Cannot read connection options in a browser context.`);
+    }
+}
+
+/**
+ * Dummy class for replacement via `package.json` in browser builds.
+ *
+ * If we don't include these functions typeorm will throw an error on runtime
+ * as well as during webpack builds.
+ */
+export class ConnectionOptionsYmlReader {
+    async read(path: string) {
+        throw new Error(`Cannot read connection options in a browser context.`);
+    }
+}
+
+/**
+ * Dummy class for replacement via `package.json` in browser builds.
+ *
+ * If we don't include these functions typeorm will throw an error on runtime
+ * as well as during webpack builds.
+ */
+export class ConnectionOptionsReader {
+    async all() {
+        throw new Error(`Cannot read connection options in a browser context.`);
+    }
+
+    async get() {
+        throw new Error(`Cannot read connection options in a browser context.`);
+    }
+
+    async has() {
+        throw new Error(`Cannot read connection options in a browser context.`);
+    }
+}

--- a/src/platform/BrowserFileLoggerDummy.template
+++ b/src/platform/BrowserFileLoggerDummy.template
@@ -1,0 +1,50 @@
+/**
+ * Performs logging of the events in TypeORM.
+ * This version of logger logs everything into ormlogs.log file.
+ */
+export class DummyLogger {
+    /**
+     * Logs query and parameters used in it.
+     */
+    logQuery() {
+        throw new Error('This logger is not applicable in a browser context');
+    }
+
+    /**
+     * Logs query that is failed.
+     */
+    logQueryError() {
+        throw new Error('This logger is not applicable in a browser context');
+    }
+
+    /**
+     * Logs query that is slow.
+     */
+    logQuerySlow() {
+        throw new Error('This logger is not applicable in a browser context');
+    }
+
+    /**
+     * Logs events from the schema build process.
+     */
+    logSchemaBuild() {
+        throw new Error('This logger is not applicable in a browser context');
+    }
+
+    /**
+     * Logs events from the migrations run process.
+     */
+    logMigration() {
+        throw new Error('This logger is not applicable in a browser context');
+    }
+
+    /**
+     * Perform logging using given logger, or by default to the console.
+     * Log has its own level and message.
+     */
+    log() {
+        throw new Error('This logger is not applicable in a browser context');
+    }
+}
+
+export class FileLogger extends DummyLogger {}


### PR DESCRIPTION
Add browser dummies for `FileLogger`, `ConnectionOptionsReader`, and change how we process the `*.template` files in `gulp`.

Ideally, we should move away from this whole process for creating browser builds by monkey-patching random parts of TypeORM in this way - such as restructuring the package or finding some other mechanism to make this happen.. but until then, this solves some of the remaining issues with browser builds according to @chriswep 

Fixes #6739 