### PR TITLE
refactor: set database variable within driver contructor

### DIFF
--- a/src/connection/Connection.ts
+++ b/src/connection/Connection.ts
@@ -38,7 +38,6 @@ import {MysqlDriver} from "../driver/mysql/MysqlDriver";
 import {ObjectUtils} from "../util/ObjectUtils";
 import {IsolationLevel} from "../driver/types/IsolationLevel";
 import {AuroraDataApiDriver} from "../driver/aurora-data-api/AuroraDataApiDriver";
-import {DriverUtils} from "../driver/DriverUtils";
 import {ReplicationMode} from "../driver/types/ReplicationMode";
 
 /**
@@ -521,28 +520,7 @@ export class Connection {
         const migrations = connectionMetadataBuilder.buildMigrations(this.options.migrations || []);
         ObjectUtils.assign(this, { migrations: migrations });
 
-        this.driver.database = this.getDatabaseName();
-
         // validate all created entity metadatas to make sure user created entities are valid and correct
         entityMetadataValidator.validateMany(this.entityMetadatas.filter(metadata => metadata.tableType !== "view"), this.driver);
     }
-
-    // This database name property is nested for replication configs.
-    protected getDatabaseName(): string {
-        const options = this.options;
-        switch (options.type) {
-            case "mysql" :
-            case "mariadb" :
-            case "postgres":
-            case "cockroachdb":
-            case "mssql":
-            case "oracle":
-                return DriverUtils.buildDriverOptions(options.replication ? options.replication.master : options).database;
-            case "mongodb":
-                return DriverUtils.buildMongoDBDriverOptions(options).database;
-            default:
-                return DriverUtils.buildDriverOptions(options).database;
-    }
-}
-
 }

--- a/src/driver/aurora-data-api-pg/AuroraDataApiPostgresDriver.ts
+++ b/src/driver/aurora-data-api-pg/AuroraDataApiPostgresDriver.ts
@@ -7,6 +7,7 @@ import {AuroraDataApiPostgresQueryRunner} from "../aurora-data-api-pg/AuroraData
 import {ReplicationMode} from "../types/ReplicationMode";
 import {ColumnMetadata} from "../../metadata/ColumnMetadata";
 import {ApplyValueTransformers} from "../../util/ApplyValueTransformers";
+import {DriverUtils} from "../DriverUtils";
 
 abstract class PostgresWrapper extends PostgresDriver {
     options: any;
@@ -68,6 +69,8 @@ export class AuroraDataApiPostgresDriver extends PostgresWrapper implements Driv
             this.options.serviceConfigOptions,
             this.options.formatOptions,
         );
+
+        this.database = DriverUtils.buildDriverOptions(this.options).database;
     }
 
     // -------------------------------------------------------------------------

--- a/src/driver/aurora-data-api/AuroraDataApiDriver.ts
+++ b/src/driver/aurora-data-api/AuroraDataApiDriver.ts
@@ -312,6 +312,8 @@ export class AuroraDataApiDriver implements Driver {
             this.options.formatOptions,
         );
 
+        this.database = DriverUtils.buildDriverOptions(this.options).database;
+
         // validate options to make sure everything is set
         // todo: revisit validation with replication in mind
         // if (!(this.options.host || (this.options.extra && this.options.extra.socketPath)) && !this.options.socketPath)

--- a/src/driver/cockroachdb/CockroachDriver.ts
+++ b/src/driver/cockroachdb/CockroachDriver.ts
@@ -220,6 +220,8 @@ export class CockroachDriver implements Driver {
         // load postgres package
         this.loadDependencies();
 
+        this.database = DriverUtils.buildDriverOptions(this.options.replication ? this.options.replication.master : this.options).database;
+
         // ObjectUtils.assign(this.options, DriverUtils.buildDriverOptions(connection.options)); // todo: do it better way
         // validate options to make sure everything is set
         // todo: revisit validation with replication in mind

--- a/src/driver/mongodb/MongoDriver.ts
+++ b/src/driver/mongodb/MongoDriver.ts
@@ -213,6 +213,8 @@ export class MongoDriver implements Driver {
 
         // load mongodb package
         this.loadDependencies();
+
+        this.database = DriverUtils.buildMongoDBDriverOptions(this.options).database;
     }
 
     // -------------------------------------------------------------------------

--- a/src/driver/mysql/MysqlDriver.ts
+++ b/src/driver/mysql/MysqlDriver.ts
@@ -310,7 +310,7 @@ export class MysqlDriver implements Driver {
         // load mysql package
         this.loadDependencies();
 
-        this.database = this.options.replication ? this.options.replication.master.database : this.options.database;
+        this.database = DriverUtils.buildDriverOptions(this.options.replication ? this.options.replication.master : this.options).database;
 
         // validate options to make sure everything is set
         // todo: revisit validation with replication in mind

--- a/src/driver/oracle/OracleDriver.ts
+++ b/src/driver/oracle/OracleDriver.ts
@@ -225,6 +225,8 @@ export class OracleDriver implements Driver {
         // extra oracle setup
         this.oracle.outFormat = this.oracle.OBJECT;
 
+        this.database = DriverUtils.buildDriverOptions(this.options.replication ? this.options.replication.master : this.options).database;
+
         // Object.assign(connection.options, DriverUtils.buildDriverOptions(connection.options)); // todo: do it better way
         // validate options to make sure everything is set
         // if (!this.options.host)

--- a/src/driver/postgres/PostgresDriver.ts
+++ b/src/driver/postgres/PostgresDriver.ts
@@ -19,6 +19,7 @@ import {ReplicationMode} from "../types/ReplicationMode";
 import {PostgresConnectionCredentialsOptions} from "./PostgresConnectionCredentialsOptions";
 import {PostgresConnectionOptions} from "./PostgresConnectionOptions";
 import {PostgresQueryRunner} from "./PostgresQueryRunner";
+import {DriverUtils} from "../DriverUtils";
 
 /**
  * Organizes communication with PostgreSQL DBMS.
@@ -262,6 +263,8 @@ export class PostgresDriver implements Driver {
         }
         // load postgres package
         this.loadDependencies();
+
+        this.database = DriverUtils.buildDriverOptions(this.options.replication ? this.options.replication.master : this.options).database;
 
         // ObjectUtils.assign(this.options, DriverUtils.buildDriverOptions(connection.options)); // todo: do it better way
         // validate options to make sure everything is set

--- a/src/driver/sap/SapDriver.ts
+++ b/src/driver/sap/SapDriver.ts
@@ -12,6 +12,7 @@ import {MappedColumnTypes} from "../types/MappedColumnTypes";
 import {SapConnectionOptions} from "./SapConnectionOptions";
 import {SapQueryRunner} from "./SapQueryRunner";
 import {ReplicationMode} from "../types/ReplicationMode";
+import {DriverUtils} from "../DriverUtils";
 
 /**
  * Organizes communication with SAP Hana DBMS.
@@ -198,6 +199,8 @@ export class SapDriver implements Driver {
         this.connection = connection;
         this.options = connection.options as SapConnectionOptions;
         this.loadDependencies();
+
+        this.database = DriverUtils.buildDriverOptions(this.options).database;
     }
 
     // -------------------------------------------------------------------------

--- a/src/driver/sqlite-abstract/AbstractSqliteDriver.ts
+++ b/src/driver/sqlite-abstract/AbstractSqliteDriver.ts
@@ -14,6 +14,7 @@ import {EntityMetadata} from "../../metadata/EntityMetadata";
 import {OrmUtils} from "../../util/OrmUtils";
 import {ApplyValueTransformers} from "../../util/ApplyValueTransformers";
 import {ReplicationMode} from "../types/ReplicationMode";
+import {DriverUtils} from "../DriverUtils";
 
 /**
  * Organizes communication with sqlite DBMS.
@@ -206,6 +207,8 @@ export abstract class AbstractSqliteDriver implements Driver {
     constructor(connection: Connection) {
         this.connection = connection;
         this.options = connection.options as BaseConnectionOptions;
+
+        this.database = DriverUtils.buildDriverOptions(this.options).database;
     }
 
     // -------------------------------------------------------------------------

--- a/src/driver/sqlserver/SqlServerDriver.ts
+++ b/src/driver/sqlserver/SqlServerDriver.ts
@@ -222,6 +222,8 @@ export class SqlServerDriver implements Driver {
         // load mssql package
         this.loadDependencies();
 
+        this.database = DriverUtils.buildDriverOptions(this.options.replication ? this.options.replication.master : this.options).database;
+
         // Object.assign(connection.options, DriverUtils.buildDriverOptions(connection.options)); // todo: do it better way
         // validate options to make sure everything is set
         // if (!this.options.host)


### PR DESCRIPTION
<!--
  😀 Wonderful!  Thank you for opening a pull request for TypeORM.

  Please fill in the information below to expedite the review
  and (hopefully) merge of your change.

  If unsure about something.. just do as best as you're able,
  or reach out through our community support channels!
  https://github.com/typeorm/typeorm/blob/master/docs/support.md
-->

### Description of change

<!--
  Please be clear and concise what the change is intended to do,
  why this change is needed, and how you've verified that it
  corrects what you intended.

  In some cases it may be helpful to include the current behavior
  and the new behavior.

  If the change is related to an open issue, you can link it here.
  If you include `Fixes #0000` (replacing `0000` with the issue number)
  when this is merged it will automatically mark the issue as fixed and
  close it.
-->

refactor: cleaning up the code some

instead of the connection setting the database name from outside
the driver we instead set the database name from within the
driver's constructor providing better encapsulation


### Pull-Request Checklist

<!--
  Please make sure to review and check all of the following.

  If an item is not applicable, you can add "N/A" to the end.
-->

- [x] Code is up-to-date with the `master` branch
- [x] `npm run lint` passes with this change
- [x] `npm run test` passes with this change

<!--
  🎉 Thank you for contributing and making TypeORM even better!
-->
