### PR TITLE
fix: handle URL objects as column field values (redux)

### DIFF
--- a/src/util/OrmUtils.ts
+++ b/src/util/OrmUtils.ts
@@ -1,4 +1,5 @@
 import {ObjectLiteral} from "../common/ObjectLiteral";
+import {PlatformTools} from "../platform/PlatformTools";
 
 /**
  * Access `URL` in environments that support it.
@@ -7,7 +8,8 @@ import {ObjectLiteral} from "../common/ObjectLiteral";
  *
  * Note: `globalThis` is being extended with a `URL` property as @types/node does not declare it (see https://github.com/DefinitelyTyped/DefinitelyTyped/issues/34960)
  */
-const GlobalURL = (typeof globalThis !== "undefined" ? globalThis as (typeof globalThis & {URL?: (typeof import("url").URL)}) : {URL: undefined}).URL;
+const _global = PlatformTools.getGlobalVariable() as (typeof globalThis & {URL?: (typeof import("url").URL)});
+const GlobalURL = (typeof _global !== "undefined" ? _global : {URL: undefined}).URL;
 
 export class OrmUtils {
 

--- a/src/util/OrmUtils.ts
+++ b/src/util/OrmUtils.ts
@@ -1,5 +1,14 @@
 import {ObjectLiteral} from "../common/ObjectLiteral";
 
+/**
+ * Access `URL` in environments that support it.
+ * For example, React Native does not include `URL` (see https://github.com/typeorm/typeorm/issues/6142),
+ * but Node.js (>= v10) and browser implementations do.
+ *
+ * Note: `globalThis` is being extended with a `URL` property as @types/node does not declare it (see https://github.com/DefinitelyTyped/DefinitelyTyped/issues/34960)
+ */
+const GlobalURL = (typeof globalThis !== "undefined" ? globalThis as (typeof globalThis & {URL?: (typeof import('url').URL)}) : {URL: undefined}).URL;
+
 export class OrmUtils {
 
     // -------------------------------------------------------------------------
@@ -82,7 +91,8 @@ export class OrmUtils {
                 && !(value instanceof Set)
                 && !(value instanceof Date)
                 && !(value instanceof Buffer)
-                && !(value instanceof RegExp)) {
+                && !(value instanceof RegExp)
+                && !(GlobalURL && value instanceof GlobalURL)) {
                     if (!target[key])
                         Object.assign(target, { [key]: Object.create(Object.getPrototypeOf(value)) });
                     this.mergeDeep(target[key], value);
@@ -212,7 +222,8 @@ export class OrmUtils {
             (x instanceof Date && y instanceof Date) ||
             (x instanceof RegExp && y instanceof RegExp) ||
             (x instanceof String && y instanceof String) ||
-            (x instanceof Number && y instanceof Number))
+            (x instanceof Number && y instanceof Number) ||
+            (GlobalURL && x instanceof GlobalURL && y instanceof GlobalURL))
             return x.toString() === y.toString();
 
         // At last checking prototypes as good as we can

--- a/src/util/OrmUtils.ts
+++ b/src/util/OrmUtils.ts
@@ -7,7 +7,7 @@ import {ObjectLiteral} from "../common/ObjectLiteral";
  *
  * Note: `globalThis` is being extended with a `URL` property as @types/node does not declare it (see https://github.com/DefinitelyTyped/DefinitelyTyped/issues/34960)
  */
-const GlobalURL = (typeof globalThis !== "undefined" ? globalThis as (typeof globalThis & {URL?: (typeof import('url').URL)}) : {URL: undefined}).URL;
+const GlobalURL = (typeof globalThis !== "undefined" ? globalThis as (typeof globalThis & {URL?: (typeof import("url").URL)}) : {URL: undefined}).URL;
 
 export class OrmUtils {
 

--- a/test/github-issues/5762/entity/User.ts
+++ b/test/github-issues/5762/entity/User.ts
@@ -1,0 +1,24 @@
+import {Entity} from "../../../../src/decorator/entity/Entity";
+ import {PrimaryColumn, Column} from "../../../../src";
+ import { URL } from "url";
+
+ @Entity()
+ export class User {
+
+   @PrimaryColumn()
+   id: number;
+
+   @Column("varchar", {
+     // marshall
+     transformer: {
+       from(value: string): URL {
+         return new URL(value);
+       },
+       to(value: URL): string {
+         return value.toString();
+       },
+     },
+   })
+   url: URL;
+
+ }

--- a/test/github-issues/5762/issue-5762.ts
+++ b/test/github-issues/5762/issue-5762.ts
@@ -1,0 +1,39 @@
+import "reflect-metadata";
+ import {expect} from "chai";
+ import {Connection} from "../../../src";
+ import {User} from "./entity/User";
+ import {createTestingConnections, reloadTestingDatabases, closeTestingConnections} from "../../utils/test-utils";
+ import { URL } from "url";
+
+ describe("github issues > #5762 `Using URL as a rich column type breaks", () => {
+
+     let connections: Connection[];
+
+     before(async () => {
+         connections = await createTestingConnections({
+             entities: [User],
+             schemaCreate: true,
+             dropSchema: true
+         });
+     });
+     beforeEach(() => reloadTestingDatabases(connections));
+     after(() => closeTestingConnections(connections));
+
+     it("should allow assigning URL as a field value", () =>
+     Promise.all(connections.map(async (connection) => {
+         const userRepository = connection.getRepository(User);
+
+         const url = new URL("https://typeorm.io");
+
+         const user = new User();
+         user.id = 1;
+         user.url = url;
+
+         const promise = userRepository.save(user);
+
+         return expect(promise).to.eventually.be.deep.equal(user)
+         .and.to.have.property("url").be.instanceOf(URL)
+         .and.to.have.nested.property("href").equal(url.href);
+     })));
+
+ });


### PR DESCRIPTION
<!--
  😀 Wonderful!  Thank you for opening a pull request for TypeORM.

  Please fill in the information below to expedite the review
  and (hopefully) merge of your change.

  If unsure about something.. just do as best as you're able,
  or reach out through our community support channels!
  https://github.com/typeorm/typeorm/blob/master/docs/support.md
-->

### Description of change

Fixes #5762
See previous PR (which was reverted) #5771 due to #6142

This time, `URL` isn't imported from the `url` module (which isn't present in React Native or browser environments). Instead, it's optionally accessed on the globalThis (if present) object, which is supported in node v.10+ and modern browser environments.

<!--
  Please be clear and concise what the change is intended to do,
  why this change is needed, and how you've verified that it
  corrects what you intended.

  In some cases it may be helpful to include the current behavior
  and the new behavior.

  If the change is related to an open issue, you can link it here.
  If you include `Fixes #0000` (replacing `0000` with the issue number)
  when this is merged it will automatically mark the issue as fixed and
  close it.
-->


### Pull-Request Checklist

<!--
  Please make sure to review and check all of the following.

  If an item is not applicable, you can add "N/A" to the end.
-->

- [x] Code is up-to-date with the `master` branch
- [x] `npm run lint` passes with this change
- [x] `npm run test` passes with this change
- [x] This pull request links relevant issues as `Fixes #0000`
- [x] There are new or updated unit tests validating the change
- [ ] Documentation has been updated to reflect this change
- [x] The new commits follow conventions explained in [CONTRIBUTING.md](https://github.com/typeorm/typeorm/blob/master/CONTRIBUTING.md)

<!--
  🎉 Thank you for contributing and making TypeORM even better!
-->
