### PR TITLE
fix: prevent reuse of broken connections in postgres pool

### DIFF
--- a/src/driver/aurora-data-api-pg/AuroraDataApiPostgresQueryRunner.ts
+++ b/src/driver/aurora-data-api-pg/AuroraDataApiPostgresQueryRunner.ts
@@ -41,11 +41,6 @@ export class AuroraDataApiPostgresQueryRunner extends PostgresQueryRunnerWrapper
      */
     protected databaseConnectionPromise: Promise<any>;
 
-    /**
-     * Special callback provided by a driver used to release a created connection.
-     */
-    protected releaseCallback: Function;
-
     // -------------------------------------------------------------------------
     // Constructor
     // -------------------------------------------------------------------------


### PR DESCRIPTION
<!--
  😀 Wonderful!  Thank you for opening a pull request for TypeORM.

  Please fill in the information below to expedite the review
  and (hopefully) merge of your change.

  If unsure about something.. just do as best as you're able,
  or reach out through our community support channels!
  https://github.com/typeorm/typeorm/blob/master/docs/support.md
-->

### Description of change

<!--
  Please be clear and concise what the change is intended to do,
  why this change is needed, and how you've verified that it
  corrects what you intended.

  In some cases it may be helpful to include the current behavior
  and the new behavior.

  If the change is related to an open issue, you can link it here.
  If you include `Fixes #0000` (replacing `0000` with the issue number)
  when this is merged it will automatically mark the issue as fixed and
  close it.
-->

fixes #5112 

passes the error back to the `pg-pool` release callback.

there aren't tests, though - because we don't really do mocking of the database for our tests & forcing a failing database is rather difficult.  until we can more gracefully do mocks / spies / etc, I'm not sure the best way to verify this functionality.

I did verify it by running a long running query, `kill -TERM`ing the postgres database & then observing the code flow.


### Pull-Request Checklist

<!--
  Please make sure to review and check all of the following.

  If an item is not applicable, you can add "N/A" to the end.
-->

- [x] Code is up-to-date with the `master` branch
- [x] `npm run lint` passes with this change
- [x] `npm run test` passes with this change
- [x] This pull request links relevant issues as `Fixes #0000`
- [ ] There are new or updated unit tests validating the change
- [ ] Documentation has been updated to reflect this change
- [x] The new commits follow conventions explained in [CONTRIBUTING.md](https://github.com/typeorm/typeorm/blob/master/CONTRIBUTING.md)

<!--
  🎉 Thank you for contributing and making TypeORM even better!
-->
