### PR TITLE
feat: add ability for escaping for Raw() find operator

### DIFF
--- a/src/find-options/FindOperator.ts
+++ b/src/find-options/FindOperator.ts
@@ -1,5 +1,7 @@
 import {FindOperatorType} from "./FindOperatorType";
 
+type SqlGeneratorType = (aliasPath: string, parameters: any[]) => string;
+
 /**
  * Find Operator used in Find Conditions.
  */
@@ -29,15 +31,27 @@ export class FindOperator<T> {
      */
     private _multipleParameters: boolean;
 
+    /**
+     * SQL generator
+     */
+    private _getSql: SqlGeneratorType|undefined;
+
     // -------------------------------------------------------------------------
     // Constructor
     // -------------------------------------------------------------------------
 
-    constructor(type: FindOperatorType, value: T|FindOperator<T>, useParameter: boolean = true, multipleParameters: boolean = false) {
+    constructor(
+        type: FindOperatorType,
+        value: T|FindOperator<T>,
+        useParameter: boolean = true,
+        multipleParameters: boolean = false,
+        getSql?: SqlGeneratorType,
+    ) {
         this._type = type;
         this._value = value;
         this._useParameter = useParameter;
         this._multipleParameters = multipleParameters;
+        this._getSql = getSql; 
     }
 
     // -------------------------------------------------------------------------
@@ -91,5 +105,15 @@ export class FindOperator<T> {
             return this._value;
 
         return undefined;
+    }
+
+    /**
+     * Gets the SQL generator
+     */
+    get getSql(): SqlGeneratorType|undefined {
+        if (this._value instanceof FindOperator)
+            return this._value.getSql;
+
+        return this._getSql;
     }
 }

--- a/src/find-options/FindOperator.ts
+++ b/src/find-options/FindOperator.ts
@@ -1,3 +1,4 @@
+import {ObjectLiteral} from "../common/ObjectLiteral";
 import {FindOperatorType} from "./FindOperatorType";
 
 type SqlGeneratorType = (aliasPath: string, parameters: any[]) => string;
@@ -20,6 +21,11 @@ export class FindOperator<T> {
      * Parameter value.
      */
     private _value: T|FindOperator<T>;
+
+    /**
+     * ObjectLiteral parameters.
+     */
+    private _objectLiteralParameters: ObjectLiteral|undefined;
 
     /**
      * Indicates if parameter is used or not for this operator.
@@ -46,12 +52,14 @@ export class FindOperator<T> {
         useParameter: boolean = true,
         multipleParameters: boolean = false,
         getSql?: SqlGeneratorType,
+        objectLiteralParameters?: ObjectLiteral,
     ) {
         this._type = type;
         this._value = value;
         this._useParameter = useParameter;
         this._multipleParameters = multipleParameters;
         this._getSql = getSql; 
+        this._objectLiteralParameters = objectLiteralParameters;
     }
 
     // -------------------------------------------------------------------------
@@ -96,6 +104,17 @@ export class FindOperator<T> {
 
         return this._value;
     }
+
+    /**
+     * Gets ObjectLiteral parameters.
+     */
+    get objectLiteralParameters(): ObjectLiteral|undefined {
+        if (this._value instanceof FindOperator)
+            return this._value.objectLiteralParameters;
+
+        return this._objectLiteralParameters;
+    }
+
 
     /**
      * Gets the child FindOperator if it exists

--- a/src/find-options/FindOperator.ts
+++ b/src/find-options/FindOperator.ts
@@ -1,7 +1,7 @@
 import {ObjectLiteral} from "../common/ObjectLiteral";
 import {FindOperatorType} from "./FindOperatorType";
 
-type SqlGeneratorType = (aliasPath: string, parameters: any[]) => string;
+type SqlGeneratorType = (aliasPath: string) => string;
 
 /**
  * Find Operator used in Find Conditions.

--- a/src/find-options/operator/Raw.ts
+++ b/src/find-options/operator/Raw.ts
@@ -1,20 +1,47 @@
 import {FindOperator} from "../FindOperator";
+import {ObjectLiteral} from "../../common/ObjectLiteral";
 
 /**
  * Find Options Operator.
  * Example: { someField: Raw([...]) }
+ */
+export function Raw<T>(value: string): FindOperator<any>;
+
+/**
+ * Find Options Operator.
  * Example: { someField: Raw((columnAlias) => `${columnAlias} = 5`) }
- * 
+ */
+export function Raw<T>(sqlGenerator: ((columnAlias: string) => string)): FindOperator<any>;
+
+/**
+ * Find Options Operator.
  * For escaping parameters use next syntax:
  * Example: { someField: Raw((columnAlias, parameters) => `${columnAlias} = ${parameters[0]}`, [5]) }
  */
+export function Raw<T>(sqlGenerator: ((columnAlias: string, parameters: any[]) => string), parameters: any[]): FindOperator<any>;
+
+/**
+ * Find Options Operator.
+ * For escaping parameters use next syntax:
+ * Example: { someField: Raw((columnAlias) => `${columnAlias} = :value`, { value: 5 }) }
+ */
+export function Raw<T>(sqlGenerator: ((columnAlias: string) => string), parameters: ObjectLiteral): FindOperator<any>;
+
 export function Raw<T>(
     valueOrSqlGenerator: string | ((columnAlias: string, parameters: any[]) => string),
-    sqlGeneratorParameters?: any[],
+    sqlGeneratorParameters?: any[] | ObjectLiteral,
 ): FindOperator<any> {
-    if (typeof valueOrSqlGenerator === 'function') {
-        return new FindOperator("raw", sqlGeneratorParameters || [], true, true, valueOrSqlGenerator);   
-    } else {
+    if (typeof valueOrSqlGenerator !== 'function') {
         return new FindOperator("raw", valueOrSqlGenerator, false);
-    }    
+    }
+
+    if (!sqlGeneratorParameters) {
+        return new FindOperator("raw", [], true, true, valueOrSqlGenerator);
+    }
+
+    if (Array.isArray(sqlGeneratorParameters)) {
+        return new FindOperator("raw", sqlGeneratorParameters, true, true, valueOrSqlGenerator);
+    }
+    
+    return new FindOperator("raw", [], true, true, valueOrSqlGenerator, sqlGeneratorParameters);
 }

--- a/src/find-options/operator/Raw.ts
+++ b/src/find-options/operator/Raw.ts
@@ -9,7 +9,7 @@ import {FindOperator} from "../FindOperator";
  * Example: { someField: Raw((columnAlias, parameters) => `${columnAlias} = ${parameters[0]}`, [5]) }
  */
 export function Raw<T>(
-    valueOrSqlGenerator: string | ((columnAlias: string, parameters: string[]) => string),
+    valueOrSqlGenerator: string | ((columnAlias: string, parameters: any[]) => string),
     sqlGeneratorParameters?: any[],
 ): FindOperator<any> {
     if (typeof valueOrSqlGenerator === 'function') {

--- a/src/find-options/operator/Raw.ts
+++ b/src/find-options/operator/Raw.ts
@@ -3,7 +3,7 @@ import {ObjectLiteral} from "../../common/ObjectLiteral";
 
 /**
  * Find Options Operator.
- * Example: { someField: Raw([...]) }
+ * Example: { someField: Raw("12") }
  */
 export function Raw<T>(value: string): FindOperator<any>;
 

--- a/src/find-options/operator/Raw.ts
+++ b/src/find-options/operator/Raw.ts
@@ -3,7 +3,18 @@ import {FindOperator} from "../FindOperator";
 /**
  * Find Options Operator.
  * Example: { someField: Raw([...]) }
+ * Example: { someField: Raw((columnAlias) => `${columnAlias} = 5`) }
+ * 
+ * For escaping parameters use next syntax:
+ * Example: { someField: Raw((columnAlias, parameters) => `${columnAlias} = ${parameters[0]}`, [5]) }
  */
-export function Raw<T>(value: string|((columnAlias: string) => string)): FindOperator<any> {
-    return new FindOperator("raw", value as any, false);
+export function Raw<T>(
+    valueOrSqlGenerator: string | ((columnAlias: string, parameters: string[]) => string),
+    sqlGeneratorParameters?: any[],
+): FindOperator<any> {
+    if (typeof valueOrSqlGenerator === 'function') {
+        return new FindOperator("raw", sqlGeneratorParameters || [], true, true, valueOrSqlGenerator);   
+    } else {
+        return new FindOperator("raw", valueOrSqlGenerator, false);
+    }    
 }

--- a/src/find-options/operator/Raw.ts
+++ b/src/find-options/operator/Raw.ts
@@ -16,32 +16,17 @@ export function Raw<T>(sqlGenerator: ((columnAlias: string) => string)): FindOpe
 /**
  * Find Options Operator.
  * For escaping parameters use next syntax:
- * Example: { someField: Raw((columnAlias, parameters) => `${columnAlias} = ${parameters[0]}`, [5]) }
- */
-export function Raw<T>(sqlGenerator: ((columnAlias: string, parameters: any[]) => string), parameters: any[]): FindOperator<any>;
-
-/**
- * Find Options Operator.
- * For escaping parameters use next syntax:
  * Example: { someField: Raw((columnAlias) => `${columnAlias} = :value`, { value: 5 }) }
  */
 export function Raw<T>(sqlGenerator: ((columnAlias: string) => string), parameters: ObjectLiteral): FindOperator<any>;
 
 export function Raw<T>(
-    valueOrSqlGenerator: string | ((columnAlias: string, parameters: any[]) => string),
-    sqlGeneratorParameters?: any[] | ObjectLiteral,
+    valueOrSqlGenerator: string | ((columnAlias: string) => string),
+    sqlGeneratorParameters?: ObjectLiteral,
 ): FindOperator<any> {
     if (typeof valueOrSqlGenerator !== 'function') {
         return new FindOperator("raw", valueOrSqlGenerator, false);
     }
 
-    if (!sqlGeneratorParameters) {
-        return new FindOperator("raw", [], true, true, valueOrSqlGenerator);
-    }
-
-    if (Array.isArray(sqlGeneratorParameters)) {
-        return new FindOperator("raw", sqlGeneratorParameters, true, true, valueOrSqlGenerator);
-    }
-    
     return new FindOperator("raw", [], true, true, valueOrSqlGenerator, sqlGeneratorParameters);
 }

--- a/src/query-builder/QueryBuilder.ts
+++ b/src/query-builder/QueryBuilder.ts
@@ -892,8 +892,8 @@ export abstract class QueryBuilder<Entity> {
             case "isNull":
                 return `${aliasPath} IS NULL`;
             case "raw":
-                if (typeof operator.value === "function") {
-                    return operator.value(aliasPath);
+                if (operator.getSql) {
+                    return operator.getSql(aliasPath, parameters);
                 } else {
                     return `${aliasPath} = ${operator.value}`;
                 }

--- a/src/query-builder/QueryBuilder.ts
+++ b/src/query-builder/QueryBuilder.ts
@@ -897,7 +897,7 @@ export abstract class QueryBuilder<Entity> {
                 return `${aliasPath} IS NULL`;
             case "raw":
                 if (operator.getSql) {
-                    return operator.getSql(aliasPath, parameters);
+                    return operator.getSql(aliasPath);
                 } else {
                     return `${aliasPath} = ${operator.value}`;
                 }

--- a/src/query-builder/QueryBuilder.ts
+++ b/src/query-builder/QueryBuilder.ts
@@ -810,12 +810,16 @@ export abstract class QueryBuilder<Entity> {
                             } else if (parameterValue instanceof FindOperator) {
                                 let parameters: any[] = [];
                                 if (parameterValue.useParameter) {
-                                    const realParameterValues: any[] = parameterValue.multipleParameters ? parameterValue.value : [parameterValue.value];
-                                    realParameterValues.forEach((realParameterValue, realParameterValueIndex) => {
-                                        this.expressionMap.nativeParameters[parameterName + (parameterBaseCount + realParameterValueIndex)] = realParameterValue;
-                                        parameterIndex++;
-                                        parameters.push(this.connection.driver.createParameter(parameterName + (parameterBaseCount + realParameterValueIndex), parameterIndex - 1));
-                                    });
+                                    if (parameterValue.objectLiteralParameters) {
+                                        this.setParameters(parameterValue.objectLiteralParameters);
+                                    } else {
+                                        const realParameterValues: any[] = parameterValue.multipleParameters ? parameterValue.value : [parameterValue.value];
+                                        realParameterValues.forEach((realParameterValue, realParameterValueIndex) => {
+                                            this.expressionMap.nativeParameters[parameterName + (parameterBaseCount + realParameterValueIndex)] = realParameterValue;
+                                            parameterIndex++;
+                                            parameters.push(this.connection.driver.createParameter(parameterName + (parameterBaseCount + realParameterValueIndex), parameterIndex - 1));
+                                        });
+                                    }
                                 }
 
                                 return this.computeFindOperatorExpression(parameterValue, aliasPath, parameters);

--- a/test/functional/repository/find-options-operators/repository-find-operators.ts
+++ b/test/functional/repository/find-options-operators/repository-find-operators.ts
@@ -616,6 +616,71 @@ describe("repository > find options > operators", () => {
         }
     })));
 
+    it("raw (function with object literal parameters)", () => Promise.all(connections.map(async connection => {
+        const createPost = (index: number): Post => {
+            const post = new Post();
+            post.title = `About #${index}`;
+            post.likes = index;
+
+            return post;
+        }
+
+        // insert some fake data
+        await connection.manager.save([
+            createPost(1),
+            createPost(2),
+            createPost(3),
+            createPost(4),
+            createPost(5),
+            createPost(6),
+        ]);
+
+        // check operator
+        const result1 = await connection.getRepository(Post).find({
+            likes: Raw((columnAlias) => {
+                return `(${columnAlias} = :value1) OR (${columnAlias} = :value2)`
+            }, { value1: 2, value2: 3 }),
+        });
+        result1.should.be.eql([
+            { id: 2, likes: 2, title: "About #2" },
+            { id: 3, likes: 3, title: "About #3" },
+        ]);
+
+        // check operator
+        const result2 = await connection.getRepository(Post).find({
+            likes: Raw((columnAlias) => {
+                return `(${columnAlias} IN (1, 4, 5, 6)) AND (${columnAlias} < :maxValue)`
+            }, { maxValue: 6 }),
+        });
+        result2.should.be.eql([
+            { id: 1, likes: 1, title: "About #1" },
+            { id: 4, likes: 4, title: "About #4" },
+            { id: 5, likes: 5, title: "About #5" },
+        ]);
+
+        // check operator
+        const result3 = await connection.getRepository(Post).find({
+            title: Raw((columnAlias) => {
+                return `${columnAlias} IN (:a, :b, :c)`;
+            }, { a: "About #1", b: "About #3", c: "About #5" }),
+            likes: Raw((columnAlias) => `${columnAlias} IN (:d, :e)`, { d: 5, e: 1 }),
+        });
+        result3.should.be.eql([
+            { id: 1, likes: 1, title: "About #1" },
+            { id: 5, likes: 5, title: "About #5" },
+        ]);
+
+        // check operator
+        const result4 = await connection.getRepository(Post).find({
+            likes: Raw((columnAlias) => `${columnAlias} IN (2, 6)`, { }),
+        });
+        result4.should.be.eql([
+            { id: 2, likes: 2, title: "About #2" },
+            { id: 6, likes: 6, title: "About #6" },
+        ]);
+    })));
+
+
     it("should work with ActiveRecord model", async () => {
         // These must run sequentially as we have the global context of the `PersonAR` ActiveRecord class
         for (const connection of connections) {


### PR DESCRIPTION
Currently, find operator ```Raw()``` not supported escaping.
I have updated the code so that it is now possible to use an escaping.
The updated syntax is as follows:

```
await connection.getRepository(Post).find({
    likes: Raw((columnAlias, parameters) => {
        return `(${columnAlias} = ${parameters[0]}) OR (${columnAlias} = ${parameters[1]})`
    }, [2, 3]),
});

await connection.getRepository(Post).find({
    likes: Raw((columnAlias, parameters) => {
        return `(${columnAlias} = ANY(${parameters[0]})) AND (${columnAlias} < ${parameters[1]})`
    }, [[1, 4, 5, 6], 6]),
});

await connection.getRepository(Post).find({
    title: Raw((columnAlias, parameters) => {
        return `${columnAlias} = ANY(${parameters[0]})`;
    }, [["About #1", "About #3", "About #5"]]),
    likes: Raw((columnAlias, parameters) => `${columnAlias} IN (${parameters[0]}, ${parameters[1]})`, [5, 1]),
});
```

The tests for the new functionality have been written. The old functionality works unchanged.