### PR TITLE
PostgresQueryRunner check getEnumTypeName result

### DIFF
--- a/src/driver/postgres/PostgresQueryRunner.ts
+++ b/src/driver/postgres/PostgresQueryRunner.ts
@@ -2093,6 +2093,11 @@ export class PostgresQueryRunner extends BaseQueryRunner implements QueryRunner 
         }
         const result = await this.query(`SELECT "udt_schema", "udt_name" ` +
             `FROM "information_schema"."columns" WHERE "table_schema" = '${schema}' AND "table_name" = '${name}' AND "column_name"='${column.name}'`);
+        
+        if (result[0] === undefined) {
+            throw new Error(`udt_schema and udt_name not found; Do you have a duplicate enum name?`);   
+        }
+        
         return {
             enumTypeSchema: result[0]["udt_schema"],
             enumTypeName: result[0]["udt_name"]


### PR DESCRIPTION
Throw an error, with duplicate enum names as possible reason), if the PostgresQueryRunner::getEnumTypeName result is undefined. Possible "fix"  for https://github.com/typeorm/typeorm/issues/7084 (at least the error message should help the user)

<!--
  😀 Wonderful!  Thank you for opening a pull request for TypeORM.

  Please fill in the information below to expedite the review
  and (hopefully) merge of your change.

  If unsure about something.. just do as best as you're able,
  or reach out through our community support channels!
  https://github.com/typeorm/typeorm/blob/master/docs/support.md
-->

### Description of change

Throw an error if PostgresQueryRunner::getEnumTypeName result is undefined. This error message contains
a hint for the developer what could be a possible reason why the `result` is `undefined`.

This helps if the user encounters #7084.

### Pull-Request Checklist

<!--
  Please make sure to review and check all of the following.

  If an item is not applicable, you can add "N/A" to the end.
-->

- [x] Code is up-to-date with the `master` branch
- [x] `npm run lint` passes with this change
- [ ] `npm run test` passes with this change
- [x] This pull request links relevant issues as `Fixes #7084`
- [ ] There are new or updated unit tests validating the change
- [ ] Documentation has been updated to reflect this change
- [x] The new commits follow conventions explained in [CONTRIBUTING.md](https://github.com/typeorm/typeorm/blob/master/CONTRIBUTING.md) (tests are missing)

<!--
  🎉 Thank you for contributing and making TypeORM even better!
-->
