### PR TITLE
fix: findRoots should get the defined primary key column

### DIFF
--- a/src/repository/TreeRepository.ts
+++ b/src/repository/TreeRepository.ts
@@ -33,7 +33,7 @@ export class TreeRepository<Entity> extends Repository<Entity> {
         const escapeAlias = (alias: string) => this.manager.connection.driver.escape(alias);
         const escapeColumn = (column: string) => this.manager.connection.driver.escape(column);
         const parentPropertyName = this.manager.connection.namingStrategy.joinColumnName(
-          this.metadata.treeParentRelation!.propertyName, "id"
+          this.metadata.treeParentRelation!.propertyName, this.metadata.primaryColumns[0].propertyName
         );
 
         return this.createQueryBuilder("treeEntity")

--- a/test/github-issues/6948/entity/Category.ts
+++ b/test/github-issues/6948/entity/Category.ts
@@ -1,0 +1,17 @@
+import { Entity, PrimaryGeneratedColumn, Column, Tree, TreeParent, TreeChildren } from "../../../../src";
+
+@Entity()
+@Tree("materialized-path")
+export class Category {
+    @PrimaryGeneratedColumn()
+    cat_id: number;
+
+    @Column()
+    cat_name: string;
+
+    @TreeParent()
+    cat_parent: Category;
+
+    @TreeChildren({ cascade: true })
+    cat_children: Category[];
+}

--- a/test/github-issues/6948/issue-6948.ts
+++ b/test/github-issues/6948/issue-6948.ts
@@ -1,0 +1,38 @@
+import "reflect-metadata";
+import { Category } from "./entity/Category";
+import { Connection } from "../../../src/connection/Connection";
+import {
+    closeTestingConnections,
+    createTestingConnections,
+    reloadTestingDatabases,
+} from "../../../test/utils/test-utils";
+
+describe("github issues > #6948 TreeRepository's findRoots query incorrectly when using a custom primary key", () => {
+    let connections: Connection[];
+    before(
+        async () =>
+            (connections = await createTestingConnections({
+                entities: [Category],
+            }))
+    );
+    beforeEach(() => reloadTestingDatabases(connections));
+    after(() => closeTestingConnections(connections));
+
+    it("entity parent column should work with custom primary column names ", () =>
+        Promise.all(
+            connections.map(async (connection) => {
+                const categoryRepository = connection.getTreeRepository(
+                    Category
+                );
+                await categoryRepository.save(
+                    categoryRepository.create({
+                        cat_name: "Root node",
+                    })
+                );
+                const rootNodes = await categoryRepository.findRoots();
+                rootNodes[0].should.deep.include({
+                    cat_name: "Root node",
+                });
+            })
+        ));
+});


### PR DESCRIPTION
### Description of change

Previously `findRoots` assumes the primary column of an entity to be named `id`
https://github.com/typeorm/typeorm/blob/a5eb946117a18d94c0157188b6a39542c8d50756/src/repository/TreeRepository.ts#L35-L37

This PR will instead use the column defined by entity class

Fixes #6948, #2361 

### Pull-Request Checklist

- [x] Code is up-to-date with the `master` branch
- [x] `npm run lint` passes with this change
- [x] `npm run test` passes with this change
- [x] This pull request links relevant issues as `Fixes #0000`
- [x] There are new or updated unit tests validating the change
- [x] The new commits follow conventions explained in [CONTRIBUTING.md](https://github.com/typeorm/typeorm/blob/master/CONTRIBUTING.md)
