### PR TITLE
feat: upsert/query-builder insert or update all columns

### DIFF
--- a/docs/entity-manager-api.md
+++ b/docs/entity-manager-api.md
@@ -123,18 +123,40 @@ await manager.remove([
 * `insert` - Inserts a new entity, or array of entities.
 
 ```typescript
-await manager.insert(User, { 
-    firstName: "Timber", 
-    lastName: "Timber" 
+await manager.insert(User, {
+    firstName: "Timber",
+    lastName: "Timber"
 });
 
-await manager.insert(User, [{ 
-    firstName: "Foo", 
-    lastName: "Bar" 
-}, { 
-    firstName: "Rizz", 
-    lastName: "Rak" 
+await manager.insert(User, [{
+    firstName: "Foo",
+    lastName: "Bar"
+}, {
+    firstName: "Rizz",
+    lastName: "Rak"
 }]);
+```
+
+* `upsert` - Inserts a new entity or updates an existing entity, or array of entities.
+
+```typescript
+await manager.upsert(User, {
+    id: 1,
+    firstName: "Timber",
+    lastName: "Timber"
+}, {columns: ['id']}); // Conflict columns not needed for MySQL
+// executes INSERT with ON CONFLICT ... DO UPDATE (Postgres)
+// executes INSERT with ON DUPLICATE KEY UPDATE (MySQL)
+
+await manager.upsert(User, [{
+    id: 1,
+    firstName: "Foo",
+    lastName: "Bar"
+}, {
+    id: 2,
+    firstName: "Rizz",
+    lastName: "Rak"
+}], {columns: ['id']});
 ```
 
 * `update` - Partially updates entity by a given update options or entity id.

--- a/docs/repository-api.md
+++ b/docs/repository-api.md
@@ -135,13 +135,35 @@ await repository.insert({
 });
 
 
-await manager.insert(User, [{
+await repository.insert([{
     firstName: "Foo",
     lastName: "Bar"
 }, {
     firstName: "Rizz",
     lastName: "Rak"
 }]);
+```
+
+* `upsert` - Inserts a new entity or updates an existing entity, or array of entities.
+
+```typescript
+await repository.upsert({
+    id: 1,
+    firstName: "Timber",
+    lastName: "Timber"
+}, {columns: ['id']}); // Conflict columns not needed for MySQL
+// executes INSERT with ON CONFLICT ... DO UPDATE (Postgres)
+// executes INSERT with ON DUPLICATE KEY UPDATE (MySQL)
+
+await repository.upsert([{
+    id: 1,
+    firstName: "Foo",
+    lastName: "Bar"
+}, {
+    id: 2,
+    firstName: "Rizz",
+    lastName: "Rak"
+}], {columns: ['id']});
 ```
 
 * `update` - Partially updates entity by a given update options or entity id.

--- a/src/query-builder/QueryExpressionMap.ts
+++ b/src/query-builder/QueryExpressionMap.ts
@@ -90,7 +90,7 @@ export class QueryExpressionMap {
     /**
      * Optional on update statement used in insertion query in databases.
      */
-    onUpdate: { columns?: string, conflict?: string, overwrite?: string };
+    onUpdate: { columns?: string[], conflict?: { columns?: string[], constraint?: string }, overwrite?: string[] | boolean };
 
     /**
      * JOIN queries.

--- a/src/repository/Repository.ts
+++ b/src/repository/Repository.ts
@@ -232,6 +232,16 @@ export class Repository<Entity extends ObjectLiteral> {
     }
 
     /**
+     * Upserts a given entity into the database.
+     * Unlike save method executes a primitive operation without cascades, relations and other operations included.
+     * Executes fast and efficient UPSERT / INSERT ON CONFLICT / INSERT ON DUPLICATE KEY query.
+     * You can execute bulk inserts using this method.
+     */
+    upsert(entity: QueryDeepPartialEntity<Entity>|(QueryDeepPartialEntity<Entity>[])): Promise<InsertResult> {
+        return this.manager.upsert(this.metadata.target as any, entity);
+    }
+
+    /**
      * Updates entity partially. Entity can be found by a given conditions.
      * Unlike save method executes a primitive operation without cascades, relations and other operations included.
      * Executes fast and efficient UPDATE query.

--- a/test/functional/query-builder/insert-or-update/entity/Post.ts
+++ b/test/functional/query-builder/insert-or-update/entity/Post.ts
@@ -1,0 +1,14 @@
+import {Entity} from "../../../../../src/decorator/entity/Entity";
+import {Column} from "../../../../../src/decorator/columns/Column";
+import {PrimaryColumn} from "../../../../../src/decorator/columns/PrimaryColumn";
+
+@Entity()
+export class Post {
+
+    @PrimaryColumn()
+    id: string;
+
+    @Column()
+    title: string;
+
+}

--- a/test/functional/query-builder/insert-or-update/query-builder-insert-or-update.ts
+++ b/test/functional/query-builder/insert-or-update/query-builder-insert-or-update.ts
@@ -1,0 +1,78 @@
+import "reflect-metadata";
+import {closeTestingConnections, createTestingConnections, reloadTestingDatabases} from "../../../utils/test-utils";
+import {Connection} from "../../../../src/connection/Connection";
+import {Post} from "./entity/Post";
+
+describe("query builder > insertion > or update", () => {
+
+    let connections: Connection[];
+    before(async () => connections = await createTestingConnections({
+        entities: [__dirname + "/entity/*{.js,.ts}"],
+        enabledDrivers: ["mysql", "postgres", "sqlite", "better-sqlite3"] // only supported in mysql, postgres and sqlite >= 3.24.0
+    }));
+    beforeEach(() => reloadTestingDatabases(connections));
+    after(() => closeTestingConnections(connections));
+
+    it("should perform insertion or update correctly", () => Promise.all(connections.map(async connection => {
+
+        const post1 = new Post();
+        post1.id = "post#1";
+        post1.title = "About post";
+
+        await connection.createQueryBuilder()
+            .insert()
+            .into(Post)
+            .values(post1)
+            .execute();
+
+        const post2 = new Post();
+        post2.id = "post#1";
+        post2.title = "Again post";
+
+        await connection.createQueryBuilder()
+            .insert()
+            .into(Post)
+            .values(post2)
+            .orUpdate({overwrite: ["title"], conflict: {columns: ["id"]}})
+            .execute();
+
+        await connection.manager.findOne(Post, "post#1").should.eventually.be.eql({
+            id: "post#1",
+            title: "Again post"
+        });
+
+        const post3 = new Post();
+        post3.id = "post#1";
+        post3.title = "Yet again post";
+
+        await connection.createQueryBuilder()
+            .insert()
+            .into(Post)
+            .values(post3)
+            .orUpdate({columns: ["title"], conflict: {columns: ["id"]}})
+            .setParameter("title", post3.title)
+            .execute();
+
+        await connection.manager.findOne(Post, "post#1").should.eventually.be.eql({
+            id: "post#1",
+            title: "Yet again post"
+        });
+
+        const post4 = new Post();
+        post4.id = "post#1";
+        post4.title = "And yet again post";
+
+        await connection.createQueryBuilder()
+            .insert()
+            .into(Post)
+            .values(post4)
+            .orUpdate({overwrite: true, conflict: {columns: ["id"]}})
+            .execute();
+
+        await connection.manager.findOne(Post, "post#1").should.eventually.be.eql({
+            id: "post#1",
+            title: "And yet again post"
+        });
+    })));
+
+});


### PR DESCRIPTION
Improves `InsertQueryBuilder.orUpdate` to allow all columns being inserted to be automatically listed in the `ON CONFLICT DO UPDATE` / `ON DUPLICATE KEY UPDATE` clauses (postgre/mysql).

`EntityManager.upsert` with this enabled.

Fixes: #1090

<!--
  😀 Wonderful!  Thank you for opening a pull request for TypeORM.

  Please fill in the information below to expedite the review
  and (hopefully) merge of your change.

  If unsure about something.. just do as best as you're able,
  or reach out through our community support channels!
  https://github.com/typeorm/typeorm/blob/master/docs/support.md
-->

### Description of change

<!--
  Please be clear and concise what the change is intended to do,
  why this change is needed, and how you've verified that it
  corrects what you intended.

  In some cases it may be helpful to include the current behavior
  and the new behavior.

  If the change is related to an open issue, you can link it here.
  If you include `Fixes #0000` (replacing `0000` with the issue number)
  when this is merged it will automatically mark the issue as fixed and
  close it.
-->


### Pull-Request Checklist

<!--
  Please make sure to review and check all of the following.

  If an item is not applicable, you can add "N/A" to the end.
-->

- [x] Code is up-to-date with the `master` branch
- [x] `npm run lint` passes with this change
- [x] `npm run test` passes with this change
- [x] This pull request links relevant issues as `Fixes #0000`
- [x] There are new or updated unit tests validating the change
- [x] Documentation has been updated to reflect this change
- [x] The new commits follow conventions explained in [CONTRIBUTING.md](https://github.com/typeorm/typeorm/blob/master/CONTRIBUTING.md)

<!--
  🎉 Thank you for contributing and making TypeORM even better!
-->
