### PR TITLE
fix: handle postgres default when tableColumn.default is not string

### DIFF
--- a/src/driver/postgres/PostgresDriver.ts
+++ b/src/driver/postgres/PostgresDriver.ts
@@ -763,21 +763,20 @@ export class PostgresDriver implements Driver {
      * Compares "default" value of the column.
      * Postgres sorts json values before it is saved, so in that case a deep comparison has to be performed to see if has changed.
      */
-    defaultEqual(columnMetadata: ColumnMetadata, tableColumn: TableColumn): boolean {
-      if (Array<ColumnType>("json", "jsonb").indexOf(columnMetadata.type) >= 0
-       && typeof columnMetadata.default !== "function"
-       && columnMetadata.default !== undefined) {
-        let columnDefault = columnMetadata.default;
-        if (typeof columnDefault !== "object") {
-          columnDefault = JSON.parse(columnMetadata.default);
+    private defaultEqual(columnMetadata: ColumnMetadata, tableColumn: TableColumn): boolean {
+        if (
+            ["json", "jsonb"].includes(columnMetadata.type as string)
+            && !["function", "undefined"].includes(typeof columnMetadata.default)
+        ) {
+            const tableColumnDefault = typeof tableColumn.default === "string" ?
+                JSON.parse(tableColumn.default.substring(1, tableColumn.default.length-1)) :
+                tableColumn.default;
+
+            return OrmUtils.deepCompare(columnMetadata.default, tableColumnDefault);
         }
-        let tableDefault = JSON.parse(tableColumn.default.substring(1, tableColumn.default.length-1));
-        return OrmUtils.deepCompare(columnDefault, tableDefault);
-      }
-      else {
+
         const columnDefault = this.lowerDefaultValueIfNecessary(this.normalizeDefault(columnMetadata));
-        return (columnDefault === tableColumn.default);
-      }
+        return columnDefault === tableColumn.default;
     }
 
     /**

--- a/test/functional/json/entity/Record.ts
+++ b/test/functional/json/entity/Record.ts
@@ -17,4 +17,9 @@ export class Record {
     @Column({ type: "jsonb", nullable: true })
     data: any;
 
+    @Column({ type: "jsonb", nullable: true, default: { hello: "world", foo: "bar" } })
+    dataWithDefaultObject: any;
+
+    @Column({ type: "jsonb", nullable: true, default: null })
+    dataWithDefaultNull: any;
 }


### PR DESCRIPTION
<!--
  😀 Wonderful!  Thank you for opening a pull request for TypeORM.

  Please fill in the information below to expedite the review
  and (hopefully) merge of your change.

  If unsure about something.. just do as best as you're able,
  or reach out through our community support channels!
  https://github.com/typeorm/typeorm/blob/master/docs/support.md
-->

### Description of change

<!--
  Please be clear and concise what the change is intended to do,
  why this change is needed, and how you've verified that it
  corrects what you intended.

  In some cases it may be helpful to include the current behavior
  and the new behavior.

  If the change is related to an open issue, you can link it here.
  If you include `Fixes #0000` (replacing `0000` with the issue number)
  when this is merged it will automatically mark the issue as fixed and
  close it.
-->

fixes #7810

there was an edge case where the tableColumn.default was not a string
and thus caused a TypeError to be emitted when we tried to `substring`
it.  instead, we check the type first and only if that type is a
string do we try to decode it




### Pull-Request Checklist

<!--
  Please make sure to review and check all of the following.

  If an item is not applicable, you can add "N/A" to the end.
-->

- [x] Code is up-to-date with the `master` branch
- [x] `npm run lint` passes with this change
- [x] `npm run test` passes with this change
- [x] This pull request links relevant issues as `Fixes #0000`
- [x] There are new or updated unit tests validating the change
- [ ] Documentation has been updated to reflect this change
- [x] The new commits follow conventions explained in [CONTRIBUTING.md](https://github.com/typeorm/typeorm/blob/master/CONTRIBUTING.md)

<!--
  🎉 Thank you for contributing and making TypeORM even better!
-->
