### PR TITLE
fix: prevent dangling transactions in sqlite

### DIFF
--- a/src/driver/cockroachdb/CockroachQueryRunner.ts
+++ b/src/driver/cockroachdb/CockroachQueryRunner.ts
@@ -112,15 +112,17 @@ export class CockroachQueryRunner extends BaseQueryRunner implements QueryRunner
      * Releases used database connection.
      * You cannot use query runner methods once its released.
      */
-    release(): Promise<void> {
+    async release(): Promise<void> {
+        if (this.isTransactionActive) {
+            await this.rollbackTransaction();
+        }
+
         this.isReleased = true;
         if (this.releaseCallback)
             this.releaseCallback();
 
         const index = this.driver.connectedQueryRunners.indexOf(this);
         if (index !== -1) this.driver.connectedQueryRunners.splice(index);
-
-        return Promise.resolve();
     }
 
     /**

--- a/src/driver/sqlite-abstract/AbstractSqliteQueryRunner.ts
+++ b/src/driver/sqlite-abstract/AbstractSqliteQueryRunner.ts
@@ -55,12 +55,16 @@ export abstract class AbstractSqliteQueryRunner extends BaseQueryRunner implemen
 
     /**
      * Releases used database connection.
-     * We just clear loaded tables and sql in memory, because sqlite do not support multiple connections thus query runners.
+     * We just roll back any open transactions and clear loaded tables / sql in memory,
+     * because sqlite does not support multiple connections thus query runners.
      */
-    release(): Promise<void> {
+    async release(): Promise<void> {
+        if (this.isTransactionActive) {
+            await this.rollbackTransaction();
+        }
+
         this.loadedTables = [];
         this.clearSqlMemory();
-        return Promise.resolve();
     }
 
     /**

--- a/test/functional/query-runner/release.ts
+++ b/test/functional/query-runner/release.ts
@@ -1,0 +1,63 @@
+import "reflect-metadata";
+import {Connection} from "../../../src/connection/Connection";
+import {closeTestingConnections, createTestingConnections, reloadTestingDatabases} from "../../utils/test-utils";
+import {expect} from "chai";
+
+describe("query runner > release", () => {
+
+    let connections: Connection[];
+    before(async () => {
+        connections = await createTestingConnections({
+            entities: [__dirname + "/entity/*{.js,.ts}"]
+        });
+    });
+    beforeEach(() => reloadTestingDatabases(connections));
+    after(() => closeTestingConnections(connections));
+
+    it("should set `isTransactionActive` to false between query runners", () => Promise.all(connections.map(async connection => {
+        const queryRunner = connection.createQueryRunner();
+        await queryRunner.connect();
+
+        await queryRunner.startTransaction();
+
+        await queryRunner.release();
+
+        const queryRunner2 = connection.createQueryRunner();
+        await queryRunner2.connect();
+
+        const isTransactionStillActive = queryRunner2.isTransactionActive;
+
+        await queryRunner2.release();
+
+        expect(isTransactionStillActive).to.be.false;
+    })));
+
+    it("should be able to start new transactions after release without error", () => Promise.all(connections.map(async connection => {
+        const queryRunner = connection.createQueryRunner();
+        await queryRunner.connect();
+        await queryRunner.startTransaction();
+        await queryRunner.release();
+
+        // Open the second query runner that should not be in a transaction now
+        const queryRunner2 = connection.createQueryRunner();
+        await queryRunner2.connect();
+        await queryRunner.startTransaction();
+        await queryRunner2.release();
+    })));
+
+    it("should roll back open transactions on release", () => Promise.all(connections.map(async connection => {
+        const queryRunner = connection.createQueryRunner();
+        await queryRunner.connect();
+        await queryRunner.startTransaction();
+        await queryRunner.query(`INSERT INTO Book (ean) VALUES('test')`)
+        await queryRunner.release();
+
+        // Open the second query runner that should not be in a transaction now
+        const queryRunner2 = connection.createQueryRunner();
+        await queryRunner2.connect();
+        const actual = await queryRunner.query(`SELECT ean FROM Book;`);
+        await queryRunner2.release();
+
+        expect(actual).to.be.eql([]);
+    })));
+});


### PR DESCRIPTION
when you release the sqlite runner and had an open transaction
we wouldn't actually do anything with it.  in other drivers,
such as postgres, releasing the runner closes the connection
and that causes the transaction to roll back.

to keep the behavior uniform across drivers, the sqlite
release now rolls back transactions if they're open

fixes #3919