### PR TITLE
fix: lock Typescript to 3.6.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "typeorm",
-  "version": "0.2.26",
+  "version": "0.2.27",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -6331,7 +6331,7 @@
     },
     "is-accessor-descriptor": {
       "version": "0.1.6",
-      "resolved": "http://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-0.1.6.tgz",
+      "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-0.1.6.tgz",
       "integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
       "dev": true,
       "requires": {
@@ -6393,7 +6393,7 @@
     },
     "is-data-descriptor": {
       "version": "0.1.4",
-      "resolved": "http://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-0.1.4.tgz",
+      "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-0.1.4.tgz",
       "integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
       "dev": true,
       "requires": {
@@ -7176,7 +7176,7 @@
     },
     "load-json-file": {
       "version": "1.1.0",
-      "resolved": "http://registry.npmjs.org/load-json-file/-/load-json-file-1.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-1.1.0.tgz",
       "integrity": "sha1-lWkFcI1YtLq0wiYbBPWfMcmTdMA=",
       "dev": true,
       "requires": {
@@ -10854,7 +10854,7 @@
     },
     "string_decoder": {
       "version": "1.1.1",
-      "resolved": "http://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
       "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
       "dev": true,
       "requires": {
@@ -11463,9 +11463,9 @@
       }
     },
     "typescript": {
-      "version": "3.9.7",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.9.7.tgz",
-      "integrity": "sha512-BLbiRkiBzAwsjut4x/dsibSTB6yWpwT5qWmC2OfuCg3GgVQCSgMs4vEctYPhsaGtd0AeuuHMkjZ2h2WG8MSzRw==",
+      "version": "3.6.5",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.6.5.tgz",
+      "integrity": "sha512-BEjlc0Z06ORZKbtcxGrIvvwYs5hAnuo6TKdNFL55frVDlB+na3z5bsLhFaIxmT+dPWgBIjMo6aNnTOgHHmHgiQ==",
       "dev": true
     },
     "uglify-js": {

--- a/package.json
+++ b/package.json
@@ -111,7 +111,7 @@
     "sqlite3": "^5.0.0",
     "ts-node": "^9.0.0",
     "typeorm-aurora-data-api-driver": "^1.4.0",
-    "typescript": "^3.9.7"
+    "typescript": "~3.6.0"
   },
   "dependencies": {
     "@sqltools/formatter": "1.2.2",

--- a/src/entity-manager/MongoEntityManager.ts
+++ b/src/entity-manager/MongoEntityManager.ts
@@ -570,7 +570,7 @@ export class MongoEntityManager extends EntityManager {
         if (!optionsOrConditions)
             return undefined;
 
-        if (FindOptionsUtils.isFindManyOptions(optionsOrConditions))
+        if (FindOptionsUtils.isFindManyOptions<Entity>(optionsOrConditions))
         // If where condition is passed as a string which contains sql we have to ignore
         // as mongo is not a sql database
             return typeof optionsOrConditions.where === "string"
@@ -587,7 +587,7 @@ export class MongoEntityManager extends EntityManager {
         if (!optionsOrConditions)
             return undefined;
 
-        if (FindOptionsUtils.isFindOneOptions(optionsOrConditions))
+        if (FindOptionsUtils.isFindOneOptions<Entity>(optionsOrConditions))
         // If where condition is passed as a string which contains sql we have to ignore
         // as mongo is not a sql database
             return typeof optionsOrConditions.where === "string"

--- a/src/find-options/FindOptionsUtils.ts
+++ b/src/find-options/FindOptionsUtils.ts
@@ -17,8 +17,8 @@ export class FindOptionsUtils {
     /**
      * Checks if given object is really instance of FindOneOptions interface.
      */
-    static isFindOneOptions(obj: any): obj is FindOneOptions<any> {
-        const possibleOptions: FindOneOptions<any> = obj;
+    static isFindOneOptions<Entity = any>(obj: any): obj is FindOneOptions<Entity> {
+        const possibleOptions: FindOneOptions<Entity> = obj;
         return possibleOptions &&
                 (
                     Array.isArray(possibleOptions.select) ||
@@ -41,8 +41,8 @@ export class FindOptionsUtils {
     /**
      * Checks if given object is really instance of FindManyOptions interface.
      */
-    static isFindManyOptions(obj: any): obj is FindManyOptions<any> {
-        const possibleOptions: FindManyOptions<any> = obj;
+    static isFindManyOptions<Entity = any>(obj: any): obj is FindManyOptions<Entity> {
+        const possibleOptions: FindManyOptions<Entity> = obj;
         return possibleOptions && (
             this.isFindOneOptions(possibleOptions) ||
             typeof (possibleOptions as FindManyOptions<any>).skip === "number" ||

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,5 +1,4 @@
 {
-    "version": "2.1.1",
     "compilerOptions": {
         "lib": ["es5", "es6"],
         "outDir": "build/compiled",
@@ -22,6 +21,11 @@
         "noUnusedLocals": true,
         "downlevelIteration": true
     },
+    "include": [
+      "sample",
+      "src",
+      "test"
+    ],
     "exclude": [
         "tmp",
         "temp",


### PR DESCRIPTION
Because of a breaking feature in Typescript 3.7.0 we cannot upgrade
past that without marooning users of Typescript 3.5 / 3.6 & 4.0+

this locks typescript to ~3.6.0 explicitly and fixes some small
issues that arise in using that version

fixes #6809
fixes #6805