### PR TITLE
fix: drop pool.autostart from mssql options because it's unused

### DIFF
--- a/docs/connection-options.md
+++ b/docs/connection-options.md
@@ -271,8 +271,6 @@ See [SSL options](https://github.com/mysqljs/mysql#ssl-options).
  
 * `pool.priorityRange` - int between 1 and x - if set, borrowers can specify their relative priority in the queue if no
  resources are available. see example. (default `1`).
- 
-* `pool.autostart` - boolean, should the pool start creating resources etc once the constructor is called, (default `true`).
 
 * `pool.evictionRunIntervalMillis` - How often to run eviction checks. Default: `0` (does not run).
 

--- a/docs/zh_CN/connection-options.md
+++ b/docs/zh_CN/connection-options.md
@@ -192,8 +192,6 @@
 
 - `pool.priorityRange` - 1和x之间的int值  - 如果设置了且没有可用资源，则borrowers可以在队列中指定其相对优先级(默认 `1`)。
 
-- `pool.autostart` - 布尔值，一旦调用构造函数，池应该开始创建资源等（默认为`true`）。
-
 - `pool.victionRunIntervalMillis` - 多久检查一次eviction checks。 默认值：`0`（不运行）。
 
 - `pool.numTestsPerRun` - 每次eviction checks资源数量。 默认值：`3`。

--- a/src/driver/sqlserver/SqlServerConnectionOptions.ts
+++ b/src/driver/sqlserver/SqlServerConnectionOptions.ts
@@ -80,11 +80,6 @@ export interface SqlServerConnectionOptions extends BaseConnectionOptions, SqlSe
         readonly priorityRange?: number;
 
         /**
-         * Should the pool start creating resources etc once the constructor is called, (default true)
-         */
-        readonly autostart?: number;
-
-        /**
          * How often to run eviction checks. Default: 0 (does not run).
          */
         readonly evictionRunIntervalMillis?: number;


### PR DESCRIPTION
<!--
  😀 Wonderful!  Thank you for opening a pull request for TypeORM.

  Please fill in the information below to expedite the review
  and (hopefully) merge of your change.

  If unsure about something.. just do as best as you're able,
  or reach out through our community support channels!
  https://github.com/typeorm/typeorm/blob/master/docs/support.md
-->

### Description of change

<!--
  Please be clear and concise what the change is intended to do,
  why this change is needed, and how you've verified that it
  corrects what you intended.

  In some cases it may be helpful to include the current behavior
  and the new behavior.

  If the change is related to an open issue, you can link it here.
  If you include `Fixes #0000` (replacing `0000` with the issue number)
  when this is merged it will automatically mark the issue as fixed and
  close it.
-->

fixes #5946

### Pull-Request Checklist

<!--
  Please make sure to review and check all of the following.

  If an item is not applicable, you can add "N/A" to the end.
-->

- [x] Code is up-to-date with the `master` branch
- [x] `npm run lint` passes with this change
- [ ] `npm run test` passes with this change
- [x] This pull request links relevant issues as `Fixes #0000`
- [ ] There are new or updated unit tests validating the change
- [x] Documentation has been updated to reflect this change
- [x] The new commits follow conventions explained in [CONTRIBUTING.md](https://github.com/typeorm/typeorm/blob/master/CONTRIBUTING.md)

<!--
  🎉 Thank you for contributing and making TypeORM even better!
-->
