### PR TITLE
fix: handle overlapping property / database names in querybuilder

### DIFF
--- a/test/github-issues/7030/entity/Post.ts
+++ b/test/github-issues/7030/entity/Post.ts
@@ -1,0 +1,20 @@
+import { Column, Entity, PrimaryGeneratedColumn } from '../../../../src';
+
+
+@Entity()
+export class Post {
+
+    @PrimaryGeneratedColumn({
+        type: 'integer',
+        name: 'id',
+    })
+    oldId: number;
+
+    @Column({
+        nullable: false,
+        unique: true,
+        length: 38,
+        name: 'new_id',
+    })
+    id: string;
+}

--- a/test/github-issues/7030/issue-7030.ts
+++ b/test/github-issues/7030/issue-7030.ts
@@ -1,0 +1,37 @@
+import { expect } from "chai";
+import {Connection} from "../../../src/connection/Connection";
+import {
+    createTestingConnections,
+    closeTestingConnections,
+    reloadTestingDatabases,
+} from "../../utils/test-utils";
+import {Post} from "./entity/Post";
+
+describe("github issues > #7030", () => {
+    let connections: Connection[];
+
+    before(async () => connections = await createTestingConnections({
+        entities: [Post],
+        schemaCreate: true,
+        dropSchema: true,
+        enabledDrivers: ["postgres"]
+    }));
+
+    beforeEach(() => reloadTestingDatabases(connections));
+    after(() => closeTestingConnections(connections));
+
+    it("should insert and fetch from the expected column", () => Promise.all(connections.map(async connection => {
+        const id = '123e4567-e89b-12d3-a456-426614174000'
+
+        const post = new Post();
+        post.id = id;
+
+        let postRepository = connection.getRepository(Post);
+
+        await postRepository.save(post);
+
+        const actualPost = await postRepository.findOneOrFail({ id });
+
+        expect(actualPost!.id).to.be.equal(id);
+    })));
+});


### PR DESCRIPTION
<!--
  😀 Wonderful!  Thank you for opening a pull request for TypeORM.

  Please fill in the information below to expedite the review
  and (hopefully) merge of your change.

  If unsure about something.. just do as best as you're able,
  or reach out through our community support channels!
  https://github.com/typeorm/typeorm/blob/master/docs/support.md
-->

### Description of change

<!--
  Please be clear and concise what the change is intended to do,
  why this change is needed, and how you've verified that it
  corrects what you intended.

  In some cases it may be helpful to include the current behavior
  and the new behavior.

  If the change is related to an open issue, you can link it here.
  If you include `Fixes #0000` (replacing `0000` with the issue number)
  when this is merged it will automatically mark the issue as fixed and
  close it.
-->

we should always prioritize replacement of any property path first,
then property names, then database names, then relation values
whenever there's ambiguous values

fixes #7030


### Pull-Request Checklist

<!--
  Please make sure to review and check all of the following.

  If an item is not applicable, you can add "N/A" to the end.
-->

- [x] Code is up-to-date with the `master` branch
- [x] `npm run lint` passes with this change
- [ ] `npm run test` passes with this change
- [x] This pull request links relevant issues as `Fixes #0000`
- [x] There are new or updated unit tests validating the change
- [x] Documentation has been updated to reflect this change (N/A)
- [x] The new commits follow conventions explained in [CONTRIBUTING.md](https://github.com/typeorm/typeorm/blob/master/CONTRIBUTING.md)

<!--
  🎉 Thank you for contributing and making TypeORM even better!
-->
