### PR TITLE
fix: `entity` to be `Partial<Entity> | undefined` in `UpdateEvent`

### DIFF
--- a/src/subscriber/event/UpdateEvent.ts
+++ b/src/subscriber/event/UpdateEvent.ts
@@ -30,7 +30,7 @@ export interface UpdateEvent<Entity> {
     /**
      * Updating entity.
      */
-    entity: Entity;
+    entity: Partial<Entity> | undefined;
 
     /**
      * Metadata of the entity.

--- a/test/github-issues/1369/subscriber/AbstractEntitySubscriber.ts
+++ b/test/github-issues/1369/subscriber/AbstractEntitySubscriber.ts
@@ -10,9 +10,11 @@ export class AbstractEntitySubscriber implements EntitySubscriberInterface<Abstr
     this.updateFullName(event.entity);
   }
   async beforeUpdate(event: UpdateEvent<AbstractEntity>) {
-    this.updateFullName(event.entity);
+    if(event.entity) {
+      this.updateFullName(event.entity);
+    }
   }
-  updateFullName(o: AbstractEntity) {
+  updateFullName(o: Partial<AbstractEntity>) {
     o.fullname = o.firstname + " " + o.lastname;
   }
 }

--- a/test/github-issues/3256/subscriber/PostSubscriber.ts
+++ b/test/github-issues/3256/subscriber/PostSubscriber.ts
@@ -12,7 +12,9 @@ export class PostSubscriber implements EntitySubscriberInterface<Post> {
     }
 
     async beforeUpdate(event: UpdateEvent<Post>) {
-        event.entity.updated = true;
+        if(event.entity) {
+            event.entity.updated = true;
+        }
     }
 
 }

--- a/test/other-issues/entity-change-in-subscribers/subscriber/PostSubscriber.ts
+++ b/test/other-issues/entity-change-in-subscribers/subscriber/PostSubscriber.ts
@@ -8,8 +8,10 @@ export class PostSubscriber implements EntitySubscriberInterface<Post> {
     }
 
     beforeUpdate(event: UpdateEvent<Post>) {
-        event.entity.updatedColumns = event.updatedColumns.length;
-        event.entity.updatedRelations = event.updatedRelations.length;
+        if(event.entity) {
+            event.entity.updatedColumns = event.updatedColumns.length;
+            event.entity.updatedRelations = event.updatedRelations.length;
+        }
     }
 
 }

--- a/test/other-issues/mongodb-entity-change-in-subscribers/subscriber/PostSubscriber.ts
+++ b/test/other-issues/mongodb-entity-change-in-subscribers/subscriber/PostSubscriber.ts
@@ -8,7 +8,9 @@ export class PostSubscriber implements EntitySubscriberInterface<Post> {
     }
 
     beforeUpdate(event: UpdateEvent<Post>) {
-        event.entity.updatedColumns = event.updatedColumns.length;
+        if(event.entity) {
+            event.entity.updatedColumns = event.updatedColumns.length;
+        }
     }
 
     afterLoad(entity: Post) {


### PR DESCRIPTION
### Description of change

This change was requested as part of https://github.com/typeorm/typeorm/pull/7724.

That change has made us realise that the type of `UpdateEvent.entity` is not strictly correct as just `Entity`.

1. The `UpdateEvent` in case of an `update`, the `entity` was `undefined`
- In https://github.com/typeorm/typeorm/pull/5443 this was changed for `beforeUpdate` to be a Partial<Entity>
- In https://github.com/typeorm/typeorm/pull/7724 this will be changed for `afterUpdate` to be a `Partial<Entity>`
2. The `UpdateEvent` in case of a `soft delete`, the `entity` is `undefined`
- There is no PR to try and update this

This PR corrects the type for all scenarios which is `entity: Partial<Entity> | undefined`.

I decided to split this out into a seperate PR from https://github.com/typeorm/typeorm/pull/7724 for a number of reasons:
- The correctness of the type spans more than just the `afterUpdate` subscriber
- It is a change in the API and is thus a breaking change, whilst https://github.com/typeorm/typeorm/pull/7724 is not.

### Pull-Request Checklist

<!--
  Please make sure to review and check all of the following.

  If an item is not applicable, you can add "N/A" to the end.
-->

- [x] Code is up-to-date with the `master` branch
- [x] `npm run lint` passes with this change
- [x] `npm run test` passes with this change
- [x] This pull request links relevant issues as `Fixes #0000` (N/A)
- [x] There are new or updated unit tests validating the change (N/A)
- [x] Documentation has been updated to reflect this change (N/A)
- [x] The new commits follow conventions explained in [CONTRIBUTING.md](https://github.com/typeorm/typeorm/blob/master/CONTRIBUTING.md)

<!--
  🎉 Thank you for contributing and making TypeORM even better!
-->
