### PR TITLE
Fix #6867

### DIFF
--- a/src/driver/postgres/PostgresQueryRunner.ts
+++ b/src/driver/postgres/PostgresQueryRunner.ts
@@ -324,8 +324,12 @@ export class PostgresQueryRunner extends BaseQueryRunner implements QueryRunner 
      * Note: Postgres does not support database creation inside a transaction block.
      */
     async createDatabase(database: string, ifNotExist?: boolean): Promise<void> {
-        if (ifNotExist)
-            throw new Error(`PostgreSQL does not support 'IF NOT EXISTS' in database creation.`);
+        if (ifNotExist) {
+            const databaseAlreadyExists = await this.hasDatabase(database);
+            
+            if (databaseAlreadyExists)
+                return Promise.resolve();
+        }
 
         const up = `CREATE DATABASE "${database}"`;
         const down = `DROP DATABASE "${database}"`;

--- a/src/driver/postgres/PostgresQueryRunner.ts
+++ b/src/driver/postgres/PostgresQueryRunner.ts
@@ -271,7 +271,8 @@ export class PostgresQueryRunner extends BaseQueryRunner implements QueryRunner 
      * Checks if database with the given name exist.
      */
     async hasDatabase(database: string): Promise<boolean> {
-        return Promise.resolve(false);
+        const result = await this.query(`SELECT * FROM pg_database WHERE datname='${database}';`);
+        return result.length ? true : false;
     }
 
     /**
@@ -320,18 +321,25 @@ export class PostgresQueryRunner extends BaseQueryRunner implements QueryRunner 
 
     /**
      * Creates a new database.
-     * Postgres does not supports database creation inside a transaction block.
+     * Note: Postgres does not support database creation inside a transaction block.
      */
     async createDatabase(database: string, ifNotExist?: boolean): Promise<void> {
-        await Promise.resolve();
+        if (ifNotExist)
+            throw new Error(`PostgreSQL does not support 'IF NOT EXISTS' in database creation.`);
+
+        const up = `CREATE DATABASE "${database}"`;
+        const down = `DROP DATABASE "${database}"`;
+        await this.executeQueries(new Query(up), new Query(down));
     }
 
     /**
      * Drops database.
-     * Postgres does not supports database drop inside a transaction block.
+     * Note: Postgres does not support database dropping inside a transaction block.
      */
     async dropDatabase(database: string, ifExist?: boolean): Promise<void> {
-        return Promise.resolve();
+        const up = ifExist ? `DROP DATABASE IF EXISTS "${database}"` : `DROP DATABASE "${database}"`;
+        const down = `CREATE DATABASE "${database}"`;
+        await this.executeQueries(new Query(up), new Query(down));
     }
 
     /**

--- a/test/functional/query-runner/create-and-drop-database.ts
+++ b/test/functional/query-runner/create-and-drop-database.ts
@@ -1,6 +1,5 @@
 import "reflect-metadata";
 import {Connection} from "../../../src/connection/Connection";
-import {PostgresDriver} from "../../../src/driver/postgres/PostgresDriver";
 import {closeTestingConnections, createTestingConnections, reloadTestingDatabases} from "../../utils/test-utils";
 
 describe("query runner > create and drop database", () => {
@@ -20,10 +19,7 @@ describe("query runner > create and drop database", () => {
 
         const queryRunner = connection.createQueryRunner();
 
-        // Postgres does not support 'IF NOT EXISTS' in database creation.
-        const ifNotExist = connection.driver instanceof PostgresDriver? false : true;
-        
-        await queryRunner.createDatabase("myTestDatabase", ifNotExist);
+        await queryRunner.createDatabase("myTestDatabase", true);
         let hasDatabase = await queryRunner.hasDatabase("myTestDatabase");
         hasDatabase.should.be.true;
 

--- a/test/functional/query-runner/create-and-drop-database.ts
+++ b/test/functional/query-runner/create-and-drop-database.ts
@@ -1,5 +1,6 @@
 import "reflect-metadata";
 import {Connection} from "../../../src/connection/Connection";
+import {PostgresDriver} from "../../../src/driver/postgres/PostgresDriver";
 import {closeTestingConnections, createTestingConnections, reloadTestingDatabases} from "../../utils/test-utils";
 
 describe("query runner > create and drop database", () => {
@@ -8,7 +9,7 @@ describe("query runner > create and drop database", () => {
     before(async () => {
         connections = await createTestingConnections({
             entities: [__dirname + "/entity/*{.js,.ts}"],
-            enabledDrivers: ["mysql", "mssql", "cockroachdb"],
+            enabledDrivers: ["mysql", "mssql", "cockroachdb", "postgres"],
             dropSchema: true,
         });
     });
@@ -19,7 +20,10 @@ describe("query runner > create and drop database", () => {
 
         const queryRunner = connection.createQueryRunner();
 
-        await queryRunner.createDatabase("myTestDatabase", true);
+        // Postgres does not support 'IF NOT EXISTS' in database creation.
+        const ifNotExist = connection.driver instanceof PostgresDriver? false : true;
+        
+        await queryRunner.createDatabase("myTestDatabase", ifNotExist);
         let hasDatabase = await queryRunner.hasDatabase("myTestDatabase");
         hasDatabase.should.be.true;
 


### PR DESCRIPTION
### Description of change

Fixes #6867.

Postgres' database creation and dropping were not implemented and just (silently) resolved an empty promise. As the comment above `createDatabase` stated, database creation really isn't allowed inside transaction blocks, but, if a user tries to do that, the query runner should throw an error.

### Pull-Request Checklist

- [x] Code is up-to-date with the `master` branch
- [x] `npm run lint` passes with this change
- [x] `npm run test` passes with this change
- [x] This pull request links relevant issues as `Fixes #0000`
- [x] There are new or updated unit tests validating the change
- [ ] Documentation has been updated to reflect this change
- [x] The new commits follow conventions explained in [CONTRIBUTING.md](https://github.com/typeorm/typeorm/blob/master/CONTRIBUTING.md)