### PR TITLE
feat: add select and map function to MySQL Driver (#296)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7016,7 +7016,7 @@
       "dependencies": {
         "pify": {
           "version": "2.3.0",
-          "resolved": "http://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
+          "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
           "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
           "dev": true
         }
@@ -9088,7 +9088,7 @@
       "dependencies": {
         "pify": {
           "version": "2.3.0",
-          "resolved": "http://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
+          "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
           "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
           "dev": true
         }

--- a/src/driver/Driver.ts
+++ b/src/driver/Driver.ts
@@ -132,7 +132,7 @@ export interface Driver {
     /**
      * Prepares given value to a value to be persisted, based on its column type.
      */
-    prepareHydratedValue(value: any, column: ColumnMetadata): any;
+    prepareHydratedValue(value: any, column: ColumnMetadata | string): any;
 
     /**
      * Transforms type of the given column to a database column type.

--- a/src/query-builder/QueryExpressionMap.ts
+++ b/src/query-builder/QueryExpressionMap.ts
@@ -46,6 +46,8 @@ export class QueryExpressionMap {
      */
     selects: SelectQuery[] = [];
 
+    computedSelects: SelectQuery[] = [];
+
     /**
      * Whether SELECT is DISTINCT.
      */

--- a/src/query-builder/SelectQuery.ts
+++ b/src/query-builder/SelectQuery.ts
@@ -2,4 +2,6 @@ export interface SelectQuery {
     selection: string;
     aliasName?: string;
     virtual?: boolean;
+    columnType?: string;
+    mapToProperty?: string;
 }

--- a/src/query-builder/SelectQueryBuilder.ts
+++ b/src/query-builder/SelectQueryBuilder.ts
@@ -164,6 +164,19 @@ export class SelectQueryBuilder<Entity> extends QueryBuilder<Entity> implements 
     }
 
     /**
+     * Adds new computed fields selection to the SELECT query.
+     */
+    addSelectAndMap(selection: string, alias: string, mapToProperty: string, columnType?: string): this {
+        if (selection) {
+            this.expressionMap.computedSelects.push({ selection: selection, aliasName: alias, mapToProperty: mapToProperty, columnType: columnType });
+            this.addSelect(selection, alias);
+        }
+
+        return this;
+    }
+
+
+    /**
      * Sets whether the selection is DISTINCT.
      */
     distinct(distinct: boolean = true): this {

--- a/src/query-builder/SelectQueryBuilder.ts
+++ b/src/query-builder/SelectQueryBuilder.ts
@@ -166,9 +166,9 @@ export class SelectQueryBuilder<Entity> extends QueryBuilder<Entity> implements 
     /**
      * Adds new computed fields selection to the SELECT query.
      */
-    addSelectAndMap(selection: string, alias: string, mapToProperty: string, columnType?: string): this {
+    addSelectAndMap(selection: string, mapToProperty: string, alias: string, columnType?: string): this {
         if (selection) {
-            this.expressionMap.computedSelects.push({ selection: selection, aliasName: alias, mapToProperty: mapToProperty, columnType: columnType });
+            this.expressionMap.computedSelects.push({ selection: selection, mapToProperty: mapToProperty, aliasName: alias, columnType: columnType });
             this.addSelect(selection, alias);
         }
 

--- a/src/query-builder/transformer/RawSqlResultsToEntityTransformer.ts
+++ b/src/query-builder/transformer/RawSqlResultsToEntityTransformer.ts
@@ -156,7 +156,7 @@ export class RawSqlResultsToEntityTransformer {
 
         this.expressionMap.computedSelects.forEach(computedSelect => {
             if (computedSelect.aliasName && computedSelect.mapToProperty) {
-                const fields: any[] = computedSelect.mapToProperty.split("_");
+                const fields: any[] = computedSelect.mapToProperty.split(".");
                 let entityPart = entity;
 
                 if (fields[0] === alias.name) {

--- a/test/github-issues/296/entity/Comment.ts
+++ b/test/github-issues/296/entity/Comment.ts
@@ -1,0 +1,26 @@
+import {Column, Entity, ManyToOne, PrimaryGeneratedColumn} from "../../../../src";
+import {User} from "./User";
+import {Post} from "./Post";
+
+@Entity()
+export class Comment {
+    @PrimaryGeneratedColumn()
+    id: number;
+
+    @Column()
+    comment: string;
+
+    @Column()
+    userId: number;
+
+    @ManyToOne(type => User, user => user.comments)
+    user: User;
+
+    @Column()
+    postId: number;
+
+    @ManyToOne(type => Post, post => post.comments)
+    post: Post;
+
+    opComment?: boolean;
+}

--- a/test/github-issues/296/entity/Post.ts
+++ b/test/github-issues/296/entity/Post.ts
@@ -1,0 +1,27 @@
+import {Entity, JoinColumn, OneToMany, OneToOne} from "../../../../src";
+import {PrimaryGeneratedColumn} from "../../../../src";
+import {Column} from "../../../../src";
+import {User} from "./User";
+import {Comment} from "./Comment";
+
+@Entity()
+export class Post {
+
+    @PrimaryGeneratedColumn()
+    id: number;
+
+    @Column()
+    title: string;
+
+    @Column()
+    userId: number;
+
+    @OneToOne(type => User, user => user.post)
+    @JoinColumn()
+    user: User;
+
+    @OneToMany(type => Comment, comment => comment.post)
+    comments: Comment[];
+
+    hasTitle?: boolean;
+}

--- a/test/github-issues/296/entity/User.ts
+++ b/test/github-issues/296/entity/User.ts
@@ -1,0 +1,26 @@
+import {Entity, OneToMany, OneToOne} from "../../../../src";
+import {PrimaryGeneratedColumn} from "../../../../src";
+import {Column} from "../../../../src";
+import {Post} from "./Post";
+import {Comment} from "./Comment";
+
+@Entity()
+export class User {
+
+    @PrimaryGeneratedColumn()
+    id: number;
+
+    @Column()
+    name: string;
+
+    @Column()
+    surname: string;
+
+    @OneToOne(type => Post, post => post.user)
+    post: Post;
+
+    @OneToMany(type => Comment, comment => comment.user)
+    comments: Comment[];
+
+    fullName?: string;
+}

--- a/test/github-issues/296/issue-296.ts
+++ b/test/github-issues/296/issue-296.ts
@@ -1,0 +1,67 @@
+import "reflect-metadata";
+import {closeTestingConnections, createTestingConnections, reloadTestingDatabases} from "../../utils/test-utils";
+import {Connection} from "../../../src";
+import {Post} from "./entity/Post";
+import {expect} from "chai";
+import {User} from "./entity/User";
+import {Comment} from "./entity/Comment";
+
+
+describe("github issues > #296 select additional computed columns", () => {
+
+    let connections: Connection[];
+    before(async () => connections = await createTestingConnections({
+        entities: [__dirname + "/entity/*{.js,.ts}"],
+        enabledDrivers: ["mysql"] // we can properly test lazy-relations only on one platform
+    }));
+    beforeEach(() => reloadTestingDatabases(connections));
+    after(() => closeTestingConnections(connections));
+
+    it("github issues > #296 should correctly select computed columns and mapping inside entity values", () => Promise.all(connections.map(async connection => {
+        const user1 = new User();
+        user1.name = "Antonio";
+        user1.surname = "Duprez";
+        await connection.manager.save(user1);
+
+        const user2 = new User();
+        user2.name = "Sebastian";
+        user2.surname = "Gomez";
+        await connection.manager.save(user2);
+
+        const post = new Post();
+        post.title = "Implement addSelectAndMap in TypeORM";
+        post.userId = user1.id;
+        await connection.manager.save(post);
+
+        const comment1 = new Comment();
+        comment1.userId = user1.id;
+        comment1.comment = "Amazing!";
+        comment1.postId = post.id;
+        await connection.manager.save(comment1);
+
+        const comment2 = new Comment();
+        comment2.userId = user2.id;
+        comment2.comment = "This is incredible!";
+        comment2.postId = post.id;
+        await connection.manager.save(comment2);
+
+        if (connection.driver.options.type === "mysql") {
+            const post = await connection.manager.createQueryBuilder(Post, "post")
+                .innerJoin("post.user", "user")
+                .innerJoin("post.comments", "comments")
+                .select(["post.id", "post.title", "user.id", "user.name", "user.surname", "comments.id", "comments.comment"]) // We need select the id of each entity for a correct mapping. This is required
+                .addSelectAndMap("IF(LENGTH(post.title > 0), true, false)", "hasTitle", "post_hasTitle", "boolean")
+                .addSelectAndMap(`CONCAT(user.name, " ", user.surname)`, "fullName", "user_fullName")
+                .addSelectAndMap("IF(comments.userId = user.id, true, false)", "opComment", "comments_opComment", "boolean")
+                .getOne();
+
+            console.log("post expected", post);
+            expect(post).not.to.be.undefined;
+            expect(post!.hasTitle).not.to.be.undefined;
+            expect(post!.user!.fullName).not.to.be.undefined;
+            post!.comments.forEach(comment => {
+                expect(comment.opComment).not.to.be.undefined;
+            });
+        }
+    })));
+});

--- a/test/github-issues/296/issue-296.ts
+++ b/test/github-issues/296/issue-296.ts
@@ -50,15 +50,15 @@ describe("github issues > #296 select additional computed columns", () => {
                 .innerJoin("post.user", "user")
                 .innerJoin("post.comments", "comments")
                 .select(["post.id", "post.title", "user.id", "user.name", "user.surname", "comments.id", "comments.comment"]) // We need select the id of each entity for a correct mapping. This is required
-                .addSelectAndMap("IF(LENGTH(post.title > 0), true, false)", "hasTitle", "post_hasTitle", "boolean")
-                .addSelectAndMap(`CONCAT(user.name, " ", user.surname)`, "fullName", "user_fullName")
-                .addSelectAndMap("IF(comments.userId = user.id, true, false)", "opComment", "comments_opComment", "boolean")
+                .addSelectAndMap("IF(LENGTH(post.title > 0), true, false)", "post.hasTitle", "hasTitle", "boolean")
+                .addSelectAndMap(`CONCAT(user.name, " ", user.surname)`, "user.fullName", "fullName")
+                .addSelectAndMap("IF(comments.userId = user.id, true, false)", "comments.opComment", "opComment", "boolean")
                 .getOne();
 
-            console.log("post expected", post);
             expect(post).not.to.be.undefined;
             expect(post!.hasTitle).not.to.be.undefined;
             expect(post!.user!.fullName).not.to.be.undefined;
+            expect(post!.comments.length).to.be.equal(2);
             post!.comments.forEach(comment => {
                 expect(comment.opComment).not.to.be.undefined;
             });


### PR DESCRIPTION
I’ve developed the function “addSelectAndMap” mentioned in the issue #296 for MySQL. It allows adding computed columns to queries. For example, let’s imagine we have 3 entities with their respective properties: User, Post and Comment.

We want to run a query that will return all Posts from the database and calculates the following properties:

* **hasTitle**: a property that indicates whether the Post has a title or not.
* **fullName**: a property that indicates the full name of the poster (name + surname).
* **opComment**: a property that indicates whether the comment belongs to the creator of the post.

The definition of the entities would be the following:

```@Entity()
export class User {

    @PrimaryGeneratedColumn()
    id: number;

    @Column()
    name: string;

    @Column()
    surname: string;

    @OneToOne(type => Post, post => post.user)
    post: Post;

    @OneToMany(type => Comment, comment => comment.user)
    comments: Comment[];

    fullName?: string;
}
```

```@Entity()
export class Post {

    @PrimaryGeneratedColumn()
    id: number;

    @Column()
    title: string;

    @Column()
    userId: number;

    @OneToOne(type => User, user => user.post)
    @JoinColumn()
    user: User;

    @OneToMany(type => Comment, comment => comment.post)
    comments: Comment[];

    hasTitle?: boolean;
}
```

```@Entity()
export class Comment {
    @PrimaryGeneratedColumn()
    id: number;

    @Column()
    comment: string;

    @Column()
    userId: number;

    @ManyToOne(type => User, user => user.comments)
    user: User;

    @Column()
    postId: number;

    @ManyToOne(type => Post, post => post.comments)
    post: Post;

    opComment?: boolean;
}
```

Defining the virtual fields in the model is not mandatory, but I think it’s good practice when working with Typescript. 
To run the query, we’ll use the new addSelectAndMap function:

```
const post = await connection.manager.createQueryBuilder(Post, "post")
                .innerJoin("post.user", "user")
                .innerJoin("post.comments", "comments")
                .select(["post.id", "post.title", "user.id", "user.name", "user.surname", "comments.id", "comments.comment"])
                .addSelectAndMap("IF(LENGTH(post.title > 0), true, false)", "hasTitle", "post_hasTitle", "boolean")
                .addSelectAndMap(`CONCAT(user.name, " ", user.surname)`, "fullName", "user_fullName")
                .addSelectAndMap("IF(comments.userId = user.id, true, false)", "opComment", "comments_opComment", "boolean")
                .getOne();
```

This function expects the following parameters:
* **selection**: the field or fields we want to Select.
* **alias**: the alias used to interact with the field in the query. For example, if we wanted to order the comments in this query it would be: `.orderBy("opComment", "ASC")`
* **mapToProperty**: the property to map the result. It uses the pattern {object}_{property}
* **columnType**: the type of the field. I’d like to create an enum with the available types. When mapping the value of the field it uses the function prepareHydratedValue of the MySQL’s driver. Accepted values: 

    -- boolean
    -- int

When executing the query the result is:

```
{
  id: 1,
  title: 'Implement addSelectAndMap in TypeORM',
  hasTitle: true,
  user: User {
    id: 1,
    name: 'Antonio',
    surname: 'Duprez',
    fullName: 'Antonio Duprez'
  },
  comments: [
    Comment { id: 1, comment: 'Amazing!', opComment: true },
    Comment { id: 2, comment: 'This is incredible!', opComment: false }
  ]
}
```

Tested with:

* Node v12.16.2 / v.8.*
* MariaDB v10.4.14 / MySQL
* Windows 10 / Ubuntu

closes #296
