### PR TITLE
feat: Add SelectQueryBuilder.getOneOrFail()

### DIFF
--- a/docs/select-query-builder.md
+++ b/docs/select-query-builder.md
@@ -174,6 +174,16 @@ const timber = await getRepository(User)
     .getOne();
 ```
 
+`getOneOrFail` will get a single result from the database, but if
+no result exists it will throw an `EntityNotFoundError`:
+
+```typescript
+const timber = await getRepository(User)
+    .createQueryBuilder("user")
+    .where("user.id = :id OR user.name = :name", { id: 1, name: "Timber" })
+    .getOneOrFail();
+```
+
 To get multiple results from the database,
 for example, to get all users from the database, use `getMany`:
 

--- a/src/query-builder/SelectQueryBuilder.ts
+++ b/src/query-builder/SelectQueryBuilder.ts
@@ -37,6 +37,7 @@ import {ObjectUtils} from "../util/ObjectUtils";
 import {DriverUtils} from "../driver/DriverUtils";
 import {AuroraDataApiDriver} from "../driver/aurora-data-api/AuroraDataApiDriver";
 import {CockroachDriver} from "../driver/cockroachdb/CockroachDriver";
+import {EntityNotFoundError} from "../error/EntityNotFoundError";
 
 /**
  * Allows to build complex sql queries in a fashion way and execute those queries.
@@ -1102,6 +1103,19 @@ export class SelectQueryBuilder<Entity> extends QueryBuilder<Entity> implements 
         }
 
         return result;
+    }
+
+    /**
+     * Gets the first entity returned by execution of generated query builder sql or rejects the returned promise on error.
+     */
+    async getOneOrFail(): Promise<Entity> {
+        const entity = await this.getOne();
+
+        if (!entity) {
+            throw new EntityNotFoundError(this.expressionMap.mainAlias!.target, this);
+        }
+
+        return entity;
     }
 
     /**


### PR DESCRIPTION
This adds a `getOneOrFail` which which is to `getOne` as
`findOneOrFail` is to `findOne` - it never returns `undefined`,
it will instead throw an `EntityNotFoundError`

closes #6246