### PR TITLE
fix DeprecationWarning. insert is deprecated. Use insertOne.

### DIFF
--- a/src/migration/MigrationExecutor.ts
+++ b/src/migration/MigrationExecutor.ts
@@ -455,7 +455,7 @@ export class MigrationExecutor {
         }
         if (this.connection.driver instanceof MongoDriver) {
             const mongoRunner = queryRunner as MongoQueryRunner;
-            await mongoRunner.databaseConnection.db(this.connection.driver.database!).collection(this.migrationsTableName).insert(values);
+            await mongoRunner.databaseConnection.db(this.connection.driver.database!).collection(this.migrationsTableName).insertOne(values);
         } else {
             const qb = queryRunner.manager.createQueryBuilder();
             await qb.insert()


### PR DESCRIPTION
Removes warning messages that occur during migration.

This message only occurs when using MongoDB.
 
```
(node:47523) DeprecationWarning: collection.insert is deprecated. Use insertOne, insertMany or bulkWrite instead.
```

### Description of change

`collection.insert` is deprecated. Change it to `insertOne`.


### Pull-Request Checklist

- [x] Code is up-to-date with the `master` branch
- [x] `npm run lint` passes with this change
- [x] `npm run test` passes with this change
- [ ] This pull request links relevant issues as `Fixes #0000`
- [ ] There are new or updated unit tests validating the change
- [ ] Documentation has been updated to reflect this change
- [x] The new commits follow conventions explained in [CONTRIBUTING.md](https://github.com/typeorm/typeorm/blob/master/CONTRIBUTING.md)
