### PR TITLE
fix: only first `\0` is removed in comments, only first `\\` is escaped etc.

### DIFF
--- a/src/driver/aurora-data-api/AuroraDataApiDriver.ts
+++ b/src/driver/aurora-data-api/AuroraDataApiDriver.ts
@@ -718,7 +718,7 @@ export class AuroraDataApiDriver implements Driver {
             // console.log("unsigned:", tableColumn.unsigned, columnMetadata.unsigned);
             // console.log("asExpression:", tableColumn.asExpression, columnMetadata.asExpression);
             // console.log("generatedType:", tableColumn.generatedType, columnMetadata.generatedType);
-            // console.log("comment:", tableColumn.comment, columnMetadata.comment);
+            // console.log("comment:", tableColumn.comment, this.escapeComment(columnMetadata.comment));
             // console.log("default:", tableColumn.default, columnMetadata.default);
             // console.log("enum:", tableColumn.enum, columnMetadata.enum);
             // console.log("default changed:", !this.compareDefaultValues(this.normalizeDefault(columnMetadata), tableColumn.default));
@@ -745,7 +745,7 @@ export class AuroraDataApiDriver implements Driver {
                 || tableColumn.unsigned !== columnMetadata.unsigned
                 || tableColumn.asExpression !== columnMetadata.asExpression
                 || tableColumn.generatedType !== columnMetadata.generatedType
-                // || tableColumn.comment !== columnMetadata.comment // todo
+                || tableColumn.comment !== this.escapeComment(columnMetadata.comment)
                 || !this.compareDefaultValues(this.normalizeDefault(columnMetadata), tableColumn.default)
                 || (tableColumn.enum && columnMetadata.enum && !OrmUtils.isArraysEqual(tableColumn.enum, columnMetadata.enum.map(val => val + "")))
                 || tableColumn.onUpdate !== columnMetadata.onUpdate
@@ -859,6 +859,17 @@ export class AuroraDataApiDriver implements Driver {
         }
 
         return columnMetadataValue === databaseValue;
+    }
+
+    /**
+     * Escapes a given comment.
+     */
+    protected escapeComment(comment?: string) {
+        if (!comment)  return comment;
+
+        comment = comment.replace(/\u0000/g, ""); // Null bytes aren't allowed in comments
+
+        return comment;
     }
 
 }

--- a/src/driver/aurora-data-api/AuroraDataApiQueryRunner.ts
+++ b/src/driver/aurora-data-api/AuroraDataApiQueryRunner.ts
@@ -1617,9 +1617,9 @@ export class AuroraDataApiQueryRunner extends BaseQueryRunner implements QueryRu
         }
 
         comment = comment
-            .replace("\\", "\\\\") // MySQL allows escaping characters via backslashes
+            .replace(/\\/g, "\\\\") // MySQL allows escaping characters via backslashes
             .replace(/'/g, "''")
-            .replace("\0", ""); // Null bytes aren't allowed in comments
+            .replace(/\u0000/g, ""); // Null bytes aren't allowed in comments
 
         return `'${comment}'`;
     }

--- a/src/driver/cockroachdb/CockroachDriver.ts
+++ b/src/driver/cockroachdb/CockroachDriver.ts
@@ -608,7 +608,7 @@ export class CockroachDriver implements Driver {
             // console.log("width:", tableColumn.width, columnMetadata.width);
             // console.log("precision:", tableColumn.precision, columnMetadata.precision);
             // console.log("scale:", tableColumn.scale, columnMetadata.scale);
-            // console.log("comment:", tableColumn.comment, columnMetadata.comment);
+            // console.log("comment:", tableColumn.comment, this.escapeComment(columnMetadata.comment));
             // console.log("default:", tableColumn.default, columnMetadata.default);
             // console.log("default changed:", !this.compareDefaultValues(this.normalizeDefault(columnMetadata), tableColumn.default));
             // console.log("isPrimary:", tableColumn.isPrimary, columnMetadata.isPrimary);
@@ -622,7 +622,7 @@ export class CockroachDriver implements Driver {
                 || tableColumn.length !== columnMetadata.length
                 || tableColumn.precision !== columnMetadata.precision
                 || (columnMetadata.scale !== undefined && tableColumn.scale !== columnMetadata.scale)
-                || tableColumn.comment !== columnMetadata.comment
+                || tableColumn.comment !== this.escapeComment(columnMetadata.comment)
                 || (!tableColumn.isGenerated && this.lowerDefaultValueIfNecessary(this.normalizeDefault(columnMetadata)) !== tableColumn.default) // we included check for generated here, because generated columns already can have default values
                 || tableColumn.isPrimary !== columnMetadata.isPrimary
                 || tableColumn.isNullable !== columnMetadata.isNullable
@@ -750,6 +750,19 @@ export class CockroachDriver implements Driver {
         return new Promise<void>((ok, fail) => {
             pool.end((err: any) => err ? fail(err) : ok());
         });
+    }
+
+    /**
+     * Escapes a given comment.
+     */
+    protected escapeComment(comment?: string) {
+        if (!comment) return comment;
+
+        comment = comment
+            .replace(/'/g, "''")
+            .replace(/\u0000/g, ""); // Null bytes aren't allowed in comments
+
+        return comment;
     }
 
 }

--- a/src/driver/cockroachdb/CockroachQueryRunner.ts
+++ b/src/driver/cockroachdb/CockroachQueryRunner.ts
@@ -1893,7 +1893,7 @@ export class CockroachQueryRunner extends BaseQueryRunner implements QueryRunner
 
         comment = comment
             .replace(/'/g, "''")
-            .replace("\0", ""); // Null bytes aren't allowed in comments
+            .replace(/\u0000/g, ""); // Null bytes aren't allowed in comments
 
         return `'${comment}'`;
     }

--- a/src/driver/mysql/MysqlDriver.ts
+++ b/src/driver/mysql/MysqlDriver.ts
@@ -752,7 +752,7 @@ export class MysqlDriver implements Driver {
                 || tableColumn.unsigned !== columnMetadata.unsigned
                 || tableColumn.asExpression !== columnMetadata.asExpression
                 || tableColumn.generatedType !== columnMetadata.generatedType
-                || tableColumn.comment !== columnMetadata.comment
+                || tableColumn.comment !== this.escapeComment(columnMetadata.comment)
                 || !this.compareDefaultValues(this.normalizeDefault(columnMetadata), tableColumn.default)
                 || (tableColumn.enum && columnMetadata.enum && !OrmUtils.isArraysEqual(tableColumn.enum, columnMetadata.enum.map(val => val + "")))
                 || tableColumn.onUpdate !== this.normalizeDatetimeFunction(columnMetadata.onUpdate)
@@ -774,7 +774,7 @@ export class MysqlDriver implements Driver {
             //     console.log("unsigned:", tableColumn.unsigned, columnMetadata.unsigned);
             //     console.log("asExpression:", tableColumn.asExpression, columnMetadata.asExpression);
             //     console.log("generatedType:", tableColumn.generatedType, columnMetadata.generatedType);
-            //     console.log("comment:", tableColumn.comment, columnMetadata.comment);
+            //     console.log("comment:", tableColumn.comment, this.escapeComment(columnMetadata.comment));
             //     console.log("default:", tableColumn.default, this.normalizeDefault(columnMetadata));
             //     console.log("enum:", tableColumn.enum, columnMetadata.enum);
             //     console.log("default changed:", !this.compareDefaultValues(this.normalizeDefault(columnMetadata), tableColumn.default));
@@ -957,6 +957,17 @@ export class MysqlDriver implements Driver {
         } else {
             return value
         }
+    }
+
+    /**
+     * Escapes a given comment.
+     */
+    protected escapeComment(comment?: string) {
+        if (!comment)  return comment;
+
+        comment = comment.replace(/\u0000/g, ""); // Null bytes aren't allowed in comments
+
+        return comment;
     }
 
 }

--- a/src/driver/mysql/MysqlQueryRunner.ts
+++ b/src/driver/mysql/MysqlQueryRunner.ts
@@ -1817,9 +1817,9 @@ export class MysqlQueryRunner extends BaseQueryRunner implements QueryRunner {
         }
 
         comment = comment
-            .replace("\\", "\\\\") // MySQL allows escaping characters via backslashes
+            .replace(/\\/g, "\\\\") // MySQL allows escaping characters via backslashes
             .replace(/'/g, "''")
-            .replace("\0", ""); // Null bytes aren't allowed in comments
+            .replace(/\u0000/g, ""); // Null bytes aren't allowed in comments
 
         return `'${comment}'`;
     }

--- a/src/driver/postgres/PostgresDriver.ts
+++ b/src/driver/postgres/PostgresDriver.ts
@@ -881,7 +881,7 @@ export class PostgresDriver implements Driver {
                 || tableColumn.isArray !== columnMetadata.isArray
                 || tableColumn.precision !== columnMetadata.precision
                 || (columnMetadata.scale !== undefined && tableColumn.scale !== columnMetadata.scale)
-                || tableColumn.comment !== columnMetadata.comment
+                || tableColumn.comment !== this.escapeComment(columnMetadata.comment)
                 || (!tableColumn.isGenerated && this.lowerDefaultValueIfNecessary(this.normalizeDefault(columnMetadata)) !== tableColumn.default) // we included check for generated here, because generated columns already can have default values
                 || tableColumn.isPrimary !== columnMetadata.isPrimary
                 || tableColumn.isNullable !== columnMetadata.isNullable
@@ -901,7 +901,7 @@ export class PostgresDriver implements Driver {
             //     console.log("isArray:", tableColumn.isArray, columnMetadata.isArray);
             //     console.log("precision:", tableColumn.precision, columnMetadata.precision);
             //     console.log("scale:", tableColumn.scale, columnMetadata.scale);
-            //     console.log("comment:", tableColumn.comment, columnMetadata.comment);
+            //     console.log("comment:", tableColumn.comment, this.escapeComment(columnMetadata.comment));
             //     console.log("enumName:", tableColumn.enumName, columnMetadata.enumName);
             //     console.log("enum:", tableColumn.enum && columnMetadata.enum && !OrmUtils.isArraysEqual(tableColumn.enum, columnMetadata.enum.map(val => val + "")));
             //     console.log("isPrimary:", tableColumn.isPrimary, columnMetadata.isPrimary);
@@ -1104,6 +1104,17 @@ export class PostgresDriver implements Driver {
         }
 
         return value
+    }
+
+    /**
+     * Escapes a given comment.
+     */
+    protected escapeComment(comment?: string) {
+        if (!comment) return comment;
+
+        comment = comment.replace(/\u0000/g, ""); // Null bytes aren't allowed in comments
+
+        return comment;
     }
 
 }

--- a/src/driver/postgres/PostgresQueryRunner.ts
+++ b/src/driver/postgres/PostgresQueryRunner.ts
@@ -2176,7 +2176,7 @@ export class PostgresQueryRunner extends BaseQueryRunner implements QueryRunner 
 
         comment = comment
             .replace(/'/g, "''")
-            .replace("\0", ""); // Null bytes aren't allowed in comments
+            .replace(/\u0000/g, ""); // Null bytes aren't allowed in comments
 
         return `'${comment}'`;
     }

--- a/test/github-issues/7521/entity/Post.ts
+++ b/test/github-issues/7521/entity/Post.ts
@@ -1,0 +1,53 @@
+import {Column, Entity, PrimaryGeneratedColumn} from "../../../../src";
+
+@Entity()
+export class Post {
+
+    @PrimaryGeneratedColumn()
+    id: number;
+
+    @Column({
+        comment: `E.g. 'foo', 'bar', or 'baz' etc.`
+    })
+    col1: string;
+
+    @Column({
+        comment: `E.g. '''foo, 'bar''', or baz' etc.`
+    })
+    col2: string;
+
+    @Column({
+        comment: `E.g. "foo", "bar", or "baz" etc.`
+    })
+    col3: string;
+
+    @Column({
+        comment: "foo\\bar, bar\\baz, foo\\\\baz"
+    })
+    col4: string;
+
+    @Column({
+        comment: "foo: \0, bar: \0\0\0"
+    })
+    col5: string;
+
+    @Column({
+        comment: `"foo", ""bar""`
+    })
+    col6: string;
+
+    @Column({
+        comment: "\"foo\", \"\"bar\"\""
+    })
+    col7: string;
+
+    @Column({
+        comment: "foo \r \n \b \t \Z \% \_ bar"
+    })
+    col8: string;
+
+    @Column({
+        comment: "foo \\r \\n \\b \\t \\Z \\% \\_ bar"
+    })
+    col9: string;
+}

--- a/test/github-issues/7521/issue-7521.ts
+++ b/test/github-issues/7521/issue-7521.ts
@@ -1,0 +1,55 @@
+import "reflect-metadata";
+import {Connection} from "../../../src";
+import {createTestingConnections, closeTestingConnections} from "../../utils/test-utils";
+import {Post} from "./entity/Post";
+
+describe("github issues > #7521 Only first \0 is removed in comments, only first \\ is escaped etc.", () => {
+    let connections: Connection[];
+    before(async () => connections = await createTestingConnections({
+        enabledDrivers: ["postgres", "cockroachdb", "mysql"],
+        schemaCreate: false,
+        dropSchema: true,
+        entities: [Post],
+    }));
+    after(() => closeTestingConnections(connections));
+
+    it("should recognize model changes", () => Promise.all(connections.map(async connection => {
+        const sqlInMemory = await connection.driver.createSchemaBuilder().log();
+        sqlInMemory.upQueries.length.should.be.greaterThan(0);
+        sqlInMemory.downQueries.length.should.be.greaterThan(0);
+    })));
+
+    it("should not generate queries when no model changes", () => Promise.all(connections.map(async connection => {
+        await connection.driver.createSchemaBuilder().build();
+        const sqlInMemory = await connection.driver.createSchemaBuilder().log();
+        sqlInMemory.upQueries.length.should.be.equal(0);
+        sqlInMemory.downQueries.length.should.be.equal(0);
+    })));
+
+    it("should properly escape quotes in comments", () => Promise.all(connections.map(async connection => {
+        const queryRunner = connection.createQueryRunner();
+
+        let table = await queryRunner.getTable("post");
+        const col1 = table!.findColumnByName("col1")!;
+        const col2 = table!.findColumnByName("col2")!;
+        const col3 = table!.findColumnByName("col3")!;
+        const col4 = table!.findColumnByName("col4")!;
+        const col5 = table!.findColumnByName("col5")!;
+        const col6 = table!.findColumnByName("col6")!;
+        const col7 = table!.findColumnByName("col7")!;
+        const col8 = table!.findColumnByName("col8")!;
+        const col9 = table!.findColumnByName("col9")!;
+
+        col1.comment!.should.be.equal(`E.g. 'foo', 'bar', or 'baz' etc.`)
+        col2.comment!.should.be.equal(`E.g. '''foo, 'bar''', or baz' etc.`)
+        col3.comment!.should.be.equal(`E.g. "foo", "bar", or "baz" etc.`)
+        col4.comment!.should.be.equal("foo\\bar, bar\\baz, foo\\\\baz")
+        col5.comment!.should.be.equal(`foo: , bar: `)
+        col6.comment!.should.be.equal(`"foo", ""bar""`)
+        col7.comment!.should.be.equal("\"foo\", \"\"bar\"\"")
+        col8.comment!.should.be.equal("foo \r \n \b \t \Z \% \_ bar")
+        col9.comment!.should.be.equal("foo \\r \\n \\b \\t \\Z \\% \\_ bar")
+
+        await queryRunner.release()
+    })));
+});


### PR DESCRIPTION
<!--
  😀 Wonderful!  Thank you for opening a pull request for TypeORM.

  Please fill in the information below to expedite the review
  and (hopefully) merge of your change.

  If unsure about something.. just do as best as you're able,
  or reach out through our community support channels!
  https://github.com/typeorm/typeorm/blob/master/docs/support.md
-->

### Description of change

fixed escaping in column `comment`.

Fixes #7521 

<!--
  Please be clear and concise what the change is intended to do,
  why this change is needed, and how you've verified that it
  corrects what you intended.

  In some cases it may be helpful to include the current behavior
  and the new behavior.

  If the change is related to an open issue, you can link it here.
  If you include `Fixes #0000` (replacing `0000` with the issue number)
  when this is merged it will automatically mark the issue as fixed and
  close it.
-->


### Pull-Request Checklist

<!--
  Please make sure to review and check all of the following.

  If an item is not applicable, you can add "N/A" to the end.
-->

- [X] Code is up-to-date with the `master` branch
- [X] `npm run lint` passes with this change
- [X] `npm run test` passes with this change
- [X] This pull request links relevant issues as `Fixes #0000`
- [X] There are new or updated unit tests validating the change
- [ ] Documentation has been updated to reflect this change
- [X] The new commits follow conventions explained in [CONTRIBUTING.md](https://github.com/typeorm/typeorm/blob/master/CONTRIBUTING.md)

<!--
  🎉 Thank you for contributing and making TypeORM even better!
-->
