### PR TITLE
Add absolute path support to other CLI commands

### DIFF
--- a/src/commands/EntityCreateCommand.ts
+++ b/src/commands/EntityCreateCommand.ts
@@ -37,7 +37,7 @@ export class EntityCreateCommand implements yargs.CommandModule {
         try {
             const fileContent = EntityCreateCommand.getTemplate(args.name as any);
             const filename = args.name + ".ts";
-            let directory = args.dir;
+            let directory = args.dir as string;
 
             // if directory is not set then try to open tsconfig and find default path there
             if (!directory) {
@@ -51,7 +51,7 @@ export class EntityCreateCommand implements yargs.CommandModule {
                 } catch (err) { }
             }
 
-            const path = process.cwd() + "/" + (directory ? (directory + "/") : "") + filename;
+            const path = (directory.startsWith("/") ? "" : process.cwd() + "/") + (directory ? (directory + "/") : "") + filename;
             const fileExists = await CommandUtils.fileExists(path);
             if (fileExists) {
                 throw `File ${chalk.blue(path)} already exists`;

--- a/src/commands/SubscriberCreateCommand.ts
+++ b/src/commands/SubscriberCreateCommand.ts
@@ -38,7 +38,7 @@ export class SubscriberCreateCommand implements yargs.CommandModule {
         try {
             const fileContent = SubscriberCreateCommand.getTemplate(args.name as any);
             const filename = args.name + ".ts";
-            let directory = args.dir;
+            let directory = args.dir as string;
 
             // if directory is not set then try to open tsconfig and find default path there
             if (!directory) {
@@ -52,7 +52,7 @@ export class SubscriberCreateCommand implements yargs.CommandModule {
                 } catch (err) { }
             }
 
-            const path = process.cwd() + "/" + (directory ? (directory + "/") : "") + filename;
+            const path = (directory.startsWith("/") ? "" : process.cwd() + "/") + (directory ? (directory + "/") : "") + filename;
             await CommandUtils.createFile(path, fileContent);
             console.log(chalk.green(`Subscriber ${chalk.blue(path)} has been created successfully.`));
 


### PR DESCRIPTION
Following up on https://github.com/typeorm/typeorm/pull/6660 and adding absolute path support to the other CLI commands (sorry it took me so long!) 

This is the same change + the type change necessary to prevent a breakage (someone please correct me if I'm missing anything)! 

Thanks!