### PR TITLE
fix: check if the connection is closed before executing a query. This…

### DIFF
--- a/src/driver/sqlite/SqliteQueryRunner.ts
+++ b/src/driver/sqlite/SqliteQueryRunner.ts
@@ -4,6 +4,7 @@ import {AbstractSqliteQueryRunner} from "../sqlite-abstract/AbstractSqliteQueryR
 import {SqliteConnectionOptions} from "./SqliteConnectionOptions";
 import {SqliteDriver} from "./SqliteDriver";
 import {Broadcaster} from "../../subscriber/Broadcaster";
+import { ConnectionIsNotSetError } from '../../error/ConnectionIsNotSetError';
 
 /**
  * Runs queries on a single sqlite database connection.
@@ -38,6 +39,10 @@ export class SqliteQueryRunner extends AbstractSqliteQueryRunner {
 
         const connection = this.driver.connection;
         const options = connection.options as SqliteConnectionOptions;
+
+        if (!connection.isConnected){
+            throw new ConnectionIsNotSetError('sqlite')
+        }
 
         return new Promise<any[]>(async (ok, fail) => {
 

--- a/test/functional/sqlite/error-on-query-after-close.ts
+++ b/test/functional/sqlite/error-on-query-after-close.ts
@@ -1,0 +1,21 @@
+import "reflect-metadata";
+import {expect} from "chai";
+import {Connection} from "../../../src/connection/Connection";
+import {closeTestingConnections, createTestingConnections, reloadTestingDatabases} from "../../utils/test-utils";
+
+describe("sqlite driver > throws an error when queried after closing connection", () => {
+    let connections: Connection[];
+    before(async () => connections = await createTestingConnections({
+        entities: [],
+        enabledDrivers: ["sqlite"],
+    }));
+    beforeEach(() => reloadTestingDatabases(connections));
+    after(() => closeTestingConnections(connections));
+
+    it("should throw", () => Promise.all(connections.map(async connection => {
+        await connection.close()
+        await expect(connection.query('select * from sqlite_master;')).to.rejectedWith(
+            'Connection with sqlite database is not established. Check connection configuration.'
+        );
+    })));
+});


### PR DESCRIPTION
### Description of change

Check if the connection is closed before executing a query. This prevents SQLITE_MISUSE errors (https://sqlite.org/rescode.html#misuse) originating from SQLite itself, which are considered something to avoid by the SQLite authors.

Also includes a test case.

### Pull-Request Checklist

- [x] Code is up-to-date with the `master` branch
- [x] `npm run lint` passes with this change
- [x] `npm run test` passes with this change
- [x] ~~This pull request links relevant issues as `Fixes #0000`~~`NA-no related issue`
- [x] There are new or updated unit tests validating the change
- [x] ~~Documentation has been updated to reflect this change~~ `NA; IMO this change reflects expected behaviour`
- [x] The new commits follow conventions explained in [CONTRIBUTING.md](https://github.com/typeorm/typeorm/blob/master/CONTRIBUTING.md)

