### PR TITLE
feat: added option flag to skip column type normalization for postgres

### DIFF
--- a/docs/connection-options.md
+++ b/docs/connection-options.md
@@ -14,7 +14,7 @@
 * [`sql.js` connection options](#sqljs-connection-options)
 * [`expo` connection options](#expo-connection-options)
 * [Connection options example](#connection-options-example)
-    
+
 ## What is `ConnectionOptions`
 
 Connection options is a connection configuration you pass to `createConnection`
@@ -27,19 +27,19 @@ Connection options is a connection configuration you pass to `createConnection`
  "oracle", "mssql", "mongodb", "sqljs", "react-native".
  This option is **required**.
 
-* `name` - Connection name. You'll use it to get connection you need using `getConnection(name: string)` 
-or `ConnectionManager.get(name: string)`. 
+* `name` - Connection name. You'll use it to get connection you need using `getConnection(name: string)`
+or `ConnectionManager.get(name: string)`.
 Connection names for different connections cannot be same - they all must be unique.
 If connection name is not given then it will be called "default".
 
-* `extra` - Extra connection options to be passed to the underlying driver. 
+* `extra` - Extra connection options to be passed to the underlying driver.
 Use it if you want to pass extra settings to underlying database driver.
 
 * `entities` - Entities, or Entity Schemas, to be loaded and used for this connection.
 Accepts both entity classes, entity schema classes, and directories paths to load from.
 Directories support glob patterns.
 Example: `entities: [Post, Category, "entity/*.js", "modules/**/entity/*.js"]`.
-Learn more about [Entities](./entities.md). 
+Learn more about [Entities](./entities.md).
 Learn more about [Entity Schemas](separating-entity-definition.md).
 
 * `subscribers` - Subscribers to be loaded and used for this connection.
@@ -54,12 +54,12 @@ Directories support glob patterns.
 Example: `migrations: [FirstMigration, SecondMigration, "migration/*.js", "modules/**/migration/*.js"]`.
 Learn more about [Migrations](./migrations.md).
 
-* `logging` - Indicates if logging is enabled or not. 
+* `logging` - Indicates if logging is enabled or not.
 If set to `true` then query and error logging will be enabled.
 You can also specify different types of logging to be enabled, for example `["query", "error", "schema"]`.
 Learn more about [Logging](./logging.md).
 
-* `logger` - Logger to be used for logging purposes. Possible values are "advanced-console", "simple-console" and "file". 
+* `logger` - Logger to be used for logging purposes. Possible values are "advanced-console", "simple-console" and "file".
 Default is "advanced-console". You can also specify a logger class that implements `Logger` interface.
 Learn more about [Logging](./logging.md).
 
@@ -111,51 +111,51 @@ Read more about caching [here](./caching.md).
 
 * `database` - Database name.
 
-* `charset` - The charset for the connection. This is called "collation" in the SQL-level of MySQL 
+* `charset` - The charset for the connection. This is called "collation" in the SQL-level of MySQL
 (like utf8_general_ci). If a SQL-level charset is specified (like utf8mb4) then the default collation for that charset is used. (Default: `UTF8_GENERAL_CI`).
 
-* `timezone` - the timezone configured on the MySQL server. This is used to typecast server date/time 
-values to JavaScript Date object and vice versa. This can be `local`, `Z`, or an offset in the form 
+* `timezone` - the timezone configured on the MySQL server. This is used to typecast server date/time
+values to JavaScript Date object and vice versa. This can be `local`, `Z`, or an offset in the form
 `+HH:MM` or `-HH:MM`. (Default: `local`)
 
 * `connectTimeout` - The milliseconds before a timeout occurs during the initial connection to the MySQL server.
  (Default: `10000`)
 
 * `acquireTimeout` - The milliseconds before a timeout occurs during the initial connection to the MySql server. It differs from `connectTimeout` as it governs the TCP connection timeout where as connectTimeout does not. (default: `10000`)
- 
-* `insecureAuth` - Allow connecting to MySQL instances that ask for the old (insecure) authentication method. 
+
+* `insecureAuth` - Allow connecting to MySQL instances that ask for the old (insecure) authentication method.
 (Default: `false`)
- 
-* `supportBigNumbers` - When dealing with big numbers (`BIGINT` and `DECIMAL` columns) in the database, 
+
+* `supportBigNumbers` - When dealing with big numbers (`BIGINT` and `DECIMAL` columns) in the database,
 you should enable this option (Default: `true`)
- 
-* `bigNumberStrings` - Enabling both `supportBigNumbers` and `bigNumberStrings` forces big numbers 
-(`BIGINT` and `DECIMAL` columns) to be always returned as JavaScript String objects (Default: `true`). 
-Enabling `supportBigNumbers` but leaving `bigNumberStrings` disabled will return big numbers as String 
-objects only when they cannot be accurately represented with 
-[JavaScript Number objects](http://ecma262-5.com/ELS5_HTML.htm#Section_8.5) 
-(which happens when they exceed the `[-2^53, +2^53]` range), otherwise they will be returned as 
+
+* `bigNumberStrings` - Enabling both `supportBigNumbers` and `bigNumberStrings` forces big numbers
+(`BIGINT` and `DECIMAL` columns) to be always returned as JavaScript String objects (Default: `true`).
+Enabling `supportBigNumbers` but leaving `bigNumberStrings` disabled will return big numbers as String
+objects only when they cannot be accurately represented with
+[JavaScript Number objects](http://ecma262-5.com/ELS5_HTML.htm#Section_8.5)
+(which happens when they exceed the `[-2^53, +2^53]` range), otherwise they will be returned as
 Number objects. This option is ignored if `supportBigNumbers` is disabled.
 
-* `dateStrings` - Force date types (`TIMESTAMP`, `DATETIME`, `DATE`) to be returned as strings rather than 
-inflated into JavaScript Date objects. Can be true/false or an array of type names to keep as strings. 
+* `dateStrings` - Force date types (`TIMESTAMP`, `DATETIME`, `DATE`) to be returned as strings rather than
+inflated into JavaScript Date objects. Can be true/false or an array of type names to keep as strings.
 (Default: `false`)
 
-* `debug` - Prints protocol details to stdout. Can be true/false or an array of packet type names that 
+* `debug` - Prints protocol details to stdout. Can be true/false or an array of packet type names that
 should be printed. (Default: `false`)
 
-* `trace` - Generates stack traces on Error to include call site of library entrance ("long stack traces"). 
+* `trace` - Generates stack traces on Error to include call site of library entrance ("long stack traces").
 Slight performance penalty for most calls. (Default: `true`)
 
-* `multipleStatements` - Allow multiple mysql statements per query. Be careful with this, it could increase the scope 
+* `multipleStatements` - Allow multiple mysql statements per query. Be careful with this, it could increase the scope
 of SQL injection attacks. (Default: `false`)
 
 * `legacySpatialSupport` - Use spatial functions like GeomFromText and AsText which are removed in MySQL 8. (Default: true)
 
 * `flags` - List of connection flags to use other than the default ones. It is also possible to blacklist default ones.
  For more information, check [Connection Flags](https://github.com/mysqljs/mysql#connection-flags).
- 
-* `ssl` -  object with ssl parameters or a string containing the name of ssl profile. 
+
+* `ssl` -  object with ssl parameters or a string containing the name of ssl profile.
 See [SSL options](https://github.com/mysqljs/mysql#ssl-options).
 
 ## `postgres` / `cockroachdb` connection options
@@ -174,7 +174,7 @@ See [SSL options](https://github.com/mysqljs/mysql#ssl-options).
 
 * `schema` - Schema name. Default is "public".
 
-* `connectTimeoutMS` - The milliseconds before a timeout occurs during the initial connection to the postgres server. If `undefined`, or set to `0`, there is no timeout. Defaults to `undefined`. 
+* `connectTimeoutMS` - The milliseconds before a timeout occurs during the initial connection to the postgres server. If `undefined`, or set to `0`, there is no timeout. Defaults to `undefined`.
 
 * `ssl` - Object with ssl parameters. See [TLS/SSL](https://node-postgres.com/features/ssl).
 
@@ -183,6 +183,8 @@ See [SSL options](https://github.com/mysqljs/mysql#ssl-options).
 * `poolErrorHandler` - A function that get's called when underlying pool emits `'error'` event. Takes single parameter (error instance) and defaults to logging with `warn` level.
 
 * `logNotifications` - A boolean to determine whether postgres server [notice messages](https://www.postgresql.org/docs/current/plpgsql-errors-and-messages.html) and [notification events](https://www.postgresql.org/docs/current/sql-notify.html) should be included in client's logs with `info` level (default: `false`).
+
+* `skipTypeNormalize` - A boolean to skip the normalization of the column type (default: `false`).
 
 ## `sqlite` connection options
 
@@ -236,27 +238,27 @@ See [SSL options](https://github.com/mysqljs/mysql#ssl-options).
 * `stream` - Stream recordsets/rows instead of returning them all at once as an argument of callback (default: `false`).
  You can also enable streaming for each request independently (`request.stream = true`). Always set to `true` if you plan to
  work with a large amount of rows.
- 
+
 * `pool.max` - The maximum number of connections there can be in the pool (default: `10`).
 
 * `pool.min` - The minimum of connections there can be in the pool (default: `0`).
 
 * `pool.maxWaitingClients` - maximum number of queued requests allowed, additional acquire calls will be callback with
  an err in a future cycle of the event loop.
- 
+
 * `pool.testOnBorrow` -  should the pool validate resources before giving them to clients. Requires that either
   `factory.validate` or `factory.validateAsync` to be specified.
-  
+
 * `pool.acquireTimeoutMillis` - max milliseconds an `acquire` call will wait for a resource before timing out.
  (default no limit), if supplied should non-zero positive integer.
- 
+
 * `pool.fifo` - if true the oldest resources will be first to be allocated. If false the most recently released resources
  will be the first to be allocated. This in effect turns the pool's behaviour from a queue into a stack. boolean,
  (default `true`).
- 
+
 * `pool.priorityRange` - int between 1 and x - if set, borrowers can specify their relative priority in the queue if no
  resources are available. see example. (default `1`).
- 
+
 * `pool.autostart` - boolean, should the pool start creating resources etc once the constructor is called, (default `true`).
 
 * `pool.evictionRunIntervalMillis` - How often to run eviction checks. Default: `0` (does not run).
@@ -266,22 +268,22 @@ See [SSL options](https://github.com/mysqljs/mysql#ssl-options).
 * `pool.softIdleTimeoutMillis` - amount of time an object may sit idle in the pool before it is eligible for eviction by
  the idle object evictor (if any), with the extra condition that at least "min idle" object instances remain in the pool.
  Default `-1` (nothing can get evicted).
- 
+
 * `pool.idleTimeoutMillis` -  the minimum amount of time that an object may sit idle in the pool before it is eligible for
  eviction due to idle time. Supersedes `softIdleTimeoutMillis`. Default: `30000`.
- 
+
  * `pool.errorHandler` - A function that get's called when underlying pool emits `'error'` event. Takes single parameter (error instance) and defaults to logging with `warn` level.
- 
+
 * `options.fallbackToDefaultDb` - By default, if the database requestion by `options.database` cannot be accessed, the connection
  will fail with an error. However, if `options.fallbackToDefaultDb` is set to `true`, then the user's default database will
   be used instead (Default: `false`).
-  
+
 * `options.instanceName` - The instance name to connect to. The SQL Server Browser service must be running on the database server, and UDP port 1434 on the database server must be reachable. Mutually exclusive with `port`. (no default).
 
 * `options.enableAnsiNullDefault` - If true, SET ANSI_NULL_DFLT_ON ON will be set in the initial sql. This means new
  columns will be nullable by default. See the [T-SQL documentation](https://msdn.microsoft.com/en-us/library/ms187375.aspx)
  for more details. (Default: `true`).
- 
+
 * `options.cancelTimeout` - The number of milliseconds before the cancel (abort) of a request is considered failed (default: `5000`).
 
 * `options.packetSize` - The size of TDS packets (subject to negotiation with the server). Should be a power of 2. (default: `4096`).
@@ -306,9 +308,9 @@ See [SSL options](https://github.com/mysqljs/mysql#ssl-options).
    * `REPEATABLE_READ`
    * `SERIALIZABLE`
    * `SNAPSHOT`
-   
+
    (default: `READ_COMMITTED`)
- 
+
 * `options.connectionIsolationLevel` - The default isolation level for new connections. All out-of-transaction queries
  are executed with this setting. The isolation levels are available from `require('tedious').ISOLATION_LEVEL`.
    * `READ_UNCOMMITTED`
@@ -316,23 +318,23 @@ See [SSL options](https://github.com/mysqljs/mysql#ssl-options).
    * `REPEATABLE_READ`
    * `SERIALIZABLE`
    * `SNAPSHOT`
-   
+
    (default: `READ_COMMITTED`)
- 
+
 * `options.readOnlyIntent` - A boolean, determining whether the connection will request read-only access from a
  SQL Server Availability Group. For more information, see here. (default: `false`).
 
 * `options.encrypt` - A boolean determining whether or not the connection will be encrypted. Set to true if you're
  on Windows Azure. (default: `false`).
- 
+
 * `options.cryptoCredentialsDetails` - When encryption is used, an object may be supplied that will be used for the
  first argument when calling [tls.createSecurePair](http://nodejs.org/docs/latest/api/tls.html#tls_tls_createsecurepair_credentials_isserver_requestcert_rejectunauthorized)
   (default: `{}`).
-  
+
 * `options.rowCollectionOnDone` - A boolean, that when true will expose received rows in Requests' `done*` events.
  See done, [doneInProc](http://tediousjs.github.io/tedious/api-request.html#event_doneInProc)
  and [doneProc](http://tediousjs.github.io/tedious/api-request.html#event_doneProc). (default: `false`)
-   
+
    Caution: If many rows are received, enabling this option could result in excessive memory usage.
 
 * `options.rowCollectionOnRequestCompletion` - A boolean, that when true will expose received rows
@@ -347,18 +349,18 @@ See [SSL options](https://github.com/mysqljs/mysql#ssl-options).
    * `7_3_A`
    * `7_3_B`
    * `7_4`
-   
+
   (default: `7_4`)
 
 * `options.debug.packet` - A boolean, controlling whether `debug` events will be emitted with text describing packet
  details (default: `false`).
- 
+
 * `options.debug.data` - A boolean, controlling whether `debug` events will be emitted with text describing packet data
  details (default: `false`).
- 
+
 * `options.debug.payload` - A boolean, controlling whether `debug` events will be emitted with text describing packet
  payload details (default: `false`).
- 
+
 * `options.debug.token` - A boolean, controlling whether `debug` events will be emitted with text describing token stream
  tokens (default: `false`).
 
@@ -378,19 +380,19 @@ See [SSL options](https://github.com/mysqljs/mysql#ssl-options).
 
 * `sslValidate` - Validate mongod server certificate against ca (needs to have a mongod server with ssl support,
  2.4 or higher). Default: `true`.
- 
+
 * `sslCA` - Array of valid certificates either as Buffers or Strings (needs to have a mongod server with ssl support,
  2.4 or higher).
- 
+
 * `sslCert` - String or buffer containing the certificate we wish to present (needs to have a mongod server with ssl
  support, 2.4 or higher)
- 
+
 * `sslKey` - String or buffer containing the certificate private key we wish to present (needs to have a mongod server
  with ssl support, 2.4 or higher).
- 
+
 * `sslPass` - String or buffer containing the certificate password (needs to have a mongod server with ssl support,
  2.4 or higher).
- 
+
 * `autoReconnect` - Reconnect on error. Default: `true`.
 
 * `noDelay` - TCP Socket NoDelay option. Default: `true`.
@@ -410,13 +412,13 @@ See [SSL options](https://github.com/mysqljs/mysql#ssl-options).
 * `haInterval` - Time between each replicaset status check. Default: `10000,5000`.
 
 * `replicaSet` - The name of the replicaset to connect to.
- 
+
 * `acceptableLatencyMS` - Sets the range of servers to pick when using NEAREST (lowest ping ms + the latency fence,
  ex: range of 1 to (1 + 15) ms). Default: `15`.
 
 * `secondaryAcceptableLatencyMS` - Sets the range of servers to pick when using NEAREST (lowest ping ms + the latency
  fence, ex: range of 1 to (1 + 15) ms). Default: `15`.
- 
+
 * `connectWithNoPrimary` - Sets if the driver should connect even if no primary is available. Default: `false`.
 
 * `authSource` - If the database authentication is dependent on another databaseName.
@@ -441,20 +443,20 @@ See [SSL options](https://github.com/mysqljs/mysql#ssl-options).
 
 * `promoteValues` - Promotes BSON values to native types where possible, set to false to only receive wrapper types.
  Default: `true`.
- 
+
 * `domainsEnabled` - Enable the wrapping of the callback in the current domain, disabled by default to avoid perf hit.
  Default: `false`.
- 
+
 * `bufferMaxEntries` - Sets a cap on how many operations the driver will buffer up before giving up on getting a
  working connection, default is -1 which is unlimited.
- 
+
 * `readPreference` - The preferred read preference.
   * `ReadPreference.PRIMARY`
   * `ReadPreference.PRIMARY_PREFERRED`
   * `ReadPreference.SECONDARY`
   * `ReadPreference.SECONDARY_PREFERRED`
   * `ReadPreference.NEAREST`
-  
+
 * `pkFactory` - A primary key factory object for generation of custom _id keys.
 
 * `promiseLibrary` - A Promise library class the application wishes to use such as Bluebird, must be ES6 compatible.
@@ -466,7 +468,7 @@ See [SSL options](https://github.com/mysqljs/mysql#ssl-options).
 * `appname` - The name of the application that created this MongoClient instance. MongoDB 3.4 and newer will print this
  value in the server log upon establishing each connection. It is also recorded in the slow query log and profile
  collections
- 
+
 * `loggerLevel` - Specify the log level used by the driver logger (`error/warn/info/debug`).
 
 * `logger` - Specify a customer logger mechanism, can be used to log using your app level logger.

--- a/src/driver/postgres/PostgresConnectionOptions.ts
+++ b/src/driver/postgres/PostgresConnectionOptions.ts
@@ -57,4 +57,9 @@ export interface PostgresConnectionOptions extends BaseConnectionOptions, Postgr
      * Include notification messages from Postgres server in client logs
      */
     readonly logNotifications?: boolean;
+
+    /**
+     * Should skip normalize for the table column generation
+     */
+    readonly skipTypeNormalize?: boolean
 }

--- a/src/driver/postgres/PostgresConnectionOptions.ts
+++ b/src/driver/postgres/PostgresConnectionOptions.ts
@@ -59,7 +59,7 @@ export interface PostgresConnectionOptions extends BaseConnectionOptions, Postgr
     readonly logNotifications?: boolean;
 
     /**
-     * Should skip normalize for the table column generation
+     * Should skip normalization for the table column generation
      */
     readonly skipTypeNormalize?: boolean
 }

--- a/src/driver/postgres/PostgresDriver.ts
+++ b/src/driver/postgres/PostgresDriver.ts
@@ -658,6 +658,10 @@ export class PostgresDriver implements Driver {
      * Creates a database type from a given column metadata.
      */
     normalizeType(column: { type?: ColumnType, length?: number | string, precision?: number|null, scale?: number, isArray?: boolean }): string {
+        if (column.type && this.options.skipTypeNormalize) {
+            return column.type as string;
+        }
+
         if (column.type === Number || column.type === "int" || column.type === "int4") {
             return "integer";
 


### PR DESCRIPTION
### Description of change
The idea of the change ti allow generation of table schema without column name normalization is that it allows to generate schema for databases where you want to use a strict column type. This change only is made currently for postgres but could be added to other database driver as well if needed.

### Pull-Request Checklist

<!--
  Please make sure to review and check all of the following.

  If an item is not applicable, you can add "N/A" to the end.
-->

- [x] Code is up-to-date with the `master` branch
- [x] `npm run lint` passes with this change
- [x] `npm run test` passes with this change
- [x] This pull request links relevant issues as `Fixes #0000`
- [x] There are new or updated unit tests validating the change
- [x] Documentation has been updated to reflect this change
- [X] The new commits follow conventions explained in [CONTRIBUTING.md](https://github.com/typeorm/typeorm/blob/master/CONTRIBUTING.md)