### PR TITLE
docs: add note about unique parameters in QueryBuilder

### DIFF
--- a/docs/select-query-builder.md
+++ b/docs/select-query-builder.md
@@ -1,6 +1,7 @@
 # Select using Query Builder
 
 * [What is `QueryBuilder`](#what-is-querybuilder)
+* [Important note when using the `QueryBuilder`](#important-note-when-using-the-querybuilder)
 * [How to create and use a `QueryBuilder`](#how-to-create-and-use-a-querybuilder)
 * [Getting values using QueryBuilder](#getting-values-using-querybuilder)
 * [What are aliases for?](#what-are-aliases-for)
@@ -61,6 +62,32 @@ User {
     lastName: "Saw"
 }
 ```
+
+## Important note when using the `QueryBuilder`
+
+When using the `QueryBuilder`, you need to provide unique parameters in your `WHERE` expressions. **This will not work**:
+
+```TypeScript
+const result = await getConnection()
+    .createQueryBuilder('user')
+    .leftJoinAndSelect('user.linkedSheep', 'linkedSheep')
+    .leftJoinAndSelect('user.linkedCow', 'linkedCow')
+    .where('user.linkedSheep = :id', { id: sheepId })
+    .andWhere('user.linkedCow = :id', { id: cowId });
+```
+
+... but this will:
+
+```TypeScript
+const result = await getConnection()
+    .createQueryBuilder('user')
+    .leftJoinAndSelect('user.linkedSheep', 'linkedSheep')
+    .leftJoinAndSelect('user.linkedCow', 'linkedCow')
+    .where('user.linkedSheep = :sheepId', { sheepId })
+    .andWhere('user.linkedCow = :cowId', { cowId });
+```
+
+Note that we uniquely named `:sheepId` and `:cowId` instead of using `:id` twice for different parameters.
 
 ## How to create and use a `QueryBuilder`
 


### PR DESCRIPTION
<!--
  😀 Wonderful!  Thank you for opening a pull request for TypeORM.

  Please fill in the information below to expedite the review
  and (hopefully) merge of your change.

  If unsure about something.. just do as best as you're able,
  or reach out through our community support channels!
  https://github.com/typeorm/typeorm/blob/master/docs/support.md
-->

### Description of change

When using the QueryBuilder, unique parameters need to be provided in WHERE expressions. This commit adds that information to the docs, as it's easy to overlook for users. Took us 2 hours to figure out this was causing a bug in our application.

Also reported in https://github.com/typeorm/typeorm/issues/1322#issuecomment-351032081

<!--
  Please be clear and concise what the change is intended to do,
  why this change is needed, and how you've verified that it
  corrects what you intended.

  In some cases it may be helpful to include the current behavior
  and the new behavior.

  If the change is related to an open issue, you can link it here.
  If you include `Fixes #0000` (replacing `0000` with the issue number)
  when this is merged it will automatically mark the issue as fixed and
  close it.
-->


### Pull-Request Checklist

<!--
  Please make sure to review and check all of the following.

  If an item is not applicable, you can add "N/A" to the end.
-->

- [x] Code is up-to-date with the `master` branch
- [x] `npm run lint` passes with this change
- [x] `npm run test` passes with this change
- [ ] This pull request links relevant issues as `Fixes #0000` N/A
- [ ] There are new or updated unit tests validating the change N/A
- [x] Documentation has been updated to reflect this change
- [x] The new commits follow conventions explained in [CONTRIBUTING.md](https://github.com/typeorm/typeorm/blob/master/CONTRIBUTING.md)

<!--
  🎉 Thank you for contributing and making TypeORM even better!
-->
