### PR TITLE
fix: create table foreign keys creation

### DIFF
--- a/src/schema-builder/RdbmsSchemaBuilder.ts
+++ b/src/schema-builder/RdbmsSchemaBuilder.ts
@@ -170,7 +170,6 @@ export class RdbmsSchemaBuilder implements SchemaBuilder {
         await this.createNewChecks();
         await this.createNewExclusions();
         await this.createCompositeUniqueConstraints();
-        await this.createForeignKeys();
         await this.createViews();
     }
 

--- a/src/schema-builder/table/Table.ts
+++ b/src/schema-builder/table/Table.ts
@@ -312,6 +312,8 @@ export class Table {
                 .filter(index => index.synchronize === true)
                 .map(index => TableIndex.create(index)),
             uniques: entityMetadata.uniques.map(unique => TableUnique.create(unique)),
+            foreignKeys: entityMetadata.foreignKeys
+                .map(foreignKey => TableForeignKey.create(foreignKey)),
             checks: entityMetadata.checks.map(check => TableCheck.create(check)),
             exclusions: entityMetadata.exclusions.map(exclusion => TableExclusion.create(exclusion)),
         };


### PR DESCRIPTION
### Description of change
Currently, the typeorm will not create foreign keys for the table from metadata.
This tiny PR fixes it.

### Pull-Request Checklist
- [x] Code is up-to-date with the `master` branch
- [x] `npm run lint` passes with this change
- [x] `npm run test` passes with this change
- [x] Fixes #4733
- [ ] There are new or updated unit tests validating the change
- [ ] Documentation has been updated to reflect this change
- [x] The new commits follow conventions explained in [CONTRIBUTING.md](https://github.com/typeorm/typeorm/blob/master/CONTRIBUTING.md)