### PR TITLE
 fix: better support of one-to-one and many-to-one relation-based properties in where clauses

### DIFF
--- a/docs/find-options.md
+++ b/docs/find-options.md
@@ -160,7 +160,10 @@ userRepository.find({
     relations: ["profile", "photos", "videos"],
     where: {
         firstName: "Timber",
-        lastName: "Saw"
+        lastName: "Saw",
+        profile: {
+          userName: "tshaw"
+        }
     },
     order: {
         name: "ASC",

--- a/src/metadata/EntityMetadata.ts
+++ b/src/metadata/EntityMetadata.ts
@@ -655,6 +655,14 @@ export class EntityMetadata {
     }
 
     /**
+     * Checks if there is a column or relationship with a given property path.
+     */
+    hasColumnWithPropertyPath(propertyPath: string): boolean {
+        const hasColumn = this.columns.some(column => column.propertyPath === propertyPath);
+        return hasColumn || this.hasRelationWithPropertyPath(propertyPath);
+    }
+
+    /**
      * Finds column with a given property path.
      */
     findColumnWithPropertyPath(propertyPath: string): ColumnMetadata|undefined {
@@ -682,11 +690,18 @@ export class EntityMetadata {
 
         // in the case if column with property path was not found, try to find a relation with such property path
         // if we find relation and it has a single join column then its the column user was seeking
-        const relation = this.relations.find(relation => relation.propertyPath === propertyPath);
+        const relation = this.findRelationWithPropertyPath(propertyPath);
         if (relation && relation.joinColumns)
             return relation.joinColumns;
 
         return [];
+    }
+
+    /**
+     * Checks if there is a relation with the given property path.
+     */
+    hasRelationWithPropertyPath(propertyPath: string): boolean {
+        return this.relations.some(relation => relation.propertyPath === propertyPath);
     }
 
     /**
@@ -740,6 +755,8 @@ export class EntityMetadata {
 
     /**
      * Creates a property paths for a given entity.
+     *
+     * @deprecated
      */
     static createPropertyPath(metadata: EntityMetadata, entity: ObjectLiteral, prefix: string = "") {
         const paths: string[] = [];

--- a/src/query-builder/UpdateQueryBuilder.ts
+++ b/src/query-builder/UpdateQueryBuilder.ts
@@ -9,7 +9,6 @@ import {SqlServerDriver} from "../driver/sqlserver/SqlServerDriver";
 import {PostgresDriver} from "../driver/postgres/PostgresDriver";
 import {WhereExpression} from "./WhereExpression";
 import {Brackets} from "./Brackets";
-import {EntityMetadata} from "../metadata/EntityMetadata";
 import {UpdateResult} from "./result/UpdateResult";
 import {ReturningStatementNotSupportedError} from "../error/ReturningStatementNotSupportedError";
 import {ReturningResultsEntityUpdator} from "./ReturningResultsEntityUpdator";
@@ -398,7 +397,7 @@ export class UpdateQueryBuilder<Entity> extends QueryBuilder<Entity> implements 
         const updateColumnAndValues: string[] = [];
         const updatedColumns: ColumnMetadata[] = [];
         if (metadata) {
-            EntityMetadata.createPropertyPath(metadata, valuesSet).forEach(propertyPath => {
+            this.createPropertyPath(metadata, valuesSet).forEach(propertyPath => {
                 // todo: make this and other query builder to work with properly with tables without metadata
                 const columns = metadata.findColumnsWithPropertyPath(propertyPath);
 

--- a/test/functional/query-builder/select/entity/Category.ts
+++ b/test/functional/query-builder/select/entity/Category.ts
@@ -2,6 +2,8 @@ import {Entity} from "../../../../../src/decorator/entity/Entity";
 import {PrimaryGeneratedColumn} from "../../../../../src/decorator/columns/PrimaryGeneratedColumn";
 import {Column} from "../../../../../src/decorator/columns/Column";
 import {VersionColumn} from "../../../../../src/decorator/columns/VersionColumn";
+import { Post } from "./Post";
+import { OneToMany } from "../../../../../src";
 
 @Entity()
 export class Category {
@@ -17,5 +19,8 @@ export class Category {
 
     @VersionColumn()
     version: string;
+
+    @OneToMany(() => Post, (post) => post.category)
+    posts: Post[]
 
 }

--- a/test/functional/query-builder/select/entity/HeroImage.ts
+++ b/test/functional/query-builder/select/entity/HeroImage.ts
@@ -1,0 +1,21 @@
+import {
+    Entity,
+    PrimaryGeneratedColumn,
+    Column,
+    OneToOne,
+} from "../../../../../src";
+import { Post } from "./Post";
+
+@Entity()
+export class HeroImage {
+
+    @PrimaryGeneratedColumn()
+    id: number;
+
+    @Column()
+    url: string;
+
+    @OneToOne(() => Post, (post) => post.heroImage)
+    post: Post;
+
+}

--- a/test/functional/query-builder/select/entity/Post.ts
+++ b/test/functional/query-builder/select/entity/Post.ts
@@ -1,9 +1,16 @@
-import {Entity} from "../../../../../src/decorator/entity/Entity";
-import {PrimaryGeneratedColumn} from "../../../../../src/decorator/columns/PrimaryGeneratedColumn";
-import {Column} from "../../../../../src/decorator/columns/Column";
-import {VersionColumn} from "../../../../../src/decorator/columns/VersionColumn";
-import {Category} from "./Category";
-import {ManyToOne} from "../../../../../src/decorator/relations/ManyToOne";
+import {
+    Entity,
+    PrimaryGeneratedColumn,
+    Column,
+    VersionColumn,
+    ManyToOne,
+    JoinTable,
+    ManyToMany,
+    OneToOne, JoinColumn,
+} from "../../../../../src";
+import { Tag } from "./Tag";
+import { Category } from "./Category";
+import { HeroImage } from "./HeroImage";
 
 @Entity()
 export class Post {
@@ -23,7 +30,15 @@ export class Post {
     @VersionColumn()
     version: string;
 
+    @OneToOne(() => HeroImage, (hero) => hero.post)
+    @JoinColumn()
+    heroImage: HeroImage;
+
     @ManyToOne(type => Category)
     category: Category;
+
+    @ManyToMany(() => Tag, (tag) => tag.posts)
+    @JoinTable()
+    tags: Tag[]
 
 }

--- a/test/functional/query-builder/select/entity/Tag.ts
+++ b/test/functional/query-builder/select/entity/Tag.ts
@@ -1,0 +1,16 @@
+import { Post } from "./Post";
+import { Entity, ManyToMany, Column, PrimaryGeneratedColumn } from "../../../../../src";
+
+@Entity()
+export class Tag {
+
+    @PrimaryGeneratedColumn()
+    id: number;
+
+    @Column()
+    name: string;
+
+    @ManyToMany(() => Post, (post) => post.tags)
+    posts: Post[]
+
+}


### PR DESCRIPTION
<!--
  😀 Wonderful!  Thank you for opening a pull request for TypeORM.

  Please fill in the information below to expedite the review
  and (hopefully) merge of your change.

  If unsure about something.. just do as best as you're able,
  or reach out through our community support channels!
  https://github.com/typeorm/typeorm/blob/master/docs/support.md
-->

### Description of change

<!--
  Please be clear and concise what the change is intended to do,
  why this change is needed, and how you've verified that it
  corrects what you intended.

  In some cases it may be helpful to include the current behavior
  and the new behavior.

  If the change is related to an open issue, you can link it here.
  If you include `Fixes #0000` (replacing `0000` with the issue number)
  when this is merged it will automatically mark the issue as fixed and
  close it.
-->

updates the `QueryBuilder` to support building `WHERE` clauses via `ObjectLiteral`s that go across relations.

Most of this was done to migrate the `whereInIDs` over to using native QueryBuilder features, and abstract the query compilation away from the `QueryBuilder` interface.

for example

```typescript
const postsWithFoo = await connection.createQueryBuilder(Post, "post")
            .select("post.id")
            .leftJoin("post.category", "category_join")
            .disableEscaping()
            .where({
                "category": {
                    "name": "Foo"
                }
            })
            .getMany()
```

This also applies to `FindOptions`

```typescript
const postsWithFoo = await connection
  .getRepository(Post).findOne({ where: { "category": { "name": "Foo" } } })
```

Fixes #1847
Fixes #2707
Fixes #7251
Fixes #4906
Fixes #6264
Fixes #4837
Fixes #4787

### Pull-Request Checklist

<!--
  Please make sure to review and check all of the following.

  If an item is not applicable, you can add "N/A" to the end.
-->

- [x] Code is up-to-date with the `master` branch
- [x] `npm run lint` passes with this change
- [x] `npm run test` passes with this change
- [x] This pull request links relevant issues as `Fixes #0000`
- [x] There are new or updated unit tests validating the change
- [x] Documentation has been updated to reflect this change
- [x] The new commits follow conventions explained in [CONTRIBUTING.md](https://github.com/typeorm/typeorm/blob/master/CONTRIBUTING.md)

<!--
  🎉 Thank you for contributing and making TypeORM even better!
-->
