### PR TITLE
fix: prevent create-type commands edge-case TypeErrors

### DIFF
--- a/src/commands/EntityCreateCommand.ts
+++ b/src/commands/EntityCreateCommand.ts
@@ -37,7 +37,7 @@ export class EntityCreateCommand implements yargs.CommandModule {
         try {
             const fileContent = EntityCreateCommand.getTemplate(args.name as any);
             const filename = args.name + ".ts";
-            let directory = args.dir as string;
+            let directory = args.dir as string | undefined;
 
             // if directory is not set then try to open tsconfig and find default path there
             if (!directory) {
@@ -51,7 +51,10 @@ export class EntityCreateCommand implements yargs.CommandModule {
                 } catch (err) { }
             }
 
-            const path = (directory.startsWith("/") ? "" : process.cwd() + "/") + (directory ? (directory + "/") : "") + filename;
+            if (directory && !directory.startsWith("/")) {
+                directory = process.cwd() + "/" + directory;
+            }
+            const path = (directory ? (directory + "/") : "") + filename;
             const fileExists = await CommandUtils.fileExists(path);
             if (fileExists) {
                 throw `File ${chalk.blue(path)} already exists`;

--- a/src/commands/MigrationCreateCommand.ts
+++ b/src/commands/MigrationCreateCommand.ts
@@ -45,7 +45,7 @@ export class MigrationCreateCommand implements yargs.CommandModule {
             const timestamp = new Date().getTime();
             const fileContent = MigrationCreateCommand.getTemplate(args.name as any, timestamp);
             const filename = timestamp + "-" + args.name + ".ts";
-            let directory = args.dir as string;
+            let directory = args.dir as string | undefined;
 
             // if directory is not set then try to open tsconfig and find default path there
             if (!directory) {
@@ -59,7 +59,10 @@ export class MigrationCreateCommand implements yargs.CommandModule {
                 } catch (err) { }
             }
 
-            const path = (directory.startsWith("/") ? "" : process.cwd() + "/") + (directory ? (directory + "/") : "") + filename;
+            if (directory && !directory.startsWith("/")) {
+                directory = process.cwd() + "/" + directory;
+            }
+            const path = (directory ? (directory + "/") : "") + filename;
             await CommandUtils.createFile(path, fileContent);
             console.log(`Migration ${chalk.blue(path)} has been generated successfully.`);
 

--- a/src/commands/SubscriberCreateCommand.ts
+++ b/src/commands/SubscriberCreateCommand.ts
@@ -38,7 +38,7 @@ export class SubscriberCreateCommand implements yargs.CommandModule {
         try {
             const fileContent = SubscriberCreateCommand.getTemplate(args.name as any);
             const filename = args.name + ".ts";
-            let directory = args.dir as string;
+            let directory = args.dir as string | undefined;
 
             // if directory is not set then try to open tsconfig and find default path there
             if (!directory) {
@@ -52,7 +52,10 @@ export class SubscriberCreateCommand implements yargs.CommandModule {
                 } catch (err) { }
             }
 
-            const path = (directory.startsWith("/") ? "" : process.cwd() + "/") + (directory ? (directory + "/") : "") + filename;
+            if (directory && !directory.startsWith("/")) {
+                directory = process.cwd() + "/" + directory;
+            }
+            const path = (directory ? (directory + "/") : "") + filename;
             await CommandUtils.createFile(path, fileContent);
             console.log(chalk.green(`Subscriber ${chalk.blue(path)} has been created successfully.`));
 


### PR DESCRIPTION
in some cases - where the connection options couldn't be read -
we would end up with the migration:create and similar commands
failing with a TypeError

this refactors the create commands a bit to defend against
an undefined directory, preventing the TypeError

fixes #6831