### PR TITLE
Support absolute path in migration:generate

### DIFF
--- a/src/commands/MigrationGenerateCommand.ts
+++ b/src/commands/MigrationGenerateCommand.ts
@@ -152,7 +152,10 @@ export class MigrationGenerateCommand implements yargs.CommandModule {
             const fileContent = args.outputJs ?
                 MigrationGenerateCommand.getJavascriptTemplate(args.name as any, timestamp, upSqls, downSqls.reverse()) :
                 MigrationGenerateCommand.getTemplate(args.name as any, timestamp, upSqls, downSqls.reverse());
-            const path = process.cwd() + "/" + (directory ? (directory + "/") : "") + filename;
+            if (directory && !directory.startsWith("/")) {
+                directory = process.cwd() + "/" + directory;
+            }
+            const path = (directory ? (directory + "/") : "") + filename;
 
             if (args.check) {
                 console.log(chalk.yellow(`Unexpected changes in database schema were found in check mode:\n\n${chalk.white(fileContent)}`));

--- a/src/commands/MigrationGenerateCommand.ts
+++ b/src/commands/MigrationGenerateCommand.ts
@@ -73,7 +73,7 @@ export class MigrationGenerateCommand implements yargs.CommandModule {
         const timestamp = new Date().getTime();
         const extension = args.outputJs ? ".js" : ".ts";
         const filename = timestamp + "-" + args.name + extension;
-        let directory = args.dir;
+        let directory = args.dir as string | undefined;
 
         // if directory is not set then try to open tsconfig and find default path there
         if (!directory) {


### PR DESCRIPTION
### Description of change

Continuation of #6807. It seems one CLI command was missed when supporting absolute paths.

I simply copied the solution from [migration create](https://github.com/typeorm/typeorm/blob/master/src/commands/MigrationCreateCommand.ts#L71-L74).

### Pull-Request Checklist

<!--
  Please make sure to review and check all of the following.

  If an item is not applicable, you can add "N/A" to the end.
-->

- [X] Code is up-to-date with the `master` branch
- [X] `npm run lint` passes with this change
- [x] `npm run test` passes with this change
- [ ] This pull request links relevant issues as `Fixes #0000`
- [ ] There are new or updated unit tests validating the change
- [ ] Documentation has been updated to reflect this change
- [X] The new commits follow conventions explained in [CONTRIBUTING.md](https://github.com/typeorm/typeorm/blob/master/CONTRIBUTING.md)
