### PR TITLE
feat: make postgres extensions install optional

### DIFF
--- a/docs/connection-options.md
+++ b/docs/connection-options.md
@@ -1,507 +1,510 @@
 # Connection Options
 
-* [What is `ConnectionOptions`](#what-is-connectionoptions)
-* [Common connection options](#common-connection-options)
-* [`mysql` / `mariadb` connection options](#mysql--mariadb-connection-options)
-* [`postgres` / `cockroachdb` connection options](#postgres--cockroachdb-connection-options)
-* [`sqlite` connection options](#sqlite-connection-options)
-* [`better-sqlite3` connection options](#better-sqlite3-connection-options)
-* [`capacitor` connection options](#capacitor-connection-options)
-* [`cordova` connection options](#cordova-connection-options)
-* [`react-native` connection options](#react-native-connection-options)
-* [`nativescript` connection options](#nativescript-connection-options)
-* [`mssql` connection options](#mssql-connection-options)
-* [`mongodb` connection options](#mongodb-connection-options)
-* [`sql.js` connection options](#sqljs-connection-options)
-* [`expo` connection options](#expo-connection-options)
-* [Connection options example](#connection-options-example)
-    
+-   [What is `ConnectionOptions`](#what-is-connectionoptions)
+-   [Common connection options](#common-connection-options)
+-   [`mysql` / `mariadb` connection options](#mysql--mariadb-connection-options)
+-   [`postgres` / `cockroachdb` connection options](#postgres--cockroachdb-connection-options)
+-   [`sqlite` connection options](#sqlite-connection-options)
+-   [`better-sqlite3` connection options](#better-sqlite3-connection-options)
+-   [`capacitor` connection options](#capacitor-connection-options)
+-   [`cordova` connection options](#cordova-connection-options)
+-   [`react-native` connection options](#react-native-connection-options)
+-   [`nativescript` connection options](#nativescript-connection-options)
+-   [`mssql` connection options](#mssql-connection-options)
+-   [`mongodb` connection options](#mongodb-connection-options)
+-   [`sql.js` connection options](#sqljs-connection-options)
+-   [`expo` connection options](#expo-connection-options)
+-   [Connection options example](#connection-options-example)
+
 ## What is `ConnectionOptions`
 
 Connection options is a connection configuration you pass to `createConnection`
- or define in `ormconfig` file. Different databases have their own specific connection options.
+or define in `ormconfig` file. Different databases have their own specific connection options.
 
 ## Common connection options
 
-* `type` - Database type. You must specify what database engine you use.
- Possible values are "mysql", "postgres", "cockroachdb", "mariadb", "sqlite", "better-sqlite3", "capacitor", "cordova", 
- "nativescript", "oracle", "mssql", "mongodb", "sqljs", "react-native".
- This option is **required**.
+-   `type` - Database type. You must specify what database engine you use.
+    Possible values are "mysql", "postgres", "cockroachdb", "mariadb", "sqlite", "better-sqlite3", "capacitor", "cordova",
+    "nativescript", "oracle", "mssql", "mongodb", "sqljs", "react-native".
+    This option is **required**.
 
-* `name` - Connection name. You'll use it to get connection you need using `getConnection(name: string)` 
-or `ConnectionManager.get(name: string)`. 
-Connection names for different connections cannot be same - they all must be unique.
-If connection name is not given then it will be called "default".
+-   `name` - Connection name. You'll use it to get connection you need using `getConnection(name: string)`
+    or `ConnectionManager.get(name: string)`.
+    Connection names for different connections cannot be same - they all must be unique.
+    If connection name is not given then it will be called "default".
 
-* `extra` - Extra connection options to be passed to the underlying driver. 
-Use it if you want to pass extra settings to underlying database driver.
+-   `extra` - Extra connection options to be passed to the underlying driver.
+    Use it if you want to pass extra settings to underlying database driver.
 
-* `entities` - Entities, or Entity Schemas, to be loaded and used for this connection.
-Accepts both entity classes, entity schema classes, and directories paths to load from.
-Directories support glob patterns.
-Example: `entities: [Post, Category, "entity/*.js", "modules/**/entity/*.js"]`.
-Learn more about [Entities](./entities.md). 
-Learn more about [Entity Schemas](separating-entity-definition.md).
+-   `entities` - Entities, or Entity Schemas, to be loaded and used for this connection.
+    Accepts both entity classes, entity schema classes, and directories paths to load from.
+    Directories support glob patterns.
+    Example: `entities: [Post, Category, "entity/*.js", "modules/**/entity/*.js"]`.
+    Learn more about [Entities](./entities.md).
+    Learn more about [Entity Schemas](separating-entity-definition.md).
 
-* `subscribers` - Subscribers to be loaded and used for this connection.
-Accepts both entity classes and directories to load from.
-Directories support glob patterns.
-Example: `subscribers: [PostSubscriber, AppSubscriber, "subscriber/*.js", "modules/**/subscriber/*.js"]`.
-Learn more about [Subscribers](listeners-and-subscribers.md).
+-   `subscribers` - Subscribers to be loaded and used for this connection.
+    Accepts both entity classes and directories to load from.
+    Directories support glob patterns.
+    Example: `subscribers: [PostSubscriber, AppSubscriber, "subscriber/*.js", "modules/**/subscriber/*.js"]`.
+    Learn more about [Subscribers](listeners-and-subscribers.md).
 
-* `migrations` - Migrations to be loaded and used for this connection.
-Accepts both migration classes and directories to load from.
-Directories support glob patterns.
-Example: `migrations: [FirstMigration, SecondMigration, "migration/*.js", "modules/**/migration/*.js"]`.
-Learn more about [Migrations](./migrations.md).
+-   `migrations` - Migrations to be loaded and used for this connection.
+    Accepts both migration classes and directories to load from.
+    Directories support glob patterns.
+    Example: `migrations: [FirstMigration, SecondMigration, "migration/*.js", "modules/**/migration/*.js"]`.
+    Learn more about [Migrations](./migrations.md).
 
-* `logging` - Indicates if logging is enabled or not. 
-If set to `true` then query and error logging will be enabled.
-You can also specify different types of logging to be enabled, for example `["query", "error", "schema"]`.
-Learn more about [Logging](./logging.md).
+-   `logging` - Indicates if logging is enabled or not.
+    If set to `true` then query and error logging will be enabled.
+    You can also specify different types of logging to be enabled, for example `["query", "error", "schema"]`.
+    Learn more about [Logging](./logging.md).
 
-* `logger` - Logger to be used for logging purposes. Possible values are "advanced-console", "simple-console" and "file". 
-Default is "advanced-console". You can also specify a logger class that implements `Logger` interface.
-Learn more about [Logging](./logging.md).
+-   `logger` - Logger to be used for logging purposes. Possible values are "advanced-console", "simple-console" and "file".
+    Default is "advanced-console". You can also specify a logger class that implements `Logger` interface.
+    Learn more about [Logging](./logging.md).
 
-* `maxQueryExecutionTime` - If query execution time exceed this given max execution time (in milliseconds)
-then logger will log this query.
+-   `maxQueryExecutionTime` - If query execution time exceed this given max execution time (in milliseconds)
+    then logger will log this query.
 
-* `namingStrategy` - Naming strategy to be used to name tables and columns in the database.
-Learn more about [Naming strategies](./naming-strategy.md).
+-   `namingStrategy` - Naming strategy to be used to name tables and columns in the database.
+    Learn more about [Naming strategies](./naming-strategy.md).
 
-* `entityPrefix` - Prefixes with the given string all tables (or collections) on this database connection.
+-   `entityPrefix` - Prefixes with the given string all tables (or collections) on this database connection.
 
-* `dropSchema` - Drops the schema each time connection is being established.
-Be careful with this option and don't use this in production - otherwise you'll lose all production data.
-This option is useful during debug and development.
+-   `dropSchema` - Drops the schema each time connection is being established.
+    Be careful with this option and don't use this in production - otherwise you'll lose all production data.
+    This option is useful during debug and development.
 
-* `synchronize` - Indicates if database schema should be auto created on every application launch.
- Be careful with this option and don't use this in production - otherwise you can lose production data.
- This option is useful during debug and development.
- As an alternative to it, you can use CLI and run schema:sync command.
- Note that for MongoDB database it does not create schema, because MongoDB is schemaless.
- Instead, it syncs just by creating indices.
+-   `synchronize` - Indicates if database schema should be auto created on every application launch.
+    Be careful with this option and don't use this in production - otherwise you can lose production data.
+    This option is useful during debug and development.
+    As an alternative to it, you can use CLI and run schema:sync command.
+    Note that for MongoDB database it does not create schema, because MongoDB is schemaless.
+    Instead, it syncs just by creating indices.
 
-* `migrationsRun` - Indicates if migrations should be auto run on every application launch.
-As an alternative, you can use CLI and run migration:run command.
+-   `migrationsRun` - Indicates if migrations should be auto run on every application launch.
+    As an alternative, you can use CLI and run migration:run command.
 
-* `migrationsTableName` - Name of the table in the database which is going to contain information about executed migrations.
-By default this table is called "migrations".
+-   `migrationsTableName` - Name of the table in the database which is going to contain information about executed migrations.
+    By default this table is called "migrations".
 
-* `cache` - Enables entity result caching. You can also configure cache type and other cache options here.
-Read more about caching [here](./caching.md).
+-   `cache` - Enables entity result caching. You can also configure cache type and other cache options here.
+    Read more about caching [here](./caching.md).
 
-* `cli.entitiesDir` - Directory where entities should be created by default by CLI.
+-   `cli.entitiesDir` - Directory where entities should be created by default by CLI.
 
-* `cli.migrationsDir` - Directory where migrations should be created by default by CLI.
+-   `cli.migrationsDir` - Directory where migrations should be created by default by CLI.
 
-* `cli.subscribersDir` - Directory where subscribers should be created by default by CLI.
+-   `cli.subscribersDir` - Directory where subscribers should be created by default by CLI.
 
 ## `mysql` / `mariadb` connection options
 
-* `url` - Connection url where perform connection to. Please note that other connection options will override parameters set from url.
+-   `url` - Connection url where perform connection to. Please note that other connection options will override parameters set from url.
 
-* `host` - Database host.
+-   `host` - Database host.
 
-* `port` - Database host port. Default mysql port is `3306`.
+-   `port` - Database host port. Default mysql port is `3306`.
 
-* `username` - Database username.
+-   `username` - Database username.
 
-* `password` - Database password.
+-   `password` - Database password.
 
-* `database` - Database name.
+-   `database` - Database name.
 
-* `charset` - The charset for the connection. This is called "collation" in the SQL-level of MySQL 
-(like utf8_general_ci). If a SQL-level charset is specified (like utf8mb4) then the default collation for that charset is used. (Default: `UTF8_GENERAL_CI`).
+-   `charset` - The charset for the connection. This is called "collation" in the SQL-level of MySQL
+    (like utf8_general_ci). If a SQL-level charset is specified (like utf8mb4) then the default collation for that charset is used. (Default: `UTF8_GENERAL_CI`).
 
-* `timezone` - the timezone configured on the MySQL server. This is used to typecast server date/time 
-values to JavaScript Date object and vice versa. This can be `local`, `Z`, or an offset in the form 
-`+HH:MM` or `-HH:MM`. (Default: `local`)
+-   `timezone` - the timezone configured on the MySQL server. This is used to typecast server date/time
+    values to JavaScript Date object and vice versa. This can be `local`, `Z`, or an offset in the form
+    `+HH:MM` or `-HH:MM`. (Default: `local`)
 
-* `connectTimeout` - The milliseconds before a timeout occurs during the initial connection to the MySQL server.
- (Default: `10000`)
+-   `connectTimeout` - The milliseconds before a timeout occurs during the initial connection to the MySQL server.
+    (Default: `10000`)
 
-* `acquireTimeout` - The milliseconds before a timeout occurs during the initial connection to the MySql server. It differs from `connectTimeout` as it governs the TCP connection timeout where as connectTimeout does not. (default: `10000`)
- 
-* `insecureAuth` - Allow connecting to MySQL instances that ask for the old (insecure) authentication method. 
-(Default: `false`)
- 
-* `supportBigNumbers` - When dealing with big numbers (`BIGINT` and `DECIMAL` columns) in the database, 
-you should enable this option (Default: `true`)
- 
-* `bigNumberStrings` - Enabling both `supportBigNumbers` and `bigNumberStrings` forces big numbers 
-(`BIGINT` and `DECIMAL` columns) to be always returned as JavaScript String objects (Default: `true`). 
-Enabling `supportBigNumbers` but leaving `bigNumberStrings` disabled will return big numbers as String 
-objects only when they cannot be accurately represented with 
-[JavaScript Number objects](http://ecma262-5.com/ELS5_HTML.htm#Section_8.5) 
-(which happens when they exceed the `[-2^53, +2^53]` range), otherwise they will be returned as 
-Number objects. This option is ignored if `supportBigNumbers` is disabled.
+-   `acquireTimeout` - The milliseconds before a timeout occurs during the initial connection to the MySql server. It differs from `connectTimeout` as it governs the TCP connection timeout where as connectTimeout does not. (default: `10000`)
 
-* `dateStrings` - Force date types (`TIMESTAMP`, `DATETIME`, `DATE`) to be returned as strings rather than 
-inflated into JavaScript Date objects. Can be true/false or an array of type names to keep as strings. 
-(Default: `false`)
+-   `insecureAuth` - Allow connecting to MySQL instances that ask for the old (insecure) authentication method.
+    (Default: `false`)
 
-* `debug` - Prints protocol details to stdout. Can be true/false or an array of packet type names that 
-should be printed. (Default: `false`)
+-   `supportBigNumbers` - When dealing with big numbers (`BIGINT` and `DECIMAL` columns) in the database,
+    you should enable this option (Default: `true`)
 
-* `trace` - Generates stack traces on Error to include call site of library entrance ("long stack traces"). 
-Slight performance penalty for most calls. (Default: `true`)
+-   `bigNumberStrings` - Enabling both `supportBigNumbers` and `bigNumberStrings` forces big numbers
+    (`BIGINT` and `DECIMAL` columns) to be always returned as JavaScript String objects (Default: `true`).
+    Enabling `supportBigNumbers` but leaving `bigNumberStrings` disabled will return big numbers as String
+    objects only when they cannot be accurately represented with
+    [JavaScript Number objects](http://ecma262-5.com/ELS5_HTML.htm#Section_8.5)
+    (which happens when they exceed the `[-2^53, +2^53]` range), otherwise they will be returned as
+    Number objects. This option is ignored if `supportBigNumbers` is disabled.
 
-* `multipleStatements` - Allow multiple mysql statements per query. Be careful with this, it could increase the scope 
-of SQL injection attacks. (Default: `false`)
+-   `dateStrings` - Force date types (`TIMESTAMP`, `DATETIME`, `DATE`) to be returned as strings rather than
+    inflated into JavaScript Date objects. Can be true/false or an array of type names to keep as strings.
+    (Default: `false`)
 
-* `legacySpatialSupport` - Use spatial functions like GeomFromText and AsText which are removed in MySQL 8. (Default: true)
+-   `debug` - Prints protocol details to stdout. Can be true/false or an array of packet type names that
+    should be printed. (Default: `false`)
 
-* `flags` - List of connection flags to use other than the default ones. It is also possible to blacklist default ones.
- For more information, check [Connection Flags](https://github.com/mysqljs/mysql#connection-flags).
- 
-* `ssl` -  object with ssl parameters or a string containing the name of ssl profile. 
-See [SSL options](https://github.com/mysqljs/mysql#ssl-options).
+-   `trace` - Generates stack traces on Error to include call site of library entrance ("long stack traces").
+    Slight performance penalty for most calls. (Default: `true`)
+
+-   `multipleStatements` - Allow multiple mysql statements per query. Be careful with this, it could increase the scope
+    of SQL injection attacks. (Default: `false`)
+
+-   `legacySpatialSupport` - Use spatial functions like GeomFromText and AsText which are removed in MySQL 8. (Default: true)
+
+-   `flags` - List of connection flags to use other than the default ones. It is also possible to blacklist default ones.
+    For more information, check [Connection Flags](https://github.com/mysqljs/mysql#connection-flags).
+
+-   `ssl` - object with ssl parameters or a string containing the name of ssl profile.
+    See [SSL options](https://github.com/mysqljs/mysql#ssl-options).
 
 ## `postgres` / `cockroachdb` connection options
 
-* `url` - Connection url where perform connection to. Please note that other connection options will override parameters set from url.
+-   `url` - Connection url where perform connection to. Please note that other connection options will override parameters set from url.
 
-* `host` - Database host.
+-   `host` - Database host.
 
-* `port` - Database host port. Default postgres port is `5432`.
+-   `port` - Database host port. Default postgres port is `5432`.
 
-* `username` - Database username.
+-   `username` - Database username.
 
-* `password` - Database password.
+-   `password` - Database password.
 
-* `database` - Database name.
+-   `database` - Database name.
 
-* `schema` - Schema name. Default is "public".
+-   `schema` - Schema name. Default is "public".
 
-* `connectTimeoutMS` - The milliseconds before a timeout occurs during the initial connection to the postgres server. If `undefined`, or set to `0`, there is no timeout. Defaults to `undefined`. 
+-   `connectTimeoutMS` - The milliseconds before a timeout occurs during the initial connection to the postgres server. If `undefined`, or set to `0`, there is no timeout. Defaults to `undefined`.
 
-* `ssl` - Object with ssl parameters. See [TLS/SSL](https://node-postgres.com/features/ssl).
+-   `ssl` - Object with ssl parameters. See [TLS/SSL](https://node-postgres.com/features/ssl).
 
-* `uuidExtension` - The Postgres extension to use when generating UUIDs. Defaults to `uuid-ossp`. Can be changed to `pgcrypto` if the `uuid-ossp` extension is unavailable.
+-   `uuidExtension` - The Postgres extension to use when generating UUIDs. Defaults to `uuid-ossp`. Can be changed to `pgcrypto` if the `uuid-ossp` extension is unavailable.
 
-* `poolErrorHandler` - A function that get's called when underlying pool emits `'error'` event. Takes single parameter (error instance) and defaults to logging with `warn` level.
+-   `poolErrorHandler` - A function that get's called when underlying pool emits `'error'` event. Takes single parameter (error instance) and defaults to logging with `warn` level.
 
-* `logNotifications` - A boolean to determine whether postgres server [notice messages](https://www.postgresql.org/docs/current/plpgsql-errors-and-messages.html) and [notification events](https://www.postgresql.org/docs/current/sql-notify.html) should be included in client's logs with `info` level (default: `false`).
+-   `logNotifications` - A boolean to determine whether postgres server [notice messages](https://www.postgresql.org/docs/current/plpgsql-errors-and-messages.html) and [notification events](https://www.postgresql.org/docs/current/sql-notify.html) should be included in client's logs with `info` level (default: `false`).
+
+-   `installExtensions` - A boolean to control whether to install necessary postgres extensions automatically or not (default: `true`)
 
 ## `sqlite` connection options
 
-* `database` - Database path. For example "./mydb.sql"
+-   `database` - Database path. For example "./mydb.sql"
 
 ## `better-sqlite3` connection options
 
-* `database` - Database path. For example "./mydb.sql"
+-   `database` - Database path. For example "./mydb.sql"
 
-* `statementCacheSize` - Cache size of sqlite statement to speed up queries (default 100).
+-   `statementCacheSize` - Cache size of sqlite statement to speed up queries (default 100).
 
-* `prepareDatabase` - Function to run before a database is used in typeorm. You can access original better-sqlite3 Database object here.
+-   `prepareDatabase` - Function to run before a database is used in typeorm. You can access original better-sqlite3 Database object here.
 
 ## `capacitor` connection options
 
-* `database` - Database name (capacitor-sqlite will add the suffix `SQLite.db`)
+-   `database` - Database name (capacitor-sqlite will add the suffix `SQLite.db`)
 
-* `driver` - The capacitor-sqlite instance. For example, `new SQLiteConnection(CapacitorSQLite)`.
+-   `driver` - The capacitor-sqlite instance. For example, `new SQLiteConnection(CapacitorSQLite)`.
 
 ## `cordova` connection options
 
-* `database` - Database name
+-   `database` - Database name
 
-* `location` - Where to save the database. See [cordova-sqlite-storage](https://github.com/litehelpers/Cordova-sqlite-storage#opening-a-database) for options.
+-   `location` - Where to save the database. See [cordova-sqlite-storage](https://github.com/litehelpers/Cordova-sqlite-storage#opening-a-database) for options.
 
 ## `react-native` connection options
-* `database` - Database name
 
-* `location` - Where to save the database. See [react-native-sqlite-storage](https://github.com/andpor/react-native-sqlite-storage#opening-a-database) for options.
+-   `database` - Database name
+
+-   `location` - Where to save the database. See [react-native-sqlite-storage](https://github.com/andpor/react-native-sqlite-storage#opening-a-database) for options.
 
 ## `nativescript` connection options
-* `database` - Database name
+
+-   `database` - Database name
 
 ## `mssql` connection options
 
-* `url` - Connection url where perform connection to. Please note that other connection options will override parameters set from url.
+-   `url` - Connection url where perform connection to. Please note that other connection options will override parameters set from url.
 
-* `host` - Database host.
+-   `host` - Database host.
 
-* `port` - Database host port. Default mssql port is `1433`.
+-   `port` - Database host port. Default mssql port is `1433`.
 
-* `username` - Database username.
+-   `username` - Database username.
 
-* `password` - Database password.
+-   `password` - Database password.
 
-* `database` - Database name.
+-   `database` - Database name.
 
-* `schema` - Schema name. Default is "public".
+-   `schema` - Schema name. Default is "public".
 
-* `domain` - Once you set domain, the driver will connect to SQL Server using domain login.
+-   `domain` - Once you set domain, the driver will connect to SQL Server using domain login.
 
-* `connectionTimeout` - Connection timeout in ms (default: `15000`).
+-   `connectionTimeout` - Connection timeout in ms (default: `15000`).
 
-* `requestTimeout` - Request timeout in ms (default: `15000`). NOTE: msnodesqlv8 driver doesn't support
- timeouts < 1 second.
+-   `requestTimeout` - Request timeout in ms (default: `15000`). NOTE: msnodesqlv8 driver doesn't support
+    timeouts < 1 second.
 
-* `stream` - Stream recordsets/rows instead of returning them all at once as an argument of callback (default: `false`).
- You can also enable streaming for each request independently (`request.stream = true`). Always set to `true` if you plan to
- work with a large amount of rows.
- 
-* `pool.max` - The maximum number of connections there can be in the pool (default: `10`).
+-   `stream` - Stream recordsets/rows instead of returning them all at once as an argument of callback (default: `false`).
+    You can also enable streaming for each request independently (`request.stream = true`). Always set to `true` if you plan to
+    work with a large amount of rows.
 
-* `pool.min` - The minimum of connections there can be in the pool (default: `0`).
+-   `pool.max` - The maximum number of connections there can be in the pool (default: `10`).
 
-* `pool.maxWaitingClients` - maximum number of queued requests allowed, additional acquire calls will be callback with
- an err in a future cycle of the event loop.
- 
-* `pool.testOnBorrow` -  should the pool validate resources before giving them to clients. Requires that either
-  `factory.validate` or `factory.validateAsync` to be specified.
-  
-* `pool.acquireTimeoutMillis` - max milliseconds an `acquire` call will wait for a resource before timing out.
- (default no limit), if supplied should non-zero positive integer.
- 
-* `pool.fifo` - if true the oldest resources will be first to be allocated. If false the most recently released resources
- will be the first to be allocated. This in effect turns the pool's behaviour from a queue into a stack. boolean,
- (default `true`).
- 
-* `pool.priorityRange` - int between 1 and x - if set, borrowers can specify their relative priority in the queue if no
- resources are available. see example. (default `1`).
- 
-* `pool.autostart` - boolean, should the pool start creating resources etc once the constructor is called, (default `true`).
+-   `pool.min` - The minimum of connections there can be in the pool (default: `0`).
 
-* `pool.evictionRunIntervalMillis` - How often to run eviction checks. Default: `0` (does not run).
+-   `pool.maxWaitingClients` - maximum number of queued requests allowed, additional acquire calls will be callback with
+    an err in a future cycle of the event loop.
 
-* `pool.numTestsPerRun` - Number of resources to check each eviction run. Default: `3`.
+-   `pool.testOnBorrow` - should the pool validate resources before giving them to clients. Requires that either
+    `factory.validate` or `factory.validateAsync` to be specified.
+-   `pool.acquireTimeoutMillis` - max milliseconds an `acquire` call will wait for a resource before timing out.
+    (default no limit), if supplied should non-zero positive integer.
 
-* `pool.softIdleTimeoutMillis` - amount of time an object may sit idle in the pool before it is eligible for eviction by
- the idle object evictor (if any), with the extra condition that at least "min idle" object instances remain in the pool.
- Default `-1` (nothing can get evicted).
- 
-* `pool.idleTimeoutMillis` -  the minimum amount of time that an object may sit idle in the pool before it is eligible for
- eviction due to idle time. Supersedes `softIdleTimeoutMillis`. Default: `30000`.
- 
- * `pool.errorHandler` - A function that get's called when underlying pool emits `'error'` event. Takes single parameter (error instance) and defaults to logging with `warn` level.
- 
-* `options.fallbackToDefaultDb` - By default, if the database requestion by `options.database` cannot be accessed, the connection
- will fail with an error. However, if `options.fallbackToDefaultDb` is set to `true`, then the user's default database will
-  be used instead (Default: `false`).
-  
-* `options.instanceName` - The instance name to connect to. The SQL Server Browser service must be running on the database server, and UDP port 1434 on the database server must be reachable. Mutually exclusive with `port`. (no default).
+-   `pool.fifo` - if true the oldest resources will be first to be allocated. If false the most recently released resources
+    will be the first to be allocated. This in effect turns the pool's behaviour from a queue into a stack. boolean,
+    (default `true`).
 
-* `options.enableAnsiNullDefault` - If true, SET ANSI_NULL_DFLT_ON ON will be set in the initial sql. This means new
- columns will be nullable by default. See the [T-SQL documentation](https://msdn.microsoft.com/en-us/library/ms187375.aspx)
- for more details. (Default: `true`).
- 
-* `options.cancelTimeout` - The number of milliseconds before the cancel (abort) of a request is considered failed (default: `5000`).
+-   `pool.priorityRange` - int between 1 and x - if set, borrowers can specify their relative priority in the queue if no
+    resources are available. see example. (default `1`).
 
-* `options.packetSize` - The size of TDS packets (subject to negotiation with the server). Should be a power of 2. (default: `4096`).
+-   `pool.autostart` - boolean, should the pool start creating resources etc once the constructor is called, (default `true`).
 
-* `options.useUTC` - A boolean determining whether to pass time values in UTC or local time. (default: `true`).
+-   `pool.evictionRunIntervalMillis` - How often to run eviction checks. Default: `0` (does not run).
 
-* `options.abortTransactionOnError` - A boolean determining whether to rollback a transaction automatically if any
- error is encountered during the given transaction's execution. This sets the value for `SET XACT_ABORT` during the
- initial SQL phase of a connection ([documentation](http://msdn.microsoft.com/en-us/library/ms188792.aspx)).
+-   `pool.numTestsPerRun` - Number of resources to check each eviction run. Default: `3`.
 
-* `options.localAddress` - A string indicating which network interface (ip address) to use when connecting to SQL Server.
+-   `pool.softIdleTimeoutMillis` - amount of time an object may sit idle in the pool before it is eligible for eviction by
+    the idle object evictor (if any), with the extra condition that at least "min idle" object instances remain in the pool.
+    Default `-1` (nothing can get evicted).
 
-* `options.useColumnNames` - A boolean determining whether to return rows as arrays or key-value collections. (default: `false`).
+-   `pool.idleTimeoutMillis` - the minimum amount of time that an object may sit idle in the pool before it is eligible for
+    eviction due to idle time. Supersedes `softIdleTimeoutMillis`. Default: `30000`.
 
-* `options.camelCaseColumns` - A boolean, controlling whether the column names returned will have the first letter
- converted to lower case (`true`) or not. This value is ignored if you provide a `columnNameReplacer`. (default: `false`).
+-   `pool.errorHandler` - A function that get's called when underlying pool emits `'error'` event. Takes single parameter (error instance) and defaults to logging with `warn` level.
 
-* `options.isolationLevel` - The default isolation level that transactions will be run with. The isolation levels are
- available from `require('tedious').ISOLATION_LEVEL`.
-   * `READ_UNCOMMITTED`
-   * `READ_COMMITTED`
-   * `REPEATABLE_READ`
-   * `SERIALIZABLE`
-   * `SNAPSHOT`
-   
-   (default: `READ_COMMITTED`)
- 
-* `options.connectionIsolationLevel` - The default isolation level for new connections. All out-of-transaction queries
- are executed with this setting. The isolation levels are available from `require('tedious').ISOLATION_LEVEL`.
-   * `READ_UNCOMMITTED`
-   * `READ_COMMITTED`
-   * `REPEATABLE_READ`
-   * `SERIALIZABLE`
-   * `SNAPSHOT`
-   
-   (default: `READ_COMMITTED`)
- 
-* `options.readOnlyIntent` - A boolean, determining whether the connection will request read-only access from a
- SQL Server Availability Group. For more information, see here. (default: `false`).
+-   `options.fallbackToDefaultDb` - By default, if the database requestion by `options.database` cannot be accessed, the connection
+    will fail with an error. However, if `options.fallbackToDefaultDb` is set to `true`, then the user's default database will
+    be used instead (Default: `false`).
+-   `options.instanceName` - The instance name to connect to. The SQL Server Browser service must be running on the database server, and UDP port 1434 on the database server must be reachable. Mutually exclusive with `port`. (no default).
 
-* `options.encrypt` - A boolean determining whether or not the connection will be encrypted. Set to true if you're
- on Windows Azure. (default: `false`).
- 
-* `options.cryptoCredentialsDetails` - When encryption is used, an object may be supplied that will be used for the
- first argument when calling [tls.createSecurePair](http://nodejs.org/docs/latest/api/tls.html#tls_tls_createsecurepair_credentials_isserver_requestcert_rejectunauthorized)
-  (default: `{}`).
-  
-* `options.rowCollectionOnDone` - A boolean, that when true will expose received rows in Requests' `done*` events.
- See done, [doneInProc](http://tediousjs.github.io/tedious/api-request.html#event_doneInProc)
- and [doneProc](http://tediousjs.github.io/tedious/api-request.html#event_doneProc). (default: `false`)
-   
-   Caution: If many rows are received, enabling this option could result in excessive memory usage.
+-   `options.enableAnsiNullDefault` - If true, SET ANSI_NULL_DFLT_ON ON will be set in the initial sql. This means new
+    columns will be nullable by default. See the [T-SQL documentation](https://msdn.microsoft.com/en-us/library/ms187375.aspx)
+    for more details. (Default: `true`).
 
-* `options.rowCollectionOnRequestCompletion` - A boolean, that when true will expose received rows
- in Requests' completion callback. See [new Request](http://tediousjs.github.io/tedious/api-request.html#function_newRequest). (default: `false`)
+-   `options.cancelTimeout` - The number of milliseconds before the cancel (abort) of a request is considered failed (default: `5000`).
 
-   Caution: If many rows are received, enabling this option could result in excessive memory usage.
+-   `options.packetSize` - The size of TDS packets (subject to negotiation with the server). Should be a power of 2. (default: `4096`).
 
-* `options.tdsVersion` - The version of TDS to use. If the server doesn't support the specified version, a negotiated version
- is used instead. The versions are available from `require('tedious').TDS_VERSION`.
-   * `7_1`
-   * `7_2`
-   * `7_3_A`
-   * `7_3_B`
-   * `7_4`
-   
-  (default: `7_4`)
+-   `options.useUTC` - A boolean determining whether to pass time values in UTC or local time. (default: `true`).
 
-* `options.debug.packet` - A boolean, controlling whether `debug` events will be emitted with text describing packet
- details (default: `false`).
- 
-* `options.debug.data` - A boolean, controlling whether `debug` events will be emitted with text describing packet data
- details (default: `false`).
- 
-* `options.debug.payload` - A boolean, controlling whether `debug` events will be emitted with text describing packet
- payload details (default: `false`).
- 
-* `options.debug.token` - A boolean, controlling whether `debug` events will be emitted with text describing token stream
- tokens (default: `false`).
+-   `options.abortTransactionOnError` - A boolean determining whether to rollback a transaction automatically if any
+    error is encountered during the given transaction's execution. This sets the value for `SET XACT_ABORT` during the
+    initial SQL phase of a connection ([documentation](http://msdn.microsoft.com/en-us/library/ms188792.aspx)).
+
+-   `options.localAddress` - A string indicating which network interface (ip address) to use when connecting to SQL Server.
+
+-   `options.useColumnNames` - A boolean determining whether to return rows as arrays or key-value collections. (default: `false`).
+
+-   `options.camelCaseColumns` - A boolean, controlling whether the column names returned will have the first letter
+    converted to lower case (`true`) or not. This value is ignored if you provide a `columnNameReplacer`. (default: `false`).
+
+-   `options.isolationLevel` - The default isolation level that transactions will be run with. The isolation levels are
+    available from `require('tedious').ISOLATION_LEVEL`.
+
+    -   `READ_UNCOMMITTED`
+    -   `READ_COMMITTED`
+    -   `REPEATABLE_READ`
+    -   `SERIALIZABLE`
+    -   `SNAPSHOT`
+
+    (default: `READ_COMMITTED`)
+
+-   `options.connectionIsolationLevel` - The default isolation level for new connections. All out-of-transaction queries
+    are executed with this setting. The isolation levels are available from `require('tedious').ISOLATION_LEVEL`.
+
+    -   `READ_UNCOMMITTED`
+    -   `READ_COMMITTED`
+    -   `REPEATABLE_READ`
+    -   `SERIALIZABLE`
+    -   `SNAPSHOT`
+
+    (default: `READ_COMMITTED`)
+
+-   `options.readOnlyIntent` - A boolean, determining whether the connection will request read-only access from a
+    SQL Server Availability Group. For more information, see here. (default: `false`).
+
+-   `options.encrypt` - A boolean determining whether or not the connection will be encrypted. Set to true if you're
+    on Windows Azure. (default: `false`).
+
+-   `options.cryptoCredentialsDetails` - When encryption is used, an object may be supplied that will be used for the
+    first argument when calling [tls.createSecurePair](http://nodejs.org/docs/latest/api/tls.html#tls_tls_createsecurepair_credentials_isserver_requestcert_rejectunauthorized)
+    (default: `{}`).
+-   `options.rowCollectionOnDone` - A boolean, that when true will expose received rows in Requests' `done*` events.
+    See done, [doneInProc](http://tediousjs.github.io/tedious/api-request.html#event_doneInProc)
+    and [doneProc](http://tediousjs.github.io/tedious/api-request.html#event_doneProc). (default: `false`)
+
+    Caution: If many rows are received, enabling this option could result in excessive memory usage.
+
+-   `options.rowCollectionOnRequestCompletion` - A boolean, that when true will expose received rows
+    in Requests' completion callback. See [new Request](http://tediousjs.github.io/tedious/api-request.html#function_newRequest). (default: `false`)
+
+    Caution: If many rows are received, enabling this option could result in excessive memory usage.
+
+-   `options.tdsVersion` - The version of TDS to use. If the server doesn't support the specified version, a negotiated version
+    is used instead. The versions are available from `require('tedious').TDS_VERSION`.
+
+    -   `7_1`
+    -   `7_2`
+    -   `7_3_A`
+    -   `7_3_B`
+    -   `7_4`
+
+    (default: `7_4`)
+
+-   `options.debug.packet` - A boolean, controlling whether `debug` events will be emitted with text describing packet
+    details (default: `false`).
+
+-   `options.debug.data` - A boolean, controlling whether `debug` events will be emitted with text describing packet data
+    details (default: `false`).
+
+-   `options.debug.payload` - A boolean, controlling whether `debug` events will be emitted with text describing packet
+    payload details (default: `false`).
+
+-   `options.debug.token` - A boolean, controlling whether `debug` events will be emitted with text describing token stream
+    tokens (default: `false`).
 
 ## `mongodb` connection options
 
-* `url` - Connection url where perform connection to. Please note that other connection options will override parameters set from url.
+-   `url` - Connection url where perform connection to. Please note that other connection options will override parameters set from url.
 
-* `host` - Database host.
+-   `host` - Database host.
 
-* `port` - Database host port. Default mongodb port is `27017`.
+-   `port` - Database host port. Default mongodb port is `27017`.
 
-* `username` - Database username (replacement for `auth.user`).
+-   `username` - Database username (replacement for `auth.user`).
 
-* `password` - Database password (replacement for `auth.password`).
+-   `password` - Database password (replacement for `auth.password`).
 
-* `database` - Database name.
+-   `database` - Database name.
 
-* `poolSize` - Set the maximum pool size for each individual server or proxy connection.
+-   `poolSize` - Set the maximum pool size for each individual server or proxy connection.
 
-* `ssl` - Use ssl connection (needs to have a mongod server with ssl support). Default: `false`.
+-   `ssl` - Use ssl connection (needs to have a mongod server with ssl support). Default: `false`.
 
-* `sslValidate` - Validate mongod server certificate against ca (needs to have a mongod server with ssl support,
- 2.4 or higher). Default: `true`.
- 
-* `sslCA` - Array of valid certificates either as Buffers or Strings (needs to have a mongod server with ssl support,
- 2.4 or higher).
- 
-* `sslCert` - String or buffer containing the certificate we wish to present (needs to have a mongod server with ssl
- support, 2.4 or higher)
- 
-* `sslKey` - String or buffer containing the certificate private key we wish to present (needs to have a mongod server
- with ssl support, 2.4 or higher).
- 
-* `sslPass` - String or buffer containing the certificate password (needs to have a mongod server with ssl support,
- 2.4 or higher).
- 
-* `autoReconnect` - Reconnect on error. Default: `true`.
+-   `sslValidate` - Validate mongod server certificate against ca (needs to have a mongod server with ssl support,
+    2.4 or higher). Default: `true`.
 
-* `noDelay` - TCP Socket NoDelay option. Default: `true`.
+-   `sslCA` - Array of valid certificates either as Buffers or Strings (needs to have a mongod server with ssl support,
+    2.4 or higher).
 
-* `keepAlive` - The number of milliseconds to wait before initiating keepAlive on the TCP socket. Default: `30000`.
+-   `sslCert` - String or buffer containing the certificate we wish to present (needs to have a mongod server with ssl
+    support, 2.4 or higher)
 
-* `connectTimeoutMS` - TCP Connection timeout setting. Default: `30000`.
+-   `sslKey` - String or buffer containing the certificate private key we wish to present (needs to have a mongod server
+    with ssl support, 2.4 or higher).
 
-* `socketTimeoutMS` - TCP Socket timeout setting. Default: `360000`.
+-   `sslPass` - String or buffer containing the certificate password (needs to have a mongod server with ssl support,
+    2.4 or higher).
 
-* `reconnectTries` - Server attempt to reconnect #times. Default: `30`.
+-   `autoReconnect` - Reconnect on error. Default: `true`.
 
-* `reconnectInterval` - Server will wait #milliseconds between retries. Default: `1000`.
+-   `noDelay` - TCP Socket NoDelay option. Default: `true`.
 
-* `ha` - Turn on high availability monitoring. Default: `true`.
+-   `keepAlive` - The number of milliseconds to wait before initiating keepAlive on the TCP socket. Default: `30000`.
 
-* `haInterval` - Time between each replicaset status check. Default: `10000,5000`.
+-   `connectTimeoutMS` - TCP Connection timeout setting. Default: `30000`.
 
-* `replicaSet` - The name of the replicaset to connect to.
- 
-* `acceptableLatencyMS` - Sets the range of servers to pick when using NEAREST (lowest ping ms + the latency fence,
- ex: range of 1 to (1 + 15) ms). Default: `15`.
+-   `socketTimeoutMS` - TCP Socket timeout setting. Default: `360000`.
 
-* `secondaryAcceptableLatencyMS` - Sets the range of servers to pick when using NEAREST (lowest ping ms + the latency
- fence, ex: range of 1 to (1 + 15) ms). Default: `15`.
- 
-* `connectWithNoPrimary` - Sets if the driver should connect even if no primary is available. Default: `false`.
+-   `reconnectTries` - Server attempt to reconnect #times. Default: `30`.
 
-* `authSource` - If the database authentication is dependent on another databaseName.
+-   `reconnectInterval` - Server will wait #milliseconds between retries. Default: `1000`.
 
-* `w` - The write concern.
+-   `ha` - Turn on high availability monitoring. Default: `true`.
 
-* `wtimeout` - The write concern timeout value.
+-   `haInterval` - Time between each replicaset status check. Default: `10000,5000`.
 
-* `j` - Specify a journal write concern. Default: `false`.
+-   `replicaSet` - The name of the replicaset to connect to.
 
-* `forceServerObjectId` - Force server to assign _id values instead of driver. Default: `false`.
+-   `acceptableLatencyMS` - Sets the range of servers to pick when using NEAREST (lowest ping ms + the latency fence,
+    ex: range of 1 to (1 + 15) ms). Default: `15`.
 
-* `serializeFunctions` - Serialize functions on any object. Default: `false`.
+-   `secondaryAcceptableLatencyMS` - Sets the range of servers to pick when using NEAREST (lowest ping ms + the latency
+    fence, ex: range of 1 to (1 + 15) ms). Default: `15`.
 
-* `ignoreUndefined` - Specify if the BSON serializer should ignore undefined fields. Default: `false`.
+-   `connectWithNoPrimary` - Sets if the driver should connect even if no primary is available. Default: `false`.
 
-* `raw` - Return document results as raw BSON buffers. Default: `false`.
+-   `authSource` - If the database authentication is dependent on another databaseName.
 
-* `promoteLongs` - Promotes Long values to number if they fit inside the 53 bits resolution. Default: `true`.
+-   `w` - The write concern.
 
-* `promoteBuffers` - Promotes Binary BSON values to native Node Buffers. Default: `false`.
+-   `wtimeout` - The write concern timeout value.
 
-* `promoteValues` - Promotes BSON values to native types where possible, set to false to only receive wrapper types.
- Default: `true`.
- 
-* `domainsEnabled` - Enable the wrapping of the callback in the current domain, disabled by default to avoid perf hit.
- Default: `false`.
- 
-* `bufferMaxEntries` - Sets a cap on how many operations the driver will buffer up before giving up on getting a
- working connection, default is -1 which is unlimited.
- 
-* `readPreference` - The preferred read preference.
-  * `ReadPreference.PRIMARY`
-  * `ReadPreference.PRIMARY_PREFERRED`
-  * `ReadPreference.SECONDARY`
-  * `ReadPreference.SECONDARY_PREFERRED`
-  * `ReadPreference.NEAREST`
-  
-* `pkFactory` - A primary key factory object for generation of custom _id keys.
+-   `j` - Specify a journal write concern. Default: `false`.
 
-* `promiseLibrary` - A Promise library class the application wishes to use such as Bluebird, must be ES6 compatible.
+-   `forceServerObjectId` - Force server to assign \_id values instead of driver. Default: `false`.
 
-* `readConcern` - Specify a read concern for the collection. (only MongoDB 3.2 or higher supported).
+-   `serializeFunctions` - Serialize functions on any object. Default: `false`.
 
-* `maxStalenessSeconds` - Specify a maxStalenessSeconds value for secondary reads, minimum is 90 seconds.
+-   `ignoreUndefined` - Specify if the BSON serializer should ignore undefined fields. Default: `false`.
 
-* `appname` - The name of the application that created this MongoClient instance. MongoDB 3.4 and newer will print this
- value in the server log upon establishing each connection. It is also recorded in the slow query log and profile
- collections
- 
-* `loggerLevel` - Specify the log level used by the driver logger (`error/warn/info/debug`).
+-   `raw` - Return document results as raw BSON buffers. Default: `false`.
 
-* `logger` - Specify a customer logger mechanism, can be used to log using your app level logger.
+-   `promoteLongs` - Promotes Long values to number if they fit inside the 53 bits resolution. Default: `true`.
 
-* `authMechanism` - Sets the authentication mechanism that MongoDB will use to authenticate the connection.
+-   `promoteBuffers` - Promotes Binary BSON values to native Node Buffers. Default: `false`.
+
+-   `promoteValues` - Promotes BSON values to native types where possible, set to false to only receive wrapper types.
+    Default: `true`.
+
+-   `domainsEnabled` - Enable the wrapping of the callback in the current domain, disabled by default to avoid perf hit.
+    Default: `false`.
+
+-   `bufferMaxEntries` - Sets a cap on how many operations the driver will buffer up before giving up on getting a
+    working connection, default is -1 which is unlimited.
+
+-   `readPreference` - The preferred read preference.
+    -   `ReadPreference.PRIMARY`
+    -   `ReadPreference.PRIMARY_PREFERRED`
+    -   `ReadPreference.SECONDARY`
+    -   `ReadPreference.SECONDARY_PREFERRED`
+    -   `ReadPreference.NEAREST`
+-   `pkFactory` - A primary key factory object for generation of custom \_id keys.
+
+-   `promiseLibrary` - A Promise library class the application wishes to use such as Bluebird, must be ES6 compatible.
+
+-   `readConcern` - Specify a read concern for the collection. (only MongoDB 3.2 or higher supported).
+
+-   `maxStalenessSeconds` - Specify a maxStalenessSeconds value for secondary reads, minimum is 90 seconds.
+
+-   `appname` - The name of the application that created this MongoClient instance. MongoDB 3.4 and newer will print this
+    value in the server log upon establishing each connection. It is also recorded in the slow query log and profile
+    collections
+
+-   `loggerLevel` - Specify the log level used by the driver logger (`error/warn/info/debug`).
+
+-   `logger` - Specify a customer logger mechanism, can be used to log using your app level logger.
+
+-   `authMechanism` - Sets the authentication mechanism that MongoDB will use to authenticate the connection.
 
 ## `sql.js` connection options
 
-* `database`: The raw UInt8Array database that should be imported.
+-   `database`: The raw UInt8Array database that should be imported.
 
-* `sqlJsConfig`: Optional initialize config for sql.js.
+-   `sqlJsConfig`: Optional initialize config for sql.js.
 
-* `autoSave`: Whether or not autoSave should be disabled. If set to true the database will be saved to the given file location (Node.js) or LocalStorage element (browser) when a change happens and `location` is specified. Otherwise `autoSaveCallback` can be used.
+-   `autoSave`: Whether or not autoSave should be disabled. If set to true the database will be saved to the given file location (Node.js) or LocalStorage element (browser) when a change happens and `location` is specified. Otherwise `autoSaveCallback` can be used.
 
-* `autoSaveCallback`: A function that get's called when changes to the database are made and `autoSave` is enabled. The function gets a `UInt8Array` that represents the database.
+-   `autoSaveCallback`: A function that get's called when changes to the database are made and `autoSave` is enabled. The function gets a `UInt8Array` that represents the database.
 
-* `location`: The file location to load and save the database to.
+-   `location`: The file location to load and save the database to.
 
-* `useLocalForage`: Enables the usage of the localforage library (https://github.com/localForage/localForage) to save & load the database asynchronously from the indexedDB instead of using the synchron local storage methods in a browser environment. The localforage node module needs to be added to your project and the localforage.js should be imported in your page.
+-   `useLocalForage`: Enables the usage of the localforage library (https://github.com/localForage/localForage) to save & load the database asynchronously from the indexedDB instead of using the synchron local storage methods in a browser environment. The localforage node module needs to be added to your project and the localforage.js should be imported in your page.
 
 ## `expo` connection options
 
-* `database` - Name of the database. For example, "mydb".
-* `driver` - The Expo SQLite module. For example, `require('expo-sqlite')`.
+-   `database` - Name of the database. For example, "mydb".
+-   `driver` - The Expo SQLite module. For example, `require('expo-sqlite')`.
 
 ## Connection options example
 

--- a/docs/connection-options.md
+++ b/docs/connection-options.md
@@ -186,6 +186,7 @@ See [SSL options](https://github.com/mysqljs/mysql#ssl-options).
 * `logNotifications` - A boolean to determine whether postgres server [notice messages](https://www.postgresql.org/docs/current/plpgsql-errors-and-messages.html) and [notification events](https://www.postgresql.org/docs/current/sql-notify.html) should be included in client's logs with `info` level (default: `false`).
 
 * `installExtensions` - A boolean to control whether to install necessary postgres extensions automatically or not (default: `true`)
+
 ## `sqlite` connection options
 
 * `database` - Database path. For example "./mydb.sql"

--- a/docs/connection-options.md
+++ b/docs/connection-options.md
@@ -1,510 +1,508 @@
 # Connection Options
 
--   [What is `ConnectionOptions`](#what-is-connectionoptions)
--   [Common connection options](#common-connection-options)
--   [`mysql` / `mariadb` connection options](#mysql--mariadb-connection-options)
--   [`postgres` / `cockroachdb` connection options](#postgres--cockroachdb-connection-options)
--   [`sqlite` connection options](#sqlite-connection-options)
--   [`better-sqlite3` connection options](#better-sqlite3-connection-options)
--   [`capacitor` connection options](#capacitor-connection-options)
--   [`cordova` connection options](#cordova-connection-options)
--   [`react-native` connection options](#react-native-connection-options)
--   [`nativescript` connection options](#nativescript-connection-options)
--   [`mssql` connection options](#mssql-connection-options)
--   [`mongodb` connection options](#mongodb-connection-options)
--   [`sql.js` connection options](#sqljs-connection-options)
--   [`expo` connection options](#expo-connection-options)
--   [Connection options example](#connection-options-example)
-
+* [What is `ConnectionOptions`](#what-is-connectionoptions)
+* [Common connection options](#common-connection-options)
+* [`mysql` / `mariadb` connection options](#mysql--mariadb-connection-options)
+* [`postgres` / `cockroachdb` connection options](#postgres--cockroachdb-connection-options)
+* [`sqlite` connection options](#sqlite-connection-options)
+* [`better-sqlite3` connection options](#better-sqlite3-connection-options)
+* [`capacitor` connection options](#capacitor-connection-options)
+* [`cordova` connection options](#cordova-connection-options)
+* [`react-native` connection options](#react-native-connection-options)
+* [`nativescript` connection options](#nativescript-connection-options)
+* [`mssql` connection options](#mssql-connection-options)
+* [`mongodb` connection options](#mongodb-connection-options)
+* [`sql.js` connection options](#sqljs-connection-options)
+* [`expo` connection options](#expo-connection-options)
+* [Connection options example](#connection-options-example)
+    
 ## What is `ConnectionOptions`
 
 Connection options is a connection configuration you pass to `createConnection`
-or define in `ormconfig` file. Different databases have their own specific connection options.
+ or define in `ormconfig` file. Different databases have their own specific connection options.
 
 ## Common connection options
 
--   `type` - Database type. You must specify what database engine you use.
-    Possible values are "mysql", "postgres", "cockroachdb", "mariadb", "sqlite", "better-sqlite3", "capacitor", "cordova",
-    "nativescript", "oracle", "mssql", "mongodb", "sqljs", "react-native".
-    This option is **required**.
+* `type` - Database type. You must specify what database engine you use.
+ Possible values are "mysql", "postgres", "cockroachdb", "mariadb", "sqlite", "better-sqlite3", "capacitor", "cordova", 
+ "nativescript", "oracle", "mssql", "mongodb", "sqljs", "react-native".
+ This option is **required**.
 
--   `name` - Connection name. You'll use it to get connection you need using `getConnection(name: string)`
-    or `ConnectionManager.get(name: string)`.
-    Connection names for different connections cannot be same - they all must be unique.
-    If connection name is not given then it will be called "default".
+* `name` - Connection name. You'll use it to get connection you need using `getConnection(name: string)` 
+or `ConnectionManager.get(name: string)`. 
+Connection names for different connections cannot be same - they all must be unique.
+If connection name is not given then it will be called "default".
 
--   `extra` - Extra connection options to be passed to the underlying driver.
-    Use it if you want to pass extra settings to underlying database driver.
+* `extra` - Extra connection options to be passed to the underlying driver. 
+Use it if you want to pass extra settings to underlying database driver.
 
--   `entities` - Entities, or Entity Schemas, to be loaded and used for this connection.
-    Accepts both entity classes, entity schema classes, and directories paths to load from.
-    Directories support glob patterns.
-    Example: `entities: [Post, Category, "entity/*.js", "modules/**/entity/*.js"]`.
-    Learn more about [Entities](./entities.md).
-    Learn more about [Entity Schemas](separating-entity-definition.md).
+* `entities` - Entities, or Entity Schemas, to be loaded and used for this connection.
+Accepts both entity classes, entity schema classes, and directories paths to load from.
+Directories support glob patterns.
+Example: `entities: [Post, Category, "entity/*.js", "modules/**/entity/*.js"]`.
+Learn more about [Entities](./entities.md). 
+Learn more about [Entity Schemas](separating-entity-definition.md).
 
--   `subscribers` - Subscribers to be loaded and used for this connection.
-    Accepts both entity classes and directories to load from.
-    Directories support glob patterns.
-    Example: `subscribers: [PostSubscriber, AppSubscriber, "subscriber/*.js", "modules/**/subscriber/*.js"]`.
-    Learn more about [Subscribers](listeners-and-subscribers.md).
+* `subscribers` - Subscribers to be loaded and used for this connection.
+Accepts both entity classes and directories to load from.
+Directories support glob patterns.
+Example: `subscribers: [PostSubscriber, AppSubscriber, "subscriber/*.js", "modules/**/subscriber/*.js"]`.
+Learn more about [Subscribers](listeners-and-subscribers.md).
 
--   `migrations` - Migrations to be loaded and used for this connection.
-    Accepts both migration classes and directories to load from.
-    Directories support glob patterns.
-    Example: `migrations: [FirstMigration, SecondMigration, "migration/*.js", "modules/**/migration/*.js"]`.
-    Learn more about [Migrations](./migrations.md).
+* `migrations` - Migrations to be loaded and used for this connection.
+Accepts both migration classes and directories to load from.
+Directories support glob patterns.
+Example: `migrations: [FirstMigration, SecondMigration, "migration/*.js", "modules/**/migration/*.js"]`.
+Learn more about [Migrations](./migrations.md).
 
--   `logging` - Indicates if logging is enabled or not.
-    If set to `true` then query and error logging will be enabled.
-    You can also specify different types of logging to be enabled, for example `["query", "error", "schema"]`.
-    Learn more about [Logging](./logging.md).
+* `logging` - Indicates if logging is enabled or not. 
+If set to `true` then query and error logging will be enabled.
+You can also specify different types of logging to be enabled, for example `["query", "error", "schema"]`.
+Learn more about [Logging](./logging.md).
 
--   `logger` - Logger to be used for logging purposes. Possible values are "advanced-console", "simple-console" and "file".
-    Default is "advanced-console". You can also specify a logger class that implements `Logger` interface.
-    Learn more about [Logging](./logging.md).
+* `logger` - Logger to be used for logging purposes. Possible values are "advanced-console", "simple-console" and "file". 
+Default is "advanced-console". You can also specify a logger class that implements `Logger` interface.
+Learn more about [Logging](./logging.md).
 
--   `maxQueryExecutionTime` - If query execution time exceed this given max execution time (in milliseconds)
-    then logger will log this query.
+* `maxQueryExecutionTime` - If query execution time exceed this given max execution time (in milliseconds)
+then logger will log this query.
 
--   `namingStrategy` - Naming strategy to be used to name tables and columns in the database.
-    Learn more about [Naming strategies](./naming-strategy.md).
+* `namingStrategy` - Naming strategy to be used to name tables and columns in the database.
+Learn more about [Naming strategies](./naming-strategy.md).
 
--   `entityPrefix` - Prefixes with the given string all tables (or collections) on this database connection.
+* `entityPrefix` - Prefixes with the given string all tables (or collections) on this database connection.
 
--   `dropSchema` - Drops the schema each time connection is being established.
-    Be careful with this option and don't use this in production - otherwise you'll lose all production data.
-    This option is useful during debug and development.
+* `dropSchema` - Drops the schema each time connection is being established.
+Be careful with this option and don't use this in production - otherwise you'll lose all production data.
+This option is useful during debug and development.
 
--   `synchronize` - Indicates if database schema should be auto created on every application launch.
-    Be careful with this option and don't use this in production - otherwise you can lose production data.
-    This option is useful during debug and development.
-    As an alternative to it, you can use CLI and run schema:sync command.
-    Note that for MongoDB database it does not create schema, because MongoDB is schemaless.
-    Instead, it syncs just by creating indices.
+* `synchronize` - Indicates if database schema should be auto created on every application launch.
+ Be careful with this option and don't use this in production - otherwise you can lose production data.
+ This option is useful during debug and development.
+ As an alternative to it, you can use CLI and run schema:sync command.
+ Note that for MongoDB database it does not create schema, because MongoDB is schemaless.
+ Instead, it syncs just by creating indices.
 
--   `migrationsRun` - Indicates if migrations should be auto run on every application launch.
-    As an alternative, you can use CLI and run migration:run command.
+* `migrationsRun` - Indicates if migrations should be auto run on every application launch.
+As an alternative, you can use CLI and run migration:run command.
 
--   `migrationsTableName` - Name of the table in the database which is going to contain information about executed migrations.
-    By default this table is called "migrations".
+* `migrationsTableName` - Name of the table in the database which is going to contain information about executed migrations.
+By default this table is called "migrations".
 
--   `cache` - Enables entity result caching. You can also configure cache type and other cache options here.
-    Read more about caching [here](./caching.md).
+* `cache` - Enables entity result caching. You can also configure cache type and other cache options here.
+Read more about caching [here](./caching.md).
 
--   `cli.entitiesDir` - Directory where entities should be created by default by CLI.
+* `cli.entitiesDir` - Directory where entities should be created by default by CLI.
 
--   `cli.migrationsDir` - Directory where migrations should be created by default by CLI.
+* `cli.migrationsDir` - Directory where migrations should be created by default by CLI.
 
--   `cli.subscribersDir` - Directory where subscribers should be created by default by CLI.
+* `cli.subscribersDir` - Directory where subscribers should be created by default by CLI.
 
 ## `mysql` / `mariadb` connection options
 
--   `url` - Connection url where perform connection to. Please note that other connection options will override parameters set from url.
+* `url` - Connection url where perform connection to. Please note that other connection options will override parameters set from url.
 
--   `host` - Database host.
+* `host` - Database host.
 
--   `port` - Database host port. Default mysql port is `3306`.
+* `port` - Database host port. Default mysql port is `3306`.
 
--   `username` - Database username.
+* `username` - Database username.
 
--   `password` - Database password.
+* `password` - Database password.
 
--   `database` - Database name.
+* `database` - Database name.
 
--   `charset` - The charset for the connection. This is called "collation" in the SQL-level of MySQL
-    (like utf8_general_ci). If a SQL-level charset is specified (like utf8mb4) then the default collation for that charset is used. (Default: `UTF8_GENERAL_CI`).
+* `charset` - The charset for the connection. This is called "collation" in the SQL-level of MySQL 
+(like utf8_general_ci). If a SQL-level charset is specified (like utf8mb4) then the default collation for that charset is used. (Default: `UTF8_GENERAL_CI`).
 
--   `timezone` - the timezone configured on the MySQL server. This is used to typecast server date/time
-    values to JavaScript Date object and vice versa. This can be `local`, `Z`, or an offset in the form
-    `+HH:MM` or `-HH:MM`. (Default: `local`)
+* `timezone` - the timezone configured on the MySQL server. This is used to typecast server date/time 
+values to JavaScript Date object and vice versa. This can be `local`, `Z`, or an offset in the form 
+`+HH:MM` or `-HH:MM`. (Default: `local`)
 
--   `connectTimeout` - The milliseconds before a timeout occurs during the initial connection to the MySQL server.
-    (Default: `10000`)
+* `connectTimeout` - The milliseconds before a timeout occurs during the initial connection to the MySQL server.
+ (Default: `10000`)
 
--   `acquireTimeout` - The milliseconds before a timeout occurs during the initial connection to the MySql server. It differs from `connectTimeout` as it governs the TCP connection timeout where as connectTimeout does not. (default: `10000`)
+* `acquireTimeout` - The milliseconds before a timeout occurs during the initial connection to the MySql server. It differs from `connectTimeout` as it governs the TCP connection timeout where as connectTimeout does not. (default: `10000`)
+ 
+* `insecureAuth` - Allow connecting to MySQL instances that ask for the old (insecure) authentication method. 
+(Default: `false`)
+ 
+* `supportBigNumbers` - When dealing with big numbers (`BIGINT` and `DECIMAL` columns) in the database, 
+you should enable this option (Default: `true`)
+ 
+* `bigNumberStrings` - Enabling both `supportBigNumbers` and `bigNumberStrings` forces big numbers 
+(`BIGINT` and `DECIMAL` columns) to be always returned as JavaScript String objects (Default: `true`). 
+Enabling `supportBigNumbers` but leaving `bigNumberStrings` disabled will return big numbers as String 
+objects only when they cannot be accurately represented with 
+[JavaScript Number objects](http://ecma262-5.com/ELS5_HTML.htm#Section_8.5) 
+(which happens when they exceed the `[-2^53, +2^53]` range), otherwise they will be returned as 
+Number objects. This option is ignored if `supportBigNumbers` is disabled.
 
--   `insecureAuth` - Allow connecting to MySQL instances that ask for the old (insecure) authentication method.
-    (Default: `false`)
+* `dateStrings` - Force date types (`TIMESTAMP`, `DATETIME`, `DATE`) to be returned as strings rather than 
+inflated into JavaScript Date objects. Can be true/false or an array of type names to keep as strings. 
+(Default: `false`)
 
--   `supportBigNumbers` - When dealing with big numbers (`BIGINT` and `DECIMAL` columns) in the database,
-    you should enable this option (Default: `true`)
+* `debug` - Prints protocol details to stdout. Can be true/false or an array of packet type names that 
+should be printed. (Default: `false`)
 
--   `bigNumberStrings` - Enabling both `supportBigNumbers` and `bigNumberStrings` forces big numbers
-    (`BIGINT` and `DECIMAL` columns) to be always returned as JavaScript String objects (Default: `true`).
-    Enabling `supportBigNumbers` but leaving `bigNumberStrings` disabled will return big numbers as String
-    objects only when they cannot be accurately represented with
-    [JavaScript Number objects](http://ecma262-5.com/ELS5_HTML.htm#Section_8.5)
-    (which happens when they exceed the `[-2^53, +2^53]` range), otherwise they will be returned as
-    Number objects. This option is ignored if `supportBigNumbers` is disabled.
+* `trace` - Generates stack traces on Error to include call site of library entrance ("long stack traces"). 
+Slight performance penalty for most calls. (Default: `true`)
 
--   `dateStrings` - Force date types (`TIMESTAMP`, `DATETIME`, `DATE`) to be returned as strings rather than
-    inflated into JavaScript Date objects. Can be true/false or an array of type names to keep as strings.
-    (Default: `false`)
+* `multipleStatements` - Allow multiple mysql statements per query. Be careful with this, it could increase the scope 
+of SQL injection attacks. (Default: `false`)
 
--   `debug` - Prints protocol details to stdout. Can be true/false or an array of packet type names that
-    should be printed. (Default: `false`)
+* `legacySpatialSupport` - Use spatial functions like GeomFromText and AsText which are removed in MySQL 8. (Default: true)
 
--   `trace` - Generates stack traces on Error to include call site of library entrance ("long stack traces").
-    Slight performance penalty for most calls. (Default: `true`)
-
--   `multipleStatements` - Allow multiple mysql statements per query. Be careful with this, it could increase the scope
-    of SQL injection attacks. (Default: `false`)
-
--   `legacySpatialSupport` - Use spatial functions like GeomFromText and AsText which are removed in MySQL 8. (Default: true)
-
--   `flags` - List of connection flags to use other than the default ones. It is also possible to blacklist default ones.
-    For more information, check [Connection Flags](https://github.com/mysqljs/mysql#connection-flags).
-
--   `ssl` - object with ssl parameters or a string containing the name of ssl profile.
-    See [SSL options](https://github.com/mysqljs/mysql#ssl-options).
+* `flags` - List of connection flags to use other than the default ones. It is also possible to blacklist default ones.
+ For more information, check [Connection Flags](https://github.com/mysqljs/mysql#connection-flags).
+ 
+* `ssl` -  object with ssl parameters or a string containing the name of ssl profile. 
+See [SSL options](https://github.com/mysqljs/mysql#ssl-options).
 
 ## `postgres` / `cockroachdb` connection options
 
--   `url` - Connection url where perform connection to. Please note that other connection options will override parameters set from url.
+* `url` - Connection url where perform connection to. Please note that other connection options will override parameters set from url.
 
--   `host` - Database host.
+* `host` - Database host.
 
--   `port` - Database host port. Default postgres port is `5432`.
+* `port` - Database host port. Default postgres port is `5432`.
 
--   `username` - Database username.
+* `username` - Database username.
 
--   `password` - Database password.
+* `password` - Database password.
 
--   `database` - Database name.
+* `database` - Database name.
 
--   `schema` - Schema name. Default is "public".
+* `schema` - Schema name. Default is "public".
 
--   `connectTimeoutMS` - The milliseconds before a timeout occurs during the initial connection to the postgres server. If `undefined`, or set to `0`, there is no timeout. Defaults to `undefined`.
+* `connectTimeoutMS` - The milliseconds before a timeout occurs during the initial connection to the postgres server. If `undefined`, or set to `0`, there is no timeout. Defaults to `undefined`. 
 
--   `ssl` - Object with ssl parameters. See [TLS/SSL](https://node-postgres.com/features/ssl).
+* `ssl` - Object with ssl parameters. See [TLS/SSL](https://node-postgres.com/features/ssl).
 
--   `uuidExtension` - The Postgres extension to use when generating UUIDs. Defaults to `uuid-ossp`. Can be changed to `pgcrypto` if the `uuid-ossp` extension is unavailable.
+* `uuidExtension` - The Postgres extension to use when generating UUIDs. Defaults to `uuid-ossp`. Can be changed to `pgcrypto` if the `uuid-ossp` extension is unavailable.
 
--   `poolErrorHandler` - A function that get's called when underlying pool emits `'error'` event. Takes single parameter (error instance) and defaults to logging with `warn` level.
+* `poolErrorHandler` - A function that get's called when underlying pool emits `'error'` event. Takes single parameter (error instance) and defaults to logging with `warn` level.
 
--   `logNotifications` - A boolean to determine whether postgres server [notice messages](https://www.postgresql.org/docs/current/plpgsql-errors-and-messages.html) and [notification events](https://www.postgresql.org/docs/current/sql-notify.html) should be included in client's logs with `info` level (default: `false`).
+* `logNotifications` - A boolean to determine whether postgres server [notice messages](https://www.postgresql.org/docs/current/plpgsql-errors-and-messages.html) and [notification events](https://www.postgresql.org/docs/current/sql-notify.html) should be included in client's logs with `info` level (default: `false`).
 
--   `installExtensions` - A boolean to control whether to install necessary postgres extensions automatically or not (default: `true`)
-
+* `installExtensions` - A boolean to control whether to install necessary postgres extensions automatically or not (default: `true`)
 ## `sqlite` connection options
 
--   `database` - Database path. For example "./mydb.sql"
+* `database` - Database path. For example "./mydb.sql"
 
 ## `better-sqlite3` connection options
 
--   `database` - Database path. For example "./mydb.sql"
+* `database` - Database path. For example "./mydb.sql"
 
--   `statementCacheSize` - Cache size of sqlite statement to speed up queries (default 100).
+* `statementCacheSize` - Cache size of sqlite statement to speed up queries (default 100).
 
--   `prepareDatabase` - Function to run before a database is used in typeorm. You can access original better-sqlite3 Database object here.
+* `prepareDatabase` - Function to run before a database is used in typeorm. You can access original better-sqlite3 Database object here.
 
 ## `capacitor` connection options
 
--   `database` - Database name (capacitor-sqlite will add the suffix `SQLite.db`)
+* `database` - Database name (capacitor-sqlite will add the suffix `SQLite.db`)
 
--   `driver` - The capacitor-sqlite instance. For example, `new SQLiteConnection(CapacitorSQLite)`.
+* `driver` - The capacitor-sqlite instance. For example, `new SQLiteConnection(CapacitorSQLite)`.
 
 ## `cordova` connection options
 
--   `database` - Database name
+* `database` - Database name
 
--   `location` - Where to save the database. See [cordova-sqlite-storage](https://github.com/litehelpers/Cordova-sqlite-storage#opening-a-database) for options.
+* `location` - Where to save the database. See [cordova-sqlite-storage](https://github.com/litehelpers/Cordova-sqlite-storage#opening-a-database) for options.
 
 ## `react-native` connection options
+* `database` - Database name
 
--   `database` - Database name
-
--   `location` - Where to save the database. See [react-native-sqlite-storage](https://github.com/andpor/react-native-sqlite-storage#opening-a-database) for options.
+* `location` - Where to save the database. See [react-native-sqlite-storage](https://github.com/andpor/react-native-sqlite-storage#opening-a-database) for options.
 
 ## `nativescript` connection options
-
--   `database` - Database name
+* `database` - Database name
 
 ## `mssql` connection options
 
--   `url` - Connection url where perform connection to. Please note that other connection options will override parameters set from url.
+* `url` - Connection url where perform connection to. Please note that other connection options will override parameters set from url.
 
--   `host` - Database host.
+* `host` - Database host.
 
--   `port` - Database host port. Default mssql port is `1433`.
+* `port` - Database host port. Default mssql port is `1433`.
 
--   `username` - Database username.
+* `username` - Database username.
 
--   `password` - Database password.
+* `password` - Database password.
 
--   `database` - Database name.
+* `database` - Database name.
 
--   `schema` - Schema name. Default is "public".
+* `schema` - Schema name. Default is "public".
 
--   `domain` - Once you set domain, the driver will connect to SQL Server using domain login.
+* `domain` - Once you set domain, the driver will connect to SQL Server using domain login.
 
--   `connectionTimeout` - Connection timeout in ms (default: `15000`).
+* `connectionTimeout` - Connection timeout in ms (default: `15000`).
 
--   `requestTimeout` - Request timeout in ms (default: `15000`). NOTE: msnodesqlv8 driver doesn't support
-    timeouts < 1 second.
+* `requestTimeout` - Request timeout in ms (default: `15000`). NOTE: msnodesqlv8 driver doesn't support
+ timeouts < 1 second.
 
--   `stream` - Stream recordsets/rows instead of returning them all at once as an argument of callback (default: `false`).
-    You can also enable streaming for each request independently (`request.stream = true`). Always set to `true` if you plan to
-    work with a large amount of rows.
+* `stream` - Stream recordsets/rows instead of returning them all at once as an argument of callback (default: `false`).
+ You can also enable streaming for each request independently (`request.stream = true`). Always set to `true` if you plan to
+ work with a large amount of rows.
+ 
+* `pool.max` - The maximum number of connections there can be in the pool (default: `10`).
 
--   `pool.max` - The maximum number of connections there can be in the pool (default: `10`).
+* `pool.min` - The minimum of connections there can be in the pool (default: `0`).
 
--   `pool.min` - The minimum of connections there can be in the pool (default: `0`).
+* `pool.maxWaitingClients` - maximum number of queued requests allowed, additional acquire calls will be callback with
+ an err in a future cycle of the event loop.
+ 
+* `pool.testOnBorrow` -  should the pool validate resources before giving them to clients. Requires that either
+  `factory.validate` or `factory.validateAsync` to be specified.
+  
+* `pool.acquireTimeoutMillis` - max milliseconds an `acquire` call will wait for a resource before timing out.
+ (default no limit), if supplied should non-zero positive integer.
+ 
+* `pool.fifo` - if true the oldest resources will be first to be allocated. If false the most recently released resources
+ will be the first to be allocated. This in effect turns the pool's behaviour from a queue into a stack. boolean,
+ (default `true`).
+ 
+* `pool.priorityRange` - int between 1 and x - if set, borrowers can specify their relative priority in the queue if no
+ resources are available. see example. (default `1`).
+ 
+* `pool.autostart` - boolean, should the pool start creating resources etc once the constructor is called, (default `true`).
 
--   `pool.maxWaitingClients` - maximum number of queued requests allowed, additional acquire calls will be callback with
-    an err in a future cycle of the event loop.
+* `pool.evictionRunIntervalMillis` - How often to run eviction checks. Default: `0` (does not run).
 
--   `pool.testOnBorrow` - should the pool validate resources before giving them to clients. Requires that either
-    `factory.validate` or `factory.validateAsync` to be specified.
--   `pool.acquireTimeoutMillis` - max milliseconds an `acquire` call will wait for a resource before timing out.
-    (default no limit), if supplied should non-zero positive integer.
+* `pool.numTestsPerRun` - Number of resources to check each eviction run. Default: `3`.
 
--   `pool.fifo` - if true the oldest resources will be first to be allocated. If false the most recently released resources
-    will be the first to be allocated. This in effect turns the pool's behaviour from a queue into a stack. boolean,
-    (default `true`).
+* `pool.softIdleTimeoutMillis` - amount of time an object may sit idle in the pool before it is eligible for eviction by
+ the idle object evictor (if any), with the extra condition that at least "min idle" object instances remain in the pool.
+ Default `-1` (nothing can get evicted).
+ 
+* `pool.idleTimeoutMillis` -  the minimum amount of time that an object may sit idle in the pool before it is eligible for
+ eviction due to idle time. Supersedes `softIdleTimeoutMillis`. Default: `30000`.
+ 
+ * `pool.errorHandler` - A function that get's called when underlying pool emits `'error'` event. Takes single parameter (error instance) and defaults to logging with `warn` level.
+ 
+* `options.fallbackToDefaultDb` - By default, if the database requestion by `options.database` cannot be accessed, the connection
+ will fail with an error. However, if `options.fallbackToDefaultDb` is set to `true`, then the user's default database will
+  be used instead (Default: `false`).
+  
+* `options.instanceName` - The instance name to connect to. The SQL Server Browser service must be running on the database server, and UDP port 1434 on the database server must be reachable. Mutually exclusive with `port`. (no default).
 
--   `pool.priorityRange` - int between 1 and x - if set, borrowers can specify their relative priority in the queue if no
-    resources are available. see example. (default `1`).
+* `options.enableAnsiNullDefault` - If true, SET ANSI_NULL_DFLT_ON ON will be set in the initial sql. This means new
+ columns will be nullable by default. See the [T-SQL documentation](https://msdn.microsoft.com/en-us/library/ms187375.aspx)
+ for more details. (Default: `true`).
+ 
+* `options.cancelTimeout` - The number of milliseconds before the cancel (abort) of a request is considered failed (default: `5000`).
 
--   `pool.autostart` - boolean, should the pool start creating resources etc once the constructor is called, (default `true`).
+* `options.packetSize` - The size of TDS packets (subject to negotiation with the server). Should be a power of 2. (default: `4096`).
 
--   `pool.evictionRunIntervalMillis` - How often to run eviction checks. Default: `0` (does not run).
+* `options.useUTC` - A boolean determining whether to pass time values in UTC or local time. (default: `true`).
 
--   `pool.numTestsPerRun` - Number of resources to check each eviction run. Default: `3`.
+* `options.abortTransactionOnError` - A boolean determining whether to rollback a transaction automatically if any
+ error is encountered during the given transaction's execution. This sets the value for `SET XACT_ABORT` during the
+ initial SQL phase of a connection ([documentation](http://msdn.microsoft.com/en-us/library/ms188792.aspx)).
 
--   `pool.softIdleTimeoutMillis` - amount of time an object may sit idle in the pool before it is eligible for eviction by
-    the idle object evictor (if any), with the extra condition that at least "min idle" object instances remain in the pool.
-    Default `-1` (nothing can get evicted).
+* `options.localAddress` - A string indicating which network interface (ip address) to use when connecting to SQL Server.
 
--   `pool.idleTimeoutMillis` - the minimum amount of time that an object may sit idle in the pool before it is eligible for
-    eviction due to idle time. Supersedes `softIdleTimeoutMillis`. Default: `30000`.
+* `options.useColumnNames` - A boolean determining whether to return rows as arrays or key-value collections. (default: `false`).
 
--   `pool.errorHandler` - A function that get's called when underlying pool emits `'error'` event. Takes single parameter (error instance) and defaults to logging with `warn` level.
+* `options.camelCaseColumns` - A boolean, controlling whether the column names returned will have the first letter
+ converted to lower case (`true`) or not. This value is ignored if you provide a `columnNameReplacer`. (default: `false`).
 
--   `options.fallbackToDefaultDb` - By default, if the database requestion by `options.database` cannot be accessed, the connection
-    will fail with an error. However, if `options.fallbackToDefaultDb` is set to `true`, then the user's default database will
-    be used instead (Default: `false`).
--   `options.instanceName` - The instance name to connect to. The SQL Server Browser service must be running on the database server, and UDP port 1434 on the database server must be reachable. Mutually exclusive with `port`. (no default).
+* `options.isolationLevel` - The default isolation level that transactions will be run with. The isolation levels are
+ available from `require('tedious').ISOLATION_LEVEL`.
+   * `READ_UNCOMMITTED`
+   * `READ_COMMITTED`
+   * `REPEATABLE_READ`
+   * `SERIALIZABLE`
+   * `SNAPSHOT`
+   
+   (default: `READ_COMMITTED`)
+ 
+* `options.connectionIsolationLevel` - The default isolation level for new connections. All out-of-transaction queries
+ are executed with this setting. The isolation levels are available from `require('tedious').ISOLATION_LEVEL`.
+   * `READ_UNCOMMITTED`
+   * `READ_COMMITTED`
+   * `REPEATABLE_READ`
+   * `SERIALIZABLE`
+   * `SNAPSHOT`
+   
+   (default: `READ_COMMITTED`)
+ 
+* `options.readOnlyIntent` - A boolean, determining whether the connection will request read-only access from a
+ SQL Server Availability Group. For more information, see here. (default: `false`).
 
--   `options.enableAnsiNullDefault` - If true, SET ANSI_NULL_DFLT_ON ON will be set in the initial sql. This means new
-    columns will be nullable by default. See the [T-SQL documentation](https://msdn.microsoft.com/en-us/library/ms187375.aspx)
-    for more details. (Default: `true`).
+* `options.encrypt` - A boolean determining whether or not the connection will be encrypted. Set to true if you're
+ on Windows Azure. (default: `false`).
+ 
+* `options.cryptoCredentialsDetails` - When encryption is used, an object may be supplied that will be used for the
+ first argument when calling [tls.createSecurePair](http://nodejs.org/docs/latest/api/tls.html#tls_tls_createsecurepair_credentials_isserver_requestcert_rejectunauthorized)
+  (default: `{}`).
+  
+* `options.rowCollectionOnDone` - A boolean, that when true will expose received rows in Requests' `done*` events.
+ See done, [doneInProc](http://tediousjs.github.io/tedious/api-request.html#event_doneInProc)
+ and [doneProc](http://tediousjs.github.io/tedious/api-request.html#event_doneProc). (default: `false`)
+   
+   Caution: If many rows are received, enabling this option could result in excessive memory usage.
 
--   `options.cancelTimeout` - The number of milliseconds before the cancel (abort) of a request is considered failed (default: `5000`).
+* `options.rowCollectionOnRequestCompletion` - A boolean, that when true will expose received rows
+ in Requests' completion callback. See [new Request](http://tediousjs.github.io/tedious/api-request.html#function_newRequest). (default: `false`)
 
--   `options.packetSize` - The size of TDS packets (subject to negotiation with the server). Should be a power of 2. (default: `4096`).
+   Caution: If many rows are received, enabling this option could result in excessive memory usage.
 
--   `options.useUTC` - A boolean determining whether to pass time values in UTC or local time. (default: `true`).
+* `options.tdsVersion` - The version of TDS to use. If the server doesn't support the specified version, a negotiated version
+ is used instead. The versions are available from `require('tedious').TDS_VERSION`.
+   * `7_1`
+   * `7_2`
+   * `7_3_A`
+   * `7_3_B`
+   * `7_4`
+   
+  (default: `7_4`)
 
--   `options.abortTransactionOnError` - A boolean determining whether to rollback a transaction automatically if any
-    error is encountered during the given transaction's execution. This sets the value for `SET XACT_ABORT` during the
-    initial SQL phase of a connection ([documentation](http://msdn.microsoft.com/en-us/library/ms188792.aspx)).
-
--   `options.localAddress` - A string indicating which network interface (ip address) to use when connecting to SQL Server.
-
--   `options.useColumnNames` - A boolean determining whether to return rows as arrays or key-value collections. (default: `false`).
-
--   `options.camelCaseColumns` - A boolean, controlling whether the column names returned will have the first letter
-    converted to lower case (`true`) or not. This value is ignored if you provide a `columnNameReplacer`. (default: `false`).
-
--   `options.isolationLevel` - The default isolation level that transactions will be run with. The isolation levels are
-    available from `require('tedious').ISOLATION_LEVEL`.
-
-    -   `READ_UNCOMMITTED`
-    -   `READ_COMMITTED`
-    -   `REPEATABLE_READ`
-    -   `SERIALIZABLE`
-    -   `SNAPSHOT`
-
-    (default: `READ_COMMITTED`)
-
--   `options.connectionIsolationLevel` - The default isolation level for new connections. All out-of-transaction queries
-    are executed with this setting. The isolation levels are available from `require('tedious').ISOLATION_LEVEL`.
-
-    -   `READ_UNCOMMITTED`
-    -   `READ_COMMITTED`
-    -   `REPEATABLE_READ`
-    -   `SERIALIZABLE`
-    -   `SNAPSHOT`
-
-    (default: `READ_COMMITTED`)
-
--   `options.readOnlyIntent` - A boolean, determining whether the connection will request read-only access from a
-    SQL Server Availability Group. For more information, see here. (default: `false`).
-
--   `options.encrypt` - A boolean determining whether or not the connection will be encrypted. Set to true if you're
-    on Windows Azure. (default: `false`).
-
--   `options.cryptoCredentialsDetails` - When encryption is used, an object may be supplied that will be used for the
-    first argument when calling [tls.createSecurePair](http://nodejs.org/docs/latest/api/tls.html#tls_tls_createsecurepair_credentials_isserver_requestcert_rejectunauthorized)
-    (default: `{}`).
--   `options.rowCollectionOnDone` - A boolean, that when true will expose received rows in Requests' `done*` events.
-    See done, [doneInProc](http://tediousjs.github.io/tedious/api-request.html#event_doneInProc)
-    and [doneProc](http://tediousjs.github.io/tedious/api-request.html#event_doneProc). (default: `false`)
-
-    Caution: If many rows are received, enabling this option could result in excessive memory usage.
-
--   `options.rowCollectionOnRequestCompletion` - A boolean, that when true will expose received rows
-    in Requests' completion callback. See [new Request](http://tediousjs.github.io/tedious/api-request.html#function_newRequest). (default: `false`)
-
-    Caution: If many rows are received, enabling this option could result in excessive memory usage.
-
--   `options.tdsVersion` - The version of TDS to use. If the server doesn't support the specified version, a negotiated version
-    is used instead. The versions are available from `require('tedious').TDS_VERSION`.
-
-    -   `7_1`
-    -   `7_2`
-    -   `7_3_A`
-    -   `7_3_B`
-    -   `7_4`
-
-    (default: `7_4`)
-
--   `options.debug.packet` - A boolean, controlling whether `debug` events will be emitted with text describing packet
-    details (default: `false`).
-
--   `options.debug.data` - A boolean, controlling whether `debug` events will be emitted with text describing packet data
-    details (default: `false`).
-
--   `options.debug.payload` - A boolean, controlling whether `debug` events will be emitted with text describing packet
-    payload details (default: `false`).
-
--   `options.debug.token` - A boolean, controlling whether `debug` events will be emitted with text describing token stream
-    tokens (default: `false`).
+* `options.debug.packet` - A boolean, controlling whether `debug` events will be emitted with text describing packet
+ details (default: `false`).
+ 
+* `options.debug.data` - A boolean, controlling whether `debug` events will be emitted with text describing packet data
+ details (default: `false`).
+ 
+* `options.debug.payload` - A boolean, controlling whether `debug` events will be emitted with text describing packet
+ payload details (default: `false`).
+ 
+* `options.debug.token` - A boolean, controlling whether `debug` events will be emitted with text describing token stream
+ tokens (default: `false`).
 
 ## `mongodb` connection options
 
--   `url` - Connection url where perform connection to. Please note that other connection options will override parameters set from url.
+* `url` - Connection url where perform connection to. Please note that other connection options will override parameters set from url.
 
--   `host` - Database host.
+* `host` - Database host.
 
--   `port` - Database host port. Default mongodb port is `27017`.
+* `port` - Database host port. Default mongodb port is `27017`.
 
--   `username` - Database username (replacement for `auth.user`).
+* `username` - Database username (replacement for `auth.user`).
 
--   `password` - Database password (replacement for `auth.password`).
+* `password` - Database password (replacement for `auth.password`).
 
--   `database` - Database name.
+* `database` - Database name.
 
--   `poolSize` - Set the maximum pool size for each individual server or proxy connection.
+* `poolSize` - Set the maximum pool size for each individual server or proxy connection.
 
--   `ssl` - Use ssl connection (needs to have a mongod server with ssl support). Default: `false`.
+* `ssl` - Use ssl connection (needs to have a mongod server with ssl support). Default: `false`.
 
--   `sslValidate` - Validate mongod server certificate against ca (needs to have a mongod server with ssl support,
-    2.4 or higher). Default: `true`.
+* `sslValidate` - Validate mongod server certificate against ca (needs to have a mongod server with ssl support,
+ 2.4 or higher). Default: `true`.
+ 
+* `sslCA` - Array of valid certificates either as Buffers or Strings (needs to have a mongod server with ssl support,
+ 2.4 or higher).
+ 
+* `sslCert` - String or buffer containing the certificate we wish to present (needs to have a mongod server with ssl
+ support, 2.4 or higher)
+ 
+* `sslKey` - String or buffer containing the certificate private key we wish to present (needs to have a mongod server
+ with ssl support, 2.4 or higher).
+ 
+* `sslPass` - String or buffer containing the certificate password (needs to have a mongod server with ssl support,
+ 2.4 or higher).
+ 
+* `autoReconnect` - Reconnect on error. Default: `true`.
 
--   `sslCA` - Array of valid certificates either as Buffers or Strings (needs to have a mongod server with ssl support,
-    2.4 or higher).
+* `noDelay` - TCP Socket NoDelay option. Default: `true`.
 
--   `sslCert` - String or buffer containing the certificate we wish to present (needs to have a mongod server with ssl
-    support, 2.4 or higher)
+* `keepAlive` - The number of milliseconds to wait before initiating keepAlive on the TCP socket. Default: `30000`.
 
--   `sslKey` - String or buffer containing the certificate private key we wish to present (needs to have a mongod server
-    with ssl support, 2.4 or higher).
+* `connectTimeoutMS` - TCP Connection timeout setting. Default: `30000`.
 
--   `sslPass` - String or buffer containing the certificate password (needs to have a mongod server with ssl support,
-    2.4 or higher).
+* `socketTimeoutMS` - TCP Socket timeout setting. Default: `360000`.
 
--   `autoReconnect` - Reconnect on error. Default: `true`.
+* `reconnectTries` - Server attempt to reconnect #times. Default: `30`.
 
--   `noDelay` - TCP Socket NoDelay option. Default: `true`.
+* `reconnectInterval` - Server will wait #milliseconds between retries. Default: `1000`.
 
--   `keepAlive` - The number of milliseconds to wait before initiating keepAlive on the TCP socket. Default: `30000`.
+* `ha` - Turn on high availability monitoring. Default: `true`.
 
--   `connectTimeoutMS` - TCP Connection timeout setting. Default: `30000`.
+* `haInterval` - Time between each replicaset status check. Default: `10000,5000`.
 
--   `socketTimeoutMS` - TCP Socket timeout setting. Default: `360000`.
+* `replicaSet` - The name of the replicaset to connect to.
+ 
+* `acceptableLatencyMS` - Sets the range of servers to pick when using NEAREST (lowest ping ms + the latency fence,
+ ex: range of 1 to (1 + 15) ms). Default: `15`.
 
--   `reconnectTries` - Server attempt to reconnect #times. Default: `30`.
+* `secondaryAcceptableLatencyMS` - Sets the range of servers to pick when using NEAREST (lowest ping ms + the latency
+ fence, ex: range of 1 to (1 + 15) ms). Default: `15`.
+ 
+* `connectWithNoPrimary` - Sets if the driver should connect even if no primary is available. Default: `false`.
 
--   `reconnectInterval` - Server will wait #milliseconds between retries. Default: `1000`.
+* `authSource` - If the database authentication is dependent on another databaseName.
 
--   `ha` - Turn on high availability monitoring. Default: `true`.
+* `w` - The write concern.
 
--   `haInterval` - Time between each replicaset status check. Default: `10000,5000`.
+* `wtimeout` - The write concern timeout value.
 
--   `replicaSet` - The name of the replicaset to connect to.
+* `j` - Specify a journal write concern. Default: `false`.
 
--   `acceptableLatencyMS` - Sets the range of servers to pick when using NEAREST (lowest ping ms + the latency fence,
-    ex: range of 1 to (1 + 15) ms). Default: `15`.
+* `forceServerObjectId` - Force server to assign _id values instead of driver. Default: `false`.
 
--   `secondaryAcceptableLatencyMS` - Sets the range of servers to pick when using NEAREST (lowest ping ms + the latency
-    fence, ex: range of 1 to (1 + 15) ms). Default: `15`.
+* `serializeFunctions` - Serialize functions on any object. Default: `false`.
 
--   `connectWithNoPrimary` - Sets if the driver should connect even if no primary is available. Default: `false`.
+* `ignoreUndefined` - Specify if the BSON serializer should ignore undefined fields. Default: `false`.
 
--   `authSource` - If the database authentication is dependent on another databaseName.
+* `raw` - Return document results as raw BSON buffers. Default: `false`.
 
--   `w` - The write concern.
+* `promoteLongs` - Promotes Long values to number if they fit inside the 53 bits resolution. Default: `true`.
 
--   `wtimeout` - The write concern timeout value.
+* `promoteBuffers` - Promotes Binary BSON values to native Node Buffers. Default: `false`.
 
--   `j` - Specify a journal write concern. Default: `false`.
+* `promoteValues` - Promotes BSON values to native types where possible, set to false to only receive wrapper types.
+ Default: `true`.
+ 
+* `domainsEnabled` - Enable the wrapping of the callback in the current domain, disabled by default to avoid perf hit.
+ Default: `false`.
+ 
+* `bufferMaxEntries` - Sets a cap on how many operations the driver will buffer up before giving up on getting a
+ working connection, default is -1 which is unlimited.
+ 
+* `readPreference` - The preferred read preference.
+  * `ReadPreference.PRIMARY`
+  * `ReadPreference.PRIMARY_PREFERRED`
+  * `ReadPreference.SECONDARY`
+  * `ReadPreference.SECONDARY_PREFERRED`
+  * `ReadPreference.NEAREST`
+  
+* `pkFactory` - A primary key factory object for generation of custom _id keys.
 
--   `forceServerObjectId` - Force server to assign \_id values instead of driver. Default: `false`.
+* `promiseLibrary` - A Promise library class the application wishes to use such as Bluebird, must be ES6 compatible.
 
--   `serializeFunctions` - Serialize functions on any object. Default: `false`.
+* `readConcern` - Specify a read concern for the collection. (only MongoDB 3.2 or higher supported).
 
--   `ignoreUndefined` - Specify if the BSON serializer should ignore undefined fields. Default: `false`.
+* `maxStalenessSeconds` - Specify a maxStalenessSeconds value for secondary reads, minimum is 90 seconds.
 
--   `raw` - Return document results as raw BSON buffers. Default: `false`.
+* `appname` - The name of the application that created this MongoClient instance. MongoDB 3.4 and newer will print this
+ value in the server log upon establishing each connection. It is also recorded in the slow query log and profile
+ collections
+ 
+* `loggerLevel` - Specify the log level used by the driver logger (`error/warn/info/debug`).
 
--   `promoteLongs` - Promotes Long values to number if they fit inside the 53 bits resolution. Default: `true`.
+* `logger` - Specify a customer logger mechanism, can be used to log using your app level logger.
 
--   `promoteBuffers` - Promotes Binary BSON values to native Node Buffers. Default: `false`.
-
--   `promoteValues` - Promotes BSON values to native types where possible, set to false to only receive wrapper types.
-    Default: `true`.
-
--   `domainsEnabled` - Enable the wrapping of the callback in the current domain, disabled by default to avoid perf hit.
-    Default: `false`.
-
--   `bufferMaxEntries` - Sets a cap on how many operations the driver will buffer up before giving up on getting a
-    working connection, default is -1 which is unlimited.
-
--   `readPreference` - The preferred read preference.
-    -   `ReadPreference.PRIMARY`
-    -   `ReadPreference.PRIMARY_PREFERRED`
-    -   `ReadPreference.SECONDARY`
-    -   `ReadPreference.SECONDARY_PREFERRED`
-    -   `ReadPreference.NEAREST`
--   `pkFactory` - A primary key factory object for generation of custom \_id keys.
-
--   `promiseLibrary` - A Promise library class the application wishes to use such as Bluebird, must be ES6 compatible.
-
--   `readConcern` - Specify a read concern for the collection. (only MongoDB 3.2 or higher supported).
-
--   `maxStalenessSeconds` - Specify a maxStalenessSeconds value for secondary reads, minimum is 90 seconds.
-
--   `appname` - The name of the application that created this MongoClient instance. MongoDB 3.4 and newer will print this
-    value in the server log upon establishing each connection. It is also recorded in the slow query log and profile
-    collections
-
--   `loggerLevel` - Specify the log level used by the driver logger (`error/warn/info/debug`).
-
--   `logger` - Specify a customer logger mechanism, can be used to log using your app level logger.
-
--   `authMechanism` - Sets the authentication mechanism that MongoDB will use to authenticate the connection.
+* `authMechanism` - Sets the authentication mechanism that MongoDB will use to authenticate the connection.
 
 ## `sql.js` connection options
 
--   `database`: The raw UInt8Array database that should be imported.
+* `database`: The raw UInt8Array database that should be imported.
 
--   `sqlJsConfig`: Optional initialize config for sql.js.
+* `sqlJsConfig`: Optional initialize config for sql.js.
 
--   `autoSave`: Whether or not autoSave should be disabled. If set to true the database will be saved to the given file location (Node.js) or LocalStorage element (browser) when a change happens and `location` is specified. Otherwise `autoSaveCallback` can be used.
+* `autoSave`: Whether or not autoSave should be disabled. If set to true the database will be saved to the given file location (Node.js) or LocalStorage element (browser) when a change happens and `location` is specified. Otherwise `autoSaveCallback` can be used.
 
--   `autoSaveCallback`: A function that get's called when changes to the database are made and `autoSave` is enabled. The function gets a `UInt8Array` that represents the database.
+* `autoSaveCallback`: A function that get's called when changes to the database are made and `autoSave` is enabled. The function gets a `UInt8Array` that represents the database.
 
--   `location`: The file location to load and save the database to.
+* `location`: The file location to load and save the database to.
 
--   `useLocalForage`: Enables the usage of the localforage library (https://github.com/localForage/localForage) to save & load the database asynchronously from the indexedDB instead of using the synchron local storage methods in a browser environment. The localforage node module needs to be added to your project and the localforage.js should be imported in your page.
+* `useLocalForage`: Enables the usage of the localforage library (https://github.com/localForage/localForage) to save & load the database asynchronously from the indexedDB instead of using the synchron local storage methods in a browser environment. The localforage node module needs to be added to your project and the localforage.js should be imported in your page.
 
 ## `expo` connection options
 
--   `database` - Name of the database. For example, "mydb".
--   `driver` - The Expo SQLite module. For example, `require('expo-sqlite')`.
+* `database` - Name of the database. For example, "mydb".
+* `driver` - The Expo SQLite module. For example, `require('expo-sqlite')`.
 
 ## Connection options example
 

--- a/src/driver/postgres/PostgresConnectionOptions.ts
+++ b/src/driver/postgres/PostgresConnectionOptions.ts
@@ -62,4 +62,9 @@ export interface PostgresConnectionOptions extends BaseConnectionOptions, Postgr
      * Include notification messages from Postgres server in client logs
      */
     readonly logNotifications?: boolean;
+
+    /**
+     * Automatically installing postgres extensions
+     */
+    readonly installExtensions?: boolean;
 }

--- a/src/driver/postgres/PostgresConnectionOptions.ts
+++ b/src/driver/postgres/PostgresConnectionOptions.ts
@@ -64,7 +64,7 @@ export interface PostgresConnectionOptions extends BaseConnectionOptions, Postgr
     readonly logNotifications?: boolean;
 
     /**
-     * Automatically installing postgres extensions
+     * Automatically install postgres extensions
      */
-    readonly installExtensions?: boolean;
+     readonly installExtensions?: boolean;
 }

--- a/src/driver/postgres/PostgresDriver.ts
+++ b/src/driver/postgres/PostgresDriver.ts
@@ -304,7 +304,7 @@ export class PostgresDriver implements Driver {
     async afterConnect(): Promise<void> {
         const extensionsMetadata = await this.checkMetadataForExtensions();
 
-        const installExtensions = this.options.installExtensions === undefined || this.options.installExtensions === null || this.options.installExtensions === true;
+        const installExtensions = this.options.installExtensions === undefined || this.options.installExtensions;
         if (installExtensions && extensionsMetadata.hasExtensions) {
                        return new Promise<void>((ok, fail) => {
                 this.master.connect(async (err: any, connection: any, release: Function) => {

--- a/src/driver/postgres/PostgresDriver.ts
+++ b/src/driver/postgres/PostgresDriver.ts
@@ -304,7 +304,8 @@ export class PostgresDriver implements Driver {
     async afterConnect(): Promise<void> {
         const extensionsMetadata = await this.checkMetadataForExtensions();
 
-        if (extensionsMetadata.hasExtensions) {
+        const installExtensions = this.options.installExtensions === undefined || this.options.installExtensions === null || this.options.installExtensions === true
+        if (installExtensions && extensionsMetadata.hasExtensions) {
             return new Promise<void>((ok, fail) => {
                 this.master.connect(async (err: any, connection: any, release: Function) => {
                     await this.enableExtensions(extensionsMetadata, connection);

--- a/src/driver/postgres/PostgresDriver.ts
+++ b/src/driver/postgres/PostgresDriver.ts
@@ -304,9 +304,9 @@ export class PostgresDriver implements Driver {
     async afterConnect(): Promise<void> {
         const extensionsMetadata = await this.checkMetadataForExtensions();
 
-        const installExtensions = this.options.installExtensions === undefined || this.options.installExtensions === null || this.options.installExtensions === true
+        const installExtensions = this.options.installExtensions === undefined || this.options.installExtensions === null || this.options.installExtensions === true;
         if (installExtensions && extensionsMetadata.hasExtensions) {
-            return new Promise<void>((ok, fail) => {
+                       return new Promise<void>((ok, fail) => {
                 this.master.connect(async (err: any, connection: any, release: Function) => {
                     await this.enableExtensions(extensionsMetadata, connection);
                     if (err) return fail(err);
@@ -1085,6 +1085,7 @@ export class PostgresDriver implements Driver {
      */
     protected executeQuery(connection: any, query: string) {
         return new Promise((ok, fail) => {
+            this.connection.logger.logQuery(query);
             connection.query(query, (err: any, result: any) => {
                 if (err) return fail(err);
                 ok(result);

--- a/test/github-issues/7662/entity/Dummy_UUID.ts
+++ b/test/github-issues/7662/entity/Dummy_UUID.ts
@@ -1,0 +1,8 @@
+import { Entity } from "../../../../src/decorator/entity/Entity";
+import { PrimaryGeneratedColumn } from "../../../../src/decorator/columns/PrimaryGeneratedColumn";
+
+@Entity()
+export class Dummy {
+    @PrimaryGeneratedColumn("uuid")
+    id: string;
+}

--- a/test/github-issues/7662/issue-7662.ts
+++ b/test/github-issues/7662/issue-7662.ts
@@ -1,0 +1,113 @@
+import { expect } from "chai";
+import { Connection } from "../../../src/connection/Connection";
+import {
+    createTestingConnections,
+    closeTestingConnections,
+} from "../../utils/test-utils";
+import { MemoryLogger } from "./memory-logger";
+
+describe("github issues > #7662 postgres extensions installation should be optional", function () {
+    it("should NOT install extensions if option is disabled", async function () {
+        let connection: Connection | null = null;
+        try {
+            const connections = await createTestingConnections({
+                entities: [`${__dirname}/entity/*{.js,.ts}`],
+                enabledDrivers: ["postgres"],
+                schemaCreate: false,
+                dropSchema: true,
+                createLogger: () => new MemoryLogger(true),
+                driverSpecific: {
+                    installExtensions: false,
+                },
+            });
+
+            if (connections.length < 1) {
+                this.skip();
+            }
+
+            expect(connections).to.have.length(1);
+
+            connection = connections[0];
+
+            const logger = connection.logger as MemoryLogger;
+            const createExtensionQueries = logger.queries.filter((q) =>
+                q.startsWith("CREATE EXTENSION IF NOT EXISTS")
+            );
+
+            expect(createExtensionQueries).to.be.empty;
+        } finally {
+            if (connection) {
+                const logger = connection.logger as MemoryLogger;
+                logger.clear();
+                await closeTestingConnections([connection]);
+            }
+        }
+    });
+
+    it("should install extensions if option is undefined", async function () {
+        let connection: Connection | null = null;
+        try {
+            const connections = await createTestingConnections({
+                entities: [`${__dirname}/entity/*{.js,.ts}`],
+                enabledDrivers: ["postgres"],
+                schemaCreate: false,
+                dropSchema: true,
+                createLogger: () => new MemoryLogger(true),
+            });
+
+            if (connections.length < 1) {
+                this.skip();
+            }
+
+            connection = connections[0];
+
+            const logger = connection.logger as MemoryLogger;
+            const createExtensionQueries = logger.queries.filter((q) =>
+                q.startsWith("CREATE EXTENSION IF NOT EXISTS")
+            );
+
+            expect(createExtensionQueries).to.have.length(1);
+        } finally {
+            if (connection) {
+                const logger = connection.logger as MemoryLogger;
+                logger.clear();
+                await closeTestingConnections([connection]);
+            }
+        }
+    });
+
+    it("should install extensions if option is enabled", async function () {
+        let connection: Connection | null = null;
+        try {
+            const connections = await createTestingConnections({
+                entities: [`${__dirname}/entity/*{.js,.ts}`],
+                enabledDrivers: ["postgres"],
+                schemaCreate: false,
+                dropSchema: true,
+                createLogger: () => new MemoryLogger(true),
+                driverSpecific: {
+                    installExtensions: true,
+                },
+            });
+
+            if (connections.length < 1) {
+                this.skip();
+            }
+
+            connection = connections[0];
+
+            const logger = connection.logger as MemoryLogger;
+            const createExtensionQueries = logger.queries.filter((q) =>
+                q.startsWith("CREATE EXTENSION IF NOT EXISTS")
+            );
+
+            expect(createExtensionQueries).to.have.length(1);
+        } finally {
+            if (connection) {
+                const logger = connection.logger as MemoryLogger;
+                logger.clear();
+                await closeTestingConnections([connection]);
+            }
+        }
+    });
+});

--- a/test/github-issues/7662/issue-7662.ts
+++ b/test/github-issues/7662/issue-7662.ts
@@ -23,9 +23,8 @@ describe("github issues > #7662 postgres extensions installation should be optio
 
             if (connections.length < 1) {
                 this.skip();
+                return;
             }
-
-            expect(connections).to.have.length(1);
 
             connection = connections[0];
 
@@ -45,9 +44,9 @@ describe("github issues > #7662 postgres extensions installation should be optio
     });
 
     it("should install extensions if option is undefined", async function () {
-        let connection: Connection | null = null;
+        let connections: Connection[] = [];
         try {
-            const connections = await createTestingConnections({
+            connections = await createTestingConnections({
                 entities: [`${__dirname}/entity/*{.js,.ts}`],
                 enabledDrivers: ["postgres"],
                 schemaCreate: false,
@@ -57,9 +56,10 @@ describe("github issues > #7662 postgres extensions installation should be optio
 
             if (connections.length < 1) {
                 this.skip();
+                return;
             }
 
-            connection = connections[0];
+            const connection = connections[0];
 
             const logger = connection.logger as MemoryLogger;
             const createExtensionQueries = logger.queries.filter((q) =>
@@ -68,18 +68,14 @@ describe("github issues > #7662 postgres extensions installation should be optio
 
             expect(createExtensionQueries).to.have.length(1);
         } finally {
-            if (connection) {
-                const logger = connection.logger as MemoryLogger;
-                logger.clear();
-                await closeTestingConnections([connection]);
-            }
+            await closeTestingConnections(connections);
         }
     });
 
     it("should install extensions if option is enabled", async function () {
-        let connection: Connection | null = null;
+        let connections: Connection[] = [];
         try {
-            const connections = await createTestingConnections({
+            connections = await createTestingConnections({
                 entities: [`${__dirname}/entity/*{.js,.ts}`],
                 enabledDrivers: ["postgres"],
                 schemaCreate: false,
@@ -94,7 +90,7 @@ describe("github issues > #7662 postgres extensions installation should be optio
                 this.skip();
             }
 
-            connection = connections[0];
+            const connection = connections[0];
 
             const logger = connection.logger as MemoryLogger;
             const createExtensionQueries = logger.queries.filter((q) =>
@@ -103,11 +99,7 @@ describe("github issues > #7662 postgres extensions installation should be optio
 
             expect(createExtensionQueries).to.have.length(1);
         } finally {
-            if (connection) {
-                const logger = connection.logger as MemoryLogger;
-                logger.clear();
-                await closeTestingConnections([connection]);
-            }
+            await closeTestingConnections(connections);
         }
     });
 });

--- a/test/github-issues/7662/memory-logger.ts
+++ b/test/github-issues/7662/memory-logger.ts
@@ -1,0 +1,28 @@
+import {Logger} from "../../../src/logger/Logger";
+
+export class MemoryLogger implements Logger {
+    constructor(public enabled = true) {}
+
+    private _queries: string[] = [];
+    get queries() { return this._queries; }
+
+    logQuery(query: string) {
+        if (this.enabled) {
+            this._queries.push(query);
+        }
+    }
+
+    logQueryError(error: string, query: string) {}
+
+    logQuerySlow(time: number, query: string) {}
+
+    logSchemaBuild(message: string) {}
+
+    logMigration(message: string) {}
+
+    log(level: "log" | "info" | "warn", message: any) {}
+
+    clear() {
+        this._queries = [];
+    }
+}


### PR DESCRIPTION
There are cases wherein the credentials given to the service are READONLY. In these cases, installing extensions automatically fails. There is no reason to run these everytime as they trigger unnecessary error logs.

Fixes #7662

<!--
  😀 Wonderful!  Thank you for opening a pull request for TypeORM.

  Please fill in the information below to expedite the review
  and (hopefully) merge of your change.

  If unsure about something.. just do as best as you're able,
  or reach out through our community support channels!
  https://github.com/typeorm/typeorm/blob/master/docs/support.md
-->

### Description of change

<!--
  Please be clear and concise what the change is intended to do,
  why this change is needed, and how you've verified that it
  corrects what you intended.

  In some cases it may be helpful to include the current behavior
  and the new behavior.

  If the change is related to an open issue, you can link it here.
  If you include `Fixes #0000` (replacing `0000` with the issue number)
  when this is merged it will automatically mark the issue as fixed and
  close it.
-->


### Pull-Request Checklist

<!--
  Please make sure to review and check all of the following.

  If an item is not applicable, you can add "N/A" to the end.
-->

- [x] Code is up-to-date with the `master` branch
- [x] `npm run lint` passes with this change
- [x] `npm run test` passes with this change
- [x] This pull request links relevant issues as `Fixes #0000`
- [x] There are new or updated unit tests validating the change
- [x] Documentation has been updated to reflect this change
- [x] The new commits follow conventions explained in [CONTRIBUTING.md](https://github.com/typeorm/typeorm/blob/master/CONTRIBUTING.md)

<!--
  🎉 Thank you for contributing and making TypeORM even better!
-->
