### PR TITLE
fix: define class properties for QueryFailedError

### DIFF
--- a/src/error/QueryFailedError.ts
+++ b/src/error/QueryFailedError.ts
@@ -4,6 +4,8 @@ import {ObjectUtils} from "../util/ObjectUtils";
  * Thrown when query execution has failed.
 */
 export class QueryFailedError extends Error {
+    query: string;
+    parameters: any[];
 
     constructor(query: string, parameters: any[]|undefined, driverError: any) {
         super();


### PR DESCRIPTION
Defining those properties allow users to access a typed error like:

```ts
if (error instanceof QueryFailedError) {
  // This will be typed
  console.log(error.query, error.parameters);
}
```