### PR TITLE
fix: resolve migration for UpdateDateColumn without ON UPDATE clause

### DIFF
--- a/src/metadata/ColumnMetadata.ts
+++ b/src/metadata/ColumnMetadata.ts
@@ -421,6 +421,8 @@ export class ColumnMetadata {
                 this.type = options.connection.driver.mappedDataTypes.updateDate;
             if (!this.default)
                 this.default = () => options.connection.driver.mappedDataTypes.updateDateDefault;
+            if (!this.onUpdate)
+                this.onUpdate = options.connection.driver.mappedDataTypes.updateDateDefault;
             if (this.precision === undefined && options.connection.driver.mappedDataTypes.updateDatePrecision)
                 this.precision = options.connection.driver.mappedDataTypes.updateDatePrecision;
         }

--- a/test/github-issues/6995/entity/default-update-date.ts
+++ b/test/github-issues/6995/entity/default-update-date.ts
@@ -1,0 +1,16 @@
+import { PrimaryGeneratedColumn, CreateDateColumn, UpdateDateColumn, Entity } from '../../../../src';
+
+@Entity()
+export class DefaultUpdateDate {
+
+	@PrimaryGeneratedColumn({
+		type: "int"
+	})
+	public id: number;
+
+	@CreateDateColumn()
+	public createdDate: Date;
+
+	@UpdateDateColumn()
+	public updatedDate: Date;
+}

--- a/test/github-issues/6995/issue-6995.ts
+++ b/test/github-issues/6995/issue-6995.ts
@@ -1,0 +1,25 @@
+import "reflect-metadata";
+import { Connection } from "../../../src";
+import { createTestingConnections, closeTestingConnections } from "../../utils/test-utils";
+import { DefaultUpdateDate } from './entity/default-update-date';
+
+describe("github issues > #6995 Generating migrations for UpdateDateColumn should generate on update clause", () => {
+
+    let connections: Connection[];
+    before(async () => connections = await createTestingConnections({
+        migrations: [],
+        enabledDrivers: ["mysql", "mariadb"],
+        schemaCreate: false,
+        dropSchema: true,
+        entities: [DefaultUpdateDate]
+    }));
+    after(() => closeTestingConnections(connections));
+
+    it("should create migration with default ON UPDATE clause", () => Promise.all(connections.map(async connection => {
+
+        const sqlInMemory = await connection.driver.createSchemaBuilder().log();
+        sqlInMemory.upQueries.filter(i => i.query.includes("ON UPDATE")).length.should.be.greaterThan(0);
+
+    })));
+
+});


### PR DESCRIPTION
Closes: #6995

<!--
  😀 Wonderful!  Thank you for opening a pull request for TypeORM.

  Please fill in the information below to expedite the review
  and (hopefully) merge of your change.

  If unsure about something.. just do as best as you're able,
  or reach out through our community support channels!
  https://github.com/typeorm/typeorm/blob/master/docs/support.md
-->

### Description of change
When generating migration for MySQL and MariaDB, `@UpdateDateColumn()` now generate a default `ON UPDATE` clause in the `up()` method
<!--
  Please be clear and concise what the change is intended to do,
  why this change is needed, and how you've verified that it
  corrects what you intended.

  In some cases it may be helpful to include the current behavior
  and the new behavior.

  If the change is related to an open issue, you can link it here.
  If you include `Fixes #0000` (replacing `0000` with the issue number)
  when this is merged it will automatically mark the issue as fixed and
  close it.
-->


### Pull-Request Checklist

<!--
  Please make sure to review and check all of the following.

  If an item is not applicable, you can add "N/A" to the end.
-->

- [x] Code is up-to-date with the `master` branch
- [x] `npm run lint` passes with this change
- [x] `npm run test` passes with this change
- [x] This pull request links relevant issues as `Fixes #0000`
- [x] There are new or updated unit tests validating the change
- [ ] Documentation has been updated to reflect this change
- [x] The new commits follow conventions explained in [CONTRIBUTING.md](https://github.com/typeorm/typeorm/blob/master/CONTRIBUTING.md)

<!--
  🎉 Thank you for contributing and making TypeORM even better!
-->
