### PR TITLE
fix: Only first single quote in comments is escaped

### DIFF
--- a/src/driver/aurora-data-api/AuroraDataApiQueryRunner.ts
+++ b/src/driver/aurora-data-api/AuroraDataApiQueryRunner.ts
@@ -1609,6 +1609,22 @@ export class AuroraDataApiQueryRunner extends BaseQueryRunner implements QueryRu
     }
 
     /**
+     * Escapes a given comment so it's safe to include in a query.
+     */
+    protected escapeComment(comment?: string) {
+        if (!comment || comment.length === 0) {
+            return `''`;
+        }
+
+        comment = comment
+            .replace("\\", "\\\\") // MySQL allows escaping characters via backslashes
+            .replace(/'/g, "''")
+            .replace("\0", ""); // Null bytes aren't allowed in comments
+
+        return `'${comment}'`;
+    }
+
+    /**
      * Escapes given table or view path.
      */
     protected escapePath(target: Table|View|string, disableEscape?: boolean): string {
@@ -1650,7 +1666,7 @@ export class AuroraDataApiQueryRunner extends BaseQueryRunner implements QueryRu
         if (column.isGenerated && column.generationStrategy === "increment") // don't use skipPrimary here since updates can update already exist primary without auto inc.
             c += " AUTO_INCREMENT";
         if (column.comment)
-            c += ` COMMENT '${column.comment}'`;
+            c += ` COMMENT ${this.escapeComment(column.comment)}`;
         if (column.default !== undefined && column.default !== null)
             c += ` DEFAULT ${column.default}`;
         if (column.onUpdate)

--- a/src/driver/cockroachdb/CockroachQueryRunner.ts
+++ b/src/driver/cockroachdb/CockroachQueryRunner.ts
@@ -1892,7 +1892,7 @@ export class CockroachQueryRunner extends BaseQueryRunner implements QueryRunner
         }
 
         comment = comment
-            .replace("'", "''")
+            .replace(/'/g, "''")
             .replace("\0", ""); // Null bytes aren't allowed in comments
 
         return `'${comment}'`;

--- a/src/driver/mysql/MysqlQueryRunner.ts
+++ b/src/driver/mysql/MysqlQueryRunner.ts
@@ -1818,7 +1818,7 @@ export class MysqlQueryRunner extends BaseQueryRunner implements QueryRunner {
 
         comment = comment
             .replace("\\", "\\\\") // MySQL allows escaping characters via backslashes
-            .replace("'", "''")
+            .replace(/'/g, "''")
             .replace("\0", ""); // Null bytes aren't allowed in comments
 
         return `'${comment}'`;

--- a/src/driver/postgres/PostgresQueryRunner.ts
+++ b/src/driver/postgres/PostgresQueryRunner.ts
@@ -2173,7 +2173,7 @@ export class PostgresQueryRunner extends BaseQueryRunner implements QueryRunner 
         }
 
         comment = comment
-            .replace("'", "''")
+            .replace(/'/g, "''")
             .replace("\0", ""); // Null bytes aren't allowed in comments
 
         return `'${comment}'`;

--- a/test/github-issues/7479/entity/Post.ts
+++ b/test/github-issues/7479/entity/Post.ts
@@ -1,0 +1,26 @@
+import {Column, Entity, PrimaryGeneratedColumn} from "../../../../src";
+
+@Entity()
+export class Post {
+
+    @PrimaryGeneratedColumn()
+    id: number;
+
+    @Column("text", {
+        nullable: false,
+        comment: `E.g. 'foo', 'bar', or 'baz' etc.`
+    })
+    text: string;
+
+    @Column("text", {
+        nullable: false,
+        comment: `E.g. '''foo, 'bar''', or baz' etc.`
+    })
+    text2: string;
+
+    @Column("text", {
+        nullable: false,
+        comment: `E.g. "foo", "bar", or "baz" etc.`
+    })
+    text3: string;
+}

--- a/test/github-issues/7479/issue-7479.ts
+++ b/test/github-issues/7479/issue-7479.ts
@@ -1,0 +1,30 @@
+import "reflect-metadata";
+import {Connection} from "../../../src";
+import {createTestingConnections, closeTestingConnections} from "../../utils/test-utils";
+import {Post} from "./entity/Post";
+
+describe("github issues > #7479 Only first single quote in comments is escaped", () => {
+    let connections: Connection[];
+    before(async () => connections = await createTestingConnections({
+        enabledDrivers: ["postgres", "cockroachdb", "mysql"],
+        schemaCreate: true,
+        dropSchema: true,
+        entities: [Post],
+    }));
+    after(() => closeTestingConnections(connections));
+
+    it("should properly escape quotes in comments", () => Promise.all(connections.map(async connection => {
+        const queryRunner = connection.createQueryRunner();
+
+        let table = await queryRunner.getTable("post");
+        const column1 = table!.findColumnByName("text")!;
+        const column2 = table!.findColumnByName("text2")!;
+        const column3 = table!.findColumnByName("text3")!;
+
+        column1.comment!.should.be.equal(`E.g. 'foo', 'bar', or 'baz' etc.`)
+        column2.comment!.should.be.equal(`E.g. '''foo, 'bar''', or baz' etc.`)
+        column3.comment!.should.be.equal(`E.g. "foo", "bar", or "baz" etc.`)
+
+        await queryRunner.release()
+    })));
+});


### PR DESCRIPTION
<!--
  😀 Wonderful!  Thank you for opening a pull request for TypeORM.

  Please fill in the information below to expedite the review
  and (hopefully) merge of your change.

  If unsure about something.. just do as best as you're able,
  or reach out through our community support channels!
  https://github.com/typeorm/typeorm/blob/master/docs/support.md
-->

### Description of change

Fixed column `comment` escaping for databases that currently supports `comment` option: 
 * PostgreSQL
 * MySQL
 * CockroachDB
 * AuroraDataAPI

Fixes #7479 

<!--
  Please be clear and concise what the change is intended to do,
  why this change is needed, and how you've verified that it
  corrects what you intended.

  In some cases it may be helpful to include the current behavior
  and the new behavior.

  If the change is related to an open issue, you can link it here.
  If you include `Fixes #0000` (replacing `0000` with the issue number)
  when this is merged it will automatically mark the issue as fixed and
  close it.
-->


### Pull-Request Checklist

<!--
  Please make sure to review and check all of the following.

  If an item is not applicable, you can add "N/A" to the end.
-->

- [x] Code is up-to-date with the `master` branch
- [x] `npm run lint` passes with this change
- [x] `npm run test` passes with this change
- [x] This pull request links relevant issues as `Fixes #0000`
- [x] There are new or updated unit tests validating the change
- [ ] `N/A` Documentation has been updated to reflect this change
- [x] The new commits follow conventions explained in [CONTRIBUTING.md](https://github.com/typeorm/typeorm/blob/master/CONTRIBUTING.md)

<!--
  🎉 Thank you for contributing and making TypeORM even better!
-->
