### PR TITLE
Fixing performance issues of `RelationId`.

### DIFF
--- a/test/github-issues/5691/enity/Child1.ts
+++ b/test/github-issues/5691/enity/Child1.ts
@@ -1,0 +1,21 @@
+import {Entity, ManyToOne, OneToMany, PrimaryGeneratedColumn, RelationId} from "../../../../src";
+import {Root} from "./Root";
+import {Shared} from "./Shared";
+
+@Entity()
+export class Child1 {
+    @PrimaryGeneratedColumn("uuid")
+    public id?: string;
+
+    @ManyToOne(() => Root, entity => entity.allChild1)
+    public root?: Root;
+
+    @RelationId("root")
+    public rootId?: string;
+
+    @OneToMany(() => Shared, entity => entity.child1)
+    public allShared?: Array<Shared>;
+
+    @RelationId("allShared")
+    public allSharedId?: Array<string>;
+}

--- a/test/github-issues/5691/enity/Child2.ts
+++ b/test/github-issues/5691/enity/Child2.ts
@@ -1,0 +1,21 @@
+import {ManyToMany, PrimaryGeneratedColumn, RelationId, OneToMany, Entity} from "../../../../src";
+import {Root} from "./Root";
+import {Shared} from "./Shared";
+
+@Entity()
+export class Child2 {
+    @PrimaryGeneratedColumn("uuid")
+    public id?: string;
+
+    @ManyToMany(() => Root, entity => entity.allChild2)
+    public allRoot?: Root;
+
+    @RelationId("allRoot")
+    public allRootId?: Array<string>;
+
+    @OneToMany(() => Shared, entity => entity.child2)
+    public allShared?: Array<Shared>;
+
+    @RelationId("allShared")
+    public allSharedId?: Array<string>;
+}

--- a/test/github-issues/5691/enity/Root.ts
+++ b/test/github-issues/5691/enity/Root.ts
@@ -1,0 +1,29 @@
+import {Entity, JoinTable, ManyToMany, OneToMany, PrimaryGeneratedColumn, RelationId} from "../../../../src";
+import {Child1} from "./Child1";
+import {Child2} from "./Child2";
+import {Shared} from "./Shared";
+
+@Entity()
+export class Root {
+    @PrimaryGeneratedColumn("uuid")
+    public id?: string;
+
+    @OneToMany(() => Shared, entity => entity.root)
+    public allShared?: Array<Shared>;
+
+    @RelationId("allShared")
+    public allSharedId?: Array<string>;
+
+    @OneToMany(() => Child1, entity => entity.root)
+    public allChild1?: Array<Child1>;
+
+    @RelationId("allChild1")
+    public allChild1Id?: Array<string>;
+
+    @ManyToMany(() => Child2, entity => entity.allRoot)
+    @JoinTable()
+    public allChild2?: Array<Child2>;
+
+    @RelationId("allChild2")
+    public allChild2Id?: Array<string>;
+}

--- a/test/github-issues/5691/enity/Shared.ts
+++ b/test/github-issues/5691/enity/Shared.ts
@@ -1,0 +1,44 @@
+import {Entity, JoinColumn, ManyToOne, OneToMany, PrimaryGeneratedColumn, RelationId} from "../../../../src";
+import {Child1} from "./Child1";
+import {Child2} from "./Child2";
+import {Root} from "./Root";
+
+@Entity()
+export class Shared {
+    @PrimaryGeneratedColumn("uuid")
+    public id?: string;
+
+    @ManyToOne(() => Root, entity => entity.allShared)
+    @JoinColumn()
+    public root?: Root;
+
+    @RelationId("root")
+    public rootId?: string;
+
+    @ManyToOne(() => Child1, entity => entity.allShared)
+    @JoinColumn()
+    public child1?: Child1;
+
+    @RelationId("child1")
+    public child1Id?: string;
+
+    @ManyToOne(() => Child2, entity => entity.allShared)
+    @JoinColumn()
+    public child2?: Child2;
+
+    @RelationId("child2")
+    public child2Id?: string;
+
+    @ManyToOne(() => Shared, entity => entity.allShared)
+    @JoinColumn()
+    public shared?: Shared;
+
+    @RelationId("shared")
+    public sharedId?: string;
+
+    @OneToMany(() => Shared, entity => entity.shared)
+    public allShared?: Array<Shared>;
+
+    @RelationId("allShared")
+    public allSharedId?: Array<string>;
+}

--- a/test/github-issues/5691/issue-5691.ts
+++ b/test/github-issues/5691/issue-5691.ts
@@ -1,0 +1,125 @@
+import "reflect-metadata";
+import {createTestingConnections, closeTestingConnections, reloadTestingDatabases} from "../../utils/test-utils";
+import {Connection} from "../../../src";
+import {expect} from "chai";
+import {Child1} from "./enity/Child1";
+import {Child2} from "./enity/Child2";
+import {Root} from "./enity/Root";
+import {Shared} from "./enity/Shared";
+
+describe("github issues > #5691 RelationId is too slow", () => {
+    const setupFixtures = async (connection: Connection, allChild2: Array<Child2>): Promise<void> => {
+        const root = new Root();
+        root.allChild2 = allChild2;
+        await connection.getRepository(Root).save(root);
+
+        const rootAllShared: Array<Shared> = [];
+        for (let indexShared = 0; indexShared < allChild2.length; indexShared ++) {
+            const rootShared = new Shared();
+            rootShared.root = root;
+            rootAllShared.push(rootShared);
+        }
+        await connection.getRepository(Shared).save(rootAllShared);
+
+        const savePromises: Array<Promise<unknown>> = [];
+        for (let indexChild1 = 0; indexChild1 < allChild2.length; indexChild1 ++) {
+            const rootChild1 = new Child1();
+            rootChild1.root = root;
+            await connection.getRepository(Child1).save(rootChild1);
+
+            for (const child2 of allChild2) {
+                const rootChild1Child2 = new Shared();
+                rootChild1Child2.root = root;
+                rootChild1Child2.child1 = rootChild1;
+                rootChild1Child2.child2 = child2;
+                savePromises.push(connection.getRepository(Shared).save(rootChild1Child2));
+            }
+            for (const shared of rootAllShared) {
+                const rootChild1Shared = new Shared();
+                rootChild1Shared.root = root;
+                rootChild1Shared.child1 = rootChild1;
+                rootChild1Shared.shared = shared;
+                savePromises.push(connection.getRepository(Shared).save(rootChild1Shared));
+            }
+        }
+        await Promise.all(savePromises);
+    };
+
+    let connections: Connection[];
+    before(async () => connections = await createTestingConnections({
+        entities: [
+            Root,
+            Child1,
+            Child2,
+            Shared,
+        ],
+        schemaCreate: true,
+        dropSchema: true,
+    }));
+    beforeEach(() => reloadTestingDatabases(connections));
+    after(() => closeTestingConnections(connections));
+
+    it("should be as fast as separate queries", () => Promise.all(connections.map(async connection => {
+        const child21 = new Child2();
+        const child22 = new Child2();
+        const child23 = new Child2();
+        const child24 = new Child2();
+        const child25 = new Child2();
+        await Promise.all([
+            connection.getRepository(Child2).save(child21),
+            connection.getRepository(Child2).save(child22),
+            connection.getRepository(Child2).save(child23),
+            connection.getRepository(Child2).save(child24),
+            connection.getRepository(Child2).save(child25),
+        ]);
+
+        await Promise.all([
+            setupFixtures(connection, [child21, child22, child23]),
+            // To understand the problem deeper add more fixtures.
+            // It will take forever.
+            // setupFixtures(connection, [child22, child23, child24]),
+            // setupFixtures(connection, [child23, child24, child25]),
+            // setupFixtures(connection, [child24, child25, child21]),
+            // setupFixtures(connection, [child25, child21, child22]),
+            // setupFixtures(connection, [child21, child22, child23]),
+            // setupFixtures(connection, [child22, child23, child24]),
+            // setupFixtures(connection, [child23, child24, child25]),
+            // setupFixtures(connection, [child24, child25, child21]),
+            // setupFixtures(connection, [child25, child21, child22]),
+        ]);
+
+        const test1Start = new Date().getTime();
+        // 54 rows for 1 root
+        await connection.getRepository(Root).find({
+            relations: [
+                "allChild1",
+                "allChild1.allShared",
+                "allChild2",
+            ],
+        });
+        // 21 rows 1 root
+        await connection.getRepository(Root).find({
+            relations: [
+                "allShared",
+            ],
+        });
+        const test1End = new Date().getTime();
+
+        const test2Start = new Date().getTime();
+        // 1134 rows 1 root
+        await connection.getRepository(Root).find({
+            relations: [
+                "allChild1",
+                "allChild1.allShared",
+                "allChild2",
+                "allShared",
+            ],
+        });
+        const test2End = new Date().getTime();
+
+        expect(test2End - test2Start).to.be.lessThan(
+            (test1End - test1Start) * 15, // yes, even 15 times slower, because amount of data requires more time.
+            "a single call should be not as more as 15 times slower than multi calls",
+        );
+    })));
+});


### PR DESCRIPTION
### Description of change

Fixes #5691

Fixing performance issues of `RelationId`.
For example, we have users and a company.
We want to select the company with relation ids.
There are 100k users, and all of them belong to the same company.

So we select `users.company`,
it selects 100k users and 100k companies, but these 100k companies are the same entity,
because all users belong to the same company.

Let's imagine, that the company has adminId, and we want it to be selected via `RelationId`.

The issue is that currently typeorm simply joins ids of entities,
so the query has 100k times `company.id = NNN or company.id = NNN or ...`, whereas NNN is the same id,
and because the query is very long, MySQL dies when parses it.

The changes reduce ids to be an unique array, so 100k ids will become a single id.

### Pull-Request Checklist

- [x] Code is up-to-date with the `master` branch
- [x] `npm run lint` passes with this change
- [x] `npm run test` passes with this change
- [x] This pull request links relevant issues as `Fixes #0000`
- [x] There are new or updated unit tests validating the change
- [x] Documentation has been updated to reflect this change
- [x] The new commits follow conventions explained in [CONTRIBUTING.md](https://github.com/typeorm/typeorm/blob/master/CONTRIBUTING.md)
