### PR TITLE
Fix stack traces when using EntityPersistExecutor

### DIFF
--- a/src/persistence/EntityPersistExecutor.ts
+++ b/src/persistence/EntityPersistExecutor.ts
@@ -38,140 +38,139 @@ export class EntityPersistExecutor {
     /**
      * Executes persistence operation ob given entity or entities.
      */
-    execute(): Promise<void> {
+    async execute(): Promise<void> {
 
         // check if entity we are going to save is valid and is an object
         if (!this.entity || typeof this.entity !== "object")
             return Promise.reject(new MustBeEntityError(this.mode, this.entity));
 
         // we MUST call "fake" resolve here to make sure all properties of lazily loaded relations are resolved
-        return Promise.resolve().then(async () => {
+        await Promise.resolve();
 
-            // if query runner is already defined in this class, it means this entity manager was already created for a single connection
-            // if its not defined we create a new query runner - single connection where we'll execute all our operations
-            const queryRunner = this.queryRunner || this.connection.createQueryRunner();
+        // if query runner is already defined in this class, it means this entity manager was already created for a single connection
+        // if its not defined we create a new query runner - single connection where we'll execute all our operations
+        const queryRunner = this.queryRunner || this.connection.createQueryRunner();
 
-            // save data in the query runner - this is useful functionality to share data from outside of the world
-            // with third classes - like subscribers and listener methods
-            if (this.options && this.options.data)
-                queryRunner.data = this.options.data;
+        // save data in the query runner - this is useful functionality to share data from outside of the world
+        // with third classes - like subscribers and listener methods
+        if (this.options && this.options.data)
+            queryRunner.data = this.options.data;
 
+        try {
+
+            // collect all operate subjects
+            const entities: ObjectLiteral[] = Array.isArray(this.entity) ? this.entity : [this.entity];
+            const entitiesInChunks = this.options && this.options.chunk && this.options.chunk > 0 ? OrmUtils.chunk(entities, this.options.chunk) : [entities];
+
+            // console.time("building subject executors...");
+            const executors = await Promise.all(entitiesInChunks.map(async entities => {
+                const subjects: Subject[] = [];
+
+                // create subjects for all entities we received for the persistence
+                entities.forEach(entity => {
+                    const entityTarget = this.target ? this.target : entity.constructor;
+                    if (entityTarget === Object)
+                        throw new CannotDetermineEntityError(this.mode);
+
+                    subjects.push(new Subject({
+                        metadata: this.connection.getMetadata(entityTarget),
+                        entity: entity,
+                        canBeInserted: this.mode === "save",
+                        canBeUpdated: this.mode === "save",
+                        mustBeRemoved: this.mode === "remove",
+                        canBeSoftRemoved: this.mode === "soft-remove",
+                        canBeRecovered: this.mode === "recover"
+                    }));
+                });
+
+                // console.time("building cascades...");
+                // go through each entity with metadata and create subjects and subjects by cascades for them
+                const cascadesSubjectBuilder = new CascadesSubjectBuilder(subjects);
+                subjects.forEach(subject => {
+                    // next step we build list of subjects we will operate with
+                    // these subjects are subjects that we need to insert or update alongside with main persisted entity
+                    cascadesSubjectBuilder.build(subject, this.mode);
+                });
+                // console.timeEnd("building cascades...");
+
+                // load database entities for all subjects we have
+                // next step is to load database entities for all operate subjects
+                // console.time("loading...");
+                await new SubjectDatabaseEntityLoader(queryRunner, subjects).load(this.mode);
+                // console.timeEnd("loading...");
+
+                // console.time("other subjects...");
+                // build all related subjects and change maps
+                if (this.mode === "save" || this.mode === "soft-remove" || this.mode === "recover") {
+                    new OneToManySubjectBuilder(subjects).build();
+                    new OneToOneInverseSideSubjectBuilder(subjects).build();
+                    new ManyToManySubjectBuilder(subjects).build();
+                } else {
+                    subjects.forEach(subject => {
+                        if (subject.mustBeRemoved) {
+                            new ManyToManySubjectBuilder(subjects).buildForAllRemoval(subject);
+                        }
+                    });
+                }
+                // console.timeEnd("other subjects...");
+                // console.timeEnd("building subjects...");
+                // console.log("subjects", subjects);
+
+                // create a subject executor
+                return new SubjectExecutor(queryRunner, subjects, this.options);
+            }));
+            // console.timeEnd("building subject executors...");
+
+            // make sure we have at least one executable operation before we create a transaction and proceed
+            // if we don't have operations it means we don't really need to update or remove something
+            const executorsWithExecutableOperations = executors.filter(executor => executor.hasExecutableOperations);
+            if (executorsWithExecutableOperations.length === 0)
+                return;
+
+            // start execute queries in a transaction
+            // if transaction is already opened in this query runner then we don't touch it
+            // if its not opened yet then we open it here, and once we finish - we close it
+            let isTransactionStartedByUs = false;
             try {
 
-                // collect all operate subjects
-                const entities: ObjectLiteral[] = Array.isArray(this.entity) ? this.entity : [this.entity];
-                const entitiesInChunks = this.options && this.options.chunk && this.options.chunk > 0 ? OrmUtils.chunk(entities, this.options.chunk) : [entities];
-
-                // console.time("building subject executors...");
-                const executors = await Promise.all(entitiesInChunks.map(async entities => {
-                    const subjects: Subject[] = [];
-
-                    // create subjects for all entities we received for the persistence
-                    entities.forEach(entity => {
-                        const entityTarget = this.target ? this.target : entity.constructor;
-                        if (entityTarget === Object)
-                            throw new CannotDetermineEntityError(this.mode);
-
-                        subjects.push(new Subject({
-                            metadata: this.connection.getMetadata(entityTarget),
-                            entity: entity,
-                            canBeInserted: this.mode === "save",
-                            canBeUpdated: this.mode === "save",
-                            mustBeRemoved: this.mode === "remove",
-                            canBeSoftRemoved: this.mode === "soft-remove",
-                            canBeRecovered: this.mode === "recover"
-                        }));
-                    });
-
-                    // console.time("building cascades...");
-                    // go through each entity with metadata and create subjects and subjects by cascades for them
-                    const cascadesSubjectBuilder = new CascadesSubjectBuilder(subjects);
-                    subjects.forEach(subject => {
-                        // next step we build list of subjects we will operate with
-                        // these subjects are subjects that we need to insert or update alongside with main persisted entity
-                        cascadesSubjectBuilder.build(subject, this.mode);
-                    });
-                    // console.timeEnd("building cascades...");
-
-                    // load database entities for all subjects we have
-                    // next step is to load database entities for all operate subjects
-                    // console.time("loading...");
-                    await new SubjectDatabaseEntityLoader(queryRunner, subjects).load(this.mode);
-                    // console.timeEnd("loading...");
-
-                    // console.time("other subjects...");
-                    // build all related subjects and change maps
-                    if (this.mode === "save" || this.mode === "soft-remove" || this.mode === "recover") {
-                        new OneToManySubjectBuilder(subjects).build();
-                        new OneToOneInverseSideSubjectBuilder(subjects).build();
-                        new ManyToManySubjectBuilder(subjects).build();
-                    } else {
-                        subjects.forEach(subject => {
-                            if (subject.mustBeRemoved) {
-                                new ManyToManySubjectBuilder(subjects).buildForAllRemoval(subject);
-                            }
-                        });
+                // open transaction if its not opened yet
+                if (!queryRunner.isTransactionActive) {
+                    if (!this.options || this.options.transaction !== false) { // start transaction until it was not explicitly disabled
+                        isTransactionStartedByUs = true;
+                        await queryRunner.startTransaction();
                     }
-                    // console.timeEnd("other subjects...");
-                    // console.timeEnd("building subjects...");
-                    // console.log("subjects", subjects);
-
-                    // create a subject executor
-                    return new SubjectExecutor(queryRunner, subjects, this.options);
-                }));
-                // console.timeEnd("building subject executors...");
-
-                // make sure we have at least one executable operation before we create a transaction and proceed
-                // if we don't have operations it means we don't really need to update or remove something
-                const executorsWithExecutableOperations = executors.filter(executor => executor.hasExecutableOperations);
-                if (executorsWithExecutableOperations.length === 0)
-                    return;
-
-                // start execute queries in a transaction
-                // if transaction is already opened in this query runner then we don't touch it
-                // if its not opened yet then we open it here, and once we finish - we close it
-                let isTransactionStartedByUs = false;
-                try {
-
-                    // open transaction if its not opened yet
-                    if (!queryRunner.isTransactionActive) {
-                        if (!this.options || this.options.transaction !== false) { // start transaction until it was not explicitly disabled
-                            isTransactionStartedByUs = true;
-                            await queryRunner.startTransaction();
-                        }
-                    }
-
-                    // execute all persistence operations for all entities we have
-                    // console.time("executing subject executors...");
-                    for (const executor of executorsWithExecutableOperations) {
-                        await executor.execute();
-                    }
-                    // console.timeEnd("executing subject executors...");
-
-                    // commit transaction if it was started by us
-                    // console.time("commit");
-                    if (isTransactionStartedByUs === true)
-                        await queryRunner.commitTransaction();
-                    // console.timeEnd("commit");
-
-                } catch (error) {
-
-                    // rollback transaction if it was started by us
-                    if (isTransactionStartedByUs) {
-                        try {
-                            await queryRunner.rollbackTransaction();
-                        } catch (rollbackError) { }
-                    }
-                    throw error;
                 }
 
-            } finally {
+                // execute all persistence operations for all entities we have
+                // console.time("executing subject executors...");
+                for (const executor of executorsWithExecutableOperations) {
+                    await executor.execute();
+                }
+                // console.timeEnd("executing subject executors...");
 
-                // release query runner only if its created by us
-                if (!this.queryRunner)
-                    await queryRunner.release();
+                // commit transaction if it was started by us
+                // console.time("commit");
+                if (isTransactionStartedByUs === true)
+                    await queryRunner.commitTransaction();
+                // console.timeEnd("commit");
+
+            } catch (error) {
+
+                // rollback transaction if it was started by us
+                if (isTransactionStartedByUs) {
+                    try {
+                        await queryRunner.rollbackTransaction();
+                    } catch (rollbackError) { }
+                }
+                throw error;
             }
-        });
+
+        } finally {
+
+            // release query runner only if its created by us
+            if (!this.queryRunner)
+                await queryRunner.release();
+        }
     }
 
 }


### PR DESCRIPTION
### Description of change

Floating promises are causing issues with lost stack traces.  Summary of a change:

``` diff
+        await Promise.resolve();
+       // do whatever
-        return Promise.resolve().then(async () => {
-          // do whatever
-       });
```
This hack was added in a4e5abe1610f0eec7061898097f3aa70e8c27c10 and related tests are passing.

### Example 

Old stack trace in my app:

```
     ObjectInvalid: An instance of Domain has failed the validation:
      at Domain.validateOrReject (lib/entities/Model.ts:171:13)
```

New stack trace in my app:

```
     ObjectInvalid: An instance of Domain has failed the validation:
      at Domain.validateOrReject (lib/entities/Model.ts:171:13)
      at Domain.captureStack (lib/entities/Model.ts:163:19)
      at EntityListenerMetadata.execute (src/metadata/EntityListenerMetadata.ts:71:45)
      at /Users/bogdan/makabu/unstoppable/unstoppable-domains-website/default/src/subscriber/Broadcaster.ts:38:54
      at Array.forEach (<anonymous>)
      at Broadcaster.broadcastBeforeInsertEvent (src/subscriber/Broadcaster.ts:36:44)
      at /Users/bogdan/makabu/unstoppable/unstoppable-domains-website/default/src/persistence/SubjectExecutor.ts:210:81
      at Array.forEach (<anonymous>)
      at SubjectExecutor.broadcastBeforeEventsForAll (src/persistence/SubjectExecutor.ts:210:33)
      at SubjectExecutor.<anonymous> (src/persistence/SubjectExecutor.ts:107:38)
      at step (node_modules/typeorm/node_modules/tslib/tslib.js:141:27)
      at Object.next (node_modules/typeorm/node_modules/tslib/tslib.js:122:57)
      at /Users/bogdan/makabu/unstoppable/unstoppable-domains-website/default/node_modules/typeorm/node_modules/tslib/tslib.js:115:75
      at new Promise (<anonymous>)
      at Object.__awaiter (node_modules/typeorm/node_modules/tslib/tslib.js:111:16)
      at SubjectExecutor.execute (node_modules/typeorm/persistence/SubjectExecutor.js:67:24)
      at EntityPersistExecutor_1.EntityPersistExecutor.execute (lib/connect.ts:226:26)
      at processTicksAndRejections (internal/process/task_queues.js:97:5)
      at Context.<anonymous> (lib/entities/Model.test.ts:20:5)
```

I was trying to make a test for an error stack to be full, but unfortunately it is only testable when typescript compiler option is set to `es2018` or above. Your target is `es5` which is too low for it even to be testable.

### Pull-Request Checklist

- [x] Code is up-to-date with the `master` branch
- [x] `npm run lint` passes with this change
- [x] `npm run test` passes with this change
- [ ] There are new or updated unit tests validating the change
- [x] Documentation has been updated to reflect this change
- [x] The new commits follow conventions explained in [CONTRIBUTING.md](https://github.com/typeorm/typeorm/blob/master/CONTRIBUTING.md)

<!--
  🎉 Thank you for contributing and making TypeORM even better!
-->
