### PR TITLE
feat(data-api): Introduced a new configuration option "formatOptions.…

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2721,12 +2721,20 @@
       }
     },
     "data-api-client": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/data-api-client/-/data-api-client-1.1.0.tgz",
-      "integrity": "sha512-ZO6i4g55afRYbDwpVuF3pa6KI0pNee5VcAGAIQRHhCFAJytFCwazzSQ3iwZU8ONcRumXoHDKTp/dyIQOub1ysg==",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/data-api-client/-/data-api-client-1.2.0.tgz",
+      "integrity": "sha512-AGv4lWOF4RyoqUOLrYWbZeIP7eyFCM2UxGJ92XG9Q0xHofrT/67plprl0mAsxpAYdWQ8u0hLZFxC+iQSASsjgQ==",
       "dev": true,
       "requires": {
-        "sqlstring": "^2.3.1"
+        "sqlstring": "^2.3.2"
+      },
+      "dependencies": {
+        "sqlstring": {
+          "version": "2.3.2",
+          "resolved": "https://registry.npmjs.org/sqlstring/-/sqlstring-2.3.2.tgz",
+          "integrity": "sha512-vF4ZbYdKS8OnoJAWBmMxCQDkiEBkGQYU7UZPtL8flbDRSNkhaXvRJ279ZtI6M+zDaQovVU4tuRgzK5fVhvFAhg==",
+          "dev": true
+        }
       }
     },
     "date-utils": {
@@ -10748,12 +10756,12 @@
       "dev": true
     },
     "typeorm-aurora-data-api-driver": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/typeorm-aurora-data-api-driver/-/typeorm-aurora-data-api-driver-1.4.0.tgz",
-      "integrity": "sha512-uGoVZvuStFknrhQuSzpdhdm7TG3XcOWrkHH47oMY8qNcNrYGEGkiK5Msqpoqu9nfEEY+HG6sDSx0ssmfmkF31g==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/typeorm-aurora-data-api-driver/-/typeorm-aurora-data-api-driver-2.0.0.tgz",
+      "integrity": "sha512-e3sAs1MtE/FB5ZSd9J91yX73OSo0NRe4sGUQGCuRhxHrslKzyOdiQvoJvnj0y4mSTCyJQGv0o/N4pXUyXjT4Lw==",
       "dev": true,
       "requires": {
-        "data-api-client": "^1.1.0"
+        "data-api-client": "^1.2.0"
       }
     },
     "typescript": {

--- a/package.json
+++ b/package.json
@@ -111,7 +111,7 @@
     "sql.js": "^1.4.0",
     "sqlite3": "^5.0.2",
     "ts-node": "^9.1.1",
-    "typeorm-aurora-data-api-driver": "^1.4.0",
+    "typeorm-aurora-data-api-driver": "^2.0.0",
     "typescript": "^4.2.2"
   },
   "dependencies": {

--- a/src/driver/aurora-data-api-pg/AuroraDataApiPostgresConnectionOptions.ts
+++ b/src/driver/aurora-data-api-pg/AuroraDataApiPostgresConnectionOptions.ts
@@ -25,6 +25,7 @@ export interface AuroraDataApiPostgresConnectionOptions extends BaseConnectionOp
      */
     readonly uuidExtension?: "pgcrypto" | "uuid-ossp";
 
+    readonly transformParameters?: boolean;
 
     /*
     * Function handling errors thrown by drivers pool.
@@ -34,5 +35,5 @@ export interface AuroraDataApiPostgresConnectionOptions extends BaseConnectionOp
 
     readonly serviceConfigOptions?: { [key: string]: any };
 
-    readonly formatOptions?: { [key: string]: any };
+    readonly formatOptions?: { [key: string]: any, castParameters: boolean };
 }

--- a/src/driver/aurora-data-api/AuroraDataApiConnectionOptions.ts
+++ b/src/driver/aurora-data-api/AuroraDataApiConnectionOptions.ts
@@ -23,7 +23,7 @@ export interface AuroraDataApiConnectionOptions extends BaseConnectionOptions, A
 
     readonly serviceConfigOptions?: { [key: string]: any }; // pass optional AWS.ConfigurationOptions here
 
-    readonly formatOptions?: { [key: string]: any };
+    readonly formatOptions?: { [key: string]: any, castParameters: boolean };
 
     /**
      * Use spatial functions like GeomFromText and AsText which are removed in MySQL 8.


### PR DESCRIPTION
### Description of change

Because the list of types supported by the Aurora Data API is limited Data API client [introduced type casts](https://github.com/jeremydaly/data-api-client#type-casting). This pull request introduces a new configuration option for the Aurora drivers called `castParameters` that enables automatic casting based on the column types. To achieve this, TypeORM will delegate the `preparePersistentValue` operation to the driver package. 

The same option will also delegate the `prepareHydratedValue` operation to unpack the Data API value types back to the TypeORM value types.

This pull request fixes existing issues for the following data types:
- [UUID](https://github.com/ArsenyYankovsky/typeorm-aurora-data-api-driver/issues/48) and  [#57](https://github.com/ArsenyYankovsky/typeorm-aurora-data-api-driver/issues/57)
- [Date/Time](https://github.com/ArsenyYankovsky/typeorm-aurora-data-api-driver/issues/51)
- [Enum](https://github.com/ArsenyYankovsky/typeorm-aurora-data-api-driver/issues/44)
- JSON

Besides fixing a bunch of existing bugs, moving this part of logic to the driver package will allow us to iterate and fix bugs in it faster as the release cycle there is shorter.

I also introduced new jobs in the driver CI workflows that test against a real server. Previously, this was tested against the local-data-api container which doesn't 100% reflect what real Data API does.

✔ A new version of the driver package for this change has already been released (2.0.0)

### Pull-Request Checklist

<!--
  Please make sure to review and check all of the following.

  If an item is not applicable, you can add "N/A" to the end.
-->

- [X] Code is up-to-date with the `master` branch
- [X] `npm run lint` passes with this change
- [X] `npm run test` passes with this change
- [X] This pull request links relevant issues as `Fixes #0000`
- [X] There are new or updated unit tests validating the change
- [X] Documentation has been updated to reflect this change
- [X] The new commits follow conventions explained in [CONTRIBUTING.md](https://github.com/typeorm/typeorm/blob/master/CONTRIBUTING.md)

<!--
  🎉 Thank you for contributing and making TypeORM even better!
-->
