### PR TITLE
test: adds test to prevent #4958 from recurring

### DIFF
--- a/test/github-issues/4958/entity/first.ts
+++ b/test/github-issues/4958/entity/first.ts
@@ -1,0 +1,11 @@
+import { Column, Entity } from "../../../../src";
+
+@Entity({ name: "first" })
+export default class Testing {
+    @Column("int", {
+        nullable: false,
+        primary: true,
+        unique: true,
+    })
+    public id!: number;
+}

--- a/test/github-issues/4958/entity/second.ts
+++ b/test/github-issues/4958/entity/second.ts
@@ -1,0 +1,11 @@
+import { Column, Entity } from "../../../../src";
+
+@Entity({ name: "second" })
+export default class Testing {
+    @Column("int", {
+        nullable: false,
+        primary: true,
+        unique: true,
+    })
+    public notId!: number;
+}

--- a/test/github-issues/4958/issue-4958.ts
+++ b/test/github-issues/4958/issue-4958.ts
@@ -1,0 +1,24 @@
+import {expect} from "chai";
+import {Connection} from "../../../src/connection/Connection";
+import {closeTestingConnections, createTestingConnections, reloadTestingDatabases} from "../../utils/test-utils";
+import First from "./entity/first";
+import Second from "./entity/second";
+
+describe("github issues > #4958 getRepository returns results from another Repo", () => {
+    let connections: Connection[];
+    before(async () => connections = await createTestingConnections({
+        entities: [First, Second],
+        enabledDrivers: ["sqlite"]
+    }));
+    beforeEach(() => reloadTestingDatabases(connections));
+    after(() => closeTestingConnections(connections));
+
+    it("sql generated is for correct model", () => Promise.all(connections.map(async connection => {
+        const rawSql = await connection
+            .getRepository(Second)
+            .createQueryBuilder("a")
+            .getSql();
+
+        expect(rawSql).to.be.equal('SELECT "a"."notId" AS "a_notId" FROM "second" "a"');
+    })));
+});


### PR DESCRIPTION
in #4958 we found that the PR #4804 caused issues in a variety
of situations.  this adds a test to prevent the issue from recurring
where similar classes get mixed up in our metadata resolver