### PR TITLE
feat: Error if postgresql enum is not specified

### DIFF
--- a/src/driver/postgres/PostgresQueryRunner.ts
+++ b/src/driver/postgres/PostgresQueryRunner.ts
@@ -2027,7 +2027,10 @@ export class PostgresQueryRunner extends BaseQueryRunner implements QueryRunner 
      */
     protected createEnumTypeSql(table: Table, column: TableColumn, enumName?: string): Query {
         if (!enumName) enumName = this.buildEnumName(table, column);
-        const enumValues = column.enum!.map(value => `'${value.replace("'", "''")}'`).join(", ");
+        if (!column.enum) {
+            throw new Error(`No enum values provided for column ${column.name} of table ${table.name}. Please provide the enum values using @Column({enum: ...})`);
+        }
+        const enumValues = column.enum.map(value => `'${value.replace("'", "''")}'`).join(", ");
         return new Query(`CREATE TYPE ${enumName} AS ENUM(${enumValues})`);
     }
 

--- a/test/functional/database-schema/column-types/postgres-enum/postgres-enum.ts
+++ b/test/functional/database-schema/column-types/postgres-enum/postgres-enum.ts
@@ -228,10 +228,10 @@ describe("database schema > column types > postgres-enum", () => {
         let table = await queryRunner.getTable("post");
         const column = table!.findColumnByName("enum")!;
         const newColumn = column.clone();
-        newColumn.enumName = "PostTypeEnum"
+        newColumn.enumName = "PostTypeEnum";
 
         // change column
-        await queryRunner.changeColumn(table!, column, newColumn)
+        await queryRunner.changeColumn(table!, column, newColumn);
 
         // check if `enumName` changed
         table = await queryRunner.getTable("post");
@@ -239,7 +239,7 @@ describe("database schema > column types > postgres-enum", () => {
         expect(changedColumn.enumName).to.equal("PostTypeEnum");
 
         // revert changes
-        await queryRunner.executeMemoryDownSql()
+        await queryRunner.executeMemoryDownSql();
 
         // check if `enumName` reverted
         table = await queryRunner.getTable("post");
@@ -275,10 +275,10 @@ describe("database schema > column types > postgres-enum", () => {
             ]
         });
 
-        await queryRunner.createTable(table)
+        await queryRunner.createTable(table);
 
         // revert changes
-        await queryRunner.executeMemoryDownSql()
+        await queryRunner.executeMemoryDownSql();
 
         await queryRunner.release();
     })));
@@ -295,16 +295,16 @@ describe("database schema > column types > postgres-enum", () => {
         await queryRunner.changeColumn(table!, enumColumn, changedColumn);
 
         table = await queryRunner.getTable("post");
-        const columnAfterChange = table!.findColumnByName("enum")!
+        const columnAfterChange = table!.findColumnByName("enum")!;
         columnAfterChange.enum!.should.be.eql(["C", "D", "E"]);
         columnAfterChange.enumName!.should.be.eql("my_enum_type");
 
         await queryRunner.executeMemoryDownSql();
 
         table = await queryRunner.getTable("post");
-        const columnAfterRevert = table!.findColumnByName("enum")!
+        const columnAfterRevert = table!.findColumnByName("enum")!;
         columnAfterRevert.enum!.should.be.eql(["A", "B", "C"]);
-        expect(columnAfterRevert.enumName).to.undefined
+        expect(columnAfterRevert.enumName).to.undefined;
 
         await queryRunner.release();
     })));
@@ -357,6 +357,16 @@ describe("database schema > column types > postgres-enum", () => {
             `WHERE "n"."nspname" = '${currentSchema}' AND "t"."typname" = 'post_enum_enum'`);
         result.length.should.be.equal(1);
 
+        await queryRunner.release();
+    })));
+
+    it("should throw an error if no enum values are provided", () => Promise.all(connections.map(async connection => {
+        const queryRunner = connection.createQueryRunner();
+        await queryRunner.addColumn("post", new TableColumn({
+            name: "newEnum",
+            type: "enum",
+            // enum missing intentionally
+        })).should.eventually.be.rejectedWith(Error).and.property("message").contain("newEnum");
         await queryRunner.release();
     })));
 


### PR DESCRIPTION

### Description of change

Print a nice error message if the enum value is missing for postgresql, including the column name that has the problem.

Message:
```
No enum values provided for column my_column of table my_table. Please provide the enum values using @Column({enum: ...})
```

Took me some time to figure out which column was causing this, since there is no error message currently and typeorm just crashes with an undefined object reference.

### Pull-Request Checklist

- [x] Code is up-to-date with the `master` branch
- [x] `npm run lint` passes with this change
- [x] `npm run test` passes with this change
- -- This pull request links relevant issues as `Fixes #0000`
- [x] There are new or updated unit tests validating the change
- -- Documentation has been updated to reflect this change
- [x] The new commits follow conventions explained in [CONTRIBUTING.md](https://github.com/typeorm/typeorm/blob/master/CONTRIBUTING.md)
