### PR TITLE
fix: properly convert to snakeCase

### DIFF
--- a/src/util/StringUtils.ts
+++ b/src/util/StringUtils.ts
@@ -16,10 +16,13 @@ export function camelCase(str: string, firstCapital: boolean = false): string {
 /**
  * Converts string into snake_case.
  *
- * @see https://regex101.com/r/QeSm2I/1
+ * @see https://regex101.com/r/OcnrZ2/1
+ * @see https://regex101.com/r/PwRjxu/1
  */
-export function snakeCase(str: string) {
-    return str.replace(/(?:([a-z])([A-Z]))|(?:((?!^)[A-Z])([a-z]))/g, "$1_$3$2$4").toLowerCase();
+ export function snakeCase(str: string): string{
+    return str.replace(/(?:((?!^)[A-Z])([a-z])([A-Z]))/g, "$1$2_$3")
+              .replace(/(?:([a-z])([A-Z]))|(?:((?!^)(?<!_)[A-Z])([a-z]))/g, "$1_$3$2$4")
+              .toLowerCase();
 }
 
 /**


### PR DESCRIPTION
### Description of change

This updates let `StringUtils.snakeCase` method property convert case like 'optionAOrB'.
As previous code can not catch `([A-Z])([a-z])([A-Z])` pattern, I add extra regex for it.

### Pull-Request Checklist

- [x] Code is up-to-date with the `master` branch
- [x] `npm run lint` passes with this change
- [ ] `npm run test` passes with this change - N/A
- [x] This pull request links relevant issues as Fixes https://github.com/typeorm/typeorm/issues/4387
- [ ] There are new or updated unit tests validating the change - N/A
- [ ] Documentation has been updated to reflect this change - N/A
- [x] The new commits follow conventions explained in [CONTRIBUTING.md](https://github.com/typeorm/typeorm/blob/master/CONTRIBUTING.md)
