### PR TITLE
Deferrable option for unique keys (postgres)

### DIFF
--- a/package.json
+++ b/package.json
@@ -141,7 +141,6 @@
     "test-ci": "gulp ci-tests",
     "test": "rimraf ./build && tsc && mocha --file ./build/compiled/test/utils/test-setup.js --bail --recursive --timeout 60000 ./build/compiled/test",
     "test-fast": "mocha --file ./build/compiled/test/utils/test-setup.js --bail --recursive --timeout 60000 ./build/compiled/test",
-    "test-one": "mocha --file ./build/compiled/test/utils/test-setup.js --bail --recursive --timeout 60000 ./build/compiled/test/functional/query-runner",
     "compile": "rimraf ./build && tsc",
     "watch": "./node_modules/.bin/tsc -w",
     "package": "gulp package",

--- a/src/decorator/Unique.ts
+++ b/src/decorator/Unique.ts
@@ -1,55 +1,63 @@
 import { getMetadataArgsStorage } from "../index";
 import { UniqueMetadataArgs } from "../metadata-args/UniqueMetadataArgs";
+import { UniqueOptions } from './options/UniqueOptions';
 
 /**
  * Composite unique constraint must be set on entity classes and must specify entity's fields to be unique.
  */
-export function Unique(name: string, fields: string[]): ClassDecorator & PropertyDecorator;
+export function Unique(options?: UniqueOptions): ClassDecorator & PropertyDecorator;
 
 /**
  * Composite unique constraint must be set on entity classes and must specify entity's fields to be unique.
  */
-export function Unique(fields: string[]): ClassDecorator & PropertyDecorator;
+export function Unique(name: string, options?: UniqueOptions): ClassDecorator & PropertyDecorator;
 
 /**
  * Composite unique constraint must be set on entity classes and must specify entity's fields to be unique.
  */
-export function Unique(fields: (object?: any) => (any[] | { [key: string]: number })): ClassDecorator & PropertyDecorator;
+export function Unique(name: string, options: { synchronize: false }): ClassDecorator & PropertyDecorator;
 
 /**
  * Composite unique constraint must be set on entity classes and must specify entity's fields to be unique.
  */
-export function Unique(name: string, fields: (object?: any) => (any[] | { [key: string]: number })): ClassDecorator & PropertyDecorator;
+export function Unique(name: string, fields: string[], options?: UniqueOptions): ClassDecorator & PropertyDecorator;
 
 /**
  * Composite unique constraint must be set on entity classes and must specify entity's fields to be unique.
  */
-export function Unique(nameOrFields?: string | string[] | ((object: any) => (any[] | { [key: string]: number })),
-    maybeFields?: ((object?: any) => (any[] | { [key: string]: number })) | string[]): ClassDecorator & PropertyDecorator {
-    const name = typeof nameOrFields === "string" ? nameOrFields : undefined;
-    const fields = typeof nameOrFields === "string" ? <((object?: any) => (any[] | { [key: string]: number })) | string[]>maybeFields : nameOrFields as string[];
+export function Unique(fields: string[], options?: UniqueOptions): ClassDecorator & PropertyDecorator;
+
+/**
+ * Composite unique constraint must be set on entity classes and must specify entity's fields to be unique.
+ */
+export function Unique(fields: (object?: any) => (any[] | { [key: string]: number }), options?: UniqueOptions): ClassDecorator & PropertyDecorator;
+
+/**
+ * Composite unique constraint must be set on entity classes and must specify entity's fields to be unique.
+ */
+export function Unique(name: string, fields: (object?: any) => (any[] | { [key: string]: number }), options?: UniqueOptions): ClassDecorator & PropertyDecorator;
+
+
+/**
+ * Composite unique constraint must be set on entity classes and must specify entity's fields to be unique.
+ */
+export function Unique(nameOrFieldsOrOptions?: string | string[] | ((object: any) => (any[] | { [key: string]: number })) | UniqueOptions,
+    maybeFieldsOrOptions?: ((object?: any) => (any[] | { [key: string]: number })) | UniqueOptions | string[] | { synchronize: false },
+    maybeOptions?: UniqueOptions): ClassDecorator & PropertyDecorator {
+
+    const name = typeof nameOrFieldsOrOptions === "string" ? nameOrFieldsOrOptions : undefined;
+    const fields = typeof nameOrFieldsOrOptions === "string" ? <((object?: any) => (any[] | { [key: string]: number })) | string[]>maybeFieldsOrOptions : nameOrFieldsOrOptions as string[];
+    let options = (typeof nameOrFieldsOrOptions === "object" && !Array.isArray(nameOrFieldsOrOptions)) ? nameOrFieldsOrOptions as UniqueOptions : maybeOptions;
+    if (!options)
+        options = (typeof maybeFieldsOrOptions === "object" && !Array.isArray(maybeFieldsOrOptions)) ? maybeFieldsOrOptions as UniqueOptions : maybeOptions;
 
     return function (clsOrObject: Function | Object, propertyName?: string | symbol) {
 
-        let columns = fields;
-
-        if (propertyName !== undefined) {
-            switch (typeof (propertyName)) {
-                case "string":
-                    columns = [propertyName];
-                    break;
-
-                case "symbol":
-                    columns = [propertyName.toString()];
-                    break;
-            }
-        }
-
-        const args: UniqueMetadataArgs = {
+        getMetadataArgsStorage().uniques.push({
             target: propertyName ? clsOrObject.constructor : clsOrObject as Function,
             name: name,
-            columns,
-        };
-        getMetadataArgsStorage().uniques.push(args);
+            columns: propertyName ? [propertyName] : fields,
+            options: options,
+        } as UniqueMetadataArgs);
     };
 }

--- a/src/decorator/Unique.ts
+++ b/src/decorator/Unique.ts
@@ -1,6 +1,6 @@
 import { getMetadataArgsStorage } from "../index";
 import { UniqueMetadataArgs } from "../metadata-args/UniqueMetadataArgs";
-import { UniqueOptions } from './options/UniqueOptions';
+import { UniqueOptions } from "./options/UniqueOptions";
 
 /**
  * Composite unique constraint must be set on entity classes and must specify entity's fields to be unique.

--- a/src/decorator/options/UniqueOptions.ts
+++ b/src/decorator/options/UniqueOptions.ts
@@ -1,0 +1,13 @@
+import { DeferrableType } from '../../metadata/types/DeferrableType';
+
+/**
+ * Describes all unique options.
+ */
+export interface UniqueOptions {
+
+  /**
+     * Indicate if unique constraints can be deferred.
+     */
+  deferrable?: DeferrableType;
+
+}

--- a/src/driver/postgres/PostgresQueryRunner.ts
+++ b/src/driver/postgres/PostgresQueryRunner.ts
@@ -1,27 +1,27 @@
-import {ObjectLiteral} from "../../common/ObjectLiteral";
-import {QueryFailedError} from "../../error/QueryFailedError";
-import {QueryRunnerAlreadyReleasedError} from "../../error/QueryRunnerAlreadyReleasedError";
-import {TransactionAlreadyStartedError} from "../../error/TransactionAlreadyStartedError";
-import {TransactionNotStartedError} from "../../error/TransactionNotStartedError";
-import {ColumnType} from "../../index";
-import {ReadStream} from "../../platform/PlatformTools";
-import {BaseQueryRunner} from "../../query-runner/BaseQueryRunner";
-import {QueryRunner} from "../../query-runner/QueryRunner";
-import {TableIndexOptions} from "../../schema-builder/options/TableIndexOptions";
-import {Table} from "../../schema-builder/table/Table";
-import {TableCheck} from "../../schema-builder/table/TableCheck";
-import {TableColumn} from "../../schema-builder/table/TableColumn";
-import {TableExclusion} from "../../schema-builder/table/TableExclusion";
-import {TableForeignKey} from "../../schema-builder/table/TableForeignKey";
-import {TableIndex} from "../../schema-builder/table/TableIndex";
-import {TableUnique} from "../../schema-builder/table/TableUnique";
-import {View} from "../../schema-builder/view/View";
-import {Broadcaster} from "../../subscriber/Broadcaster";
-import {OrmUtils} from "../../util/OrmUtils";
-import {Query} from "../Query";
-import {IsolationLevel} from "../types/IsolationLevel";
-import {PostgresDriver} from "./PostgresDriver";
-import {ReplicationMode} from "../types/ReplicationMode";
+import { ObjectLiteral } from "../../common/ObjectLiteral";
+import { QueryFailedError } from "../../error/QueryFailedError";
+import { QueryRunnerAlreadyReleasedError } from "../../error/QueryRunnerAlreadyReleasedError";
+import { TransactionAlreadyStartedError } from "../../error/TransactionAlreadyStartedError";
+import { TransactionNotStartedError } from "../../error/TransactionNotStartedError";
+import { ColumnType } from "../../index";
+import { ReadStream } from "../../platform/PlatformTools";
+import { BaseQueryRunner } from "../../query-runner/BaseQueryRunner";
+import { QueryRunner } from "../../query-runner/QueryRunner";
+import { TableIndexOptions } from "../../schema-builder/options/TableIndexOptions";
+import { Table } from "../../schema-builder/table/Table";
+import { TableCheck } from "../../schema-builder/table/TableCheck";
+import { TableColumn } from "../../schema-builder/table/TableColumn";
+import { TableExclusion } from "../../schema-builder/table/TableExclusion";
+import { TableForeignKey } from "../../schema-builder/table/TableForeignKey";
+import { TableIndex } from "../../schema-builder/table/TableIndex";
+import { TableUnique } from "../../schema-builder/table/TableUnique";
+import { View } from "../../schema-builder/view/View";
+import { Broadcaster } from "../../subscriber/Broadcaster";
+import { OrmUtils } from "../../util/OrmUtils";
+import { Query } from "../Query";
+import { IsolationLevel } from "../types/IsolationLevel";
+import { PostgresDriver } from "./PostgresDriver";
+import { ReplicationMode } from "../types/ReplicationMode";
 
 /**
  * Runs queries on a single postgres database connection.
@@ -78,7 +78,7 @@ export class PostgresQueryRunner extends BaseQueryRunner implements QueryRunner 
         if (this.databaseConnectionPromise)
             return this.databaseConnectionPromise;
 
-        if (this.mode === "slave" && this.driver.isReplicated)  {
+        if (this.mode === "slave" && this.driver.isReplicated) {
             this.databaseConnectionPromise = this.driver.obtainSlaveConnection().then(([connection, release]: any[]) => {
                 this.driver.connectedQueryRunners.push(this);
                 this.databaseConnection = connection;
@@ -268,7 +268,7 @@ export class PostgresQueryRunner extends BaseQueryRunner implements QueryRunner 
     /**
      * Checks if table with the given name exist in the database.
      */
-    async hasTable(tableOrName: Table|string): Promise<boolean> {
+    async hasTable(tableOrName: Table | string): Promise<boolean> {
         const parsedTableName = this.parseTableName(tableOrName);
         const sql = `SELECT * FROM "information_schema"."tables" WHERE "table_schema" = ${parsedTableName.schema} AND "table_name" = ${parsedTableName.tableName}`;
         const result = await this.query(sql);
@@ -278,7 +278,7 @@ export class PostgresQueryRunner extends BaseQueryRunner implements QueryRunner 
     /**
      * Checks if column with the given name exist in the given table.
      */
-    async hasColumn(tableOrName: Table|string, columnName: string): Promise<boolean> {
+    async hasColumn(tableOrName: Table | string, columnName: string): Promise<boolean> {
         const parsedTableName = this.parseTableName(tableOrName);
         const sql = `SELECT * FROM "information_schema"."columns" WHERE "table_schema" = ${parsedTableName.schema} AND "table_name" = ${parsedTableName.tableName} AND "column_name" = '${columnName}'`;
         const result = await this.query(sql);
@@ -369,7 +369,7 @@ export class PostgresQueryRunner extends BaseQueryRunner implements QueryRunner 
     /**
      * Drops the table.
      */
-    async dropTable(target: Table|string, ifExist?: boolean, dropForeignKeys: boolean = true, dropIndices: boolean = true): Promise<void> {// It needs because if table does not exist and dropForeignKeys or dropIndices is true, we don't need
+    async dropTable(target: Table | string, ifExist?: boolean, dropForeignKeys: boolean = true, dropIndices: boolean = true): Promise<void> {// It needs because if table does not exist and dropForeignKeys or dropIndices is true, we don't need
         // to perform drop queries for foreign keys and indices.
         if (ifExist) {
             const isTableExist = await this.hasTable(target);
@@ -416,7 +416,7 @@ export class PostgresQueryRunner extends BaseQueryRunner implements QueryRunner 
     /**
      * Drops the view.
      */
-    async dropView(target: View|string): Promise<void> {
+    async dropView(target: View | string): Promise<void> {
         const viewName = target instanceof View ? target.name : target;
         const view = await this.getCachedView(viewName);
 
@@ -432,7 +432,7 @@ export class PostgresQueryRunner extends BaseQueryRunner implements QueryRunner 
     /**
      * Renames the given table.
      */
-    async renameTable(oldTableOrName: Table|string, newTableName: string): Promise<void> {
+    async renameTable(oldTableOrName: Table | string, newTableName: string): Promise<void> {
         const upQueries: Query[] = [];
         const downQueries: Query[] = [];
         const oldTable = oldTableOrName instanceof Table ? oldTableOrName : await this.getCachedTable(oldTableOrName);
@@ -510,7 +510,7 @@ export class PostgresQueryRunner extends BaseQueryRunner implements QueryRunner 
     /**
      * Creates a new column from the column in the table.
      */
-    async addColumn(tableOrName: Table|string, column: TableColumn): Promise<void> {
+    async addColumn(tableOrName: Table | string, column: TableColumn): Promise<void> {
         const table = tableOrName instanceof Table ? tableOrName : await this.getCachedTable(tableOrName);
         const clonedTable = table.clone();
         const upQueries: Query[] = [];
@@ -572,7 +572,7 @@ export class PostgresQueryRunner extends BaseQueryRunner implements QueryRunner 
     /**
      * Creates a new columns from the column in the table.
      */
-    async addColumns(tableOrName: Table|string, columns: TableColumn[]): Promise<void> {
+    async addColumns(tableOrName: Table | string, columns: TableColumn[]): Promise<void> {
         for (const column of columns) {
             await this.addColumn(tableOrName, column);
         }
@@ -581,7 +581,7 @@ export class PostgresQueryRunner extends BaseQueryRunner implements QueryRunner 
     /**
      * Renames column in the given table.
      */
-    async renameColumn(tableOrName: Table|string, oldTableColumnOrName: TableColumn|string, newTableColumnOrName: TableColumn|string): Promise<void> {
+    async renameColumn(tableOrName: Table | string, oldTableColumnOrName: TableColumn | string, newTableColumnOrName: TableColumn | string): Promise<void> {
         const table = tableOrName instanceof Table ? tableOrName : await this.getCachedTable(tableOrName);
         const oldColumn = oldTableColumnOrName instanceof TableColumn ? oldTableColumnOrName : table.columns.find(c => c.name === oldTableColumnOrName);
         if (!oldColumn)
@@ -601,7 +601,7 @@ export class PostgresQueryRunner extends BaseQueryRunner implements QueryRunner 
     /**
      * Changes a column in the table.
      */
-    async changeColumn(tableOrName: Table|string, oldTableColumnOrName: TableColumn|string, newColumn: TableColumn): Promise<void> {
+    async changeColumn(tableOrName: Table | string, oldTableColumnOrName: TableColumn | string, newColumn: TableColumn): Promise<void> {
         const table = tableOrName instanceof Table ? tableOrName : await this.getCachedTable(tableOrName);
         let clonedTable = table.clone();
         const upQueries: Query[] = [];
@@ -892,8 +892,8 @@ export class PostgresQueryRunner extends BaseQueryRunner implements QueryRunner 
     /**
      * Changes a column in the table.
      */
-    async changeColumns(tableOrName: Table|string, changedColumns: { newColumn: TableColumn, oldColumn: TableColumn }[]): Promise<void> {
-        for (const {oldColumn, newColumn} of changedColumns) {
+    async changeColumns(tableOrName: Table | string, changedColumns: { newColumn: TableColumn, oldColumn: TableColumn }[]): Promise<void> {
+        for (const { oldColumn, newColumn } of changedColumns) {
             await this.changeColumn(tableOrName, oldColumn, newColumn);
         }
     }
@@ -901,7 +901,7 @@ export class PostgresQueryRunner extends BaseQueryRunner implements QueryRunner 
     /**
      * Drops column in the table.
      */
-    async dropColumn(tableOrName: Table|string, columnOrName: TableColumn|string): Promise<void> {
+    async dropColumn(tableOrName: Table | string, columnOrName: TableColumn | string): Promise<void> {
         const table = tableOrName instanceof Table ? tableOrName : await this.getCachedTable(tableOrName);
         const column = columnOrName instanceof TableColumn ? columnOrName : table.findColumnByName(columnOrName);
         if (!column)
@@ -978,7 +978,7 @@ export class PostgresQueryRunner extends BaseQueryRunner implements QueryRunner 
     /**
      * Drops the columns in the table.
      */
-    async dropColumns(tableOrName: Table|string, columns: TableColumn[]): Promise<void> {
+    async dropColumns(tableOrName: Table | string, columns: TableColumn[]): Promise<void> {
         for (const column of columns) {
             await this.dropColumn(tableOrName, column);
         }
@@ -987,7 +987,7 @@ export class PostgresQueryRunner extends BaseQueryRunner implements QueryRunner 
     /**
      * Creates a new primary key.
      */
-    async createPrimaryKey(tableOrName: Table|string, columnNames: string[]): Promise<void> {
+    async createPrimaryKey(tableOrName: Table | string, columnNames: string[]): Promise<void> {
         const table = tableOrName instanceof Table ? tableOrName : await this.getCachedTable(tableOrName);
         const clonedTable = table.clone();
 
@@ -1007,7 +1007,7 @@ export class PostgresQueryRunner extends BaseQueryRunner implements QueryRunner 
     /**
      * Updates composite primary keys.
      */
-    async updatePrimaryKeys(tableOrName: Table|string, columns: TableColumn[]): Promise<void> {
+    async updatePrimaryKeys(tableOrName: Table | string, columns: TableColumn[]): Promise<void> {
         const table = tableOrName instanceof Table ? tableOrName : await this.getCachedTable(tableOrName);
         const clonedTable = table.clone();
         const columnNames = columns.map(column => column.name);
@@ -1040,7 +1040,7 @@ export class PostgresQueryRunner extends BaseQueryRunner implements QueryRunner 
     /**
      * Drops a primary key.
      */
-    async dropPrimaryKey(tableOrName: Table|string): Promise<void> {
+    async dropPrimaryKey(tableOrName: Table | string): Promise<void> {
         const table = tableOrName instanceof Table ? tableOrName : await this.getCachedTable(tableOrName);
         const up = this.dropPrimaryKeySql(table);
         const down = this.createPrimaryKeySql(table, table.primaryColumns.map(column => column.name));
@@ -1053,7 +1053,7 @@ export class PostgresQueryRunner extends BaseQueryRunner implements QueryRunner 
     /**
      * Creates new unique constraint.
      */
-    async createUniqueConstraint(tableOrName: Table|string, uniqueConstraint: TableUnique): Promise<void> {
+    async createUniqueConstraint(tableOrName: Table | string, uniqueConstraint: TableUnique): Promise<void> {
         const table = tableOrName instanceof Table ? tableOrName : await this.getCachedTable(tableOrName);
 
         // new unique constraint may be passed without name. In this case we generate unique name manually.
@@ -1069,7 +1069,7 @@ export class PostgresQueryRunner extends BaseQueryRunner implements QueryRunner 
     /**
      * Creates new unique constraints.
      */
-    async createUniqueConstraints(tableOrName: Table|string, uniqueConstraints: TableUnique[]): Promise<void> {
+    async createUniqueConstraints(tableOrName: Table | string, uniqueConstraints: TableUnique[]): Promise<void> {
         for (const uniqueConstraint of uniqueConstraints) {
             await this.createUniqueConstraint(tableOrName, uniqueConstraint);
         }
@@ -1078,7 +1078,7 @@ export class PostgresQueryRunner extends BaseQueryRunner implements QueryRunner 
     /**
      * Drops unique constraint.
      */
-    async dropUniqueConstraint(tableOrName: Table|string, uniqueOrName: TableUnique|string): Promise<void> {
+    async dropUniqueConstraint(tableOrName: Table | string, uniqueOrName: TableUnique | string): Promise<void> {
         const table = tableOrName instanceof Table ? tableOrName : await this.getCachedTable(tableOrName);
         const uniqueConstraint = uniqueOrName instanceof TableUnique ? uniqueOrName : table.uniques.find(u => u.name === uniqueOrName);
         if (!uniqueConstraint)
@@ -1093,7 +1093,7 @@ export class PostgresQueryRunner extends BaseQueryRunner implements QueryRunner 
     /**
      * Drops unique constraints.
      */
-    async dropUniqueConstraints(tableOrName: Table|string, uniqueConstraints: TableUnique[]): Promise<void> {
+    async dropUniqueConstraints(tableOrName: Table | string, uniqueConstraints: TableUnique[]): Promise<void> {
         for (const uniqueConstraint of uniqueConstraints) {
             await this.dropUniqueConstraint(tableOrName, uniqueConstraint);
         }
@@ -1102,7 +1102,7 @@ export class PostgresQueryRunner extends BaseQueryRunner implements QueryRunner 
     /**
      * Creates new check constraint.
      */
-    async createCheckConstraint(tableOrName: Table|string, checkConstraint: TableCheck): Promise<void> {
+    async createCheckConstraint(tableOrName: Table | string, checkConstraint: TableCheck): Promise<void> {
         const table = tableOrName instanceof Table ? tableOrName : await this.getCachedTable(tableOrName);
 
         // new unique constraint may be passed without name. In this case we generate unique name manually.
@@ -1118,7 +1118,7 @@ export class PostgresQueryRunner extends BaseQueryRunner implements QueryRunner 
     /**
      * Creates new check constraints.
      */
-    async createCheckConstraints(tableOrName: Table|string, checkConstraints: TableCheck[]): Promise<void> {
+    async createCheckConstraints(tableOrName: Table | string, checkConstraints: TableCheck[]): Promise<void> {
         const promises = checkConstraints.map(checkConstraint => this.createCheckConstraint(tableOrName, checkConstraint));
         await Promise.all(promises);
     }
@@ -1126,7 +1126,7 @@ export class PostgresQueryRunner extends BaseQueryRunner implements QueryRunner 
     /**
      * Drops check constraint.
      */
-    async dropCheckConstraint(tableOrName: Table|string, checkOrName: TableCheck|string): Promise<void> {
+    async dropCheckConstraint(tableOrName: Table | string, checkOrName: TableCheck | string): Promise<void> {
         const table = tableOrName instanceof Table ? tableOrName : await this.getCachedTable(tableOrName);
         const checkConstraint = checkOrName instanceof TableCheck ? checkOrName : table.checks.find(c => c.name === checkOrName);
         if (!checkConstraint)
@@ -1141,7 +1141,7 @@ export class PostgresQueryRunner extends BaseQueryRunner implements QueryRunner 
     /**
      * Drops check constraints.
      */
-    async dropCheckConstraints(tableOrName: Table|string, checkConstraints: TableCheck[]): Promise<void> {
+    async dropCheckConstraints(tableOrName: Table | string, checkConstraints: TableCheck[]): Promise<void> {
         const promises = checkConstraints.map(checkConstraint => this.dropCheckConstraint(tableOrName, checkConstraint));
         await Promise.all(promises);
     }
@@ -1149,7 +1149,7 @@ export class PostgresQueryRunner extends BaseQueryRunner implements QueryRunner 
     /**
      * Creates new exclusion constraint.
      */
-    async createExclusionConstraint(tableOrName: Table|string, exclusionConstraint: TableExclusion): Promise<void> {
+    async createExclusionConstraint(tableOrName: Table | string, exclusionConstraint: TableExclusion): Promise<void> {
         const table = tableOrName instanceof Table ? tableOrName : await this.getCachedTable(tableOrName);
 
         // new unique constraint may be passed without name. In this case we generate unique name manually.
@@ -1165,7 +1165,7 @@ export class PostgresQueryRunner extends BaseQueryRunner implements QueryRunner 
     /**
      * Creates new exclusion constraints.
      */
-    async createExclusionConstraints(tableOrName: Table|string, exclusionConstraints: TableExclusion[]): Promise<void> {
+    async createExclusionConstraints(tableOrName: Table | string, exclusionConstraints: TableExclusion[]): Promise<void> {
         const promises = exclusionConstraints.map(exclusionConstraint => this.createExclusionConstraint(tableOrName, exclusionConstraint));
         await Promise.all(promises);
     }
@@ -1173,7 +1173,7 @@ export class PostgresQueryRunner extends BaseQueryRunner implements QueryRunner 
     /**
      * Drops exclusion constraint.
      */
-    async dropExclusionConstraint(tableOrName: Table|string, exclusionOrName: TableExclusion|string): Promise<void> {
+    async dropExclusionConstraint(tableOrName: Table | string, exclusionOrName: TableExclusion | string): Promise<void> {
         const table = tableOrName instanceof Table ? tableOrName : await this.getCachedTable(tableOrName);
         const exclusionConstraint = exclusionOrName instanceof TableExclusion ? exclusionOrName : table.exclusions.find(c => c.name === exclusionOrName);
         if (!exclusionConstraint)
@@ -1188,7 +1188,7 @@ export class PostgresQueryRunner extends BaseQueryRunner implements QueryRunner 
     /**
      * Drops exclusion constraints.
      */
-    async dropExclusionConstraints(tableOrName: Table|string, exclusionConstraints: TableExclusion[]): Promise<void> {
+    async dropExclusionConstraints(tableOrName: Table | string, exclusionConstraints: TableExclusion[]): Promise<void> {
         const promises = exclusionConstraints.map(exclusionConstraint => this.dropExclusionConstraint(tableOrName, exclusionConstraint));
         await Promise.all(promises);
     }
@@ -1196,7 +1196,7 @@ export class PostgresQueryRunner extends BaseQueryRunner implements QueryRunner 
     /**
      * Creates a new foreign key.
      */
-    async createForeignKey(tableOrName: Table|string, foreignKey: TableForeignKey): Promise<void> {
+    async createForeignKey(tableOrName: Table | string, foreignKey: TableForeignKey): Promise<void> {
         const table = tableOrName instanceof Table ? tableOrName : await this.getCachedTable(tableOrName);
 
         // new FK may be passed without name. In this case we generate FK name manually.
@@ -1212,7 +1212,7 @@ export class PostgresQueryRunner extends BaseQueryRunner implements QueryRunner 
     /**
      * Creates a new foreign keys.
      */
-    async createForeignKeys(tableOrName: Table|string, foreignKeys: TableForeignKey[]): Promise<void> {
+    async createForeignKeys(tableOrName: Table | string, foreignKeys: TableForeignKey[]): Promise<void> {
         for (const foreignKey of foreignKeys) {
             await this.createForeignKey(tableOrName, foreignKey);
         }
@@ -1221,7 +1221,7 @@ export class PostgresQueryRunner extends BaseQueryRunner implements QueryRunner 
     /**
      * Drops a foreign key from the table.
      */
-    async dropForeignKey(tableOrName: Table|string, foreignKeyOrName: TableForeignKey|string): Promise<void> {
+    async dropForeignKey(tableOrName: Table | string, foreignKeyOrName: TableForeignKey | string): Promise<void> {
         const table = tableOrName instanceof Table ? tableOrName : await this.getCachedTable(tableOrName);
         const foreignKey = foreignKeyOrName instanceof TableForeignKey ? foreignKeyOrName : table.foreignKeys.find(fk => fk.name === foreignKeyOrName);
         if (!foreignKey)
@@ -1236,7 +1236,7 @@ export class PostgresQueryRunner extends BaseQueryRunner implements QueryRunner 
     /**
      * Drops a foreign keys from the table.
      */
-    async dropForeignKeys(tableOrName: Table|string, foreignKeys: TableForeignKey[]): Promise<void> {
+    async dropForeignKeys(tableOrName: Table | string, foreignKeys: TableForeignKey[]): Promise<void> {
         for (const foreignKey of foreignKeys) {
             await this.dropForeignKey(tableOrName, foreignKey);
         }
@@ -1245,7 +1245,7 @@ export class PostgresQueryRunner extends BaseQueryRunner implements QueryRunner 
     /**
      * Creates a new index.
      */
-    async createIndex(tableOrName: Table|string, index: TableIndex): Promise<void> {
+    async createIndex(tableOrName: Table | string, index: TableIndex): Promise<void> {
         const table = tableOrName instanceof Table ? tableOrName : await this.getCachedTable(tableOrName);
 
         // new index may be passed without name. In this case we generate index name manually.
@@ -1261,7 +1261,7 @@ export class PostgresQueryRunner extends BaseQueryRunner implements QueryRunner 
     /**
      * Creates a new indices
      */
-    async createIndices(tableOrName: Table|string, indices: TableIndex[]): Promise<void> {
+    async createIndices(tableOrName: Table | string, indices: TableIndex[]): Promise<void> {
         for (const index of indices) {
             await this.createIndex(tableOrName, index);
         }
@@ -1270,7 +1270,7 @@ export class PostgresQueryRunner extends BaseQueryRunner implements QueryRunner 
     /**
      * Drops an index from the table.
      */
-    async dropIndex(tableOrName: Table|string, indexOrName: TableIndex|string): Promise<void> {
+    async dropIndex(tableOrName: Table | string, indexOrName: TableIndex | string): Promise<void> {
         const table = tableOrName instanceof Table ? tableOrName : await this.getCachedTable(tableOrName);
         const index = indexOrName instanceof TableIndex ? indexOrName : table.indices.find(i => i.name === indexOrName);
         if (!index)
@@ -1285,7 +1285,7 @@ export class PostgresQueryRunner extends BaseQueryRunner implements QueryRunner 
     /**
      * Drops an indices from the table.
      */
-    async dropIndices(tableOrName: Table|string, indices: TableIndex[]): Promise<void> {
+    async dropIndices(tableOrName: Table | string, indices: TableIndex[]): Promise<void> {
         for (const index of indices) {
             await this.dropIndex(tableOrName, index);
         }
@@ -1319,7 +1319,7 @@ export class PostgresQueryRunner extends BaseQueryRunner implements QueryRunner 
         await this.startTransaction();
         try {
             const selectViewDropsQuery = `SELECT 'DROP VIEW IF EXISTS "' || schemaname || '"."' || viewname || '" CASCADE;' as "query" ` +
-             `FROM "pg_views" WHERE "schemaname" IN (${schemaNamesString}) AND "viewname" NOT IN ('geography_columns', 'geometry_columns', 'raster_columns', 'raster_overviews')`;
+                `FROM "pg_views" WHERE "schemaname" IN (${schemaNamesString}) AND "viewname" NOT IN ('geography_columns', 'geometry_columns', 'raster_columns', 'raster_overviews')`;
             const dropViewQueries: ObjectLiteral[] = await this.query(selectViewDropsQuery);
             await Promise.all(dropViewQueries.map(q => this.query(q["query"])));
 
@@ -1509,7 +1509,7 @@ export class PostgresQueryRunner extends BaseQueryRunner implements QueryRunner 
                     if (dbColumn["data_type"].toLowerCase() === "array") {
                         tableColumn.isArray = true;
                         const type = tableColumn.type.replace("[]", "");
-                        tableColumn.type = this.connection.driver.normalizeType({type: type});
+                        tableColumn.type = this.connection.driver.normalizeType({ type: type });
                     }
 
                     if (tableColumn.type === "interval"
@@ -1523,9 +1523,9 @@ export class PostgresQueryRunner extends BaseQueryRunner implements QueryRunner 
                     if (tableColumn.type.indexOf("enum") !== -1) {
                         tableColumn.type = "enum";
                         const sql = `SELECT "e"."enumlabel" AS "value" FROM "pg_enum" "e" ` +
-                        `INNER JOIN "pg_type" "t" ON "t"."oid" = "e"."enumtypid" ` +
-                        `INNER JOIN "pg_namespace" "n" ON "n"."oid" = "t"."typnamespace" ` +
-                        `WHERE "n"."nspname" = '${dbTable["table_schema"]}' AND "t"."typname" = '${this.buildEnumName(table, tableColumn.name, false, true)}'`;
+                            `INNER JOIN "pg_type" "t" ON "t"."oid" = "e"."enumtypid" ` +
+                            `INNER JOIN "pg_namespace" "n" ON "n"."oid" = "t"."typnamespace" ` +
+                            `WHERE "n"."nspname" = '${dbTable["table_schema"]}' AND "t"."typname" = '${this.buildEnumName(table, tableColumn.name, false, true)}'`;
                         const results: ObjectLiteral[] = await this.query(sql);
                         tableColumn.enum = results.map(result => result["value"]);
                     }
@@ -1610,7 +1610,8 @@ export class PostgresQueryRunner extends BaseQueryRunner implements QueryRunner 
                 const uniques = dbConstraints.filter(dbC => dbC["constraint_name"] === constraint["constraint_name"]);
                 return new TableUnique({
                     name: constraint["constraint_name"],
-                    columnNames: uniques.map(u => u["column_name"])
+                    columnNames: uniques.map(u => u["column_name"]),
+                    deferrable: constraint["deferrable"] ? constraint["deferred"] : undefined,
                 });
             });
 
@@ -1713,7 +1714,10 @@ export class PostgresQueryRunner extends BaseQueryRunner implements QueryRunner 
             const uniquesSql = table.uniques.map(unique => {
                 const uniqueName = unique.name ? unique.name : this.connection.namingStrategy.uniqueConstraintName(table.name, unique.columnNames);
                 const columnNames = unique.columnNames.map(columnName => `"${columnName}"`).join(", ");
-                return `CONSTRAINT "${uniqueName}" UNIQUE (${columnNames})`;
+                let constraint = `CONSTRAINT "${uniqueName}" UNIQUE (${columnNames})`;
+                if (unique.deferrable)
+                    constraint += ` DEFERRABLE ${unique.deferrable}`;
+                return constraint
             }).join(", ");
 
             sql += `, ${uniquesSql}`;
@@ -1773,7 +1777,7 @@ export class PostgresQueryRunner extends BaseQueryRunner implements QueryRunner 
     /**
      * Builds drop table sql.
      */
-    protected dropTableSql(tableOrPath: Table|string): Query {
+    protected dropTableSql(tableOrPath: Table | string): Query {
         return new Query(`DROP TABLE ${this.escapePath(tableOrPath)}`);
     }
 
@@ -1812,14 +1816,14 @@ export class PostgresQueryRunner extends BaseQueryRunner implements QueryRunner 
     /**
      * Builds drop view sql.
      */
-    protected dropViewSql(viewOrPath: View|string): Query {
+    protected dropViewSql(viewOrPath: View | string): Query {
         return new Query(`DROP VIEW ${this.escapePath(viewOrPath)}`);
     }
 
     /**
      * Builds remove view sql.
      */
-    protected async deleteViewDefinitionSql(viewOrPath: View|string): Promise<Query> {
+    protected async deleteViewDefinitionSql(viewOrPath: View | string): Promise<Query> {
         const currentSchemaQuery = await this.query(`SELECT * FROM current_schema()`);
         const currentSchema = currentSchemaQuery[0]["current_schema"];
         const viewName = viewOrPath instanceof View ? viewOrPath.name : viewOrPath;
@@ -1845,7 +1849,7 @@ export class PostgresQueryRunner extends BaseQueryRunner implements QueryRunner 
     /**
      * Extracts schema name from given Table object or table name string.
      */
-    protected extractSchema(target: Table|string): string|undefined {
+    protected extractSchema(target: Table | string): string | undefined {
         const tableName = target instanceof Table ? target.name : target;
         return tableName.indexOf(".") === -1 ? this.driver.options.schema : tableName.split(".")[0];
     }
@@ -1905,7 +1909,7 @@ export class PostgresQueryRunner extends BaseQueryRunner implements QueryRunner 
     /**
      * Builds drop index sql.
      */
-    protected dropIndexSql(table: Table, indexOrName: TableIndex|string): Query {
+    protected dropIndexSql(table: Table, indexOrName: TableIndex | string): Query {
         let indexName = indexOrName instanceof TableIndex ? indexOrName.name : indexOrName;
         const schema = this.extractSchema(table);
         return schema ? new Query(`DROP INDEX "${schema}"."${indexName}"`) : new Query(`DROP INDEX "${indexName}"`);
@@ -1934,13 +1938,19 @@ export class PostgresQueryRunner extends BaseQueryRunner implements QueryRunner 
      */
     protected createUniqueConstraintSql(table: Table, uniqueConstraint: TableUnique): Query {
         const columnNames = uniqueConstraint.columnNames.map(column => `"` + column + `"`).join(", ");
-        return new Query(`ALTER TABLE ${this.escapePath(table)} ADD CONSTRAINT "${uniqueConstraint.name}" UNIQUE (${columnNames})`);
+        // return new Query(`ALTER TABLE ${this.escapePath(table)} ADD CONSTRAINT "${uniqueConstraint.name}" UNIQUE (${columnNames})`);
+
+        let sql = `ALTER TABLE ${this.escapePath(table)} ADD CONSTRAINT "${uniqueConstraint.name}" UNIQUE (${columnNames})`;
+        if (uniqueConstraint.deferrable)
+            sql += ` DEFERRABLE ${uniqueConstraint.deferrable}`;
+        return new Query(sql);
+
     }
 
     /**
      * Builds drop unique constraint sql.
      */
-    protected dropUniqueConstraintSql(table: Table, uniqueOrName: TableUnique|string): Query {
+    protected dropUniqueConstraintSql(table: Table, uniqueOrName: TableUnique | string): Query {
         const uniqueName = uniqueOrName instanceof TableUnique ? uniqueOrName.name : uniqueOrName;
         return new Query(`ALTER TABLE ${this.escapePath(table)} DROP CONSTRAINT "${uniqueName}"`);
     }
@@ -1955,7 +1965,7 @@ export class PostgresQueryRunner extends BaseQueryRunner implements QueryRunner 
     /**
      * Builds drop check constraint sql.
      */
-    protected dropCheckConstraintSql(table: Table, checkOrName: TableCheck|string): Query {
+    protected dropCheckConstraintSql(table: Table, checkOrName: TableCheck | string): Query {
         const checkName = checkOrName instanceof TableCheck ? checkOrName.name : checkOrName;
         return new Query(`ALTER TABLE ${this.escapePath(table)} DROP CONSTRAINT "${checkName}"`);
     }
@@ -1970,7 +1980,7 @@ export class PostgresQueryRunner extends BaseQueryRunner implements QueryRunner 
     /**
      * Builds drop exclusion constraint sql.
      */
-    protected dropExclusionConstraintSql(table: Table, exclusionOrName: TableExclusion|string): Query {
+    protected dropExclusionConstraintSql(table: Table, exclusionOrName: TableExclusion | string): Query {
         const exclusionName = exclusionOrName instanceof TableExclusion ? exclusionOrName.name : exclusionOrName;
         return new Query(`ALTER TABLE ${this.escapePath(table)} DROP CONSTRAINT "${exclusionName}"`);
     }
@@ -1996,7 +2006,7 @@ export class PostgresQueryRunner extends BaseQueryRunner implements QueryRunner 
     /**
      * Builds drop foreign key sql.
      */
-    protected dropForeignKeySql(table: Table, foreignKeyOrName: TableForeignKey|string): Query {
+    protected dropForeignKeySql(table: Table, foreignKeyOrName: TableForeignKey | string): Query {
         const foreignKeyName = foreignKeyOrName instanceof TableForeignKey ? foreignKeyOrName.name : foreignKeyOrName;
         return new Query(`ALTER TABLE ${this.escapePath(table)} DROP CONSTRAINT "${foreignKeyName}"`);
     }
@@ -2004,10 +2014,10 @@ export class PostgresQueryRunner extends BaseQueryRunner implements QueryRunner 
     /**
      * Builds sequence name from given table and column.
      */
-    protected buildSequenceName(table: Table, columnOrName: TableColumn|string, currentSchema?: string, disableEscape?: true, skipSchema?: boolean): string {
+    protected buildSequenceName(table: Table, columnOrName: TableColumn | string, currentSchema?: string, disableEscape?: true, skipSchema?: boolean): string {
         const columnName = columnOrName instanceof TableColumn ? columnOrName.name : columnOrName;
-        let schema: string|undefined = undefined;
-        let tableName: string|undefined = undefined;
+        let schema: string | undefined = undefined;
+        let tableName: string | undefined = undefined;
 
         if (table.name.indexOf(".") === -1) {
             tableName = table.name;
@@ -2027,7 +2037,7 @@ export class PostgresQueryRunner extends BaseQueryRunner implements QueryRunner 
     /**
      * Builds ENUM type name from given table and column.
      */
-    protected buildEnumName(table: Table, columnOrName: TableColumn|string, withSchema: boolean = true, disableEscape?: boolean, toOld?: boolean): string {
+    protected buildEnumName(table: Table, columnOrName: TableColumn | string, withSchema: boolean = true, disableEscape?: boolean, toOld?: boolean): string {
         /**
          * If enumName is specified in column options then use it instead
          */
@@ -2067,7 +2077,7 @@ export class PostgresQueryRunner extends BaseQueryRunner implements QueryRunner 
     /**
      * Escapes given table or view path.
      */
-    protected escapePath(target: Table|View|string, disableEscape?: boolean): string {
+    protected escapePath(target: Table | View | string, disableEscape?: boolean): string {
         let tableName = target instanceof Table || target instanceof View ? target.name : target;
         tableName = tableName.indexOf(".") === -1 && this.driver.options.schema ? `${this.driver.options.schema}.${tableName}` : tableName;
 
@@ -2079,7 +2089,7 @@ export class PostgresQueryRunner extends BaseQueryRunner implements QueryRunner 
     /**
      * Returns object with table schema and table name.
      */
-    protected parseTableName(target: Table|string) {
+    protected parseTableName(target: Table | string) {
         const tableName = target instanceof Table ? target.name : target;
         if (tableName.indexOf(".") === -1) {
             return {

--- a/src/entity-schema/EntitySchemaTransformer.ts
+++ b/src/entity-schema/EntitySchemaTransformer.ts
@@ -1,18 +1,18 @@
-import {EntitySchema} from "./EntitySchema";
-import {MetadataArgsStorage} from "../metadata-args/MetadataArgsStorage";
-import {TableMetadataArgs} from "../metadata-args/TableMetadataArgs";
-import {ColumnMetadataArgs} from "../metadata-args/ColumnMetadataArgs";
-import {IndexMetadataArgs} from "../metadata-args/IndexMetadataArgs";
-import {RelationMetadataArgs} from "../metadata-args/RelationMetadataArgs";
-import {JoinColumnMetadataArgs} from "../metadata-args/JoinColumnMetadataArgs";
-import {JoinTableMetadataArgs} from "../metadata-args/JoinTableMetadataArgs";
-import {JoinTableOptions} from "../decorator/options/JoinTableOptions";
-import {JoinTableMultipleColumnsOptions} from "../decorator/options/JoinTableMultipleColumnsOptions";
-import {ColumnMode} from "../metadata-args/types/ColumnMode";
-import {GeneratedMetadataArgs} from "../metadata-args/GeneratedMetadataArgs";
-import {UniqueMetadataArgs} from "../metadata-args/UniqueMetadataArgs";
-import {CheckMetadataArgs} from "../metadata-args/CheckMetadataArgs";
-import {ExclusionMetadataArgs} from "../metadata-args/ExclusionMetadataArgs";
+import { EntitySchema } from "./EntitySchema";
+import { MetadataArgsStorage } from "../metadata-args/MetadataArgsStorage";
+import { TableMetadataArgs } from "../metadata-args/TableMetadataArgs";
+import { ColumnMetadataArgs } from "../metadata-args/ColumnMetadataArgs";
+import { IndexMetadataArgs } from "../metadata-args/IndexMetadataArgs";
+import { RelationMetadataArgs } from "../metadata-args/RelationMetadataArgs";
+import { JoinColumnMetadataArgs } from "../metadata-args/JoinColumnMetadataArgs";
+import { JoinTableMetadataArgs } from "../metadata-args/JoinTableMetadataArgs";
+import { JoinTableOptions } from "../decorator/options/JoinTableOptions";
+import { JoinTableMultipleColumnsOptions } from "../decorator/options/JoinTableMultipleColumnsOptions";
+import { ColumnMode } from "../metadata-args/types/ColumnMode";
+import { GeneratedMetadataArgs } from "../metadata-args/GeneratedMetadataArgs";
+import { UniqueMetadataArgs } from "../metadata-args/UniqueMetadataArgs";
+import { CheckMetadataArgs } from "../metadata-args/CheckMetadataArgs";
+import { ExclusionMetadataArgs } from "../metadata-args/ExclusionMetadataArgs";
 
 /**
  * Transforms entity schema into metadata args storage.
@@ -214,7 +214,8 @@ export class EntitySchemaTransformer {
                     const uniqueAgrs: UniqueMetadataArgs = {
                         target: options.target || options.name,
                         name: unique.name,
-                        columns: unique.columns
+                        columns: unique.columns,
+                        options: unique.options
                     };
                     metadataArgsStorage.uniques.push(uniqueAgrs);
                 });

--- a/src/entity-schema/EntitySchemaUniqueOptions.ts
+++ b/src/entity-schema/EntitySchemaUniqueOptions.ts
@@ -1,3 +1,5 @@
+import { UniqueOptions } from '../decorator/options/UniqueOptions';
+
 export interface EntitySchemaUniqueOptions {
 
     /**
@@ -8,6 +10,11 @@ export interface EntitySchemaUniqueOptions {
     /**
      * Unique column names.
      */
-    columns?: ((object?: any) => (any[]|{ [key: string]: number }))|string[];
+    columns?: ((object?: any) => (any[] | { [key: string]: number })) | string[];
+
+    /**
+     * Additional relation options.
+     */
+    readonly options?: UniqueOptions;
 
 }

--- a/src/entity-schema/EntitySchemaUniqueOptions.ts
+++ b/src/entity-schema/EntitySchemaUniqueOptions.ts
@@ -1,4 +1,4 @@
-import { UniqueOptions } from '../decorator/options/UniqueOptions';
+import { UniqueOptions } from "../decorator/options/UniqueOptions";
 
 export interface EntitySchemaUniqueOptions {
 

--- a/src/metadata-args/UniqueMetadataArgs.ts
+++ b/src/metadata-args/UniqueMetadataArgs.ts
@@ -1,3 +1,5 @@
+import { UniqueOptions } from '../decorator/options/UniqueOptions';
+
 /**
  * Arguments for UniqueMetadata class.
  */
@@ -6,7 +8,7 @@ export interface UniqueMetadataArgs {
     /**
      * Class to which index is applied.
      */
-    target: Function|string;
+    target: Function | string;
 
     /**
      * Unique constraint name.
@@ -16,5 +18,12 @@ export interface UniqueMetadataArgs {
     /**
      * Columns combination to be unique.
      */
-    columns?: ((object?: any) => (any[]|{ [key: string]: number }))|string[];
+    columns?: ((object?: any) => (any[] | { [key: string]: number })) | string[];
+
+
+    /**
+     * Additional relation options.
+     */
+    readonly options?: UniqueOptions;
+
 }

--- a/src/metadata-args/UniqueMetadataArgs.ts
+++ b/src/metadata-args/UniqueMetadataArgs.ts
@@ -1,4 +1,4 @@
-import { UniqueOptions } from '../decorator/options/UniqueOptions';
+import { UniqueOptions } from "../decorator/options/UniqueOptions";
 
 /**
  * Arguments for UniqueMetadata class.

--- a/src/metadata/UniqueMetadata.ts
+++ b/src/metadata/UniqueMetadata.ts
@@ -1,8 +1,9 @@
-import {EmbeddedMetadata} from "./EmbeddedMetadata";
-import {EntityMetadata} from "./EntityMetadata";
-import {NamingStrategyInterface} from "../naming-strategy/NamingStrategyInterface";
-import {ColumnMetadata} from "./ColumnMetadata";
-import {UniqueMetadataArgs} from "../metadata-args/UniqueMetadataArgs";
+import { EmbeddedMetadata } from "./EmbeddedMetadata";
+import { EntityMetadata } from "./EntityMetadata";
+import { NamingStrategyInterface } from "../naming-strategy/NamingStrategyInterface";
+import { ColumnMetadata } from "./ColumnMetadata";
+import { UniqueMetadataArgs } from "../metadata-args/UniqueMetadataArgs";
+import { DeferrableType } from './types/DeferrableType';
 
 /**
  * Unique metadata contains all information about table's unique constraints.
@@ -26,7 +27,7 @@ export class UniqueMetadata {
     /**
      * Target class to which metadata is applied.
      */
-    target?: Function|string;
+    target?: Function | string;
 
     /**
      * Unique columns.
@@ -41,7 +42,7 @@ export class UniqueMetadata {
     /**
      * User specified column names.
      */
-    givenColumnNames?: ((object?: any) => (any[]|{ [key: string]: number }))|string[];
+    givenColumnNames?: ((object?: any) => (any[] | { [key: string]: number })) | string[];
 
     /**
      * Final unique constraint name.
@@ -55,6 +56,11 @@ export class UniqueMetadata {
      * Used only by MongoDB driver.
      */
     columnNamesWithOrderingMap: { [key: string]: number } = {};
+
+    /**
+     * When to check the constraints of a foreign key.
+     */
+    deferrable?: DeferrableType;
 
     // ---------------------------------------------------------------------
     // Constructor
@@ -75,6 +81,7 @@ export class UniqueMetadata {
             this.target = options.args.target;
             this.givenName = options.args.name;
             this.givenColumnNames = options.args.columns;
+            this.deferrable = options.args.options ? options.args.options.deferrable : undefined;
         }
     }
 
@@ -126,7 +133,7 @@ export class UniqueMetadata {
                 const entityName = this.entityMetadata.targetName;
                 throw new Error(`Unique constraint ${indexName}contains column that is missing in the entity (${entityName}): ` + propertyName);
             })
-            .reduce((a, b) => a.concat(b));
+                .reduce((a, b) => a.concat(b));
         }
 
         this.columnNamesWithOrderingMap = Object.keys(map).reduce((updatedMap, key) => {

--- a/src/metadata/UniqueMetadata.ts
+++ b/src/metadata/UniqueMetadata.ts
@@ -3,7 +3,7 @@ import { EntityMetadata } from "./EntityMetadata";
 import { NamingStrategyInterface } from "../naming-strategy/NamingStrategyInterface";
 import { ColumnMetadata } from "./ColumnMetadata";
 import { UniqueMetadataArgs } from "../metadata-args/UniqueMetadataArgs";
-import { DeferrableType } from './types/DeferrableType';
+import { DeferrableType } from "./types/DeferrableType";
 
 /**
  * Unique metadata contains all information about table's unique constraints.

--- a/src/schema-builder/options/TableUniqueOptions.ts
+++ b/src/schema-builder/options/TableUniqueOptions.ts
@@ -17,4 +17,10 @@ export interface TableUniqueOptions {
      */
     columnNames: string[];
 
+    /**
+     * Set this foreign key constraint as "DEFERRABLE" e.g. check constraints at start 
+     * or at the end of a transaction
+     */
+    deferrable?: string;
+
 }

--- a/src/schema-builder/table/TableUnique.ts
+++ b/src/schema-builder/table/TableUnique.ts
@@ -1,5 +1,5 @@
-import {TableUniqueOptions} from "../options/TableUniqueOptions";
-import {UniqueMetadata} from "../../metadata/UniqueMetadata";
+import { TableUniqueOptions } from "../options/TableUniqueOptions";
+import { UniqueMetadata } from "../../metadata/UniqueMetadata";
 
 /**
  * Database's table unique constraint stored in this class.
@@ -20,6 +20,12 @@ export class TableUnique {
      */
     columnNames: string[] = [];
 
+    /**
+     * Set this foreign key constraint as "DEFERRABLE" e.g. check constraints at start
+     * or at the end of a transaction
+     */
+    deferrable?: string;
+
     // -------------------------------------------------------------------------
     // Constructor
     // -------------------------------------------------------------------------
@@ -27,6 +33,7 @@ export class TableUnique {
     constructor(options: TableUniqueOptions) {
         this.name = options.name;
         this.columnNames = options.columnNames;
+        this.deferrable = options.deferrable;
     }
 
     // -------------------------------------------------------------------------
@@ -39,7 +46,8 @@ export class TableUnique {
     clone(): TableUnique {
         return new TableUnique(<TableUniqueOptions>{
             name: this.name,
-            columnNames: [...this.columnNames]
+            columnNames: [...this.columnNames],
+            deferrable: this.deferrable,
         });
     }
 
@@ -53,7 +61,8 @@ export class TableUnique {
     static create(uniqueMetadata: UniqueMetadata): TableUnique {
         return new TableUnique(<TableUniqueOptions>{
             name: uniqueMetadata.name,
-            columnNames: uniqueMetadata.columns.map(column => column.databaseName)
+            columnNames: uniqueMetadata.columns.map(column => column.databaseName),
+            deferrable: uniqueMetadata.deferrable,
         });
     }
 

--- a/test/functional/query-runner/create-table.ts
+++ b/test/functional/query-runner/create-table.ts
@@ -1,17 +1,17 @@
 import "reflect-metadata";
-import {expect} from "chai";
-import {Connection} from "../../../src/connection/Connection";
-import {CockroachDriver} from "../../../src/driver/cockroachdb/CockroachDriver";
-import {SapDriver} from "../../../src/driver/sap/SapDriver";
-import {closeTestingConnections, createTestingConnections} from "../../utils/test-utils";
-import {Table} from "../../../src/schema-builder/table/Table";
-import {TableOptions} from "../../../src/schema-builder/options/TableOptions";
-import {Post} from "./entity/Post";
-import {MysqlDriver} from "../../../src/driver/mysql/MysqlDriver";
-import {AbstractSqliteDriver} from "../../../src/driver/sqlite-abstract/AbstractSqliteDriver";
-import {OracleDriver} from "../../../src/driver/oracle/OracleDriver";
-import {Photo} from "./entity/Photo";
-import {Book2, Book} from "./entity/Book";
+import { expect } from "chai";
+import { Connection } from "../../../src/connection/Connection";
+import { CockroachDriver } from "../../../src/driver/cockroachdb/CockroachDriver";
+import { SapDriver } from "../../../src/driver/sap/SapDriver";
+import { closeTestingConnections, createTestingConnections } from "../../utils/test-utils";
+import { Table } from "../../../src/schema-builder/table/Table";
+import { TableOptions } from "../../../src/schema-builder/options/TableOptions";
+import { Post } from "./entity/Post";
+import { MysqlDriver } from "../../../src/driver/mysql/MysqlDriver";
+import { AbstractSqliteDriver } from "../../../src/driver/sqlite-abstract/AbstractSqliteDriver";
+import { OracleDriver } from "../../../src/driver/oracle/OracleDriver";
+import { Photo } from "./entity/Photo";
+import { Book2, Book } from "./entity/Book";
 
 describe("query runner > create table", () => {
 
@@ -200,9 +200,9 @@ describe("query runner > create table", () => {
         };
 
         if (connection.driver instanceof MysqlDriver || connection.driver instanceof SapDriver) {
-            categoryTableOptions.indices = [{ columnNames: ["name", "alternativeName"]}];
+            categoryTableOptions.indices = [{ columnNames: ["name", "alternativeName"] }];
         } else {
-            categoryTableOptions.uniques = [{ columnNames: ["name", "alternativeName"]}];
+            categoryTableOptions.uniques = [{ columnNames: ["name", "alternativeName"] }];
         }
 
         // When we mark column as unique, MySql create index for that column and we don't need to create index separately.

--- a/test/functional/query-runner/entity/Post.ts
+++ b/test/functional/query-runner/entity/Post.ts
@@ -1,12 +1,12 @@
-import {Entity} from "../../../../src/decorator/entity/Entity";
-import {Column} from "../../../../src/decorator/columns/Column";
-import {Unique} from "../../../../src/decorator/Unique";
-import {PrimaryColumn} from "../../../../src/decorator/columns/PrimaryColumn";
-import {Check} from "../../../../src/decorator/Check";
-import {Exclusion} from "../../../../src/decorator/Exclusion";
+import { Entity } from "../../../../src/decorator/entity/Entity";
+import { Column } from "../../../../src/decorator/columns/Column";
+import { Unique } from "../../../../src/decorator/Unique";
+import { PrimaryColumn } from "../../../../src/decorator/columns/PrimaryColumn";
+import { Check } from "../../../../src/decorator/Check";
+import { Exclusion } from "../../../../src/decorator/Exclusion";
 
 @Entity()
-@Unique(["text", "tag"])
+@Unique(["text", "tag"], { deferrable: 'INITIALLY DEFERRED' })
 @Exclusion(`USING gist ("name" WITH =)`)
 @Check(`"version" < 999`)
 export class Post {


### PR DESCRIPTION
I've added deferrable options for UNIQUE keys on Postgres, see DEFERRABLE on CREATE TABLE, or on SET CONSTRAINTS. Based on that documentation the following declarations are equivalent (at final of column or constraint definition):

"" == "NOT DEFERRABLE" (default)
"DEFERRABLE" == "DEFERRABLE INITIALLY IMMEDIATE"
"DEFERRABLE INITIALLY DEFERRED"
Thus, with a single property on UNIQUE options all three cases are covered (undefined means "NOT DEFERRABLE", default in postgres):

deferrable: "INITIALLY IMMEDIATE" | "INITIALLY DEFERRED"