### PR TITLE
add set datatype support for aurora-data-api

### DIFF
--- a/src/driver/aurora-data-api/AuroraDataApiDriver.ts
+++ b/src/driver/aurora-data-api/AuroraDataApiDriver.ts
@@ -445,7 +445,7 @@ export class AuroraDataApiDriver implements Driver {
         } else if (columnMetadata.type === "simple-array" || columnMetadata.type === "set") {
             return DateUtils.simpleArrayToString(value);
 
-	} else if (columnMetadata.type === "simple-json") {
+        } else if (columnMetadata.type === "simple-json") {
             return DateUtils.simpleJsonToString(value);
 
         } else if (columnMetadata.type === "enum" || columnMetadata.type === "simple-enum") {

--- a/src/driver/aurora-data-api/AuroraDataApiDriver.ts
+++ b/src/driver/aurora-data-api/AuroraDataApiDriver.ts
@@ -1,27 +1,28 @@
-import { Driver } from "../Driver";
-import { DriverUtils } from "../DriverUtils";
-import { AuroraDataApiQueryRunner } from "./AuroraDataApiQueryRunner";
-import { ObjectLiteral } from "../../common/ObjectLiteral";
-import { ColumnMetadata } from "../../metadata/ColumnMetadata";
-import { DateUtils } from "../../util/DateUtils";
-import { PlatformTools } from "../../platform/PlatformTools";
-import { Connection } from "../../connection/Connection";
-import { RdbmsSchemaBuilder } from "../../schema-builder/RdbmsSchemaBuilder";
-import { AuroraDataApiConnectionOptions } from "./AuroraDataApiConnectionOptions";
-import { MappedColumnTypes } from "../types/MappedColumnTypes";
-import { ColumnType } from "../types/ColumnTypes";
-import { DataTypeDefaults } from "../types/DataTypeDefaults";
-import { TableColumn } from "../../schema-builder/table/TableColumn";
-import { AuroraDataApiConnectionCredentialsOptions } from "./AuroraDataApiConnectionCredentialsOptions";
-import { EntityMetadata } from "../../metadata/EntityMetadata";
-import { OrmUtils } from "../../util/OrmUtils";
-import { ApplyValueTransformers } from "../../util/ApplyValueTransformers";
-import { ReplicationMode } from "../types/ReplicationMode";
+import {Driver} from "../Driver";
+import {DriverUtils} from "../DriverUtils";
+import {AuroraDataApiQueryRunner} from "./AuroraDataApiQueryRunner";
+import {ObjectLiteral} from "../../common/ObjectLiteral";
+import {ColumnMetadata} from "../../metadata/ColumnMetadata";
+import {DateUtils} from "../../util/DateUtils";
+import {PlatformTools} from "../../platform/PlatformTools";
+import {Connection} from "../../connection/Connection";
+import {RdbmsSchemaBuilder} from "../../schema-builder/RdbmsSchemaBuilder";
+import {AuroraDataApiConnectionOptions} from "./AuroraDataApiConnectionOptions";
+import {MappedColumnTypes} from "../types/MappedColumnTypes";
+import {ColumnType} from "../types/ColumnTypes";
+import {DataTypeDefaults} from "../types/DataTypeDefaults";
+import {TableColumn} from "../../schema-builder/table/TableColumn";
+import {AuroraDataApiConnectionCredentialsOptions} from "./AuroraDataApiConnectionCredentialsOptions";
+import {EntityMetadata} from "../../metadata/EntityMetadata";
+import {OrmUtils} from "../../util/OrmUtils";
+import {ApplyValueTransformers} from "../../util/ApplyValueTransformers";
+import {ReplicationMode} from "../types/ReplicationMode";
 
 /**
  * Organizes communication with MySQL DBMS.
  */
 export class AuroraDataApiDriver implements Driver {
+
     // -------------------------------------------------------------------------
     // Public Properties
     // -------------------------------------------------------------------------
@@ -79,7 +80,7 @@ export class AuroraDataApiDriver implements Driver {
         // numeric types
         "bit",
         "int",
-        "integer", // synonym for int
+        "integer",          // synonym for int
         "tinyint",
         "smallint",
         "mediumint",
@@ -87,13 +88,13 @@ export class AuroraDataApiDriver implements Driver {
         "float",
         "double",
         "double precision", // synonym for double
-        "real", // synonym for double
+        "real",             // synonym for double
         "decimal",
-        "dec", // synonym for decimal
-        "numeric", // synonym for decimal
-        "fixed", // synonym for decimal
-        "bool", // synonym for tinyint
-        "boolean", // synonym for tinyint
+        "dec",              // synonym for decimal
+        "numeric",          // synonym for decimal
+        "fixed",            // synonym for decimal
+        "bool",             // synonym for tinyint
+        "boolean",          // synonym for tinyint
         // date and time types
         "date",
         "datetime",
@@ -102,10 +103,10 @@ export class AuroraDataApiDriver implements Driver {
         "year",
         // string types
         "char",
-        "nchar", // synonym for national char
+        "nchar",            // synonym for national char
         "national char",
         "varchar",
-        "nvarchar", // synonym for national varchar
+        "nvarchar",         // synonym for national varchar
         "national varchar",
         "blob",
         "text",
@@ -129,7 +130,7 @@ export class AuroraDataApiDriver implements Driver {
         "multipoint",
         "multilinestring",
         "multipolygon",
-        "geometrycollection",
+        "geometrycollection"
     ];
 
     /**
@@ -143,7 +144,7 @@ export class AuroraDataApiDriver implements Driver {
         "multipoint",
         "multilinestring",
         "multipolygon",
-        "geometrycollection",
+        "geometrycollection"
     ];
 
     /**
@@ -154,7 +155,7 @@ export class AuroraDataApiDriver implements Driver {
         "varchar",
         "nvarchar",
         "binary",
-        "varbinary",
+        "varbinary"
     ];
 
     /**
@@ -167,7 +168,7 @@ export class AuroraDataApiDriver implements Driver {
         "mediumint",
         "int",
         "integer",
-        "bigint",
+        "bigint"
     ];
 
     /**
@@ -184,7 +185,7 @@ export class AuroraDataApiDriver implements Driver {
         "real",
         "time",
         "datetime",
-        "timestamp",
+        "timestamp"
     ];
 
     /**
@@ -198,7 +199,7 @@ export class AuroraDataApiDriver implements Driver {
         "float",
         "double",
         "double precision",
-        "real",
+        "real"
     ];
 
     /**
@@ -218,7 +219,7 @@ export class AuroraDataApiDriver implements Driver {
         "float",
         "double",
         "double precision",
-        "real",
+        "real"
     ];
 
     /**
@@ -259,29 +260,30 @@ export class AuroraDataApiDriver implements Driver {
      * Used in the cases when length/precision/scale is not specified by user.
      */
     dataTypeDefaults: DataTypeDefaults = {
-        varchar: { length: 255 },
-        nvarchar: { length: 255 },
+        "varchar": { length: 255 },
+        "nvarchar": { length: 255 },
         "national varchar": { length: 255 },
-        char: { length: 1 },
-        binary: { length: 1 },
-        varbinary: { length: 255 },
-        decimal: { precision: 10, scale: 0 },
-        dec: { precision: 10, scale: 0 },
-        numeric: { precision: 10, scale: 0 },
-        fixed: { precision: 10, scale: 0 },
-        float: { precision: 12 },
-        double: { precision: 22 },
-        time: { precision: 0 },
-        datetime: { precision: 0 },
-        timestamp: { precision: 0 },
-        bit: { width: 1 },
-        int: { width: 11 },
-        integer: { width: 11 },
-        tinyint: { width: 4 },
-        smallint: { width: 6 },
-        mediumint: { width: 9 },
-        bigint: { width: 20 },
+        "char": { length: 1 },
+        "binary": { length: 1 },
+        "varbinary": { length: 255 },
+        "decimal": { precision: 10, scale: 0 },
+        "dec": { precision: 10, scale: 0 },
+        "numeric": { precision: 10, scale: 0 },
+        "fixed": { precision: 10, scale: 0 },
+        "float": { precision: 12 },
+        "double": { precision: 22 },
+        "time": { precision: 0 },
+        "datetime": { precision: 0 },
+        "timestamp": { precision: 0 },
+        "bit": { width: 1 },
+        "int": { width: 11 },
+        "integer": { width: 11 },
+        "tinyint": { width: 4 },
+        "smallint": { width: 6 },
+        "mediumint": { width: 9 },
+        "bigint": { width: 20 }
     };
+
 
     /**
      * Max length allowed by MySQL for aliases.
@@ -305,10 +307,9 @@ export class AuroraDataApiDriver implements Driver {
             this.options.secretArn,
             this.options.resourceArn,
             this.options.database,
-            (query: string, parameters?: any[]) =>
-                this.connection.logger.logQuery(query, parameters),
+            (query: string, parameters?: any[]) => this.connection.logger.logQuery(query, parameters),
             this.options.serviceConfigOptions,
-            this.options.formatOptions
+            this.options.formatOptions,
         );
 
         // validate options to make sure everything is set
@@ -330,7 +331,8 @@ export class AuroraDataApiDriver implements Driver {
     /**
      * Performs connection to the database.
      */
-    async connect(): Promise<void> {}
+    async connect(): Promise<void> {
+    }
 
     /**
      * Makes any action after connection (e.g. create extensions in Postgres driver).
@@ -342,7 +344,8 @@ export class AuroraDataApiDriver implements Driver {
     /**
      * Closes connection with the database.
      */
-    async disconnect(): Promise<void> {}
+    async disconnect(): Promise<void> {
+    }
 
     /**
      * Creates a schema builder used to build and sync a schema.
@@ -355,39 +358,27 @@ export class AuroraDataApiDriver implements Driver {
      * Creates a query runner used to execute database queries.
      */
     createQueryRunner(mode: ReplicationMode) {
-        return new AuroraDataApiQueryRunner(
-            this,
-            new this.DataApiDriver(
-                this.options.region,
-                this.options.secretArn,
-                this.options.resourceArn,
-                this.options.database,
-                (query: string, parameters?: any[]) =>
-                    this.connection.logger.logQuery(query, parameters),
-                this.options.serviceConfigOptions,
-                this.options.formatOptions
-            )
-        );
+        return new AuroraDataApiQueryRunner(this, new this.DataApiDriver(
+            this.options.region,
+            this.options.secretArn,
+            this.options.resourceArn,
+            this.options.database,
+            (query: string, parameters?: any[]) => this.connection.logger.logQuery(query, parameters),
+            this.options.serviceConfigOptions,
+            this.options.formatOptions,
+        ));
     }
 
     /**
      * Replaces parameters in the given sql with special escaping character
      * and an array of parameter names to be passed to a query.
      */
-    escapeQueryWithParameters(
-        sql: string,
-        parameters: ObjectLiteral,
-        nativeParameters: ObjectLiteral
-    ): [string, any[]] {
-        const escapedParameters: any[] = Object.keys(nativeParameters).map(
-            (key) => nativeParameters[key]
-        );
+    escapeQueryWithParameters(sql: string, parameters: ObjectLiteral, nativeParameters: ObjectLiteral): [string, any[]] {
+        const escapedParameters: any[] = Object.keys(nativeParameters).map(key => nativeParameters[key]);
         if (!parameters || !Object.keys(parameters).length)
             return [sql, escapedParameters];
 
-        const keys = Object.keys(parameters)
-            .map((parameter) => "(:(\\.\\.\\.)?" + parameter + "\\b)")
-            .join("|");
+        const keys = Object.keys(parameters).map(parameter => "(:(\\.\\.\\.)?" + parameter + "\\b)").join("|");
         sql = sql.replace(new RegExp(keys, "g"), (key: string) => {
             let value: any;
             if (key.substr(0, 4) === ":...") {
@@ -398,6 +389,7 @@ export class AuroraDataApiDriver implements Driver {
 
             if (value instanceof Function) {
                 return value();
+
             } else {
                 escapedParameters.push(value);
                 return "?";
@@ -417,11 +409,7 @@ export class AuroraDataApiDriver implements Driver {
      * Build full table name with database name, schema name and table name.
      * E.g. "myDB"."mySchema"."myTable"
      */
-    buildTableName(
-        tableName: string,
-        schema?: string,
-        database?: string
-    ): string {
+    buildTableName(tableName: string, schema?: string, database?: string): string {
         return database ? `${database}.${tableName}` : tableName;
     }
 
@@ -430,45 +418,37 @@ export class AuroraDataApiDriver implements Driver {
      */
     preparePersistentValue(value: any, columnMetadata: ColumnMetadata): any {
         if (columnMetadata.transformer)
-            value = ApplyValueTransformers.transformTo(
-                columnMetadata.transformer,
-                value
-            );
+            value = ApplyValueTransformers.transformTo(columnMetadata.transformer, value);
 
-        if (
-            !this.options.formatOptions ||
-            this.options.formatOptions.castParameters !== false
-        ) {
-            return this.client.preparePersistentValue(value, columnMetadata);
+        if (!this.options.formatOptions || this.options.formatOptions.castParameters !== false) {
+            return this.client.preparePersistentValue(value, columnMetadata)
         }
 
-        if (value === null || value === undefined) return value;
+        if (value === null || value === undefined)
+            return value;
 
         if (columnMetadata.type === Boolean) {
             return value === true ? 1 : 0;
+
         } else if (columnMetadata.type === "date") {
             return DateUtils.mixedDateToDateString(value);
+
         } else if (columnMetadata.type === "time") {
             return DateUtils.mixedDateToTimeString(value);
+
         } else if (columnMetadata.type === "json") {
             return JSON.stringify(value);
-        } else if (
-            columnMetadata.type === "timestamp" ||
-            columnMetadata.type === "datetime" ||
-            columnMetadata.type === Date
-        ) {
+
+        } else if (columnMetadata.type === "timestamp" || columnMetadata.type === "datetime" || columnMetadata.type === Date) {
             return DateUtils.mixedDateToDate(value);
-        } else if (
-            columnMetadata.type === "simple-array" ||
-            columnMetadata.type === "set"
-        ) {
+
+        } else if (columnMetadata.type === "simple-array" || columnMetadata.type === "set") {
             return DateUtils.simpleArrayToString(value);
-        } else if (columnMetadata.type === "simple-json") {
+
+	} else if (columnMetadata.type === "simple-json") {
             return DateUtils.simpleJsonToString(value);
-        } else if (
-            columnMetadata.type === "enum" ||
-            columnMetadata.type === "simple-enum"
-        ) {
+
+        } else if (columnMetadata.type === "enum" || columnMetadata.type === "simple-enum") {
             return "" + value;
         }
 
@@ -480,60 +460,43 @@ export class AuroraDataApiDriver implements Driver {
      */
     prepareHydratedValue(value: any, columnMetadata: ColumnMetadata): any {
         if (value === null || value === undefined)
-            return columnMetadata.transformer
-                ? ApplyValueTransformers.transformFrom(
-                      columnMetadata.transformer,
-                      value
-                  )
-                : value;
+            return columnMetadata.transformer ? ApplyValueTransformers.transformFrom(columnMetadata.transformer, value) : value;
 
-        if (
-            !this.options.formatOptions ||
-            this.options.formatOptions.castParameters !== false
-        ) {
-            return this.client.prepareHydratedValue(value, columnMetadata);
+        if (!this.options.formatOptions || this.options.formatOptions.castParameters !== false) {
+            return this.client.prepareHydratedValue(value, columnMetadata)
         }
 
-        if (
-            columnMetadata.type === Boolean ||
-            columnMetadata.type === "bool" ||
-            columnMetadata.type === "boolean"
-        ) {
+        if (columnMetadata.type === Boolean || columnMetadata.type === "bool" || columnMetadata.type === "boolean") {
             value = value ? true : false;
-        } else if (
-            columnMetadata.type === "datetime" ||
-            columnMetadata.type === Date
-        ) {
+
+        } else if (columnMetadata.type === "datetime" || columnMetadata.type === Date) {
             value = DateUtils.normalizeHydratedDate(value);
+
         } else if (columnMetadata.type === "date") {
             value = DateUtils.mixedDateToDateString(value);
+
         } else if (columnMetadata.type === "json") {
             value = typeof value === "string" ? JSON.parse(value) : value;
+
         } else if (columnMetadata.type === "time") {
             value = DateUtils.mixedTimeToString(value);
-        } else if (
-            columnMetadata.type === "simple-array" ||
-            columnMetadata.type === "set"
-        ) {
+
+        } else if (columnMetadata.type === "simple-array" || columnMetadata.type === "set") {
             value = DateUtils.stringToSimpleArray(value);
+
         } else if (columnMetadata.type === "simple-json") {
             value = DateUtils.stringToSimpleJson(value);
-        } else if (
-            (columnMetadata.type === "enum" ||
-                columnMetadata.type === "simple-enum") &&
-            columnMetadata.enum &&
-            !isNaN(value) &&
-            columnMetadata.enum.indexOf(parseInt(value)) >= 0
-        ) {
+
+        } else if ((columnMetadata.type === "enum" || columnMetadata.type === "simple-enum")
+            && columnMetadata.enum
+            && !isNaN(value)
+            && columnMetadata.enum.indexOf(parseInt(value)) >= 0) {
             // convert to number if that exists in possible enum options
             value = parseInt(value);
         }
 
         if (columnMetadata.transformer)
-            value = ApplyValueTransformers.transformFrom(
-                columnMetadata.transformer,
-                value
-            );
+            value = ApplyValueTransformers.transformFrom(columnMetadata.transformer, value);
 
         return value;
     }
@@ -541,53 +504,48 @@ export class AuroraDataApiDriver implements Driver {
     /**
      * Creates a database type from a given column metadata.
      */
-    normalizeType(column: {
-        type: ColumnType;
-        length?: number | string;
-        precision?: number | null;
-        scale?: number;
-    }): string {
+    normalizeType(column: { type: ColumnType, length?: number|string, precision?: number|null, scale?: number }): string {
         if (column.type === Number || column.type === "integer") {
             return "int";
+
         } else if (column.type === String) {
             return "varchar";
+
         } else if (column.type === Date) {
             return "datetime";
+
         } else if ((column.type as any) === Buffer) {
             return "blob";
+
         } else if (column.type === Boolean) {
             return "tinyint";
+
         } else if (column.type === "uuid") {
             return "varchar";
-        } else if (
-            column.type === "simple-array" ||
-            column.type === "simple-json"
-        ) {
+
+        } else if (column.type === "simple-array" || column.type === "simple-json") {
             return "text";
+
         } else if (column.type === "simple-enum") {
             return "enum";
-        } else if (
-            column.type === "double precision" ||
-            column.type === "real"
-        ) {
+
+        } else if (column.type === "double precision" || column.type === "real") {
             return "double";
-        } else if (
-            column.type === "dec" ||
-            column.type === "numeric" ||
-            column.type === "fixed"
-        ) {
+
+        } else if (column.type === "dec" || column.type === "numeric" || column.type === "fixed") {
             return "decimal";
+
         } else if (column.type === "bool" || column.type === "boolean") {
             return "tinyint";
-        } else if (
-            column.type === "nvarchar" ||
-            column.type === "national varchar"
-        ) {
+
+        } else if (column.type === "nvarchar" || column.type === "national varchar") {
             return "varchar";
+
         } else if (column.type === "nchar" || column.type === "national char") {
             return "char";
+
         } else {
-            return (column.type as string) || "";
+            return column.type as string || "";
         }
     }
 
@@ -598,27 +556,28 @@ export class AuroraDataApiDriver implements Driver {
         const defaultValue = columnMetadata.default;
 
         if (defaultValue === null) {
-            return undefined;
+            return undefined
         }
 
-        if (
-            (columnMetadata.type === "enum" ||
-                columnMetadata.type === "simple-enum") &&
-            defaultValue !== undefined
-        ) {
+        if ((columnMetadata.type === "enum" || columnMetadata.type === "simple-enum") && defaultValue !== undefined) {
             return `'${defaultValue}'`;
         }
-        if (columnMetadata.type === "set" && defaultValue !== undefined) {
+        if ((columnMetadata.type === "set") && defaultValue !== undefined) {
             return `'${DateUtils.simpleArrayToString(defaultValue)}'`;
+
         }
         if (typeof defaultValue === "number") {
             return "" + defaultValue;
+
         } else if (typeof defaultValue === "boolean") {
             return defaultValue === true ? "1" : "0";
+
         } else if (typeof defaultValue === "function") {
             return defaultValue();
+
         } else if (typeof defaultValue === "string") {
             return `'${defaultValue}'`;
+
         } else {
             return defaultValue;
         }
@@ -628,24 +587,21 @@ export class AuroraDataApiDriver implements Driver {
      * Normalizes "isUnique" value of the column.
      */
     normalizeIsUnique(column: ColumnMetadata): boolean {
-        return column.entityMetadata.indices.some(
-            (idx) =>
-                idx.isUnique &&
-                idx.columns.length === 1 &&
-                idx.columns[0] === column
-        );
+        return column.entityMetadata.indices.some(idx => idx.isUnique && idx.columns.length === 1 && idx.columns[0] === column);
     }
 
     /**
      * Returns default column lengths, which is required on column creation.
      */
-    getColumnLength(column: ColumnMetadata | TableColumn): string {
-        if (column.length) return column.length.toString();
+    getColumnLength(column: ColumnMetadata|TableColumn): string {
+        if (column.length)
+            return column.length.toString();
 
         /**
          * fix https://github.com/typeorm/typeorm/issues/1139
          */
-        if (column.generationStrategy === "uuid") return "36";
+        if (column.generationStrategy === "uuid")
+            return "36";
 
         switch (column.type) {
             case String:
@@ -669,23 +625,19 @@ export class AuroraDataApiDriver implements Driver {
         // used 'getColumnLength()' method, because MySQL requires column length for `varchar`, `nvarchar` and `varbinary` data types
         if (this.getColumnLength(column)) {
             type += `(${this.getColumnLength(column)})`;
+
         } else if (column.width) {
             type += `(${column.width})`;
-        } else if (
-            column.precision !== null &&
-            column.precision !== undefined &&
-            column.scale !== null &&
-            column.scale !== undefined
-        ) {
+
+        } else if (column.precision !== null && column.precision !== undefined && column.scale !== null && column.scale !== undefined) {
             type += `(${column.precision},${column.scale})`;
-        } else if (
-            column.precision !== null &&
-            column.precision !== undefined
-        ) {
+
+        } else if (column.precision !== null && column.precision !== undefined) {
             type += `(${column.precision})`;
         }
 
-        if (column.isArray) type += " array";
+        if (column.isArray)
+            type += " array";
 
         return type;
     }
@@ -698,26 +650,16 @@ export class AuroraDataApiDriver implements Driver {
     obtainMasterConnection(): Promise<any> {
         return new Promise<any>((ok, fail) => {
             if (this.poolCluster) {
-                this.poolCluster.getConnection(
-                    "MASTER",
-                    (err: any, dbConnection: any) => {
-                        err
-                            ? fail(err)
-                            : ok(this.prepareDbConnection(dbConnection));
-                    }
-                );
+                this.poolCluster.getConnection("MASTER", (err: any, dbConnection: any) => {
+                    err ? fail(err) : ok(this.prepareDbConnection(dbConnection));
+                });
+
             } else if (this.pool) {
                 this.pool.getConnection((err: any, dbConnection: any) => {
-                    err
-                        ? fail(err)
-                        : ok(this.prepareDbConnection(dbConnection));
+                    err ? fail(err) : ok(this.prepareDbConnection(dbConnection));
                 });
             } else {
-                fail(
-                    new Error(
-                        `Connection is not established with mysql database`
-                    )
-                );
+                fail(new Error(`Connection is not established with mysql database`));
             }
         });
     }
@@ -728,50 +670,33 @@ export class AuroraDataApiDriver implements Driver {
      * If replication is not setup then returns master (default) connection's database connection.
      */
     obtainSlaveConnection(): Promise<any> {
-        if (!this.poolCluster) return this.obtainMasterConnection();
+        if (!this.poolCluster)
+            return this.obtainMasterConnection();
 
         return new Promise<any>((ok, fail) => {
-            this.poolCluster.getConnection(
-                "SLAVE*",
-                (err: any, dbConnection: any) => {
-                    err
-                        ? fail(err)
-                        : ok(this.prepareDbConnection(dbConnection));
-                }
-            );
+            this.poolCluster.getConnection("SLAVE*", (err: any, dbConnection: any) => {
+                err ? fail(err) : ok(this.prepareDbConnection(dbConnection));
+            });
         });
     }
 
     /**
      * Creates generated map of values generated or returned by database after INSERT query.
      */
-    createGeneratedMap(
-        metadata: EntityMetadata,
-        insertResult: any,
-        entityIndex: number
-    ) {
-        const generatedMap = metadata.generatedColumns.reduce(
-            (map, generatedColumn) => {
-                let value: any;
-                if (
-                    generatedColumn.generationStrategy === "increment" &&
-                    insertResult.insertId
-                ) {
-                    // NOTE: When multiple rows is inserted by a single INSERT statement,
-                    // `insertId` is the value generated for the first inserted row only.
-                    value = insertResult.insertId + entityIndex;
-                    // } else if (generatedColumn.generationStrategy === "uuid") {
-                    //     console.log("getting db value:", generatedColumn.databaseName);
-                    //     value = generatedColumn.getEntityValue(uuidMap);
-                }
+    createGeneratedMap(metadata: EntityMetadata, insertResult: any, entityIndex: number) {
+        const generatedMap = metadata.generatedColumns.reduce((map, generatedColumn) => {
+            let value: any;
+            if (generatedColumn.generationStrategy === "increment" && insertResult.insertId) {
+                // NOTE: When multiple rows is inserted by a single INSERT statement,
+                // `insertId` is the value generated for the first inserted row only.
+                value = insertResult.insertId + entityIndex;
+            // } else if (generatedColumn.generationStrategy === "uuid") {
+            //     console.log("getting db value:", generatedColumn.databaseName);
+            //     value = generatedColumn.getEntityValue(uuidMap);
+            }
 
-                return OrmUtils.mergeDeep(
-                    map,
-                    generatedColumn.createValueMap(value)
-                );
-            },
-            {} as ObjectLiteral
-        );
+            return OrmUtils.mergeDeep(map, generatedColumn.createValueMap(value));
+        }, {} as ObjectLiteral);
 
         return Object.keys(generatedMap).length > 0 ? generatedMap : undefined;
     }
@@ -780,15 +705,11 @@ export class AuroraDataApiDriver implements Driver {
      * Differentiate columns of this table and columns from the given column metadatas columns
      * and returns only changed.
      */
-    findChangedColumns(
-        tableColumns: TableColumn[],
-        columnMetadatas: ColumnMetadata[]
-    ): ColumnMetadata[] {
-        return columnMetadatas.filter((columnMetadata) => {
-            const tableColumn = tableColumns.find(
-                (c) => c.name === columnMetadata.databaseName
-            );
-            if (!tableColumn) return false; // we don't need new columns, we only need exist and changed
+    findChangedColumns(tableColumns: TableColumn[], columnMetadatas: ColumnMetadata[]): ColumnMetadata[] {
+        return columnMetadatas.filter(columnMetadata => {
+            const tableColumn = tableColumns.find(c => c.name === columnMetadata.databaseName);
+            if (!tableColumn)
+                return false; // we don't need new columns, we only need exist and changed
 
             // console.log("table:", columnMetadata.entityMetadata.tableName);
             // console.log("name:", tableColumn.name, columnMetadata.databaseName);
@@ -814,45 +735,28 @@ export class AuroraDataApiDriver implements Driver {
             // console.log("==========================================");
 
             let columnMetadataLength = columnMetadata.length;
-            if (
-                !columnMetadataLength &&
-                columnMetadata.generationStrategy === "uuid"
-            ) {
-                // fixing #3374
+            if (!columnMetadataLength && columnMetadata.generationStrategy === "uuid") { // fixing #3374
                 columnMetadataLength = this.getColumnLength(columnMetadata);
             }
 
-            return (
-                tableColumn.name !== columnMetadata.databaseName ||
-                tableColumn.type !== this.normalizeType(columnMetadata) ||
-                tableColumn.length !== columnMetadataLength ||
-                tableColumn.width !== columnMetadata.width ||
-                tableColumn.precision !== columnMetadata.precision ||
-                tableColumn.scale !== columnMetadata.scale ||
-                tableColumn.zerofill !== columnMetadata.zerofill ||
-                tableColumn.unsigned !== columnMetadata.unsigned ||
-                tableColumn.asExpression !== columnMetadata.asExpression ||
-                tableColumn.generatedType !== columnMetadata.generatedType ||
-                tableColumn.comment !==
-                    this.escapeComment(columnMetadata.comment) ||
-                !this.compareDefaultValues(
-                    this.normalizeDefault(columnMetadata),
-                    tableColumn.default
-                ) ||
-                (tableColumn.enum &&
-                    columnMetadata.enum &&
-                    !OrmUtils.isArraysEqual(
-                        tableColumn.enum,
-                        columnMetadata.enum.map((val) => val + "")
-                    )) ||
-                tableColumn.onUpdate !== columnMetadata.onUpdate ||
-                tableColumn.isPrimary !== columnMetadata.isPrimary ||
-                tableColumn.isNullable !== columnMetadata.isNullable ||
-                tableColumn.isUnique !==
-                    this.normalizeIsUnique(columnMetadata) ||
-                (columnMetadata.generationStrategy !== "uuid" &&
-                    tableColumn.isGenerated !== columnMetadata.isGenerated)
-            );
+            return tableColumn.name !== columnMetadata.databaseName
+                || tableColumn.type !== this.normalizeType(columnMetadata)
+                || tableColumn.length !== columnMetadataLength
+                || tableColumn.width !== columnMetadata.width
+                || tableColumn.precision !== columnMetadata.precision
+                || tableColumn.scale !== columnMetadata.scale
+                || tableColumn.zerofill !== columnMetadata.zerofill
+                || tableColumn.unsigned !== columnMetadata.unsigned
+                || tableColumn.asExpression !== columnMetadata.asExpression
+                || tableColumn.generatedType !== columnMetadata.generatedType
+                || tableColumn.comment !== this.escapeComment(columnMetadata.comment)
+                || !this.compareDefaultValues(this.normalizeDefault(columnMetadata), tableColumn.default)
+                || (tableColumn.enum && columnMetadata.enum && !OrmUtils.isArraysEqual(tableColumn.enum, columnMetadata.enum.map(val => val + "")))
+                || tableColumn.onUpdate !== columnMetadata.onUpdate
+                || tableColumn.isPrimary !== columnMetadata.isPrimary
+                || tableColumn.isNullable !== columnMetadata.isNullable
+                || tableColumn.isUnique !== this.normalizeIsUnique(columnMetadata)
+                || (columnMetadata.generationStrategy !== "uuid" && tableColumn.isGenerated !== columnMetadata.isGenerated);
         });
     }
 
@@ -892,9 +796,7 @@ export class AuroraDataApiDriver implements Driver {
      * Loads all driver dependencies.
      */
     protected loadDependencies(): void {
-        this.DataApiDriver = PlatformTools.load(
-            "typeorm-aurora-data-api-driver"
-        );
+        this.DataApiDriver = PlatformTools.load("typeorm-aurora-data-api-driver");
 
         // Driver uses rollup for publishing, which has issues when using typeorm in combination with webpack
         // See https://github.com/webpack/webpack/issues/4742#issuecomment-295556787
@@ -904,37 +806,27 @@ export class AuroraDataApiDriver implements Driver {
     /**
      * Creates a new connection pool for a given database credentials.
      */
-    protected createConnectionOptions(
-        options: AuroraDataApiConnectionOptions,
-        credentials: AuroraDataApiConnectionCredentialsOptions
-    ): Promise<any> {
-        credentials = Object.assign(
-            {},
-            credentials,
-            DriverUtils.buildDriverOptions(credentials)
-        ); // todo: do it better way
+    protected createConnectionOptions(options: AuroraDataApiConnectionOptions, credentials: AuroraDataApiConnectionCredentialsOptions): Promise<any> {
+
+        credentials = Object.assign({}, credentials, DriverUtils.buildDriverOptions(credentials)); // todo: do it better way
 
         // build connection options for the driver
-        return Object.assign(
-            {},
-            {
-                resourceArn: options.resourceArn,
-                secretArn: options.secretArn,
-                database: options.database,
-                region: options.region,
-                type: options.type,
-            },
-            {
-                host: credentials.host,
-                user: credentials.username,
-                password: credentials.password,
-                database: credentials.database,
-                port: credentials.port,
-                ssl: options.ssl,
-            },
+        return Object.assign({}, {
+            resourceArn: options.resourceArn,
+            secretArn: options.secretArn,
+            database: options.database,
+            region: options.region,
+            type: options.type,
+        }, {
+            host: credentials.host,
+            user: credentials.username,
+            password: credentials.password,
+            database: credentials.database,
+            port: credentials.port,
+            ssl: options.ssl
+        },
 
-            options.extra || {}
-        );
+        options.extra || {});
     }
 
     /**
@@ -954,9 +846,7 @@ export class AuroraDataApiDriver implements Driver {
           cause the hosting app to crash.
          */
         if (connection.listeners("error").length === 0) {
-            connection.on("error", (error: any) =>
-                logger.log("warn", `MySQL connection raised an error. ${error}`)
-            );
+            connection.on("error", (error: any) => logger.log("warn", `MySQL connection raised an error. ${error}`));
         }
         return connection;
     }
@@ -964,14 +854,8 @@ export class AuroraDataApiDriver implements Driver {
     /**
      * Checks if "DEFAULT" values in the column metadata and in the database are equal.
      */
-    protected compareDefaultValues(
-        columnMetadataValue: string | undefined,
-        databaseValue: string | undefined
-    ): boolean {
-        if (
-            typeof columnMetadataValue === "string" &&
-            typeof databaseValue === "string"
-        ) {
+    protected compareDefaultValues(columnMetadataValue: string | undefined, databaseValue: string | undefined): boolean {
+        if (typeof columnMetadataValue === "string" && typeof databaseValue === "string") {
             // we need to cut out "'" because in mysql we can understand returned value is a string or a function
             // as result compare cannot understand if default is really changed or not
             columnMetadataValue = columnMetadataValue.replace(/^'+|'+$/g, "");
@@ -985,10 +869,11 @@ export class AuroraDataApiDriver implements Driver {
      * Escapes a given comment.
      */
     protected escapeComment(comment?: string) {
-        if (!comment) return comment;
+        if (!comment)  return comment;
 
         comment = comment.replace(/\u0000/g, ""); // Null bytes aren't allowed in comments
 
         return comment;
     }
+
 }

--- a/src/driver/aurora-data-api/AuroraDataApiDriver.ts
+++ b/src/driver/aurora-data-api/AuroraDataApiDriver.ts
@@ -1,28 +1,27 @@
-import {Driver} from "../Driver";
-import {DriverUtils} from "../DriverUtils";
-import {AuroraDataApiQueryRunner} from "./AuroraDataApiQueryRunner";
-import {ObjectLiteral} from "../../common/ObjectLiteral";
-import {ColumnMetadata} from "../../metadata/ColumnMetadata";
-import {DateUtils} from "../../util/DateUtils";
-import {PlatformTools} from "../../platform/PlatformTools";
-import {Connection} from "../../connection/Connection";
-import {RdbmsSchemaBuilder} from "../../schema-builder/RdbmsSchemaBuilder";
-import {AuroraDataApiConnectionOptions} from "./AuroraDataApiConnectionOptions";
-import {MappedColumnTypes} from "../types/MappedColumnTypes";
-import {ColumnType} from "../types/ColumnTypes";
-import {DataTypeDefaults} from "../types/DataTypeDefaults";
-import {TableColumn} from "../../schema-builder/table/TableColumn";
-import {AuroraDataApiConnectionCredentialsOptions} from "./AuroraDataApiConnectionCredentialsOptions";
-import {EntityMetadata} from "../../metadata/EntityMetadata";
-import {OrmUtils} from "../../util/OrmUtils";
-import {ApplyValueTransformers} from "../../util/ApplyValueTransformers";
-import {ReplicationMode} from "../types/ReplicationMode";
+import { Driver } from "../Driver";
+import { DriverUtils } from "../DriverUtils";
+import { AuroraDataApiQueryRunner } from "./AuroraDataApiQueryRunner";
+import { ObjectLiteral } from "../../common/ObjectLiteral";
+import { ColumnMetadata } from "../../metadata/ColumnMetadata";
+import { DateUtils } from "../../util/DateUtils";
+import { PlatformTools } from "../../platform/PlatformTools";
+import { Connection } from "../../connection/Connection";
+import { RdbmsSchemaBuilder } from "../../schema-builder/RdbmsSchemaBuilder";
+import { AuroraDataApiConnectionOptions } from "./AuroraDataApiConnectionOptions";
+import { MappedColumnTypes } from "../types/MappedColumnTypes";
+import { ColumnType } from "../types/ColumnTypes";
+import { DataTypeDefaults } from "../types/DataTypeDefaults";
+import { TableColumn } from "../../schema-builder/table/TableColumn";
+import { AuroraDataApiConnectionCredentialsOptions } from "./AuroraDataApiConnectionCredentialsOptions";
+import { EntityMetadata } from "../../metadata/EntityMetadata";
+import { OrmUtils } from "../../util/OrmUtils";
+import { ApplyValueTransformers } from "../../util/ApplyValueTransformers";
+import { ReplicationMode } from "../types/ReplicationMode";
 
 /**
  * Organizes communication with MySQL DBMS.
  */
 export class AuroraDataApiDriver implements Driver {
-
     // -------------------------------------------------------------------------
     // Public Properties
     // -------------------------------------------------------------------------
@@ -80,7 +79,7 @@ export class AuroraDataApiDriver implements Driver {
         // numeric types
         "bit",
         "int",
-        "integer",          // synonym for int
+        "integer", // synonym for int
         "tinyint",
         "smallint",
         "mediumint",
@@ -88,13 +87,13 @@ export class AuroraDataApiDriver implements Driver {
         "float",
         "double",
         "double precision", // synonym for double
-        "real",             // synonym for double
+        "real", // synonym for double
         "decimal",
-        "dec",              // synonym for decimal
-        "numeric",          // synonym for decimal
-        "fixed",            // synonym for decimal
-        "bool",             // synonym for tinyint
-        "boolean",          // synonym for tinyint
+        "dec", // synonym for decimal
+        "numeric", // synonym for decimal
+        "fixed", // synonym for decimal
+        "bool", // synonym for tinyint
+        "boolean", // synonym for tinyint
         // date and time types
         "date",
         "datetime",
@@ -103,10 +102,10 @@ export class AuroraDataApiDriver implements Driver {
         "year",
         // string types
         "char",
-        "nchar",            // synonym for national char
+        "nchar", // synonym for national char
         "national char",
         "varchar",
-        "nvarchar",         // synonym for national varchar
+        "nvarchar", // synonym for national varchar
         "national varchar",
         "blob",
         "text",
@@ -117,6 +116,7 @@ export class AuroraDataApiDriver implements Driver {
         "longblob",
         "longtext",
         "enum",
+        "set",
         "binary",
         "varbinary",
         // json data type
@@ -129,7 +129,7 @@ export class AuroraDataApiDriver implements Driver {
         "multipoint",
         "multilinestring",
         "multipolygon",
-        "geometrycollection"
+        "geometrycollection",
     ];
 
     /**
@@ -143,7 +143,7 @@ export class AuroraDataApiDriver implements Driver {
         "multipoint",
         "multilinestring",
         "multipolygon",
-        "geometrycollection"
+        "geometrycollection",
     ];
 
     /**
@@ -154,7 +154,7 @@ export class AuroraDataApiDriver implements Driver {
         "varchar",
         "nvarchar",
         "binary",
-        "varbinary"
+        "varbinary",
     ];
 
     /**
@@ -167,7 +167,7 @@ export class AuroraDataApiDriver implements Driver {
         "mediumint",
         "int",
         "integer",
-        "bigint"
+        "bigint",
     ];
 
     /**
@@ -184,7 +184,7 @@ export class AuroraDataApiDriver implements Driver {
         "real",
         "time",
         "datetime",
-        "timestamp"
+        "timestamp",
     ];
 
     /**
@@ -198,7 +198,7 @@ export class AuroraDataApiDriver implements Driver {
         "float",
         "double",
         "double precision",
-        "real"
+        "real",
     ];
 
     /**
@@ -218,7 +218,7 @@ export class AuroraDataApiDriver implements Driver {
         "float",
         "double",
         "double precision",
-        "real"
+        "real",
     ];
 
     /**
@@ -259,30 +259,29 @@ export class AuroraDataApiDriver implements Driver {
      * Used in the cases when length/precision/scale is not specified by user.
      */
     dataTypeDefaults: DataTypeDefaults = {
-        "varchar": { length: 255 },
-        "nvarchar": { length: 255 },
+        varchar: { length: 255 },
+        nvarchar: { length: 255 },
         "national varchar": { length: 255 },
-        "char": { length: 1 },
-        "binary": { length: 1 },
-        "varbinary": { length: 255 },
-        "decimal": { precision: 10, scale: 0 },
-        "dec": { precision: 10, scale: 0 },
-        "numeric": { precision: 10, scale: 0 },
-        "fixed": { precision: 10, scale: 0 },
-        "float": { precision: 12 },
-        "double": { precision: 22 },
-        "time": { precision: 0 },
-        "datetime": { precision: 0 },
-        "timestamp": { precision: 0 },
-        "bit": { width: 1 },
-        "int": { width: 11 },
-        "integer": { width: 11 },
-        "tinyint": { width: 4 },
-        "smallint": { width: 6 },
-        "mediumint": { width: 9 },
-        "bigint": { width: 20 }
+        char: { length: 1 },
+        binary: { length: 1 },
+        varbinary: { length: 255 },
+        decimal: { precision: 10, scale: 0 },
+        dec: { precision: 10, scale: 0 },
+        numeric: { precision: 10, scale: 0 },
+        fixed: { precision: 10, scale: 0 },
+        float: { precision: 12 },
+        double: { precision: 22 },
+        time: { precision: 0 },
+        datetime: { precision: 0 },
+        timestamp: { precision: 0 },
+        bit: { width: 1 },
+        int: { width: 11 },
+        integer: { width: 11 },
+        tinyint: { width: 4 },
+        smallint: { width: 6 },
+        mediumint: { width: 9 },
+        bigint: { width: 20 },
     };
-
 
     /**
      * Max length allowed by MySQL for aliases.
@@ -306,9 +305,10 @@ export class AuroraDataApiDriver implements Driver {
             this.options.secretArn,
             this.options.resourceArn,
             this.options.database,
-            (query: string, parameters?: any[]) => this.connection.logger.logQuery(query, parameters),
+            (query: string, parameters?: any[]) =>
+                this.connection.logger.logQuery(query, parameters),
             this.options.serviceConfigOptions,
-            this.options.formatOptions,
+            this.options.formatOptions
         );
 
         // validate options to make sure everything is set
@@ -330,8 +330,7 @@ export class AuroraDataApiDriver implements Driver {
     /**
      * Performs connection to the database.
      */
-    async connect(): Promise<void> {
-    }
+    async connect(): Promise<void> {}
 
     /**
      * Makes any action after connection (e.g. create extensions in Postgres driver).
@@ -343,8 +342,7 @@ export class AuroraDataApiDriver implements Driver {
     /**
      * Closes connection with the database.
      */
-    async disconnect(): Promise<void> {
-    }
+    async disconnect(): Promise<void> {}
 
     /**
      * Creates a schema builder used to build and sync a schema.
@@ -357,27 +355,39 @@ export class AuroraDataApiDriver implements Driver {
      * Creates a query runner used to execute database queries.
      */
     createQueryRunner(mode: ReplicationMode) {
-        return new AuroraDataApiQueryRunner(this, new this.DataApiDriver(
-            this.options.region,
-            this.options.secretArn,
-            this.options.resourceArn,
-            this.options.database,
-            (query: string, parameters?: any[]) => this.connection.logger.logQuery(query, parameters),
-            this.options.serviceConfigOptions,
-            this.options.formatOptions,
-        ));
+        return new AuroraDataApiQueryRunner(
+            this,
+            new this.DataApiDriver(
+                this.options.region,
+                this.options.secretArn,
+                this.options.resourceArn,
+                this.options.database,
+                (query: string, parameters?: any[]) =>
+                    this.connection.logger.logQuery(query, parameters),
+                this.options.serviceConfigOptions,
+                this.options.formatOptions
+            )
+        );
     }
 
     /**
      * Replaces parameters in the given sql with special escaping character
      * and an array of parameter names to be passed to a query.
      */
-    escapeQueryWithParameters(sql: string, parameters: ObjectLiteral, nativeParameters: ObjectLiteral): [string, any[]] {
-        const escapedParameters: any[] = Object.keys(nativeParameters).map(key => nativeParameters[key]);
+    escapeQueryWithParameters(
+        sql: string,
+        parameters: ObjectLiteral,
+        nativeParameters: ObjectLiteral
+    ): [string, any[]] {
+        const escapedParameters: any[] = Object.keys(nativeParameters).map(
+            (key) => nativeParameters[key]
+        );
         if (!parameters || !Object.keys(parameters).length)
             return [sql, escapedParameters];
 
-        const keys = Object.keys(parameters).map(parameter => "(:(\\.\\.\\.)?" + parameter + "\\b)").join("|");
+        const keys = Object.keys(parameters)
+            .map((parameter) => "(:(\\.\\.\\.)?" + parameter + "\\b)")
+            .join("|");
         sql = sql.replace(new RegExp(keys, "g"), (key: string) => {
             let value: any;
             if (key.substr(0, 4) === ":...") {
@@ -388,7 +398,6 @@ export class AuroraDataApiDriver implements Driver {
 
             if (value instanceof Function) {
                 return value();
-
             } else {
                 escapedParameters.push(value);
                 return "?";
@@ -408,7 +417,11 @@ export class AuroraDataApiDriver implements Driver {
      * Build full table name with database name, schema name and table name.
      * E.g. "myDB"."mySchema"."myTable"
      */
-    buildTableName(tableName: string, schema?: string, database?: string): string {
+    buildTableName(
+        tableName: string,
+        schema?: string,
+        database?: string
+    ): string {
         return database ? `${database}.${tableName}` : tableName;
     }
 
@@ -417,37 +430,45 @@ export class AuroraDataApiDriver implements Driver {
      */
     preparePersistentValue(value: any, columnMetadata: ColumnMetadata): any {
         if (columnMetadata.transformer)
-            value = ApplyValueTransformers.transformTo(columnMetadata.transformer, value);
+            value = ApplyValueTransformers.transformTo(
+                columnMetadata.transformer,
+                value
+            );
 
-        if (!this.options.formatOptions || this.options.formatOptions.castParameters !== false) {
-            return this.client.preparePersistentValue(value, columnMetadata)
+        if (
+            !this.options.formatOptions ||
+            this.options.formatOptions.castParameters !== false
+        ) {
+            return this.client.preparePersistentValue(value, columnMetadata);
         }
 
-        if (value === null || value === undefined)
-            return value;
+        if (value === null || value === undefined) return value;
 
         if (columnMetadata.type === Boolean) {
             return value === true ? 1 : 0;
-
         } else if (columnMetadata.type === "date") {
             return DateUtils.mixedDateToDateString(value);
-
         } else if (columnMetadata.type === "time") {
             return DateUtils.mixedDateToTimeString(value);
-
         } else if (columnMetadata.type === "json") {
             return JSON.stringify(value);
-
-        } else if (columnMetadata.type === "timestamp" || columnMetadata.type === "datetime" || columnMetadata.type === Date) {
+        } else if (
+            columnMetadata.type === "timestamp" ||
+            columnMetadata.type === "datetime" ||
+            columnMetadata.type === Date
+        ) {
             return DateUtils.mixedDateToDate(value);
-
-        } else if (columnMetadata.type === "simple-array") {
+        } else if (
+            columnMetadata.type === "simple-array" ||
+            columnMetadata.type === "set"
+        ) {
             return DateUtils.simpleArrayToString(value);
-
         } else if (columnMetadata.type === "simple-json") {
             return DateUtils.simpleJsonToString(value);
-
-        } else if (columnMetadata.type === "enum" || columnMetadata.type === "simple-enum") {
+        } else if (
+            columnMetadata.type === "enum" ||
+            columnMetadata.type === "simple-enum"
+        ) {
             return "" + value;
         }
 
@@ -459,43 +480,60 @@ export class AuroraDataApiDriver implements Driver {
      */
     prepareHydratedValue(value: any, columnMetadata: ColumnMetadata): any {
         if (value === null || value === undefined)
-            return columnMetadata.transformer ? ApplyValueTransformers.transformFrom(columnMetadata.transformer, value) : value;
+            return columnMetadata.transformer
+                ? ApplyValueTransformers.transformFrom(
+                      columnMetadata.transformer,
+                      value
+                  )
+                : value;
 
-        if (!this.options.formatOptions || this.options.formatOptions.castParameters !== false) {
-            return this.client.prepareHydratedValue(value, columnMetadata)
+        if (
+            !this.options.formatOptions ||
+            this.options.formatOptions.castParameters !== false
+        ) {
+            return this.client.prepareHydratedValue(value, columnMetadata);
         }
 
-        if (columnMetadata.type === Boolean || columnMetadata.type === "bool" || columnMetadata.type === "boolean") {
+        if (
+            columnMetadata.type === Boolean ||
+            columnMetadata.type === "bool" ||
+            columnMetadata.type === "boolean"
+        ) {
             value = value ? true : false;
-
-        } else if (columnMetadata.type === "datetime" || columnMetadata.type === Date) {
+        } else if (
+            columnMetadata.type === "datetime" ||
+            columnMetadata.type === Date
+        ) {
             value = DateUtils.normalizeHydratedDate(value);
-
         } else if (columnMetadata.type === "date") {
             value = DateUtils.mixedDateToDateString(value);
-
         } else if (columnMetadata.type === "json") {
             value = typeof value === "string" ? JSON.parse(value) : value;
-
         } else if (columnMetadata.type === "time") {
             value = DateUtils.mixedTimeToString(value);
-
-        } else if (columnMetadata.type === "simple-array") {
+        } else if (
+            columnMetadata.type === "simple-array" ||
+            columnMetadata.type === "set"
+        ) {
             value = DateUtils.stringToSimpleArray(value);
-
         } else if (columnMetadata.type === "simple-json") {
             value = DateUtils.stringToSimpleJson(value);
-
-        } else if ((columnMetadata.type === "enum" || columnMetadata.type === "simple-enum")
-            && columnMetadata.enum
-            && !isNaN(value)
-            && columnMetadata.enum.indexOf(parseInt(value)) >= 0) {
+        } else if (
+            (columnMetadata.type === "enum" ||
+                columnMetadata.type === "simple-enum") &&
+            columnMetadata.enum &&
+            !isNaN(value) &&
+            columnMetadata.enum.indexOf(parseInt(value)) >= 0
+        ) {
             // convert to number if that exists in possible enum options
             value = parseInt(value);
         }
 
         if (columnMetadata.transformer)
-            value = ApplyValueTransformers.transformFrom(columnMetadata.transformer, value);
+            value = ApplyValueTransformers.transformFrom(
+                columnMetadata.transformer,
+                value
+            );
 
         return value;
     }
@@ -503,48 +541,53 @@ export class AuroraDataApiDriver implements Driver {
     /**
      * Creates a database type from a given column metadata.
      */
-    normalizeType(column: { type: ColumnType, length?: number|string, precision?: number|null, scale?: number }): string {
+    normalizeType(column: {
+        type: ColumnType;
+        length?: number | string;
+        precision?: number | null;
+        scale?: number;
+    }): string {
         if (column.type === Number || column.type === "integer") {
             return "int";
-
         } else if (column.type === String) {
             return "varchar";
-
         } else if (column.type === Date) {
             return "datetime";
-
         } else if ((column.type as any) === Buffer) {
             return "blob";
-
         } else if (column.type === Boolean) {
             return "tinyint";
-
         } else if (column.type === "uuid") {
             return "varchar";
-
-        } else if (column.type === "simple-array" || column.type === "simple-json") {
+        } else if (
+            column.type === "simple-array" ||
+            column.type === "simple-json"
+        ) {
             return "text";
-
         } else if (column.type === "simple-enum") {
             return "enum";
-
-        } else if (column.type === "double precision" || column.type === "real") {
+        } else if (
+            column.type === "double precision" ||
+            column.type === "real"
+        ) {
             return "double";
-
-        } else if (column.type === "dec" || column.type === "numeric" || column.type === "fixed") {
+        } else if (
+            column.type === "dec" ||
+            column.type === "numeric" ||
+            column.type === "fixed"
+        ) {
             return "decimal";
-
         } else if (column.type === "bool" || column.type === "boolean") {
             return "tinyint";
-
-        } else if (column.type === "nvarchar" || column.type === "national varchar") {
+        } else if (
+            column.type === "nvarchar" ||
+            column.type === "national varchar"
+        ) {
             return "varchar";
-
         } else if (column.type === "nchar" || column.type === "national char") {
             return "char";
-
         } else {
-            return column.type as string || "";
+            return (column.type as string) || "";
         }
     }
 
@@ -555,25 +598,27 @@ export class AuroraDataApiDriver implements Driver {
         const defaultValue = columnMetadata.default;
 
         if (defaultValue === null) {
-            return undefined
+            return undefined;
         }
 
-        if ((columnMetadata.type === "enum" || columnMetadata.type === "simple-enum") && defaultValue !== undefined) {
+        if (
+            (columnMetadata.type === "enum" ||
+                columnMetadata.type === "simple-enum") &&
+            defaultValue !== undefined
+        ) {
             return `'${defaultValue}'`;
         }
-
+        if (columnMetadata.type === "set" && defaultValue !== undefined) {
+            return `'${DateUtils.simpleArrayToString(defaultValue)}'`;
+        }
         if (typeof defaultValue === "number") {
             return "" + defaultValue;
-
         } else if (typeof defaultValue === "boolean") {
             return defaultValue === true ? "1" : "0";
-
         } else if (typeof defaultValue === "function") {
             return defaultValue();
-
         } else if (typeof defaultValue === "string") {
             return `'${defaultValue}'`;
-
         } else {
             return defaultValue;
         }
@@ -583,21 +628,24 @@ export class AuroraDataApiDriver implements Driver {
      * Normalizes "isUnique" value of the column.
      */
     normalizeIsUnique(column: ColumnMetadata): boolean {
-        return column.entityMetadata.indices.some(idx => idx.isUnique && idx.columns.length === 1 && idx.columns[0] === column);
+        return column.entityMetadata.indices.some(
+            (idx) =>
+                idx.isUnique &&
+                idx.columns.length === 1 &&
+                idx.columns[0] === column
+        );
     }
 
     /**
      * Returns default column lengths, which is required on column creation.
      */
-    getColumnLength(column: ColumnMetadata|TableColumn): string {
-        if (column.length)
-            return column.length.toString();
+    getColumnLength(column: ColumnMetadata | TableColumn): string {
+        if (column.length) return column.length.toString();
 
         /**
          * fix https://github.com/typeorm/typeorm/issues/1139
          */
-        if (column.generationStrategy === "uuid")
-            return "36";
+        if (column.generationStrategy === "uuid") return "36";
 
         switch (column.type) {
             case String:
@@ -621,19 +669,23 @@ export class AuroraDataApiDriver implements Driver {
         // used 'getColumnLength()' method, because MySQL requires column length for `varchar`, `nvarchar` and `varbinary` data types
         if (this.getColumnLength(column)) {
             type += `(${this.getColumnLength(column)})`;
-
         } else if (column.width) {
             type += `(${column.width})`;
-
-        } else if (column.precision !== null && column.precision !== undefined && column.scale !== null && column.scale !== undefined) {
+        } else if (
+            column.precision !== null &&
+            column.precision !== undefined &&
+            column.scale !== null &&
+            column.scale !== undefined
+        ) {
             type += `(${column.precision},${column.scale})`;
-
-        } else if (column.precision !== null && column.precision !== undefined) {
+        } else if (
+            column.precision !== null &&
+            column.precision !== undefined
+        ) {
             type += `(${column.precision})`;
         }
 
-        if (column.isArray)
-            type += " array";
+        if (column.isArray) type += " array";
 
         return type;
     }
@@ -646,16 +698,26 @@ export class AuroraDataApiDriver implements Driver {
     obtainMasterConnection(): Promise<any> {
         return new Promise<any>((ok, fail) => {
             if (this.poolCluster) {
-                this.poolCluster.getConnection("MASTER", (err: any, dbConnection: any) => {
-                    err ? fail(err) : ok(this.prepareDbConnection(dbConnection));
-                });
-
+                this.poolCluster.getConnection(
+                    "MASTER",
+                    (err: any, dbConnection: any) => {
+                        err
+                            ? fail(err)
+                            : ok(this.prepareDbConnection(dbConnection));
+                    }
+                );
             } else if (this.pool) {
                 this.pool.getConnection((err: any, dbConnection: any) => {
-                    err ? fail(err) : ok(this.prepareDbConnection(dbConnection));
+                    err
+                        ? fail(err)
+                        : ok(this.prepareDbConnection(dbConnection));
                 });
             } else {
-                fail(new Error(`Connection is not established with mysql database`));
+                fail(
+                    new Error(
+                        `Connection is not established with mysql database`
+                    )
+                );
             }
         });
     }
@@ -666,33 +728,50 @@ export class AuroraDataApiDriver implements Driver {
      * If replication is not setup then returns master (default) connection's database connection.
      */
     obtainSlaveConnection(): Promise<any> {
-        if (!this.poolCluster)
-            return this.obtainMasterConnection();
+        if (!this.poolCluster) return this.obtainMasterConnection();
 
         return new Promise<any>((ok, fail) => {
-            this.poolCluster.getConnection("SLAVE*", (err: any, dbConnection: any) => {
-                err ? fail(err) : ok(this.prepareDbConnection(dbConnection));
-            });
+            this.poolCluster.getConnection(
+                "SLAVE*",
+                (err: any, dbConnection: any) => {
+                    err
+                        ? fail(err)
+                        : ok(this.prepareDbConnection(dbConnection));
+                }
+            );
         });
     }
 
     /**
      * Creates generated map of values generated or returned by database after INSERT query.
      */
-    createGeneratedMap(metadata: EntityMetadata, insertResult: any, entityIndex: number) {
-        const generatedMap = metadata.generatedColumns.reduce((map, generatedColumn) => {
-            let value: any;
-            if (generatedColumn.generationStrategy === "increment" && insertResult.insertId) {
-                // NOTE: When multiple rows is inserted by a single INSERT statement,
-                // `insertId` is the value generated for the first inserted row only.
-                value = insertResult.insertId + entityIndex;
-            // } else if (generatedColumn.generationStrategy === "uuid") {
-            //     console.log("getting db value:", generatedColumn.databaseName);
-            //     value = generatedColumn.getEntityValue(uuidMap);
-            }
+    createGeneratedMap(
+        metadata: EntityMetadata,
+        insertResult: any,
+        entityIndex: number
+    ) {
+        const generatedMap = metadata.generatedColumns.reduce(
+            (map, generatedColumn) => {
+                let value: any;
+                if (
+                    generatedColumn.generationStrategy === "increment" &&
+                    insertResult.insertId
+                ) {
+                    // NOTE: When multiple rows is inserted by a single INSERT statement,
+                    // `insertId` is the value generated for the first inserted row only.
+                    value = insertResult.insertId + entityIndex;
+                    // } else if (generatedColumn.generationStrategy === "uuid") {
+                    //     console.log("getting db value:", generatedColumn.databaseName);
+                    //     value = generatedColumn.getEntityValue(uuidMap);
+                }
 
-            return OrmUtils.mergeDeep(map, generatedColumn.createValueMap(value));
-        }, {} as ObjectLiteral);
+                return OrmUtils.mergeDeep(
+                    map,
+                    generatedColumn.createValueMap(value)
+                );
+            },
+            {} as ObjectLiteral
+        );
 
         return Object.keys(generatedMap).length > 0 ? generatedMap : undefined;
     }
@@ -701,11 +780,15 @@ export class AuroraDataApiDriver implements Driver {
      * Differentiate columns of this table and columns from the given column metadatas columns
      * and returns only changed.
      */
-    findChangedColumns(tableColumns: TableColumn[], columnMetadatas: ColumnMetadata[]): ColumnMetadata[] {
-        return columnMetadatas.filter(columnMetadata => {
-            const tableColumn = tableColumns.find(c => c.name === columnMetadata.databaseName);
-            if (!tableColumn)
-                return false; // we don't need new columns, we only need exist and changed
+    findChangedColumns(
+        tableColumns: TableColumn[],
+        columnMetadatas: ColumnMetadata[]
+    ): ColumnMetadata[] {
+        return columnMetadatas.filter((columnMetadata) => {
+            const tableColumn = tableColumns.find(
+                (c) => c.name === columnMetadata.databaseName
+            );
+            if (!tableColumn) return false; // we don't need new columns, we only need exist and changed
 
             // console.log("table:", columnMetadata.entityMetadata.tableName);
             // console.log("name:", tableColumn.name, columnMetadata.databaseName);
@@ -731,28 +814,45 @@ export class AuroraDataApiDriver implements Driver {
             // console.log("==========================================");
 
             let columnMetadataLength = columnMetadata.length;
-            if (!columnMetadataLength && columnMetadata.generationStrategy === "uuid") { // fixing #3374
+            if (
+                !columnMetadataLength &&
+                columnMetadata.generationStrategy === "uuid"
+            ) {
+                // fixing #3374
                 columnMetadataLength = this.getColumnLength(columnMetadata);
             }
 
-            return tableColumn.name !== columnMetadata.databaseName
-                || tableColumn.type !== this.normalizeType(columnMetadata)
-                || tableColumn.length !== columnMetadataLength
-                || tableColumn.width !== columnMetadata.width
-                || tableColumn.precision !== columnMetadata.precision
-                || tableColumn.scale !== columnMetadata.scale
-                || tableColumn.zerofill !== columnMetadata.zerofill
-                || tableColumn.unsigned !== columnMetadata.unsigned
-                || tableColumn.asExpression !== columnMetadata.asExpression
-                || tableColumn.generatedType !== columnMetadata.generatedType
-                || tableColumn.comment !== this.escapeComment(columnMetadata.comment)
-                || !this.compareDefaultValues(this.normalizeDefault(columnMetadata), tableColumn.default)
-                || (tableColumn.enum && columnMetadata.enum && !OrmUtils.isArraysEqual(tableColumn.enum, columnMetadata.enum.map(val => val + "")))
-                || tableColumn.onUpdate !== columnMetadata.onUpdate
-                || tableColumn.isPrimary !== columnMetadata.isPrimary
-                || tableColumn.isNullable !== columnMetadata.isNullable
-                || tableColumn.isUnique !== this.normalizeIsUnique(columnMetadata)
-                || (columnMetadata.generationStrategy !== "uuid" && tableColumn.isGenerated !== columnMetadata.isGenerated);
+            return (
+                tableColumn.name !== columnMetadata.databaseName ||
+                tableColumn.type !== this.normalizeType(columnMetadata) ||
+                tableColumn.length !== columnMetadataLength ||
+                tableColumn.width !== columnMetadata.width ||
+                tableColumn.precision !== columnMetadata.precision ||
+                tableColumn.scale !== columnMetadata.scale ||
+                tableColumn.zerofill !== columnMetadata.zerofill ||
+                tableColumn.unsigned !== columnMetadata.unsigned ||
+                tableColumn.asExpression !== columnMetadata.asExpression ||
+                tableColumn.generatedType !== columnMetadata.generatedType ||
+                tableColumn.comment !==
+                    this.escapeComment(columnMetadata.comment) ||
+                !this.compareDefaultValues(
+                    this.normalizeDefault(columnMetadata),
+                    tableColumn.default
+                ) ||
+                (tableColumn.enum &&
+                    columnMetadata.enum &&
+                    !OrmUtils.isArraysEqual(
+                        tableColumn.enum,
+                        columnMetadata.enum.map((val) => val + "")
+                    )) ||
+                tableColumn.onUpdate !== columnMetadata.onUpdate ||
+                tableColumn.isPrimary !== columnMetadata.isPrimary ||
+                tableColumn.isNullable !== columnMetadata.isNullable ||
+                tableColumn.isUnique !==
+                    this.normalizeIsUnique(columnMetadata) ||
+                (columnMetadata.generationStrategy !== "uuid" &&
+                    tableColumn.isGenerated !== columnMetadata.isGenerated)
+            );
         });
     }
 
@@ -792,7 +892,9 @@ export class AuroraDataApiDriver implements Driver {
      * Loads all driver dependencies.
      */
     protected loadDependencies(): void {
-        this.DataApiDriver = PlatformTools.load("typeorm-aurora-data-api-driver");
+        this.DataApiDriver = PlatformTools.load(
+            "typeorm-aurora-data-api-driver"
+        );
 
         // Driver uses rollup for publishing, which has issues when using typeorm in combination with webpack
         // See https://github.com/webpack/webpack/issues/4742#issuecomment-295556787
@@ -802,27 +904,37 @@ export class AuroraDataApiDriver implements Driver {
     /**
      * Creates a new connection pool for a given database credentials.
      */
-    protected createConnectionOptions(options: AuroraDataApiConnectionOptions, credentials: AuroraDataApiConnectionCredentialsOptions): Promise<any> {
-
-        credentials = Object.assign({}, credentials, DriverUtils.buildDriverOptions(credentials)); // todo: do it better way
+    protected createConnectionOptions(
+        options: AuroraDataApiConnectionOptions,
+        credentials: AuroraDataApiConnectionCredentialsOptions
+    ): Promise<any> {
+        credentials = Object.assign(
+            {},
+            credentials,
+            DriverUtils.buildDriverOptions(credentials)
+        ); // todo: do it better way
 
         // build connection options for the driver
-        return Object.assign({}, {
-            resourceArn: options.resourceArn,
-            secretArn: options.secretArn,
-            database: options.database,
-            region: options.region,
-            type: options.type,
-        }, {
-            host: credentials.host,
-            user: credentials.username,
-            password: credentials.password,
-            database: credentials.database,
-            port: credentials.port,
-            ssl: options.ssl
-        },
+        return Object.assign(
+            {},
+            {
+                resourceArn: options.resourceArn,
+                secretArn: options.secretArn,
+                database: options.database,
+                region: options.region,
+                type: options.type,
+            },
+            {
+                host: credentials.host,
+                user: credentials.username,
+                password: credentials.password,
+                database: credentials.database,
+                port: credentials.port,
+                ssl: options.ssl,
+            },
 
-        options.extra || {});
+            options.extra || {}
+        );
     }
 
     /**
@@ -842,7 +954,9 @@ export class AuroraDataApiDriver implements Driver {
           cause the hosting app to crash.
          */
         if (connection.listeners("error").length === 0) {
-            connection.on("error", (error: any) => logger.log("warn", `MySQL connection raised an error. ${error}`));
+            connection.on("error", (error: any) =>
+                logger.log("warn", `MySQL connection raised an error. ${error}`)
+            );
         }
         return connection;
     }
@@ -850,8 +964,14 @@ export class AuroraDataApiDriver implements Driver {
     /**
      * Checks if "DEFAULT" values in the column metadata and in the database are equal.
      */
-    protected compareDefaultValues(columnMetadataValue: string | undefined, databaseValue: string | undefined): boolean {
-        if (typeof columnMetadataValue === "string" && typeof databaseValue === "string") {
+    protected compareDefaultValues(
+        columnMetadataValue: string | undefined,
+        databaseValue: string | undefined
+    ): boolean {
+        if (
+            typeof columnMetadataValue === "string" &&
+            typeof databaseValue === "string"
+        ) {
             // we need to cut out "'" because in mysql we can understand returned value is a string or a function
             // as result compare cannot understand if default is really changed or not
             columnMetadataValue = columnMetadataValue.replace(/^'+|'+$/g, "");
@@ -865,11 +985,10 @@ export class AuroraDataApiDriver implements Driver {
      * Escapes a given comment.
      */
     protected escapeComment(comment?: string) {
-        if (!comment)  return comment;
+        if (!comment) return comment;
 
         comment = comment.replace(/\u0000/g, ""); // Null bytes aren't allowed in comments
 
         return comment;
     }
-
 }

--- a/src/driver/aurora-data-api/AuroraDataApiQueryRunner.ts
+++ b/src/driver/aurora-data-api/AuroraDataApiQueryRunner.ts
@@ -1,33 +1,32 @@
-import { QueryRunner } from "../../query-runner/QueryRunner";
-import { ObjectLiteral } from "../../common/ObjectLiteral";
-import { TransactionAlreadyStartedError } from "../../error/TransactionAlreadyStartedError";
-import { TransactionNotStartedError } from "../../error/TransactionNotStartedError";
-import { TableColumn } from "../../schema-builder/table/TableColumn";
-import { Table } from "../../schema-builder/table/Table";
-import { TableForeignKey } from "../../schema-builder/table/TableForeignKey";
-import { TableIndex } from "../../schema-builder/table/TableIndex";
-import { QueryRunnerAlreadyReleasedError } from "../../error/QueryRunnerAlreadyReleasedError";
-import { View } from "../../schema-builder/view/View";
-import { Query } from "../Query";
-import { AuroraDataApiDriver } from "./AuroraDataApiDriver";
-import { ReadStream } from "../../platform/PlatformTools";
-import { OrmUtils } from "../../util/OrmUtils";
-import { TableIndexOptions } from "../../schema-builder/options/TableIndexOptions";
-import { TableUnique } from "../../schema-builder/table/TableUnique";
-import { BaseQueryRunner } from "../../query-runner/BaseQueryRunner";
-import { Broadcaster } from "../../subscriber/Broadcaster";
-import { ColumnType } from "../../index";
-import { TableCheck } from "../../schema-builder/table/TableCheck";
-import { IsolationLevel } from "../types/IsolationLevel";
-import { TableExclusion } from "../../schema-builder/table/TableExclusion";
-import { BroadcasterResult } from "../../subscriber/BroadcasterResult";
+import {QueryRunner} from "../../query-runner/QueryRunner";
+import {ObjectLiteral} from "../../common/ObjectLiteral";
+import {TransactionAlreadyStartedError} from "../../error/TransactionAlreadyStartedError";
+import {TransactionNotStartedError} from "../../error/TransactionNotStartedError";
+import {TableColumn} from "../../schema-builder/table/TableColumn";
+import {Table} from "../../schema-builder/table/Table";
+import {TableForeignKey} from "../../schema-builder/table/TableForeignKey";
+import {TableIndex} from "../../schema-builder/table/TableIndex";
+import {QueryRunnerAlreadyReleasedError} from "../../error/QueryRunnerAlreadyReleasedError";
+import {View} from "../../schema-builder/view/View";
+import {Query} from "../Query";
+import {AuroraDataApiDriver} from "./AuroraDataApiDriver";
+import {ReadStream} from "../../platform/PlatformTools";
+import {OrmUtils} from "../../util/OrmUtils";
+import {TableIndexOptions} from "../../schema-builder/options/TableIndexOptions";
+import {TableUnique} from "../../schema-builder/table/TableUnique";
+import {BaseQueryRunner} from "../../query-runner/BaseQueryRunner";
+import {Broadcaster} from "../../subscriber/Broadcaster";
+import {ColumnType} from "../../index";
+import {TableCheck} from "../../schema-builder/table/TableCheck";
+import {IsolationLevel} from "../types/IsolationLevel";
+import {TableExclusion} from "../../schema-builder/table/TableExclusion";
+import {BroadcasterResult} from "../../subscriber/BroadcasterResult";
 
 /**
  * Runs queries on a single mysql database connection.
  */
-export class AuroraDataApiQueryRunner
-    extends BaseQueryRunner
-    implements QueryRunner {
+export class AuroraDataApiQueryRunner extends BaseQueryRunner implements QueryRunner {
+
     // -------------------------------------------------------------------------
     // Public Implemented Properties
     // -------------------------------------------------------------------------
@@ -38,7 +37,7 @@ export class AuroraDataApiQueryRunner
 
     driver: AuroraDataApiDriver;
 
-    protected client: any;
+    protected client: any
 
     // -------------------------------------------------------------------------
     // Protected Properties
@@ -79,7 +78,8 @@ export class AuroraDataApiQueryRunner
      */
     release(): Promise<void> {
         this.isReleased = true;
-        if (this.databaseConnection) this.databaseConnection.release();
+        if (this.databaseConnection)
+            this.databaseConnection.release();
         return Promise.resolve();
     }
 
@@ -91,21 +91,16 @@ export class AuroraDataApiQueryRunner
             throw new TransactionAlreadyStartedError();
 
         const beforeBroadcastResult = new BroadcasterResult();
-        this.broadcaster.broadcastBeforeTransactionStartEvent(
-            beforeBroadcastResult
-        );
-        if (beforeBroadcastResult.promises.length > 0)
-            await Promise.all(beforeBroadcastResult.promises);
+        this.broadcaster.broadcastBeforeTransactionStartEvent(beforeBroadcastResult);
+        if (beforeBroadcastResult.promises.length > 0) await Promise.all(beforeBroadcastResult.promises);
 
         this.isTransactionActive = true;
         await this.client.startTransaction();
 
+
         const afterBroadcastResult = new BroadcasterResult();
-        this.broadcaster.broadcastAfterTransactionStartEvent(
-            afterBroadcastResult
-        );
-        if (afterBroadcastResult.promises.length > 0)
-            await Promise.all(afterBroadcastResult.promises);
+        this.broadcaster.broadcastAfterTransactionStartEvent(afterBroadcastResult);
+        if (afterBroadcastResult.promises.length > 0) await Promise.all(afterBroadcastResult.promises);
     }
 
     /**
@@ -113,24 +108,19 @@ export class AuroraDataApiQueryRunner
      * Error will be thrown if transaction was not started.
      */
     async commitTransaction(): Promise<void> {
-        if (!this.isTransactionActive) throw new TransactionNotStartedError();
+        if (!this.isTransactionActive)
+            throw new TransactionNotStartedError();
 
         const beforeBroadcastResult = new BroadcasterResult();
-        this.broadcaster.broadcastBeforeTransactionCommitEvent(
-            beforeBroadcastResult
-        );
-        if (beforeBroadcastResult.promises.length > 0)
-            await Promise.all(beforeBroadcastResult.promises);
+        this.broadcaster.broadcastBeforeTransactionCommitEvent(beforeBroadcastResult);
+        if (beforeBroadcastResult.promises.length > 0) await Promise.all(beforeBroadcastResult.promises);
 
         await this.client.commitTransaction();
         this.isTransactionActive = false;
 
         const afterBroadcastResult = new BroadcasterResult();
-        this.broadcaster.broadcastAfterTransactionCommitEvent(
-            afterBroadcastResult
-        );
-        if (afterBroadcastResult.promises.length > 0)
-            await Promise.all(afterBroadcastResult.promises);
+        this.broadcaster.broadcastAfterTransactionCommitEvent(afterBroadcastResult);
+        if (afterBroadcastResult.promises.length > 0) await Promise.all(afterBroadcastResult.promises);
     }
 
     /**
@@ -138,32 +128,28 @@ export class AuroraDataApiQueryRunner
      * Error will be thrown if transaction was not started.
      */
     async rollbackTransaction(): Promise<void> {
-        if (!this.isTransactionActive) throw new TransactionNotStartedError();
+        if (!this.isTransactionActive)
+            throw new TransactionNotStartedError();
 
         const beforeBroadcastResult = new BroadcasterResult();
-        this.broadcaster.broadcastBeforeTransactionRollbackEvent(
-            beforeBroadcastResult
-        );
-        if (beforeBroadcastResult.promises.length > 0)
-            await Promise.all(beforeBroadcastResult.promises);
+        this.broadcaster.broadcastBeforeTransactionRollbackEvent(beforeBroadcastResult);
+        if (beforeBroadcastResult.promises.length > 0) await Promise.all(beforeBroadcastResult.promises);
 
         await this.client.rollbackTransaction();
 
         this.isTransactionActive = false;
 
         const afterBroadcastResult = new BroadcasterResult();
-        this.broadcaster.broadcastAfterTransactionRollbackEvent(
-            afterBroadcastResult
-        );
-        if (afterBroadcastResult.promises.length > 0)
-            await Promise.all(afterBroadcastResult.promises);
+        this.broadcaster.broadcastAfterTransactionRollbackEvent(afterBroadcastResult);
+        if (afterBroadcastResult.promises.length > 0) await Promise.all(afterBroadcastResult.promises);
     }
 
     /**
      * Executes a raw SQL query.
      */
     async query(query: string, parameters?: any[]): Promise<any> {
-        if (this.isReleased) throw new QueryRunnerAlreadyReleasedError();
+        if (this.isReleased)
+            throw new QueryRunnerAlreadyReleasedError();
 
         const result = await this.client.query(query, parameters);
 
@@ -177,13 +163,9 @@ export class AuroraDataApiQueryRunner
     /**
      * Returns raw data stream.
      */
-    stream(
-        query: string,
-        parameters?: any[],
-        onEnd?: Function,
-        onError?: Function
-    ): Promise<ReadStream> {
-        if (this.isReleased) throw new QueryRunnerAlreadyReleasedError();
+    stream(query: string, parameters?: any[], onEnd?: Function, onError?: Function): Promise<ReadStream> {
+        if (this.isReleased)
+            throw new QueryRunnerAlreadyReleasedError();
 
         return new Promise(async (ok, fail) => {
             try {
@@ -192,6 +174,7 @@ export class AuroraDataApiQueryRunner
                 if (onEnd) stream.on("end", onEnd);
                 if (onError) stream.on("error", onError);
                 ok(stream);
+
             } catch (err) {
                 fail(err);
             }
@@ -217,9 +200,7 @@ export class AuroraDataApiQueryRunner
      * Checks if database with the given name exist.
      */
     async hasDatabase(database: string): Promise<boolean> {
-        const result = await this.query(
-            `SELECT * FROM \`INFORMATION_SCHEMA\`.\`SCHEMATA\` WHERE \`SCHEMA_NAME\` = '${database}'`
-        );
+        const result = await this.query(`SELECT * FROM \`INFORMATION_SCHEMA\`.\`SCHEMATA\` WHERE \`SCHEMA_NAME\` = '${database}'`);
         return result.length ? true : false;
     }
 
@@ -249,7 +230,7 @@ export class AuroraDataApiQueryRunner
     /**
      * Checks if table with the given name exist in the database.
      */
-    async hasTable(tableOrName: Table | string): Promise<boolean> {
+    async hasTable(tableOrName: Table|string): Promise<boolean> {
         const parsedTableName = this.parseTableName(tableOrName);
         const sql = `SELECT * FROM \`INFORMATION_SCHEMA\`.\`COLUMNS\` WHERE \`TABLE_SCHEMA\` = '${parsedTableName.database}' AND \`TABLE_NAME\` = '${parsedTableName.tableName}'`;
         const result = await this.query(sql);
@@ -259,10 +240,7 @@ export class AuroraDataApiQueryRunner
     /**
      * Checks if column with the given name exist in the given table.
      */
-    async hasColumn(
-        tableOrName: Table | string,
-        column: TableColumn | string
-    ): Promise<boolean> {
+    async hasColumn(tableOrName: Table|string, column: TableColumn|string): Promise<boolean> {
         const parsedTableName = this.parseTableName(tableOrName);
         const columnName = column instanceof TableColumn ? column.name : column;
         const sql = `SELECT * FROM \`INFORMATION_SCHEMA\`.\`COLUMNS\` WHERE \`TABLE_SCHEMA\` = '${parsedTableName.database}' AND \`TABLE_NAME\` = '${parsedTableName.tableName}' AND \`COLUMN_NAME\` = '${columnName}'`;
@@ -273,13 +251,8 @@ export class AuroraDataApiQueryRunner
     /**
      * Creates a new database.
      */
-    async createDatabase(
-        database: string,
-        ifNotExist?: boolean
-    ): Promise<void> {
-        const up = ifNotExist
-            ? `CREATE DATABASE IF NOT EXISTS \`${database}\``
-            : `CREATE DATABASE \`${database}\``;
+    async createDatabase(database: string, ifNotExist?: boolean): Promise<void> {
+        const up = ifNotExist ? `CREATE DATABASE IF NOT EXISTS \`${database}\`` : `CREATE DATABASE \`${database}\``;
         const down = `DROP DATABASE \`${database}\``;
         await this.executeQueries(new Query(up), new Query(down));
     }
@@ -288,9 +261,7 @@ export class AuroraDataApiQueryRunner
      * Drops database.
      */
     async dropDatabase(database: string, ifExist?: boolean): Promise<void> {
-        const up = ifExist
-            ? `DROP DATABASE IF EXISTS \`${database}\``
-            : `DROP DATABASE \`${database}\``;
+        const up = ifExist ? `DROP DATABASE IF EXISTS \`${database}\`` : `DROP DATABASE \`${database}\``;
         const down = `CREATE DATABASE \`${database}\``;
         await this.executeQueries(new Query(up), new Query(down));
     }
@@ -299,28 +270,20 @@ export class AuroraDataApiQueryRunner
      * Creates a new table schema.
      */
     async createSchema(schema: string, ifNotExist?: boolean): Promise<void> {
-        throw new Error(
-            `Schema create queries are not supported by MySql driver.`
-        );
+        throw new Error(`Schema create queries are not supported by MySql driver.`);
     }
 
     /**
      * Drops table schema.
      */
     async dropSchema(schemaPath: string, ifExist?: boolean): Promise<void> {
-        throw new Error(
-            `Schema drop queries are not supported by MySql driver.`
-        );
+        throw new Error(`Schema drop queries are not supported by MySql driver.`);
     }
 
     /**
      * Creates a new table.
      */
-    async createTable(
-        table: Table,
-        ifNotExist: boolean = false,
-        createForeignKeys: boolean = true
-    ): Promise<void> {
+    async createTable(table: Table, ifNotExist: boolean = false, createForeignKeys: boolean = true): Promise<void> {
         if (ifNotExist) {
             const isTableExist = await this.hasTable(table);
             if (isTableExist) return Promise.resolve();
@@ -336,16 +299,12 @@ export class AuroraDataApiQueryRunner
         // if it related to the foreign key.
 
         // createTable does not need separate method to create indices, because it create indices in the same query with table creation.
-        table.indices.forEach((index) =>
-            downQueries.push(this.dropIndexSql(table, index))
-        );
+        table.indices.forEach(index => downQueries.push(this.dropIndexSql(table, index)));
 
         // if createForeignKeys is true, we must drop created foreign keys in down query.
         // createTable does not need separate method to create foreign keys, because it create fk's in the same query with table creation.
         if (createForeignKeys)
-            table.foreignKeys.forEach((foreignKey) =>
-                downQueries.push(this.dropForeignKeySql(table, foreignKey))
-            );
+            table.foreignKeys.forEach(foreignKey => downQueries.push(this.dropForeignKeySql(table, foreignKey)));
 
         return this.executeQueries(upQueries, downQueries);
     }
@@ -353,11 +312,7 @@ export class AuroraDataApiQueryRunner
     /**
      * Drop the table.
      */
-    async dropTable(
-        target: Table | string,
-        ifExist?: boolean,
-        dropForeignKeys: boolean = true
-    ): Promise<void> {
+    async dropTable(target: Table|string, ifExist?: boolean, dropForeignKeys: boolean = true): Promise<void> {
         // It needs because if table does not exist and dropForeignKeys or dropIndices is true, we don't need
         // to perform drop queries for foreign keys and indices.
         if (ifExist) {
@@ -373,13 +328,9 @@ export class AuroraDataApiQueryRunner
         const downQueries: Query[] = [];
 
         if (dropForeignKeys)
-            table.foreignKeys.forEach((foreignKey) =>
-                upQueries.push(this.dropForeignKeySql(table, foreignKey))
-            );
+            table.foreignKeys.forEach(foreignKey => upQueries.push(this.dropForeignKeySql(table, foreignKey)));
 
-        table.indices.forEach((index) =>
-            upQueries.push(this.dropIndexSql(table, index))
-        );
+        table.indices.forEach(index => upQueries.push(this.dropIndexSql(table, index)));
 
         upQueries.push(this.dropTableSql(table));
         downQueries.push(this.createTableSql(table, createForeignKeys));
@@ -403,7 +354,7 @@ export class AuroraDataApiQueryRunner
     /**
      * Drops the view.
      */
-    async dropView(target: View | string): Promise<void> {
+    async dropView(target: View|string): Promise<void> {
         const viewName = target instanceof View ? target.name : target;
         const view = await this.getCachedView(viewName);
 
@@ -419,111 +370,56 @@ export class AuroraDataApiQueryRunner
     /**
      * Renames a table.
      */
-    async renameTable(
-        oldTableOrName: Table | string,
-        newTableName: string
-    ): Promise<void> {
+    async renameTable(oldTableOrName: Table|string, newTableName: string): Promise<void> {
         const upQueries: Query[] = [];
         const downQueries: Query[] = [];
-        const oldTable =
-            oldTableOrName instanceof Table
-                ? oldTableOrName
-                : await this.getCachedTable(oldTableOrName);
+        const oldTable = oldTableOrName instanceof Table ? oldTableOrName : await this.getCachedTable(oldTableOrName);
         const newTable = oldTable.clone();
-        const dbName =
-            oldTable.name.indexOf(".") === -1
-                ? undefined
-                : oldTable.name.split(".")[0];
+        const dbName = oldTable.name.indexOf(".") === -1 ? undefined : oldTable.name.split(".")[0];
         newTable.name = dbName ? `${dbName}.${newTableName}` : newTableName;
 
         // rename table
-        upQueries.push(
-            new Query(
-                `RENAME TABLE ${this.escapePath(
-                    oldTable.name
-                )} TO ${this.escapePath(newTable.name)}`
-            )
-        );
-        downQueries.push(
-            new Query(
-                `RENAME TABLE ${this.escapePath(
-                    newTable.name
-                )} TO ${this.escapePath(oldTable.name)}`
-            )
-        );
+        upQueries.push(new Query(`RENAME TABLE ${this.escapePath(oldTable.name)} TO ${this.escapePath(newTable.name)}`));
+        downQueries.push(new Query(`RENAME TABLE ${this.escapePath(newTable.name)} TO ${this.escapePath(oldTable.name)}`));
 
         // rename index constraints
-        newTable.indices.forEach((index) => {
+        newTable.indices.forEach(index => {
             // build new constraint name
-            const columnNames = index.columnNames
-                .map((column) => `\`${column}\``)
-                .join(", ");
-            const newIndexName = this.connection.namingStrategy.indexName(
-                newTable,
-                index.columnNames,
-                index.where
-            );
+            const columnNames = index.columnNames.map(column => `\`${column}\``).join(", ");
+            const newIndexName = this.connection.namingStrategy.indexName(newTable, index.columnNames, index.where);
 
             // build queries
             let indexType = "";
-            if (index.isUnique) indexType += "UNIQUE ";
-            if (index.isSpatial) indexType += "SPATIAL ";
-            if (index.isFulltext) indexType += "FULLTEXT ";
-            upQueries.push(
-                new Query(
-                    `ALTER TABLE ${this.escapePath(newTable)} DROP INDEX \`${
-                        index.name
-                    }\`, ADD ${indexType}INDEX \`${newIndexName}\` (${columnNames})`
-                )
-            );
-            downQueries.push(
-                new Query(
-                    `ALTER TABLE ${this.escapePath(
-                        newTable
-                    )} DROP INDEX \`${newIndexName}\`, ADD ${indexType}INDEX \`${
-                        index.name
-                    }\` (${columnNames})`
-                )
-            );
+            if (index.isUnique)
+                indexType += "UNIQUE ";
+            if (index.isSpatial)
+                indexType += "SPATIAL ";
+            if (index.isFulltext)
+                indexType += "FULLTEXT ";
+            upQueries.push(new Query(`ALTER TABLE ${this.escapePath(newTable)} DROP INDEX \`${index.name}\`, ADD ${indexType}INDEX \`${newIndexName}\` (${columnNames})`));
+            downQueries.push(new Query(`ALTER TABLE ${this.escapePath(newTable)} DROP INDEX \`${newIndexName}\`, ADD ${indexType}INDEX \`${index.name}\` (${columnNames})`));
 
             // replace constraint name
             index.name = newIndexName;
         });
 
         // rename foreign key constraint
-        newTable.foreignKeys.forEach((foreignKey) => {
+        newTable.foreignKeys.forEach(foreignKey => {
             // build new constraint name
-            const columnNames = foreignKey.columnNames
-                .map((column) => `\`${column}\``)
-                .join(", ");
-            const referencedColumnNames = foreignKey.referencedColumnNames
-                .map((column) => `\`${column}\``)
-                .join(",");
-            const newForeignKeyName = this.connection.namingStrategy.foreignKeyName(
-                newTable,
-                foreignKey.columnNames
-            );
+            const columnNames = foreignKey.columnNames.map(column => `\`${column}\``).join(", ");
+            const referencedColumnNames = foreignKey.referencedColumnNames.map(column => `\`${column}\``).join(",");
+            const newForeignKeyName = this.connection.namingStrategy.foreignKeyName(newTable, foreignKey.columnNames);
 
             // build queries
-            let up =
-                `ALTER TABLE ${this.escapePath(newTable)} DROP FOREIGN KEY \`${
-                    foreignKey.name
-                }\`, ADD CONSTRAINT \`${newForeignKeyName}\` FOREIGN KEY (${columnNames}) ` +
-                `REFERENCES ${this.escapePath(
-                    foreignKey.referencedTableName
-                )}(${referencedColumnNames})`;
-            if (foreignKey.onDelete) up += ` ON DELETE ${foreignKey.onDelete}`;
-            if (foreignKey.onUpdate) up += ` ON UPDATE ${foreignKey.onUpdate}`;
+            let up = `ALTER TABLE ${this.escapePath(newTable)} DROP FOREIGN KEY \`${foreignKey.name}\`, ADD CONSTRAINT \`${newForeignKeyName}\` FOREIGN KEY (${columnNames}) ` +
+                `REFERENCES ${this.escapePath(foreignKey.referencedTableName)}(${referencedColumnNames})`;
+            if (foreignKey.onDelete)
+                up += ` ON DELETE ${foreignKey.onDelete}`;
+            if (foreignKey.onUpdate)
+                up += ` ON UPDATE ${foreignKey.onUpdate}`;
 
-            let down =
-                `ALTER TABLE ${this.escapePath(
-                    newTable
-                )} DROP FOREIGN KEY \`${newForeignKeyName}\`, ADD CONSTRAINT \`${
-                    foreignKey.name
-                }\` FOREIGN KEY (${columnNames}) ` +
-                `REFERENCES ${this.escapePath(
-                    foreignKey.referencedTableName
-                )}(${referencedColumnNames})`;
+            let down = `ALTER TABLE ${this.escapePath(newTable)} DROP FOREIGN KEY \`${newForeignKeyName}\`, ADD CONSTRAINT \`${foreignKey.name}\` FOREIGN KEY (${columnNames}) ` +
+                `REFERENCES ${this.escapePath(foreignKey.referencedTableName)}(${referencedColumnNames})`;
             if (foreignKey.onDelete)
                 down += ` ON DELETE ${foreignKey.onDelete}`;
             if (foreignKey.onUpdate)
@@ -546,166 +442,67 @@ export class AuroraDataApiQueryRunner
     /**
      * Creates a new column from the column in the table.
      */
-    async addColumn(
-        tableOrName: Table | string,
-        column: TableColumn
-    ): Promise<void> {
-        const table =
-            tableOrName instanceof Table
-                ? tableOrName
-                : await this.getCachedTable(tableOrName);
+    async addColumn(tableOrName: Table|string, column: TableColumn): Promise<void> {
+        const table = tableOrName instanceof Table ? tableOrName : await this.getCachedTable(tableOrName);
         const clonedTable = table.clone();
         const upQueries: Query[] = [];
         const downQueries: Query[] = [];
         const skipColumnLevelPrimary = clonedTable.primaryColumns.length > 0;
 
-        upQueries.push(
-            new Query(
-                `ALTER TABLE ${this.escapePath(
-                    table
-                )} ADD ${this.buildCreateColumnSql(
-                    column,
-                    skipColumnLevelPrimary,
-                    false
-                )}`
-            )
-        );
-        downQueries.push(
-            new Query(
-                `ALTER TABLE ${this.escapePath(table)} DROP COLUMN \`${
-                    column.name
-                }\``
-            )
-        );
+        upQueries.push(new Query(`ALTER TABLE ${this.escapePath(table)} ADD ${this.buildCreateColumnSql(column, skipColumnLevelPrimary, false)}`));
+        downQueries.push(new Query(`ALTER TABLE ${this.escapePath(table)} DROP COLUMN \`${column.name}\``));
 
         // create or update primary key constraint
         if (column.isPrimary && skipColumnLevelPrimary) {
             // if we already have generated column, we must temporary drop AUTO_INCREMENT property.
-            const generatedColumn = clonedTable.columns.find(
-                (column) =>
-                    column.isGenerated &&
-                    column.generationStrategy === "increment"
-            );
+            const generatedColumn = clonedTable.columns.find(column => column.isGenerated && column.generationStrategy === "increment");
             if (generatedColumn) {
                 const nonGeneratedColumn = generatedColumn.clone();
                 nonGeneratedColumn.isGenerated = false;
                 nonGeneratedColumn.generationStrategy = undefined;
-                upQueries.push(
-                    new Query(
-                        `ALTER TABLE ${this.escapePath(table)} CHANGE \`${
-                            column.name
-                        }\` ${this.buildCreateColumnSql(
-                            nonGeneratedColumn,
-                            true
-                        )}`
-                    )
-                );
-                downQueries.push(
-                    new Query(
-                        `ALTER TABLE ${this.escapePath(table)} CHANGE \`${
-                            nonGeneratedColumn.name
-                        }\` ${this.buildCreateColumnSql(column, true)}`
-                    )
-                );
+                upQueries.push(new Query(`ALTER TABLE ${this.escapePath(table)} CHANGE \`${column.name}\` ${this.buildCreateColumnSql(nonGeneratedColumn, true)}`));
+                downQueries.push(new Query(`ALTER TABLE ${this.escapePath(table)} CHANGE \`${nonGeneratedColumn.name}\` ${this.buildCreateColumnSql(column, true)}`));
             }
 
             const primaryColumns = clonedTable.primaryColumns;
-            let columnNames = primaryColumns
-                .map((column) => `\`${column.name}\``)
-                .join(", ");
-            upQueries.push(
-                new Query(
-                    `ALTER TABLE ${this.escapePath(table)} DROP PRIMARY KEY`
-                )
-            );
-            downQueries.push(
-                new Query(
-                    `ALTER TABLE ${this.escapePath(
-                        table
-                    )} ADD PRIMARY KEY (${columnNames})`
-                )
-            );
+            let columnNames = primaryColumns.map(column => `\`${column.name}\``).join(", ");
+            upQueries.push(new Query(`ALTER TABLE ${this.escapePath(table)} DROP PRIMARY KEY`));
+            downQueries.push(new Query(`ALTER TABLE ${this.escapePath(table)} ADD PRIMARY KEY (${columnNames})`));
 
             primaryColumns.push(column);
-            columnNames = primaryColumns
-                .map((column) => `\`${column.name}\``)
-                .join(", ");
-            upQueries.push(
-                new Query(
-                    `ALTER TABLE ${this.escapePath(
-                        table
-                    )} ADD PRIMARY KEY (${columnNames})`
-                )
-            );
-            downQueries.push(
-                new Query(
-                    `ALTER TABLE ${this.escapePath(table)} DROP PRIMARY KEY`
-                )
-            );
+            columnNames = primaryColumns.map(column => `\`${column.name}\``).join(", ");
+            upQueries.push(new Query(`ALTER TABLE ${this.escapePath(table)} ADD PRIMARY KEY (${columnNames})`));
+            downQueries.push(new Query(`ALTER TABLE ${this.escapePath(table)} DROP PRIMARY KEY`));
 
             // if we previously dropped AUTO_INCREMENT property, we must bring it back
             if (generatedColumn) {
                 const nonGeneratedColumn = generatedColumn.clone();
                 nonGeneratedColumn.isGenerated = false;
                 nonGeneratedColumn.generationStrategy = undefined;
-                upQueries.push(
-                    new Query(
-                        `ALTER TABLE ${this.escapePath(table)} CHANGE \`${
-                            nonGeneratedColumn.name
-                        }\` ${this.buildCreateColumnSql(column, true)}`
-                    )
-                );
-                downQueries.push(
-                    new Query(
-                        `ALTER TABLE ${this.escapePath(table)} CHANGE \`${
-                            column.name
-                        }\` ${this.buildCreateColumnSql(
-                            nonGeneratedColumn,
-                            true
-                        )}`
-                    )
-                );
+                upQueries.push(new Query(`ALTER TABLE ${this.escapePath(table)} CHANGE \`${nonGeneratedColumn.name}\` ${this.buildCreateColumnSql(column, true)}`));
+                downQueries.push(new Query(`ALTER TABLE ${this.escapePath(table)} CHANGE \`${column.name}\` ${this.buildCreateColumnSql(nonGeneratedColumn, true)}`));
             }
         }
 
         // create column index
-        const columnIndex = clonedTable.indices.find(
-            (index) =>
-                index.columnNames.length === 1 &&
-                index.columnNames[0] === column.name
-        );
+        const columnIndex = clonedTable.indices.find(index => index.columnNames.length === 1 && index.columnNames[0] === column.name);
         if (columnIndex) {
             upQueries.push(this.createIndexSql(table, columnIndex));
             downQueries.push(this.dropIndexSql(table, columnIndex));
+
         } else if (column.isUnique) {
             const uniqueIndex = new TableIndex({
-                name: this.connection.namingStrategy.indexName(table.name, [
-                    column.name,
-                ]),
+                name: this.connection.namingStrategy.indexName(table.name, [column.name]),
                 columnNames: [column.name],
-                isUnique: true,
+                isUnique: true
             });
             clonedTable.indices.push(uniqueIndex);
-            clonedTable.uniques.push(
-                new TableUnique({
-                    name: uniqueIndex.name,
-                    columnNames: uniqueIndex.columnNames,
-                })
-            );
-            upQueries.push(
-                new Query(
-                    `ALTER TABLE ${this.escapePath(table)} ADD UNIQUE INDEX \`${
-                        uniqueIndex.name
-                    }\` (\`${column.name}\`)`
-                )
-            );
-            downQueries.push(
-                new Query(
-                    `ALTER TABLE ${this.escapePath(table)} DROP INDEX \`${
-                        uniqueIndex.name
-                    }\``
-                )
-            );
+            clonedTable.uniques.push(new TableUnique({
+                name: uniqueIndex.name,
+                columnNames: uniqueIndex.columnNames
+            }));
+            upQueries.push(new Query(`ALTER TABLE ${this.escapePath(table)} ADD UNIQUE INDEX \`${uniqueIndex.name}\` (\`${column.name}\`)`));
+            downQueries.push(new Query(`ALTER TABLE ${this.escapePath(table)} DROP INDEX \`${uniqueIndex.name}\``));
         }
 
         await this.executeQueries(upQueries, downQueries);
@@ -717,10 +514,7 @@ export class AuroraDataApiQueryRunner
     /**
      * Creates a new columns from the column in the table.
      */
-    async addColumns(
-        tableOrName: Table | string,
-        columns: TableColumn[]
-    ): Promise<void> {
+    async addColumns(tableOrName: Table|string, columns: TableColumn[]): Promise<void> {
         for (const column of columns) {
             await this.addColumn(tableOrName, column);
         }
@@ -729,25 +523,13 @@ export class AuroraDataApiQueryRunner
     /**
      * Renames column in the given table.
      */
-    async renameColumn(
-        tableOrName: Table | string,
-        oldTableColumnOrName: TableColumn | string,
-        newTableColumnOrName: TableColumn | string
-    ): Promise<void> {
-        const table =
-            tableOrName instanceof Table
-                ? tableOrName
-                : await this.getCachedTable(tableOrName);
-        const oldColumn =
-            oldTableColumnOrName instanceof TableColumn
-                ? oldTableColumnOrName
-                : table.columns.find((c) => c.name === oldTableColumnOrName);
+    async renameColumn(tableOrName: Table|string, oldTableColumnOrName: TableColumn|string, newTableColumnOrName: TableColumn|string): Promise<void> {
+        const table = tableOrName instanceof Table ? tableOrName : await this.getCachedTable(tableOrName);
+        const oldColumn = oldTableColumnOrName instanceof TableColumn ? oldTableColumnOrName : table.columns.find(c => c.name === oldTableColumnOrName);
         if (!oldColumn)
-            throw new Error(
-                `Column "${oldTableColumnOrName}" was not found in the "${table.name}" table.`
-            );
+            throw new Error(`Column "${oldTableColumnOrName}" was not found in the "${table.name}" table.`);
 
-        let newColumn: TableColumn | undefined = undefined;
+        let newColumn: TableColumn|undefined = undefined;
         if (newTableColumnOrName instanceof TableColumn) {
             newColumn = newTableColumnOrName;
         } else {
@@ -761,311 +543,141 @@ export class AuroraDataApiQueryRunner
     /**
      * Changes a column in the table.
      */
-    async changeColumn(
-        tableOrName: Table | string,
-        oldColumnOrName: TableColumn | string,
-        newColumn: TableColumn
-    ): Promise<void> {
-        const table =
-            tableOrName instanceof Table
-                ? tableOrName
-                : await this.getCachedTable(tableOrName);
+    async changeColumn(tableOrName: Table|string, oldColumnOrName: TableColumn|string, newColumn: TableColumn): Promise<void> {
+        const table = tableOrName instanceof Table ? tableOrName : await this.getCachedTable(tableOrName);
         let clonedTable = table.clone();
         const upQueries: Query[] = [];
         const downQueries: Query[] = [];
 
-        const oldColumn =
-            oldColumnOrName instanceof TableColumn
-                ? oldColumnOrName
-                : table.columns.find(
-                      (column) => column.name === oldColumnOrName
-                  );
+        const oldColumn = oldColumnOrName instanceof TableColumn
+            ? oldColumnOrName
+            : table.columns.find(column => column.name === oldColumnOrName);
         if (!oldColumn)
-            throw new Error(
-                `Column "${oldColumnOrName}" was not found in the "${table.name}" table.`
-            );
+            throw new Error(`Column "${oldColumnOrName}" was not found in the "${table.name}" table.`);
 
-        if (
-            (newColumn.isGenerated !== oldColumn.isGenerated &&
-                newColumn.generationStrategy !== "uuid") ||
-            oldColumn.type !== newColumn.type ||
-            oldColumn.length !== newColumn.length ||
-            oldColumn.generatedType !== newColumn.generatedType
-        ) {
+        if ((newColumn.isGenerated !== oldColumn.isGenerated && newColumn.generationStrategy !== "uuid")
+            || oldColumn.type !== newColumn.type
+            || oldColumn.length !== newColumn.length
+            || oldColumn.generatedType !== newColumn.generatedType) {
             await this.dropColumn(table, oldColumn);
             await this.addColumn(table, newColumn);
 
             // update cloned table
             clonedTable = table.clone();
+
         } else {
             if (newColumn.name !== oldColumn.name) {
                 // We don't change any column properties, just rename it.
-                upQueries.push(
-                    new Query(
-                        `ALTER TABLE ${this.escapePath(table)} CHANGE \`${
-                            oldColumn.name
-                        }\` \`${newColumn.name}\` ${this.buildCreateColumnSql(
-                            oldColumn,
-                            true,
-                            true
-                        )}`
-                    )
-                );
-                downQueries.push(
-                    new Query(
-                        `ALTER TABLE ${this.escapePath(table)} CHANGE \`${
-                            newColumn.name
-                        }\` \`${oldColumn.name}\` ${this.buildCreateColumnSql(
-                            oldColumn,
-                            true,
-                            true
-                        )}`
-                    )
-                );
+                upQueries.push(new Query(`ALTER TABLE ${this.escapePath(table)} CHANGE \`${oldColumn.name}\` \`${newColumn.name}\` ${this.buildCreateColumnSql(oldColumn, true, true)}`));
+                downQueries.push(new Query(`ALTER TABLE ${this.escapePath(table)} CHANGE \`${newColumn.name}\` \`${oldColumn.name}\` ${this.buildCreateColumnSql(oldColumn, true, true)}`));
 
                 // rename index constraints
-                clonedTable.findColumnIndices(oldColumn).forEach((index) => {
+                clonedTable.findColumnIndices(oldColumn).forEach(index => {
                     // build new constraint name
-                    index.columnNames.splice(
-                        index.columnNames.indexOf(oldColumn.name),
-                        1
-                    );
+                    index.columnNames.splice(index.columnNames.indexOf(oldColumn.name), 1);
                     index.columnNames.push(newColumn.name);
-                    const columnNames = index.columnNames
-                        .map((column) => `\`${column}\``)
-                        .join(", ");
-                    const newIndexName = this.connection.namingStrategy.indexName(
-                        clonedTable,
-                        index.columnNames,
-                        index.where
-                    );
+                    const columnNames = index.columnNames.map(column => `\`${column}\``).join(", ");
+                    const newIndexName = this.connection.namingStrategy.indexName(clonedTable, index.columnNames, index.where);
 
                     // build queries
                     let indexType = "";
-                    if (index.isUnique) indexType += "UNIQUE ";
-                    if (index.isSpatial) indexType += "SPATIAL ";
-                    if (index.isFulltext) indexType += "FULLTEXT ";
-                    upQueries.push(
-                        new Query(
-                            `ALTER TABLE ${this.escapePath(
-                                table
-                            )} DROP INDEX \`${
-                                index.name
-                            }\`, ADD ${indexType}INDEX \`${newIndexName}\` (${columnNames})`
-                        )
-                    );
-                    downQueries.push(
-                        new Query(
-                            `ALTER TABLE ${this.escapePath(
-                                table
-                            )} DROP INDEX \`${newIndexName}\`, ADD ${indexType}INDEX \`${
-                                index.name
-                            }\` (${columnNames})`
-                        )
-                    );
+                    if (index.isUnique)
+                        indexType += "UNIQUE ";
+                    if (index.isSpatial)
+                        indexType += "SPATIAL ";
+                    if (index.isFulltext)
+                        indexType += "FULLTEXT ";
+                    upQueries.push(new Query(`ALTER TABLE ${this.escapePath(table)} DROP INDEX \`${index.name}\`, ADD ${indexType}INDEX \`${newIndexName}\` (${columnNames})`));
+                    downQueries.push(new Query(`ALTER TABLE ${this.escapePath(table)} DROP INDEX \`${newIndexName}\`, ADD ${indexType}INDEX \`${index.name}\` (${columnNames})`));
 
                     // replace constraint name
                     index.name = newIndexName;
                 });
 
                 // rename foreign key constraints
-                clonedTable
-                    .findColumnForeignKeys(oldColumn)
-                    .forEach((foreignKey) => {
-                        // build new constraint name
-                        foreignKey.columnNames.splice(
-                            foreignKey.columnNames.indexOf(oldColumn.name),
-                            1
-                        );
-                        foreignKey.columnNames.push(newColumn.name);
-                        const columnNames = foreignKey.columnNames
-                            .map((column) => `\`${column}\``)
-                            .join(", ");
-                        const referencedColumnNames = foreignKey.referencedColumnNames
-                            .map((column) => `\`${column}\``)
-                            .join(",");
-                        const newForeignKeyName = this.connection.namingStrategy.foreignKeyName(
-                            clonedTable,
-                            foreignKey.columnNames
-                        );
+                clonedTable.findColumnForeignKeys(oldColumn).forEach(foreignKey => {
+                    // build new constraint name
+                    foreignKey.columnNames.splice(foreignKey.columnNames.indexOf(oldColumn.name), 1);
+                    foreignKey.columnNames.push(newColumn.name);
+                    const columnNames = foreignKey.columnNames.map(column => `\`${column}\``).join(", ");
+                    const referencedColumnNames = foreignKey.referencedColumnNames.map(column => `\`${column}\``).join(",");
+                    const newForeignKeyName = this.connection.namingStrategy.foreignKeyName(clonedTable, foreignKey.columnNames);
 
-                        // build queries
-                        let up =
-                            `ALTER TABLE ${this.escapePath(
-                                table
-                            )} DROP FOREIGN KEY \`${
-                                foreignKey.name
-                            }\`, ADD CONSTRAINT \`${newForeignKeyName}\` FOREIGN KEY (${columnNames}) ` +
-                            `REFERENCES ${this.escapePath(
-                                foreignKey.referencedTableName
-                            )}(${referencedColumnNames})`;
-                        if (foreignKey.onDelete)
-                            up += ` ON DELETE ${foreignKey.onDelete}`;
-                        if (foreignKey.onUpdate)
-                            up += ` ON UPDATE ${foreignKey.onUpdate}`;
+                    // build queries
+                    let up = `ALTER TABLE ${this.escapePath(table)} DROP FOREIGN KEY \`${foreignKey.name}\`, ADD CONSTRAINT \`${newForeignKeyName}\` FOREIGN KEY (${columnNames}) ` +
+                        `REFERENCES ${this.escapePath(foreignKey.referencedTableName)}(${referencedColumnNames})`;
+                    if (foreignKey.onDelete)
+                        up += ` ON DELETE ${foreignKey.onDelete}`;
+                    if (foreignKey.onUpdate)
+                        up += ` ON UPDATE ${foreignKey.onUpdate}`;
 
-                        let down =
-                            `ALTER TABLE ${this.escapePath(
-                                table
-                            )} DROP FOREIGN KEY \`${newForeignKeyName}\`, ADD CONSTRAINT \`${
-                                foreignKey.name
-                            }\` FOREIGN KEY (${columnNames}) ` +
-                            `REFERENCES ${this.escapePath(
-                                foreignKey.referencedTableName
-                            )}(${referencedColumnNames})`;
-                        if (foreignKey.onDelete)
-                            down += ` ON DELETE ${foreignKey.onDelete}`;
-                        if (foreignKey.onUpdate)
-                            down += ` ON UPDATE ${foreignKey.onUpdate}`;
+                    let down = `ALTER TABLE ${this.escapePath(table)} DROP FOREIGN KEY \`${newForeignKeyName}\`, ADD CONSTRAINT \`${foreignKey.name}\` FOREIGN KEY (${columnNames}) ` +
+                        `REFERENCES ${this.escapePath(foreignKey.referencedTableName)}(${referencedColumnNames})`;
+                    if (foreignKey.onDelete)
+                        down += ` ON DELETE ${foreignKey.onDelete}`;
+                    if (foreignKey.onUpdate)
+                        down += ` ON UPDATE ${foreignKey.onUpdate}`;
 
-                        upQueries.push(new Query(up));
-                        downQueries.push(new Query(down));
+                    upQueries.push(new Query(up));
+                    downQueries.push(new Query(down));
 
-                        // replace constraint name
-                        foreignKey.name = newForeignKeyName;
-                    });
+                    // replace constraint name
+                    foreignKey.name = newForeignKeyName;
+                });
 
                 // rename old column in the Table object
-                const oldTableColumn = clonedTable.columns.find(
-                    (column) => column.name === oldColumn.name
-                );
-                clonedTable.columns[
-                    clonedTable.columns.indexOf(oldTableColumn!)
-                ].name = newColumn.name;
+                const oldTableColumn = clonedTable.columns.find(column => column.name === oldColumn.name);
+                clonedTable.columns[clonedTable.columns.indexOf(oldTableColumn!)].name = newColumn.name;
                 oldColumn.name = newColumn.name;
             }
 
             if (this.isColumnChanged(oldColumn, newColumn, true)) {
-                upQueries.push(
-                    new Query(
-                        `ALTER TABLE ${this.escapePath(table)} CHANGE \`${
-                            oldColumn.name
-                        }\` ${this.buildCreateColumnSql(newColumn, true)}`
-                    )
-                );
-                downQueries.push(
-                    new Query(
-                        `ALTER TABLE ${this.escapePath(table)} CHANGE \`${
-                            newColumn.name
-                        }\` ${this.buildCreateColumnSql(oldColumn, true)}`
-                    )
-                );
+                upQueries.push(new Query(`ALTER TABLE ${this.escapePath(table)} CHANGE \`${oldColumn.name}\` ${this.buildCreateColumnSql(newColumn, true)}`));
+                downQueries.push(new Query(`ALTER TABLE ${this.escapePath(table)} CHANGE \`${newColumn.name}\` ${this.buildCreateColumnSql(oldColumn, true)}`));
             }
 
             if (newColumn.isPrimary !== oldColumn.isPrimary) {
                 // if table have generated column, we must drop AUTO_INCREMENT before changing primary constraints.
-                const generatedColumn = clonedTable.columns.find(
-                    (column) =>
-                        column.isGenerated &&
-                        column.generationStrategy === "increment"
-                );
+                const generatedColumn = clonedTable.columns.find(column => column.isGenerated && column.generationStrategy === "increment");
                 if (generatedColumn) {
                     const nonGeneratedColumn = generatedColumn.clone();
                     nonGeneratedColumn.isGenerated = false;
                     nonGeneratedColumn.generationStrategy = undefined;
 
-                    upQueries.push(
-                        new Query(
-                            `ALTER TABLE ${this.escapePath(table)} CHANGE \`${
-                                generatedColumn.name
-                            }\` ${this.buildCreateColumnSql(
-                                nonGeneratedColumn,
-                                true
-                            )}`
-                        )
-                    );
-                    downQueries.push(
-                        new Query(
-                            `ALTER TABLE ${this.escapePath(table)} CHANGE \`${
-                                nonGeneratedColumn.name
-                            }\` ${this.buildCreateColumnSql(
-                                generatedColumn,
-                                true
-                            )}`
-                        )
-                    );
+                    upQueries.push(new Query(`ALTER TABLE ${this.escapePath(table)} CHANGE \`${generatedColumn.name}\` ${this.buildCreateColumnSql(nonGeneratedColumn, true)}`));
+                    downQueries.push(new Query(`ALTER TABLE ${this.escapePath(table)} CHANGE \`${nonGeneratedColumn.name}\` ${this.buildCreateColumnSql(generatedColumn, true)}`));
                 }
 
                 const primaryColumns = clonedTable.primaryColumns;
 
                 // if primary column state changed, we must always drop existed constraint.
                 if (primaryColumns.length > 0) {
-                    const columnNames = primaryColumns
-                        .map((column) => `\`${column.name}\``)
-                        .join(", ");
-                    upQueries.push(
-                        new Query(
-                            `ALTER TABLE ${this.escapePath(
-                                table
-                            )} DROP PRIMARY KEY`
-                        )
-                    );
-                    downQueries.push(
-                        new Query(
-                            `ALTER TABLE ${this.escapePath(
-                                table
-                            )} ADD PRIMARY KEY (${columnNames})`
-                        )
-                    );
+                    const columnNames = primaryColumns.map(column => `\`${column.name}\``).join(", ");
+                    upQueries.push(new Query(`ALTER TABLE ${this.escapePath(table)} DROP PRIMARY KEY`));
+                    downQueries.push(new Query(`ALTER TABLE ${this.escapePath(table)} ADD PRIMARY KEY (${columnNames})`));
                 }
 
                 if (newColumn.isPrimary === true) {
                     primaryColumns.push(newColumn);
                     // update column in table
-                    const column = clonedTable.columns.find(
-                        (column) => column.name === newColumn.name
-                    );
+                    const column = clonedTable.columns.find(column => column.name === newColumn.name);
                     column!.isPrimary = true;
-                    const columnNames = primaryColumns
-                        .map((column) => `\`${column.name}\``)
-                        .join(", ");
-                    upQueries.push(
-                        new Query(
-                            `ALTER TABLE ${this.escapePath(
-                                table
-                            )} ADD PRIMARY KEY (${columnNames})`
-                        )
-                    );
-                    downQueries.push(
-                        new Query(
-                            `ALTER TABLE ${this.escapePath(
-                                table
-                            )} DROP PRIMARY KEY`
-                        )
-                    );
+                    const columnNames = primaryColumns.map(column => `\`${column.name}\``).join(", ");
+                    upQueries.push(new Query(`ALTER TABLE ${this.escapePath(table)} ADD PRIMARY KEY (${columnNames})`));
+                    downQueries.push(new Query(`ALTER TABLE ${this.escapePath(table)} DROP PRIMARY KEY`));
+
                 } else {
-                    const primaryColumn = primaryColumns.find(
-                        (c) => c.name === newColumn.name
-                    );
-                    primaryColumns.splice(
-                        primaryColumns.indexOf(primaryColumn!),
-                        1
-                    );
+                    const primaryColumn = primaryColumns.find(c => c.name === newColumn.name);
+                    primaryColumns.splice(primaryColumns.indexOf(primaryColumn!), 1);
                     // update column in table
-                    const column = clonedTable.columns.find(
-                        (column) => column.name === newColumn.name
-                    );
+                    const column = clonedTable.columns.find(column => column.name === newColumn.name);
                     column!.isPrimary = false;
 
                     // if we have another primary keys, we must recreate constraint.
                     if (primaryColumns.length > 0) {
-                        const columnNames = primaryColumns
-                            .map((column) => `\`${column.name}\``)
-                            .join(", ");
-                        upQueries.push(
-                            new Query(
-                                `ALTER TABLE ${this.escapePath(
-                                    table
-                                )} ADD PRIMARY KEY (${columnNames})`
-                            )
-                        );
-                        downQueries.push(
-                            new Query(
-                                `ALTER TABLE ${this.escapePath(
-                                    table
-                                )} DROP PRIMARY KEY`
-                            )
-                        );
+                        const columnNames = primaryColumns.map(column => `\`${column.name}\``).join(", ");
+                        upQueries.push(new Query(`ALTER TABLE ${this.escapePath(table)} ADD PRIMARY KEY (${columnNames})`));
+                        downQueries.push(new Query(`ALTER TABLE ${this.escapePath(table)} DROP PRIMARY KEY`));
                     }
                 }
 
@@ -1075,101 +687,37 @@ export class AuroraDataApiQueryRunner
                     nonGeneratedColumn.isGenerated = false;
                     nonGeneratedColumn.generationStrategy = undefined;
 
-                    upQueries.push(
-                        new Query(
-                            `ALTER TABLE ${this.escapePath(table)} CHANGE \`${
-                                nonGeneratedColumn.name
-                            }\` ${this.buildCreateColumnSql(
-                                generatedColumn,
-                                true
-                            )}`
-                        )
-                    );
-                    downQueries.push(
-                        new Query(
-                            `ALTER TABLE ${this.escapePath(table)} CHANGE \`${
-                                generatedColumn.name
-                            }\` ${this.buildCreateColumnSql(
-                                nonGeneratedColumn,
-                                true
-                            )}`
-                        )
-                    );
+                    upQueries.push(new Query(`ALTER TABLE ${this.escapePath(table)} CHANGE \`${nonGeneratedColumn.name}\` ${this.buildCreateColumnSql(generatedColumn, true)}`));
+                    downQueries.push(new Query(`ALTER TABLE ${this.escapePath(table)} CHANGE \`${generatedColumn.name}\` ${this.buildCreateColumnSql(nonGeneratedColumn, true)}`));
                 }
             }
 
             if (newColumn.isUnique !== oldColumn.isUnique) {
                 if (newColumn.isUnique === true) {
                     const uniqueIndex = new TableIndex({
-                        name: this.connection.namingStrategy.indexName(
-                            table.name,
-                            [newColumn.name]
-                        ),
+                        name: this.connection.namingStrategy.indexName(table.name, [newColumn.name]),
                         columnNames: [newColumn.name],
-                        isUnique: true,
+                        isUnique: true
                     });
                     clonedTable.indices.push(uniqueIndex);
-                    clonedTable.uniques.push(
-                        new TableUnique({
-                            name: uniqueIndex.name,
-                            columnNames: uniqueIndex.columnNames,
-                        })
-                    );
-                    upQueries.push(
-                        new Query(
-                            `ALTER TABLE ${this.escapePath(
-                                table
-                            )} ADD UNIQUE INDEX \`${uniqueIndex.name}\` (\`${
-                                newColumn.name
-                            }\`)`
-                        )
-                    );
-                    downQueries.push(
-                        new Query(
-                            `ALTER TABLE ${this.escapePath(
-                                table
-                            )} DROP INDEX \`${uniqueIndex.name}\``
-                        )
-                    );
+                    clonedTable.uniques.push(new TableUnique({
+                        name: uniqueIndex.name,
+                        columnNames: uniqueIndex.columnNames
+                    }));
+                    upQueries.push(new Query(`ALTER TABLE ${this.escapePath(table)} ADD UNIQUE INDEX \`${uniqueIndex.name}\` (\`${newColumn.name}\`)`));
+                    downQueries.push(new Query(`ALTER TABLE ${this.escapePath(table)} DROP INDEX \`${uniqueIndex.name}\``));
+
                 } else {
-                    const uniqueIndex = clonedTable.indices.find((index) => {
-                        return (
-                            index.columnNames.length === 1 &&
-                            index.isUnique === true &&
-                            !!index.columnNames.find(
-                                (columnName) => columnName === newColumn.name
-                            )
-                        );
+                    const uniqueIndex = clonedTable.indices.find(index => {
+                        return index.columnNames.length === 1 && index.isUnique === true && !!index.columnNames.find(columnName => columnName === newColumn.name);
                     });
-                    clonedTable.indices.splice(
-                        clonedTable.indices.indexOf(uniqueIndex!),
-                        1
-                    );
+                    clonedTable.indices.splice(clonedTable.indices.indexOf(uniqueIndex!), 1);
 
-                    const tableUnique = clonedTable.uniques.find(
-                        (unique) => unique.name === uniqueIndex!.name
-                    );
-                    clonedTable.uniques.splice(
-                        clonedTable.uniques.indexOf(tableUnique!),
-                        1
-                    );
+                    const tableUnique = clonedTable.uniques.find(unique => unique.name === uniqueIndex!.name);
+                    clonedTable.uniques.splice(clonedTable.uniques.indexOf(tableUnique!), 1);
 
-                    upQueries.push(
-                        new Query(
-                            `ALTER TABLE ${this.escapePath(
-                                table
-                            )} DROP INDEX \`${uniqueIndex!.name}\``
-                        )
-                    );
-                    downQueries.push(
-                        new Query(
-                            `ALTER TABLE ${this.escapePath(
-                                table
-                            )} ADD UNIQUE INDEX \`${uniqueIndex!.name}\` (\`${
-                                newColumn.name
-                            }\`)`
-                        )
-                    );
+                    upQueries.push(new Query(`ALTER TABLE ${this.escapePath(table)} DROP INDEX \`${uniqueIndex!.name}\``));
+                    downQueries.push(new Query(`ALTER TABLE ${this.escapePath(table)} ADD UNIQUE INDEX \`${uniqueIndex!.name}\` (\`${newColumn.name}\`)`));
                 }
             }
         }
@@ -1181,34 +729,20 @@ export class AuroraDataApiQueryRunner
     /**
      * Changes a column in the table.
      */
-    async changeColumns(
-        tableOrName: Table | string,
-        changedColumns: { newColumn: TableColumn; oldColumn: TableColumn }[]
-    ): Promise<void> {
-        for (const { oldColumn, newColumn } of changedColumns) {
-            await this.changeColumn(tableOrName, oldColumn, newColumn);
+    async changeColumns(tableOrName: Table|string, changedColumns: { newColumn: TableColumn, oldColumn: TableColumn }[]): Promise<void> {
+        for (const {oldColumn, newColumn} of changedColumns) {
+            await this.changeColumn(tableOrName, oldColumn, newColumn)
         }
     }
 
     /**
      * Drops column in the table.
      */
-    async dropColumn(
-        tableOrName: Table | string,
-        columnOrName: TableColumn | string
-    ): Promise<void> {
-        const table =
-            tableOrName instanceof Table
-                ? tableOrName
-                : await this.getCachedTable(tableOrName);
-        const column =
-            columnOrName instanceof TableColumn
-                ? columnOrName
-                : table.findColumnByName(columnOrName);
+    async dropColumn(tableOrName: Table|string, columnOrName: TableColumn|string): Promise<void> {
+        const table = tableOrName instanceof Table ? tableOrName : await this.getCachedTable(tableOrName);
+        const column = columnOrName instanceof TableColumn ? columnOrName : table.findColumnByName(columnOrName);
         if (!column)
-            throw new Error(
-                `Column "${columnOrName}" was not found in table "${table.name}"`
-            );
+            throw new Error(`Column "${columnOrName}" was not found in table "${table.name}"`);
 
         const clonedTable = table.clone();
         const upQueries: Query[] = [];
@@ -1217,53 +751,20 @@ export class AuroraDataApiQueryRunner
         // drop primary key constraint
         if (column.isPrimary) {
             // if table have generated column, we must drop AUTO_INCREMENT before changing primary constraints.
-            const generatedColumn = clonedTable.columns.find(
-                (column) =>
-                    column.isGenerated &&
-                    column.generationStrategy === "increment"
-            );
+            const generatedColumn = clonedTable.columns.find(column => column.isGenerated && column.generationStrategy === "increment");
             if (generatedColumn) {
                 const nonGeneratedColumn = generatedColumn.clone();
                 nonGeneratedColumn.isGenerated = false;
                 nonGeneratedColumn.generationStrategy = undefined;
 
-                upQueries.push(
-                    new Query(
-                        `ALTER TABLE ${this.escapePath(table)} CHANGE \`${
-                            generatedColumn.name
-                        }\` ${this.buildCreateColumnSql(
-                            nonGeneratedColumn,
-                            true
-                        )}`
-                    )
-                );
-                downQueries.push(
-                    new Query(
-                        `ALTER TABLE ${this.escapePath(table)} CHANGE \`${
-                            nonGeneratedColumn.name
-                        }\` ${this.buildCreateColumnSql(generatedColumn, true)}`
-                    )
-                );
+                upQueries.push(new Query(`ALTER TABLE ${this.escapePath(table)} CHANGE \`${generatedColumn.name}\` ${this.buildCreateColumnSql(nonGeneratedColumn, true)}`));
+                downQueries.push(new Query(`ALTER TABLE ${this.escapePath(table)} CHANGE \`${nonGeneratedColumn.name}\` ${this.buildCreateColumnSql(generatedColumn, true)}`));
             }
 
             // dropping primary key constraint
-            const columnNames = clonedTable.primaryColumns
-                .map((primaryColumn) => `\`${primaryColumn.name}\``)
-                .join(", ");
-            upQueries.push(
-                new Query(
-                    `ALTER TABLE ${this.escapePath(
-                        clonedTable
-                    )} DROP PRIMARY KEY`
-                )
-            );
-            downQueries.push(
-                new Query(
-                    `ALTER TABLE ${this.escapePath(
-                        clonedTable
-                    )} ADD PRIMARY KEY (${columnNames})`
-                )
-            );
+            const columnNames = clonedTable.primaryColumns.map(primaryColumn => `\`${primaryColumn.name}\``).join(", ");
+            upQueries.push(new Query(`ALTER TABLE ${this.escapePath(clonedTable)} DROP PRIMARY KEY`));
+            downQueries.push(new Query(`ALTER TABLE ${this.escapePath(clonedTable)} ADD PRIMARY KEY (${columnNames})`));
 
             // update column in table
             const tableColumn = clonedTable.findColumnByName(column.name);
@@ -1271,23 +772,9 @@ export class AuroraDataApiQueryRunner
 
             // if primary key have multiple columns, we must recreate it without dropped column
             if (clonedTable.primaryColumns.length > 0) {
-                const columnNames = clonedTable.primaryColumns
-                    .map((primaryColumn) => `\`${primaryColumn.name}\``)
-                    .join(", ");
-                upQueries.push(
-                    new Query(
-                        `ALTER TABLE ${this.escapePath(
-                            clonedTable
-                        )} ADD PRIMARY KEY (${columnNames})`
-                    )
-                );
-                downQueries.push(
-                    new Query(
-                        `ALTER TABLE ${this.escapePath(
-                            clonedTable
-                        )} DROP PRIMARY KEY`
-                    )
-                );
+                const columnNames = clonedTable.primaryColumns.map(primaryColumn => `\`${primaryColumn.name}\``).join(", ");
+                upQueries.push(new Query(`ALTER TABLE ${this.escapePath(clonedTable)} ADD PRIMARY KEY (${columnNames})`));
+                downQueries.push(new Query(`ALTER TABLE ${this.escapePath(clonedTable)} DROP PRIMARY KEY`));
             }
 
             // if we have generated column, and we dropped AUTO_INCREMENT property before, and this column is not current dropping column, we must bring it back
@@ -1296,97 +783,36 @@ export class AuroraDataApiQueryRunner
                 nonGeneratedColumn.isGenerated = false;
                 nonGeneratedColumn.generationStrategy = undefined;
 
-                upQueries.push(
-                    new Query(
-                        `ALTER TABLE ${this.escapePath(table)} CHANGE \`${
-                            nonGeneratedColumn.name
-                        }\` ${this.buildCreateColumnSql(generatedColumn, true)}`
-                    )
-                );
-                downQueries.push(
-                    new Query(
-                        `ALTER TABLE ${this.escapePath(table)} CHANGE \`${
-                            generatedColumn.name
-                        }\` ${this.buildCreateColumnSql(
-                            nonGeneratedColumn,
-                            true
-                        )}`
-                    )
-                );
+                upQueries.push(new Query(`ALTER TABLE ${this.escapePath(table)} CHANGE \`${nonGeneratedColumn.name}\` ${this.buildCreateColumnSql(generatedColumn, true)}`));
+                downQueries.push(new Query(`ALTER TABLE ${this.escapePath(table)} CHANGE \`${generatedColumn.name}\` ${this.buildCreateColumnSql(nonGeneratedColumn, true)}`));
             }
         }
 
         // drop column index
-        const columnIndex = clonedTable.indices.find(
-            (index) =>
-                index.columnNames.length === 1 &&
-                index.columnNames[0] === column.name
-        );
+        const columnIndex = clonedTable.indices.find(index => index.columnNames.length === 1 && index.columnNames[0] === column.name);
         if (columnIndex) {
-            clonedTable.indices.splice(
-                clonedTable.indices.indexOf(columnIndex),
-                1
-            );
+            clonedTable.indices.splice(clonedTable.indices.indexOf(columnIndex), 1);
             upQueries.push(this.dropIndexSql(table, columnIndex));
             downQueries.push(this.createIndexSql(table, columnIndex));
+
         } else if (column.isUnique) {
             // we splice constraints both from table uniques and indices.
-            const uniqueName = this.connection.namingStrategy.uniqueConstraintName(
-                table.name,
-                [column.name]
-            );
-            const foundUnique = clonedTable.uniques.find(
-                (unique) => unique.name === uniqueName
-            );
+            const uniqueName = this.connection.namingStrategy.uniqueConstraintName(table.name, [column.name]);
+            const foundUnique = clonedTable.uniques.find(unique => unique.name === uniqueName);
             if (foundUnique)
-                clonedTable.uniques.splice(
-                    clonedTable.uniques.indexOf(foundUnique),
-                    1
-                );
+                clonedTable.uniques.splice(clonedTable.uniques.indexOf(foundUnique), 1);
 
-            const indexName = this.connection.namingStrategy.indexName(
-                table.name,
-                [column.name]
-            );
-            const foundIndex = clonedTable.indices.find(
-                (index) => index.name === indexName
-            );
+            const indexName = this.connection.namingStrategy.indexName(table.name, [column.name]);
+            const foundIndex = clonedTable.indices.find(index => index.name === indexName);
             if (foundIndex)
-                clonedTable.indices.splice(
-                    clonedTable.indices.indexOf(foundIndex),
-                    1
-                );
+                clonedTable.indices.splice(clonedTable.indices.indexOf(foundIndex), 1);
 
-            upQueries.push(
-                new Query(
-                    `ALTER TABLE ${this.escapePath(
-                        table
-                    )} DROP INDEX \`${indexName}\``
-                )
-            );
-            downQueries.push(
-                new Query(
-                    `ALTER TABLE ${this.escapePath(
-                        table
-                    )} ADD UNIQUE INDEX \`${indexName}\` (\`${column.name}\`)`
-                )
-            );
+            upQueries.push(new Query(`ALTER TABLE ${this.escapePath(table)} DROP INDEX \`${indexName}\``));
+            downQueries.push(new Query(`ALTER TABLE ${this.escapePath(table)} ADD UNIQUE INDEX \`${indexName}\` (\`${column.name}\`)`));
         }
 
-        upQueries.push(
-            new Query(
-                `ALTER TABLE ${this.escapePath(table)} DROP COLUMN \`${
-                    column.name
-                }\``
-            )
-        );
-        downQueries.push(
-            new Query(
-                `ALTER TABLE ${this.escapePath(
-                    table
-                )} ADD ${this.buildCreateColumnSql(column, true)}`
-            )
-        );
+        upQueries.push(new Query(`ALTER TABLE ${this.escapePath(table)} DROP COLUMN \`${column.name}\``));
+        downQueries.push(new Query(`ALTER TABLE ${this.escapePath(table)} ADD ${this.buildCreateColumnSql(column, true)}`));
 
         await this.executeQueries(upQueries, downQueries);
 
@@ -1397,10 +823,7 @@ export class AuroraDataApiQueryRunner
     /**
      * Drops the columns in the table.
      */
-    async dropColumns(
-        tableOrName: Table | string,
-        columns: TableColumn[]
-    ): Promise<void> {
+    async dropColumns(tableOrName: Table|string, columns: TableColumn[]): Promise<void> {
         for (const column of columns) {
             await this.dropColumn(tableOrName, column);
         }
@@ -1409,22 +832,16 @@ export class AuroraDataApiQueryRunner
     /**
      * Creates a new primary key.
      */
-    async createPrimaryKey(
-        tableOrName: Table | string,
-        columnNames: string[]
-    ): Promise<void> {
-        const table =
-            tableOrName instanceof Table
-                ? tableOrName
-                : await this.getCachedTable(tableOrName);
+    async createPrimaryKey(tableOrName: Table|string, columnNames: string[]): Promise<void> {
+        const table = tableOrName instanceof Table ? tableOrName : await this.getCachedTable(tableOrName);
         const clonedTable = table.clone();
 
         const up = this.createPrimaryKeySql(table, columnNames);
         const down = this.dropPrimaryKeySql(table);
 
         await this.executeQueries(up, down);
-        clonedTable.columns.forEach((column) => {
-            if (columnNames.find((columnName) => columnName === column.name))
+        clonedTable.columns.forEach(column => {
+            if (columnNames.find(columnName => columnName === column.name))
                 column.isPrimary = true;
         });
         this.replaceCachedTable(table, clonedTable);
@@ -1433,119 +850,53 @@ export class AuroraDataApiQueryRunner
     /**
      * Updates composite primary keys.
      */
-    async updatePrimaryKeys(
-        tableOrName: Table | string,
-        columns: TableColumn[]
-    ): Promise<void> {
-        const table =
-            tableOrName instanceof Table
-                ? tableOrName
-                : await this.getCachedTable(tableOrName);
+    async updatePrimaryKeys(tableOrName: Table|string, columns: TableColumn[]): Promise<void> {
+        const table = tableOrName instanceof Table ? tableOrName : await this.getCachedTable(tableOrName);
         const clonedTable = table.clone();
-        const columnNames = columns.map((column) => column.name);
+        const columnNames = columns.map(column => column.name);
         const upQueries: Query[] = [];
         const downQueries: Query[] = [];
 
         // if table have generated column, we must drop AUTO_INCREMENT before changing primary constraints.
-        const generatedColumn = clonedTable.columns.find(
-            (column) =>
-                column.isGenerated && column.generationStrategy === "increment"
-        );
+        const generatedColumn = clonedTable.columns.find(column => column.isGenerated && column.generationStrategy === "increment");
         if (generatedColumn) {
             const nonGeneratedColumn = generatedColumn.clone();
             nonGeneratedColumn.isGenerated = false;
             nonGeneratedColumn.generationStrategy = undefined;
 
-            upQueries.push(
-                new Query(
-                    `ALTER TABLE ${this.escapePath(table)} CHANGE \`${
-                        generatedColumn.name
-                    }\` ${this.buildCreateColumnSql(nonGeneratedColumn, true)}`
-                )
-            );
-            downQueries.push(
-                new Query(
-                    `ALTER TABLE ${this.escapePath(table)} CHANGE \`${
-                        nonGeneratedColumn.name
-                    }\` ${this.buildCreateColumnSql(generatedColumn, true)}`
-                )
-            );
+            upQueries.push(new Query(`ALTER TABLE ${this.escapePath(table)} CHANGE \`${generatedColumn.name}\` ${this.buildCreateColumnSql(nonGeneratedColumn, true)}`));
+            downQueries.push(new Query(`ALTER TABLE ${this.escapePath(table)} CHANGE \`${nonGeneratedColumn.name}\` ${this.buildCreateColumnSql(generatedColumn, true)}`));
         }
 
         // if table already have primary columns, we must drop them.
         const primaryColumns = clonedTable.primaryColumns;
         if (primaryColumns.length > 0) {
-            const columnNames = primaryColumns
-                .map((column) => `\`${column.name}\``)
-                .join(", ");
-            upQueries.push(
-                new Query(
-                    `ALTER TABLE ${this.escapePath(table)} DROP PRIMARY KEY`
-                )
-            );
-            downQueries.push(
-                new Query(
-                    `ALTER TABLE ${this.escapePath(
-                        table
-                    )} ADD PRIMARY KEY (${columnNames})`
-                )
-            );
+            const columnNames = primaryColumns.map(column => `\`${column.name}\``).join(", ");
+            upQueries.push(new Query(`ALTER TABLE ${this.escapePath(table)} DROP PRIMARY KEY`));
+            downQueries.push(new Query(`ALTER TABLE ${this.escapePath(table)} ADD PRIMARY KEY (${columnNames})`));
         }
 
         // update columns in table.
         clonedTable.columns
-            .filter((column) => columnNames.indexOf(column.name) !== -1)
-            .forEach((column) => (column.isPrimary = true));
+            .filter(column => columnNames.indexOf(column.name) !== -1)
+            .forEach(column => column.isPrimary = true);
 
-        const columnNamesString = columnNames
-            .map((columnName) => `\`${columnName}\``)
-            .join(", ");
-        upQueries.push(
-            new Query(
-                `ALTER TABLE ${this.escapePath(
-                    table
-                )} ADD PRIMARY KEY (${columnNamesString})`
-            )
-        );
-        downQueries.push(
-            new Query(`ALTER TABLE ${this.escapePath(table)} DROP PRIMARY KEY`)
-        );
+        const columnNamesString = columnNames.map(columnName => `\`${columnName}\``).join(", ");
+        upQueries.push(new Query(`ALTER TABLE ${this.escapePath(table)} ADD PRIMARY KEY (${columnNamesString})`));
+        downQueries.push(new Query(`ALTER TABLE ${this.escapePath(table)} DROP PRIMARY KEY`));
 
         // if we already have generated column or column is changed to generated, and we dropped AUTO_INCREMENT property before, we must bring it back
-        const newOrExistGeneratedColumn = generatedColumn
-            ? generatedColumn
-            : columns.find(
-                  (column) =>
-                      column.isGenerated &&
-                      column.generationStrategy === "increment"
-              );
+        const newOrExistGeneratedColumn = generatedColumn ? generatedColumn : columns.find(column => column.isGenerated && column.generationStrategy === "increment");
         if (newOrExistGeneratedColumn) {
             const nonGeneratedColumn = newOrExistGeneratedColumn.clone();
             nonGeneratedColumn.isGenerated = false;
             nonGeneratedColumn.generationStrategy = undefined;
 
-            upQueries.push(
-                new Query(
-                    `ALTER TABLE ${this.escapePath(table)} CHANGE \`${
-                        nonGeneratedColumn.name
-                    }\` ${this.buildCreateColumnSql(
-                        newOrExistGeneratedColumn,
-                        true
-                    )}`
-                )
-            );
-            downQueries.push(
-                new Query(
-                    `ALTER TABLE ${this.escapePath(table)} CHANGE \`${
-                        newOrExistGeneratedColumn.name
-                    }\` ${this.buildCreateColumnSql(nonGeneratedColumn, true)}`
-                )
-            );
+            upQueries.push(new Query(`ALTER TABLE ${this.escapePath(table)} CHANGE \`${nonGeneratedColumn.name}\` ${this.buildCreateColumnSql(newOrExistGeneratedColumn, true)}`));
+            downQueries.push(new Query(`ALTER TABLE ${this.escapePath(table)} CHANGE \`${newOrExistGeneratedColumn.name}\` ${this.buildCreateColumnSql(nonGeneratedColumn, true)}`));
 
             // if column changed to generated, we must update it in table
-            const changedGeneratedColumn = clonedTable.columns.find(
-                (column) => column.name === newOrExistGeneratedColumn.name
-            );
+            const changedGeneratedColumn = clonedTable.columns.find(column => column.name === newOrExistGeneratedColumn.name);
             changedGeneratedColumn!.isGenerated = true;
             changedGeneratedColumn!.generationStrategy = "increment";
         }
@@ -1557,18 +908,12 @@ export class AuroraDataApiQueryRunner
     /**
      * Drops a primary key.
      */
-    async dropPrimaryKey(tableOrName: Table | string): Promise<void> {
-        const table =
-            tableOrName instanceof Table
-                ? tableOrName
-                : await this.getCachedTable(tableOrName);
+    async dropPrimaryKey(tableOrName: Table|string): Promise<void> {
+        const table = tableOrName instanceof Table ? tableOrName : await this.getCachedTable(tableOrName);
         const up = this.dropPrimaryKeySql(table);
-        const down = this.createPrimaryKeySql(
-            table,
-            table.primaryColumns.map((column) => column.name)
-        );
+        const down = this.createPrimaryKeySql(table, table.primaryColumns.map(column => column.name));
         await this.executeQueries(up, down);
-        table.primaryColumns.forEach((column) => {
+        table.primaryColumns.forEach(column => {
             column.isPrimary = false;
         });
     }
@@ -1576,149 +921,96 @@ export class AuroraDataApiQueryRunner
     /**
      * Creates a new unique constraint.
      */
-    async createUniqueConstraint(
-        tableOrName: Table | string,
-        uniqueConstraint: TableUnique
-    ): Promise<void> {
-        throw new Error(
-            `MySql does not support unique constraints. Use unique index instead.`
-        );
+    async createUniqueConstraint(tableOrName: Table|string, uniqueConstraint: TableUnique): Promise<void> {
+        throw new Error(`MySql does not support unique constraints. Use unique index instead.`);
     }
 
     /**
      * Creates a new unique constraints.
      */
-    async createUniqueConstraints(
-        tableOrName: Table | string,
-        uniqueConstraints: TableUnique[]
-    ): Promise<void> {
-        throw new Error(
-            `MySql does not support unique constraints. Use unique index instead.`
-        );
+    async createUniqueConstraints(tableOrName: Table|string, uniqueConstraints: TableUnique[]): Promise<void> {
+        throw new Error(`MySql does not support unique constraints. Use unique index instead.`);
     }
 
     /**
      * Drops an unique constraint.
      */
-    async dropUniqueConstraint(
-        tableOrName: Table | string,
-        uniqueOrName: TableUnique | string
-    ): Promise<void> {
-        throw new Error(
-            `MySql does not support unique constraints. Use unique index instead.`
-        );
+    async dropUniqueConstraint(tableOrName: Table|string, uniqueOrName: TableUnique|string): Promise<void> {
+        throw new Error(`MySql does not support unique constraints. Use unique index instead.`);
     }
 
     /**
      * Drops an unique constraints.
      */
-    async dropUniqueConstraints(
-        tableOrName: Table | string,
-        uniqueConstraints: TableUnique[]
-    ): Promise<void> {
-        throw new Error(
-            `MySql does not support unique constraints. Use unique index instead.`
-        );
+    async dropUniqueConstraints(tableOrName: Table|string, uniqueConstraints: TableUnique[]): Promise<void> {
+        throw new Error(`MySql does not support unique constraints. Use unique index instead.`);
     }
 
     /**
      * Creates a new check constraint.
      */
-    async createCheckConstraint(
-        tableOrName: Table | string,
-        checkConstraint: TableCheck
-    ): Promise<void> {
+    async createCheckConstraint(tableOrName: Table|string, checkConstraint: TableCheck): Promise<void> {
         throw new Error(`MySql does not support check constraints.`);
     }
 
     /**
      * Creates a new check constraints.
      */
-    async createCheckConstraints(
-        tableOrName: Table | string,
-        checkConstraints: TableCheck[]
-    ): Promise<void> {
+    async createCheckConstraints(tableOrName: Table|string, checkConstraints: TableCheck[]): Promise<void> {
         throw new Error(`MySql does not support check constraints.`);
     }
 
     /**
      * Drops check constraint.
      */
-    async dropCheckConstraint(
-        tableOrName: Table | string,
-        checkOrName: TableCheck | string
-    ): Promise<void> {
+    async dropCheckConstraint(tableOrName: Table|string, checkOrName: TableCheck|string): Promise<void> {
         throw new Error(`MySql does not support check constraints.`);
     }
 
     /**
      * Drops check constraints.
      */
-    async dropCheckConstraints(
-        tableOrName: Table | string,
-        checkConstraints: TableCheck[]
-    ): Promise<void> {
+    async dropCheckConstraints(tableOrName: Table|string, checkConstraints: TableCheck[]): Promise<void> {
         throw new Error(`MySql does not support check constraints.`);
     }
 
     /**
      * Creates a new exclusion constraint.
      */
-    async createExclusionConstraint(
-        tableOrName: Table | string,
-        exclusionConstraint: TableExclusion
-    ): Promise<void> {
+    async createExclusionConstraint(tableOrName: Table|string, exclusionConstraint: TableExclusion): Promise<void> {
         throw new Error(`MySql does not support exclusion constraints.`);
     }
 
     /**
      * Creates a new exclusion constraints.
      */
-    async createExclusionConstraints(
-        tableOrName: Table | string,
-        exclusionConstraints: TableExclusion[]
-    ): Promise<void> {
+    async createExclusionConstraints(tableOrName: Table|string, exclusionConstraints: TableExclusion[]): Promise<void> {
         throw new Error(`MySql does not support exclusion constraints.`);
     }
 
     /**
      * Drops exclusion constraint.
      */
-    async dropExclusionConstraint(
-        tableOrName: Table | string,
-        exclusionOrName: TableExclusion | string
-    ): Promise<void> {
+    async dropExclusionConstraint(tableOrName: Table|string, exclusionOrName: TableExclusion|string): Promise<void> {
         throw new Error(`MySql does not support exclusion constraints.`);
     }
 
     /**
      * Drops exclusion constraints.
      */
-    async dropExclusionConstraints(
-        tableOrName: Table | string,
-        exclusionConstraints: TableExclusion[]
-    ): Promise<void> {
+    async dropExclusionConstraints(tableOrName: Table|string, exclusionConstraints: TableExclusion[]): Promise<void> {
         throw new Error(`MySql does not support exclusion constraints.`);
     }
 
     /**
      * Creates a new foreign key.
      */
-    async createForeignKey(
-        tableOrName: Table | string,
-        foreignKey: TableForeignKey
-    ): Promise<void> {
-        const table =
-            tableOrName instanceof Table
-                ? tableOrName
-                : await this.getCachedTable(tableOrName);
+    async createForeignKey(tableOrName: Table|string, foreignKey: TableForeignKey): Promise<void> {
+        const table = tableOrName instanceof Table ? tableOrName : await this.getCachedTable(tableOrName);
 
         // new FK may be passed without name. In this case we generate FK name manually.
         if (!foreignKey.name)
-            foreignKey.name = this.connection.namingStrategy.foreignKeyName(
-                table.name,
-                foreignKey.columnNames
-            );
+            foreignKey.name = this.connection.namingStrategy.foreignKeyName(table.name, foreignKey.columnNames);
 
         const up = this.createForeignKeySql(table, foreignKey);
         const down = this.dropForeignKeySql(table, foreignKey);
@@ -1729,35 +1021,19 @@ export class AuroraDataApiQueryRunner
     /**
      * Creates a new foreign keys.
      */
-    async createForeignKeys(
-        tableOrName: Table | string,
-        foreignKeys: TableForeignKey[]
-    ): Promise<void> {
-        const promises = foreignKeys.map((foreignKey) =>
-            this.createForeignKey(tableOrName, foreignKey)
-        );
+    async createForeignKeys(tableOrName: Table|string, foreignKeys: TableForeignKey[]): Promise<void> {
+        const promises = foreignKeys.map(foreignKey => this.createForeignKey(tableOrName, foreignKey));
         await Promise.all(promises);
     }
 
     /**
      * Drops a foreign key.
      */
-    async dropForeignKey(
-        tableOrName: Table | string,
-        foreignKeyOrName: TableForeignKey | string
-    ): Promise<void> {
-        const table =
-            tableOrName instanceof Table
-                ? tableOrName
-                : await this.getCachedTable(tableOrName);
-        const foreignKey =
-            foreignKeyOrName instanceof TableForeignKey
-                ? foreignKeyOrName
-                : table.foreignKeys.find((fk) => fk.name === foreignKeyOrName);
+    async dropForeignKey(tableOrName: Table|string, foreignKeyOrName: TableForeignKey|string): Promise<void> {
+        const table = tableOrName instanceof Table ? tableOrName : await this.getCachedTable(tableOrName);
+        const foreignKey = foreignKeyOrName instanceof TableForeignKey ? foreignKeyOrName : table.foreignKeys.find(fk => fk.name === foreignKeyOrName);
         if (!foreignKey)
-            throw new Error(
-                `Supplied foreign key was not found in table ${table.name}`
-            );
+            throw new Error(`Supplied foreign key was not found in table ${table.name}`);
 
         const up = this.dropForeignKeySql(table, foreignKey);
         const down = this.createForeignKeySql(table, foreignKey);
@@ -1768,35 +1044,20 @@ export class AuroraDataApiQueryRunner
     /**
      * Drops a foreign keys from the table.
      */
-    async dropForeignKeys(
-        tableOrName: Table | string,
-        foreignKeys: TableForeignKey[]
-    ): Promise<void> {
-        const promises = foreignKeys.map((foreignKey) =>
-            this.dropForeignKey(tableOrName, foreignKey)
-        );
+    async dropForeignKeys(tableOrName: Table|string, foreignKeys: TableForeignKey[]): Promise<void> {
+        const promises = foreignKeys.map(foreignKey => this.dropForeignKey(tableOrName, foreignKey));
         await Promise.all(promises);
     }
 
     /**
      * Creates a new index.
      */
-    async createIndex(
-        tableOrName: Table | string,
-        index: TableIndex
-    ): Promise<void> {
-        const table =
-            tableOrName instanceof Table
-                ? tableOrName
-                : await this.getCachedTable(tableOrName);
+    async createIndex(tableOrName: Table|string, index: TableIndex): Promise<void> {
+        const table = tableOrName instanceof Table ? tableOrName : await this.getCachedTable(tableOrName);
 
         // new index may be passed without name. In this case we generate index name manually.
         if (!index.name)
-            index.name = this.connection.namingStrategy.indexName(
-                table.name,
-                index.columnNames,
-                index.where
-            );
+            index.name = this.connection.namingStrategy.indexName(table.name, index.columnNames, index.where);
 
         const up = this.createIndexSql(table, index);
         const down = this.dropIndexSql(table, index);
@@ -1807,35 +1068,19 @@ export class AuroraDataApiQueryRunner
     /**
      * Creates a new indices
      */
-    async createIndices(
-        tableOrName: Table | string,
-        indices: TableIndex[]
-    ): Promise<void> {
-        const promises = indices.map((index) =>
-            this.createIndex(tableOrName, index)
-        );
+    async createIndices(tableOrName: Table|string, indices: TableIndex[]): Promise<void> {
+        const promises = indices.map(index => this.createIndex(tableOrName, index));
         await Promise.all(promises);
     }
 
     /**
      * Drops an index.
      */
-    async dropIndex(
-        tableOrName: Table | string,
-        indexOrName: TableIndex | string
-    ): Promise<void> {
-        const table =
-            tableOrName instanceof Table
-                ? tableOrName
-                : await this.getCachedTable(tableOrName);
-        const index =
-            indexOrName instanceof TableIndex
-                ? indexOrName
-                : table.indices.find((i) => i.name === indexOrName);
+    async dropIndex(tableOrName: Table|string, indexOrName: TableIndex|string): Promise<void> {
+        const table = tableOrName instanceof Table ? tableOrName : await this.getCachedTable(tableOrName);
+        const index = indexOrName instanceof TableIndex ? indexOrName : table.indices.find(i => i.name === indexOrName);
         if (!index)
-            throw new Error(
-                `Supplied index was not found in table ${table.name}`
-            );
+            throw new Error(`Supplied index was not found in table ${table.name}`);
 
         const up = this.dropIndexSql(table, index);
         const down = this.createIndexSql(table, index);
@@ -1846,13 +1091,8 @@ export class AuroraDataApiQueryRunner
     /**
      * Drops an indices from the table.
      */
-    async dropIndices(
-        tableOrName: Table | string,
-        indices: TableIndex[]
-    ): Promise<void> {
-        const promises = indices.map((index) =>
-            this.dropIndex(tableOrName, index)
-        );
+    async dropIndices(tableOrName: Table|string, indices: TableIndex[]): Promise<void> {
+        const promises = indices.map(index => this.dropIndex(tableOrName, index));
         await Promise.all(promises);
     }
 
@@ -1860,7 +1100,7 @@ export class AuroraDataApiQueryRunner
      * Clears all table contents.
      * Note: this operation uses SQL's TRUNCATE query which cannot be reverted in transactions.
      */
-    async clearTable(tableOrName: Table | string): Promise<void> {
+    async clearTable(tableOrName: Table|string): Promise<void> {
         await this.query(`TRUNCATE TABLE ${this.escapePath(tableOrName)}`);
     }
 
@@ -1873,40 +1113,34 @@ export class AuroraDataApiQueryRunner
         const dbName = database ? database : this.driver.database;
         if (dbName) {
             const isDatabaseExist = await this.hasDatabase(dbName);
-            if (!isDatabaseExist) return Promise.resolve();
+            if (!isDatabaseExist)
+                return Promise.resolve();
         } else {
             throw new Error(`Can not clear database. No database is specified`);
         }
 
         await this.startTransaction();
         try {
+
             const selectViewDropsQuery = `SELECT concat('DROP VIEW IF EXISTS \`', table_schema, '\`.\`', table_name, '\`') AS \`query\` FROM \`INFORMATION_SCHEMA\`.\`VIEWS\` WHERE \`TABLE_SCHEMA\` = '${dbName}'`;
-            const dropViewQueries: ObjectLiteral[] = await this.query(
-                selectViewDropsQuery
-            );
-            await Promise.all(
-                dropViewQueries.map((q) => this.query(q["query"]))
-            );
+            const dropViewQueries: ObjectLiteral[] = await this.query(selectViewDropsQuery);
+            await Promise.all(dropViewQueries.map(q => this.query(q["query"])));
 
             const disableForeignKeysCheckQuery = `SET FOREIGN_KEY_CHECKS = 0;`;
             const dropTablesQuery = `SELECT concat('DROP TABLE IF EXISTS \`', table_schema, '\`.\`', table_name, '\`') AS \`query\` FROM \`INFORMATION_SCHEMA\`.\`TABLES\` WHERE \`TABLE_SCHEMA\` = '${dbName}'`;
             const enableForeignKeysCheckQuery = `SET FOREIGN_KEY_CHECKS = 1;`;
 
             await this.query(disableForeignKeysCheckQuery);
-            const dropQueries: ObjectLiteral[] = await this.query(
-                dropTablesQuery
-            );
-            await Promise.all(
-                dropQueries.map((query) => this.query(query["query"]))
-            );
+            const dropQueries: ObjectLiteral[] = await this.query(dropTablesQuery);
+            await Promise.all(dropQueries.map(query => this.query(query["query"])));
             await this.query(enableForeignKeysCheckQuery);
 
             await this.commitTransaction();
+
         } catch (error) {
-            try {
-                // we throw original error even if rollback thrown an error
+            try { // we throw original error even if rollback thrown an error
                 await this.rollbackTransaction();
-            } catch (rollbackError) {}
+            } catch (rollbackError) { }
             throw error;
         }
     }
@@ -1916,42 +1150,27 @@ export class AuroraDataApiQueryRunner
     // -------------------------------------------------------------------------
 
     protected async loadViews(viewNames: string[]): Promise<View[]> {
-        const hasTable = await this.hasTable(
-            this.getTypeormMetadataTableName()
-        );
-        if (!hasTable) return Promise.resolve([]);
+        const hasTable = await this.hasTable(this.getTypeormMetadataTableName());
+        if (!hasTable)
+            return Promise.resolve([]);
 
         const currentDatabase = await this.getCurrentDatabase();
-        const viewsCondition = viewNames
-            .map((tableName) => {
-                let [database, name] = tableName.split(".");
-                if (!name) {
-                    name = database;
-                    database = this.driver.database || currentDatabase;
-                }
-                return `(\`t\`.\`schema\` = '${database}' AND \`t\`.\`name\` = '${name}')`;
-            })
-            .join(" OR ");
+        const viewsCondition = viewNames.map(tableName => {
+            let [database, name] = tableName.split(".");
+            if (!name) {
+                name = database;
+                database = this.driver.database || currentDatabase;
+            }
+            return `(\`t\`.\`schema\` = '${database}' AND \`t\`.\`name\` = '${name}')`;
+        }).join(" OR ");
 
-        const query =
-            `SELECT \`t\`.*, \`v\`.\`check_option\` FROM ${this.escapePath(
-                this.getTypeormMetadataTableName()
-            )} \`t\` ` +
-            `INNER JOIN \`information_schema\`.\`views\` \`v\` ON \`v\`.\`table_schema\` = \`t\`.\`schema\` AND \`v\`.\`table_name\` = \`t\`.\`name\` WHERE \`t\`.\`type\` = 'VIEW' ${
-                viewsCondition ? `AND (${viewsCondition})` : ""
-            }`;
+        const query = `SELECT \`t\`.*, \`v\`.\`check_option\` FROM ${this.escapePath(this.getTypeormMetadataTableName())} \`t\` ` +
+            `INNER JOIN \`information_schema\`.\`views\` \`v\` ON \`v\`.\`table_schema\` = \`t\`.\`schema\` AND \`v\`.\`table_name\` = \`t\`.\`name\` WHERE \`t\`.\`type\` = 'VIEW' ${viewsCondition ? `AND (${viewsCondition})` : ""}`;
         const dbViews = await this.query(query);
         return dbViews.map((dbView: any) => {
             const view = new View();
-            const db =
-                dbView["schema"] === currentDatabase
-                    ? undefined
-                    : dbView["schema"];
-            view.name = this.driver.buildTableName(
-                dbView["name"],
-                undefined,
-                db
-            );
+            const db = dbView["schema"] === currentDatabase ? undefined : dbView["schema"];
+            view.name = this.driver.buildTableName(dbView["name"], undefined, db);
             view.expression = dbView["value"];
             return view;
         });
@@ -1961,561 +1180,313 @@ export class AuroraDataApiQueryRunner
      * Loads all tables (with given names) from the database and creates a Table from them.
      */
     protected async loadTables(tableNames: string[]): Promise<Table[]> {
+
         // if no tables given then no need to proceed
-        if (!tableNames || !tableNames.length) return [];
+        if (!tableNames || !tableNames.length)
+            return [];
 
         const currentDatabase = await this.getCurrentDatabase();
-        const tablesCondition = tableNames
-            .map((tableName) => {
-                let [database, name] = tableName.split(".");
-                if (!name) {
-                    name = database;
-                    database = this.driver.database || currentDatabase;
-                }
-                return `(\`TABLE_SCHEMA\` = '${database}' AND \`TABLE_NAME\` = '${name}')`;
-            })
-            .join(" OR ");
-        const tablesSql =
-            `SELECT * FROM \`INFORMATION_SCHEMA\`.\`TABLES\` WHERE ` +
-            tablesCondition;
+        const tablesCondition = tableNames.map(tableName => {
+            let [database, name] = tableName.split(".");
+            if (!name) {
+                name = database;
+                database = this.driver.database || currentDatabase;
+            }
+            return `(\`TABLE_SCHEMA\` = '${database}' AND \`TABLE_NAME\` = '${name}')`;
+        }).join(" OR ");
+        const tablesSql = `SELECT * FROM \`INFORMATION_SCHEMA\`.\`TABLES\` WHERE ` + tablesCondition;
 
-        const columnsSql =
-            `SELECT * FROM \`INFORMATION_SCHEMA\`.\`COLUMNS\` WHERE ` +
-            tablesCondition;
+        const columnsSql = `SELECT * FROM \`INFORMATION_SCHEMA\`.\`COLUMNS\` WHERE ` + tablesCondition;
 
         const primaryKeySql = `SELECT * FROM \`INFORMATION_SCHEMA\`.\`KEY_COLUMN_USAGE\` WHERE \`CONSTRAINT_NAME\` = 'PRIMARY' AND (${tablesCondition})`;
 
         const collationsSql = `SELECT \`SCHEMA_NAME\`, \`DEFAULT_CHARACTER_SET_NAME\` as \`CHARSET\`, \`DEFAULT_COLLATION_NAME\` AS \`COLLATION\` FROM \`INFORMATION_SCHEMA\`.\`SCHEMATA\``;
 
-        const indicesCondition = tableNames
-            .map((tableName) => {
-                let [database, name] = tableName.split(".");
-                if (!name) {
-                    name = database;
-                    database = this.driver.database || currentDatabase;
-                }
-                return `(\`s\`.\`TABLE_SCHEMA\` = '${database}' AND \`s\`.\`TABLE_NAME\` = '${name}')`;
-            })
-            .join(" OR ");
-        const indicesSql =
-            `SELECT \`s\`.* FROM \`INFORMATION_SCHEMA\`.\`STATISTICS\` \`s\` ` +
+        const indicesCondition = tableNames.map(tableName => {
+            let [database, name] = tableName.split(".");
+            if (!name) {
+                name = database;
+                database = this.driver.database || currentDatabase;
+            }
+            return `(\`s\`.\`TABLE_SCHEMA\` = '${database}' AND \`s\`.\`TABLE_NAME\` = '${name}')`;
+        }).join(" OR ");
+        const indicesSql = `SELECT \`s\`.* FROM \`INFORMATION_SCHEMA\`.\`STATISTICS\` \`s\` ` +
             `LEFT JOIN \`INFORMATION_SCHEMA\`.\`REFERENTIAL_CONSTRAINTS\` \`rc\` ON \`s\`.\`INDEX_NAME\` = \`rc\`.\`CONSTRAINT_NAME\` ` +
             `WHERE (${indicesCondition}) AND \`s\`.\`INDEX_NAME\` != 'PRIMARY' AND \`rc\`.\`CONSTRAINT_NAME\` IS NULL`;
 
-        const foreignKeysCondition = tableNames
-            .map((tableName) => {
-                let [database, name] = tableName.split(".");
-                if (!name) {
-                    name = database;
-                    database = this.driver.database || currentDatabase;
-                }
-                return `(\`kcu\`.\`TABLE_SCHEMA\` = '${database}' AND \`kcu\`.\`TABLE_NAME\` = '${name}')`;
-            })
-            .join(" OR ");
-        const foreignKeysSql =
-            `SELECT \`kcu\`.\`TABLE_SCHEMA\`, \`kcu\`.\`TABLE_NAME\`, \`kcu\`.\`CONSTRAINT_NAME\`, \`kcu\`.\`COLUMN_NAME\`, \`kcu\`.\`REFERENCED_TABLE_SCHEMA\`, ` +
+        const foreignKeysCondition = tableNames.map(tableName => {
+            let [database, name] = tableName.split(".");
+            if (!name) {
+                name = database;
+                database = this.driver.database || currentDatabase;
+            }
+            return `(\`kcu\`.\`TABLE_SCHEMA\` = '${database}' AND \`kcu\`.\`TABLE_NAME\` = '${name}')`;
+        }).join(" OR ");
+        const foreignKeysSql = `SELECT \`kcu\`.\`TABLE_SCHEMA\`, \`kcu\`.\`TABLE_NAME\`, \`kcu\`.\`CONSTRAINT_NAME\`, \`kcu\`.\`COLUMN_NAME\`, \`kcu\`.\`REFERENCED_TABLE_SCHEMA\`, ` +
             `\`kcu\`.\`REFERENCED_TABLE_NAME\`, \`kcu\`.\`REFERENCED_COLUMN_NAME\`, \`rc\`.\`DELETE_RULE\` \`ON_DELETE\`, \`rc\`.\`UPDATE_RULE\` \`ON_UPDATE\` ` +
             `FROM \`INFORMATION_SCHEMA\`.\`KEY_COLUMN_USAGE\` \`kcu\` ` +
             `INNER JOIN \`INFORMATION_SCHEMA\`.\`REFERENTIAL_CONSTRAINTS\` \`rc\` ON \`rc\`.\`constraint_name\` = \`kcu\`.\`constraint_name\` ` +
-            `WHERE ` +
-            foreignKeysCondition;
-        const [
-            dbTables,
-            dbColumns,
-            dbPrimaryKeys,
-            dbCollations,
-            dbIndices,
-            dbForeignKeys,
-        ]: ObjectLiteral[][] = await Promise.all([
+            `WHERE ` + foreignKeysCondition;
+        const [dbTables, dbColumns, dbPrimaryKeys, dbCollations, dbIndices, dbForeignKeys]: ObjectLiteral[][] = await Promise.all([
             this.query(tablesSql),
             this.query(columnsSql),
             this.query(primaryKeySql),
             this.query(collationsSql),
             this.query(indicesSql),
-            this.query(foreignKeysSql),
+            this.query(foreignKeysSql)
         ]);
 
         // if tables were not found in the db, no need to proceed
-        if (!dbTables.length) return [];
+        if (!dbTables.length)
+            return [];
+
 
         // create tables for loaded tables
-        return Promise.all(
-            dbTables.map(async (dbTable) => {
-                const table = new Table();
+        return Promise.all(dbTables.map(async dbTable => {
+            const table = new Table();
 
-                const dbCollation = dbCollations.find(
-                    (coll) => coll["SCHEMA_NAME"] === dbTable["TABLE_SCHEMA"]
-                )!;
-                const defaultCollation = dbCollation["COLLATION"];
-                const defaultCharset = dbCollation["CHARSET"];
+            const dbCollation = dbCollations.find(coll => coll["SCHEMA_NAME"] === dbTable["TABLE_SCHEMA"])!;
+            const defaultCollation = dbCollation["COLLATION"];
+            const defaultCharset = dbCollation["CHARSET"];
 
-                // We do not need to join database name, when database is by default.
-                // In this case we need local variable `tableFullName` for below comparision.
-                const db =
-                    dbTable["TABLE_SCHEMA"] === currentDatabase
-                        ? undefined
-                        : dbTable["TABLE_SCHEMA"];
-                table.name = this.driver.buildTableName(
-                    dbTable["TABLE_NAME"],
-                    undefined,
-                    db
-                );
-                const tableFullName = this.driver.buildTableName(
-                    dbTable["TABLE_NAME"],
-                    undefined,
-                    dbTable["TABLE_SCHEMA"]
-                );
+            // We do not need to join database name, when database is by default.
+            // In this case we need local variable `tableFullName` for below comparision.
+            const db = dbTable["TABLE_SCHEMA"] === currentDatabase ? undefined : dbTable["TABLE_SCHEMA"];
+            table.name = this.driver.buildTableName(dbTable["TABLE_NAME"], undefined, db);
+            const tableFullName = this.driver.buildTableName(dbTable["TABLE_NAME"], undefined, dbTable["TABLE_SCHEMA"]);
 
-                // create columns from the loaded columns
-                table.columns = dbColumns
-                    .filter(
-                        (dbColumn) =>
-                            this.driver.buildTableName(
-                                dbColumn["TABLE_NAME"],
-                                undefined,
-                                dbColumn["TABLE_SCHEMA"]
-                            ) === tableFullName
-                    )
-                    .map((dbColumn) => {
-                        const columnUniqueIndex = dbIndices.find((dbIndex) => {
-                            const indexTableFullName = this.driver.buildTableName(
-                                dbIndex["TABLE_NAME"],
-                                undefined,
-                                dbIndex["TABLE_SCHEMA"]
-                            );
-                            if (indexTableFullName !== tableFullName) {
-                                return false;
-                            }
+            // create columns from the loaded columns
+            table.columns = dbColumns
+                .filter(dbColumn => this.driver.buildTableName(dbColumn["TABLE_NAME"], undefined, dbColumn["TABLE_SCHEMA"]) === tableFullName)
+                .map(dbColumn => {
 
-                            // Index is not for this column
-                            if (
-                                dbIndex["COLUMN_NAME"] !==
-                                dbColumn["COLUMN_NAME"]
-                            ) {
-                                return false;
-                            }
-
-                            const nonUnique = parseInt(
-                                dbIndex["NON_UNIQUE"],
-                                10
-                            );
-                            return nonUnique === 0;
-                        });
-
-                        const tableMetadata = this.connection.entityMetadatas.find(
-                            (metadata) => metadata.tablePath === table.name
-                        );
-                        const hasIgnoredIndex =
-                            columnUniqueIndex &&
-                            tableMetadata &&
-                            tableMetadata.indices.some(
-                                (index) =>
-                                    index.name ===
-                                        columnUniqueIndex["INDEX_NAME"] &&
-                                    index.synchronize === false
-                            );
-
-                        const isConstraintComposite = columnUniqueIndex
-                            ? !!dbIndices.find(
-                                  (dbIndex) =>
-                                      dbIndex["INDEX_NAME"] ===
-                                          columnUniqueIndex["INDEX_NAME"] &&
-                                      dbIndex["COLUMN_NAME"] !==
-                                          dbColumn["COLUMN_NAME"]
-                              )
-                            : false;
-
-                        const tableColumn = new TableColumn();
-                        tableColumn.name = dbColumn["COLUMN_NAME"];
-                        tableColumn.type = dbColumn["DATA_TYPE"].toLowerCase();
-
-                        if (
-                            this.driver.withWidthColumnTypes.indexOf(
-                                tableColumn.type as ColumnType
-                            ) !== -1
-                        ) {
-                            const width = dbColumn["COLUMN_TYPE"].substring(
-                                dbColumn["COLUMN_TYPE"].indexOf("(") + 1,
-                                dbColumn["COLUMN_TYPE"].indexOf(")")
-                            );
-                            tableColumn.width =
-                                width &&
-                                !this.isDefaultColumnWidth(
-                                    table,
-                                    tableColumn,
-                                    parseInt(width)
-                                )
-                                    ? parseInt(width)
-                                    : undefined;
+                    const columnUniqueIndex = dbIndices.find(dbIndex => {
+                        const indexTableFullName = this.driver.buildTableName(dbIndex["TABLE_NAME"], undefined, dbIndex["TABLE_SCHEMA"]);
+                        if (indexTableFullName !== tableFullName) {
+                            return false;
                         }
 
-                        if (
-                            dbColumn["COLUMN_DEFAULT"] === null ||
-                            dbColumn["COLUMN_DEFAULT"] === undefined
-                        ) {
-                            tableColumn.default = undefined;
-                        } else {
-                            tableColumn.default =
-                                dbColumn["COLUMN_DEFAULT"] ===
-                                "CURRENT_TIMESTAMP"
-                                    ? dbColumn["COLUMN_DEFAULT"]
-                                    : `'${dbColumn["COLUMN_DEFAULT"]}'`;
+                        // Index is not for this column
+                        if (dbIndex["COLUMN_NAME"] !== dbColumn["COLUMN_NAME"]) {
+                            return false;
                         }
 
-                        if (dbColumn["EXTRA"].indexOf("on update") !== -1) {
-                            tableColumn.onUpdate = dbColumn["EXTRA"].substring(
-                                dbColumn["EXTRA"].indexOf("on update") + 10
-                            );
-                        }
-
-                        if (dbColumn["GENERATION_EXPRESSION"]) {
-                            tableColumn.asExpression =
-                                dbColumn["GENERATION_EXPRESSION"];
-                            tableColumn.generatedType =
-                                dbColumn["EXTRA"].indexOf("VIRTUAL") !== -1
-                                    ? "VIRTUAL"
-                                    : "STORED";
-                        }
-
-                        tableColumn.isUnique =
-                            !!columnUniqueIndex &&
-                            !hasIgnoredIndex &&
-                            !isConstraintComposite;
-                        tableColumn.isNullable =
-                            dbColumn["IS_NULLABLE"] === "YES";
-                        tableColumn.isPrimary = dbPrimaryKeys.some(
-                            (dbPrimaryKey) => {
-                                return (
-                                    this.driver.buildTableName(
-                                        dbPrimaryKey["TABLE_NAME"],
-                                        undefined,
-                                        dbPrimaryKey["TABLE_SCHEMA"]
-                                    ) === tableFullName &&
-                                    dbPrimaryKey["COLUMN_NAME"] ===
-                                        tableColumn.name
-                                );
-                            }
-                        );
-                        tableColumn.zerofill =
-                            dbColumn["COLUMN_TYPE"].indexOf("zerofill") !== -1;
-                        tableColumn.unsigned = tableColumn.zerofill
-                            ? true
-                            : dbColumn["COLUMN_TYPE"].indexOf("unsigned") !==
-                              -1;
-                        tableColumn.isGenerated =
-                            dbColumn["EXTRA"].indexOf("auto_increment") !== -1;
-                        if (tableColumn.isGenerated)
-                            tableColumn.generationStrategy = "increment";
-
-                        tableColumn.comment = dbColumn["COLUMN_COMMENT"];
-                        if (dbColumn["CHARACTER_SET_NAME"])
-                            tableColumn.charset =
-                                dbColumn["CHARACTER_SET_NAME"] ===
-                                defaultCharset
-                                    ? undefined
-                                    : dbColumn["CHARACTER_SET_NAME"];
-                        if (dbColumn["COLLATION_NAME"])
-                            tableColumn.collation =
-                                dbColumn["COLLATION_NAME"] === defaultCollation
-                                    ? undefined
-                                    : dbColumn["COLLATION_NAME"];
-
-                        // check only columns that have length property
-                        if (
-                            this.driver.withLengthColumnTypes.indexOf(
-                                tableColumn.type as ColumnType
-                            ) !== -1 &&
-                            dbColumn["CHARACTER_MAXIMUM_LENGTH"]
-                        ) {
-                            const length = dbColumn[
-                                "CHARACTER_MAXIMUM_LENGTH"
-                            ].toString();
-                            tableColumn.length = !this.isDefaultColumnLength(
-                                table,
-                                tableColumn,
-                                length
-                            )
-                                ? length
-                                : "";
-                        }
-
-                        if (
-                            tableColumn.type === "decimal" ||
-                            tableColumn.type === "double" ||
-                            tableColumn.type === "float"
-                        ) {
-                            if (
-                                dbColumn["NUMERIC_PRECISION"] !== null &&
-                                !this.isDefaultColumnPrecision(
-                                    table,
-                                    tableColumn,
-                                    dbColumn["NUMERIC_PRECISION"]
-                                )
-                            )
-                                tableColumn.precision = parseInt(
-                                    dbColumn["NUMERIC_PRECISION"]
-                                );
-                            if (
-                                dbColumn["NUMERIC_SCALE"] !== null &&
-                                !this.isDefaultColumnScale(
-                                    table,
-                                    tableColumn,
-                                    dbColumn["NUMERIC_SCALE"]
-                                )
-                            )
-                                tableColumn.scale = parseInt(
-                                    dbColumn["NUMERIC_SCALE"]
-                                );
-                        }
-
-                        if (
-                            tableColumn.type === "enum" ||
-                            tableColumn.type === "simple-enum" ||
-                            tableColumn.type === "set"
-                        ) {
-                            const colType = dbColumn["COLUMN_TYPE"];
-                            const items = colType
-                                .substring(
-                                    colType.indexOf("(") + 1,
-                                    colType.lastIndexOf(")")
-                                )
-                                .split(",");
-                            tableColumn.enum = (items as string[]).map(
-                                (item) => {
-                                    return item.substring(1, item.length - 1);
-                                }
-                            );
-                            tableColumn.length = "";
-                        }
-
-                        if (
-                            (tableColumn.type === "datetime" ||
-                                tableColumn.type === "time" ||
-                                tableColumn.type === "timestamp") &&
-                            dbColumn["DATETIME_PRECISION"] !== null &&
-                            dbColumn["DATETIME_PRECISION"] !== undefined &&
-                            !this.isDefaultColumnPrecision(
-                                table,
-                                tableColumn,
-                                parseInt(dbColumn["DATETIME_PRECISION"])
-                            )
-                        ) {
-                            tableColumn.precision = parseInt(
-                                dbColumn["DATETIME_PRECISION"]
-                            );
-                        }
-
-                        return tableColumn;
+                        const nonUnique = parseInt(dbIndex["NON_UNIQUE"], 10);
+                        return nonUnique === 0;
                     });
 
-                // find foreign key constraints of table, group them by constraint name and build TableForeignKey.
-                const tableForeignKeyConstraints = OrmUtils.uniq(
-                    dbForeignKeys.filter((dbForeignKey) => {
-                        return (
-                            this.driver.buildTableName(
-                                dbForeignKey["TABLE_NAME"],
-                                undefined,
-                                dbForeignKey["TABLE_SCHEMA"]
-                            ) === tableFullName
-                        );
-                    }),
-                    (dbForeignKey) => dbForeignKey["CONSTRAINT_NAME"]
-                );
+                    const tableMetadata = this.connection.entityMetadatas.find(metadata => metadata.tablePath === table.name);
+                    const hasIgnoredIndex = columnUniqueIndex && tableMetadata && tableMetadata.indices
+                        .some(index => index.name === columnUniqueIndex["INDEX_NAME"] && index.synchronize === false);
 
-                table.foreignKeys = tableForeignKeyConstraints.map(
-                    (dbForeignKey) => {
-                        const foreignKeys = dbForeignKeys.filter(
-                            (dbFk) =>
-                                dbFk["CONSTRAINT_NAME"] ===
-                                dbForeignKey["CONSTRAINT_NAME"]
-                        );
+                    const isConstraintComposite = columnUniqueIndex
+                        ? !!dbIndices.find(dbIndex => dbIndex["INDEX_NAME"] === columnUniqueIndex["INDEX_NAME"] && dbIndex["COLUMN_NAME"] !== dbColumn["COLUMN_NAME"])
+                        : false;
 
-                        // if referenced table located in currently used db, we don't need to concat db name to table name.
-                        const database =
-                            dbForeignKey["REFERENCED_TABLE_SCHEMA"] ===
-                            currentDatabase
-                                ? undefined
-                                : dbForeignKey["REFERENCED_TABLE_SCHEMA"];
-                        const referencedTableName = this.driver.buildTableName(
-                            dbForeignKey["REFERENCED_TABLE_NAME"],
-                            undefined,
-                            database
-                        );
+                    const tableColumn = new TableColumn();
+                    tableColumn.name = dbColumn["COLUMN_NAME"];
+                    tableColumn.type = dbColumn["DATA_TYPE"].toLowerCase();
 
-                        return new TableForeignKey({
-                            name: dbForeignKey["CONSTRAINT_NAME"],
-                            columnNames: foreignKeys.map(
-                                (dbFk) => dbFk["COLUMN_NAME"]
-                            ),
-                            referencedTableName: referencedTableName,
-                            referencedColumnNames: foreignKeys.map(
-                                (dbFk) => dbFk["REFERENCED_COLUMN_NAME"]
-                            ),
-                            onDelete: dbForeignKey["ON_DELETE"],
-                            onUpdate: dbForeignKey["ON_UPDATE"],
-                        });
+                    if (this.driver.withWidthColumnTypes.indexOf(tableColumn.type as ColumnType) !== -1) {
+                        const width = dbColumn["COLUMN_TYPE"].substring(dbColumn["COLUMN_TYPE"].indexOf("(") + 1, dbColumn["COLUMN_TYPE"].indexOf(")"));
+                        tableColumn.width = width && !this.isDefaultColumnWidth(table, tableColumn, parseInt(width)) ? parseInt(width) : undefined;
                     }
-                );
 
-                // find index constraints of table, group them by constraint name and build TableIndex.
-                const tableIndexConstraints = OrmUtils.uniq(
-                    dbIndices.filter((dbIndex) => {
-                        return (
-                            this.driver.buildTableName(
-                                dbIndex["TABLE_NAME"],
-                                undefined,
-                                dbIndex["TABLE_SCHEMA"]
-                            ) === tableFullName
-                        );
-                    }),
-                    (dbIndex) => dbIndex["INDEX_NAME"]
-                );
+                    if (dbColumn["COLUMN_DEFAULT"] === null
+                        || dbColumn["COLUMN_DEFAULT"] === undefined) {
+                        tableColumn.default = undefined;
 
-                table.indices = tableIndexConstraints.map((constraint) => {
-                    const indices = dbIndices.filter((index) => {
-                        return (
-                            index["TABLE_SCHEMA"] ===
-                                constraint["TABLE_SCHEMA"] &&
-                            index["TABLE_NAME"] === constraint["TABLE_NAME"] &&
-                            index["INDEX_NAME"] === constraint["INDEX_NAME"]
-                        );
+                    } else {
+                        tableColumn.default = dbColumn["COLUMN_DEFAULT"] === "CURRENT_TIMESTAMP" ? dbColumn["COLUMN_DEFAULT"] : `'${dbColumn["COLUMN_DEFAULT"]}'`;
+                    }
+
+                    if (dbColumn["EXTRA"].indexOf("on update") !== -1) {
+                        tableColumn.onUpdate = dbColumn["EXTRA"].substring(dbColumn["EXTRA"].indexOf("on update") + 10);
+                    }
+
+                    if (dbColumn["GENERATION_EXPRESSION"]) {
+                        tableColumn.asExpression = dbColumn["GENERATION_EXPRESSION"];
+                        tableColumn.generatedType = dbColumn["EXTRA"].indexOf("VIRTUAL") !== -1 ? "VIRTUAL" : "STORED";
+                    }
+
+                    tableColumn.isUnique = !!columnUniqueIndex && !hasIgnoredIndex && !isConstraintComposite;
+                    tableColumn.isNullable = dbColumn["IS_NULLABLE"] === "YES";
+                    tableColumn.isPrimary = dbPrimaryKeys.some(dbPrimaryKey => {
+                        return this.driver.buildTableName(dbPrimaryKey["TABLE_NAME"], undefined, dbPrimaryKey["TABLE_SCHEMA"]) === tableFullName && dbPrimaryKey["COLUMN_NAME"] === tableColumn.name;
                     });
+                    tableColumn.zerofill = dbColumn["COLUMN_TYPE"].indexOf("zerofill") !== -1;
+                    tableColumn.unsigned = tableColumn.zerofill ? true : dbColumn["COLUMN_TYPE"].indexOf("unsigned") !== -1;
+                    tableColumn.isGenerated = dbColumn["EXTRA"].indexOf("auto_increment") !== -1;
+                    if (tableColumn.isGenerated)
+                        tableColumn.generationStrategy = "increment";
 
-                    const nonUnique = parseInt(constraint["NON_UNIQUE"], 10);
+                    tableColumn.comment = dbColumn["COLUMN_COMMENT"];
+                    if (dbColumn["CHARACTER_SET_NAME"])
+                        tableColumn.charset = dbColumn["CHARACTER_SET_NAME"] === defaultCharset ? undefined : dbColumn["CHARACTER_SET_NAME"];
+                    if (dbColumn["COLLATION_NAME"])
+                        tableColumn.collation = dbColumn["COLLATION_NAME"] === defaultCollation ? undefined : dbColumn["COLLATION_NAME"];
 
-                    return new TableIndex(<TableIndexOptions>{
-                        table: table,
-                        name: constraint["INDEX_NAME"],
-                        columnNames: indices.map((i) => i["COLUMN_NAME"]),
-                        isUnique: nonUnique === 0,
-                        isSpatial: constraint["INDEX_TYPE"] === "SPATIAL",
-                        isFulltext: constraint["INDEX_TYPE"] === "FULLTEXT",
-                    });
+                    // check only columns that have length property
+                    if (this.driver.withLengthColumnTypes.indexOf(tableColumn.type as ColumnType) !== -1 && dbColumn["CHARACTER_MAXIMUM_LENGTH"]) {
+                        const length = dbColumn["CHARACTER_MAXIMUM_LENGTH"].toString();
+                        tableColumn.length = !this.isDefaultColumnLength(table, tableColumn, length) ? length : "";
+                    }
+
+                    if (tableColumn.type === "decimal" || tableColumn.type === "double" || tableColumn.type === "float") {
+                        if (dbColumn["NUMERIC_PRECISION"] !== null && !this.isDefaultColumnPrecision(table, tableColumn, dbColumn["NUMERIC_PRECISION"]))
+                            tableColumn.precision = parseInt(dbColumn["NUMERIC_PRECISION"]);
+                        if (dbColumn["NUMERIC_SCALE"] !== null && !this.isDefaultColumnScale(table, tableColumn, dbColumn["NUMERIC_SCALE"]))
+                            tableColumn.scale = parseInt(dbColumn["NUMERIC_SCALE"]);
+                    }
+
+                    if (tableColumn.type === "enum" || tableColumn.type === "simple-enum" || tableColumn.type === "set") {
+                        const colType = dbColumn["COLUMN_TYPE"];
+                        const items = colType.substring(colType.indexOf("(") + 1, colType.lastIndexOf(")")).split(",");
+                        tableColumn.enum = (items as string[]).map(item => {
+                            return item.substring(1, item.length - 1);
+                        });
+                        tableColumn.length = "";
+                    }
+
+                    if ((tableColumn.type === "datetime" || tableColumn.type === "time" || tableColumn.type === "timestamp")
+                        && dbColumn["DATETIME_PRECISION"] !== null && dbColumn["DATETIME_PRECISION"] !== undefined
+                        && !this.isDefaultColumnPrecision(table, tableColumn, parseInt(dbColumn["DATETIME_PRECISION"]))) {
+                        tableColumn.precision = parseInt(dbColumn["DATETIME_PRECISION"]);
+                    }
+
+                    return tableColumn;
                 });
 
-                return table;
-            })
-        );
+            // find foreign key constraints of table, group them by constraint name and build TableForeignKey.
+            const tableForeignKeyConstraints = OrmUtils.uniq(dbForeignKeys.filter(dbForeignKey => {
+                return this.driver.buildTableName(dbForeignKey["TABLE_NAME"], undefined, dbForeignKey["TABLE_SCHEMA"]) === tableFullName;
+            }), dbForeignKey => dbForeignKey["CONSTRAINT_NAME"]);
+
+            table.foreignKeys = tableForeignKeyConstraints.map(dbForeignKey => {
+                const foreignKeys = dbForeignKeys.filter(dbFk => dbFk["CONSTRAINT_NAME"] === dbForeignKey["CONSTRAINT_NAME"]);
+
+                // if referenced table located in currently used db, we don't need to concat db name to table name.
+                const database = dbForeignKey["REFERENCED_TABLE_SCHEMA"] === currentDatabase ? undefined : dbForeignKey["REFERENCED_TABLE_SCHEMA"];
+                const referencedTableName = this.driver.buildTableName(dbForeignKey["REFERENCED_TABLE_NAME"], undefined, database);
+
+                return new TableForeignKey({
+                    name: dbForeignKey["CONSTRAINT_NAME"],
+                    columnNames: foreignKeys.map(dbFk => dbFk["COLUMN_NAME"]),
+                    referencedTableName: referencedTableName,
+                    referencedColumnNames: foreignKeys.map(dbFk => dbFk["REFERENCED_COLUMN_NAME"]),
+                    onDelete: dbForeignKey["ON_DELETE"],
+                    onUpdate: dbForeignKey["ON_UPDATE"]
+                });
+            });
+
+            // find index constraints of table, group them by constraint name and build TableIndex.
+            const tableIndexConstraints = OrmUtils.uniq(dbIndices.filter(dbIndex => {
+                return this.driver.buildTableName(dbIndex["TABLE_NAME"], undefined, dbIndex["TABLE_SCHEMA"]) === tableFullName;
+            }), dbIndex => dbIndex["INDEX_NAME"]);
+
+            table.indices = tableIndexConstraints.map(constraint => {
+                const indices = dbIndices.filter(index => {
+                    return index["TABLE_SCHEMA"] === constraint["TABLE_SCHEMA"]
+                        && index["TABLE_NAME"] === constraint["TABLE_NAME"]
+                        && index["INDEX_NAME"] === constraint["INDEX_NAME"];
+                });
+
+                const nonUnique = parseInt(constraint["NON_UNIQUE"], 10);
+
+                return new TableIndex(<TableIndexOptions>{
+                    table: table,
+                    name: constraint["INDEX_NAME"],
+                    columnNames: indices.map(i => i["COLUMN_NAME"]),
+                    isUnique: nonUnique === 0,
+                    isSpatial: constraint["INDEX_TYPE"] === "SPATIAL",
+                    isFulltext: constraint["INDEX_TYPE"] === "FULLTEXT"
+                });
+            });
+
+            return table;
+        }));
     }
 
     /**
      * Builds create table sql
      */
     protected createTableSql(table: Table, createForeignKeys?: boolean): Query {
-        const columnDefinitions = table.columns
-            .map((column) => this.buildCreateColumnSql(column, true))
-            .join(", ");
-        let sql = `CREATE TABLE ${this.escapePath(
-            table
-        )} (${columnDefinitions}`;
+        const columnDefinitions = table.columns.map(column => this.buildCreateColumnSql(column, true)).join(", ");
+        let sql = `CREATE TABLE ${this.escapePath(table)} (${columnDefinitions}`;
 
         // we create unique indexes instead of unique constraints, because MySql does not have unique constraints.
         // if we mark column as Unique, it means that we create UNIQUE INDEX.
         table.columns
-            .filter((column) => column.isUnique)
-            .forEach((column) => {
-                const isUniqueIndexExist = table.indices.some((index) => {
-                    return (
-                        index.columnNames.length === 1 &&
-                        !!index.isUnique &&
-                        index.columnNames.indexOf(column.name) !== -1
-                    );
+            .filter(column => column.isUnique)
+            .forEach(column => {
+                const isUniqueIndexExist = table.indices.some(index => {
+                    return index.columnNames.length === 1 && !!index.isUnique && index.columnNames.indexOf(column.name) !== -1;
                 });
-                const isUniqueConstraintExist = table.uniques.some((unique) => {
-                    return (
-                        unique.columnNames.length === 1 &&
-                        unique.columnNames.indexOf(column.name) !== -1
-                    );
+                const isUniqueConstraintExist = table.uniques.some(unique => {
+                    return unique.columnNames.length === 1 && unique.columnNames.indexOf(column.name) !== -1;
                 });
                 if (!isUniqueIndexExist && !isUniqueConstraintExist)
-                    table.indices.push(
-                        new TableIndex({
-                            name: this.connection.namingStrategy.uniqueConstraintName(
-                                table.name,
-                                [column.name]
-                            ),
-                            columnNames: [column.name],
-                            isUnique: true,
-                        })
-                    );
+                    table.indices.push(new TableIndex({
+                        name: this.connection.namingStrategy.uniqueConstraintName(table.name, [column.name]),
+                        columnNames: [column.name],
+                        isUnique: true
+                    }));
             });
 
         // as MySql does not have unique constraints, we must create table indices from table uniques and mark them as unique.
         if (table.uniques.length > 0) {
-            table.uniques.forEach((unique) => {
-                const uniqueExist = table.indices.some(
-                    (index) => index.name === unique.name
-                );
+            table.uniques.forEach(unique => {
+                const uniqueExist = table.indices.some(index => index.name === unique.name);
                 if (!uniqueExist) {
-                    table.indices.push(
-                        new TableIndex({
-                            name: unique.name,
-                            columnNames: unique.columnNames,
-                            isUnique: true,
-                        })
-                    );
+                    table.indices.push(new TableIndex({
+                        name: unique.name,
+                        columnNames: unique.columnNames,
+                        isUnique: true
+                    }));
                 }
             });
         }
 
         if (table.indices.length > 0) {
-            const indicesSql = table.indices
-                .map((index) => {
-                    const columnNames = index.columnNames
-                        .map((columnName) => `\`${columnName}\``)
-                        .join(", ");
-                    if (!index.name)
-                        index.name = this.connection.namingStrategy.indexName(
-                            table.name,
-                            index.columnNames,
-                            index.where
-                        );
+            const indicesSql = table.indices.map(index => {
+                const columnNames = index.columnNames.map(columnName => `\`${columnName}\``).join(", ");
+                if (!index.name)
+                    index.name = this.connection.namingStrategy.indexName(table.name, index.columnNames, index.where);
 
-                    let indexType = "";
-                    if (index.isUnique) indexType += "UNIQUE ";
-                    if (index.isSpatial) indexType += "SPATIAL ";
-                    if (index.isFulltext) indexType += "FULLTEXT ";
-                    return `${indexType}INDEX \`${index.name}\` (${columnNames})`;
-                })
-                .join(", ");
+                let indexType = "";
+                if (index.isUnique)
+                    indexType += "UNIQUE ";
+                if (index.isSpatial)
+                    indexType += "SPATIAL ";
+                if (index.isFulltext)
+                    indexType += "FULLTEXT ";
+                return `${indexType}INDEX \`${index.name}\` (${columnNames})`;
+            }).join(", ");
 
             sql += `, ${indicesSql}`;
         }
 
         if (table.foreignKeys.length > 0 && createForeignKeys) {
-            const foreignKeysSql = table.foreignKeys
-                .map((fk) => {
-                    const columnNames = fk.columnNames
-                        .map((columnName) => `\`${columnName}\``)
-                        .join(", ");
-                    if (!fk.name)
-                        fk.name = this.connection.namingStrategy.foreignKeyName(
-                            table.name,
-                            fk.columnNames
-                        );
-                    const referencedColumnNames = fk.referencedColumnNames
-                        .map((columnName) => `\`${columnName}\``)
-                        .join(", ");
+            const foreignKeysSql = table.foreignKeys.map(fk => {
+                const columnNames = fk.columnNames.map(columnName => `\`${columnName}\``).join(", ");
+                if (!fk.name)
+                    fk.name = this.connection.namingStrategy.foreignKeyName(table.name, fk.columnNames);
+                const referencedColumnNames = fk.referencedColumnNames.map(columnName => `\`${columnName}\``).join(", ");
 
-                    let constraint = `CONSTRAINT \`${
-                        fk.name
-                    }\` FOREIGN KEY (${columnNames}) REFERENCES ${this.escapePath(
-                        fk.referencedTableName
-                    )} (${referencedColumnNames})`;
-                    if (fk.onDelete) constraint += ` ON DELETE ${fk.onDelete}`;
-                    if (fk.onUpdate) constraint += ` ON UPDATE ${fk.onUpdate}`;
+                let constraint = `CONSTRAINT \`${fk.name}\` FOREIGN KEY (${columnNames}) REFERENCES ${this.escapePath(fk.referencedTableName)} (${referencedColumnNames})`;
+                if (fk.onDelete)
+                    constraint += ` ON DELETE ${fk.onDelete}`;
+                if (fk.onUpdate)
+                    constraint += ` ON UPDATE ${fk.onUpdate}`;
 
-                    return constraint;
-                })
-                .join(", ");
+                return constraint;
+            }).join(", ");
 
             sql += `, ${foreignKeysSql}`;
         }
 
         if (table.primaryColumns.length > 0) {
-            const columnNames = table.primaryColumns
-                .map((column) => `\`${column.name}\``)
-                .join(", ");
+            const columnNames = table.primaryColumns.map(column => `\`${column.name}\``).join(", ");
             sql += `, PRIMARY KEY (${columnNames})`;
         }
 
@@ -2527,43 +1498,25 @@ export class AuroraDataApiQueryRunner
     /**
      * Builds drop table sql
      */
-    protected dropTableSql(tableOrName: Table | string): Query {
+    protected dropTableSql(tableOrName: Table|string): Query {
         return new Query(`DROP TABLE ${this.escapePath(tableOrName)}`);
     }
 
     protected createViewSql(view: View): Query {
         if (typeof view.expression === "string") {
-            return new Query(
-                `CREATE VIEW ${this.escapePath(view)} AS ${view.expression}`
-            );
+            return new Query(`CREATE VIEW ${this.escapePath(view)} AS ${view.expression}`);
         } else {
-            return new Query(
-                `CREATE VIEW ${this.escapePath(view)} AS ${view
-                    .expression(this.connection)
-                    .getQuery()}`
-            );
+            return new Query(`CREATE VIEW ${this.escapePath(view)} AS ${view.expression(this.connection).getQuery()}`);
         }
     }
 
     protected async insertViewDefinitionSql(view: View): Promise<Query> {
         const currentDatabase = await this.getCurrentDatabase();
-        const expression =
-            typeof view.expression === "string"
-                ? view.expression.trim()
-                : view.expression(this.connection).getQuery();
-        const [
-            query,
-            parameters,
-        ] = this.connection
-            .createQueryBuilder()
+        const expression = typeof view.expression === "string" ? view.expression.trim() : view.expression(this.connection).getQuery();
+        const [query, parameters] = this.connection.createQueryBuilder()
             .insert()
             .into(this.getTypeormMetadataTableName())
-            .values({
-                type: "VIEW",
-                schema: currentDatabase,
-                name: view.name,
-                value: expression,
-            })
+            .values({ type: "VIEW", schema: currentDatabase, name: view.name, value: expression })
             .getQueryAndParameters();
 
         return new Query(query, parameters);
@@ -2572,27 +1525,21 @@ export class AuroraDataApiQueryRunner
     /**
      * Builds drop view sql.
      */
-    protected dropViewSql(viewOrPath: View | string): Query {
+    protected dropViewSql(viewOrPath: View|string): Query {
         return new Query(`DROP VIEW ${this.escapePath(viewOrPath)}`);
     }
 
     /**
      * Builds remove view sql.
      */
-    protected async deleteViewDefinitionSql(
-        viewOrPath: View | string
-    ): Promise<Query> {
+    protected async deleteViewDefinitionSql(viewOrPath: View|string): Promise<Query> {
         const currentDatabase = await this.getCurrentDatabase();
-        const viewName =
-            viewOrPath instanceof View ? viewOrPath.name : viewOrPath;
+        const viewName = viewOrPath instanceof View ? viewOrPath.name : viewOrPath;
         const qb = this.connection.createQueryBuilder();
-        const [query, parameters] = qb
-            .delete()
+        const [query, parameters] = qb.delete()
             .from(this.getTypeormMetadataTableName())
             .where(`${qb.escape("type")} = 'VIEW'`)
-            .andWhere(`${qb.escape("schema")} = :schema`, {
-                schema: currentDatabase,
-            })
+            .andWhere(`${qb.escape("schema")} = :schema`, { schema: currentDatabase })
             .andWhere(`${qb.escape("name")} = :name`, { name: viewName })
             .getQueryAndParameters();
 
@@ -2603,79 +1550,52 @@ export class AuroraDataApiQueryRunner
      * Builds create index sql.
      */
     protected createIndexSql(table: Table, index: TableIndex): Query {
-        const columns = index.columnNames
-            .map((columnName) => `\`${columnName}\``)
-            .join(", ");
+        const columns = index.columnNames.map(columnName => `\`${columnName}\``).join(", ");
         let indexType = "";
-        if (index.isUnique) indexType += "UNIQUE ";
-        if (index.isSpatial) indexType += "SPATIAL ";
-        if (index.isFulltext) indexType += "FULLTEXT ";
-        return new Query(
-            `CREATE ${indexType}INDEX \`${index.name}\` ON ${this.escapePath(
-                table
-            )} (${columns})`
-        );
+        if (index.isUnique)
+            indexType += "UNIQUE ";
+        if (index.isSpatial)
+            indexType += "SPATIAL ";
+        if (index.isFulltext)
+            indexType += "FULLTEXT ";
+        return new Query(`CREATE ${indexType}INDEX \`${index.name}\` ON ${this.escapePath(table)} (${columns})`);
     }
 
     /**
      * Builds drop index sql.
      */
-    protected dropIndexSql(
-        table: Table,
-        indexOrName: TableIndex | string
-    ): Query {
-        let indexName =
-            indexOrName instanceof TableIndex ? indexOrName.name : indexOrName;
-        return new Query(
-            `DROP INDEX \`${indexName}\` ON ${this.escapePath(table)}`
-        );
+    protected dropIndexSql(table: Table, indexOrName: TableIndex|string): Query {
+        let indexName = indexOrName instanceof TableIndex ? indexOrName.name : indexOrName;
+        return new Query(`DROP INDEX \`${indexName}\` ON ${this.escapePath(table)}`);
     }
 
     /**
      * Builds create primary key sql.
      */
     protected createPrimaryKeySql(table: Table, columnNames: string[]): Query {
-        const columnNamesString = columnNames
-            .map((columnName) => `\`${columnName}\``)
-            .join(", ");
-        return new Query(
-            `ALTER TABLE ${this.escapePath(
-                table
-            )} ADD PRIMARY KEY (${columnNamesString})`
-        );
+        const columnNamesString = columnNames.map(columnName => `\`${columnName}\``).join(", ");
+        return new Query(`ALTER TABLE ${this.escapePath(table)} ADD PRIMARY KEY (${columnNamesString})`);
     }
 
     /**
      * Builds drop primary key sql.
      */
     protected dropPrimaryKeySql(table: Table): Query {
-        return new Query(
-            `ALTER TABLE ${this.escapePath(table)} DROP PRIMARY KEY`
-        );
+        return new Query(`ALTER TABLE ${this.escapePath(table)} DROP PRIMARY KEY`);
     }
 
     /**
      * Builds create foreign key sql.
      */
-    protected createForeignKeySql(
-        table: Table,
-        foreignKey: TableForeignKey
-    ): Query {
-        const columnNames = foreignKey.columnNames
-            .map((column) => `\`${column}\``)
-            .join(", ");
-        const referencedColumnNames = foreignKey.referencedColumnNames
-            .map((column) => `\`${column}\``)
-            .join(",");
-        let sql =
-            `ALTER TABLE ${this.escapePath(table)} ADD CONSTRAINT \`${
-                foreignKey.name
-            }\` FOREIGN KEY (${columnNames}) ` +
-            `REFERENCES ${this.escapePath(
-                foreignKey.referencedTableName
-            )}(${referencedColumnNames})`;
-        if (foreignKey.onDelete) sql += ` ON DELETE ${foreignKey.onDelete}`;
-        if (foreignKey.onUpdate) sql += ` ON UPDATE ${foreignKey.onUpdate}`;
+    protected createForeignKeySql(table: Table, foreignKey: TableForeignKey): Query {
+        const columnNames = foreignKey.columnNames.map(column => `\`${column}\``).join(", ");
+        const referencedColumnNames = foreignKey.referencedColumnNames.map(column => `\`${column}\``).join(",");
+        let sql = `ALTER TABLE ${this.escapePath(table)} ADD CONSTRAINT \`${foreignKey.name}\` FOREIGN KEY (${columnNames}) ` +
+            `REFERENCES ${this.escapePath(foreignKey.referencedTableName)}(${referencedColumnNames})`;
+        if (foreignKey.onDelete)
+            sql += ` ON DELETE ${foreignKey.onDelete}`;
+        if (foreignKey.onUpdate)
+            sql += ` ON UPDATE ${foreignKey.onUpdate}`;
 
         return new Query(sql);
     }
@@ -2683,32 +1603,16 @@ export class AuroraDataApiQueryRunner
     /**
      * Builds drop foreign key sql.
      */
-    protected dropForeignKeySql(
-        table: Table,
-        foreignKeyOrName: TableForeignKey | string
-    ): Query {
-        const foreignKeyName =
-            foreignKeyOrName instanceof TableForeignKey
-                ? foreignKeyOrName.name
-                : foreignKeyOrName;
-        return new Query(
-            `ALTER TABLE ${this.escapePath(
-                table
-            )} DROP FOREIGN KEY \`${foreignKeyName}\``
-        );
+    protected dropForeignKeySql(table: Table, foreignKeyOrName: TableForeignKey|string): Query {
+        const foreignKeyName = foreignKeyOrName instanceof TableForeignKey ? foreignKeyOrName.name : foreignKeyOrName;
+        return new Query(`ALTER TABLE ${this.escapePath(table)} DROP FOREIGN KEY \`${foreignKeyName}\``);
     }
 
-    protected parseTableName(target: Table | string) {
+    protected parseTableName(target: Table|string) {
         const tableName = target instanceof Table ? target.name : target;
         return {
-            database:
-                tableName.indexOf(".") !== -1
-                    ? tableName.split(".")[0]
-                    : this.driver.database,
-            tableName:
-                tableName.indexOf(".") !== -1
-                    ? tableName.split(".")[1]
-                    : tableName,
+            database: tableName.indexOf(".") !== -1 ? tableName.split(".")[0] : this.driver.database,
+            tableName: tableName.indexOf(".") !== -1 ? tableName.split(".")[1] : tableName
         };
     }
 
@@ -2731,40 +1635,23 @@ export class AuroraDataApiQueryRunner
     /**
      * Escapes given table or view path.
      */
-    protected escapePath(
-        target: Table | View | string,
-        disableEscape?: boolean
-    ): string {
-        const tableName =
-            target instanceof Table || target instanceof View
-                ? target.name
-                : target;
-        return tableName
-            .split(".")
-            .map((i) => (disableEscape ? i : `\`${i}\``))
-            .join(".");
+    protected escapePath(target: Table|View|string, disableEscape?: boolean): string {
+        const tableName = target instanceof Table || target instanceof View ? target.name : target;
+        return tableName.split(".").map(i => disableEscape ? i : `\`${i}\``).join(".");
     }
 
     /**
      * Builds a part of query to create/change a column.
      */
-    protected buildCreateColumnSql(
-        column: TableColumn,
-        skipPrimary: boolean,
-        skipName: boolean = false
-    ) {
+    protected buildCreateColumnSql(column: TableColumn, skipPrimary: boolean, skipName: boolean = false) {
         let c = "";
         if (skipName) {
             c = this.connection.driver.createFullType(column);
         } else {
-            c = `\`${column.name}\` ${this.connection.driver.createFullType(
-                column
-            )}`;
+            c = `\`${column.name}\` ${this.connection.driver.createFullType(column)}`;
         }
         if (column.asExpression)
-            c += ` AS (${column.asExpression}) ${
-                column.generatedType ? column.generatedType : "VIRTUAL"
-            }`;
+            c += ` AS (${column.asExpression}) ${column.generatedType ? column.generatedType : "VIRTUAL"}`;
 
         // if you specify ZEROFILL for a numeric column, MySQL automatically adds the UNSIGNED attribute to that column.
         if (column.zerofill) {
@@ -2773,22 +1660,25 @@ export class AuroraDataApiQueryRunner
             c += " UNSIGNED";
         }
         if (column.enum)
-            c += ` (${column.enum
-                .map((value) => "'" + value + "'")
-                .join(", ")})`;
-        if (column.charset) c += ` CHARACTER SET "${column.charset}"`;
-        if (column.collation) c += ` COLLATE "${column.collation}"`;
-        if (!column.isNullable) c += " NOT NULL";
-        if (column.isNullable) c += " NULL";
-        if (column.isPrimary && !skipPrimary) c += " PRIMARY KEY";
-        if (column.isGenerated && column.generationStrategy === "increment")
-            // don't use skipPrimary here since updates can update already exist primary without auto inc.
+            c += ` (${column.enum.map(value => "'" + value + "'").join(", ")})`;
+        if (column.charset)
+            c += ` CHARACTER SET "${column.charset}"`;
+        if (column.collation)
+            c += ` COLLATE "${column.collation}"`;
+        if (!column.isNullable)
+            c += " NOT NULL";
+        if (column.isNullable)
+            c += " NULL";
+        if (column.isPrimary && !skipPrimary)
+            c += " PRIMARY KEY";
+        if (column.isGenerated && column.generationStrategy === "increment") // don't use skipPrimary here since updates can update already exist primary without auto inc.
             c += " AUTO_INCREMENT";
         if (column.comment)
             c += ` COMMENT ${this.escapeComment(column.comment)}`;
         if (column.default !== undefined && column.default !== null)
             c += ` DEFAULT ${column.default}`;
-        if (column.onUpdate) c += ` ON UPDATE ${column.onUpdate}`;
+        if (column.onUpdate)
+            c += ` ON UPDATE ${column.onUpdate}`;
 
         return c;
     }
@@ -2796,28 +1686,23 @@ export class AuroraDataApiQueryRunner
     /**
      * Checks if column display width is by default.
      */
-    protected isDefaultColumnWidth(
-        table: Table,
-        column: TableColumn,
-        width: number
-    ): boolean {
+    protected isDefaultColumnWidth(table: Table, column: TableColumn, width: number): boolean {
         // if table have metadata, we check if length is specified in column metadata
         if (this.connection.hasMetadata(table.name)) {
             const metadata = this.connection.getMetadata(table.name);
-            const columnMetadata = metadata.findColumnWithDatabaseName(
-                column.name
-            );
-            if (columnMetadata && columnMetadata.width) return false;
+            const columnMetadata = metadata.findColumnWithDatabaseName(column.name);
+            if (columnMetadata && columnMetadata.width)
+                return false;
         }
 
-        const defaultWidthForType =
-            this.connection.driver.dataTypeDefaults &&
-            this.connection.driver.dataTypeDefaults[column.type] &&
-            this.connection.driver.dataTypeDefaults[column.type].width;
+        const defaultWidthForType = this.connection.driver.dataTypeDefaults
+            && this.connection.driver.dataTypeDefaults[column.type]
+            && this.connection.driver.dataTypeDefaults[column.type].width;
 
         if (defaultWidthForType) {
             return defaultWidthForType === width;
         }
         return false;
     }
+
 }

--- a/src/driver/aurora-data-api/AuroraDataApiQueryRunner.ts
+++ b/src/driver/aurora-data-api/AuroraDataApiQueryRunner.ts
@@ -1,32 +1,33 @@
-import {QueryRunner} from "../../query-runner/QueryRunner";
-import {ObjectLiteral} from "../../common/ObjectLiteral";
-import {TransactionAlreadyStartedError} from "../../error/TransactionAlreadyStartedError";
-import {TransactionNotStartedError} from "../../error/TransactionNotStartedError";
-import {TableColumn} from "../../schema-builder/table/TableColumn";
-import {Table} from "../../schema-builder/table/Table";
-import {TableForeignKey} from "../../schema-builder/table/TableForeignKey";
-import {TableIndex} from "../../schema-builder/table/TableIndex";
-import {QueryRunnerAlreadyReleasedError} from "../../error/QueryRunnerAlreadyReleasedError";
-import {View} from "../../schema-builder/view/View";
-import {Query} from "../Query";
-import {AuroraDataApiDriver} from "./AuroraDataApiDriver";
-import {ReadStream} from "../../platform/PlatformTools";
-import {OrmUtils} from "../../util/OrmUtils";
-import {TableIndexOptions} from "../../schema-builder/options/TableIndexOptions";
-import {TableUnique} from "../../schema-builder/table/TableUnique";
-import {BaseQueryRunner} from "../../query-runner/BaseQueryRunner";
-import {Broadcaster} from "../../subscriber/Broadcaster";
-import {ColumnType} from "../../index";
-import {TableCheck} from "../../schema-builder/table/TableCheck";
-import {IsolationLevel} from "../types/IsolationLevel";
-import {TableExclusion} from "../../schema-builder/table/TableExclusion";
-import {BroadcasterResult} from "../../subscriber/BroadcasterResult";
+import { QueryRunner } from "../../query-runner/QueryRunner";
+import { ObjectLiteral } from "../../common/ObjectLiteral";
+import { TransactionAlreadyStartedError } from "../../error/TransactionAlreadyStartedError";
+import { TransactionNotStartedError } from "../../error/TransactionNotStartedError";
+import { TableColumn } from "../../schema-builder/table/TableColumn";
+import { Table } from "../../schema-builder/table/Table";
+import { TableForeignKey } from "../../schema-builder/table/TableForeignKey";
+import { TableIndex } from "../../schema-builder/table/TableIndex";
+import { QueryRunnerAlreadyReleasedError } from "../../error/QueryRunnerAlreadyReleasedError";
+import { View } from "../../schema-builder/view/View";
+import { Query } from "../Query";
+import { AuroraDataApiDriver } from "./AuroraDataApiDriver";
+import { ReadStream } from "../../platform/PlatformTools";
+import { OrmUtils } from "../../util/OrmUtils";
+import { TableIndexOptions } from "../../schema-builder/options/TableIndexOptions";
+import { TableUnique } from "../../schema-builder/table/TableUnique";
+import { BaseQueryRunner } from "../../query-runner/BaseQueryRunner";
+import { Broadcaster } from "../../subscriber/Broadcaster";
+import { ColumnType } from "../../index";
+import { TableCheck } from "../../schema-builder/table/TableCheck";
+import { IsolationLevel } from "../types/IsolationLevel";
+import { TableExclusion } from "../../schema-builder/table/TableExclusion";
+import { BroadcasterResult } from "../../subscriber/BroadcasterResult";
 
 /**
  * Runs queries on a single mysql database connection.
  */
-export class AuroraDataApiQueryRunner extends BaseQueryRunner implements QueryRunner {
-
+export class AuroraDataApiQueryRunner
+    extends BaseQueryRunner
+    implements QueryRunner {
     // -------------------------------------------------------------------------
     // Public Implemented Properties
     // -------------------------------------------------------------------------
@@ -37,7 +38,7 @@ export class AuroraDataApiQueryRunner extends BaseQueryRunner implements QueryRu
 
     driver: AuroraDataApiDriver;
 
-    protected client: any
+    protected client: any;
 
     // -------------------------------------------------------------------------
     // Protected Properties
@@ -78,8 +79,7 @@ export class AuroraDataApiQueryRunner extends BaseQueryRunner implements QueryRu
      */
     release(): Promise<void> {
         this.isReleased = true;
-        if (this.databaseConnection)
-            this.databaseConnection.release();
+        if (this.databaseConnection) this.databaseConnection.release();
         return Promise.resolve();
     }
 
@@ -91,16 +91,21 @@ export class AuroraDataApiQueryRunner extends BaseQueryRunner implements QueryRu
             throw new TransactionAlreadyStartedError();
 
         const beforeBroadcastResult = new BroadcasterResult();
-        this.broadcaster.broadcastBeforeTransactionStartEvent(beforeBroadcastResult);
-        if (beforeBroadcastResult.promises.length > 0) await Promise.all(beforeBroadcastResult.promises);
+        this.broadcaster.broadcastBeforeTransactionStartEvent(
+            beforeBroadcastResult
+        );
+        if (beforeBroadcastResult.promises.length > 0)
+            await Promise.all(beforeBroadcastResult.promises);
 
         this.isTransactionActive = true;
         await this.client.startTransaction();
 
-
         const afterBroadcastResult = new BroadcasterResult();
-        this.broadcaster.broadcastAfterTransactionStartEvent(afterBroadcastResult);
-        if (afterBroadcastResult.promises.length > 0) await Promise.all(afterBroadcastResult.promises);
+        this.broadcaster.broadcastAfterTransactionStartEvent(
+            afterBroadcastResult
+        );
+        if (afterBroadcastResult.promises.length > 0)
+            await Promise.all(afterBroadcastResult.promises);
     }
 
     /**
@@ -108,19 +113,24 @@ export class AuroraDataApiQueryRunner extends BaseQueryRunner implements QueryRu
      * Error will be thrown if transaction was not started.
      */
     async commitTransaction(): Promise<void> {
-        if (!this.isTransactionActive)
-            throw new TransactionNotStartedError();
+        if (!this.isTransactionActive) throw new TransactionNotStartedError();
 
         const beforeBroadcastResult = new BroadcasterResult();
-        this.broadcaster.broadcastBeforeTransactionCommitEvent(beforeBroadcastResult);
-        if (beforeBroadcastResult.promises.length > 0) await Promise.all(beforeBroadcastResult.promises);
+        this.broadcaster.broadcastBeforeTransactionCommitEvent(
+            beforeBroadcastResult
+        );
+        if (beforeBroadcastResult.promises.length > 0)
+            await Promise.all(beforeBroadcastResult.promises);
 
         await this.client.commitTransaction();
         this.isTransactionActive = false;
 
         const afterBroadcastResult = new BroadcasterResult();
-        this.broadcaster.broadcastAfterTransactionCommitEvent(afterBroadcastResult);
-        if (afterBroadcastResult.promises.length > 0) await Promise.all(afterBroadcastResult.promises);
+        this.broadcaster.broadcastAfterTransactionCommitEvent(
+            afterBroadcastResult
+        );
+        if (afterBroadcastResult.promises.length > 0)
+            await Promise.all(afterBroadcastResult.promises);
     }
 
     /**
@@ -128,28 +138,32 @@ export class AuroraDataApiQueryRunner extends BaseQueryRunner implements QueryRu
      * Error will be thrown if transaction was not started.
      */
     async rollbackTransaction(): Promise<void> {
-        if (!this.isTransactionActive)
-            throw new TransactionNotStartedError();
+        if (!this.isTransactionActive) throw new TransactionNotStartedError();
 
         const beforeBroadcastResult = new BroadcasterResult();
-        this.broadcaster.broadcastBeforeTransactionRollbackEvent(beforeBroadcastResult);
-        if (beforeBroadcastResult.promises.length > 0) await Promise.all(beforeBroadcastResult.promises);
+        this.broadcaster.broadcastBeforeTransactionRollbackEvent(
+            beforeBroadcastResult
+        );
+        if (beforeBroadcastResult.promises.length > 0)
+            await Promise.all(beforeBroadcastResult.promises);
 
         await this.client.rollbackTransaction();
 
         this.isTransactionActive = false;
 
         const afterBroadcastResult = new BroadcasterResult();
-        this.broadcaster.broadcastAfterTransactionRollbackEvent(afterBroadcastResult);
-        if (afterBroadcastResult.promises.length > 0) await Promise.all(afterBroadcastResult.promises);
+        this.broadcaster.broadcastAfterTransactionRollbackEvent(
+            afterBroadcastResult
+        );
+        if (afterBroadcastResult.promises.length > 0)
+            await Promise.all(afterBroadcastResult.promises);
     }
 
     /**
      * Executes a raw SQL query.
      */
     async query(query: string, parameters?: any[]): Promise<any> {
-        if (this.isReleased)
-            throw new QueryRunnerAlreadyReleasedError();
+        if (this.isReleased) throw new QueryRunnerAlreadyReleasedError();
 
         const result = await this.client.query(query, parameters);
 
@@ -163,9 +177,13 @@ export class AuroraDataApiQueryRunner extends BaseQueryRunner implements QueryRu
     /**
      * Returns raw data stream.
      */
-    stream(query: string, parameters?: any[], onEnd?: Function, onError?: Function): Promise<ReadStream> {
-        if (this.isReleased)
-            throw new QueryRunnerAlreadyReleasedError();
+    stream(
+        query: string,
+        parameters?: any[],
+        onEnd?: Function,
+        onError?: Function
+    ): Promise<ReadStream> {
+        if (this.isReleased) throw new QueryRunnerAlreadyReleasedError();
 
         return new Promise(async (ok, fail) => {
             try {
@@ -174,7 +192,6 @@ export class AuroraDataApiQueryRunner extends BaseQueryRunner implements QueryRu
                 if (onEnd) stream.on("end", onEnd);
                 if (onError) stream.on("error", onError);
                 ok(stream);
-
             } catch (err) {
                 fail(err);
             }
@@ -200,7 +217,9 @@ export class AuroraDataApiQueryRunner extends BaseQueryRunner implements QueryRu
      * Checks if database with the given name exist.
      */
     async hasDatabase(database: string): Promise<boolean> {
-        const result = await this.query(`SELECT * FROM \`INFORMATION_SCHEMA\`.\`SCHEMATA\` WHERE \`SCHEMA_NAME\` = '${database}'`);
+        const result = await this.query(
+            `SELECT * FROM \`INFORMATION_SCHEMA\`.\`SCHEMATA\` WHERE \`SCHEMA_NAME\` = '${database}'`
+        );
         return result.length ? true : false;
     }
 
@@ -230,7 +249,7 @@ export class AuroraDataApiQueryRunner extends BaseQueryRunner implements QueryRu
     /**
      * Checks if table with the given name exist in the database.
      */
-    async hasTable(tableOrName: Table|string): Promise<boolean> {
+    async hasTable(tableOrName: Table | string): Promise<boolean> {
         const parsedTableName = this.parseTableName(tableOrName);
         const sql = `SELECT * FROM \`INFORMATION_SCHEMA\`.\`COLUMNS\` WHERE \`TABLE_SCHEMA\` = '${parsedTableName.database}' AND \`TABLE_NAME\` = '${parsedTableName.tableName}'`;
         const result = await this.query(sql);
@@ -240,7 +259,10 @@ export class AuroraDataApiQueryRunner extends BaseQueryRunner implements QueryRu
     /**
      * Checks if column with the given name exist in the given table.
      */
-    async hasColumn(tableOrName: Table|string, column: TableColumn|string): Promise<boolean> {
+    async hasColumn(
+        tableOrName: Table | string,
+        column: TableColumn | string
+    ): Promise<boolean> {
         const parsedTableName = this.parseTableName(tableOrName);
         const columnName = column instanceof TableColumn ? column.name : column;
         const sql = `SELECT * FROM \`INFORMATION_SCHEMA\`.\`COLUMNS\` WHERE \`TABLE_SCHEMA\` = '${parsedTableName.database}' AND \`TABLE_NAME\` = '${parsedTableName.tableName}' AND \`COLUMN_NAME\` = '${columnName}'`;
@@ -251,8 +273,13 @@ export class AuroraDataApiQueryRunner extends BaseQueryRunner implements QueryRu
     /**
      * Creates a new database.
      */
-    async createDatabase(database: string, ifNotExist?: boolean): Promise<void> {
-        const up = ifNotExist ? `CREATE DATABASE IF NOT EXISTS \`${database}\`` : `CREATE DATABASE \`${database}\``;
+    async createDatabase(
+        database: string,
+        ifNotExist?: boolean
+    ): Promise<void> {
+        const up = ifNotExist
+            ? `CREATE DATABASE IF NOT EXISTS \`${database}\``
+            : `CREATE DATABASE \`${database}\``;
         const down = `DROP DATABASE \`${database}\``;
         await this.executeQueries(new Query(up), new Query(down));
     }
@@ -261,7 +288,9 @@ export class AuroraDataApiQueryRunner extends BaseQueryRunner implements QueryRu
      * Drops database.
      */
     async dropDatabase(database: string, ifExist?: boolean): Promise<void> {
-        const up = ifExist ? `DROP DATABASE IF EXISTS \`${database}\`` : `DROP DATABASE \`${database}\``;
+        const up = ifExist
+            ? `DROP DATABASE IF EXISTS \`${database}\``
+            : `DROP DATABASE \`${database}\``;
         const down = `CREATE DATABASE \`${database}\``;
         await this.executeQueries(new Query(up), new Query(down));
     }
@@ -270,20 +299,28 @@ export class AuroraDataApiQueryRunner extends BaseQueryRunner implements QueryRu
      * Creates a new table schema.
      */
     async createSchema(schema: string, ifNotExist?: boolean): Promise<void> {
-        throw new Error(`Schema create queries are not supported by MySql driver.`);
+        throw new Error(
+            `Schema create queries are not supported by MySql driver.`
+        );
     }
 
     /**
      * Drops table schema.
      */
     async dropSchema(schemaPath: string, ifExist?: boolean): Promise<void> {
-        throw new Error(`Schema drop queries are not supported by MySql driver.`);
+        throw new Error(
+            `Schema drop queries are not supported by MySql driver.`
+        );
     }
 
     /**
      * Creates a new table.
      */
-    async createTable(table: Table, ifNotExist: boolean = false, createForeignKeys: boolean = true): Promise<void> {
+    async createTable(
+        table: Table,
+        ifNotExist: boolean = false,
+        createForeignKeys: boolean = true
+    ): Promise<void> {
         if (ifNotExist) {
             const isTableExist = await this.hasTable(table);
             if (isTableExist) return Promise.resolve();
@@ -299,12 +336,16 @@ export class AuroraDataApiQueryRunner extends BaseQueryRunner implements QueryRu
         // if it related to the foreign key.
 
         // createTable does not need separate method to create indices, because it create indices in the same query with table creation.
-        table.indices.forEach(index => downQueries.push(this.dropIndexSql(table, index)));
+        table.indices.forEach((index) =>
+            downQueries.push(this.dropIndexSql(table, index))
+        );
 
         // if createForeignKeys is true, we must drop created foreign keys in down query.
         // createTable does not need separate method to create foreign keys, because it create fk's in the same query with table creation.
         if (createForeignKeys)
-            table.foreignKeys.forEach(foreignKey => downQueries.push(this.dropForeignKeySql(table, foreignKey)));
+            table.foreignKeys.forEach((foreignKey) =>
+                downQueries.push(this.dropForeignKeySql(table, foreignKey))
+            );
 
         return this.executeQueries(upQueries, downQueries);
     }
@@ -312,7 +353,11 @@ export class AuroraDataApiQueryRunner extends BaseQueryRunner implements QueryRu
     /**
      * Drop the table.
      */
-    async dropTable(target: Table|string, ifExist?: boolean, dropForeignKeys: boolean = true): Promise<void> {
+    async dropTable(
+        target: Table | string,
+        ifExist?: boolean,
+        dropForeignKeys: boolean = true
+    ): Promise<void> {
         // It needs because if table does not exist and dropForeignKeys or dropIndices is true, we don't need
         // to perform drop queries for foreign keys and indices.
         if (ifExist) {
@@ -328,9 +373,13 @@ export class AuroraDataApiQueryRunner extends BaseQueryRunner implements QueryRu
         const downQueries: Query[] = [];
 
         if (dropForeignKeys)
-            table.foreignKeys.forEach(foreignKey => upQueries.push(this.dropForeignKeySql(table, foreignKey)));
+            table.foreignKeys.forEach((foreignKey) =>
+                upQueries.push(this.dropForeignKeySql(table, foreignKey))
+            );
 
-        table.indices.forEach(index => upQueries.push(this.dropIndexSql(table, index)));
+        table.indices.forEach((index) =>
+            upQueries.push(this.dropIndexSql(table, index))
+        );
 
         upQueries.push(this.dropTableSql(table));
         downQueries.push(this.createTableSql(table, createForeignKeys));
@@ -354,7 +403,7 @@ export class AuroraDataApiQueryRunner extends BaseQueryRunner implements QueryRu
     /**
      * Drops the view.
      */
-    async dropView(target: View|string): Promise<void> {
+    async dropView(target: View | string): Promise<void> {
         const viewName = target instanceof View ? target.name : target;
         const view = await this.getCachedView(viewName);
 
@@ -370,56 +419,111 @@ export class AuroraDataApiQueryRunner extends BaseQueryRunner implements QueryRu
     /**
      * Renames a table.
      */
-    async renameTable(oldTableOrName: Table|string, newTableName: string): Promise<void> {
+    async renameTable(
+        oldTableOrName: Table | string,
+        newTableName: string
+    ): Promise<void> {
         const upQueries: Query[] = [];
         const downQueries: Query[] = [];
-        const oldTable = oldTableOrName instanceof Table ? oldTableOrName : await this.getCachedTable(oldTableOrName);
+        const oldTable =
+            oldTableOrName instanceof Table
+                ? oldTableOrName
+                : await this.getCachedTable(oldTableOrName);
         const newTable = oldTable.clone();
-        const dbName = oldTable.name.indexOf(".") === -1 ? undefined : oldTable.name.split(".")[0];
+        const dbName =
+            oldTable.name.indexOf(".") === -1
+                ? undefined
+                : oldTable.name.split(".")[0];
         newTable.name = dbName ? `${dbName}.${newTableName}` : newTableName;
 
         // rename table
-        upQueries.push(new Query(`RENAME TABLE ${this.escapePath(oldTable.name)} TO ${this.escapePath(newTable.name)}`));
-        downQueries.push(new Query(`RENAME TABLE ${this.escapePath(newTable.name)} TO ${this.escapePath(oldTable.name)}`));
+        upQueries.push(
+            new Query(
+                `RENAME TABLE ${this.escapePath(
+                    oldTable.name
+                )} TO ${this.escapePath(newTable.name)}`
+            )
+        );
+        downQueries.push(
+            new Query(
+                `RENAME TABLE ${this.escapePath(
+                    newTable.name
+                )} TO ${this.escapePath(oldTable.name)}`
+            )
+        );
 
         // rename index constraints
-        newTable.indices.forEach(index => {
+        newTable.indices.forEach((index) => {
             // build new constraint name
-            const columnNames = index.columnNames.map(column => `\`${column}\``).join(", ");
-            const newIndexName = this.connection.namingStrategy.indexName(newTable, index.columnNames, index.where);
+            const columnNames = index.columnNames
+                .map((column) => `\`${column}\``)
+                .join(", ");
+            const newIndexName = this.connection.namingStrategy.indexName(
+                newTable,
+                index.columnNames,
+                index.where
+            );
 
             // build queries
             let indexType = "";
-            if (index.isUnique)
-                indexType += "UNIQUE ";
-            if (index.isSpatial)
-                indexType += "SPATIAL ";
-            if (index.isFulltext)
-                indexType += "FULLTEXT ";
-            upQueries.push(new Query(`ALTER TABLE ${this.escapePath(newTable)} DROP INDEX \`${index.name}\`, ADD ${indexType}INDEX \`${newIndexName}\` (${columnNames})`));
-            downQueries.push(new Query(`ALTER TABLE ${this.escapePath(newTable)} DROP INDEX \`${newIndexName}\`, ADD ${indexType}INDEX \`${index.name}\` (${columnNames})`));
+            if (index.isUnique) indexType += "UNIQUE ";
+            if (index.isSpatial) indexType += "SPATIAL ";
+            if (index.isFulltext) indexType += "FULLTEXT ";
+            upQueries.push(
+                new Query(
+                    `ALTER TABLE ${this.escapePath(newTable)} DROP INDEX \`${
+                        index.name
+                    }\`, ADD ${indexType}INDEX \`${newIndexName}\` (${columnNames})`
+                )
+            );
+            downQueries.push(
+                new Query(
+                    `ALTER TABLE ${this.escapePath(
+                        newTable
+                    )} DROP INDEX \`${newIndexName}\`, ADD ${indexType}INDEX \`${
+                        index.name
+                    }\` (${columnNames})`
+                )
+            );
 
             // replace constraint name
             index.name = newIndexName;
         });
 
         // rename foreign key constraint
-        newTable.foreignKeys.forEach(foreignKey => {
+        newTable.foreignKeys.forEach((foreignKey) => {
             // build new constraint name
-            const columnNames = foreignKey.columnNames.map(column => `\`${column}\``).join(", ");
-            const referencedColumnNames = foreignKey.referencedColumnNames.map(column => `\`${column}\``).join(",");
-            const newForeignKeyName = this.connection.namingStrategy.foreignKeyName(newTable, foreignKey.columnNames);
+            const columnNames = foreignKey.columnNames
+                .map((column) => `\`${column}\``)
+                .join(", ");
+            const referencedColumnNames = foreignKey.referencedColumnNames
+                .map((column) => `\`${column}\``)
+                .join(",");
+            const newForeignKeyName = this.connection.namingStrategy.foreignKeyName(
+                newTable,
+                foreignKey.columnNames
+            );
 
             // build queries
-            let up = `ALTER TABLE ${this.escapePath(newTable)} DROP FOREIGN KEY \`${foreignKey.name}\`, ADD CONSTRAINT \`${newForeignKeyName}\` FOREIGN KEY (${columnNames}) ` +
-                `REFERENCES ${this.escapePath(foreignKey.referencedTableName)}(${referencedColumnNames})`;
-            if (foreignKey.onDelete)
-                up += ` ON DELETE ${foreignKey.onDelete}`;
-            if (foreignKey.onUpdate)
-                up += ` ON UPDATE ${foreignKey.onUpdate}`;
+            let up =
+                `ALTER TABLE ${this.escapePath(newTable)} DROP FOREIGN KEY \`${
+                    foreignKey.name
+                }\`, ADD CONSTRAINT \`${newForeignKeyName}\` FOREIGN KEY (${columnNames}) ` +
+                `REFERENCES ${this.escapePath(
+                    foreignKey.referencedTableName
+                )}(${referencedColumnNames})`;
+            if (foreignKey.onDelete) up += ` ON DELETE ${foreignKey.onDelete}`;
+            if (foreignKey.onUpdate) up += ` ON UPDATE ${foreignKey.onUpdate}`;
 
-            let down = `ALTER TABLE ${this.escapePath(newTable)} DROP FOREIGN KEY \`${newForeignKeyName}\`, ADD CONSTRAINT \`${foreignKey.name}\` FOREIGN KEY (${columnNames}) ` +
-                `REFERENCES ${this.escapePath(foreignKey.referencedTableName)}(${referencedColumnNames})`;
+            let down =
+                `ALTER TABLE ${this.escapePath(
+                    newTable
+                )} DROP FOREIGN KEY \`${newForeignKeyName}\`, ADD CONSTRAINT \`${
+                    foreignKey.name
+                }\` FOREIGN KEY (${columnNames}) ` +
+                `REFERENCES ${this.escapePath(
+                    foreignKey.referencedTableName
+                )}(${referencedColumnNames})`;
             if (foreignKey.onDelete)
                 down += ` ON DELETE ${foreignKey.onDelete}`;
             if (foreignKey.onUpdate)
@@ -442,67 +546,166 @@ export class AuroraDataApiQueryRunner extends BaseQueryRunner implements QueryRu
     /**
      * Creates a new column from the column in the table.
      */
-    async addColumn(tableOrName: Table|string, column: TableColumn): Promise<void> {
-        const table = tableOrName instanceof Table ? tableOrName : await this.getCachedTable(tableOrName);
+    async addColumn(
+        tableOrName: Table | string,
+        column: TableColumn
+    ): Promise<void> {
+        const table =
+            tableOrName instanceof Table
+                ? tableOrName
+                : await this.getCachedTable(tableOrName);
         const clonedTable = table.clone();
         const upQueries: Query[] = [];
         const downQueries: Query[] = [];
         const skipColumnLevelPrimary = clonedTable.primaryColumns.length > 0;
 
-        upQueries.push(new Query(`ALTER TABLE ${this.escapePath(table)} ADD ${this.buildCreateColumnSql(column, skipColumnLevelPrimary, false)}`));
-        downQueries.push(new Query(`ALTER TABLE ${this.escapePath(table)} DROP COLUMN \`${column.name}\``));
+        upQueries.push(
+            new Query(
+                `ALTER TABLE ${this.escapePath(
+                    table
+                )} ADD ${this.buildCreateColumnSql(
+                    column,
+                    skipColumnLevelPrimary,
+                    false
+                )}`
+            )
+        );
+        downQueries.push(
+            new Query(
+                `ALTER TABLE ${this.escapePath(table)} DROP COLUMN \`${
+                    column.name
+                }\``
+            )
+        );
 
         // create or update primary key constraint
         if (column.isPrimary && skipColumnLevelPrimary) {
             // if we already have generated column, we must temporary drop AUTO_INCREMENT property.
-            const generatedColumn = clonedTable.columns.find(column => column.isGenerated && column.generationStrategy === "increment");
+            const generatedColumn = clonedTable.columns.find(
+                (column) =>
+                    column.isGenerated &&
+                    column.generationStrategy === "increment"
+            );
             if (generatedColumn) {
                 const nonGeneratedColumn = generatedColumn.clone();
                 nonGeneratedColumn.isGenerated = false;
                 nonGeneratedColumn.generationStrategy = undefined;
-                upQueries.push(new Query(`ALTER TABLE ${this.escapePath(table)} CHANGE \`${column.name}\` ${this.buildCreateColumnSql(nonGeneratedColumn, true)}`));
-                downQueries.push(new Query(`ALTER TABLE ${this.escapePath(table)} CHANGE \`${nonGeneratedColumn.name}\` ${this.buildCreateColumnSql(column, true)}`));
+                upQueries.push(
+                    new Query(
+                        `ALTER TABLE ${this.escapePath(table)} CHANGE \`${
+                            column.name
+                        }\` ${this.buildCreateColumnSql(
+                            nonGeneratedColumn,
+                            true
+                        )}`
+                    )
+                );
+                downQueries.push(
+                    new Query(
+                        `ALTER TABLE ${this.escapePath(table)} CHANGE \`${
+                            nonGeneratedColumn.name
+                        }\` ${this.buildCreateColumnSql(column, true)}`
+                    )
+                );
             }
 
             const primaryColumns = clonedTable.primaryColumns;
-            let columnNames = primaryColumns.map(column => `\`${column.name}\``).join(", ");
-            upQueries.push(new Query(`ALTER TABLE ${this.escapePath(table)} DROP PRIMARY KEY`));
-            downQueries.push(new Query(`ALTER TABLE ${this.escapePath(table)} ADD PRIMARY KEY (${columnNames})`));
+            let columnNames = primaryColumns
+                .map((column) => `\`${column.name}\``)
+                .join(", ");
+            upQueries.push(
+                new Query(
+                    `ALTER TABLE ${this.escapePath(table)} DROP PRIMARY KEY`
+                )
+            );
+            downQueries.push(
+                new Query(
+                    `ALTER TABLE ${this.escapePath(
+                        table
+                    )} ADD PRIMARY KEY (${columnNames})`
+                )
+            );
 
             primaryColumns.push(column);
-            columnNames = primaryColumns.map(column => `\`${column.name}\``).join(", ");
-            upQueries.push(new Query(`ALTER TABLE ${this.escapePath(table)} ADD PRIMARY KEY (${columnNames})`));
-            downQueries.push(new Query(`ALTER TABLE ${this.escapePath(table)} DROP PRIMARY KEY`));
+            columnNames = primaryColumns
+                .map((column) => `\`${column.name}\``)
+                .join(", ");
+            upQueries.push(
+                new Query(
+                    `ALTER TABLE ${this.escapePath(
+                        table
+                    )} ADD PRIMARY KEY (${columnNames})`
+                )
+            );
+            downQueries.push(
+                new Query(
+                    `ALTER TABLE ${this.escapePath(table)} DROP PRIMARY KEY`
+                )
+            );
 
             // if we previously dropped AUTO_INCREMENT property, we must bring it back
             if (generatedColumn) {
                 const nonGeneratedColumn = generatedColumn.clone();
                 nonGeneratedColumn.isGenerated = false;
                 nonGeneratedColumn.generationStrategy = undefined;
-                upQueries.push(new Query(`ALTER TABLE ${this.escapePath(table)} CHANGE \`${nonGeneratedColumn.name}\` ${this.buildCreateColumnSql(column, true)}`));
-                downQueries.push(new Query(`ALTER TABLE ${this.escapePath(table)} CHANGE \`${column.name}\` ${this.buildCreateColumnSql(nonGeneratedColumn, true)}`));
+                upQueries.push(
+                    new Query(
+                        `ALTER TABLE ${this.escapePath(table)} CHANGE \`${
+                            nonGeneratedColumn.name
+                        }\` ${this.buildCreateColumnSql(column, true)}`
+                    )
+                );
+                downQueries.push(
+                    new Query(
+                        `ALTER TABLE ${this.escapePath(table)} CHANGE \`${
+                            column.name
+                        }\` ${this.buildCreateColumnSql(
+                            nonGeneratedColumn,
+                            true
+                        )}`
+                    )
+                );
             }
         }
 
         // create column index
-        const columnIndex = clonedTable.indices.find(index => index.columnNames.length === 1 && index.columnNames[0] === column.name);
+        const columnIndex = clonedTable.indices.find(
+            (index) =>
+                index.columnNames.length === 1 &&
+                index.columnNames[0] === column.name
+        );
         if (columnIndex) {
             upQueries.push(this.createIndexSql(table, columnIndex));
             downQueries.push(this.dropIndexSql(table, columnIndex));
-
         } else if (column.isUnique) {
             const uniqueIndex = new TableIndex({
-                name: this.connection.namingStrategy.indexName(table.name, [column.name]),
+                name: this.connection.namingStrategy.indexName(table.name, [
+                    column.name,
+                ]),
                 columnNames: [column.name],
-                isUnique: true
+                isUnique: true,
             });
             clonedTable.indices.push(uniqueIndex);
-            clonedTable.uniques.push(new TableUnique({
-                name: uniqueIndex.name,
-                columnNames: uniqueIndex.columnNames
-            }));
-            upQueries.push(new Query(`ALTER TABLE ${this.escapePath(table)} ADD UNIQUE INDEX \`${uniqueIndex.name}\` (\`${column.name}\`)`));
-            downQueries.push(new Query(`ALTER TABLE ${this.escapePath(table)} DROP INDEX \`${uniqueIndex.name}\``));
+            clonedTable.uniques.push(
+                new TableUnique({
+                    name: uniqueIndex.name,
+                    columnNames: uniqueIndex.columnNames,
+                })
+            );
+            upQueries.push(
+                new Query(
+                    `ALTER TABLE ${this.escapePath(table)} ADD UNIQUE INDEX \`${
+                        uniqueIndex.name
+                    }\` (\`${column.name}\`)`
+                )
+            );
+            downQueries.push(
+                new Query(
+                    `ALTER TABLE ${this.escapePath(table)} DROP INDEX \`${
+                        uniqueIndex.name
+                    }\``
+                )
+            );
         }
 
         await this.executeQueries(upQueries, downQueries);
@@ -514,7 +717,10 @@ export class AuroraDataApiQueryRunner extends BaseQueryRunner implements QueryRu
     /**
      * Creates a new columns from the column in the table.
      */
-    async addColumns(tableOrName: Table|string, columns: TableColumn[]): Promise<void> {
+    async addColumns(
+        tableOrName: Table | string,
+        columns: TableColumn[]
+    ): Promise<void> {
         for (const column of columns) {
             await this.addColumn(tableOrName, column);
         }
@@ -523,13 +729,25 @@ export class AuroraDataApiQueryRunner extends BaseQueryRunner implements QueryRu
     /**
      * Renames column in the given table.
      */
-    async renameColumn(tableOrName: Table|string, oldTableColumnOrName: TableColumn|string, newTableColumnOrName: TableColumn|string): Promise<void> {
-        const table = tableOrName instanceof Table ? tableOrName : await this.getCachedTable(tableOrName);
-        const oldColumn = oldTableColumnOrName instanceof TableColumn ? oldTableColumnOrName : table.columns.find(c => c.name === oldTableColumnOrName);
+    async renameColumn(
+        tableOrName: Table | string,
+        oldTableColumnOrName: TableColumn | string,
+        newTableColumnOrName: TableColumn | string
+    ): Promise<void> {
+        const table =
+            tableOrName instanceof Table
+                ? tableOrName
+                : await this.getCachedTable(tableOrName);
+        const oldColumn =
+            oldTableColumnOrName instanceof TableColumn
+                ? oldTableColumnOrName
+                : table.columns.find((c) => c.name === oldTableColumnOrName);
         if (!oldColumn)
-            throw new Error(`Column "${oldTableColumnOrName}" was not found in the "${table.name}" table.`);
+            throw new Error(
+                `Column "${oldTableColumnOrName}" was not found in the "${table.name}" table.`
+            );
 
-        let newColumn: TableColumn|undefined = undefined;
+        let newColumn: TableColumn | undefined = undefined;
         if (newTableColumnOrName instanceof TableColumn) {
             newColumn = newTableColumnOrName;
         } else {
@@ -543,141 +761,311 @@ export class AuroraDataApiQueryRunner extends BaseQueryRunner implements QueryRu
     /**
      * Changes a column in the table.
      */
-    async changeColumn(tableOrName: Table|string, oldColumnOrName: TableColumn|string, newColumn: TableColumn): Promise<void> {
-        const table = tableOrName instanceof Table ? tableOrName : await this.getCachedTable(tableOrName);
+    async changeColumn(
+        tableOrName: Table | string,
+        oldColumnOrName: TableColumn | string,
+        newColumn: TableColumn
+    ): Promise<void> {
+        const table =
+            tableOrName instanceof Table
+                ? tableOrName
+                : await this.getCachedTable(tableOrName);
         let clonedTable = table.clone();
         const upQueries: Query[] = [];
         const downQueries: Query[] = [];
 
-        const oldColumn = oldColumnOrName instanceof TableColumn
-            ? oldColumnOrName
-            : table.columns.find(column => column.name === oldColumnOrName);
+        const oldColumn =
+            oldColumnOrName instanceof TableColumn
+                ? oldColumnOrName
+                : table.columns.find(
+                      (column) => column.name === oldColumnOrName
+                  );
         if (!oldColumn)
-            throw new Error(`Column "${oldColumnOrName}" was not found in the "${table.name}" table.`);
+            throw new Error(
+                `Column "${oldColumnOrName}" was not found in the "${table.name}" table.`
+            );
 
-        if ((newColumn.isGenerated !== oldColumn.isGenerated && newColumn.generationStrategy !== "uuid")
-            || oldColumn.type !== newColumn.type
-            || oldColumn.length !== newColumn.length
-            || oldColumn.generatedType !== newColumn.generatedType) {
+        if (
+            (newColumn.isGenerated !== oldColumn.isGenerated &&
+                newColumn.generationStrategy !== "uuid") ||
+            oldColumn.type !== newColumn.type ||
+            oldColumn.length !== newColumn.length ||
+            oldColumn.generatedType !== newColumn.generatedType
+        ) {
             await this.dropColumn(table, oldColumn);
             await this.addColumn(table, newColumn);
 
             // update cloned table
             clonedTable = table.clone();
-
         } else {
             if (newColumn.name !== oldColumn.name) {
                 // We don't change any column properties, just rename it.
-                upQueries.push(new Query(`ALTER TABLE ${this.escapePath(table)} CHANGE \`${oldColumn.name}\` \`${newColumn.name}\` ${this.buildCreateColumnSql(oldColumn, true, true)}`));
-                downQueries.push(new Query(`ALTER TABLE ${this.escapePath(table)} CHANGE \`${newColumn.name}\` \`${oldColumn.name}\` ${this.buildCreateColumnSql(oldColumn, true, true)}`));
+                upQueries.push(
+                    new Query(
+                        `ALTER TABLE ${this.escapePath(table)} CHANGE \`${
+                            oldColumn.name
+                        }\` \`${newColumn.name}\` ${this.buildCreateColumnSql(
+                            oldColumn,
+                            true,
+                            true
+                        )}`
+                    )
+                );
+                downQueries.push(
+                    new Query(
+                        `ALTER TABLE ${this.escapePath(table)} CHANGE \`${
+                            newColumn.name
+                        }\` \`${oldColumn.name}\` ${this.buildCreateColumnSql(
+                            oldColumn,
+                            true,
+                            true
+                        )}`
+                    )
+                );
 
                 // rename index constraints
-                clonedTable.findColumnIndices(oldColumn).forEach(index => {
+                clonedTable.findColumnIndices(oldColumn).forEach((index) => {
                     // build new constraint name
-                    index.columnNames.splice(index.columnNames.indexOf(oldColumn.name), 1);
+                    index.columnNames.splice(
+                        index.columnNames.indexOf(oldColumn.name),
+                        1
+                    );
                     index.columnNames.push(newColumn.name);
-                    const columnNames = index.columnNames.map(column => `\`${column}\``).join(", ");
-                    const newIndexName = this.connection.namingStrategy.indexName(clonedTable, index.columnNames, index.where);
+                    const columnNames = index.columnNames
+                        .map((column) => `\`${column}\``)
+                        .join(", ");
+                    const newIndexName = this.connection.namingStrategy.indexName(
+                        clonedTable,
+                        index.columnNames,
+                        index.where
+                    );
 
                     // build queries
                     let indexType = "";
-                    if (index.isUnique)
-                        indexType += "UNIQUE ";
-                    if (index.isSpatial)
-                        indexType += "SPATIAL ";
-                    if (index.isFulltext)
-                        indexType += "FULLTEXT ";
-                    upQueries.push(new Query(`ALTER TABLE ${this.escapePath(table)} DROP INDEX \`${index.name}\`, ADD ${indexType}INDEX \`${newIndexName}\` (${columnNames})`));
-                    downQueries.push(new Query(`ALTER TABLE ${this.escapePath(table)} DROP INDEX \`${newIndexName}\`, ADD ${indexType}INDEX \`${index.name}\` (${columnNames})`));
+                    if (index.isUnique) indexType += "UNIQUE ";
+                    if (index.isSpatial) indexType += "SPATIAL ";
+                    if (index.isFulltext) indexType += "FULLTEXT ";
+                    upQueries.push(
+                        new Query(
+                            `ALTER TABLE ${this.escapePath(
+                                table
+                            )} DROP INDEX \`${
+                                index.name
+                            }\`, ADD ${indexType}INDEX \`${newIndexName}\` (${columnNames})`
+                        )
+                    );
+                    downQueries.push(
+                        new Query(
+                            `ALTER TABLE ${this.escapePath(
+                                table
+                            )} DROP INDEX \`${newIndexName}\`, ADD ${indexType}INDEX \`${
+                                index.name
+                            }\` (${columnNames})`
+                        )
+                    );
 
                     // replace constraint name
                     index.name = newIndexName;
                 });
 
                 // rename foreign key constraints
-                clonedTable.findColumnForeignKeys(oldColumn).forEach(foreignKey => {
-                    // build new constraint name
-                    foreignKey.columnNames.splice(foreignKey.columnNames.indexOf(oldColumn.name), 1);
-                    foreignKey.columnNames.push(newColumn.name);
-                    const columnNames = foreignKey.columnNames.map(column => `\`${column}\``).join(", ");
-                    const referencedColumnNames = foreignKey.referencedColumnNames.map(column => `\`${column}\``).join(",");
-                    const newForeignKeyName = this.connection.namingStrategy.foreignKeyName(clonedTable, foreignKey.columnNames);
+                clonedTable
+                    .findColumnForeignKeys(oldColumn)
+                    .forEach((foreignKey) => {
+                        // build new constraint name
+                        foreignKey.columnNames.splice(
+                            foreignKey.columnNames.indexOf(oldColumn.name),
+                            1
+                        );
+                        foreignKey.columnNames.push(newColumn.name);
+                        const columnNames = foreignKey.columnNames
+                            .map((column) => `\`${column}\``)
+                            .join(", ");
+                        const referencedColumnNames = foreignKey.referencedColumnNames
+                            .map((column) => `\`${column}\``)
+                            .join(",");
+                        const newForeignKeyName = this.connection.namingStrategy.foreignKeyName(
+                            clonedTable,
+                            foreignKey.columnNames
+                        );
 
-                    // build queries
-                    let up = `ALTER TABLE ${this.escapePath(table)} DROP FOREIGN KEY \`${foreignKey.name}\`, ADD CONSTRAINT \`${newForeignKeyName}\` FOREIGN KEY (${columnNames}) ` +
-                        `REFERENCES ${this.escapePath(foreignKey.referencedTableName)}(${referencedColumnNames})`;
-                    if (foreignKey.onDelete)
-                        up += ` ON DELETE ${foreignKey.onDelete}`;
-                    if (foreignKey.onUpdate)
-                        up += ` ON UPDATE ${foreignKey.onUpdate}`;
+                        // build queries
+                        let up =
+                            `ALTER TABLE ${this.escapePath(
+                                table
+                            )} DROP FOREIGN KEY \`${
+                                foreignKey.name
+                            }\`, ADD CONSTRAINT \`${newForeignKeyName}\` FOREIGN KEY (${columnNames}) ` +
+                            `REFERENCES ${this.escapePath(
+                                foreignKey.referencedTableName
+                            )}(${referencedColumnNames})`;
+                        if (foreignKey.onDelete)
+                            up += ` ON DELETE ${foreignKey.onDelete}`;
+                        if (foreignKey.onUpdate)
+                            up += ` ON UPDATE ${foreignKey.onUpdate}`;
 
-                    let down = `ALTER TABLE ${this.escapePath(table)} DROP FOREIGN KEY \`${newForeignKeyName}\`, ADD CONSTRAINT \`${foreignKey.name}\` FOREIGN KEY (${columnNames}) ` +
-                        `REFERENCES ${this.escapePath(foreignKey.referencedTableName)}(${referencedColumnNames})`;
-                    if (foreignKey.onDelete)
-                        down += ` ON DELETE ${foreignKey.onDelete}`;
-                    if (foreignKey.onUpdate)
-                        down += ` ON UPDATE ${foreignKey.onUpdate}`;
+                        let down =
+                            `ALTER TABLE ${this.escapePath(
+                                table
+                            )} DROP FOREIGN KEY \`${newForeignKeyName}\`, ADD CONSTRAINT \`${
+                                foreignKey.name
+                            }\` FOREIGN KEY (${columnNames}) ` +
+                            `REFERENCES ${this.escapePath(
+                                foreignKey.referencedTableName
+                            )}(${referencedColumnNames})`;
+                        if (foreignKey.onDelete)
+                            down += ` ON DELETE ${foreignKey.onDelete}`;
+                        if (foreignKey.onUpdate)
+                            down += ` ON UPDATE ${foreignKey.onUpdate}`;
 
-                    upQueries.push(new Query(up));
-                    downQueries.push(new Query(down));
+                        upQueries.push(new Query(up));
+                        downQueries.push(new Query(down));
 
-                    // replace constraint name
-                    foreignKey.name = newForeignKeyName;
-                });
+                        // replace constraint name
+                        foreignKey.name = newForeignKeyName;
+                    });
 
                 // rename old column in the Table object
-                const oldTableColumn = clonedTable.columns.find(column => column.name === oldColumn.name);
-                clonedTable.columns[clonedTable.columns.indexOf(oldTableColumn!)].name = newColumn.name;
+                const oldTableColumn = clonedTable.columns.find(
+                    (column) => column.name === oldColumn.name
+                );
+                clonedTable.columns[
+                    clonedTable.columns.indexOf(oldTableColumn!)
+                ].name = newColumn.name;
                 oldColumn.name = newColumn.name;
             }
 
             if (this.isColumnChanged(oldColumn, newColumn, true)) {
-                upQueries.push(new Query(`ALTER TABLE ${this.escapePath(table)} CHANGE \`${oldColumn.name}\` ${this.buildCreateColumnSql(newColumn, true)}`));
-                downQueries.push(new Query(`ALTER TABLE ${this.escapePath(table)} CHANGE \`${newColumn.name}\` ${this.buildCreateColumnSql(oldColumn, true)}`));
+                upQueries.push(
+                    new Query(
+                        `ALTER TABLE ${this.escapePath(table)} CHANGE \`${
+                            oldColumn.name
+                        }\` ${this.buildCreateColumnSql(newColumn, true)}`
+                    )
+                );
+                downQueries.push(
+                    new Query(
+                        `ALTER TABLE ${this.escapePath(table)} CHANGE \`${
+                            newColumn.name
+                        }\` ${this.buildCreateColumnSql(oldColumn, true)}`
+                    )
+                );
             }
 
             if (newColumn.isPrimary !== oldColumn.isPrimary) {
                 // if table have generated column, we must drop AUTO_INCREMENT before changing primary constraints.
-                const generatedColumn = clonedTable.columns.find(column => column.isGenerated && column.generationStrategy === "increment");
+                const generatedColumn = clonedTable.columns.find(
+                    (column) =>
+                        column.isGenerated &&
+                        column.generationStrategy === "increment"
+                );
                 if (generatedColumn) {
                     const nonGeneratedColumn = generatedColumn.clone();
                     nonGeneratedColumn.isGenerated = false;
                     nonGeneratedColumn.generationStrategy = undefined;
 
-                    upQueries.push(new Query(`ALTER TABLE ${this.escapePath(table)} CHANGE \`${generatedColumn.name}\` ${this.buildCreateColumnSql(nonGeneratedColumn, true)}`));
-                    downQueries.push(new Query(`ALTER TABLE ${this.escapePath(table)} CHANGE \`${nonGeneratedColumn.name}\` ${this.buildCreateColumnSql(generatedColumn, true)}`));
+                    upQueries.push(
+                        new Query(
+                            `ALTER TABLE ${this.escapePath(table)} CHANGE \`${
+                                generatedColumn.name
+                            }\` ${this.buildCreateColumnSql(
+                                nonGeneratedColumn,
+                                true
+                            )}`
+                        )
+                    );
+                    downQueries.push(
+                        new Query(
+                            `ALTER TABLE ${this.escapePath(table)} CHANGE \`${
+                                nonGeneratedColumn.name
+                            }\` ${this.buildCreateColumnSql(
+                                generatedColumn,
+                                true
+                            )}`
+                        )
+                    );
                 }
 
                 const primaryColumns = clonedTable.primaryColumns;
 
                 // if primary column state changed, we must always drop existed constraint.
                 if (primaryColumns.length > 0) {
-                    const columnNames = primaryColumns.map(column => `\`${column.name}\``).join(", ");
-                    upQueries.push(new Query(`ALTER TABLE ${this.escapePath(table)} DROP PRIMARY KEY`));
-                    downQueries.push(new Query(`ALTER TABLE ${this.escapePath(table)} ADD PRIMARY KEY (${columnNames})`));
+                    const columnNames = primaryColumns
+                        .map((column) => `\`${column.name}\``)
+                        .join(", ");
+                    upQueries.push(
+                        new Query(
+                            `ALTER TABLE ${this.escapePath(
+                                table
+                            )} DROP PRIMARY KEY`
+                        )
+                    );
+                    downQueries.push(
+                        new Query(
+                            `ALTER TABLE ${this.escapePath(
+                                table
+                            )} ADD PRIMARY KEY (${columnNames})`
+                        )
+                    );
                 }
 
                 if (newColumn.isPrimary === true) {
                     primaryColumns.push(newColumn);
                     // update column in table
-                    const column = clonedTable.columns.find(column => column.name === newColumn.name);
+                    const column = clonedTable.columns.find(
+                        (column) => column.name === newColumn.name
+                    );
                     column!.isPrimary = true;
-                    const columnNames = primaryColumns.map(column => `\`${column.name}\``).join(", ");
-                    upQueries.push(new Query(`ALTER TABLE ${this.escapePath(table)} ADD PRIMARY KEY (${columnNames})`));
-                    downQueries.push(new Query(`ALTER TABLE ${this.escapePath(table)} DROP PRIMARY KEY`));
-
+                    const columnNames = primaryColumns
+                        .map((column) => `\`${column.name}\``)
+                        .join(", ");
+                    upQueries.push(
+                        new Query(
+                            `ALTER TABLE ${this.escapePath(
+                                table
+                            )} ADD PRIMARY KEY (${columnNames})`
+                        )
+                    );
+                    downQueries.push(
+                        new Query(
+                            `ALTER TABLE ${this.escapePath(
+                                table
+                            )} DROP PRIMARY KEY`
+                        )
+                    );
                 } else {
-                    const primaryColumn = primaryColumns.find(c => c.name === newColumn.name);
-                    primaryColumns.splice(primaryColumns.indexOf(primaryColumn!), 1);
+                    const primaryColumn = primaryColumns.find(
+                        (c) => c.name === newColumn.name
+                    );
+                    primaryColumns.splice(
+                        primaryColumns.indexOf(primaryColumn!),
+                        1
+                    );
                     // update column in table
-                    const column = clonedTable.columns.find(column => column.name === newColumn.name);
+                    const column = clonedTable.columns.find(
+                        (column) => column.name === newColumn.name
+                    );
                     column!.isPrimary = false;
 
                     // if we have another primary keys, we must recreate constraint.
                     if (primaryColumns.length > 0) {
-                        const columnNames = primaryColumns.map(column => `\`${column.name}\``).join(", ");
-                        upQueries.push(new Query(`ALTER TABLE ${this.escapePath(table)} ADD PRIMARY KEY (${columnNames})`));
-                        downQueries.push(new Query(`ALTER TABLE ${this.escapePath(table)} DROP PRIMARY KEY`));
+                        const columnNames = primaryColumns
+                            .map((column) => `\`${column.name}\``)
+                            .join(", ");
+                        upQueries.push(
+                            new Query(
+                                `ALTER TABLE ${this.escapePath(
+                                    table
+                                )} ADD PRIMARY KEY (${columnNames})`
+                            )
+                        );
+                        downQueries.push(
+                            new Query(
+                                `ALTER TABLE ${this.escapePath(
+                                    table
+                                )} DROP PRIMARY KEY`
+                            )
+                        );
                     }
                 }
 
@@ -687,37 +1075,101 @@ export class AuroraDataApiQueryRunner extends BaseQueryRunner implements QueryRu
                     nonGeneratedColumn.isGenerated = false;
                     nonGeneratedColumn.generationStrategy = undefined;
 
-                    upQueries.push(new Query(`ALTER TABLE ${this.escapePath(table)} CHANGE \`${nonGeneratedColumn.name}\` ${this.buildCreateColumnSql(generatedColumn, true)}`));
-                    downQueries.push(new Query(`ALTER TABLE ${this.escapePath(table)} CHANGE \`${generatedColumn.name}\` ${this.buildCreateColumnSql(nonGeneratedColumn, true)}`));
+                    upQueries.push(
+                        new Query(
+                            `ALTER TABLE ${this.escapePath(table)} CHANGE \`${
+                                nonGeneratedColumn.name
+                            }\` ${this.buildCreateColumnSql(
+                                generatedColumn,
+                                true
+                            )}`
+                        )
+                    );
+                    downQueries.push(
+                        new Query(
+                            `ALTER TABLE ${this.escapePath(table)} CHANGE \`${
+                                generatedColumn.name
+                            }\` ${this.buildCreateColumnSql(
+                                nonGeneratedColumn,
+                                true
+                            )}`
+                        )
+                    );
                 }
             }
 
             if (newColumn.isUnique !== oldColumn.isUnique) {
                 if (newColumn.isUnique === true) {
                     const uniqueIndex = new TableIndex({
-                        name: this.connection.namingStrategy.indexName(table.name, [newColumn.name]),
+                        name: this.connection.namingStrategy.indexName(
+                            table.name,
+                            [newColumn.name]
+                        ),
                         columnNames: [newColumn.name],
-                        isUnique: true
+                        isUnique: true,
                     });
                     clonedTable.indices.push(uniqueIndex);
-                    clonedTable.uniques.push(new TableUnique({
-                        name: uniqueIndex.name,
-                        columnNames: uniqueIndex.columnNames
-                    }));
-                    upQueries.push(new Query(`ALTER TABLE ${this.escapePath(table)} ADD UNIQUE INDEX \`${uniqueIndex.name}\` (\`${newColumn.name}\`)`));
-                    downQueries.push(new Query(`ALTER TABLE ${this.escapePath(table)} DROP INDEX \`${uniqueIndex.name}\``));
-
+                    clonedTable.uniques.push(
+                        new TableUnique({
+                            name: uniqueIndex.name,
+                            columnNames: uniqueIndex.columnNames,
+                        })
+                    );
+                    upQueries.push(
+                        new Query(
+                            `ALTER TABLE ${this.escapePath(
+                                table
+                            )} ADD UNIQUE INDEX \`${uniqueIndex.name}\` (\`${
+                                newColumn.name
+                            }\`)`
+                        )
+                    );
+                    downQueries.push(
+                        new Query(
+                            `ALTER TABLE ${this.escapePath(
+                                table
+                            )} DROP INDEX \`${uniqueIndex.name}\``
+                        )
+                    );
                 } else {
-                    const uniqueIndex = clonedTable.indices.find(index => {
-                        return index.columnNames.length === 1 && index.isUnique === true && !!index.columnNames.find(columnName => columnName === newColumn.name);
+                    const uniqueIndex = clonedTable.indices.find((index) => {
+                        return (
+                            index.columnNames.length === 1 &&
+                            index.isUnique === true &&
+                            !!index.columnNames.find(
+                                (columnName) => columnName === newColumn.name
+                            )
+                        );
                     });
-                    clonedTable.indices.splice(clonedTable.indices.indexOf(uniqueIndex!), 1);
+                    clonedTable.indices.splice(
+                        clonedTable.indices.indexOf(uniqueIndex!),
+                        1
+                    );
 
-                    const tableUnique = clonedTable.uniques.find(unique => unique.name === uniqueIndex!.name);
-                    clonedTable.uniques.splice(clonedTable.uniques.indexOf(tableUnique!), 1);
+                    const tableUnique = clonedTable.uniques.find(
+                        (unique) => unique.name === uniqueIndex!.name
+                    );
+                    clonedTable.uniques.splice(
+                        clonedTable.uniques.indexOf(tableUnique!),
+                        1
+                    );
 
-                    upQueries.push(new Query(`ALTER TABLE ${this.escapePath(table)} DROP INDEX \`${uniqueIndex!.name}\``));
-                    downQueries.push(new Query(`ALTER TABLE ${this.escapePath(table)} ADD UNIQUE INDEX \`${uniqueIndex!.name}\` (\`${newColumn.name}\`)`));
+                    upQueries.push(
+                        new Query(
+                            `ALTER TABLE ${this.escapePath(
+                                table
+                            )} DROP INDEX \`${uniqueIndex!.name}\``
+                        )
+                    );
+                    downQueries.push(
+                        new Query(
+                            `ALTER TABLE ${this.escapePath(
+                                table
+                            )} ADD UNIQUE INDEX \`${uniqueIndex!.name}\` (\`${
+                                newColumn.name
+                            }\`)`
+                        )
+                    );
                 }
             }
         }
@@ -729,20 +1181,34 @@ export class AuroraDataApiQueryRunner extends BaseQueryRunner implements QueryRu
     /**
      * Changes a column in the table.
      */
-    async changeColumns(tableOrName: Table|string, changedColumns: { newColumn: TableColumn, oldColumn: TableColumn }[]): Promise<void> {
-        for (const {oldColumn, newColumn} of changedColumns) {
-            await this.changeColumn(tableOrName, oldColumn, newColumn)
+    async changeColumns(
+        tableOrName: Table | string,
+        changedColumns: { newColumn: TableColumn; oldColumn: TableColumn }[]
+    ): Promise<void> {
+        for (const { oldColumn, newColumn } of changedColumns) {
+            await this.changeColumn(tableOrName, oldColumn, newColumn);
         }
     }
 
     /**
      * Drops column in the table.
      */
-    async dropColumn(tableOrName: Table|string, columnOrName: TableColumn|string): Promise<void> {
-        const table = tableOrName instanceof Table ? tableOrName : await this.getCachedTable(tableOrName);
-        const column = columnOrName instanceof TableColumn ? columnOrName : table.findColumnByName(columnOrName);
+    async dropColumn(
+        tableOrName: Table | string,
+        columnOrName: TableColumn | string
+    ): Promise<void> {
+        const table =
+            tableOrName instanceof Table
+                ? tableOrName
+                : await this.getCachedTable(tableOrName);
+        const column =
+            columnOrName instanceof TableColumn
+                ? columnOrName
+                : table.findColumnByName(columnOrName);
         if (!column)
-            throw new Error(`Column "${columnOrName}" was not found in table "${table.name}"`);
+            throw new Error(
+                `Column "${columnOrName}" was not found in table "${table.name}"`
+            );
 
         const clonedTable = table.clone();
         const upQueries: Query[] = [];
@@ -751,20 +1217,53 @@ export class AuroraDataApiQueryRunner extends BaseQueryRunner implements QueryRu
         // drop primary key constraint
         if (column.isPrimary) {
             // if table have generated column, we must drop AUTO_INCREMENT before changing primary constraints.
-            const generatedColumn = clonedTable.columns.find(column => column.isGenerated && column.generationStrategy === "increment");
+            const generatedColumn = clonedTable.columns.find(
+                (column) =>
+                    column.isGenerated &&
+                    column.generationStrategy === "increment"
+            );
             if (generatedColumn) {
                 const nonGeneratedColumn = generatedColumn.clone();
                 nonGeneratedColumn.isGenerated = false;
                 nonGeneratedColumn.generationStrategy = undefined;
 
-                upQueries.push(new Query(`ALTER TABLE ${this.escapePath(table)} CHANGE \`${generatedColumn.name}\` ${this.buildCreateColumnSql(nonGeneratedColumn, true)}`));
-                downQueries.push(new Query(`ALTER TABLE ${this.escapePath(table)} CHANGE \`${nonGeneratedColumn.name}\` ${this.buildCreateColumnSql(generatedColumn, true)}`));
+                upQueries.push(
+                    new Query(
+                        `ALTER TABLE ${this.escapePath(table)} CHANGE \`${
+                            generatedColumn.name
+                        }\` ${this.buildCreateColumnSql(
+                            nonGeneratedColumn,
+                            true
+                        )}`
+                    )
+                );
+                downQueries.push(
+                    new Query(
+                        `ALTER TABLE ${this.escapePath(table)} CHANGE \`${
+                            nonGeneratedColumn.name
+                        }\` ${this.buildCreateColumnSql(generatedColumn, true)}`
+                    )
+                );
             }
 
             // dropping primary key constraint
-            const columnNames = clonedTable.primaryColumns.map(primaryColumn => `\`${primaryColumn.name}\``).join(", ");
-            upQueries.push(new Query(`ALTER TABLE ${this.escapePath(clonedTable)} DROP PRIMARY KEY`));
-            downQueries.push(new Query(`ALTER TABLE ${this.escapePath(clonedTable)} ADD PRIMARY KEY (${columnNames})`));
+            const columnNames = clonedTable.primaryColumns
+                .map((primaryColumn) => `\`${primaryColumn.name}\``)
+                .join(", ");
+            upQueries.push(
+                new Query(
+                    `ALTER TABLE ${this.escapePath(
+                        clonedTable
+                    )} DROP PRIMARY KEY`
+                )
+            );
+            downQueries.push(
+                new Query(
+                    `ALTER TABLE ${this.escapePath(
+                        clonedTable
+                    )} ADD PRIMARY KEY (${columnNames})`
+                )
+            );
 
             // update column in table
             const tableColumn = clonedTable.findColumnByName(column.name);
@@ -772,9 +1271,23 @@ export class AuroraDataApiQueryRunner extends BaseQueryRunner implements QueryRu
 
             // if primary key have multiple columns, we must recreate it without dropped column
             if (clonedTable.primaryColumns.length > 0) {
-                const columnNames = clonedTable.primaryColumns.map(primaryColumn => `\`${primaryColumn.name}\``).join(", ");
-                upQueries.push(new Query(`ALTER TABLE ${this.escapePath(clonedTable)} ADD PRIMARY KEY (${columnNames})`));
-                downQueries.push(new Query(`ALTER TABLE ${this.escapePath(clonedTable)} DROP PRIMARY KEY`));
+                const columnNames = clonedTable.primaryColumns
+                    .map((primaryColumn) => `\`${primaryColumn.name}\``)
+                    .join(", ");
+                upQueries.push(
+                    new Query(
+                        `ALTER TABLE ${this.escapePath(
+                            clonedTable
+                        )} ADD PRIMARY KEY (${columnNames})`
+                    )
+                );
+                downQueries.push(
+                    new Query(
+                        `ALTER TABLE ${this.escapePath(
+                            clonedTable
+                        )} DROP PRIMARY KEY`
+                    )
+                );
             }
 
             // if we have generated column, and we dropped AUTO_INCREMENT property before, and this column is not current dropping column, we must bring it back
@@ -783,36 +1296,97 @@ export class AuroraDataApiQueryRunner extends BaseQueryRunner implements QueryRu
                 nonGeneratedColumn.isGenerated = false;
                 nonGeneratedColumn.generationStrategy = undefined;
 
-                upQueries.push(new Query(`ALTER TABLE ${this.escapePath(table)} CHANGE \`${nonGeneratedColumn.name}\` ${this.buildCreateColumnSql(generatedColumn, true)}`));
-                downQueries.push(new Query(`ALTER TABLE ${this.escapePath(table)} CHANGE \`${generatedColumn.name}\` ${this.buildCreateColumnSql(nonGeneratedColumn, true)}`));
+                upQueries.push(
+                    new Query(
+                        `ALTER TABLE ${this.escapePath(table)} CHANGE \`${
+                            nonGeneratedColumn.name
+                        }\` ${this.buildCreateColumnSql(generatedColumn, true)}`
+                    )
+                );
+                downQueries.push(
+                    new Query(
+                        `ALTER TABLE ${this.escapePath(table)} CHANGE \`${
+                            generatedColumn.name
+                        }\` ${this.buildCreateColumnSql(
+                            nonGeneratedColumn,
+                            true
+                        )}`
+                    )
+                );
             }
         }
 
         // drop column index
-        const columnIndex = clonedTable.indices.find(index => index.columnNames.length === 1 && index.columnNames[0] === column.name);
+        const columnIndex = clonedTable.indices.find(
+            (index) =>
+                index.columnNames.length === 1 &&
+                index.columnNames[0] === column.name
+        );
         if (columnIndex) {
-            clonedTable.indices.splice(clonedTable.indices.indexOf(columnIndex), 1);
+            clonedTable.indices.splice(
+                clonedTable.indices.indexOf(columnIndex),
+                1
+            );
             upQueries.push(this.dropIndexSql(table, columnIndex));
             downQueries.push(this.createIndexSql(table, columnIndex));
-
         } else if (column.isUnique) {
             // we splice constraints both from table uniques and indices.
-            const uniqueName = this.connection.namingStrategy.uniqueConstraintName(table.name, [column.name]);
-            const foundUnique = clonedTable.uniques.find(unique => unique.name === uniqueName);
+            const uniqueName = this.connection.namingStrategy.uniqueConstraintName(
+                table.name,
+                [column.name]
+            );
+            const foundUnique = clonedTable.uniques.find(
+                (unique) => unique.name === uniqueName
+            );
             if (foundUnique)
-                clonedTable.uniques.splice(clonedTable.uniques.indexOf(foundUnique), 1);
+                clonedTable.uniques.splice(
+                    clonedTable.uniques.indexOf(foundUnique),
+                    1
+                );
 
-            const indexName = this.connection.namingStrategy.indexName(table.name, [column.name]);
-            const foundIndex = clonedTable.indices.find(index => index.name === indexName);
+            const indexName = this.connection.namingStrategy.indexName(
+                table.name,
+                [column.name]
+            );
+            const foundIndex = clonedTable.indices.find(
+                (index) => index.name === indexName
+            );
             if (foundIndex)
-                clonedTable.indices.splice(clonedTable.indices.indexOf(foundIndex), 1);
+                clonedTable.indices.splice(
+                    clonedTable.indices.indexOf(foundIndex),
+                    1
+                );
 
-            upQueries.push(new Query(`ALTER TABLE ${this.escapePath(table)} DROP INDEX \`${indexName}\``));
-            downQueries.push(new Query(`ALTER TABLE ${this.escapePath(table)} ADD UNIQUE INDEX \`${indexName}\` (\`${column.name}\`)`));
+            upQueries.push(
+                new Query(
+                    `ALTER TABLE ${this.escapePath(
+                        table
+                    )} DROP INDEX \`${indexName}\``
+                )
+            );
+            downQueries.push(
+                new Query(
+                    `ALTER TABLE ${this.escapePath(
+                        table
+                    )} ADD UNIQUE INDEX \`${indexName}\` (\`${column.name}\`)`
+                )
+            );
         }
 
-        upQueries.push(new Query(`ALTER TABLE ${this.escapePath(table)} DROP COLUMN \`${column.name}\``));
-        downQueries.push(new Query(`ALTER TABLE ${this.escapePath(table)} ADD ${this.buildCreateColumnSql(column, true)}`));
+        upQueries.push(
+            new Query(
+                `ALTER TABLE ${this.escapePath(table)} DROP COLUMN \`${
+                    column.name
+                }\``
+            )
+        );
+        downQueries.push(
+            new Query(
+                `ALTER TABLE ${this.escapePath(
+                    table
+                )} ADD ${this.buildCreateColumnSql(column, true)}`
+            )
+        );
 
         await this.executeQueries(upQueries, downQueries);
 
@@ -823,7 +1397,10 @@ export class AuroraDataApiQueryRunner extends BaseQueryRunner implements QueryRu
     /**
      * Drops the columns in the table.
      */
-    async dropColumns(tableOrName: Table|string, columns: TableColumn[]): Promise<void> {
+    async dropColumns(
+        tableOrName: Table | string,
+        columns: TableColumn[]
+    ): Promise<void> {
         for (const column of columns) {
             await this.dropColumn(tableOrName, column);
         }
@@ -832,16 +1409,22 @@ export class AuroraDataApiQueryRunner extends BaseQueryRunner implements QueryRu
     /**
      * Creates a new primary key.
      */
-    async createPrimaryKey(tableOrName: Table|string, columnNames: string[]): Promise<void> {
-        const table = tableOrName instanceof Table ? tableOrName : await this.getCachedTable(tableOrName);
+    async createPrimaryKey(
+        tableOrName: Table | string,
+        columnNames: string[]
+    ): Promise<void> {
+        const table =
+            tableOrName instanceof Table
+                ? tableOrName
+                : await this.getCachedTable(tableOrName);
         const clonedTable = table.clone();
 
         const up = this.createPrimaryKeySql(table, columnNames);
         const down = this.dropPrimaryKeySql(table);
 
         await this.executeQueries(up, down);
-        clonedTable.columns.forEach(column => {
-            if (columnNames.find(columnName => columnName === column.name))
+        clonedTable.columns.forEach((column) => {
+            if (columnNames.find((columnName) => columnName === column.name))
                 column.isPrimary = true;
         });
         this.replaceCachedTable(table, clonedTable);
@@ -850,53 +1433,119 @@ export class AuroraDataApiQueryRunner extends BaseQueryRunner implements QueryRu
     /**
      * Updates composite primary keys.
      */
-    async updatePrimaryKeys(tableOrName: Table|string, columns: TableColumn[]): Promise<void> {
-        const table = tableOrName instanceof Table ? tableOrName : await this.getCachedTable(tableOrName);
+    async updatePrimaryKeys(
+        tableOrName: Table | string,
+        columns: TableColumn[]
+    ): Promise<void> {
+        const table =
+            tableOrName instanceof Table
+                ? tableOrName
+                : await this.getCachedTable(tableOrName);
         const clonedTable = table.clone();
-        const columnNames = columns.map(column => column.name);
+        const columnNames = columns.map((column) => column.name);
         const upQueries: Query[] = [];
         const downQueries: Query[] = [];
 
         // if table have generated column, we must drop AUTO_INCREMENT before changing primary constraints.
-        const generatedColumn = clonedTable.columns.find(column => column.isGenerated && column.generationStrategy === "increment");
+        const generatedColumn = clonedTable.columns.find(
+            (column) =>
+                column.isGenerated && column.generationStrategy === "increment"
+        );
         if (generatedColumn) {
             const nonGeneratedColumn = generatedColumn.clone();
             nonGeneratedColumn.isGenerated = false;
             nonGeneratedColumn.generationStrategy = undefined;
 
-            upQueries.push(new Query(`ALTER TABLE ${this.escapePath(table)} CHANGE \`${generatedColumn.name}\` ${this.buildCreateColumnSql(nonGeneratedColumn, true)}`));
-            downQueries.push(new Query(`ALTER TABLE ${this.escapePath(table)} CHANGE \`${nonGeneratedColumn.name}\` ${this.buildCreateColumnSql(generatedColumn, true)}`));
+            upQueries.push(
+                new Query(
+                    `ALTER TABLE ${this.escapePath(table)} CHANGE \`${
+                        generatedColumn.name
+                    }\` ${this.buildCreateColumnSql(nonGeneratedColumn, true)}`
+                )
+            );
+            downQueries.push(
+                new Query(
+                    `ALTER TABLE ${this.escapePath(table)} CHANGE \`${
+                        nonGeneratedColumn.name
+                    }\` ${this.buildCreateColumnSql(generatedColumn, true)}`
+                )
+            );
         }
 
         // if table already have primary columns, we must drop them.
         const primaryColumns = clonedTable.primaryColumns;
         if (primaryColumns.length > 0) {
-            const columnNames = primaryColumns.map(column => `\`${column.name}\``).join(", ");
-            upQueries.push(new Query(`ALTER TABLE ${this.escapePath(table)} DROP PRIMARY KEY`));
-            downQueries.push(new Query(`ALTER TABLE ${this.escapePath(table)} ADD PRIMARY KEY (${columnNames})`));
+            const columnNames = primaryColumns
+                .map((column) => `\`${column.name}\``)
+                .join(", ");
+            upQueries.push(
+                new Query(
+                    `ALTER TABLE ${this.escapePath(table)} DROP PRIMARY KEY`
+                )
+            );
+            downQueries.push(
+                new Query(
+                    `ALTER TABLE ${this.escapePath(
+                        table
+                    )} ADD PRIMARY KEY (${columnNames})`
+                )
+            );
         }
 
         // update columns in table.
         clonedTable.columns
-            .filter(column => columnNames.indexOf(column.name) !== -1)
-            .forEach(column => column.isPrimary = true);
+            .filter((column) => columnNames.indexOf(column.name) !== -1)
+            .forEach((column) => (column.isPrimary = true));
 
-        const columnNamesString = columnNames.map(columnName => `\`${columnName}\``).join(", ");
-        upQueries.push(new Query(`ALTER TABLE ${this.escapePath(table)} ADD PRIMARY KEY (${columnNamesString})`));
-        downQueries.push(new Query(`ALTER TABLE ${this.escapePath(table)} DROP PRIMARY KEY`));
+        const columnNamesString = columnNames
+            .map((columnName) => `\`${columnName}\``)
+            .join(", ");
+        upQueries.push(
+            new Query(
+                `ALTER TABLE ${this.escapePath(
+                    table
+                )} ADD PRIMARY KEY (${columnNamesString})`
+            )
+        );
+        downQueries.push(
+            new Query(`ALTER TABLE ${this.escapePath(table)} DROP PRIMARY KEY`)
+        );
 
         // if we already have generated column or column is changed to generated, and we dropped AUTO_INCREMENT property before, we must bring it back
-        const newOrExistGeneratedColumn = generatedColumn ? generatedColumn : columns.find(column => column.isGenerated && column.generationStrategy === "increment");
+        const newOrExistGeneratedColumn = generatedColumn
+            ? generatedColumn
+            : columns.find(
+                  (column) =>
+                      column.isGenerated &&
+                      column.generationStrategy === "increment"
+              );
         if (newOrExistGeneratedColumn) {
             const nonGeneratedColumn = newOrExistGeneratedColumn.clone();
             nonGeneratedColumn.isGenerated = false;
             nonGeneratedColumn.generationStrategy = undefined;
 
-            upQueries.push(new Query(`ALTER TABLE ${this.escapePath(table)} CHANGE \`${nonGeneratedColumn.name}\` ${this.buildCreateColumnSql(newOrExistGeneratedColumn, true)}`));
-            downQueries.push(new Query(`ALTER TABLE ${this.escapePath(table)} CHANGE \`${newOrExistGeneratedColumn.name}\` ${this.buildCreateColumnSql(nonGeneratedColumn, true)}`));
+            upQueries.push(
+                new Query(
+                    `ALTER TABLE ${this.escapePath(table)} CHANGE \`${
+                        nonGeneratedColumn.name
+                    }\` ${this.buildCreateColumnSql(
+                        newOrExistGeneratedColumn,
+                        true
+                    )}`
+                )
+            );
+            downQueries.push(
+                new Query(
+                    `ALTER TABLE ${this.escapePath(table)} CHANGE \`${
+                        newOrExistGeneratedColumn.name
+                    }\` ${this.buildCreateColumnSql(nonGeneratedColumn, true)}`
+                )
+            );
 
             // if column changed to generated, we must update it in table
-            const changedGeneratedColumn = clonedTable.columns.find(column => column.name === newOrExistGeneratedColumn.name);
+            const changedGeneratedColumn = clonedTable.columns.find(
+                (column) => column.name === newOrExistGeneratedColumn.name
+            );
             changedGeneratedColumn!.isGenerated = true;
             changedGeneratedColumn!.generationStrategy = "increment";
         }
@@ -908,12 +1557,18 @@ export class AuroraDataApiQueryRunner extends BaseQueryRunner implements QueryRu
     /**
      * Drops a primary key.
      */
-    async dropPrimaryKey(tableOrName: Table|string): Promise<void> {
-        const table = tableOrName instanceof Table ? tableOrName : await this.getCachedTable(tableOrName);
+    async dropPrimaryKey(tableOrName: Table | string): Promise<void> {
+        const table =
+            tableOrName instanceof Table
+                ? tableOrName
+                : await this.getCachedTable(tableOrName);
         const up = this.dropPrimaryKeySql(table);
-        const down = this.createPrimaryKeySql(table, table.primaryColumns.map(column => column.name));
+        const down = this.createPrimaryKeySql(
+            table,
+            table.primaryColumns.map((column) => column.name)
+        );
         await this.executeQueries(up, down);
-        table.primaryColumns.forEach(column => {
+        table.primaryColumns.forEach((column) => {
             column.isPrimary = false;
         });
     }
@@ -921,96 +1576,149 @@ export class AuroraDataApiQueryRunner extends BaseQueryRunner implements QueryRu
     /**
      * Creates a new unique constraint.
      */
-    async createUniqueConstraint(tableOrName: Table|string, uniqueConstraint: TableUnique): Promise<void> {
-        throw new Error(`MySql does not support unique constraints. Use unique index instead.`);
+    async createUniqueConstraint(
+        tableOrName: Table | string,
+        uniqueConstraint: TableUnique
+    ): Promise<void> {
+        throw new Error(
+            `MySql does not support unique constraints. Use unique index instead.`
+        );
     }
 
     /**
      * Creates a new unique constraints.
      */
-    async createUniqueConstraints(tableOrName: Table|string, uniqueConstraints: TableUnique[]): Promise<void> {
-        throw new Error(`MySql does not support unique constraints. Use unique index instead.`);
+    async createUniqueConstraints(
+        tableOrName: Table | string,
+        uniqueConstraints: TableUnique[]
+    ): Promise<void> {
+        throw new Error(
+            `MySql does not support unique constraints. Use unique index instead.`
+        );
     }
 
     /**
      * Drops an unique constraint.
      */
-    async dropUniqueConstraint(tableOrName: Table|string, uniqueOrName: TableUnique|string): Promise<void> {
-        throw new Error(`MySql does not support unique constraints. Use unique index instead.`);
+    async dropUniqueConstraint(
+        tableOrName: Table | string,
+        uniqueOrName: TableUnique | string
+    ): Promise<void> {
+        throw new Error(
+            `MySql does not support unique constraints. Use unique index instead.`
+        );
     }
 
     /**
      * Drops an unique constraints.
      */
-    async dropUniqueConstraints(tableOrName: Table|string, uniqueConstraints: TableUnique[]): Promise<void> {
-        throw new Error(`MySql does not support unique constraints. Use unique index instead.`);
+    async dropUniqueConstraints(
+        tableOrName: Table | string,
+        uniqueConstraints: TableUnique[]
+    ): Promise<void> {
+        throw new Error(
+            `MySql does not support unique constraints. Use unique index instead.`
+        );
     }
 
     /**
      * Creates a new check constraint.
      */
-    async createCheckConstraint(tableOrName: Table|string, checkConstraint: TableCheck): Promise<void> {
+    async createCheckConstraint(
+        tableOrName: Table | string,
+        checkConstraint: TableCheck
+    ): Promise<void> {
         throw new Error(`MySql does not support check constraints.`);
     }
 
     /**
      * Creates a new check constraints.
      */
-    async createCheckConstraints(tableOrName: Table|string, checkConstraints: TableCheck[]): Promise<void> {
+    async createCheckConstraints(
+        tableOrName: Table | string,
+        checkConstraints: TableCheck[]
+    ): Promise<void> {
         throw new Error(`MySql does not support check constraints.`);
     }
 
     /**
      * Drops check constraint.
      */
-    async dropCheckConstraint(tableOrName: Table|string, checkOrName: TableCheck|string): Promise<void> {
+    async dropCheckConstraint(
+        tableOrName: Table | string,
+        checkOrName: TableCheck | string
+    ): Promise<void> {
         throw new Error(`MySql does not support check constraints.`);
     }
 
     /**
      * Drops check constraints.
      */
-    async dropCheckConstraints(tableOrName: Table|string, checkConstraints: TableCheck[]): Promise<void> {
+    async dropCheckConstraints(
+        tableOrName: Table | string,
+        checkConstraints: TableCheck[]
+    ): Promise<void> {
         throw new Error(`MySql does not support check constraints.`);
     }
 
     /**
      * Creates a new exclusion constraint.
      */
-    async createExclusionConstraint(tableOrName: Table|string, exclusionConstraint: TableExclusion): Promise<void> {
+    async createExclusionConstraint(
+        tableOrName: Table | string,
+        exclusionConstraint: TableExclusion
+    ): Promise<void> {
         throw new Error(`MySql does not support exclusion constraints.`);
     }
 
     /**
      * Creates a new exclusion constraints.
      */
-    async createExclusionConstraints(tableOrName: Table|string, exclusionConstraints: TableExclusion[]): Promise<void> {
+    async createExclusionConstraints(
+        tableOrName: Table | string,
+        exclusionConstraints: TableExclusion[]
+    ): Promise<void> {
         throw new Error(`MySql does not support exclusion constraints.`);
     }
 
     /**
      * Drops exclusion constraint.
      */
-    async dropExclusionConstraint(tableOrName: Table|string, exclusionOrName: TableExclusion|string): Promise<void> {
+    async dropExclusionConstraint(
+        tableOrName: Table | string,
+        exclusionOrName: TableExclusion | string
+    ): Promise<void> {
         throw new Error(`MySql does not support exclusion constraints.`);
     }
 
     /**
      * Drops exclusion constraints.
      */
-    async dropExclusionConstraints(tableOrName: Table|string, exclusionConstraints: TableExclusion[]): Promise<void> {
+    async dropExclusionConstraints(
+        tableOrName: Table | string,
+        exclusionConstraints: TableExclusion[]
+    ): Promise<void> {
         throw new Error(`MySql does not support exclusion constraints.`);
     }
 
     /**
      * Creates a new foreign key.
      */
-    async createForeignKey(tableOrName: Table|string, foreignKey: TableForeignKey): Promise<void> {
-        const table = tableOrName instanceof Table ? tableOrName : await this.getCachedTable(tableOrName);
+    async createForeignKey(
+        tableOrName: Table | string,
+        foreignKey: TableForeignKey
+    ): Promise<void> {
+        const table =
+            tableOrName instanceof Table
+                ? tableOrName
+                : await this.getCachedTable(tableOrName);
 
         // new FK may be passed without name. In this case we generate FK name manually.
         if (!foreignKey.name)
-            foreignKey.name = this.connection.namingStrategy.foreignKeyName(table.name, foreignKey.columnNames);
+            foreignKey.name = this.connection.namingStrategy.foreignKeyName(
+                table.name,
+                foreignKey.columnNames
+            );
 
         const up = this.createForeignKeySql(table, foreignKey);
         const down = this.dropForeignKeySql(table, foreignKey);
@@ -1021,19 +1729,35 @@ export class AuroraDataApiQueryRunner extends BaseQueryRunner implements QueryRu
     /**
      * Creates a new foreign keys.
      */
-    async createForeignKeys(tableOrName: Table|string, foreignKeys: TableForeignKey[]): Promise<void> {
-        const promises = foreignKeys.map(foreignKey => this.createForeignKey(tableOrName, foreignKey));
+    async createForeignKeys(
+        tableOrName: Table | string,
+        foreignKeys: TableForeignKey[]
+    ): Promise<void> {
+        const promises = foreignKeys.map((foreignKey) =>
+            this.createForeignKey(tableOrName, foreignKey)
+        );
         await Promise.all(promises);
     }
 
     /**
      * Drops a foreign key.
      */
-    async dropForeignKey(tableOrName: Table|string, foreignKeyOrName: TableForeignKey|string): Promise<void> {
-        const table = tableOrName instanceof Table ? tableOrName : await this.getCachedTable(tableOrName);
-        const foreignKey = foreignKeyOrName instanceof TableForeignKey ? foreignKeyOrName : table.foreignKeys.find(fk => fk.name === foreignKeyOrName);
+    async dropForeignKey(
+        tableOrName: Table | string,
+        foreignKeyOrName: TableForeignKey | string
+    ): Promise<void> {
+        const table =
+            tableOrName instanceof Table
+                ? tableOrName
+                : await this.getCachedTable(tableOrName);
+        const foreignKey =
+            foreignKeyOrName instanceof TableForeignKey
+                ? foreignKeyOrName
+                : table.foreignKeys.find((fk) => fk.name === foreignKeyOrName);
         if (!foreignKey)
-            throw new Error(`Supplied foreign key was not found in table ${table.name}`);
+            throw new Error(
+                `Supplied foreign key was not found in table ${table.name}`
+            );
 
         const up = this.dropForeignKeySql(table, foreignKey);
         const down = this.createForeignKeySql(table, foreignKey);
@@ -1044,20 +1768,35 @@ export class AuroraDataApiQueryRunner extends BaseQueryRunner implements QueryRu
     /**
      * Drops a foreign keys from the table.
      */
-    async dropForeignKeys(tableOrName: Table|string, foreignKeys: TableForeignKey[]): Promise<void> {
-        const promises = foreignKeys.map(foreignKey => this.dropForeignKey(tableOrName, foreignKey));
+    async dropForeignKeys(
+        tableOrName: Table | string,
+        foreignKeys: TableForeignKey[]
+    ): Promise<void> {
+        const promises = foreignKeys.map((foreignKey) =>
+            this.dropForeignKey(tableOrName, foreignKey)
+        );
         await Promise.all(promises);
     }
 
     /**
      * Creates a new index.
      */
-    async createIndex(tableOrName: Table|string, index: TableIndex): Promise<void> {
-        const table = tableOrName instanceof Table ? tableOrName : await this.getCachedTable(tableOrName);
+    async createIndex(
+        tableOrName: Table | string,
+        index: TableIndex
+    ): Promise<void> {
+        const table =
+            tableOrName instanceof Table
+                ? tableOrName
+                : await this.getCachedTable(tableOrName);
 
         // new index may be passed without name. In this case we generate index name manually.
         if (!index.name)
-            index.name = this.connection.namingStrategy.indexName(table.name, index.columnNames, index.where);
+            index.name = this.connection.namingStrategy.indexName(
+                table.name,
+                index.columnNames,
+                index.where
+            );
 
         const up = this.createIndexSql(table, index);
         const down = this.dropIndexSql(table, index);
@@ -1068,19 +1807,35 @@ export class AuroraDataApiQueryRunner extends BaseQueryRunner implements QueryRu
     /**
      * Creates a new indices
      */
-    async createIndices(tableOrName: Table|string, indices: TableIndex[]): Promise<void> {
-        const promises = indices.map(index => this.createIndex(tableOrName, index));
+    async createIndices(
+        tableOrName: Table | string,
+        indices: TableIndex[]
+    ): Promise<void> {
+        const promises = indices.map((index) =>
+            this.createIndex(tableOrName, index)
+        );
         await Promise.all(promises);
     }
 
     /**
      * Drops an index.
      */
-    async dropIndex(tableOrName: Table|string, indexOrName: TableIndex|string): Promise<void> {
-        const table = tableOrName instanceof Table ? tableOrName : await this.getCachedTable(tableOrName);
-        const index = indexOrName instanceof TableIndex ? indexOrName : table.indices.find(i => i.name === indexOrName);
+    async dropIndex(
+        tableOrName: Table | string,
+        indexOrName: TableIndex | string
+    ): Promise<void> {
+        const table =
+            tableOrName instanceof Table
+                ? tableOrName
+                : await this.getCachedTable(tableOrName);
+        const index =
+            indexOrName instanceof TableIndex
+                ? indexOrName
+                : table.indices.find((i) => i.name === indexOrName);
         if (!index)
-            throw new Error(`Supplied index was not found in table ${table.name}`);
+            throw new Error(
+                `Supplied index was not found in table ${table.name}`
+            );
 
         const up = this.dropIndexSql(table, index);
         const down = this.createIndexSql(table, index);
@@ -1091,8 +1846,13 @@ export class AuroraDataApiQueryRunner extends BaseQueryRunner implements QueryRu
     /**
      * Drops an indices from the table.
      */
-    async dropIndices(tableOrName: Table|string, indices: TableIndex[]): Promise<void> {
-        const promises = indices.map(index => this.dropIndex(tableOrName, index));
+    async dropIndices(
+        tableOrName: Table | string,
+        indices: TableIndex[]
+    ): Promise<void> {
+        const promises = indices.map((index) =>
+            this.dropIndex(tableOrName, index)
+        );
         await Promise.all(promises);
     }
 
@@ -1100,7 +1860,7 @@ export class AuroraDataApiQueryRunner extends BaseQueryRunner implements QueryRu
      * Clears all table contents.
      * Note: this operation uses SQL's TRUNCATE query which cannot be reverted in transactions.
      */
-    async clearTable(tableOrName: Table|string): Promise<void> {
+    async clearTable(tableOrName: Table | string): Promise<void> {
         await this.query(`TRUNCATE TABLE ${this.escapePath(tableOrName)}`);
     }
 
@@ -1113,34 +1873,40 @@ export class AuroraDataApiQueryRunner extends BaseQueryRunner implements QueryRu
         const dbName = database ? database : this.driver.database;
         if (dbName) {
             const isDatabaseExist = await this.hasDatabase(dbName);
-            if (!isDatabaseExist)
-                return Promise.resolve();
+            if (!isDatabaseExist) return Promise.resolve();
         } else {
             throw new Error(`Can not clear database. No database is specified`);
         }
 
         await this.startTransaction();
         try {
-
             const selectViewDropsQuery = `SELECT concat('DROP VIEW IF EXISTS \`', table_schema, '\`.\`', table_name, '\`') AS \`query\` FROM \`INFORMATION_SCHEMA\`.\`VIEWS\` WHERE \`TABLE_SCHEMA\` = '${dbName}'`;
-            const dropViewQueries: ObjectLiteral[] = await this.query(selectViewDropsQuery);
-            await Promise.all(dropViewQueries.map(q => this.query(q["query"])));
+            const dropViewQueries: ObjectLiteral[] = await this.query(
+                selectViewDropsQuery
+            );
+            await Promise.all(
+                dropViewQueries.map((q) => this.query(q["query"]))
+            );
 
             const disableForeignKeysCheckQuery = `SET FOREIGN_KEY_CHECKS = 0;`;
             const dropTablesQuery = `SELECT concat('DROP TABLE IF EXISTS \`', table_schema, '\`.\`', table_name, '\`') AS \`query\` FROM \`INFORMATION_SCHEMA\`.\`TABLES\` WHERE \`TABLE_SCHEMA\` = '${dbName}'`;
             const enableForeignKeysCheckQuery = `SET FOREIGN_KEY_CHECKS = 1;`;
 
             await this.query(disableForeignKeysCheckQuery);
-            const dropQueries: ObjectLiteral[] = await this.query(dropTablesQuery);
-            await Promise.all(dropQueries.map(query => this.query(query["query"])));
+            const dropQueries: ObjectLiteral[] = await this.query(
+                dropTablesQuery
+            );
+            await Promise.all(
+                dropQueries.map((query) => this.query(query["query"]))
+            );
             await this.query(enableForeignKeysCheckQuery);
 
             await this.commitTransaction();
-
         } catch (error) {
-            try { // we throw original error even if rollback thrown an error
+            try {
+                // we throw original error even if rollback thrown an error
                 await this.rollbackTransaction();
-            } catch (rollbackError) { }
+            } catch (rollbackError) {}
             throw error;
         }
     }
@@ -1150,27 +1916,42 @@ export class AuroraDataApiQueryRunner extends BaseQueryRunner implements QueryRu
     // -------------------------------------------------------------------------
 
     protected async loadViews(viewNames: string[]): Promise<View[]> {
-        const hasTable = await this.hasTable(this.getTypeormMetadataTableName());
-        if (!hasTable)
-            return Promise.resolve([]);
+        const hasTable = await this.hasTable(
+            this.getTypeormMetadataTableName()
+        );
+        if (!hasTable) return Promise.resolve([]);
 
         const currentDatabase = await this.getCurrentDatabase();
-        const viewsCondition = viewNames.map(tableName => {
-            let [database, name] = tableName.split(".");
-            if (!name) {
-                name = database;
-                database = this.driver.database || currentDatabase;
-            }
-            return `(\`t\`.\`schema\` = '${database}' AND \`t\`.\`name\` = '${name}')`;
-        }).join(" OR ");
+        const viewsCondition = viewNames
+            .map((tableName) => {
+                let [database, name] = tableName.split(".");
+                if (!name) {
+                    name = database;
+                    database = this.driver.database || currentDatabase;
+                }
+                return `(\`t\`.\`schema\` = '${database}' AND \`t\`.\`name\` = '${name}')`;
+            })
+            .join(" OR ");
 
-        const query = `SELECT \`t\`.*, \`v\`.\`check_option\` FROM ${this.escapePath(this.getTypeormMetadataTableName())} \`t\` ` +
-            `INNER JOIN \`information_schema\`.\`views\` \`v\` ON \`v\`.\`table_schema\` = \`t\`.\`schema\` AND \`v\`.\`table_name\` = \`t\`.\`name\` WHERE \`t\`.\`type\` = 'VIEW' ${viewsCondition ? `AND (${viewsCondition})` : ""}`;
+        const query =
+            `SELECT \`t\`.*, \`v\`.\`check_option\` FROM ${this.escapePath(
+                this.getTypeormMetadataTableName()
+            )} \`t\` ` +
+            `INNER JOIN \`information_schema\`.\`views\` \`v\` ON \`v\`.\`table_schema\` = \`t\`.\`schema\` AND \`v\`.\`table_name\` = \`t\`.\`name\` WHERE \`t\`.\`type\` = 'VIEW' ${
+                viewsCondition ? `AND (${viewsCondition})` : ""
+            }`;
         const dbViews = await this.query(query);
         return dbViews.map((dbView: any) => {
             const view = new View();
-            const db = dbView["schema"] === currentDatabase ? undefined : dbView["schema"];
-            view.name = this.driver.buildTableName(dbView["name"], undefined, db);
+            const db =
+                dbView["schema"] === currentDatabase
+                    ? undefined
+                    : dbView["schema"];
+            view.name = this.driver.buildTableName(
+                dbView["name"],
+                undefined,
+                db
+            );
             view.expression = dbView["value"];
             return view;
         });
@@ -1180,313 +1961,561 @@ export class AuroraDataApiQueryRunner extends BaseQueryRunner implements QueryRu
      * Loads all tables (with given names) from the database and creates a Table from them.
      */
     protected async loadTables(tableNames: string[]): Promise<Table[]> {
-
         // if no tables given then no need to proceed
-        if (!tableNames || !tableNames.length)
-            return [];
+        if (!tableNames || !tableNames.length) return [];
 
         const currentDatabase = await this.getCurrentDatabase();
-        const tablesCondition = tableNames.map(tableName => {
-            let [database, name] = tableName.split(".");
-            if (!name) {
-                name = database;
-                database = this.driver.database || currentDatabase;
-            }
-            return `(\`TABLE_SCHEMA\` = '${database}' AND \`TABLE_NAME\` = '${name}')`;
-        }).join(" OR ");
-        const tablesSql = `SELECT * FROM \`INFORMATION_SCHEMA\`.\`TABLES\` WHERE ` + tablesCondition;
+        const tablesCondition = tableNames
+            .map((tableName) => {
+                let [database, name] = tableName.split(".");
+                if (!name) {
+                    name = database;
+                    database = this.driver.database || currentDatabase;
+                }
+                return `(\`TABLE_SCHEMA\` = '${database}' AND \`TABLE_NAME\` = '${name}')`;
+            })
+            .join(" OR ");
+        const tablesSql =
+            `SELECT * FROM \`INFORMATION_SCHEMA\`.\`TABLES\` WHERE ` +
+            tablesCondition;
 
-        const columnsSql = `SELECT * FROM \`INFORMATION_SCHEMA\`.\`COLUMNS\` WHERE ` + tablesCondition;
+        const columnsSql =
+            `SELECT * FROM \`INFORMATION_SCHEMA\`.\`COLUMNS\` WHERE ` +
+            tablesCondition;
 
         const primaryKeySql = `SELECT * FROM \`INFORMATION_SCHEMA\`.\`KEY_COLUMN_USAGE\` WHERE \`CONSTRAINT_NAME\` = 'PRIMARY' AND (${tablesCondition})`;
 
         const collationsSql = `SELECT \`SCHEMA_NAME\`, \`DEFAULT_CHARACTER_SET_NAME\` as \`CHARSET\`, \`DEFAULT_COLLATION_NAME\` AS \`COLLATION\` FROM \`INFORMATION_SCHEMA\`.\`SCHEMATA\``;
 
-        const indicesCondition = tableNames.map(tableName => {
-            let [database, name] = tableName.split(".");
-            if (!name) {
-                name = database;
-                database = this.driver.database || currentDatabase;
-            }
-            return `(\`s\`.\`TABLE_SCHEMA\` = '${database}' AND \`s\`.\`TABLE_NAME\` = '${name}')`;
-        }).join(" OR ");
-        const indicesSql = `SELECT \`s\`.* FROM \`INFORMATION_SCHEMA\`.\`STATISTICS\` \`s\` ` +
+        const indicesCondition = tableNames
+            .map((tableName) => {
+                let [database, name] = tableName.split(".");
+                if (!name) {
+                    name = database;
+                    database = this.driver.database || currentDatabase;
+                }
+                return `(\`s\`.\`TABLE_SCHEMA\` = '${database}' AND \`s\`.\`TABLE_NAME\` = '${name}')`;
+            })
+            .join(" OR ");
+        const indicesSql =
+            `SELECT \`s\`.* FROM \`INFORMATION_SCHEMA\`.\`STATISTICS\` \`s\` ` +
             `LEFT JOIN \`INFORMATION_SCHEMA\`.\`REFERENTIAL_CONSTRAINTS\` \`rc\` ON \`s\`.\`INDEX_NAME\` = \`rc\`.\`CONSTRAINT_NAME\` ` +
             `WHERE (${indicesCondition}) AND \`s\`.\`INDEX_NAME\` != 'PRIMARY' AND \`rc\`.\`CONSTRAINT_NAME\` IS NULL`;
 
-        const foreignKeysCondition = tableNames.map(tableName => {
-            let [database, name] = tableName.split(".");
-            if (!name) {
-                name = database;
-                database = this.driver.database || currentDatabase;
-            }
-            return `(\`kcu\`.\`TABLE_SCHEMA\` = '${database}' AND \`kcu\`.\`TABLE_NAME\` = '${name}')`;
-        }).join(" OR ");
-        const foreignKeysSql = `SELECT \`kcu\`.\`TABLE_SCHEMA\`, \`kcu\`.\`TABLE_NAME\`, \`kcu\`.\`CONSTRAINT_NAME\`, \`kcu\`.\`COLUMN_NAME\`, \`kcu\`.\`REFERENCED_TABLE_SCHEMA\`, ` +
+        const foreignKeysCondition = tableNames
+            .map((tableName) => {
+                let [database, name] = tableName.split(".");
+                if (!name) {
+                    name = database;
+                    database = this.driver.database || currentDatabase;
+                }
+                return `(\`kcu\`.\`TABLE_SCHEMA\` = '${database}' AND \`kcu\`.\`TABLE_NAME\` = '${name}')`;
+            })
+            .join(" OR ");
+        const foreignKeysSql =
+            `SELECT \`kcu\`.\`TABLE_SCHEMA\`, \`kcu\`.\`TABLE_NAME\`, \`kcu\`.\`CONSTRAINT_NAME\`, \`kcu\`.\`COLUMN_NAME\`, \`kcu\`.\`REFERENCED_TABLE_SCHEMA\`, ` +
             `\`kcu\`.\`REFERENCED_TABLE_NAME\`, \`kcu\`.\`REFERENCED_COLUMN_NAME\`, \`rc\`.\`DELETE_RULE\` \`ON_DELETE\`, \`rc\`.\`UPDATE_RULE\` \`ON_UPDATE\` ` +
             `FROM \`INFORMATION_SCHEMA\`.\`KEY_COLUMN_USAGE\` \`kcu\` ` +
             `INNER JOIN \`INFORMATION_SCHEMA\`.\`REFERENTIAL_CONSTRAINTS\` \`rc\` ON \`rc\`.\`constraint_name\` = \`kcu\`.\`constraint_name\` ` +
-            `WHERE ` + foreignKeysCondition;
-        const [dbTables, dbColumns, dbPrimaryKeys, dbCollations, dbIndices, dbForeignKeys]: ObjectLiteral[][] = await Promise.all([
+            `WHERE ` +
+            foreignKeysCondition;
+        const [
+            dbTables,
+            dbColumns,
+            dbPrimaryKeys,
+            dbCollations,
+            dbIndices,
+            dbForeignKeys,
+        ]: ObjectLiteral[][] = await Promise.all([
             this.query(tablesSql),
             this.query(columnsSql),
             this.query(primaryKeySql),
             this.query(collationsSql),
             this.query(indicesSql),
-            this.query(foreignKeysSql)
+            this.query(foreignKeysSql),
         ]);
 
         // if tables were not found in the db, no need to proceed
-        if (!dbTables.length)
-            return [];
-
+        if (!dbTables.length) return [];
 
         // create tables for loaded tables
-        return Promise.all(dbTables.map(async dbTable => {
-            const table = new Table();
+        return Promise.all(
+            dbTables.map(async (dbTable) => {
+                const table = new Table();
 
-            const dbCollation = dbCollations.find(coll => coll["SCHEMA_NAME"] === dbTable["TABLE_SCHEMA"])!;
-            const defaultCollation = dbCollation["COLLATION"];
-            const defaultCharset = dbCollation["CHARSET"];
+                const dbCollation = dbCollations.find(
+                    (coll) => coll["SCHEMA_NAME"] === dbTable["TABLE_SCHEMA"]
+                )!;
+                const defaultCollation = dbCollation["COLLATION"];
+                const defaultCharset = dbCollation["CHARSET"];
 
-            // We do not need to join database name, when database is by default.
-            // In this case we need local variable `tableFullName` for below comparision.
-            const db = dbTable["TABLE_SCHEMA"] === currentDatabase ? undefined : dbTable["TABLE_SCHEMA"];
-            table.name = this.driver.buildTableName(dbTable["TABLE_NAME"], undefined, db);
-            const tableFullName = this.driver.buildTableName(dbTable["TABLE_NAME"], undefined, dbTable["TABLE_SCHEMA"]);
+                // We do not need to join database name, when database is by default.
+                // In this case we need local variable `tableFullName` for below comparision.
+                const db =
+                    dbTable["TABLE_SCHEMA"] === currentDatabase
+                        ? undefined
+                        : dbTable["TABLE_SCHEMA"];
+                table.name = this.driver.buildTableName(
+                    dbTable["TABLE_NAME"],
+                    undefined,
+                    db
+                );
+                const tableFullName = this.driver.buildTableName(
+                    dbTable["TABLE_NAME"],
+                    undefined,
+                    dbTable["TABLE_SCHEMA"]
+                );
 
-            // create columns from the loaded columns
-            table.columns = dbColumns
-                .filter(dbColumn => this.driver.buildTableName(dbColumn["TABLE_NAME"], undefined, dbColumn["TABLE_SCHEMA"]) === tableFullName)
-                .map(dbColumn => {
+                // create columns from the loaded columns
+                table.columns = dbColumns
+                    .filter(
+                        (dbColumn) =>
+                            this.driver.buildTableName(
+                                dbColumn["TABLE_NAME"],
+                                undefined,
+                                dbColumn["TABLE_SCHEMA"]
+                            ) === tableFullName
+                    )
+                    .map((dbColumn) => {
+                        const columnUniqueIndex = dbIndices.find((dbIndex) => {
+                            const indexTableFullName = this.driver.buildTableName(
+                                dbIndex["TABLE_NAME"],
+                                undefined,
+                                dbIndex["TABLE_SCHEMA"]
+                            );
+                            if (indexTableFullName !== tableFullName) {
+                                return false;
+                            }
 
-                    const columnUniqueIndex = dbIndices.find(dbIndex => {
-                        const indexTableFullName = this.driver.buildTableName(dbIndex["TABLE_NAME"], undefined, dbIndex["TABLE_SCHEMA"]);
-                        if (indexTableFullName !== tableFullName) {
-                            return false;
-                        }
+                            // Index is not for this column
+                            if (
+                                dbIndex["COLUMN_NAME"] !==
+                                dbColumn["COLUMN_NAME"]
+                            ) {
+                                return false;
+                            }
 
-                        // Index is not for this column
-                        if (dbIndex["COLUMN_NAME"] !== dbColumn["COLUMN_NAME"]) {
-                            return false;
-                        }
-
-                        const nonUnique = parseInt(dbIndex["NON_UNIQUE"], 10);
-                        return nonUnique === 0;
-                    });
-
-                    const tableMetadata = this.connection.entityMetadatas.find(metadata => metadata.tablePath === table.name);
-                    const hasIgnoredIndex = columnUniqueIndex && tableMetadata && tableMetadata.indices
-                        .some(index => index.name === columnUniqueIndex["INDEX_NAME"] && index.synchronize === false);
-
-                    const isConstraintComposite = columnUniqueIndex
-                        ? !!dbIndices.find(dbIndex => dbIndex["INDEX_NAME"] === columnUniqueIndex["INDEX_NAME"] && dbIndex["COLUMN_NAME"] !== dbColumn["COLUMN_NAME"])
-                        : false;
-
-                    const tableColumn = new TableColumn();
-                    tableColumn.name = dbColumn["COLUMN_NAME"];
-                    tableColumn.type = dbColumn["DATA_TYPE"].toLowerCase();
-
-                    if (this.driver.withWidthColumnTypes.indexOf(tableColumn.type as ColumnType) !== -1) {
-                        const width = dbColumn["COLUMN_TYPE"].substring(dbColumn["COLUMN_TYPE"].indexOf("(") + 1, dbColumn["COLUMN_TYPE"].indexOf(")"));
-                        tableColumn.width = width && !this.isDefaultColumnWidth(table, tableColumn, parseInt(width)) ? parseInt(width) : undefined;
-                    }
-
-                    if (dbColumn["COLUMN_DEFAULT"] === null
-                        || dbColumn["COLUMN_DEFAULT"] === undefined) {
-                        tableColumn.default = undefined;
-
-                    } else {
-                        tableColumn.default = dbColumn["COLUMN_DEFAULT"] === "CURRENT_TIMESTAMP" ? dbColumn["COLUMN_DEFAULT"] : `'${dbColumn["COLUMN_DEFAULT"]}'`;
-                    }
-
-                    if (dbColumn["EXTRA"].indexOf("on update") !== -1) {
-                        tableColumn.onUpdate = dbColumn["EXTRA"].substring(dbColumn["EXTRA"].indexOf("on update") + 10);
-                    }
-
-                    if (dbColumn["GENERATION_EXPRESSION"]) {
-                        tableColumn.asExpression = dbColumn["GENERATION_EXPRESSION"];
-                        tableColumn.generatedType = dbColumn["EXTRA"].indexOf("VIRTUAL") !== -1 ? "VIRTUAL" : "STORED";
-                    }
-
-                    tableColumn.isUnique = !!columnUniqueIndex && !hasIgnoredIndex && !isConstraintComposite;
-                    tableColumn.isNullable = dbColumn["IS_NULLABLE"] === "YES";
-                    tableColumn.isPrimary = dbPrimaryKeys.some(dbPrimaryKey => {
-                        return this.driver.buildTableName(dbPrimaryKey["TABLE_NAME"], undefined, dbPrimaryKey["TABLE_SCHEMA"]) === tableFullName && dbPrimaryKey["COLUMN_NAME"] === tableColumn.name;
-                    });
-                    tableColumn.zerofill = dbColumn["COLUMN_TYPE"].indexOf("zerofill") !== -1;
-                    tableColumn.unsigned = tableColumn.zerofill ? true : dbColumn["COLUMN_TYPE"].indexOf("unsigned") !== -1;
-                    tableColumn.isGenerated = dbColumn["EXTRA"].indexOf("auto_increment") !== -1;
-                    if (tableColumn.isGenerated)
-                        tableColumn.generationStrategy = "increment";
-
-                    tableColumn.comment = dbColumn["COLUMN_COMMENT"];
-                    if (dbColumn["CHARACTER_SET_NAME"])
-                        tableColumn.charset = dbColumn["CHARACTER_SET_NAME"] === defaultCharset ? undefined : dbColumn["CHARACTER_SET_NAME"];
-                    if (dbColumn["COLLATION_NAME"])
-                        tableColumn.collation = dbColumn["COLLATION_NAME"] === defaultCollation ? undefined : dbColumn["COLLATION_NAME"];
-
-                    // check only columns that have length property
-                    if (this.driver.withLengthColumnTypes.indexOf(tableColumn.type as ColumnType) !== -1 && dbColumn["CHARACTER_MAXIMUM_LENGTH"]) {
-                        const length = dbColumn["CHARACTER_MAXIMUM_LENGTH"].toString();
-                        tableColumn.length = !this.isDefaultColumnLength(table, tableColumn, length) ? length : "";
-                    }
-
-                    if (tableColumn.type === "decimal" || tableColumn.type === "double" || tableColumn.type === "float") {
-                        if (dbColumn["NUMERIC_PRECISION"] !== null && !this.isDefaultColumnPrecision(table, tableColumn, dbColumn["NUMERIC_PRECISION"]))
-                            tableColumn.precision = parseInt(dbColumn["NUMERIC_PRECISION"]);
-                        if (dbColumn["NUMERIC_SCALE"] !== null && !this.isDefaultColumnScale(table, tableColumn, dbColumn["NUMERIC_SCALE"]))
-                            tableColumn.scale = parseInt(dbColumn["NUMERIC_SCALE"]);
-                    }
-
-                    if (tableColumn.type === "enum" || tableColumn.type === "simple-enum") {
-                        const colType = dbColumn["COLUMN_TYPE"];
-                        const items = colType.substring(colType.indexOf("(") + 1, colType.lastIndexOf(")")).split(",");
-                        tableColumn.enum = (items as string[]).map(item => {
-                            return item.substring(1, item.length - 1);
+                            const nonUnique = parseInt(
+                                dbIndex["NON_UNIQUE"],
+                                10
+                            );
+                            return nonUnique === 0;
                         });
-                        tableColumn.length = "";
+
+                        const tableMetadata = this.connection.entityMetadatas.find(
+                            (metadata) => metadata.tablePath === table.name
+                        );
+                        const hasIgnoredIndex =
+                            columnUniqueIndex &&
+                            tableMetadata &&
+                            tableMetadata.indices.some(
+                                (index) =>
+                                    index.name ===
+                                        columnUniqueIndex["INDEX_NAME"] &&
+                                    index.synchronize === false
+                            );
+
+                        const isConstraintComposite = columnUniqueIndex
+                            ? !!dbIndices.find(
+                                  (dbIndex) =>
+                                      dbIndex["INDEX_NAME"] ===
+                                          columnUniqueIndex["INDEX_NAME"] &&
+                                      dbIndex["COLUMN_NAME"] !==
+                                          dbColumn["COLUMN_NAME"]
+                              )
+                            : false;
+
+                        const tableColumn = new TableColumn();
+                        tableColumn.name = dbColumn["COLUMN_NAME"];
+                        tableColumn.type = dbColumn["DATA_TYPE"].toLowerCase();
+
+                        if (
+                            this.driver.withWidthColumnTypes.indexOf(
+                                tableColumn.type as ColumnType
+                            ) !== -1
+                        ) {
+                            const width = dbColumn["COLUMN_TYPE"].substring(
+                                dbColumn["COLUMN_TYPE"].indexOf("(") + 1,
+                                dbColumn["COLUMN_TYPE"].indexOf(")")
+                            );
+                            tableColumn.width =
+                                width &&
+                                !this.isDefaultColumnWidth(
+                                    table,
+                                    tableColumn,
+                                    parseInt(width)
+                                )
+                                    ? parseInt(width)
+                                    : undefined;
+                        }
+
+                        if (
+                            dbColumn["COLUMN_DEFAULT"] === null ||
+                            dbColumn["COLUMN_DEFAULT"] === undefined
+                        ) {
+                            tableColumn.default = undefined;
+                        } else {
+                            tableColumn.default =
+                                dbColumn["COLUMN_DEFAULT"] ===
+                                "CURRENT_TIMESTAMP"
+                                    ? dbColumn["COLUMN_DEFAULT"]
+                                    : `'${dbColumn["COLUMN_DEFAULT"]}'`;
+                        }
+
+                        if (dbColumn["EXTRA"].indexOf("on update") !== -1) {
+                            tableColumn.onUpdate = dbColumn["EXTRA"].substring(
+                                dbColumn["EXTRA"].indexOf("on update") + 10
+                            );
+                        }
+
+                        if (dbColumn["GENERATION_EXPRESSION"]) {
+                            tableColumn.asExpression =
+                                dbColumn["GENERATION_EXPRESSION"];
+                            tableColumn.generatedType =
+                                dbColumn["EXTRA"].indexOf("VIRTUAL") !== -1
+                                    ? "VIRTUAL"
+                                    : "STORED";
+                        }
+
+                        tableColumn.isUnique =
+                            !!columnUniqueIndex &&
+                            !hasIgnoredIndex &&
+                            !isConstraintComposite;
+                        tableColumn.isNullable =
+                            dbColumn["IS_NULLABLE"] === "YES";
+                        tableColumn.isPrimary = dbPrimaryKeys.some(
+                            (dbPrimaryKey) => {
+                                return (
+                                    this.driver.buildTableName(
+                                        dbPrimaryKey["TABLE_NAME"],
+                                        undefined,
+                                        dbPrimaryKey["TABLE_SCHEMA"]
+                                    ) === tableFullName &&
+                                    dbPrimaryKey["COLUMN_NAME"] ===
+                                        tableColumn.name
+                                );
+                            }
+                        );
+                        tableColumn.zerofill =
+                            dbColumn["COLUMN_TYPE"].indexOf("zerofill") !== -1;
+                        tableColumn.unsigned = tableColumn.zerofill
+                            ? true
+                            : dbColumn["COLUMN_TYPE"].indexOf("unsigned") !==
+                              -1;
+                        tableColumn.isGenerated =
+                            dbColumn["EXTRA"].indexOf("auto_increment") !== -1;
+                        if (tableColumn.isGenerated)
+                            tableColumn.generationStrategy = "increment";
+
+                        tableColumn.comment = dbColumn["COLUMN_COMMENT"];
+                        if (dbColumn["CHARACTER_SET_NAME"])
+                            tableColumn.charset =
+                                dbColumn["CHARACTER_SET_NAME"] ===
+                                defaultCharset
+                                    ? undefined
+                                    : dbColumn["CHARACTER_SET_NAME"];
+                        if (dbColumn["COLLATION_NAME"])
+                            tableColumn.collation =
+                                dbColumn["COLLATION_NAME"] === defaultCollation
+                                    ? undefined
+                                    : dbColumn["COLLATION_NAME"];
+
+                        // check only columns that have length property
+                        if (
+                            this.driver.withLengthColumnTypes.indexOf(
+                                tableColumn.type as ColumnType
+                            ) !== -1 &&
+                            dbColumn["CHARACTER_MAXIMUM_LENGTH"]
+                        ) {
+                            const length = dbColumn[
+                                "CHARACTER_MAXIMUM_LENGTH"
+                            ].toString();
+                            tableColumn.length = !this.isDefaultColumnLength(
+                                table,
+                                tableColumn,
+                                length
+                            )
+                                ? length
+                                : "";
+                        }
+
+                        if (
+                            tableColumn.type === "decimal" ||
+                            tableColumn.type === "double" ||
+                            tableColumn.type === "float"
+                        ) {
+                            if (
+                                dbColumn["NUMERIC_PRECISION"] !== null &&
+                                !this.isDefaultColumnPrecision(
+                                    table,
+                                    tableColumn,
+                                    dbColumn["NUMERIC_PRECISION"]
+                                )
+                            )
+                                tableColumn.precision = parseInt(
+                                    dbColumn["NUMERIC_PRECISION"]
+                                );
+                            if (
+                                dbColumn["NUMERIC_SCALE"] !== null &&
+                                !this.isDefaultColumnScale(
+                                    table,
+                                    tableColumn,
+                                    dbColumn["NUMERIC_SCALE"]
+                                )
+                            )
+                                tableColumn.scale = parseInt(
+                                    dbColumn["NUMERIC_SCALE"]
+                                );
+                        }
+
+                        if (
+                            tableColumn.type === "enum" ||
+                            tableColumn.type === "simple-enum" ||
+                            tableColumn.type === "set"
+                        ) {
+                            const colType = dbColumn["COLUMN_TYPE"];
+                            const items = colType
+                                .substring(
+                                    colType.indexOf("(") + 1,
+                                    colType.lastIndexOf(")")
+                                )
+                                .split(",");
+                            tableColumn.enum = (items as string[]).map(
+                                (item) => {
+                                    return item.substring(1, item.length - 1);
+                                }
+                            );
+                            tableColumn.length = "";
+                        }
+
+                        if (
+                            (tableColumn.type === "datetime" ||
+                                tableColumn.type === "time" ||
+                                tableColumn.type === "timestamp") &&
+                            dbColumn["DATETIME_PRECISION"] !== null &&
+                            dbColumn["DATETIME_PRECISION"] !== undefined &&
+                            !this.isDefaultColumnPrecision(
+                                table,
+                                tableColumn,
+                                parseInt(dbColumn["DATETIME_PRECISION"])
+                            )
+                        ) {
+                            tableColumn.precision = parseInt(
+                                dbColumn["DATETIME_PRECISION"]
+                            );
+                        }
+
+                        return tableColumn;
+                    });
+
+                // find foreign key constraints of table, group them by constraint name and build TableForeignKey.
+                const tableForeignKeyConstraints = OrmUtils.uniq(
+                    dbForeignKeys.filter((dbForeignKey) => {
+                        return (
+                            this.driver.buildTableName(
+                                dbForeignKey["TABLE_NAME"],
+                                undefined,
+                                dbForeignKey["TABLE_SCHEMA"]
+                            ) === tableFullName
+                        );
+                    }),
+                    (dbForeignKey) => dbForeignKey["CONSTRAINT_NAME"]
+                );
+
+                table.foreignKeys = tableForeignKeyConstraints.map(
+                    (dbForeignKey) => {
+                        const foreignKeys = dbForeignKeys.filter(
+                            (dbFk) =>
+                                dbFk["CONSTRAINT_NAME"] ===
+                                dbForeignKey["CONSTRAINT_NAME"]
+                        );
+
+                        // if referenced table located in currently used db, we don't need to concat db name to table name.
+                        const database =
+                            dbForeignKey["REFERENCED_TABLE_SCHEMA"] ===
+                            currentDatabase
+                                ? undefined
+                                : dbForeignKey["REFERENCED_TABLE_SCHEMA"];
+                        const referencedTableName = this.driver.buildTableName(
+                            dbForeignKey["REFERENCED_TABLE_NAME"],
+                            undefined,
+                            database
+                        );
+
+                        return new TableForeignKey({
+                            name: dbForeignKey["CONSTRAINT_NAME"],
+                            columnNames: foreignKeys.map(
+                                (dbFk) => dbFk["COLUMN_NAME"]
+                            ),
+                            referencedTableName: referencedTableName,
+                            referencedColumnNames: foreignKeys.map(
+                                (dbFk) => dbFk["REFERENCED_COLUMN_NAME"]
+                            ),
+                            onDelete: dbForeignKey["ON_DELETE"],
+                            onUpdate: dbForeignKey["ON_UPDATE"],
+                        });
                     }
+                );
 
-                    if ((tableColumn.type === "datetime" || tableColumn.type === "time" || tableColumn.type === "timestamp")
-                        && dbColumn["DATETIME_PRECISION"] !== null && dbColumn["DATETIME_PRECISION"] !== undefined
-                        && !this.isDefaultColumnPrecision(table, tableColumn, parseInt(dbColumn["DATETIME_PRECISION"]))) {
-                        tableColumn.precision = parseInt(dbColumn["DATETIME_PRECISION"]);
-                    }
+                // find index constraints of table, group them by constraint name and build TableIndex.
+                const tableIndexConstraints = OrmUtils.uniq(
+                    dbIndices.filter((dbIndex) => {
+                        return (
+                            this.driver.buildTableName(
+                                dbIndex["TABLE_NAME"],
+                                undefined,
+                                dbIndex["TABLE_SCHEMA"]
+                            ) === tableFullName
+                        );
+                    }),
+                    (dbIndex) => dbIndex["INDEX_NAME"]
+                );
 
-                    return tableColumn;
+                table.indices = tableIndexConstraints.map((constraint) => {
+                    const indices = dbIndices.filter((index) => {
+                        return (
+                            index["TABLE_SCHEMA"] ===
+                                constraint["TABLE_SCHEMA"] &&
+                            index["TABLE_NAME"] === constraint["TABLE_NAME"] &&
+                            index["INDEX_NAME"] === constraint["INDEX_NAME"]
+                        );
+                    });
+
+                    const nonUnique = parseInt(constraint["NON_UNIQUE"], 10);
+
+                    return new TableIndex(<TableIndexOptions>{
+                        table: table,
+                        name: constraint["INDEX_NAME"],
+                        columnNames: indices.map((i) => i["COLUMN_NAME"]),
+                        isUnique: nonUnique === 0,
+                        isSpatial: constraint["INDEX_TYPE"] === "SPATIAL",
+                        isFulltext: constraint["INDEX_TYPE"] === "FULLTEXT",
+                    });
                 });
 
-            // find foreign key constraints of table, group them by constraint name and build TableForeignKey.
-            const tableForeignKeyConstraints = OrmUtils.uniq(dbForeignKeys.filter(dbForeignKey => {
-                return this.driver.buildTableName(dbForeignKey["TABLE_NAME"], undefined, dbForeignKey["TABLE_SCHEMA"]) === tableFullName;
-            }), dbForeignKey => dbForeignKey["CONSTRAINT_NAME"]);
-
-            table.foreignKeys = tableForeignKeyConstraints.map(dbForeignKey => {
-                const foreignKeys = dbForeignKeys.filter(dbFk => dbFk["CONSTRAINT_NAME"] === dbForeignKey["CONSTRAINT_NAME"]);
-
-                // if referenced table located in currently used db, we don't need to concat db name to table name.
-                const database = dbForeignKey["REFERENCED_TABLE_SCHEMA"] === currentDatabase ? undefined : dbForeignKey["REFERENCED_TABLE_SCHEMA"];
-                const referencedTableName = this.driver.buildTableName(dbForeignKey["REFERENCED_TABLE_NAME"], undefined, database);
-
-                return new TableForeignKey({
-                    name: dbForeignKey["CONSTRAINT_NAME"],
-                    columnNames: foreignKeys.map(dbFk => dbFk["COLUMN_NAME"]),
-                    referencedTableName: referencedTableName,
-                    referencedColumnNames: foreignKeys.map(dbFk => dbFk["REFERENCED_COLUMN_NAME"]),
-                    onDelete: dbForeignKey["ON_DELETE"],
-                    onUpdate: dbForeignKey["ON_UPDATE"]
-                });
-            });
-
-            // find index constraints of table, group them by constraint name and build TableIndex.
-            const tableIndexConstraints = OrmUtils.uniq(dbIndices.filter(dbIndex => {
-                return this.driver.buildTableName(dbIndex["TABLE_NAME"], undefined, dbIndex["TABLE_SCHEMA"]) === tableFullName;
-            }), dbIndex => dbIndex["INDEX_NAME"]);
-
-            table.indices = tableIndexConstraints.map(constraint => {
-                const indices = dbIndices.filter(index => {
-                    return index["TABLE_SCHEMA"] === constraint["TABLE_SCHEMA"]
-                        && index["TABLE_NAME"] === constraint["TABLE_NAME"]
-                        && index["INDEX_NAME"] === constraint["INDEX_NAME"];
-                });
-
-                const nonUnique = parseInt(constraint["NON_UNIQUE"], 10);
-
-                return new TableIndex(<TableIndexOptions>{
-                    table: table,
-                    name: constraint["INDEX_NAME"],
-                    columnNames: indices.map(i => i["COLUMN_NAME"]),
-                    isUnique: nonUnique === 0,
-                    isSpatial: constraint["INDEX_TYPE"] === "SPATIAL",
-                    isFulltext: constraint["INDEX_TYPE"] === "FULLTEXT"
-                });
-            });
-
-            return table;
-        }));
+                return table;
+            })
+        );
     }
 
     /**
      * Builds create table sql
      */
     protected createTableSql(table: Table, createForeignKeys?: boolean): Query {
-        const columnDefinitions = table.columns.map(column => this.buildCreateColumnSql(column, true)).join(", ");
-        let sql = `CREATE TABLE ${this.escapePath(table)} (${columnDefinitions}`;
+        const columnDefinitions = table.columns
+            .map((column) => this.buildCreateColumnSql(column, true))
+            .join(", ");
+        let sql = `CREATE TABLE ${this.escapePath(
+            table
+        )} (${columnDefinitions}`;
 
         // we create unique indexes instead of unique constraints, because MySql does not have unique constraints.
         // if we mark column as Unique, it means that we create UNIQUE INDEX.
         table.columns
-            .filter(column => column.isUnique)
-            .forEach(column => {
-                const isUniqueIndexExist = table.indices.some(index => {
-                    return index.columnNames.length === 1 && !!index.isUnique && index.columnNames.indexOf(column.name) !== -1;
+            .filter((column) => column.isUnique)
+            .forEach((column) => {
+                const isUniqueIndexExist = table.indices.some((index) => {
+                    return (
+                        index.columnNames.length === 1 &&
+                        !!index.isUnique &&
+                        index.columnNames.indexOf(column.name) !== -1
+                    );
                 });
-                const isUniqueConstraintExist = table.uniques.some(unique => {
-                    return unique.columnNames.length === 1 && unique.columnNames.indexOf(column.name) !== -1;
+                const isUniqueConstraintExist = table.uniques.some((unique) => {
+                    return (
+                        unique.columnNames.length === 1 &&
+                        unique.columnNames.indexOf(column.name) !== -1
+                    );
                 });
                 if (!isUniqueIndexExist && !isUniqueConstraintExist)
-                    table.indices.push(new TableIndex({
-                        name: this.connection.namingStrategy.uniqueConstraintName(table.name, [column.name]),
-                        columnNames: [column.name],
-                        isUnique: true
-                    }));
+                    table.indices.push(
+                        new TableIndex({
+                            name: this.connection.namingStrategy.uniqueConstraintName(
+                                table.name,
+                                [column.name]
+                            ),
+                            columnNames: [column.name],
+                            isUnique: true,
+                        })
+                    );
             });
 
         // as MySql does not have unique constraints, we must create table indices from table uniques and mark them as unique.
         if (table.uniques.length > 0) {
-            table.uniques.forEach(unique => {
-                const uniqueExist = table.indices.some(index => index.name === unique.name);
+            table.uniques.forEach((unique) => {
+                const uniqueExist = table.indices.some(
+                    (index) => index.name === unique.name
+                );
                 if (!uniqueExist) {
-                    table.indices.push(new TableIndex({
-                        name: unique.name,
-                        columnNames: unique.columnNames,
-                        isUnique: true
-                    }));
+                    table.indices.push(
+                        new TableIndex({
+                            name: unique.name,
+                            columnNames: unique.columnNames,
+                            isUnique: true,
+                        })
+                    );
                 }
             });
         }
 
         if (table.indices.length > 0) {
-            const indicesSql = table.indices.map(index => {
-                const columnNames = index.columnNames.map(columnName => `\`${columnName}\``).join(", ");
-                if (!index.name)
-                    index.name = this.connection.namingStrategy.indexName(table.name, index.columnNames, index.where);
+            const indicesSql = table.indices
+                .map((index) => {
+                    const columnNames = index.columnNames
+                        .map((columnName) => `\`${columnName}\``)
+                        .join(", ");
+                    if (!index.name)
+                        index.name = this.connection.namingStrategy.indexName(
+                            table.name,
+                            index.columnNames,
+                            index.where
+                        );
 
-                let indexType = "";
-                if (index.isUnique)
-                    indexType += "UNIQUE ";
-                if (index.isSpatial)
-                    indexType += "SPATIAL ";
-                if (index.isFulltext)
-                    indexType += "FULLTEXT ";
-                return `${indexType}INDEX \`${index.name}\` (${columnNames})`;
-            }).join(", ");
+                    let indexType = "";
+                    if (index.isUnique) indexType += "UNIQUE ";
+                    if (index.isSpatial) indexType += "SPATIAL ";
+                    if (index.isFulltext) indexType += "FULLTEXT ";
+                    return `${indexType}INDEX \`${index.name}\` (${columnNames})`;
+                })
+                .join(", ");
 
             sql += `, ${indicesSql}`;
         }
 
         if (table.foreignKeys.length > 0 && createForeignKeys) {
-            const foreignKeysSql = table.foreignKeys.map(fk => {
-                const columnNames = fk.columnNames.map(columnName => `\`${columnName}\``).join(", ");
-                if (!fk.name)
-                    fk.name = this.connection.namingStrategy.foreignKeyName(table.name, fk.columnNames);
-                const referencedColumnNames = fk.referencedColumnNames.map(columnName => `\`${columnName}\``).join(", ");
+            const foreignKeysSql = table.foreignKeys
+                .map((fk) => {
+                    const columnNames = fk.columnNames
+                        .map((columnName) => `\`${columnName}\``)
+                        .join(", ");
+                    if (!fk.name)
+                        fk.name = this.connection.namingStrategy.foreignKeyName(
+                            table.name,
+                            fk.columnNames
+                        );
+                    const referencedColumnNames = fk.referencedColumnNames
+                        .map((columnName) => `\`${columnName}\``)
+                        .join(", ");
 
-                let constraint = `CONSTRAINT \`${fk.name}\` FOREIGN KEY (${columnNames}) REFERENCES ${this.escapePath(fk.referencedTableName)} (${referencedColumnNames})`;
-                if (fk.onDelete)
-                    constraint += ` ON DELETE ${fk.onDelete}`;
-                if (fk.onUpdate)
-                    constraint += ` ON UPDATE ${fk.onUpdate}`;
+                    let constraint = `CONSTRAINT \`${
+                        fk.name
+                    }\` FOREIGN KEY (${columnNames}) REFERENCES ${this.escapePath(
+                        fk.referencedTableName
+                    )} (${referencedColumnNames})`;
+                    if (fk.onDelete) constraint += ` ON DELETE ${fk.onDelete}`;
+                    if (fk.onUpdate) constraint += ` ON UPDATE ${fk.onUpdate}`;
 
-                return constraint;
-            }).join(", ");
+                    return constraint;
+                })
+                .join(", ");
 
             sql += `, ${foreignKeysSql}`;
         }
 
         if (table.primaryColumns.length > 0) {
-            const columnNames = table.primaryColumns.map(column => `\`${column.name}\``).join(", ");
+            const columnNames = table.primaryColumns
+                .map((column) => `\`${column.name}\``)
+                .join(", ");
             sql += `, PRIMARY KEY (${columnNames})`;
         }
 
@@ -1498,25 +2527,43 @@ export class AuroraDataApiQueryRunner extends BaseQueryRunner implements QueryRu
     /**
      * Builds drop table sql
      */
-    protected dropTableSql(tableOrName: Table|string): Query {
+    protected dropTableSql(tableOrName: Table | string): Query {
         return new Query(`DROP TABLE ${this.escapePath(tableOrName)}`);
     }
 
     protected createViewSql(view: View): Query {
         if (typeof view.expression === "string") {
-            return new Query(`CREATE VIEW ${this.escapePath(view)} AS ${view.expression}`);
+            return new Query(
+                `CREATE VIEW ${this.escapePath(view)} AS ${view.expression}`
+            );
         } else {
-            return new Query(`CREATE VIEW ${this.escapePath(view)} AS ${view.expression(this.connection).getQuery()}`);
+            return new Query(
+                `CREATE VIEW ${this.escapePath(view)} AS ${view
+                    .expression(this.connection)
+                    .getQuery()}`
+            );
         }
     }
 
     protected async insertViewDefinitionSql(view: View): Promise<Query> {
         const currentDatabase = await this.getCurrentDatabase();
-        const expression = typeof view.expression === "string" ? view.expression.trim() : view.expression(this.connection).getQuery();
-        const [query, parameters] = this.connection.createQueryBuilder()
+        const expression =
+            typeof view.expression === "string"
+                ? view.expression.trim()
+                : view.expression(this.connection).getQuery();
+        const [
+            query,
+            parameters,
+        ] = this.connection
+            .createQueryBuilder()
             .insert()
             .into(this.getTypeormMetadataTableName())
-            .values({ type: "VIEW", schema: currentDatabase, name: view.name, value: expression })
+            .values({
+                type: "VIEW",
+                schema: currentDatabase,
+                name: view.name,
+                value: expression,
+            })
             .getQueryAndParameters();
 
         return new Query(query, parameters);
@@ -1525,21 +2572,27 @@ export class AuroraDataApiQueryRunner extends BaseQueryRunner implements QueryRu
     /**
      * Builds drop view sql.
      */
-    protected dropViewSql(viewOrPath: View|string): Query {
+    protected dropViewSql(viewOrPath: View | string): Query {
         return new Query(`DROP VIEW ${this.escapePath(viewOrPath)}`);
     }
 
     /**
      * Builds remove view sql.
      */
-    protected async deleteViewDefinitionSql(viewOrPath: View|string): Promise<Query> {
+    protected async deleteViewDefinitionSql(
+        viewOrPath: View | string
+    ): Promise<Query> {
         const currentDatabase = await this.getCurrentDatabase();
-        const viewName = viewOrPath instanceof View ? viewOrPath.name : viewOrPath;
+        const viewName =
+            viewOrPath instanceof View ? viewOrPath.name : viewOrPath;
         const qb = this.connection.createQueryBuilder();
-        const [query, parameters] = qb.delete()
+        const [query, parameters] = qb
+            .delete()
             .from(this.getTypeormMetadataTableName())
             .where(`${qb.escape("type")} = 'VIEW'`)
-            .andWhere(`${qb.escape("schema")} = :schema`, { schema: currentDatabase })
+            .andWhere(`${qb.escape("schema")} = :schema`, {
+                schema: currentDatabase,
+            })
             .andWhere(`${qb.escape("name")} = :name`, { name: viewName })
             .getQueryAndParameters();
 
@@ -1550,52 +2603,79 @@ export class AuroraDataApiQueryRunner extends BaseQueryRunner implements QueryRu
      * Builds create index sql.
      */
     protected createIndexSql(table: Table, index: TableIndex): Query {
-        const columns = index.columnNames.map(columnName => `\`${columnName}\``).join(", ");
+        const columns = index.columnNames
+            .map((columnName) => `\`${columnName}\``)
+            .join(", ");
         let indexType = "";
-        if (index.isUnique)
-            indexType += "UNIQUE ";
-        if (index.isSpatial)
-            indexType += "SPATIAL ";
-        if (index.isFulltext)
-            indexType += "FULLTEXT ";
-        return new Query(`CREATE ${indexType}INDEX \`${index.name}\` ON ${this.escapePath(table)} (${columns})`);
+        if (index.isUnique) indexType += "UNIQUE ";
+        if (index.isSpatial) indexType += "SPATIAL ";
+        if (index.isFulltext) indexType += "FULLTEXT ";
+        return new Query(
+            `CREATE ${indexType}INDEX \`${index.name}\` ON ${this.escapePath(
+                table
+            )} (${columns})`
+        );
     }
 
     /**
      * Builds drop index sql.
      */
-    protected dropIndexSql(table: Table, indexOrName: TableIndex|string): Query {
-        let indexName = indexOrName instanceof TableIndex ? indexOrName.name : indexOrName;
-        return new Query(`DROP INDEX \`${indexName}\` ON ${this.escapePath(table)}`);
+    protected dropIndexSql(
+        table: Table,
+        indexOrName: TableIndex | string
+    ): Query {
+        let indexName =
+            indexOrName instanceof TableIndex ? indexOrName.name : indexOrName;
+        return new Query(
+            `DROP INDEX \`${indexName}\` ON ${this.escapePath(table)}`
+        );
     }
 
     /**
      * Builds create primary key sql.
      */
     protected createPrimaryKeySql(table: Table, columnNames: string[]): Query {
-        const columnNamesString = columnNames.map(columnName => `\`${columnName}\``).join(", ");
-        return new Query(`ALTER TABLE ${this.escapePath(table)} ADD PRIMARY KEY (${columnNamesString})`);
+        const columnNamesString = columnNames
+            .map((columnName) => `\`${columnName}\``)
+            .join(", ");
+        return new Query(
+            `ALTER TABLE ${this.escapePath(
+                table
+            )} ADD PRIMARY KEY (${columnNamesString})`
+        );
     }
 
     /**
      * Builds drop primary key sql.
      */
     protected dropPrimaryKeySql(table: Table): Query {
-        return new Query(`ALTER TABLE ${this.escapePath(table)} DROP PRIMARY KEY`);
+        return new Query(
+            `ALTER TABLE ${this.escapePath(table)} DROP PRIMARY KEY`
+        );
     }
 
     /**
      * Builds create foreign key sql.
      */
-    protected createForeignKeySql(table: Table, foreignKey: TableForeignKey): Query {
-        const columnNames = foreignKey.columnNames.map(column => `\`${column}\``).join(", ");
-        const referencedColumnNames = foreignKey.referencedColumnNames.map(column => `\`${column}\``).join(",");
-        let sql = `ALTER TABLE ${this.escapePath(table)} ADD CONSTRAINT \`${foreignKey.name}\` FOREIGN KEY (${columnNames}) ` +
-            `REFERENCES ${this.escapePath(foreignKey.referencedTableName)}(${referencedColumnNames})`;
-        if (foreignKey.onDelete)
-            sql += ` ON DELETE ${foreignKey.onDelete}`;
-        if (foreignKey.onUpdate)
-            sql += ` ON UPDATE ${foreignKey.onUpdate}`;
+    protected createForeignKeySql(
+        table: Table,
+        foreignKey: TableForeignKey
+    ): Query {
+        const columnNames = foreignKey.columnNames
+            .map((column) => `\`${column}\``)
+            .join(", ");
+        const referencedColumnNames = foreignKey.referencedColumnNames
+            .map((column) => `\`${column}\``)
+            .join(",");
+        let sql =
+            `ALTER TABLE ${this.escapePath(table)} ADD CONSTRAINT \`${
+                foreignKey.name
+            }\` FOREIGN KEY (${columnNames}) ` +
+            `REFERENCES ${this.escapePath(
+                foreignKey.referencedTableName
+            )}(${referencedColumnNames})`;
+        if (foreignKey.onDelete) sql += ` ON DELETE ${foreignKey.onDelete}`;
+        if (foreignKey.onUpdate) sql += ` ON UPDATE ${foreignKey.onUpdate}`;
 
         return new Query(sql);
     }
@@ -1603,16 +2683,32 @@ export class AuroraDataApiQueryRunner extends BaseQueryRunner implements QueryRu
     /**
      * Builds drop foreign key sql.
      */
-    protected dropForeignKeySql(table: Table, foreignKeyOrName: TableForeignKey|string): Query {
-        const foreignKeyName = foreignKeyOrName instanceof TableForeignKey ? foreignKeyOrName.name : foreignKeyOrName;
-        return new Query(`ALTER TABLE ${this.escapePath(table)} DROP FOREIGN KEY \`${foreignKeyName}\``);
+    protected dropForeignKeySql(
+        table: Table,
+        foreignKeyOrName: TableForeignKey | string
+    ): Query {
+        const foreignKeyName =
+            foreignKeyOrName instanceof TableForeignKey
+                ? foreignKeyOrName.name
+                : foreignKeyOrName;
+        return new Query(
+            `ALTER TABLE ${this.escapePath(
+                table
+            )} DROP FOREIGN KEY \`${foreignKeyName}\``
+        );
     }
 
-    protected parseTableName(target: Table|string) {
+    protected parseTableName(target: Table | string) {
         const tableName = target instanceof Table ? target.name : target;
         return {
-            database: tableName.indexOf(".") !== -1 ? tableName.split(".")[0] : this.driver.database,
-            tableName: tableName.indexOf(".") !== -1 ? tableName.split(".")[1] : tableName
+            database:
+                tableName.indexOf(".") !== -1
+                    ? tableName.split(".")[0]
+                    : this.driver.database,
+            tableName:
+                tableName.indexOf(".") !== -1
+                    ? tableName.split(".")[1]
+                    : tableName,
         };
     }
 
@@ -1635,23 +2731,40 @@ export class AuroraDataApiQueryRunner extends BaseQueryRunner implements QueryRu
     /**
      * Escapes given table or view path.
      */
-    protected escapePath(target: Table|View|string, disableEscape?: boolean): string {
-        const tableName = target instanceof Table || target instanceof View ? target.name : target;
-        return tableName.split(".").map(i => disableEscape ? i : `\`${i}\``).join(".");
+    protected escapePath(
+        target: Table | View | string,
+        disableEscape?: boolean
+    ): string {
+        const tableName =
+            target instanceof Table || target instanceof View
+                ? target.name
+                : target;
+        return tableName
+            .split(".")
+            .map((i) => (disableEscape ? i : `\`${i}\``))
+            .join(".");
     }
 
     /**
      * Builds a part of query to create/change a column.
      */
-    protected buildCreateColumnSql(column: TableColumn, skipPrimary: boolean, skipName: boolean = false) {
+    protected buildCreateColumnSql(
+        column: TableColumn,
+        skipPrimary: boolean,
+        skipName: boolean = false
+    ) {
         let c = "";
         if (skipName) {
             c = this.connection.driver.createFullType(column);
         } else {
-            c = `\`${column.name}\` ${this.connection.driver.createFullType(column)}`;
+            c = `\`${column.name}\` ${this.connection.driver.createFullType(
+                column
+            )}`;
         }
         if (column.asExpression)
-            c += ` AS (${column.asExpression}) ${column.generatedType ? column.generatedType : "VIRTUAL"}`;
+            c += ` AS (${column.asExpression}) ${
+                column.generatedType ? column.generatedType : "VIRTUAL"
+            }`;
 
         // if you specify ZEROFILL for a numeric column, MySQL automatically adds the UNSIGNED attribute to that column.
         if (column.zerofill) {
@@ -1660,25 +2773,22 @@ export class AuroraDataApiQueryRunner extends BaseQueryRunner implements QueryRu
             c += " UNSIGNED";
         }
         if (column.enum)
-            c += ` (${column.enum.map(value => "'" + value + "'").join(", ")})`;
-        if (column.charset)
-            c += ` CHARACTER SET "${column.charset}"`;
-        if (column.collation)
-            c += ` COLLATE "${column.collation}"`;
-        if (!column.isNullable)
-            c += " NOT NULL";
-        if (column.isNullable)
-            c += " NULL";
-        if (column.isPrimary && !skipPrimary)
-            c += " PRIMARY KEY";
-        if (column.isGenerated && column.generationStrategy === "increment") // don't use skipPrimary here since updates can update already exist primary without auto inc.
+            c += ` (${column.enum
+                .map((value) => "'" + value + "'")
+                .join(", ")})`;
+        if (column.charset) c += ` CHARACTER SET "${column.charset}"`;
+        if (column.collation) c += ` COLLATE "${column.collation}"`;
+        if (!column.isNullable) c += " NOT NULL";
+        if (column.isNullable) c += " NULL";
+        if (column.isPrimary && !skipPrimary) c += " PRIMARY KEY";
+        if (column.isGenerated && column.generationStrategy === "increment")
+            // don't use skipPrimary here since updates can update already exist primary without auto inc.
             c += " AUTO_INCREMENT";
         if (column.comment)
             c += ` COMMENT ${this.escapeComment(column.comment)}`;
         if (column.default !== undefined && column.default !== null)
             c += ` DEFAULT ${column.default}`;
-        if (column.onUpdate)
-            c += ` ON UPDATE ${column.onUpdate}`;
+        if (column.onUpdate) c += ` ON UPDATE ${column.onUpdate}`;
 
         return c;
     }
@@ -1686,23 +2796,28 @@ export class AuroraDataApiQueryRunner extends BaseQueryRunner implements QueryRu
     /**
      * Checks if column display width is by default.
      */
-    protected isDefaultColumnWidth(table: Table, column: TableColumn, width: number): boolean {
+    protected isDefaultColumnWidth(
+        table: Table,
+        column: TableColumn,
+        width: number
+    ): boolean {
         // if table have metadata, we check if length is specified in column metadata
         if (this.connection.hasMetadata(table.name)) {
             const metadata = this.connection.getMetadata(table.name);
-            const columnMetadata = metadata.findColumnWithDatabaseName(column.name);
-            if (columnMetadata && columnMetadata.width)
-                return false;
+            const columnMetadata = metadata.findColumnWithDatabaseName(
+                column.name
+            );
+            if (columnMetadata && columnMetadata.width) return false;
         }
 
-        const defaultWidthForType = this.connection.driver.dataTypeDefaults
-            && this.connection.driver.dataTypeDefaults[column.type]
-            && this.connection.driver.dataTypeDefaults[column.type].width;
+        const defaultWidthForType =
+            this.connection.driver.dataTypeDefaults &&
+            this.connection.driver.dataTypeDefaults[column.type] &&
+            this.connection.driver.dataTypeDefaults[column.type].width;
 
         if (defaultWidthForType) {
             return defaultWidthForType === width;
         }
         return false;
     }
-
 }


### PR DESCRIPTION
### Description of change
The set type was already added to typeorm with tests, but it was not yet added to aurora-data-api. This simply adds the same needed code there, and has been tested with a migration on another codebase that successfully created a 'set' column using data-api.
Uses same changes from https://github.com/typeorm/typeorm/pull/4538 but in the data-api files.

### Pull-Request Checklist
- [x] Code is up-to-date with the `master` branch
- [x] `npm run lint` passes with this change
- [x] `npm run test` passes with this change
- [ ] This pull request links relevant issues as `Fixes #0000`
- [ ] There are new or updated unit tests validating the change
- [ ] Documentation has been updated to reflect this change
- [x] The new commits follow conventions explained in [CONTRIBUTING.md]

