### PR TITLE
fix:use host if hostReplicaSet is not provided

### DIFF
--- a/src/driver/mongodb/MongoDriver.ts
+++ b/src/driver/mongodb/MongoDriver.ts
@@ -444,13 +444,13 @@ export class MongoDriver implements Driver {
             : "";
 
         let connectionString = undefined;
+        const portUrlPart = (schemaUrlPart === "mongodb+srv")
+            ? ""
+            : `:${options.port || "27017"}`;
 
         if(options.replicaSet) {
-            connectionString = `${schemaUrlPart}://${credentialsUrlPart}${options.hostReplicaSet}/${options.database || ""}`;
+            connectionString = `${schemaUrlPart}://${credentialsUrlPart}${options.hostReplicaSet || options.host + portUrlPart || "127.0.0.1" + portUrlPart}/${options.database || ""}`;
         } else {
-            const portUrlPart = (schemaUrlPart === "mongodb+srv")
-                ? ""
-                : `:${options.port || "27017"}`;
             connectionString = `${schemaUrlPart}://${credentialsUrlPart}${options.host || "127.0.0.1"}${portUrlPart}/${options.database || ""}`;
         }
             


### PR DESCRIPTION
<!--
  😀 Wonderful!  Thank you for opening a pull request for TypeORM.

  Please fill in the information below to expedite the review
  and (hopefully) merge of your change.

  If unsure about something.. just do as best as you're able,
  or reach out through our community support channels!
  https://github.com/typeorm/typeorm/blob/master/docs/support.md
-->

Change was for MongoDriver's buildConnectionUrl method for building a connection url for a replica set.
Currently the host that is used is the config option called "hostReplicaSet"
The change updates this so that if this option is not provided it uses a provided "host" with the given port.
It also defaults to using "127.0.0.1" as a host if none is provided, and "27017" if no port was provided.

This change was needed because I did not provide a connection url to my typeorm config, but I provided all other neccessary info to build a connection url. However, I provided only a "host" and not "hostReplicaSet" which caused it to create a url with the host "undefined". I tested this on an environment with a replica set.

<!--
  Please be clear and concise what the change is intended to do,
  why this change is needed, and how you've verified that it
  corrects what you intended.

  In some cases it may be helpful to include the current behavior
  and the new behavior.

  If the change is related to an open issue, you can link it here.
  If you include `Fixes #0000` (replacing `0000` with the issue number)
  when this is merged it will automatically mark the issue as fixed and
  close it.
-->


### Pull-Request Checklist

<!--
  Please make sure to review and check all of the following.

  If an item is not applicable, you can add "N/A" to the end.
-->

- [x] Code is up-to-date with the `master` branch
- [x] `npm run lint` passes with this change
- [ ] `npm run test` passes with this change
- [x] This pull request links relevant issues as `Fixes #0000`
- [ ] There are new or updated unit tests validating the change
- [ ] Documentation has been updated to reflect this change
- [x] The new commits follow conventions explained in [CONTRIBUTING.md](https://github.com/typeorm/typeorm/blob/master/CONTRIBUTING.md)

<!--
  🎉 Thank you for contributing and making TypeORM even better!
-->
