### PR TITLE
chore: add `funding` to the package manifest

### DIFF
--- a/package.json
+++ b/package.json
@@ -150,6 +150,7 @@
   "bin": {
     "typeorm": "./cli.js"
   },
+  "funding": "https://opencollective.com/typeorm",
   "collective": {
     "type": "opencollective",
     "url": "https://opencollective.com/typeorm",


### PR DESCRIPTION
adds the funding key to the manifest as the opencollective
per https://docs.npmjs.com/configuring-npm/package-json.html#funding

fixes #4649