### PR TITLE
feat(migrations): add a flag to return zero from migration generation…

### DIFF
--- a/src/commands/MigrationGenerateCommand.ts
+++ b/src/commands/MigrationGenerateCommand.ts
@@ -50,6 +50,12 @@ export class MigrationGenerateCommand implements yargs.CommandModule {
                 type: "boolean",
                 default: false,
                 describe: "Generate a migration file on Javascript instead of Typescript",
+            })
+            .option("z", {
+                alias: "allowEmptyMigration",
+                type: "boolean",
+                default: false,
+                describe: "Zero exit status on no mibgration changes; no file will be generated"
             });
     }
 
@@ -138,7 +144,9 @@ export class MigrationGenerateCommand implements yargs.CommandModule {
                 }
             } else {
                 console.log(chalk.yellow(`No changes in database schema were found - cannot generate a migration. To create a new empty migration use "typeorm migration:create" command`));
-                process.exit(1);
+                if (!args.allowEmptyMigration) {
+                    process.exit(1);
+                }
             }
         } catch (err) {
             console.log(chalk.black.bgRed("Error during migration generation:"));

--- a/src/commands/MigrationGenerateCommand.ts
+++ b/src/commands/MigrationGenerateCommand.ts
@@ -55,7 +55,7 @@ export class MigrationGenerateCommand implements yargs.CommandModule {
                 alias: "allowEmptyMigration",
                 type: "boolean",
                 default: false,
-                describe: "Zero exit status on no mibgration changes; no file will be generated"
+                describe: "Zero exit status on no migration changes; no file will be generated"
             });
     }
 


### PR DESCRIPTION
### Description of change

This adds a flag to return a zero status for migration:generate script when no changes are to be made. This flag is to allow for functionality as it was before an October 2020 commit when the non zero status was added. I have automation based on that behavior.

There flag is solely for `migration:generate` script, shorthand option is `-z` and long option is `--allowEmptyMigration`. Camel case seems to be in spirit with the other options there.

I did not find any separate documentation files for these flags.

### Pull-Request Checklist

- [x] Code is up-to-date with the `master` branch
- [x] `npm run lint` passes with this change
- [x] `npm run test` passes with this change
- [N/A] This pull request links relevant issues as `Fixes #0000`
- [N/A] There are new or updated unit tests validating the change
- [N/A] Documentation has been updated to reflect this change
- [X] The new commits follow conventions explained in [CONTRIBUTING.md](https://github.com/typeorm/typeorm/blob/master/CONTRIBUTING.md)
