### PR TITLE
Fix schema synchronization for partitioned tables with PostgreSQL 12+

### DIFF
--- a/src/driver/postgres/PostgresQueryRunner.ts
+++ b/src/driver/postgres/PostgresQueryRunner.ts
@@ -1412,7 +1412,7 @@ export class PostgresQueryRunner extends BaseQueryRunner implements QueryRunner 
             `INNER JOIN "pg_class" "t" ON "t"."oid" = "cnst"."conrelid" ` +
             `INNER JOIN "pg_namespace" "ns" ON "ns"."oid" = "cnst"."connamespace" ` +
             `LEFT JOIN "pg_attribute" "a" ON "a"."attrelid" = "cnst"."conrelid" AND "a"."attnum" = ANY ("cnst"."conkey") ` +
-            `WHERE "t"."relkind" = 'r' AND (${constraintsCondition})`;
+            `WHERE "t"."relkind" IN ('r', 'p') AND (${constraintsCondition})`;
 
         const indicesSql = `SELECT "ns"."nspname" AS "table_schema", "t"."relname" AS "table_name", "i"."relname" AS "constraint_name", "a"."attname" AS "column_name", ` +
             `CASE "ix"."indisunique" WHEN 't' THEN 'TRUE' ELSE'FALSE' END AS "is_unique", pg_get_expr("ix"."indpred", "ix"."indrelid") AS "condition", ` +
@@ -1424,7 +1424,7 @@ export class PostgresQueryRunner extends BaseQueryRunner implements QueryRunner 
             `INNER JOIN "pg_class" "i" ON "i"."oid" = "ix"."indexrelid" ` +
             `INNER JOIN "pg_type" "types" ON "types"."oid" = "a"."atttypid" ` +
             `LEFT JOIN "pg_constraint" "cnst" ON "cnst"."conname" = "i"."relname" ` +
-            `WHERE "t"."relkind" = 'r' AND "cnst"."contype" IS NULL AND (${constraintsCondition})`;
+            `WHERE "t"."relkind" IN ('r', 'p') AND "cnst"."contype" IS NULL AND (${constraintsCondition})`;
 
         const foreignKeysCondition = tableNames.map(tableName => {
             let [schema, name] = tableName.split(".");


### PR DESCRIPTION
### Consider partitioned tables as regular tables

Typeorm currently excludes partitioned tables from schema synchronization. We could also take them into account as their behavior regarding schema modifications is the same as regular tables.

### Ignore foreign keys on partitions of the partitioned tables when syncing schema on PostgreSQL 12+

When a table has foreign keys referencing a partitioned table, the `PostgresQueryRunner` will load the constraints from every partition.
We need to ignore those foreign keys as they are not managed by the user.

Example:
`table_A` has a foreign key constraint referencing `table_B` which is a partitioned table on `key1` and `key2`.

The command `typeorm schema:log` will return this kind of list of queries to remove the FK constraints from `table_A`.
```
------------------------------------------------------------------
-- Schema syncronization will execute following sql queries (220):
------------------------------------------------------------------
ALTER TABLE "table_A" DROP CONSTRAINT "table_A_table_B_key1_key2__fkey";
ALTER TABLE "table_A" DROP CONSTRAINT "table_A_table_B_key1_key2_fkey1";
ALTER TABLE "table_A" DROP CONSTRAINT "table_A_table_B_key1_key2_fkey2";
ALTER TABLE "table_A" DROP CONSTRAINT "table_A_table_B_key1_key2_fkey3";
ALTER TABLE "table_A" DROP CONSTRAINT "table_A_table_B_key1_key2_fkey4";
ALTER TABLE "table_A" DROP CONSTRAINT "table_A_table_B_key1_key2_fkey5";
ALTER TABLE "table_A" DROP CONSTRAINT "table_A_table_B_key1_key2_fkey6";
ALTER TABLE "table_A" DROP CONSTRAINT "table_A_table_B_key1_key2_fkey7";
ALTER TABLE "table_A" DROP CONSTRAINT "table_A_table_B_key1_key2_fkey8";
ALTER TABLE "table_A" DROP CONSTRAINT "table_A_table_B_key1_key2_fkey9";
ALTER TABLE "table_A" DROP CONSTRAINT "table_A_table_B_key1_key2_fkey10";
ALTER TABLE "table_A" DROP CONSTRAINT "table_A_table_B_key1_key2_fkey11";
ALTER TABLE "table_A" DROP CONSTRAINT "table_A_table_B_key1_key2_fkey12";
ALTER TABLE "table_A" DROP CONSTRAINT "table_A_table_B_key1_key2_fkey13";
ALTER TABLE "table_A" DROP CONSTRAINT "table_A_table_B_key1_key2_fkey14";
ALTER TABLE "table_A" DROP CONSTRAINT "table_A_table_B_key1_key2_fkey15";
ALTER TABLE "table_A" DROP CONSTRAINT "table_A_table_B_key1_key2_fkey16";
ALTER TABLE "table_A" DROP CONSTRAINT "table_A_table_B_key1_key2_fkey17";
ALTER TABLE "table_A" DROP CONSTRAINT "table_A_table_B_key1_key2_fkey18";
ALTER TABLE "table_A" DROP CONSTRAINT "table_A_table_B_key1_key2_fkey19";
ALTER TABLE "table_A" DROP CONSTRAINT "table_A_table_B_key1_key2_fkey20";
ALTER TABLE "table_A" DROP CONSTRAINT "table_A_table_B_key1_key2_fkey21";
ALTER TABLE "table_A" DROP CONSTRAINT "table_A_table_B_key1_key2_fkey22";
ALTER TABLE "table_A" DROP CONSTRAINT "table_A_table_B_key1_key2_fkey23";
ALTER TABLE "table_A" DROP CONSTRAINT "table_A_table_B_key1_key2_fkey24";
ALTER TABLE "table_A" DROP CONSTRAINT "table_A_table_B_key1_key2_fkey25";
...
```

Typeorm should ignore those constraints.