### PR TITLE
refactor: create a lock class for fifo query execution locks

### DIFF
--- a/src/query-runner/QueryLock.ts
+++ b/src/query-runner/QueryLock.ts
@@ -1,0 +1,25 @@
+export class QueryLock {
+    private readonly queue: Promise<void>[] = [];
+
+    async acquire(): Promise<() => void> {
+        let release: Function;
+        const waitingPromise = new Promise<void>((ok) => release = ok);
+
+        // Get track of everyone we need to wait on..
+        const otherWaitingPromises = [...this.queue];
+        // Put ourselves onto the end of the queue
+        this.queue.push(waitingPromise);
+
+        if (otherWaitingPromises.length > 0) {
+            await Promise.all(otherWaitingPromises);
+        }
+
+        return () => {
+            release();
+
+            if (this.queue.includes(waitingPromise)) {
+                this.queue.splice(this.queue.indexOf(waitingPromise), 1);
+            }
+        };
+    }
+}


### PR DESCRIPTION
<!--
  😀 Wonderful!  Thank you for opening a pull request for TypeORM.

  Please fill in the information below to expedite the review
  and (hopefully) merge of your change.

  If unsure about something.. just do as best as you're able,
  or reach out through our community support channels!
  https://github.com/typeorm/typeorm/blob/master/docs/support.md
-->

### Description of change

<!--
  Please be clear and concise what the change is intended to do,
  why this change is needed, and how you've verified that it
  corrects what you intended.

  In some cases it may be helpful to include the current behavior
  and the new behavior.

  If the change is related to an open issue, you can link it here.
  If you include `Fixes #0000` (replacing `0000` with the issue number)
  when this is merged it will automatically mark the issue as fixed and
  close it.
-->

this refactors both SAPQueryRunner & SQLServerQueryRunner to use
a new QueryLock class which cleans up the code significantly.  the
refactor unravels the Promise wrapping & also cleans up the
stream function for MSSQLQueryRunner

### Pull-Request Checklist

<!--
  Please make sure to review and check all of the following.

  If an item is not applicable, you can add "N/A" to the end.
-->

- [x] Code is up-to-date with the `master` branch
- [x] `npm run lint` passes with this change
- [x] `npm run test` passes with this change
- [ ] This pull request links relevant issues as `Fixes #0000`
- [ ] There are new or updated unit tests validating the change
- [ ] Documentation has been updated to reflect this change
- [x] The new commits follow conventions explained in [CONTRIBUTING.md](https://github.com/typeorm/typeorm/blob/master/CONTRIBUTING.md)

<!--
  🎉 Thank you for contributing and making TypeORM even better!
-->
