### PR TITLE
Use defaults provided in entity definition decorators

### DIFF
--- a/src/query-builder/InsertQueryBuilder.ts
+++ b/src/query-builder/InsertQueryBuilder.ts
@@ -472,17 +472,18 @@ export class InsertQueryBuilder<Entity> extends QueryBuilder<Entity> {
 
                     // if value for this column was not provided then insert default value
                     } else if (value === undefined) {
-                        if (this.connection.driver instanceof AbstractSqliteDriver || this.connection.driver instanceof SapDriver) { // unfortunately sqlite does not support DEFAULT expression in INSERT queries
-                            if (column.default !== undefined) { // try to use default defined in the column
-                                expression += this.connection.driver.normalizeDefault(column);
-                            } else {
-                                expression += "NULL"; // otherwise simply use NULL and pray if column is nullable
-                            }
-
+                        if (column.default !== undefined) {
+                            // if default value presented in the default property then use it
+                            expression += this.connection.driver.normalizeDefault(column);
                         } else {
-                            expression += "DEFAULT";
+                            // otherwise use null for sqlite and sap (becauze these dbs not supported defaults in schema)
+                            // of use default keyword for other databases
+                            if (this.connection.driver instanceof AbstractSqliteDriver || this.connection.driver instanceof SapDriver) {
+                                expression += "NULL"
+                            } else {
+                                expression += "DEFAULT";
+                            }
                         }
-
                     // support for SQL expressions in queries
                     } else if (value instanceof Function) {
                         expression += value();

--- a/src/query-builder/InsertQueryBuilder.ts
+++ b/src/query-builder/InsertQueryBuilder.ts
@@ -479,7 +479,7 @@ export class InsertQueryBuilder<Entity> extends QueryBuilder<Entity> {
                             // otherwise use null for sqlite and sap (becauze these dbs not supported defaults in schema)
                             // of use default keyword for other databases
                             if (this.connection.driver instanceof AbstractSqliteDriver || this.connection.driver instanceof SapDriver) {
-                                expression += "NULL"
+                                expression += "NULL";
                             } else {
                                 expression += "DEFAULT";
                             }


### PR DESCRIPTION
Imagine then we already have some database with no default provided in schema. But in entity(model) definition we want to determine default value, without touching database schema (default modification on big table can take a very long time).
Now when you have default value provided in Column decorator (`@Column({ default: 'default_value'})`) but not defined in database schema cause error `null value in column <column_name> violates not-null constraint. But honestly I wait that this value can be inserted with "default_value" value. So I prepare repository with this issue reproduce 
- https://github.com/jougene/typeorm-default-issue

And make a pr that fix this issue.