### PR TITLE
fix: prefix relation id columns contained in embedded entities (#6977)

### DIFF
--- a/src/connection/BaseConnectionOptions.ts
+++ b/src/connection/BaseConnectionOptions.ts
@@ -175,4 +175,8 @@ export interface BaseConnectionOptions {
 
     };
 
+    /**
+     * Flag to enable breaking changes that are planned for release in next version.
+     */
+    readonly enableNextFeatures?: boolean;
 }

--- a/src/connection/options-reader/ConnectionOptionsEnvReader.ts
+++ b/src/connection/options-reader/ConnectionOptionsEnvReader.ts
@@ -46,7 +46,8 @@ export class ConnectionOptionsEnvReader {
                 subscribersDir: PlatformTools.getEnvVariable("TYPEORM_SUBSCRIBERS_DIR"),
             },
             cache: this.transformCaching(),
-            uuidExtension: PlatformTools.getEnvVariable("TYPEORM_UUID_EXTENSION")
+            uuidExtension: PlatformTools.getEnvVariable("TYPEORM_UUID_EXTENSION"),
+            enableNextFeatures: !!PlatformTools.getEnvVariable("TYPEORM_ENABLE_NEXT_FEATURES")
         }];
     }
 

--- a/src/connection/options-reader/ConnectionOptionsXmlReader.ts
+++ b/src/connection/options-reader/ConnectionOptionsXmlReader.ts
@@ -16,7 +16,7 @@ export class ConnectionOptionsXmlReader {
      */
     async read(path: string): Promise<ConnectionOptions[]> {
         const xml = await this.readXml(path);
-        return (xml.connection as any[]).map(connection => {
+        return (xml.connection as any[]).map<ConnectionOptions>(connection => {
             return {
                 name: connection.$.name,
                 type: connection.$.type,
@@ -32,6 +32,7 @@ export class ConnectionOptionsXmlReader {
                 entities: connection.entities ? connection.entities[0].entity : [],
                 subscribers: connection.subscribers ? connection.subscribers[0].entity : [],
                 logging: connection.logging[0] ? connection.logging[0].split(",") : undefined,
+                enableNextFeatures: !!connection.enableNextFeatures
             };
         });
     }

--- a/test/functional/entity-metadata/entity/Counters.ts
+++ b/test/functional/entity-metadata/entity/Counters.ts
@@ -18,7 +18,7 @@ export class Counters {
     @Column()
     favorites: number;
 
-    @Column(() => Subcounters)
+    @Column(() => Subcounters, {prefix: "sub"})
     subcounters: Subcounters;
 
     @ManyToMany(type => User, user => user.likedPosts)

--- a/test/functional/metadata-builder/column-metadata/entity/Counters.ts
+++ b/test/functional/metadata-builder/column-metadata/entity/Counters.ts
@@ -15,7 +15,7 @@ export class Counters {
     @Column()
     favorites: number;
 
-    @Column(() => Subcounters)
+    @Column(() => Subcounters, {prefix: "sub"})
     subcounters: Subcounters;
 
 }

--- a/test/functional/query-builder/relation-id/many-to-many/embedded-with-multiple-pk/entity/Counters.ts
+++ b/test/functional/query-builder/relation-id/many-to-many/embedded-with-multiple-pk/entity/Counters.ts
@@ -23,7 +23,7 @@ export class Counters {
     @JoinTable({ name: "counter_categories" })
     categories: Category[];
 
-    @Column(() => Subcounters)
+    @Column(() => Subcounters, {prefix: "sub"})
     subcntrs: Subcounters;
 
     categoryIds: number[];

--- a/test/functional/query-builder/relation-id/many-to-one/embedded-with-multiple-pk/entity/Counters.ts
+++ b/test/functional/query-builder/relation-id/many-to-one/embedded-with-multiple-pk/entity/Counters.ts
@@ -21,7 +21,7 @@ export class Counters {
     @ManyToOne(type => Category)
     category: Category;
 
-    @Column(() => Subcounters)
+    @Column(() => Subcounters, {prefix: "sub"})
     subcounters: Subcounters;
 
     categoryId: number[];

--- a/test/functional/query-builder/relation-id/many-to-one/embedded/entity/Counters.ts
+++ b/test/functional/query-builder/relation-id/many-to-one/embedded/entity/Counters.ts
@@ -17,7 +17,7 @@ export class Counters {
     @ManyToOne(type => Category, category => category.posts)
     category: Category;
 
-    @Column(() => Subcounters)
+    @Column(() => Subcounters, {prefix: "sub"})
     subcounters: Subcounters;
 
     categoryId: number;

--- a/test/functional/query-builder/relation-id/one-to-many/embedded-with-multiple-pk/entity/Counters.ts
+++ b/test/functional/query-builder/relation-id/one-to-many/embedded-with-multiple-pk/entity/Counters.ts
@@ -21,7 +21,7 @@ export class Counters {
     @OneToMany(type => Category, category => category.post)
     categories: Category[];
 
-    @Column(() => Subcounters)
+    @Column(() => Subcounters, {prefix: "sub"})
     subcounters: Subcounters;
 
     categoryIds: number[];

--- a/test/functional/query-builder/relation-id/one-to-many/embedded/entity/Counters.ts
+++ b/test/functional/query-builder/relation-id/one-to-many/embedded/entity/Counters.ts
@@ -17,7 +17,7 @@ export class Counters {
     @OneToMany(type => Category, category => category.posts)
     categories: Category[];
 
-    @Column(() => Subcounters)
+    @Column(() => Subcounters, {prefix: "sub"})
     subcounters: Subcounters;
 
     categoryIds: number[];

--- a/test/functional/query-builder/relation-id/one-to-one/embedded-with-multiple-pk/entity/Counters.ts
+++ b/test/functional/query-builder/relation-id/one-to-one/embedded-with-multiple-pk/entity/Counters.ts
@@ -23,7 +23,7 @@ export class Counters {
     @JoinColumn()
     category: Category;
 
-    @Column(() => Subcounters)
+    @Column(() => Subcounters, {prefix: "sub"})
     subcounters: Subcounters;
 
     categoryId: number[];

--- a/test/functional/query-builder/relation-id/one-to-one/embedded/entity/Counters.ts
+++ b/test/functional/query-builder/relation-id/one-to-one/embedded/entity/Counters.ts
@@ -19,7 +19,7 @@ export class Counters {
     @JoinColumn()
     category: Category;
 
-    @Column(() => Subcounters)
+    @Column(() => Subcounters, {prefix: "sub"})
     subcounters: Subcounters;
 
     categoryId: number;

--- a/test/github-issues/6977/entity/Embedded.ts
+++ b/test/github-issues/6977/entity/Embedded.ts
@@ -1,0 +1,9 @@
+import { Column, ManyToOne } from '../../../../src';
+import { User } from './User';
+
+export class Embedded {
+    @ManyToOne(() => User) relationUser1: User;
+
+    @ManyToOne(() => User) relationUser2: User;
+    @Column() relationUser2Id: number;
+}

--- a/test/github-issues/6977/entity/User.ts
+++ b/test/github-issues/6977/entity/User.ts
@@ -1,0 +1,9 @@
+import { Column, Entity, PrimaryGeneratedColumn } from '../../../../src';
+import { Embedded } from './Embedded';
+
+@Entity()
+export class User {
+    @PrimaryGeneratedColumn() id: number;
+
+    @Column(() => Embedded) embedded: Embedded;
+}

--- a/test/github-issues/6977/issue-6977.ts
+++ b/test/github-issues/6977/issue-6977.ts
@@ -1,0 +1,26 @@
+import { closeTestingConnections, createTestingConnections, reloadTestingDatabases } from "../../utils/test-utils";
+import { Connection } from "../../../src";
+import { expect } from "chai";
+
+import { Embedded } from "./entity/Embedded";
+import { User } from "./entity/User";
+
+describe("github issues > #6977 Relation columns in embedded entities are not prefixed", () => {
+
+    let connections: Connection[];
+    before(async () => connections = await createTestingConnections({
+        entities: [User, Embedded],
+        enabledDrivers: ["mysql"],
+        enableNextFeatures: true // TODO: NEXT 0.3.0 default to fixed embedded columns
+    }));
+    beforeEach(() => reloadTestingDatabases(connections));
+    after(() => closeTestingConnections(connections));
+
+    it("should correctly assign foreign key columns in embedded entity", () => Promise.all(connections.map(async connection => {
+        const columns = connection.entityMetadatas.find(entity => entity.name === "User")!.columns;
+        expect(columns.length).to.equal(3); // id, embeddedRelationuser1id, embeddedRelationuser2id
+        expect(columns.some(column => column.databaseName === "id")).to.be.true;
+        expect(columns.some(column => column.databaseName === "embeddedRelationuser1id")).to.be.true;
+        expect(columns.some(column => column.databaseName === "embeddedRelationuser2id")).to.be.true;
+    })));
+});

--- a/test/utils/test-utils.ts
+++ b/test/utils/test-utils.ts
@@ -129,6 +129,11 @@ export interface TestingOptions {
     };
 
     /**
+     * Flag to enable breaking changes that are planned for release in next version.
+     */
+    enableNextFeatures?: boolean;
+
+    /**
      * Options that may be specific to a driver.
      * They are passed down to the enabled drivers.
      */
@@ -155,7 +160,8 @@ export function setupSingleTestingConnection(driverType: DatabaseType, options: 
         enabledDrivers: [driverType],
         cache: options.cache,
         schema: options.schema ? options.schema : undefined,
-        namingStrategy: options.namingStrategy ? options.namingStrategy : undefined
+        namingStrategy: options.namingStrategy ? options.namingStrategy : undefined,
+        enableNextFeatures: options.enableNextFeatures ? options.enableNextFeatures : false
     });
     if (!testingConnections.length)
         return undefined;
@@ -208,13 +214,14 @@ export function setupTestingConnections(options?: TestingOptions): ConnectionOpt
             return true;
         })
         .map(connectionOptions => {
-            let newOptions: any = Object.assign({}, connectionOptions as ConnectionOptions, {
+            let newOptions: any = Object.assign({}, connectionOptions as ConnectionOptions, <ConnectionOptions>{
                 name: options && options.name ? options.name : connectionOptions.name,
                 entities: options && options.entities ? options.entities : [],
                 migrations: options && options.migrations ? options.migrations : [],
                 subscribers: options && options.subscribers ? options.subscribers : [],
                 dropSchema: options && options.dropSchema !== undefined ? options.dropSchema : false,
                 cache: options ? options.cache : undefined,
+                enableNextFeatures: options && options.enableNextFeatures !== undefined ? options.enableNextFeatures : false
             });
             if (options && options.driverSpecific)
                 newOptions = Object.assign({}, options.driverSpecific, newOptions);


### PR DESCRIPTION
Searches embedded entity columns for relation ID column if relation column is in embedded entity. If not found, creates new relation ID with embedded metadata set to match the relation column.

Fixes: #2254
Fixes: #3132
Fixes: #3226
Fixes: #6977

### Description of change

See #6977. 

Currently the relation column's `entityMetadata` is searched for columns matching the join column, rather than `embeddedMetadata` (when present).

https://github.com/typeorm/typeorm/blob/a5eb946117a18d94c0157188b6a39542c8d50756/src/metadata-builder/RelationJoinColumnBuilder.ts#L136.

This changes that behavior to match 

https://github.com/typeorm/typeorm/blob/a5eb946117a18d94c0157188b6a39542c8d50756/src/metadata-builder/EntityMetadataBuilder.ts#L152-L156


### Pull-Request Checklist

<!--
  Please make sure to review and check all of the following.

  If an item is not applicable, you can add "N/A" to the end.
-->

- [x] Code is up-to-date with the `master` branch
- [x] `npm run lint` passes with this change
- [x] `npm run test` passes with this change
- [x] This pull request links relevant issues as `Fixes #0000`
- [x] There are new or updated unit tests validating the change
- [x] Documentation has been updated to reflect this change
- [x] The new commits follow conventions explained in [CONTRIBUTING.md](https://github.com/typeorm/typeorm/blob/master/CONTRIBUTING.md)

<!--
  🎉 Thank you for contributing and making TypeORM even better!
-->
