### PR TITLE
refactor: encapsulate query-result logic in query runner

### DIFF
--- a/src/driver/aurora-data-api-pg/AuroraDataApiPostgresQueryRunner.ts
+++ b/src/driver/aurora-data-api-pg/AuroraDataApiPostgresQueryRunner.ts
@@ -7,6 +7,7 @@ import {AuroraDataApiPostgresDriver} from "./AuroraDataApiPostgresDriver";
 import {PostgresQueryRunner} from "../postgres/PostgresQueryRunner";
 import {ReplicationMode} from "../types/ReplicationMode";
 import {BroadcasterResult} from "../../subscriber/BroadcasterResult";
+import { QueryResult } from "../../query-runner/QueryResult";
 
 class PostgresQueryRunnerWrapper extends PostgresQueryRunner {
     driver: any;
@@ -149,14 +150,26 @@ export class AuroraDataApiPostgresQueryRunner extends PostgresQueryRunnerWrapper
     /**
      * Executes a given SQL query.
      */
-    async query(query: string, parameters?: any[]): Promise<any> {
+    async query(query: string, parameters?: any[], useStructuredResult = false): Promise<any> {
         if (this.isReleased)
             throw new QueryRunnerAlreadyReleasedError();
 
-        const result = await this.client.query(query, parameters);
+        const raw = await this.client.query(query, parameters);
 
-        if (result.records) {
-            return result.records;
+        const result = new QueryResult();
+
+        result.raw = raw;
+
+        if (raw?.hasOwnProperty('records') && Array.isArray(raw.records)) {
+            result.records = raw.records;
+        }
+
+        if (raw?.hasOwnProperty('numberOfRecordsUpdated')) {
+            result.affected = raw.numberOfRecordsUpdated;
+        }
+
+        if (!useStructuredResult) {
+            return result.raw;
         }
 
         return result;

--- a/src/driver/capacitor/CapacitorQueryRunner.ts
+++ b/src/driver/capacitor/CapacitorQueryRunner.ts
@@ -3,7 +3,8 @@ import { QueryFailedError } from "../../error/QueryFailedError";
 import { AbstractSqliteQueryRunner } from "../sqlite-abstract/AbstractSqliteQueryRunner";
 import { CapacitorDriver } from "./CapacitorDriver";
 import { Broadcaster } from "../../subscriber/Broadcaster";
-import { ObjectLiteral } from "../..";
+import { ObjectLiteral } from "../../common/ObjectLiteral";
+import { QueryResult } from "../../query-runner/QueryResult";
 
 /**
  * Runs queries on a single sqlite database connection.
@@ -36,47 +37,57 @@ export class CapacitorQueryRunner extends AbstractSqliteQueryRunner {
     /**
      * Executes a given SQL query.
      */
-    async query(query: string, parameters?: any[]): Promise<any> {
+    async query(query: string, parameters?: any[], useStructuredResult = false): Promise<any> {
         if (this.isReleased) throw new QueryRunnerAlreadyReleasedError();
 
         const databaseConnection = await this.connect();
 
         this.driver.connection.logger.logQuery(query, parameters, this);
 
-        let pResult: Promise<any>;
         const command = query.substr(0, query.indexOf(" "));
 
-        if (
-            ["BEGIN", "ROLLBACK", "COMMIT", "CREATE", "ALTER", "DROP"].indexOf(
-                command
-            ) !== -1
-        ) {
-            pResult = databaseConnection.execute(query, false);
-        } else if (["INSERT", "UPDATE", "DELETE"].indexOf(command) !== -1) {
-            pResult = databaseConnection
-                .run(query, parameters, false)
-                .then(
-                    ({
-                        changes,
-                    }: {
-                        changes: { changes?: number; lastId?: number };
-                    }) => changes.lastId || changes.changes
-                );
-        } else {
-            pResult = databaseConnection
-                .query(query, parameters || [])
-                .then(({ values }: { values: any[] }) => values);
-        }
+        try {
+            let raw: any;
 
-        return pResult.catch((err: any) => {
+            if (
+                [ "BEGIN", "ROLLBACK", "COMMIT", "CREATE", "ALTER", "DROP" ].indexOf(
+                    command
+                ) !== -1
+            ) {
+                raw = await databaseConnection.execute(query, false);
+            } else if ([ "INSERT", "UPDATE", "DELETE" ].indexOf(command) !== -1) {
+                raw = await databaseConnection.run(query, parameters, false);
+            } else {
+                raw = await databaseConnection.query(query, parameters || []);
+            }
+
+            const result = new QueryResult();
+
+            if (raw?.hasOwnProperty('values')) {
+                result.raw = raw.values;
+                result.records = raw.values;
+            }
+
+            if (raw?.hasOwnProperty('changes')) {
+                result.affected = raw.changes.changes;
+                result.raw = raw.changes.lastId || raw.changes.changes;
+            }
+
+            if (!useStructuredResult) {
+                return result.raw;
+            }
+
+            return result;
+        } catch (err) {
             this.driver.connection.logger.logQueryError(
                 err,
                 query,
                 parameters,
                 this
             );
+
             throw new QueryFailedError(query, parameters, err);
-        });
+        }
     }
 
     // -------------------------------------------------------------------------

--- a/src/index.ts
+++ b/src/index.ts
@@ -125,6 +125,7 @@ export {WhereExpressionBuilder} from "./query-builder/WhereExpressionBuilder";
 export {InsertResult} from "./query-builder/result/InsertResult";
 export {UpdateResult} from "./query-builder/result/UpdateResult";
 export {DeleteResult} from "./query-builder/result/DeleteResult";
+export {QueryResult} from "./query-runner/QueryResult";
 export {QueryRunner} from "./query-runner/QueryRunner";
 export {MongoEntityManager} from "./entity-manager/MongoEntityManager";
 export {Migration} from "./migration/Migration";

--- a/src/persistence/tree/NestedSetSubjectExecutor.ts
+++ b/src/persistence/tree/NestedSetSubjectExecutor.ts
@@ -68,7 +68,7 @@ export class NestedSetSubjectExecutor {
             );
         } else {
             const isUniqueRoot = await this.isUniqueRootEntity(subject, parent);
-            
+
             // Validate if a root entity already exits and throw an exception
             if (!isUniqueRoot)
                 throw new NestedSetMultipleRootError();
@@ -138,18 +138,18 @@ export class NestedSetSubjectExecutor {
                 } else {
                     entitySize = parentNs.right - entityNs.left;
                 }
-                
+
                 // Moved entity logic
-                const updateLeftSide = 
+                const updateLeftSide =
                     `WHEN ${leftColumnName} >= ${entityNs.left} AND ` +
                         `${leftColumnName} < ${entityNs.right} ` +
                     `THEN ${leftColumnName} + ${entitySize} `;
 
-                const updateRightSide = 
+                const updateRightSide =
                     `WHEN ${rightColumnName} > ${entityNs.left} AND ` +
                         `${rightColumnName} <= ${entityNs.right} ` +
                     `THEN ${rightColumnName} + ${entitySize} `;
-                
+
                 // Update the surrounding entities
                 if (isMovingUp) {
                     await this.queryRunner.query(`UPDATE ${tableName} ` +
@@ -187,7 +187,7 @@ export class NestedSetSubjectExecutor {
             }
         } else {
             const isUniqueRoot = await this.isUniqueRootEntity(subject, parent);
-            
+
             // Validate if a root entity already exits and throw an exception
             if (!isUniqueRoot)
                 throw new NestedSetMultipleRootError();
@@ -211,7 +211,7 @@ export class NestedSetSubjectExecutor {
         let entitiesIds: ObjectLiteral[] = [];
         for (const subject of subjects) {
             const entityId = metadata.getEntityIdMap(subject.entity);
-            
+
             if (entityId) {
                 entitiesIds.push(entityId);
             }
@@ -267,7 +267,7 @@ export class NestedSetSubjectExecutor {
                     }
                     data.push(entry);
                 }
-                
+
                 return data;
             });
     }
@@ -290,9 +290,13 @@ export class NestedSetSubjectExecutor {
         }).join(" AND ");
 
         const countAlias = "count";
-        const result = await this.queryRunner.query(`SELECT COUNT(1) AS ${escape(countAlias)} FROM ${tableName} WHERE ${whereCondition}`, parameters);
+        const result = await this.queryRunner.query(
+            `SELECT COUNT(1) AS ${escape(countAlias)} FROM ${tableName} WHERE ${whereCondition}`,
+            parameters,
+            true
+        );
 
-        return parseInt(result[0][countAlias]) === 0;
+        return parseInt(result.records[0][countAlias]) === 0;
     }
 
     /**

--- a/src/query-builder/InsertQueryBuilder.ts
+++ b/src/query-builder/InsertQueryBuilder.ts
@@ -100,13 +100,15 @@ export class InsertQueryBuilder<Entity> extends QueryBuilder<Entity> {
             // console.time(".getting query and parameters");
             const [insertSql, parameters] = this.getQueryAndParameters();
             // console.timeEnd(".getting query and parameters");
-            const insertResult = new InsertResult();
+
             // console.time(".query execution by database");
             const statements = [declareSql, insertSql, selectOutputSql];
-            insertResult.raw = await queryRunner.query(
-                statements.filter(sql => sql != null).join(";\n\n"),
-                parameters,
-            );
+            const sql = statements.filter(s => s != null).join(";\n\n");
+
+            const queryResult = await queryRunner.query(sql, parameters, true);
+
+            const insertResult = InsertResult.from(queryResult);
+
             // console.timeEnd(".query execution by database");
 
             // load returning results and set them to the entity if entity updation is enabled

--- a/src/query-builder/QueryBuilder.ts
+++ b/src/query-builder/QueryBuilder.ts
@@ -450,7 +450,6 @@ export abstract class QueryBuilder<Entity> {
         const queryRunner = this.obtainQueryRunner();
         try {
             return await queryRunner.query(sql, parameters);  // await is needed here because we are using finally
-
         } finally {
             if (queryRunner !== this.queryRunner) { // means we created our own query runner
                 await queryRunner.release();

--- a/src/query-builder/SelectQueryBuilder.ts
+++ b/src/query-builder/SelectQueryBuilder.ts
@@ -2101,8 +2101,9 @@ export class SelectQueryBuilder<Entity> extends QueryBuilder<Entity> implements 
                     query: queryId,
                     duration: this.expressionMap.cacheDuration || cacheOptions.duration || 1000
                 }, queryRunner);
-                if (savedQueryResultCacheOptions && !this.connection.queryResultCache.isExpired(savedQueryResultCacheOptions))
+                if (savedQueryResultCacheOptions && !this.connection.queryResultCache.isExpired(savedQueryResultCacheOptions)) {
                     return JSON.parse(savedQueryResultCacheOptions.result);
+                }
             } catch(error) {
                 if (!cacheOptions.ignoreErrors) {
                     throw error;
@@ -2111,7 +2112,7 @@ export class SelectQueryBuilder<Entity> extends QueryBuilder<Entity> implements 
             }
         }
 
-        const results = await queryRunner.query(sql, parameters);
+        const results = await queryRunner.query(sql, parameters, true);
 
         if (!cacheError && this.connection.queryResultCache && (this.expressionMap.cache || cacheOptions.alwaysEnabled)) {
             try {
@@ -2120,7 +2121,7 @@ export class SelectQueryBuilder<Entity> extends QueryBuilder<Entity> implements 
                     query: queryId,
                     time: new Date().getTime(),
                     duration: this.expressionMap.cacheDuration || cacheOptions.duration || 1000,
-                    result: JSON.stringify(results)
+                    result: JSON.stringify(results.records)
                 }, savedQueryResultCacheOptions, queryRunner);
             } catch(error) {
                 if (!cacheOptions.ignoreErrors) {
@@ -2129,7 +2130,7 @@ export class SelectQueryBuilder<Entity> extends QueryBuilder<Entity> implements 
             }
         }
 
-        return results;
+        return results.records;
     }
 
     /**

--- a/src/query-builder/SoftDeleteQueryBuilder.ts
+++ b/src/query-builder/SoftDeleteQueryBuilder.ts
@@ -81,17 +81,9 @@ export class SoftDeleteQueryBuilder<Entity> extends QueryBuilder<Entity> impleme
 
             // execute update query
             const [sql, parameters] = this.getQueryAndParameters();
-            const updateResult = new UpdateResult();
-            const result = await queryRunner.query(sql, parameters);
 
-            const driver = queryRunner.connection.driver;
-            if (driver instanceof PostgresDriver) {
-                updateResult.raw = result[0];
-                updateResult.affected = result[1];
-            }
-            else {
-                updateResult.raw = result;
-            }
+            const queryResult = await queryRunner.query(sql, parameters, true);
+            const updateResult = UpdateResult.from(queryResult);
 
             // if we are updating entities and entity updation is enabled we must update some of entity columns (like version, update date, etc.)
             if (this.expressionMap.updateEntity === true &&

--- a/src/query-builder/result/DeleteResult.ts
+++ b/src/query-builder/result/DeleteResult.ts
@@ -1,7 +1,18 @@
+import {QueryResult} from "../../query-runner/QueryResult";
+
 /**
  * Result object returned by DeleteQueryBuilder execution.
  */
 export class DeleteResult {
+    static from(queryResult: QueryResult) {
+        const result = new this();
+
+        result.raw = queryResult.records;
+        result.affected = queryResult.affected;
+
+        return result;
+    }
+
     /**
      * Raw SQL result returned by executed query.
      */

--- a/src/query-builder/result/InsertResult.ts
+++ b/src/query-builder/result/InsertResult.ts
@@ -1,9 +1,15 @@
 import {ObjectLiteral} from "../../common/ObjectLiteral";
+import {QueryResult} from "../../query-runner/QueryResult";
 
 /**
  * Result object returned by InsertQueryBuilder execution.
  */
 export class InsertResult {
+    static from(queryResult: QueryResult) {
+        const result = new this();
+        result.raw = queryResult.raw;
+        return result;
+    }
 
     /**
      * Contains inserted entity id.

--- a/src/query-builder/result/UpdateResult.ts
+++ b/src/query-builder/result/UpdateResult.ts
@@ -1,9 +1,16 @@
 import {ObjectLiteral} from "../../common/ObjectLiteral";
+import { QueryResult } from "../../query-runner/QueryResult";
 
 /**
  * Result object returned by UpdateQueryBuilder execution.
  */
 export class UpdateResult {
+    static from(queryResult: QueryResult) {
+        const result = new this();
+        result.raw = queryResult.records;
+        result.affected = queryResult.affected;
+        return result;
+    }
 
     /**
      * Raw SQL result returned by executed query.

--- a/src/query-runner/BaseQueryRunner.ts
+++ b/src/query-runner/BaseQueryRunner.ts
@@ -92,7 +92,7 @@ export abstract class BaseQueryRunner {
     /**
      * Executes a given SQL query.
      */
-    abstract query(query: string, parameters?: any[]): Promise<any>;
+    abstract query(query: string, parameters?: any[], useStructuredResult?: boolean): Promise<any>;
 
     // -------------------------------------------------------------------------
     // Protected Abstract Methods

--- a/src/query-runner/QueryResult.ts
+++ b/src/query-runner/QueryResult.ts
@@ -1,0 +1,20 @@
+/**
+ * Result object returned by UpdateQueryBuilder execution.
+ */
+export class QueryResult {
+
+    /**
+     * Raw SQL result returned by executed query.
+     */
+    raw: any;
+
+    /**
+     * Rows
+     */
+    records: any[] = [];
+
+    /**
+     * Number of affected rows/documents
+     */
+    affected?: number;
+}

--- a/src/query-runner/QueryRunner.ts
+++ b/src/query-runner/QueryRunner.ts
@@ -13,6 +13,7 @@ import {Broadcaster} from "../subscriber/Broadcaster";
 import {TableCheck} from "../schema-builder/table/TableCheck";
 import {IsolationLevel} from "../driver/types/IsolationLevel";
 import {TableExclusion} from "../schema-builder/table/TableExclusion";
+import {QueryResult} from "./QueryResult";
 
 /**
  * Runs queries on a single database connection.
@@ -96,6 +97,11 @@ export interface QueryRunner {
      * Error will be thrown if transaction was not started.
      */
     rollbackTransaction(): Promise<void>;
+
+    /**
+     * Executes a given SQL query and returns raw database results.
+     */
+    query(query: string, parameters: any[] | undefined, useStructuredResult: true): Promise<QueryResult>;
 
     /**
      * Executes a given SQL query and returns raw database results.

--- a/test/functional/repository/find-options-locking/find-options-locking.ts
+++ b/test/functional/repository/find-options-locking/find-options-locking.ts
@@ -73,7 +73,7 @@ describe("repository > find options > locking", () => {
 
         await connection.manager.transaction(entityManager => {
             const originalQuery = entityManager.queryRunner!.query.bind(entityManager.queryRunner);
-            entityManager.queryRunner!.query = (...args) => {
+            entityManager.queryRunner!.query = (...args: any[]) => {
                 executedSql.push(args[0]);
                 return originalQuery(...args);
             };
@@ -106,7 +106,7 @@ describe("repository > find options > locking", () => {
 
         await connection.manager.transaction(entityManager => {
             const originalQuery = entityManager.queryRunner!.query.bind(entityManager.queryRunner);
-            entityManager.queryRunner!.query = (...args) => {
+            entityManager.queryRunner!.query = (...args: any[]) => {
                 executedSql.push(args[0]);
                 return originalQuery(...args);
             };
@@ -132,7 +132,7 @@ describe("repository > find options > locking", () => {
 
         await connection.manager.transaction(entityManager => {
             const originalQuery = entityManager.queryRunner!.query.bind(entityManager.queryRunner);
-            entityManager.queryRunner!.query = (...args) => {
+            entityManager.queryRunner!.query = (...args: any[]) => {
                 executedSql.push(args[0]);
                 return originalQuery(...args);
             };


### PR DESCRIPTION
<!--
  😀 Wonderful!  Thank you for opening a pull request for TypeORM.

  Please fill in the information below to expedite the review
  and (hopefully) merge of your change.

  If unsure about something.. just do as best as you're able,
  or reach out through our community support channels!
  https://github.com/typeorm/typeorm/blob/master/docs/support.md
-->

### Description of change

<!--
  Please be clear and concise what the change is intended to do,
  why this change is needed, and how you've verified that it
  corrects what you intended.

  In some cases it may be helpful to include the current behavior
  and the new behavior.

  If the change is related to an open issue, you can link it here.
  If you include `Fixes #0000` (replacing `0000` with the issue number)
  when this is merged it will automatically mark the issue as fixed and
  close it.
-->

the query results really have more to do with the `QueryRunner`, not the `QueryBuilder`.

I've taken the driver-specific code and encapsulated it within each driver's
`QueryRunner`, exporting a `QueryResult` from the driver's `query`.  then, each
QueryBuilder will use that normalized data to create the query result
of a specific type so as not to break the existing API.

fixes #4758

### Pull-Request Checklist

<!--
  Please make sure to review and check all of the following.

  If an item is not applicable, you can add "N/A" to the end.
-->

- [x] Code is up-to-date with the `master` branch
- [x] `npm run lint` passes with this change
- [x] `npm run test` passes with this change
- [x] This pull request links relevant issues as `Fixes #0000`
- [ ] There are new or updated unit tests validating the change
- [ ] Documentation has been updated to reflect this change
- [x] The new commits follow conventions explained in [CONTRIBUTING.md](https://github.com/typeorm/typeorm/blob/master/CONTRIBUTING.md)

<!--
  🎉 Thank you for contributing and making TypeORM even better!
-->
