### PR TITLE
Github issue 7178: order should allow only model fields, not methods

### DIFF
--- a/src/common/EntityFieldsNames.ts
+++ b/src/common/EntityFieldsNames.ts
@@ -1,0 +1,6 @@
+/**
+ * Interface of the entity fields names only (without functions)
+ */
+export type EntityFieldsNames<Entity = any> = {
+    [P in keyof Entity]: Entity[P] extends Function ? never : P;
+}[keyof Entity];

--- a/src/find-options/FindOneOptions.ts
+++ b/src/find-options/FindOneOptions.ts
@@ -1,3 +1,4 @@
+import {EntityFieldsNames} from "../common/EntityFieldsNames";
 import {JoinOptions} from "./JoinOptions";
 import {ObjectLiteral} from "../common/ObjectLiteral";
 import {FindConditions} from "./FindConditions";
@@ -30,7 +31,7 @@ export interface FindOneOptions<Entity = any> {
     /**
      * Order, in which entities should be ordered.
      */
-    order?: { [P in keyof Entity]?: "ASC"|"DESC"|1|-1 };
+    order?: { [P in EntityFieldsNames<Entity>]?: "ASC"|"DESC"|1|-1 };
 
     /**
      * Enables or disables query result caching.


### PR DESCRIPTION
### Description of change
In "order" clause it should be possible only to pass field-names, not methods.
Fixes: #7178 

### Pull-Request Checklist

<!--
  Please make sure to review and check all of the following.

  If an item is not applicable, you can add "N/A" to the end.
-->

- [x] Code is up-to-date with the `master` branch
- [x] `npm run lint` passes with this change
- [x] `npm run test` passes with this change
- [x] This pull request links relevant issues as `Fixes #0000`
- [ ] There are new or updated unit tests validating the change
- [ ] Documentation has been updated to reflect this change
- [x] The new commits follow conventions explained in [CONTRIBUTING.md](https://github.com/typeorm/typeorm/blob/master/CONTRIBUTING.md)

<!--
  🎉 Thank you for contributing and making TypeORM even better!
-->
