### PR TITLE
fix: Fix CLI query command TypeError

### DIFF
--- a/src/commands/QueryCommand.ts
+++ b/src/commands/QueryCommand.ts
@@ -53,8 +53,9 @@ export class QueryCommand implements yargs.CommandModule {
 
             // create a query runner and execute query using it
             queryRunner = connection.createQueryRunner();
-            console.log(chalk.green("Running query: ") + PlatformTools.highlightSql(args._[1]));
-            const queryResult = await queryRunner.query(args._[1]);
+            const query = args.query as string;
+            console.log(chalk.green("Running query: ") + PlatformTools.highlightSql(query));
+            const queryResult = await queryRunner.query(query);
 
             if (typeof queryResult === "undefined") {
                 console.log(chalk.green("Query has been executed. No result was returned."));


### PR DESCRIPTION
Fix TypeError in CLI query command. 

<!--
  😀 Wonderful!  Thank you for opening a pull request for TypeORM.

  Please fill in the information below to expedite the review
  and (hopefully) merge of your change.

  If unsure about something.. just do as best as you're able,
  or reach out through our community support channels!
  https://github.com/typeorm/typeorm/blob/master/docs/support.md
-->

### Description of change
Switch to using the named query property for the CLI `query` command. https://github.com/typeorm/typeorm/pull/6899 modified the command definition with a named positional argument. This leads to an error in 0.2.29 when executing e.g. When executing `npx typeorm query -f path/to/ormconfig.js "query" "SELECT 1"`:
```
Error during query execution:
TypeError: Cannot read property 'replace' of undefined
    at escape (/projectPath/node_modules/highlight.js/lib/highlight.js:71:18)
    at Object.highlight (/projectPath/node_modules/highlight.js/lib/highlight.js:799:18)
    at Object.highlight (/projectPath/node_modules/cli-highlight/dist/index.js:76:21)
    at Function.PlatformTools.highlightSql (/projectPath/node_modules/typeorm/platform/PlatformTools.js:186:32)
    at Object.<anonymous> (/projectPath/node_modules/typeorm/commands/QueryCommand.js:64:110)
    at step (/projectPath/node_modules/tslib/tslib.js:141:27)
    at Object.next (/projectPath/node_modules/tslib/tslib.js:122:57)
    at fulfilled (/projectPath/node_modules/tslib/tslib.js:112:62)
```


Example `args` object in last working cli query version 0.2.26:
```javascript
{
  _: [ 'query', 'SELECT 1' ],
  f: 'build/db/ormconfig.js',
  config: 'build/db/ormconfig.js',
  c: 'default',
  connection: 'default',
  '$0': 'node_modules/typeorm/cli'
}
```

Example `args` object in 0.2.29:
```javascript
 {
  _: [ 'query' ],
  f: 'build/db/ormconfig.js',
  config: 'build/db/ormconfig.js',
  c: 'default',
  connection: 'default',
  '$0': 'node_modules/typeorm/cli',
  query: 'SELECT 1'
}
```

Fixes #7044 

<!--
  Please be clear and concise what the change is intended to do,
  why this change is needed, and how you've verified that it
  corrects what you intended.

  In some cases it may be helpful to include the current behavior
  and the new behavior.

  If the change is related to an open issue, you can link it here.
  If you include `Fixes #0000` (replacing `0000` with the issue number)
  when this is merged it will automatically mark the issue as fixed and
  close it.
-->


### Pull-Request Checklist

<!--
  Please make sure to review and check all of the following.

  If an item is not applicable, you can add "N/A" to the end.
-->

- [x] Code is up-to-date with the `master` branch
- [x] `npm run lint` passes with this change
- [x] `npm run test` passes with this change
- [x] This pull request links relevant issues as `Fixes #0000`
- [ ] There are new or updated unit tests validating the change- _I cannot see any existing tests for the CLI_
- [ ] Documentation has been updated to reflect this change N/A
- [x] The new commits follow conventions explained in [CONTRIBUTING.md](https://github.com/typeorm/typeorm/blob/master/CONTRIBUTING.md)

<!--
  🎉 Thank you for contributing and making TypeORM even better!
-->
