### PR TITLE
fix: avoid early release of PostgresQueryRunner (#7109)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "typeorm",
-  "version": "0.2.28",
+  "version": "0.2.29",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -9298,6 +9298,12 @@
       "integrity": "sha512-ukMTJXLI7/hZIwTW7hGMZJ0Lj0S2XQBCJ4Shv4y1zgQ/vqVea+FLhzywvPj0ujSuofu+yA4MYHGZPTsgjBgJ+w==",
       "dev": true
     },
+    "pg-cursor": {
+      "version": "2.5.2",
+      "resolved": "https://registry.npmjs.org/pg-cursor/-/pg-cursor-2.5.2.tgz",
+      "integrity": "sha512-yS0lxXA5WoIVK7BUgJr1uOJDJe5JxVezItTLvqnTXj6bF3di4UtQOrPx8RW3GpFmom2NTQfpEc2N6vvdpopQSw==",
+      "dev": true
+    },
     "pg-int8": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/pg-int8/-/pg-int8-1.0.1.tgz",
@@ -9315,6 +9321,15 @@
       "resolved": "https://registry.npmjs.org/pg-protocol/-/pg-protocol-1.2.5.tgz",
       "integrity": "sha512-1uYCckkuTfzz/FCefvavRywkowa6M5FohNMF5OjKrqo9PSR8gYc8poVmwwYQaBxhmQdBjhtP514eXy9/Us2xKg==",
       "dev": true
+    },
+    "pg-query-stream": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/pg-query-stream/-/pg-query-stream-4.0.0.tgz",
+      "integrity": "sha512-Jftit2EUBn+ilh4JtAgw0JXKR54vATmYHlZ4fmIlbZgL1qT/GKUuwMzLFT8QQm+qJHZwlRIIfkMUOP7soY38ag==",
+      "dev": true,
+      "requires": {
+        "pg-cursor": "^2.5.2"
+      }
     },
     "pg-types": {
       "version": "2.2.0",

--- a/package.json
+++ b/package.json
@@ -101,6 +101,7 @@
     "mysql2": "^2.1.0",
     "oracledb": "^5.0.0",
     "pg": "^8.3.0",
+    "pg-query-stream": "^4.0.0",
     "redis": "^3.0.2",
     "remap-istanbul": "^0.13.0",
     "rimraf": "^3.0.2",

--- a/src/driver/postgres/PostgresQueryRunner.ts
+++ b/src/driver/postgres/PostgresQueryRunner.ts
@@ -122,12 +122,17 @@ export class PostgresQueryRunner extends BaseQueryRunner implements QueryRunner 
             return Promise.resolve();
         }
 
+        const index = this.driver.connectedQueryRunners.indexOf(this);
+        if (index === -1) {
+            // Driver was not connected yet, do not try to release
+            return Promise.resolve();
+        }
+        
+        this.driver.connectedQueryRunners.splice(index);
+
         this.isReleased = true;
         if (this.releaseCallback)
             this.releaseCallback();
-
-        const index = this.driver.connectedQueryRunners.indexOf(this);
-        if (index !== -1) this.driver.connectedQueryRunners.splice(index);
 
         return Promise.resolve();
     }

--- a/src/driver/postgres/PostgresQueryRunner.ts
+++ b/src/driver/postgres/PostgresQueryRunner.ts
@@ -122,17 +122,12 @@ export class PostgresQueryRunner extends BaseQueryRunner implements QueryRunner 
             return Promise.resolve();
         }
 
-        const index = this.driver.connectedQueryRunners.indexOf(this);
-        if (index === -1) {
-            // Driver was not connected yet, do not try to release
-            return Promise.resolve();
-        }
-        
-        this.driver.connectedQueryRunners.splice(index);
-
         this.isReleased = true;
         if (this.releaseCallback)
             this.releaseCallback();
+
+        const index = this.driver.connectedQueryRunners.indexOf(this);
+        if (index !== -1) this.driver.connectedQueryRunners.splice(index);
 
         return Promise.resolve();
     }

--- a/src/query-builder/SelectQueryBuilder.ts
+++ b/src/query-builder/SelectQueryBuilder.ts
@@ -1261,9 +1261,6 @@ export class SelectQueryBuilder<Entity> extends QueryBuilder<Entity> implements 
             }
             throw error;
 
-        } finally {
-            if (queryRunner !== this.queryRunner) // means we created our own query runner
-                await queryRunner.release();
         }
     }
 

--- a/test/github-issues/7109/entity/Dummy.ts
+++ b/test/github-issues/7109/entity/Dummy.ts
@@ -1,0 +1,13 @@
+import {Entity, PrimaryGeneratedColumn} from "../../../../src";
+import {Column} from "../../../../src/decorator/columns/Column";
+
+@Entity()
+export class Dummy {
+
+    @PrimaryGeneratedColumn()
+    id: number;
+    
+    @Column()
+    field: string;
+
+}

--- a/test/github-issues/7109/issue-7109.ts
+++ b/test/github-issues/7109/issue-7109.ts
@@ -1,0 +1,46 @@
+import "reflect-metadata";
+import {createTestingConnections, closeTestingConnections, reloadTestingDatabases} from "../../utils/test-utils";
+import {Connection} from "../../../src/connection/Connection";
+import { Dummy } from './entity/Dummy';
+import { ReadStream } from 'fs';
+import {expect} from "chai";
+
+function ingestStream (stream: ReadStream): Promise<any[]> {
+    let chunks: any[] = [];
+    return new Promise((resolve, reject) => {
+      stream.on('data', chunk => chunks.push(chunk))
+      stream.on('error', reject)
+      stream.on('end', () => resolve(chunks))
+    })
+  }
+  
+describe("github issues > #7109 stream() bug from 0.2.25 to 0.2.26 with postgresql", () => {
+
+    let connections: Connection[];
+    before(async () => connections = await createTestingConnections({
+        entities: [__dirname + "/entity/*{.js,.ts}"],
+        schemaCreate: true,
+        dropSchema: true,
+    }));
+    beforeEach(() => reloadTestingDatabases(connections));
+    after(() => closeTestingConnections(connections));
+
+    it("should release the QueryRunner created by a SelectQueryBuilder", () => Promise.all(connections.map(async connection => {
+        const values = [{field: "abc"}, {field: "def"}, {field: "ghi"}];
+        // First create some test data
+        await connection.createQueryBuilder()
+            .insert()
+            .into(Dummy)
+            .values(values)
+            .execute();
+
+       // Stream data:
+       const stream = await connection.createQueryBuilder().from(Dummy, 'dummy').select('field').stream();
+       const streamedEntities = await ingestStream(stream);
+
+       // If the runner is properly released, the test is already successful; this assert is just a sanity check.
+       const extractFields = (val: {field: string}) => val.field;
+       expect(streamedEntities.map(extractFields)).to.have.members(values.map(extractFields));
+
+    })));
+});

--- a/test/github-issues/7109/issue-7109.ts
+++ b/test/github-issues/7109/issue-7109.ts
@@ -1,8 +1,8 @@
 import "reflect-metadata";
 import {createTestingConnections, closeTestingConnections, reloadTestingDatabases} from "../../utils/test-utils";
 import {Connection} from "../../../src/connection/Connection";
-import { Dummy } from './entity/Dummy';
-import { ReadStream } from 'fs';
+import {Dummy} from './entity/Dummy';
+import {ReadStream} from 'fs';
 import {expect} from "chai";
 
 function ingestStream (stream: ReadStream): Promise<any[]> {
@@ -15,12 +15,12 @@ function ingestStream (stream: ReadStream): Promise<any[]> {
   }
   
 describe("github issues > #7109 stream() bug from 0.2.25 to 0.2.26 with postgresql", () => {
-
     let connections: Connection[];
     before(async () => connections = await createTestingConnections({
         entities: [__dirname + "/entity/*{.js,.ts}"],
         schemaCreate: true,
         dropSchema: true,
+        enabledDrivers: ["postgres", "mysql", "mariadb", "mssql", "cockroachdb", "aurora-data-api", "aurora-data-api-pg"]
     }));
     beforeEach(() => reloadTestingDatabases(connections));
     after(() => closeTestingConnections(connections));

--- a/test/github-issues/7109/issue-7109.ts
+++ b/test/github-issues/7109/issue-7109.ts
@@ -20,7 +20,7 @@ describe("github issues > #7109 stream() bug from 0.2.25 to 0.2.26 with postgres
         entities: [__dirname + "/entity/*{.js,.ts}"],
         schemaCreate: true,
         dropSchema: true,
-        enabledDrivers: ["postgres", "mysql", "mariadb", "mssql", "cockroachdb", "aurora-data-api", "aurora-data-api-pg"]
+        enabledDrivers: ["postgres", "mysql", "mariadb", "cockroachdb"]
     }));
     beforeEach(() => reloadTestingDatabases(connections));
     after(() => closeTestingConnections(connections));


### PR DESCRIPTION
Don't release the queryRunner too early from SelectQueryBuilder when streaming queries.

<!--
  😀 Wonderful!  Thank you for opening a pull request for TypeORM.

  Please fill in the information below to expedite the review
  and (hopefully) merge of your change.

  If unsure about something.. just do as best as you're able,
  or reach out through our community support channels!
  https://github.com/typeorm/typeorm/blob/master/docs/support.md
-->

### Description of change
Fixes #7109 

In release 0.2.26, streaming queries for postgres were broken. The problem is that SelectQueryBuilder releases the queryRunner too early (when it might not be connected yet), and therefore prevents release at the appropriate moment (using the release callback) to happen (since it will think that it's already released, and quit).

This PR fixes this by delegating the release of the query runner to the stream callback functions, ensuring that it's called when a connection is certainly established.

To test that streaming queries now work again, I had to add `pg-query-stream` to the dev dependencies.

The unit test I added fails as expected without this PR's changes, but passes with the changes.

### Pull-Request Checklist

<!--
  Please make sure to review and check all of the following.

  If an item is not applicable, you can add "N/A" to the end.
-->

- [x] Code is up-to-date with the `master` branch
- [x] `npm run lint` passes with this change
- [x] `npm run test` passes with this change
- [x] This pull request links relevant issues as `Fixes #0000`
- [x] There are new or updated unit tests validating the change
- [x] Documentation has been updated to reflect this change (N/A)
- [x] The new commits follow conventions explained in [CONTRIBUTING.md](https://github.com/typeorm/typeorm/blob/master/CONTRIBUTING.md)

<!--
  🎉 Thank you for contributing and making TypeORM even better!
-->
