### PR TITLE
fix: support empty `IN` clause across all dialects

### DIFF
--- a/src/query-builder/QueryBuilder.ts
+++ b/src/query-builder/QueryBuilder.ts
@@ -17,7 +17,6 @@ import {ColumnMetadata} from "../metadata/ColumnMetadata";
 import {SqljsDriver} from "../driver/sqljs/SqljsDriver";
 import {SqlServerDriver} from "../driver/sqlserver/SqlServerDriver";
 import {OracleDriver} from "../driver/oracle/OracleDriver";
-import {MysqlDriver} from "../driver/mysql/MysqlDriver";
 import {EntitySchema} from "../";
 import {FindOperator} from "../find-options/FindOperator";
 import {In} from "../find-options/operator/In";
@@ -916,8 +915,8 @@ export abstract class QueryBuilder<Entity> {
             case "between":
                 return `${aliasPath} BETWEEN ${parameters[0]} AND ${parameters[1]}`;
             case "in":
-                if ((this.connection.driver instanceof OracleDriver || this.connection.driver instanceof MysqlDriver) && parameters.length === 0) {
-                    return `${aliasPath} IN (null)`;
+                if (parameters.length === 0) {
+                    return "0=1";
                 }
                 return `${aliasPath} IN (${parameters.join(", ")})`;
             case "any":

--- a/test/functional/repository/find-options-operators/repository-find-operators.ts
+++ b/test/functional/repository/find-options-operators/repository-find-operators.ts
@@ -433,6 +433,10 @@ describe("repository > find options > operators", () => {
         });
         loadedPosts.should.be.eql([{ id: 2, likes: 3, title: "About #2" }]);
 
+        const noPosts = await connection.getRepository(Post).find({
+            title: In([])
+        });
+        noPosts.length.should.be.eql(0);
     })));
 
     it("not(in)", () => Promise.all(connections.map(async connection => {
@@ -453,6 +457,10 @@ describe("repository > find options > operators", () => {
         });
         loadedPosts.should.be.eql([{ id: 2, likes: 3, title: "About #2" }]);
 
+        const noPosts = await connection.getRepository(Post).find({
+            title: Not(In([]))
+        });
+        noPosts.length.should.be.eql(2);
     })));
 
     it("any", () => Promise.all(connections.map(async connection => {


### PR DESCRIPTION
we were supporting an empty `IN` clause for MySQL and Oracle
and this updates the handling to be for all other dialects as well
by making the "empty" clause be `0=1`

This follows the lead of a number of other projects in a similar space:

* [Laravel: `1=0`](https://github.com/laravel/framework/blob/8.x/src/Illuminate/Database/Query/Grammars/Grammar.php#L265-L272)
* [SQLAlchemy: `1!=1`](https://docs.sqlalchemy.org/en/13/core/sqlelement.html#sqlalchemy.sql.operators.ColumnOperators.in_)
* [Knex: `1=0`](http://knexjs.org/#Builder-whereIn)
* [Sequel: `1!=1`](https://github.com/jeremyevans/sequel/blob/67cc4245227a6c01ecb20d0138aaf37b05a5aebc/doc/release_notes/3.32.0.txt#L171)
    
I've also chosen to use `1=0` in the empty case because it's the most likely technique which allows the various query optimizers to do their magic. :)

Closes #4865
fixes #2195