### PR TITLE
refactor: Move `tablePath` calculation out of the `EntityMetadata` class

### DIFF
--- a/src/driver/Driver.ts
+++ b/src/driver/Driver.ts
@@ -120,7 +120,7 @@ export interface Driver {
 
     /**
      * Build full table name with database name, schema name and table name.
-     * E.g. "myDB"."mySchema"."myTable"
+     * E.g. myDB.mySchema.myTable
      */
     buildTableName(tableName: string, schema?: string, database?: string): string;
 

--- a/src/driver/aurora-data-api/AuroraDataApiDriver.ts
+++ b/src/driver/aurora-data-api/AuroraDataApiDriver.ts
@@ -416,10 +416,16 @@ export class AuroraDataApiDriver implements Driver {
 
     /**
      * Build full table name with database name, schema name and table name.
-     * E.g. "myDB"."mySchema"."myTable"
+     * E.g. myDB.mySchema.myTable
      */
     buildTableName(tableName: string, schema?: string, database?: string): string {
-        return database ? `${database}.${tableName}` : tableName;
+        let tablePath = [ tableName ];
+
+        if (database) {
+            tablePath.unshift(database);
+        }
+
+        return tablePath.join('.');
     }
 
     /**

--- a/src/driver/cockroachdb/CockroachDriver.ts
+++ b/src/driver/cockroachdb/CockroachDriver.ts
@@ -420,10 +420,16 @@ export class CockroachDriver implements Driver {
 
     /**
      * Build full table name with schema name and table name.
-     * E.g. "mySchema"."myTable"
+     * E.g. myDB.mySchema.myTable
      */
     buildTableName(tableName: string, schema?: string): string {
-        return schema ? `${schema}.${tableName}` : tableName;
+        let tablePath = [ tableName ];
+
+        if (schema) {
+            tablePath.unshift(schema);
+        }
+
+        return tablePath.join('.');
     }
 
     /**

--- a/src/driver/mongodb/MongoDriver.ts
+++ b/src/driver/mongodb/MongoDriver.ts
@@ -292,7 +292,7 @@ export class MongoDriver implements Driver {
 
     /**
      * Build full table name with database name, schema name and table name.
-     * E.g. "myDB"."mySchema"."myTable"
+     * E.g. myDB.mySchema.myTable
      */
     buildTableName(tableName: string, schema?: string, database?: string): string {
         return tableName;

--- a/src/driver/mysql/MysqlDriver.ts
+++ b/src/driver/mysql/MysqlDriver.ts
@@ -435,10 +435,16 @@ export class MysqlDriver implements Driver {
 
     /**
      * Build full table name with database name, schema name and table name.
-     * E.g. "myDB"."mySchema"."myTable"
+     * E.g. myDB.mySchema.myTable
      */
     buildTableName(tableName: string, schema?: string, database?: string): string {
-        return database ? `${database}.${tableName}` : tableName;
+        let tablePath = [ tableName ];
+
+        if (database) {
+            tablePath.unshift(database);
+        }
+
+        return tablePath.join('.');
     }
 
     /**

--- a/src/driver/oracle/OracleDriver.ts
+++ b/src/driver/oracle/OracleDriver.ts
@@ -349,7 +349,17 @@ export class OracleDriver implements Driver {
      * Oracle does not support table schemas. One user can have only one schema.
      */
     buildTableName(tableName: string, schema?: string, database?: string): string {
-        return tableName;
+        let tablePath = [ tableName ];
+
+        if (schema) {
+            tablePath.unshift(schema);
+        }
+
+        if (database) {
+            tablePath.unshift(database);
+        }
+
+        return tablePath.join('.');
     }
 
     /**

--- a/src/driver/postgres/PostgresDriver.ts
+++ b/src/driver/postgres/PostgresDriver.ts
@@ -659,10 +659,16 @@ export class PostgresDriver implements Driver {
 
     /**
      * Build full table name with schema name and table name.
-     * E.g. "mySchema"."myTable"
+     * E.g. myDB.mySchema.myTable
      */
     buildTableName(tableName: string, schema?: string): string {
-        return schema ? `${schema}.${tableName}` : tableName;
+        let tablePath = [ tableName ];
+
+        if (schema) {
+            tablePath.unshift(schema);
+        }
+
+        return tablePath.join('.');
     }
 
     /**

--- a/src/driver/sap/SapDriver.ts
+++ b/src/driver/sap/SapDriver.ts
@@ -336,10 +336,16 @@ export class SapDriver implements Driver {
 
     /**
      * Build full table name with schema name and table name.
-     * E.g. "mySchema"."myTable"
+     * E.g. myDB.mySchema.myTable
      */
     buildTableName(tableName: string, schema?: string): string {
-        return schema ? `${schema}.${tableName}` : tableName;
+        let tablePath = [ tableName ];
+
+        if (schema) {
+            tablePath.unshift(schema);
+        }
+
+        return tablePath.join('.');
     }
 
     /**

--- a/src/driver/sqlite-abstract/AbstractSqliteDriver.ts
+++ b/src/driver/sqlite-abstract/AbstractSqliteDriver.ts
@@ -404,7 +404,7 @@ export abstract class AbstractSqliteDriver implements Driver {
 
     /**
      * Build full table name with database name, schema name and table name.
-     * E.g. "myDB"."mySchema"."myTable"
+     * E.g. myDB.mySchema.myTable
      *
      * Returns only simple table name because all inherited drivers does not supports schema and database.
      */

--- a/src/driver/sqlserver/SqlServerDriver.ts
+++ b/src/driver/sqlserver/SqlServerDriver.ts
@@ -347,21 +347,24 @@ export class SqlServerDriver implements Driver {
 
     /**
      * Build full table name with database name, schema name and table name.
-     * E.g. "myDB"."mySchema"."myTable"
+     * E.g. myDB.mySchema.myTable
      */
     buildTableName(tableName: string, schema?: string, database?: string): string {
-        let fullName = tableName;
-        if (schema)
-            fullName = schema + "." + tableName;
-        if (database) {
-            if (!schema) {
-                fullName = database + ".." + tableName;
-            } else {
-                fullName = database + "." + fullName;
-            }
+        let tablePath = [ tableName ];
+
+        if (schema) {
+            tablePath.unshift(schema);
         }
 
-        return fullName;
+        if (database) {
+            if (!schema) {
+                tablePath.unshift('')
+            }
+
+            tablePath.unshift(database);
+        }
+
+        return tablePath.join('.');
     }
 
     /**

--- a/src/metadata/EntityMetadata.ts
+++ b/src/metadata/EntityMetadata.ts
@@ -130,12 +130,6 @@ export class EntityMetadata {
     tablePath: string;
 
     /**
-     * Entity schema path. Contains database name and schema name.
-     * E.g. myDB.mySchema
-     */
-    schemaPath?: string;
-
-    /**
      * Gets the table name without global table prefix.
      * When querying table you need a table name with prefix, but in some scenarios,
      * for example when you want to name a junction table that contains names of two other tables,
@@ -842,7 +836,6 @@ export class EntityMetadata {
         this.expression = this.tableMetadataArgs.expression;
         this.withoutRowid = this.tableMetadataArgs.withoutRowid === true ? true : false;
         this.tablePath = this.buildTablePath();
-        this.schemaPath = this.buildSchemaPath();
         this.orderBy = (this.tableMetadataArgs.orderBy instanceof Function) ? this.tableMetadataArgs.orderBy(this.propertiesMap) : this.tableMetadataArgs.orderBy; // todo: is propertiesMap available here? Looks like its not
 
         if (entitySkipConstructor !== undefined) {
@@ -904,15 +897,4 @@ export class EntityMetadata {
 
         return tablePath;
     }
-
-    /**
-     * Builds table path using schema name and database name.
-     */
-    protected buildSchemaPath(): string|undefined {
-        if (!this.schema)
-            return undefined;
-
-        return this.database && !(this.connection.driver instanceof PostgresDriver) ? this.database + "." + this.schema : this.schema;
-    }
-
 }

--- a/src/metadata/EntityMetadata.ts
+++ b/src/metadata/EntityMetadata.ts
@@ -1,12 +1,6 @@
 import {QueryRunner, SelectQueryBuilder} from "..";
 import {ObjectLiteral} from "../common/ObjectLiteral";
 import {Connection} from "../connection/Connection";
-import {PostgresConnectionOptions} from "../driver/postgres/PostgresConnectionOptions";
-import {PostgresDriver} from "../driver/postgres/PostgresDriver";
-import {SapDriver} from "../driver/sap/SapDriver";
-import {SqlServerConnectionOptions} from "../driver/sqlserver/SqlServerConnectionOptions";
-import {SqlServerDriver} from "../driver/sqlserver/SqlServerDriver";
-import {OracleDriver} from "../driver/oracle/OracleDriver";
 import {CannotCreateEntityIdMapError} from "../error/CannotCreateEntityIdMapError";
 import {OrderByCondition} from "../find-options/OrderByCondition";
 import {TableMetadataArgs} from "../metadata-args/TableMetadataArgs";
@@ -812,9 +806,8 @@ export class EntityMetadata {
         }
         else if ((this.tableMetadataArgs.type === "entity-child") && this.parentEntityMetadata) {
             this.schema = this.parentEntityMetadata.schema;
-        }
-        else {
-            this.schema = (this.connection.options as PostgresConnectionOptions|SqlServerConnectionOptions).schema;
+        } else if (this.connection.options?.hasOwnProperty("schema")) {
+            this.schema = (this.connection.options as any).schema;
         }
         this.givenTableName = this.tableMetadataArgs.type === "entity-child" && this.parentEntityMetadata ? this.parentEntityMetadata.givenTableName : this.tableMetadataArgs.name;
         this.synchronize = this.tableMetadataArgs.synchronize === false ? false : true;
@@ -835,7 +828,7 @@ export class EntityMetadata {
         this.name = this.targetName ? this.targetName : this.tableName;
         this.expression = this.tableMetadataArgs.expression;
         this.withoutRowid = this.tableMetadataArgs.withoutRowid === true ? true : false;
-        this.tablePath = this.buildTablePath();
+        this.tablePath = this.connection.driver.buildTableName(this.tableName, this.schema, this.database);
         this.orderBy = (this.tableMetadataArgs.orderBy instanceof Function) ? this.tableMetadataArgs.orderBy(this.propertiesMap) : this.tableMetadataArgs.orderBy; // todo: is propertiesMap available here? Looks like its not
 
         if (entitySkipConstructor !== undefined) {
@@ -876,25 +869,5 @@ export class EntityMetadata {
         this.columns.forEach(column => OrmUtils.mergeDeep(map, column.createValueMap(column.propertyPath)));
         this.relations.forEach(relation => OrmUtils.mergeDeep(map, relation.createValueMap(relation.propertyPath)));
         return map;
-    }
-
-    /**
-     * Builds table path using database name, schema name and table name.
-     */
-    protected buildTablePath(): string {
-        let tablePath = this.tableName;
-        if (this.schema && ((this.connection.driver instanceof OracleDriver) || (this.connection.driver instanceof PostgresDriver) || (this.connection.driver instanceof SqlServerDriver) || (this.connection.driver instanceof SapDriver))) {
-            tablePath = this.schema + "." + tablePath;
-        }
-
-        if (this.database && !(this.connection.driver instanceof PostgresDriver)) {
-            if (!this.schema && this.connection.driver instanceof SqlServerDriver) {
-                tablePath = this.database + ".." + tablePath;
-            } else {
-                tablePath = this.database + "." + tablePath;
-            }
-        }
-
-        return tablePath;
     }
 }

--- a/src/schema-builder/table/Table.ts
+++ b/src/schema-builder/table/Table.ts
@@ -20,7 +20,7 @@ export class Table {
 
     /**
      * Contains database name, schema name and table name.
-     * E.g. "myDB"."mySchema"."myTable"
+     * E.g. myDB.mySchema.myTable
      */
     name: string;
 

--- a/src/schema-builder/view/View.ts
+++ b/src/schema-builder/view/View.ts
@@ -12,7 +12,7 @@ export class View {
 
     /**
      * Contains database name, schema name and table name.
-     * E.g. "myDB"."mySchema"."myTable"
+     * E.g. myDB.mySchema.myTable
      */
     name: string;
 

--- a/test/functional/schema-builder/custom-db-and-schema-sync.ts
+++ b/test/functional/schema-builder/custom-db-and-schema-sync.ts
@@ -33,27 +33,28 @@ describe("schema builder > custom-db-and-schema-sync", () => {
             photoMetadata.database = "secondDB";
             photoMetadata.schema = "photo-schema";
             photoMetadata.tablePath = "secondDB.photo-schema.photo";
-            photoMetadata.schemaPath = "secondDB.photo-schema";
+            const photoMetadataSchemaPath = "secondDB.photo-schema";
 
             albumMetadata.database = "secondDB";
             albumMetadata.schema = "album-schema";
             albumMetadata.tablePath = "secondDB.album-schema.album";
-            albumMetadata.schemaPath = "secondDB.album-schema";
+            const albumMetadataSchemaPath = "secondDB.album-schema";
 
             await queryRunner.createDatabase(photoMetadata.database, true);
-            await queryRunner.createSchema(photoMetadata.schemaPath, true);
-            await queryRunner.createSchema(albumMetadata.schemaPath, true);
+            await queryRunner.createSchema(photoMetadataSchemaPath, true);
+            await queryRunner.createSchema(albumMetadataSchemaPath, true);
 
         } else if (connection.driver instanceof PostgresDriver || connection.driver instanceof SapDriver) {
             photoMetadata.schema = "photo-schema";
             photoMetadata.tablePath = "photo-schema.photo";
-            photoMetadata.schemaPath = "photo-schema";
+            const photoMetadataSchemaPath = "photo-schema";
 
             albumMetadata.schema = "album-schema";
             albumMetadata.tablePath = "album-schema.album";
-            albumMetadata.schemaPath = "album-schema";
-            await queryRunner.createSchema(photoMetadata.schemaPath, true);
-            await queryRunner.createSchema(albumMetadata.schemaPath, true);
+            const albumMetadataSchemaPath = "album-schema";
+
+            await queryRunner.createSchema(photoMetadataSchemaPath, true);
+            await queryRunner.createSchema(albumMetadataSchemaPath, true);
 
         } else if (connection.driver instanceof MysqlDriver) {
             photoMetadata.database = "secondDB";

--- a/test/github-issues/3857/issue-3857.ts
+++ b/test/github-issues/3857/issue-3857.ts
@@ -9,7 +9,7 @@ describe("github issues > #3857 Schema inheritance when STI pattern is used", ()
 
     let connections: Connection[];
     before(async () => connections = await createTestingConnections({
-        enabledDrivers: ["postgres", "mariadb", "mysql"],
+        enabledDrivers: ["postgres"],
         entities: [__dirname + "/entity/*{.js,.ts}"],
         schema: "custom",
         schemaCreate: true


### PR DESCRIPTION
<!--
  😀 Wonderful!  Thank you for opening a pull request for TypeORM.

  Please fill in the information below to expedite the review
  and (hopefully) merge of your change.

  If unsure about something.. just do as best as you're able,
  or reach out through our community support channels!
  https://github.com/typeorm/typeorm/blob/master/docs/support.md
-->

### Description of change

<!--
  Please be clear and concise what the change is intended to do,
  why this change is needed, and how you've verified that it
  corrects what you intended.

  In some cases it may be helpful to include the current behavior
  and the new behavior.

  If the change is related to an open issue, you can link it here.
  If you include `Fixes #0000` (replacing `0000` with the issue number)
  when this is merged it will automatically mark the issue as fixed and
  close it.
-->

refactors the way tablePath is handled in `EntityMetadata` to use the driver's `buildTableName` we don't keep a list elsewhere of who supports a schema in their table name and who doesn't.

### Pull-Request Checklist

<!--
  Please make sure to review and check all of the following.

  If an item is not applicable, you can add "N/A" to the end.
-->

- [x] Code is up-to-date with the `master` branch
- [x] `npm run lint` passes with this change
- [x] `npm run test` passes with this change
- [ ] This pull request links relevant issues as `Fixes #0000`
- [ ] There are new or updated unit tests validating the change
- [ ] Documentation has been updated to reflect this change
- [x] The new commits follow conventions explained in [CONTRIBUTING.md](https://github.com/typeorm/typeorm/blob/master/CONTRIBUTING.md)

<!--
  🎉 Thank you for contributing and making TypeORM even better!
-->
