### PR TITLE
fix: TreeRepository based entities primary column supports custom name.

### DIFF
--- a/src/repository/TreeRepository.ts
+++ b/src/repository/TreeRepository.ts
@@ -265,7 +265,7 @@ export class TreeRepository<Entity> extends Repository<Entity> {
         const parentEntityId = this.metadata.primaryColumns[0].getEntityValue(entity);
         const childRelationMaps = relationMaps.filter(relationMap => relationMap.parentId === parentEntityId);
         const childIds = new Set(childRelationMaps.map(relationMap => relationMap.id));
-        entity[childProperty] = entities.filter(entity => childIds.has(entity.id));
+        entity[childProperty] = entities.filter(entity => childIds.has(entity[this.metadata.primaryColumns[0].propertyName]));
         entity[childProperty].forEach((childEntity: any) => {
             this.buildChildrenEntityTree(childEntity, entities, relationMaps);
         });

--- a/test/github-issues/6947/entity/Category.ts
+++ b/test/github-issues/6947/entity/Category.ts
@@ -1,0 +1,17 @@
+import { Entity, PrimaryGeneratedColumn, Column, Tree, TreeParent, TreeChildren } from "../../../../src";
+
+@Entity()
+@Tree("closure-table")
+export class Category {
+    @PrimaryGeneratedColumn()
+    cat_id: number;
+
+    @Column()
+    cat_name: string;
+
+    @TreeParent()
+    parent: Category;
+
+    @TreeChildren({ cascade: true })
+    children: Category[];
+}

--- a/test/github-issues/6947/issue-6947.ts
+++ b/test/github-issues/6947/issue-6947.ts
@@ -1,0 +1,54 @@
+import "reflect-metadata";
+import { Category } from "./entity/Category";
+import { Connection } from "../../../src/connection/Connection";
+import {
+    closeTestingConnections,
+    createTestingConnections,
+    reloadTestingDatabases,
+} from "../../../test/utils/test-utils";
+
+describe("github issues > #6947 Custom primary column for TreeRepository based entities unable to get tree descendants", () => {
+    let connections: Connection[];
+    before(
+        async () =>
+            (connections = await createTestingConnections({
+                entities: [Category],
+            }))
+    );
+    beforeEach(() => reloadTestingDatabases(connections));
+    after(() => closeTestingConnections(connections));
+
+    it("entities with custom primary column names should work", () =>
+        Promise.all(
+            connections.map(async (connection) => {
+                const categoryRepository = connection.getTreeRepository(
+                    Category
+                );
+
+                const parent = new Category();
+                parent.cat_name = "parent";
+                await categoryRepository.save(parent);
+
+                const child = new Category();
+                child.cat_name = "child";
+                child.parent = parent;
+                await categoryRepository.save(child);
+
+                const tree = await categoryRepository.findDescendantsTree(
+                    (await categoryRepository.findOne({ cat_name: "parent" }))!
+                );
+
+                tree.should.deep.include({
+                    cat_id: 1,
+                    cat_name: "parent",
+                    children: [
+                        {
+                            cat_id: 2,
+                            cat_name: "child",
+                            children: [],
+                        },
+                    ],
+                });
+            })
+        ));
+});


### PR DESCRIPTION
Previously "id" was hardcoded, thus errors when an entity has a custom primary column name other than "id". 
Now it fetches the column name from metadata instead.