### PR TITLE
Added socketPath support for replicas

### DIFF
--- a/src/driver/mysql/MysqlConnectionCredentialsOptions.ts
+++ b/src/driver/mysql/MysqlConnectionCredentialsOptions.ts
@@ -40,4 +40,8 @@ export interface MysqlConnectionCredentialsOptions {
      */
     readonly ssl?: any;
 
+    /**
+     * Database socket path
+     */
+    readonly socketPath?: string;
 }

--- a/src/driver/mysql/MysqlDriver.ts
+++ b/src/driver/mysql/MysqlDriver.ts
@@ -870,7 +870,8 @@ export class MysqlDriver implements Driver {
             password: credentials.password,
             database: credentials.database,
             port: credentials.port,
-            ssl: options.ssl
+            ssl: options.ssl,
+            socketPath: credentials.socketPath
         },
         options.acquireTimeout === undefined
           ? {}


### PR DESCRIPTION
Currently, Typeorm doesn't support socket connections for replicas. We use Google CloudSQL (mysql) and the preferred way to connect to CloudSQL from Cloud Run is sockets. The implementation is pretty straight forward and works the same as the none replica configuration; when a socketPath is set the host and port are ignored.
