### PR TITLE
Nullable default value for `Enum` types

### DIFF
--- a/src/driver/mysql/MysqlDriver.ts
+++ b/src/driver/mysql/MysqlDriver.ts
@@ -582,7 +582,7 @@ export class MysqlDriver implements Driver {
     normalizeDefault(columnMetadata: ColumnMetadata): string {
         const defaultValue = columnMetadata.default;
 
-        if ((columnMetadata.type === "enum" || columnMetadata.type === "simple-enum") && defaultValue !== undefined) {
+        if ((columnMetadata.type === "enum" || columnMetadata.type === "simple-enum") && defaultValue != null) {
             return `'${defaultValue}'`;
         }
 

--- a/src/driver/postgres/PostgresDriver.ts
+++ b/src/driver/postgres/PostgresDriver.ts
@@ -725,7 +725,7 @@ export class PostgresDriver implements Driver {
             (
                 columnMetadata.type === "enum"
                 || columnMetadata.type === "simple-enum"
-            ) && defaultValue !== undefined
+            ) && defaultValue != null
         ) {
             if (columnMetadata.isArray && Array.isArray(defaultValue)) {
                 return `'{${defaultValue.map((val: string) => `${val}`).join(",")}}'`;


### PR DESCRIPTION
### Description of change
This PR is the result of a conversation at #5371 regarding a bug with TypeOrm and MySQL resulting in the generation of an invalid table create query for enum fields with a default value of `null`
This happens simply due to treating `null` as another value for the enum and therefore, escaping and passing it as a string to the database.
The fix was easy, we are already checking for `undefined` before searching in enum and escaping the value in case there was no default value specified, now we are also checking for `null` in case the passed default value is _special_ and should not be treated like others.
This is done by simply replacing `value !== undefined` with `value != null` therefore checking for both conditions.

### Pull-Request Checklist

- [X] Code is up-to-date with the `master` branch
- [ ] `npm run lint` passes with this change
- [ ] `npm run test` passes with this change
- [X] This pull request links relevant issues as `Fixes #0000`
- [ ] There are new or updated unit tests validating the change
- [ ] Documentation has been updated to reflect this change
- [ ] The new commits follow conventions explained in [CONTRIBUTING.md](https://github.com/typeorm/typeorm/blob/master/CONTRIBUTING.md)

This is a small change and so I did the changes on my browser without setting up the project for test, build, and lint. But honestly, I don't think it can break anything! Feel free to reject it if it doesn't fits the standards!

Thank you for the great library.