### PR TITLE
fix: entity object undefined in `afterUpdate` subscriber

### DIFF
--- a/src/query-builder/UpdateQueryBuilder.ts
+++ b/src/query-builder/UpdateQueryBuilder.ts
@@ -132,7 +132,7 @@ export class UpdateQueryBuilder<Entity> extends QueryBuilder<Entity> implements 
             // call after updation methods in listeners and subscribers
             if (this.expressionMap.callListeners === true && this.expressionMap.mainAlias!.hasMetadata) {
                 const broadcastResult = new BroadcasterResult();
-                queryRunner.broadcaster.broadcastAfterUpdateEvent(broadcastResult, this.expressionMap.mainAlias!.metadata);
+                queryRunner.broadcaster.broadcastAfterUpdateEvent(broadcastResult, this.expressionMap.mainAlias!.metadata, this.expressionMap.valuesSet);
                 if (broadcastResult.promises.length > 0) await Promise.all(broadcastResult.promises);
             }
 

--- a/test/github-issues/2809/entity/Post.ts
+++ b/test/github-issues/2809/entity/Post.ts
@@ -1,0 +1,16 @@
+import {Entity} from "../../../../src/decorator/entity/Entity";
+import {PrimaryGeneratedColumn} from "../../../../src/decorator/columns/PrimaryGeneratedColumn";
+import {Column} from "../../../../src/decorator/columns/Column";
+
+@Entity()
+export class Post {
+
+    @PrimaryGeneratedColumn()
+    id: number;
+
+    @Column({ nullable: true })
+    title?: string;
+
+    @Column()
+    colToUpdate: number = 0;
+}

--- a/test/github-issues/2809/issue-2809.ts
+++ b/test/github-issues/2809/issue-2809.ts
@@ -1,0 +1,39 @@
+import "reflect-metadata";
+import {expect} from "chai";
+import {closeTestingConnections, createTestingConnections, reloadTestingDatabases} from "../../utils/test-utils";
+import {Connection} from "../../../src/connection/Connection";
+import {Post} from "./entity/Post";
+
+describe("github issues > #2809 afterUpdate subscriber entity argument is undefined", () => {
+    let connections: Connection[];
+    before(async () => connections = await createTestingConnections({
+        entities: [__dirname + "/entity/*{.js,.ts}"],
+        subscribers: [__dirname + "/subscriber/*{.js,.ts}"]
+    }));
+    beforeEach(() => reloadTestingDatabases(connections));
+    after(() => closeTestingConnections(connections));
+
+    it("if entity has been updated via repository update(), subscriber should get passed entity to change", () => Promise.all(connections.map(async function (connection) {
+
+        let repo = connection.getRepository(Post);
+
+        const insertPost = new Post()
+
+        await repo.save(insertPost);
+
+        const createdPost = await repo.findOne();
+        expect(createdPost).not.to.be.undefined;
+
+        const { id } = createdPost!
+
+        // test that the in memory post was touched by afterInsert PostSubscriber event
+        expect(insertPost.title).to.equal("set in subscriber after created");
+
+        const updatePost: Partial<Post> = {colToUpdate: 1}
+        // change the entity
+        await repo.update(id, updatePost);
+
+        // test that the in memory post was touched by afterUpdate PostSubscriber event
+        expect(updatePost.title).to.equal("set in subscriber after updated");
+    })));
+});

--- a/test/github-issues/2809/subscriber/PostSubscriber.ts
+++ b/test/github-issues/2809/subscriber/PostSubscriber.ts
@@ -1,0 +1,21 @@
+import {Post} from "../entity/Post";
+import {EntitySubscriberInterface, EventSubscriber, UpdateEvent, InsertEvent} from "../../../../src";
+
+@EventSubscriber()
+export class PostSubscriber implements EntitySubscriberInterface<Post> {
+    listenTo() {
+        return Post;
+    }
+
+    afterUpdate(event: UpdateEvent<Post>) {
+        if (event.entity) {
+            event.entity["title"] = "set in subscriber after updated";
+        }
+    }
+
+    afterInsert(event: InsertEvent<Post>) {
+        if (event.entity) {
+            event.entity["title"]  = "set in subscriber after created";
+        }
+    }
+}


### PR DESCRIPTION
<!--
  😀 Wonderful!  Thank you for opening a pull request for TypeORM.

  Please fill in the information below to expedite the review
  and (hopefully) merge of your change.

  If unsure about something.. just do as best as you're able,
  or reach out through our community support channels!
  https://github.com/typeorm/typeorm/blob/master/docs/support.md
-->

### Description of change

<!--
  Please be clear and concise what the change is intended to do,
  why this change is needed, and how you've verified that it
  corrects what you intended.

  In some cases it may be helpful to include the current behavior
  and the new behavior.

  If the change is related to an open issue, you can link it here.
  If you include `Fixes #0000` (replacing `0000` with the issue number)
  when this is merged it will automatically mark the issue as fixed and
  close it.
-->

Similar to #5443, just for the `afterUpdate` subscribers.

This, alongside #5443 should fix the bug raised in https://github.com/typeorm/typeorm/issues/2809 and https://github.com/typeorm/typeorm/issues/2246.


### Pull-Request Checklist

<!--
  Please make sure to review and check all of the following.

  If an item is not applicable, you can add "N/A" to the end.
-->

- [x] Code is up-to-date with the `master` branch
- [x] `npm run lint` passes with this change
- [x] `npm run test` passes with this change
- [x] This pull request links relevant issues as `Fixes #2809`
- [x] There are new or updated unit tests validating the change
- [x] Documentation has been updated to reflect this change
- [x] The new commits follow conventions explained in [CONTRIBUTING.md](https://github.com/typeorm/typeorm/blob/master/CONTRIBUTING.md)

<!--
  🎉 Thank you for contributing and making TypeORM even better!
-->
