### PR TITLE
feat: allow passing custom user-data through local entity manager

### DIFF
--- a/docs/logging.md
+++ b/docs/logging.md
@@ -55,7 +55,7 @@ There are other options you can use:
 * `info` - logs internal orm informative messages.
 * `log` - logs internal orm log messages.
 
-You can specify as many options as needed. 
+You can specify as many options as needed.
 If you want to enable all logging you can simply specify `logging: "all"`:
 
 ```typescript
@@ -85,7 +85,7 @@ This code will log all queries which run more then `1 second`.
 
 TypeORM ships with 4 different types of logger:
 
-* `advanced-console` - this is the default logger which logs all messages into the console using color 
+* `advanced-console` - this is the default logger which logs all messages into the console using color
 and sql syntax highlighting (using [chalk](https://github.com/chalk/chalk)).
 * `simple-console` - this is a simple console logger which is exactly the same as the advanced logger, but it does not use any color highlighting.
 This logger can be used if you have problems / or don't like colorized logs.
@@ -153,11 +153,16 @@ getConnectionOptions().then(connectionOptions => {
 ```
 
 Logger methods can accept `QueryRunner` when it's available. It's helpful if you want to log additional data.
-Also, via query runner, you can get access to additional data passed during persist/remove. For example:
+Also, via query runner, you can get access to additional data passed during persist/remove, or attached to a local instance of `EntityManager`. For example:
 
 ```typescript
-// user sends request during entity save
+// either: (1) user sends request during entity save
 postRepository.save(post, { data: { request: request } });
+
+// or: (2) user creates request-scoped entity manager, and attaches request
+const manager = connection.createEntityManager();
+manager.data = { request: request };
+manager.query("SELECT * FROM post");
 
 // in logger you can access it this way:
 logQuery(query: string, parameters?: any[], queryRunner?: QueryRunner) {

--- a/src/connection/Connection.ts
+++ b/src/connection/Connection.ts
@@ -32,7 +32,7 @@ import {QueryResultCache} from "../cache/QueryResultCache";
 import {SqljsEntityManager} from "../entity-manager/SqljsEntityManager";
 import {RelationLoader} from "../query-builder/RelationLoader";
 import {RelationIdLoader} from "../query-builder/RelationIdLoader";
-import {EntitySchema} from "../";
+import {EntitySchema, ObjectLiteral} from "../";
 import {SqlServerDriver} from "../driver/sqlserver/SqlServerDriver";
 import {MysqlDriver} from "../driver/mysql/MysqlDriver";
 import {ObjectUtils} from "../util/ObjectUtils";
@@ -391,7 +391,7 @@ export class Connection {
     /**
      * Executes raw SQL query and returns raw database results.
      */
-    async query(query: string, parameters?: any[], queryRunner?: QueryRunner): Promise<any> {
+    async query(query: string, parameters?: any[], queryRunner?: QueryRunner, data?: ObjectLiteral): Promise<any> {
         if (this instanceof MongoEntityManager)
             throw new Error(`Queries aren't supported by MongoDB.`);
 
@@ -399,6 +399,10 @@ export class Connection {
             throw new QueryRunnerProviderAlreadyReleasedError();
 
         const usedQueryRunner = queryRunner || this.createQueryRunner();
+
+        if (data) {
+            ObjectUtils.assign(usedQueryRunner.data, data);
+        }
 
         try {
             return await usedQueryRunner.query(query, parameters);  // await is needed here because we are using finally

--- a/src/query-builder/QueryBuilder.ts
+++ b/src/query-builder/QueryBuilder.ts
@@ -23,6 +23,7 @@ import {EntitySchema} from "../";
 import {FindOperator} from "../find-options/FindOperator";
 import {In} from "../find-options/operator/In";
 import {EntityColumnNotFound} from "../error/EntityColumnNotFound";
+import { ObjectUtils } from "../util/ObjectUtils";
 
 // todo: completely cover query builder with tests
 // todo: entityOrProperty can be target name. implement proper behaviour if it is.
@@ -58,6 +59,12 @@ export abstract class QueryBuilder<Entity> {
      */
     readonly expressionMap: QueryExpressionMap;
 
+    /**
+     * Stores temporarily user data.
+     * Useful for sharing data with subscribers.
+     */
+    data?: ObjectLiteral;
+
     // -------------------------------------------------------------------------
     // Protected Properties
     // -------------------------------------------------------------------------
@@ -89,6 +96,7 @@ export abstract class QueryBuilder<Entity> {
             this.connection = connectionOrQueryBuilder.connection;
             this.queryRunner = connectionOrQueryBuilder.queryRunner;
             this.expressionMap = connectionOrQueryBuilder.expressionMap.clone();
+            this.data = connectionOrQueryBuilder.data;
 
         } else {
             this.connection = connectionOrQueryBuilder;
@@ -980,10 +988,12 @@ export abstract class QueryBuilder<Entity> {
     }
 
     /**
-     * Creates a query builder used to execute sql queries inside this query builder.
+     * Obtains or creates query runner used to execute sql queries inside this query builder.
      */
     protected obtainQueryRunner() {
-        return this.queryRunner || this.connection.createQueryRunner();
+        const queryRunner = this.queryRunner || this.connection.createQueryRunner();
+        if (this.data) ObjectUtils.assign(queryRunner.data, this.data);
+        return queryRunner;
     }
 
 }

--- a/src/query-builder/SelectQueryBuilder.ts
+++ b/src/query-builder/SelectQueryBuilder.ts
@@ -2123,7 +2123,11 @@ export class SelectQueryBuilder<Entity> extends QueryBuilder<Entity> implements 
      * Creates a query builder used to execute sql queries inside this query builder.
      */
     protected obtainQueryRunner() {
-        return this.queryRunner || this.connection.createQueryRunner("slave");
+        const queryRunner = this.queryRunner || this.connection.createQueryRunner("slave");
+        if (this.data) {
+            ObjectUtils.assign(queryRunner.data, this.data);
+        }
+        return queryRunner;
     }
 
 }

--- a/src/query-runner/QueryRunner.ts
+++ b/src/query-runner/QueryRunner.ts
@@ -47,7 +47,7 @@ export interface QueryRunner {
 
     /**
      * Stores temporarily user data.
-     * Useful for sharing data with subscribers.
+     * Useful for sharing data with subscribers/logger.
      */
     data: ObjectLiteral;
 

--- a/src/util/ObjectUtils.ts
+++ b/src/util/ObjectUtils.ts
@@ -1,7 +1,7 @@
 export class ObjectUtils {
   /**
    * Copy the values of all of the enumerable own properties from one or more source objects to a
-   * target object. Returns the target object.
+   * target object.
    * @param target The target object to copy to.
    * @param source The source object from which to copy properties.
    */
@@ -9,7 +9,7 @@ export class ObjectUtils {
 
   /**
    * Copy the values of all of the enumerable own properties from one or more source objects to a
-   * target object. Returns the target object.
+   * target object.
    * @param target The target object to copy to.
    * @param source1 The first source object from which to copy properties.
    * @param source2 The second source object from which to copy properties.
@@ -18,7 +18,7 @@ export class ObjectUtils {
 
   /**
    * Copy the values of all of the enumerable own properties from one or more source objects to a
-   * target object. Returns the target object.
+   * target object.
    * @param target The target object to copy to.
    * @param source1 The first source object from which to copy properties.
    * @param source2 The second source object from which to copy properties.
@@ -28,7 +28,7 @@ export class ObjectUtils {
 
   /**
    * Copy the values of all of the enumerable own properties from one or more source objects to a
-   * target object. Returns the target object.
+   * target object.
    * @param target The target object to copy to.
    * @param sources One or more source objects from which to copy properties
    */

--- a/test/other-issues/custom-user-data/custom-user-data.ts
+++ b/test/other-issues/custom-user-data/custom-user-data.ts
@@ -1,0 +1,176 @@
+import sinon from "sinon";
+import {Connection} from "../../../src/connection/Connection";
+import {createTestingConnections, closeTestingConnections, reloadTestingDatabases } from "../../utils/test-utils";
+import { SimpleConsoleLogger, EntityManager } from "../../../src";
+import { Foo } from "./entity/Foo";
+
+describe("other issues > capture custom user data in logger (e.g. trace id)", () => {
+    let connections: Connection[];
+    let manager: EntityManager;
+    let logQueryStub: sinon.SinonStub;
+    const testFoo: Foo = {
+        id: 1,
+        name: "foo",
+    };
+
+    before(async() => {
+        logQueryStub = sinon.stub(SimpleConsoleLogger.prototype, "logQuery");
+        connections = await createTestingConnections({
+            enabledDrivers: ["postgres"],
+            entities: [Foo],
+            logging: true,
+            createLogger: () => new SimpleConsoleLogger(),
+        });
+    });
+    beforeEach(async () => {
+        await reloadTestingDatabases(connections);
+        await Promise.all(connections.map(connection => connection.getRepository(Foo).insert(testFoo)));
+    });
+    afterEach(async () => {
+        await Promise.all(connections.map(connection => connection.getRepository(Foo).delete({})));
+        logQueryStub.resetHistory();
+    });
+    after(() => {
+        closeTestingConnections(connections);
+        logQueryStub.restore();
+    });
+
+    describe("when attaching user data to request-scoped entity manager", () => {
+
+        const tests = [{
+            testTarget: "entity manager query",
+            testFunc: async() => await manager.query("SELECT * FROM foo"),
+            loggerArgs: [
+                ["SELECT * FROM foo", undefined]
+            ],
+        },{
+            testTarget: "entity manager transaction",
+            testFunc: async() => await manager.transaction(trx => trx.query("SELECT * FROM foo")),
+            loggerArgs: [
+                ["START TRANSACTION", undefined],
+                ["SELECT * FROM foo", undefined],
+                ["COMMIT", undefined]
+            ],
+        }, {
+            testTarget: "repository save query",
+            testFunc: async() => await manager.getRepository(Foo).save({id: 2, name: "secondFoo"}),
+            loggerArgs: [
+                ["START TRANSACTION", undefined],
+                [`INSERT INTO "foo"("name", "delete_date") VALUES ($1, DEFAULT) RETURNING "id", "delete_date"`, ["secondFoo"]],
+                ["COMMIT", undefined]
+            ],
+        }, {
+            testTarget: "repository remove query",
+            testFunc: async() => await manager.getRepository(Foo).remove({id: 2, name: "secondFoo"}),
+            loggerArgs: [
+                ["START TRANSACTION", undefined],
+                [`DELETE FROM "foo" WHERE "id" = $1`, [2]],
+                ["COMMIT", undefined]
+            ],
+        }, {
+            testTarget: "repository soft remove query",
+            testFunc: async() => await manager.getRepository(Foo).softRemove({id: 1, name: "foo"}),
+            loggerArgs: [
+                ["START TRANSACTION", undefined],
+                [`UPDATE "foo" SET "delete_date" = CURRENT_TIMESTAMP WHERE "id" IN ($1)`, [1]],
+                ["COMMIT", undefined]
+            ],
+        }, {
+            testTarget: "repository recover query",
+            testFunc: async() => await manager.getRepository(Foo).recover({id: 1, name: "foo"}),
+            loggerArgs: [
+                ["START TRANSACTION", undefined],
+                [`UPDATE "foo" SET "delete_date" = NULL WHERE "id" IN ($1)`, [1]],
+                ["COMMIT", undefined]
+            ],
+        }, {
+            testTarget: "repository insert query",
+            testFunc: async() => await manager.getRepository(Foo).insert({id: 2, name: "secondFoo"}),
+            loggerArgs: [
+                [`INSERT INTO "foo"("name", "delete_date") VALUES ($1, DEFAULT) RETURNING "id", "delete_date"`, ["secondFoo"]]
+            ],
+        }, {
+            testTarget: "repository update query",
+            testFunc: async() => await manager.getRepository(Foo).update(1, {name: "foo2"}),
+            loggerArgs: [
+                [`UPDATE "foo" SET "name" = $2 WHERE "id" IN ($1)`, [1, "foo2"]]
+            ],
+        }, {
+            testTarget: "repository delete query",
+            testFunc: async() => await manager.getRepository(Foo).delete({}),
+            loggerArgs: [
+                [`DELETE FROM "foo"`, []]
+            ],
+        }, {
+            testTarget: "repository soft-delete query",
+            testFunc: async() => await manager.getRepository(Foo).softDelete({}),
+            loggerArgs: [
+                [`UPDATE "foo" SET "delete_date" = CURRENT_TIMESTAMP`, []]
+            ],
+        }, {
+            testTarget: "repository restore query",
+            testFunc: async() => await manager.getRepository(Foo).restore({id: 1}),
+            loggerArgs: [
+                [`UPDATE "foo" SET "delete_date" = NULL WHERE "id" = $1`, [1]]
+            ],
+        }, {
+            testTarget: "repository count query",
+            testFunc: async() => await manager.getRepository(Foo).count(),
+            loggerArgs: [
+                [`SELECT COUNT(1) AS "cnt" FROM "foo" "Foo" WHERE "Foo"."delete_date" IS NULL`, []]
+            ],
+        }, {
+            testTarget: "repository find query",
+            testFunc: async() => await manager.getRepository(Foo).find(),
+            loggerArgs: [
+                [`SELECT "Foo"."id" AS "Foo_id", "Foo"."name" AS "Foo_name", "Foo"."delete_date" AS "Foo_delete_date" FROM "foo" "Foo" WHERE "Foo"."delete_date" IS NULL`, []]
+            ],
+        }, {
+            testTarget: "repository findAndCount query",
+            testFunc: async() => await manager.getRepository(Foo).findAndCount(),
+            loggerArgs: [
+                [`SELECT "Foo"."id" AS "Foo_id", "Foo"."name" AS "Foo_name", "Foo"."delete_date" AS "Foo_delete_date" FROM "foo" "Foo" WHERE "Foo"."delete_date" IS NULL`, []]
+            ],
+        }, {
+            testTarget: "repository findByIds",
+            testFunc: async() => await manager.getRepository(Foo).findByIds([1]),
+            loggerArgs: [
+                [`SELECT "Foo"."id" AS "Foo_id", "Foo"."name" AS "Foo_name", "Foo"."delete_date" AS "Foo_delete_date" FROM "foo" "Foo" WHERE ( "Foo"."id" IN ($1) ) AND ( "Foo"."delete_date" IS NULL )`, [1]]
+            ],
+        },{
+            testTarget: "repository findOne query",
+            testFunc: async() => await manager.getRepository(Foo).findOne(),
+            loggerArgs: [
+                [`SELECT "Foo"."id" AS "Foo_id", "Foo"."name" AS "Foo_name", "Foo"."delete_date" AS "Foo_delete_date" FROM "foo" "Foo" WHERE "Foo"."delete_date" IS NULL LIMIT 1`, []]
+            ],
+        }, {
+            testTarget: "repository clear query",
+            testFunc: async() => await manager.getRepository(Foo).clear(),
+            loggerArgs: [
+                [`TRUNCATE TABLE "foo"`, undefined]
+            ],
+        }, {
+            testTarget: "repository increment query",
+            testFunc: async() => await manager.getRepository(Foo).increment({}, "id", 1),
+            loggerArgs: [
+                [`UPDATE "foo" SET "id" = "id" + 1`, []]
+            ],
+        }];
+
+        tests.forEach(({testTarget, testFunc, loggerArgs}) => {
+            it(`${testTarget} passes the data to the logger`, async () => Promise.all(connections.map(async connection => {
+                manager = connection.createEntityManager();
+                manager.data = { trace_id: "request-id" };
+                await testFunc();
+                loggerArgs.forEach((args: [string, any]) => {
+                    sinon.assert.calledWith(
+                        logQueryStub,
+                        args[0], // query
+                        args[1], // params
+                        sinon.match.hasNested("data.trace_id", "request-id"), // queryRunner with trace_id
+                    );
+                });
+            })));
+        });
+    });
+});

--- a/test/other-issues/custom-user-data/entity/Foo.ts
+++ b/test/other-issues/custom-user-data/entity/Foo.ts
@@ -1,0 +1,17 @@
+import {
+  Column,
+  Entity,
+  PrimaryGeneratedColumn,
+  DeleteDateColumn,
+} from "../../../../src";
+
+@Entity("foo")
+export class Foo {
+  @PrimaryGeneratedColumn("increment") public id: number;
+
+  @Column()
+  public name: string;
+
+  @DeleteDateColumn()
+  delete_date?: string;
+}


### PR DESCRIPTION
Only QueryRunner currently accepts custom user-data.

This commit allows data to be added to local instances of EntityManager (and QueryBuilder).

Makes it possible to pass request tracing data to the query logger.

### Description of change

**Current behaviour**: `data` property is only exposed via the `QueryRunner`, or passed automatically when using persist/remove methods. There is, to my knowledge, no way to attach the data to "transient" runners created and released by typeorm when executing regular queries.

**New behaviour**: you can pass user data to local instances of `EntityManager`, which in turn passes it to any "transient" query runners - examples in the tests.

**Rationale**: The `data` property is very useful for attaching tracing information at the request level. For example if you get some sort of `connection terminated` error, you can trace the log back to the original http request. However, you either need to use 1 query runner per request (makes no difference for transactional requests, but adds a bottleneck for the rest: once you've run out of connections in the pool, new requests have to wait for the last one to complete), or rewrite all the queries manually to get the runner and attach the data each time. We have some very long running `GET` requests that make both these alternatives difficult.

Let me know if there's any feedback or concerns.

### Pull-Request Checklist

- [x] Code is up-to-date with the `master` branch
- [x] `npm run lint` passes with this change
- [x] `npm run test` passes with this change
- ~[ ] This pull request links relevant issues as `Fixes #0000`~ N/A
- [x] There are new or updated unit tests validating the change
- [x] Documentation has been updated to reflect this change
- [x] The new commits follow conventions explained in [CONTRIBUTING.md](https://github.com/typeorm/typeorm/blob/master/CONTRIBUTING.md)