### PR TITLE
fix: support ESM in ormconfig js & ts

### DIFF
--- a/docs/using-ormconfig.md
+++ b/docs/using-ormconfig.md
@@ -80,6 +80,19 @@ module.exports = {
 }
 ```
 
+Alternatively, you may use the ECMAScript module format if your environment supports it:
+
+```javascript
+export default {
+   "type": "mysql",
+   "host": "localhost",
+   "port": 3306,
+   "username": "test",
+   "password": "test",
+   "database": "test"
+}
+```
+
 You can specify any other options from [ConnectionOptions](./connection-options.md).
 If you want to create multiple connections then simply create multiple connections in a single array and return it.
 

--- a/src/connection/ConnectionOptionsReader.ts
+++ b/src/connection/ConnectionOptionsReader.ts
@@ -106,11 +106,14 @@ export class ConnectionOptionsReader {
         if (PlatformTools.getEnvVariable("TYPEORM_CONNECTION") || PlatformTools.getEnvVariable("TYPEORM_URL")) {
             connectionOptions = await new ConnectionOptionsEnvReader().read();
 
-        } else if (foundFileFormat === "js" || foundFileFormat === "cjs") {
-            connectionOptions = await require(configFile);
+        } else if (foundFileFormat === "js" || foundFileFormat === "cjs" || foundFileFormat === "ts") {
+            const configModule = await require(configFile);
 
-        } else if (foundFileFormat === "ts") {
-            connectionOptions = await require(configFile);
+            if (configModule && "__esModule" in configModule && "default" in configModule) {
+                connectionOptions = configModule.default;
+            } else {
+                connectionOptions = configModule;
+            }
 
         } else if (foundFileFormat === "json") {
             connectionOptions = require(configFile);

--- a/test/functional/connection-options-reader/configs/test-path-config-esm.ts
+++ b/test/functional/connection-options-reader/configs/test-path-config-esm.ts
@@ -1,0 +1,5 @@
+export default [{
+  type: "sqlite",
+  name: "file",
+  database: "test-js"
+}];

--- a/test/functional/connection-options-reader/connection-options-reader.ts
+++ b/test/functional/connection-options-reader/connection-options-reader.ts
@@ -37,6 +37,12 @@ describe("ConnectionOptionsReader", () => {
     expect(fileOptions.database).to.have.string("/test-js-async");
   });
 
+  it("properly loads config with specified file path from esm in js", async () => {
+    const connectionOptionsReader = new ConnectionOptionsReader({ root: __dirname, configName: "configs/test-path-config-esm.js" });
+    const fileOptions: ConnectionOptions = await connectionOptionsReader.get("file");
+    expect(fileOptions.database).to.have.string("/test-js");
+  });
+
   // TODO This test requires the configs/.env file be moved to the matching directory in build/compiled
   it.skip("properly loads config from .env file", async () => {
     const connectionOptionsReader = new ConnectionOptionsReader({ root: __dirname, configName: "configs/.env" });


### PR DESCRIPTION
allows for the use of ESM `export default` for exporting an ORM Config.

fixes #5003