### PR TITLE
fix: update code to cater for custom deep merge

### DIFF
--- a/docs/connection-options.md
+++ b/docs/connection-options.md
@@ -92,6 +92,9 @@ By default this table is called "migrations".
 * `cache` - Enables entity result caching. You can also configure cache type and other cache options here.
 Read more about caching [here](./caching.md).
 
+* `customDeepMerge` - Configure custom handling for deep merge given a list of predicate/handler pair.
+This is useful especially for self referencing objects which would cause a stack overflow.
+
 * `cli.entitiesDir` - Directory where entities should be created by default by CLI.
 
 * `cli.migrationsDir` - Directory where migrations should be created by default by CLI.

--- a/src/connection/BaseConnectionOptions.ts
+++ b/src/connection/BaseConnectionOptions.ts
@@ -6,6 +6,13 @@ import {Logger} from "../logger/Logger";
 import {Connection} from "./Connection";
 import {QueryResultCache} from "../cache/QueryResultCache";
 
+export type CustomDeepMerge = {
+    predicate: CustomDeepMergePredicate
+    handler: CustomDeepMergeHandler
+};
+
+export type CustomDeepMergePredicate = (x: any) => boolean;
+export type CustomDeepMergeHandler = (x: any) => any;
 /**
  * BaseConnectionOptions is set of connection options shared by all database types.
  */
@@ -109,6 +116,11 @@ export interface BaseConnectionOptions {
      * todo: deprecate this and move all database-specific types into hts own connection options object.
      */
     readonly extra?: any;
+
+    /**
+     * Any custom handlers for deep merge
+     */
+    readonly customDeepMerge?: CustomDeepMerge[];
 
     /**
      * Allows to setup cache options.

--- a/src/driver/aurora-data-api/AuroraDataApiDriver.ts
+++ b/src/driver/aurora-data-api/AuroraDataApiDriver.ts
@@ -695,7 +695,7 @@ export class AuroraDataApiDriver implements Driver {
             //     value = generatedColumn.getEntityValue(uuidMap);
             }
 
-            return OrmUtils.mergeDeep(map, generatedColumn.createValueMap(value));
+            return OrmUtils.mergeDeep(this.connection.options.customDeepMerge, map, generatedColumn.createValueMap(value));
         }, {} as ObjectLiteral);
 
         return Object.keys(generatedMap).length > 0 ? generatedMap : undefined;

--- a/src/driver/cockroachdb/CockroachDriver.ts
+++ b/src/driver/cockroachdb/CockroachDriver.ts
@@ -585,7 +585,7 @@ export class CockroachDriver implements Driver {
         return Object.keys(insertResult).reduce((map, key) => {
             const column = metadata.findColumnWithDatabaseName(key);
             if (column) {
-                OrmUtils.mergeDeep(map, column.createValueMap(this.prepareHydratedValue(insertResult[key], column)));
+                OrmUtils.mergeDeep(this.connection.options.customDeepMerge, map, column.createValueMap(this.prepareHydratedValue(insertResult[key], column)));
             }
             return map;
         }, {} as ObjectLiteral);

--- a/src/driver/mysql/MysqlDriver.ts
+++ b/src/driver/mysql/MysqlDriver.ts
@@ -721,7 +721,7 @@ export class MysqlDriver implements Driver {
             //     value = generatedColumn.getEntityValue(uuidMap);
             }
 
-            return OrmUtils.mergeDeep(map, generatedColumn.createValueMap(value));
+            return OrmUtils.mergeDeep(this.connection.options.customDeepMerge, map, generatedColumn.createValueMap(value));
         }, {} as ObjectLiteral);
 
         return Object.keys(generatedMap).length > 0 ? generatedMap : undefined;

--- a/src/driver/oracle/OracleDriver.ts
+++ b/src/driver/oracle/OracleDriver.ts
@@ -586,7 +586,7 @@ export class OracleDriver implements Driver {
         return Object.keys(insertResult).reduce((map, key) => {
             const column = metadata.findColumnWithDatabaseName(key);
             if (column) {
-                OrmUtils.mergeDeep(map, column.createValueMap(this.prepareHydratedValue(insertResult[key], column)));
+                OrmUtils.mergeDeep(this.connection.options.customDeepMerge, map, column.createValueMap(this.prepareHydratedValue(insertResult[key], column)));
             }
             return map;
         }, {} as ObjectLiteral);

--- a/src/driver/postgres/PostgresDriver.ts
+++ b/src/driver/postgres/PostgresDriver.ts
@@ -877,7 +877,7 @@ export class PostgresDriver implements Driver {
         return Object.keys(insertResult).reduce((map, key) => {
             const column = metadata.findColumnWithDatabaseName(key);
             if (column) {
-                OrmUtils.mergeDeep(map, column.createValueMap(insertResult[key]));
+                OrmUtils.mergeDeep(this.connection.options.customDeepMerge, map, column.createValueMap(insertResult[key]));
                 // OrmUtils.mergeDeep(map, column.createValueMap(this.prepareHydratedValue(insertResult[key], column))); // TODO: probably should be like there, but fails on enums, fix later
             }
             return map;

--- a/src/driver/sap/SapDriver.ts
+++ b/src/driver/sap/SapDriver.ts
@@ -563,7 +563,7 @@ export class SapDriver implements Driver {
                 //     value = generatedColumn.getEntityValue(uuidMap);
             }
 
-            return OrmUtils.mergeDeep(map, generatedColumn.createValueMap(value));
+            return OrmUtils.mergeDeep(this.connection.options.customDeepMerge, map, generatedColumn.createValueMap(value));
         }, {} as ObjectLiteral);
 
         return Object.keys(generatedMap).length > 0 ? generatedMap : undefined;

--- a/src/driver/sqlite-abstract/AbstractSqliteDriver.ts
+++ b/src/driver/sqlite-abstract/AbstractSqliteDriver.ts
@@ -542,7 +542,7 @@ export abstract class AbstractSqliteDriver implements Driver {
             }
 
             if (!value) return map;
-            return OrmUtils.mergeDeep(map, generatedColumn.createValueMap(value));
+            return OrmUtils.mergeDeep(this.connection.options.customDeepMerge, map, generatedColumn.createValueMap(value));
         }, {} as ObjectLiteral);
 
         return Object.keys(generatedMap).length > 0 ? generatedMap : undefined;

--- a/src/driver/sqljs/SqljsDriver.ts
+++ b/src/driver/sqljs/SqljsDriver.ts
@@ -213,7 +213,7 @@ export class SqljsDriver extends AbstractSqliteDriver {
                 try {
                     let result = this.databaseConnection.exec(query);
                     this.connection.logger.logQuery(query);
-                    return OrmUtils.mergeDeep(map, generatedColumn.createValueMap(result[0].values[0][0]));
+                    return OrmUtils.mergeDeep(this.connection.options.customDeepMerge, map, generatedColumn.createValueMap(result[0].values[0][0]));
                 }
                 catch (e) {
                     this.connection.logger.logQueryError(e, query, []);

--- a/src/driver/sqlserver/SqlServerDriver.ts
+++ b/src/driver/sqlserver/SqlServerDriver.ts
@@ -590,7 +590,7 @@ export class SqlServerDriver implements Driver {
         return Object.keys(insertResult).reduce((map, key) => {
             const column = metadata.findColumnWithDatabaseName(key);
             if (column) {
-                OrmUtils.mergeDeep(map, column.createValueMap(this.prepareHydratedValue(insertResult[key], column)));
+                OrmUtils.mergeDeep(this.connection.options.customDeepMerge, map, column.createValueMap(this.prepareHydratedValue(insertResult[key], column)));
             }
             return map;
         }, {} as ObjectLiteral);

--- a/src/metadata/ColumnMetadata.ts
+++ b/src/metadata/ColumnMetadata.ts
@@ -558,7 +558,7 @@ export class ColumnMetadata {
                 const map = this.relationMetadata.joinColumns.reduce((map, joinColumn) => {
                     const value = joinColumn.referencedColumn!.getEntityValueMap(entity[this.relationMetadata!.propertyName]);
                     if (value === undefined) return map;
-                    return OrmUtils.mergeDeep(map, value);
+                    return OrmUtils.mergeDeep(this.entityMetadata.connection.options.customDeepMerge, map, value);
                 }, {});
                 if (Object.keys(map).length > 0)
                     return { [this.propertyName]: map };

--- a/src/metadata/EntityMetadata.ts
+++ b/src/metadata/EntityMetadata.ts
@@ -590,7 +590,7 @@ export class EntityMetadata {
         if (!entity)
             return undefined;
 
-        return EntityMetadata.getValueMap(entity, this.primaryColumns, { skipNulls: true });
+        return this.getValueMap(entity, this.primaryColumns, { skipNulls: true });
     }
 
     /**
@@ -762,7 +762,7 @@ export class EntityMetadata {
      * Creates value map from the given values and columns.
      * Examples of usages are primary columns map and join columns map.
      */
-    static getValueMap(entity: ObjectLiteral, columns: ColumnMetadata[], options?: { skipNulls?: boolean }): ObjectLiteral|undefined {
+    getValueMap(entity: ObjectLiteral, columns: ColumnMetadata[], options?: { skipNulls?: boolean }): ObjectLiteral|undefined {
         return columns.reduce((map, column) => {
             const value = column.getEntityValueMap(entity, options);
 
@@ -770,7 +770,7 @@ export class EntityMetadata {
             if (map === undefined || value === null || value === undefined)
                 return undefined;
 
-            return column.isObjectId ? Object.assign(map, value) : OrmUtils.mergeDeep(map, value);
+            return column.isObjectId ? Object.assign(map, value) : OrmUtils.mergeDeep(this.connection.options.customDeepMerge, map, value);
         }, {} as ObjectLiteral|undefined);
     }
 
@@ -846,8 +846,8 @@ export class EntityMetadata {
      */
     createPropertiesMap(): { [name: string]: string|any } {
         const map: { [name: string]: string|any } = {};
-        this.columns.forEach(column => OrmUtils.mergeDeep(map, column.createValueMap(column.propertyPath)));
-        this.relations.forEach(relation => OrmUtils.mergeDeep(map, relation.createValueMap(relation.propertyPath)));
+        this.columns.forEach(column => OrmUtils.mergeDeep(this.connection.options.customDeepMerge, map, column.createValueMap(column.propertyPath)));
+        this.relations.forEach(relation => OrmUtils.mergeDeep(this.connection.options.customDeepMerge, map, relation.createValueMap(relation.propertyPath)));
         return map;
     }
 

--- a/src/metadata/RelationMetadata.ts
+++ b/src/metadata/RelationMetadata.ts
@@ -336,7 +336,7 @@ export class RelationMetadata {
         const referencedColumns = joinColumns.map(joinColumn => joinColumn.referencedColumn!);
         // console.log("entity", entity);
         // console.log("referencedColumns", referencedColumns);
-        return EntityMetadata.getValueMap(entity, referencedColumns);
+        return this.entityMetadata.getValueMap(entity, referencedColumns);
     }
 
     /**

--- a/src/persistence/Subject.ts
+++ b/src/persistence/Subject.ts
@@ -272,7 +272,7 @@ export class Subject {
                 }
             }
 
-            OrmUtils.mergeDeep(updateMap, valueMap);
+            OrmUtils.mergeDeep(this.metadata.connection.options.customDeepMerge, updateMap, valueMap);
             return updateMap;
         }, {} as ObjectLiteral);
         this.changeMaps = changeMapsWithoutValues;

--- a/src/persistence/SubjectExecutor.ts
+++ b/src/persistence/SubjectExecutor.ts
@@ -387,7 +387,7 @@ export class SubjectExecutor {
 
             // for mongodb we have a bit different updation logic
             if (this.queryRunner instanceof MongoQueryRunner) {
-                const partialEntity = OrmUtils.mergeDeep({}, subject.entity!);
+                const partialEntity = OrmUtils.mergeDeep(this.queryRunner.connection.options.customDeepMerge, {}, subject.entity!);
                 if (subject.metadata.objectIdColumn && subject.metadata.objectIdColumn.propertyName) {
                     delete partialEntity[subject.metadata.objectIdColumn.propertyName];
                 }
@@ -551,7 +551,7 @@ export class SubjectExecutor {
 
             // for mongodb we have a bit different updation logic
             if (this.queryRunner instanceof MongoQueryRunner) {
-                const partialEntity = OrmUtils.mergeDeep({}, subject.entity!);
+                const partialEntity = OrmUtils.mergeDeep(this.queryRunner.connection.options.customDeepMerge, {}, subject.entity!);
                 if (subject.metadata.objectIdColumn && subject.metadata.objectIdColumn.propertyName) {
                     delete partialEntity[subject.metadata.objectIdColumn.propertyName];
                 }
@@ -631,7 +631,7 @@ export class SubjectExecutor {
 
             // for mongodb we have a bit different updation logic
             if (this.queryRunner instanceof MongoQueryRunner) {
-                const partialEntity = OrmUtils.mergeDeep({}, subject.entity!);
+                const partialEntity = OrmUtils.mergeDeep(this.queryRunner.connection.options.customDeepMerge, {}, subject.entity!);
                 if (subject.metadata.objectIdColumn && subject.metadata.objectIdColumn.propertyName) {
                     delete partialEntity[subject.metadata.objectIdColumn.propertyName];
                 }

--- a/src/persistence/subject-builder/ManyToManySubjectBuilder.ts
+++ b/src/persistence/subject-builder/ManyToManySubjectBuilder.ts
@@ -232,10 +232,10 @@ export class ManyToManySubjectBuilder {
 
         const identifier: ObjectLiteral = {};
         relation.junctionEntityMetadata!.ownerColumns.forEach(column => {
-            OrmUtils.mergeDeep(identifier, column.createValueMap(column.referencedColumn!.getEntityValue(ownerEntityMap)));
+            OrmUtils.mergeDeep(subject.metadata.connection.options.customDeepMerge, identifier, column.createValueMap(column.referencedColumn!.getEntityValue(ownerEntityMap)));
         });
         relation.junctionEntityMetadata!.inverseColumns.forEach(column => {
-            OrmUtils.mergeDeep(identifier, column.createValueMap(column.referencedColumn!.getEntityValue(inverseEntityMap)));
+            OrmUtils.mergeDeep(subject.metadata.connection.options.customDeepMerge, identifier, column.createValueMap(column.referencedColumn!.getEntityValue(inverseEntityMap)));
         });
         return identifier;
     }

--- a/src/persistence/tree/NestedSetSubjectExecutor.ts
+++ b/src/persistence/tree/NestedSetSubjectExecutor.ts
@@ -62,6 +62,7 @@ export class NestedSetSubjectExecutor {
                 `WHERE ${rightColumnName} >= ${parentNsRight}`);
 
             OrmUtils.mergeDeep(
+                this.queryRunner.connection.options.customDeepMerge,
                 subject.insertedValueSet,
                 subject.metadata.nestedSetLeftColumn!.createValueMap(parentNsRight),
                 subject.metadata.nestedSetRightColumn!.createValueMap(parentNsRight + 1),
@@ -74,6 +75,7 @@ export class NestedSetSubjectExecutor {
                 throw new NestedSetMultipleRootError();
 
             OrmUtils.mergeDeep(
+                this.queryRunner.connection.options.customDeepMerge,
                 subject.insertedValueSet,
                 subject.metadata.nestedSetLeftColumn!.createValueMap(1),
                 subject.metadata.nestedSetRightColumn!.createValueMap(2),

--- a/src/query-builder/ReturningResultsEntityUpdator.ts
+++ b/src/query-builder/ReturningResultsEntityUpdator.ts
@@ -105,7 +105,7 @@ export class ReturningResultsEntityUpdator {
                         if (!uuid) // if it was not defined by a user then InsertQueryBuilder generates it by its own, get this generated uuid value
                             uuid = this.expressionMap.nativeParameters["uuid_" + generatedColumn.databaseName + entityIndex];
 
-                        OrmUtils.mergeDeep(generatedMap, generatedColumn.createValueMap(uuid));
+                        OrmUtils.mergeDeep(this.queryRunner.connection.options.customDeepMerge, generatedMap, generatedColumn.createValueMap(uuid));
                     }
                 });
             }

--- a/src/query-builder/transformer/RawSqlResultsToEntityTransformer.ts
+++ b/src/query-builder/transformer/RawSqlResultsToEntityTransformer.ts
@@ -247,12 +247,12 @@ export class RawSqlResultsToEntityTransformer {
                         if (column.isVirtual && column.referencedColumn && column.referencedColumn.propertyName !== column.propertyName) // if column is a relation
                             value = column.referencedColumn.createValueMap(value);
 
-                        return OrmUtils.mergeDeep(idMap, column.createValueMap(value));
+                        return OrmUtils.mergeDeep(this.driver.options.customDeepMerge, idMap, column.createValueMap(value));
                     } else {
                         if (column.referencedColumn!.referencedColumn) // if column is a relation
                             value = column.referencedColumn!.referencedColumn!.createValueMap(value);
 
-                        return OrmUtils.mergeDeep(idMap, column.referencedColumn!.createValueMap(value));
+                        return OrmUtils.mergeDeep(this.driver.options.customDeepMerge, idMap, column.referencedColumn!.createValueMap(value));
                     }
                 }, {} as ObjectLiteral);
 

--- a/test/github-issues/6181/entity/Post.ts
+++ b/test/github-issues/6181/entity/Post.ts
@@ -1,0 +1,18 @@
+import { Column } from "../../../../src/decorator/columns/Column";
+import { PrimaryColumn } from "../../../../src/decorator/columns/PrimaryColumn";
+import { Entity } from "../../../../src/decorator/entity/Entity";
+import { SelfReferencing } from "./SelfReferencing";
+import { SelfReferencingTransformer } from "./SelfReferencingTransformer";
+
+@Entity()
+export class Post {
+    @PrimaryColumn()
+    id: number;
+
+    @Column({
+        type: "simple-json",
+        nullable: true,
+        transformer: new SelfReferencingTransformer()
+    })
+    selfReferencing: SelfReferencing;
+}

--- a/test/github-issues/6181/entity/SelfReferencing.ts
+++ b/test/github-issues/6181/entity/SelfReferencing.ts
@@ -1,0 +1,10 @@
+export class SelfReferencing {
+    constructor(value: string) {
+        this.value = value;
+        this.self = this;
+    }
+
+    value: string;
+
+    self: SelfReferencing;
+}

--- a/test/github-issues/6181/entity/SelfReferencingTransformer.ts
+++ b/test/github-issues/6181/entity/SelfReferencingTransformer.ts
@@ -1,0 +1,14 @@
+import {ValueTransformer} from "../../../../src/decorator/options/ValueTransformer";
+import {SelfReferencing} from "./SelfReferencing";
+
+export class SelfReferencingTransformer implements ValueTransformer {
+
+    to ({value}: SelfReferencing): string {
+        return value;
+    }
+
+    from (value: string): SelfReferencing {
+        return new SelfReferencing(value);
+    }
+
+}

--- a/test/github-issues/6181/issue-6181.ts
+++ b/test/github-issues/6181/issue-6181.ts
@@ -1,0 +1,61 @@
+import "reflect-metadata";
+import { Connection } from "../../../src/connection/Connection";
+import { closeTestingConnections, createTestingConnections, reloadTestingDatabases } from "../../utils/test-utils";
+import { Post } from "./entity/Post";
+import { expect } from "chai";
+import { SelfReferencing } from "./entity/SelfReferencing";
+
+describe("github issues > #6181 stackoverflow, OrmUtils.deepmerge with circular reference", () => {
+
+    describe("without custom merge deep", () => {
+        let connections: Connection[];
+        before(async () => {
+            connections = await createTestingConnections({
+                entities: [Post],
+                schemaCreate: true,
+                dropSchema: true
+            });
+        });
+        beforeEach(() => reloadTestingDatabases(connections));
+        after(() => closeTestingConnections(connections));
+
+        it("should stack overflow", () => Promise.all(connections.map(async (connection) => {
+            const id = 1;
+            const selfReferencing = new SelfReferencing("some-value");
+
+            const repository = connection.getRepository(Post);
+            await expect(repository.save({id, selfReferencing})).to.rejectedWith(RangeError);
+        })));
+    });
+
+    describe("with custom merge deep", () => {
+        let connections: Connection[];
+        before(async () => {
+            connections = await createTestingConnections({
+                customDeepMerge: [{
+                    predicate: x => x instanceof SelfReferencing,
+                    handler: x => x
+                }],
+                entities: [Post],
+                schemaCreate: true,
+                dropSchema: true
+            });
+        });
+        beforeEach(() => reloadTestingDatabases(connections));
+        after(() => closeTestingConnections(connections));
+
+        it("should correctly save and retrieve the entity", () => Promise.all(connections.map(async (connection) => {
+            const id = 1;
+            const selfReferencing = new SelfReferencing("some-value");
+
+            const repository = connection.getRepository(Post);
+            await repository.save({id, selfReferencing});
+
+            const savedEntity = await repository.findOne(id);
+            expect(savedEntity).not.to.be.undefined;
+            expect(savedEntity!.selfReferencing).not.to.be.undefined;
+            expect(savedEntity!.selfReferencing!.value).to.eq("some-value");
+            expect(savedEntity!.selfReferencing!.self).to.eq(savedEntity!.selfReferencing!.self);
+        })));
+    });
+});

--- a/test/utils/test-utils.ts
+++ b/test/utils/test-utils.ts
@@ -8,6 +8,7 @@ import {createConnections} from "../../src/index";
 import {NamingStrategyInterface} from "../../src/naming-strategy/NamingStrategyInterface";
 import {QueryResultCache} from "../../src/cache/QueryResultCache";
 import {Logger} from "../../src/logger/Logger";
+import {CustomDeepMerge} from "../../src/connection/BaseConnectionOptions";
 
 /**
  * Interface in which data is stored in ormconfig.json of the project.
@@ -138,6 +139,12 @@ export interface TestingOptions {
      * Factory to create a logger for each test connection.
      */
     createLogger?: () => "advanced-console"|"simple-console"|"file"|"debug"|Logger;
+
+    /**
+     * Any custom handlers for deep merge
+     */
+    customDeepMerge?: CustomDeepMerge[];
+
 }
 
 /**
@@ -232,6 +239,8 @@ export function setupTestingConnections(options?: TestingOptions): ConnectionOpt
                 newOptions.migrations = [options.__dirname + "/migration/*{.js,.ts}"];
             if (options && options.namingStrategy)
                 newOptions.namingStrategy = options.namingStrategy;
+            if (options && options.customDeepMerge)
+                newOptions.customDeepMerge = options.customDeepMerge;
             return newOptions;
         });
 }


### PR DESCRIPTION
<!--
  😀 Wonderful!  Thank you for opening a pull request for TypeORM.

  Please fill in the information below to expedite the review
  and (hopefully) merge of your change.

  If unsure about something.. just do as best as you're able,
  or reach out through our community support channels!
  https://github.com/typeorm/typeorm/blob/master/docs/support.md
-->

### Description of change

<!--
  Please be clear and concise what the change is intended to do,
  why this change is needed, and how you've verified that it
  corrects what you intended.

  In some cases it may be helpful to include the current behavior
  and the new behavior.

  If the change is related to an open issue, you can link it here.
  If you include `Fixes #0000` (replacing `0000` with the issue number)
  when this is merged it will automatically mark the issue as fixed and
  close it.
-->

Unfortunately the current version of TypeORM fails to save an entity with a property that is of a self referencing type. This can be seen by this open issue (https://github.com/typeorm/typeorm/issues/6181). `js-joda`'s `ZonedDateTime` has a `ZoneOffset` which is self referencing and it causes a stack overflow on `OrmUtils.mergeDeep`.

Finding a solution for deep merging a self referencing object is not an easy task as explained by this [open issue](https://github.com/TehShrike/deepmerge/issues/207) in the [deepmerge](https://www.npmjs.com/package/deepmerge) library.

This PR adds a way for a consumer to configure custom deep merge handling given a list of predicate/handler combination.

This will allow https://github.com/typeorm/typeorm/issues/6181 to be closed as they will be able to configure the `customDeepMerge` as follows:

```
customDeepMerge: [{
    predicate: x => x instanceof ZoneOffset,
    handler: x => x
}]
```

This will effectively break out of the recursive call to `OrmUtils.mergeDeep`.

### Pull-Request Checklist

<!--
  Please make sure to review and check all of the following.

  If an item is not applicable, you can add "N/A" to the end.
-->

- [x] Code is up-to-date with the `master` branch
- [x] `npm run lint` passes with this change
- [x] `npm run test` passes with this change
- [x] This pull request links relevant issues as `Fixes #6181`
- [x] There are new or updated unit tests validating the change
- [x] Documentation has been updated to reflect this change
- [x] The new commits follow conventions explained in [CONTRIBUTING.md](https://github.com/typeorm/typeorm/blob/master/CONTRIBUTING.md)

<!--
  🎉 Thank you for contributing and making TypeORM even better!
-->
