### PR TITLE
test: SQL Server error when requesting additional returning columns (#7100)

### DIFF
--- a/test/github-issues/7100/entity/Post.ts
+++ b/test/github-issues/7100/entity/Post.ts
@@ -1,0 +1,17 @@
+import {Entity} from "../../../../src/decorator/entity/Entity";
+import {PrimaryGeneratedColumn} from "../../../../src/decorator/columns/PrimaryGeneratedColumn";
+import {Column} from "../../../../src/decorator/columns/Column";
+
+@Entity()
+export class Post {
+
+    @PrimaryGeneratedColumn()
+    id: number;
+
+    @Column()
+    title: string;
+
+    @Column()
+    text: string;
+
+}

--- a/test/github-issues/7100/issue-7100.ts
+++ b/test/github-issues/7100/issue-7100.ts
@@ -1,0 +1,57 @@
+import "reflect-metadata";
+import {Connection} from "../../../src";
+import {Post} from "./entity/Post";
+import {createTestingConnections, reloadTestingDatabases, closeTestingConnections} from "../../utils/test-utils";
+import {SqlServerDriver} from "../../../src/driver/sqlserver/SqlServerDriver";
+
+describe("github issues > #7100 MSSQL error when user requests additional columns to be returned", () => {
+
+    let connections: Connection[];
+
+    before(async () => {
+        connections = await createTestingConnections({
+            entities: [Post],
+            schemaCreate: true,
+            dropSchema: true
+        });
+    });
+    beforeEach(async () => {
+        await reloadTestingDatabases(connections);
+
+        return Promise.all(connections.map(async connection => {
+            if (!(connection.driver instanceof SqlServerDriver)) {
+                return;
+            }
+        }));
+    });
+    after(() => closeTestingConnections(connections));
+
+    it("should return user requested columns", () => Promise.all(connections.map(async connection => {
+        if (!(connection.driver instanceof SqlServerDriver)) {
+            return;
+        }
+
+        const post = new Post();
+        post.title = "title";
+        post.text = "text"
+
+        await connection.createQueryBuilder()
+            .insert()
+            .into(Post)
+            .values(post)
+            .returning(["text"])
+            .execute();
+
+        // Locally we have forgotten what text was set to, must re-fetch
+        post.text = "";
+        await connection.createQueryBuilder(Post, "post")
+            .update()
+            .set({ title: "TITLE" })
+            .returning(["text"])
+            .whereEntity(post)
+            .updateEntity(true)
+            .execute();
+
+        post.text.should.be.equal("text");
+    })));
+});


### PR DESCRIPTION
Test for #7100 (currently failing until fixed)

### Description of change

#5361 broke `QueryBuilder.returning()` for SQL Server, test to validate fix.

### Pull-Request Checklist

- [x] Code is up-to-date with the `master` branch
- [x] `npm run lint` passes with this change
- [ ] `npm run test` passes with this change
- [x] This pull request links relevant issues as `Fixes #0000`
- [ ] There are new or updated unit tests validating the change
- [x] Documentation has been updated to reflect this change
- [x] The new commits follow conventions explained in [CONTRIBUTING.md](https://github.com/typeorm/typeorm/blob/master/CONTRIBUTING.md)
