### PR TITLE
useUTC for oracle and postgres

### DIFF
--- a/src/driver/oracle/OracleConnectionOptions.ts
+++ b/src/driver/oracle/OracleConnectionOptions.ts
@@ -17,6 +17,11 @@ export interface OracleConnectionOptions extends BaseConnectionOptions, OracleCo
     readonly schema?: string;
 
     /**
+    * A boolean determining whether to pass time values in UTC or local time. (default: true).
+    */
+    readonly useUTC?: boolean;
+
+    /**
      * Replication setup.
      */
     readonly replication?: {

--- a/src/driver/oracle/OracleDriver.ts
+++ b/src/driver/oracle/OracleDriver.ts
@@ -216,6 +216,9 @@ export class OracleDriver implements Driver {
         this.connection = connection;
         this.options = connection.options as OracleConnectionOptions;
 
+        if (this.options.useUTC === true) {
+            process.env.ORA_SDTZ = 'UTC';
+        }
         // load oracle package
         this.loadDependencies();
 

--- a/src/driver/postgres/PostgresConnectionOptions.ts
+++ b/src/driver/postgres/PostgresConnectionOptions.ts
@@ -17,6 +17,11 @@ export interface PostgresConnectionOptions extends BaseConnectionOptions, Postgr
     readonly schema?: string;
 
     /**
+    * A boolean determining whether to pass time values in UTC or local time. (default: true).
+    */
+    readonly useUTC?: boolean;
+
+    /**
      * Replication setup.
      */
     readonly replication?: {

--- a/src/driver/postgres/PostgresDriver.ts
+++ b/src/driver/postgres/PostgresDriver.ts
@@ -257,7 +257,9 @@ export class PostgresDriver implements Driver {
         this.connection = connection;
         this.options = connection.options as PostgresConnectionOptions;
         this.isReplicated = this.options.replication ? true : false;
-
+        if(this.options.useUTC) {
+            process.env.PGTZ = 'UTC';
+        }
         // load postgres package
         this.loadDependencies();
 


### PR DESCRIPTION
If useUTC is set to true, then for Oracle set environment variable 'ORA_SDTZ' and for postgres set 'PGTZ'.

Based on documentation I thought 'useUTC' was used for all databases, but it was actually set only for MSSQL.
If this option is set to true then I am setting environment variables for oracle and Postgres.

<!--
  😀 Wonderful!  Thank you for opening a pull request for TypeORM.

  Please fill in the information below to expedite the review
  and (hopefully) merge of your change.

  If unsure about something.. just do as best as you're able,
  or reach out through our community support channels!
  https://github.com/typeorm/typeorm/blob/master/docs/support.md
-->

### Description of change

<!--
  Please be clear and concise what the change is intended to do,
  why this change is needed, and how you've verified that it
  corrects what you intended.

  In some cases it may be helpful to include the current behavior
  and the new behavior.

  If the change is related to an open issue, you can link it here.
  If you include `Fixes #0000` (replacing `0000` with the issue number)
  when this is merged it will automatically mark the issue as fixed and
  close it.
-->


### Pull-Request Checklist

<!--
  Please make sure to review and check all of the following.

  If an item is not applicable, you can add "N/A" to the end.
-->

- [x] Code is up-to-date with the `master` branch
- [x] `npm run lint` passes with this change
- [x] `npm run test` passes with this change
- [ ] This pull request links relevant issues as `Fixes #0000`
- [ ] There are new or updated unit tests validating the change
- [ ] Documentation has been updated to reflect this change
- [ ] The new commits follow conventions explained in [CONTRIBUTING.md](https://github.com/typeorm/typeorm/blob/master/CONTRIBUTING.md)

<!--
  🎉 Thank you for contributing and making TypeORM even better!
-->
