### PR TITLE
fix: reject nullable primary columns

### DIFF
--- a/src/decorator/columns/PrimaryColumn.ts
+++ b/src/decorator/columns/PrimaryColumn.ts
@@ -5,35 +5,41 @@ import {ColumnMetadataArgs} from "../../metadata-args/ColumnMetadataArgs";
 import {GeneratedMetadataArgs} from "../../metadata-args/GeneratedMetadataArgs";
 
 /**
- * Column decorator is used to mark a specific class property as a table column.
- * Only properties decorated with this decorator will be persisted to the database when entity be saved.
- * Primary columns also creates a PRIMARY KEY for this column in a db.
+ * Describes all primary key column's options.
+ * If specified, the nullable field must be set to false.
  */
-export function PrimaryColumn(options?: ColumnOptions): PropertyDecorator;
+export type PrimaryColumnOptions = ColumnOptions & { nullable?: false };
 
 /**
  * Column decorator is used to mark a specific class property as a table column.
  * Only properties decorated with this decorator will be persisted to the database when entity be saved.
  * Primary columns also creates a PRIMARY KEY for this column in a db.
  */
-export function PrimaryColumn(type?: ColumnType, options?: ColumnOptions): PropertyDecorator;
+export function PrimaryColumn(options?: PrimaryColumnOptions): PropertyDecorator;
 
 /**
  * Column decorator is used to mark a specific class property as a table column.
  * Only properties decorated with this decorator will be persisted to the database when entity be saved.
  * Primary columns also creates a PRIMARY KEY for this column in a db.
  */
-export function PrimaryColumn(typeOrOptions?: ColumnType|ColumnOptions, options?: ColumnOptions): PropertyDecorator {
+export function PrimaryColumn(type?: ColumnType, options?: PrimaryColumnOptions): PropertyDecorator;
+
+/**
+ * Column decorator is used to mark a specific class property as a table column.
+ * Only properties decorated with this decorator will be persisted to the database when entity be saved.
+ * Primary columns also creates a PRIMARY KEY for this column in a db.
+ */
+export function PrimaryColumn(typeOrOptions?: ColumnType|PrimaryColumnOptions, options?: PrimaryColumnOptions): PropertyDecorator {
     return function (object: Object, propertyName: string) {
 
         // normalize parameters
         let type: ColumnType|undefined;
         if (typeof typeOrOptions === "string") {
-            type = <ColumnType> typeOrOptions;
+            type = typeOrOptions;
         } else {
-            options = Object.assign({}, <ColumnOptions> typeOrOptions);
+            options = Object.assign({}, <PrimaryColumnOptions> typeOrOptions);
         }
-        if (!options) options = {} as ColumnOptions;
+        if (!options) options = {} as PrimaryColumnOptions;
 
         // if type is not given explicitly then try to guess it
         const reflectMetadataType = Reflect && (Reflect as any).getMetadata ? (Reflect as any).getMetadata("design:type", object, propertyName) : undefined;

--- a/test/github-issues/4570/issue-4570.ts
+++ b/test/github-issues/4570/issue-4570.ts
@@ -1,11 +1,11 @@
 import "reflect-metadata";
 
 import {expect} from "chai";
-import {ColumnOptions, PrimaryColumn} from "../../../src";
+import {PrimaryColumnOptions, PrimaryColumn} from "../../../src";
 
 describe("github issues > #4570 Fix PrimaryColumn decorator modifies passed option", () => {
     it("should not modify passed options to PrimaryColumn", () => {
-        const options: ColumnOptions = {type: "varchar" };
+        const options: PrimaryColumnOptions = {type: "varchar" };
         const clone = Object.assign({}, options);
 
         class Entity {


### PR DESCRIPTION
Every supported back-end requires that primary key columns be non-nullable.
As of this PR, this mistake is caught at compile-time rather than as part of execution.

BREAKING CHANGE: passing `ColumnOptions` to `@PrimaryKeyColumn` does not function anymore. One must use `PrimaryKeyColumnOptions` instead.

### Description of change

Forbid primary columns from being marked as nullable. This condition is expected by all currently-supported back-ends and is generally understood to be standard.

As of the time this PR was opened, some of the tests aren't passing on my machine, and I've not touched documentation. I'd like to validate that this change is desired and likely to be merged before spending more time on it.

### Pull-Request Checklist

- [x] Code is up-to-date with the `master` branch
- [x] `npm run lint` passes with this change
- [x] `npm run test` passes with this change
- [x] This pull request links relevant issues as `Fixes #0000` (N/A)
- [x] There are new or updated unit tests validating the change (N/A)
- [ ] Documentation has been updated to reflect this change
- [x] The new commits follow conventions explained in [CONTRIBUTING.md](https://github.com/typeorm/typeorm/blob/master/CONTRIBUTING.md)
