### PR TITLE
test: remove console logging from tests

### DIFF
--- a/test/functional/connection/modules/blog/subscriber/TestBlogSubscriber.ts
+++ b/test/functional/connection/modules/blog/subscriber/TestBlogSubscriber.ts
@@ -4,12 +4,12 @@ import {InsertEvent} from "../../../../../../src/subscriber/event/InsertEvent";
 
 @EventSubscriber()
 export class TestBlogSubscriber implements EntitySubscriberInterface {
-    
+
     /**
      * Called after entity insertion.
      */
     beforeInsert(event: InsertEvent<any>) {
-        console.log(`BEFORE ENTITY INSERTED: `, event.entity);
+        // Do nothing
     }
 
 }

--- a/test/functional/connection/modules/question/subscriber/TestQuestionSubscriber.ts
+++ b/test/functional/connection/modules/question/subscriber/TestQuestionSubscriber.ts
@@ -4,12 +4,12 @@ import {InsertEvent} from "../../../../../../src/subscriber/event/InsertEvent";
 
 @EventSubscriber()
 export class TestQuestionSubscriber implements EntitySubscriberInterface {
-    
+
     /**
      * Called before entity insertion.
      */
     beforeInsert(event: InsertEvent<any>) {
-        console.log(`BEFORE ENTITY INSERTED: `, event.entity);
+        // Do nothing
     }
 
 }

--- a/test/functional/connection/modules/video/subscriber/TestVideoSubscriber.ts
+++ b/test/functional/connection/modules/video/subscriber/TestVideoSubscriber.ts
@@ -4,12 +4,12 @@ import {InsertEvent} from "../../../../../../src/subscriber/event/InsertEvent";
 
 @EventSubscriber()
 export class TestVideoSubscriber implements EntitySubscriberInterface {
-    
+
     /**
      * Called after entity insertion.
      */
     beforeInsert(event: InsertEvent<any>) {
-        console.log(`BEFORE ENTITY INSERTED: `, event.entity);
+        // Do nothing
     }
 
 }

--- a/test/functional/connection/subscriber/FirstConnectionSubscriber.ts
+++ b/test/functional/connection/subscriber/FirstConnectionSubscriber.ts
@@ -4,12 +4,12 @@ import {InsertEvent} from "../../../../src/subscriber/event/InsertEvent";
 
 @EventSubscriber()
 export class FirstConnectionSubscriber implements EntitySubscriberInterface {
-    
+
     /**
      * Called after entity insertion.
      */
     beforeInsert(event: InsertEvent<any>) {
-        console.log(`BEFORE ENTITY INSERTED: `, event.entity);
+        // Do nothing
     }
 
 }

--- a/test/functional/connection/subscriber/SecondConnectionSubscriber.ts
+++ b/test/functional/connection/subscriber/SecondConnectionSubscriber.ts
@@ -4,12 +4,12 @@ import {InsertEvent} from "../../../../src/subscriber/event/InsertEvent";
 
 @EventSubscriber()
 export class SecondConnectionSubscriber implements EntitySubscriberInterface {
-    
+
     /**
      * Called after entity insertion.
      */
     beforeInsert(event: InsertEvent<any>) {
-        console.log(`BEFORE ENTITY INSERTED: `, event.entity);
+        // Do nothing
     }
 
 }

--- a/test/functional/migrations/generate-command/command.ts
+++ b/test/functional/migrations/generate-command/command.ts
@@ -28,7 +28,6 @@ describe("migrations > generate command", () => {
 
         const sqlInMemory = await connection.driver.createSchemaBuilder().log();
 
-        console.log(sqlInMemory.upQueries);
         sqlInMemory.upQueries.length.should.be.equal(0);
         sqlInMemory.downQueries.length.should.be.equal(0);
 

--- a/test/functional/persistence/custom-column-names/persistence-custom-column-names.ts
+++ b/test/functional/persistence/custom-column-names/persistence-custom-column-names.ts
@@ -34,7 +34,6 @@ describe("persistence > custom-column-names", function() {
         return connection
             .synchronize(true)
             .catch(e => {
-                console.log("Error during schema re-creation: ", e);
                 throw e;
             });
     }
@@ -53,7 +52,7 @@ describe("persistence > custom-column-names", function() {
     // -------------------------------------------------------------------------
     // Specifications
     // -------------------------------------------------------------------------
-    
+
     describe("attach exist entity to exist entity with many-to-one relation", function() {
         if (!connection)
             return;

--- a/test/github-issues/2703/memory-logger.ts
+++ b/test/github-issues/2703/memory-logger.ts
@@ -22,10 +22,6 @@ export class MemoryLogger implements Logger {
 
     log(level: "log" | "info" | "warn", message: any) {}
 
-    writeToConsole() {
-        this.queries.forEach(q => console.log(`query: ${q}`));
-    }
-
     clear() {
         this._queries = [];
     }


### PR DESCRIPTION
we have a bunch of console loggers in our tests that cause
extra output to be emitted when we don't need it.  because
these were for debugging & not part of the tests success
this removes them