### PR TITLE
fix description of Spread Operator from " ``` " (×) to "..."（√）in separating-entity-definition.md

### DIFF
--- a/docs/zh_CN/separating-entity-definition.md
+++ b/docs/zh_CN/separating-entity-definition.md
@@ -141,9 +141,9 @@ export const CategoryEntity = new EntitySchema<Category>({
 当使用`Decorator`方法时，很容易将基本列`extend`为抽象类并简单地扩展它。
 例如，在`BaseEntity`中这样定义`id`，`createdAt`和`updatedAt`列。 有关更多详细信息，请参阅[具体表继承](entity-inheritance.md#concrete-table-inheritance)的文档
 
-当使用`EntitySchema`方法时该方法便不可行。 但是，你可以使用`Spread Operator`（```）来改善。
+当使用 `EntitySchema` 方法时该方法便不可行。 但是，你可以使用`Spread Operator`（...）来改善。
 
-重新审视上面的`Category`示例。 你可能希望`extract`基本列描述并在其他模式中复用它，则可以通过以下方式完成：
+重新审视上面的 `Category` 示例。 你可能希望 `extract` 基本列描述并在其他模式中复用它，则可以通过以下方式完成：
 
 ```ts
 import {EntitySchemaColumnOptions} from "typeorm";


### PR DESCRIPTION
<!--
  😀 Wonderful!  Thank you for opening a pull request for TypeORM.

  Please fill in the information below to expedite the review
  and (hopefully) merge of your change.

  If unsure about something.. just do as best as you're able,
  or reach out through our community support channels!
  https://github.com/typeorm/typeorm/blob/master/docs/support.md
-->

### Description of change

<!--
  Please be clear and concise what the change is intended to do,
  why this change is needed, and how you've verified that it
  corrects what you intended.

  In some cases it may be helpful to include the current behavior
  and the new behavior.

  If the change is related to an open issue, you can link it here.
  If you include `Fixes #0000` (replacing `0000` with the issue number)
  when this is merged it will automatically mark the issue as fixed and
  close it.
-->


### Pull-Request Checklist

<!--
  Please make sure to review and check all of the following.

  If an item is not applicable, you can add "N/A" to the end.
-->

- [ ] Code is up-to-date with the `master` branch
- [ ] `npm run lint` passes with this change
- [ ] `npm run test` passes with this change
- [ ] This pull request links relevant issues as `Fixes #0000`
- [ ] There are new or updated unit tests validating the change
- [ ] Documentation has been updated to reflect this change
- [ ] The new commits follow conventions explained in [CONTRIBUTING.md](https://github.com/typeorm/typeorm/blob/master/CONTRIBUTING.md)

<!--
  🎉 Thank you for contributing and making TypeORM even better!
-->
