### PR TITLE
fix: only pass `data` from SaveOptions during that query

### DIFF
--- a/src/persistence/EntityPersistExecutor.ts
+++ b/src/persistence/EntityPersistExecutor.ts
@@ -53,8 +53,10 @@ export class EntityPersistExecutor {
 
         // save data in the query runner - this is useful functionality to share data from outside of the world
         // with third classes - like subscribers and listener methods
-        if (this.options && this.options.data)
+        let oldQueryRunnerData = queryRunner.data;
+        if (this.options && this.options.data) {
             queryRunner.data = this.options.data;
+        }
 
         try {
 
@@ -166,6 +168,7 @@ export class EntityPersistExecutor {
             }
 
         } finally {
+            queryRunner.data = oldQueryRunnerData;
 
             // release query runner only if its created by us
             if (!this.queryRunner)

--- a/test/functional/entity-subscriber/query-data/entity/Example.ts
+++ b/test/functional/entity-subscriber/query-data/entity/Example.ts
@@ -1,0 +1,10 @@
+import { Column, Entity, PrimaryGeneratedColumn } from "../../../../../src/";
+
+@Entity()
+export class Example {
+    @PrimaryGeneratedColumn()
+    id: number;
+
+    @Column()
+    value: number = 0;
+}

--- a/test/functional/entity-subscriber/query-data/query-data.ts
+++ b/test/functional/entity-subscriber/query-data/query-data.ts
@@ -1,0 +1,61 @@
+import {
+    Connection,
+} from "../../../../src";
+import {closeTestingConnections, createTestingConnections} from "../../../utils/test-utils";
+import {expect} from "chai";
+import { MockSubscriber } from "./subscribers/MockSubscriber";
+import { Example } from "./entity/Example";
+
+describe("entity subscriber > query data", () => {
+    let connections: Connection[];
+    before(async () => connections = await createTestingConnections({
+        entities: [ Example ],
+        subscribers: [ MockSubscriber ],
+        dropSchema: true,
+        schemaCreate: true,
+        enabledDrivers: [ "sqlite" ]
+    }));
+    beforeEach(() => {
+        for (const connection of connections) {
+            (connection.subscribers[0] as MockSubscriber).calledData.length = 0;
+        }
+    })
+    after(() => closeTestingConnections(connections));
+
+    it("passes query data to subscriber", () => Promise.all(connections.map(async connection => {
+        const subscriber = connection.subscribers[0] as MockSubscriber;
+
+        const example = new Example();
+
+        await connection.manager.save(example);
+
+        example.value++;
+
+        await connection.manager.save(example, { data: { Hello: "World" } });
+
+        expect(subscriber.calledData).to.be.eql([
+            { Hello: "World" },
+        ]);
+    })));
+
+    it("cleans up the data after the save completes", () => Promise.all(connections.map(async connection => {
+        const subscriber = connection.subscribers[0] as MockSubscriber;
+
+        const example = new Example();
+
+        await connection.manager.save(example);
+
+        example.value++;
+
+        await connection.manager.save(example, { data: { Hello: "World" } });
+
+        example.value++;
+
+        await connection.manager.save(example);
+
+        expect(subscriber.calledData).to.be.eql([
+            { Hello: "World" },
+            {},
+        ]);
+    })));
+});

--- a/test/functional/entity-subscriber/query-data/subscribers/MockSubscriber.ts
+++ b/test/functional/entity-subscriber/query-data/subscribers/MockSubscriber.ts
@@ -1,0 +1,10 @@
+import { EntitySubscriberInterface, EventSubscriber, UpdateEvent } from "../../../../../src";
+
+@EventSubscriber()
+export class MockSubscriber implements EntitySubscriberInterface {
+    calledData: any[] = [];
+
+    afterUpdate(event: UpdateEvent<any>): void {
+        this.calledData.push(event.queryRunner.data);
+    }
+}

--- a/test/functional/entity-subscriber/transaction-flow/entity-subscriber-transaction-flow.ts
+++ b/test/functional/entity-subscriber/transaction-flow/entity-subscriber-transaction-flow.ts
@@ -2,17 +2,17 @@ import {
     Connection,
     EntitySubscriberInterface,
     EventSubscriber,
-} from "../../../src";
-import {closeTestingConnections, createTestingConnections} from "../../utils/test-utils";
+} from "../../../../src";
+import {closeTestingConnections, createTestingConnections} from "../../../utils/test-utils";
 import sinon from "sinon";
 import {expect} from "chai";
-import {SapDriver} from "../../../src/driver/sap/SapDriver";
-import {OracleDriver} from "../../../src/driver/oracle/OracleDriver";
-import {AuroraDataApiPostgresDriver} from "../../../src/driver/aurora-data-api-pg/AuroraDataApiPostgresDriver";
-import {AuroraDataApiDriver} from "../../../src/driver/aurora-data-api/AuroraDataApiDriver";
-import {SqlServerDriver} from "../../../src/driver/sqlserver/SqlServerDriver";
+import {SapDriver} from "../../../../src/driver/sap/SapDriver";
+import {OracleDriver} from "../../../../src/driver/oracle/OracleDriver";
+import {AuroraDataApiPostgresDriver} from "../../../../src/driver/aurora-data-api-pg/AuroraDataApiPostgresDriver";
+import {AuroraDataApiDriver} from "../../../../src/driver/aurora-data-api/AuroraDataApiDriver";
+import {SqlServerDriver} from "../../../../src/driver/sqlserver/SqlServerDriver";
 
-describe("entity subscriber transaction flow", () => {
+describe("entity subscriber > transaction flow", () => {
 
     let beforeTransactionStart = sinon.spy();
     let afterTransactionStart = sinon.spy();


### PR DESCRIPTION
<!--
  😀 Wonderful!  Thank you for opening a pull request for TypeORM.

  Please fill in the information below to expedite the review
  and (hopefully) merge of your change.

  If unsure about something.. just do as best as you're able,
  or reach out through our community support channels!
  https://github.com/typeorm/typeorm/blob/master/docs/support.md
-->

### Description of change

<!--
  Please be clear and concise what the change is intended to do,
  why this change is needed, and how you've verified that it
  corrects what you intended.

  In some cases it may be helpful to include the current behavior
  and the new behavior.

  If the change is related to an open issue, you can link it here.
  If you include `Fixes #0000` (replacing `0000` with the issue number)
  when this is merged it will automatically mark the issue as fixed and
  close it.
-->

this resets the `data` passed from `SaveOptions` to `QueryRunner`
once the persistence operation has completed

fixes #4146

### Pull-Request Checklist

<!--
  Please make sure to review and check all of the following.

  If an item is not applicable, you can add "N/A" to the end.
-->

- [x] Code is up-to-date with the `master` branch
- [x] `npm run lint` passes with this change
- [x] `npm run test` passes with this change
- [x] This pull request links relevant issues as `Fixes #0000`
- [x] There are new or updated unit tests validating the change
- [ ] Documentation has been updated to reflect this change
- [x] The new commits follow conventions explained in [CONTRIBUTING.md](https://github.com/typeorm/typeorm/blob/master/CONTRIBUTING.md)

<!--
  🎉 Thank you for contributing and making TypeORM even better!
-->
