### PR TITLE
Add support for Access Token Authentication for SQL Server Driver (mssql)

### DIFF
--- a/src/driver/sqlserver/SqlServerConnectionCredentialsOptions.ts
+++ b/src/driver/sqlserver/SqlServerConnectionCredentialsOptions.ts
@@ -41,7 +41,18 @@ export interface SqlServerConnectionCredentialsOptions {
     readonly database?: string;
 
     /**
+     * Database username.
+     */
+    readonly username?: string;
+
+    /**
+     * Database password.
+     */
+    readonly password?: string;
+
+    /**
      * Authentication settings
+     * It overrides username and password, when passed.
      */
     readonly authentication?: SqlServerConnectionCredentialsAuthenticationOptions
 
@@ -52,21 +63,5 @@ export interface SqlServerConnectionCredentialsOptions {
      * @deprecated
      */
     readonly domain?: string;
-
-    /**
-     * Database username.
-     * @see SqlServerConnectionCredentialsOptions.authentication
-     * @see DefaultAuthentication
-     * @deprecated
-     */
-    readonly username?: string;
-
-    /**
-     * Database password.
-     * @see SqlServerConnectionCredentialsOptions.authentication
-     * @see DefaultAuthentication
-     * @deprecated
-     */
-    readonly password?: string;
 
 }

--- a/src/driver/sqlserver/SqlServerConnectionCredentialsOptions.ts
+++ b/src/driver/sqlserver/SqlServerConnectionCredentialsOptions.ts
@@ -1,3 +1,20 @@
+import {DefaultAuthentication} from "./authentication/DefaultAuthentication";
+import {AzureActiveDirectoryAccessTokenAuthentication} from "./authentication/AzureActiveDirectoryAccessTokenAuthentication";
+import {AzureActiveDirectoryMsiAppServiceAuthentication} from "./authentication/AzureActiveDirectoryMsiAppServiceAuthentication";
+import {AzureActiveDirectoryMsiVmAuthentication} from "./authentication/AzureActiveDirectoryMsiVmAuthentication";
+import {AzureActiveDirectoryPasswordAuthentication} from "./authentication/AzureActiveDirectoryPasswordAuthentication";
+import {AzureActiveDirectoryServicePrincipalSecret} from "./authentication/AzureActiveDirectoryServicePrincipalSecret";
+import {NtlmAuthentication} from "./authentication/NtlmAuthentication";
+
+export type SqlServerConnectionCredentialsAuthenticationOptions =
+    DefaultAuthentication
+    | NtlmAuthentication
+    | AzureActiveDirectoryAccessTokenAuthentication
+    | AzureActiveDirectoryMsiAppServiceAuthentication
+    | AzureActiveDirectoryMsiVmAuthentication
+    | AzureActiveDirectoryPasswordAuthentication
+    | AzureActiveDirectoryServicePrincipalSecret
+
 /**
  * SqlServer specific connection credential options.
  */
@@ -19,23 +36,37 @@ export interface SqlServerConnectionCredentialsOptions {
     readonly port?: number;
 
     /**
-     * Database username.
-     */
-    readonly username?: string;
-
-    /**
-     * Database password.
-     */
-    readonly password?: string;
-
-    /**
      * Database name to connect to.
      */
     readonly database?: string;
 
     /**
+     * Authentication settings
+     */
+    readonly authentication?: SqlServerConnectionCredentialsAuthenticationOptions
+
+    /**
      * Once you set domain, driver will connect to SQL Server using domain login.
+     * @see SqlServerConnectionCredentialsOptions.authentication
+     * @see NtlmAuthentication
+     * @deprecated
      */
     readonly domain?: string;
+
+    /**
+     * Database username.
+     * @see SqlServerConnectionCredentialsOptions.authentication
+     * @see DefaultAuthentication
+     * @deprecated
+     */
+    readonly username?: string;
+
+    /**
+     * Database password.
+     * @see SqlServerConnectionCredentialsOptions.authentication
+     * @see DefaultAuthentication
+     * @deprecated
+     */
+    readonly password?: string;
 
 }

--- a/src/driver/sqlserver/SqlServerDriver.ts
+++ b/src/driver/sqlserver/SqlServerDriver.ts
@@ -765,6 +765,15 @@ export class SqlServerDriver implements Driver {
 
         credentials = Object.assign({}, credentials, DriverUtils.buildDriverOptions(credentials)); // todo: do it better way
 
+        // todo: credentials.domain is deprecation. remove it in future
+        const authentication = !credentials.domain ? credentials.authentication : {
+            type: "ntlm",
+            options: {
+                domain: credentials.domain,
+                userName: credentials.username,
+                password: credentials.password
+            }
+        };
         // build connection options for the driver
         const connectionOptions = Object.assign({}, {
             connectionTimeout: this.options.connectionTimeout,
@@ -776,14 +785,9 @@ export class SqlServerDriver implements Driver {
             server: credentials.host,
             database: credentials.database,
             port: credentials.port,
-            authentication: credentials.authentication || {
-                // fallback for support deprecation
-                type: credentials.domain ? "ntlm" : "default",
-                options: {
-                    userName: credentials.username,
-                    password: credentials.password,
-                }
-            },
+            user: credentials.username,
+            password: credentials.password,
+            authentication: authentication,
         }, options.extra || {});
 
         // set default useUTC option if it hasn't been set

--- a/src/driver/sqlserver/SqlServerDriver.ts
+++ b/src/driver/sqlserver/SqlServerDriver.ts
@@ -774,11 +774,16 @@ export class SqlServerDriver implements Driver {
             options: this.options.options,
         }, {
             server: credentials.host,
-            user: credentials.username,
-            password: credentials.password,
             database: credentials.database,
             port: credentials.port,
-            domain: credentials.domain,
+            authentication: credentials.authentication || {
+                // fallback for support deprecation
+                type: credentials.domain ? "ntlm" : "default",
+                options: {
+                    userName: credentials.username,
+                    password: credentials.password,
+                }
+            },
         }, options.extra || {});
 
         // set default useUTC option if it hasn't been set

--- a/src/driver/sqlserver/authentication/AzureActiveDirectoryAccessTokenAuthentication.ts
+++ b/src/driver/sqlserver/authentication/AzureActiveDirectoryAccessTokenAuthentication.ts
@@ -1,0 +1,10 @@
+export interface AzureActiveDirectoryAccessTokenAuthentication {
+    type: "azure-active-directory-access-token";
+    options: {
+        /**
+         * A user need to provide `token` which they retrived else where
+         * to forming the connection.
+         */
+        token: string;
+    };
+}

--- a/src/driver/sqlserver/authentication/AzureActiveDirectoryMsiAppServiceAuthentication.ts
+++ b/src/driver/sqlserver/authentication/AzureActiveDirectoryMsiAppServiceAuthentication.ts
@@ -1,0 +1,20 @@
+export interface AzureActiveDirectoryMsiAppServiceAuthentication {
+    type: "azure-active-directory-msi-app-service";
+    options: {
+        /**
+         * If you user want to connect to an Azure app service using a specific client account
+         * they need to provide `clientId` asscoiate to their created idnetity.
+         *
+         * This is optional for retrieve token from azure web app service
+         */
+        clientId?: string;
+        /**
+         * A msi app service environment need to provide `msiEndpoint` for retriving the accesstoken.
+         */
+        msiEndpoint?: string;
+        /**
+         * A msi app service environment need to provide `msiSecret` for retriving the accesstoken.
+         */
+        msiSecret?: string;
+    };
+}

--- a/src/driver/sqlserver/authentication/AzureActiveDirectoryMsiVmAuthentication.ts
+++ b/src/driver/sqlserver/authentication/AzureActiveDirectoryMsiVmAuthentication.ts
@@ -1,0 +1,16 @@
+export interface AzureActiveDirectoryMsiVmAuthentication {
+    type: "azure-active-directory-msi-vm";
+    options: {
+        /**
+         * If you user want to connect to an Azure app service using a specific client account
+         * they need to provide `clientId` asscoiate to their created idnetity.
+         *
+         * This is optional for retrieve token from azure web app service
+         */
+        clientId?: string;
+        /**
+         * A user need to provide `msiEndpoint` for retriving the accesstoken.
+         */
+        msiEndpoint?: string;
+    };
+}

--- a/src/driver/sqlserver/authentication/AzureActiveDirectoryPasswordAuthentication.ts
+++ b/src/driver/sqlserver/authentication/AzureActiveDirectoryPasswordAuthentication.ts
@@ -1,0 +1,18 @@
+export interface AzureActiveDirectoryPasswordAuthentication {
+    type: "azure-active-directory-password";
+    options: {
+        /**
+         * A user need to provide `userName` asscoiate to their account.
+         */
+        userName: string;
+        /**
+         * A user need to provide `password` asscoiate to their account.
+         */
+        password: string;
+
+        /**
+         * Optional parameter for specific Azure tenant ID
+         */
+        domain: string;
+    };
+}

--- a/src/driver/sqlserver/authentication/AzureActiveDirectoryServicePrincipalSecret.ts
+++ b/src/driver/sqlserver/authentication/AzureActiveDirectoryServicePrincipalSecret.ts
@@ -1,0 +1,17 @@
+export interface AzureActiveDirectoryServicePrincipalSecret {
+    type: "azure-active-directory-service-principal-secret";
+    options: {
+        /**
+         * Application (`client`) ID from your registered Azure application
+         */
+        clientId: string;
+        /**
+         * The created `client secret` for this registered Azure application
+         */
+        clientSecret: string;
+        /**
+         * Directory (`tenant`) ID from your registered Azure application
+         */
+        tenantId: string;
+    };
+}

--- a/src/driver/sqlserver/authentication/DefaultAuthentication.ts
+++ b/src/driver/sqlserver/authentication/DefaultAuthentication.ts
@@ -1,0 +1,13 @@
+export interface DefaultAuthentication {
+    type: "default";
+    options: {
+        /**
+         * User name to use for sql server login.
+         */
+        userName?: string;
+        /**
+         * Password to use for sql server login.
+         */
+        password?: string;
+    };
+}

--- a/src/driver/sqlserver/authentication/NtlmAuthentication.ts
+++ b/src/driver/sqlserver/authentication/NtlmAuthentication.ts
@@ -1,0 +1,19 @@
+export interface NtlmAuthentication {
+    type: "ntlm";
+    options: {
+        /**
+         * User name from your windows account.
+         */
+        userName: string;
+        /**
+         * Password from your windows account.
+         */
+        password: string;
+        /**
+         * Once you set domain for ntlm authentication type, driver will connect to SQL Server using domain login.
+         *
+         * This is necessary for forming a connection using ntlm type
+         */
+        domain: string;
+    };
+}


### PR DESCRIPTION
### Overview
When I was modifying `mmsql` package, I noticed that it accepts `authentication` parameters in the config object. See discussion under PR https://github.com/tediousjs/node-mssql/pull/1208 and documentation I've updated https://github.com/tediousjs/node-mssql#tedious. It passes authentication configuration directly to the `tedious` library, which supports the following authentication types.


- `DefaultAuthentication`
- `NtlmAuthentication`
- `AzureActiveDirectoryAccessTokenAuthentication`
- `AzureActiveDirectoryMsiAppServiceAuthentication`
- `AzureActiveDirectoryMsiVmAuthentication`
- `AzureActiveDirectoryPasswordAuthentication`
- `AzureActiveDirectoryServicePrincipalSecret`

I copied authentication options interfaces directly from the `tedious` repository and modified TypeORM code to support passing authentication options for the sqlserver driver.



### What does it change?
It changes a way of passing credentials to the SQLServer database. I modified current interfaces to deprecate `domain` property directly in the configuration model. Instead of this I proposed to pass `authentication` property which is compatible with the `mssql` and `tedious` one. 

I'd recommend to remove `options.domain` in future, to give developers time for any adjustments.  Then instead of passing: 
```javascript
createConnection({
  type: "mssql",
  database: "db-name",
  host: "db-server",
  username: "username",
  password: "password",
  domain: "domain"
}).then(connection => {
  // here you can start to work with your entities
}).catch(error => console.log(error));
```
developers should pass:
```javascript
createConnection({
  type: "mssql",
  database: "db-name",
  host: "db-server",
  authentication: {
    type: "ntlm",
    options: {
        userName: "username",
        password: "password",
        domain: "domain"
    }
  }
}).then(connection => {
  // here you can start to work with your entities
}).catch(error => console.log(error));
```

### Solves
- https://github.com/typeorm/typeorm/issues/4510 
- https://github.com/typeorm/typeorm/issues/7340

### Usage

#### Default authentication type
```javascript
createConnection({
  type: "mssql",
  database: "db-name",
  host: "db-server",
  authentication: {
    type: "default",
    options: {
      userName: "username",
      password: "password"
    }
  }
}).then(connection => {
  // here you can start to work with your entities
}).catch(error => console.log(error));
```


#### AAD Access Token
```javascript
createConnection({
  type: "mssql",
  database: "db-name",
  host: "db-server",
  authentication: {
    type: "azure-active-directory-access-token",
    options: {
      token: "token"
    }
  }
}).then(connection => {
  // here you can start to work with your entities
}).catch(error => console.log(error));
```


#### AAD Service Principal (secret)
```javascript
createConnection({
  type: "mssql",
  database: "db-name",
  host: "db-server",
  authentication: {
    type: "azure-active-directory-service-principal-secret",
    options: {
      tenantId: 'tenant-id',
      clientId: 'client-id',
      clientSecret: 'client-secret'
    }
  }
}).then(connection => {
  // here you can start to work with your entities
}).catch(error => console.log(error));
```

#### AAD MSI App Service Authentication
```javascript
createConnection({
  type: "mssql",
  database: "db-name",
  host: "db-server",
  authentication: {
    type: "azure-active-directory-msi-app-service",
    options: {
      clientId: "optional clientId (it should be taken from app service environment)",
      msiEndpoint: "optional msiEndpoint (it should be taken from app service environment)",
      msiSecret: "optional msiSecret (it should be taken from app service environment)"
    }
  }
}).then(connection => {
  // here you can start to work with your entities
}).catch(error => console.log(error));
```
