### PR TITLE
relationLoader: load with existing queryRunner

### DIFF
--- a/src/driver/mysql/MysqlDriver.ts
+++ b/src/driver/mysql/MysqlDriver.ts
@@ -896,6 +896,11 @@ export class MysqlDriver implements Driver {
 
                 connection.release();
                 ok(pool);
+                
+                pool.on('acquire', function (connection: any) {
+                    console.log('Connection %d acquired', connection.threadId);
+                });
+
             });
         });
     }

--- a/src/driver/mysql/MysqlDriver.ts
+++ b/src/driver/mysql/MysqlDriver.ts
@@ -896,11 +896,6 @@ export class MysqlDriver implements Driver {
 
                 connection.release();
                 ok(pool);
-                
-                pool.on('acquire', function (connection: any) {
-                    console.log('Connection %d acquired', connection.threadId);
-                });
-
             });
         });
     }

--- a/src/query-builder/RelationQueryBuilder.ts
+++ b/src/query-builder/RelationQueryBuilder.ts
@@ -161,7 +161,7 @@ export class RelationQueryBuilder<Entity> extends QueryBuilder<Entity> {
             of = metadata.primaryColumns[0].createValueMap(of);
         }
 
-        return this.connection.relationLoader.load(this.expressionMap.relationMetadata, of);
+        return this.connection.relationLoader.load(this.expressionMap.relationMetadata, of, this.queryRunner);
     }
 
 }

--- a/test/functional/transaction/transaction-with-load-many/entity/Category.ts
+++ b/test/functional/transaction/transaction-with-load-many/entity/Category.ts
@@ -1,0 +1,18 @@
+import {Entity} from "../../../../../src/decorator/entity/Entity";
+import {PrimaryGeneratedColumn} from "../../../../../src/decorator/columns/PrimaryGeneratedColumn";
+import {Column} from "../../../../../src/decorator/columns/Column";
+import {ManyToOne} from "../../../../../src/decorator/relations/ManyToOne";
+import {Post} from "./Post";
+
+@Entity()
+export class Category {
+
+    @PrimaryGeneratedColumn()
+    id: number;
+
+    @Column()
+    name: string;
+
+    @ManyToOne(() => Post, post => post.categories)
+    post: Post;
+}

--- a/test/functional/transaction/transaction-with-load-many/entity/Post.ts
+++ b/test/functional/transaction/transaction-with-load-many/entity/Post.ts
@@ -1,0 +1,18 @@
+import {Entity} from "../../../../../src/decorator/entity/Entity";
+import {PrimaryGeneratedColumn} from "../../../../../src/decorator/columns/PrimaryGeneratedColumn";
+import {Column} from "../../../../../src/decorator/columns/Column";
+import {OneToMany} from "../../../../../src/decorator/relations/OneToMany";
+import {Category} from "./Category";
+
+@Entity()
+export class Post {
+
+    @PrimaryGeneratedColumn()
+    id: number;
+
+    @Column()
+    title: string;
+
+    @OneToMany(() => Category, category => category.post)
+    categories: Category[];
+}

--- a/test/functional/transaction/transaction-with-load-many/transaction-load-many.ts
+++ b/test/functional/transaction/transaction-with-load-many/transaction-load-many.ts
@@ -14,7 +14,7 @@ describe("transaction > transaction with load many", () => {
     beforeEach(() => reloadTestingDatabases(connections));
     after(() => closeTestingConnections(connections));
 
-    it.only("should loadMany in same transaction with same query runner", () => Promise.all(connections.map(async connection => {
+    it("should loadMany in same transaction with same query runner", () => Promise.all(connections.map(async connection => {
         
         await connection.manager.transaction(async entityManager => {
             

--- a/test/functional/transaction/transaction-with-load-many/transaction-load-many.ts
+++ b/test/functional/transaction/transaction-with-load-many/transaction-load-many.ts
@@ -4,7 +4,7 @@ import {Connection} from "../../../../src/connection/Connection";
 import {Post} from "./entity/Post";
 import {expect} from "chai";
 
-describe.only("transaction > transaction with load many", () => {
+describe("transaction > transaction with load many", () => {
 
     let connections: Connection[];
     before(async () => connections = await createTestingConnections({

--- a/test/functional/transaction/transaction-with-load-many/transaction-load-many.ts
+++ b/test/functional/transaction/transaction-with-load-many/transaction-load-many.ts
@@ -1,0 +1,33 @@
+import "reflect-metadata";
+import {closeTestingConnections, createTestingConnections, reloadTestingDatabases} from "../../../utils/test-utils";
+import {Connection} from "../../../../src/connection/Connection";
+import {Post} from "./entity/Post";
+import {expect} from "chai";
+
+describe.only("transaction > transaction with load many", () => {
+
+    let connections: Connection[];
+    before(async () => connections = await createTestingConnections({
+        entities: [__dirname + "/entity/*{.js,.ts}"],
+        enabledDrivers: ["mysql", "sqlite", "better-sqlite3", "postgres"] // todo: for some reasons mariadb tests are not passing here
+    }));
+    beforeEach(() => reloadTestingDatabases(connections));
+    after(() => closeTestingConnections(connections));
+
+    it.only("should loadMany in same transaction with same query runner", () => Promise.all(connections.map(async connection => {
+        
+        await connection.manager.transaction(async entityManager => {
+            
+            await entityManager
+            .createQueryBuilder()
+            .relation(Post, "categories")
+            .of(1)
+            .loadMany();
+
+            // remove `this.queryRunner` in src/query-builder/RelationQueryBuilder.ts:164 
+            // and loadMany uses different connections, despite it's inside a transaction
+
+            expect(true); // todo: find a way to test which connection is used and remove console.log inside src/driver/mysql/MysqlDriver.ts:900
+        });
+    })));
+});


### PR DESCRIPTION
<!--
  😀 Wonderful!  Thank you for opening a pull request for TypeORM.

  Please fill in the information below to expedite the review
  and (hopefully) merge of your change.

  If unsure about something.. just do as best as you're able,
  or reach out through our community support channels!
  https://github.com/typeorm/typeorm/blob/master/docs/support.md
-->

### Description of change

Pass queryRunner in order to use existing transaction. **Since testing is not complete, changes can not be merged yet.**

Todo:
- Find a way to test which connection from connection pool is used 

Fixes: #5338

### Pull-Request Checklist

- [x] Code is up-to-date with the `master` branch
- [x] `npm run lint` passes with this change
- [x] `npm run test` passes with this change
- [x] This pull request links relevant issues as `Fixes #0000`
- [x] There are new or updated unit tests validating the change
- [ ] Documentation has been updated to reflect this change
- [x] The new commits follow conventions explained in [CONTRIBUTING.md](https://github.com/typeorm/typeorm/blob/master/CONTRIBUTING.md)
