### PR TITLE
feat: selectAndMap, computed/virtual/mapped columns (WIP)

### DIFF
--- a/src/decorator/columns/Virtual.ts
+++ b/src/decorator/columns/Virtual.ts
@@ -1,0 +1,100 @@
+import { ColumnOptions, getMetadataArgsStorage } from "../../";
+import {
+    ColumnType, SpatialColumnType
+} from "../../driver/types/ColumnTypes";
+import {ColumnMetadataArgs} from "../../metadata-args/ColumnMetadataArgs";
+import {ColumnTypeUndefinedError} from "../../error/ColumnTypeUndefinedError";
+import { ColumnEnumOptions } from '../options/ColumnEnumOptions';
+import { ColumnHstoreOptions } from '../options/ColumnHstoreOptions';
+import { SpatialColumnOptions } from '../options/SpatialColumnOptions';
+import { VirtualOptions } from '../options/VirtualOptions';
+
+/**
+ * Column decorator is used to mark a specific class property as a table column.
+ * Only properties decorated with this decorator will be persisted to the database when entity be saved.
+ */
+export function Virtual(): PropertyDecorator;
+
+/**
+ * Column decorator is used to mark a specific class property as a table column.
+ * Only properties decorated with this decorator will be persisted to the database when entity be saved.
+ */
+export function Virtual(type: ColumnType): PropertyDecorator;
+
+/**
+ * Column decorator is used to mark a specific class property as a table column.
+ * Only properties decorated with this decorator will be persisted to the database when entity be saved.
+ */
+export function Virtual(type: SpatialColumnType, options?: SpatialColumnOptions): PropertyDecorator;
+
+/**
+ * Column decorator is used to mark a specific class property as a table column.
+ * Only properties decorated with this decorator will be persisted to the database when entity be saved.
+ */
+export function Virtual(type: "enum", options?: ColumnEnumOptions): PropertyDecorator;
+
+/**
+ * Column decorator is used to mark a specific class property as a table column.
+ * Only properties decorated with this decorator will be persisted to the database when entity be saved.
+ */
+export function Virtual(type: "simple-enum", options?: ColumnEnumOptions): PropertyDecorator;
+
+/**
+ * Column decorator is used to mark a specific class property as a table column.
+ * Only properties decorated with this decorator will be persisted to the database when entity be saved.
+ */
+export function Virtual(type: "set", options?: ColumnEnumOptions): PropertyDecorator;
+
+/**
+ * Column decorator is used to mark a specific class property as a table column.
+ * Only properties decorated with this decorator will be persisted to the database when entity be saved.
+ */
+export function Virtual(type: "hstore", options?: ColumnHstoreOptions): PropertyDecorator;
+
+/**
+ * Column decorator is used to mark a specific class property as a table column.
+ * Only properties decorated with this decorator will be persisted to the database when entity be saved.
+ */
+export function Virtual(typeOrOptions?: ColumnType|VirtualOptions, options?: VirtualOptions): PropertyDecorator {
+    return function (object: Object, propertyName: string) {
+
+        // normalize parameters
+        let type: ColumnType|undefined;
+        if (typeof typeOrOptions === "string" || typeOrOptions instanceof Function) {
+            type = <ColumnType> typeOrOptions;
+
+        } else if (typeOrOptions) {
+            options = <ColumnOptions> typeOrOptions;
+            type = typeOrOptions.type;
+        }
+        if (!options) options = {} as ColumnOptions;
+
+        // if type is not given explicitly then try to guess it
+        const reflectMetadataType = Reflect && (Reflect as any).getMetadata ? (Reflect as any).getMetadata("design:type", object, propertyName) : undefined;
+        if (!type && reflectMetadataType) // if type is not given explicitly then try to guess it
+            type = reflectMetadataType;
+
+        // check if there is no type in column options then set type from first function argument, or guessed one
+        if (!options.type && type)
+            options.type = type;
+
+        // specify HSTORE type if column is HSTORE
+        if (options.type === "hstore" && !options.hstoreType)
+            options.hstoreType = reflectMetadataType === Object ? "object" : "string";
+
+         // register a regular column
+        if (!options.type)
+            throw new ColumnTypeUndefinedError(object, propertyName);
+        getMetadataArgsStorage().columns.push({
+            target: object.constructor,
+            propertyName: propertyName,
+            mode: "computed",
+            options: {
+                ...options,
+                select: false,
+                insert: false,
+                update: false
+            }
+        } as ColumnMetadataArgs);
+    };
+}

--- a/src/decorator/columns/Virtual.ts
+++ b/src/decorator/columns/Virtual.ts
@@ -1,6 +1,6 @@
 import { ColumnOptions, getMetadataArgsStorage } from "../../";
 import {
-    ColumnType, SpatialColumnType
+    ColumnType, SimpleColumnType, SpatialColumnType
 } from "../../driver/types/ColumnTypes";
 import {ColumnMetadataArgs} from "../../metadata-args/ColumnMetadataArgs";
 import {ColumnTypeUndefinedError} from "../../error/ColumnTypeUndefinedError";
@@ -19,13 +19,19 @@ export function Virtual(): PropertyDecorator;
  * Column decorator is used to mark a specific class property as a table column.
  * Only properties decorated with this decorator will be persisted to the database when entity be saved.
  */
-export function Virtual(type: ColumnType): PropertyDecorator;
+export function Virtual(type: VirtualOptions): PropertyDecorator;
 
 /**
  * Column decorator is used to mark a specific class property as a table column.
  * Only properties decorated with this decorator will be persisted to the database when entity be saved.
  */
-export function Virtual(type: SpatialColumnType, options?: SpatialColumnOptions): PropertyDecorator;
+export function Virtual(type: SimpleColumnType): PropertyDecorator;
+
+/**
+ * Column decorator is used to mark a specific class property as a table column.
+ * Only properties decorated with this decorator will be persisted to the database when entity be saved.
+ */
+export function Virtual(type: SpatialColumnType, options?: VirtualOptions & SpatialColumnOptions): PropertyDecorator;
 
 /**
  * Column decorator is used to mark a specific class property as a table column.

--- a/src/decorator/options/VirtualCommonOptions.ts
+++ b/src/decorator/options/VirtualCommonOptions.ts
@@ -1,4 +1,4 @@
-import { ColumnType, ValueTransformer } from "../..";
+import { ValueTransformer } from '../..';
 
 /**
  * Describes all virtual column's options.
@@ -9,26 +9,6 @@ export class VirtualOptions {
      * Default computed expression
      */
     expression?: string;
-
-    /**
-     * Column type. Must be one of the value from the ColumnTypes class.
-     */
-    type?: ColumnType;
-
-    /**
-     * Array of possible enumerated values.
-     */
-    enum?: (string|number)[]|Object;
-    /**
-     * Exact name of enum
-     */
-    enumName?: string;
-
-    /**
-     * Return type of HSTORE column.
-     * Returns value as string or as object.
-     */
-    hstoreType?: "object"|"string";
 
     /**
      * Indicates if this column is an array.

--- a/src/decorator/options/VirtualOptions.ts
+++ b/src/decorator/options/VirtualOptions.ts
@@ -1,0 +1,49 @@
+import { ColumnType, ValueTransformer } from '../..';
+
+/**
+ * Describes all virtual column's options.
+ */
+export class VirtualOptions {
+    /**
+     * Column type. Must be one of the value from the ColumnTypes class.
+     */
+    type?: ColumnType;
+
+    /**
+     * Array of possible enumerated values.
+     */
+    enum?: (string|number)[]|Object;
+    /**
+     * Exact name of enum
+     */
+    enumName?: string;
+
+    /**
+     * Return type of HSTORE column.
+     * Returns value as string or as object.
+     */
+    hstoreType?: "object"|"string";
+
+    /**
+     * Indicates if this column is an array.
+     * Can be simply set to true or array length can be specified.
+     * Supported only by postgres.
+     */
+    array?: boolean;
+
+    /**
+     * Specifies a value transformer that is to be used to (un)marshal
+     * this column when reading or writing to the database.
+     */
+    transformer?: ValueTransformer|ValueTransformer[];
+
+    /**
+     * Spatial Feature Type (Geometry, Point, Polygon, etc.)
+     */
+    spatialFeatureType?: string;
+
+    /**
+     * SRID (Spatial Reference ID (EPSG code))
+     */
+    srid?: number;
+}

--- a/src/metadata-args/types/ColumnMode.ts
+++ b/src/metadata-args/types/ColumnMode.ts
@@ -4,4 +4,4 @@
  * For example, "primary" means that it will be a primary column, or "createDate" means that it will create a create
  * date column.
  */
-export type ColumnMode = "regular"|"virtual"|"createDate"|"updateDate"|"deleteDate"|"version"|"treeChildrenCount"|"treeLevel"|"objectId"|"array";
+export type ColumnMode = "regular"|"computed"|"virtual"|"createDate"|"updateDate"|"deleteDate"|"version"|"treeChildrenCount"|"treeLevel"|"objectId"|"array";

--- a/src/metadata-builder/EntityMetadataBuilder.ts
+++ b/src/metadata-builder/EntityMetadataBuilder.ts
@@ -625,6 +625,7 @@ export class EntityMetadataBuilder {
         entityMetadata.beforeRemoveListeners = entityMetadata.listeners.filter(listener => listener.type === EventListenerTypes.BEFORE_REMOVE);
         entityMetadata.indices = entityMetadata.embeddeds.reduce((columns, embedded) => columns.concat(embedded.indicesFromTree), entityMetadata.ownIndices);
         entityMetadata.uniques = entityMetadata.embeddeds.reduce((columns, embedded) => columns.concat(embedded.uniquesFromTree), entityMetadata.ownUniques);
+        entityMetadata.databaseColumns = entityMetadata.columns.filter(column => !column.isComputed);
         entityMetadata.primaryColumns = entityMetadata.columns.filter(column => column.isPrimary);
         entityMetadata.nonVirtualColumns = entityMetadata.columns.filter(column => !column.isVirtual);
         entityMetadata.ancestorColumns = entityMetadata.columns.filter(column => column.closureType === "ancestor");

--- a/src/metadata/ColumnMetadata.ts
+++ b/src/metadata/ColumnMetadata.ts
@@ -163,6 +163,11 @@ export class ColumnMetadata {
     enumName?: string;
 
     /**
+     * Computed column expression.
+     */
+    computedExpression?: string;
+
+    /**
      * Generated column expression. Supports only in MySQL.
      */
     asExpression?: string;

--- a/src/metadata/ColumnMetadata.ts
+++ b/src/metadata/ColumnMetadata.ts
@@ -226,6 +226,11 @@ export class ColumnMetadata {
     isVirtual: boolean = false;
 
     /**
+     * Indicates if column is computed. Computed columns are created in the database.
+     */
+    isComputed: boolean = false;
+
+    /**
      * Indicates if column is discriminator. Discriminator columns are not mapped to the entity.
      */
     isDiscriminator: boolean = false;
@@ -393,6 +398,7 @@ export class ColumnMetadata {
             this.isArray = options.args.options.array;
         if (options.args.mode) {
             this.isVirtual = options.args.mode === "virtual";
+            this.isComputed = options.args.mode === "computed";
             this.isTreeLevel = options.args.mode === "treeLevel";
             this.isCreateDate = options.args.mode === "createDate";
             this.isUpdateDate = options.args.mode === "updateDate";

--- a/src/metadata/EntityMetadata.ts
+++ b/src/metadata/EntityMetadata.ts
@@ -224,6 +224,11 @@ export class EntityMetadata {
     columns: ColumnMetadata[] = [];
 
     /**
+     * Columns of the entity that are to be stored in the database (excluding computed).
+     */
+    databaseColumns: ColumnMetadata[] = [];
+
+    /**
      * Ancestor columns used only in closure junction tables.
      */
     ancestorColumns: ColumnMetadata[] = [];

--- a/src/query-builder/SelectQuery.ts
+++ b/src/query-builder/SelectQuery.ts
@@ -2,4 +2,5 @@ export interface SelectQuery {
     selection: string;
     aliasName?: string;
     virtual?: boolean;
+    mapToProperty?: string;
 }

--- a/src/query-builder/SelectQueryBuilder.ts
+++ b/src/query-builder/SelectQueryBuilder.ts
@@ -1761,7 +1761,10 @@ export class SelectQueryBuilder<Entity> extends QueryBuilder<Entity> implements 
 
         return allColumns.map(column => {
             const selection = this.expressionMap.selects.find(select => select.selection === aliasName + "." + column.propertyPath || select.mapToProperty === column.propertyPath);
-            let selectionPath = selection && selection.mapToProperty === column.propertyPath ? selection.selection : this.escape(aliasName) + "." + this.escape(column.databaseName);
+            let selectionPath: string = this.escape(aliasName) + "." + this.escape(column.databaseName);
+            if (column.isComputed) {
+                selectionPath = selection ? selection.selection : column.computedExpression;
+            }
             if (this.connection.driver.spatialTypes.indexOf(column.type) !== -1) {
                 if (this.connection.driver instanceof MysqlDriver || this.connection.driver instanceof AuroraDataApiDriver) {
                     const useLegacy = this.connection.driver.options.legacySpatialSupport;

--- a/src/schema-builder/RdbmsSchemaBuilder.ts
+++ b/src/schema-builder/RdbmsSchemaBuilder.ts
@@ -220,10 +220,10 @@ export class RdbmsSchemaBuilder implements SchemaBuilder {
             if (!table)
                 continue;
 
-            if (metadata.columns.length !== table.columns.length)
+            if (metadata.databaseColumns.length !== table.columns.length)
                 continue;
 
-            const renamedMetadataColumns = metadata.columns.filter(column => {
+            const renamedMetadataColumns = metadata.databaseColumns.filter(column => {
                 return !table.columns.find(tableColumn => {
                     return tableColumn.name === column.databaseName
                         && tableColumn.type === this.connection.driver.normalizeType(column)
@@ -236,7 +236,7 @@ export class RdbmsSchemaBuilder implements SchemaBuilder {
                 continue;
 
             const renamedTableColumns = table.columns.filter(tableColumn => {
-                return !metadata.columns.find(column => {
+                return !metadata.databaseColumns.find(column => {
                     return column.databaseName === tableColumn.name
                         && this.connection.driver.normalizeType(column) === tableColumn.type
                         && column.isNullable === tableColumn.isNullable
@@ -440,7 +440,7 @@ export class RdbmsSchemaBuilder implements SchemaBuilder {
 
             // find columns that exist in the database but does not exist in the metadata
             const droppedTableColumns = table.columns.filter(tableColumn => {
-                return !metadata.columns.find(columnMetadata => columnMetadata.databaseName === tableColumn.name);
+                return !metadata.databaseColumns.find(columnMetadata => columnMetadata.databaseName === tableColumn.name);
             });
             if (droppedTableColumns.length === 0)
                 continue;
@@ -463,7 +463,7 @@ export class RdbmsSchemaBuilder implements SchemaBuilder {
                 continue;
 
             // find which columns are new
-            const newColumnMetadatas = metadata.columns.filter(columnMetadata => {
+            const newColumnMetadatas = metadata.databaseColumns.filter(columnMetadata => {
                 return !table.columns.find(tableColumn => tableColumn.name === columnMetadata.databaseName);
             });
             if (newColumnMetadatas.length === 0)
@@ -490,7 +490,7 @@ export class RdbmsSchemaBuilder implements SchemaBuilder {
             if (!table)
                 continue;
 
-            const primaryMetadataColumns = metadata.columns.filter(column => column.isPrimary);
+            const primaryMetadataColumns = metadata.databaseColumns.filter(column => column.isPrimary);
             const primaryTableColumns = table.columns.filter(column => column.isPrimary);
             if (primaryTableColumns.length !== primaryMetadataColumns.length && primaryMetadataColumns.length > 1) {
                 const changedPrimaryColumns = primaryMetadataColumns.map(primaryMetadataColumn => {
@@ -511,7 +511,7 @@ export class RdbmsSchemaBuilder implements SchemaBuilder {
             if (!table)
                 continue;
 
-            const changedColumns = this.connection.driver.findChangedColumns(table.columns, metadata.columns);
+            const changedColumns = this.connection.driver.findChangedColumns(table.columns, metadata.databaseColumns);
             if (changedColumns.length === 0)
                 continue;
 

--- a/src/schema-builder/table/Table.ts
+++ b/src/schema-builder/table/Table.ts
@@ -305,7 +305,7 @@ export class Table {
         const options: TableOptions = {
             name: driver.buildTableName(entityMetadata.tableName, entityMetadata.schema, entityMetadata.database),
             engine: entityMetadata.engine,
-            columns: entityMetadata.columns
+            columns: entityMetadata.databaseColumns
                 .filter(column => column)
                 .map(column => TableUtils.createTableColumnOptions(column, driver)),
             indices: entityMetadata.indices


### PR DESCRIPTION
*Still WIP, gathering feedback*

Fixes #296, #1822, #7008
Alternative to #4703, #6855

### Description of change
Universal `selectAndMap` for computed/virtual/mapped columns with minimal disruption to existing systems and no changes to database drivers.

The column system in TypeORM can generally be broken down into two sides: entity -> database and database -> entity. With computed columns everything in the database -> entity side remains useful, namely the existing `RawSqlResultsToEntityTransformer`, `Driver.prepareHydratedValue` and `SelectQueryBuilder` column aliasing, while the entity -> database side should not be used at all.

With this solution for `selectAndMap` I have attempted to make the most of the column system and keep a similar pattern for defining computed properties.

#### 1. `@Virtual(type: ColumnType, options?: VirtualOptions)` decorator
A new decorator is introduced for marking entity properties as being virtual and storing their database type for later reference. It removes all the options from `@Column()` that are only relevant to database storage. The `ColumnMetadataArgs.mode` is set to `'computed'`.

Normally the type will be inferred from the property type, but for special values such as `'json'`, `'date'`, `'enum'` and `'hstore'` I have left the parameter in. Ideally the available `ColumnType`s would be more restrictive given that a `'tinyint'` and `'int'` are both just numbers once they have been parsed into the result, but there is no harm.

The name "Virtual" is slightly confusing currently since there are already 'virtual' columns from junction tables and table inheritance. I think the current 'virtual' columns should be renamed to 'internal' columns as they are internal to the ORM, while the new mapped properties should be known as virtual. Alternatively 'computed' or 'mapped' could be used, but I would like to see `@Computed` reserved for putting the select expression directly in the entity in future.

#### 2. `addSelectAndMap(selection: string|qb..., mapToProperty: string)`
Only the selection expression and mapped property are provided, rather than using an alias, since the main intention is to access the computed value at the property and not have to worry about how exactly that happens.

There might be situations where an alias is also useful if the computed value is being used further in other expressions, but I'm not sure what the best approach is for this. Since the virtual property is still defined as a metadata column it should be possible to use it in where, order, etc using its property name, although I have not yet tested this.

The type of the computed value is determined by the annotated property in the entity, unlike with #6855. I think this is a better approach for maintaining type safety, and avoids all the changes to `prepareHydratedValue`. 

#### 3. `EntityMetadata.databaseColumns`
A filtered version of `columns` is added to hold all the non computed columns and only these are used in schema building. This works well, although the naming of all the various column lists is now becoming quite messy, and it feels wrong introducing a new array just because of them.

A possible alternative could be to split up the concept of 'properties' and 'columns' to represent the entity -> database and database -> entity sides. The difficulty is that the new virtual columns mainly care about the property, but they do also need to maintain their `databaseName` for example, so way to split it isn't exactly obvious. Ideally `ColumnMetadata` would extend `PropertyMetadata`, and the appropriate one would be used throughout depending on what is being done.

A list just for virtual would also work, but I think this requires even more changes to the existing code (`[...columns, ...virtual]`, etc).

### Sample
```typescript
@Entity()
export class UserEntity {
    @PrimaryGeneratedColumn()
    id: number;

    @Virtual()
    test: number;
}

const entityManager = connection.createEntityManager();
await entityManager.save(UserEntity, { id: 1 });
const result = await entityManager.createQueryBuilder(UserEntity, 'user')
        .select()
        .addSelectAndMap('5 + 5', 'test')
        .getOne();
```

```sql
SELECT `user`.`id` AS `user_id`, 5 + 5 AS `user_test` FROM `user_entity` `user`
```

```typescript

UserEntity { id: 1, test: 10 }
```

### Feedback
Currently only tested with above sample code so might have issues for insert/update/etc, but I think this is a step in the right direction for `selectAndMap`. Please let me know what you think and send ideas.

### Pull-Request Checklist

<!--
  Please make sure to review and check all of the following.

  If an item is not applicable, you can add "N/A" to the end.
-->

- [x] Code is up-to-date with the `master` branch
- [ ] `npm run lint` passes with this change
- [ ] `npm run test` passes with this change
- [x] This pull request links relevant issues as `Fixes #0000`
- [ ] There are new or updated unit tests validating the change
- [ ] Documentation has been updated to reflect this change
- [x] The new commits follow conventions explained in [CONTRIBUTING.md](https://github.com/typeorm/typeorm/blob/master/CONTRIBUTING.md)

<!--
  🎉 Thank you for contributing and making TypeORM even better!
-->
