### PR TITLE
Fix typos in Repository.ts

### DIFF
--- a/src/repository/Repository.ts
+++ b/src/repository/Repository.ts
@@ -80,14 +80,14 @@ export class Repository<Entity extends ObjectLiteral> {
     create(): Entity;
 
     /**
-     * Creates a new entities and copies all entity properties from given objects into their new entities.
-     * Note that it copies only properties that present in entity schema.
+     * Creates new entities and copies all entity properties from given objects into their new entities.
+     * Note that it copies only properties that are present in entity schema.
      */
     create(entityLikeArray: DeepPartial<Entity>[]): Entity[];
 
     /**
      * Creates a new entity instance and copies all entity properties from this object into a new entity.
-     * Note that it copies only properties that present in entity schema.
+     * Note that it copies only properties that are present in entity schema.
      */
     create(entityLike: DeepPartial<Entity>): Entity;
 


### PR DESCRIPTION



### Description of change
Fixed typos in method documentations:
Intended use of "present" in its meaning as an adjective should be preceded with a verb (in this case, "are").
Fixed an indefinite article before plural noun: "an entities" -> "entities"


### Pull-Request Checklist


- [x] Code is up-to-date with the `master` branch
- [x] `npm run lint` passes with this change
- [x] `npm run test` passes with this change
- [x] This pull request links relevant issues as `Fixes #0000`
- [x] There are new or updated unit tests validating the change
- [x] Documentation has been updated to reflect this change
- [x] The new commits follow conventions explained in [CONTRIBUTING.md](https://github.com/typeorm/typeorm/blob/master/CONTRIBUTING.md)

