### PR TITLE
feat: use char(36) for uuid representation in mysql

### DIFF
--- a/src/driver/mysql/MysqlDriver.ts
+++ b/src/driver/mysql/MysqlDriver.ts
@@ -546,7 +546,7 @@ export class MysqlDriver implements Driver {
             return "tinyint";
 
         } else if (column.type === "uuid") {
-            return "varchar";
+            return "char";
 
         } else if (column.type === "json" && this.options.type === "mariadb") {
             /*
@@ -639,13 +639,10 @@ export class MysqlDriver implements Driver {
         if (column.length)
             return column.length.toString();
 
-        /**
-         * fix https://github.com/typeorm/typeorm/issues/1139
-         */
-        if (column.generationStrategy === "uuid")
-            return "36";
-
         switch (column.type) {
+            case "uuid":
+                return "36";
+
             case String:
             case "varchar":
             case "nvarchar":

--- a/test/functional/uuid/mysql/uuid-mysql.ts
+++ b/test/functional/uuid/mysql/uuid-mysql.ts
@@ -30,7 +30,7 @@ describe("uuid-mysql", () => {
         await postRepository.save(post);
         const loadedPost = await postRepository.findOne(1);
         expect(loadedPost!.uuid).to.be.exist;
-        postTable!.findColumnByName("uuid")!.type.should.be.equal("varchar");
+        postTable!.findColumnByName("uuid")!.type.should.be.equal("char");
 
         const post2 = new Post();
         post2.uuid = "fd357b8f-8838-42f6-b7a2-ae027444e895";
@@ -47,10 +47,11 @@ describe("uuid-mysql", () => {
         expect(loadedQuestion!.uuid2).to.equal("fd357b8f-8838-42f6-b7a2-ae027444e895");
         expect(loadedQuestion!.uuid3).to.be.null;
         expect(loadedQuestion!.uuid4).to.be.exist;
-        questionTable!.findColumnByName("id")!.type.should.be.equal("varchar");
-        questionTable!.findColumnByName("uuid")!.type.should.be.equal("varchar");
+        questionTable!.findColumnByName("id")!.type.should.be.equal("char");
+        questionTable!.findColumnByName("uuid")!.type.should.be.equal("char");
         questionTable!.findColumnByName("uuid2")!.type.should.be.equal("varchar");
         questionTable!.findColumnByName("uuid3")!.type.should.be.equal("varchar");
+        questionTable!.findColumnByName("uuid4")!.type.should.be.equal("char");
 
         const question2 = new Question();
         question2.id = "1ecad7f6-23ee-453e-bb44-16eca26d5189";
@@ -74,6 +75,15 @@ describe("uuid-mysql", () => {
         expect(question!.id).to.exist;
         expect(question!.uuid).to.exist;
         expect(question!.uuid2).to.exist;
+    })));
+
+    it("should create a table column that's char(36)", () => Promise.all(connections.map(async connection => {
+        const table = await connection.createQueryRunner().getTable('question')
+
+        const column = table?.findColumnByName("uuid")
+
+        expect(column?.type).to.equal("char")
+        expect(column?.length).to.equal("36")
     })));
 
 });


### PR DESCRIPTION
<!--
  😀 Wonderful!  Thank you for opening a pull request for TypeORM.

  Please fill in the information below to expedite the review
  and (hopefully) merge of your change.

  If unsure about something.. just do as best as you're able,
  or reach out through our community support channels!
  https://github.com/typeorm/typeorm/blob/master/docs/support.md
-->

### Description of change

<!--
  Please be clear and concise what the change is intended to do,
  why this change is needed, and how you've verified that it
  corrects what you intended.

  In some cases it may be helpful to include the current behavior
  and the new behavior.

  If the change is related to an open issue, you can link it here.
  If you include `Fixes #0000` (replacing `0000` with the issue number)
  when this is merged it will automatically mark the issue as fixed and
  close it.
-->

uses `CHAR(36)` for all `uuid` types in MySQL.

fixes #7228 

### Pull-Request Checklist

<!--
  Please make sure to review and check all of the following.

  If an item is not applicable, you can add "N/A" to the end.
-->

- [x] Code is up-to-date with the `master` branch
- [x] `npm run lint` passes with this change
- [x] `npm run test` passes with this change
- [x] This pull request links relevant issues as `Fixes #0000`
- [x] There are new or updated unit tests validating the change
- [ ] Documentation has been updated to reflect this change
- [x] The new commits follow conventions explained in [CONTRIBUTING.md](https://github.com/typeorm/typeorm/blob/master/CONTRIBUTING.md)

<!--
  🎉 Thank you for contributing and making TypeORM even better!
-->
