### PR TITLE
Pass the entity through on `afterUpdate`

### DIFF
--- a/src/query-builder/UpdateQueryBuilder.ts
+++ b/src/query-builder/UpdateQueryBuilder.ts
@@ -132,7 +132,7 @@ export class UpdateQueryBuilder<Entity> extends QueryBuilder<Entity> implements 
             // call after updation methods in listeners and subscribers
             if (this.expressionMap.callListeners === true && this.expressionMap.mainAlias!.hasMetadata) {
                 const broadcastResult = new BroadcasterResult();
-                queryRunner.broadcaster.broadcastAfterUpdateEvent(broadcastResult, this.expressionMap.mainAlias!.metadata);
+                queryRunner.broadcaster.broadcastAfterUpdateEvent(broadcastResult, this.expressionMap.mainAlias!.metadata, this.expressionMap.valuesSet);
                 if (broadcastResult.promises.length > 0) await Promise.all(broadcastResult.promises);
             }
 

--- a/test/github-issues/2809/entity/Post.ts
+++ b/test/github-issues/2809/entity/Post.ts
@@ -1,0 +1,16 @@
+import {Entity} from "../../../../src/decorator/entity/Entity";
+import {PrimaryGeneratedColumn} from "../../../../src/decorator/columns/PrimaryGeneratedColumn";
+import {Column} from "../../../../src/decorator/columns/Column";
+
+@Entity()
+export class Post {
+
+    @PrimaryGeneratedColumn()
+    id: number;
+
+    @Column({ nullable: true })
+    title?: string;
+
+    @Column()
+    colToUpdate: number = 0;
+}

--- a/test/github-issues/2809/issue-2809.ts
+++ b/test/github-issues/2809/issue-2809.ts
@@ -1,0 +1,37 @@
+import "reflect-metadata";
+import {expect} from "chai";
+import {closeTestingConnections, createTestingConnections, reloadTestingDatabases} from "../../utils/test-utils";
+import {Connection} from "../../../src/connection/Connection";
+import {Post} from "./entity/Post";
+
+describe("github issues > #2809 afterUpdate subscriber entity argument is undefined", () => {
+    let connections: Connection[];
+    before(async () => connections = await createTestingConnections({
+        entities: [__dirname + "/entity/*{.js,.ts}"],
+        subscribers: [__dirname + "/subscriber/*{.js,.ts}"]
+    }));
+    beforeEach(() => reloadTestingDatabases(connections));
+    after(() => closeTestingConnections(connections));
+
+    it("if entity has been updated via repository update(), subscriber should get passed entity to change", () => Promise.all(connections.map(async function (connection) {
+
+        let repo = connection.getRepository(Post);
+
+        await repo.save(new Post());
+
+        const createdPost = await repo.findOne();
+
+        // test that the newly inserted post was touched by afterInsert PostSubscriber event
+        expect(createdPost).not.to.be.undefined;
+        expect(createdPost!.title).to.equal("set in subscriber after created");
+
+        // change the entity
+        await repo.update(createdPost!.id, {colToUpdate: 1});
+
+        const updatedPost = await repo.findOne();
+
+        // test that the updated post was touched by afterUpdate PostSubscriber event
+        expect(updatedPost).not.to.be.undefined;
+        expect(updatedPost!.title).to.equal("set in subscriber after updated");
+    })));
+});

--- a/test/github-issues/2809/subscriber/PostSubscriber.ts
+++ b/test/github-issues/2809/subscriber/PostSubscriber.ts
@@ -1,0 +1,21 @@
+import {Post} from "../entity/Post";
+import {EntitySubscriberInterface, EventSubscriber, UpdateEvent, InsertEvent} from "../../../../src";
+
+@EventSubscriber()
+export class PostSubscriber implements EntitySubscriberInterface<Post> {
+    listenTo() {
+        return Post;
+    }
+
+    afterUpdate(event: UpdateEvent<Post>) {
+        if (event.entity) {
+            event.entity["title"] = "set in subscriber after updated";
+        }
+    }
+
+    afterInsert(event: InsertEvent<Post>) {
+        if (event.entity) {
+            event.entity["title"]  = "set in subscriber after created";
+        }
+    }
+}


### PR DESCRIPTION
### Description of change

Similar to https://github.com/typeorm/typeorm/pull/5443, just for the afterUpdate subscribers.


### Pull-Request Checklist

- [ ] Code is up-to-date with the `master` branch
- [ ] `npm run lint` passes with this change
- [ ] `npm run test` passes with this change
- [ ] This pull request links relevant issues as `Fixes #0000`
- [ ] There are new or updated unit tests validating the change
- [ ] Documentation has been updated to reflect this change
- [ ] The new commits follow conventions explained in [CONTRIBUTING.md](https://github.com/typeorm/typeorm/blob/master/CONTRIBUTING.md)
