### PR TITLE
fix(1532) Array type default value should not generate SQL commands without change

### DIFF
--- a/src/driver/postgres/PostgresDriver.ts
+++ b/src/driver/postgres/PostgresDriver.ts
@@ -727,12 +727,14 @@ export class PostgresDriver implements Driver {
             (
                 columnMetadata.type === "enum"
                 || columnMetadata.type === "simple-enum"
+                || columnMetadata.isArray
             ) && defaultValue !== undefined
         ) {
-            if (columnMetadata.isArray && Array.isArray(defaultValue)) {
-                return `'{${defaultValue.map((val: string) => `${val}`).join(",")}}'`;
+            const invokedDefaultValue = typeof defaultValue === "function" ? defaultValue() : defaultValue;
+            if (columnMetadata.isArray && Array.isArray(invokedDefaultValue)) {
+                return `'{${invokedDefaultValue.map((val: string) => `${val}`).join(",")}}'`;
             }
-            return `'${defaultValue}'`;
+            return `'${invokedDefaultValue}'`;
         }
 
         if (typeof defaultValue === "number") {

--- a/test/github-issues/1532/entity/User.ts
+++ b/test/github-issues/1532/entity/User.ts
@@ -19,21 +19,9 @@ export class User {
     @Column({ type: "varchar", array: true, nullable: false, default: ["a", "b", "c"] })
     filledArrayDefault: string[];
 
-    @Column({ type: "varchar", array: true, nullable: false, default: () => [] })
-    emptyArrayDefaultFunc: string[];
-
-    @Column({ type: "varchar", array: true, nullable: false, default: () => ["a", "b", "c"] })
-    filledArrayDefaultFunc: string[];
-
     @Column({ type: "varchar", array: true, nullable: false, default: "{}" })
     emptyArrayDefaultString: string[];
 
     @Column({ type: "varchar", array: true, nullable: false, default: "{a,b,c}" })
     filledArrayDefaultString: string[];
-
-    @Column({ type: "varchar", array: true, nullable: false, default: () => "{}" })
-    emptyArrayDefaultStringFunc: string[];
-
-    @Column({ type: "varchar", array: true, nullable: false, default: () => "{a,b,c}" })
-    filledArrayDefaultStringFunc: string[];
 }

--- a/test/github-issues/1532/entity/User.ts
+++ b/test/github-issues/1532/entity/User.ts
@@ -1,0 +1,39 @@
+import {PrimaryColumn, Column} from "../../../../src";
+import {Entity} from "../../../../src/decorator/entity/Entity";
+
+@Entity()
+export class User {
+
+    @PrimaryColumn()
+    id: number;
+
+    @Column({ type: "varchar", array: true })
+    array: string[];
+
+    @Column({ type: "varchar", array: true, nullable: false })
+    nonNullArray: string[];
+
+    @Column({ type: "varchar", array: true, nullable: false, default: [] })
+    emptyArrayDefault: string[];
+
+    @Column({ type: "varchar", array: true, nullable: false, default: ["a", "b", "c"] })
+    filledArrayDefault: string[];
+
+    @Column({ type: "varchar", array: true, nullable: false, default: () => [] })
+    emptyArrayDefaultFunc: string[];
+
+    @Column({ type: "varchar", array: true, nullable: false, default: () => ["a", "b", "c"] })
+    filledArrayDefaultFunc: string[];
+
+    @Column({ type: "varchar", array: true, nullable: false, default: "{}" })
+    emptyArrayDefaultString: string[];
+
+    @Column({ type: "varchar", array: true, nullable: false, default: "{a,b,c}" })
+    filledArrayDefaultString: string[];
+
+    @Column({ type: "varchar", array: true, nullable: false, default: () => "{}" })
+    emptyArrayDefaultStringFunc: string[];
+
+    @Column({ type: "varchar", array: true, nullable: false, default: () => "{a,b,c}" })
+    filledArrayDefaultStringFunc: string[];
+}

--- a/test/github-issues/1532/issue-1532.ts
+++ b/test/github-issues/1532/issue-1532.ts
@@ -1,0 +1,30 @@
+import "reflect-metadata";
+import {Connection} from "../../../src";
+import {createTestingConnections, closeTestingConnections} from "../../utils/test-utils";
+import {User} from "./entity/User";
+
+describe("github issues > #1532 Array type default value doesnt work. PostgreSQL", () => {
+    let connections: Connection[];
+    before(async () => connections = await createTestingConnections({
+        migrations: [],
+        enabledDrivers: ["postgres"],
+        schemaCreate: false,
+        dropSchema: true,
+        entities: [User],
+    }));
+    after(() => closeTestingConnections(connections));
+
+    it("can recognize model changes", () => Promise.all(connections.map(async connection => {
+        const sqlInMemory = await connection.driver.createSchemaBuilder().log();
+        sqlInMemory.upQueries.length.should.be.greaterThan(0);
+        sqlInMemory.downQueries.length.should.be.greaterThan(0);
+    })));
+
+    it("does not generate when no model changes", () => Promise.all(connections.map(async connection => {
+        await connection.driver.createSchemaBuilder().build();
+
+        const sqlInMemory = await connection.driver.createSchemaBuilder().log();
+        sqlInMemory.upQueries.length.should.be.equal(0);
+        sqlInMemory.downQueries.length.should.be.equal(0);
+    })));
+});


### PR DESCRIPTION
### Description of change

Array defaulting for PostgreSQL would generate a change to the comment and the default value every time you ran `typeorm migration:generate`.

Example:

```
        await queryRunner.query(`
            COMMENT ON COLUMN "users"."array" IS NULL
        `);
        await queryRunner.query(`
            ALTER TABLE "users"
            ALTER COLUMN "array"
            SET DEFAULT '[]'
        `);
```

Fixes #1532


### Pull-Request Checklist

- [x] Code is up-to-date with the `master` branch
- [x] `npm run lint` passes with this change
- [x] `npm run test` passes with this change
- [x] This pull request links relevant issues as `Fixes #0000`
- [x] There are new or updated unit tests validating the change
- [x] N/A - Documentation has been updated to reflect this change
- [x] The new commits follow conventions explained in [CONTRIBUTING.md](https://github.com/typeorm/typeorm/blob/master/CONTRIBUTING.md)