### PR TITLE
fix: Adjust mongodb driver options & connect driver to support replica set

### DIFF
--- a/src/connection/Connection.ts
+++ b/src/connection/Connection.ts
@@ -538,6 +538,8 @@ export class Connection {
             case "mssql":
             case "oracle":
                 return DriverUtils.buildDriverOptions(options.replication ? options.replication.master : options).database;
+            case "mongodb":
+                return DriverUtils.buildMongoDBDriverOptions(options).database;
             default:
                 return DriverUtils.buildDriverOptions(options).database;
     }

--- a/src/driver/DriverUtils.ts
+++ b/src/driver/DriverUtils.ts
@@ -34,6 +34,28 @@ export class DriverUtils {
     }
 
     /**
+     * buildDriverOptions for MongodDB only to support replica set
+     */
+    static buildMongoDBDriverOptions(options: any, buildOptions?: { useSid: boolean }): any {
+        if (options.url) {
+            const urlDriverOptions = this.parseMongoDBConnectionUrl(options.url) as { [key: string]: any };
+
+            if (buildOptions && buildOptions.useSid && urlDriverOptions.database) {
+                urlDriverOptions.sid = urlDriverOptions.database;
+            }
+
+            for (const key of Object.keys(urlDriverOptions)) {
+                if (typeof urlDriverOptions[key] === "undefined") {
+                    delete urlDriverOptions[key];
+                }
+            }
+
+            return Object.assign({}, options, urlDriverOptions);
+        }
+        return Object.assign({}, options);
+    }
+
+    /**
      * Builds column alias from given alias name and column name.
      *
      * If alias length is greater than the limit (if any) allowed by the current
@@ -94,6 +116,60 @@ export class DriverUtils {
             password: decodeURIComponent(password),
             port: port ? parseInt(port) : undefined,
             database: afterBase || undefined
+        };
+    }
+
+    /**
+     * Extracts connection data from the connection url for MongoDB to support replica set.
+     */
+    private static parseMongoDBConnectionUrl(url: string) {
+        const type = url.split(":")[0];
+        const firstSlashes = url.indexOf("//");
+        const preBase = url.substr(firstSlashes + 2);
+        const secondSlash = preBase.indexOf("/");
+        const base = (secondSlash !== -1) ? preBase.substr(0, secondSlash) : preBase;
+        let afterBase = (secondSlash !== -1) ? preBase.substr(secondSlash + 1) : undefined;
+        let afterQuestionMark = "";
+        let host = undefined;
+        let port = undefined;
+        let hostReplicaSet = undefined;
+        let replicaSet = undefined;
+        // remove mongodb query params
+        if (afterBase && afterBase.indexOf("?") !== -1) {
+            // split params to get replica set
+            afterQuestionMark = afterBase.substr((afterBase.indexOf("?") + 1), afterBase.length);
+            replicaSet = afterQuestionMark.split("=")[1];
+
+            afterBase = afterBase.substr(0, afterBase.indexOf("?"));
+        }
+
+        const lastAtSign = base.lastIndexOf("@");
+        const usernameAndPassword = base.substr(0, lastAtSign);
+        const hostAndPort = base.substr(lastAtSign + 1);
+
+        let username = usernameAndPassword;
+        let password = "";
+        const firstColon = usernameAndPassword.indexOf(":");
+        if (firstColon !== -1) {
+            username = usernameAndPassword.substr(0, firstColon);
+            password = usernameAndPassword.substr(firstColon + 1);
+        }
+
+        if (replicaSet) {
+            hostReplicaSet = hostAndPort;
+        } else {
+            [host, port] = hostAndPort.split(":");
+        }
+
+        return {
+            type: type,
+            host: host,
+            hostReplicaSet: hostReplicaSet,
+            username: decodeURIComponent(username),
+            password: decodeURIComponent(password),
+            port: port ? parseInt(port) : undefined,
+            database: afterBase || undefined,
+            replicaSet: replicaSet || undefined
         };
     }
 }

--- a/src/driver/mongodb/MongoConnectionOptions.ts
+++ b/src/driver/mongodb/MongoConnectionOptions.ts
@@ -21,6 +21,11 @@ export interface MongoConnectionOptions extends BaseConnectionOptions {
      * Database host.
      */
     readonly host?: string;
+    
+    /**
+     * Database host replica set.
+     */
+    readonly hostReplicaSet?: string;
 
     /**
      * Database host port.

--- a/src/driver/mongodb/MongoDriver.ts
+++ b/src/driver/mongodb/MongoDriver.ts
@@ -224,7 +224,7 @@ export class MongoDriver implements Driver {
      */
     connect(): Promise<void> {
         return new Promise<void>((ok, fail) => {
-            const options = DriverUtils.buildDriverOptions(this.options);
+            const options = DriverUtils.buildMongoDBDriverOptions(this.options);
 
             this.mongodb.MongoClient.connect(
                 this.buildConnectionUrl(options),
@@ -442,11 +442,19 @@ export class MongoDriver implements Driver {
          const credentialsUrlPart = (options.username && options.password)
             ? `${options.username}:${options.password}@`
             : "";
-        const portUrlPart = (schemaUrlPart === "mongodb+srv")
-            ? ""
-            : `:${options.port || "27017"}`;
 
-        return `${schemaUrlPart}://${credentialsUrlPart}${options.host || "127.0.0.1"}${portUrlPart}/${options.database || ""}`;
+        let connectionString = undefined;
+
+        if(options.replicaSet) {
+            connectionString = `${schemaUrlPart}://${credentialsUrlPart}${options.hostReplicaSet}/${options.database || ""}`;
+        } else {
+            const portUrlPart = (schemaUrlPart === "mongodb+srv")
+                ? ""
+                : `:${options.port || "27017"}`;
+            connectionString = `${schemaUrlPart}://${credentialsUrlPart}${options.host || "127.0.0.1"}${portUrlPart}/${options.database || ""}`;
+        }
+            
+        return connectionString;
     }
 
     /**


### PR DESCRIPTION
- Dupplicate buildDriverOptions for mongodb especially
- Add hostReplicaSet to MongoConnectionOptions properties for collect host replica list
- Adjust buildConnectionUrl to build replica set connection url

### Description of change

## src\connection\Connection.ts
```
case "mongodb":
          return DriverUtils.buildMongoDBDriverOptions(options).database;
```
Use dupplicate DriverOptions for MongoDB especially (not effect another driver).


## src\driver\DriverUtils.ts
```
static buildMongoDBDriverOptions(options: any, buildOptions?: { useSid: boolean }): any {
        if (options.url) {
            const urlDriverOptions = this.parseMongoDBConnectionUrl(options.url) as { [key: string]: any };
```
Dupplicate DriverOptions for MongoDB especially to call specific parseConnectionUrl (not effect another driver).

```
if (afterBase && afterBase.indexOf("?") !== -1) {
      // split params to get replica set
      afterQuestionMark = afterBase.substr((afterBase.indexOf("?") + 1), afterBase.length);
      replicaSet = afterQuestionMark.split("=")[1];

      afterBase = afterBase.substr(0, afterBase.indexOf("?"));
}
```
Get replica set params from connection string.

```
if (replicaSet) {
    hostReplicaSet = hostAndPort;
} else {
    [host, port] = hostAndPort.split(":");
}
```
Collect separately between host, port and got all hostname of replicaset

```
return {
            type: type,
            host: host,
            hostReplicaSet: hostReplicaSet,
            username: decodeURIComponent(username),
            password: decodeURIComponent(password),
            port: port ? parseInt(port) : undefined,
            database: afterBase || undefined,
            replicaSet: replicaSet || undefined
  }
```
Addition return hostReplicaSet & replica set.


## src\driver\mongodb\MongoConnectionOptions.ts
```
readonly hostReplicaSet?: string;
```
Add new properties to collect all host name (primary and all secondary) to build replica host name list.


## src\driver\mongodb\MongoDriver.ts
```
if(options.replicaSet) {
    connectionString = `${schemaUrlPart}://${credentialsUrlPart}${options.hostReplicaSet}/${options.database || ""}`;
} else {
    const portUrlPart = (schemaUrlPart === "mongodb+srv")
        ? ""
        : `:${options.port || "27017"}`;
    connectionString = `${schemaUrlPart}://${credentialsUrlPart}${options.host || "127.0.0.1"}${portUrlPart}/${options.database || ""}`;
}
```
Add condition to create connectionstring of replica set especially (if options.replicaSet was exist).


### Pull-Request Checklist

- [x] Code is up-to-date with the `master` branch
- [x] `npm run lint` passes with this change
- [ ] `npm run test` passes with this change
- [x] This pull request links relevant issues as Fixes [#7401](https://github.com/typeorm/typeorm/issues/7401)
- [ ] There are new or updated unit tests validating the change
- [ ] Documentation has been updated to reflect this change
- [ ] The new commits follow conventions explained in [CONTRIBUTING.md](https://github.com/typeorm/typeorm/blob/master/CONTRIBUTING.md)
