### PR TITLE
Update MongoDriver.ts

### DIFF
--- a/src/driver/mongodb/MongoConnectionOptions.ts
+++ b/src/driver/mongodb/MongoConnectionOptions.ts
@@ -327,4 +327,9 @@ export interface MongoConnectionOptions extends BaseConnectionOptions {
      * https://github.com/mongodb/node-mongodb-native/releases/tag/v3.2.1
      */
     readonly useUnifiedTopology?: boolean;
+    
+    /**
+     * Automatic Client-Side Field Level Encryption configuration.
+     */
+    readonly autoEncryption?: any;
 }

--- a/src/driver/mongodb/MongoDriver.ts
+++ b/src/driver/mongodb/MongoDriver.ts
@@ -195,7 +195,8 @@ export class MongoDriver implements Driver {
         "minSize",
         "monitorCommands",
         "useNewUrlParser",
-        "useUnifiedTopology"
+        "useUnifiedTopology",
+        "autoEncryption"
     ];
 
     // -------------------------------------------------------------------------

--- a/src/driver/mongodb/MongoDriver.ts
+++ b/src/driver/mongodb/MongoDriver.ts
@@ -134,7 +134,7 @@ export class MongoDriver implements Driver {
     /**
      * Valid mongo connection options
      * NOTE: Keep sync with MongoConnectionOptions
-     * Sync with http://mongodb.github.io/node-mongodb-native/3.1/api/MongoClient.html
+     * Sync with http://mongodb.github.io/node-mongodb-native/3.5/api/MongoClient.html
      */
     protected validOptionNames: string[] = [
         "poolSize",


### PR DESCRIPTION
Support autoEncryption option for mongodb.
Doesn't sync with with http://mongodb.github.io/node-mongodb-native/3.1/api/MongoClient.html.
However, can still be supported.