### PR TITLE
Fix Caching won't work with replication enabled

### DIFF
--- a/src/cache/DbQueryResultCache.ts
+++ b/src/cache/DbQueryResultCache.ts
@@ -158,7 +158,9 @@ export class DbQueryResultCache implements QueryResultCache {
      * Stores given query result in the cache.
      */
     async storeInCache(options: QueryResultCacheOptions, savedCache: QueryResultCacheOptions|undefined, queryRunner?: QueryRunner): Promise<void> {
-        queryRunner = this.getQueryRunner(queryRunner);
+        if (queryRunner === undefined || queryRunner?.getReplicationMode() === "slave") {
+            queryRunner = this.connection.createQueryRunner();
+        }
 
         let insertedValues: ObjectLiteral = options;
         if (this.connection.driver instanceof SqlServerDriver) { // todo: bad abstraction, re-implement this part, probably better if we create an entity metadata for cache table

--- a/src/cache/DbQueryResultCache.ts
+++ b/src/cache/DbQueryResultCache.ts
@@ -158,8 +158,10 @@ export class DbQueryResultCache implements QueryResultCache {
      * Stores given query result in the cache.
      */
     async storeInCache(options: QueryResultCacheOptions, savedCache: QueryResultCacheOptions|undefined, queryRunner?: QueryRunner): Promise<void> {
-        if (queryRunner === undefined || queryRunner?.getReplicationMode() === "slave") {
-            queryRunner = this.connection.createQueryRunner();
+        const shouldCreateQueryRunner = queryRunner === undefined || queryRunner?.getReplicationMode() === "slave";
+
+        if (queryRunner === undefined || shouldCreateQueryRunner) {
+            queryRunner = this.connection.createQueryRunner("master");
         }
 
         let insertedValues: ObjectLiteral = options;
@@ -204,6 +206,10 @@ export class DbQueryResultCache implements QueryResultCache {
                 .into(this.queryResultCacheTable)
                 .values(insertedValues)
                 .execute();
+        }
+
+        if (shouldCreateQueryRunner) {
+            await queryRunner.release();
         }
     }
 

--- a/src/driver/mongodb/MongoQueryRunner.ts
+++ b/src/driver/mongodb/MongoQueryRunner.ts
@@ -1,20 +1,10 @@
-import {ObjectLiteral} from "../../common/ObjectLiteral";
-import {Connection} from "../../connection/Connection";
-import {MongoEntityManager} from "../../entity-manager/MongoEntityManager";
-import {TypeORMError} from "../../error";
-import {ReadStream} from "../../platform/PlatformTools";
 import {QueryRunner} from "../../query-runner/QueryRunner";
-import {Table} from "../../schema-builder/table/Table";
-import {TableCheck} from "../../schema-builder/table/TableCheck";
+import {ObjectLiteral} from "../../common/ObjectLiteral";
 import {TableColumn} from "../../schema-builder/table/TableColumn";
-import {TableExclusion} from "../../schema-builder/table/TableExclusion";
+import {Table} from "../../schema-builder/table/Table";
 import {TableForeignKey} from "../../schema-builder/table/TableForeignKey";
 import {TableIndex} from "../../schema-builder/table/TableIndex";
-import {TableUnique} from "../../schema-builder/table/TableUnique";
 import {View} from "../../schema-builder/view/View";
-import {Broadcaster} from "../../subscriber/Broadcaster";
-import {SqlInMemory} from "../SqlInMemory";
-import {ReplicationMode} from "../types/ReplicationMode";
 import {
     AggregationCursor,
     BulkWriteOpResultObject,
@@ -48,6 +38,16 @@ import {
     UnorderedBulkOperation,
     UpdateWriteOpResult
 } from "./typings";
+import {Connection} from "../../connection/Connection";
+import {ReadStream} from "../../platform/PlatformTools";
+import {MongoEntityManager} from "../../entity-manager/MongoEntityManager";
+import {SqlInMemory} from "../SqlInMemory";
+import {TableUnique} from "../../schema-builder/table/TableUnique";
+import {Broadcaster} from "../../subscriber/Broadcaster";
+import {TableCheck} from "../../schema-builder/table/TableCheck";
+import {TableExclusion} from "../../schema-builder/table/TableExclusion";
+import {TypeORMError} from "../../error";
+import {ReplicationMode} from "../types/ReplicationMode";
  
 /**
  * Runs queries on a single MongoDB connection.

--- a/src/driver/mongodb/MongoQueryRunner.ts
+++ b/src/driver/mongodb/MongoQueryRunner.ts
@@ -1,10 +1,20 @@
-import {QueryRunner} from "../../query-runner/QueryRunner";
 import {ObjectLiteral} from "../../common/ObjectLiteral";
-import {TableColumn} from "../../schema-builder/table/TableColumn";
+import {Connection} from "../../connection/Connection";
+import {MongoEntityManager} from "../../entity-manager/MongoEntityManager";
+import {TypeORMError} from "../../error";
+import {ReadStream} from "../../platform/PlatformTools";
+import {QueryRunner} from "../../query-runner/QueryRunner";
 import {Table} from "../../schema-builder/table/Table";
+import {TableCheck} from "../../schema-builder/table/TableCheck";
+import {TableColumn} from "../../schema-builder/table/TableColumn";
+import {TableExclusion} from "../../schema-builder/table/TableExclusion";
 import {TableForeignKey} from "../../schema-builder/table/TableForeignKey";
 import {TableIndex} from "../../schema-builder/table/TableIndex";
+import {TableUnique} from "../../schema-builder/table/TableUnique";
 import {View} from "../../schema-builder/view/View";
+import {Broadcaster} from "../../subscriber/Broadcaster";
+import {SqlInMemory} from "../SqlInMemory";
+import {ReplicationMode} from "../types/ReplicationMode";
 import {
     AggregationCursor,
     BulkWriteOpResultObject,
@@ -38,16 +48,7 @@ import {
     UnorderedBulkOperation,
     UpdateWriteOpResult
 } from "./typings";
-import {Connection} from "../../connection/Connection";
-import {ReadStream} from "../../platform/PlatformTools";
-import {MongoEntityManager} from "../../entity-manager/MongoEntityManager";
-import {SqlInMemory} from "../SqlInMemory";
-import {TableUnique} from "../../schema-builder/table/TableUnique";
-import {Broadcaster} from "../../subscriber/Broadcaster";
-import {TableCheck} from "../../schema-builder/table/TableCheck";
-import {TableExclusion} from "../../schema-builder/table/TableExclusion";
-import { TypeORMError } from "../../error";
-
+ 
 /**
  * Runs queries on a single MongoDB connection.
  */
@@ -505,6 +506,10 @@ export class MongoQueryRunner implements QueryRunner {
      */
     async getViews(collectionNames: string[]): Promise<View[]> {
         throw new TypeORMError(`Schema update queries are not supported by MongoDB driver.`);
+    }
+
+    getReplicationMode(): ReplicationMode {
+        return 'master';
     }
 
     /**

--- a/src/query-runner/BaseQueryRunner.ts
+++ b/src/query-runner/BaseQueryRunner.ts
@@ -202,6 +202,10 @@ export abstract class BaseQueryRunner {
         }
     }
 
+    getReplicationMode(): ReplicationMode {
+        return this.mode;
+    }
+
     // -------------------------------------------------------------------------
     // Protected Methods
     // -------------------------------------------------------------------------

--- a/src/query-runner/QueryRunner.ts
+++ b/src/query-runner/QueryRunner.ts
@@ -1,18 +1,19 @@
-import {TableColumn} from "../schema-builder/table/TableColumn";
+import {ObjectLiteral} from "../common/ObjectLiteral";
+import {Connection} from "../connection/Connection";
+import {SqlInMemory} from "../driver/SqlInMemory";
+import {IsolationLevel} from "../driver/types/IsolationLevel";
+import {ReplicationMode} from "../driver/types/ReplicationMode";
+import {EntityManager} from "../entity-manager/EntityManager";
+import {ReadStream} from "../platform/PlatformTools";
 import {Table} from "../schema-builder/table/Table";
+import {TableCheck} from "../schema-builder/table/TableCheck";
+import {TableColumn} from "../schema-builder/table/TableColumn";
+import {TableExclusion} from "../schema-builder/table/TableExclusion";
 import {TableForeignKey} from "../schema-builder/table/TableForeignKey";
 import {TableIndex} from "../schema-builder/table/TableIndex";
-import {Connection} from "../connection/Connection";
-import {ReadStream} from "../platform/PlatformTools";
-import {EntityManager} from "../entity-manager/EntityManager";
-import {ObjectLiteral} from "../common/ObjectLiteral";
-import {SqlInMemory} from "../driver/SqlInMemory";
 import {TableUnique} from "../schema-builder/table/TableUnique";
 import {View} from "../schema-builder/view/View";
 import {Broadcaster} from "../subscriber/Broadcaster";
-import {TableCheck} from "../schema-builder/table/TableCheck";
-import {IsolationLevel} from "../driver/types/IsolationLevel";
-import {TableExclusion} from "../schema-builder/table/TableExclusion";
 import {QueryResult} from "./QueryResult";
 
 /**
@@ -148,6 +149,11 @@ export interface QueryRunner {
      * Loads all views from the database and returns them.
      */
     getViews(viewPaths?: string[]): Promise<View[]>;
+
+    /**
+     * Returns replication mode (ex: `master` or `slave`).
+     */
+    getReplicationMode(): ReplicationMode;
 
     /**
      * Checks if a database with the given name exist.

--- a/src/query-runner/QueryRunner.ts
+++ b/src/query-runner/QueryRunner.ts
@@ -1,20 +1,20 @@
-import {ObjectLiteral} from "../common/ObjectLiteral";
-import {Connection} from "../connection/Connection";
-import {SqlInMemory} from "../driver/SqlInMemory";
-import {IsolationLevel} from "../driver/types/IsolationLevel";
-import {ReplicationMode} from "../driver/types/ReplicationMode";
-import {EntityManager} from "../entity-manager/EntityManager";
-import {ReadStream} from "../platform/PlatformTools";
-import {Table} from "../schema-builder/table/Table";
-import {TableCheck} from "../schema-builder/table/TableCheck";
 import {TableColumn} from "../schema-builder/table/TableColumn";
-import {TableExclusion} from "../schema-builder/table/TableExclusion";
+import {Table} from "../schema-builder/table/Table";
 import {TableForeignKey} from "../schema-builder/table/TableForeignKey";
 import {TableIndex} from "../schema-builder/table/TableIndex";
+import {Connection} from "../connection/Connection";
+import {ReadStream} from "../platform/PlatformTools";
+import {EntityManager} from "../entity-manager/EntityManager";
+import {ObjectLiteral} from "../common/ObjectLiteral";
+import {SqlInMemory} from "../driver/SqlInMemory";
 import {TableUnique} from "../schema-builder/table/TableUnique";
 import {View} from "../schema-builder/view/View";
 import {Broadcaster} from "../subscriber/Broadcaster";
+import {TableCheck} from "../schema-builder/table/TableCheck";
+import {IsolationLevel} from "../driver/types/IsolationLevel";
+import {TableExclusion} from "../schema-builder/table/TableExclusion";
 import {QueryResult} from "./QueryResult";
+import {ReplicationMode} from "../driver/types/ReplicationMode";
 
 /**
  * Runs queries on a single database connection.

--- a/test/github-issues/5919/entities.ts
+++ b/test/github-issues/5919/entities.ts
@@ -1,0 +1,10 @@
+import { Column, Entity, PrimaryGeneratedColumn } from "../../../src";
+
+@Entity()
+export class Comment {
+    @PrimaryGeneratedColumn()
+    id: number;
+
+    @Column()
+    text: string;
+}

--- a/test/github-issues/5919/issue-6399.ts
+++ b/test/github-issues/5919/issue-6399.ts
@@ -1,0 +1,107 @@
+import { expect } from "chai";
+import Sinon from "sinon";
+import { Connection } from "../../../src";
+import {
+    closeTestingConnections,
+    createTestingConnections,
+    reloadTestingDatabases,
+} from "../../utils/test-utils";
+import { Comment } from "./entities";
+
+describe("github issues > #5919 Caching won't work with replication enabled", () => {
+    let connections: Connection[];
+
+    beforeEach(async () => {
+        connections = await createTestingConnections({
+            entities: [Comment],
+            schemaCreate: true,
+            dropSchema: true,
+            cache: true,
+            enabledDrivers: ["postgres"],
+        });
+        await reloadTestingDatabases(connections);
+    });
+    afterEach(() => closeTestingConnections(connections));
+
+    it("should not another queryRunner for cache with a given masterQueryRunner", () =>
+        Promise.all(
+            connections.map(async (connection) => {
+                const comment1 = new Comment();
+                comment1.text = "tata";
+                await connection.manager.save(comment1);
+
+                const masterQueryRunner = connection.createQueryRunner(
+                    "master"
+                );
+                const createQueryRunnerSpy = Sinon.spy(
+                    connection,
+                    "createQueryRunner"
+                );
+
+                const results1 = await connection
+                    .createQueryBuilder()
+                    .from(Comment, "c")
+                    .cache(true)
+                    .setQueryRunner(masterQueryRunner)
+                    .getRawMany();
+
+                expect(results1.length).eq(1);
+
+                expect(createQueryRunnerSpy.notCalled);
+
+                // add another one and ensure cache works
+                const comment2 = new Comment();
+                comment2.text = "tata";
+                await connection.manager.save(comment2);
+
+                const results2 = await connection
+                    .createQueryBuilder()
+                    .from(Comment, "c")
+                    .cache(true)
+                    .setQueryRunner(masterQueryRunner)
+                    .getRawMany();
+
+                expect(results2.length).eq(1);
+            })
+        ));
+
+    it("should create another queryRunner for cache with a given slaveQueryRunner", () =>
+        Promise.all(
+            connections.map(async (connection) => {
+                const comment1 = new Comment();
+                comment1.text = "tata";
+                await connection.manager.save(comment1);
+
+                const slaveQueryRunner = connection.createQueryRunner("slave");
+                const createQueryRunnerSpy = Sinon.spy(
+                    connection,
+                    "createQueryRunner"
+                );
+
+                const results1 = await connection
+                    .createQueryBuilder()
+                    .from(Comment, "c")
+                    .cache(true)
+                    .setQueryRunner(slaveQueryRunner)
+                    .getRawMany();
+
+                expect(results1.length).eq(1);
+
+                expect(createQueryRunnerSpy.calledOnce);
+
+                // add another one and ensure cache works
+                const comment2 = new Comment();
+                comment2.text = "tata";
+                await connection.manager.save(comment2);
+
+                const results2 = await connection
+                    .createQueryBuilder()
+                    .from(Comment, "c")
+                    .cache(true)
+                    .setQueryRunner(slaveQueryRunner)
+                    .getRawMany();
+
+                expect(results2.length).eq(1);
+            })
+        ));
+});


### PR DESCRIPTION
Fix #5919 

<!--
  😀 Wonderful!  Thank you for opening a pull request for TypeORM.

  Please fill in the information below to expedite the review
  and (hopefully) merge of your change.

  If unsure about something.. just do as best as you're able,
  or reach out through our community support channels!
  https://github.com/typeorm/typeorm/blob/master/docs/support.md
-->

### Description of change

I just added a new method `QueryRunner.getReplicationMode` to check if we can insert cache into `DbQueryResultCache.storeInCache`. If query runner is in slave mode, we create a new one in master mode

<!--
  Please be clear and concise what the change is intended to do,
  why this change is needed, and how you've verified that it
  corrects what you intended.

  In some cases it may be helpful to include the current behavior
  and the new behavior.

  If the change is related to an open issue, you can link it here.
  If you include `Fixes #0000` (replacing `0000` with the issue number)
  when this is merged it will automatically mark the issue as fixed and
  close it.
-->


### Pull-Request Checklist

<!--
  Please make sure to review and check all of the following.

  If an item is not applicable, you can add "N/A" to the end.
-->

- [x] Code is up-to-date with the `master` branch
- [x]  `npm run lint` passes with this change
- [x] `npm run test` passes with this change
- [x] This pull request links relevant issues as `Fixes #0000`
- [x] There are new or updated unit tests validating the change
- [x] Documentation has been updated to reflect this change N/A
- [x] The new commits follow conventions explained in [CONTRIBUTING.md](https://github.com/typeorm/typeorm/blob/master/CONTRIBUTING.md)

<!--
  🎉 Thank you for contributing and making TypeORM even better!
-->
