### PR TITLE
feat: add connection option `entitySkipConstructor`

### DIFF
--- a/docs/connection-options.md
+++ b/docs/connection-options.md
@@ -72,6 +72,10 @@ Learn more about [Naming strategies](./naming-strategy.md).
 
 * `entityPrefix` - Prefixes with the given string all tables (or collections) on this database connection.
 
+* `entitySkipConstructor` - Indicates if TypeORM should skip constructors when deserializing entities
+  from the database. Note that when you do not call the constructor both private properties and default
+  properties will not operate as expected.
+
 * `dropSchema` - Drops the schema each time connection is being established.
 Be careful with this option and don't use this in production - otherwise you'll lose all production data.
 This option is useful during debug and development.

--- a/src/connection/BaseConnectionOptions.ts
+++ b/src/connection/BaseConnectionOptions.ts
@@ -104,6 +104,11 @@ export interface BaseConnectionOptions {
     readonly entityPrefix?: string;
 
     /**
+     * When creating new Entity instances, skip all constructors when true.
+     */
+    readonly entitySkipConstructor?: boolean;
+
+    /**
      * Extra connection options to be passed to the underlying driver.
      *
      * todo: deprecate this and move all database-specific types into hts own connection options object.

--- a/src/query-builder/transformer/DocumentToEntityTransformer.ts
+++ b/src/query-builder/transformer/DocumentToEntityTransformer.ts
@@ -28,7 +28,7 @@ export class DocumentToEntityTransformer {
     }
 
     transform(document: any, metadata: EntityMetadata) {
-        const entity: any = metadata.create();
+        const entity: any = metadata.create(undefined, { fromDeserializer: true });
         let hasData = false;
 
         // handle _id property the special way
@@ -87,7 +87,7 @@ export class DocumentToEntityTransformer {
 
                 if (embedded.isArray) {
                     entity[embedded.propertyName] = (document[embedded.prefix] as any[]).map((subValue: any, index: number) => {
-                        const newItem = embedded.create();
+                        const newItem = embedded.create({ fromDeserializer: true });
                         embedded.columns.forEach(column => {
                             newItem[column.propertyName] = subValue[column.databaseNameWithoutPrefixes];
                         });
@@ -96,15 +96,15 @@ export class DocumentToEntityTransformer {
                     });
 
                 } else {
-                    if (embedded.embeddeds.length && !entity[embedded.propertyName]) 
-                        entity[embedded.propertyName] = embedded.create();
-                    
+                    if (embedded.embeddeds.length && !entity[embedded.propertyName])
+                        entity[embedded.propertyName] = embedded.create({ fromDeserializer: true });
+
                     embedded.columns.forEach(column => {
                         const value = document[embedded.prefix][column.databaseNameWithoutPrefixes];
                         if (value === undefined) return;
 
                         if (!entity[embedded.propertyName])
-                            entity[embedded.propertyName] = embedded.create();
+                            entity[embedded.propertyName] = embedded.create({ fromDeserializer: true });
 
                         entity[embedded.propertyName][column.propertyName] = value;
                     });

--- a/src/query-builder/transformer/PlainObjectToNewEntityTransformer.ts
+++ b/src/query-builder/transformer/PlainObjectToNewEntityTransformer.ts
@@ -66,7 +66,7 @@ export class PlainObjectToNewEntityTransformer {
 
                         // if such item already exist then merge new data into it, if its not we create a new entity and merge it into the array
                         if (!objectRelatedValueEntity) {
-                            objectRelatedValueEntity = relation.inverseEntityMetadata.create();
+                            objectRelatedValueEntity = relation.inverseEntityMetadata.create(undefined, { fromDeserializer: true });
                             entityRelatedValue.push(objectRelatedValueEntity);
                         }
 
@@ -86,7 +86,7 @@ export class PlainObjectToNewEntityTransformer {
                     }
 
                     if (!entityRelatedValue) {
-                        entityRelatedValue = relation.inverseEntityMetadata.create();
+                        entityRelatedValue = relation.inverseEntityMetadata.create(undefined, { fromDeserializer: true });
                         relation.setEntityValue(entity, entityRelatedValue);
                     }
 

--- a/src/query-builder/transformer/RawSqlResultsToEntityTransformer.ts
+++ b/src/query-builder/transformer/RawSqlResultsToEntityTransformer.ts
@@ -102,7 +102,7 @@ export class RawSqlResultsToEntityTransformer {
             if (discriminatorMetadata)
                 metadata = discriminatorMetadata;
         }
-        let entity: any = this.expressionMap.options.indexOf("create-pojo") !== -1 ? {} : metadata.create(this.queryRunner);
+        let entity: any = this.expressionMap.options.indexOf("create-pojo") !== -1 ? {} : metadata.create(this.queryRunner, { fromDeserializer: true });
 
         // get value from columns selections and put them into newly created entity
         const hasColumns = this.transformColumns(rawResults, alias, entity, metadata);

--- a/test/functional/entity-metadata/entity-metadata-create.ts
+++ b/test/functional/entity-metadata/entity-metadata-create.ts
@@ -1,0 +1,81 @@
+import "reflect-metadata";
+import { Connection } from "../../../src/connection/Connection";
+import { expect } from "chai";
+import { closeTestingConnections, createTestingConnections, reloadTestingDatabases } from "../../utils/test-utils";
+import { TestCreate } from "./entity/TestCreate";
+
+describe("entity-metadata > create", () => {
+    describe("without entitySkipConstructor", () => {
+        let connections: Connection[];
+        before(async () => connections = await createTestingConnections({
+                enabledDrivers: [ "sqlite" ],
+                entities: [
+                    TestCreate
+                ]
+            })
+        );
+
+        beforeEach(() => reloadTestingDatabases(connections));
+        after(() => closeTestingConnections(connections));
+
+        it("should call the constructor when creating an object", () => Promise.all(connections.map(async connection => {
+            const entity = connection.manager.create(TestCreate);
+
+            expect(entity.hasCalledConstructor).to.be.true;
+        })))
+
+        it("should set the default property values", () => Promise.all(connections.map(async connection => {
+            const entity = connection.manager.create(TestCreate);
+
+            expect(entity.foo).to.be.equal("bar");
+        })))
+
+        it("should call the constructor when retrieving an object", () => Promise.all(connections.map(async connection => {
+            const repo = connection.manager.getRepository(TestCreate);
+
+            const { id } = await repo.save({ foo: "baz" });
+
+            const entity = await repo.findOneOrFail(id);
+
+            expect(entity.hasCalledConstructor).to.be.true;
+        })))
+    })
+
+    describe("with entitySkipConstructor", () => {
+        let connections: Connection[];
+        before(async () => connections = await createTestingConnections({
+            enabledDrivers: [ "sqlite" ],
+            entities: [
+                TestCreate
+            ],
+            driverSpecific: {
+                entitySkipConstructor: true,
+            }
+        }));
+
+        beforeEach(() => reloadTestingDatabases(connections));
+        after(() => closeTestingConnections(connections));
+
+        it("should call the constructor when creating an object", () => Promise.all(connections.map(async connection => {
+            const entity = connection.manager.create(TestCreate);
+
+            expect(entity.hasCalledConstructor).to.be.true;
+        })))
+
+        it("should set the default property values when creating an object", () => Promise.all(connections.map(async connection => {
+            const entity = connection.manager.create(TestCreate);
+
+            expect(entity.foo).to.be.equal("bar");
+        })))
+
+        it("should not call the constructor when retrieving an object", () => Promise.all(connections.map(async connection => {
+            const repo = connection.manager.getRepository(TestCreate);
+
+            const { id } = await repo.save({ foo: "baz" });
+
+            const entity = await repo.findOneOrFail(id);
+
+            expect(entity.hasCalledConstructor).not.to.be.true;
+        })))
+    })
+})

--- a/test/functional/entity-metadata/entity/TestCreate.ts
+++ b/test/functional/entity-metadata/entity/TestCreate.ts
@@ -1,0 +1,18 @@
+import { Column } from "../../../../src/decorator/columns/Column";
+import { Entity } from "../../../../src/decorator/entity/Entity";
+import { PrimaryGeneratedColumn } from "../../../../src";
+
+@Entity()
+export class TestCreate {
+    constructor() {
+        this.hasCalledConstructor = true;
+    }
+
+    hasCalledConstructor = false;
+
+    @PrimaryGeneratedColumn()
+    id: number;
+
+    @Column()
+    foo: string = 'bar';
+}


### PR DESCRIPTION
<!--
  😀 Wonderful!  Thank you for opening a pull request for TypeORM.

  Please fill in the information below to expedite the review
  and (hopefully) merge of your change.

  If unsure about something.. just do as best as you're able,
  or reach out through our community support channels!
  https://github.com/typeorm/typeorm/blob/master/docs/support.md
-->

### Description of change

<!--
  Please be clear and concise what the change is intended to do,
  why this change is needed, and how you've verified that it
  corrects what you intended.

  In some cases it may be helpful to include the current behavior
  and the new behavior.

  If the change is related to an open issue, you can link it here.
  If you include `Fixes #0000` (replacing `0000` with the issue number)
  when this is merged it will automatically mark the issue as fixed and
  close it.
-->

this adds the option for bypassing the constructor when deserializing
the Entities.  note that this may cause problems with class-based
JavaScript features that rely on the constructor to operate - such as private
properties or default values

fixes #1772 


### Pull-Request Checklist

<!--
  Please make sure to review and check all of the following.

  If an item is not applicable, you can add "N/A" to the end.
-->

- [x] Code is up-to-date with the `master` branch
- [x] `npm run lint` passes with this change
- [x] `npm run test` passes with this change
- [x] This pull request links relevant issues as `Fixes #0000`
- [x] There are new or updated unit tests validating the change
- [x] Documentation has been updated to reflect this change
- [x] The new commits follow conventions explained in [CONTRIBUTING.md](https://github.com/typeorm/typeorm/blob/master/CONTRIBUTING.md)

<!--
  🎉 Thank you for contributing and making TypeORM even better!
-->
