### PR TITLE
Improve conditional where (andWhere / orWhere)

### DIFF
--- a/src/query-builder/SelectQueryBuilder.ts
+++ b/src/query-builder/SelectQueryBuilder.ts
@@ -729,7 +729,11 @@ export class SelectQueryBuilder<Entity> extends QueryBuilder<Entity> implements 
      * Adds new AND WHERE condition in the query builder.
      * Additionally you can add parameters used in where expression.
      */
-    andWhere(where: string|Brackets|((qb: this) => string), parameters?: ObjectLiteral): this {
+    andWhere(where: string|Brackets|null|((qb: this) => string), parameters?: ObjectLiteral): this {
+        if(!where) {
+            return this;
+        }
+
         this.expressionMap.wheres.push({ type: "and", condition: this.computeWhereParameter(where) });
         if (parameters) this.setParameters(parameters);
         return this;
@@ -739,7 +743,11 @@ export class SelectQueryBuilder<Entity> extends QueryBuilder<Entity> implements 
      * Adds new OR WHERE condition in the query builder.
      * Additionally you can add parameters used in where expression.
      */
-    orWhere(where: Brackets|string|((qb: this) => string), parameters?: ObjectLiteral): this {
+    orWhere(where: Brackets|string|null|((qb: this) => string), parameters?: ObjectLiteral): this {
+        if(!where) {
+            return this;
+        }
+
         this.expressionMap.wheres.push({ type: "or", condition: this.computeWhereParameter(where) });
         if (parameters) this.setParameters(parameters);
         return this;

--- a/test/functional/query-builder/select/query-builder-select.ts
+++ b/test/functional/query-builder/select/query-builder-select.ts
@@ -167,4 +167,32 @@ describe("query builder > select", () => {
 
         expect(sql).contains("SELECT /*+ MAX_EXECUTION_TIME(1000) */");
     })));
+
+    it("should erased andWhere condition when null condition", () => Promise.all(connections.map(async connection => {
+        const sql = connection.createQueryBuilder(Post, "post")
+            .select("post.id")
+            .where("post.title = :title", { title: "test" })
+            .andWhere(null)
+            .disableEscaping()
+            .getSql();
+
+        expect(sql).to.equal("SELECT post.id AS post_id " +
+            "FROM post post " +
+            "WHERE post.title = ?"
+        );
+    })));
+
+    it("should erased orWhere condition when null condition", () => Promise.all(connections.map(async connection => {
+        const sql = connection.createQueryBuilder(Post, "post")
+            .select("post.id")
+            .where("post.title = :title", { title: "test" })
+            .orWhere(null)
+            .disableEscaping()
+            .getSql();
+
+        expect(sql).to.equal("SELECT post.id AS post_id " +
+            "FROM post post " +
+            "WHERE post.title = ?"
+        );
+    })));
 });


### PR DESCRIPTION
### Description of change

Suggest a new method for conditional where queries that were previously discussed(https://github.com/typeorm/typeorm/issues/3103).

If null is received, the corresponding `andWhere` / `orWhere` condition is not added to the conditional statement.

Querydsl library of JAVA language supports similar type.
So there is no big burden to actually make a dynamic query.

```java
// Querydsl)

query.from(customer)
     .where(
         isFirstNameLike(customerQueryInfo.getFirstName()), // if null return then erased condition
         isLastNameLike(customerQueryInfo.getLastName()),
         isStatusEq(customerQueryInfo.getStatus()))
     .list(customer);

private BooleanExpression isFirstNameLike(String firstName){
    return firstName != null ? customer.firstName.like(firstName) : null;        
}

private BooleanExpression isStatusEq(StatusEnum status){
    return status != null ? customer.status.eq(status) : null;
}

```
* https://stackoverflow.com/a/12287074


In typeORM, can use it like this:

Expect the following code.

```javascript
    findAllByDto (dto: ArticleSearchDto) {
        return createQueryBuilder()
            .select("article")
            .from(Article, "article")
            .andWhere(this.eqTitle(dto.title)) // or title? `article.title = :${title}` : null;
            .orderBy("article.id desc")
            .getMany();
    }
  
   // erase or andWhere
    private eqTitle(title: string): string {
        if(!title) {
            return null;
        }

        return `article.title = :${title}`;
    }
```

### Pull-Request Checklist

- [x] Code is up-to-date with the `master` branch
- [x] `npm run lint` passes with this change
- [x] `npm run test` passes with this change
- [ ] This pull request links relevant issues as `Fixes #0000`
- [ ] There are new or updated unit tests validating the change
- [ ] Documentation has been updated to reflect this change
- [x] The new commits follow conventions explained in [CONTRIBUTING.md](https://github.com/typeorm/typeorm/blob/master/CONTRIBUTING.md)

