### PR TITLE
photo.views/isPublished are required fields

### DIFF
--- a/README.md
+++ b/README.md
@@ -1205,6 +1205,7 @@ let photo = new Photo();
 photo.name = "Me and Bears";
 photo.description = "I am near polar bears";
 photo.filename = "photo-with-bears.jpg";
+photo.views = 1
 photo.albums = [album1, album2];
 await connection.manager.save(photo);
 

--- a/README.md
+++ b/README.md
@@ -1206,6 +1206,7 @@ photo.name = "Me and Bears";
 photo.description = "I am near polar bears";
 photo.filename = "photo-with-bears.jpg";
 photo.views = 1
+photo.isPublished = true
 photo.albums = [album1, album2];
 await connection.manager.save(photo);
 


### PR DESCRIPTION
In the many-to-many photos/albums example - photo.views is required field

I was following through the tutorial using postgres, and my `views` column is defined as:

```typescript
  @Column()
  views: number
```

Later, I was required to provide `photo.views = 1` for the photo/albums example