### PR TITLE
fix: for mysql use boolean type alias for boolean type

### DIFF
--- a/src/driver/mysql/MysqlDriver.ts
+++ b/src/driver/mysql/MysqlDriver.ts
@@ -167,6 +167,7 @@ export class MysqlDriver implements Driver {
      * Gets list of column data types that support length by a driver.
      */
     withWidthColumnTypes: ColumnType[] = [
+        "boolean",
         "bit",
         "tinyint",
         "smallint",
@@ -280,6 +281,7 @@ export class MysqlDriver implements Driver {
         "time": { precision: 0 },
         "datetime": { precision: 0 },
         "timestamp": { precision: 0 },
+        "boolean": { width: 1 },
         "bit": { width: 1 },
         "int": { width: 11 },
         "integer": { width: 11 },
@@ -543,7 +545,7 @@ export class MysqlDriver implements Driver {
             return "blob";
 
         } else if (column.type === Boolean) {
-            return "tinyint";
+            return "boolean";
 
         } else if (column.type === "uuid") {
             return "varchar";
@@ -570,7 +572,7 @@ export class MysqlDriver implements Driver {
             return "decimal";
 
         } else if (column.type === "bool" || column.type === "boolean") {
-            return "tinyint";
+            return "boolean";
 
         } else if (column.type === "nvarchar" || column.type === "national varchar") {
             return "varchar";


### PR DESCRIPTION
<!--
  😀 Wonderful!  Thank you for opening a pull request for TypeORM.

  Please fill in the information below to expedite the review
  and (hopefully) merge of your change.

  If unsure about something.. just do as best as you're able,
  or reach out through our community support channels!
  https://github.com/typeorm/typeorm/blob/master/docs/support.md
-->

### Description of change

<!--
  Please be clear and concise what the change is intended to do,
  why this change is needed, and how you've verified that it
  corrects what you intended.

  In some cases it may be helpful to include the current behavior
  and the new behavior.

  If the change is related to an open issue, you can link it here.
  If you include `Fixes #0000` (replacing `0000` with the issue number)
  when this is merged it will automatically mark the issue as fixed and
  close it.
-->

the boolean type in typeorm currently uses a tinyint(4)
when instead we could be using the mysql alias boolean
which is a tinyint(1)

fixes #3622

### Pull-Request Checklist

<!--
  Please make sure to review and check all of the following.

  If an item is not applicable, you can add "N/A" to the end.
-->

- [x] Code is up-to-date with the `master` branch
- [x] `npm run lint` passes with this change
- [ ] `npm run test` passes with this change
- [ ] This pull request links relevant issues as `Fixes #0000`
- [ ] There are new or updated unit tests validating the change
- [ ] Documentation has been updated to reflect this change
- [ ] The new commits follow conventions explained in [CONTRIBUTING.md](https://github.com/typeorm/typeorm/blob/master/CONTRIBUTING.md)

<!--
  🎉 Thank you for contributing and making TypeORM even better!
-->
