### PR TITLE
fix: Error when sorting by an embedded entity while using join and skip/take

### DIFF
--- a/src/query-builder/SelectQueryBuilder.ts
+++ b/src/query-builder/SelectQueryBuilder.ts
@@ -2007,9 +2007,11 @@ export class SelectQueryBuilder<Entity> extends QueryBuilder<Entity> implements 
         const selectString = Object.keys(orderBys)
             .map(orderCriteria => {
                 if (orderCriteria.indexOf(".") !== -1) {
-                    const [aliasName, propertyPath] = orderCriteria.split(".");
+                    const criteriaParts = orderCriteria.split(".");
+                    const aliasName = criteriaParts[0];
+                    const propertyPath = criteriaParts.slice(1).join(".");
                     const alias = this.expressionMap.findAliasByName(aliasName);
-                    const column = alias.metadata.findColumnWithPropertyName(propertyPath);
+                    const column = alias.metadata.findColumnWithPropertyPath(propertyPath);
                     return this.escape(parentAlias) + "." + this.escape(DriverUtils.buildColumnAlias(this.connection.driver, aliasName, column!.databaseName));
                 } else {
                     if (this.expressionMap.selects.find(select => select.selection === orderCriteria || select.aliasName === orderCriteria))
@@ -2023,9 +2025,11 @@ export class SelectQueryBuilder<Entity> extends QueryBuilder<Entity> implements 
         const orderByObject: OrderByCondition = {};
         Object.keys(orderBys).forEach(orderCriteria => {
             if (orderCriteria.indexOf(".") !== -1) {
-                const [aliasName, propertyPath] = orderCriteria.split(".");
+                const criteriaParts = orderCriteria.split(".");
+                const aliasName = criteriaParts[0];
+                const propertyPath = criteriaParts.slice(1).join(".");
                 const alias = this.expressionMap.findAliasByName(aliasName);
-                const column = alias.metadata.findColumnWithPropertyName(propertyPath);
+                const column = alias.metadata.findColumnWithPropertyPath(propertyPath);
                 orderByObject[this.escape(parentAlias) + "." + this.escape(DriverUtils.buildColumnAlias(this.connection.driver, aliasName, column!.databaseName))] = orderBys[orderCriteria];
             } else {
                 if (this.expressionMap.selects.find(select => select.selection === orderCriteria || select.aliasName === orderCriteria)) {

--- a/test/github-issues/7079/entities.ts
+++ b/test/github-issues/7079/entities.ts
@@ -1,0 +1,43 @@
+import { Column, Entity, ManyToOne, OneToMany, PrimaryGeneratedColumn } from "../../../src";
+
+
+@Entity()
+export class User {
+    @PrimaryGeneratedColumn()
+    id: number;
+
+    @Column()
+    name: string;
+
+    @OneToMany(
+        () => Post,
+        (post) => post.user,
+    )
+    posts: Post[];
+}
+
+export class PublishInfo {
+    @Column({ nullable: true })
+    date: Date;
+}
+
+@Entity()
+export class Post {
+    @PrimaryGeneratedColumn()
+    id: number;
+
+    @Column()
+    text: string;
+
+    @Column(_type => PublishInfo)
+    blog: PublishInfo;
+
+    @Column(_type => PublishInfo)
+    newsletter: PublishInfo;
+
+    @ManyToOne(
+        () => User,
+        (user) => user.posts,
+    )
+    user: User
+}

--- a/test/github-issues/7079/issue-7079.ts
+++ b/test/github-issues/7079/issue-7079.ts
@@ -1,0 +1,62 @@
+import "reflect-metadata";
+import { createTestingConnections, closeTestingConnections, reloadTestingDatabases } from "../../utils/test-utils";
+import { Connection } from "../../../src/connection/Connection";
+import { expect } from "chai";
+import {Post, User} from "./entities"
+
+describe("github issues > #7079 Error when sorting by an embedded entity while using join and skip/take", () => {
+
+    let connections: Connection[];
+    before(async () => connections = await createTestingConnections({
+        entities: [Post, User],
+        schemaCreate: true,
+        dropSchema: true,
+    }));
+    beforeEach(() => reloadTestingDatabases(connections));
+    after(() => closeTestingConnections(connections));
+
+    it("should be able to getMany with join and sorting by an embedded entity column while user take and skip", () => Promise.all(connections.map(async connection => {
+        const postRepo = connection.getRepository(Post)
+        const userRepo = connection.getRepository(User)
+
+        const users = [
+            { id: 1, name: "Mike" },
+            { id: 2, name: "Alice" }
+        ]
+        await userRepo.save(users)
+
+        const posts = [
+            {
+                id: 1,
+                text: "Happy Holidays",
+                userId: 1,
+                blog: { date: new Date().toISOString() },
+                newsletter: { date: new Date().toISOString() }
+            },
+            {
+                id: 2,
+                text: "My Vacation",
+                userId: 1,
+                blog: { date: new Date().toISOString() },
+                newsletter: { date: new Date().toISOString() }
+            },
+            {
+                id: 3,
+                text: "Working with TypeORM",
+                userId: 2,
+                blog: { date: new Date().toISOString() },
+                newsletter: { date: new Date().toISOString() }
+            }
+        ]
+        await postRepo.save(posts);
+
+        const result = await postRepo.createQueryBuilder("post")
+            .leftJoinAndSelect("post.user", "user")
+            .orderBy("post.blog.date")
+            .take(2)
+            .skip(1)
+            .getMany();
+        expect(result.length).eq(2);
+    })));
+
+});


### PR DESCRIPTION
<!--
  😀 Wonderful!  Thank you for opening a pull request for TypeORM.

  Please fill in the information below to expedite the review
  and (hopefully) merge of your change.

  If unsure about something.. just do as best as you're able,
  or reach out through our community support channels!
  https://github.com/typeorm/typeorm/blob/master/docs/support.md
-->

### Description of change

Using `findColumnWithPropertyPath` instead of `findColumnWithPropertyName` in `createOrderByCombinedWithSelectExpression` to fix sorting by embedded entity properties.

Fixes #7079 

<!--
  Please be clear and concise what the change is intended to do,
  why this change is needed, and how you've verified that it
  corrects what you intended.

  In some cases it may be helpful to include the current behavior
  and the new behavior.

  If the change is related to an open issue, you can link it here.
  If you include `Fixes #0000` (replacing `0000` with the issue number)
  when this is merged it will automatically mark the issue as fixed and
  close it.
-->


### Pull-Request Checklist

<!--
  Please make sure to review and check all of the following.

  If an item is not applicable, you can add "N/A" to the end.
-->

- [x] Code is up-to-date with the `master` branch
- [x] `npm run lint` passes with this change
- [x] `npm run test` passes with this change
- [x] This pull request links relevant issues as `Fixes #0000`
- [x] There are new or updated unit tests validating the change
- [x] Documentation has been updated to reflect this change N/A
- [x] The new commits follow conventions explained in [CONTRIBUTING.md](https://github.com/typeorm/typeorm/blob/master/CONTRIBUTING.md)

<!--
  🎉 Thank you for contributing and making TypeORM even better!
-->
