### PR TITLE
fix: find by Date object in sqlite driver

### DIFF
--- a/src/driver/sqlite-abstract/AbstractSqliteDriver.ts
+++ b/src/driver/sqlite-abstract/AbstractSqliteDriver.ts
@@ -393,6 +393,11 @@ export abstract class AbstractSqliteDriver implements Driver {
 
             }
 
+            if (value instanceof Date) {
+                escapedParameters.push(DateUtils.mixedDateToUtcDatetimeString(value));
+                return this.createParameter(key, escapedParameters.length - 1);
+            }
+
             escapedParameters.push(value);
             return this.createParameter(key, escapedParameters.length - 1);
         }); // todo: make replace only in value statements, otherwise problems

--- a/src/driver/sqlite-abstract/AbstractSqliteDriver.ts
+++ b/src/driver/sqlite-abstract/AbstractSqliteDriver.ts
@@ -363,6 +363,10 @@ export abstract class AbstractSqliteDriver implements Driver {
                 return nativeParameters[key] === true ? 1 : 0;
             }
 
+            if (nativeParameters[key] instanceof Date) {
+                return DateUtils.mixedDateToUtcDatetimeString(nativeParameters[key]);
+            }
+
             return nativeParameters[key];
         });
 

--- a/test/github-issues/2286/entity/Example.ts
+++ b/test/github-issues/2286/entity/Example.ts
@@ -1,0 +1,12 @@
+import {Entity} from "../../../../src/decorator/entity/Entity";
+import {PrimaryColumn} from "../../../../src/decorator/columns/PrimaryColumn";
+import {Column} from "../../../../src/decorator/columns/Column";
+
+@Entity()
+export class Example {
+    @PrimaryColumn()
+    id: Date;
+
+    @Column()
+    text: string
+}

--- a/test/github-issues/2286/entity/Post.ts
+++ b/test/github-issues/2286/entity/Post.ts
@@ -1,0 +1,12 @@
+import {Entity} from "../../../../src/decorator/entity/Entity";
+import {PrimaryColumn} from "../../../../src/decorator/columns/PrimaryColumn";
+import {Column} from "../../../../src/decorator/columns/Column";
+
+@Entity()
+export class Post {
+    @PrimaryColumn("int")
+    id: number;
+
+    @Column()
+    dateTimeColumn: Date;
+} 

--- a/test/github-issues/2286/issue-2286.ts
+++ b/test/github-issues/2286/issue-2286.ts
@@ -3,20 +3,21 @@ import { createTestingConnections, closeTestingConnections, reloadTestingDatabas
 import { Connection } from "../../../src/connection/Connection";
 import { expect } from "chai";
 import { Post } from "./entity/Post";
+import { Example } from "./entity/Example";
 import { Between } from "../../../src";
 
 describe("github issues > #2286 find operators like MoreThan and LessThan doesn't work properly for date fields", () => {
 
     let connections: Connection[];
     before(async () => connections = await createTestingConnections({
-        entities: [__dirname + "/entity/*{.js,.ts}"],
+        entities: [ Post, Example ],
         schemaCreate: true,
         dropSchema: true,
         /* Test not eligible for better-sql where binding Dates is impossible */
         enabledDrivers: ["sqlite"]
     }));
     beforeEach(() => reloadTestingDatabases(connections));
-    
+
     after(() => closeTestingConnections(connections));
 
     it("should find a record by its datetime value with find options", () => Promise.all(connections.map(async connection => {
@@ -51,5 +52,29 @@ describe("github issues > #2286 find operators like MoreThan and LessThan doesn'
             .where("post.dateTimeColumn = :now", { now })
             .getOne();
         expect(postByDateEquals).to.not.be.undefined;
+    })));
+
+    it("should save, update, and load with a date PK", () => Promise.all(connections.map(async connection => {
+        const start = new Date("2000-01-01");
+        const middle = new Date("2000-06-30");
+        const end = new Date("2001-01-01");
+
+        await connection.manager.save(Example, { id: start, text: "start" });
+        await connection.manager.save(Example, { id: middle, text: "middle" });
+        await connection.manager.save(Example, { id: end, text: "end" });
+
+        const repo = connection.manager.getRepository(Example);
+
+        let example = await repo.findOneOrFail({ id: middle });
+
+        expect(example.text).to.be.equal("middle");
+
+        example.text = "in between";
+
+        await repo.save(example);
+
+        example = await repo.findOneOrFail({ id: middle });
+
+        expect(example.text).to.be.equal("in between");
     })));
 });

--- a/test/github-issues/2286/issue-2286.ts
+++ b/test/github-issues/2286/issue-2286.ts
@@ -1,0 +1,41 @@
+import "reflect-metadata";
+import { createTestingConnections, closeTestingConnections, reloadTestingDatabases } from "../../utils/test-utils";
+import { Connection } from "../../../src/connection/Connection";
+import { expect } from "chai";
+import { Post } from "./entity/Post";
+import { Between } from "../../../src";
+
+describe("github issues > #2286 find operators like MoreThan and LessThan doesn't work properly for date fields", () => {
+
+    let connections: Connection[];
+    before(async () => connections = await createTestingConnections({
+        entities: [__dirname + "/entity/*{.js,.ts}"],
+        schemaCreate: true,
+        dropSchema: true,
+        /* Test not eligible for better-sql where binding Dates is impossible */
+        enabledDrivers: ["sqlite"]
+    }));
+    beforeEach(() => reloadTestingDatabases(connections));
+    
+    after(() => closeTestingConnections(connections));
+
+    it("should find a record by its datetime value", () => Promise.all(connections.map(async connection => {
+        const start = new Date("2000-01-01");
+        const end = new Date("2001-01-01");
+        const middle = new Date("2000-06-30");
+        const post = new Post();
+        post.dateTimeColumn = middle;
+
+        await connection.manager.save(post);
+
+        const postByDateEquals = await connection.manager.findOne(Post, {
+            dateTimeColumn: middle
+        });
+        expect(postByDateEquals).to.not.be.undefined;
+
+        const postByDateBetween = await connection.manager.findOne(Post, {
+            dateTimeColumn: Between(start, end)
+        });
+        expect(postByDateBetween).to.not.be.undefined;
+    })));
+});

--- a/test/github-issues/2286/issue-2286.ts
+++ b/test/github-issues/2286/issue-2286.ts
@@ -19,7 +19,7 @@ describe("github issues > #2286 find operators like MoreThan and LessThan doesn'
     
     after(() => closeTestingConnections(connections));
 
-    it("should find a record by its datetime value", () => Promise.all(connections.map(async connection => {
+    it("should find a record by its datetime value with find options", () => Promise.all(connections.map(async connection => {
         const start = new Date("2000-01-01");
         const end = new Date("2001-01-01");
         const middle = new Date("2000-06-30");
@@ -37,5 +37,19 @@ describe("github issues > #2286 find operators like MoreThan and LessThan doesn'
             dateTimeColumn: Between(start, end)
         });
         expect(postByDateBetween).to.not.be.undefined;
+    })));
+
+    it("should find a record by its datetime value with query builder", () => Promise.all(connections.map(async connection => {
+        const now = new Date();
+        const post = new Post();
+        post.dateTimeColumn = now;
+
+        await connection.manager.save(post);
+
+        const postByDateEquals = await connection.manager.getRepository(Post)
+            .createQueryBuilder("post")
+            .where("post.dateTimeColumn = :now", { now })
+            .getOne();
+        expect(postByDateEquals).to.not.be.undefined;
     })));
 });


### PR DESCRIPTION
### Description of change (copied from commit message)

In sqlite, Date objects are persisted as UtcDatetimeString.
But a Date object parameter was escaped with .toISOString(), making such queries impossible.
This commit aligns both transforms.
This bug does *not* apply to better-sql where you can only bind numbers, strings, bigints, buffers,
and null.
This is breaking for when the user inserted their dates manually as ISO and relied on this old
maltransformation, after this their find()s by Date won't work anymore.

BREAKING CHANGE: Change Date serialization in selects

fixes #2286
fixes #3426 

### Pull-Request Checklist

- [x] Code is up-to-date with the `master` branch
- [x] `npm run lint` passes with this change
- [x] `npm run test` passes with this change
- [x] This pull request links relevant issues as `Fixes #0000`
- [x] There are new or updated unit tests validating the change
- [ ] Documentation has been updated to reflect this change
- [x] The new commits follow conventions explained in [CONTRIBUTING.md](https://github.com/typeorm/typeorm/blob/master/CONTRIBUTING.md)
