### PR TITLE
fix: explicitly define `query` command's param

### DIFF
--- a/src/commands/QueryCommand.ts
+++ b/src/commands/QueryCommand.ts
@@ -10,11 +10,15 @@ import chalk from "chalk";
  * Executes an sql query on the given connection.
  */
 export class QueryCommand implements yargs.CommandModule {
-    command = "query";
+    command = "query [query]";
     describe = "Executes given SQL query on a default connection. Specify connection name to run query on a specific connection.";
 
     builder(args: yargs.Argv) {
         return args
+            .positional("query", {
+                describe: "The SQL Query to run",
+                type: "string"
+            })
             .option("c", {
                 alias: "connection",
                 default: "default",


### PR DESCRIPTION
the CLI command `query` had an implicit `query` positional
parameter and in earlier versions of yargs that was okay -
but in the later versions aiming for more correct code they've
refactored it to not support that

explicitly define the `query` positional parameter & add a
helpful description so people can tell what it is for

fixes #6896