### PR TITLE
Support max execution time for MySQL driver.

### DIFF
--- a/docs/select-query-builder.md
+++ b/docs/select-query-builder.md
@@ -22,6 +22,7 @@
 * [Streaming result data](#streaming-result-data)
 * [Using pagination](#using-pagination)
 * [Set locking](#set-locking)
+* [Max execution time](#max-execution-time)
 * [Partial selection](#partial-selection)
 * [Using subqueries](#using-subqueries)
 * [Hidden Columns](#hidden-columns)
@@ -913,6 +914,17 @@ const users = await getRepository(User)
 ```
 
 Optimistic locking works in conjunction with both `@Version` and `@UpdatedDate` decorators.
+
+## Max execution time
+
+We can drop slow query to avoid crashing the server. Only MySQL driver is supported at the moment:
+
+```typescript
+const users = await getRepository(User)
+    .createQueryBuilder("user")
+    .maxExecutionTime(1000) // milliseconds.
+    .getMany();
+```
 
 ## Partial selection
 

--- a/src/query-builder/QueryExpressionMap.ts
+++ b/src/query-builder/QueryExpressionMap.ts
@@ -47,6 +47,11 @@ export class QueryExpressionMap {
     selects: SelectQuery[] = [];
 
     /**
+     * Max execution time in millisecond.
+     */
+    maxExecutionTime: number = 0;
+
+    /**
      * Whether SELECT is DISTINCT.
      */
     selectDistinct: boolean = false;
@@ -399,6 +404,7 @@ export class QueryExpressionMap {
         const map = new QueryExpressionMap(this.connection);
         map.queryType = this.queryType;
         map.selects = this.selects.map(select => select);
+        map.maxExecutionTime = this.maxExecutionTime;
         map.selectDistinct = this.selectDistinct;
         map.selectDistinctOn = this.selectDistinctOn;
         this.aliases.forEach(alias => map.aliases.push(new Alias(alias)));

--- a/test/functional/query-builder/select/query-builder-select.ts
+++ b/test/functional/query-builder/select/query-builder-select.ts
@@ -4,6 +4,7 @@ import {Connection} from "../../../../src/connection/Connection";
 import {Post} from "./entity/Post";
 import {expect} from "chai";
 import {EntityNotFoundError} from "../../../../src/error/EntityNotFoundError";
+import { MysqlDriver } from '../../../../src/driver/mysql/MysqlDriver';
 
 describe("query builder > select", () => {
 
@@ -153,4 +154,16 @@ describe("query builder > select", () => {
             .getOneOrFail()
         ).to.be.rejectedWith(EntityNotFoundError);
     })));
+
+    it("Support max execution time", async () => Promise.all(
+        connections
+            .filter(connection => connection.driver instanceof MysqlDriver)
+            .map(async connection => {
+                const sql = connection
+                    .createQueryBuilder(Post, "post")
+                    .maxExecutionTime(1000)
+                    .getSql();
+                expect(sql).contains("SELECT /*+ MAX_EXECUTION_TIME(1000) */");
+            })
+    ));
 });


### PR DESCRIPTION
### Description of change

Support  `MAX_EXECUTION_TIME` hint for MySQL driver.

Fix #7639

### Pull-Request Checklist

- [x] Code is up-to-date with the `master` branch
- [x] `npm run lint` passes with this change
- [x] `npm run test` passes with this change
- [x] This pull request links relevant issues as `Fixes #0000`
- [x] There are new or updated unit tests validating the change
- [x] Documentation has been updated to reflect this change
- [x] The new commits follow conventions explained in [CONTRIBUTING.md](https://github.com/typeorm/typeorm/blob/master/CONTRIBUTING.md)
