### PR TITLE
feat: add index options to many-to-one relation decorator

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "typeorm",
-  "version": "0.2.28",
+  "version": "0.2.29",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/src/decorator/options/ManyToOneOptions.ts
+++ b/src/decorator/options/ManyToOneOptions.ts
@@ -1,0 +1,12 @@
+import {IndexOptions} from './IndexOptions';
+import {RelationOptions} from './RelationOptions';
+
+/**
+ * Describes a many-to-one relation's options
+ */
+export interface ManyToOneOptions extends RelationOptions {
+  /**
+   * Create an index on the referencing column of the many-to-one relation.
+   */
+  index?: boolean | IndexOptions & { name?: string };
+}

--- a/src/decorator/relations/ManyToOne.ts
+++ b/src/decorator/relations/ManyToOne.ts
@@ -1,12 +1,12 @@
-import {getMetadataArgsStorage, ObjectType, RelationOptions} from "../../";
+import {getMetadataArgsStorage, IndexOptions, ObjectType, RelationOptions, ManyToOneOptions} from "../../";
 import {RelationMetadataArgs} from "../../metadata-args/RelationMetadataArgs";
-
+import {Index} from '../Index';
 /**
  * Many-to-one relation allows to create type of relation when Entity1 can have single instance of Entity2, but
  * Entity2 can have a multiple instances of Entity1. Entity1 is an owner of the relationship, and storages Entity2 id
  * on its own side.
  */
-export function ManyToOne<T>(typeFunctionOrTarget: string|((type?: any) => ObjectType<T>), options?: RelationOptions): PropertyDecorator;
+export function ManyToOne<T>(typeFunctionOrTarget: string|((type?: any) => ObjectType<T>), options?: ManyToOneOptions): PropertyDecorator;
 
 /**
  * Many-to-one relation allows to create type of relation when Entity1 can have single instance of Entity2, but
@@ -15,7 +15,7 @@ export function ManyToOne<T>(typeFunctionOrTarget: string|((type?: any) => Objec
  */
 export function ManyToOne<T>(typeFunctionOrTarget: string|((type?: any) => ObjectType<T>),
                              inverseSide?: string|((object: T) => any),
-                             options?: RelationOptions): PropertyDecorator;
+                             options?: ManyToOneOptions): PropertyDecorator;
 
 /**
  * Many-to-one relation allows to create type of relation when Entity1 can have single instance of Entity2, but
@@ -24,7 +24,7 @@ export function ManyToOne<T>(typeFunctionOrTarget: string|((type?: any) => Objec
  */
 export function ManyToOne<T>(typeFunctionOrTarget: string|((type?: any) => ObjectType<T>),
                              inverseSideOrOptions?: string|((object: T) => any)|RelationOptions,
-                             options?: RelationOptions): PropertyDecorator {
+                             options?: ManyToOneOptions): PropertyDecorator {
 
     // normalize parameters
     let inverseSideProperty: string|((object: T) => any);
@@ -55,5 +55,16 @@ export function ManyToOne<T>(typeFunctionOrTarget: string|((type?: any) => Objec
             inverseSideProperty: inverseSideProperty,
             options: options
         } as RelationMetadataArgs);
+
+        if (options && options.index) {
+            const normalizedOptions: IndexOptions & { name?: string } = typeof options.index === 'object' ? options.index : {};
+            const { name, ...indexOptions } = normalizedOptions;
+
+            if (name) {
+                Index(name, indexOptions)(object, propertyName);
+            } else {
+                Index(indexOptions)(object, propertyName);
+            }
+        }
     };
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -49,6 +49,7 @@ export * from "./decorator/options/ColumnOptions";
 export * from "./decorator/options/IndexOptions";
 export * from "./decorator/options/JoinColumnOptions";
 export * from "./decorator/options/JoinTableOptions";
+export * from "./decorator/options/ManyToOneOptions";
 export * from "./decorator/options/RelationOptions";
 export * from "./decorator/options/EntityOptions";
 export * from "./decorator/options/ValueTransformer";


### PR DESCRIPTION
<!--
  😀 Wonderful!  Thank you for opening a pull request for TypeORM.

  Please fill in the information below to expedite the review
  and (hopefully) merge of your change.

  If unsure about something.. just do as best as you're able,
  or reach out through our community support channels!
  https://github.com/typeorm/typeorm/blob/master/docs/support.md
-->

### Description of change

Adds option to create index on the referencing side of Many-To-One relations.  
Closes #7118 

<!--
  Please be clear and concise what the change is intended to do,
  why this change is needed, and how you've verified that it
  corrects what you intended.

  In some cases it may be helpful to include the current behavior
  and the new behavior.

  If the change is related to an open issue, you can link it here.
  If you include `Fixes #0000` (replacing `0000` with the issue number)
  when this is merged it will automatically mark the issue as fixed and
  close it.
-->


### Pull-Request Checklist

<!--
  Please make sure to review and check all of the following.

  If an item is not applicable, you can add "N/A" to the end.
-->

- [ ] Code is up-to-date with the `master` branch
- [ ] `npm run lint` passes with this change
- [ ] `npm run test` passes with this change
- [ ] This pull request links relevant issues as `Fixes #0000`
- [ ] There are new or updated unit tests validating the change
- [ ] Documentation has been updated to reflect this change
- [ ] The new commits follow conventions explained in [CONTRIBUTING.md](https://github.com/typeorm/typeorm/blob/master/CONTRIBUTING.md)

<!--
  🎉 Thank you for contributing and making TypeORM even better!
-->
