### PR TITLE
Remove SAP registry

### DIFF
--- a/README.md
+++ b/README.md
@@ -211,7 +211,6 @@ await timber.remove();
     * for **SAP Hana**
 
         ```
-        npm config set @sap:registry https://npm.sap.com
         npm i @sap/hana-client
 		npm i hdb-pool
         ```


### PR DESCRIPTION


### Description of change
This registry is deprecated now: <https://blogs.sap.com/2017/05/16/sap-npm-registry-launched-making-the-lives-of-node.js-developers-easier/>


### Pull-Request Checklist


- [X] Code is up-to-date with the `master` branch
- [X] `npm run lint` passes with this change
- [X] `npm run test` passes with this change
- [X] This pull request links relevant issues as `Fixes #0000` NA
- [X] There are new or updated unit tests validating the change NA
- [X] Documentation has been updated to reflect this change NA
- [X] The new commits follow conventions explained in [CONTRIBUTING.md](https://github.com/typeorm/typeorm/blob/master/CONTRIBUTING.md) NA


