### PR TITLE
feat: relations: Orphaned row action

### DIFF
--- a/src/decorator/options/RelationOptions.ts
+++ b/src/decorator/options/RelationOptions.ts
@@ -64,4 +64,9 @@ export interface RelationOptions {
      */
     persistence?: boolean;
 
+    /**
+     * When a child row is removed from its parent, determines if the child row should be orphaned (default) or deleted.
+     */
+    orphanedRowAction?: "nullify" | "delete";
+
 }

--- a/src/metadata/RelationMetadata.ts
+++ b/src/metadata/RelationMetadata.ts
@@ -110,6 +110,11 @@ export class RelationMetadata {
     persistenceEnabled: boolean = true;
 
     /**
+     * When a child row is removed from its parent, determines if the child row should be orphaned (default) or deleted.
+     */
+    orphanedRowAction?: "nullify" | "delete";
+
+    /**
      * If set to true then related objects are allowed to be inserted to the database.
      */
     isCascadeInsert: boolean = false;
@@ -298,6 +303,7 @@ export class RelationMetadata {
         this.deferrable = args.options.deferrable;
         this.isEager = args.options.eager || false;
         this.persistenceEnabled = args.options.persistence === false ? false : true;
+        this.orphanedRowAction = args.options.orphanedRowAction || "nullify";
         this.isTreeParent = args.isTreeParent || false;
         this.isTreeChildren = args.isTreeChildren || false;
         this.type = args.type instanceof Function ? (args.type as () => any)() : args.type;

--- a/src/persistence/subject-builder/OneToManySubjectBuilder.ts
+++ b/src/persistence/subject-builder/OneToManySubjectBuilder.ts
@@ -165,13 +165,19 @@ export class OneToManySubjectBuilder {
                 const removedRelatedEntitySubject = new Subject({
                     metadata: relation.inverseEntityMetadata,
                     parentSubject: subject,
-                    canBeUpdated: true,
                     identifier: removedRelatedEntityRelationId,
-                    changeMaps: [{
+                });
+
+                if (!relation.inverseRelation || relation.inverseRelation.orphanedRowAction === "nullify") {
+                    removedRelatedEntitySubject.canBeUpdated = true;
+                    removedRelatedEntitySubject.changeMaps = [{
                         relation: relation.inverseRelation!,
                         value: null
-                    }]
-                });
+                    }];
+                } else if (relation.inverseRelation.orphanedRowAction === "delete") {
+                    removedRelatedEntitySubject.mustBeRemoved = true;
+                }
+
                 this.subjects.push(removedRelatedEntitySubject);
             });
     }

--- a/test/functional/persistence/delete-orphans/delete-orphans.ts
+++ b/test/functional/persistence/delete-orphans/delete-orphans.ts
@@ -1,0 +1,73 @@
+import "reflect-metadata";
+import { Connection, Repository } from "../../../../src/index";
+import { reloadTestingDatabases, createTestingConnections, closeTestingConnections } from "../../../utils/test-utils";
+import { expect } from "chai";
+import { Category } from "./entity/Category";
+import { Post } from "./entity/Post";
+
+describe("persistence > delete orphans", () => {
+
+    // -------------------------------------------------------------------------
+    // Configuration
+    // -------------------------------------------------------------------------
+
+    // connect to db
+    let connections: Connection[] = [];
+
+    before(async () => connections = await createTestingConnections({
+        entities: [__dirname + "/entity/*{.js,.ts}"],
+
+    }));
+    beforeEach(() => reloadTestingDatabases(connections));
+    after(() => closeTestingConnections(connections));
+
+    // -------------------------------------------------------------------------
+    // Specifications
+    // -------------------------------------------------------------------------
+
+    describe("when a Post is removed from a Category", () => {
+        let categoryRepository: Repository<Category>;
+        let postRepository: Repository<Post>;
+        let categoryId: number;
+
+        beforeEach(async () => {
+            await Promise.all(connections.map(async connection => {
+                categoryRepository = connection.getRepository(Category);
+                postRepository = connection.getRepository(Post);
+            }));
+
+            const categoryToInsert = await categoryRepository.save(new Category());
+            categoryToInsert.posts = [
+                new Post(),
+                new Post()
+            ];
+
+            await categoryRepository.save(categoryToInsert);
+            categoryId = categoryToInsert.id;
+
+            const categoryToUpdate = (await categoryRepository.findOne(categoryId))!;
+            categoryToUpdate.posts = categoryToInsert.posts.filter(p => p.id === 1); // Keep the first post
+
+            await categoryRepository.save(categoryToUpdate);
+        });
+
+        it("should retain a Post on the Category", async () => {
+            const category = await categoryRepository.findOne(categoryId);
+            expect(category).not.to.be.undefined;
+            expect(category!.posts).to.have.lengthOf(1);
+            expect(category!.posts[0].id).to.equal(1);
+        });
+
+        it("should delete the orphaned Post from the database", async () => {
+            const postCount = await postRepository.count();
+            expect(postCount).to.equal(1);
+        });
+
+        it("should retain foreign keys on remaining Posts", async () => {
+            const postsWithoutForeignKeys = (await postRepository.find())
+                .filter(p => !p.categoryId);
+            expect(postsWithoutForeignKeys).to.have.lengthOf(0);
+        });
+    });
+
+});

--- a/test/functional/persistence/delete-orphans/entity/Category.ts
+++ b/test/functional/persistence/delete-orphans/entity/Category.ts
@@ -1,0 +1,18 @@
+import {Entity} from "../../../../../src/decorator/entity/Entity";
+import {PrimaryGeneratedColumn} from "../../../../../src/decorator/columns/PrimaryGeneratedColumn";
+import {Post} from "./Post";
+import {OneToMany} from "../../../../../src/decorator/relations/OneToMany";
+
+@Entity()
+export class Category {
+
+    @PrimaryGeneratedColumn()
+    id: number;
+
+    @OneToMany(() => Post, post => post.category, {
+        cascade: ["insert"],
+        eager: true
+    })
+    posts: Post[];
+
+}

--- a/test/functional/persistence/delete-orphans/entity/Post.ts
+++ b/test/functional/persistence/delete-orphans/entity/Post.ts
@@ -1,0 +1,21 @@
+import {Category} from "./Category";
+import {Entity} from "../../../../../src/decorator/entity/Entity";
+import {PrimaryGeneratedColumn} from "../../../../../src/decorator/columns/PrimaryGeneratedColumn";
+import {Column} from "../../../../../src/decorator/columns/Column";
+import {ManyToOne} from "../../../../../src/decorator/relations/ManyToOne";
+import {JoinColumn} from "../../../../../src/decorator/relations/JoinColumn";
+
+@Entity()
+export class Post {
+
+    @PrimaryGeneratedColumn()
+    id: number;
+
+    @Column()
+    categoryId: string;
+
+    @ManyToOne(() => Category, category => category.posts, { orphanedRowAction: "delete" })
+    @JoinColumn({ name: "categoryId" })
+    category: Category;
+
+}


### PR DESCRIPTION
Rebase of #1665 with some modifications.

---

Per @adenhertog from the original PR:

This adds an additional option on one-to-many relationships where child entities are deleted, rather than having their foreign key set to null, when removed from their parent.

Many times we have the situation where a parent entity "owns" a child. An example of this is when a User has a set of `RoleAssignment` in the context of permissions. When a `RoleAssignment` is removed from the user, we expect for the row to be deleted. Previously the row would remain in the database but with the `userId` column set to `null`, leaving an orphaned row that would clog up the table.

This fix allows for `RoleAssignment` to specify on its relationship with `User` that it should be deleted, rather than orphaned, when the relationship is removed.

By default, the original behaviour of setting the foreign key to `null` is retained.

---

See also #6704, and other issues taken from it:

Closes #1761
Closes #2467
Closes #5645

Related #1286
Related #1351
Related #6382

<!--
  😀 Wonderful!  Thank you for opening a pull request for TypeORM.

  Please fill in the information below to expedite the review
  and (hopefully) merge of your change.

  If unsure about something.. just do as best as you're able,
  or reach out through our community support channels!
  https://github.com/typeorm/typeorm/blob/master/docs/support.md
-->

### Description of change

<!--
  Please be clear and concise what the change is intended to do,
  why this change is needed, and how you've verified that it
  corrects what you intended.

  In some cases it may be helpful to include the current behavior
  and the new behavior.

  If the change is related to an open issue, you can link it here.
  If you include `Fixes #0000` (replacing `0000` with the issue number)
  when this is merged it will automatically mark the issue as fixed and
  close it.
-->


### Pull-Request Checklist

<!--
  Please make sure to review and check all of the following.

  If an item is not applicable, you can add "N/A" to the end.
-->

- [x] Code is up-to-date with the `master` branch
- [x] `npm run lint` passes with this change
- [x] `npm run test` passes with this change
- [x] This pull request links relevant issues as `Fixes #0000`
- [x] There are new or updated unit tests validating the change
- [ ] Documentation has been updated to reflect this change
- [x] The new commits follow conventions explained in [CONTRIBUTING.md](https://github.com/typeorm/typeorm/blob/master/CONTRIBUTING.md)

<!--
  🎉 Thank you for contributing and making TypeORM even better!
-->
