### PR TITLE
Fixes #7150 (bug with transformers on UpdatedAtColumn)

### DIFF
--- a/src/persistence/SubjectChangedColumnsComputer.ts
+++ b/src/persistence/SubjectChangedColumnsComputer.ts
@@ -74,18 +74,22 @@ export class SubjectChangedColumnsComputer {
                         return;
                 }
                 let normalizedValue = entityValue;
+
                 // normalize special values to make proper comparision
                 if (entityValue !== null) {
+                    if (column.transformer && shouldTransformDatabaseEntity) {
+                      normalizedValue = ApplyValueTransformers.transformTo(column.transformer, entityValue);
+                    }
                     switch (column.type) {
                         case "date":
-                            normalizedValue = DateUtils.mixedDateToDateString(entityValue);
+                            normalizedValue = DateUtils.mixedDateToDateString(normalizedValue);
                             break;
 
                         case "time":
                         case "time with time zone":
                         case "time without time zone":
                         case "timetz":
-                            normalizedValue = DateUtils.mixedDateToTimeString(entityValue);
+                            normalizedValue = DateUtils.mixedDateToTimeString(normalizedValue);
                             break;
 
                         case "datetime":
@@ -96,7 +100,7 @@ export class SubjectChangedColumnsComputer {
                         case "timestamp with time zone":
                         case "timestamp with local time zone":
                         case "timestamptz":
-                            normalizedValue = DateUtils.mixedDateToUtcDatetimeString(entityValue);
+                            normalizedValue = DateUtils.mixedDateToUtcDatetimeString(normalizedValue);
                             databaseValue = DateUtils.mixedDateToUtcDatetimeString(databaseValue);
                             break;
 
@@ -105,26 +109,23 @@ export class SubjectChangedColumnsComputer {
                             // JSON.stringify doesn't work because postgresql sorts jsonb before save.
                             // If you try to save json '[{"messages": "", "attribute Key": "", "level":""}] ' as jsonb,
                             // then postgresql will save it as '[{"level": "", "message":"", "attributeKey": ""}]'
-                            if (OrmUtils.deepCompare(entityValue, databaseValue)) return;
+                            if (OrmUtils.deepCompare(normalizedValue, databaseValue)) return;
                             break;
 
                         case "simple-array":
-                            normalizedValue = DateUtils.simpleArrayToString(entityValue);
+                            normalizedValue = DateUtils.simpleArrayToString(normalizedValue);
                             databaseValue = DateUtils.simpleArrayToString(databaseValue);
                             break;
                         case "simple-enum":
-                            normalizedValue = DateUtils.simpleEnumToString(entityValue);
+                            normalizedValue = DateUtils.simpleEnumToString(normalizedValue);
                             databaseValue = DateUtils.simpleEnumToString(databaseValue);
                             break;
                         case "simple-json":
-                            normalizedValue = DateUtils.simpleJsonToString(entityValue);
+                            normalizedValue = DateUtils.simpleJsonToString(normalizedValue);
                             databaseValue = DateUtils.simpleJsonToString(databaseValue);
                             break;
                     }
 
-                    if (column.transformer) {
-                        normalizedValue = ApplyValueTransformers.transformTo(column.transformer, entityValue);
-                    }
                 }
 
                 // if value is not changed - then do nothing

--- a/test/github-issues/7150/entity/Post.ts
+++ b/test/github-issues/7150/entity/Post.ts
@@ -1,0 +1,45 @@
+import {
+  Column,
+  Entity,
+  PrimaryGeneratedColumn,
+  CreateDateColumn,
+  UpdateDateColumn,
+  ValueTransformer,
+} from "../../../../src";
+
+const unixTimestamp: ValueTransformer = {
+  from: (value: Date | null | undefined): number | null | undefined => {
+    return value ? value.getTime() : value;
+  },
+  to: (value: number | null | undefined): Date | null | undefined => {
+    return typeof value === "number" ? new Date(value) : value;
+  },
+};
+
+
+@Entity({ name: "posts" })
+export class Post {
+    @PrimaryGeneratedColumn()
+    id: number;
+
+    @CreateDateColumn({
+        name: "created_at",
+        type: "timestamptz",
+        transformer: unixTimestamp,
+    })
+    createdAt: number;
+
+    @UpdateDateColumn({
+        name: "updated_at",
+        type: "timestamptz",
+        transformer: unixTimestamp,
+    })
+
+    updatedAt: number;
+
+    @Column({
+      name: "content",
+      type: "text",
+    })
+    content: string;
+}

--- a/test/github-issues/7150/issue-7150.ts
+++ b/test/github-issues/7150/issue-7150.ts
@@ -1,0 +1,41 @@
+import "reflect-metadata";
+import {Connection} from "../../../src";
+import {createTestingConnections, closeTestingConnections} from "../../utils/test-utils";
+import {Post} from "./entity/Post";
+
+describe("github issues > #7150 Transformers break CreatedDate / UpdatedDate columns", () => {
+    let connections: Connection[];
+    before(async () => connections = await createTestingConnections({
+        enabledDrivers: ["postgres"],
+        schemaCreate: true,
+        dropSchema: true,
+        entities: [Post],
+    }));
+    after(() => closeTestingConnections(connections));
+
+    it("updates updatedAt when changes occur", () => Promise.all(connections.map(async connection => {
+        const repo = connection.getRepository(Post);
+        const post = repo.create({ content: "hello!" });
+        const savedPost = await repo.save(post);
+        savedPost.createdAt!.should.be.a("number");
+        savedPost.updatedAt!.should.be.a("number");
+        savedPost.updatedAt!.should.be.equal(savedPost.createdAt!);
+
+        const update = repo.merge(savedPost, { content: "hello world!" });
+        const updatedPost = await repo.save(update);
+        updatedPost.createdAt!.should.be.a("number");
+        updatedPost.updatedAt!.should.be.a("number");
+        updatedPost.createdAt!.should.be.equal(savedPost.createdAt!);
+        updatedPost.updatedAt!.should.be.greaterThan(savedPost.createdAt!);
+    })));
+
+    it("leaves updatedAt column alone when no changes occur", () => Promise.all(connections.map(async connection => {
+        const repo = connection.getRepository(Post);
+        const post = repo.create({ content: "hello!" });
+        await repo.save(post);
+        const savedPost = await repo.save(post);
+        savedPost.createdAt!.should.be.a("number");
+        savedPost.updatedAt!.should.be.a("number");
+        savedPost.updatedAt!.should.be.equal(savedPost.createdAt!);
+    })));
+});


### PR DESCRIPTION
### Description of change

Because the transformer was being applied _after_ special handling logic
for dates, typeorm was comparing a date object to a string object.  This
PR flips the logic so that the transformer (if any) is applied prior to
normalization for comparisons.

Fixes #7150 (see for more details)


### Pull-Request Checklist

- [x] Code is up-to-date with the `master` branch
- [x] `npm run lint` passes with this change
- [x] `npm run test` passes with this change
- [x] This pull request links relevant issues as `Fixes #0000`
- [x] There are new or updated unit tests validating the change
- [x] Documentation has been updated to reflect this change
- [x] The new commits follow conventions explained in [CONTRIBUTING.md](https://github.com/typeorm/typeorm/blob/master/CONTRIBUTING.md)

