### PR TITLE
Fixing problem in date parser (for `next` branch)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4,36 +4,87 @@
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
+    "@azure/abort-controller": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@azure/abort-controller/-/abort-controller-1.0.2.tgz",
+      "integrity": "sha512-XUyTo+bcyxHEf+jlN2MXA7YU9nxVehaubngHV1MIZZaqYmZqykkoeAz/JMMEeR7t3TcyDwbFa3Zw8BZywmIx4g==",
+      "dev": true,
+      "requires": {
+        "tslib": "^2.0.0"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.1.0.tgz",
+          "integrity": "sha512-hcVC3wYEziELGGmEEXue7D75zbwIIVUMWAVbHItGPx0ziyXxrOMQx4rQEVEV45Ut/1IotuEvwqPopzIOkDMf0A==",
+          "dev": true
+        }
+      }
+    },
+    "@azure/core-auth": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@azure/core-auth/-/core-auth-1.1.4.tgz",
+      "integrity": "sha512-+j1embyH1jqf04AIfJPdLafd5SC1y6z1Jz4i+USR1XkTp6KM8P5u4/AjmWMVoEQdM/M29PJcRDZcCEWjK9S1bw==",
+      "dev": true,
+      "requires": {
+        "@azure/abort-controller": "^1.0.0",
+        "tslib": "^2.0.0"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.1.0.tgz",
+          "integrity": "sha512-hcVC3wYEziELGGmEEXue7D75zbwIIVUMWAVbHItGPx0ziyXxrOMQx4rQEVEV45Ut/1IotuEvwqPopzIOkDMf0A==",
+          "dev": true
+        }
+      }
+    },
     "@azure/ms-rest-azure-env": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/@azure/ms-rest-azure-env/-/ms-rest-azure-env-1.1.2.tgz",
-      "integrity": "sha512-l7z0DPCi2Hp88w12JhDTtx5d0Y3+vhfE7JKJb9O7sEz71Cwp053N8piTtTnnk/tUor9oZHgEKi/p3tQQmLPjvA==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@azure/ms-rest-azure-env/-/ms-rest-azure-env-2.0.0.tgz",
+      "integrity": "sha512-dG76W7ElfLi+fbTjnZVGj+M9e0BIEJmRxU6fHaUQ12bZBe8EJKYb2GV50YWNaP2uJiVQ5+7nXEVj1VN1UQtaEw==",
       "dev": true
     },
     "@azure/ms-rest-js": {
-      "version": "1.8.15",
-      "resolved": "https://registry.npmjs.org/@azure/ms-rest-js/-/ms-rest-js-1.8.15.tgz",
-      "integrity": "sha512-kIB71V3DcrA4iysBbOsYcxd4WWlOE7OFtCUYNfflPODM0lbIR23A236QeTn5iAeYwcHmMjR/TAKp5KQQh/WqoQ==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@azure/ms-rest-js/-/ms-rest-js-2.2.0.tgz",
+      "integrity": "sha512-lmSqjNuqx/TmwXLpVs1acAExUhHGkHvXIdfyttNc3qlpcn6xoT8JqGFRVwvoh5rZKPfy84aSaXUEPf/gwfRZHg==",
       "dev": true,
       "requires": {
-        "@types/tunnel": "0.0.0",
-        "axios": "^0.19.0",
-        "form-data": "^2.3.2",
-        "tough-cookie": "^2.4.3",
-        "tslib": "^1.9.2",
+        "@azure/core-auth": "^1.1.4",
+        "@types/node-fetch": "^2.3.7",
+        "@types/tunnel": "0.0.1",
+        "abort-controller": "^3.0.0",
+        "form-data": "^2.5.0",
+        "node-fetch": "^2.6.0",
+        "tough-cookie": "^3.0.1",
+        "tslib": "^1.10.0",
         "tunnel": "0.0.6",
-        "uuid": "^3.2.1",
+        "uuid": "^3.3.2",
         "xml2js": "^0.4.19"
+      },
+      "dependencies": {
+        "tough-cookie": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-3.0.1.tgz",
+          "integrity": "sha512-yQyJ0u4pZsv9D4clxO69OEjLWYw+jbgspjTue4lTQZLfV0c5l1VmK2y1JK8E9ahdpltPOaAThPcp5nKPUgSnsg==",
+          "dev": true,
+          "requires": {
+            "ip-regex": "^2.1.0",
+            "psl": "^1.1.28",
+            "punycode": "^2.1.1"
+          }
+        }
       }
     },
     "@azure/ms-rest-nodeauth": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/@azure/ms-rest-nodeauth/-/ms-rest-nodeauth-2.0.2.tgz",
-      "integrity": "sha512-KmNNICOxt3EwViAJI3iu2VH8t8BQg5J2rSAyO4IUYLF9ZwlyYsP419pdvl4NBUhluAP2cgN7dfD2V6E6NOMZlQ==",
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/@azure/ms-rest-nodeauth/-/ms-rest-nodeauth-3.0.6.tgz",
+      "integrity": "sha512-2twuzsXHdKMzEFI2+Sr82o6yS4ppNGZceYwil8PFo+rJxOZIoBm9e0//YC+dKilV/3F+6K/HuW8LdskDrJEQWA==",
       "dev": true,
       "requires": {
-        "@azure/ms-rest-azure-env": "^1.1.2",
-        "@azure/ms-rest-js": "^1.8.7",
+        "@azure/ms-rest-azure-env": "^2.0.0",
+        "@azure/ms-rest-js": "^2.0.4",
         "adal-node": "^0.1.28"
       }
     },
@@ -218,6 +269,12 @@
         }
       }
     },
+    "@js-joda/core": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/@js-joda/core/-/core-3.2.0.tgz",
+      "integrity": "sha512-PMqgJ0sw5B7FKb2d5bWYIoxjri+QlW/Pys7+Rw82jSH0QN3rB05jZ/VrrsUdh1w4+i2kw9JOejXGq/KhDOX7Kg==",
+      "dev": true
+    },
     "@nodelib/fs.scandir": {
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.3.tgz",
@@ -293,6 +350,12 @@
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/@sqltools/formatter/-/formatter-1.2.2.tgz",
       "integrity": "sha512-/5O7Fq6Vnv8L6ucmPjaWbVG1XkP4FO+w5glqfkIsq3Xw4oyNAdJddbnYodNDAfjVUvo/rrSCTom4kAND7T1o5Q=="
+    },
+    "@tediousjs/connection-string": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@tediousjs/connection-string/-/connection-string-0.3.0.tgz",
+      "integrity": "sha512-d/keJiNKfpHo+GmSB8QcsAwBx8h+V1UbdozA5TD+eSLXprNY53JAYub47J9evsSKWDdNG5uVj0FiMozLKuzowQ==",
+      "dev": true
     },
     "@types/app-root-path": {
       "version": "1.2.4",
@@ -426,6 +489,29 @@
       "integrity": "sha512-aYNbO+FZ/3KGeQCEkNhHFRIzBOUgc7QvcVNKXbfnhDkSfwUv91JsQQa10rDgKSTSLkXZ1UIyPe4FJJNVgw1xWQ==",
       "dev": true
     },
+    "@types/node-fetch": {
+      "version": "2.5.8",
+      "resolved": "https://registry.npmjs.org/@types/node-fetch/-/node-fetch-2.5.8.tgz",
+      "integrity": "sha512-fbjI6ja0N5ZA8TV53RUqzsKNkl9fv8Oj3T7zxW7FGv1GSH7gwJaNF8dzCjrqKaxKeUpTz4yT1DaJFq/omNpGfw==",
+      "dev": true,
+      "requires": {
+        "@types/node": "*",
+        "form-data": "^3.0.0"
+      },
+      "dependencies": {
+        "form-data": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/form-data/-/form-data-3.0.0.tgz",
+          "integrity": "sha512-CKMFDglpbMi6PyN+brwB9Q/GOw0eAnsrEZDgcsH5Krhz5Od/haKHAX0NmQfha2zPPz0JpWzA7GJHGSnvCRLWsg==",
+          "dev": true,
+          "requires": {
+            "asynckit": "^0.4.0",
+            "combined-stream": "^1.0.8",
+            "mime-types": "^2.1.12"
+          }
+        }
+      }
+    },
     "@types/normalize-package-data": {
       "version": "2.4.0",
       "resolved": "https://registry.npmjs.org/@types/normalize-package-data/-/normalize-package-data-2.4.0.tgz",
@@ -437,16 +523,6 @@
       "resolved": "https://registry.npmjs.org/@types/parse-json/-/parse-json-4.0.0.tgz",
       "integrity": "sha512-//oorEZjL6sbPcKUaCdIGlIUeH26mgzimjBB77G6XRgnDl/L5wOnpyBGRe/Mmf5CVW3PwEBE1NjiMZ/ssFh4wA==",
       "dev": true
-    },
-    "@types/readable-stream": {
-      "version": "2.3.9",
-      "resolved": "https://registry.npmjs.org/@types/readable-stream/-/readable-stream-2.3.9.tgz",
-      "integrity": "sha512-sqsgQqFT7HmQz/V5jH1O0fvQQnXAJO46Gg9LRO/JPfjmVmGUlcx831TZZO3Y3HtWhIkzf3kTsNT0Z0kzIhIvZw==",
-      "dev": true,
-      "requires": {
-        "@types/node": "*",
-        "safe-buffer": "*"
-      }
     },
     "@types/rimraf": {
       "version": "3.0.0",
@@ -492,9 +568,9 @@
       }
     },
     "@types/tunnel": {
-      "version": "0.0.0",
-      "resolved": "https://registry.npmjs.org/@types/tunnel/-/tunnel-0.0.0.tgz",
-      "integrity": "sha512-FGDp0iBRiBdPjOgjJmn1NH0KDLN+Z8fRmo+9J7XGBhubq1DPrGrbmG4UTlGzrpbCpesMqD0sWkzi27EYkOMHyg==",
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/@types/tunnel/-/tunnel-0.0.1.tgz",
+      "integrity": "sha512-AOqu6bQu5MSWwYvehMXLukFHnupHrpZ8nvgae5Ggie9UwzDR1CCwoXgSSWNZJuyOlCdfdsWMA5F2LlmvyoTv8A==",
       "dev": true,
       "requires": {
         "@types/node": "*"
@@ -660,6 +736,15 @@
       "integrity": "sha1-kbR5JYinc4wl813W9jdSovh3YTU=",
       "dev": true
     },
+    "abort-controller": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/abort-controller/-/abort-controller-3.0.0.tgz",
+      "integrity": "sha512-h8lQ8tacZYnR3vNQTgibj+tODHI5/+l06Au2Pcriv/Gmet0eaj4TwWH41sO9wnHDiQsEj19q0drzdWdeAHtweg==",
+      "dev": true,
+      "requires": {
+        "event-target-shim": "^5.0.0"
+      }
+    },
     "acorn": {
       "version": "7.4.0",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-7.4.0.tgz",
@@ -690,9 +775,9 @@
       },
       "dependencies": {
         "@types/node": {
-          "version": "8.10.63",
-          "resolved": "https://registry.npmjs.org/@types/node/-/node-8.10.63.tgz",
-          "integrity": "sha512-g+nSkeHFDd2WOQChfmy9SAXLywT47WZBrGS/NC5ym5PJ8c8RC6l4pbGaUW/X0+eZJnXw6/AVNEouXWhV4iz72Q==",
+          "version": "8.10.66",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-8.10.66.tgz",
+          "integrity": "sha512-tktOkFUA4kXx2hhhrB8bIFb5TbwzS4uOhKEmwiD+NoiL0qtP2OQ9mFldbgD4dV1djrlBYP6eBuQZiWjuHUpqFw==",
           "dev": true
         }
       }
@@ -1241,15 +1326,6 @@
       "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.10.1.tgz",
       "integrity": "sha512-zg7Hz2k5lI8kb7U32998pRRFin7zJlkfezGJjUc2heaD4Pw2wObakCDVzkKztTm/Ln7eiVvYsjqak0Ed4LkMDA==",
       "dev": true
-    },
-    "axios": {
-      "version": "0.19.2",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-0.19.2.tgz",
-      "integrity": "sha512-fjgm5MvRHLhx+osE2xoekY70AhARk3a6hkN+3Io1jc00jtquGvxYlKlsFUhmUET0V5te6CcZI7lcv2Ym61mjHA==",
-      "dev": true,
-      "requires": {
-        "follow-redirects": "1.5.10"
-      }
     },
     "bach": {
       "version": "1.2.0",
@@ -3048,6 +3124,12 @@
         "es5-ext": "~0.10.14"
       }
     },
+    "event-target-shim": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/event-target-shim/-/event-target-shim-5.0.1.tgz",
+      "integrity": "sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ==",
+      "dev": true
+    },
     "execa": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/execa/-/execa-2.1.0.tgz",
@@ -3554,32 +3636,6 @@
       "requires": {
         "inherits": "^2.0.3",
         "readable-stream": "^2.3.6"
-      }
-    },
-    "follow-redirects": {
-      "version": "1.5.10",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.5.10.tgz",
-      "integrity": "sha512-0V5l4Cizzvqt5D44aTXbFZz+FtyXV1vrDN6qrelxtfYQKW0KO0W2T/hkE8xvGa/540LkZlkaUjO4ailYTFtHVQ==",
-      "dev": true,
-      "requires": {
-        "debug": "=3.1.0"
-      },
-      "dependencies": {
-        "debug": {
-          "version": "3.1.0",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
-          "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
-          "dev": true,
-          "requires": {
-            "ms": "2.0.0"
-          }
-        },
-        "ms": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
-          "dev": true
-        }
       }
     },
     "for-in": {
@@ -5570,6 +5626,12 @@
       "integrity": "sha1-EEqOSqym09jNFXqO+L+rLXo//bY=",
       "dev": true
     },
+    "ip-regex": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/ip-regex/-/ip-regex-2.1.0.tgz",
+      "integrity": "sha1-+ni/XS5pE8kRzp+BnuUUa7bYROk=",
+      "dev": true
+    },
     "is-absolute": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/is-absolute/-/is-absolute-1.0.0.tgz",
@@ -7339,14 +7401,15 @@
       "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
     },
     "mssql": {
-      "version": "6.2.1",
-      "resolved": "https://registry.npmjs.org/mssql/-/mssql-6.2.1.tgz",
-      "integrity": "sha512-erINJ9EUPvPuWXifZfhum0CVEVrdvnFYlpgU6WKkQW69W4W7DWqJS2FHdedHnuJWlJ8x1WW1NcD8GFfF15O2aA==",
+      "version": "7.0.0-beta.3",
+      "resolved": "https://registry.npmjs.org/mssql/-/mssql-7.0.0-beta.3.tgz",
+      "integrity": "sha512-Jn/q64Dg2UjbNTqsBwCHFdMjxs4xIVqgWQ1hmDKvBR0T8ebHfPnGTzfNl4oE/VwqP1m0As+v2CMjyqOi9WneuQ==",
       "dev": true,
       "requires": {
+        "@tediousjs/connection-string": "^0.3.0",
         "debug": "^4",
-        "tarn": "^1.1.5",
-        "tedious": "^6.6.2"
+        "tarn": "^3.0.1",
+        "tedious": "^9.2.3"
       }
     },
     "mute-stdout": {
@@ -7583,6 +7646,12 @@
           "dev": true
         }
       }
+    },
+    "node-fetch": {
+      "version": "2.6.1",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.1.tgz",
+      "integrity": "sha512-V4aYg89jEoVRxRb2fJdAg8FHvI7cEyYdVAh94HH0UIK8oJxUfkjlDQN9RbMx+bEjP7+ggMiFRprSti032Oipxw==",
+      "dev": true
     },
     "node-gyp": {
       "version": "3.8.0",
@@ -10076,27 +10145,27 @@
       }
     },
     "tarn": {
-      "version": "1.1.5",
-      "resolved": "https://registry.npmjs.org/tarn/-/tarn-1.1.5.tgz",
-      "integrity": "sha512-PMtJ3HCLAZeedWjJPgGnCvcphbCOMbtZpjKgLq3qM5Qq9aQud+XHrL0WlrlgnTyS8U+jrjGbEXprFcQrxPy52g==",
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/tarn/-/tarn-3.0.1.tgz",
+      "integrity": "sha512-6usSlV9KyHsspvwu2duKH+FMUhqJnAh6J5J/4MITl8s94iSUQTLkJggdiewKv4RyARQccnigV48Z+khiuVZDJw==",
       "dev": true
     },
     "tedious": {
-      "version": "6.7.0",
-      "resolved": "https://registry.npmjs.org/tedious/-/tedious-6.7.0.tgz",
-      "integrity": "sha512-8qr7+sB0h4SZVQBRWUgHmYuOEflAOl2eihvxk0fVNvpvGJV4V5UC/YmSvebyfgyfwWcPO22/AnSbYVZZqf9wuQ==",
+      "version": "9.2.3",
+      "resolved": "https://registry.npmjs.org/tedious/-/tedious-9.2.3.tgz",
+      "integrity": "sha512-+mI2r/5mqxpTHKBZ/SW+NNH2MK5i3Pwwkw0gF5ZrS2wf2uT/03bLSss8nm7xh604abJXyjx0sirhwH63H328qA==",
       "dev": true,
       "requires": {
-        "@azure/ms-rest-nodeauth": "2.0.2",
-        "@types/node": "^12.12.17",
-        "@types/readable-stream": "^2.3.5",
+        "@azure/ms-rest-nodeauth": "^3.0.6",
+        "@js-joda/core": "^3.1.0",
+        "adal-node": "^0.1.28",
         "bl": "^3.0.0",
         "depd": "^2.0.0",
-        "iconv-lite": "^0.5.0",
-        "jsbi": "^3.1.1",
+        "iconv-lite": "^0.6.2",
+        "jsbi": "^3.1.3",
         "native-duplexpair": "^1.0.0",
         "punycode": "^2.1.0",
-        "readable-stream": "^3.4.0",
+        "readable-stream": "^3.6.0",
         "sprintf-js": "^1.1.2"
       },
       "dependencies": {
@@ -10116,12 +10185,12 @@
           }
         },
         "iconv-lite": {
-          "version": "0.5.2",
-          "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.5.2.tgz",
-          "integrity": "sha512-kERHXvpSaB4aU3eANwidg79K8FlrN77m8G9V+0vOR3HYaRifrlwMEpT7ZBJqLSEIHnEgJTHcWK82wwLwwKwtag==",
+          "version": "0.6.2",
+          "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.2.tgz",
+          "integrity": "sha512-2y91h5OpQlolefMPmUlivelittSWy0rP+oYVpn6A7GwVHNE8AWzoYOBNmlwks3LobaJxgHCYZAnyNo2GgpNRNQ==",
           "dev": true,
           "requires": {
-            "safer-buffer": ">= 2.1.2 < 3"
+            "safer-buffer": ">= 2.1.2 < 3.0.0"
           }
         },
         "readable-stream": {
@@ -10468,9 +10537,9 @@
       "dev": true
     },
     "underscore": {
-      "version": "1.11.0",
-      "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.11.0.tgz",
-      "integrity": "sha512-xY96SsN3NA461qIRKZ/+qox37YXPtSBswMGfiNptr+wrt6ds4HaMw23TP612fEyGekRE6LNRiLYr/aqbHXNedw==",
+      "version": "1.12.0",
+      "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.12.0.tgz",
+      "integrity": "sha512-21rQzss/XPMjolTiIezSu3JAjgagXKROtNrYFEOWK109qY1Uv2tVjPTZ1ci2HgvQDA16gHYSthQIJfB+XId/rQ==",
       "dev": true
     },
     "undertaker": {
@@ -10872,9 +10941,9 @@
       "integrity": "sha512-fDlsI/kFEx7gLvbecc0/ohLG50fugQp8ryHzMTuW9vSa1GJ0XYWKnhsUx7oie3G98+r56aTQIUB4kht42R3JvA=="
     },
     "xmldom": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/xmldom/-/xmldom-0.3.0.tgz",
-      "integrity": "sha512-z9s6k3wxE+aZHgXYxSTpGDo7BYOUfJsIRyoZiX6HTjwpwfS2wpQBQKa2fD+ShLyPkqDYo5ud7KitmLZ2Cd6r0g==",
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/xmldom/-/xmldom-0.4.0.tgz",
+      "integrity": "sha512-2E93k08T30Ugs+34HBSTQLVtpi6mCddaY8uO+pMNk1pqSjV5vElzn4mmh6KLxN3hki8rNcHSYzILoh3TEWORvA==",
       "dev": true
     },
     "xpath.js": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -2282,6 +2282,12 @@
         "sqlstring": "^2.3.1"
       }
     },
+    "date-fns": {
+      "version": "2.22.1",
+      "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-2.22.1.tgz",
+      "integrity": "sha512-yUFPQjrxEmIsMqlHhAhmxkuH769baF21Kk+nZwZGyrMoyLA+LugaQtC0+Tqf9CBUUULWwUJt6Q5ySI3LJDDCGg==",
+      "dev": true
+    },
     "date-utils": {
       "version": "1.2.21",
       "resolved": "https://registry.npmjs.org/date-utils/-/date-utils-1.2.21.tgz",

--- a/package.json
+++ b/package.json
@@ -91,7 +91,7 @@
     "lint-staged": "^10.0.8",
     "mocha": "^8.1.3",
     "mongodb": "^3.5.4",
-    "mssql": "^6.1.0",
+    "mssql": "^7.0.0-beta.3",
     "mysql": "^2.18.1",
     "mysql2": "^2.1.0",
     "oracledb": "^5.0.0",

--- a/package.json
+++ b/package.json
@@ -106,7 +106,8 @@
     "sqlite3": "^5.0.0",
     "ts-node": "^9.0.0",
     "typeorm-aurora-data-api-driver": "^1.4.0",
-    "typescript": "^3.9.7"
+    "typescript": "^3.9.7",
+    "date-fns": "2.22.1"
   },
   "dependencies": {
     "@sqltools/formatter": "1.2.2",

--- a/src/driver/sqlserver/SqlServerQueryRunner.ts
+++ b/src/driver/sqlserver/SqlServerQueryRunner.ts
@@ -187,15 +187,16 @@ export class SqlServerQueryRunner extends BaseQueryRunner implements QueryRunner
                 const request = new this.driver.mssql.Request(this.isTransactionActive ? this.databaseConnection : pool);
                 if (parameters && parameters.length) {
                     parameters.forEach((parameter, index) => {
+                        const parameterName = index.toString();
                         if (parameter instanceof MssqlParameter) {
                             const mssqlParameter = this.mssqlParameterToNativeParameter(parameter);
                             if (mssqlParameter) {
-                                request.input(index, mssqlParameter, parameter.value);
+                                request.input(parameterName, mssqlParameter, parameter.value);
                             } else {
-                                request.input(index, parameter.value);
+                                request.input(parameterName, parameter.value);
                             }
                         } else {
-                            request.input(index, parameter);
+                            request.input(parameterName, parameter);
                         }
                     });
                 }
@@ -270,10 +271,11 @@ export class SqlServerQueryRunner extends BaseQueryRunner implements QueryRunner
             request.stream = true;
             if (parameters && parameters.length) {
                 parameters.forEach((parameter, index) => {
+                    const parameterName = index.toString();
                     if (parameter instanceof MssqlParameter) {
-                        request.input(index, this.mssqlParameterToNativeParameter(parameter), parameter.value);
+                        request.input(parameterName, this.mssqlParameterToNativeParameter(parameter), parameter.value);
                     } else {
-                        request.input(index, parameter);
+                        request.input(parameterName, parameter);
                     }
                 });
             }

--- a/src/util/DateUtils.ts
+++ b/src/util/DateUtils.ts
@@ -1,4 +1,5 @@
-import {ColumnMetadata} from "../metadata/ColumnMetadata";
+import { ColumnMetadata } from "../metadata/ColumnMetadata";
+import { parseISO } from "date-fns";
 
 /**
  * Provides utilities to transform hydrated and persisted data.
@@ -33,7 +34,21 @@ export class DateUtils {
      * Converts given value into date object.
      */
     static mixedDateToDate(mixedDate: Date|string, toUtc: boolean = false, useMilliseconds = true): Date {
-        let date = typeof mixedDate === "string" ? new Date(mixedDate) : mixedDate;
+        /**
+         * new Date(ISOString) is not a reliable parser to date strings.
+         * It's better to use 'date-fns' parser to parser string in ISO Format.
+         *
+         * The problem here is with wrong timezone.
+         *
+         * For example:
+         *
+         * ``new Date('2021-04-28')`` will generate `2021-04-28T00:00:00.000Z`
+         * in my timezone, which is not true for my timezone (GMT-0300). It should
+         * be `2021-04-28T03:00:00.000Z` as `new Date(2021, 3, 28)` generates.
+         *
+         * https://stackoverflow.com/a/2587398
+         */
+        let date = typeof mixedDate === "string" ? parseISO(mixedDate) : mixedDate;
 
         if (toUtc)
             date = new Date(


### PR DESCRIPTION
(cherry picked from commit c517024a46fa97985574bc0305bebbf367e99ead)

new Date(ISOString) is not a reliable parser to date strings.
 It's better to use 'date-fns' parser to parser string in ISO Format.

The problem here is with wrong timezone.

For example:

``new Date('2021-04-28')`` will generate `2021-04-28T00:00:00.000Z`
 in my timezone, which is not true for my timezone (GMT-0300). It should
 be `2021-04-28T03:00:00.000Z` as `new Date(2021, 3, 28)` generates.

https://stackoverflow.com/a/2587398

origin from #7600 


### Description of change

<!--
  Please be clear and concise what the change is intended to do,
  why this change is needed, and how you've verified that it
  corrects what you intended.

  In some cases it may be helpful to include the current behavior
  and the new behavior.

  If the change is related to an open issue, you can link it here.
  If you include `Fixes #0000` (replacing `0000` with the issue number)
  when this is merged it will automatically mark the issue as fixed and
  close it.
-->


### Pull-Request Checklist

<!--
  Please make sure to review and check all of the following.

  If an item is not applicable, you can add "N/A" to the end.
-->

- [x] Code is up-to-date with the `master` branch
- [x] `npm run lint` passes with this change
- [x] `npm run test` passes with this change
- [x] This pull request links relevant issues as `Fixes #0000`
- [x] There are new or updated unit tests validating the change
- [x] Documentation has been updated to reflect this change
- [x] The new commits follow conventions explained in [CONTRIBUTING.md](https://github.com/typeorm/typeorm/blob/master/CONTRIBUTING.md)

<!--
  🎉 Thank you for contributing and making TypeORM even better!
-->
