### PR TITLE
fix: printSql and getSql no longer break InsertQueryBuilder with Postgres

### DIFF
--- a/src/query-builder/InsertQueryBuilder.ts
+++ b/src/query-builder/InsertQueryBuilder.ts
@@ -427,7 +427,7 @@ export class InsertQueryBuilder<Entity> extends QueryBuilder<Entity> {
         // if column metadatas are given then apply all necessary operations with values
         if (columns.length > 0) {
             let expression = "";
-            let parametersCount = Object.keys(this.expressionMap.nativeParameters).length;
+            let paramNum = 0;
             valueSets.forEach((valueSet, valueSetIndex) => {
                 columns.forEach((column, columnIndex) => {
                     if (columnIndex === 0) {
@@ -473,9 +473,9 @@ export class InsertQueryBuilder<Entity> extends QueryBuilder<Entity> {
                     //     expression += subQuery;
 
                     } else if (column.isDiscriminator) {
-                        this.expressionMap.nativeParameters["discriminator_value_" + parametersCount] = this.expressionMap.mainAlias!.metadata.discriminatorValue;
-                        expression += this.connection.driver.createParameter("discriminator_value_" + parametersCount, parametersCount);
-                        parametersCount++;
+                        this.expressionMap.nativeParameters["discriminator_value_" + paramNum] = this.expressionMap.mainAlias!.metadata.discriminatorValue;
+                        expression += this.connection.driver.createParameter("discriminator_value_" + paramNum, paramNum);
+                        paramNum++;
                         // return "1";
 
                     // for create and update dates we insert current date
@@ -490,8 +490,8 @@ export class InsertQueryBuilder<Entity> extends QueryBuilder<Entity> {
                         const paramName = "uuid_" + column.databaseName + valueSetIndex;
                         value = RandomGenerator.uuid4();
                         this.expressionMap.nativeParameters[paramName] = value;
-                        expression += this.connection.driver.createParameter(paramName, parametersCount);
-                        parametersCount++;
+                        expression += this.connection.driver.createParameter(paramName, paramNum);
+                        paramNum++;
 
                     // if value for this column was not provided then insert default value
                     } else if (value === undefined) {
@@ -524,22 +524,22 @@ export class InsertQueryBuilder<Entity> extends QueryBuilder<Entity> {
                             const useLegacy = this.connection.driver.options.legacySpatialSupport;
                             const geomFromText = useLegacy ? "GeomFromText" : "ST_GeomFromText";
                             if (column.srid != null) {
-                                expression += `${geomFromText}(${this.connection.driver.createParameter(paramName, parametersCount)}, ${column.srid})`;
+                                expression += `${geomFromText}(${this.connection.driver.createParameter(paramName, paramNum)}, ${column.srid})`;
                             } else {
-                                expression += `${geomFromText}(${this.connection.driver.createParameter(paramName, parametersCount)})`;
+                                expression += `${geomFromText}(${this.connection.driver.createParameter(paramName, paramNum)})`;
                             }
                         } else if (this.connection.driver instanceof PostgresDriver && this.connection.driver.spatialTypes.indexOf(column.type) !== -1) {
                             if (column.srid != null) {
-                              expression += `ST_SetSRID(ST_GeomFromGeoJSON(${this.connection.driver.createParameter(paramName, parametersCount)}), ${column.srid})::${column.type}`;
+                              expression += `ST_SetSRID(ST_GeomFromGeoJSON(${this.connection.driver.createParameter(paramName, paramNum)}), ${column.srid})::${column.type}`;
                             } else {
-                              expression += `ST_GeomFromGeoJSON(${this.connection.driver.createParameter(paramName, parametersCount)})::${column.type}`;
+                              expression += `ST_GeomFromGeoJSON(${this.connection.driver.createParameter(paramName, paramNum)})::${column.type}`;
                             }
                         } else if (this.connection.driver instanceof SqlServerDriver && this.connection.driver.spatialTypes.indexOf(column.type) !== -1) {
-                            expression += column.type + "::STGeomFromText(" + this.connection.driver.createParameter(paramName, parametersCount) + ", " + (column.srid || "0") + ")";
+                            expression += column.type + "::STGeomFromText(" + this.connection.driver.createParameter(paramName, paramNum) + ", " + (column.srid || "0") + ")";
                         } else {
-                            expression += this.connection.driver.createParameter(paramName, parametersCount);
+                            expression += this.connection.driver.createParameter(paramName, paramNum);
                         }
-                        parametersCount++;
+                        paramNum++;
                     }
 
                     if (columnIndex === columns.length - 1) {
@@ -568,7 +568,7 @@ export class InsertQueryBuilder<Entity> extends QueryBuilder<Entity> {
         } else { // for tables without metadata
             // get values needs to be inserted
             let expression = "";
-            let parametersCount = Object.keys(this.expressionMap.nativeParameters).length;
+            let paramNum = 0;
 
             valueSets.forEach((valueSet, insertionIndex) => {
                 const columns = Object.keys(valueSet);
@@ -595,8 +595,8 @@ export class InsertQueryBuilder<Entity> extends QueryBuilder<Entity> {
                     // just any other regular value
                     } else {
                         this.expressionMap.nativeParameters[paramName] = value;
-                        expression += this.connection.driver.createParameter(paramName, parametersCount);
-                        parametersCount++;
+                        expression += this.connection.driver.createParameter(paramName, paramNum);
+                        paramNum++;
                     }
 
                     if (columnIndex === Object.keys(valueSet).length - 1) {

--- a/test/github-issues/3016/entity/User.ts
+++ b/test/github-issues/3016/entity/User.ts
@@ -1,0 +1,12 @@
+import { Entity } from "../../../../src/decorator/entity/Entity";
+import { Column } from "../../../../src/decorator/columns/Column";
+import { PrimaryGeneratedColumn } from "../../../../src/decorator/columns/PrimaryGeneratedColumn";
+@Entity()
+export class User {
+    @PrimaryGeneratedColumn()
+    id: number;
+    @Column({ type: "varchar", length: 100 })
+    first_name: string;
+    @Column({ type: "varchar", length: 100 })
+    last_name: string;
+}

--- a/test/github-issues/3016/issue-3016.ts
+++ b/test/github-issues/3016/issue-3016.ts
@@ -1,0 +1,58 @@
+import "reflect-metadata";
+import {
+    createTestingConnections,
+    closeTestingConnections,
+    reloadTestingDatabases,
+} from "../../utils/test-utils";
+import { Connection } from "../../../src/connection/Connection";
+import { User } from "./entity/User";
+import { expect } from "chai";
+
+describe("github issues > #3016 'could not determine data type of parameter $1' in createQueryBuilder insert", () => {
+    let connections: Connection[];
+    before(
+        async () =>
+            (connections = await createTestingConnections({
+                entities: [__dirname + "/entity/*{.js,.ts}"],
+                schemaCreate: true,
+                dropSchema: true,
+            }))
+    );
+    beforeEach(() => reloadTestingDatabases(connections));
+    after(() => closeTestingConnections(connections));
+
+    it("should execute parameterized insert statement following printSql", () =>
+        Promise.all(
+            connections.map(async (connection) => {
+                const repo = connection.getRepository(User);
+                const result = await repo
+                    .createQueryBuilder()
+                    .insert()
+                    .into(User)
+                    .values({
+                        first_name: `Test`,
+                        last_name: `User`,
+                    })
+                    .printSql()
+                    .execute();
+                expect(result).not.to.be.undefined;
+            })
+        ));
+
+    it("should execute parameterized insert statement following getSql", () =>
+        Promise.all(
+            connections.map(async (connection) => {
+                const repo = connection.getRepository(User);
+                const q = repo.createQueryBuilder().insert().into(User).values({
+                    first_name: `Test`,
+                    last_name: `User`,
+                });
+
+                const sql = q.getSql();
+                expect(sql).not.to.be.undefined;
+
+                const result = await q.execute();
+                expect(result).not.to.be.undefined;
+            })
+        ));
+});


### PR DESCRIPTION

This corrects parameter numbering on `InsertQueryBuilder` to start from zero each time a query and parameters are requested. This resolves an issue whereby calling `printSql` or `getSql` followed by `execute` would generate incorrect parameter numbering, causing an error `could not determine data type of parameter $1` with Postgres.

### Description of change

Currently, if using a query builder to insert with values, and trying to print the query prior to execution, such as:

```
const result = await repo
                    .createQueryBuilder()
                    .insert()
                    .into(User)
                    .values({
                        first_name: `Test`,
                        last_name: `User`,
                    })
                    .printSql()
                    .execute();
```
                   
The insert operation will fail with an error on Postgres similar to:

```
could not determine data type of parameter $1
```

The reason is that `printSql` and `getSql` populate `QueryBuilder.expressionMap.nativeParameters`, which subsequently affects the behaviour of `execute` due to this line in `InsertQueryBuilder.createValuesExpression`:

```
let parametersCount = Object.keys(this.expressionMap.nativeParameters).length;
```

Here, parameter numbering is started from the number of native parameters already present in the instance. Since `printSql` or `getSql` populate `nativeParameters`, the behaviour differs depending on whether they have been called prior to execution.

With Postgres, since we use numbered placeholders (`$1`), the misnumbering causes an error.

This PR resolves the issue by always starting parameter numbering from zero when generating a query and parameters. I also choose to rename `parametersCount` to `paramNum` to indicate that it increments per parameter rather than representing the total count.

I'm having a hard time seeing why we'd ever want parameter numbering in a builder to not start from zero, but the existing behaviour seems like it could have been intentional so I'm prepared to learn that I missed something :laughing:

Fixes #3016


### Pull-Request Checklist

- [X] Code is up-to-date with the `master` branch
- [X] `npm run lint` passes with this change
- [X] `npm run test` passes with this change
- [X] This pull request links relevant issues as `Fixes #0000`
- [X] There are new or updated unit tests validating the change
- [X] Documentation has been updated to reflect this change
- [X] The new commits follow conventions explained in [CONTRIBUTING.md](https://github.com/typeorm/typeorm/blob/master/CONTRIBUTING.md)