### PR TITLE
fix: `@Unique` constraint is not created with specified name

### DIFF
--- a/test/github-issues/2376/entity/User.ts
+++ b/test/github-issues/2376/entity/User.ts
@@ -1,0 +1,19 @@
+import {Column, Entity, PrimaryGeneratedColumn, Unique} from "../../../../src";
+
+@Entity()
+@Unique(["age"])
+@Unique("unique-email", ["email"])
+@Unique("unique-email-nickname", ["email", "nickname"])
+export class User {
+    @PrimaryGeneratedColumn()
+    id: number;
+
+    @Column()
+    email: string;
+
+    @Column()
+    nickname: string;
+
+    @Column()
+    age: number;
+}

--- a/test/github-issues/2376/issue-2376.ts
+++ b/test/github-issues/2376/issue-2376.ts
@@ -1,0 +1,35 @@
+import "reflect-metadata";
+import {Connection} from "../../../src";
+import {createTestingConnections, closeTestingConnections} from "../../utils/test-utils";
+import {User} from "./entity/User";
+import {expect} from "chai";
+import {MysqlDriver} from "../../../src/driver/mysql/MysqlDriver";
+
+describe("github issues > #2376 Naming single column unique constraint with decorator not working as expected", () => {
+    let connections: Connection[];
+    before(async () => connections = await createTestingConnections({
+        schemaCreate: true,
+        dropSchema: true,
+        entities: [User],
+    }));
+    after(() => closeTestingConnections(connections));
+
+    it("should keep user-specified Unique constraint name", () => Promise.all(connections.map(async connection => {
+        const queryRunner = connection.createQueryRunner();
+
+        const table = await queryRunner.getTable("user");
+        await queryRunner.release()
+
+        let unique1 = table!.uniques.find(it => it.name === "unique-email");
+        let unique2 = table!.uniques.find(it => it.name === "unique-email-nickname");
+
+        if (connection.driver instanceof MysqlDriver) {
+            unique1 = table!.indices.find(it => it.name === "unique-email");
+            unique2 = table!.indices.find(it => it.name === "unique-email-nickname");
+        }
+
+        expect(unique1).to.be.not.undefined
+        expect(unique2).to.be.not.undefined
+
+    })));
+});


### PR DESCRIPTION
<!--
  😀 Wonderful!  Thank you for opening a pull request for TypeORM.

  Please fill in the information below to expedite the review
  and (hopefully) merge of your change.

  If unsure about something.. just do as best as you're able,
  or reach out through our community support channels!
  https://github.com/typeorm/typeorm/blob/master/docs/support.md
-->

### Description of change

Fixed `@Unique` constraint name behavior in SQLite. Looks like other drivers was already fixed because test is successfully passing.

Fixes #2376 
Fixes #4795
Fixes #5155

<!--
  Please be clear and concise what the change is intended to do,
  why this change is needed, and how you've verified that it
  corrects what you intended.

  In some cases it may be helpful to include the current behavior
  and the new behavior.

  If the change is related to an open issue, you can link it here.
  If you include `Fixes #0000` (replacing `0000` with the issue number)
  when this is merged it will automatically mark the issue as fixed and
  close it.
-->


### Pull-Request Checklist

<!--
  Please make sure to review and check all of the following.

  If an item is not applicable, you can add "N/A" to the end.
-->

- [x] Code is up-to-date with the `master` branch
- [x] `npm run lint` passes with this change
- [x] `npm run test` passes with this change
- [x] This pull request links relevant issues as `Fixes #0000`
- [x] There are new or updated unit tests validating the change
- [ ] Documentation has been updated to reflect this change
- [x] The new commits follow conventions explained in [CONTRIBUTING.md](https://github.com/typeorm/typeorm/blob/master/CONTRIBUTING.md)

<!--
  🎉 Thank you for contributing and making TypeORM even better!
-->
