### PR TITLE
fix: empty entity when query with nested relations

### DIFF
--- a/src/query-builder/transformer/RawSqlResultsToEntityTransformer.ts
+++ b/src/query-builder/transformer/RawSqlResultsToEntityTransformer.ts
@@ -41,7 +41,7 @@ export class RawSqlResultsToEntityTransformer {
         const entities: any[] = [];
         group.forEach(results => {
             const entity = this.transformRawResultsGroup(results, alias);
-            if (entity !== undefined)
+            if (entity !== undefined && !Object.values(entity).every((value) => value === null))
                 entities.push(entity);
         });
         return entities;
@@ -187,10 +187,7 @@ export class RawSqlResultsToEntityTransformer {
             // transform joined data into entities
             let result: any = this.transform(rawResults, join.alias);
             result = !join.isMany ? result[0] : result;
-            // this is needed to make relations to return null when its joined but nothing was found in the database
-            result = !join.isMany && (result === undefined || Object.values(result).every((value) => value === null)) ? null : result;
-            // this is needed to make many relations to return [] when nothing found on nested joins
-            result = join.isMany && result.length === 1 && Object.values(result[0]).every((value) => value === null) ? [] : result;
+            result = !join.isMany && result === undefined ? null : result; // this is needed to make relations to return null when its joined but nothing was found in the database
             if (result === undefined) // if nothing was joined then simply return
                 return;
 

--- a/src/query-builder/transformer/RawSqlResultsToEntityTransformer.ts
+++ b/src/query-builder/transformer/RawSqlResultsToEntityTransformer.ts
@@ -187,7 +187,10 @@ export class RawSqlResultsToEntityTransformer {
             // transform joined data into entities
             let result: any = this.transform(rawResults, join.alias);
             result = !join.isMany ? result[0] : result;
-            result = !join.isMany && result === undefined ? null : result; // this is needed to make relations to return null when its joined but nothing was found in the database
+            // this is needed to make relations to return null when its joined but nothing was found in the database
+            result = !join.isMany && (result === undefined || Object.values(result).every((value) => value === null)) ? null : result;
+            // this is needed to make many relations to return [] when nothing found on nested joins
+            result = join.isMany && result.length === 1 && Object.values(result[0]).every((value) => value === null) ? [] : result;
             if (result === undefined) // if nothing was joined then simply return
                 return;
 

--- a/test/github-issues/7041/entity/Admin.ts
+++ b/test/github-issues/7041/entity/Admin.ts
@@ -1,0 +1,23 @@
+import {
+    BaseEntity,
+    Column,
+    Entity,
+    JoinColumn,
+    OneToOne,
+} from "../../../../src";
+import { User } from "./User";
+import { Organization } from "./Organization";
+
+@Entity()
+export class Admin extends BaseEntity {
+    @OneToOne(() => User, (user) => user.admin, { primary: true })
+    @JoinColumn()
+    user: User;
+
+    @OneToOne(() => Organization, (org) => org.admin)
+    @JoinColumn()
+    organization: Organization;
+
+    @Column()
+    randomField: string;
+}

--- a/test/github-issues/7041/entity/Organization.ts
+++ b/test/github-issues/7041/entity/Organization.ts
@@ -1,0 +1,28 @@
+import {
+    BaseEntity,
+    Column,
+    Entity,
+    OneToMany,
+    OneToOne,
+    PrimaryGeneratedColumn,
+} from "../../../../src";
+import { Admin } from "./Admin";
+import { OrganizationMembership } from "./OrganizationMembership";
+
+@Entity()
+export class Organization extends BaseEntity {
+    @PrimaryGeneratedColumn("uuid")
+    id: string;
+
+    @OneToOne(() => Admin, (admin) => admin.organization, { nullable: true })
+    admin: Admin;
+
+    @Column()
+    randomField: string;
+
+    @OneToMany(
+        () => OrganizationMembership,
+        (membership) => membership.organization
+    )
+    membership: OrganizationMembership[];
+}

--- a/test/github-issues/7041/entity/OrganizationMembership.ts
+++ b/test/github-issues/7041/entity/OrganizationMembership.ts
@@ -1,0 +1,19 @@
+import { BaseEntity, Column, Entity, ManyToOne } from "../../../../src";
+import { User } from "./User";
+import { Organization } from "./Organization";
+
+@Entity()
+export class OrganizationMembership extends BaseEntity {
+    @ManyToOne(() => User, (user) => user.membership, {
+        primary: true,
+    })
+    user: User;
+
+    @ManyToOne(() => Organization, (organization) => organization.membership, {
+        primary: true,
+    })
+    organization: Organization;
+
+    @Column()
+    accessLevel: string;
+}

--- a/test/github-issues/7041/entity/User.ts
+++ b/test/github-issues/7041/entity/User.ts
@@ -1,0 +1,27 @@
+import {
+    BaseEntity,
+    Column,
+    Entity,
+    OneToMany,
+    OneToOne,
+    PrimaryGeneratedColumn,
+} from "../../../../src";
+import { Admin } from "./Admin";
+import { OrganizationMembership } from "./OrganizationMembership";
+
+@Entity()
+export class User extends BaseEntity {
+    @PrimaryGeneratedColumn("uuid")
+    id: string;
+
+    @Column()
+    randomField: string;
+
+    @OneToOne(() => Admin, (admin) => admin.user, { nullable: true })
+    admin: Admin;
+
+    @OneToMany(() => OrganizationMembership, (membership) => membership.user, {
+        nullable: true,
+    })
+    membership: OrganizationMembership[];
+}

--- a/test/github-issues/7041/entity/index.ts
+++ b/test/github-issues/7041/entity/index.ts
@@ -1,0 +1,4 @@
+export { Admin } from "./Admin";
+export { Organization } from "./Organization";
+export { User } from "./User";
+export { OrganizationMembership } from "./OrganizationMembership";

--- a/test/github-issues/7041/issue-7041.ts
+++ b/test/github-issues/7041/issue-7041.ts
@@ -1,0 +1,53 @@
+import "reflect-metadata";
+import {
+    createTestingConnections,
+    closeTestingConnections,
+    reloadTestingDatabases,
+} from "../../utils/test-utils";
+import { Connection } from "../../../src";
+import { expect } from "chai";
+import { Organization, Admin, User, OrganizationMembership } from "./entity";
+
+describe("github issues > #7041 When requesting nested relations on foreign key primary entities, relation becomes empty entity rather than null", () => {
+    let connections: Connection[];
+    before(
+        async () =>
+            (connections = await createTestingConnections({
+                entities: [Organization, Admin, User, OrganizationMembership],
+                schemaCreate: true,
+                dropSchema: true,
+            }))
+    );
+    beforeEach(() => reloadTestingDatabases(connections));
+    after(() => closeTestingConnections(connections));
+
+    it("should return null when requested nested relations are empty on OneToOne relation", () =>
+        Promise.all(
+            connections.map(async (connection) => {
+                const userRepo = connection.getRepository(User);
+                const testUser = new User();
+                testUser.randomField = "foo";
+                await userRepo.save(testUser);
+                const foundUser = await userRepo.findOne(testUser.id, {
+                    relations: ["admin", "admin.organization"],
+                });
+                expect(foundUser?.randomField).eq("foo");
+                expect(foundUser?.admin).eq(null);
+            })
+        ));
+
+    it("should return [] when requested nested relations are empty on OneToMany relation", () =>
+        Promise.all(
+            connections.map(async (connection) => {
+                const userRepo = connection.getRepository(User);
+                const testUser = new User();
+                testUser.randomField = "foo";
+                await userRepo.save(testUser);
+                const foundUser = await userRepo.findOne(testUser.id, {
+                    relations: ["membership", "membership.organization"],
+                });
+                expect(foundUser?.randomField).eq("foo");
+                expect(foundUser?.membership).eql([]);
+            })
+        ));
+});


### PR DESCRIPTION
Closes: #7041

### Description of change

If there is a nested join for example User->OrganizationMembership->Organization and there is no OrganizationMembership for an User currently 
- it's returning empty Entity (all fields are nulls) for oneToOne relations
- it's returning an array with one element - empty Entity for many relations
the new behavior
- returns null for oneToOne relations
- returns empty array for many relations

Example old
User{id: "1", name: "me", membership: {id: null, organization: null}}
User{id: "1", name: "me", membership: [{id: null, organization: null}}]

Example new
User{id: "1", name: "me", membership: null}
User{id: "1", name: "me", membership: []}

Fixes #7041 
Fixes #3163
Fixes #3145

### Pull-Request Checklist

- [x] Code is up-to-date with the `master` branch
- [x] `npm run lint` passes with this change
- [x] `npm run test` passes with this change
- [x] This pull request links relevant issues as `Fixes #0000`
- [x] There are new or updated unit tests validating the change
- [ ] Documentation has been updated to reflect this change
- [x] The new commits follow conventions explained in [CONTRIBUTING.md](https://github.com/typeorm/typeorm/blob/master/CONTRIBUTING.md)
