### PR TITLE
Add missing Date to string conversion on SQLite's driver (Fix #7675)

### DIFF
--- a/src/driver/sqlite-abstract/AbstractSqliteDriver.ts
+++ b/src/driver/sqlite-abstract/AbstractSqliteDriver.ts
@@ -354,12 +354,17 @@ export abstract class AbstractSqliteDriver implements Driver {
      */
     escapeQueryWithParameters(sql: string, parameters: ObjectLiteral, nativeParameters: ObjectLiteral): [string, any[]] {
         const builtParameters: any[] = Object.keys(nativeParameters).map(key => {
+            const parameter = nativeParameters[key];
             // Mapping boolean values to their numeric representation
-            if (typeof nativeParameters[key] === "boolean") {
-                return nativeParameters[key] === true ? 1 : 0;
+            if (typeof parameter === "boolean") {
+                return parameter === true ? 1 : 0;
             }
 
-            return nativeParameters[key];
+            if (parameter instanceof Date) {
+                return DateUtils.mixedDateToUtcDatetimeString(parameter);
+            }
+
+            return parameter;
         });
 
         if (!parameters || !Object.keys(parameters).length)

--- a/test/github-issues/7675/entity/Foo.ts
+++ b/test/github-issues/7675/entity/Foo.ts
@@ -1,0 +1,10 @@
+import { Column, Entity, PrimaryGeneratedColumn } from "../../../../src";
+
+@Entity()
+export class Foo {
+    @PrimaryGeneratedColumn()
+    id: number;
+
+    @Column()
+    someField: Date;
+}

--- a/test/github-issues/7675/issue-7675.ts
+++ b/test/github-issues/7675/issue-7675.ts
@@ -1,0 +1,32 @@
+import "reflect-metadata";
+import {Between, Connection} from "../../../src";
+import {closeTestingConnections, createTestingConnections} from "../../utils/test-utils";
+import {Foo} from "./entity/Foo";
+
+describe("github issues > #7675 [sqlite] Find operation with between filter returns empty array", () => {
+    let connections: Connection[];
+    before(async () => connections = await createTestingConnections({
+        enabledDrivers: ["sqlite"],
+        schemaCreate: true,
+        dropSchema: true,
+        entities: [Foo],
+    }));
+    after(() => closeTestingConnections(connections));
+
+    it("should correctly perform select queries using Date objects as parameters on sqlite", () => Promise.all(connections.map(async connection => {
+        const repository = connection.getRepository(Foo);
+
+        const obj = await repository.save({ someField: new Date("2020-08-29") });
+        await repository.save({ someField: new Date("2020-09-23") });
+        
+        let startDate = new Date("2020-08-01");
+        let endDate = new Date("2020-09-01");
+
+        const res = await repository.find({
+            where: { someField: Between(startDate, endDate) },
+        });
+        
+        res.length.should.be.equal(1);
+        res[0].someField.should.be.eql(obj.someField);
+    })));
+});


### PR DESCRIPTION
### Description of change

The behavior reported on the issue happened because, as stated on
https://github.com/typeorm/typeorm/blob/283413d8460208c68b0362afc2cbf7ebf8e35cc7/src/driver/sqlite-abstract/AbstractSqliteDriver.ts#L274-L277
Date objects need to be converted before being forwarded to sqlite. But, on the `escapeQueryWithParameters` method, it wasn't. I added the needed conversion and created a new test to catch the bug.

Fixes #7675

### Pull-Request Checklist

- [x] Code is up-to-date with the `master` branch
- [x] `npm run lint` passes with this change
- [x] `npm run test` passes with this change
- [x] This pull request links relevant issues as `Fixes #0000`
- [x] There are new or updated unit tests validating the change
- [ ] Documentation has been updated to reflect this change N/A
- [x] The new commits follow conventions explained in [CONTRIBUTING.md](https://github.com/typeorm/typeorm/blob/master/CONTRIBUTING.md)