### PR TITLE
    fix: add support for specifying ioredis cache with a URL (to conf…

### DIFF
--- a/src/cache/RedisQueryResultCache.ts
+++ b/src/cache/RedisQueryResultCache.ts
@@ -55,7 +55,14 @@ export class RedisQueryResultCache implements QueryResultCache {
                 this.client = this.redis.createClient();
             }
         } else if (this.clientType === "ioredis") {
-            if (cacheOptions && cacheOptions.options) {
+            if (cacheOptions && cacheOptions.port) {
+                if (cacheOptions.options) {
+                    this.client = new this.redis( cacheOptions.port, cacheOptions.options );
+                } else {
+                    this.client = new this.redis( cacheOptions.port );
+                }
+            }
+            else if (cacheOptions && cacheOptions.options) {
                 this.client = new this.redis(cacheOptions.options);
             } else {
                 this.client = new this.redis();


### PR DESCRIPTION
…orm to ioredis docs)

    According to the ioredis documentation, a URL may be passed in the 'port' parameter.
    This does not currently work when using an ioredis cache. Modify ioredis connection logic
    to conform to ioredis standards.

Closes: #7631

<!--
  😀 Wonderful!  Thank you for opening a pull request for TypeORM.

  Please fill in the information below to expedite the review
  and (hopefully) merge of your change.

  If unsure about something.. just do as best as you're able,
  or reach out through our community support channels!
  https://github.com/typeorm/typeorm/blob/master/docs/support.md
-->

### Description of change

<!--
  Please be clear and concise what the change is intended to do,
  why this change is needed, and how you've verified that it
  corrects what you intended.

  In some cases it may be helpful to include the current behavior
  and the new behavior.

  If the change is related to an open issue, you can link it here.
  If you include `Fixes #0000` (replacing `0000` with the issue number)
  when this is merged it will automatically mark the issue as fixed and
  close it.
-->


### Pull-Request Checklist

<!--
  Please make sure to review and check all of the following.

  If an item is not applicable, you can add "N/A" to the end.
-->

- [x] Code is up-to-date with the `master` branch
- [x] `npm run lint` passes with this change
- [x] `npm run test` passes with this change
- [x] This pull request links relevant issues as `Fixes #0000`
- [ ] There are new or updated unit tests validating the change
- [x] Documentation has been updated to reflect this change
- [x] The new commits follow conventions explained in [CONTRIBUTING.md](https://github.com/typeorm/typeorm/blob/master/CONTRIBUTING.md)

<!--
  🎉 Thank you for contributing and making TypeORM even better!
-->
