### PR TITLE
refactor: clean up parent query builder & Brackets in `where`

### DIFF
--- a/src/query-builder/QueryBuilder.ts
+++ b/src/query-builder/QueryBuilder.ts
@@ -67,6 +67,11 @@ export abstract class QueryBuilder<Entity> {
      */
     protected queryRunner?: QueryRunner;
 
+    /**
+     * If QueryBuilder was created in a subquery mode then its parent QueryBuilder (who created subquery) will be stored here.
+     */
+    protected parentQueryBuilder: QueryBuilder<any>;
+
     // -------------------------------------------------------------------------
     // Constructor
     // -------------------------------------------------------------------------
@@ -340,8 +345,8 @@ export abstract class QueryBuilder<Entity> {
         });
 
         // set parent query builder parameters as well in sub-query mode
-        if (this.expressionMap.parentQueryBuilder)
-            this.expressionMap.parentQueryBuilder.setParameters(parameters);
+        if (this.parentQueryBuilder)
+            this.parentQueryBuilder.setParameters(parameters);
 
         Object.keys(parameters).forEach(key => this.setParameter(key, parameters[key]));
         return this;
@@ -353,8 +358,8 @@ export abstract class QueryBuilder<Entity> {
     setNativeParameters(parameters: ObjectLiteral): this {
 
         // set parent query builder parameters as well in sub-query mode
-        if (this.expressionMap.parentQueryBuilder)
-            this.expressionMap.parentQueryBuilder.setNativeParameters(parameters);
+        if (this.parentQueryBuilder)
+            this.parentQueryBuilder.setNativeParameters(parameters);
 
         Object.keys(parameters).forEach(key => {
             this.expressionMap.nativeParameters[key] = parameters[key];

--- a/src/query-builder/QueryBuilder.ts
+++ b/src/query-builder/QueryBuilder.ts
@@ -840,12 +840,17 @@ export abstract class QueryBuilder<Entity> {
 
         if (where instanceof Brackets) {
             const whereQueryBuilder = this.createQueryBuilder();
+
+            whereQueryBuilder.parentQueryBuilder = this;
+
             whereQueryBuilder.expressionMap.mainAlias = this.expressionMap.mainAlias;
             whereQueryBuilder.expressionMap.aliasNamePrefixingEnabled = this.expressionMap.aliasNamePrefixingEnabled;
+            whereQueryBuilder.expressionMap.parameters = this.expressionMap.parameters;
             whereQueryBuilder.expressionMap.nativeParameters = this.expressionMap.nativeParameters;
+
             where.whereFactory(whereQueryBuilder as any);
+
             const whereString = whereQueryBuilder.createWhereExpressionString();
-            this.setParameters(whereQueryBuilder.getParameters());
             return whereString ? "(" + whereString + ")" : "";
 
         } else if (where instanceof Function) {

--- a/src/query-builder/QueryExpressionMap.ts
+++ b/src/query-builder/QueryExpressionMap.ts
@@ -9,7 +9,6 @@ import {EntityMetadata} from "../metadata/EntityMetadata";
 import {SelectQuery} from "./SelectQuery";
 import {ColumnMetadata} from "../metadata/ColumnMetadata";
 import {RelationMetadata} from "../metadata/RelationMetadata";
-import {QueryBuilder} from "./QueryBuilder";
 import {SelectQueryBuilderOption} from "./SelectQueryBuilderOption";
 
 /**
@@ -202,11 +201,6 @@ export class QueryExpressionMap {
      * Indicates if query builder creates a subquery.
      */
     subQuery: boolean = false;
-
-    /**
-     * If QueryBuilder was created in a subquery mode then its parent QueryBuilder (who created subquery) will be stored here.
-     */
-    parentQueryBuilder: QueryBuilder<any>;
 
     /**
      * Indicates if property names are prefixed with alias names during property replacement.

--- a/src/query-builder/SelectQueryBuilder.ts
+++ b/src/query-builder/SelectQueryBuilder.ts
@@ -77,7 +77,7 @@ export class SelectQueryBuilder<Entity> extends QueryBuilder<Entity> implements 
     subQuery(): SelectQueryBuilder<any> {
         const qb = this.createQueryBuilder();
         qb.expressionMap.subQuery = true;
-        qb.expressionMap.parentQueryBuilder = this;
+        qb.parentQueryBuilder = this;
         return qb;
     }
 


### PR DESCRIPTION
<!--
  😀 Wonderful!  Thank you for opening a pull request for TypeORM.

  Please fill in the information below to expedite the review
  and (hopefully) merge of your change.

  If unsure about something.. just do as best as you're able,
  or reach out through our community support channels!
  https://github.com/typeorm/typeorm/blob/master/docs/support.md
-->

### Description of change

<!--
  Please be clear and concise what the change is intended to do,
  why this change is needed, and how you've verified that it
  corrects what you intended.

  In some cases it may be helpful to include the current behavior
  and the new behavior.

  If the change is related to an open issue, you can link it here.
  If you include `Fixes #0000` (replacing `0000` with the issue number)
  when this is merged it will automatically mark the issue as fixed and
  close it.
-->

the parent query builder bits weren't really used in the expression-map, just as part of the query builder itself.  Instead, put it in the QueryBuilder and have it be protected. 

Update the `setParameter` to also call parent query builders

Update `Brackets` to use this instead of setting everything manually.

### Pull-Request Checklist

<!--
  Please make sure to review and check all of the following.

  If an item is not applicable, you can add "N/A" to the end.
-->

- [x] Code is up-to-date with the `master` branch
- [x] `npm run lint` passes with this change
- [x] `npm run test` passes with this change
- [ ] This pull request links relevant issues as `Fixes #0000`
- [ ] There are new or updated unit tests validating the change
- [ ] Documentation has been updated to reflect this change
- [x] The new commits follow conventions explained in [CONTRIBUTING.md](https://github.com/typeorm/typeorm/blob/master/CONTRIBUTING.md)

<!--
  🎉 Thank you for contributing and making TypeORM even better!
-->
