### PR TITLE
fix: resolve issue building tree entities with embeded primary column

### DIFF
--- a/src/repository/TreeRepository.ts
+++ b/src/repository/TreeRepository.ts
@@ -265,7 +265,7 @@ export class TreeRepository<Entity> extends Repository<Entity> {
         const parentEntityId = this.metadata.primaryColumns[0].getEntityValue(entity);
         const childRelationMaps = relationMaps.filter(relationMap => relationMap.parentId === parentEntityId);
         const childIds = new Set(childRelationMaps.map(relationMap => relationMap.id));
-        entity[childProperty] = entities.filter(entity => childIds.has(entity[this.metadata.primaryColumns[0].propertyName]));
+        entity[childProperty] = entities.filter(entity => childIds.has(this.metadata.primaryColumns[0].getEntityValue(entity)));
         entity[childProperty].forEach((childEntity: any) => {
             this.buildChildrenEntityTree(childEntity, entities, relationMaps);
         });
@@ -279,7 +279,7 @@ export class TreeRepository<Entity> extends Repository<Entity> {
             if (!parentRelationMap)
                 return false;
 
-            return entity[this.metadata.primaryColumns[0].propertyName] === parentRelationMap.parentId;
+            return this.metadata.primaryColumns[0].getEntityValue(entity) === parentRelationMap.parentId;
         });
         if (parentEntity) {
             entity[parentProperty] = parentEntity;

--- a/test/github-issues/7415/entity/Category.ts
+++ b/test/github-issues/7415/entity/Category.ts
@@ -1,0 +1,26 @@
+import {
+    Column,
+    Entity,
+    Tree,
+    TreeChildren,
+    TreeParent,
+} from "../../../../src";
+import { Slug } from "./Slug";
+
+@Entity()
+@Tree("materialized-path")
+export class Category {
+    @Column((type) => Slug, { prefix: false })
+    id: Slug;
+
+    @TreeChildren()
+    children: Category[];
+
+    @TreeParent()
+    parent: Category;
+
+    constructor(slug: string, parent?: Category) {
+        this.id = new Slug(slug);
+        if (parent) this.parent = parent;
+    }
+}

--- a/test/github-issues/7415/entity/Slug.ts
+++ b/test/github-issues/7415/entity/Slug.ts
@@ -1,0 +1,10 @@
+import { PrimaryColumn } from "../../../../src";
+
+export class Slug {
+    @PrimaryColumn()
+    slug: string;
+
+    constructor(slug: string) {
+        this.slug = slug;
+    }
+}

--- a/test/github-issues/7415/issue-7415.ts
+++ b/test/github-issues/7415/issue-7415.ts
@@ -1,0 +1,87 @@
+import "reflect-metadata";
+import {
+    createTestingConnections,
+    closeTestingConnections,
+    reloadTestingDatabases,
+} from "../../utils/test-utils";
+import { Connection } from "../../../src/connection/Connection";
+import { Category } from "./entity/Category";
+import { Slug } from "./entity/Slug";
+import { expect } from "chai";
+
+describe("github issues > #7415 Tree entities with embedded primary columns are not built correctly", () => {
+    let connections: Connection[];
+    before(
+        async () =>
+            (connections = await createTestingConnections({
+                entities: [__dirname + "/entity/*{.js,.ts}"],
+                schemaCreate: true,
+                dropSchema: true,
+            }))
+    );
+    beforeEach(() => reloadTestingDatabases(connections));
+    after(() => closeTestingConnections(connections));
+
+    it("should build tree entities with embedded primary columns correctly", () =>
+        Promise.all(
+            connections.map(async (connection) => {
+                const manager = connection.manager;
+
+                const a1 = new Category("1");
+                await manager.save(a1);
+
+                const a2 = new Category("2");
+                await manager.save(a2);
+
+                const a11 = new Category("1.1", a1);
+                await manager.save(a11);
+
+                const a12 = new Category("1.2", a1);
+                await manager.save(a12);
+
+                const a13 = new Category("1.3", a1);
+                await manager.save(a13);
+
+                const a121 = new Category("1.2.1", a12);
+                await manager.save(a121);
+
+                const a122 = new Category("1.2.2", a12);
+                await manager.save(a122);
+
+                const repository = manager.getTreeRepository(Category);
+
+                const descendantsTree = await repository.findDescendantsTree(
+                    a1
+                );
+
+                const expectedDescendantsTree = {
+                    id: new Slug("1"),
+                    children: [
+                        { id: new Slug("1.1"), children: [] },
+                        {
+                            id: new Slug("1.2"),
+                            children: [
+                                { id: new Slug("1.2.1"), children: [] },
+                                { id: new Slug("1.2.2"), children: [] },
+                            ],
+                        },
+                        { id: new Slug("1.3"), children: [] },
+                    ],
+                };
+
+                expect(descendantsTree).to.be.eql(expectedDescendantsTree);
+
+                const ancestorsTree = await repository.findAncestorsTree(a121);
+
+                const expectedAncestorsTree = {
+                    id: new Slug("1.2.1"),
+                    parent: {
+                        id: new Slug("1.2"),
+                        parent: { id: new Slug("1") },
+                    },
+                };
+
+                expect(ancestorsTree).to.be.eql(expectedAncestorsTree);
+            })
+        ));
+});


### PR DESCRIPTION
Closes: #7415

### Description of change

Simply replaced all occurrences of

```ts
entity[this.metadata.primaryColumns[0].propertyName]
```

with

```ts
this.metadata.primaryColumns[0].getEntityValue(entity)
```

in the TreeRepository to be consistent in order for the comparisons to be processed correctly. More explanation in the linked issue.


### Pull-Request Checklist

- [x] Code is up-to-date with the `master` branch
- [x] `npm run lint` passes with this change
- [x] `npm run test` passes with this change
- [x] This pull request links relevant issues as `Fixes #0000`
- [x] There are new or updated unit tests validating the change
- [x] Documentation has been updated to reflect this change (N/A)
- [x] The new commits follow conventions explained in [CONTRIBUTING.md](https://github.com/typeorm/typeorm/blob/master/CONTRIBUTING.md)