### PR TITLE
refactor: create base error and simplify error creation

### DIFF
--- a/src/driver/DriverFactory.ts
+++ b/src/driver/DriverFactory.ts
@@ -67,7 +67,13 @@ export class DriverFactory {
             case "capacitor":
                 return new CapacitorDriver(connection);
             default:
-                throw new MissingDriverError(type);
+                throw new MissingDriverError(
+                    type,
+                    [
+                        "cordova", "expo", "mariadb", "mongodb", "mssql", "mysql", "oracle", "postgres",
+                        "sqlite", "better-sqlite3", "sqljs", "react-native", "aurora-data-api", "aurora-data-api-pg"
+                    ]
+                );
         }
     }
 

--- a/src/error/AlreadyHasActiveConnectionError.ts
+++ b/src/error/AlreadyHasActiveConnectionError.ts
@@ -1,14 +1,13 @@
+import { TypeORMError } from "./TypeORMError";
+
 /**
  * Thrown when consumer tries to recreate connection with the same name, but previous connection was not closed yet.
  */
-export class AlreadyHasActiveConnectionError extends Error {
-    name = "AlreadyHasActiveConnectionError";
-
+export class AlreadyHasActiveConnectionError extends TypeORMError {
     constructor(connectionName: string) {
-        super();
-        Object.setPrototypeOf(this, AlreadyHasActiveConnectionError.prototype);
-        this.message = `Cannot create a new connection named "${connectionName}", because connection with such name ` +
-            `already exist and it now has an active connection session.`;
+        super(
+            `Cannot create a new connection named "${connectionName}", because connection with such name ` +
+            `already exist and it now has an active connection session.`
+        );
     }
-
 }

--- a/src/error/CannotAttachTreeChildrenEntityError.ts
+++ b/src/error/CannotAttachTreeChildrenEntityError.ts
@@ -1,13 +1,14 @@
+import {TypeORMError} from "./TypeORMError";
+
 /**
  * Thrown when user saves tree children entity but its parent is not saved yet.
 */
-export class CannotAttachTreeChildrenEntityError extends Error {
-    name = "CannotAttachTreeChildrenEntityError";
-
+export class CannotAttachTreeChildrenEntityError extends TypeORMError {
     constructor(entityName: string) {
-        super();
-        Object.setPrototypeOf(this, CannotAttachTreeChildrenEntityError.prototype);
-        this.message = `Cannot attach entity "${entityName}" to its parent. Please make sure parent is saved in the database before saving children nodes.`;
+        super(
+            `Cannot attach entity "${entityName}" to its parent. Please make sure parent ` +
+            `is saved in the database before saving children nodes.`
+        );
     }
 
 }

--- a/src/error/CannotConnectAlreadyConnectedError.ts
+++ b/src/error/CannotConnectAlreadyConnectedError.ts
@@ -1,13 +1,12 @@
+import {TypeORMError} from "./TypeORMError";
+
 /**
  * Thrown when consumer tries to connect when he already connected.
  */
-export class CannotConnectAlreadyConnectedError extends Error {
-    name = "CannotConnectAlreadyConnectedError";
-
+export class CannotConnectAlreadyConnectedError extends TypeORMError {
     constructor(connectionName: string) {
-        super();
-        Object.setPrototypeOf(this, CannotConnectAlreadyConnectedError.prototype);
-        this.message = `Cannot create a "${connectionName}" connection because connection to the database already established.`;
+        super(
+            `Cannot create a "${connectionName}" connection because connection to the database already established.`
+        );
     }
-
 }

--- a/src/error/CannotCreateEntityIdMapError.ts
+++ b/src/error/CannotCreateEntityIdMapError.ts
@@ -1,21 +1,19 @@
 import {EntityMetadata} from "../metadata/EntityMetadata";
 import {ObjectLiteral} from "../common/ObjectLiteral";
+import {TypeORMError} from "./TypeORMError";
 
 /**
  * Thrown when user tries to create entity id map from the mixed id value,
  * but id value is a single value when entity requires multiple values.
  */
-export class CannotCreateEntityIdMapError extends Error {
-    name = "CannotCreateEntityIdMapError";
-
+export class CannotCreateEntityIdMapError extends TypeORMError {
     constructor(metadata: EntityMetadata, id: any) {
         super();
-        Object.setPrototypeOf(this, CannotCreateEntityIdMapError.prototype);
+
         const objectExample = metadata.primaryColumns.reduce((object, column, index) => {
             column.setEntityValue(object, index + 1);
             return object;
         }, {} as ObjectLiteral);
         this.message = `Cannot use given entity id "${id}" because "${metadata.targetName}" contains multiple primary columns, you must provide object in following form: ${JSON.stringify(objectExample)} as an id.`;
     }
-
 }

--- a/src/error/CannotDetermineEntityError.ts
+++ b/src/error/CannotDetermineEntityError.ts
@@ -1,13 +1,13 @@
+import {TypeORMError} from "./TypeORMError";
+
 /**
  * Thrown when user tries to save/remove/etc. constructor-less object (object literal) instead of entity.
  */
-export class CannotDetermineEntityError extends Error {
-    name = "CannotDetermineEntityError";
-
+export class CannotDetermineEntityError extends TypeORMError {
     constructor(operation: string) {
-        super();
-        Object.setPrototypeOf(this, CannotDetermineEntityError.prototype);
-        this.message = `Cannot ${operation}, given value must be instance of entity class, instead object literal is given. Or you must specify an entity target to method call.`;
+        super(
+            `Cannot ${operation}, given value must be instance of entity class, ` +
+            `instead object literal is given. Or you must specify an entity target to method call.`
+        );
     }
-
 }

--- a/src/error/CannotExecuteNotConnectedError.ts
+++ b/src/error/CannotExecuteNotConnectedError.ts
@@ -1,13 +1,12 @@
+import {TypeORMError} from "./TypeORMError";
+
 /**
  * Thrown when consumer tries to execute operation allowed only if connection is opened.
  */
-export class CannotExecuteNotConnectedError extends Error {
-    name = "CannotExecuteNotConnectedError";
-
+export class CannotExecuteNotConnectedError extends TypeORMError {
     constructor(connectionName: string) {
-        super();
-        Object.setPrototypeOf(this, CannotExecuteNotConnectedError.prototype);
-        this.message = `Cannot execute operation on "${connectionName}" connection because connection is not yet established.`;
+        super(
+            `Cannot execute operation on "${connectionName}" connection because connection is not yet established.`
+        );
     }
-
 }

--- a/src/error/CannotGetEntityManagerNotConnectedError.ts
+++ b/src/error/CannotGetEntityManagerNotConnectedError.ts
@@ -1,13 +1,12 @@
+import {TypeORMError} from "./TypeORMError";
+
 /**
  * Thrown when consumer tries to access entity manager before connection is established.
  */
-export class CannotGetEntityManagerNotConnectedError extends Error {
-    name = "CannotGetEntityManagerNotConnectedError";
-
+export class CannotGetEntityManagerNotConnectedError extends TypeORMError {
     constructor(connectionName: string) {
-        super();
-        Object.setPrototypeOf(this, CannotGetEntityManagerNotConnectedError.prototype);
-        this.message = `Cannot get entity manager for "${connectionName}" connection because connection is not yet established.`;
+        super(
+            `Cannot get entity manager for "${connectionName}" connection because connection is not yet established.`
+        );
     }
-
 }

--- a/src/error/CannotReflectMethodParameterTypeError.ts
+++ b/src/error/CannotReflectMethodParameterTypeError.ts
@@ -1,16 +1,15 @@
+import {TypeORMError} from "./TypeORMError";
+
 /**
  * Thrown when ORM cannot get method parameter's type.
  * Basically, when reflect-metadata is not available or tsconfig is not properly setup.
  */
-export class CannotReflectMethodParameterTypeError extends Error {
-    name = "CannotReflectMethodParameterTypeError";
-
+export class CannotReflectMethodParameterTypeError extends TypeORMError {
     constructor(target: Function, methodName: string) {
-        super();
-        Object.setPrototypeOf(this, CannotReflectMethodParameterTypeError.prototype);
-        this.message = `Cannot get reflected type for a "${methodName}" method's parameter of "${target.name}" class. ` +
+        super(
+            `Cannot get reflected type for a "${methodName}" method's parameter of "${target.name}" class. ` +
             `Make sure you have turned on an "emitDecoratorMetadata": true option in tsconfig.json. ` +
-            `Also make sure you have imported "reflect-metadata" on top of the main entry file in your application.`;
+            `Also make sure you have imported "reflect-metadata" on top of the main entry file in your application.`
+        );
     }
-
 }

--- a/src/error/CircularRelationsError.ts
+++ b/src/error/CircularRelationsError.ts
@@ -1,13 +1,13 @@
+import {TypeORMError} from "./TypeORMError";
+
 /**
  * Thrown when circular relations detected with nullable set to false.
  */
-export class CircularRelationsError extends Error {
-    name = "CircularRelationsError";
-
+export class CircularRelationsError extends TypeORMError {
     constructor(path: string) {
-        super();
-        Object.setPrototypeOf(this, CircularRelationsError.prototype);
-        this.message = `Circular relations detected: ${path}. To resolve this issue you need to set nullable: true somewhere in this dependency structure.`;
+        super(
+            `Circular relations detected: ${path}. To resolve this issue you need to ` +
+            `set nullable: true somewhere in this dependency structure.`
+        );
     }
-
 }

--- a/src/error/ColumnTypeUndefinedError.ts
+++ b/src/error/ColumnTypeUndefinedError.ts
@@ -1,17 +1,16 @@
+import {TypeORMError} from "./TypeORMError";
+
 /**
  * Thrown when ORM cannot get column's type automatically.
  * Basically, when reflect-metadata is not available or tsconfig is not properly setup.
  */
-export class ColumnTypeUndefinedError extends Error {
-    name = "ColumnTypeUndefinedError";
-
+export class ColumnTypeUndefinedError extends TypeORMError {
     constructor(object: Object, propertyName: string) {
-        super();
-        Object.setPrototypeOf(this, ColumnTypeUndefinedError.prototype);
-        this.message = `Column type for ${object.constructor.name}#${propertyName} is not defined and cannot be guessed. ` +
+        super(
+            `Column type for ${object.constructor.name}#${propertyName} is not defined and cannot be guessed. ` +
             `Make sure you have turned on an "emitDecoratorMetadata": true option in tsconfig.json. ` +
             `Also make sure you have imported "reflect-metadata" on top of the main entry file in your application (before any entity imported).` +
-            `If you are using JavaScript instead of TypeScript you must explicitly provide a column type.`;
+            `If you are using JavaScript instead of TypeScript you must explicitly provide a column type.`
+        );
     }
-
 }

--- a/src/error/ConnectionIsNotSetError.ts
+++ b/src/error/ConnectionIsNotSetError.ts
@@ -1,13 +1,12 @@
+import {TypeORMError} from "./TypeORMError";
+
 /**
  * Thrown when user tries to execute operation that requires connection to be established.
  */
-export class ConnectionIsNotSetError extends Error {
-    name = "ConnectionIsNotSetError";
-
+export class ConnectionIsNotSetError extends TypeORMError {
     constructor(dbType: string) {
-        super();
-        Object.setPrototypeOf(this, ConnectionIsNotSetError.prototype);
-        this.message = `Connection with ${dbType} database is not established. Check connection configuration.`;
+        super(
+            `Connection with ${dbType} database is not established. Check connection configuration.`
+        );
     }
-
 }

--- a/src/error/ConnectionNotFoundError.ts
+++ b/src/error/ConnectionNotFoundError.ts
@@ -1,13 +1,12 @@
+import {TypeORMError} from "./TypeORMError";
+
 /**
  * Thrown when consumer tries to get connection that does not exist.
  */
-export class ConnectionNotFoundError extends Error {
-    name = "ConnectionNotFoundError";
-
+export class ConnectionNotFoundError extends TypeORMError {
     constructor(name: string) {
-        super();
-        Object.setPrototypeOf(this, ConnectionNotFoundError.prototype);
-        this.message = `Connection "${name}" was not found.`;
+        super(
+            `Connection "${name}" was not found.`
+        );
     }
-
 }

--- a/src/error/CustomRepositoryCannotInheritRepositoryError.ts
+++ b/src/error/CustomRepositoryCannotInheritRepositoryError.ts
@@ -1,14 +1,13 @@
+import {TypeORMError} from "./TypeORMError";
+
 /**
  * Thrown if custom repository inherits Repository class however entity is not set in @EntityRepository decorator.
  */
-export class CustomRepositoryCannotInheritRepositoryError extends Error {
-    name = "CustomRepositoryCannotInheritRepositoryError";
-
+export class CustomRepositoryCannotInheritRepositoryError extends TypeORMError {
     constructor(repository: any) {
-        super();
-        Object.setPrototypeOf(this, CustomRepositoryCannotInheritRepositoryError.prototype);
-        this.message = `Custom entity repository ${repository instanceof Function ? repository.name : repository.constructor.name} ` +
-            ` cannot inherit Repository class without entity being set in the @EntityRepository decorator.`;
+        super(
+            `Custom entity repository ${repository instanceof Function ? repository.name : repository.constructor.name} ` +
+            ` cannot inherit Repository class without entity being set in the @EntityRepository decorator.`
+        );
     }
-
 }

--- a/src/error/CustomRepositoryDoesNotHaveEntityError.ts
+++ b/src/error/CustomRepositoryDoesNotHaveEntityError.ts
@@ -1,14 +1,13 @@
+import {TypeORMError} from "./TypeORMError";
+
 /**
  * Thrown if custom repositories that extend AbstractRepository classes does not have managed entity.
  */
-export class CustomRepositoryDoesNotHaveEntityError extends Error {
-    name = "CustomRepositoryDoesNotHaveEntityError";
-
+export class CustomRepositoryDoesNotHaveEntityError extends TypeORMError {
     constructor(repository: any) {
-        super();
-        Object.setPrototypeOf(this, CustomRepositoryDoesNotHaveEntityError.prototype);
-        this.message = `Custom repository ${repository instanceof Function ? repository.name : repository.constructor.name} does not have managed entity. ` +
-            `Did you forget to specify entity for it @EntityRepository(MyEntity)? `;
+        super(
+            `Custom repository ${repository instanceof Function ? repository.name : repository.constructor.name} does not have managed entity. ` +
+            `Did you forget to specify entity for it @EntityRepository(MyEntity)? `
+        );
     }
-
 }

--- a/src/error/CustomRepositoryNotFoundError.ts
+++ b/src/error/CustomRepositoryNotFoundError.ts
@@ -1,14 +1,13 @@
+import {TypeORMError} from "./TypeORMError";
+
 /**
  * Thrown if custom repository was not found.
  */
-export class CustomRepositoryNotFoundError extends Error {
-    name = "CustomRepositoryNotFoundError";
-
+export class CustomRepositoryNotFoundError extends TypeORMError {
     constructor(repository: any) {
-        super();
-        Object.setPrototypeOf(this, CustomRepositoryNotFoundError.prototype);
-        this.message = `Custom repository ${repository instanceof Function ? repository.name : repository.constructor.name } was not found. ` +
-            `Did you forgot to put @EntityRepository decorator on it?`;
+        super(
+            `Custom repository ${repository instanceof Function ? repository.name : repository.constructor.name } was not found. ` +
+            `Did you forgot to put @EntityRepository decorator on it?`
+        );
     }
-
 }

--- a/src/error/DataTypeNotSupportedError.ts
+++ b/src/error/DataTypeNotSupportedError.ts
@@ -1,15 +1,13 @@
 import {ColumnType} from "../driver/types/ColumnTypes";
 import {DatabaseType} from "../driver/types/DatabaseType";
 import {ColumnMetadata} from "../metadata/ColumnMetadata";
+import {TypeORMError} from "./TypeORMError";
 
-export class DataTypeNotSupportedError extends Error {
-    name = "DataTypeNotSupportedError";
-
+export class DataTypeNotSupportedError extends TypeORMError {
     constructor(column: ColumnMetadata, dataType: ColumnType, database?: DatabaseType) {
         super();
-        Object.setPrototypeOf(this, DataTypeNotSupportedError.prototype);
+
         const type = typeof dataType === "string" ? dataType : (<any>dataType).name;
         this.message = `Data type "${type}" in "${column.entityMetadata.targetName}.${column.propertyName}" is not supported by "${database}" database.`;
     }
-
 }

--- a/src/error/DriverOptionNotSetError.ts
+++ b/src/error/DriverOptionNotSetError.ts
@@ -1,13 +1,13 @@
+import {TypeORMError} from "./TypeORMError";
+
 /**
  * Thrown if some required driver's option is not set.
  */
-export class DriverOptionNotSetError extends Error {
-    name = "DriverOptionNotSetError";
-
+export class DriverOptionNotSetError extends TypeORMError {
     constructor(optionName: string) {
-        super();
-        Object.setPrototypeOf(this, DriverOptionNotSetError.prototype);
-        this.message = `Driver option (${optionName}) is not set. Please set it to perform connection to the database.`;
+        super(
+            `Driver option (${optionName}) is not set. ` +
+            `Please set it to perform connection to the database.`
+        );
     }
-
 }

--- a/src/error/DriverPackageNotInstalledError.ts
+++ b/src/error/DriverPackageNotInstalledError.ts
@@ -1,13 +1,13 @@
+import {TypeORMError} from "./TypeORMError";
+
 /**
  * Thrown when required driver's package is not installed.
  */
-export class DriverPackageNotInstalledError extends Error {
-    name = "DriverPackageNotInstalledError";
-
+export class DriverPackageNotInstalledError extends TypeORMError {
     constructor(driverName: string, packageName: string) {
-        super();
-        Object.setPrototypeOf(this, DriverPackageNotInstalledError.prototype);
-        this.message = `${driverName} package has not been found installed. Try to install it: npm install ${packageName} --save`;
+        super(
+            `${driverName} package has not been found installed. ` +
+            `Try to install it: npm install ${packageName} --save`
+        );
     }
-
 }

--- a/src/error/EntityColumnNotFound.ts
+++ b/src/error/EntityColumnNotFound.ts
@@ -1,13 +1,9 @@
-/**
- *
- */
-export class EntityColumnNotFound extends Error {
-    name = "EntityColumnNotFound";
+import {TypeORMError} from "./TypeORMError";
 
+export class EntityColumnNotFound extends TypeORMError {
     constructor(propertyPath: string) {
-        super();
-        Object.setPrototypeOf(this, EntityColumnNotFound.prototype);
-        this.message = `No entity column "${propertyPath}" was found.`;
+        super(
+            `No entity column "${propertyPath}" was found.`
+        );
     }
-
 }

--- a/src/error/EntityMetadataNotFoundError.ts
+++ b/src/error/EntityMetadataNotFoundError.ts
@@ -1,25 +1,23 @@
 import {EntityTarget} from "../common/EntityTarget";
 import {EntitySchema} from "../index";
+import {TypeORMError} from "./TypeORMError";
 
-/**
- */
-export class EntityMetadataNotFoundError extends Error {
-    name = "EntityMetadataNotFound";
-
+export class EntityMetadataNotFoundError extends TypeORMError {
     constructor(target: EntityTarget<any>) {
         super();
-        Object.setPrototypeOf(this, EntityMetadataNotFoundError.prototype);
-        let targetName: string;
-        if (target instanceof EntitySchema) {
-            targetName = target.options.name;
-        } else if (typeof target === "function") {
-            targetName = target.name;
-        } else if (typeof target === "object" && "name" in target) {
-            targetName = target.name;
-        } else {
-            targetName = target;
-        }
-        this.message = `No metadata for "${targetName}" was found.`;
+
+        this.message = `No metadata for "${this.stringifyTarget(target)}" was found.`;
     }
 
+    private stringifyTarget(target: EntityTarget<any>): string {
+        if (target instanceof EntitySchema) {
+            return target.options.name;
+        } else if (typeof target === "function") {
+            return target.name;
+        } else if (typeof target === "object" && "name" in target) {
+            return target.name;
+        } else {
+            return target;
+        }
+    }
 }

--- a/src/error/EntityNotFoundError.ts
+++ b/src/error/EntityNotFoundError.ts
@@ -1,27 +1,28 @@
 import {EntityTarget} from "../common/EntityTarget";
 import {EntitySchema} from "../index";
+import {TypeORMError} from "./TypeORMError";
 
 /**
  * Thrown when no result could be found in methods which are not allowed to return undefined or an empty set.
  */
-export class EntityNotFoundError extends Error {
-    name = "EntityNotFound";
-
+export class EntityNotFoundError extends TypeORMError {
     constructor(entityClass: EntityTarget<any>, criteria: any) {
         super();
-        Object.setPrototypeOf(this, EntityNotFoundError.prototype);
-        let targetName: string;
-        if (entityClass instanceof EntitySchema) {
-            targetName = entityClass.options.name;
-        } else if (typeof entityClass === "function") {
-            targetName = entityClass.name;
-        } else if (typeof entityClass === "object" && "name" in entityClass) {
-            targetName = entityClass.name;
+
+        this.message = `Could not find any entity of type "${this.stringifyTarget(entityClass)}" ` +
+            `matching: ${this.stringifyCriteria(criteria)}`;
+    }
+
+    private stringifyTarget(target: EntityTarget<any>): string {
+        if (target instanceof EntitySchema) {
+            return target.options.name;
+        } else if (typeof target === "function") {
+            return target.name;
+        } else if (typeof target === "object" && "name" in target) {
+            return target.name;
         } else {
-            targetName = entityClass;
+            return target;
         }
-        const criteriaString = this.stringifyCriteria(criteria);
-        this.message = `Could not find any entity of type "${targetName}" matching: ${criteriaString}`;
     }
 
     private stringifyCriteria(criteria: any): string {
@@ -30,5 +31,4 @@ export class EntityNotFoundError extends Error {
         } catch (e) { }
         return "" + criteria;
     }
-
 }

--- a/src/error/FindRelationsNotFoundError.ts
+++ b/src/error/FindRelationsNotFoundError.ts
@@ -1,16 +1,16 @@
+import {TypeORMError} from "./TypeORMError";
+
 /**
  * Thrown when relations specified in the find options were not found in the entities.
 */
-export class FindRelationsNotFoundError extends Error {
-
+export class FindRelationsNotFoundError extends TypeORMError {
     constructor(notFoundRelations: string[]) {
         super();
-        Object.setPrototypeOf(this, FindRelationsNotFoundError.prototype);
+
         if (notFoundRelations.length === 1) {
             this.message = `Relation "${notFoundRelations[0]}" was not found; please check if it is correct and really exists in your entity.`;
         } else {
             this.message = `Relations ${notFoundRelations.map(relation => `"${relation}"`).join(", ")} were not found; please check if relations are correct and they exist in your entities.`;
         }
     }
-
 }

--- a/src/error/InitializedRelationError.ts
+++ b/src/error/InitializedRelationError.ts
@@ -1,4 +1,5 @@
 import {RelationMetadata} from "../metadata/RelationMetadata";
+import {TypeORMError} from "./TypeORMError";
 
 /**
  * Thrown when relation has array initialized which is forbidden my ORM.
@@ -6,14 +7,12 @@ import {RelationMetadata} from "../metadata/RelationMetadata";
  * @see https://github.com/typeorm/typeorm/issues/1319
  * @see http://typeorm.io/#/relations-faq/avoid-relation-property-initializers
  */
-export class InitializedRelationError extends Error {
-
+export class InitializedRelationError extends TypeORMError {
     constructor(relation: RelationMetadata) {
-        super();
-        Object.setPrototypeOf(this, InitializedRelationError.prototype);
-        this.message = `Array initializations are not allowed in entity relations. ` +
-                        `Please remove array initialization (= []) from "${relation.entityMetadata.targetName}#${relation.propertyPath}". ` +
-                        `This is ORM requirement to make relations to work properly. Refer docs for more information.`;
+        super(
+            `Array initializations are not allowed in entity relations. ` +
+            `Please remove array initialization (= []) from "${relation.entityMetadata.targetName}#${relation.propertyPath}". ` +
+            `This is ORM requirement to make relations to work properly. Refer docs for more information.`
+        );
     }
-
 }

--- a/src/error/InsertValuesMissingError.ts
+++ b/src/error/InsertValuesMissingError.ts
@@ -1,13 +1,13 @@
+import {TypeORMError} from "./TypeORMError";
+
 /**
  * Thrown when user tries to insert using QueryBuilder but do not specify what to insert.
  */
-export class InsertValuesMissingError extends Error {
-    name = "InsertValuesMissingError";
-
+export class InsertValuesMissingError extends TypeORMError {
     constructor() {
-        super();
-        Object.setPrototypeOf(this, InsertValuesMissingError.prototype);
-        this.message = `Cannot perform insert query because values are not defined. Call "qb.values(...)" method to specify inserted values.`;
+        super(
+            `Cannot perform insert query because values are not defined. ` +
+            `Call "qb.values(...)" method to specify inserted values.`
+        );
     }
-
 }

--- a/src/error/LimitOnUpdateNotSupportedError.ts
+++ b/src/error/LimitOnUpdateNotSupportedError.ts
@@ -1,13 +1,13 @@
+import {TypeORMError} from "./TypeORMError";
+
 /**
  * Thrown when user tries to build an UPDATE query with LIMIT but the database does not support it.
 */
-export class LimitOnUpdateNotSupportedError extends Error {
-    name = "LimitOnUpdateNotSupportedError";
 
+export class LimitOnUpdateNotSupportedError extends TypeORMError {
     constructor() {
-        super();
-        Object.setPrototypeOf(this, LimitOnUpdateNotSupportedError.prototype);
-        this.message = `Your database does not support LIMIT on UPDATE statements.`;
+        super(
+            `Your database does not support LIMIT on UPDATE statements.`
+        );
     }
-
 }

--- a/src/error/LockNotSupportedOnGivenDriverError.ts
+++ b/src/error/LockNotSupportedOnGivenDriverError.ts
@@ -1,13 +1,12 @@
+import {TypeORMError} from "./TypeORMError";
+
 /**
  * Thrown when selected sql driver does not supports locking.
  */
-export class LockNotSupportedOnGivenDriverError extends Error {
-    name = "LockNotSupportedOnGivenDriverError";
-
+export class LockNotSupportedOnGivenDriverError extends TypeORMError {
     constructor() {
-        super();
-        Object.setPrototypeOf(this, LockNotSupportedOnGivenDriverError.prototype);
-        this.message = `Locking not supported on given driver.`;
+        super(
+            `Locking not supported on given driver.`
+        );
     }
-
 }

--- a/src/error/MetadataAlreadyExistsError.ts
+++ b/src/error/MetadataAlreadyExistsError.ts
@@ -1,14 +1,11 @@
-/**
- */
-export class MetadataAlreadyExistsError extends Error {
-    name = "MetadataAlreadyExistsError";
+import {TypeORMError} from "./TypeORMError";
 
+export class MetadataAlreadyExistsError extends TypeORMError {
     constructor(metadataType: string, constructor: Function, propertyName?: string) {
-        super();
-        Object.setPrototypeOf(this, MetadataAlreadyExistsError.prototype);
-        this.message = metadataType + " metadata already exists for the class constructor " + JSON.stringify(constructor) +
+        super(
+            metadataType + " metadata already exists for the class constructor " + JSON.stringify(constructor) +
             (propertyName ? " on property " + propertyName : ". If you previously renamed or moved entity class, make sure" +
-            " that compiled version of old entity class source wasn't left in the compiler output directory.");
+                " that compiled version of old entity class source wasn't left in the compiler output directory.")
+        );
     }
-
 }

--- a/src/error/MetadataWithSuchNameAlreadyExistsError.ts
+++ b/src/error/MetadataWithSuchNameAlreadyExistsError.ts
@@ -1,13 +1,10 @@
-/**
- */
-export class MetadataWithSuchNameAlreadyExistsError extends Error {
-    name = "MetadataWithSuchNameAlreadyExistsError";
+import {TypeORMError} from "./TypeORMError";
 
+export class MetadataWithSuchNameAlreadyExistsError extends TypeORMError {
     constructor(metadataType: string, name: string) {
-        super();
-        Object.setPrototypeOf(this, MetadataWithSuchNameAlreadyExistsError.prototype);
-        this.message = metadataType + " metadata with such name " + name + " already exists. " +
-            "Do you apply decorator twice? Or maybe try to change a name?";
+        super(
+            metadataType + " metadata with such name " + name + " already exists. " +
+            "Do you apply decorator twice? Or maybe try to change a name?"
+        );
     }
-
 }

--- a/src/error/MissingDeleteDateColumnError.ts
+++ b/src/error/MissingDeleteDateColumnError.ts
@@ -1,14 +1,10 @@
 import {EntityMetadata} from "../metadata/EntityMetadata";
+import {TypeORMError} from "./TypeORMError";
 
-/**
- */
-export class MissingDeleteDateColumnError extends Error {
-    name = "MissingDeleteDateColumnError";
-
+export class MissingDeleteDateColumnError extends TypeORMError {
     constructor(entityMetadata: EntityMetadata) {
-        super();
-        Object.setPrototypeOf(this, MissingDeleteDateColumnError.prototype);
-        this.message = `Entity "${entityMetadata.name}" does not have delete date columns.`;
+        super(
+            `Entity "${entityMetadata.name}" does not have delete date columns.`
+        );
     }
-
 }

--- a/src/error/MissingDriverError.ts
+++ b/src/error/MissingDriverError.ts
@@ -1,13 +1,13 @@
+import {TypeORMError} from "./TypeORMError";
+
 /**
  * Thrown when consumer specifies driver type that does not exist or supported.
  */
-export class MissingDriverError extends Error {
-    name = "MissingDriverError";
-
-    constructor(driverType: string) {
-        super();
-        Object.setPrototypeOf(this, MissingDriverError.prototype);
-        this.message = `Wrong driver: "${driverType}" given. Supported drivers are: "cordova", "expo", "mariadb", "mongodb", "mssql", "mysql", "oracle", "postgres", "sqlite", "better-sqlite3", "sqljs", "react-native", "aurora-data-api", "aurora-data-api-pg".`;
+export class MissingDriverError extends TypeORMError {
+    constructor(driverType: string, availableDrivers: string[] = []) {
+        super(
+            `Wrong driver: "${driverType}" given. Supported drivers are: ` +
+            `${availableDrivers.map(d => `"${d}"`).join(", ")}.`
+        );
     }
-
 }

--- a/src/error/MissingJoinColumnError.ts
+++ b/src/error/MissingJoinColumnError.ts
@@ -1,14 +1,11 @@
 import {EntityMetadata} from "../metadata/EntityMetadata";
 import {RelationMetadata} from "../metadata/RelationMetadata";
+import {TypeORMError} from "./TypeORMError";
 
-/**
- */
-export class MissingJoinColumnError extends Error {
-    name = "MissingJoinColumnError";
-
+export class MissingJoinColumnError extends TypeORMError {
     constructor(entityMetadata: EntityMetadata, relation: RelationMetadata) {
         super();
-        Object.setPrototypeOf(this, MissingJoinColumnError.prototype);
+
         if (relation.inverseRelation) {
             this.message = `JoinColumn is missing on both sides of ${entityMetadata.name}#${relation.propertyName} and ` +
                 `${relation.inverseEntityMetadata.name}#${relation.inverseRelation.propertyName} one-to-one relationship. ` +
@@ -18,5 +15,4 @@ export class MissingJoinColumnError extends Error {
                 `You need to put JoinColumn decorator on it.`;
         }
     }
-
 }

--- a/src/error/MissingJoinTableError.ts
+++ b/src/error/MissingJoinTableError.ts
@@ -1,14 +1,10 @@
 import {EntityMetadata} from "../metadata/EntityMetadata";
 import {RelationMetadata} from "../metadata/RelationMetadata";
+import {TypeORMError} from "./TypeORMError";
 
-/**
- */
-export class MissingJoinTableError extends Error {
-    name = "MissingJoinTableError";
-
+export class MissingJoinTableError extends TypeORMError {
     constructor(entityMetadata: EntityMetadata, relation: RelationMetadata) {
         super();
-        Object.setPrototypeOf(this, MissingJoinTableError.prototype);
 
         if (relation.inverseRelation) {
             this.message = `JoinTable is missing on both sides of ${entityMetadata.name}#${relation.propertyName} and ` +
@@ -19,5 +15,4 @@ export class MissingJoinTableError extends Error {
                 `You need to put JoinTable decorator on it.`;
         }
     }
-
 }

--- a/src/error/MissingPrimaryColumnError.ts
+++ b/src/error/MissingPrimaryColumnError.ts
@@ -1,15 +1,11 @@
 import {EntityMetadata} from "../metadata/EntityMetadata";
+import {TypeORMError} from "./TypeORMError";
 
-/**
- */
-export class MissingPrimaryColumnError extends Error {
-    name = "MissingPrimaryColumnError";
-
+export class MissingPrimaryColumnError extends TypeORMError {
     constructor(entityMetadata: EntityMetadata) {
-        super();
-        Object.setPrototypeOf(this, MissingPrimaryColumnError.prototype);
-        this.message = `Entity "${entityMetadata.name}" does not have a primary column. Primary column is required to ` +
-            `have in all your entities. Use @PrimaryColumn decorator to add a primary column to your entity.`;
+        super(
+            `Entity "${entityMetadata.name}" does not have a primary column. Primary column is required to ` +
+            `have in all your entities. Use @PrimaryColumn decorator to add a primary column to your entity.`
+        );
     }
-
 }

--- a/src/error/MustBeEntityError.ts
+++ b/src/error/MustBeEntityError.ts
@@ -1,13 +1,12 @@
+import {TypeORMError} from "./TypeORMError";
+
 /**
  * Thrown when method expects entity but instead something else is given.
  */
-export class MustBeEntityError extends Error {
-    name = "MustBeEntityError";
-
+export class MustBeEntityError extends TypeORMError {
     constructor(operation: string, wrongValue: any) {
-        super();
-        Object.setPrototypeOf(this, MustBeEntityError.prototype);
-        this.message = `Cannot ${operation}, given value must be an entity, instead "${wrongValue}" is given.`;
+        super(
+            `Cannot ${operation}, given value must be an entity, instead "${wrongValue}" is given.`
+        );
     }
-
 }

--- a/src/error/NamingStrategyNotFoundError.ts
+++ b/src/error/NamingStrategyNotFoundError.ts
@@ -1,15 +1,14 @@
+import {TypeORMError} from "./TypeORMError";
+
 /**
  * Thrown when consumer tries to use naming strategy that does not exist.
  */
-export class NamingStrategyNotFoundError extends Error {
-    name = "NamingStrategyNotFoundError";
-
+export class NamingStrategyNotFoundError extends TypeORMError {
     constructor(strategyName: string|Function, connectionName: string) {
         super();
-        Object.setPrototypeOf(this, NamingStrategyNotFoundError.prototype);
+
         const name = strategyName instanceof Function ? (strategyName as any).name : strategyName;
         this.message = `Naming strategy "${name}" was not found. Looks like this naming strategy does not ` +
             `exist or it was not registered in current "${connectionName}" connection?`;
     }
-
 }

--- a/src/error/NestedSetMultipleRootError.ts
+++ b/src/error/NestedSetMultipleRootError.ts
@@ -1,10 +1,9 @@
-export class NestedSetMultipleRootError extends Error {
-    name = "NestedSetMultipleRootError";
+import {TypeORMError} from "./TypeORMError";
 
+export class NestedSetMultipleRootError extends TypeORMError {
     constructor() {
-        super();
-        Object.setPrototypeOf(this, NestedSetMultipleRootError.prototype);
-        this.message = `Nested sets do not support multiple root entities.`;
+        super(
+            `Nested sets do not support multiple root entities.`
+        );
     }
-
 }

--- a/src/error/NoConnectionForRepositoryError.ts
+++ b/src/error/NoConnectionForRepositoryError.ts
@@ -1,14 +1,13 @@
+import {TypeORMError} from "./TypeORMError";
+
 /**
  * Thrown when consumer tries to access repository before connection is established.
  */
-export class NoConnectionForRepositoryError extends Error {
-    name = "NoConnectionForRepositoryError";
-
+export class NoConnectionForRepositoryError extends TypeORMError {
     constructor(connectionName: string) {
-        super();
-        Object.setPrototypeOf(this, NoConnectionForRepositoryError.prototype);
-        this.message = `Cannot get a Repository for "${connectionName} connection, because connection with the database ` +
-            `is not established yet. Call connection#connect method to establish connection.`;
+        super(
+            `Cannot get a Repository for "${connectionName} connection, because connection with the database ` +
+            `is not established yet. Call connection#connect method to establish connection.`
+        );
     }
-
 }

--- a/src/error/NoConnectionOptionError.ts
+++ b/src/error/NoConnectionOptionError.ts
@@ -1,12 +1,13 @@
+import {TypeORMError} from "./TypeORMError";
+
 /**
  * Thrown when some option is not set in the connection options.
  */
-export class NoConnectionOptionError extends Error {
-
+export class NoConnectionOptionError extends TypeORMError {
     constructor(optionName: string) {
-        super();
-        Object.setPrototypeOf(this, NoConnectionOptionError.prototype);
-        this.message = `Option "${optionName}" is not set in your connection options, please define "${optionName}" option in your connection options or ormconfig.json`;
+        super(
+            `Option "${optionName}" is not set in your connection options, please ` +
+            `define "${optionName}" option in your connection options or ormconfig.json`
+        );
     }
-
 }

--- a/src/error/NoNeedToReleaseEntityManagerError.ts
+++ b/src/error/NoNeedToReleaseEntityManagerError.ts
@@ -1,15 +1,14 @@
+import {TypeORMError} from "./TypeORMError";
+
 /**
  * Thrown when consumer tries to release entity manager that does not use single database connection.
  */
-export class NoNeedToReleaseEntityManagerError extends Error {
-    name = "NoNeedToReleaseEntityManagerError";
-
+export class NoNeedToReleaseEntityManagerError extends TypeORMError {
     constructor() {
-        super();
-        Object.setPrototypeOf(this, NoNeedToReleaseEntityManagerError.prototype);
-        this.message = `Entity manager is not using single database connection and cannot be released. ` +
+        super(
+            `Entity manager is not using single database connection and cannot be released. ` +
             `Only entity managers created by connection#createEntityManagerWithSingleDatabaseConnection ` +
-            `methods have a single database connection and they should be released.`;
+            `methods have a single database connection and they should be released.`
+        );
     }
-
 }

--- a/src/error/NoVersionOrUpdateDateColumnError.ts
+++ b/src/error/NoVersionOrUpdateDateColumnError.ts
@@ -1,13 +1,13 @@
+import {TypeORMError} from "./TypeORMError";
+
 /**
  * Thrown when an entity does not have no version and no update date column.
  */
-export class NoVersionOrUpdateDateColumnError extends Error {
-    name = "NoVersionOrUpdateDateColumnError";
-
+export class NoVersionOrUpdateDateColumnError extends TypeORMError {
     constructor(entity: string) {
-        super();
-        Object.setPrototypeOf(this, NoVersionOrUpdateDateColumnError.prototype);
-        this.message = `Entity ${entity} does not have version or update date columns.`;
+        super(
+            `Entity ${entity} does not have version or update date columns.`
+        );
     }
 
 }

--- a/src/error/OffsetWithoutLimitNotSupportedError.ts
+++ b/src/error/OffsetWithoutLimitNotSupportedError.ts
@@ -1,13 +1,14 @@
+import {TypeORMError} from "./TypeORMError";
+
 /**
  * Thrown when user tries to build SELECT query using OFFSET without LIMIT applied but database does not support it.
 */
-export class OffsetWithoutLimitNotSupportedError extends Error {
-    name = "OffsetWithoutLimitNotSupportedError";
-
+export class OffsetWithoutLimitNotSupportedError extends TypeORMError {
     constructor() {
-        super();
-        Object.setPrototypeOf(this, OffsetWithoutLimitNotSupportedError.prototype);
-        this.message = `RDBMS does not support OFFSET without LIMIT in SELECT statements. You must use limit in conjunction with offset function (or take in conjunction with skip function if you are using pagination).`;
+        super(
+            `RDBMS does not support OFFSET without LIMIT in SELECT statements. You must use limit in ` +
+            `conjunction with offset function (or take in conjunction with skip function if you are ` +
+            `using pagination).`
+        );
     }
-
 }

--- a/src/error/OptimisticLockCanNotBeUsedError.ts
+++ b/src/error/OptimisticLockCanNotBeUsedError.ts
@@ -1,13 +1,12 @@
+import {TypeORMError} from "./TypeORMError";
+
 /**
  * Thrown when an optimistic lock cannot be used in query builder.
  */
-export class OptimisticLockCanNotBeUsedError extends Error {
-    name = "OptimisticLockCanNotBeUsedError";
-
+export class OptimisticLockCanNotBeUsedError extends TypeORMError {
     constructor() {
-        super();
-        Object.setPrototypeOf(this, OptimisticLockCanNotBeUsedError.prototype);
-        this.message = `The optimistic lock can be used only with getOne() method.`;
+        super(
+            `The optimistic lock can be used only with getOne() method.`
+        );
     }
-
 }

--- a/src/error/OptimisticLockVersionMismatchError.ts
+++ b/src/error/OptimisticLockVersionMismatchError.ts
@@ -1,13 +1,12 @@
+import {TypeORMError} from "./TypeORMError";
+
 /**
  * Thrown when a version check on an object that uses optimistic locking through a version field fails.
  */
-export class OptimisticLockVersionMismatchError extends Error {
-    name = "OptimisticLockVersionMismatchError";
-
+export class OptimisticLockVersionMismatchError extends TypeORMError {
     constructor(entity: string, expectedVersion: number|Date, actualVersion: number|Date) {
-        super();
-        Object.setPrototypeOf(this, OptimisticLockVersionMismatchError.prototype);
-        this.message = `The optimistic lock on entity ${entity} failed, version ${expectedVersion} was expected, but is actually ${actualVersion}.`;
+        super(
+            `The optimistic lock on entity ${entity} failed, version ${expectedVersion} was expected, but is actually ${actualVersion}.`
+        );
     }
-
 }

--- a/src/error/PersistedEntityNotFoundError.ts
+++ b/src/error/PersistedEntityNotFoundError.ts
@@ -1,13 +1,12 @@
+import {TypeORMError} from "./TypeORMError";
+
 /**
  * Thrown . Theoretically can't be thrown.
  */
-export class PersistedEntityNotFoundError extends Error {
-    name = "PersistedEntityNotFoundError";
-
+export class PersistedEntityNotFoundError extends TypeORMError {
     constructor() {
-        super();
-        Object.setPrototypeOf(this, PersistedEntityNotFoundError.prototype);
-        this.message = `Internal error. Persisted entity was not found in the list of prepared operated entities.`;
+        super(
+            `Internal error. Persisted entity was not found in the list of prepared operated entities.`
+        );
     }
-
 }

--- a/src/error/PessimisticLockTransactionRequiredError.ts
+++ b/src/error/PessimisticLockTransactionRequiredError.ts
@@ -1,13 +1,12 @@
+import {TypeORMError} from "./TypeORMError";
+
 /**
  * Thrown when a transaction is required for the current operation, but there is none open.
  */
-export class PessimisticLockTransactionRequiredError extends Error {
-    name = "PessimisticLockTransactionRequiredError";
-
+export class PessimisticLockTransactionRequiredError extends TypeORMError {
     constructor() {
-        super();
-        Object.setPrototypeOf(this, PessimisticLockTransactionRequiredError.prototype);
-        this.message = `An open transaction is required for pessimistic lock.`;
+        super(
+            `An open transaction is required for pessimistic lock.`
+        );
     }
-
 }

--- a/src/error/PrimaryColumnCannotBeNullableError.ts
+++ b/src/error/PrimaryColumnCannotBeNullableError.ts
@@ -1,11 +1,10 @@
-export class PrimaryColumnCannotBeNullableError extends Error {
-    name = "PrimaryColumnCannotBeNullableError";
+import {TypeORMError} from "./TypeORMError";
 
+export class PrimaryColumnCannotBeNullableError extends TypeORMError {
     constructor(object: Object, propertyName: string) {
-        super();
-        Object.setPrototypeOf(this, PrimaryColumnCannotBeNullableError.prototype);
-        this.message = `Primary column ${(<any>object.constructor).name}#${propertyName} cannot be nullable. ` +
-            `Its not allowed for primary keys. Try to remove nullable option.`;
+        super(
+            `Primary column ${(<any>object.constructor).name}#${propertyName} cannot be nullable. ` +
+            `Its not allowed for primary keys. Try to remove nullable option.`
+        );
     }
-
 }

--- a/src/error/QueryFailedError.ts
+++ b/src/error/QueryFailedError.ts
@@ -1,25 +1,27 @@
 import {ObjectUtils} from "../util/ObjectUtils";
+import {TypeORMError} from "./TypeORMError";
 
 /**
  * Thrown when query execution has failed.
 */
-export class QueryFailedError extends Error {
-    query: string;
-    parameters: any[];
+export class QueryFailedError extends TypeORMError {
+    constructor(readonly query: string, readonly parameters: any[]|undefined, readonly driverError: any) {
+        super(
+            driverError.toString()
+                .replace(/^error: /, "")
+                .replace(/^Error: /, "")
+                .replace(/^Request/, "")
+        );
 
-    constructor(query: string, parameters: any[]|undefined, driverError: any) {
-        super();
-        Object.setPrototypeOf(this, QueryFailedError.prototype);
-        this.message = driverError.toString()
-            .replace(/^error: /, "")
-            .replace(/^Error: /, "")
-            .replace(/^Request/, "");
-        ObjectUtils.assign(this, {
-            ...driverError,
-            name: "QueryFailedError",
-            query: query,
-            parameters: parameters || []
-        });
+        if (driverError) {
+            const {
+                name: _, // eslint-disable-line
+                ...otherProperties
+            } = driverError;
+
+            ObjectUtils.assign(this, {
+                ...otherProperties
+            });
+        }
     }
-
 }

--- a/src/error/QueryRunnerAlreadyReleasedError.ts
+++ b/src/error/QueryRunnerAlreadyReleasedError.ts
@@ -1,12 +1,9 @@
-/**
- */
-export class QueryRunnerAlreadyReleasedError extends Error {
-    name = "QueryRunnerAlreadyReleasedError";
+import {TypeORMError} from "./TypeORMError";
 
+export class QueryRunnerAlreadyReleasedError extends TypeORMError {
     constructor() {
-        super();
-        Object.setPrototypeOf(this, QueryRunnerAlreadyReleasedError.prototype);
-        this.message = `Query runner already released. Cannot run queries anymore.`;
+        super(
+            `Query runner already released. Cannot run queries anymore.`
+        );
     }
-
 }

--- a/src/error/QueryRunnerProviderAlreadyReleasedError.ts
+++ b/src/error/QueryRunnerProviderAlreadyReleasedError.ts
@@ -1,13 +1,13 @@
+import {TypeORMError} from "./TypeORMError";
+
 /**
  * Thrown when consumer tries to use query runner from query runner provider after it was released.
  */
-export class QueryRunnerProviderAlreadyReleasedError extends Error {
-    name = "QueryRunnerProviderAlreadyReleasedError";
-
+export class QueryRunnerProviderAlreadyReleasedError extends TypeORMError {
     constructor() {
-        super();
-        Object.setPrototypeOf(this, QueryRunnerProviderAlreadyReleasedError.prototype);
-        this.message = `Database connection provided by a query runner was already released, cannot continue to use its querying methods anymore.`;
+        super(
+            `Database connection provided by a query runner was already ` +
+            `released, cannot continue to use its querying methods anymore.`
+        );
     }
-
 }

--- a/src/error/RepositoryNotFoundError.ts
+++ b/src/error/RepositoryNotFoundError.ts
@@ -1,15 +1,13 @@
 import {EntityTarget} from "../common/EntityTarget";
 import {EntitySchema} from "../index";
+import {TypeORMError} from "./TypeORMError";
 
 /**
  * Thrown when repository for the given class is not found.
  */
-export class RepositoryNotFoundError extends Error {
-    name = "RepositoryNotFoundError";
-
+export class RepositoryNotFoundError extends TypeORMError {
     constructor(connectionName: string, entityClass: EntityTarget<any>) {
         super();
-        Object.setPrototypeOf(this, RepositoryNotFoundError.prototype);
         let targetName: string;
         if (entityClass instanceof EntitySchema) {
             targetName = entityClass.options.name;
@@ -23,5 +21,4 @@ export class RepositoryNotFoundError extends Error {
         this.message = `No repository for "${targetName}" was found. Looks like this entity is not registered in ` +
             `current "${connectionName}" connection?`;
     }
-
 }

--- a/src/error/RepositoryNotTreeError.ts
+++ b/src/error/RepositoryNotTreeError.ts
@@ -1,15 +1,14 @@
 import {EntityTarget} from "../common/EntityTarget";
 import {EntitySchema} from "../index";
+import {TypeORMError} from "./TypeORMError";
 
 /**
  * Thrown when repository for the given class is not found.
  */
-export class RepositoryNotTreeError extends Error {
-    name = "RepositoryNotTreeError";
-
+export class RepositoryNotTreeError extends TypeORMError {
     constructor(entityClass: EntityTarget<any>) {
         super();
-        Object.setPrototypeOf(this, RepositoryNotTreeError.prototype);
+
         let targetName: string;
         if (entityClass instanceof EntitySchema) {
             targetName = entityClass.options.name;
@@ -22,5 +21,4 @@ export class RepositoryNotTreeError extends Error {
         }
         this.message = `Repository of the "${targetName}" class is not a TreeRepository. Try to apply @Tree decorator on your entity.`;
     }
-
 }

--- a/src/error/ReturningStatementNotSupportedError.ts
+++ b/src/error/ReturningStatementNotSupportedError.ts
@@ -1,14 +1,13 @@
+import {TypeORMError} from "./TypeORMError";
+
 /**
  * Thrown when user tries to build a query with RETURNING / OUTPUT statement,
  * but used database does not support it.
  */
-export class ReturningStatementNotSupportedError extends Error {
-    name = "ReturningStatementNotSupportedError";
-
+export class ReturningStatementNotSupportedError extends TypeORMError {
     constructor() {
-        super();
-        Object.setPrototypeOf(this, ReturningStatementNotSupportedError.prototype);
-        this.message = `OUTPUT or RETURNING clause only supported by Microsoft SQL Server or PostgreSQL databases.`;
+        super(
+            `OUTPUT or RETURNING clause only supported by Microsoft SQL Server or PostgreSQL databases.`
+        );
     }
-
 }

--- a/src/error/SubjectRemovedAndUpdatedError.ts
+++ b/src/error/SubjectRemovedAndUpdatedError.ts
@@ -1,16 +1,14 @@
 import {Subject} from "../persistence/Subject";
+import {TypeORMError} from "./TypeORMError";
 
 /**
  * Thrown when same object is scheduled for remove and updation at the same time.
  */
-export class SubjectRemovedAndUpdatedError extends Error {
-    name = "SubjectRemovedAndUpdatedError";
-
+export class SubjectRemovedAndUpdatedError extends TypeORMError {
     constructor(subject: Subject) {
-        super();
-        Object.setPrototypeOf(this, SubjectRemovedAndUpdatedError.prototype);
-        this.message = `Removed entity "${subject.metadata.name}" is also scheduled for update operation. ` +
-            `Make sure you are not updating and removing same object (note that update or remove may be executed by cascade operations).`;
+        super(
+            `Removed entity "${subject.metadata.name}" is also scheduled for update operation. ` +
+            `Make sure you are not updating and removing same object (note that update or remove may be executed by cascade operations).`
+        );
     }
-
 }

--- a/src/error/SubjectWithoutIdentifierError.ts
+++ b/src/error/SubjectWithoutIdentifierError.ts
@@ -1,18 +1,15 @@
 import {Subject} from "../persistence/Subject";
+import {TypeORMError} from "./TypeORMError";
 
 /**
  * Thrown when operation is going to be executed on a subject without identifier.
  * This error should never be thrown, however it still presents to prevent user from updation or removing the whole table.
  * If this error occurs still, it most probably is an ORM internal problem which must be reported and fixed.
  */
-export class SubjectWithoutIdentifierError extends Error {
-    name = "SubjectWithoutIdentifierError";
-
+export class SubjectWithoutIdentifierError extends TypeORMError {
     constructor(subject: Subject) {
-        super();
-        Object.setPrototypeOf(this, SubjectWithoutIdentifierError.prototype);
-        this.message = `Internal error. Subject ${subject.metadata.targetName} must have an identifier to perform operation. ` +
-            `Please report a github issue if you face this error.`;
+        super(
+            `Internal error. Subject ${subject.metadata.targetName} must have an identifier to perform operation.`
+        );
     }
-
 }

--- a/src/error/TransactionAlreadyStartedError.ts
+++ b/src/error/TransactionAlreadyStartedError.ts
@@ -1,13 +1,12 @@
+import {TypeORMError} from "./TypeORMError";
+
 /**
  * Thrown when transaction is already started and user tries to run it again.
  */
-export class TransactionAlreadyStartedError extends Error {
-    name = "TransactionAlreadyStartedError";
-
+export class TransactionAlreadyStartedError extends TypeORMError {
     constructor() {
-        super();
-        Object.setPrototypeOf(this, TransactionAlreadyStartedError.prototype);
-        this.message = `Transaction already started for the given connection, commit current transaction before starting a new one.`;
+        super(
+            `Transaction already started for the given connection, commit current transaction before starting a new one.`
+        );
     }
-
 }

--- a/src/error/TransactionNotStartedError.ts
+++ b/src/error/TransactionNotStartedError.ts
@@ -1,13 +1,12 @@
+import {TypeORMError} from "./TypeORMError";
+
 /**
  * Thrown when transaction is not started yet and user tries to run commit or rollback.
  */
-export class TransactionNotStartedError extends Error {
-    name = "TransactionNotStartedError";
-
+export class TransactionNotStartedError extends TypeORMError {
     constructor() {
-        super();
-        Object.setPrototypeOf(this, TransactionNotStartedError.prototype);
-        this.message = `Transaction is not started yet, start transaction before committing or rolling it back.`;
+        super(
+            `Transaction is not started yet, start transaction before committing or rolling it back.`
+        );
     }
-
 }

--- a/src/error/TreeRepositoryNotSupportedError.ts
+++ b/src/error/TreeRepositoryNotSupportedError.ts
@@ -1,12 +1,10 @@
 import {Driver} from "../driver/Driver";
+import {TypeORMError} from "./TypeORMError";
 
-export class TreeRepositoryNotSupportedError extends Error {
-    name = "TreeRepositoryNotSupportedError";
-
+export class TreeRepositoryNotSupportedError extends TypeORMError {
     constructor(driver: Driver) {
-        super();
-        Object.setPrototypeOf(this, TreeRepositoryNotSupportedError.prototype);
-        this.message = `Tree repositories are not supported in ${driver.options.type} driver.`;
+        super(
+            `Tree repositories are not supported in ${driver.options.type} driver.`
+        );
     }
-
 }

--- a/src/error/TypeORMError.ts
+++ b/src/error/TypeORMError.ts
@@ -1,0 +1,17 @@
+export abstract class TypeORMError extends Error {
+    get name() {
+        return this.constructor.name;
+    }
+
+    constructor(message?: string) {
+        super(message);
+
+        // restore prototype chain because the base `Error` type
+        // will break the prototype chain a little
+        if (Object.setPrototypeOf) {
+            Object.setPrototypeOf(this, new.target.prototype);
+        }  else {
+            (this as any).__proto__ = new.target.prototype;
+        }
+    }
+}

--- a/src/error/UpdateValuesMissingError.ts
+++ b/src/error/UpdateValuesMissingError.ts
@@ -1,13 +1,9 @@
-/**
- * Thrown when user tries to update using QueryBuilder but do not specify what to update.
- */
-export class UpdateValuesMissingError extends Error {
-    name = "UpdateValuesMissingError";
+import {TypeORMError} from "./TypeORMError";
 
+export class UpdateValuesMissingError extends TypeORMError {
     constructor() {
-        super();
-        Object.setPrototypeOf(this, UpdateValuesMissingError.prototype);
-        this.message = `Cannot perform update query because update values are not defined. Call "qb.set(...)" method to specify updated values.`;
+        super(
+            `Cannot perform update query because update values are not defined. Call "qb.set(...)" method to specify updated values.`
+        );
     }
-
 }

--- a/src/error/UsingJoinColumnIsNotAllowedError.ts
+++ b/src/error/UsingJoinColumnIsNotAllowedError.ts
@@ -1,16 +1,12 @@
 import {EntityMetadata} from "../metadata/EntityMetadata";
 import {RelationMetadata} from "../metadata/RelationMetadata";
+import {TypeORMError} from "./TypeORMError";
 
-/**
- */
-export class UsingJoinColumnIsNotAllowedError extends Error {
-    name = "UsingJoinColumnIsNotAllowedError";
-
+export class UsingJoinColumnIsNotAllowedError extends TypeORMError {
     constructor(entityMetadata: EntityMetadata, relation: RelationMetadata) {
-        super();
-        Object.setPrototypeOf(this, UsingJoinColumnIsNotAllowedError.prototype);
-        this.message = `Using JoinColumn on ${entityMetadata.name}#${relation.propertyName} is wrong. ` +
-            `You can use JoinColumn only on one-to-one and many-to-one relations.`;
+        super(
+            `Using JoinColumn on ${entityMetadata.name}#${relation.propertyName} is wrong. ` +
+            `You can use JoinColumn only on one-to-one and many-to-one relations.`
+        );
     }
-
 }

--- a/src/error/UsingJoinColumnOnlyOnOneSideAllowedError.ts
+++ b/src/error/UsingJoinColumnOnlyOnOneSideAllowedError.ts
@@ -1,17 +1,13 @@
 import {EntityMetadata} from "../metadata/EntityMetadata";
 import {RelationMetadata} from "../metadata/RelationMetadata";
+import {TypeORMError} from "./TypeORMError";
 
-/**
- */
-export class UsingJoinColumnOnlyOnOneSideAllowedError extends Error {
-    name = "UsingJoinColumnOnlyOnOneSideAllowedError";
-
+export class UsingJoinColumnOnlyOnOneSideAllowedError extends TypeORMError {
     constructor(entityMetadata: EntityMetadata, relation: RelationMetadata) {
-        super();
-        Object.setPrototypeOf(this, UsingJoinColumnOnlyOnOneSideAllowedError.prototype);
-        this.message = `Using JoinColumn is allowed only on one side of the one-to-one relationship. ` +
+        super(
+            `Using JoinColumn is allowed only on one side of the one-to-one relationship. ` +
             `Both ${entityMetadata.name}#${relation.propertyName} and ${relation.inverseEntityMetadata.name}#${relation.inverseRelation!.propertyName} ` +
-            `has JoinTable decorators. Choose one of them and left JoinTable decorator only on it.`;
+            `has JoinTable decorators. Choose one of them and left JoinTable decorator only on it.`
+        );
     }
-
 }

--- a/src/error/UsingJoinTableIsNotAllowedError.ts
+++ b/src/error/UsingJoinTableIsNotAllowedError.ts
@@ -1,17 +1,13 @@
 import {EntityMetadata} from "../metadata/EntityMetadata";
 import {RelationMetadata} from "../metadata/RelationMetadata";
+import {TypeORMError} from "./TypeORMError";
 
-/**
- */
-export class UsingJoinTableIsNotAllowedError extends Error {
-    name = "UsingJoinTableIsNotAllowedError";
-
+export class UsingJoinTableIsNotAllowedError extends TypeORMError {
     constructor(entityMetadata: EntityMetadata, relation: RelationMetadata) {
-        super();
-        Object.setPrototypeOf(this, UsingJoinTableIsNotAllowedError.prototype);
-        this.message = `Using JoinTable on ${entityMetadata.name}#${relation.propertyName} is wrong. ` +
+        super(
+            `Using JoinTable on ${entityMetadata.name}#${relation.propertyName} is wrong. ` +
             `${entityMetadata.name}#${relation.propertyName} has ${relation.relationType} relation, ` +
-            `however you can use JoinTable only on many-to-many relations.`;
+            `however you can use JoinTable only on many-to-many relations.`
+        );
     }
-
 }

--- a/src/error/UsingJoinTableOnlyOnOneSideAllowedError.ts
+++ b/src/error/UsingJoinTableOnlyOnOneSideAllowedError.ts
@@ -1,17 +1,13 @@
 import {EntityMetadata} from "../metadata/EntityMetadata";
 import {RelationMetadata} from "../metadata/RelationMetadata";
+import {TypeORMError} from "./TypeORMError";
 
-/**
- */
-export class UsingJoinTableOnlyOnOneSideAllowedError extends Error {
-    name = "UsingJoinTableOnlyOnOneSideAllowedError";
-
+export class UsingJoinTableOnlyOnOneSideAllowedError extends TypeORMError {
     constructor(entityMetadata: EntityMetadata, relation: RelationMetadata) {
-        super();
-        Object.setPrototypeOf(this, UsingJoinTableOnlyOnOneSideAllowedError.prototype);
-        this.message = `Using JoinTable is allowed only on one side of the many-to-many relationship. ` +
+        super(
+            `Using JoinTable is allowed only on one side of the many-to-many relationship. ` +
             `Both ${entityMetadata.name}#${relation.propertyName} and ${relation.inverseEntityMetadata.name}#${relation.inverseRelation!.propertyName} ` +
-            `has JoinTable decorators. Choose one of them and left JoinColumn decorator only on it.`;
+            `has JoinTable decorators. Choose one of them and left JoinColumn decorator only on it.`
+        );
     }
-
 }

--- a/test/functional/errors/prototype-tree/errors-prototype-tree.ts
+++ b/test/functional/errors/prototype-tree/errors-prototype-tree.ts
@@ -1,0 +1,19 @@
+import {expect} from "chai";
+
+import {AlreadyHasActiveConnectionError} from "../../../../src/error/AlreadyHasActiveConnectionError"
+import {CannotGetEntityManagerNotConnectedError} from "../../../../src/error/CannotGetEntityManagerNotConnectedError";
+
+describe("errors > prototype tree", () => {
+
+    it("prototype tree makes sense", () => {
+        const err = new AlreadyHasActiveConnectionError("test");
+
+        expect(err.name).to.be.equal("AlreadyHasActiveConnectionError");
+        expect(err).to.be.instanceOf(AlreadyHasActiveConnectionError);
+
+        const otherErr = new CannotGetEntityManagerNotConnectedError("test");
+
+        expect(otherErr).to.be.instanceOf(CannotGetEntityManagerNotConnectedError);
+    });
+
+});


### PR DESCRIPTION
This creates a base TypeORM Error that follows the conventions needed to fix the prototype tree & allow hierarchical error trees 

fixes #3479