### PR TITLE
fix: snake naming strategy

### DIFF
--- a/src/connection/Connection.ts
+++ b/src/connection/Connection.ts
@@ -484,7 +484,7 @@ export class Connection {
      */
     protected findMetadata(target: EntityTarget<any>): EntityMetadata|undefined {
         return this.entityMetadatas.find(metadata => {
-            if (metadata.target === target)
+            if (metadata.target.toString() === target.toString())
                 return true;
             if (target instanceof EntitySchema) {
                 return metadata.name === target.options.name;


### PR DESCRIPTION
fix for issue #6509 

**Summary:**
Solution for this problem -
```
getRepository(UserProfile); // didn't work - throws error No Repository "UserProfile" found
getRepository("user_profile"); // works fine
```

**Reason:**
`triple equal comparison between [Function: User] and [Function: User] was returning false`

**Hack used for workaround:**
By using "user" string instead of passing entity class.

This change is working with both methods - string `"user"` and entity class `User`.