### PR TITLE
Fix Redirecting for "cascades"

### DIFF
--- a/docs/one-to-one-relations.md
+++ b/docs/one-to-one-relations.md
@@ -82,7 +82,7 @@ user.profile = profile;
 await connection.manager.save(user);
 ```
 
-With [cascades](https://github.com/typeorm/typeorm/blob/master/docs/relations.md#cascades) enabled you can save this relation with only one `save` call.
+With <a href="https://github.com/typeorm/typeorm/blob/master/docs/relations.md#cascades" target="_blank">cascades</a> enabled you can save this relation with only one `save` call.
 
 To load user with profile inside you must specify relation in `FindOptions`:
  


### PR DESCRIPTION
### Description of change

Reason: When documentation opened in browser, on clicking the "cascades" link, it indeed redirects to `https://typeorm.io/#/https://github.com/typeorm/typeorm/blob/master/docs/relations/cascades` instead of `https://github.com/typeorm/typeorm/blob/master/docs/relations/cascades`