### PR TITLE
Document withDeleted option

### DIFF
--- a/docs/find-options.md
+++ b/docs/find-options.md
@@ -74,6 +74,13 @@ userRepository.find({
 });
 ```
 
+* `withDeleted` - include entities which have been soft deleted with `softDelete` or `softRemove`, e.g. have their `@DeleteDateColumn` column set. By default, soft deleted entities are not included.
+
+```typescript
+userRepository.find({
+    withDeleted: true
+});
+
 `find` methods which return multiple entities (`find`, `findAndCount`, `findByIds`) also accept following options:
 
 * `skip` - offset (paginated) from where entities should be taken.


### PR DESCRIPTION
### Description of change
Add `withDeleted` option to the list of find options on the documentation page.

After reading up on softDelete in #534, it was a bit unclear to me whether soft deleted entities are included in the find results or not and how to change the behavior.

### Pull-Request Checklist

- [x] Code is up-to-date with the `master` branch
- [ ] `npm run lint` passes with this change N/A
- [ ] `npm run test` passes with this change N/A
- [x] This pull request links relevant issues as `Fixes #0000`
- [ ] There are new or updated unit tests validating the change N/A
- [x] Documentation has been updated to reflect this change
- [x] The new commits follow conventions explained in [CONTRIBUTING.md](https://github.com/typeorm/typeorm/blob/master/CONTRIBUTING.md)