### PR TITLE
Fix STI validator

### DIFF
--- a/src/metadata-builder/EntityMetadataValidator.ts
+++ b/src/metadata-builder/EntityMetadataValidator.ts
@@ -11,6 +11,7 @@ import {MysqlDriver} from "../driver/mysql/MysqlDriver";
 import {NoConnectionOptionError} from "../error/NoConnectionOptionError";
 import {InitializedRelationError} from "../error/InitializedRelationError";
 import {AuroraDataApiDriver} from "../driver/aurora-data-api/AuroraDataApiDriver";
+import {BaseEntity} from "../repository/BaseEntity";
 
 /// todo: add check if there are multiple tables with the same name
 /// todo: add checks when generated column / table names are too long for the specific driver
@@ -69,7 +70,7 @@ export class EntityMetadataValidator {
                 return metadata !== entityMetadata
                     && (metadata.inheritancePattern === "STI" || metadata.tableType === "entity-child")
                     && metadata.discriminatorValue === entityMetadata.discriminatorValue
-                    && metadata.inheritanceTree.some(parent => entityMetadata.inheritanceTree.indexOf(parent) !== -1);
+                    && metadata.inheritanceTree.some(parent => entityMetadata.inheritanceTree.filter(item => item !== BaseEntity.BaseEntity).includes(parent));
             });
             if (sameDiscriminatorValueEntityMetadata)
                 throw new Error(`Entities ${entityMetadata.name} and ${sameDiscriminatorValueEntityMetadata.name} have the same discriminator values. Make sure they are different while using the @ChildEntity decorator.`);


### PR DESCRIPTION
### Description of change

Fixes #7148; STI validator checked for matching discriminator values but when checking the inheritance chain it also matches on BaseEntity. This fix excludes BaseEntity as it is a part of TypeORM and should never get the STI decorator.

### Pull-Request Checklist

- [x] Code is up-to-date with the `master` branch
- [?] `npm run lint` passes with this change
- [?] `npm run test` passes with this change
- [x] This pull request links relevant issues as `Fixes #0000`
- [ ] There are new or updated unit tests validating the change
- [ ] Documentation has been updated to reflect this change
- [ ] The new commits follow conventions explained in [CONTRIBUTING.md](https://github.com/typeorm/typeorm/blob/master/CONTRIBUTING.md)
