### PR TITLE
refactor: Unify logic between @Column/@PrimaryColumn/@PrimaryGeneratedColumn

### DIFF
--- a/src/decorator/columns/ObjectIdColumn.ts
+++ b/src/decorator/columns/ObjectIdColumn.ts
@@ -7,7 +7,6 @@ import {ColumnMetadataArgs} from "../../metadata-args/ColumnMetadataArgs";
  */
 export function ObjectIdColumn(options?: ColumnOptions): PropertyDecorator {
     return function (object: Object, propertyName: string) {
-
         // if column options are not given then create a new empty options
         if (!options) options = {} as ColumnOptions;
         options.primary = true;

--- a/src/decorator/columns/PrimaryColumn.ts
+++ b/src/decorator/columns/PrimaryColumn.ts
@@ -5,35 +5,41 @@ import {ColumnMetadataArgs} from "../../metadata-args/ColumnMetadataArgs";
 import {GeneratedMetadataArgs} from "../../metadata-args/GeneratedMetadataArgs";
 
 /**
- * Column decorator is used to mark a specific class property as a table column.
- * Only properties decorated with this decorator will be persisted to the database when entity be saved.
- * Primary columns also creates a PRIMARY KEY for this column in a db.
+ * Describes all primary key column's options.
+ * If specified, the nullable field must be set to false.
  */
-export function PrimaryColumn(options?: ColumnOptions): PropertyDecorator;
+export type PrimaryColumnOptions = ColumnOptions & { nullable?: false };
 
 /**
  * Column decorator is used to mark a specific class property as a table column.
  * Only properties decorated with this decorator will be persisted to the database when entity be saved.
  * Primary columns also creates a PRIMARY KEY for this column in a db.
  */
-export function PrimaryColumn(type?: ColumnType, options?: ColumnOptions): PropertyDecorator;
+export function PrimaryColumn(options?: PrimaryColumnOptions): PropertyDecorator;
 
 /**
  * Column decorator is used to mark a specific class property as a table column.
  * Only properties decorated with this decorator will be persisted to the database when entity be saved.
  * Primary columns also creates a PRIMARY KEY for this column in a db.
  */
-export function PrimaryColumn(typeOrOptions?: ColumnType|ColumnOptions, options?: ColumnOptions): PropertyDecorator {
+export function PrimaryColumn(type?: ColumnType, options?: PrimaryColumnOptions): PropertyDecorator;
+
+/**
+ * Column decorator is used to mark a specific class property as a table column.
+ * Only properties decorated with this decorator will be persisted to the database when entity be saved.
+ * Primary columns also creates a PRIMARY KEY for this column in a db.
+ */
+export function PrimaryColumn(typeOrOptions?: ColumnType|PrimaryColumnOptions, options?: PrimaryColumnOptions): PropertyDecorator {
     return function (object: Object, propertyName: string) {
 
         // normalize parameters
         let type: ColumnType|undefined;
         if (typeof typeOrOptions === "string") {
-            type = <ColumnType> typeOrOptions;
+            type = typeOrOptions;
         } else {
-            options = Object.assign({}, <ColumnOptions> typeOrOptions);
+            options = Object.assign({}, <PrimaryColumnOptions> typeOrOptions);
         }
-        if (!options) options = {} as ColumnOptions;
+        if (!options) options = {} as PrimaryColumnOptions;
 
         // if type is not given explicitly then try to guess it
         const reflectMetadataType = Reflect && (Reflect as any).getMetadata ? (Reflect as any).getMetadata("design:type", object, propertyName) : undefined;

--- a/src/decorator/columns/PrimaryColumn.ts
+++ b/src/decorator/columns/PrimaryColumn.ts
@@ -1,8 +1,4 @@
-import {ColumnOptions, ColumnType, getMetadataArgsStorage} from "../../";
-import {ColumnTypeUndefinedError} from "../../error/ColumnTypeUndefinedError";
-import {PrimaryColumnCannotBeNullableError} from "../../error/PrimaryColumnCannotBeNullableError";
-import {ColumnMetadataArgs} from "../../metadata-args/ColumnMetadataArgs";
-import {GeneratedMetadataArgs} from "../../metadata-args/GeneratedMetadataArgs";
+import {Column, ColumnOptions, ColumnType} from "../../";
 
 /**
  * Describes all primary key column's options.
@@ -29,53 +25,22 @@ export function PrimaryColumn(type?: ColumnType, options?: PrimaryColumnOptions)
  * Only properties decorated with this decorator will be persisted to the database when entity be saved.
  * Primary columns also creates a PRIMARY KEY for this column in a db.
  */
-export function PrimaryColumn(typeOrOptions?: ColumnType|PrimaryColumnOptions, options?: PrimaryColumnOptions): PropertyDecorator {
-    return function (object: Object, propertyName: string) {
-
-        // normalize parameters
-        let type: ColumnType|undefined;
-        if (typeof typeOrOptions === "string") {
-            type = typeOrOptions;
-        } else {
-            options = Object.assign({}, <PrimaryColumnOptions> typeOrOptions);
+export function PrimaryColumn(typeOrOptions?: ColumnType|PrimaryColumnOptions, maybeOptions?: PrimaryColumnOptions): PropertyDecorator {
+    // normalize parameters
+    let options: ColumnOptions = {};
+    if (typeof typeOrOptions === "string") {
+        options.type = typeOrOptions;
+        if (maybeOptions) {
+            options = Object.assign(options, <ColumnOptions> maybeOptions);
         }
-        if (!options) options = {} as PrimaryColumnOptions;
+    } else {
+        options = Object.assign(options, <ColumnOptions> typeOrOptions);
+    }
+    if (!options) options = {} as PrimaryColumnOptions;
 
-        // if type is not given explicitly then try to guess it
-        const reflectMetadataType = Reflect && (Reflect as any).getMetadata ? (Reflect as any).getMetadata("design:type", object, propertyName) : undefined;
-        if (!type && reflectMetadataType)
-            type = reflectMetadataType;
+    // explicitly set a primary to column options
+    options.primary = true;
 
-        // check if there is no type in column options then set type from first function argument, or guessed one
-        if (!options.type && type)
-            options.type = type;
-
-        // if we still don't have a type then we need to give error to user that type is required
-        if (!options.type)
-            throw new ColumnTypeUndefinedError(object, propertyName);
-
-        // check if column is not nullable, because we cannot allow a primary key to be nullable
-        if (options.nullable)
-            throw new PrimaryColumnCannotBeNullableError(object, propertyName);
-
-        // explicitly set a primary to column options
-        options.primary = true;
-
-        // create and register a new column metadata
-        getMetadataArgsStorage().columns.push({
-            target: object.constructor,
-            propertyName: propertyName,
-            mode: "regular",
-            options: options
-        } as ColumnMetadataArgs);
-
-        if (options.generated) {
-            getMetadataArgsStorage().generations.push({
-                target: object.constructor,
-                propertyName: propertyName,
-                strategy: typeof options.generated === "string" ? options.generated : "increment"
-            } as GeneratedMetadataArgs);
-        }
-    };
+    return Column(options);
 }
 

--- a/src/decorator/columns/PrimaryGeneratedColumn.ts
+++ b/src/decorator/columns/PrimaryGeneratedColumn.ts
@@ -1,7 +1,6 @@
-import {ColumnOptions, getMetadataArgsStorage} from "../../";
+import {Column, ColumnOptions} from "../../";
 import {PrimaryGeneratedColumnNumericOptions} from "../options/PrimaryGeneratedColumnNumericOptions";
 import {PrimaryGeneratedColumnUUIDOptions} from "../options/PrimaryGeneratedColumnUUIDOptions";
-import {GeneratedMetadataArgs} from "../../metadata-args/GeneratedMetadataArgs";
 
 /**
  * Column decorator is used to mark a specific class property as a table column.
@@ -35,53 +34,32 @@ export function PrimaryGeneratedColumn(strategy: "rowid", options?: PrimaryGener
  */
 export function PrimaryGeneratedColumn(strategyOrOptions?: "increment"|"uuid"|"rowid"|PrimaryGeneratedColumnNumericOptions|PrimaryGeneratedColumnUUIDOptions,
                                        maybeOptions?: PrimaryGeneratedColumnNumericOptions|PrimaryGeneratedColumnUUIDOptions): PropertyDecorator {
-
     // normalize parameters
-    const options: ColumnOptions = {};
-    let strategy: "increment"|"uuid"|"rowid";
-    if (strategyOrOptions) {
-        if (typeof strategyOrOptions === "string")
-            strategy = strategyOrOptions as "increment"|"uuid"|"rowid";
-
-        if (strategyOrOptions instanceof Object) {
-            strategy = "increment";
-            Object.assign(options, strategyOrOptions);
+    let options: ColumnOptions = {};
+    let strategy: "increment"|"uuid"|"rowid" = "increment";
+    if (typeof strategyOrOptions === "string") {
+        strategy = strategyOrOptions as "increment"|"uuid"|"rowid";
+        if (maybeOptions) {
+            options = Object.assign(options, <ColumnOptions> maybeOptions);
         }
-    } else {
-        strategy = "increment";
+    } else if (strategyOrOptions) {
+        options = Object.assign(options, <ColumnOptions> strategyOrOptions);
     }
-    if (maybeOptions instanceof Object)
-        Object.assign(options, maybeOptions);
 
-    return function (object: Object, propertyName: string) {
-
-        // if column type is not explicitly set then determine it based on generation strategy
-        if (!options.type) {
-            if (strategy === "increment") {
-                options.type = Number;
-            } else if (strategy === "uuid") {
-                options.type = "uuid";
-            } else if (strategy === "rowid") {
-                options.type = "int";
-            }
+    // if column type is not explicitly set then determine it based on generation strategy
+    if (!options.type) {
+        if (strategy === "increment") {
+            options.type = Number;
+        } else if (strategy === "uuid") {
+            options.type = "uuid";
+        } else if (strategy === "rowid") {
+            options.type = "int";
         }
+    }
 
-        // explicitly set a primary and generated to column options
-        options.primary = true;
+    // explicitly set a primary and generated to column options
+    options.primary = true;
+    options.generated = strategy;
 
-        // register column metadata args
-        getMetadataArgsStorage().columns.push({
-            target: object.constructor,
-            propertyName: propertyName,
-            mode: "regular",
-            options: options
-        });
-
-        // register generated metadata args
-        getMetadataArgsStorage().generations.push({
-            target: object.constructor,
-            propertyName: propertyName,
-            strategy: strategy
-        } as GeneratedMetadataArgs);
-    };
+    return Column(options);
 }

--- a/src/decorator/columns/UpdateDateColumn.ts
+++ b/src/decorator/columns/UpdateDateColumn.ts
@@ -7,7 +7,6 @@ import {ColumnMetadataArgs} from "../../metadata-args/ColumnMetadataArgs";
  */
 export function UpdateDateColumn(options?: ColumnOptions): PropertyDecorator {
     return function (object: Object, propertyName: string) {
-
         getMetadataArgsStorage().columns.push({
             target: object.constructor,
             propertyName: propertyName,

--- a/src/decorator/columns/VersionColumn.ts
+++ b/src/decorator/columns/VersionColumn.ts
@@ -8,7 +8,6 @@ import {ColumnMetadataArgs} from "../../metadata-args/ColumnMetadataArgs";
  */
 export function VersionColumn(options?: ColumnOptions): PropertyDecorator {
     return function (object: Object, propertyName: string) {
-
         getMetadataArgsStorage().columns.push({
             target: object.constructor,
             propertyName: propertyName,

--- a/test/github-issues/4570/issue-4570.ts
+++ b/test/github-issues/4570/issue-4570.ts
@@ -1,11 +1,11 @@
 import "reflect-metadata";
 
 import {expect} from "chai";
-import {ColumnOptions, PrimaryColumn} from "../../../src";
+import {PrimaryColumnOptions, PrimaryColumn} from "../../../src";
 
 describe("github issues > #4570 Fix PrimaryColumn decorator modifies passed option", () => {
     it("should not modify passed options to PrimaryColumn", () => {
-        const options: ColumnOptions = {type: "varchar" };
+        const options: PrimaryColumnOptions = {type: "varchar" };
         const clone = Object.assign({}, options);
 
         class Entity {


### PR DESCRIPTION
### Description of change

`@PrimaryColumn` and `@PrimaryGeneratedColumn` effectively just set `ColumnOptions.primary/generated`, but duplicate some of the code in `@Column`. Change them to all use `@Column`, no change in expected behavior except for cherry-picked #7001


### Pull-Request Checklist

<!--
  Please make sure to review and check all of the following.

  If an item is not applicable, you can add "N/A" to the end.
-->

- [x] Code is up-to-date with the `master` branch
- [x] `npm run lint` passes with this change
- [x] `npm run test` passes with this change
- [x] This pull request links relevant issues as `Fixes #0000`
- [x] There are new or updated unit tests validating the change
- [x] Documentation has been updated to reflect this change
- [x] The new commits follow conventions explained in [CONTRIBUTING.md](https://github.com/typeorm/typeorm/blob/master/CONTRIBUTING.md)

<!--
  🎉 Thank you for contributing and making TypeORM even better!
-->
