### PR TITLE
fix: column name with empty spaces causes bug in `Index`/`Unique` decorators

### DIFF
--- a/src/metadata/IndexMetadata.ts
+++ b/src/metadata/IndexMetadata.ts
@@ -164,7 +164,7 @@ export class IndexMetadata {
                     if (this.embeddedMetadata)
                         return this.embeddedMetadata.propertyPath + "." + columnName;
 
-                    return columnName;
+                    return columnName.trim();
                 });
                 columnPropertyPaths.forEach(propertyPath => map[propertyPath] = 1);
             } else { // todo: indices in embeds are not implemented in this syntax. deprecate this syntax?

--- a/src/metadata/UniqueMetadata.ts
+++ b/src/metadata/UniqueMetadata.ts
@@ -98,7 +98,7 @@ export class UniqueMetadata {
                     if (this.embeddedMetadata)
                         return this.embeddedMetadata.propertyPath + "." + columnName;
 
-                    return columnName;
+                    return columnName.trim();
                 });
                 columnPropertyPaths.forEach(propertyPath => map[propertyPath] = 1);
             } else {

--- a/test/github-issues/6752/entity/Block.ts
+++ b/test/github-issues/6752/entity/Block.ts
@@ -1,9 +1,6 @@
-import {
-    Column, Entity, Index, OneToMany, PrimaryGeneratedColumn,
-} from "../../../../src";
-import { PlanOfRecord } from "./PlanOfRecord";
+import {Column, Entity, Index, OneToMany, PrimaryGeneratedColumn} from "../../../../src";
+import {PlanOfRecord} from "./PlanOfRecord";
 
-// @Entity({ synchronize: false })
 @Entity({ synchronize: true })
 @Index(["chip_name", "manual", "frequency", "mode"], { unique: true })
 export class Block {
@@ -30,7 +27,6 @@ export class Block {
     @Index()
     public mode: string;
 
-    @OneToMany((type) => PlanOfRecord, (por) => por.block)
+    @OneToMany(() => PlanOfRecord, (por) => por.block)
     public plan_of_records: PlanOfRecord[];
 }
- 

--- a/test/github-issues/6752/entity/PlanOfRecord.ts
+++ b/test/github-issues/6752/entity/PlanOfRecord.ts
@@ -1,12 +1,11 @@
 import {
-    Check, Column, Entity, Index, ManyToOne, PrimaryGeneratedColumn,
+    Check, Column, Entity, Index, ManyToOne, PrimaryGeneratedColumn, Unique,
 } from "../../../../src";
 import { Block } from "./Block";
 
-// @Entity({ synchronize: false })
 @Entity({ synchronize: true })
 @Index(["block", "softwareComponent", "module", "module_sku ", "isSafety"], { unique: true })
-// Enable sync will sometimes cause planOfRecord column become null
+@Unique(["block", "softwareComponent", "module", "module_sku ", "isSafety"])
 @Check(`"planOfRecord" IN ('NOT_POR', 'POR_BUT_PROD_VAL', 'POR_BUT_RESET_VAL')`)
 export class PlanOfRecord {
     @PrimaryGeneratedColumn()

--- a/test/github-issues/6752/issue-6752.ts
+++ b/test/github-issues/6752/issue-6752.ts
@@ -1,15 +1,11 @@
 import "reflect-metadata";
-import {
-    createTestingConnections,
-    closeTestingConnections,
-    reloadTestingDatabases,
-} from "../../utils/test-utils";
-import { Connection } from "../../../src/connection/Connection";
-import { expect } from "chai";
-import { Block } from "./entity/Block";
-import { PlanOfRecord } from "./entity/PlanOfRecord";
+import {closeTestingConnections, createTestingConnections, reloadTestingDatabases,} from "../../utils/test-utils";
+import {Connection} from "../../../src";
+import {expect} from "chai";
+import {Block} from "./entity/Block";
+import {PlanOfRecord} from "./entity/PlanOfRecord";
 
-describe.skip("github issues > #6752 column name not been find on unique index decorator", () => {
+describe("github issues > #6752 column name not been find on unique index decorator", () => {
     it("dont change anything", async () => {
         let connections: Connection[];
         connections = await createTestingConnections({


### PR DESCRIPTION
<!--
  😀 Wonderful!  Thank you for opening a pull request for TypeORM.

  Please fill in the information below to expedite the review
  and (hopefully) merge of your change.

  If unsure about something.. just do as best as you're able,
  or reach out through our community support channels!
  https://github.com/typeorm/typeorm/blob/master/docs/support.md
-->

### Description of change

Fixes #6752

<!--
  Please be clear and concise what the change is intended to do,
  why this change is needed, and how you've verified that it
  corrects what you intended.

  In some cases it may be helpful to include the current behavior
  and the new behavior.

  If the change is related to an open issue, you can link it here.
  If you include `Fixes #0000` (replacing `0000` with the issue number)
  when this is merged it will automatically mark the issue as fixed and
  close it.
-->


### Pull-Request Checklist

<!--
  Please make sure to review and check all of the following.

  If an item is not applicable, you can add "N/A" to the end.
-->

- [X] Code is up-to-date with the `master` branch
- [X] `npm run lint` passes with this change
- [X] `npm run test` passes with this change
- [X] This pull request links relevant issues as `Fixes #0000`
- [X] There are new or updated unit tests validating the change
- [ ] Documentation has been updated to reflect this change
- [X] The new commits follow conventions explained in [CONTRIBUTING.md](https://github.com/typeorm/typeorm/blob/master/CONTRIBUTING.md)

<!--
  🎉 Thank you for contributing and making TypeORM even better!
-->
