### PR TITLE
fix: add missing "comment" field to QueryExpressionMap.clone() method

### DIFF
--- a/src/query-builder/QueryExpressionMap.ts
+++ b/src/query-builder/QueryExpressionMap.ts
@@ -434,6 +434,7 @@ export class QueryExpressionMap {
         map.callListeners = this.callListeners;
         map.useTransaction = this.useTransaction;
         map.nativeParameters = Object.assign({}, this.nativeParameters);
+        map.comment = this.comment;
         return map;
     }
 

--- a/test/github-issues/7203/issue-7203.ts
+++ b/test/github-issues/7203/issue-7203.ts
@@ -1,0 +1,23 @@
+import {closeTestingConnections, createTestingConnections, reloadTestingDatabases} from "../../utils/test-utils";
+import {Connection} from "../../../src/connection/Connection";
+import {expect} from "chai";
+
+describe("github issues > #7203 QueryExpressionMap doesn't clone comment field", () => {
+  let connections: Connection[];
+  before(
+    async () =>
+      (connections = await createTestingConnections({
+        dropSchema: true,
+        enabledDrivers: ["postgres"],
+      }))
+  );
+  beforeEach(() => reloadTestingDatabases(connections));
+  after(() => closeTestingConnections(connections));
+
+    it("should be able to clone comment field", () => Promise.all(connections.map(async connection => {
+        const comment = "a comment";
+        const queryBuilder = await connection.createQueryBuilder().comment(comment);
+        const clonedQueryBuilder = queryBuilder.clone();
+        expect(clonedQueryBuilder.expressionMap.comment).to.be.eq(comment);
+    })));
+});


### PR DESCRIPTION
Closes: #7203

<!--
  😀 Wonderful!  Thank you for opening a pull request for TypeORM.

  Please fill in the information below to expedite the review
  and (hopefully) merge of your change.

  If unsure about something.. just do as best as you're able,
  or reach out through our community support channels!
  https://github.com/typeorm/typeorm/blob/master/docs/support.md
-->

### Description of change

<!--
  Please be clear and concise what the change is intended to do,
  why this change is needed, and how you've verified that it
  corrects what you intended.

  In some cases it may be helpful to include the current behavior
  and the new behavior.

  If the change is related to an open issue, you can link it here.
  If you include `Fixes #0000` (replacing `0000` with the issue number)
  when this is merged it will automatically mark the issue as fixed and
  close it.
-->
Added missing "comment" filed to QueryExpressionMap.clone() method.
In my understanding, clone method should copy every field, including the "comment" one.
Seems that clone() method was not updated after adding "comment" field to QueryExpressionMap.
In my case I have used "comment" for something special and when calling getManyAndCount(), count query was missing the "comment".
Added a unit test to confirm that clone method copies comment as well.
### Pull-Request Checklist

<!--
  Please make sure to review and check all of the following.

  If an item is not applicable, you can add "N/A" to the end.
-->

- [x ] Code is up-to-date with the `master` branch
- [ x] `npm run lint` passes with this change
- [ ] `npm run test` passes with this change
- [x ] This pull request links relevant issues as `Fixes #7203 `
- [x ] There are new or updated unit tests validating the change
- [ ] Documentation has been updated to reflect this change
- [ x] The new commits follow conventions explained in [CONTRIBUTING.md](https://github.com/typeorm/typeorm/blob/master/CONTRIBUTING.md)

<!--
  🎉 Thank you for contributing and making TypeORM even better!
-->
