### PR TITLE
fix: set the search path for postgres when schema is set

### DIFF
--- a/test/functional/connection/connection.ts
+++ b/test/functional/connection/connection.ts
@@ -335,6 +335,25 @@ describe("Connection", () => {
 
         });
 
+        it("sets the default schema search path", () => {
+            return Promise.all(connections.map(async connection => {
+                await connection.synchronize(true);
+                const schemaName = (connection.options as PostgresConnectionOptions).schema;
+                const comment = new CommentV1();
+                comment.title = "Change SchemaName";
+                comment.context = `To ${schemaName}`;
+
+                const commentRepo = connection.getRepository(CommentV1);
+                await commentRepo.save(comment);
+
+                const queryRunner = connection.createQueryRunner();
+                const rows = await queryRunner.query(`select * from "comment" where id = $1`, [comment.id]);
+                await queryRunner.release();
+                expect(rows[0]["context"]).to.be.eq(comment.context);
+            }));
+
+        });
+
     });
 
 });


### PR DESCRIPTION
when the schema option is set for postgres we used to set
the search path - to much rejoice - but we no longer do
because it was accidentally removed

however, as of this change, it'll be back

fixes #6734