### PR TITLE
fix: Stop test suite from only running one spec file

### DIFF
--- a/test/github-issues/7068/issue-7068.ts
+++ b/test/github-issues/7068/issue-7068.ts
@@ -3,7 +3,7 @@ import {Category} from "./entity/Category";
 import {Connection} from "../../../src/connection/Connection";
 import {closeTestingConnections, createTestingConnections, reloadTestingDatabases} from "../../utils/test-utils";
 
-describe.only("github issues > #7068", () => {
+describe("github issues > #7068", () => {
 
     let connections: Connection[];
     before(async () => connections = await createTestingConnections({


### PR DESCRIPTION
### Description of change
Remove `describe.only` from spec file as this was stopping all other
spec files from running.

Closes #7284

### Pull-Request Checklist
- [x] Code is up-to-date with the `master` branch
- [x] `npm run lint` passes with this change
- [x] `npm run test` passes with this change
- [x] This pull request links relevant issues as `Fixes #0000`
- [x] There are new or updated unit tests validating the change
- [x] Documentation has been updated to reflect this change
- [x] The new commits follow conventions explained in [CONTRIBUTING.md](https://github.com/typeorm/typeorm/blob/master/CONTRIBUTING.md)
