### PR TITLE
Add ability to set session variables, as per issue#7472

### DIFF
--- a/src/driver/mongodb/MongoQueryRunner.ts
+++ b/src/driver/mongodb/MongoQueryRunner.ts
@@ -862,7 +862,13 @@ export class MongoQueryRunner implements QueryRunner {
     async executeMemoryDownSql(): Promise<void> {
         throw new Error(`This operation is not supported by MongoDB driver.`);
     }
-
+    
+    /**
+     * Sets session variables to use. Starts a transaction if one does not exist.
+     */
+     async setSessionVariables(sessionVariables: {[variableName: string]: ObjectLiteral}): Promise<void> {
+        throw new Error(`This operation is not supported by MongoDB driver.`);
+    }
     // -------------------------------------------------------------------------
     // Protected Methods
     // -------------------------------------------------------------------------

--- a/src/find-options/FindOneOptions.ts
+++ b/src/find-options/FindOneOptions.ts
@@ -67,4 +67,9 @@ export interface FindOneOptions<Entity = any> {
      */
     transaction?: boolean
 
+    /**
+     * An object containing session variables to use for this query. This will set `transaction` to true to prevent session variables bleeding across queries.
+     * This can be used to help implement row level security for application users.
+     */
+    sessionVariables?: {[variableName: string]: ObjectLiteral};
 }

--- a/src/find-options/FindOptionsUtils.ts
+++ b/src/find-options/FindOptionsUtils.ts
@@ -35,7 +35,8 @@ export class FindOptionsUtils {
                     typeof possibleOptions.loadRelationIds === "boolean" ||
                     typeof possibleOptions.loadEagerRelations === "boolean" ||
                     typeof possibleOptions.withDeleted === "boolean" ||
-                    typeof possibleOptions.transaction === "boolean"
+                    typeof possibleOptions.transaction === "boolean" ||
+                    possibleOptions.sessionVariables instanceof Object
                 );
     }
 
@@ -85,8 +86,16 @@ export class FindOptionsUtils {
         if (!options || (!this.isFindOneOptions(options) && !this.isFindManyOptions(options)))
             return qb;
 
+        if (options.transaction === false && options.sessionVariables) {
+            throw new Error("cannot set transaction to false when using session variables.");
+        }
+
         if (options.transaction === true) {
             qb.expressionMap.useTransaction = true;
+        }
+
+        if (options.sessionVariables) {
+            qb.expressionMap.sessionVariables = options.sessionVariables;
         }
 
         if (!qb.expressionMap.mainAlias || !qb.expressionMap.mainAlias.hasMetadata)

--- a/src/query-builder/DeleteQueryBuilder.ts
+++ b/src/query-builder/DeleteQueryBuilder.ts
@@ -56,9 +56,15 @@ export class DeleteQueryBuilder<Entity> extends QueryBuilder<Entity> implements 
         try {
 
             // start transaction if it was enabled
-            if (this.expressionMap.useTransaction === true && queryRunner.isTransactionActive === false) {
+            if ((this.expressionMap.useTransaction === true || this.expressionMap.sessionVariables)
+             && queryRunner.isTransactionActive === false) {
                 await queryRunner.startTransaction();
                 transactionStartedByUs = true;
+            }
+
+            // set configuration parameters / session variables
+            if (this.expressionMap.sessionVariables) {
+                await queryRunner.setSessionVariables(this.expressionMap.sessionVariables);
             }
 
             // call before deletion methods in listeners and subscribers

--- a/src/query-builder/InsertQueryBuilder.ts
+++ b/src/query-builder/InsertQueryBuilder.ts
@@ -64,9 +64,15 @@ export class InsertQueryBuilder<Entity> extends QueryBuilder<Entity> {
         try {
 
             // start transaction if it was enabled
-            if (this.expressionMap.useTransaction === true && queryRunner.isTransactionActive === false) {
+            if ((this.expressionMap.useTransaction === true || this.expressionMap.sessionVariables)
+             && queryRunner.isTransactionActive === false) {
                 await queryRunner.startTransaction();
                 transactionStartedByUs = true;
+            }
+
+            // set configuration parameters / session variables
+            if (this.expressionMap.sessionVariables) {
+                await queryRunner.setSessionVariables(this.expressionMap.sessionVariables);
             }
 
             // console.timeEnd(".database stuff");

--- a/src/query-builder/QueryBuilder.ts
+++ b/src/query-builder/QueryBuilder.ts
@@ -495,7 +495,19 @@ export abstract class QueryBuilder<Entity> {
      * If set to true the query will be wrapped into a transaction.
      */
     useTransaction(enabled: boolean): this {
+        if (!enabled && this.expressionMap.sessionVariables)
+            throw new Error(`Must use transaction when using sessionVariables.`)
         this.expressionMap.useTransaction = enabled;
+        return this;
+    }
+
+    /**
+     * If set to true the query will be wrapped into a transaction.
+     */
+    setSessionVariables(sessionVariables: {[variableName: string]: ObjectLiteral}): this {
+        if (this.expressionMap.sessionVariables)
+            throw new Error(`Cannot specify sessionVariables outside of a transaction. call "qb.useTransaction(true)" method to enable transaction.`)
+        this.expressionMap.sessionVariables = sessionVariables;
         return this;
     }
 

--- a/src/query-builder/QueryBuilder.ts
+++ b/src/query-builder/QueryBuilder.ts
@@ -496,7 +496,7 @@ export abstract class QueryBuilder<Entity> {
      */
     useTransaction(enabled: boolean): this {
         if (!enabled && this.expressionMap.sessionVariables)
-            throw new Error(`Must use transaction when using sessionVariables.`)
+            throw new Error(`Must use transaction when using sessionVariables.`);
         this.expressionMap.useTransaction = enabled;
         return this;
     }
@@ -505,8 +505,8 @@ export abstract class QueryBuilder<Entity> {
      * If set to true the query will be wrapped into a transaction.
      */
     setSessionVariables(sessionVariables: {[variableName: string]: ObjectLiteral}): this {
-        if (this.expressionMap.sessionVariables)
-            throw new Error(`Cannot specify sessionVariables outside of a transaction. call "qb.useTransaction(true)" method to enable transaction.`)
+        if (this.expressionMap.useTransaction === false)
+            throw new Error(`Cannot specify sessionVariables outside of a transaction. call "qb.useTransaction(true)" method to enable transaction.`);
         this.expressionMap.sessionVariables = sessionVariables;
         return this;
     }

--- a/src/query-builder/QueryExpressionMap.ts
+++ b/src/query-builder/QueryExpressionMap.ts
@@ -174,6 +174,13 @@ export class QueryExpressionMap {
     parameters: ObjectLiteral = {};
 
     /**
+     * An object mapping sessionVariableName(s) to sessionVariableValue
+     * This enables using a transaction.
+     * This creates "SET LOCAL" clauses before the query, and the variables will be unset after the transaction ends.
+     */
+    sessionVariables?: {[variableName: string]: ObjectLiteral};
+
+    /**
      * Indicates if alias, table names and column names will be ecaped by driver, or not.
      *
      * todo: rename to isQuotingDisabled, also think if it should be named "escaping"
@@ -441,6 +448,7 @@ export class QueryExpressionMap {
         map.useTransaction = this.useTransaction;
         map.nativeParameters = Object.assign({}, this.nativeParameters);
         map.comment = this.comment;
+        map.sessionVariables = Object.assign({}, this.sessionVariables);
         return map;
     }
 

--- a/src/query-builder/SelectQueryBuilder.ts
+++ b/src/query-builder/SelectQueryBuilder.ts
@@ -1005,9 +1005,13 @@ export class SelectQueryBuilder<Entity> extends QueryBuilder<Entity> implements 
         try {
 
             // start transaction if it was enabled
-            if (this.expressionMap.useTransaction === true && queryRunner.isTransactionActive === false) {
+            if ((this.expressionMap.useTransaction === true || this.expressionMap.sessionVariables)
+             && queryRunner.isTransactionActive === false) {
                 await queryRunner.startTransaction();
                 transactionStartedByUs = true;
+            }
+            if (this.expressionMap.sessionVariables) {
+                await queryRunner.setSessionVariables(this.expressionMap.sessionVariables);
             }
 
             const results = await this.loadRawResults(queryRunner);
@@ -1045,9 +1049,15 @@ export class SelectQueryBuilder<Entity> extends QueryBuilder<Entity> implements 
         try {
 
             // start transaction if it was enabled
-            if (this.expressionMap.useTransaction === true && queryRunner.isTransactionActive === false) {
+            if ((this.expressionMap.useTransaction === true || this.expressionMap.sessionVariables)
+             && queryRunner.isTransactionActive === false) {
                 await queryRunner.startTransaction();
                 transactionStartedByUs = true;
+            }
+
+            // set configuration parameters / session variables
+            if (this.expressionMap.sessionVariables) {
+                await queryRunner.setSessionVariables(this.expressionMap.sessionVariables);
             }
 
             this.expressionMap.queryEntity = true;

--- a/src/query-builder/SoftDeleteQueryBuilder.ts
+++ b/src/query-builder/SoftDeleteQueryBuilder.ts
@@ -60,9 +60,15 @@ export class SoftDeleteQueryBuilder<Entity> extends QueryBuilder<Entity> impleme
         try {
 
             // start transaction if it was enabled
-            if (this.expressionMap.useTransaction === true && queryRunner.isTransactionActive === false) {
+            if ((this.expressionMap.useTransaction === true || this.expressionMap.sessionVariables)
+             && queryRunner.isTransactionActive === false) {
                 await queryRunner.startTransaction();
                 transactionStartedByUs = true;
+            }
+
+            // set configuration parameters / session variables
+            if (this.expressionMap.sessionVariables) {
+                await queryRunner.setSessionVariables(this.expressionMap.sessionVariables);
             }
 
             // call before updation methods in listeners and subscribers

--- a/src/query-builder/UpdateQueryBuilder.ts
+++ b/src/query-builder/UpdateQueryBuilder.ts
@@ -65,9 +65,15 @@ export class UpdateQueryBuilder<Entity> extends QueryBuilder<Entity> implements 
         try {
 
             // start transaction if it was enabled
-            if (this.expressionMap.useTransaction === true && queryRunner.isTransactionActive === false) {
+            if ((this.expressionMap.useTransaction === true || this.expressionMap.sessionVariables)
+             && queryRunner.isTransactionActive === false) {
                 await queryRunner.startTransaction();
                 transactionStartedByUs = true;
+            }
+
+            // set configuration parameters / session variables
+            if (this.expressionMap.sessionVariables) {
+                await queryRunner.setSessionVariables(this.expressionMap.sessionVariables);
             }
 
             // call before updation methods in listeners and subscribers

--- a/src/query-runner/BaseQueryRunner.ts
+++ b/src/query-runner/BaseQueryRunner.ts
@@ -9,6 +9,7 @@ import {EntityManager} from "../entity-manager/EntityManager";
 import {TableColumn} from "../schema-builder/table/TableColumn";
 import {Broadcaster} from "../subscriber/Broadcaster";
 import {ReplicationMode} from "../driver/types/ReplicationMode";
+import { ObjectLiteral } from "../common/ObjectLiteral";
 
 export abstract class BaseQueryRunner {
 
@@ -188,6 +189,13 @@ export abstract class BaseQueryRunner {
         for (const {query, parameters} of this.sqlInMemory.downQueries.reverse()) {
             await this.query(query, parameters);
         }
+    }
+
+    /**
+     * Sets session variables to use. Starts a transaction if one does not exist.
+     */
+    async setSessionVariables(sessionVariables: {[variableName: string]: ObjectLiteral}): Promise<void> {
+        throw new Error(`This feature is not supported by this dbms at this time.`);
     }
 
     // -------------------------------------------------------------------------

--- a/src/query-runner/QueryRunner.ts
+++ b/src/query-runner/QueryRunner.ts
@@ -98,6 +98,11 @@ export interface QueryRunner {
     rollbackTransaction(): Promise<void>;
 
     /**
+     * Sets session variables to use. Starts a transaction if one does not exist.
+     */
+    setSessionVariables(sessionVariables: {[variableName: string]: ObjectLiteral}): Promise<void>;
+
+    /**
      * Executes a given SQL query and returns raw database results.
      */
     query(query: string, parameters?: any[]): Promise<any>;

--- a/src/repository/RemoveOptions.ts
+++ b/src/repository/RemoveOptions.ts
@@ -22,6 +22,12 @@ export interface RemoveOptions {
     transaction?: boolean;
 
     /**
+     * An object containing session variables to use for this query. This will set `transaction` to true to prevent session variables bleeding across queries.
+     * This can be used to help implement row level security for application users.
+     */
+    sessionVariables?: Record<string, any>;
+    
+    /**
      * Breaks save execution into given number of chunks.
      * For example, if you want to save 100,000 objects but you have issues with saving them,
      * you can break them into 10 groups of 10,000 objects (by setting { chunk: 10000 }) and save each group separately.

--- a/src/repository/SaveOptions.ts
+++ b/src/repository/SaveOptions.ts
@@ -30,6 +30,12 @@ export interface SaveOptions {
     chunk?: number;
 
     /**
+     * An object containing session variables to use for this query. This will set `transaction` to true to prevent session variables bleeding across queries.
+     * This can be used to help implement row level security for application users.
+     */
+    sessionVariables?: Record<string, any>;
+    
+    /**
      * Flag to determine whether the entity that is being persisted
      * should be reloaded during the persistence operation.
      *

--- a/test/github-issues/7472/entity/Post.ts
+++ b/test/github-issues/7472/entity/Post.ts
@@ -1,0 +1,12 @@
+import {Entity, Column, PrimaryColumn} from "../../../../src";
+
+@Entity()
+export class Post {
+
+    @PrimaryColumn({"type": "int"})
+    id: number;
+
+    @Column({type: "text"})
+    owner: string;
+
+}

--- a/test/github-issues/7472/issue-7472.ts
+++ b/test/github-issues/7472/issue-7472.ts
@@ -1,0 +1,160 @@
+import "reflect-metadata";
+import {Connection} from "../../../src/connection/Connection";
+import {closeTestingConnections, createTestingConnections} from "../../utils/test-utils";
+import {Post} from "./entity/Post";
+
+// This creates a role test_role which, which will be used to check that the RLSes defined in `makePolicy` work correctly.
+const prepTest = async(connection: Connection) =>{
+    await becomeAdmin(connection);
+
+    await connection.query("DROP OWNED BY test_role");
+    await connection.query("DROP ROLE IF EXISTS test_role");
+    await connection.query("CREATE ROLE test_role WITH login nobypassrls PASSWORD 'test_role'");
+
+    await connection.query("ALTER DEFAULT PRIVILEGES GRANT ALL PRIVILEGES ON TABLES TO test_role");
+    await connection.query("ALTER DEFAULT PRIVILEGES GRANT ALL PRIVILEGES ON FUNCTIONS TO test_role");
+    await connection.query("ALTER DEFAULT PRIVILEGES GRANT ALL PRIVILEGES ON SEQUENCES TO test_role");
+    await connection.query("ALTER DEFAULT PRIVILEGES GRANT ALL PRIVILEGES ON TYPES TO test_role");
+    
+    await connection.query("GRANT ALL PRIVILEGES ON ALL TABLES IN SCHEMA public TO test_role");
+    await connection.query("GRANT ALL PRIVILEGES ON ALL FUNCTIONS IN SCHEMA public TO test_role");
+    await connection.query("GRANT ALL PRIVILEGES ON ALL SEQUENCES IN SCHEMA public TO test_role");
+
+    await releaseAdmin(connection);
+};
+
+// Calling this makes the connection bypass RLS policies.
+const becomeAdmin = async(connection: Connection)=>{
+    await connection.query("RESET SESSION AUTHORIZATION");
+};
+
+// Calling this makes the connection subject to RLS policies
+const releaseAdmin = async(connection: Connection)=>{
+    await connection.query("SET SESSION AUTHORIZATION test_role");
+};
+
+
+// As there is currently no way to define a row level security policy,
+// We make a helper function here to do the set up for us.
+const makePolicy = async(connection: Connection) => {
+    await connection.query("RESET SESSION AUTHORIZATION");
+    await connection.query(`ALTER TABLE "post" ENABLE ROW LEVEL SECURITY`); 
+    await connection.query(`ALTER TABLE "post" FORCE ROW LEVEL SECURITY`);
+    await connection.query(`DROP POLICY IF EXISTS my_policy ON "post"`);
+    await connection.query(`CREATE POLICY my_policy ON "post" FOR ALL ` +
+        `USING (current_setting('myVar.isAdmin', true)='true' OR owner=current_setting('myVar.user', true))`
+    );
+    await connection.query(`SET SESSION AUTHORIZATION test_role`);
+};
+
+describe("github issues -> #7472 ", () => {
+
+    let connections: Connection[];
+
+    before(async () => {
+        connections = await createTestingConnections({
+            entities: [__dirname + "/entity/*{.js,.ts}"],
+            enabledDrivers: ["postgres"],
+            schema: "public",
+            schemaCreate: true,
+            dropSchema: true,
+            logging: true,
+        });
+        await prepTest(connections[0]);
+    });
+    beforeEach(async () => {
+        await makePolicy(connections[0]);
+    });
+    after(() => closeTestingConnections(connections));
+
+    it("should correctly select ONLY accessible data when session variables set the user to different users", async () => {
+        const connection = connections[0];
+        const em = connection.createEntityManager();
+        const alice = "alice", bob = "bob";
+        
+        await becomeAdmin(connection);
+        await em.save([
+            em.create(Post, {id: 1, owner: alice}),
+            em.create(Post, {id: 2, owner: bob})
+        ]);
+        await releaseAdmin(connection);
+        
+        await em.find(Post, {sessionVariables: {myVar: {user: alice}}, transaction:false}).should.rejected;
+
+        await em.find(Post, {sessionVariables: {myVar: {user: alice}}}).should.become([{id:1, owner: alice}]);
+        await em.find(Post, {sessionVariables: {myVar: {user: bob}}}).should.become([{id:2, owner: bob}]);
+
+        await em.findOne(Post, 1, {sessionVariables: {myVar: {user: alice}}}).should.become({id:1, owner: alice});
+        await em.findOne(Post, 1, {sessionVariables: {myVar: {user: bob}}}).should.become(undefined);
+        
+        await em.find(Post, {
+            sessionVariables: {
+                myVar: {isAdmin: true},
+            },
+            order: {id: "ASC"},
+        }).should.become([{id:1, owner: alice}, {id:2, owner: bob}]);
+        
+        // Querying without specifying any session variables is expected to return no rows,
+        // as postgres is effectively checking `owner = ""` for all rows (which is false for all rows.)
+        await em.find(Post, {order: {id: "ASC"}}).should.become([]);
+    });
+
+    it("should correctly delete ONLY accessible data when session variables set the user to different users", async () => {
+        const connection = connections[0];
+        const em = connection.createEntityManager();
+        const alice = "alice", bob = "bob";
+
+        await becomeAdmin(connection);
+        await em.save([
+            em.create(Post, {id: 1, owner: alice}),
+            em.create(Post, {id: 2, owner: bob})
+        ]);
+        await releaseAdmin(connection);
+
+        // Deleting without setting any session vars/config params should not delete any rows (due to our RLS policy)
+        await em.createQueryBuilder().delete().from(Post, "post").execute();
+        await becomeAdmin(connection);
+        await em.find(Post, {order: {id: "ASC"}}).should.become([{id:1, owner: alice}, {id:2, owner: bob}]);
+        await releaseAdmin(connection);
+
+        await em.createQueryBuilder().setSessionVariables({myVar: {user: alice}}).delete().from(Post, "post").execute();
+        await becomeAdmin(connection);
+        await em.find(Post, {order: {id: "ASC"}}).should.become([{id:2, owner: bob}]);
+        await releaseAdmin(connection);
+
+        // Deleting 'alice' again shouldn't change the db entries.
+        await em.createQueryBuilder().setSessionVariables({myVar: {user: alice}}).delete().from(Post, "post").execute();
+        await becomeAdmin(connection);
+        await em.find(Post, {order: {id: "ASC"}}).should.become([{id:2, owner: bob}]);
+        await releaseAdmin(connection);
+
+        await em.createQueryBuilder().setSessionVariables({myVar: {user: bob}}).delete().from(Post, "post").execute();
+        await becomeAdmin(connection);
+        await em.find(Post).should.become([]);
+        await releaseAdmin(connection);
+    });
+
+    it("should correctly update ONLY accessible data when session variables set the user to different users", async () => {
+        const connection = connections[0];
+        const em = connection.createEntityManager();
+        const alice = "alice", bob = "bob";
+        
+        await becomeAdmin(connection);
+        await em.save([
+            em.create(Post, {id: 1, owner: alice}),
+            em.create(Post, {id: 2, owner: bob})
+        ]);
+        await releaseAdmin(connection);
+        
+        // Updating without setting any session vars/config params should not modify any rows (due to our RLS policy)
+        await em.createQueryBuilder().update(Post, {owner: "fail"}).execute();
+        await becomeAdmin(connection);
+        await em.find(Post, {order: {id: "ASC"}}).should.become([{id:1, owner: alice}, {id:2, owner: bob}]);
+        await releaseAdmin(connection);
+
+        await em.createQueryBuilder().setSessionVariables({myVar: {user: alice}}).update(Post, {id: 3}).execute();
+        await becomeAdmin(connection);
+        await em.find(Post, {order: {id: "ASC"}}).should.become([{id:2, owner: bob}, {id:3, owner: alice}]);
+        await releaseAdmin(connection);
+    });
+});

--- a/test/github-issues/7472/issue-7472.ts
+++ b/test/github-issues/7472/issue-7472.ts
@@ -47,7 +47,7 @@ const makePolicy = async(connection: Connection) => {
     await connection.query(`SET SESSION AUTHORIZATION test_role`);
 };
 
-describe("github issues -> #7472 ", () => {
+describe("github issues -> #7472 Add ability for entitymanager and query builder to set session variables. This PR is only for postgresql support.", () => {
 
     let connections: Connection[];
 

--- a/test/github-issues/7472/issue-7472.ts
+++ b/test/github-issues/7472/issue-7472.ts
@@ -117,6 +117,13 @@ describe("github issues -> #7472 ", () => {
         await em.find(Post, {order: {id: "ASC"}}).should.become([{id:1, owner: alice}, {id:2, owner: bob}]);
         await releaseAdmin(connection);
 
+        // Check again, using EntityManager.
+        await em.remove(Post, {id: 1, owner: alice} as Post, {sessionVariables: {myVar: {user: bob}}});
+        await becomeAdmin(connection);
+        await em.find(Post, {order: {id: "ASC"}}).should.become([{id:1, owner: alice}, {id:2, owner: bob}]);
+        await releaseAdmin(connection);
+        
+        // Delete ""everything"" from Post as alice. Bob should remain, as alice can't see bob's row.
         await em.createQueryBuilder().setSessionVariables({myVar: {user: alice}}).delete().from(Post, "post").execute();
         await becomeAdmin(connection);
         await em.find(Post, {order: {id: "ASC"}}).should.become([{id:2, owner: bob}]);
@@ -128,7 +135,7 @@ describe("github issues -> #7472 ", () => {
         await em.find(Post, {order: {id: "ASC"}}).should.become([{id:2, owner: bob}]);
         await releaseAdmin(connection);
 
-        await em.createQueryBuilder().setSessionVariables({myVar: {user: bob}}).delete().from(Post, "post").execute();
+        await em.remove(Post, {id: 2, owner: bob} as Post, {sessionVariables: {myVar: {user: bob}}});
         await becomeAdmin(connection);
         await em.find(Post).should.become([]);
         await releaseAdmin(connection);

--- a/test/github-issues/my_test/entity/Post.ts
+++ b/test/github-issues/my_test/entity/Post.ts
@@ -1,0 +1,12 @@
+import {Entity, Column, PrimaryColumn} from "../../../../src";
+
+@Entity()
+export class Post {
+
+    @PrimaryColumn({"type": "int"})
+    id: number;
+
+    @Column({type: "text"})
+    owner: string;
+
+}

--- a/test/github-issues/my_test/my_test.ts
+++ b/test/github-issues/my_test/my_test.ts
@@ -1,0 +1,162 @@
+import "reflect-metadata";
+//import {getConnection } from "../../../src";
+import {Connection} from "../../../src/connection/Connection";
+import {closeTestingConnections, createTestingConnections} from "../../utils/test-utils";
+import {Post} from "./entity/Post";
+
+const prepTest = async(connection: Connection) =>{
+    await becomeAdmin(connection);
+
+    await connection.query("DROP OWNED BY test_role");
+    await connection.query("DROP ROLE IF EXISTS test_role");
+    await connection.query("CREATE ROLE test_role WITH login nobypassrls PASSWORD 'test_role'");
+    // await connection.query("GRANT ALL ON SCHEMA public TO test_role");
+    await connection.query("ALTER DEFAULT PRIVILEGES GRANT ALL PRIVILEGES ON TABLES TO test_role");
+    await connection.query("ALTER DEFAULT PRIVILEGES GRANT ALL PRIVILEGES ON FUNCTIONS TO test_role");
+    await connection.query("ALTER DEFAULT PRIVILEGES GRANT ALL PRIVILEGES ON SEQUENCES TO test_role");
+    await connection.query("ALTER DEFAULT PRIVILEGES GRANT ALL PRIVILEGES ON TYPES TO test_role");
+    
+    await connection.query("GRANT ALL PRIVILEGES ON ALL TABLES IN SCHEMA public TO test_role");
+    await connection.query("GRANT ALL PRIVILEGES ON ALL FUNCTIONS IN SCHEMA public TO test_role");
+    await connection.query("GRANT ALL PRIVILEGES ON ALL SEQUENCES IN SCHEMA public TO test_role");
+
+    await releaseAdmin(connection);
+};
+
+// Calling this makes the connection bypass RLS policies.
+const becomeAdmin = async(connection: Connection)=>{
+    await connection.query("RESET SESSION AUTHORIZATION");
+};
+
+// Calling this makes the connection subject to RLS policies
+const releaseAdmin = async(connection: Connection)=>{
+    await connection.query("SET SESSION AUTHORIZATION test_role");
+};
+
+
+// As there is currently no way to define a row level security policy,
+// We make a helper function here to do the set up for us.
+const makePolicy = async(connection: Connection) => {
+    const postMeta = connection.getMetadata(Post);
+    //connection.query(`ALTER SYSTEM "${postMeta.tableName}" ENABLE ROW LEVEL SECURITY`); 
+    await connection.query("RESET SESSION AUTHORIZATION");
+    await connection.query(`ALTER TABLE "${postMeta.tableName}" ENABLE ROW LEVEL SECURITY`); 
+    await connection.query(`ALTER TABLE "${postMeta.tableName}" FORCE ROW LEVEL SECURITY`); // use force here?
+    await connection.query(`DROP POLICY IF EXISTS my_policy ON "${postMeta.tableName}"`);
+    await connection.query(`CREATE POLICY my_policy ON "${postMeta.tableName}" FOR ALL ` +
+        `USING (current_setting('myVar.isAdmin', true)='true' OR owner = current_setting('myVar.user', true))`
+    );
+    await connection.query(`SET SESSION AUTHORIZATION test_role`);
+};
+
+describe("my_test", () => {
+
+    let connections: Connection[];
+
+    before(async () => {
+        connections = await createTestingConnections({
+            entities: [__dirname + "/entity/*{.js,.ts}"],
+            enabledDrivers: ["postgres"],
+            schema: "public",
+            schemaCreate: true,
+            dropSchema: true,
+            logging: true,
+        });
+        await prepTest(connections[0]);
+    });
+    beforeEach(async () => {
+        await makePolicy(connections[0]);
+    });
+    after(() => closeTestingConnections(connections));
+
+    it("should correctly select ONLY accessible data when session variables set the user to different users", async () => {
+        const connection = connections[0];
+        const em = connection.createEntityManager();
+        const alice = "alice", bob = "bob";
+        
+        await becomeAdmin(connection);
+        await em.save([
+            em.create(Post, {id: 1, owner: alice}),
+            em.create(Post, {id: 2, owner: bob})
+        ]);
+        await releaseAdmin(connection);
+        
+        await em.find(Post, {sessionVariables: {myVar: {user: alice}}, transaction:false}).should.rejected;
+
+        await em.find(Post, {sessionVariables: {myVar: {user: alice}}}).should.become([{id:1, owner: alice}]);
+        await em.find(Post, {sessionVariables: {myVar: {user: bob}}}).should.become([{id:2, owner: bob}]);
+
+        await em.findOne(Post, 1, {sessionVariables: {myVar: {user: alice}}}).should.become({id:1, owner: alice});
+        await em.findOne(Post, 1, {sessionVariables: {myVar: {user: bob}}}).should.become(undefined);
+        
+        await em.find(Post, {
+            sessionVariables: {
+                myVar: {isAdmin: true},
+            },
+            order: {id: "ASC"},
+        }).should.become([{id:1, owner: alice}, {id:2, owner: bob}]);
+        
+        // Querying without specifying any session variables is expected to return no rows,
+        // as postgres is effectively checking `owner = ""` for all rows (which is false for all rows.)
+        await em.find(Post, {order: {id: "ASC"}}).should.become([]);
+    });
+
+    it("should correctly delete ONLY accessible data when session variables set the user to different users", async () => {
+        const connection = connections[0];
+        const em = connection.createEntityManager();
+        const alice = "alice", bob = "bob";
+
+        await becomeAdmin(connection);
+        await em.save([
+            em.create(Post, {id: 1, owner: alice}),
+            em.create(Post, {id: 2, owner: bob})
+        ]);
+        await releaseAdmin(connection);
+
+        // Deleting without setting any session vars/config params should not delete any rows (due to our RLS policy)
+        await em.createQueryBuilder().delete().from(Post, "post").execute();
+        await becomeAdmin(connection);
+        await em.find(Post, {order: {id: "ASC"}}).should.become([{id:1, owner: alice}, {id:2, owner: bob}]);
+        await releaseAdmin(connection);
+
+        await em.createQueryBuilder().setSessionVariables({myVar: {user: alice}}).delete().from(Post, "post").execute();
+        await becomeAdmin(connection);
+        await em.find(Post, {order: {id: "ASC"}}).should.become([{id:2, owner: bob}]);
+        await releaseAdmin(connection);
+
+        // Deleting 'alice' again shouldn't change the db entries.
+        await em.createQueryBuilder().setSessionVariables({myVar: {user: alice}}).delete().from(Post, "post").execute();
+        await becomeAdmin(connection);
+        await em.find(Post, {order: {id: "ASC"}}).should.become([{id:2, owner: bob}]);
+        await releaseAdmin(connection);
+
+        await em.createQueryBuilder().setSessionVariables({myVar: {user: bob}}).delete().from(Post, "post").execute();
+        await becomeAdmin(connection);
+        await em.find(Post).should.become([]);
+        await releaseAdmin(connection);
+    });
+
+    it("should correctly update ONLY accessible data when session variables set the user to different users", async () => {
+        const connection = connections[0];
+        const em = connection.createEntityManager();
+        const alice = "alice", bob = "bob";
+        
+        await becomeAdmin(connection);
+        await em.save([
+            em.create(Post, {id: 1, owner: alice}),
+            em.create(Post, {id: 2, owner: bob})
+        ]);
+        await releaseAdmin(connection);
+        
+        // Updating without setting any session vars/config params should not modify any rows (due to our RLS policy)
+        await em.createQueryBuilder().update(Post, {owner: "fail"}).execute();
+        await becomeAdmin(connection);
+        await em.find(Post, {order: {id: "ASC"}}).should.become([{id:1, owner: alice}, {id:2, owner: bob}]);
+        await releaseAdmin(connection);
+
+        await em.createQueryBuilder().setSessionVariables({myVar: {user: alice}}).update(Post, {id: 3}).execute();
+        await becomeAdmin(connection);
+        await em.find(Post, {order: {id: "ASC"}}).should.become([{id:2, owner: bob}, {id:3, owner: alice}]);
+        await releaseAdmin(connection);
+    });
+});


### PR DESCRIPTION
### Description of change

This PR implements a way to set custom configuration parameters (ie session variables) when executing find* queries using the EntityManager, as well as a lower level interface for accomplishing the same end using the existing *QueryBuilder/s.

I have added unit tests for the various QueryBuilder and EntityManager methods which require the ability to set session variables.

For motivations and more context, see discussion at the GH issue I opened [here](https://github.com/typeorm/typeorm/issues/7472)

This PR implements the change requested and described in https://github.com/typeorm/typeorm/issues/7472

### Pull-Request Checklist

- [x] Code is up-to-date with the `master` branch
- [x] `npm run lint` passes with this change
- [x] `npm run test` passes with this change
- [x] This pull request links relevant issues as `Fixes #0000`
- [x] There are new or updated unit tests validating the change
- [ ] Documentation has been updated to reflect this change
- [x] The new commits follow conventions explained in [CONTRIBUTING.md](https://github.com/typeorm/typeorm/blob/master/CONTRIBUTING.md)
