### PR TITLE
fix: postgres: do a deep comparison to see if the default value has changed for json types

### DIFF
--- a/test/github-issues/7650/entity/Test.ts
+++ b/test/github-issues/7650/entity/Test.ts
@@ -1,0 +1,13 @@
+import { Column, Entity, PrimaryColumn } from "../../../../src";
+
+@Entity()
+export class Test {
+    @PrimaryColumn()
+    id: number;
+
+    @Column({
+        type: 'jsonb',
+        default: {"z": 1, "a": 2},
+    })
+    myjsoncolumn: string;
+}

--- a/test/github-issues/7650/issue-7650.ts
+++ b/test/github-issues/7650/issue-7650.ts
@@ -1,0 +1,29 @@
+import "reflect-metadata";
+import { expect } from "chai";
+import { Connection } from "../../../src";
+import { closeTestingConnections, createTestingConnections, reloadTestingDatabases } from "../../utils/test-utils";
+import { Test } from "./entity/Test";
+
+describe("github issues > #7650 Inappropriate migration generated", () => {
+
+    let connections: Connection[];
+
+    before(async () => {
+        connections = await createTestingConnections({
+            enabledDrivers: ["postgres"],
+            entities: [Test],
+            schemaCreate: true,
+            dropSchema: true
+        });
+    });
+    beforeEach(() => reloadTestingDatabases(connections));
+    after(() => closeTestingConnections(connections));
+
+    it("should not create migrations for json default which are equivalent", () =>
+        Promise.all(connections.map(async (connection) => {
+            const sqlInMemory = await connection.driver.createSchemaBuilder().log();
+
+            expect(sqlInMemory.upQueries).to.eql([]);
+            expect(sqlInMemory.downQueries).to.eql([]);
+        })));
+});


### PR DESCRIPTION
<!--
  😀 Wonderful!  Thank you for opening a pull request for TypeORM.

  Please fill in the information below to expedite the review
  and (hopefully) merge of your change.

  If unsure about something.. just do as best as you're able,
  or reach out through our community support channels!
  https://github.com/typeorm/typeorm/blob/master/docs/support.md
-->

### Description of change

Hello. First of all, I am not a typeorm expert but this is my attempt at solving a problem that I encountered. Please feel free to update this branch to make any kind of change (maintainers can update the branch). I may very well have missed certain edge cases since I did not test this extensively.

Postgres sorts the `json` and `jsonb` values before saving them. Additionally, postgres has different whitespacing than `JSON.serialize` so just pre-sorting the values will still cause persistent migrations. So if you have anything other than an empty object then you will always see a persistent migration. This PR adds a new method that parses the JSON default that is used in the table, and then does a `deepCompare` on the two objects.

This kind of thing is already done in another part of the code:

https://github.com/typeorm/typeorm/blob/beea2e1e4429d13d7864ebc23aa6e58fa01647ea/src/persistence/SubjectChangedColumnsComputer.ts#L103-L109

Example:

```typescript
  @Column({
    type: 'jsonb',
    default: {"z": 1, "a": 2},
  })
  myjsoncolumn: string;
```

First migration:

```typescript
    public async up(queryRunner: QueryRunner): Promise<void> {
        await queryRunner.query(`ALTER TABLE "mytable" ADD "myjsoncolumn" jsonb NOT NULL DEFAULT '{"z":1,"a":2}'`);
    }

    public async down(queryRunner: QueryRunner): Promise<void> {
        await queryRunner.query(`ALTER TABLE "mytable" DROP COLUMN "myjsoncolumn"`);
    }
```

But then any subsequent migrations will always contain:

```typescript
    public async up(queryRunner: QueryRunner): Promise<void> {
        await queryRunner.query(`ALTER TABLE "mytable" ALTER COLUMN "myjsoncolumn" SET DEFAULT '{"z":1,"a":2}'`);
    }

    public async down(queryRunner: QueryRunner): Promise<void> {
        await queryRunner.query(`ALTER TABLE "mytable" ALTER COLUMN "myjsoncolumn" SET DEFAULT '{"a": 2, "z": 1}'`);
    }
```

<!--
  Please be clear and concise what the change is intended to do,
  why this change is needed, and how you've verified that it
  corrects what you intended.

  In some cases it may be helpful to include the current behavior
  and the new behavior.

  If the change is related to an open issue, you can link it here.
  If you include `Fixes #0000` (replacing `0000` with the issue number)
  when this is merged it will automatically mark the issue as fixed and
  close it.
-->


### Pull-Request Checklist

Sorry, I had issues running `npm install` because I'm on an Apple M1 computer. Got this error:

```
% npm install
npm ERR! code 87
npm ERR! path /Users/stefan/source/typeorm/node_modules/oracledb
npm ERR! command failed
npm ERR! command sh -c node package/install.js
npm ERR! oracledb ERR! NJS-067: a pre-built node-oracledb binary was not found for darwin arm64
npm ERR! oracledb ERR! Try compiling node-oracledb source code using https://oracle.github.io/node-oracledb/INSTALL.html#github
```

So if someone else can do the polishing that would be awesome. Thank you!

<!--
  Please make sure to review and check all of the following.

  If an item is not applicable, you can add "N/A" to the end.
-->

- [x] Code is up-to-date with the `master` branch
- [x] `npm run lint` passes with this change
- [ ] `npm run test` passes with this change
- [ ] This pull request links relevant issues as `Fixes #0000`
- [x] There are new or updated unit tests validating the change
- [ ] Documentation has been updated to reflect this change
- [ ] The new commits follow conventions explained in [CONTRIBUTING.md](https://github.com/typeorm/typeorm/blob/master/CONTRIBUTING.md)

<!--
  🎉 Thank you for contributing and making TypeORM even better!
-->
