### PR TITLE
feat: add schema support for orphanedRowAction

### DIFF
--- a/src/entity-schema/EntitySchemaRelationOptions.ts
+++ b/src/entity-schema/EntitySchemaRelationOptions.ts
@@ -98,4 +98,8 @@ export interface EntitySchemaRelationOptions {
      */
     deferrable?: DeferrableType;
 
+    /**
+     * When a child row is removed from its parent, determines if the child row should be orphaned (default) or deleted.
+     */
+    orphanedRowAction?: "nullify" | "delete";
 }

--- a/src/entity-schema/EntitySchemaTransformer.ts
+++ b/src/entity-schema/EntitySchemaTransformer.ts
@@ -136,7 +136,8 @@ export class EntitySchemaTransformer {
                             onUpdate: relationSchema.onUpdate,
                             deferrable: relationSchema.deferrable,
                             primary: relationSchema.primary,
-                            persistence: relationSchema.persistence
+                            persistence: relationSchema.persistence,
+                            orphanedRowAction: relationSchema.orphanedRowAction
                         }
                     };
 


### PR DESCRIPTION
Adds support for setting the action for orphaned relation rows when using separate entity definitions

Fixes #7417

### Description of change

As described in #7105 it's useful to be able to delete an orphaned relationships row however that pull request only added support for enabling the behaviour with decorators. This pull request also adds support for the `orphanedRowAction` prop in `EntitySchemaRelationOptions` so we can also use it when defining our models using separate entity schemas.

### Pull-Request Checklist

- [x] Code is up-to-date with the `master` branch
- [x] `npm run lint` passes with this change
- [x] `npm run test` passes with this change
- [x] This pull request links relevant issues as `Fixes #0000`
- [ ] There are new or updated unit tests validating the change
- [ ] Documentation has been updated to reflect this change
- [x] The new commits follow conventions explained in [CONTRIBUTING.md](https://github.com/typeorm/typeorm/blob/master/CONTRIBUTING.md)