### PR TITLE
fix: get length attribute of postgres array columns

### DIFF
--- a/test/github-issues/6990/entity/foo.ts
+++ b/test/github-issues/6990/entity/foo.ts
@@ -1,0 +1,15 @@
+import { Column, Entity, PrimaryGeneratedColumn } from "../../../../src";
+
+@Entity()
+export class Foo {
+    @PrimaryGeneratedColumn()
+    id: number;
+
+    @Column({
+        array: true,
+        type: "varchar",
+        length: 64,
+        nullable: true,
+    })
+    varchararray: string[];    
+}

--- a/test/github-issues/6990/issue-6990.ts
+++ b/test/github-issues/6990/issue-6990.ts
@@ -1,0 +1,46 @@
+import "reflect-metadata";
+import {
+    closeTestingConnections,
+    createTestingConnections,
+    reloadTestingDatabases,
+} from "../../utils/test-utils";
+import { Connection } from "../../../src/connection/Connection";
+import { Foo } from "./entity/foo";
+import { expect } from "chai";
+
+describe("github issues > #6990 synchronize drops array columns in postgres if a length is set", () => {
+    let connections: Connection[];
+    before(
+        async () =>
+            (connections = await createTestingConnections({
+                entities: [__dirname + "/entity/*{.js,.ts}"],
+                subscribers: [__dirname + "/subscriber/*{.js,.ts}"],
+                enabledDrivers: ["postgres"],
+            }))
+    );
+    beforeEach(() => reloadTestingDatabases(connections));
+    after(() => closeTestingConnections(connections));
+
+    it("should not drop varchar array column on synchronize using postgres driver", () =>
+        Promise.all(
+            connections.map(async function (connection) {
+                const foo = new Foo();
+                foo.id = 1;
+                foo.varchararray = ["able", "baker", "charlie"];
+                await connection.manager.save(foo);
+
+                await connection.synchronize();
+
+                const loadedFoo:
+                    | Foo
+                    | undefined = await connection.manager.findOne(Foo, 1);
+
+                expect(loadedFoo).to.be.not.empty;
+                expect(loadedFoo!.varchararray).to.deep.eq([
+                    "able",
+                    "baker",
+                    "charlie",
+                ]);
+            })
+        ));
+});


### PR DESCRIPTION
### Description of change

Fixes #6990. 

PostgresQueryRunner method loadTables is used to determine if the database is in sync with the entity definitions. This change updates how loadTables determines the length value of array columns. It uses the postgres-specific pg_catalog.pg_attribute table and the pg_catalog.format_type function to find the data type name, which includes the length for types that have a length attribute. Previously, loadTables relied solely on character_maximum_length in information_schema.columns, which is null for array columns. Because of this, array columns with a length attribute were always dropped. 

This also includes a test that confirms the issues is resolved by this fix. 

### Pull-Request Checklist

- [X] Code is up-to-date with the `master` branch
- [X] `npm run lint` passes with this change
- [X] `npm run test` passes with this change
- [X] This pull request links relevant issues as `Fixes #0000`
- [X] There are new or updated unit tests validating the change
- [ ] Documentation has been updated to reflect this change N/A
- [X] The new commits follow conventions explained in [CONTRIBUTING.md] 
