### PR TITLE
fix: allow falsey discriminator values

### DIFF
--- a/src/decorator/entity/ChildEntity.ts
+++ b/src/decorator/entity/ChildEntity.ts
@@ -15,7 +15,7 @@ export function ChildEntity(discriminatorValue?: any): ClassDecorator {
         } as TableMetadataArgs);
 
         // register discriminator value if it was provided
-        if (discriminatorValue) {
+        if (typeof discriminatorValue !== 'undefined') {
             getMetadataArgsStorage().discriminatorValues.push({
                 target: target,
                 value: discriminatorValue

--- a/src/metadata-builder/EntityMetadataBuilder.ts
+++ b/src/metadata-builder/EntityMetadataBuilder.ts
@@ -335,7 +335,12 @@ export class EntityMetadataBuilder {
         const entityInheritance = this.metadataArgsStorage.findInheritanceType(entityMetadata.target);
 
         const discriminatorValue = this.metadataArgsStorage.findDiscriminatorValue(entityMetadata.target);
-        entityMetadata.discriminatorValue = discriminatorValue ? discriminatorValue.value : (entityMetadata.target as any).name; // todo: pass this to naming strategy to generate a name
+
+        if (typeof discriminatorValue !== "undefined") {
+            entityMetadata.discriminatorValue = discriminatorValue.value;
+        } else {
+            entityMetadata.discriminatorValue = (entityMetadata.target as any).name;
+        }
 
         // if single table inheritance is used, we need to mark all embedded columns as nullable
         entityMetadata.embeddeds = this.createEmbeddedsRecursively(entityMetadata, this.metadataArgsStorage.filterEmbeddeds(entityMetadata.inheritanceTree))

--- a/src/metadata-builder/EntityMetadataValidator.ts
+++ b/src/metadata-builder/EntityMetadataValidator.ts
@@ -62,8 +62,8 @@ export class EntityMetadataValidator {
             if (!entityMetadata.discriminatorColumn)
                 throw new Error(`Entity ${entityMetadata.name} using single-table inheritance, it should also have a discriminator column. Did you forget to put discriminator column options?`);
 
-            if (["", undefined, null].indexOf(entityMetadata.discriminatorValue) !== -1)
-                throw new Error(`Entity ${entityMetadata.name} has empty discriminator value. Discriminator value should not be empty.`);
+            if (typeof entityMetadata.discriminatorValue === "undefined")
+                throw new Error(`Entity ${entityMetadata.name} has an undefined discriminator value. Discriminator value should be defined.`);
 
             const sameDiscriminatorValueEntityMetadata = allEntityMetadatas.find(metadata => {
                 return metadata !== entityMetadata && metadata.discriminatorValue === entityMetadata.discriminatorValue;

--- a/src/query-builder/transformer/RawSqlResultsToEntityTransformer.ts
+++ b/src/query-builder/transformer/RawSqlResultsToEntityTransformer.ts
@@ -97,7 +97,7 @@ export class RawSqlResultsToEntityTransformer {
         if (metadata.discriminatorColumn) {
             const discriminatorValues = rawResults.map(result => result[DriverUtils.buildColumnAlias(this.driver, alias.name, alias.metadata.discriminatorColumn!.databaseName)]);
             const discriminatorMetadata = metadata.childEntityMetadatas.find(childEntityMetadata => {
-                return !!discriminatorValues.find(value => value === childEntityMetadata.discriminatorValue);
+                return typeof discriminatorValues.find(value => value === childEntityMetadata.discriminatorValue) !== 'undefined';
             });
             if (discriminatorMetadata)
                 metadata = discriminatorMetadata;

--- a/test/functional/table-inheritance/single-table/non-virtual-discriminator-column/entity/Other.ts
+++ b/test/functional/table-inheritance/single-table/non-virtual-discriminator-column/entity/Other.ts
@@ -1,0 +1,11 @@
+import {Column} from "../../../../../../src/decorator/columns/Column";
+import {ChildEntity} from "../../../../../../src/decorator/entity/ChildEntity";
+import {Person} from "./Person";
+
+@ChildEntity("")
+export class Other extends Person {
+
+    @Column()
+    mood: string;
+
+}

--- a/test/functional/table-inheritance/single-table/non-virtual-discriminator-column/non-virtual-discriminator-column.ts
+++ b/test/functional/table-inheritance/single-table/non-virtual-discriminator-column/non-virtual-discriminator-column.ts
@@ -3,7 +3,9 @@ import {closeTestingConnections, createTestingConnections, reloadTestingDatabase
 import {Connection} from "../../../../../src/connection/Connection";
 import {Student} from "./entity/Student";
 import {Employee} from "./entity/Employee";
+import {Other} from "./entity/Other";
 import {Person} from "./entity/Person";
+import {OracleDriver} from "../../../../../src/driver/oracle/OracleDriver";
 
 describe("table-inheritance > single-table > non-virtual-discriminator-column", () => {
 
@@ -30,6 +32,15 @@ describe("table-inheritance > single-table > non-virtual-discriminator-column", 
         employee.salary = 1000;
         await connection.getRepository(Employee).save(employee);
 
+        if (!(connection.driver instanceof OracleDriver)) {
+            // In Oracle, empty string is a `null` so this isn't exactly possible there.
+
+            const other = new Other();
+            other.name = "Empty";
+            other.mood = "Happy"
+            await connection.getRepository(Other).save(other);
+        }
+
         // -------------------------------------------------------------------------
         // Select
         // -------------------------------------------------------------------------
@@ -47,6 +58,15 @@ describe("table-inheritance > single-table > non-virtual-discriminator-column", 
         persons[1].type.should.be.equal("employee-type");
         persons[1].name.should.be.equal("Roger");
         (persons[1] as Employee).salary.should.be.equal(1000);
+
+        if (!(connection.driver instanceof OracleDriver)) {
+            // In Oracle, empty string is a `null` so this isn't exactly possible there.
+
+            persons[2].id.should.be.equal(3);
+            persons[2].type.should.be.equal("");
+            persons[2].name.should.be.equal("Empty");
+            (persons[2] as Other).mood.should.be.equal("Happy");
+        }
     })));
 
 });

--- a/test/functional/table-inheritance/single-table/numeric-types/entity/Person.ts
+++ b/test/functional/table-inheritance/single-table/numeric-types/entity/Person.ts
@@ -1,0 +1,18 @@
+import {Column} from "../../../../../../src/decorator/columns/Column";
+import {TableInheritance} from "../../../../../../src/decorator/entity/TableInheritance";
+import {Entity} from "../../../../../../src/decorator/entity/Entity";
+import {PrimaryGeneratedColumn} from "../../../../../../src/decorator/columns/PrimaryGeneratedColumn";
+
+@Entity()
+@TableInheritance({ column: { name: "type", type: "int" } })
+export class Person {
+
+    @PrimaryGeneratedColumn()
+    id: number;
+
+    @Column()
+    name: string;
+
+    @Column()
+    type: number;
+}

--- a/test/functional/table-inheritance/single-table/numeric-types/entity/Student.ts
+++ b/test/functional/table-inheritance/single-table/numeric-types/entity/Student.ts
@@ -1,0 +1,11 @@
+import {Column} from "../../../../../../src/decorator/columns/Column";
+import {ChildEntity} from "../../../../../../src/decorator/entity/ChildEntity";
+import {Person} from "./Person";
+
+@ChildEntity(0)
+export class Student extends Person {
+
+    @Column()
+    faculty: string;
+
+}

--- a/test/functional/table-inheritance/single-table/numeric-types/entity/Teacher.ts
+++ b/test/functional/table-inheritance/single-table/numeric-types/entity/Teacher.ts
@@ -1,0 +1,11 @@
+import {Column} from "../../../../../../src/decorator/columns/Column";
+import {ChildEntity} from "../../../../../../src/decorator/entity/ChildEntity";
+import {Person} from "./Person";
+
+@ChildEntity(1)
+export class Teacher extends Person {
+
+    @Column()
+    specialization: string;
+
+}

--- a/test/functional/table-inheritance/single-table/numeric-types/numeric-types.ts
+++ b/test/functional/table-inheritance/single-table/numeric-types/numeric-types.ts
@@ -1,0 +1,57 @@
+import "reflect-metadata";
+import {expect} from "chai";
+import {closeTestingConnections, createTestingConnections, reloadTestingDatabases} from "../../../../utils/test-utils";
+import {Connection} from "../../../../../src/connection/Connection";
+import {Student} from "./entity/Student";
+import {Teacher} from "./entity/Teacher";
+import {Person} from "./entity/Person";
+import {CockroachDriver} from "../../../../../src/driver/cockroachdb/CockroachDriver";
+
+describe("table-inheritance > single-table > numeric types", () => {
+
+    let connections: Connection[];
+    before(async () => connections = await createTestingConnections({
+        entities: [Person, Student, Teacher]
+    }));
+    beforeEach(() => reloadTestingDatabases(connections));
+    after(() => closeTestingConnections(connections));
+
+    it("should allow numeric types for the discriminator, including 0", () => Promise.all(connections.map(async connection => {
+        if (connection.driver instanceof CockroachDriver) {
+            return;
+        }
+
+        // -------------------------------------------------------------------------
+        // Create
+        // -------------------------------------------------------------------------
+
+        const student = new Student();
+        student.name = "Alice";
+        student.faculty = "Economics";
+        await connection.getRepository(Student).save(student);
+
+        const teacher = new Teacher();
+        teacher.name = "Roger";
+        teacher.specialization = "Math";
+        await connection.getRepository(Teacher).save(teacher);
+
+        // -------------------------------------------------------------------------
+        // Select
+        // -------------------------------------------------------------------------
+
+        let persons = await connection.manager
+            .createQueryBuilder(Person, "person")
+            .getMany();
+
+        expect(persons[0].id).to.be.equal(1);
+        expect(persons[0].type).to.be.equal(0);
+        expect(persons[0].name).to.be.equal("Alice");
+        expect((persons[0] as Student).faculty).to.be.equal("Economics");
+
+        expect(persons[1].id).to.be.equal(2);
+        expect(persons[1].type).to.be.equal(1);
+        expect(persons[1].name).to.be.equal("Roger");
+        expect((persons[1] as Teacher).specialization).to.be.equal("Math");
+    })));
+
+});


### PR DESCRIPTION
<!--
  😀 Wonderful!  Thank you for opening a pull request for TypeORM.

  Please fill in the information below to expedite the review
  and (hopefully) merge of your change.

  If unsure about something.. just do as best as you're able,
  or reach out through our community support channels!
  https://github.com/typeorm/typeorm/blob/master/docs/support.md
-->

### Description of change

<!--
  Please be clear and concise what the change is intended to do,
  why this change is needed, and how you've verified that it
  corrects what you intended.

  In some cases it may be helpful to include the current behavior
  and the new behavior.

  If the change is related to an open issue, you can link it here.
  If you include `Fixes #0000` (replacing `0000` with the issue number)
  when this is merged it will automatically mark the issue as fixed and
  close it.
-->

This allows discriminator values in Single Table Inheritance - such as 0, "", or `null`

Before, if you attempted to use a discriminator for `0` you'd receive errors about an invalid
discriminator value, or the metadata just wouldn't register correctly.

Now, you can use a discriminator value that's "falsey" but not `undefined`.

fixes #3891


### Pull-Request Checklist

<!--
  Please make sure to review and check all of the following.

  If an item is not applicable, you can add "N/A" to the end.
-->

- [x] Code is up-to-date with the `master` branch
- [x] `npm run lint` passes with this change
- [x] `npm run test` passes with this change
- [x] This pull request links relevant issues as `Fixes #0000`
- [x] There are new or updated unit tests validating the change
- [x] ~~Documentation has been updated to reflect this change~~ N/A
- [x] The new commits follow conventions explained in [CONTRIBUTING.md](https://github.com/typeorm/typeorm/blob/master/CONTRIBUTING.md)

<!--
  🎉 Thank you for contributing and making TypeORM even better!
-->
