### PR TITLE
fix: Fix unnecessary migrations for timestamps with default values of CURRENT_TIMESTAMP and precision

### DIFF
--- a/src/driver/cockroachdb/CockroachDriver.ts
+++ b/src/driver/cockroachdb/CockroachDriver.ts
@@ -483,6 +483,9 @@ export class CockroachDriver implements Driver {
         const defaultValue = columnMetadata.default;
         const arrayCast = columnMetadata.isArray ? `::${columnMetadata.type}[]` : "";
 
+        // console.log(`normalizeDefault() : columnMetadata.propertyName = ${columnMetadata.propertyName}`);
+        // console.log(`normalizeDefault() : defaultValue = ${defaultValue}`);
+
         if (typeof defaultValue === "number") {
             return `(${defaultValue})`;
 

--- a/src/driver/cockroachdb/CockroachQueryRunner.ts
+++ b/src/driver/cockroachdb/CockroachQueryRunner.ts
@@ -1533,6 +1533,10 @@ export class CockroachQueryRunner extends BaseQueryRunner implements QueryRunner
                         }
                     }
 
+                    // console.log(`loadTables() : tableColumn.name = ${tableColumn.name}`);
+                    // console.log(`loadTables() : dbColumn["column_default"] = ${dbColumn["column_default"]}`);
+                    // console.log(`loadTables() : tableColumn.default = ${tableColumn.default}`);
+
                     tableColumn.comment = dbColumn["description"] == null ? undefined : dbColumn["description"];
                     if (dbColumn["character_set_name"])
                         tableColumn.charset = dbColumn["character_set_name"];

--- a/src/driver/mysql/MysqlDriver.ts
+++ b/src/driver/mysql/MysqlDriver.ts
@@ -582,6 +582,9 @@ export class MysqlDriver implements Driver {
     normalizeDefault(columnMetadata: ColumnMetadata): string {
         const defaultValue = columnMetadata.default;
 
+        // console.log(`normalizeDefault() : columnMetadata.propertyName = ${columnMetadata.propertyName}`);
+        // console.log(`normalizeDefault() : defaultValue = ${defaultValue}`);
+
         if ((columnMetadata.type === "enum" || columnMetadata.type === "simple-enum") && defaultValue !== undefined) {
             return `'${defaultValue}'`;
         }

--- a/src/driver/mysql/MysqlQueryRunner.ts
+++ b/src/driver/mysql/MysqlQueryRunner.ts
@@ -1488,6 +1488,10 @@ export class MysqlQueryRunner extends BaseQueryRunner implements QueryRunner {
                         tableColumn.default = `'${dbColumn["COLUMN_DEFAULT"]}'`;
                     }
 
+                    // console.log(`loadTables() : tableColumn.name = ${tableColumn.name}`);
+                    // console.log(`loadTables() : dbColumn["COLUMN_DEFAULT"] = ${dbColumn["COLUMN_DEFAULT"]}`);
+                    // console.log(`loadTables() : tableColumn.default = ${tableColumn.default}`);
+
                     if (dbColumn["EXTRA"].indexOf("on update") !== -1) {
                         // New versions of MariaDB return expressions in lowercase.  We need to set it in
                         // uppercase so the comparison in MysqlDriver#compareExtraValues does not fail.

--- a/src/driver/postgres/PostgresDriver.ts
+++ b/src/driver/postgres/PostgresDriver.ts
@@ -721,6 +721,9 @@ export class PostgresDriver implements Driver {
         const defaultValue = columnMetadata.default;
         const arrayCast = columnMetadata.isArray ? `::${columnMetadata.type}[]` : "";
 
+        // console.log(`normalizeDefault() : columnMetadata.propertyName = ${columnMetadata.propertyName}`);
+        // console.log(`normalizeDefault() : defaultValue = ${defaultValue}`);
+
         if (
             (
                 columnMetadata.type === "enum"

--- a/src/driver/postgres/PostgresQueryRunner.ts
+++ b/src/driver/postgres/PostgresQueryRunner.ts
@@ -1623,6 +1623,10 @@ export class PostgresQueryRunner extends BaseQueryRunner implements QueryRunner 
                         }
                     }
 
+                    // console.log(`loadTables() : tableColumn.name = ${tableColumn.name}`);
+                    // console.log(`loadTables() : dbColumn["column_default"] = ${dbColumn["column_default"]}`);
+                    // console.log(`loadTables() : tableColumn.default = ${tableColumn.default}`);
+
                     tableColumn.comment = dbColumn["description"] == null ? undefined : dbColumn["description"];
                     if (dbColumn["character_set_name"])
                         tableColumn.charset = dbColumn["character_set_name"];

--- a/test/github-issues/3991/entity/Test.ts
+++ b/test/github-issues/3991/entity/Test.ts
@@ -1,0 +1,28 @@
+import { CreateDateColumn, Column, Entity, PrimaryGeneratedColumn, UpdateDateColumn } from "../../../../src";
+
+@Entity({ name: "Test" })
+export class Test {
+
+    @PrimaryGeneratedColumn()
+    id?: number;
+
+    @CreateDateColumn({
+        type: "timestamp",
+        precision: null,
+        default: () => "CURRENT_TIMESTAMP"
+    })
+    createTimestamp: Date;
+
+    @UpdateDateColumn({
+        type: "timestamp",
+        precision: null,
+        default: () => "CURRENT_TIMESTAMP"
+    })
+    updateTimestamp: Date;
+
+    @Column({
+        type: "timestamp",
+        default: () => "CURRENT_TIMESTAMP",
+    })
+    anotherTimestamp: Date;
+}

--- a/test/github-issues/3991/issue-3991.ts
+++ b/test/github-issues/3991/issue-3991.ts
@@ -1,0 +1,30 @@
+import { Connection } from "../../../src";
+import { closeTestingConnections, createTestingConnections, reloadTestingDatabases } from "../../utils/test-utils";
+import { Test } from "./entity/Test";
+import { expect } from "chai";
+
+describe("github issues > #3991 migration issues for timestamps with default values and precision", () => {
+    let connections: Connection[];
+    before(async () => connections = await createTestingConnections({
+        entities: [Test],
+        enabledDrivers: ["cockroachdb", "mariadb", "mysql", "postgres"],
+    }));
+    beforeEach(() => reloadTestingDatabases(connections));
+    after(() => closeTestingConnections(connections));
+
+    it("can recognize model changes", async () => {
+        await Promise.all(connections.map(async (connection) => {
+            const sqlInMemory = await connection.driver.createSchemaBuilder().log();
+            expect(sqlInMemory.upQueries).to.eql([]);
+            expect(sqlInMemory.downQueries).to.eql([]);
+        }));
+    });
+
+    it("does not generate when no model changes", () => Promise.all(connections.map(async connection => {
+        await connection.driver.createSchemaBuilder().build();
+
+        const sqlInMemory = await connection.driver.createSchemaBuilder().log();
+        expect(sqlInMemory.upQueries).to.eql([]);
+        expect(sqlInMemory.downQueries).to.eql([]);
+    })));
+});


### PR DESCRIPTION
<!--
  😀 Wonderful!  Thank you for opening a pull request for TypeORM.

  Please fill in the information below to expedite the review
  and (hopefully) merge of your change.

  If unsure about something.. just do as best as you're able,
  or reach out through our community support channels!
  https://github.com/typeorm/typeorm/blob/master/docs/support.md
-->

### Description of change

<!--
  Please be clear and concise what the change is intended to do,
  why this change is needed, and how you've verified that it
  corrects what you intended.

  In some cases it may be helpful to include the current behavior
  and the new behavior.

  If the change is related to an open issue, you can link it here.
  If you include `Fixes #0000` (replacing `0000` with the issue number)
  when this is merged it will automatically mark the issue as fixed and
  close it.
-->

After upgrading `typeorm` from `0.2.12` to `0.2.29`, I started seeing `COMMENT ON COLUMN "tableName"."columnName" IS NULL` statements in both the `up` and `down` migrations for columns that had default values but no changes.

I saw that issue #3991 looked similar, so I fixed it.  I have a separate fix for the comment issue that I will send in another pull request.

Details:
- Returned the database specific equivalent of CURRENT_TIMESTAMP in normalizeDefault().
- Pulled out individual conditions for easier debugging.
- Intentionally used '!=' instead of '!==' for the precision comparison, so that undefined and null compare as equal.

Fixes #3991

### Pull-Request Checklist

<!--
  Please make sure to review and check all of the following.

  If an item is not applicable, you can add "N/A" to the end.
-->

- [x] Code is up-to-date with the `master` branch
- [x] `npm run lint` passes with this change
- [x] `npm run test` passes with this change
- [x] This pull request links relevant issues as `Fixes #0000`
- [x] There are new or updated unit tests validating the change
- [ ] Documentation has been updated to reflect this change - N/A
- [x] The new commits follow conventions explained in [CONTRIBUTING.md](https://github.com/typeorm/typeorm/blob/master/CONTRIBUTING.md)

<!--
  🎉 Thank you for contributing and making TypeORM even better!
-->
