### PR TITLE
 fix: return 'null' (instead of 'undefined') on lazy relations that have no results

### DIFF
--- a/src/query-builder/RelationLoader.ts
+++ b/src/query-builder/RelationLoader.ts
@@ -216,7 +216,7 @@ export class RelationLoader {
 
                 // nothing is loaded yet, load relation data and save it in the model once they are loaded
                 const loader = relationLoader.load(relation, this, queryRunner).then(
-                    result => relation.isOneToOne || relation.isManyToOne ? result[0] : result
+                    result => relation.isOneToOne || relation.isManyToOne ? (result.length === 0 ? null : result[0]) : result
                 );
                 return setPromise(this, loader);
             },

--- a/test/github-issues/7146/entity/Category.ts
+++ b/test/github-issues/7146/entity/Category.ts
@@ -1,0 +1,18 @@
+import { Entity, JoinColumn, OneToOne, PrimaryGeneratedColumn } from "../../../../src";
+import { Post } from "./Post";
+
+@Entity()
+export class Category {
+
+    @PrimaryGeneratedColumn()
+    id: number;
+
+    @OneToOne(type => Post, post => post.lazyOneToOne, { nullable: true, eager: false })
+    @JoinColumn()
+    backRef1: Post;
+
+    @OneToOne(type => Post, post => post.eagerOneToOne, { nullable: true, eager: false })
+    @JoinColumn()
+    backRef2: Post;
+
+}

--- a/test/github-issues/7146/entity/Post.ts
+++ b/test/github-issues/7146/entity/Post.ts
@@ -1,0 +1,32 @@
+import { Entity, JoinColumn, ManyToOne, OneToOne, PrimaryGeneratedColumn } from "../../../../src";
+import { Category } from "./Category";
+
+@Entity()
+export class Post {
+
+    @PrimaryGeneratedColumn()
+    id: number;
+
+    @ManyToOne(type => Category, { nullable: true, eager: false })
+    lazyManyToOne: Promise<Category | null>;
+
+    @ManyToOne(type => Category, { nullable: true, eager: true })
+    eagerManyToOne: Category | null;
+
+    @OneToOne(type => Category, { nullable: true, eager: false })
+    @JoinColumn()
+    lazyOneToOneOwner: Promise<Category | null>;
+
+    @OneToOne(type => Category, { nullable: true, eager: true })
+    @JoinColumn()
+    eagerOneToOneOwner: Category | null;
+
+    // Not a column; actual value is stored on the other side of this relation
+    @OneToOne(type => Category, category => category.backRef1, { eager: false })
+    lazyOneToOne: Promise<Category | null>;
+
+    // Not a column; actual value is stored on the other side of this relation
+    @OneToOne(type => Category, category => category.backRef2, { eager: true })
+    eagerOneToOne: Category | null;
+
+}

--- a/test/github-issues/7146/issue-7146.ts
+++ b/test/github-issues/7146/issue-7146.ts
@@ -1,0 +1,92 @@
+import "reflect-metadata";
+import { createTestingConnections, closeTestingConnections, reloadTestingDatabases } from "../../utils/test-utils";
+import { Connection } from "../../../src/connection/Connection";
+import { expect } from "chai";
+import { Post } from "./entity/Post";
+
+describe("github issues > #7146 Lazy relations resolve to 'undefined' instead of 'null'", () => {
+
+    let connections: Connection[];
+    before(async () => connections = await createTestingConnections({
+        entities: [__dirname + "/entity/*{.js,.ts}"],
+        schemaCreate: true,
+        dropSchema: true,
+    }));
+    beforeEach(() => reloadTestingDatabases(connections));
+    after(() => closeTestingConnections(connections));
+
+    async function prepareData(connection: Connection) {
+        const savedPost = new Post();
+        await connection.manager.save(savedPost);
+    }
+
+    // The following 3 tests hilight the reported issue.
+    // The remaining 6 tests were already succeeding before, but are included for completeness sake.
+
+    describe("lazy-loaded relations", () => {
+
+        it("should return null if ManyToOne relation has NULL in database", () => Promise.all(connections.map(async connection => {
+            await prepareData(connection);
+            const post = (await connection.manager.findOneOrFail(Post, 1));
+            expect(await post.lazyManyToOne).to.be.null;
+        })));
+
+        it("should return null if OneToOne+JoinColumn relation has NULL in database", () => Promise.all(connections.map(async connection => {
+            await prepareData(connection);
+            const post = (await connection.manager.findOneOrFail(Post, 1));
+            expect(await post.lazyOneToOneOwner).to.be.null;
+        })));
+
+        it("should return null if OneToOne relation has NULL in database", () => Promise.all(connections.map(async connection => {
+            await prepareData(connection);
+            const post = (await connection.manager.findOneOrFail(Post, 1));
+            expect(await post.lazyOneToOne).to.be.null;
+        })));
+
+    });
+
+    describe("lazy-loaded relations included in 'relations' find option", () => {
+
+        it("should return null if ManyToOne relation has NULL in database", () => Promise.all(connections.map(async connection => {
+            await prepareData(connection);
+            const post = (await connection.manager.findOneOrFail(Post, 1, { relations: ['lazyManyToOne'] }));
+            expect(await post.lazyManyToOne).to.be.null;
+        })));
+
+        it("should return null if OneToOne+JoinColumn relation has NULL in database", () => Promise.all(connections.map(async connection => {
+            await prepareData(connection);
+            const post = (await connection.manager.findOneOrFail(Post, 1, { relations: ['lazyOneToOneOwner'] }));
+            expect(await post.lazyOneToOneOwner).to.be.null;
+        })));
+
+        it("should return null if OneToOne relation has NULL in database", () => Promise.all(connections.map(async connection => {
+            await prepareData(connection);
+            const post = (await connection.manager.findOneOrFail(Post, 1, { relations: ['lazyOneToOne'] }));
+            expect(await post.lazyOneToOne).to.be.null;
+        })));
+
+    });
+
+    describe("eager-loaded relations", () => {
+
+        it("should return null if ManyToOne relation has NULL in database", () => Promise.all(connections.map(async connection => {
+            await prepareData(connection);
+            const post = (await connection.manager.findOneOrFail(Post, 1));
+            expect(post.eagerManyToOne).to.be.null;
+        })));
+
+        it("should return null if OneToOne+JoinColumn relation has NULL in database", () => Promise.all(connections.map(async connection => {
+            await prepareData(connection);
+            const post = (await connection.manager.findOneOrFail(Post, 1));
+            expect(post.eagerOneToOneOwner).to.be.null;
+        })));
+
+        it("should return null if OneToOne relation has NULL in database", () => Promise.all(connections.map(async connection => {
+            await prepareData(connection);
+            const post = (await connection.manager.findOneOrFail(Post, 1));
+            expect(post.eagerOneToOne).to.be.null;
+        })));
+
+    });
+
+});


### PR DESCRIPTION
<!--
  😀 Wonderful!  Thank you for opening a pull request for TypeORM.

  Please fill in the information below to expedite the review
  and (hopefully) merge of your change.

  If unsure about something.. just do as best as you're able,
  or reach out through our community support channels!
  https://github.com/typeorm/typeorm/blob/master/docs/support.md
-->

### Description of change

<!--
  Please be clear and concise what the change is intended to do,
  why this change is needed, and how you've verified that it
  corrects what you intended.

  In some cases it may be helpful to include the current behavior
  and the new behavior.

  If the change is related to an open issue, you can link it here.
  If you include `Fixes #0000` (replacing `0000` with the issue number)
  when this is merged it will automatically mark the issue as fixed and
  close it.
-->

Fix an issue where a lazy relation returns a Promise that resolves to 'undefined'. As implied by
documentation, if the database has a NULL or no results, the result should be a literal 'null'
in Javascript. Also added units tests to hilight the three scenarios in which this occurred.

This PR is to fix reported issue #7146.

### Pull-Request Checklist

<!--
  Please make sure to review and check all of the following.

  If an item is not applicable, you can add "N/A" to the end.
-->

- [x] Code is up-to-date with the `master` branch
- [x] `npm run lint` passes with this change
- [x] `npm run test` passes with this change
- [x] This pull request links relevant issues as `Fixes #0000`
- [x] There are new or updated unit tests validating the change
- [x] Documentation has been updated to reflect this change
- [x] The new commits follow conventions explained in [CONTRIBUTING.md](https://github.com/typeorm/typeorm/blob/master/CONTRIBUTING.md)

<!--
  🎉 Thank you for contributing and making TypeORM even better!
-->
