### PR TITLE
fix: correctly strip type conversion in postgres for default values

### DIFF
--- a/src/driver/postgres/PostgresQueryRunner.ts
+++ b/src/driver/postgres/PostgresQueryRunner.ts
@@ -1730,7 +1730,7 @@ export class PostgresQueryRunner extends BaseQueryRunner implements QueryRunner 
                         } else if (dbColumn["column_default"] === "now()" || dbColumn["column_default"].indexOf("'now'::text") !== -1) {
                             tableColumn.default = dbColumn["column_default"];
                         } else {
-                            tableColumn.default = dbColumn["column_default"].replace(/::[\w\s]+/g, "");
+                            tableColumn.default = dbColumn["column_default"].replace(/::[\w\s\[\]]+/g, "");
                             tableColumn.default = tableColumn.default.replace(/^(-?\d+)$/, "'$1'");
                         }
                     }

--- a/src/driver/postgres/PostgresQueryRunner.ts
+++ b/src/driver/postgres/PostgresQueryRunner.ts
@@ -1728,9 +1728,9 @@ export class PostgresQueryRunner extends BaseQueryRunner implements QueryRunner 
                             tableColumn.isGenerated = true;
                             tableColumn.generationStrategy = "uuid";
                         } else if (dbColumn["column_default"] === "now()" || dbColumn["column_default"].indexOf("'now'::text") !== -1) {
-                            tableColumn.default = dbColumn["column_default"]
+                            tableColumn.default = dbColumn["column_default"];
                         } else {
-                            tableColumn.default = dbColumn["column_default"].replace(/::.*/, "");
+                            tableColumn.default = dbColumn["column_default"].replace(/::\w+/g, "");
                             tableColumn.default = tableColumn.default.replace(/^(-?\d+)$/, "'$1'");
                         }
                     }

--- a/src/driver/postgres/PostgresQueryRunner.ts
+++ b/src/driver/postgres/PostgresQueryRunner.ts
@@ -1730,7 +1730,7 @@ export class PostgresQueryRunner extends BaseQueryRunner implements QueryRunner 
                         } else if (dbColumn["column_default"] === "now()" || dbColumn["column_default"].indexOf("'now'::text") !== -1) {
                             tableColumn.default = dbColumn["column_default"];
                         } else {
-                            tableColumn.default = dbColumn["column_default"].replace(/::[\w\s\[\]]+/g, "");
+                            tableColumn.default = dbColumn["column_default"].replace(/::[\w\s\[\]\"]+/g, "");
                             tableColumn.default = tableColumn.default.replace(/^(-?\d+)$/, "'$1'");
                         }
                     }

--- a/src/driver/postgres/PostgresQueryRunner.ts
+++ b/src/driver/postgres/PostgresQueryRunner.ts
@@ -1730,7 +1730,7 @@ export class PostgresQueryRunner extends BaseQueryRunner implements QueryRunner 
                         } else if (dbColumn["column_default"] === "now()" || dbColumn["column_default"].indexOf("'now'::text") !== -1) {
                             tableColumn.default = dbColumn["column_default"];
                         } else {
-                            tableColumn.default = dbColumn["column_default"].replace(/::\w+/g, "");
+                            tableColumn.default = dbColumn["column_default"].replace(/::[\w\s]+/g, "");
                             tableColumn.default = tableColumn.default.replace(/^(-?\d+)$/, "'$1'");
                         }
                     }

--- a/test/github-issues/5132/entity/foo.entity.ts
+++ b/test/github-issues/5132/entity/foo.entity.ts
@@ -1,0 +1,13 @@
+import { BaseEntity, Column, Entity, PrimaryGeneratedColumn } from "../../../../src";
+
+@Entity("foo")
+export class Foo extends BaseEntity {
+    @PrimaryGeneratedColumn()
+    id: number;
+
+    @Column({ default: 1, type: "int" })
+    bar_default_1: number;
+
+    @Column({ default: -1, type: "int" })
+    bar_default_minus_1: number;
+}

--- a/test/github-issues/5132/issue-5132.ts
+++ b/test/github-issues/5132/issue-5132.ts
@@ -1,0 +1,40 @@
+import "reflect-metadata";
+import { Connection } from "../../../src";
+
+import { createTestingConnections, closeTestingConnections } from "../../utils/test-utils";
+
+import { Foo } from "./entity/foo.entity";
+
+describe("github issues > #5132 postgres: Default of -1 (minus 1) generates useless migrations`", () => {
+    describe("-1 (minus 1) in default value", () => {
+        let connections: Connection[];
+        before(async () => connections = await createTestingConnections({
+            schemaCreate: false,
+            dropSchema: true,
+            entities: [Foo],
+        }));
+        after(() => closeTestingConnections(connections));
+
+        it("can recognize model changes", () => Promise.all(connections.map(async connection => {
+            if (connection.driver.options.type !== "postgres") {
+                return;
+            }
+            const sqlInMemory = await connection.driver.createSchemaBuilder().log();
+
+            sqlInMemory.upQueries.length.should.be.greaterThan(0);
+            sqlInMemory.downQueries.length.should.be.greaterThan(0);
+        })));
+
+        it("does not generate when no model changes", () => Promise.all(connections.map(async connection => {
+            if (connection.driver.options.type !== "postgres") {
+                return;
+            }
+            await connection.driver.createSchemaBuilder().build();
+
+            const sqlInMemory = await connection.driver.createSchemaBuilder().log();
+
+            sqlInMemory.upQueries.length.should.be.equal(0);
+            sqlInMemory.downQueries.length.should.be.equal(0);
+        })));
+    });
+});

--- a/test/github-issues/7110/entity/foo.entity.ts
+++ b/test/github-issues/7110/entity/foo.entity.ts
@@ -1,0 +1,15 @@
+import {BaseEntity, Column, Entity, PrimaryGeneratedColumn} from "../../../../src";
+
+@Entity("foo_test")
+export class Foo extends BaseEntity {
+
+    @PrimaryGeneratedColumn()
+    id: number;
+
+    @Column({
+        nullable: false,
+        type: "varchar",
+        default: () => "TO_CHAR(100, 'FMU000')",
+    })
+    displayId: string;
+}

--- a/test/github-issues/7110/issue-7110.ts
+++ b/test/github-issues/7110/issue-7110.ts
@@ -1,0 +1,39 @@
+import "reflect-metadata";
+import { Connection } from "../../../src";
+
+import { createTestingConnections, closeTestingConnections } from "../../utils/test-utils";
+
+import { Foo } from "./entity/foo.entity";
+
+describe("github issues > #7110 postgres: Typeorm Migrations ignore existing default value on column`", () => {
+    describe("double type conversion in default value", () => {
+        let connections: Connection[];
+        before(async () => connections = await createTestingConnections({
+            schemaCreate: false,
+            dropSchema: true,
+            entities: [Foo],
+        }));
+        after(() => closeTestingConnections(connections));
+
+        it("can recognize model changes", () => Promise.all(connections.map(async connection => {
+            if (connection.driver.options.type !== "postgres") {
+                return;
+            }
+            const sqlInMemory = await connection.driver.createSchemaBuilder().log();
+            sqlInMemory.upQueries.length.should.be.greaterThan(0);
+            sqlInMemory.downQueries.length.should.be.greaterThan(0);
+        })));
+
+        it("does not generate when no model changes", () => Promise.all(connections.map(async connection => {
+            if (connection.driver.options.type !== "postgres") {
+                return;
+            }
+            await connection.driver.createSchemaBuilder().build();
+
+            const sqlInMemory = await connection.driver.createSchemaBuilder().log();
+
+            sqlInMemory.upQueries.length.should.be.equal(0);
+            sqlInMemory.downQueries.length.should.be.equal(0);
+        })));
+    });
+});


### PR DESCRIPTION
Use better regex to remove only type conversion, not the whole string to the end

Closes: 7110

<!--
  😀 Wonderful!  Thank you for opening a pull request for TypeORM.

  Please fill in the information below to expedite the review
  and (hopefully) merge of your change.

  If unsure about something.. just do as best as you're able,
  or reach out through our community support channels!
  https://github.com/typeorm/typeorm/blob/master/docs/support.md
-->

### Description of change

<!--
  Please be clear and concise what the change is intended to do,
  why this change is needed, and how you've verified that it
  corrects what you intended.

  In some cases it may be helpful to include the current behavior
  and the new behavior.

  If the change is related to an open issue, you can link it here.
  If you include `Fixes #0000` (replacing `0000` with the issue number)
  when this is merged it will automatically mark the issue as fixed and
  close it.
-->
When loading schema with postgres driver typeorm currently strips explicit type conversions from column default value. But current RegExp in some cases does this incorrectly, that leads to part of string after conversion being stripped to the end. 
For example value `to_char(nextval('orders_display_id_seq'::regclass), 'FMU999'::text)` is stripped to just `to_char(nextval('orders_display_id_seq'`. This behaviour causes duplications when generating migrations.  

Fixes #7110
Fixes #5132
### Pull-Request Checklist

<!--
  Please make sure to review and check all of the following.

  If an item is not applicable, you can add "N/A" to the end.
-->

- [x] Code is up-to-date with the `master` branch
- [x] `npm run lint` passes with this change
- [x] `npm run test` passes with this change
- [x] This pull request links relevant issues as `Fixes #0000`
- [x] There are new or updated unit tests validating the change
- [x] Documentation has been updated to reflect this change - no need
- [x] The new commits follow conventions explained in [CONTRIBUTING.md](https://github.com/typeorm/typeorm/blob/master/CONTRIBUTING.md)

<!--
  🎉 Thank you for contributing and making TypeORM even better!
-->
