### PR TITLE
[FEAT] Add NOWAIT and SKIP LOCKED lock support for MySQL

### DIFF
--- a/src/query-builder/SelectQueryBuilder.ts
+++ b/src/query-builder/SelectQueryBuilder.ts
@@ -1686,14 +1686,14 @@ export class SelectQueryBuilder<Entity> extends QueryBuilder<Entity> implements 
                     throw new LockNotSupportedOnGivenDriverError();
                 }
             case "pessimistic_partial_write":
-                if (driver instanceof PostgresDriver) {
+                if (driver instanceof PostgresDriver || driver instanceof MysqlDriver) {
                     return " FOR UPDATE SKIP LOCKED";
 
                 } else {
                     throw new LockNotSupportedOnGivenDriverError();
                 }
             case "pessimistic_write_or_fail":
-                if (driver instanceof PostgresDriver) {
+                if (driver instanceof PostgresDriver || driver instanceof MysqlDriver) {
                     return " FOR UPDATE NOWAIT";
                 } else {
                     throw new LockNotSupportedOnGivenDriverError();

--- a/test/functional/query-builder/locking/query-builder-locking.ts
+++ b/test/functional/query-builder/locking/query-builder-locking.ts
@@ -18,6 +18,7 @@ import {SqlServerDriver} from "../../../../src/driver/sqlserver/SqlServerDriver"
 import {AbstractSqliteDriver} from "../../../../src/driver/sqlite-abstract/AbstractSqliteDriver";
 import {OracleDriver} from "../../../../src/driver/oracle/OracleDriver";
 import {LockNotSupportedOnGivenDriverError} from "../../../../src/error/LockNotSupportedOnGivenDriverError";
+import { VersionUtils } from "../../../../src/util/VersionUtils";
 
 describe("query builder > locking", () => {
 
@@ -100,17 +101,31 @@ describe("query builder > locking", () => {
     })));
 
     it("should throw error if pessimistic_partial_write lock used without transaction", () => Promise.all(connections.map(async connection => {
-        if (connection.driver instanceof PostgresDriver || connection.driver instanceof MysqlDriver) {
+        if (connection.driver instanceof PostgresDriver) {
             return connection.createQueryBuilder(PostWithVersion, "post")
                 .setLock("pessimistic_partial_write")
                 .where("post.id = :id", { id: 1 })
                 .getOne().should.be.rejectedWith(PessimisticLockTransactionRequiredError);
         }
+
+        if (connection.driver instanceof MysqlDriver) {
+            let [{ version }] = await connection.query(
+                "SELECT VERSION() as version;"
+            );
+            version = version.toLowerCase();
+            if (version.includes('maria')) return; // not supported in mariadb
+            if (VersionUtils.isGreaterOrEqual(version, '8.0.0')) {
+                return connection.createQueryBuilder(PostWithVersion, "post")
+                .setLock("pessimistic_partial_write")
+                .where("post.id = :id", { id: 1 })
+                .getOne().should.be.rejectedWith(PessimisticLockTransactionRequiredError);                
+            }
+        }
         return;
     })));    
 
     it("should not throw error if pessimistic_partial_write lock used with transaction", () => Promise.all(connections.map(async connection => {
-        if (connection.driver instanceof PostgresDriver || connection.driver instanceof MysqlDriver) {
+        if (connection.driver instanceof PostgresDriver) {  
             return connection.manager.transaction(entityManager => {
                 return Promise.all([entityManager.createQueryBuilder(PostWithVersion, "post")
                     .setLock("pessimistic_partial_write")
@@ -118,21 +133,50 @@ describe("query builder > locking", () => {
                     .getOne().should.not.be.rejected]);
             });
         }
+
+        if (connection.driver instanceof MysqlDriver) {
+            let [{ version }] = await connection.query(
+                "SELECT VERSION() as version;"
+            );
+            version = version.toLowerCase();
+            if (version.includes('maria')) return; // not supported in mariadb
+            if (VersionUtils.isGreaterOrEqual(version, '8.0.0')) {
+                return connection.manager.transaction(entityManager => {
+                    return Promise.all([entityManager.createQueryBuilder(PostWithVersion, "post")
+                        .setLock("pessimistic_partial_write")
+                        .where("post.id = :id", { id: 1})
+                        .getOne().should.not.be.rejected]);
+                });
+            }
+        }        
         return;
     })));
     
     it("should throw error if pessimistic_write_or_fail lock used without transaction", () => Promise.all(connections.map(async connection => {
-        if (connection.driver instanceof PostgresDriver || connection.driver instanceof MysqlDriver) {
+        if (connection.driver instanceof PostgresDriver) {
             return connection.createQueryBuilder(PostWithVersion, "post")
                 .setLock("pessimistic_write_or_fail")
                 .where("post.id = :id", { id: 1 })
                 .getOne().should.be.rejectedWith(PessimisticLockTransactionRequiredError);
         }
-        return;
+
+        if (connection.driver instanceof MysqlDriver) {
+            let [{ version }] = await connection.query(
+                "SELECT VERSION() as version;"
+            );
+            version = version.toLowerCase();
+            if ((version.includes('maria') && VersionUtils.isGreaterOrEqual(version, "10.3.0")) || !version.includes('maria') && VersionUtils.isGreaterOrEqual(version, '8.0.0')) {
+                return connection.createQueryBuilder(PostWithVersion, "post")
+                .setLock("pessimistic_write_or_fail")
+                .where("post.id = :id", { id: 1 })
+                .getOne().should.be.rejectedWith(PessimisticLockTransactionRequiredError);
+            }
+        }
+        return;        
     })));    
 
     it("should not throw error if pessimistic_write_or_fail lock used with transaction", () => Promise.all(connections.map(async connection => {
-        if (connection.driver instanceof PostgresDriver || connection.driver instanceof MysqlDriver) {
+        if (connection.driver instanceof PostgresDriver) {
             return connection.manager.transaction(entityManager => {
                 return Promise.all([entityManager.createQueryBuilder(PostWithVersion, "post")
                     .setLock("pessimistic_write_or_fail")
@@ -140,6 +184,21 @@ describe("query builder > locking", () => {
                     .getOne().should.not.be.rejected]);
             });
         }
+
+        if (connection.driver instanceof MysqlDriver) {
+            let [{ version }] = await connection.query(
+                "SELECT VERSION() as version;"
+            );
+            version = version.toLowerCase();
+            if ((version.includes('maria') && VersionUtils.isGreaterOrEqual(version, "10.3.0")) || !version.includes('maria') && VersionUtils.isGreaterOrEqual(version, '8.0.0')) {
+                return connection.manager.transaction(entityManager => {
+                    return Promise.all([entityManager.createQueryBuilder(PostWithVersion, "post")
+                        .setLock("pessimistic_write_or_fail")
+                        .where("post.id = :id", { id: 1})
+                        .getOne().should.not.be.rejected]);
+                });
+            }
+        }        
         return;
     })));    
 

--- a/test/functional/query-builder/locking/query-builder-locking.ts
+++ b/test/functional/query-builder/locking/query-builder-locking.ts
@@ -99,7 +99,7 @@ describe("query builder > locking", () => {
         return;
     })));
 
-    it.only("should throw error if pessimistic_partial_write lock used without transaction", () => Promise.all(connections.map(async connection => {
+    it("should throw error if pessimistic_partial_write lock used without transaction", () => Promise.all(connections.map(async connection => {
         if (connection.driver instanceof PostgresDriver || connection.driver instanceof MysqlDriver) {
             return connection.createQueryBuilder(PostWithVersion, "post")
                 .setLock("pessimistic_partial_write")
@@ -109,7 +109,7 @@ describe("query builder > locking", () => {
         return;
     })));    
 
-    it.only("should not throw error if pessimistic_partial_write lock used with transaction", () => Promise.all(connections.map(async connection => {
+    it("should not throw error if pessimistic_partial_write lock used with transaction", () => Promise.all(connections.map(async connection => {
         if (connection.driver instanceof PostgresDriver || connection.driver instanceof MysqlDriver) {
             return connection.manager.transaction(entityManager => {
                 return Promise.all([entityManager.createQueryBuilder(PostWithVersion, "post")
@@ -121,7 +121,7 @@ describe("query builder > locking", () => {
         return;
     })));
     
-    it.only("should throw error if pessimistic_write_or_fail lock used without transaction", () => Promise.all(connections.map(async connection => {
+    it("should throw error if pessimistic_write_or_fail lock used without transaction", () => Promise.all(connections.map(async connection => {
         if (connection.driver instanceof PostgresDriver || connection.driver instanceof MysqlDriver) {
             return connection.createQueryBuilder(PostWithVersion, "post")
                 .setLock("pessimistic_write_or_fail")
@@ -131,7 +131,7 @@ describe("query builder > locking", () => {
         return;
     })));    
 
-    it.only("should not throw error if pessimistic_write_or_fail lock used with transaction", () => Promise.all(connections.map(async connection => {
+    it("should not throw error if pessimistic_write_or_fail lock used with transaction", () => Promise.all(connections.map(async connection => {
         if (connection.driver instanceof PostgresDriver || connection.driver instanceof MysqlDriver) {
             return connection.manager.transaction(entityManager => {
                 return Promise.all([entityManager.createQueryBuilder(PostWithVersion, "post")
@@ -231,7 +231,7 @@ describe("query builder > locking", () => {
 
     })));
 
-    it.only("should not attach pessimistic_partial_write lock statement on query if locking is not used", () => Promise.all(connections.map(async connection => {
+    it("should not attach pessimistic_partial_write lock statement on query if locking is not used", () => Promise.all(connections.map(async connection => {
         if (connection.driver instanceof PostgresDriver || connection.driver instanceof MysqlDriver) {
             const sql = connection.createQueryBuilder(PostWithVersion, "post")
                 .where("post.id = :id", { id: 1 })
@@ -242,7 +242,7 @@ describe("query builder > locking", () => {
         return;
     })));    
 
-    it.only("should attach pessimistic_partial_write lock statement on query if locking enabled", () => Promise.all(connections.map(async connection => {
+    it("should attach pessimistic_partial_write lock statement on query if locking enabled", () => Promise.all(connections.map(async connection => {
         if (connection.driver instanceof PostgresDriver || connection.driver instanceof MysqlDriver) {
             const sql = connection.createQueryBuilder(PostWithVersion, "post")
                 .setLock("pessimistic_partial_write")
@@ -255,7 +255,7 @@ describe("query builder > locking", () => {
 
     })));    
 
-    it.only("should not attach pessimistic_write_or_fail lock statement on query if locking is not used", () => Promise.all(connections.map(async connection => {
+    it("should not attach pessimistic_write_or_fail lock statement on query if locking is not used", () => Promise.all(connections.map(async connection => {
         if (connection.driver instanceof PostgresDriver || connection.driver instanceof MysqlDriver) {
             const sql = connection.createQueryBuilder(PostWithVersion, "post")
                 .where("post.id = :id", { id: 1 })
@@ -266,7 +266,7 @@ describe("query builder > locking", () => {
         return;
     })));    
 
-    it.only("should attach pessimistic_write_or_fail lock statement on query if locking enabled", () => Promise.all(connections.map(async connection => {
+    it("should attach pessimistic_write_or_fail lock statement on query if locking enabled", () => Promise.all(connections.map(async connection => {
         if (connection.driver instanceof PostgresDriver || connection.driver instanceof MysqlDriver) {
             const sql = connection.createQueryBuilder(PostWithVersion, "post")
                 .setLock("pessimistic_write_or_fail")


### PR DESCRIPTION
Adds `SKIP LOCKED` (pessimistic_partial_write) and `NOWAIT` (pessimistic_write_or_fail) support for Mysql drivers. 

Database support as follows
Database | SKIP LOCKED | NOWAIT
------------ | ------------- | ------------
MySQL | 8.0 | 8.0
MariaDB | Unsupported | 10.3.0

Added test cases, but they do not pass with the current versions listed in docker-compose. (Have tested with the versions listed above and they pass). Generally, how does typeorm handle cases like this?

References: 
https://dev.mysql.com/doc/refman/8.0/en/innodb-locking-reads.html
https://jira.mariadb.org/browse/MDEV-13115
https://mariadb.com/kb/en/wait-and-nowait/