### PR TITLE
fix: ILike operator generally available for any driver

### DIFF
--- a/src/query-builder/QueryBuilder.ts
+++ b/src/query-builder/QueryBuilder.ts
@@ -916,7 +916,7 @@ export abstract class QueryBuilder<Entity> {
      * Gets SQL needs to be inserted into final query.
      */
     protected computeFindOperatorExpression(operator: FindOperator<any>, aliasPath: string, parameters: any[]): string {
-        const { driver } = this.connection
+        const { driver } = this.connection;
 
         switch (operator.type) {
             case "not":

--- a/src/query-builder/QueryBuilder.ts
+++ b/src/query-builder/QueryBuilder.ts
@@ -15,6 +15,8 @@ import {QueryDeepPartialEntity} from "./QueryPartialEntity";
 import {EntityMetadata} from "../metadata/EntityMetadata";
 import {ColumnMetadata} from "../metadata/ColumnMetadata";
 import {SqljsDriver} from "../driver/sqljs/SqljsDriver";
+import {PostgresDriver} from "../driver/postgres/PostgresDriver";
+import {CockroachDriver} from "../driver/cockroachdb/CockroachDriver";
 import {SqlServerDriver} from "../driver/sqlserver/SqlServerDriver";
 import {OracleDriver} from "../driver/oracle/OracleDriver";
 import {EntitySchema} from "../";
@@ -914,6 +916,8 @@ export abstract class QueryBuilder<Entity> {
      * Gets SQL needs to be inserted into final query.
      */
     protected computeFindOperatorExpression(operator: FindOperator<any>, aliasPath: string, parameters: any[]): string {
+        const { driver } = this.connection
+
         switch (operator.type) {
             case "not":
                 if (operator.child) {
@@ -932,7 +936,11 @@ export abstract class QueryBuilder<Entity> {
             case "equal":
                 return `${aliasPath} = ${parameters[0]}`;
             case "ilike":
-                return `${aliasPath} ILIKE ${parameters[0]}`;
+                if (driver instanceof PostgresDriver || driver instanceof CockroachDriver) {
+                    return `${aliasPath} ILIKE ${parameters[0]}`;
+                }
+
+                return `UPPER(${aliasPath}) LIKE UPPER(${parameters[0]})`;
             case "like":
                 return `${aliasPath} LIKE ${parameters[0]}`;
             case "between":

--- a/test/functional/repository/find-options-operators/repository-find-operators.ts
+++ b/test/functional/repository/find-options-operators/repository-find-operators.ts
@@ -273,9 +273,6 @@ describe("repository > find options > operators", () => {
     })));
 
     it("ilike", () => Promise.all(connections.map(async connection => {
-        if (!(connection.driver instanceof PostgresDriver))
-            return;
-
         // insert some fake data
         const post1 = new Post();
         post1.title = "about #1";
@@ -295,9 +292,6 @@ describe("repository > find options > operators", () => {
     })));
 
     it("not(ilike)", () => Promise.all(connections.map(async connection => {
-        if (!(connection.driver instanceof PostgresDriver))
-            return;
-
         // insert some fake data
         const post1 = new Post();
         post1.title = "about #1";


### PR DESCRIPTION
https://github.com/typeorm/typeorm/issues/4418

Although this issue is already closed, I thought it could do a bit more. It makes ILIKE compatible with non Postgres drivers.