### PR TITLE
Allow Error to be a type of logQueryError param

### DIFF
--- a/src/logger/Logger.ts
+++ b/src/logger/Logger.ts
@@ -13,7 +13,7 @@ export interface Logger {
     /**
      * Logs query that is failed.
      */
-    logQueryError(error: string, query: string, parameters?: any[], queryRunner?: QueryRunner): any;
+    logQueryError(error: string | Error, query: string, parameters?: any[], queryRunner?: QueryRunner): any;
 
     /**
      * Logs query that is slow.


### PR DESCRIPTION
I haven't inspected the code to know if string or any other type does get returned, but this can at least inform people without needing to inspect the code that it can be an easily parsable Error instance.

Closes #6933 