### PR TITLE
docs: update lock modes in find-options.md

### DIFF
--- a/docs/find-options.md
+++ b/docs/find-options.md
@@ -128,7 +128,7 @@ userRepository.find({
 ```
 or
 ```ts
-{ mode: "pessimistic_read"|"pessimistic_write"|"dirty_read"|"pessimistic_partial_write"|"pessimistic_write_or_fail" }
+{ mode: "pessimistic_read"|"pessimistic_write"|"dirty_read"|"pessimistic_partial_write"|"pessimistic_write_or_fail"|"for_no_key_update" }
 ```
 
 for example:
@@ -139,7 +139,18 @@ userRepository.findOne(1, {
 })
 ```
 
-`pessimistic_partial_write` and `pessimistic_write_or_fail` are supported only on Postgres and are equivalents of `SELECT .. FOR UPDATE SKIP LOCKED` and `SELECT .. FOR UPDATE NOWAIT`, accordingly.
+Support of lock modes, and SQL statements they translate to, are listed in the table below (blank cell denotes unsupported). When specified lock mode is not supported, a `LockNotSupportedOnGivenDriverError` error will be thrown.
+
+```text
+|                 | pessimistic_read         | pessimistic_write       | dirty_read    | pessimistic_partial_write   | pessimistic_write_or_fail   | for_no_key_update   |
+| --------------- | --------------------     | ----------------------- | ------------- | --------------------------- | --------------------------- | ------------------- |
+| MySQL           | LOCK IN SHARE MODE       | FOR UPDATE              | (nothing)     | FOR UPDATE SKIP LOCKED      | FOR UPDATE NOWAIT           |                     |
+| Postgres        | FOR SHARE                | FOR UPDATE              | (nothing)     | FOR UPDATE SKIP LOCKED      | FOR UPDATE NOWAIT           | FOR NO KEY UPDATE   |
+| Oracle          | FOR UPDATE               | FOR UPDATE              | (nothing)     |                             |                             |                     |
+| SQL Server      | WITH (HOLDLOCK, ROWLOCK) | WITH (UPDLOCK, ROWLOCK) | WITH (NOLOCK) |                             |                             |                     |
+| AuroraDataApi   | LOCK IN SHARE MODE       | FOR UPDATE              | (nothing)     |                             |                             |                     |
+
+```
 
 Complete example of find options:
 


### PR DESCRIPTION
### Description of change

This PR updates `docs/find-options.md` to reflect actually supported lock modes and their behavior in [latest master](https://github.com/typeorm/typeorm/blob/e1e94236e71c14a4682356ada7774d657eba8936/src/query-builder/SelectQueryBuilder.ts) (looking at a few other PRs I assumed this is the only file lock modes get interpreted) .

### Pull-Request Checklist

- [x] Code is up-to-date with the `master` branch
- [ ] `npm run lint` passes with this change       // N/A
- [ ] `npm run test` passes with this change      // N/A
- [ ] This pull request links relevant issues as `Fixes #0000`       // N/A
- [ ] There are new or updated unit tests validating the change       // N/A
- [x] Documentation has been updated to reflect this change 
- [x] The new commits follow conventions explained in [CONTRIBUTING.md ](https://github.com/typeorm/typeorm/blob/master/CONTRIBUTING.md)


