### PR TITLE
docs: fix revert example code for migration api

### DIFF
--- a/docs/migrations.md
+++ b/docs/migrations.md
@@ -269,10 +269,10 @@ export class QuestionRefactoringTIMESTAMP implements MigrationInterface {
     }
 
     async down(queryRunner: QueryRunner): Promise<void> {
-        const table = await queryRunner.getTable("question");
+        const table = await queryRunner.getTable("answer");
         const foreignKey = table.foreignKeys.find(fk => fk.columnNames.indexOf("questionId") !== -1);
-        await queryRunner.dropForeignKey("question", foreignKey);
-        await queryRunner.dropColumn("question", "questionId");
+        await queryRunner.dropForeignKey("answer", foreignKey);
+        await queryRunner.dropColumn("answer", "questionId");
         await queryRunner.dropTable("answer");
         await queryRunner.dropIndex("question", "IDX_QUESTION_NAME");
         await queryRunner.dropTable("question");


### PR DESCRIPTION
Incorrect table is referenced in an example that shows how to use migrations API.
This change references the correct tables that allow migrations:revert to  drop the foreign key and newly added column.

### Description of change

Here is the error when `migrations:revert` is run on the Migrations API example code.
```
Error during migration revert:
Error: Supplied foreign key was not found in table question
```

After applying the change, here is the output when `migrations:revert` was run in a test migration

```
Migration TestQuestionAnswer1610926293858 has been executed successfully.
query: COMMIT
✨  Done in 5.26s.
```

### Pull-Request Checklist

- [x] Code is up-to-date with the `master` branch
- [n/a] `npm run lint` passes with this change
- [n/a] `npm run test` passes with this change
- [n/a ] This pull request links relevant issues as `Fixes #0000`
- [n/a] There are new or updated unit tests validating the change
- [x] Documentation has been updated to reflect this change
- [x] The new commits follow conventions explained in [CONTRIBUTING.md](https://github.com/typeorm/typeorm/blob/master/CONTRIBUTING.md)
