### PR TITLE
fix: actually return a working ReadStream from SQL Server query runner

### DIFF
--- a/test/functional/query-runner/stream.ts
+++ b/test/functional/query-runner/stream.ts
@@ -1,0 +1,40 @@
+import "reflect-metadata";
+import { Connection } from "../../../src";
+import { expect } from "chai";
+import { closeTestingConnections, createTestingConnections, reloadTestingDatabases } from "../../utils/test-utils";
+import { Book } from "./entity/Book";
+
+describe("query runner > stream", () => {
+
+    let connections: Connection[];
+    before(async () => {
+        connections = await createTestingConnections({
+            entities: [Book],
+            enabledDrivers: [ "mysql", "cockroachdb", "postgres", "mssql" ],
+        });
+    });
+    beforeEach(() => reloadTestingDatabases(connections));
+    after(() => closeTestingConnections(connections));
+
+    it("should stream data", () => Promise.all(connections.map(async connection => {
+        await connection.manager.save(Book, { ean: 'a' });
+        await connection.manager.save(Book, { ean: 'b' });
+        await connection.manager.save(Book, { ean: 'c' });
+        await connection.manager.save(Book, { ean: 'd' });
+
+        const queryRunner = connection.createQueryRunner();
+
+        const readStream = await queryRunner.stream('SELECT * FROM book');
+
+        await new Promise((ok) => readStream.on('readable', ok));
+
+        expect(readStream.read()).to.be.eql({ ean: 'a' });
+        expect(readStream.read()).to.be.eql({ ean: 'b' });
+        expect(readStream.read()).to.be.eql({ ean: 'c' });
+        expect(readStream.read()).to.be.eql({ ean: 'd' });
+        expect(readStream.read()).to.be.null;
+
+        await queryRunner.release();
+    })));
+
+});


### PR DESCRIPTION
<!--
  😀 Wonderful!  Thank you for opening a pull request for TypeORM.

  Please fill in the information below to expedite the review
  and (hopefully) merge of your change.

  If unsure about something.. just do as best as you're able,
  or reach out through our community support channels!
  https://github.com/typeorm/typeorm/blob/master/docs/support.md
-->

### Description of change

<!--
  Please be clear and concise what the change is intended to do,
  why this change is needed, and how you've verified that it
  corrects what you intended.

  In some cases it may be helpful to include the current behavior
  and the new behavior.

  If the change is related to an open issue, you can link it here.
  If you include `Fixes #0000` (replacing `0000` with the issue number)
  when this is merged it will automatically mark the issue as fixed and
  close it.
-->

the sql server query runner wasn't actually returning a ReadStream as expected
and there were no tests that confirmed the stream functionality.  this corrects
both of those problems

### Pull-Request Checklist

<!--
  Please make sure to review and check all of the following.

  If an item is not applicable, you can add "N/A" to the end.
-->

- [x] Code is up-to-date with the `master` branch
- [x] `npm run lint` passes with this change
- [ ] `npm run test` passes with this change
- [ ] This pull request links relevant issues as `Fixes #0000`
- [x] There are new or updated unit tests validating the change
- [ ] Documentation has been updated to reflect this change
- [x] The new commits follow conventions explained in [CONTRIBUTING.md](https://github.com/typeorm/typeorm/blob/master/CONTRIBUTING.md)

<!--
  🎉 Thank you for contributing and making TypeORM even better!
-->
