### PR TITLE
fix: mongodb typings for findOne method

### DIFF
--- a/src/driver/mongodb/typings.ts
+++ b/src/driver/mongodb/typings.ts
@@ -2929,8 +2929,7 @@ export interface Collection<T> {
      *
      * @param query Query for find Operation.
      * @param callback The command result callback.
-     * @see http://mongodb.github.io/node-mongodb-native/2.1/api/Collection.html#findOne
-     * @deprecated use find().limit(1).next(function(err, doc){}).
+     * @see https://mongodb.github.io/node-mongodb-native/3.6/api/Collection.html#findOne
      */
     findOne(query: FilterQuery<T>, callback: MongoCallback<any>): void;
 
@@ -2939,8 +2938,7 @@ export interface Collection<T> {
      *
      * @param query Query for find Operation.
      * @param options Optional.
-     * @see http://mongodb.github.io/node-mongodb-native/2.1/api/Collection.html#findOne
-     * @deprecated use find().limit(1).next(function(err, doc){}).
+     * @see https://mongodb.github.io/node-mongodb-native/3.6/api/Collection.html#findOne
      */
     findOne(query: FilterQuery<T>, options?: MongodbFindOneOptions): Promise<any>;
 
@@ -2950,8 +2948,7 @@ export interface Collection<T> {
      * @param query Query for find Operation.
      * @param options Optional settings.
      * @param callback The command result callback.
-     * @see http://mongodb.github.io/node-mongodb-native/2.1/api/Collection.html#findOne
-     * @deprecated use find().limit(1).next(function(err, doc){}).
+     * @see https://mongodb.github.io/node-mongodb-native/3.6/api/Collection.html#findOne
      */
     findOne(query: FilterQuery<T>, options: MongodbFindOneOptions, callback: MongoCallback<any>): void;
 


### PR DESCRIPTION
deprecation was overturned

see: https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/mongodb/index.d.ts#L1488-L1507
<!--
  😀 Wonderful!  Thank you for opening a pull request for TypeORM.

  Please fill in the information below to expedite the review
  and (hopefully) merge of your change.

  If unsure about something.. just do as best as you're able,
  or reach out through our community support channels!
  https://github.com/typeorm/typeorm/blob/master/docs/support.md
-->

### Description of change

<!--
  Please be clear and concise what the change is intended to do,
  why this change is needed, and how you've verified that it
  corrects what you intended.

  In some cases it may be helpful to include the current behavior
  and the new behavior.

  If the change is related to an open issue, you can link it here.
  If you include `Fixes #0000` (replacing `0000` with the issue number)
  when this is merged it will automatically mark the issue as fixed and
  close it.
-->


### Pull-Request Checklist

<!--
  Please make sure to review and check all of the following.

  If an item is not applicable, you can add "N/A" to the end.
-->

- [x] Code is up-to-date with the `master` branch
- [x] `npm run lint` passes with this change
- [x] `npm run test` passes with this change
- [ ] This pull request links relevant issues as `Fixes #0000`
- [ ] There are new or updated unit tests validating the change
- [ ] Documentation has been updated to reflect this change
- [x] The new commits follow conventions explained in [CONTRIBUTING.md](https://github.com/typeorm/typeorm/blob/master/CONTRIBUTING.md)

<!--
  🎉 Thank you for contributing and making TypeORM even better!
-->
