### PR TITLE
refactor: allow driver to define which query-builders to use

### DIFF
--- a/src/connection/Connection.ts
+++ b/src/connection/Connection.ts
@@ -392,9 +392,6 @@ export class Connection {
      * Executes raw SQL query and returns raw database results.
      */
     async query(query: string, parameters?: any[], queryRunner?: QueryRunner): Promise<any> {
-        if (this instanceof MongoEntityManager)
-            throw new Error(`Queries aren't supported by MongoDB.`);
-
         if (queryRunner && queryRunner.isReleased)
             throw new QueryRunnerProviderAlreadyReleasedError();
 
@@ -423,17 +420,14 @@ export class Connection {
      * Creates a new query builder that can be used to build a sql query.
      */
     createQueryBuilder<Entity>(entityOrRunner?: EntityTarget<Entity>|QueryRunner, alias?: string, queryRunner?: QueryRunner): SelectQueryBuilder<Entity> {
-        if (this instanceof MongoEntityManager)
-            throw new Error(`Query Builder is not supported by MongoDB.`);
-
         if (alias) {
             const metadata = this.getMetadata(entityOrRunner as EntityTarget<Entity>);
-            return new SelectQueryBuilder(this, queryRunner)
+            return this.driver.getDialect().getSelectQueryBuilder(this, queryRunner)
                 .select(alias)
                 .from(metadata.target, alias);
 
         } else {
-            return new SelectQueryBuilder(this, entityOrRunner as QueryRunner|undefined);
+            return this.driver.getDialect().getSelectQueryBuilder(this, entityOrRunner as QueryRunner|undefined);
         }
     }
 

--- a/src/driver/Dialect.ts
+++ b/src/driver/Dialect.ts
@@ -1,0 +1,71 @@
+import { Connection } from "../connection/Connection";
+import { QueryRunner } from "../query-runner/QueryRunner";
+import { SelectQueryBuilder } from "../query-builder/SelectQueryBuilder";
+import { QueryBuilder } from "../query-builder/QueryBuilder";
+import { InsertQueryBuilder } from "../query-builder/InsertQueryBuilder";
+import { DeleteQueryBuilder } from "../query-builder/DeleteQueryBuilder";
+import { UpdateQueryBuilder } from "../query-builder/UpdateQueryBuilder";
+import { SoftDeleteQueryBuilder } from "../query-builder/SoftDeleteQueryBuilder";
+import { RelationQueryBuilder } from "../query-builder/RelationQueryBuilder";
+
+export interface Dialect {
+    /**
+     * Retrieves a Select Query builder given a connection and optionally a QueryRunner.
+     */
+    getSelectQueryBuilder<T>(connection: Connection, queryRunner?: QueryRunner | undefined): SelectQueryBuilder<T>;
+
+    /**
+     * Retrieves a Select Query builder using the connection and state of an existing query builder.
+     */
+    getSelectQueryBuilder<T>(query: QueryBuilder<T>): SelectQueryBuilder<T>;
+
+    /**
+     * Retrieves an Insert Query builder given a connection and optionally a QueryRunner.
+     */
+    getInsertQueryBuilder<T>(connection: Connection, queryRunner?: QueryRunner | undefined): InsertQueryBuilder<T>;
+
+    /**
+     * Retrieves a Insert Query builder using the connection and state of an existing query builder.
+     */
+    getInsertQueryBuilder<T>(query: QueryBuilder<T>): InsertQueryBuilder<T>;
+
+    /**
+     * Retrieves a Delete Query builder given a connection and optionally a QueryRunner.
+     */
+    getDeleteQueryBuilder<T>(connection: Connection, queryRunner?: QueryRunner | undefined): DeleteQueryBuilder<T>;
+
+    /**
+     * Retrieves a Delete Query builder using the connection and state of an existing query builder.
+     */
+    getDeleteQueryBuilder<T>(query: QueryBuilder<T>): DeleteQueryBuilder<T>;
+
+    /**
+     * Retrieves an Update Query builder given a connection and optionally a QueryRunner.
+     */
+    getUpdateQueryBuilder<T>(connection: Connection, queryRunner?: QueryRunner | undefined): UpdateQueryBuilder<T>;
+
+    /**
+     * Retrieves an Update Query builder using the connection and state of an existing query builder.
+     */
+    getUpdateQueryBuilder<T>(query: QueryBuilder<T>): UpdateQueryBuilder<T>;
+
+    /**
+     * Retrieves a Soft-Delete Query builder given a connection and optionally a QueryRunner.
+     */
+    getSoftDeleteQueryBuilder<T>(connection: Connection, queryRunner?: QueryRunner | undefined): SoftDeleteQueryBuilder<T>;
+
+    /**
+     * Retrieves a Soft-Delete Query builder using the connection and state of an existing query builder.
+     */
+    getSoftDeleteQueryBuilder<T>(query: QueryBuilder<T>): SoftDeleteQueryBuilder<T>;
+
+    /**
+     * Retrieves a Relation Query builder given a connection and optionally a QueryRunner.
+     */
+    getRelationQueryBuilder<T>(connection: Connection, queryRunner?: QueryRunner | undefined): RelationQueryBuilder<T>;
+
+    /**
+     * Retrieves a Relation Query builder using the connection and state of an existing query builder.
+     */
+    getRelationQueryBuilder<T>(query: QueryBuilder<T>): RelationQueryBuilder<T>;
+}

--- a/src/driver/Driver.ts
+++ b/src/driver/Driver.ts
@@ -9,6 +9,7 @@ import {BaseConnectionOptions} from "../connection/BaseConnectionOptions";
 import {TableColumn} from "../schema-builder/table/TableColumn";
 import {EntityMetadata} from "../metadata/EntityMetadata";
 import {ReplicationMode} from "./types/ReplicationMode";
+import {Dialect} from "./Dialect";
 
 /**
  * Driver organizes TypeORM communication with specific database management system.
@@ -204,4 +205,8 @@ export interface Driver {
      */
     createParameter(parameterName: string, index: number): string;
 
+    /**
+     * Gets the Dialect object
+     */
+    getDialect(): Dialect;
 }

--- a/src/driver/LegacyDialect.ts
+++ b/src/driver/LegacyDialect.ts
@@ -1,0 +1,104 @@
+import { Dialect } from "./Dialect";
+import { SelectQueryBuilder } from "../query-builder/SelectQueryBuilder";
+import { InsertQueryBuilder } from "../query-builder/InsertQueryBuilder";
+import { DeleteQueryBuilder } from "../query-builder/DeleteQueryBuilder";
+import { UpdateQueryBuilder } from "../query-builder/UpdateQueryBuilder";
+import { SoftDeleteQueryBuilder } from "../query-builder/SoftDeleteQueryBuilder";
+import { RelationQueryBuilder } from "../query-builder/RelationQueryBuilder";
+
+/**
+ * This dialect effectively keeps the same behaviors as the original
+ * where the base QueryBuilders have code in place to maintain multiple
+ * dialects at once.
+ */
+export class LegacyDialect implements Dialect{
+    /**
+     * Retrieves a Select Query builder.
+     */
+    getSelectQueryBuilder<T>(connectionOrQuery: any, queryRunner?: any): SelectQueryBuilder<T> {
+        // There's a bizarre circular dependency weirdness that we're trying to get around with this
+        // Once we extract the imports back to drivers we can remove this `require`
+        const { SelectQueryBuilder: Builder } = require("../query-builder/SelectQueryBuilder");
+
+        if (connectionOrQuery instanceof Builder) {
+            return connectionOrQuery;
+        }
+
+        return new Builder(connectionOrQuery, queryRunner);
+    }
+
+    /**
+     * Retrieves an Insert Query builder for this driver.
+     */
+    getInsertQueryBuilder<T>(connectionOrQuery: any, queryRunner?: any): InsertQueryBuilder<T> {
+        // There's a bizarre circular dependency weirdness that we're trying to get around with this
+        // Once we extract the imports back to drivers we can remove this `require`
+        const { InsertQueryBuilder: Builder } = require("../query-builder/InsertQueryBuilder");
+
+        if (connectionOrQuery instanceof Builder) {
+            return connectionOrQuery;
+        }
+
+        return new Builder(connectionOrQuery, queryRunner);
+    }
+
+    /**
+     * Retrieves a Delete Query builder for this driver.
+     */
+    getDeleteQueryBuilder<T>(connectionOrQuery: any, queryRunner?: any): DeleteQueryBuilder<T> {
+        // There's a bizarre circular dependency weirdness that we're trying to get around with this
+        // Once we extract the imports back to drivers we can remove this `require`
+        const { DeleteQueryBuilder: Builder } = require("../query-builder/DeleteQueryBuilder");
+
+        if (connectionOrQuery instanceof Builder) {
+            return connectionOrQuery;
+        }
+
+        return new Builder(connectionOrQuery, queryRunner);
+    }
+
+    /**
+     * Retrieves an Update Query builder for this driver.
+     */
+    getUpdateQueryBuilder<T>(connectionOrQuery: any, queryRunner?: any): UpdateQueryBuilder<T> {
+        // There's a bizarre circular dependency weirdness that we're trying to get around with this
+        // Once we extract the imports back to drivers we can remove this `require`
+        const { UpdateQueryBuilder: Builder } = require("../query-builder/UpdateQueryBuilder");
+
+        if (connectionOrQuery instanceof Builder) {
+            return connectionOrQuery;
+        }
+
+        return new Builder(connectionOrQuery, queryRunner);
+    }
+
+    /**
+     * Retrieves a Delete Query builder for this driver.
+     */
+    getSoftDeleteQueryBuilder<T>(connectionOrQuery: any, queryRunner?: any): SoftDeleteQueryBuilder<T> {
+        // There's a bizarre circular dependency weirdness that we're trying to get around with this
+        // Once we extract the imports back to drivers we can remove this `require`
+        const { SoftDeleteQueryBuilder: Builder } = require("../query-builder/SoftDeleteQueryBuilder");
+
+        if (connectionOrQuery instanceof Builder) {
+            return connectionOrQuery;
+        }
+
+        return new Builder(connectionOrQuery, queryRunner);
+    }
+
+    /**
+     * Retrieves a Relation Query builder for this driver.
+     */
+    getRelationQueryBuilder<T>(connectionOrQuery: any, queryRunner?: any): RelationQueryBuilder<T> {
+        // There's a bizarre circular dependency weirdness that we're trying to get around with this
+        // Once we extract the imports back to drivers we can remove this `require`
+        const { RelationQueryBuilder: Builder } = require("../query-builder/RelationQueryBuilder");
+
+        if (connectionOrQuery instanceof Builder) {
+            return connectionOrQuery;
+        }
+
+        return new Builder(connectionOrQuery, queryRunner);
+    }
+}

--- a/src/driver/aurora-data-api/AuroraDataApiDriver.ts
+++ b/src/driver/aurora-data-api/AuroraDataApiDriver.ts
@@ -17,6 +17,8 @@ import {EntityMetadata} from "../../metadata/EntityMetadata";
 import {OrmUtils} from "../../util/OrmUtils";
 import {ApplyValueTransformers} from "../../util/ApplyValueTransformers";
 import {ReplicationMode} from "../types/ReplicationMode";
+import {Dialect} from "../Dialect";
+import {LegacyDialect} from "../LegacyDialect";
 
 /**
  * Organizes communication with MySQL DBMS.
@@ -876,4 +878,10 @@ export class AuroraDataApiDriver implements Driver {
         return comment;
     }
 
+    /**
+     * Retrieves a Select Query builder given a connection and optionally a QueryRunner.
+     */
+    getDialect(): Dialect {
+        return new LegacyDialect()
+    }
 }

--- a/src/driver/cockroachdb/CockroachDriver.ts
+++ b/src/driver/cockroachdb/CockroachDriver.ts
@@ -20,6 +20,8 @@ import {OrmUtils} from "../../util/OrmUtils";
 import {CockroachQueryRunner} from "./CockroachQueryRunner";
 import {ApplyValueTransformers} from "../../util/ApplyValueTransformers";
 import {ReplicationMode} from "../types/ReplicationMode";
+import {Dialect} from "../Dialect";
+import {LegacyDialect} from "../LegacyDialect";
 
 /**
  * Organizes communication with Cockroach DBMS.
@@ -765,4 +767,10 @@ export class CockroachDriver implements Driver {
         return comment;
     }
 
+    /**
+     * Retrieves the Dialect for this driver.
+     */
+    getDialect(): Dialect {
+        return new LegacyDialect()
+    }
 }

--- a/src/driver/mongodb/MongoDialect.ts
+++ b/src/driver/mongodb/MongoDialect.ts
@@ -1,0 +1,34 @@
+import { Dialect } from "../Dialect";
+import { SelectQueryBuilder } from "../../query-builder/SelectQueryBuilder";
+import { InsertQueryBuilder } from "../../query-builder/InsertQueryBuilder";
+import { DeleteQueryBuilder } from "../../query-builder/DeleteQueryBuilder";
+import { UpdateQueryBuilder } from "../../query-builder/UpdateQueryBuilder";
+import { SoftDeleteQueryBuilder } from "../../query-builder/SoftDeleteQueryBuilder";
+import { RelationQueryBuilder } from "../../query-builder/RelationQueryBuilder";
+
+export class MongoDialect implements Dialect {
+
+    getSelectQueryBuilder<T>(connectionOrQuery: any, queryRunner?: any): SelectQueryBuilder<T> {
+        throw new Error(`Query Builder is not supported by MongoDB.`);
+    }
+
+    getInsertQueryBuilder<T>(connectionOrQuery: any, queryRunner?: any): InsertQueryBuilder<T> {
+        throw new Error(`Query Builder is not supported by MongoDB.`);
+    }
+
+    getDeleteQueryBuilder<T>(connectionOrQuery: any, queryRunner?: any): DeleteQueryBuilder<T> {
+        throw new Error(`Query Builder is not supported by MongoDB.`);
+    }
+
+    getUpdateQueryBuilder<T>(connectionOrQuery: any, queryRunner?: any): UpdateQueryBuilder<T> {
+        throw new Error(`Query Builder is not supported by MongoDB.`);
+    }
+
+    getSoftDeleteQueryBuilder<T>(connectionOrQuery: any, queryRunner?: any): SoftDeleteQueryBuilder<T> {
+        throw new Error(`Query Builder is not supported by MongoDB.`);
+    }
+
+    getRelationQueryBuilder<T>(connectionOrQuery: any, queryRunner?: any): RelationQueryBuilder<T> {
+        throw new Error(`Query Builder is not supported by MongoDB.`);
+    }
+}

--- a/src/driver/mongodb/MongoDriver.ts
+++ b/src/driver/mongodb/MongoDriver.ts
@@ -18,6 +18,8 @@ import {ObjectUtils} from "../../util/ObjectUtils";
 import {ApplyValueTransformers} from "../../util/ApplyValueTransformers";
 import {ReplicationMode} from "../types/ReplicationMode";
 import {DriverUtils} from "../DriverUtils";
+import {MongoDialect} from "./MongoDialect";
+import {Dialect} from "../Dialect";
 
 /**
  * Organizes communication with MongoDB.
@@ -453,7 +455,7 @@ export class MongoDriver implements Driver {
         } else {
             connectionString = `${schemaUrlPart}://${credentialsUrlPart}${options.host || "127.0.0.1"}${portUrlPart}/${options.database || ""}`;
         }
-            
+
         return connectionString;
     }
 
@@ -476,4 +478,10 @@ export class MongoDriver implements Driver {
         return mongoOptions;
     }
 
+    /**
+     * Retrieves the Dialect for this driver.
+     */
+    getDialect(): Dialect {
+        return new MongoDialect();
+    }
 }

--- a/src/driver/mysql/MysqlDriver.ts
+++ b/src/driver/mysql/MysqlDriver.ts
@@ -19,6 +19,8 @@ import {EntityMetadata} from "../../metadata/EntityMetadata";
 import {OrmUtils} from "../../util/OrmUtils";
 import {ApplyValueTransformers} from "../../util/ApplyValueTransformers";
 import {ReplicationMode} from "../types/ReplicationMode";
+import {LegacyDialect} from "../LegacyDialect";
+import {Dialect} from "../Dialect";
 
 /**
  * Organizes communication with MySQL DBMS.
@@ -970,4 +972,10 @@ export class MysqlDriver implements Driver {
         return comment;
     }
 
+    /**
+     * Gets the Dialect in use by this driver.
+     */
+    getDialect(): Dialect {
+        return new LegacyDialect()
+    }
 }

--- a/src/driver/oracle/OracleDriver.ts
+++ b/src/driver/oracle/OracleDriver.ts
@@ -19,6 +19,8 @@ import {EntityMetadata} from "../../metadata/EntityMetadata";
 import {OrmUtils} from "../../util/OrmUtils";
 import {ApplyValueTransformers} from "../../util/ApplyValueTransformers";
 import {ReplicationMode} from "../types/ReplicationMode";
+import {Dialect} from "../Dialect";
+import {LegacyDialect} from "../LegacyDialect";
 
 /**
  * Organizes communication with Oracle RDBMS.
@@ -747,4 +749,10 @@ export class OracleDriver implements Driver {
         });
     }
 
+    /**
+     * Retrieves a Select Query builder given a connection and optionally a QueryRunner.
+     */
+    getDialect(): Dialect {
+        return new LegacyDialect()
+    }
 }

--- a/src/driver/postgres/PostgresDriver.ts
+++ b/src/driver/postgres/PostgresDriver.ts
@@ -19,6 +19,8 @@ import {ReplicationMode} from "../types/ReplicationMode";
 import {PostgresConnectionCredentialsOptions} from "./PostgresConnectionCredentialsOptions";
 import {PostgresConnectionOptions} from "./PostgresConnectionOptions";
 import {PostgresQueryRunner} from "./PostgresQueryRunner";
+import {Dialect} from "../Dialect";
+import {LegacyDialect} from "../LegacyDialect";
 
 /**
  * Organizes communication with PostgreSQL DBMS.
@@ -1139,4 +1141,10 @@ export class PostgresDriver implements Driver {
         return comment;
     }
 
+    /**
+     * Gets the Dialect in use by this driver.
+     */
+    getDialect(): Dialect {
+        return new LegacyDialect()
+    }
 }

--- a/src/driver/sap/SapDriver.ts
+++ b/src/driver/sap/SapDriver.ts
@@ -12,6 +12,8 @@ import {MappedColumnTypes} from "../types/MappedColumnTypes";
 import {SapConnectionOptions} from "./SapConnectionOptions";
 import {SapQueryRunner} from "./SapQueryRunner";
 import {ReplicationMode} from "../types/ReplicationMode";
+import {Dialect} from "../Dialect";
+import {LegacyDialect} from "../LegacyDialect";
 
 /**
  * Organizes communication with SAP Hana DBMS.
@@ -662,4 +664,10 @@ export class SapDriver implements Driver {
         }
     }
 
+    /**
+     * Retrieves a Select Query builder given a connection and optionally a QueryRunner.
+     */
+    getDialect(): Dialect {
+        return new LegacyDialect()
+    }
 }

--- a/src/driver/sqlite-abstract/AbstractSqliteDriver.ts
+++ b/src/driver/sqlite-abstract/AbstractSqliteDriver.ts
@@ -14,6 +14,8 @@ import {EntityMetadata} from "../../metadata/EntityMetadata";
 import {OrmUtils} from "../../util/OrmUtils";
 import {ApplyValueTransformers} from "../../util/ApplyValueTransformers";
 import {ReplicationMode} from "../types/ReplicationMode";
+import {Dialect} from "../Dialect";
+import {LegacyDialect} from "../LegacyDialect";
 
 /**
  * Organizes communication with sqlite DBMS.
@@ -634,4 +636,10 @@ export abstract class AbstractSqliteDriver implements Driver {
         // dependencies have to be loaded in the specific driver
     }
 
+    /**
+     * Retrieves the Dialect for this driver.
+     */
+    getDialect(): Dialect {
+        return new LegacyDialect()
+    }
 }

--- a/src/driver/sqlserver/SqlServerDriver.ts
+++ b/src/driver/sqlserver/SqlServerDriver.ts
@@ -20,6 +20,8 @@ import {EntityMetadata} from "../../metadata/EntityMetadata";
 import {OrmUtils} from "../../util/OrmUtils";
 import {ApplyValueTransformers} from "../../util/ApplyValueTransformers";
 import {ReplicationMode} from "../types/ReplicationMode";
+import {LegacyDialect} from "../LegacyDialect";
+import {Dialect} from "../Dialect";
 
 /**
  * Organizes communication with SQL Server DBMS.
@@ -819,4 +821,10 @@ export class SqlServerDriver implements Driver {
         });
     }
 
+    /**
+     * Retrieves the Dialect for this driver.
+     */
+    getDialect(): Dialect {
+        return new LegacyDialect()
+    }
 }

--- a/src/query-builder/QueryBuilder.ts
+++ b/src/query-builder/QueryBuilder.ts
@@ -23,6 +23,7 @@ import {EntitySchema} from "../";
 import {FindOperator} from "../find-options/FindOperator";
 import {In} from "../find-options/operator/In";
 import {EntityColumnNotFound} from "../error/EntityColumnNotFound";
+import {Dialect} from "../driver/Dialect";
 
 // todo: completely cover query builder with tests
 // todo: entityOrProperty can be target name. implement proper behaviour if it is.
@@ -63,6 +64,11 @@ export abstract class QueryBuilder<Entity> {
     // -------------------------------------------------------------------------
 
     /**
+     * Dialect with which the QueryBuilder is working with
+     */
+    protected readonly dialect: Dialect;
+
+    /**
      * Query runner used to execute query builder query.
      */
     protected queryRunner?: QueryRunner;
@@ -95,6 +101,8 @@ export abstract class QueryBuilder<Entity> {
             this.queryRunner = queryRunner;
             this.expressionMap = new QueryExpressionMap(this.connection);
         }
+
+        this.dialect = this.connection.driver.getDialect();
     }
 
     // -------------------------------------------------------------------------
@@ -154,12 +162,7 @@ export abstract class QueryBuilder<Entity> {
             this.expressionMap.selects = [{ selection: selection, aliasName: selectionAliasName }];
         }
 
-        // loading it dynamically because of circular issue
-        const SelectQueryBuilderCls = require("./SelectQueryBuilder").SelectQueryBuilder;
-        if (this instanceof SelectQueryBuilderCls)
-            return this as any;
-
-        return new SelectQueryBuilderCls(this);
+        return this.dialect.getSelectQueryBuilder(this);
     }
 
     /**
@@ -168,12 +171,7 @@ export abstract class QueryBuilder<Entity> {
     insert(): InsertQueryBuilder<Entity> {
         this.expressionMap.queryType = "insert";
 
-        // loading it dynamically because of circular issue
-        const InsertQueryBuilderCls = require("./InsertQueryBuilder").InsertQueryBuilder;
-        if (this instanceof InsertQueryBuilderCls)
-            return this as any;
-
-        return new InsertQueryBuilderCls(this);
+        return this.dialect.getInsertQueryBuilder(this);
     }
 
     /**
@@ -211,12 +209,7 @@ export abstract class QueryBuilder<Entity> {
         this.expressionMap.queryType = "update";
         this.expressionMap.valuesSet = updateSet;
 
-        // loading it dynamically because of circular issue
-        const UpdateQueryBuilderCls = require("./UpdateQueryBuilder").UpdateQueryBuilder;
-        if (this instanceof UpdateQueryBuilderCls)
-            return this as any;
-
-        return new UpdateQueryBuilderCls(this);
+        return this.dialect.getUpdateQueryBuilder(this);
     }
 
     /**
@@ -225,34 +218,19 @@ export abstract class QueryBuilder<Entity> {
     delete(): DeleteQueryBuilder<Entity> {
         this.expressionMap.queryType = "delete";
 
-        // loading it dynamically because of circular issue
-        const DeleteQueryBuilderCls = require("./DeleteQueryBuilder").DeleteQueryBuilder;
-        if (this instanceof DeleteQueryBuilderCls)
-            return this as any;
-
-        return new DeleteQueryBuilderCls(this);
+        return this.dialect.getDeleteQueryBuilder(this);
     }
 
     softDelete(): SoftDeleteQueryBuilder<any> {
         this.expressionMap.queryType = "soft-delete";
 
-        // loading it dynamically because of circular issue
-        const SoftDeleteQueryBuilderCls = require("./SoftDeleteQueryBuilder").SoftDeleteQueryBuilder;
-        if (this instanceof SoftDeleteQueryBuilderCls)
-            return this as any;
-
-        return new SoftDeleteQueryBuilderCls(this);
+        return this.dialect.getSoftDeleteQueryBuilder(this);
     }
 
     restore(): SoftDeleteQueryBuilder<any> {
         this.expressionMap.queryType = "restore";
 
-        // loading it dynamically because of circular issue
-        const SoftDeleteQueryBuilderCls = require("./SoftDeleteQueryBuilder").SoftDeleteQueryBuilder;
-        if (this instanceof SoftDeleteQueryBuilderCls)
-            return this as any;
-
-        return new SoftDeleteQueryBuilderCls(this);
+        return this.dialect.getSoftDeleteQueryBuilder(this);
     }
 
     /**
@@ -280,12 +258,7 @@ export abstract class QueryBuilder<Entity> {
             this.expressionMap.setMainAlias(mainAlias);
         }
 
-        // loading it dynamically because of circular issue
-        const RelationQueryBuilderCls = require("./RelationQueryBuilder").RelationQueryBuilder;
-        if (this instanceof RelationQueryBuilderCls)
-            return this as any;
-
-        return new RelationQueryBuilderCls(this);
+        return this.dialect.getRelationQueryBuilder(this);
     }
 
 

--- a/src/query-builder/SelectQueryBuilder.ts
+++ b/src/query-builder/SelectQueryBuilder.ts
@@ -1969,7 +1969,7 @@ export class SelectQueryBuilder<Entity> extends QueryBuilder<Entity> implements 
                 return `${distinctAlias}.${columnAlias} as "${alias}"`;
             });
 
-            rawResults = await new SelectQueryBuilder(this.connection, queryRunner)
+            rawResults = await this.dialect.getSelectQueryBuilder(this.connection, queryRunner)
                 .select(`DISTINCT ${querySelects.join(", ")}`)
                 .addSelect(selects)
                 .from(`(${this.clone().orderBy().getQuery()})`, "distinctAlias")


### PR DESCRIPTION
<!--
  😀 Wonderful!  Thank you for opening a pull request for TypeORM.

  Please fill in the information below to expedite the review
  and (hopefully) merge of your change.

  If unsure about something.. just do as best as you're able,
  or reach out through our community support channels!
  https://github.com/typeorm/typeorm/blob/master/docs/support.md
-->

### Description of change

<!--
  Please be clear and concise what the change is intended to do,
  why this change is needed, and how you've verified that it
  corrects what you intended.

  In some cases it may be helpful to include the current behavior
  and the new behavior.

  If the change is related to an open issue, you can link it here.
  If you include `Fixes #0000` (replacing `0000` with the issue number)
  when this is merged it will automatically mark the issue as fixed and
  close it.
-->

this updates typeorm to request a new query builder
from the driver rather than using a hard-coded module.
in many cases we want to return query builders with
a different embedded dialect within them.

this is a tiny step to encapsulating some of the dialect
code out of the QueryBuilders and instead bundling
them together under the drivers

### Pull-Request Checklist

<!--
  Please make sure to review and check all of the following.

  If an item is not applicable, you can add "N/A" to the end.
-->

- [ ] Code is up-to-date with the `master` branch
- [ ] `npm run lint` passes with this change
- [ ] `npm run test` passes with this change
- [ ] This pull request links relevant issues as `Fixes #0000`
- [ ] There are new or updated unit tests validating the change
- [ ] Documentation has been updated to reflect this change
- [ ] The new commits follow conventions explained in [CONTRIBUTING.md](https://github.com/typeorm/typeorm/blob/master/CONTRIBUTING.md)

<!--
  🎉 Thank you for contributing and making TypeORM even better!
-->
