### PR TITLE
fix: return null for nullable RelationId() column

### DIFF
--- a/src/metadata/ColumnMetadata.ts
+++ b/src/metadata/ColumnMetadata.ts
@@ -477,7 +477,7 @@ export class ColumnMetadata {
                 }
 
                 // this is bugfix for #720 when increment number is bigint we need to make sure its a string
-                if ((this.generationStrategy === "increment" || this.generationStrategy === "rowid") && this.type === "bigint")
+                if ((this.generationStrategy === "increment" || this.generationStrategy === "rowid") && this.type === "bigint" && value !== null)
                     value = String(value);
 
                 map[useDatabaseName ? this.databaseName : this.propertyName] = value;
@@ -488,7 +488,7 @@ export class ColumnMetadata {
         } else { // no embeds - no problems. Simply return column property name and its value of the entity
 
             // this is bugfix for #720 when increment number is bigint we need to make sure its a string
-            if ((this.generationStrategy === "increment" || this.generationStrategy === "rowid") && this.type === "bigint")
+            if ((this.generationStrategy === "increment" || this.generationStrategy === "rowid") && this.type === "bigint" && value !== null)
                 value = String(value);
 
             return { [useDatabaseName ? this.databaseName : this.propertyName]: value };

--- a/src/query-builder/transformer/RawSqlResultsToEntityTransformer.ts
+++ b/src/query-builder/transformer/RawSqlResultsToEntityTransformer.ts
@@ -253,7 +253,7 @@ export class RawSqlResultsToEntityTransformer {
                     }
                 }
                 return idMap;
-            }).filter(result => result);
+            }).filter(result => result !== undefined);
 
             const properties = rawRelationIdResult.relationIdAttribute.mapToPropertyPropertyPath.split(".");
             const mapToProperty = (properties: string[], map: ObjectLiteral, value: any): any => {

--- a/test/github-issues/6815/entity/ChildEntity.ts
+++ b/test/github-issues/6815/entity/ChildEntity.ts
@@ -1,0 +1,7 @@
+import {Entity, PrimaryGeneratedColumn} from "../../../../src";
+
+@Entity()
+export class ChildEntity {
+  @PrimaryGeneratedColumn({type: "bigint"})
+  id: string;
+}

--- a/test/github-issues/6815/entity/ParentEntity.ts
+++ b/test/github-issues/6815/entity/ParentEntity.ts
@@ -1,0 +1,15 @@
+import {Entity, JoinColumn, OneToOne, PrimaryGeneratedColumn, RelationId} from "../../../../src";
+import {ChildEntity} from "./ChildEntity";
+
+@Entity()
+export class ParentEntity {
+  @PrimaryGeneratedColumn({type: "bigint"})
+  id: string;
+
+  @OneToOne(() => ChildEntity, {nullable: true})
+  @JoinColumn()
+  child: ChildEntity|null;
+
+  @RelationId((parent: ParentEntity) => parent.child)
+  childId: string|null;
+}

--- a/test/github-issues/6815/issue-6815.ts
+++ b/test/github-issues/6815/issue-6815.ts
@@ -1,0 +1,56 @@
+import {expect} from "chai";
+import {Connection} from "../../../src/connection/Connection";
+import {EntityManager} from "../../../src/entity-manager/EntityManager";
+import {
+    createTestingConnections,
+    closeTestingConnections,
+    reloadTestingDatabases,
+} from "../../utils/test-utils";
+import {ChildEntity} from "./entity/ChildEntity";
+import {ParentEntity} from "./entity/ParentEntity";
+
+describe("github issues > #6815 RelationId() on nullable relation returns 'null' string", () => {
+    let connections: Connection[];
+
+    before(async () => connections = await createTestingConnections({
+        entities: [__dirname + "/entity/*{.js,.ts}"],
+        schemaCreate: true,
+        dropSchema: true,
+        enabledDrivers: ["cockroachdb", "mariadb", "mssql", "mysql", "postgres"]
+    }));
+
+    beforeEach(() => reloadTestingDatabases(connections));
+    after(() => closeTestingConnections(connections));
+
+    it("should return null as childId if child doesn't exist", () => Promise.all(
+        connections.map(async connection => {
+            const em = new EntityManager(connection);
+            const parent = em.create(ParentEntity);
+            await em.save(parent);
+
+            const loaded = await em.findOneOrFail(ParentEntity, parent.id);
+            expect(loaded.childId).to.be.null;
+        })
+    ));
+
+    it("should return string as childId if child exists", () => Promise.all(
+        connections.map(async connection => {
+            const em = new EntityManager(connection);
+            const child = em.create(ChildEntity);
+            await em.save(child);
+
+            const parent = em.create(ParentEntity);
+            parent.child = child;
+            await em.save(parent);
+
+            const loaded = await em.findOneOrFail(ParentEntity, parent.id);
+
+            if (connection.name === "cockroachdb") {
+                // CockroachDB returns id as a number.
+                expect(loaded.childId).to.equal(child.id.toString());
+            } else {
+                expect(loaded.childId).to.equal(child.id);
+            }
+        })
+    ));
+});


### PR DESCRIPTION
Fix issue where attempting to cast bigints to strings also did it for
null values.

Fix issue where transformRelationIds() filtered out null values when
it should only be done for undefined.

Closes: #6815