### PR TITLE
docs: fix invalid comment at snakeCase method

### DIFF
--- a/src/util/StringUtils.ts
+++ b/src/util/StringUtils.ts
@@ -16,11 +16,10 @@ export function camelCase(str: string, firstCapital: boolean = false): string {
 /**
  * Converts string into snake_case.
  *
- * @see https://regex101.com/r/QeSm2I/1
  */
 export function snakeCase(str: string): string{
     return str
-        // ABc -> ab_c
+        // ABc -> a_bc
         .replace(/([A-Z])([A-Z])([a-z])/g, "$1_$2$3")
         // aC -> a_c
         .replace(/([a-z])([A-Z])/g, "$1_$2")


### PR DESCRIPTION
### Description of change

As regex example at comment is not matched with actual one, fix it properly.
And remove invalid example link as it is not represent current code.

<img width="307" alt="스크린샷 2021-07-12 오전 11 59 19" src="https://user-images.githubusercontent.com/45849656/125224437-98ef5f80-e308-11eb-81e0-adce607e70bb.png">

### Pull-Request Checklist

- [x] Code is up-to-date with the `master` branch
- [x] `npm run lint` passes with this change
- [ ] `npm run test` passes with this change - N/A
- [ ] This pull request links relevant issues as `Fixes #0000` - N/A
- [ ] There are new or updated unit tests validating the change - N/A
- [ ] Documentation has been updated to reflect this change - N/A
- [x] The new commits follow conventions explained in [CONTRIBUTING.md](https://github.com/typeorm/typeorm/blob/master/CONTRIBUTING.md)

