### PR TITLE
fix typo: docs - one to many

### DIFF
--- a/docs/many-to-one-one-to-many-relations.md
+++ b/docs/many-to-one-one-to-many-relations.md
@@ -84,7 +84,7 @@ user.photos = [photo1, photo2];
 await connection.manager.save(user);
 ```
 
-or alternative you can do:
+or alternatively you can do:
 
 ```typescript
 const user = new User();


### PR DESCRIPTION

### Description of change

Change word alternative to alternatively as this is the correct English grammar.

### Pull-Request Checklist

<!--
  Please make sure to review and check all of the following.

  If an item is not applicable, you can add "N/A" to the end.
-->

- [x] Code is up-to-date with the `master` branch N/A
- [ ] `npm run lint` passes with this change N/A
- [ ] `npm run test` passes with this change N/A
- [ ] This pull request links relevant issues as `Fixes #0000` N/A
- [ ] There are new or updated unit tests validating the change N/A
- [x] Documentation has been updated to reflect this change 
- [x] The new commits follow conventions explained in [CONTRIBUTING.md] (https://github.com/typeorm/typeorm/blob/master/CONTRIBUTING.md)

<!--
  🎉 Thank you for contributing and making TypeORM even better!
-->
