### PR TITLE
feat: Add check and dryrun to migration generate

### DIFF
--- a/src/commands/MigrationGenerateCommand.ts
+++ b/src/commands/MigrationGenerateCommand.ts
@@ -50,6 +50,18 @@ export class MigrationGenerateCommand implements yargs.CommandModule {
                 type: "boolean",
                 default: false,
                 describe: "Generate a migration file on Javascript instead of Typescript",
+            })
+            .option("dr", {
+                alias: "dryrun",
+                type: "boolean",
+                default: false,
+                describe: "Prints out the contents of the migration instead of writing it to a file",
+            })
+            .option("ch", {
+                alias: "check",
+                type: "boolean",
+                default: false,
+                describe: "Verifies that the current database is up to date and that no migrations are needed. Otherwise exits with code 1.",
             });
     }
 
@@ -124,21 +136,35 @@ export class MigrationGenerateCommand implements yargs.CommandModule {
                 await connection.close();
             }
 
-            if (upSqls.length) {
-                if (args.name) {
-                    const fileContent = args.outputJs ?
-                        MigrationGenerateCommand.getJavascriptTemplate(args.name as any, timestamp, upSqls, downSqls.reverse()) :
-                        MigrationGenerateCommand.getTemplate(args.name as any, timestamp, upSqls, downSqls.reverse());
-                    const path = process.cwd() + "/" + (directory ? (directory + "/") : "") + filename;
-                    await CommandUtils.createFile(path, fileContent);
-
-                    console.log(chalk.green(`Migration ${chalk.blue(path)} has been generated successfully.`));
+            if (!upSqls.length) {
+                if (args.check) {
+                    console.log(chalk.green(`No changes in database schema were found`));
+                    process.exit(0);
                 } else {
-                    console.log(chalk.yellow("Please specify a migration name using the `-n` argument"));
+                    console.log(chalk.yellow(`No changes in database schema were found - cannot generate a migration. To create a new empty migration use "typeorm migration:create" command`));
+                    process.exit(1);
                 }
-            } else {
-                console.log(chalk.yellow(`No changes in database schema were found - cannot generate a migration. To create a new empty migration use "typeorm migration:create" command`));
+            } else if (!args.name) {
+                console.log(chalk.yellow("Please specify a migration name using the `-n` argument"));
                 process.exit(1);
+            }
+
+            const fileContent = args.outputJs ?
+                MigrationGenerateCommand.getJavascriptTemplate(args.name as any, timestamp, upSqls, downSqls.reverse()) :
+                MigrationGenerateCommand.getTemplate(args.name as any, timestamp, upSqls, downSqls.reverse());
+            const path = process.cwd() + "/" + (directory ? (directory + "/") : "") + filename;
+
+            if (args.check) {
+                console.log(chalk.yellow(`Unexpected changes in database schema were found in check mode:\n\n${chalk.white(fileContent)}`));
+                process.exit(1);
+            }
+
+            if (args.dryrun) {
+                console.log(chalk.green(`Migration ${chalk.blue(path)} has content:\n\n${chalk.white(fileContent)}`));
+            } else {
+                await CommandUtils.createFile(path, fileContent);
+
+                console.log(chalk.green(`Migration ${chalk.blue(path)} has been generated successfully.`));
             }
         } catch (err) {
             console.log(chalk.black.bgRed("Error during migration generation:"));


### PR DESCRIPTION
### Description of change

There was some disagreement with a previous change I suggested in https://github.com/typeorm/typeorm/pull/6978. The proposal to (also) add a "check" mode makes sense, so I have added that here, but kept backwards compatibility when the new flag is not used.

In addition there was a feeling that the original issue, https://github.com/typeorm/typeorm/issues/3037, was not resolved, and rightly so. So I have also added a "dryrun" mode that will print out the migration instead of writing it to a file.

Hopefully fixes #3037 

### Pull-Request Checklist

- [X] Code is up-to-date with the `master` branch
- [X] `npm run lint` passes with this change
- [ ] `npm run test` passes with this change
- [X] This pull request links relevant issues as `Fixes #0000`
- [ ] There are new or updated unit tests validating the change - N/A
- [ ] Documentation has been updated to reflect this change - N/A
- [X] The new commits follow conventions explained in [CONTRIBUTING.md](https://github.com/typeorm/typeorm/blob/master/CONTRIBUTING.md)
