### PR TITLE
Commit insert transaction before broadcasting after insert event

### DIFF
--- a/src/query-builder/InsertQueryBuilder.ts
+++ b/src/query-builder/InsertQueryBuilder.ts
@@ -117,6 +117,13 @@ export class InsertQueryBuilder<Entity> extends QueryBuilder<Entity> {
                 // console.timeEnd(".updating entity");
             }
 
+            // close transaction if we started it
+            // console.time(".commit");
+            if (transactionStartedByUs) {
+                await queryRunner.commitTransaction();
+            }
+            // console.timeEnd(".commit");
+
             // call after insertion methods in listeners and subscribers
             if (this.expressionMap.callListeners === true && this.expressionMap.mainAlias!.hasMetadata) {
                 const broadcastResult = new BroadcasterResult();
@@ -125,13 +132,6 @@ export class InsertQueryBuilder<Entity> extends QueryBuilder<Entity> {
                 });
                 if (broadcastResult.promises.length > 0) await Promise.all(broadcastResult.promises);
             }
-
-            // close transaction if we started it
-            // console.time(".commit");
-            if (transactionStartedByUs) {
-                await queryRunner.commitTransaction();
-            }
-            // console.timeEnd(".commit");
 
             return insertResult;
 
@@ -632,15 +632,15 @@ export class InsertQueryBuilder<Entity> extends QueryBuilder<Entity> {
 
     /**
      * Checks if column is an auto-generated primary key, but the current insertion specifies a value for it.
-     * 
+     *
      * @param column
      */
     protected isOverridingAutoIncrementBehavior(column: ColumnMetadata): boolean {
-        return column.isPrimary 
-                && column.isGenerated 
+        return column.isPrimary
+                && column.isGenerated
                 && column.generationStrategy === "increment"
-                && this.getValueSets().some((valueSet) => 
-                    column.getEntityValue(valueSet) !== undefined 
+                && this.getValueSets().some((valueSet) =>
+                    column.getEntityValue(valueSet) !== undefined
                     && column.getEntityValue(valueSet) !== null
                 );
     }


### PR DESCRIPTION
<!--
  😀 Wonderful!  Thank you for opening a pull request for TypeORM.

  Please fill in the information below to expedite the review
  and (hopefully) merge of your change.

  If unsure about something.. just do as best as you're able,
  or reach out through our community support channels!
  https://github.com/typeorm/typeorm/blob/master/docs/support.md
-->

### Description of change

Fixes #6450 

Commits an insert transaction before broadcasting the after insert event. Fixes issue #6450. We have been having a similar issue as described there. When the `afterInsert` event is triggered, we would like to emit a job to our queue worker that will index the entity data in elastic search. However, we have noticed that we cannot fetch the entity from the database at the time that the subscriber event is triggered. As the issue describes, this is because the `afterInsert` event is broadcasted before the entity is committed to the database. This PR flips that code around.

### Pull-Request Checklist

- [X] Code is up-to-date with the `master` branch
- [X] `npm run lint` passes with this change
- [X] `npm run test` passes with this change
- [X] This pull request links relevant issues as `Fixes #0000`
- [ ] There are new or updated unit tests validating the change
- [ ] Documentation has been updated to reflect this change
- [X] The new commits follow conventions explained in [CONTRIBUTING.md](https://github.com/typeorm/typeorm/blob/master/CONTRIBUTING.md)

<!--
  🎉 Thank you for contributing and making TypeORM even better!
-->
