### PR TITLE
fix: Make QueryRunner do not generate duplicate query when enum is same name

### DIFF
--- a/test/github-issues/7523/issue-7523.ts
+++ b/test/github-issues/7523/issue-7523.ts
@@ -1,4 +1,5 @@
 import "reflect-metadata";
+import {expect} from "chai";
 import {Connection} from "../../../src";
 import {createTestingConnections, closeTestingConnections} from "../../utils/test-utils";
 import {ChildEntity1, ChildEntity2} from "./entity/Test";
@@ -15,14 +16,14 @@ describe("github issues > #7523 Do not create duplicate CREATE TYPE migration qu
 
     it("should recognize model changes", () => Promise.all(connections.map(async connection => {
         const sqlInMemory = await connection.driver.createSchemaBuilder().log();
-        sqlInMemory.upQueries.length.should.be.greaterThan(0);
-        sqlInMemory.downQueries.length.should.be.greaterThan(0);
+        expect(sqlInMemory.upQueries.length).greaterThan(0);
+        expect(sqlInMemory.downQueries.length).greaterThan(0);
     })));
 
     it("should not generate queries when no model changes", () => Promise.all(connections.map(async connection => {
         await connection.driver.createSchemaBuilder().build();
         const sqlInMemory = await connection.driver.createSchemaBuilder().log();
-        sqlInMemory.upQueries.length.should.be.equal(0);
-        sqlInMemory.downQueries.length.should.be.equal(0);
+        expect(sqlInMemory.upQueries.length).equals(0);
+        expect(sqlInMemory.downQueries.length).equals(0);
     })));
 });

--- a/test/github-issues/7523/issue-7523.ts
+++ b/test/github-issues/7523/issue-7523.ts
@@ -14,10 +14,10 @@ describe("github issues > #7523 Do not create duplicate CREATE TYPE migration qu
     }));
     after(() => closeTestingConnections(connections));
 
-    it("should recognize model changes", () => Promise.all(connections.map(async connection => {
+    it("should not generate duplicate CREATE TYPE query", () => Promise.all(connections.map(async connection => {
         const sqlInMemory = await connection.driver.createSchemaBuilder().log();
-        expect(sqlInMemory.upQueries.length).greaterThan(0);
-        expect(sqlInMemory.downQueries.length).greaterThan(0);
+        expect(sqlInMemory.upQueries.length).equals(3);
+        expect(sqlInMemory.downQueries.length).equals(3);
     })));
 
     it("should not generate queries when no model changes", () => Promise.all(connections.map(async connection => {


### PR DESCRIPTION
<!--
  😀 Wonderful!  Thank you for opening a pull request for TypeORM.

  Please fill in the information below to expedite the review
  and (hopefully) merge of your change.

  If unsure about something.. just do as best as you're able,
  or reach out through our community support channels!
  https://github.com/typeorm/typeorm/blob/master/docs/support.md
-->

### Description of change

<!--
  Please be clear and concise what the change is intended to do,
  why this change is needed, and how you've verified that it
  corrects what you intended.

  In some cases it may be helpful to include the current behavior
  and the new behavior.

  If the change is related to an open issue, you can link it here.
  If you include `Fixes #0000` (replacing `0000` with the issue number)
  when this is merged it will automatically mark the issue as fixed and
  close it.
-->
This issue fixes #7523 by storing built enum names in set class property.


### Pull-Request Checklist

<!--
  Please make sure to review and check all of the following.

  If an item is not applicable, you can add "N/A" to the end.
-->

- [x] Code is up-to-date with the `master` branch
- [x] `npm run lint` passes with this change
- [x] `npm run test` passes with this change
- [x] This pull request links relevant issues as `Fixes #0000`
- [x] There are new or updated unit tests validating the change
- [ ] Documentation has been updated to reflect this change N/A
- [x] The new commits follow conventions explained in [CONTRIBUTING.md](https://github.com/typeorm/typeorm/blob/master/CONTRIBUTING.md)

<!--
  🎉 Thank you for contributing and making TypeORM even better!
-->
