### PR TITLE
fix,feat: support MongoDB DNS seed list connection

### DIFF
--- a/src/driver/mongodb/MongoDriver.ts
+++ b/src/driver/mongodb/MongoDriver.ts
@@ -438,11 +438,15 @@ export class MongoDriver implements Driver {
      * Builds connection url that is passed to underlying driver to perform connection to the mongodb database.
      */
     protected buildConnectionUrl(options: { [key: string]: any }): string {
-        const credentialsUrlPart = (options.username && options.password)
+         const schemaUrlPart = options.type.toLowerCase();
+         const credentialsUrlPart = (options.username && options.password)
             ? `${options.username}:${options.password}@`
             : "";
+        const portUrlPart = (schemaUrlPart === "mongodb+srv") 
+            ? "" 
+            : `:${options.port || "27017"}`;
 
-        return `mongodb://${credentialsUrlPart}${options.host || "127.0.0.1"}:${options.port || "27017"}/${options.database || ""}`;
+        return `${schemaUrlPart}://${credentialsUrlPart}${options.host || "127.0.0.1"}${portUrlPart}/${options.database || ""}`;
     }
 
     /**


### PR DESCRIPTION
As described in [MongoDB Docs](https://docs.mongodb.com/manual/reference/connection-string/#dns-seed-list-connection-format), an additional connection string format called DNS Seed List Connection format can be used. As this is the default format for MongoDB Atlas, the hosted service of MongoDB, this should be available also for typeorm. 
The connection format is identified by the url-schema "mongodb+srv" and does not allow specifying a port.

### Description of change

When using the DNS seed connection list format, `mongodb+srv` must be used as URL schema and a port must not be provided!
Can simply be verified with a free account of [MongoDB Atlas](https://cloud.mongodb.com), where this connection format is the default when using MongoDB driver 3.6+


Fixes #3347
Fixes #3133
Fixes #7009

### Pull-Request Checklist

<!--
  Please make sure to review and check all of the following.

  If an item is not applicable, you can add "N/A" to the end.
-->

- [x] Code is up-to-date with the `master` branch
- [x] `npm run lint` passes with this change 
- [x] `npm run test` passes with this change
- [x] This pull request links relevant issues as `Fixes #0000`
- [ ] There are new or updated unit tests validating the change N/A
- [ ] Documentation has been updated to reflect this change N/A
- [x] The new commits follow conventions explained in [CONTRIBUTING.md](https://github.com/typeorm/typeorm/blob/master/CONTRIBUTING.md)
