### PR TITLE
feat: set `enableArithAbort` for SQLServerDriver

### DIFF
--- a/src/driver/sqlserver/SqlServerDriver.ts
+++ b/src/driver/sqlserver/SqlServerDriver.ts
@@ -805,8 +805,21 @@ export class SqlServerDriver implements Driver {
         }, options.extra || {});
 
         // set default useUTC option if it hasn't been set
-        if (!connectionOptions.options) connectionOptions.options = { useUTC: false };
-        else if (!connectionOptions.options.useUTC) connectionOptions.options.useUTC = false;
+        if (!connectionOptions.options) {
+            connectionOptions.options = { useUTC: false };
+        } else if (!connectionOptions.options.useUTC) {
+            Object.assign(
+                connectionOptions.options,
+                { useUTC: false }
+            )
+        }
+
+        // Match the next release of tedious for configuration options
+        // Also prevents warning messages.
+        Object.assign(
+            connectionOptions.options,
+            { enableArithAbort: true }
+        )
 
         // pooling is enabled either when its set explicitly to true,
         // either when its not defined at all (e.g. enabled by default)


### PR DESCRIPTION
<!--
  😀 Wonderful!  Thank you for opening a pull request for TypeORM.

  Please fill in the information below to expedite the review
  and (hopefully) merge of your change.

  If unsure about something.. just do as best as you're able,
  or reach out through our community support channels!
  https://github.com/typeorm/typeorm/blob/master/docs/support.md
-->

### Description of change

<!--
  Please be clear and concise what the change is intended to do,
  why this change is needed, and how you've verified that it
  corrects what you intended.

  In some cases it may be helpful to include the current behavior
  and the new behavior.

  If the change is related to an open issue, you can link it here.
  If you include `Fixes #0000` (replacing `0000` with the issue number)
  when this is merged it will automatically mark the issue as fixed and
  close it.
-->

this prevents the deprecation message & also prevents us from
disabling `ARTITHABORT` which is the default on SQL Server

### Pull-Request Checklist

<!--
  Please make sure to review and check all of the following.

  If an item is not applicable, you can add "N/A" to the end.
-->

- [ ] Code is up-to-date with the `master` branch
- [ ] `npm run lint` passes with this change
- [ ] `npm run test` passes with this change
- [ ] This pull request links relevant issues as `Fixes #0000`
- [ ] There are new or updated unit tests validating the change
- [ ] Documentation has been updated to reflect this change
- [ ] The new commits follow conventions explained in [CONTRIBUTING.md](https://github.com/typeorm/typeorm/blob/master/CONTRIBUTING.md)

<!--
  🎉 Thank you for contributing and making TypeORM even better!
-->
