### PR TITLE
add example to getting relation id without joining relation

### DIFF
--- a/docs/relations-faq.md
+++ b/docs/relations-faq.md
@@ -120,7 +120,18 @@ export class User {
     
 }
 ```
+Or alernatively, if your join column is renamed then:
 
+```
+  @Column({ nullable: true, name: "profile_id"} )
+  profileId: number;
+  
+  @OneToOne(type => Profile)
+  @JoinColumn({  name: "profile_id", referencedColumnName: "profileId" })
+  profile: Profile;
+
+ ```
+ 
 That's all. Next time you load a user object it will contain a profile id:
 
 ```javascript


### PR DESCRIPTION
### Description of change
The example in the documentation shows how to get a relation id without joining the relation but this does not work if the variable name of the column does not match the actual database column name.   Added an example

