### PR TITLE
docs: fix javascript usage examples

### DIFF
--- a/docs/usage-with-javascript.md
+++ b/docs/usage-with-javascript.md
@@ -58,7 +58,9 @@ typeorm.createConnection({
 ##### entity/Category.js
 
 ```typescript
-module.exports = {
+var EntitySchema = require("typeorm").EntitySchema;
+
+module.exports = new EntitySchema({
     name: "Category", // Will use table name `category` as default behaviour.
     tableName: "categories", // Optional: Provide `tableName` property to override the default behaviour for table name. 
     columns: {
@@ -68,16 +70,18 @@ module.exports = {
             generated: true
         },
         name: {
-            type: "string"
+            type: "varchar"
         }
     }
-};
+});
 ```
 
 ##### entity/Post.js
 
 ```typescript
-module.exports = {
+var EntitySchema = require("typeorm").EntitySchema;
+
+module.exports = new EntitySchema({
     name: "Post", // Will use table name `post` as default behaviour.
     tableName: "posts", // Optional: Provide `tableName` property to override the default behaviour for table name. 
     columns: {
@@ -87,7 +91,7 @@ module.exports = {
             generated: true
         },
         title: {
-            type: "string"
+            type: "varchar"
         },
         text: {
             type: "text"
@@ -101,7 +105,7 @@ module.exports = {
             cascade: true
         }
     }
-};
+});
 ```
 
 You can checkout this example [typeorm/javascript-example](https://github.com/typeorm/javascript-example) to learn more.

--- a/docs/zh_CN/usage-with-javascript.md
+++ b/docs/zh_CN/usage-with-javascript.md
@@ -17,7 +17,10 @@ typeorm
     password: "admin",
     database: "test",
     synchronize: true,
-    entitySchemas: [require("./entity/Post"), require("./entity/Category")]
+    entities: [
+        require("./entity/Post"), 
+        require("./entity/Category")
+    ]
   })
   .then(function(connection) {
     var category1 = {
@@ -54,7 +57,9 @@ typeorm
 ##### entity/Category.js
 
 ```typescript
-module.exports = {
+var EntitySchema = require("typeorm").EntitySchema;
+
+module.exports = new EntitySchema({
   name: "Category",
   columns: {
     id: {
@@ -63,16 +68,18 @@ module.exports = {
       generated: true
     },
     name: {
-      type: "string"
+      type: "varchar"
     }
   }
-};
+});
 ```
 
 ##### entity/Post.js
 
 ```typescript
-module.exports = {
+var EntitySchema = require("typeorm").EntitySchema;
+
+module.exports = new EntitySchema({
   name: "Post",
   columns: {
     id: {
@@ -81,7 +88,7 @@ module.exports = {
       generated: true
     },
     title: {
-      type: "string"
+      type: "varchar"
     },
     text: {
       type: "text"
@@ -95,7 +102,7 @@ module.exports = {
       cascade: true
     }
   }
-};
+});
 ```
 
 您可以查看此示例[typeorm/javascript-example](https://github.com/typeorm/javascript-example)以了解更多信息。


### PR DESCRIPTION

### Description of change
Updated Javascript usage example in docs/usage-with-javascript.md and docs/zh_CN/usage-with-javascript.md to pass EntitySchema objects in the ConnectionOptions instead of plain objects and changed type:"string" in the schemas to type:"varchar". Also updated docs/zh_CN/usage-with-javascript.md to use "entities" instead of "entitySchemas" in the ConnectionOptions.
