### PR TITLE
[Issue #3336] Specifying order per column using `@Index` decorator *to PostgresSQL and SQLite*

### DIFF
--- a/src/decorator/Index.ts
+++ b/src/decorator/Index.ts
@@ -1,5 +1,6 @@
 import {getMetadataArgsStorage, IndexOptions} from "../";
 import {IndexMetadataArgs} from "../metadata-args/IndexMetadataArgs";
+import {IndexOrderOptions} from "../metadata/types/IndexOrderOptions";
 
 /**
  * Creates a database index.
@@ -67,6 +68,20 @@ export function Index(nameOrFieldsOrOptions?: string|string[]|((object: any) => 
         options = (typeof maybeFieldsOrOptions === "object" && !Array.isArray(maybeFieldsOrOptions)) ? maybeFieldsOrOptions as IndexOptions : maybeOptions;
 
     return function (clsOrObject: Function|Object, propertyName?: string | symbol) {
+        let orderBy: IndexOrderOptions | undefined;
+        if (options) {
+            if (!propertyName || typeof options.orderBy === "string") {
+                orderBy = options.orderBy;
+            } else if (propertyName && options.orderBy && options.orderBy.hasOwnProperty(propertyName)) {
+                orderBy = {
+                    [propertyName]: options.orderBy[propertyName.toString()]
+                };
+            } else {
+                orderBy = undefined;
+            }
+        } else {
+            orderBy = undefined;
+        }
 
         getMetadataArgsStorage().indices.push({
             target: propertyName ? clsOrObject.constructor : clsOrObject as Function,
@@ -80,7 +95,8 @@ export function Index(nameOrFieldsOrOptions?: string|string[]|((object: any) => 
             parser: options ? options.parser : undefined,
             sparse: options && options.sparse ? true : false,
             background: options && options.background ? true : false,
-            expireAfterSeconds: options ? options.expireAfterSeconds : undefined
+            expireAfterSeconds: options ? options.expireAfterSeconds : undefined,
+            orderBy: orderBy
         } as IndexMetadataArgs);
     };
 }

--- a/src/decorator/options/IndexOptions.ts
+++ b/src/decorator/options/IndexOptions.ts
@@ -1,6 +1,8 @@
 /**
  * Describes all index options.
  */
+import {IndexOrderOptions} from "../../metadata/types/IndexOrderOptions";
+
 export interface IndexOptions {
 
     /**
@@ -50,4 +52,8 @@ export interface IndexOptions {
      */
     expireAfterSeconds?: number;
 
+    /**
+     * Specifies a sort order used in index creation.
+     */
+    orderBy?: IndexOrderOptions;
 }

--- a/src/entity-schema/EntitySchemaIndexOptions.ts
+++ b/src/entity-schema/EntitySchemaIndexOptions.ts
@@ -1,3 +1,5 @@
+import {IndexOrderOptions} from "../metadata/types/IndexOrderOptions";
+
 export interface EntitySchemaIndexOptions {
 
     /**
@@ -38,7 +40,7 @@ export interface EntitySchemaIndexOptions {
      * Works only in MySQL.
      */
     fulltext?: boolean;
-    
+
     /**
      * Fulltext parser.
      * Works only in MySQL.
@@ -49,5 +51,10 @@ export interface EntitySchemaIndexOptions {
      * Index filter condition.
      */
     where?: string;
+
+    /**
+     * Specifies a sort order used in index creation.
+     */
+    orderBy?: IndexOrderOptions;
 
 }

--- a/src/entity-schema/EntitySchemaTransformer.ts
+++ b/src/entity-schema/EntitySchemaTransformer.ts
@@ -202,7 +202,8 @@ export class EntitySchemaTransformer {
                         synchronize: index.synchronize === false ? false : true,
                         where: index.where,
                         sparse: index.sparse,
-                        columns: index.columns
+                        columns: index.columns,
+                        orderBy: index.orderBy
                     };
                     metadataArgsStorage.indices.push(indexAgrs);
                 });

--- a/src/metadata-args/IndexMetadataArgs.ts
+++ b/src/metadata-args/IndexMetadataArgs.ts
@@ -1,6 +1,8 @@
 /**
  * Arguments for IndexMetadata class.
  */
+import {IndexOrderOptions} from "../metadata/types/IndexOrderOptions";
+
 export interface IndexMetadataArgs {
 
     /**
@@ -34,7 +36,7 @@ export interface IndexMetadataArgs {
      * Works only in MySQL.
      */
     fulltext?: boolean;
-    
+
     /**
      * Fulltext parser.
      * Works only in MySQL.
@@ -69,4 +71,9 @@ export interface IndexMetadataArgs {
      * This option is only supported for mongodb database.
      */
     expireAfterSeconds?: number;
+
+    /**
+     * Specifies a sort order used in index creation.
+     */
+    orderBy?: IndexOrderOptions;
 }

--- a/src/metadata/IndexMetadata.ts
+++ b/src/metadata/IndexMetadata.ts
@@ -3,6 +3,7 @@ import {IndexMetadataArgs} from "../metadata-args/IndexMetadataArgs";
 import {NamingStrategyInterface} from "../naming-strategy/NamingStrategyInterface";
 import {ColumnMetadata} from "./ColumnMetadata";
 import {EmbeddedMetadata} from "./EmbeddedMetadata";
+import {IndexOrderOptions} from "./types/IndexOrderOptions";
 
 /**
  * Index metadata contains all information about table's index.
@@ -103,6 +104,11 @@ export class IndexMetadata {
     where?: string;
 
     /**
+     * Specifies a sort order used in index creation.
+     */
+    orderBy?: IndexOrderOptions;
+
+    /**
      * Map of column names with order set.
      * Used only by MongoDB driver.
      */
@@ -137,6 +143,7 @@ export class IndexMetadata {
             this.expireAfterSeconds = options.args.expireAfterSeconds;
             this.givenName = options.args.name;
             this.givenColumnNames = options.args.columns;
+            this.orderBy = options.args.orderBy;
         }
     }
 

--- a/src/metadata/types/IndexOrderOptions.ts
+++ b/src/metadata/types/IndexOrderOptions.ts
@@ -1,0 +1,6 @@
+import {OrderByCondition} from "../..";
+
+/**
+ * Used to specify a sort order used in index creation.
+ */
+export type IndexOrderOptions = OrderByCondition | ("ASC"|"DESC");

--- a/src/schema-builder/options/TableIndexOptions.ts
+++ b/src/schema-builder/options/TableIndexOptions.ts
@@ -1,6 +1,8 @@
 /**
  * Database's table index options.
  */
+import {IndexOrderOptions} from "../../metadata/types/IndexOrderOptions";
+
 export interface TableIndexOptions {
 
     // -------------------------------------------------------------------------
@@ -45,4 +47,8 @@ export interface TableIndexOptions {
      */
     where?: string;
 
+    /**
+     * Specifies a sort order used in index creation.
+     */
+    orderBy?: IndexOrderOptions;
 }

--- a/src/schema-builder/table/TableIndex.ts
+++ b/src/schema-builder/table/TableIndex.ts
@@ -1,5 +1,6 @@
 import {IndexMetadata} from "../../metadata/IndexMetadata";
 import {TableIndexOptions} from "../options/TableIndexOptions";
+import {IndexOrderOptions} from "../../metadata/types/IndexOrderOptions";
 
 /**
  * Database's table index stored in this class.
@@ -48,6 +49,11 @@ export class TableIndex {
      */
     where: string;
 
+    /**
+     * Specifies a sort order used in index creation.
+     */
+    orderBy?: IndexOrderOptions;
+
     // -------------------------------------------------------------------------
     // Constructor
     // -------------------------------------------------------------------------
@@ -60,6 +66,7 @@ export class TableIndex {
         this.isFulltext = !!options.isFulltext;
         this.parser = options.parser;
         this.where = options.where ? options.where : "";
+        this.orderBy = options.orderBy;
     }
 
     // -------------------------------------------------------------------------
@@ -77,7 +84,8 @@ export class TableIndex {
             isSpatial: this.isSpatial,
             isFulltext: this.isFulltext,
             parser: this.parser,
-            where: this.where
+            where: this.where,
+            orderBy: this.orderBy
         });
     }
 
@@ -96,7 +104,8 @@ export class TableIndex {
             isSpatial: indexMetadata.isSpatial,
             isFulltext: indexMetadata.isFulltext,
             parser: indexMetadata.parser,
-            where: indexMetadata.where
+            where: indexMetadata.where,
+            orderBy: indexMetadata.orderBy
         });
     }
 

--- a/test/github-issues/3336/entity/Asc.ts
+++ b/test/github-issues/3336/entity/Asc.ts
@@ -1,0 +1,27 @@
+import {Index, PrimaryColumn} from "../../../../src";
+import {Column} from "../../../../src";
+import {Entity} from "../../../../src";
+
+@Entity()
+export class Asc {
+    @PrimaryColumn()
+    public id: number;
+
+    @Column()
+    @Index({
+        orderBy: "ASC"
+    })
+    public numberField!: number;
+
+    @Column()
+    @Index({
+        orderBy: "ASC"
+    })
+    public dateField!: Date;
+
+    @Column()
+    @Index({
+        orderBy: "ASC"
+    })
+    public stringField!: string;
+}

--- a/test/github-issues/3336/entity/AscNullFirst.ts
+++ b/test/github-issues/3336/entity/AscNullFirst.ts
@@ -1,0 +1,42 @@
+import {Index, PrimaryColumn} from "../../../../src";
+import {Column} from "../../../../src";
+import {Entity} from "../../../../src";
+
+@Entity()
+export class AscNullFirst {
+    @PrimaryColumn()
+    public id: number;
+
+    @Column({ nullable: true })
+    @Index({
+        orderBy: {
+            numberField: {
+                nulls: "NULLS FIRST",
+                order: "ASC"
+            }
+        }
+    })
+    public numberField?: number;
+
+    @Column({ nullable: true })
+    @Index({
+        orderBy: {
+            dateField: {
+                nulls: "NULLS FIRST",
+                order: "ASC"
+            }
+        }
+    })
+    public dateField?: Date;
+
+    @Column({ nullable: true })
+    @Index({
+        orderBy: {
+            stringField: {
+                nulls: "NULLS FIRST",
+                order: "ASC"
+            }
+        }
+    })
+    public stringField?: string;
+}

--- a/test/github-issues/3336/entity/AscNullLast.ts
+++ b/test/github-issues/3336/entity/AscNullLast.ts
@@ -1,0 +1,42 @@
+import {Index, PrimaryColumn} from "../../../../src";
+import {Column} from "../../../../src";
+import {Entity} from "../../../../src";
+
+@Entity()
+export class AscNullLast {
+    @PrimaryColumn()
+    public id: number;
+
+    @Column({ nullable: true })
+    @Index({
+        orderBy: {
+            numberField: {
+                nulls: "NULLS LAST",
+                order: "ASC"
+            }
+        }
+    })
+    public numberField?: number;
+
+    @Column({ nullable: true })
+    @Index({
+        orderBy: {
+            dateField: {
+                nulls: "NULLS LAST",
+                order: "ASC"
+            }
+        }
+    })
+    public dateField?: Date;
+
+    @Column({ nullable: true })
+    @Index({
+        orderBy: {
+            stringField: {
+                nulls: "NULLS LAST",
+                order: "ASC"
+            }
+        }
+    })
+    public stringField?: string;
+}

--- a/test/github-issues/3336/entity/Desc.ts
+++ b/test/github-issues/3336/entity/Desc.ts
@@ -1,0 +1,27 @@
+import {Index, PrimaryColumn} from "../../../../src";
+import {Column} from "../../../../src";
+import {Entity} from "../../../../src";
+
+@Entity()
+export class Desc {
+    @PrimaryColumn()
+    public id: number;
+
+    @Column()
+    @Index({
+        orderBy: "DESC"
+    })
+    public numberField!: number;
+
+    @Column()
+    @Index({
+        orderBy: "DESC"
+    })
+    public dateField!: Date;
+
+    @Column()
+    @Index({
+        orderBy: "DESC"
+    })
+    public stringField!: string;
+}

--- a/test/github-issues/3336/entity/DescNullFirst.ts
+++ b/test/github-issues/3336/entity/DescNullFirst.ts
@@ -1,0 +1,42 @@
+import {Index, PrimaryColumn} from "../../../../src";
+import {Column} from "../../../../src";
+import {Entity} from "../../../../src";
+
+@Entity()
+export class DescNullFirst {
+    @PrimaryColumn()
+    public id: number;
+
+    @Column({ nullable: true })
+    @Index({
+        orderBy: {
+            numberField: {
+                nulls: "NULLS FIRST",
+                order: "DESC"
+            }
+        }
+    })
+    public numberField?: number;
+
+    @Column({ nullable: true })
+    @Index({
+        orderBy: {
+            dateField: {
+                nulls: "NULLS FIRST",
+                order: "DESC"
+            }
+        }
+    })
+    public dateField?: Date;
+
+    @Column({ nullable: true })
+    @Index({
+        orderBy: {
+            stringField: {
+                nulls: "NULLS FIRST",
+                order: "DESC"
+            }
+        }
+    })
+    public stringField?: string;
+}

--- a/test/github-issues/3336/entity/DescNullLast.ts
+++ b/test/github-issues/3336/entity/DescNullLast.ts
@@ -1,0 +1,42 @@
+import {Index, PrimaryColumn} from "../../../../src";
+import {Column} from "../../../../src";
+import {Entity} from "../../../../src";
+
+@Entity()
+export class DescNullLast {
+    @PrimaryColumn()
+    public id: number;
+
+    @Column({ nullable: true })
+    @Index({
+        orderBy: {
+            numberField: {
+                nulls: "NULLS LAST",
+                order: "DESC"
+            }
+        }
+    })
+    public numberField?: number;
+
+    @Column({ nullable: true })
+    @Index({
+        orderBy: {
+            dateField: {
+                nulls: "NULLS LAST",
+                order: "DESC"
+            }
+        }
+    })
+    public dateField?: Date;
+
+    @Column({ nullable: true })
+    @Index({
+        orderBy: {
+            stringField: {
+                nulls: "NULLS LAST",
+                order: "DESC"
+            }
+        }
+    })
+    public stringField?: string;
+}

--- a/test/github-issues/3336/entity/Mixed.ts
+++ b/test/github-issues/3336/entity/Mixed.ts
@@ -1,0 +1,32 @@
+import {Index, PrimaryColumn} from "../../../../src";
+import {Column} from "../../../../src";
+import {Entity} from "../../../../src";
+
+@Entity()
+export class Mixed {
+    @PrimaryColumn()
+    public id: number;
+
+    @Column()
+    @Index({
+        orderBy: "ASC"
+    })
+    public numberField!: number;
+
+    @Column()
+    @Index({
+        orderBy: "DESC"
+    })
+    public dateField!: Date;
+
+    @Column({ nullable: true })
+    @Index({
+        orderBy: {
+            stringField: {
+                nulls: "NULLS FIRST",
+                order: "ASC"
+            }
+        }
+    })
+    public stringField?: string;
+}

--- a/test/github-issues/3336/entity/MixedNormal.ts
+++ b/test/github-issues/3336/entity/MixedNormal.ts
@@ -1,0 +1,22 @@
+import {Index, PrimaryColumn} from "../../../../src";
+import {Column} from "../../../../src";
+import {Entity} from "../../../../src";
+
+@Entity()
+export class MixedNormal {
+    @PrimaryColumn()
+    public id: number;
+
+    @Column()
+    public numberField!: number;
+
+    @Column()
+    @Index()
+    public dateField!: Date;
+
+    @Column()
+    @Index({
+        orderBy: "ASC"
+    })
+    public stringField!: string;
+}

--- a/test/github-issues/3336/entity/Multiple.ts
+++ b/test/github-issues/3336/entity/Multiple.ts
@@ -1,0 +1,30 @@
+import {Index, PrimaryColumn} from "../../../../src";
+import {Column} from "../../../../src";
+import {Entity} from "../../../../src";
+
+@Entity()
+@Index(["numberField", "dateField", "stringField"],{
+    orderBy: {
+        numberField: {
+            order: "ASC"
+        },
+        dateField: "DESC",
+        stringField: {
+            order: "DESC",
+            nulls: "NULLS LAST"
+        }
+    }
+})
+export class Multiple {
+    @PrimaryColumn()
+    public id: number;
+
+    @Column()
+    public numberField!: number;
+
+    @Column()
+    public dateField!: Date;
+
+    @Column()
+    public stringField!: string;
+}

--- a/test/github-issues/3336/entity/MultipleString.ts
+++ b/test/github-issues/3336/entity/MultipleString.ts
@@ -1,0 +1,21 @@
+import {Index, PrimaryColumn} from "../../../../src";
+import {Column} from "../../../../src";
+import {Entity} from "../../../../src";
+
+@Entity()
+@Index(["numberField", "dateField", "stringField"],{
+    orderBy: "ASC"
+})
+export class MultipleString {
+    @PrimaryColumn()
+    public id: number;
+
+    @Column()
+    public numberField!: number;
+
+    @Column()
+    public dateField!: Date;
+
+    @Column()
+    public stringField!: string;
+}

--- a/test/github-issues/3336/issue-3349.ts
+++ b/test/github-issues/3336/issue-3349.ts
@@ -1,0 +1,577 @@
+import "reflect-metadata";
+import { createTestingConnections, closeTestingConnections, reloadTestingDatabases } from "../../utils/test-utils";
+import { Connection } from "../../../src/connection/Connection";
+import { expect } from "chai";
+import {Asc} from "./entity/Asc";
+import {AscNullFirst} from "./entity/AscNullFirst";
+import {AscNullLast} from "./entity/AscNullLast";
+import {Desc} from "./entity/Desc";
+import {DescNullFirst} from "./entity/DescNullFirst";
+import {DescNullLast} from "./entity/DescNullLast";
+import {Mixed} from "./entity/Mixed";
+import {MixedNormal} from "./entity/MixedNormal";
+import {Multiple} from "./entity/Multiple";
+import {MultipleString} from "./entity/MultipleString";
+
+interface OrderByOptions {
+    order: "ASC" | "DESC",
+    nulls?: "NULLS FIRST" | "NULLS LAST"
+};
+
+describe("github issues > #3336 Order option in @Index decorator", () => {
+
+    let connections: Connection[];
+    before(async () => connections = await createTestingConnections({
+        entities: [__dirname + "/entity/*{.js,.ts}"],
+    }));
+    beforeEach(() => reloadTestingDatabases(connections));
+    after(() => closeTestingConnections(connections));
+
+    it("should retrieve index order type from created indexes in table asc", () => Promise.all(connections.map(async connection => {
+        const queryRunner = connection.createQueryRunner();
+
+        // clear sqls in memory to avoid removing tables when down queries executed.
+        queryRunner.clearSqlMemory();
+
+        let tableOrUndefined = await queryRunner.getTable("asc");
+
+        expect(tableOrUndefined).to.not.be.undefined;
+
+        let table = tableOrUndefined!;
+
+        expect(table.indices.length).to.be.equal(3);
+
+        let indicesMap: any = {};
+        for (let index of table!.indices) {
+            // @ts-ignore
+            indicesMap[index.columnNames[0]] = index.orderBy[index.columnNames[0]];
+        }
+
+        expect(indicesMap).to.be.have.all.keys(["numberField", "dateField", "stringField"]);
+
+        expect(indicesMap["numberField"]).to.be.deep.equal(getAscNullLast());
+        expect(indicesMap["dateField"]).to.be.deep.equal(getAscNullLast());
+        expect(indicesMap["stringField"]).to.be.deep.equal(getAscNullLast());
+
+        await queryRunner.release();
+    })));
+
+    it("should retrieve index order type from created indexes in table asc_null_first", () => Promise.all(connections.map(async connection => {
+        const queryRunner = connection.createQueryRunner();
+
+        // clear sqls in memory to avoid removing tables when down queries executed.
+        queryRunner.clearSqlMemory();
+
+        let tableOrUndefined = await queryRunner.getTable("asc_null_first");
+
+        expect(tableOrUndefined).to.not.be.undefined;
+
+        let table = tableOrUndefined!;
+
+        expect(table.indices.length).to.be.equal(3);
+
+        let indicesMap: any = {};
+        for (let index of table!.indices) {
+            // @ts-ignore
+            indicesMap[index.columnNames[0]] = index.orderBy[index.columnNames[0]];
+        }
+
+        expect(indicesMap).to.be.have.all.keys(["numberField", "dateField", "stringField"]);
+
+        expect(indicesMap["numberField"]).to.be.deep.equal(getAscNullFirst());
+        expect(indicesMap["dateField"]).to.be.deep.equal(getAscNullFirst());
+        expect(indicesMap["stringField"]).to.be.deep.equal(getAscNullFirst());
+
+        await queryRunner.release();
+    })));
+
+    it("should retrieve index order type from created indexes in table asc_null_last", () => Promise.all(connections.map(async connection => {
+        const queryRunner = connection.createQueryRunner();
+
+        // clear sqls in memory to avoid removing tables when down queries executed.
+        queryRunner.clearSqlMemory();
+
+        let tableOrUndefined = await queryRunner.getTable("asc_null_last");
+
+        expect(tableOrUndefined).to.not.be.undefined;
+
+        let table = tableOrUndefined!;
+
+        expect(table.indices.length).to.be.equal(3);
+
+        let indicesMap: any = {};
+        for (let index of table!.indices) {
+            // @ts-ignore
+            indicesMap[index.columnNames[0]] = index.orderBy[index.columnNames[0]];
+        }
+
+        expect(indicesMap).to.be.have.all.keys(["numberField", "dateField", "stringField"]);
+
+        expect(indicesMap["numberField"]).to.be.deep.equal(getAscNullLast());
+        expect(indicesMap["dateField"]).to.be.deep.equal(getAscNullLast());
+        expect(indicesMap["stringField"]).to.be.deep.equal(getAscNullLast());
+
+        await queryRunner.release();
+    })));
+
+    it("should retrieve index order type from created indexes in table desc", () => Promise.all(connections.map(async connection => {
+        const queryRunner = connection.createQueryRunner();
+
+        // clear sqls in memory to avoid removing tables when down queries executed.
+        queryRunner.clearSqlMemory();
+
+        let tableOrUndefined = await queryRunner.getTable("desc");
+
+        expect(tableOrUndefined).to.not.be.undefined;
+
+        let table = tableOrUndefined!;
+
+        expect(table.indices.length).to.be.equal(3);
+
+        let indicesMap: any = {};
+        for (let index of table!.indices) {
+            // @ts-ignore
+            indicesMap[index.columnNames[0]] = index.orderBy[index.columnNames[0]];
+        }
+
+        expect(indicesMap).to.be.have.all.keys(["numberField", "dateField", "stringField"]);
+
+        expect(indicesMap["numberField"]).to.be.deep.equal(getDescNullFirst());
+        expect(indicesMap["dateField"]).to.be.deep.equal(getDescNullFirst());
+        expect(indicesMap["stringField"]).to.be.deep.equal(getDescNullFirst());
+
+        await queryRunner.release();
+    })));
+
+    it("should retrieve index order type from created indexes in table desc_null_first", () => Promise.all(connections.map(async connection => {
+        const queryRunner = connection.createQueryRunner();
+
+        // clear sqls in memory to avoid removing tables when down queries executed.
+        queryRunner.clearSqlMemory();
+
+        let tableOrUndefined = await queryRunner.getTable("desc_null_first");
+
+        expect(tableOrUndefined).to.not.be.undefined;
+
+        let table = tableOrUndefined!;
+
+        expect(table.indices.length).to.be.equal(3);
+
+        let indicesMap: any = {};
+        for (let index of table!.indices) {
+            // @ts-ignore
+            indicesMap[index.columnNames[0]] = index.orderBy[index.columnNames[0]];
+        }
+
+        expect(indicesMap).to.be.have.all.keys(["numberField", "dateField", "stringField"]);
+
+        expect(indicesMap["numberField"]).to.be.deep.equal(getDescNullFirst());
+        expect(indicesMap["dateField"]).to.be.deep.equal(getDescNullFirst());
+        expect(indicesMap["stringField"]).to.be.deep.equal(getDescNullFirst());
+
+        await queryRunner.release();
+    })));
+
+    it("should retrieve index order type from created indexes in table desc_null_last", () => Promise.all(connections.map(async connection => {
+        const queryRunner = connection.createQueryRunner();
+
+        // clear sqls in memory to avoid removing tables when down queries executed.
+        queryRunner.clearSqlMemory();
+
+        let tableOrUndefined = await queryRunner.getTable("desc_null_last");
+
+        expect(tableOrUndefined).to.not.be.undefined;
+
+        let table = tableOrUndefined!;
+
+        expect(table.indices.length).to.be.equal(3);
+
+        let indicesMap: any = {};
+        for (let index of table!.indices) {
+            // @ts-ignore
+            indicesMap[index.columnNames[0]] = index.orderBy[index.columnNames[0]];
+        }
+
+        expect(indicesMap).to.be.have.all.keys(["numberField", "dateField", "stringField"]);
+
+        expect(indicesMap["numberField"]).to.be.deep.equal(getDescNullLast());
+        expect(indicesMap["dateField"]).to.be.deep.equal(getDescNullLast());
+        expect(indicesMap["stringField"]).to.be.deep.equal(getDescNullLast());
+
+        await queryRunner.release();
+    })));
+
+    it("should retrieve index order type from created indexes in table mixed", () => Promise.all(connections.map(async connection => {
+        const queryRunner = connection.createQueryRunner();
+
+        // clear sqls in memory to avoid removing tables when down queries executed.
+        queryRunner.clearSqlMemory();
+
+        let tableOrUndefined = await queryRunner.getTable("mixed");
+
+        expect(tableOrUndefined).to.not.be.undefined;
+
+        let table = tableOrUndefined!;
+
+        expect(table.indices.length).to.be.equal(3);
+
+        let indicesMap: any = {};
+        for (let index of table!.indices) {
+            // @ts-ignore
+            indicesMap[index.columnNames[0]] = index.orderBy[index.columnNames[0]];
+        }
+
+        expect(indicesMap).to.be.have.all.keys(["numberField", "dateField", "stringField"]);
+
+        expect(indicesMap["numberField"]).to.be.deep.equal(getAscNullLast());
+        expect(indicesMap["dateField"]).to.be.deep.equal(getDescNullFirst());
+        expect(indicesMap["stringField"]).to.be.deep.equal(getAscNullFirst());
+
+        await queryRunner.release();
+    })));
+
+    it("should retrieve index order type from created indexes in table mixed_normal", () => Promise.all(connections.map(async connection => {
+        const queryRunner = connection.createQueryRunner();
+
+        // clear sqls in memory to avoid removing tables when down queries executed.
+        queryRunner.clearSqlMemory();
+
+        let tableOrUndefined = await queryRunner.getTable("mixed_normal");
+
+        expect(tableOrUndefined).to.not.be.undefined;
+
+        let table = tableOrUndefined!;
+
+        expect(table.indices.length).to.be.equal(2);
+
+        let indicesMap: any = {};
+        for (let index of table!.indices) {
+            // @ts-ignore
+            indicesMap[index.columnNames[0]] = index.orderBy[index.columnNames[0]];
+        }
+
+        expect(indicesMap).to.be.have.all.keys(["dateField", "stringField"]);
+
+        expect(indicesMap["dateField"]).to.be.deep.equal(getAscNullLast());
+        expect(indicesMap["stringField"]).to.be.deep.equal(getAscNullLast());
+
+        await queryRunner.release();
+    })));
+
+    it("should retrieve index order type from created indexes in table multiple", () => Promise.all(connections.map(async connection => {
+        const queryRunner = connection.createQueryRunner();
+
+        // clear sqls in memory to avoid removing tables when down queries executed.
+        queryRunner.clearSqlMemory();
+
+        let tableOrUndefined = await queryRunner.getTable("multiple");
+
+        expect(tableOrUndefined).to.not.be.undefined;
+
+        let table = tableOrUndefined!;
+
+        expect(table.indices.length).to.be.equal(1);
+
+        expect(table.indices[0].columnNames).to.have.all.members(["numberField", "dateField", "stringField"]);
+
+        // @ts-ignore
+        expect(table.indices[0].orderBy["numberField"]).to.be.deep.equal(getAscNullLast());
+        // @ts-ignore
+        expect(table.indices[0].orderBy["dateField"]).to.be.deep.equal(getDescNullFirst());
+        // @ts-ignore
+        expect(table.indices[0].orderBy["stringField"]).to.be.deep.equal(getDescNullLast());
+
+        await queryRunner.release();
+    })));
+
+    it("should retrieve index order type from created indexes in table multiple_string", () => Promise.all(connections.map(async connection => {
+        const queryRunner = connection.createQueryRunner();
+
+        // clear sqls in memory to avoid removing tables when down queries executed.
+        queryRunner.clearSqlMemory();
+
+        let tableOrUndefined = await queryRunner.getTable("multiple_string");
+
+        expect(tableOrUndefined).to.not.be.undefined;
+
+        let table = tableOrUndefined!;
+
+        expect(table.indices.length).to.be.equal(1);
+
+        expect(table.indices[0].columnNames).to.have.all.members(["numberField", "dateField", "stringField"]);
+
+        // @ts-ignore
+        expect(table.indices[0].orderBy["numberField"]).to.be.deep.equal(getAscNullLast());
+        // @ts-ignore
+        expect(table.indices[0].orderBy["dateField"]).to.be.deep.equal(getAscNullLast());
+        // @ts-ignore
+        expect(table.indices[0].orderBy["stringField"]).to.be.deep.equal(getAscNullLast());
+
+        await queryRunner.release();
+    })));
+
+    it("should work as usual with asc", () => Promise.all(connections.map(async connection => {
+        let repository = connection.getRepository(Asc);
+
+        let entities = [];
+        for (let i = 0; i < 5; i++) {
+            let entity = new Asc();
+            entity.numberField = i;
+            entity.stringField = "" + i;
+            entity.dateField = new Date(2020, 9, i);
+            entity.id = i;
+            entities.push(entity);
+        }
+        await repository.save(entities);
+
+        let result = await repository.createQueryBuilder("t")
+            .select()
+            .getMany();
+
+        expect(result).lengthOf(5);
+    })));
+
+    it("should work as usual with asc nulls first", () => Promise.all(connections.map(async connection => {
+        let repository = connection.getRepository(AscNullFirst);
+
+        let entities = [];
+        for (let i = 0; i < 5; i++) {
+            let entity = new AscNullFirst();
+            entity.numberField = i;
+            entity.stringField = "" + i;
+            entity.dateField = new Date(2020, 9, i);
+            entity.id = i;
+            entities.push(entity);
+        }
+        for (let i = 5; i < 10; i++) {
+            let entity = new AscNullFirst();
+            entity.id = i;
+            entities.push(entity);
+        }
+        await repository.save(entities);
+
+        let result = await repository.createQueryBuilder("t")
+            .select()
+            .getMany();
+
+        expect(result).lengthOf(10);
+    })));
+
+    it("should work as usual with asc nulls last", () => Promise.all(connections.map(async connection => {
+        let repository = connection.getRepository(AscNullLast);
+
+        let entities = [];
+        for (let i = 0; i < 5; i++) {
+            let entity = new AscNullLast();
+            entity.numberField = i;
+            entity.stringField = "" + i;
+            entity.dateField = new Date(2020, 9, i);
+            entity.id = i;
+            entities.push(entity);
+        }
+        for (let i = 5; i < 10; i++) {
+            let entity = new AscNullLast();
+            entity.id = i;
+            entities.push(entity);
+        }
+        await repository.save(entities);
+
+        let result = await repository.createQueryBuilder("t")
+            .select()
+            .getMany();
+
+        expect(result).lengthOf(10);
+    })));
+
+    it("should work as usual with desc", () => Promise.all(connections.map(async connection => {
+        let repository = connection.getRepository(Desc);
+
+        let entities = [];
+        for (let i = 0; i < 5; i++) {
+            let entity = new Desc();
+            entity.numberField = i;
+            entity.stringField = "" + i;
+            entity.dateField = new Date(2020, 9, i);
+            entity.id = i;
+            entities.push(entity);
+        }
+        await repository.save(entities);
+
+        let result = await repository.createQueryBuilder("t")
+            .select()
+            .getMany();
+
+        expect(result).lengthOf(5);
+    })));
+
+    it("should work as usual with desc nulls first", () => Promise.all(connections.map(async connection => {
+        let repository = connection.getRepository(DescNullFirst);
+
+        let entities = [];
+        for (let i = 0; i < 5; i++) {
+            let entity = new DescNullFirst();
+            entity.numberField = i;
+            entity.stringField = "" + i;
+            entity.dateField = new Date(2020, 9, i);
+            entity.id = i;
+            entities.push(entity);
+        }
+        for (let i = 5; i < 10; i++) {
+            let entity = new DescNullFirst();
+            entity.id = i;
+            entities.push(entity);
+        }
+        await repository.save(entities);
+
+        let result = await repository.createQueryBuilder("t")
+            .select()
+            .getMany();
+
+        expect(result).lengthOf(10);
+    })));
+
+    it("should work as usual with desc nulls last", () => Promise.all(connections.map(async connection => {
+        let repository = connection.getRepository(DescNullLast);
+
+        let entities = [];
+        for (let i = 0; i < 5; i++) {
+            let entity = new DescNullLast();
+            entity.numberField = i;
+            entity.stringField = "" + i;
+            entity.dateField = new Date(2020, 9, i);
+            entity.id = i;
+            entities.push(entity);
+        }
+        for (let i = 5; i < 10; i++) {
+            let entity = new DescNullLast();
+            entity.id = i;
+            entities.push(entity);
+        }
+        await repository.save(entities);
+
+        let result = await repository.createQueryBuilder("t")
+            .select()
+            .getMany();
+
+        expect(result).lengthOf(10);
+    })));
+
+    it("should work as usual with mixed", () => Promise.all(connections.map(async connection => {
+        let repository = connection.getRepository(Mixed);
+
+        let entities = [];
+        for (let i = 0; i < 5; i++) {
+            let entity = new Mixed();
+            entity.numberField = i;
+            entity.stringField = "" + i;
+            entity.dateField = new Date(2020, 9, i);
+            entity.id = i;
+            entities.push(entity);
+        }
+        for (let i = 5; i < 10; i++) {
+            let entity = new Mixed();
+            entity.dateField = new Date(2020, 9, i);
+            entity.numberField = i;
+            entity.id = i;
+            entities.push(entity);
+        }
+        await repository.save(entities);
+
+        let result = await repository.createQueryBuilder("t")
+            .select()
+            .getMany();
+
+        expect(result).lengthOf(10);
+    })));
+
+    it("should work as usual with mixed normal", () => Promise.all(connections.map(async connection => {
+        let repository = connection.getRepository(MixedNormal);
+
+        let entities = [];
+        for (let i = 0; i < 5; i++) {
+            let entity = new MixedNormal();
+            entity.numberField = i;
+            entity.stringField = "" + i;
+            entity.dateField = new Date(2020, 9, i);
+            entity.id = i;
+            entities.push(entity);
+        }
+        await repository.save(entities);
+
+        let result = await repository.createQueryBuilder("t")
+            .select()
+            .getMany();
+
+        expect(result).lengthOf(5);
+    })));
+
+    it("should work as usual with multiple", () => Promise.all(connections.map(async connection => {
+        let repository = connection.getRepository(Multiple);
+
+        let entities = [];
+        for (let i = 0; i < 5; i++) {
+            let entity = new Multiple();
+            entity.numberField = i;
+            entity.stringField = "" + i;
+            entity.dateField = new Date(2020, 9, i);
+            entity.id = i;
+            entities.push(entity);
+        }
+        await repository.save(entities);
+
+        let result = await repository.createQueryBuilder("t")
+            .select()
+            .getMany();
+
+        expect(result).lengthOf(5);
+    })));
+
+    it("should work as usual with multiple string", () => Promise.all(connections.map(async connection => {
+        let repository = connection.getRepository(MultipleString);
+
+        let entities = [];
+        for (let i = 0; i < 5; i++) {
+            let entity = new MultipleString();
+            entity.numberField = i;
+            entity.stringField = "" + i;
+            entity.dateField = new Date(2020, 9, i);
+            entity.id = i;
+            entities.push(entity);
+        }
+        await repository.save(entities);
+
+        let result = await repository.createQueryBuilder("t")
+            .select()
+            .getMany();
+
+        expect(result).lengthOf(5);
+    })));
+
+    function getAscNullFirst(): OrderByOptions {
+        return {
+            order: "ASC",
+            nulls: "NULLS FIRST"
+        };
+    }
+
+    function getAscNullLast(): OrderByOptions {
+        return {
+            order: "ASC",
+            nulls: "NULLS LAST"
+        };
+    }
+
+    function getDescNullFirst(): OrderByOptions {
+        return {
+            order: "DESC",
+            nulls: "NULLS FIRST"
+        };
+    }
+
+    function getDescNullLast(): OrderByOptions {
+        return {
+            order: "DESC",
+            nulls: "NULLS LAST"
+        };
+    }
+});


### PR DESCRIPTION
Added support for creating sorted indexes in PostgresSQL and SQLite databases.

The new option is available when using the Index decorator to decorate a field or a whole class

Usage:

```typescript
    @Column({ nullable: true })
    @Index({
        orderBy: {
            stringField: {
                nulls: "NULLS FIRST", // Only available in PostgresSQL
                order: "ASC"
            }
        }
    })
    public stringField?: string;

    @Column({ nullable: false })
    @Index({
        orderBy: {
            stringField: {
                order: "DESC"
            }
        }
    })
    public stringField2: string;

    @Column()
    @Index({
        orderBy: "DESC"
    })
    public stringField3: string;
```

or


```typescript
@Entity()
@Index(["numberField", "dateField", "stringField"],{
    orderBy: {
        numberField: {
            order: "ASC"
        },
        dateField: "DESC",
        stringField: {
            order: "DESC",
            nulls: "NULLS LAST"
        }
    }
})
export class Multiple {
    @PrimaryColumn()
    public id: number;

    @Column()
    public numberField!: number;

    @Column()
    public dateField!: Date;

    @Column()
    public stringField!: string;
}
```
