### PR TITLE
Feature/cache option ignore errors

### DIFF
--- a/docs/caching.md
+++ b/docs/caching.md
@@ -249,7 +249,7 @@ Example:
             host: "localhost",
             port: 6379
         },
-        ignoreErrors:true
+        ignoreErrors: true
     }
 }
 ```

--- a/docs/caching.md
+++ b/docs/caching.md
@@ -234,4 +234,24 @@ class CustomQueryResultCache implements QueryResultCache {
 }
 ```
 
+If you wish to ignore cache errors and want the queries to pass through to database in case of cache errors, you can use ignoreErrors option. 
+Example:
+
+```typescript
+{
+    type: "mysql",
+    host: "localhost",
+    username: "test",
+    ...
+    cache: {
+        type: "redis",
+        options: {
+            host: "localhost",
+            port: 6379
+        },
+        ignoreErrors:true
+    }
+}
+```
+
 You can use `typeorm cache:clear` to clear everything stored in the cache.

--- a/src/connection/BaseConnectionOptions.ts
+++ b/src/connection/BaseConnectionOptions.ts
@@ -151,6 +151,10 @@ export interface BaseConnectionOptions {
          */
         readonly duration?: number;
 
+        /**
+         * Used to specify if cache errors should be ignored, and pass through the call to the Database.
+         */
+        readonly ignoreErrors?: boolean;
     };
 
     /**


### PR DESCRIPTION
### Description of change

In case of cache errors like network failure, redis out of memory etc, default behaviour is to return that error to the caller. 
But there are some cases where cache is only there to minimize database calls and its failure can be tolerated.
Issue https://github.com/typeorm/typeorm/issues/926 has been pending for this purpose.  

This change introduces cacheoption - `ignoreErrors` and based on its value decides to throw the cache error or not. 

Closes #926 


### Pull-Request Checklist

- [x] Code is up-to-date with the `master` branch
- [x] `npm run lint` passes with this change
- [x] `npm run test` passes with this change
- [x] This pull request links relevant issues as `Fixes #0000`
- [ ] There are new or updated unit tests validating the change
- [x] Documentation has been updated to reflect this change
- [x] The new commits follow conventions explained in [CONTRIBUTING.md](https://github.com/typeorm/typeorm/blob/master/CONTRIBUTING.md)
