### PR TITLE
allow explicit default values on saving an object without relying on db defaults

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "typeorm",
-  "version": "0.2.28",
+  "version": "0.2.29",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -4227,7 +4227,6 @@
       "resolved": "https://registry.npmjs.org/fstream/-/fstream-1.0.12.tgz",
       "integrity": "sha512-WvJ193OHa0GHPEL+AycEJgxvBEwyfRkN1vhjca23OaPVMCaLCXTd5qAu82AjTcgP1UJmytkOKb63Ypde7raDIg==",
       "dev": true,
-      "optional": true,
       "requires": {
         "graceful-fs": "^4.1.2",
         "inherits": "~2.0.0",
@@ -4239,15 +4238,13 @@
           "version": "1.2.5",
           "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
           "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "mkdirp": {
           "version": "0.5.5",
           "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.5.tgz",
           "integrity": "sha512-NKmAlESf6jMGym1++R0Ra7wvhV+wFW63FaSOFPwRahvea0gMUcGUhVeAg/0BC0wiv9ih5NYPB1Wn1UEI1/L+xQ==",
           "dev": true,
-          "optional": true,
           "requires": {
             "minimist": "^1.2.5"
           }
@@ -4257,7 +4254,6 @@
           "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.7.1.tgz",
           "integrity": "sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==",
           "dev": true,
-          "optional": true,
           "requires": {
             "glob": "^7.1.3"
           }

--- a/src/decorator/options/ColumnOptions.ts
+++ b/src/decorator/options/ColumnOptions.ts
@@ -70,6 +70,12 @@ export interface ColumnOptions extends ColumnCommonOptions {
     default?: any;
 
     /**
+     * Saves the default value (if one was given in this ColumnOptions) to the db in case none was given
+     * regardless of the database's default value
+     */
+    explicitDefault? : boolean;
+
+    /**
      * ON UPDATE trigger. Works only for MySQL.
      */
     onUpdate?: string;

--- a/src/metadata/ColumnMetadata.ts
+++ b/src/metadata/ColumnMetadata.ts
@@ -122,6 +122,12 @@ export class ColumnMetadata {
     default?: any;
 
     /**
+     * Saves the default value (if one was given in this ColumnOptions) to the db in case none was given
+     * regardless of the database's default value
+     */
+    explicitDefault? : boolean = false;
+    
+    /**
      * ON UPDATE trigger. Works only for MySQL.
      */
     onUpdate?: string;
@@ -344,6 +350,8 @@ export class ColumnMetadata {
             this.isPrimary = options.args.options.primary;
         if (options.args.options.default === null) // to make sure default: null is the same as nullable: true
             this.isNullable = true;
+        if (options.args.options.explicitDefault)
+            this.explicitDefault = options.args.options.explicitDefault;
         if (options.args.options.nullable !== undefined)
             this.isNullable = options.args.options.nullable;
         if (options.args.options.select !== undefined)

--- a/src/query-builder/InsertQueryBuilder.ts
+++ b/src/query-builder/InsertQueryBuilder.ts
@@ -482,7 +482,7 @@ export class InsertQueryBuilder<Entity> extends QueryBuilder<Entity> {
 
                     // if value for this column was not provided then insert default value
                     } else if (value === undefined) {
-                        if ((this.connection.driver instanceof OracleDriver && valueSets.length > 1) || this.connection.driver instanceof AbstractSqliteDriver || this.connection.driver instanceof SapDriver) { // unfortunately sqlite does not support DEFAULT expression in INSERT queries
+                        if ((this.connection.driver instanceof OracleDriver && valueSets.length > 1) || this.connection.driver instanceof AbstractSqliteDriver || this.connection.driver instanceof SapDriver || column.explicitDefault) { // unfortunately sqlite does not support DEFAULT expression in INSERT queries
                             if (column.default !== undefined) { // try to use default defined in the column
                                 expression += this.connection.driver.normalizeDefault(column);
                             } else {


### PR DESCRIPTION
…ults

Fixes #7098

<!--
  😀 Wonderful!  Thank you for opening a pull request for TypeORM.

  Please fill in the information below to expedite the review
  and (hopefully) merge of your change.

  If unsure about something.. just do as best as you're able,
  or reach out through our community support channels!
  https://github.com/typeorm/typeorm/blob/master/docs/support.md
-->

per https://github.com/typeorm/typeorm/issues/7098 
allow setting default values from code and not just from the database 

<!--
  Please be clear and concise what the change is intended to do,
  why this change is needed, and how you've verified that it
  corrects what you intended.

  In some cases it may be helpful to include the current behavior
  and the new behavior.

  If the change is related to an open issue, you can link it here.
  If you include `Fixes #0000` (replacing `0000` with the issue number)
  when this is merged it will automatically mark the issue as fixed and
  close it.
-->


### Pull-Request Checklist

<!--
  Please make sure to review and check all of the following.

  If an item is not applicable, you can add "N/A" to the end.
-->

- [v ] Code is up-to-date with the `master` branch
- [ x] `npm run lint` passes with this change
- [ ] `npm run test` passes with this change
- [ v] This pull request links relevant issues as `Fixes #0000`
- [x ] There are new or updated unit tests validating the change
- [ v] Documentation has been updated to reflect this change
- [ ] The new commits follow conventions explained in [CONTRIBUTING.md](https://github.com/typeorm/typeorm/blob/master/CONTRIBUTING.md)

<!--
  🎉 Thank you for contributing and making TypeORM even better!
-->
