### PR TITLE
fix: wrap where clauses in parentheses

### DIFF
--- a/src/query-builder/QueryBuilder.ts
+++ b/src/query-builder/QueryBuilder.ts
@@ -757,11 +757,11 @@ export abstract class QueryBuilder<Entity> {
         return this.expressionMap.wheres.map((where, index) => {
             switch (where.type) {
                 case "and":
-                    return (index > 0 ? "AND " : "") + this.replacePropertyNames(where.condition);
+                    return (index > 0 ? "AND " : "") + "(" + this.replacePropertyNames(where.condition) + ")";
                 case "or":
-                    return (index > 0 ? "OR " : "") + this.replacePropertyNames(where.condition);
+                    return (index > 0 ? "OR " : "") + "(" + this.replacePropertyNames(where.condition) + ")";
                 default:
-                    return this.replacePropertyNames(where.condition);
+                    return "(" + this.replacePropertyNames(where.condition) + ")";
             }
         }).join(" ");
     }
@@ -802,7 +802,7 @@ export abstract class QueryBuilder<Entity> {
                 this.expressionMap.nativeParameters[parameterName] = primaryColumn.getEntityValue(id, true);
                 parameterIndex++;
             });
-            return whereSubStrings.join(" AND ");
+            return whereSubStrings.map(where => "(" + where + ")").join(" AND ");
         });
 
         return whereStrings.length > 1
@@ -879,8 +879,8 @@ export abstract class QueryBuilder<Entity> {
                                 return `${aliasPath} = ${parameter}`;
                             }
 
-                        }).filter(expression => !!expression).join(" AND ");
-                    }).filter(expression => !!expression).join(" AND ");
+                        }).filter(expression => !!expression).map(w => "(" + w + ")").join(" AND ");
+                    }).filter(expression => !!expression).map(w => "(" + w + ")").join(" AND ");
                 });
 
             } else {

--- a/test/functional/multi-schema-and-database/multi-schema-and-database-basic-functionality/multi-schema-and-database-basic-functionality.ts
+++ b/test/functional/multi-schema-and-database/multi-schema-and-database-basic-functionality/multi-schema-and-database-basic-functionality.ts
@@ -42,10 +42,10 @@ describe("multi-schema-and-database > basic-functionality", () => {
                 .getSql();
 
             if (connection.driver instanceof PostgresDriver)
-                sql.should.be.equal(`SELECT "post"."id" AS "post_id", "post"."name" AS "post_name" FROM "custom"."post" "post" WHERE "post"."id" = $1`);
+                sql.should.be.equal(`SELECT "post"."id" AS "post_id", "post"."name" AS "post_name" FROM "custom"."post" "post" WHERE ("post"."id" = $1)`);
 
             if (connection.driver instanceof SqlServerDriver)
-                sql.should.be.equal(`SELECT "post"."id" AS "post_id", "post"."name" AS "post_name" FROM "custom"."post" "post" WHERE "post"."id" = @0`);
+                sql.should.be.equal(`SELECT "post"."id" AS "post_id", "post"."name" AS "post_name" FROM "custom"."post" "post" WHERE ("post"."id" = @0)`);
 
             table!.name.should.be.equal("custom.post");
         })));
@@ -65,10 +65,10 @@ describe("multi-schema-and-database > basic-functionality", () => {
                 .getSql();
 
             if (connection.driver instanceof PostgresDriver)
-                sql.should.be.equal(`SELECT "user"."id" AS "user_id", "user"."name" AS "user_name" FROM "userSchema"."user" "user" WHERE "user"."id" = $1`);
+                sql.should.be.equal(`SELECT "user"."id" AS "user_id", "user"."name" AS "user_name" FROM "userSchema"."user" "user" WHERE ("user"."id" = $1)`);
 
             if (connection.driver instanceof SqlServerDriver)
-                sql.should.be.equal(`SELECT "user"."id" AS "user_id", "user"."name" AS "user_name" FROM "userSchema"."user" "user" WHERE "user"."id" = @0`);
+                sql.should.be.equal(`SELECT "user"."id" AS "user_id", "user"."name" AS "user_name" FROM "userSchema"."user" "user" WHERE ("user"."id" = @0)`);
 
             table!.name.should.be.equal("userSchema.user");
         })));
@@ -105,12 +105,12 @@ describe("multi-schema-and-database > basic-functionality", () => {
             if (connection.driver instanceof PostgresDriver)
                 sql.should.be.equal(`SELECT "category"."id" AS "category_id", "category"."name" AS "category_name",` +
                     ` "category"."postId" AS "category_postId", "post"."id" AS "post_id", "post"."name" AS "post_name"` +
-                    ` FROM "guest"."category" "category" INNER JOIN "custom"."post" "post" ON "post"."id"="category"."postId" WHERE "category"."id" = $1`);
+                    ` FROM "guest"."category" "category" INNER JOIN "custom"."post" "post" ON "post"."id"="category"."postId" WHERE ("category"."id" = $1)`);
 
             if (connection.driver instanceof SqlServerDriver)
                 sql.should.be.equal(`SELECT "category"."id" AS "category_id", "category"."name" AS "category_name",` +
                     ` "category"."postId" AS "category_postId", "post"."id" AS "post_id", "post"."name" AS "post_name"` +
-                    ` FROM "guest"."category" "category" INNER JOIN "custom"."post" "post" ON "post"."id"="category"."postId" WHERE "category"."id" = @0`);
+                    ` FROM "guest"."category" "category" INNER JOIN "custom"."post" "post" ON "post"."id"="category"."postId" WHERE ("category"."id" = @0)`);
 
             table!.name.should.be.equal("guest.category");
         })));
@@ -142,11 +142,11 @@ describe("multi-schema-and-database > basic-functionality", () => {
 
             if (connection.driver instanceof PostgresDriver)
                 query.getSql().should.be.equal(`SELECT * FROM "guest"."category" "category", "userSchema"."user" "user",` +
-                    ` "custom"."post" "post" WHERE "category"."id" = $1 AND "post"."id" = "category"."postId"`);
+                    ` "custom"."post" "post" WHERE ("category"."id" = $1) AND ("post"."id" = "category"."postId")`);
 
             if (connection.driver instanceof SqlServerDriver)
                 query.getSql().should.be.equal(`SELECT * FROM "guest"."category" "category", "userSchema"."user" "user",` +
-                    ` "custom"."post" "post" WHERE "category"."id" = @0 AND "post"."id" = "category"."postId"`);
+                    ` "custom"."post" "post" WHERE ("category"."id" = @0) AND ("post"."id" = "category"."postId")`);
         })));
     });
 
@@ -176,7 +176,7 @@ describe("multi-schema-and-database > basic-functionality", () => {
                 .where("question.id = :id", {id: 1})
                 .getSql();
 
-            sql.should.be.equal(`SELECT "question"."id" AS "question_id", "question"."name" AS "question_name" FROM "testDB"."questions"."question" "question" WHERE "question"."id" = @0`);
+            sql.should.be.equal(`SELECT "question"."id" AS "question_id", "question"."name" AS "question_name" FROM "testDB"."questions"."question" "question" WHERE ("question"."id" = @0)`);
             table!.name.should.be.equal("testDB.questions.question");
         })));
 
@@ -211,7 +211,7 @@ describe("multi-schema-and-database > basic-functionality", () => {
             expect(await query.getRawOne()).to.be.not.empty;
 
             query.getSql().should.be.equal(`SELECT * FROM "testDB"."questions"."question" "question", "secondDB"."answers"."answer"` +
-                ` "answer" WHERE "question"."id" = @0 AND "answer"."questionId" = "question"."id"`);
+                ` "answer" WHERE ("question"."id" = @0) AND ("answer"."questionId" = "question"."id")`);
 
             questionTable!.name.should.be.equal("testDB.questions.question");
             answerTable!.name.should.be.equal("secondDB.answers.answer");
@@ -246,10 +246,10 @@ describe("multi-schema-and-database > basic-functionality", () => {
                 .getSql();
 
             if (connection.driver instanceof SqlServerDriver)
-                sql.should.be.equal(`SELECT "person"."id" AS "person_id", "person"."name" AS "person_name" FROM "secondDB".."person" "person" WHERE "person"."id" = @0`);
+                sql.should.be.equal(`SELECT "person"."id" AS "person_id", "person"."name" AS "person_name" FROM "secondDB".."person" "person" WHERE ("person"."id" = @0)`);
 
             if (connection.driver instanceof MysqlDriver)
-                sql.should.be.equal("SELECT `person`.`id` AS `person_id`, `person`.`name` AS `person_name` FROM `secondDB`.`person` `person` WHERE `person`.`id` = ?");
+                sql.should.be.equal("SELECT `person`.`id` AS `person_id`, `person`.`name` AS `person_name` FROM `secondDB`.`person` `person` WHERE (`person`.`id` = ?)");
 
             table!.name.should.be.equal(tablePath);
         })));

--- a/test/github-issues/660/issue-660.ts
+++ b/test/github-issues/660/issue-660.ts
@@ -77,9 +77,9 @@ describe("github issues > #660 Specifying a RETURNING or OUTPUT clause with Quer
                 .getSql();
     
             if (connection.driver instanceof SqlServerDriver) {
-                expect(sql).to.equal("UPDATE user SET name = @0 OUTPUT inserted.* WHERE name = @1");
+                expect(sql).to.equal("UPDATE user SET name = @0 OUTPUT inserted.* WHERE (name = @1)");
             } else if (connection.driver instanceof PostgresDriver) {
-                expect(sql).to.equal("UPDATE user SET name = $1 WHERE name = $2 RETURNING *");
+                expect(sql).to.equal("UPDATE user SET name = $1 WHERE (name = $2) RETURNING *");
             }
         } catch (err) {
             expect(err.message).to.eql(new ReturningStatementNotSupportedError().message);
@@ -122,9 +122,9 @@ describe("github issues > #660 Specifying a RETURNING or OUTPUT clause with Quer
                 .getSql();
     
             if (connection.driver instanceof SqlServerDriver) {
-                expect(sql).to.equal("DELETE FROM user OUTPUT deleted.* WHERE name = @0");
+                expect(sql).to.equal("DELETE FROM user OUTPUT deleted.* WHERE (name = @0)");
             } else if (connection.driver instanceof PostgresDriver) {
-                expect(sql).to.equal("DELETE FROM user WHERE name = $1 RETURNING *");
+                expect(sql).to.equal("DELETE FROM user WHERE (name = $1) RETURNING *");
             }
         } catch (err) {
             expect(err.message).to.eql(new ReturningStatementNotSupportedError().message);


### PR DESCRIPTION
prevents issues where order of operations takes precedence
over the intended query builder query

fixes #6170