### PR TITLE
fix: wrong migration generation when column default value is set to null #6950

### DIFF
--- a/src/driver/Driver.ts
+++ b/src/driver/Driver.ts
@@ -142,7 +142,7 @@ export interface Driver {
     /**
      * Normalizes "default" value of the column.
      */
-    normalizeDefault(columnMetadata: ColumnMetadata): string;
+    normalizeDefault(columnMetadata: ColumnMetadata): string | undefined;
 
     /**
      * Normalizes "isUnique" value of the column.

--- a/src/driver/aurora-data-api/AuroraDataApiDriver.ts
+++ b/src/driver/aurora-data-api/AuroraDataApiDriver.ts
@@ -531,7 +531,7 @@ export class AuroraDataApiDriver implements Driver {
     /**
      * Normalizes "default" value of the column.
      */
-    normalizeDefault(columnMetadata: ColumnMetadata): string {
+    normalizeDefault(columnMetadata: ColumnMetadata): string | undefined {
         const defaultValue = columnMetadata.default;
 
         if ((columnMetadata.type === "enum" || columnMetadata.type === "simple-enum") && defaultValue !== undefined) {
@@ -549,9 +549,6 @@ export class AuroraDataApiDriver implements Driver {
 
         } else if (typeof defaultValue === "string") {
             return `'${defaultValue}'`;
-
-        } else if (defaultValue === null) {
-            return `null`;
 
         } else {
             return defaultValue;
@@ -827,7 +824,7 @@ export class AuroraDataApiDriver implements Driver {
     /**
      * Checks if "DEFAULT" values in the column metadata and in the database are equal.
      */
-    protected compareDefaultValues(columnMetadataValue: string, databaseValue: string): boolean {
+    protected compareDefaultValues(columnMetadataValue: string | undefined, databaseValue: string | undefined): boolean {
         if (typeof columnMetadataValue === "string" && typeof databaseValue === "string") {
             // we need to cut out "'" because in mysql we can understand returned value is a string or a function
             // as result compare cannot understand if default is really changed or not

--- a/src/driver/cockroachdb/CockroachDriver.ts
+++ b/src/driver/cockroachdb/CockroachDriver.ts
@@ -616,7 +616,7 @@ export class CockroachDriver implements Driver {
                 || tableColumn.length !== columnMetadata.length
                 || tableColumn.precision !== columnMetadata.precision
                 || (columnMetadata.scale !== undefined && tableColumn.scale !== columnMetadata.scale)
-                || (tableColumn.comment || "") !== columnMetadata.comment
+                || tableColumn.comment !== columnMetadata.comment
                 || (!tableColumn.isGenerated && this.lowerDefaultValueIfNecessary(this.normalizeDefault(columnMetadata)) !== tableColumn.default) // we included check for generated here, because generated columns already can have default values
                 || tableColumn.isPrimary !== columnMetadata.isPrimary
                 || tableColumn.isNullable !== columnMetadata.isNullable

--- a/src/driver/cockroachdb/CockroachDriver.ts
+++ b/src/driver/cockroachdb/CockroachDriver.ts
@@ -479,7 +479,7 @@ export class CockroachDriver implements Driver {
     /**
      * Normalizes "default" value of the column.
      */
-    normalizeDefault(columnMetadata: ColumnMetadata): string {
+    normalizeDefault(columnMetadata: ColumnMetadata): string | undefined {
         const defaultValue = columnMetadata.default;
         const arrayCast = columnMetadata.isArray ? `::${columnMetadata.type}[]` : "";
 
@@ -495,10 +495,7 @@ export class CockroachDriver implements Driver {
         } else if (typeof defaultValue === "string") {
             return `'${defaultValue}'${arrayCast}`;
 
-        } else if (defaultValue === null) {
-            return `null`;
-
-        } else if (typeof defaultValue === "object") {
+        } else if (typeof defaultValue === "object" && defaultValue !== null) {
             return `'${JSON.stringify(defaultValue)}'`;
 
         } else {

--- a/src/driver/mongodb/MongoDriver.ts
+++ b/src/driver/mongodb/MongoDriver.ts
@@ -322,7 +322,7 @@ export class MongoDriver implements Driver {
     /**
      * Normalizes "default" value of the column.
      */
-    normalizeDefault(columnMetadata: ColumnMetadata): string {
+    normalizeDefault(columnMetadata: ColumnMetadata): string | undefined {
         throw new Error(`MongoDB is schema-less, not supported by this driver.`);
     }
 
@@ -442,8 +442,8 @@ export class MongoDriver implements Driver {
          const credentialsUrlPart = (options.username && options.password)
             ? `${options.username}:${options.password}@`
             : "";
-        const portUrlPart = (schemaUrlPart === "mongodb+srv") 
-            ? "" 
+        const portUrlPart = (schemaUrlPart === "mongodb+srv")
+            ? ""
             : `:${options.port || "27017"}`;
 
         return `${schemaUrlPart}://${credentialsUrlPart}${options.host || "127.0.0.1"}${portUrlPart}/${options.database || ""}`;

--- a/src/driver/mysql/MysqlDriver.ts
+++ b/src/driver/mysql/MysqlDriver.ts
@@ -579,7 +579,7 @@ export class MysqlDriver implements Driver {
     /**
      * Normalizes "default" value of the column.
      */
-    normalizeDefault(columnMetadata: ColumnMetadata): string {
+    normalizeDefault(columnMetadata: ColumnMetadata): string | undefined {
         const defaultValue = columnMetadata.default;
 
         if ((columnMetadata.type === "enum" || columnMetadata.type === "simple-enum") && defaultValue !== undefined) {
@@ -603,7 +603,7 @@ export class MysqlDriver implements Driver {
             return `'${defaultValue}'`;
 
         } else if (defaultValue === null) {
-            return `NULL`;
+            return undefined;
 
         } else {
             return defaultValue;
@@ -776,7 +776,7 @@ export class MysqlDriver implements Driver {
                 || tableColumn.unsigned !== columnMetadata.unsigned
                 || tableColumn.asExpression !== columnMetadata.asExpression
                 || tableColumn.generatedType !== columnMetadata.generatedType
-                || (tableColumn.comment || "") !== columnMetadata.comment
+                || tableColumn.comment !== columnMetadata.comment
                 || !this.compareDefaultValues(this.normalizeDefault(columnMetadata), tableColumn.default)
                 || (tableColumn.enum && columnMetadata.enum && !OrmUtils.isArraysEqual(tableColumn.enum, columnMetadata.enum.map(val => val + "")))
                 || tableColumn.onUpdate !== columnMetadata.onUpdate
@@ -919,7 +919,7 @@ export class MysqlDriver implements Driver {
     /**
      * Checks if "DEFAULT" values in the column metadata and in the database are equal.
      */
-    protected compareDefaultValues(columnMetadataValue: string, databaseValue: string): boolean {
+    protected compareDefaultValues(columnMetadataValue: string | undefined, databaseValue: string | undefined): boolean {
         if (typeof columnMetadataValue === "string" && typeof databaseValue === "string") {
             // we need to cut out "'" because in mysql we can understand returned value is a string or a function
             // as result compare cannot understand if default is really changed or not

--- a/src/driver/mysql/MysqlQueryRunner.ts
+++ b/src/driver/mysql/MysqlQueryRunner.ts
@@ -1812,7 +1812,7 @@ export class MysqlQueryRunner extends BaseQueryRunner implements QueryRunner {
      * Escapes a given comment so it's safe to include in a query.
      */
     protected escapeComment(comment?: string) {
-        if (comment === undefined || comment.length === 0) {
+        if (!comment || comment.length === 0) {
             return `''`;
         }
 
@@ -1865,7 +1865,7 @@ export class MysqlQueryRunner extends BaseQueryRunner implements QueryRunner {
             c += " PRIMARY KEY";
         if (column.isGenerated && column.generationStrategy === "increment") // don't use skipPrimary here since updates can update already exist primary without auto inc.
             c += " AUTO_INCREMENT";
-        if (column.comment !== undefined && column.comment.length > 0)
+        if (column.comment && column.comment.length > 0)
             c += ` COMMENT ${this.escapeComment(column.comment)}`;
         if (column.default !== undefined && column.default !== null)
             c += ` DEFAULT ${column.default}`;

--- a/src/driver/oracle/OracleDriver.ts
+++ b/src/driver/oracle/OracleDriver.ts
@@ -464,7 +464,7 @@ export class OracleDriver implements Driver {
     /**
      * Normalizes "default" value of the column.
      */
-    normalizeDefault(columnMetadata: ColumnMetadata): string {
+    normalizeDefault(columnMetadata: ColumnMetadata): string | undefined {
         const defaultValue = columnMetadata.default;
 
         if (typeof defaultValue === "number") {

--- a/src/driver/oracle/OracleDriver.ts
+++ b/src/driver/oracle/OracleDriver.ts
@@ -479,6 +479,9 @@ export class OracleDriver implements Driver {
         } else if (typeof defaultValue === "string") {
             return `'${defaultValue}'`;
 
+        } else if (defaultValue === null) {
+            return undefined;
+
         } else {
             return defaultValue;
         }
@@ -599,17 +602,38 @@ export class OracleDriver implements Driver {
             if (!tableColumn)
                 return false; // we don't need new columns, we only need exist and changed
 
-            return tableColumn.name !== columnMetadata.databaseName
+            const isColumnChanged = tableColumn.name !== columnMetadata.databaseName
                 || tableColumn.type !== this.normalizeType(columnMetadata)
                 || tableColumn.length !== columnMetadata.length
                 || tableColumn.precision !== columnMetadata.precision
                 || tableColumn.scale !== columnMetadata.scale
-                // || tableColumn.comment !== columnMetadata.comment || // todo
-                || this.normalizeDefault(columnMetadata) !== tableColumn.default
+                // || tableColumn.comment !== columnMetadata.comment
+                || tableColumn.default !== this.normalizeDefault(columnMetadata)
                 || tableColumn.isPrimary !== columnMetadata.isPrimary
                 || tableColumn.isNullable !== columnMetadata.isNullable
                 || tableColumn.isUnique !== this.normalizeIsUnique(columnMetadata)
                 || (columnMetadata.generationStrategy !== "uuid" && tableColumn.isGenerated !== columnMetadata.isGenerated);
+
+            // DEBUG SECTION
+            if (isColumnChanged) {
+                console.log("table:", columnMetadata.entityMetadata.tableName);
+                console.log("name:", tableColumn.name, columnMetadata.databaseName);
+                console.log("type:", tableColumn.type, this.normalizeType(columnMetadata));
+                console.log("length:", tableColumn.length, columnMetadata.length);
+                console.log("precision:", tableColumn.precision, columnMetadata.precision);
+                console.log("scale:", tableColumn.scale, columnMetadata.scale);
+                console.log("comment:", tableColumn.comment, columnMetadata.comment);
+                console.log("default:", tableColumn.default, this.normalizeDefault(columnMetadata));
+                console.log("enum:", tableColumn.enum && columnMetadata.enum && !OrmUtils.isArraysEqual(tableColumn.enum, columnMetadata.enum.map(val => val + "")));
+                console.log("onUpdate:", tableColumn.onUpdate, columnMetadata.onUpdate);
+                console.log("isPrimary:", tableColumn.isPrimary, columnMetadata.isPrimary);
+                console.log("isNullable:", tableColumn.isNullable, columnMetadata.isNullable);
+                console.log("isUnique:", tableColumn.isUnique, this.normalizeIsUnique(columnMetadata));
+                console.log("isGenerated:", tableColumn.isGenerated, columnMetadata.isGenerated);
+                console.log("==========================================");
+            }
+
+            return isColumnChanged
         });
     }
 

--- a/src/driver/oracle/OracleDriver.ts
+++ b/src/driver/oracle/OracleDriver.ts
@@ -615,23 +615,23 @@ export class OracleDriver implements Driver {
                 || (columnMetadata.generationStrategy !== "uuid" && tableColumn.isGenerated !== columnMetadata.isGenerated);
 
             // DEBUG SECTION
-            if (isColumnChanged) {
-                console.log("table:", columnMetadata.entityMetadata.tableName);
-                console.log("name:", tableColumn.name, columnMetadata.databaseName);
-                console.log("type:", tableColumn.type, this.normalizeType(columnMetadata));
-                console.log("length:", tableColumn.length, columnMetadata.length);
-                console.log("precision:", tableColumn.precision, columnMetadata.precision);
-                console.log("scale:", tableColumn.scale, columnMetadata.scale);
-                console.log("comment:", tableColumn.comment, columnMetadata.comment);
-                console.log("default:", tableColumn.default, this.normalizeDefault(columnMetadata));
-                console.log("enum:", tableColumn.enum && columnMetadata.enum && !OrmUtils.isArraysEqual(tableColumn.enum, columnMetadata.enum.map(val => val + "")));
-                console.log("onUpdate:", tableColumn.onUpdate, columnMetadata.onUpdate);
-                console.log("isPrimary:", tableColumn.isPrimary, columnMetadata.isPrimary);
-                console.log("isNullable:", tableColumn.isNullable, columnMetadata.isNullable);
-                console.log("isUnique:", tableColumn.isUnique, this.normalizeIsUnique(columnMetadata));
-                console.log("isGenerated:", tableColumn.isGenerated, columnMetadata.isGenerated);
-                console.log("==========================================");
-            }
+            // if (isColumnChanged) {
+            //     console.log("table:", columnMetadata.entityMetadata.tableName);
+            //     console.log("name:", tableColumn.name, columnMetadata.databaseName);
+            //     console.log("type:", tableColumn.type, this.normalizeType(columnMetadata));
+            //     console.log("length:", tableColumn.length, columnMetadata.length);
+            //     console.log("precision:", tableColumn.precision, columnMetadata.precision);
+            //     console.log("scale:", tableColumn.scale, columnMetadata.scale);
+            //     console.log("comment:", tableColumn.comment, columnMetadata.comment);
+            //     console.log("default:", tableColumn.default, this.normalizeDefault(columnMetadata));
+            //     console.log("enum:", tableColumn.enum && columnMetadata.enum && !OrmUtils.isArraysEqual(tableColumn.enum, columnMetadata.enum.map(val => val + "")));
+            //     console.log("onUpdate:", tableColumn.onUpdate, columnMetadata.onUpdate);
+            //     console.log("isPrimary:", tableColumn.isPrimary, columnMetadata.isPrimary);
+            //     console.log("isNullable:", tableColumn.isNullable, columnMetadata.isNullable);
+            //     console.log("isUnique:", tableColumn.isUnique, this.normalizeIsUnique(columnMetadata));
+            //     console.log("isGenerated:", tableColumn.isGenerated, columnMetadata.isGenerated);
+            //     console.log("==========================================");
+            // }
 
             return isColumnChanged
         });

--- a/src/driver/postgres/PostgresDriver.ts
+++ b/src/driver/postgres/PostgresDriver.ts
@@ -747,10 +747,7 @@ export class PostgresDriver implements Driver {
         } else if (typeof defaultValue === "string") {
             return `'${defaultValue}'${arrayCast}`;
 
-        } else if (defaultValue === null) {
-            return `null`;
-
-        } else if (typeof defaultValue === "object") {
+        } else if (typeof defaultValue === "object" && defaultValue !== null) {
             return `'${JSON.stringify(defaultValue)}'`;
 
         } else {
@@ -871,6 +868,24 @@ export class PostgresDriver implements Driver {
             const tableColumn = tableColumns.find(c => c.name === columnMetadata.databaseName);
             if (!tableColumn)
                 return false; // we don't need new columns, we only need exist and changed
+
+            // console.log("table:", columnMetadata.entityMetadata.tableName);
+            // console.log("name:", tableColumn.name, columnMetadata.databaseName);
+            // console.log("type:", tableColumn.type, this.normalizeType(columnMetadata));
+            // console.log("length:", tableColumn.length, columnMetadata.length);
+            // console.log("width:", tableColumn.width, columnMetadata.width);
+            // console.log("precision:", tableColumn.precision, columnMetadata.precision);
+            // console.log("comment:", tableColumn.comment, columnMetadata.comment);
+            // console.log("default:", tableColumn.default, columnMetadata.default);
+            // console.log("enum:", tableColumn.enum, columnMetadata.enum);
+            // console.log("default changed:", !this.compareDefaultValues(this.normalizeDefault(columnMetadata), tableColumn.default));
+            // console.log("onUpdate:", tableColumn.onUpdate, columnMetadata.onUpdate);
+            // console.log("isPrimary:", tableColumn.isPrimary, columnMetadata.isPrimary);
+            // console.log("isNullable:", tableColumn.isNullable, columnMetadata.isNullable);
+            // console.log("isUnique:", tableColumn.isUnique, this.normalizeIsUnique(columnMetadata));
+            // console.log("isGenerated:", tableColumn.isGenerated, columnMetadata.isGenerated);
+            // console.log((columnMetadata.generationStrategy !== "uuid" && tableColumn.isGenerated !== columnMetadata.isGenerated));
+            // console.log("==========================================");
 
             return tableColumn.name !== columnMetadata.databaseName
                 || tableColumn.type !== this.normalizeType(columnMetadata)

--- a/src/driver/postgres/PostgresDriver.ts
+++ b/src/driver/postgres/PostgresDriver.ts
@@ -869,30 +869,12 @@ export class PostgresDriver implements Driver {
             if (!tableColumn)
                 return false; // we don't need new columns, we only need exist and changed
 
-            // console.log("table:", columnMetadata.entityMetadata.tableName);
-            // console.log("name:", tableColumn.name, columnMetadata.databaseName);
-            // console.log("type:", tableColumn.type, this.normalizeType(columnMetadata));
-            // console.log("length:", tableColumn.length, columnMetadata.length);
-            // console.log("width:", tableColumn.width, columnMetadata.width);
-            // console.log("precision:", tableColumn.precision, columnMetadata.precision);
-            // console.log("comment:", tableColumn.comment, columnMetadata.comment);
-            // console.log("default:", tableColumn.default, columnMetadata.default);
-            // console.log("enum:", tableColumn.enum, columnMetadata.enum);
-            // console.log("default changed:", !this.compareDefaultValues(this.normalizeDefault(columnMetadata), tableColumn.default));
-            // console.log("onUpdate:", tableColumn.onUpdate, columnMetadata.onUpdate);
-            // console.log("isPrimary:", tableColumn.isPrimary, columnMetadata.isPrimary);
-            // console.log("isNullable:", tableColumn.isNullable, columnMetadata.isNullable);
-            // console.log("isUnique:", tableColumn.isUnique, this.normalizeIsUnique(columnMetadata));
-            // console.log("isGenerated:", tableColumn.isGenerated, columnMetadata.isGenerated);
-            // console.log((columnMetadata.generationStrategy !== "uuid" && tableColumn.isGenerated !== columnMetadata.isGenerated));
-            // console.log("==========================================");
-
-            return tableColumn.name !== columnMetadata.databaseName
+            const isColumnChanged = tableColumn.name !== columnMetadata.databaseName
                 || tableColumn.type !== this.normalizeType(columnMetadata)
                 || tableColumn.length !== columnMetadata.length
                 || tableColumn.precision !== columnMetadata.precision
                 || (columnMetadata.scale !== undefined && tableColumn.scale !== columnMetadata.scale)
-                || (tableColumn.comment || "") !== columnMetadata.comment
+                || tableColumn.comment !== columnMetadata.comment
                 || (!tableColumn.isGenerated && this.lowerDefaultValueIfNecessary(this.normalizeDefault(columnMetadata)) !== tableColumn.default) // we included check for generated here, because generated columns already can have default values
                 || tableColumn.isPrimary !== columnMetadata.isPrimary
                 || tableColumn.isNullable !== columnMetadata.isNullable
@@ -901,6 +883,29 @@ export class PostgresDriver implements Driver {
                 || tableColumn.isGenerated !== columnMetadata.isGenerated
                 || (tableColumn.spatialFeatureType || "").toLowerCase() !== (columnMetadata.spatialFeatureType || "").toLowerCase()
                 || tableColumn.srid !== columnMetadata.srid;
+
+            // DEBUG SECTION
+            // if (isColumnChanged) {
+            //     console.log("table:", columnMetadata.entityMetadata.tableName);
+            //     console.log("name:", tableColumn.name, columnMetadata.databaseName);
+            //     console.log("type:", tableColumn.type, this.normalizeType(columnMetadata));
+            //     console.log("length:", tableColumn.length, columnMetadata.length);
+            //     console.log("precision:", tableColumn.precision, columnMetadata.precision);
+            //     console.log("scale:", tableColumn.scale, columnMetadata.scale);
+            //     console.log("comment:", tableColumn.comment, columnMetadata.comment);
+            //     console.log("enum:", tableColumn.enum && columnMetadata.enum && !OrmUtils.isArraysEqual(tableColumn.enum, columnMetadata.enum.map(val => val + "")));
+            //     console.log("onUpdate:", tableColumn.onUpdate, columnMetadata.onUpdate);
+            //     console.log("isPrimary:", tableColumn.isPrimary, columnMetadata.isPrimary);
+            //     console.log("isNullable:", tableColumn.isNullable, columnMetadata.isNullable);
+            //     console.log("isUnique:", tableColumn.isUnique, this.normalizeIsUnique(columnMetadata));
+            //     console.log("isGenerated:", tableColumn.isGenerated, columnMetadata.isGenerated);
+            //     console.log("isGenerated 2:", !tableColumn.isGenerated && this.lowerDefaultValueIfNecessary(this.normalizeDefault(columnMetadata)) !== tableColumn.default);
+            //     console.log("spatialFeatureType:", (tableColumn.spatialFeatureType || "").toLowerCase(), (columnMetadata.spatialFeatureType || "").toLowerCase());
+            //     console.log("srid", tableColumn.srid, columnMetadata.srid);
+            //     console.log("==========================================");
+            // }
+
+            return isColumnChanged
         });
     }
 
@@ -913,6 +918,7 @@ export class PostgresDriver implements Driver {
             return i % 2 === 1 ? v : v.toLowerCase();
         }).join(`'`);
     }
+
     /**
      * Returns true if driver supports RETURNING / OUTPUT statement.
      */

--- a/src/driver/postgres/PostgresQueryRunner.ts
+++ b/src/driver/postgres/PostgresQueryRunner.ts
@@ -1417,9 +1417,9 @@ export class PostgresQueryRunner extends BaseQueryRunner implements QueryRunner 
             return `("table_schema" = '${schema}' AND "table_name" = '${name}')`;
         }).join(" OR ");
         const tablesSql = `SELECT * FROM "information_schema"."tables" WHERE ` + tablesCondition;
-        
+
         /**
-         * Uses standard SQL information_schema.columns table and postgres-specific 
+         * Uses standard SQL information_schema.columns table and postgres-specific
          * pg_catalog.pg_attribute table to get column information.
          * @see https://stackoverflow.com/a/19541865
          */
@@ -1647,7 +1647,7 @@ export class PostgresQueryRunner extends BaseQueryRunner implements QueryRunner 
                         }
                     }
 
-                    tableColumn.comment = dbColumn["description"] == null ? undefined : dbColumn["description"];
+                    tableColumn.comment = dbColumn["description"] ? dbColumn["description"] : undefined;
                     if (dbColumn["character_set_name"])
                         tableColumn.charset = dbColumn["character_set_name"];
                     if (dbColumn["collation_name"])
@@ -2078,7 +2078,7 @@ export class PostgresQueryRunner extends BaseQueryRunner implements QueryRunner 
         let seqName = `${tableName}_${columnName}_seq`;
         if (seqName.length > this.connection.driver.maxAliasLength!) // note doesn't yet handle corner cases where .length differs from number of UTF-8 bytes
             seqName=`${tableName.substring(0,29)}_${columnName.substring(0,Math.max(29,63-tableName.length-5))}_seq`;
-        
+
         if (schema && schema !== currentSchema && !skipSchema) {
             return disableEscape ? `${schema}.${seqName}` : `"${schema}"."${seqName}"`;
         } else {
@@ -2130,7 +2130,7 @@ export class PostgresQueryRunner extends BaseQueryRunner implements QueryRunner 
      * Escapes a given comment so it's safe to include in a query.
      */
     protected escapeComment(comment?: string) {
-        if (comment === undefined || comment.length === 0) {
+        if (!comment || comment.length === 0) {
             return "NULL";
         }
 

--- a/src/driver/sap/SapDriver.ts
+++ b/src/driver/sap/SapDriver.ts
@@ -457,7 +457,7 @@ export class SapDriver implements Driver {
     /**
      * Normalizes "default" value of the column.
      */
-    normalizeDefault(columnMetadata: ColumnMetadata): string {
+    normalizeDefault(columnMetadata: ColumnMetadata): string | undefined {
         const defaultValue = columnMetadata.default;
 
         if (typeof defaultValue === "number") {

--- a/src/driver/sqlite-abstract/AbstractSqliteDriver.ts
+++ b/src/driver/sqlite-abstract/AbstractSqliteDriver.ts
@@ -448,7 +448,7 @@ export abstract class AbstractSqliteDriver implements Driver {
     /**
      * Normalizes "default" value of the column.
      */
-    normalizeDefault(columnMetadata: ColumnMetadata): string {
+    normalizeDefault(columnMetadata: ColumnMetadata): string | undefined {
         const defaultValue = columnMetadata.default;
 
         if (typeof defaultValue === "number") {
@@ -462,6 +462,9 @@ export abstract class AbstractSqliteDriver implements Driver {
 
         } else if (typeof defaultValue === "string") {
             return `'${defaultValue}'`;
+
+        } else if (defaultValue === null) {
+            return undefined;
 
         } else {
             return defaultValue;

--- a/src/driver/sqlserver/SqlServerDriver.ts
+++ b/src/driver/sqlserver/SqlServerDriver.ts
@@ -491,7 +491,7 @@ export class SqlServerDriver implements Driver {
     /**
      * Normalizes "default" value of the column.
      */
-    normalizeDefault(columnMetadata: ColumnMetadata): string {
+    normalizeDefault(columnMetadata: ColumnMetadata): string | undefined {
         const defaultValue = columnMetadata.default;
 
         if (typeof defaultValue === "number") {

--- a/src/metadata/ColumnMetadata.ts
+++ b/src/metadata/ColumnMetadata.ts
@@ -114,7 +114,7 @@ export class ColumnMetadata {
      * Column comment.
      * This feature is not supported by all databases.
      */
-    comment: string = "";
+    comment?: string;
 
     /**
      * Default database value.

--- a/src/query-builder/InsertQueryBuilder.ts
+++ b/src/query-builder/InsertQueryBuilder.ts
@@ -483,7 +483,7 @@ export class InsertQueryBuilder<Entity> extends QueryBuilder<Entity> {
                     // if value for this column was not provided then insert default value
                     } else if (value === undefined) {
                         if ((this.connection.driver instanceof OracleDriver && valueSets.length > 1) || this.connection.driver instanceof AbstractSqliteDriver || this.connection.driver instanceof SapDriver) { // unfortunately sqlite does not support DEFAULT expression in INSERT queries
-                            if (column.default !== undefined) { // try to use default defined in the column
+                            if (column.default !== undefined && column.default !== null) { // try to use default defined in the column
                                 expression += this.connection.driver.normalizeDefault(column);
                             } else {
                                 expression += "NULL"; // otherwise simply use NULL and pray if column is nullable

--- a/test/functional/migrations/generate-command/command.ts
+++ b/test/functional/migrations/generate-command/command.ts
@@ -23,7 +23,6 @@ describe("migrations > generate command", () => {
         await connection.driver.createSchemaBuilder().build();
 
         const sqlInMemory = await connection.driver.createSchemaBuilder().log();
-        console.log(sqlInMemory);
 
         sqlInMemory.upQueries.length.should.be.equal(0);
         sqlInMemory.downQueries.length.should.be.equal(0);

--- a/test/functional/migrations/generate-command/command.ts
+++ b/test/functional/migrations/generate-command/command.ts
@@ -1,5 +1,5 @@
 import "reflect-metadata";
-import {createTestingConnections, closeTestingConnections, /*reloadTestingDatabases*/} from "../../../utils/test-utils";
+import {createTestingConnections, closeTestingConnections} from "../../../utils/test-utils";
 import {Connection} from "../../../../src/connection/Connection";
 import { Category, Post } from "./entity";
 
@@ -7,13 +7,10 @@ describe("migrations > generate command", () => {
     let connections: Connection[];
     before(async () => connections = await createTestingConnections({
         migrations: [],
-        enabledDrivers: ["postgres", "cockroachdb", "mysql"],
         schemaCreate: false,
         dropSchema: true,
         entities: [Post, Category],
-        schema: "public",
     }));
-    // beforeEach(() => reloadTestingDatabases(connections));
     after(() => closeTestingConnections(connections));
 
     it("can recognize model changes", () => Promise.all(connections.map(async connection => {
@@ -26,6 +23,7 @@ describe("migrations > generate command", () => {
         await connection.driver.createSchemaBuilder().build();
 
         const sqlInMemory = await connection.driver.createSchemaBuilder().log();
+        console.log(sqlInMemory);
 
         sqlInMemory.upQueries.length.should.be.equal(0);
         sqlInMemory.downQueries.length.should.be.equal(0);

--- a/test/functional/migrations/generate-command/entity/category.entity.ts
+++ b/test/functional/migrations/generate-command/entity/category.entity.ts
@@ -3,7 +3,7 @@ import {Entity} from "../../../../../src/decorator/entity/Entity";
 import {BaseEntity} from "../../../../../src/repository/BaseEntity";
 import {Column} from "../../../../../src/decorator/columns/Column";
 
-@Entity("category_test", { schema: "public" })
+@Entity("category_test")
 export class Category  extends BaseEntity {
 
     @PrimaryColumn()

--- a/test/functional/migrations/generate-command/entity/post.entity.ts
+++ b/test/functional/migrations/generate-command/entity/post.entity.ts
@@ -5,7 +5,7 @@ import {Column} from "../../../../../src/decorator/columns/Column";
 import {ManyToMany, JoinTable} from "../../../../../src";
 import {Category} from "./category.entity";
 
-@Entity("post_test", { schema: "public" })
+@Entity("post_test")
 export class Post extends BaseEntity {
 
     @PrimaryGeneratedColumn()

--- a/test/functional/migrations/generate-command/entity/tag.entity.ts
+++ b/test/functional/migrations/generate-command/entity/tag.entity.ts
@@ -6,7 +6,7 @@ import {BaseEntity} from "../../../../../src/repository/BaseEntity";
 import {Column} from "../../../../../src/decorator/columns/Column";
 import {Post} from "./post.entity";
 
-@Entity("tag_test", { schema: "public" })
+@Entity("tag_test")
 export class Tag  extends BaseEntity {
 
     @PrimaryColumn()

--- a/test/github-issues/6950/entity/post_with_null_1.entity.ts
+++ b/test/github-issues/6950/entity/post_with_null_1.entity.ts
@@ -1,8 +1,6 @@
-import { Category } from "../../../functional/migrations/generate-command/entity";
-import { Entity, BaseEntity, PrimaryGeneratedColumn, Column, ManyToMany, JoinTable } from "../../../../src";
-import "reflect-metadata";
+import {BaseEntity, Column, Entity, PrimaryGeneratedColumn} from "../../../../src";
 
-@Entity("post_test", { schema: "public" })
+@Entity("post_test")
 export class Post extends BaseEntity {
 
     @PrimaryGeneratedColumn()
@@ -20,9 +18,5 @@ export class Post extends BaseEntity {
         default: null,
     })
     comments: string;
-
-    @ManyToMany(type => Category)
-    @JoinTable()
-    categories: Category[];
 
 }

--- a/test/github-issues/6950/entity/post_with_null_2.entity.ts
+++ b/test/github-issues/6950/entity/post_with_null_2.entity.ts
@@ -1,7 +1,6 @@
-import { Category } from "../../../functional/migrations/generate-command/entity";
-import { Entity, BaseEntity, PrimaryGeneratedColumn, Column, ManyToMany, JoinTable } from "../../../../src";
+import {BaseEntity, Column, Entity, PrimaryGeneratedColumn} from "../../../../src";
 
-@Entity("post_test", { schema: "public" })
+@Entity("post_test_2")
 export class Post extends BaseEntity {
 
     @PrimaryGeneratedColumn()
@@ -21,9 +20,5 @@ export class Post extends BaseEntity {
         type: 'text'
     })
     comments: string | null;
-
-    @ManyToMany(type => Category)
-    @JoinTable()
-    categories: Category[];
 
 }

--- a/test/github-issues/6950/entity/post_with_null_2.entity.ts
+++ b/test/github-issues/6950/entity/post_with_null_2.entity.ts
@@ -17,7 +17,7 @@ export class Post extends BaseEntity {
     @Column({
         nullable: true,
         default: null,
-        type: 'text'
+        type: 'varchar'
     })
     comments: string | null;
 

--- a/test/github-issues/6950/issue-6950.ts
+++ b/test/github-issues/6950/issue-6950.ts
@@ -10,7 +10,6 @@ describe("github issues > #6950 postgres: Inappropiate migration generated for `
     describe("null default", () => {
         let connections: Connection[];
         before(async () => connections = await createTestingConnections({
-            enabledDrivers: ["mysql"],
             schemaCreate: false,
             dropSchema: true,
             entities: [Post1],
@@ -37,7 +36,6 @@ describe("github issues > #6950 postgres: Inappropiate migration generated for `
     describe("null default and nullable", () => {
         let connections: Connection[];
         before(async () => connections = await createTestingConnections({
-            enabledDrivers: ["mysql"],
             schemaCreate: false,
             dropSchema: true,
             entities: [Post2],

--- a/test/github-issues/6950/issue-6950.ts
+++ b/test/github-issues/6950/issue-6950.ts
@@ -1,24 +1,20 @@
 import "reflect-metadata";
 import { Connection } from "../../../src";
 
-import { Category } from "../../functional/migrations/generate-command/entity";
 import { createTestingConnections, closeTestingConnections } from "../../utils/test-utils";
 
-import { Post as Post1 } from './entity/post_with_null_1.entity'
-import { Post as Post2 } from './entity/post_with_null_1.entity'
+import { Post as Post1 } from "./entity/post_with_null_1.entity"
+import { Post as Post2 } from "./entity/post_with_null_2.entity"
 
-describe("github issues > #6950 postgres: Inappropiate migration generated for 'default: null'", () => {
-    describe('null default', () => {
+describe("github issues > #6950 postgres: Inappropiate migration generated for `default: null`", () => {
+    describe("null default", () => {
         let connections: Connection[];
         before(async () => connections = await createTestingConnections({
-            migrations: [],
-            enabledDrivers: ["postgres", "cockroachdb", "mysql"],
+            enabledDrivers: ["mysql"],
             schemaCreate: false,
             dropSchema: true,
-            entities: [Post1, Category],
-            schema: "public",
+            entities: [Post1],
         }));
-        // beforeEach(() => reloadTestingDatabases(connections));
         after(() => closeTestingConnections(connections));
 
         it("can recognize model changes", () => Promise.all(connections.map(async connection => {
@@ -27,7 +23,7 @@ describe("github issues > #6950 postgres: Inappropiate migration generated for '
             sqlInMemory.downQueries.length.should.be.greaterThan(0);
         })));
 
-        it.skip("does not generate when no model changes", () => Promise.all(connections.map(async connection => {
+        it("does not generate when no model changes", () => Promise.all(connections.map(async connection => {
             await connection.driver.createSchemaBuilder().build();
 
             const sqlInMemory = await connection.driver.createSchemaBuilder().log();
@@ -36,19 +32,16 @@ describe("github issues > #6950 postgres: Inappropiate migration generated for '
             sqlInMemory.downQueries.length.should.be.equal(0);
 
         })));
-
     })
-    describe('null default and nullable ', () => {
+
+    describe("null default and nullable", () => {
         let connections: Connection[];
         before(async () => connections = await createTestingConnections({
-            migrations: [],
-            enabledDrivers: ["postgres", "cockroachdb", "mysql"],
+            enabledDrivers: ["mysql"],
             schemaCreate: false,
             dropSchema: true,
-            entities: [Post2, Category],
-            schema: "public",
+            entities: [Post2],
         }));
-        // beforeEach(() => reloadTestingDatabases(connections));
         after(() => closeTestingConnections(connections));
 
         it("can recognize model changes", () => Promise.all(connections.map(async connection => {
@@ -57,7 +50,7 @@ describe("github issues > #6950 postgres: Inappropiate migration generated for '
             sqlInMemory.downQueries.length.should.be.greaterThan(0);
         })));
 
-        it.skip("does not generate when no model changes", () => Promise.all(connections.map(async connection => {
+        it("does not generate when no model changes", () => Promise.all(connections.map(async connection => {
             await connection.driver.createSchemaBuilder().build();
 
             const sqlInMemory = await connection.driver.createSchemaBuilder().log();


### PR DESCRIPTION
<!--
  😀 Wonderful!  Thank you for opening a pull request for TypeORM.

  Please fill in the information below to expedite the review
  and (hopefully) merge of your change.

  If unsure about something.. just do as best as you're able,
  or reach out through our community support channels!
  https://github.com/typeorm/typeorm/blob/master/docs/support.md
-->

### Description of change

<!--
  Please be clear and concise what the change is intended to do,
  why this change is needed, and how you've verified that it
  corrects what you intended.

  In some cases it may be helpful to include the current behavior
  and the new behavior.

  If the change is related to an open issue, you can link it here.
  If you include `Fixes #0000` (replacing `0000` with the issue number)
  when this is merged it will automatically mark the issue as fixed and
  close it.
-->

Fixed wrong migration generation when column `default` value is set to `null`.
Additionally fixed wrong `comment` comparisons.

refactor: removed `public` schema from test since it is not related to the testing subject and causes `mssql` driver fail because `public` is reserved keyword in SqlServer.

Fixes: #6950 


### Pull-Request Checklist

<!--
  Please make sure to review and check all of the following.

  If an item is not applicable, you can add "N/A" to the end.
-->

- [x] Code is up-to-date with the `master` branch
- [x] `npm run lint` passes with this change
- [x] `npm run test` passes with this change
- [x] This pull request links relevant issues as `Fixes #0000`
- [x] There are new or updated unit tests validating the change
- [ ] Documentation has been updated to reflect this change
- [x] The new commits follow conventions explained in [CONTRIBUTING.md](https://github.com/typeorm/typeorm/blob/master/CONTRIBUTING.md)

<!--
  🎉 Thank you for contributing and making TypeORM even better!
-->
