### PR TITLE
fix: [aurora-data-api] Return number of affected rows in UpdatedResult and DeleteResult

### DIFF
--- a/src/query-builder/DeleteQueryBuilder.ts
+++ b/src/query-builder/DeleteQueryBuilder.ts
@@ -73,9 +73,13 @@ export class DeleteQueryBuilder<Entity> extends QueryBuilder<Entity> implements 
             const result = await queryRunner.query(sql, parameters);
 
             const driver = queryRunner.connection.driver;
-            if (driver instanceof MysqlDriver || driver instanceof AuroraDataApiDriver) {
+            if (driver instanceof MysqlDriver) {
                 deleteResult.raw = result;
                 deleteResult.affected = result.affectedRows;
+
+            } else if (driver instanceof AuroraDataApiDriver) {
+                deleteResult.raw = result;
+                deleteResult.affected = result.numberOfRecordsUpdated;
 
             } else if (driver instanceof SqlServerDriver || driver instanceof PostgresDriver || driver instanceof CockroachDriver) {
                 deleteResult.raw = result[0] ? result[0] : null;

--- a/src/query-builder/UpdateQueryBuilder.ts
+++ b/src/query-builder/UpdateQueryBuilder.ts
@@ -110,6 +110,10 @@ export class UpdateQueryBuilder<Entity> extends QueryBuilder<Entity> implements 
                 updateResult.raw = result;
                 updateResult.affected = result.affectedRows;
             }
+            else if (this.connection.driver instanceof AuroraDataApiDriver) {
+                updateResult.raw = result;
+                updateResult.affected = result.numberOfRecordsUpdated;
+            }
             else if (this.connection.driver instanceof BetterSqlite3Driver) { // only works for better-sqlite3
                 updateResult.raw = result;
                 updateResult.affected = result.changes;

--- a/test/github-issues/1308/issue-1308.ts
+++ b/test/github-issues/1308/issue-1308.ts
@@ -11,7 +11,7 @@ describe("github issues > #1308 Raw Postgresql Update query result is always an 
       (connections = await createTestingConnections({
         entities: [new EntitySchema<Author>(AuthorSchema), new EntitySchema<Post>(PostSchema)],
         dropSchema: true,
-        enabledDrivers: ["postgres", "mysql", "mariadb"],
+        enabledDrivers: ["postgres", "mysql", "mariadb", "aurora-data-api"],
       }))
   );
   beforeEach(() => reloadTestingDatabases(connections));

--- a/test/github-issues/2499/issue-2499.ts
+++ b/test/github-issues/2499/issue-2499.ts
@@ -11,18 +11,16 @@ describe("github issues > #2499 Postgres DELETE query result is useless", () => 
         entities: [__dirname + "/entity/*{.js,.ts}"],
         schemaCreate: true,
         dropSchema: true,
+        // skip test for sqlite because sqlite doesn't return any data on delete
+        // sqljs -- the same
+        // mongodb requires another test and it is also doesn't return correct number
+        // of removed documents (possibly a bug with mongodb itself)
+        enabledDrivers: ["mysql", "mariadb", "mssql", "postgres", "aurora-data-api"]
     }));
     beforeEach(() => reloadTestingDatabases(connections));
     after(() => closeTestingConnections(connections));
 
     it("should return correct number of affected rows for mysql, mariadb, postgres", () => Promise.all(connections.map(async connection => {
-        // skip test for sqlite because sqlite doesn't return any data on delete
-        // sqljs -- the same
-        // mongodb requires another test and it is also doesn't return correct number
-        // of removed documents (possibly a bug with mongodb itself)
-        if (["mysql", "mariadb", "mssql", "postgres"].indexOf(connection.name) === -1) {
-            return;
-        }
         const repo = connection.getRepository(Foo);
 
         await repo.save({ id: 1, description: "test1" });


### PR DESCRIPTION
Closes: #7386

<!--
  😀 Wonderful!  Thank you for opening a pull request for TypeORM.

  Please fill in the information below to expedite the review
  and (hopefully) merge of your change.

  If unsure about something.. just do as best as you're able,
  or reach out through our community support channels!
  https://github.com/typeorm/typeorm/blob/master/docs/support.md
-->

Add correct parsing of raw result for Aurora Data API (mysql-based) driver so that number of records updated are copied to the "generic" affected property.

<!--
  Please be clear and concise what the change is intended to do,
  why this change is needed, and how you've verified that it
  corrects what you intended.

  In some cases it may be helpful to include the current behavior
  and the new behavior.

  If the change is related to an open issue, you can link it here.
  If you include `Fixes #0000` (replacing `0000` with the issue number)
  when this is merged it will automatically mark the issue as fixed and
  close it.
-->


### Pull-Request Checklist

<!--
  Please make sure to review and check all of the following.

  If an item is not applicable, you can add "N/A" to the end.
-->

- [x] Code is up-to-date with the `master` branch
- [ ] `npm run lint` passes with this change (there are already failures on my machines)
- [x] `npm run test` passes with this change
- [x] This pull request links relevant issues as `Fixes #0000`
- [x] There are new or updated unit tests validating the change
- [ ] Documentation has been updated to reflect this change N/A
- [x] The new commits follow conventions explained in [CONTRIBUTING.md](https://github.com/typeorm/typeorm/blob/master/CONTRIBUTING.md)

<!--
  🎉 Thank you for contributing and making TypeORM even better!
-->
