### PR TITLE
Fixes #7579

### DIFF
--- a/src/driver/mysql/MysqlDriver.ts
+++ b/src/driver/mysql/MysqlDriver.ts
@@ -583,8 +583,9 @@ export class MysqlDriver implements Driver {
         const defaultValue = columnMetadata.default;
 
         if (defaultValue === null) {
-            return undefined
-
+            return 'NULL';
+        } else if (defaultValue === undefined && columnMetadata.isNullable) {
+            return 'NULL';
         } else if (
             (columnMetadata.type === "enum"
             || columnMetadata.type === "simple-enum"


### PR DESCRIPTION
Fixes #7579 

When using `nullable: true` or `default: null` tyeorm will generate wrong migrations as normalize function is returning `undefined` for `null` default value. Also MySql/MariaDB sets default value automatically to `null` if the column is marked as nullable so we should return also 'NULL' in normalize function when default value is not set and column is marked as nullable