### PR TITLE
Fix #6958

### DIFF
--- a/src/driver/postgres/PostgresDriver.ts
+++ b/src/driver/postgres/PostgresDriver.ts
@@ -1051,7 +1051,10 @@ export class PostgresDriver implements Driver {
      * Closes connection pool.
      */
     protected async closePool(pool: any): Promise<void> {
-        await Promise.all(this.connectedQueryRunners.map(queryRunner => queryRunner.release()));
+        while (this.connectedQueryRunners.length) {
+            await this.connectedQueryRunners[0].release();
+        }
+
         return new Promise<void>((ok, fail) => {
             pool.end((err: any) => err ? fail(err) : ok());
         });

--- a/src/driver/postgres/PostgresQueryRunner.ts
+++ b/src/driver/postgres/PostgresQueryRunner.ts
@@ -127,7 +127,7 @@ export class PostgresQueryRunner extends BaseQueryRunner implements QueryRunner 
             this.releaseCallback();
 
         const index = this.driver.connectedQueryRunners.indexOf(this);
-        if (index !== -1) this.driver.connectedQueryRunners.splice(index);
+        if (index !== -1) this.driver.connectedQueryRunners.splice(index, 1);
 
         return Promise.resolve();
     }

--- a/test/github-issues/6958/issue-6958.ts
+++ b/test/github-issues/6958/issue-6958.ts
@@ -1,0 +1,28 @@
+import "reflect-metadata";
+import { createTestingConnections, closeTestingConnections, reloadTestingDatabases } from "../../utils/test-utils";
+import { Connection } from "../../../src/connection/Connection";
+import { PostgresDriver } from "../../../src/driver/postgres/PostgresDriver";
+import { expect } from "chai";
+
+describe("github issues > #6958 Promises never get resolved in specific cases", () => {
+
+    let connections: Connection[];
+    before(async () => connections = await createTestingConnections({
+        enabledDrivers: ["postgres"],
+    }));
+    beforeEach(() => reloadTestingDatabases(connections));
+    after(() => closeTestingConnections(connections));
+
+    it("should release all used query runners upon disconnection", () => Promise.all(connections.map(async connection => {
+        const runner1 = connection.createQueryRunner();
+        await runner1.query("SELECT 1 as foo;"); // dummy query to ensure that a database connection is established
+        const runner2 = connection.createQueryRunner();
+        await runner2.query("SELECT 2 as foo;");
+
+        await connection.close();
+
+        expect(runner1.isReleased).to.be.true;
+        expect(runner2.isReleased).to.be.true;
+        expect((connection.driver as PostgresDriver).connectedQueryRunners.length).to.equal(0);
+    })));
+});


### PR DESCRIPTION
### Description of change

When releasing a used query runner on postgres' driver, `splice()` was used without limiting the number of elements to be deleted, causing all the query runners to be removed, thus, preventing the driver from releasing them properly. So, the callback on https://github.com/typeorm/typeorm/blob/f85f436f51fb000cd9959b44e8d7a79bf0cd10ab/src/driver/postgres/PostgresDriver.ts#L1056 was never called on node-postgres and the promise never resolved. 

I created a test based on the issue's demo, which works now.

Fixes #6958

### Pull-Request Checklist

- [x] Code is up-to-date with the `master` branch
- [x] `npm run lint` passes with this change
- [x] `npm run test` passes with this change
- [x] This pull request links relevant issues as `Fixes #0000`
- [x] There are new or updated unit tests validating the change
- [ ] Documentation has been updated to reflect this change N/A
- [x] The new commits follow conventions explained in [CONTRIBUTING.md](https://github.com/typeorm/typeorm/blob/master/CONTRIBUTING.md)