### PR TITLE
docs: improve the doc about Raw operator and add missing test

### DIFF
--- a/docs/find-options.md
+++ b/docs/find-options.md
@@ -367,8 +367,39 @@ will execute following query:
 SELECT * FROM "post" WHERE "currentDate" > NOW()
 ```
 
-> Note: beware with `Raw` operator. It executes pure SQL from supplied expression and should not contain a user input,
- otherwise it will lead to SQL-injection.
+If you need to provide user input, you should not include the user input directly in your query as this may create a SQL injection vulnerability.  Instead, you can use the second argument of the `Raw` function to provide a list of parameters to bind to the query.
+
+```ts
+import {Raw} from "typeorm";
+
+const loadedPosts = await connection.getRepository(Post).find({
+    currentDate: Raw(alias =>`${alias} > ':date'`, { date: "2020-10-06" })
+});
+```
+
+will execute following query:
+
+```sql
+SELECT * FROM "post" WHERE "currentDate" > '2020-10-06'
+```
+
+If you need to provide user input that is an array, you can bind them as a list of values in the SQL statement by using the special expression syntax:
+
+```ts
+import {Raw} from "typeorm";
+
+const loadedPosts = await connection.getRepository(Post).find({
+    title: Raw(alias =>`${alias} IN (:...titles)`, { titles: ["Go To Statement Considered Harmful", "Structured Programming"] })
+});
+```
+
+will execute following query:
+
+```sql
+SELECT * FROM "post" WHERE "titles" IN ('Go To Statement Considered Harmful', 'Structured Programming')
+```
+
+## Combining Advanced Options
 
 Also you can combine these operators with `Not` operator:
 

--- a/test/functional/repository/find-options-operators/repository-find-operators.ts
+++ b/test/functional/repository/find-options-operators/repository-find-operators.ts
@@ -605,6 +605,16 @@ describe("repository > find options > operators", () => {
             { id: 3, likes: 3, title: "About #3" },
             { id: 6, likes: 6, title: "About #6" },
         ]);
+
+        // check operator
+        const result6 = await connection.getRepository(Post).find({
+            likes: Raw((columnAlias) => `${columnAlias} IN (:...values)`, { values: [2, 3, 6] }),
+        });
+        result6.should.be.eql([
+            { id: 2, likes: 2, title: "About #2" },
+            { id: 3, likes: 3, title: "About #3" },
+            { id: 6, likes: 6, title: "About #6" },
+        ]);
     })));
 
     it("should work with ActiveRecord model", async () => {


### PR DESCRIPTION
Closes https://github.com/typeorm/typeorm/issues/6860
(see the discussion there)

# What

- Improves the doc after the recent merge of https://github.com/typeorm/typeorm/pull/6850 

> (feat: add ability for escaping for Raw() find operator)

- add a missing test

# Test plan

- no code change
- waiting for CI to let new test pass
- I didn't test my changes on website as I don't know how to run the site locally: let me know if that is needed

# Note 

- I'm not a native English speaker so feel free to comment to improve the wordings, if needed, and I will update the PR.
- maybe we shall merge this once (or just before) the code is deployed on npm.