### PR TITLE
Exit with code 1 if no changes were found

### DIFF
--- a/docs/using-cli.md
+++ b/docs/using-cli.md
@@ -203,6 +203,8 @@ Learn more about [Migrations](./migrations.md).
 Automatic migration generation creates a new migration file
 and writes all sql queries that must be executed to update the database.
 
+If no there were no changes generated, the command will exit with code 1.
+
 ```
 typeorm migration:generate -n UserMigration
 ```


### PR DESCRIPTION
### Description of change

This makes `migration:generate` exit with error code 1 if no changes were found. In general I think this qualifies as a non-successful run, but the main benefit is that it allows the command to be used to verify that there are no changes between the code and the current database schema.

I am not sure how best to make a test case for this. Any pointers on this would be appreciated.

Fixes #3037

### Pull-Request Checklist

- [X] Code is up-to-date with the `master` branch
- [X] `npm run lint` passes with this change
- [X] `npm run test` passes with this change
- [X] This pull request links relevant issues as `Fixes #0000`
- [ ] There are new or updated unit tests validating the change
- [X] Documentation has been updated to reflect this change
- [X] The new commits follow conventions explained in [CONTRIBUTING.md](https://github.com/typeorm/typeorm/blob/master/CONTRIBUTING.md)