### PR TITLE
Fix invalid code block in "find many options" article

### DIFF
--- a/docs/find-options.md
+++ b/docs/find-options.md
@@ -80,6 +80,7 @@ userRepository.find({
 userRepository.find({
     withDeleted: true
 });
+```
 
 `find` methods which return multiple entities (`find`, `findAndCount`, `findByIds`) also accept following options:
 


### PR DESCRIPTION
### Description of change

Seems like there was an unclosed code block added in #7132 that broke the documentation page's appearance:

![image](https://user-images.githubusercontent.com/6490265/104222485-08b08a80-544b-11eb-8e7f-44f3f07bc004.png)

### Pull-Request Checklist

- [x] Code is up-to-date with the `master` branch
- [ ] `npm run lint` passes with this change N/A
- [ ] `npm run test` passes with this change N/A
- [ ] This pull request links relevant issues as `Fixes #0000`  N/A
- [ ] There are new or updated unit tests validating the change N/A
- [ ] Documentation has been updated to reflect this change N/A
- [x] The new commits follow conventions explained in [CONTRIBUTING.md](https://github.com/typeorm/typeorm/blob/master/CONTRIBUTING.md)