### PR TITLE
Improve the query parameter escaping to reuse parameter indexes

### DIFF
--- a/src/driver/cockroachdb/CockroachDriver.ts
+++ b/src/driver/cockroachdb/CockroachDriver.ts
@@ -382,30 +382,34 @@ export class CockroachDriver implements Driver {
         if (!parameters || !Object.keys(parameters).length)
             return [sql, builtParameters];
 
+        const queryPlaceholders: ObjectLiteral = {};
+        Object.keys(nativeParameters).map((key, index) => { queryPlaceholders[key] = "$" + index + 1; });
+
         const keys = Object.keys(parameters).map(parameter => "(:(\\.\\.\\.)?" + parameter + "\\b)").join("|");
         sql = sql.replace(new RegExp(keys, "g"), (key: string): string => {
-            let value: any;
-            let isArray = false;
-            if (key.substr(0, 4) === ":...") {
-                isArray = true;
-                value = parameters[key.substr(4)];
-            } else {
-                value = parameters[key.substr(1)];
+            const isArray = key.substr(0, 4) === ":...";
+            const cleanKey = isArray ? key.substr(4) : key.substr(1);
+            const value = parameters[cleanKey];
+
+            if (value instanceof Function) {
+                return value();
+            }
+
+            if (queryPlaceholders.hasOwnProperty(cleanKey)) {
+                return queryPlaceholders[cleanKey];
             }
 
             if (isArray) {
-                return value.map((v: any) => {
+                queryPlaceholders[cleanKey] = value.map((v: any) => {
                     builtParameters.push(v);
                     return "$" + builtParameters.length;
                 }).join(", ");
-
-            } else if (value instanceof Function) {
-                return value();
-
             } else {
                 builtParameters.push(value);
-                return "$" + builtParameters.length;
+                queryPlaceholders[cleanKey] = "$" + builtParameters.length;
             }
+
+            return queryPlaceholders[cleanKey];
         }); // todo: make replace only in value statements, otherwise problems
         return [sql, builtParameters];
     }

--- a/src/driver/postgres/PostgresDriver.ts
+++ b/src/driver/postgres/PostgresDriver.ts
@@ -622,30 +622,34 @@ export class PostgresDriver implements Driver {
         if (!parameters || !Object.keys(parameters).length)
             return [sql, builtParameters];
 
+        const queryPlaceholders: ObjectLiteral = {};
+        Object.keys(nativeParameters).map((key, index) => { queryPlaceholders[key] = "$" + index + 1; });
+
         const keys = Object.keys(parameters).map(parameter => "(:(\\.\\.\\.)?" + parameter + "\\b)").join("|");
         sql = sql.replace(new RegExp(keys, "g"), (key: string): string => {
-            let value: any;
-            let isArray = false;
-            if (key.substr(0, 4) === ":...") {
-                isArray = true;
-                value = parameters[key.substr(4)];
-            } else {
-                value = parameters[key.substr(1)];
+            const isArray = key.substr(0, 4) === ":...";
+            const cleanKey = isArray ? key.substr(4) : key.substr(1);
+            const value = parameters[cleanKey];
+
+            if (value instanceof Function) {
+                return value();
+            }
+
+            if (queryPlaceholders.hasOwnProperty(cleanKey)) {
+                return queryPlaceholders[cleanKey];
             }
 
             if (isArray) {
-                return value.map((v: any) => {
+                queryPlaceholders[cleanKey] = value.map((v: any) => {
                     builtParameters.push(v);
                     return "$" + builtParameters.length;
                 }).join(", ");
-
-            } else if (value instanceof Function) {
-                return value();
-
             } else {
                 builtParameters.push(value);
-                return "$" + builtParameters.length;
+                queryPlaceholders[cleanKey] = "$" + builtParameters.length;
             }
+
+            return queryPlaceholders[cleanKey];
         }); // todo: make replace only in value statements, otherwise problems
         return [sql, builtParameters];
     }

--- a/test/github-issues/7605/entity/foo.ts
+++ b/test/github-issues/7605/entity/foo.ts
@@ -1,0 +1,10 @@
+import { Column, Entity, PrimaryGeneratedColumn } from "../../../../src";
+
+@Entity()
+export class Foo {
+    @PrimaryGeneratedColumn()
+    id: number;
+
+    @Column()
+    created: Date;    
+}

--- a/test/github-issues/7605/issue-7605.ts
+++ b/test/github-issues/7605/issue-7605.ts
@@ -1,0 +1,38 @@
+import "reflect-metadata";
+import {
+    closeTestingConnections,
+    createTestingConnections,
+    reloadTestingDatabases,
+} from "../../utils/test-utils";
+import { Connection } from "../../../src/connection/Connection";
+import { Foo } from "./entity/foo";
+import { expect } from "chai";
+
+describe("github issues > #7605 Giving 'column \"response.created\" must appear in the GROUP BY clause or be used in an aggregate function', but it does", () => {
+    let connections: Connection[];
+    before(
+        async () =>
+            (connections = await createTestingConnections({
+                entities: [__dirname + "/entity/*{.js,.ts}"],
+                enabledDrivers: ["postgres", "cockroachdb", "mssql"],
+            }))
+    );
+    beforeEach(() => reloadTestingDatabases(connections));
+    after(() => closeTestingConnections(connections));
+
+    it("should use the same parameter index for all ocurrences of a parameter on drivers that use indexed parameters", () =>
+        Promise.all(
+            connections.map(async connection => {
+                let query = connection.getRepository(Foo)
+                    .createQueryBuilder()
+                    .addSelect(`created at time zone :tz as "creationDate"`)
+                    .where("created in (:...dates)")
+                    .groupBy("created at time zone :tz")
+                    .setParameter("tz", "GMT+03:00")
+                    .setParameter("dates", ["2020-01-01", "2020-01-02"]);
+
+                let parametersUsed = query.getQueryAndParameters()[1];
+                expect(parametersUsed).to.be.eql(["GMT+03:00", "2020-01-01", "2020-01-02"]);
+            })
+        ));
+});


### PR DESCRIPTION
### Description of change

<!--
  Please be clear and concise what the change is intended to do,
  why this change is needed, and how you've verified that it
  corrects what you intended.

  In some cases it may be helpful to include the current behavior
  and the new behavior.

  If the change is related to an open issue, you can link it here.
  If you include `Fixes #0000` (replacing `0000` with the issue number)
  when this is merged it will automatically mark the issue as fixed and
  close it.
-->

This pull request changes the query parameter escaping function on cockroachdb, postgres and sqlserver drivers (which are the only ones to use indexes for the parameters). The behavior reported on the related issue happened because, in those drivers, when the parameters on a query were escaped, different indexes were used for the same parameter, i.e.:

 In postgres' driver, this:
 
```typescript
connection.getRepository(Foo)
  .createQueryBuilder("testQuery")
  .select('count(*) as "total"')
  .addSelect(`created at time zone :tz as "creationDate"`)
  .where("created in (:...dates)")
  .groupBy("created at time zone :tz")   
  .setParameter("tz", "GMT+03:00")
  .setParameter("dates", ["2020-01-01", "2020-01-02"]);
```

Would result in the following SQL query:

```sql
SELECT count(*) as "total", created at time zone $1 as "creationDate" FROM "response" "testQuery" WHERE created IN ($2, $3) GROUP BY created at time zone $4
```

(Notice that ":tz" is replaced by $1 and $4)

This query would throw the error reported in the issue. After the changes in this pull request, the query looks like this:

```sql
SELECT count(*) as "total", created at time zone $1 as "creationDate" FROM "response" "testQuery" WHERE created IN ($2, $3) GROUP BY created at time zone $1
```

Which works as expected because the db knows it's the same parameter being used in the `SELECT` and `GROUP BY` clauses.

Fixes #7605

### Pull-Request Checklist

- [x] Code is up-to-date with the `master` branch
- [x] `npm run lint` passes with this change
- [x] `npm run test` passes with this change
- [x] This pull request links relevant issues as `Fixes #0000`
- [x] There are new or updated unit tests validating the change
- [ ] Documentation has been updated to reflect this change N/A
- [x] The new commits follow conventions explained in [CONTRIBUTING.md](https://github.com/typeorm/typeorm/blob/master/CONTRIBUTING.md)