### PR TITLE
Fix MariaDB VIRTUAL [NOT NULL|NULL] error

### DIFF
--- a/src/driver/mysql/MysqlQueryRunner.ts
+++ b/src/driver/mysql/MysqlQueryRunner.ts
@@ -1859,8 +1859,9 @@ export class MysqlQueryRunner extends BaseQueryRunner implements QueryRunner {
             c += ` COLLATE "${column.collation}"`;
 
         const isMariaDb = this.driver.options.type === "mariadb";
-        // MariaDB does not support NULL/NOT NULL expressions for VIRTUAL columns
-        if (!(isMariaDb && column.asExpression && (column.generatedType || "VIRTUAL") === "VIRTUAL")) {
+        if (isMariaDb && column.asExpression && (column.generatedType || "VIRTUAL") === "VIRTUAL") {
+            // do nothing - MariaDB does not support NULL/NOT NULL expressions for VIRTUAL columns
+        } else {   
             if (!column.isNullable)
                 c += " NOT NULL";
             if (column.isNullable)


### PR DESCRIPTION
<!--
  😀 Wonderful!  Thank you for opening a pull request for TypeORM.

  Please fill in the information below to expedite the review
  and (hopefully) merge of your change.

  If unsure about something.. just do as best as you're able,
  or reach out through our community support channels!
  https://github.com/typeorm/typeorm/blob/master/docs/support.md
-->

### Description of change

Fixes #2691

query failed: ALTER TABLE `customer` CHANGE `fullName` `fullName` varchar(255) AS (CONCAT(`firstName`, ' ', `lastName`)) VIRTUAL NULL
error: Error: You have an error in your SQL syntax; check the manual that corresponds to your MariaDB server version for the right syntax to use near 'NULL' at line 1
<!--
  Please be clear and concise what the change is intended to do,
  why this change is needed, and how you've verified that it
  corrects what you intended.

  In some cases it may be helpful to include the current behavior
  and the new behavior.

  If the change is related to an open issue, you can link it here.
  If you include `Fixes #0000` (replacing `0000` with the issue number)
  when this is merged it will automatically mark the issue as fixed and
  close it.
-->


### Pull-Request Checklist

<!--
  Please make sure to review and check all of the following.

  If an item is not applicable, you can add "N/A" to the end.
-->

- [x] Code is up-to-date with the `master` branch
- [ ] `npm run lint` passes with this change
- [ ] `npm run test` passes with this change
- [x] This pull request links relevant issues as `Fixes #2691`
- [ ] There are new or updated unit tests validating the change N/A
- [ ] Documentation has been updated to reflect this change N/A
- [ ] The new commits follow conventions explained in [CONTRIBUTING.md] (https://github.com/typeorm/typeorm/blob/master/CONTRIBUTING.md)

<!--
  🎉 Thank you for contributing and making TypeORM even better!
-->
