### PR TITLE
[FEAT] Optionally output migrations as Javascript files instead of TypeScript

### DIFF
--- a/src/commands/MigrationCreateCommand.ts
+++ b/src/commands/MigrationCreateCommand.ts
@@ -33,6 +33,12 @@ export class MigrationCreateCommand implements yargs.CommandModule {
                 alias: "config",
                 default: "ormconfig",
                 describe: "Name of the file with connection configuration."
+            })
+            .option("o", {
+                alias: "outputJs",
+                type: "boolean",
+                default: false,
+                describe: "Generate a migration file on Javascript instead of Typescript",
             });
     }
 
@@ -43,8 +49,11 @@ export class MigrationCreateCommand implements yargs.CommandModule {
 
         try {
             const timestamp = new Date().getTime();
-            const fileContent = MigrationCreateCommand.getTemplate(args.name as any, timestamp);
-            const filename = timestamp + "-" + args.name + ".ts";
+            const fileContent = args.outputJs ?
+                MigrationCreateCommand.getJavascriptTemplate(args.name as any, timestamp)
+                : MigrationCreateCommand.getTemplate(args.name as any, timestamp);
+            const extension = args.outputJs ? ".js" : ".ts";
+            const filename = timestamp + "-" + args.name + extension;
             let directory = args.dir as string | undefined;
 
             // if directory is not set then try to open tsconfig and find default path there
@@ -95,4 +104,20 @@ export class ${camelCase(name, true)}${timestamp} implements MigrationInterface 
 `;
     }
 
+    /**
+     * Gets contents of the migration file in Javascript.
+     */
+    protected static getJavascriptTemplate(name: string, timestamp: number): string {
+        return `const { MigrationInterface, QueryRunner } = require("typeorm");
+
+module.exports = class ${camelCase(name, true)}${timestamp} {
+
+    async up(queryRunner) {
+    }
+
+    async down(queryRunner) {
+    }
+}
+        `;
+    }
 }


### PR DESCRIPTION
<!--
  😀 Wonderful!  Thank you for opening a pull request for TypeORM.

  Please fill in the information below to expedite the review
  and (hopefully) merge of your change.

  If unsure about something.. just do as best as you're able,
  or reach out through our community support channels!
  https://github.com/typeorm/typeorm/blob/master/docs/support.md
-->

### Description of change

This is a proposal that attempts to address the discussion here: https://github.com/typeorm/typeorm/issues/1675

Added a new `-o` / `--outputJs` option to the `migrate:create` and `migrate:generate` commands, to be able to output directly to Javascript. This would help for Javascript only projects in which having TypeScript files as part of the project would complicate maintenance, and eliminates the need for an extra `ts-node` transpiling command to run the `migrate:run`. 

Tested locally the `migrate:create`, by manually running the compiled project `cli.js` file. I didn't manage to link my local build version to work with the generate. I'd like some help or instructions to be able to compile and test the other command.

<!--
  Please be clear and concise what the change is intended to do,
  why this change is needed, and how you've verified that it
  corrects what you intended.

  In some cases it may be helpful to include the current behavior
  and the new behavior.

  If the change is related to an open issue, you can link it here.
  If you include `Fixes #0000` (replacing `0000` with the issue number)
  when this is merged it will automatically mark the issue as fixed and
  close it.
-->


### Pull-Request Checklist

<!--
  Please make sure to review and check all of the following.

  If an item is not applicable, you can add "N/A" to the end.
-->

- [x] Code is up-to-date with the `master` branch
- [x] `npm run lint` passes with this change
- [x] `npm run test` passes with this change
- [x] This pull request links relevant issues as `Fixes #0000`
- [ ] There are new or updated unit tests validating the change
- [ ] Documentation has been updated to reflect this change
- [ ] The new commits follow conventions explained in [CONTRIBUTING.md](https://github.com/typeorm/typeorm/blob/master/CONTRIBUTING.md)

<!--
  🎉 Thank you for contributing and making TypeORM even better!
-->
