### PR TITLE
Update link to sql.js

### DIFF
--- a/docs/supported-platforms.md
+++ b/docs/supported-platforms.md
@@ -13,7 +13,7 @@ TypeORM was tested on Node.js version 4 and above.
 
 ## Browser
 
-You can use [sql.js](https://github.com/kripken/sql.js) in the browser.
+You can use [sql.js](https://sql.js.org) in the browser.
 
 **Webpack configuration**
     


### PR DESCRIPTION
The sql.js project has moved from https://github.com/kripken/sql.js to https://github.com/sql-js/sql.js and now uses https://sql.js.org as its official website.