### PR TITLE
fix: handle count multiple PK & edge cases more gracefully

### DIFF
--- a/test/functional/query-builder/count/entity/AmbigiousPrimaryKey.ts
+++ b/test/functional/query-builder/count/entity/AmbigiousPrimaryKey.ts
@@ -1,0 +1,19 @@
+import {Entity, PrimaryColumn} from "../../../../../src";
+
+@Entity("ambig_primary_key")
+export class AmbigiousPrimaryKey {
+    @PrimaryColumn()
+    a: string;
+
+    @PrimaryColumn()
+    b: string;
+
+    static make({ a, b }: { a: string, b: string }): AmbigiousPrimaryKey {
+        const apk = new AmbigiousPrimaryKey();
+        apk.a = a;
+        apk.b = b;
+
+        return apk;
+    }
+
+}

--- a/test/functional/query-builder/count/query-builder-count.ts
+++ b/test/functional/query-builder/count/query-builder-count.ts
@@ -2,21 +2,88 @@ import {closeTestingConnections, createTestingConnections, reloadTestingDatabase
 import {Connection} from "../../../../src/connection/Connection";
 import {expect} from "chai";
 import {Test} from "./entity/Test";
+import {AmbigiousPrimaryKey} from "./entity/AmbigiousPrimaryKey";
 
 describe("query builder > count", () => {
 
     let connections: Connection[];
     before(async () => connections = await createTestingConnections({
-        entities: [Test],
+        entities: [Test, AmbigiousPrimaryKey],
         schemaCreate: true,
         dropSchema: true,
     }));
     beforeEach(() => reloadTestingDatabases(connections));
     after(() => closeTestingConnections(connections));
 
-    it("Count query should be completed successfully", () => Promise.all(connections.map(async connection => {
-        const count = await connection.getRepository(Test).count();
+    it("Count query should of empty table should be 0", () => Promise.all(connections.map(async connection => {
+        const repo = connection.getRepository(Test);
+
+        const count = await repo.count();
         expect(count).to.be.equal(0);
+    })));
+
+    it("Count query should count database values", () => Promise.all(connections.map(async connection => {
+        const repo = connection.getRepository(Test);
+
+        await Promise.all([
+            repo.save({ varcharField: 'ok', uuidField: '123e4567-e89b-12d3-a456-426614174000', intField: 4}),
+            repo.save({ varcharField: 'ok', uuidField: '123e4567-e89b-12d3-a456-426614174001', intField: 4}),
+        ]);
+
+        const count = await repo.count();
+        expect(count).to.be.equal(2);
+    })));
+
+    it("Count query should handle ambiguous values", () => Promise.all(connections.map(async connection => {
+        const repo = connection.getRepository(AmbigiousPrimaryKey);
+
+        await Promise.all([
+            repo.save({ a: 'A', b: 'AAA' }),
+            repo.save({ a: 'AAA', b: 'A' }),
+            repo.save({ a: 'AA', b: 'AA' }),
+            repo.save({ a: 'BB', b: 'BB' }),
+            repo.save({ a: 'B', b: 'BBB' }),
+            repo.save({ a: 'BBB', b: 'B' })
+        ]);
+
+        const count = await repo.count();
+        expect(count).to.be.equal(6, connection.name);
+    })));
+
+    it("counting joined query should count database values", () => Promise.all(connections.map(async connection => {
+        const repo = connection.getRepository(Test);
+
+        await Promise.all([
+            repo.save({ varcharField: 'ok', uuidField: '123e4567-e89b-12d3-a456-426614174000', intField: 4}),
+            repo.save({ varcharField: 'ok', uuidField: '123e4567-e89b-12d3-a456-426614174001', intField: 4}),
+        ]);
+
+        const count = await repo.createQueryBuilder()
+            .from(Test, 'main')
+            .leftJoin(Test, 'self', 'self.intField = main.intField')
+            .getCount();
+
+        expect(count).to.be.equal(2);
+    })));
+
+    it("counting joined queries should handle ambiguous values", () => Promise.all(connections.map(async connection => {
+        const repo = connection.getRepository(AmbigiousPrimaryKey);
+
+        await Promise.all([
+            repo.save({ a: 'A', b: 'AAA' }),
+            repo.save({ a: 'AAA', b: 'A' }),
+            repo.save({ a: 'AA', b: 'AA' }),
+            repo.save({ a: 'BB', b: 'BB' }),
+            repo.save({ a: 'B', b: 'BBB' }),
+            repo.save({ a: 'BBB', b: 'B' })
+        ]);
+
+        const count = await repo.createQueryBuilder()
+            .from(AmbigiousPrimaryKey, 'main')
+            .leftJoin(AmbigiousPrimaryKey, 'self', 'self.a = main.a')
+            .getCount();
+
+        expect(count).to.be.equal(6, connection.name);
     })));
 
 });


### PR DESCRIPTION
currently we use concatenation of multiple primary keys and a
COUNT DISTINCT of that to figure out how many records we have
matched in a query.

however, that fails if the records have keys when the keys
are ambigious when concatenated (`"A", "AA"` & `"AA", "A"`)

the fact that we do a distinct can also be a performance impact
that isn't needed when we aren't doing joins

as such, in MySQL & Postgres we can use the built in counting
of multiple distinct values to resolve some of the issues,
and in other environments we can make it SLIGHTLY better by
adding delimiters between the concatenated values.  It is not
perfect because it technically could run into the same issue
if the delimiters are in the primary keys but it's BETTER
in most cases.

also, in cases where we do not perform any joins we can
short circuit all of this and do a much more performant
`COUNT(1)` operation

fixes #5989
fixes #5314
fixes #4550
fixes: #4998