### PR TITLE
feat(RelationDecorators): allow to pass the given table name as string

### DIFF
--- a/src/metadata-builder/EntityMetadataBuilder.ts
+++ b/src/metadata-builder/EntityMetadataBuilder.ts
@@ -666,7 +666,7 @@ export class EntityMetadataBuilder {
         entityMetadata.relations.forEach(relation => {
 
             // compute inverse side (related) entity metadatas for all relation metadatas
-            const inverseEntityMetadata = entityMetadatas.find(m => m.target === relation.type || (typeof relation.type === "string" && m.targetName === relation.type || m.givenTableName === relation.type));
+            const inverseEntityMetadata = entityMetadatas.find(m => m.target === relation.type || (typeof relation.type === "string" && (m.targetName === relation.type || m.givenTableName === relation.type)));
             if (!inverseEntityMetadata)
                 throw new Error("Entity metadata for " + entityMetadata.name + "#" + relation.propertyPath + " was not found. Check if you specified a correct entity object and if it's connected in the connection options.");
 

--- a/src/metadata-builder/EntityMetadataBuilder.ts
+++ b/src/metadata-builder/EntityMetadataBuilder.ts
@@ -666,7 +666,7 @@ export class EntityMetadataBuilder {
         entityMetadata.relations.forEach(relation => {
 
             // compute inverse side (related) entity metadatas for all relation metadatas
-            const inverseEntityMetadata = entityMetadatas.find(m => m.target === relation.type || (typeof relation.type === "string" && m.targetName === relation.type));
+            const inverseEntityMetadata = entityMetadatas.find(m => m.target === relation.type || (typeof relation.type === "string" && m.targetName === relation.type || m.givenTableName === relation.type));
             if (!inverseEntityMetadata)
                 throw new Error("Entity metadata for " + entityMetadata.name + "#" + relation.propertyPath + " was not found. Check if you specified a correct entity object and if it's connected in the connection options.");
 

--- a/test/other-issues/table-name-relation/entity/Category.ts
+++ b/test/other-issues/table-name-relation/entity/Category.ts
@@ -1,0 +1,12 @@
+import {Entity, PrimaryGeneratedColumn, Column} from "../../../../src";
+
+@Entity("categories")
+export class Category {
+
+    @PrimaryGeneratedColumn()
+    id: number;
+
+    @Column()
+    name: string;
+
+}

--- a/test/other-issues/table-name-relation/entity/Photo.ts
+++ b/test/other-issues/table-name-relation/entity/Photo.ts
@@ -1,0 +1,16 @@
+import {Entity, PrimaryGeneratedColumn, Column, ManyToOne} from "../../../../src";
+import {User} from "./User";
+
+@Entity("photographs")
+export class Photo {
+
+    @PrimaryGeneratedColumn()
+    id: number;
+
+    @Column()
+    url: string;
+
+    @ManyToOne("users", "photos")
+    user: User;
+
+}

--- a/test/other-issues/table-name-relation/entity/Profile.ts
+++ b/test/other-issues/table-name-relation/entity/Profile.ts
@@ -1,0 +1,15 @@
+import {Entity, PrimaryGeneratedColumn, Column} from "../../../../src";
+
+@Entity("profiles")
+export class Profile {
+
+    @PrimaryGeneratedColumn()
+    id: number;
+
+    @Column()
+    gender: string;
+
+    @Column()
+    photo: string;
+
+}

--- a/test/other-issues/table-name-relation/entity/Question.ts
+++ b/test/other-issues/table-name-relation/entity/Question.ts
@@ -1,0 +1,18 @@
+import {Entity, PrimaryGeneratedColumn, ManyToMany, JoinTable} from "../../../../src";
+import {Column} from "../../../../src/decorator/columns/Column";
+import {Category} from "./Category";
+
+@Entity("questions")
+export class Question {
+
+    @PrimaryGeneratedColumn()
+    id: number;
+
+    @Column()
+    name: string;
+
+    @ManyToMany("categories")
+    @JoinTable()
+    categories: Category[];
+
+}

--- a/test/other-issues/table-name-relation/entity/User.ts
+++ b/test/other-issues/table-name-relation/entity/User.ts
@@ -1,0 +1,21 @@
+import {Entity, PrimaryGeneratedColumn, Column, OneToMany, OneToOne, JoinColumn} from "../../../../src";
+import {Photo} from "./Photo";
+import {Profile} from "./Profile";
+
+@Entity("users")
+export class User {
+
+    @PrimaryGeneratedColumn()
+    id: number;
+
+    @Column()
+    name: string;
+
+    @OneToMany("photographs", "user")
+    photos: Photo[];
+
+    @OneToOne("profiles")
+    @JoinColumn()
+    profile: Profile;
+
+}

--- a/test/other-issues/table-name-relation/table-name-relation.ts
+++ b/test/other-issues/table-name-relation/table-name-relation.ts
@@ -1,0 +1,130 @@
+import "reflect-metadata";
+import {createTestingConnections, closeTestingConnections, reloadTestingDatabases} from "../../utils/test-utils";
+import {Connection} from "../../../src/connection/Connection";
+
+import {Photo} from "./entity/Photo";
+import {User} from "./entity/User";
+import {Profile} from "./entity/Profile";
+import {Category} from "./entity/Category";
+import {Question} from "./entity/Question";
+
+describe("other issues > Relation decorators: allow to pass given table name string instead of typeFunction or entity name", () => {
+
+    let connections: Connection[];
+    before(async () => connections = await createTestingConnections({
+        entities: [__dirname + "/entity/*{.js,.ts}"],
+        schemaCreate: true,
+        dropSchema: true,
+    }));
+    beforeEach(() => reloadTestingDatabases(connections));
+    after(() => closeTestingConnections(connections));
+
+    it("should work with one-to-one relations", () => Promise.all(connections.map(async connection => {
+
+        const profile = new Profile();
+        profile.gender = "male";
+        profile.photo = "me.jpg";
+        await connection.manager.save(profile);
+
+        const user = new User();
+        user.name = "Joe Smith";
+        user.profile = profile;
+        await connection.manager.save(user);
+
+        const users = await connection.manager.find(User, { relations: ["profile"] });
+
+        users.should.eql([{
+            id: 1,
+            name: "Joe Smith",
+            profile: {
+                id: 1,
+                gender: "male",
+                photo: "me.jpg"
+            }
+        }]);
+
+    })));
+
+    it("should work with many-to-one/one-to-many relations", () => Promise.all(connections.map(async connection => {
+
+        const photo1 = new Photo();
+        photo1.url = "me.jpg";
+        await connection.manager.save(photo1);
+
+        const photo2 = new Photo();
+        photo2.url = "me-and-bears.jpg";
+        await connection.manager.save(photo2);
+
+        const user = new User();
+        user.name = "John";
+        user.photos = [photo1, photo2];
+        await connection.manager.save(user);
+
+        const users = await connection.manager.find(User, { relations: ["photos"] });
+        const photos = await connection.manager.find(Photo, { relations: ["user"] });
+
+        // Check one-to-many
+        users[0].photos.should.have.deep.members([
+            {
+                id: 1,
+                url: "me.jpg"
+            },
+            {
+                id: 2,
+                url: "me-and-bears.jpg"
+            }
+        ]);
+
+        // Check many-to-one
+        photos.should.have.deep.members([
+            {
+                id: 1,
+                url: "me.jpg",
+                user: {
+                    id: 1,
+                    name: "John"
+                }
+            },
+            {
+                id: 2,
+                url: "me-and-bears.jpg",
+                user: {
+                    id: 1,
+                    name: "John"
+                }
+            }
+        ]);
+
+    })));
+
+    it("should work with many-to-many relations", () => Promise.all(connections.map(async connection => {
+
+        const category1 = new Category();
+        category1.name = "animals";
+        await connection.manager.save(category1);
+
+        const category2 = new Category();
+        category2.name = "zoo";
+        await connection.manager.save(category2);
+
+        const question = new Question();
+        question.name = "About animals";
+        question.categories = [category1, category2];
+        await connection.manager.save(question);
+
+        const questions = await connection.manager.find(Question, { relations: ["categories"] });
+
+        questions[0].categories.should.have.deep.members([
+            {
+                id: 1,
+                name: "animals"
+            },
+            {
+                id: 2,
+                name: "zoo"
+            }
+        ]);
+
+    })));
+
+});


### PR DESCRIPTION
<!--
  😀 Wonderful!  Thank you for opening a pull request for TypeORM.

  Please fill in the information below to expedite the review
  and (hopefully) merge of your change.

  If unsure about something.. just do as best as you're able,
  or reach out through our community support channels!
  https://github.com/typeorm/typeorm/blob/master/docs/support.md
-->

### Description of change

<!--
  Please be clear and concise what the change is intended to do,
  why this change is needed, and how you've verified that it
  corrects what you intended.

  In some cases it may be helpful to include the current behavior
  and the new behavior.

  If the change is related to an open issue, you can link it here.
  If you include `Fixes #0000` (replacing `0000` with the issue number)
  when this is merged it will automatically mark the issue as fixed and
  close it.
-->

Supplemental to #4190/#4195, also allows specifying the table name as a string in the relation.

WIth
```
@Entity('profiles')
class Profile {
  // ...
}

// then the relation can be made with
@OneToOne('profiles')
```

### Pull-Request Checklist

<!--
  Please make sure to review and check all of the following.

  If an item is not applicable, you can add "N/A" to the end.
-->

- [x] Code is up-to-date with the `master` branch
- [x] `npm run lint` passes with this change
- [x] `npm run test` passes with this change
- [x] This pull request links relevant issues as `Fixes #0000`
- [x] There are new or updated unit tests validating the change
- [ ] Documentation has been updated to reflect this change
- [x] The new commits follow conventions explained in [CONTRIBUTING.md](https://github.com/typeorm/typeorm/blob/master/CONTRIBUTING.md)

<!--
  🎉 Thank you for contributing and making TypeORM even better!
-->
