### PR TITLE
feat: Support column comments in Postgres and CockroachDB

### DIFF
--- a/src/driver/cockroachdb/CockroachDriver.ts
+++ b/src/driver/cockroachdb/CockroachDriver.ts
@@ -619,7 +619,7 @@ export class CockroachDriver implements Driver {
                 || tableColumn.length !== columnMetadata.length
                 || tableColumn.precision !== columnMetadata.precision
                 || (columnMetadata.scale !== undefined && tableColumn.scale !== columnMetadata.scale)
-                // || tableColumn.comment !== columnMetadata.comment // todo
+                || (tableColumn.comment || "") !== columnMetadata.comment
                 || (!tableColumn.isGenerated && this.lowerDefaultValueIfNecessary(this.normalizeDefault(columnMetadata)) !== tableColumn.default) // we included check for generated here, because generated columns already can have default values
                 || tableColumn.isPrimary !== columnMetadata.isPrimary
                 || tableColumn.isNullable !== columnMetadata.isNullable

--- a/src/driver/postgres/PostgresDriver.ts
+++ b/src/driver/postgres/PostgresDriver.ts
@@ -875,7 +875,7 @@ export class PostgresDriver implements Driver {
                 || tableColumn.length !== columnMetadata.length
                 || tableColumn.precision !== columnMetadata.precision
                 || (columnMetadata.scale !== undefined && tableColumn.scale !== columnMetadata.scale)
-                // || tableColumn.comment !== columnMetadata.comment // todo
+                || (tableColumn.comment || "") !== columnMetadata.comment
                 || (!tableColumn.isGenerated && this.lowerDefaultValueIfNecessary(this.normalizeDefault(columnMetadata)) !== tableColumn.default) // we included check for generated here, because generated columns already can have default values
                 || tableColumn.isPrimary !== columnMetadata.isPrimary
                 || tableColumn.isNullable !== columnMetadata.isNullable

--- a/test/functional/columns/comments/columns-comments.ts
+++ b/test/functional/columns/comments/columns-comments.ts
@@ -9,8 +9,8 @@ describe("columns > comments", () => {
     let connections: Connection[];
     before(async () => connections = await createTestingConnections({
         entities: [Test],
-        // Only supported on mysql
-        enabledDrivers: ["mysql"]
+        // Only supported on postgres, cockroachdb, and mysql
+        enabledDrivers: ["postgres", "cockroachdb", "mysql"]
     }));
     beforeEach(() => reloadTestingDatabases(connections));
     after(() => closeTestingConnections(connections));

--- a/test/functional/schema-builder/change-column.ts
+++ b/test/functional/schema-builder/change-column.ts
@@ -250,7 +250,7 @@ describe("schema builder > change column", () => {
 
     it("should correctly change column comment", () => Promise.all(connections.map(async connection => {
         // Skip thie contents of this test if not one of the drivers that support comments
-        if (!(connection.driver instanceof MysqlDriver)) {
+        if (!(connection.driver instanceof CockroachDriver || connection.driver instanceof PostgresDriver || connection.driver instanceof MysqlDriver)) {
             return;
         }
 


### PR DESCRIPTION
adds support for column comments to both the Postgres and
CockroachDB driver - for migrations & in metadata.  also includes
new tests that validate the functionality works as expected

closes #4461
fixes #3360