### PR TITLE
 fix: use fully qualified table path for looking up tables 

### DIFF
--- a/src/driver/Driver.ts
+++ b/src/driver/Driver.ts
@@ -21,11 +21,16 @@ export interface Driver {
     options: BaseConnectionOptions;
 
     /**
-     * Master database used to perform all write queries.
+     * Database name used to perform all write queries.
      *
      * todo: probably move into query runner.
      */
     database?: string;
+
+    /**
+     * Schema name used to perform all write queries.
+     */
+    schema?: string;
 
     /**
      * Indicates if replication is enabled.

--- a/src/driver/aurora-data-api/AuroraDataApiDriver.ts
+++ b/src/driver/aurora-data-api/AuroraDataApiDriver.ts
@@ -57,9 +57,14 @@ export class AuroraDataApiDriver implements Driver {
     options: AuroraDataApiConnectionOptions;
 
     /**
-     * Master database used to perform all write queries.
+     * Database name used to perform all write queries.
      */
     database?: string;
+
+    /**
+     * Schema name used to performn all write queries.
+     */
+    schema?: string;
 
     /**
      * Indicates if replication is enabled.
@@ -335,6 +340,12 @@ export class AuroraDataApiDriver implements Driver {
      * Performs connection to the database.
      */
     async connect(): Promise<void> {
+        const queryRunner = await this.createQueryRunner("master");
+
+        // Ask the database for where we've connected to
+        this.database = await queryRunner.getCurrentDatabase();
+
+        await queryRunner.release();
     }
 
     /**

--- a/src/driver/aurora-data-api/AuroraDataApiQueryRunner.ts
+++ b/src/driver/aurora-data-api/AuroraDataApiQueryRunner.ts
@@ -1672,7 +1672,24 @@ export class AuroraDataApiQueryRunner extends BaseQueryRunner implements QueryRu
      * Escapes given table or view path.
      */
     protected escapePath(target: Table|View|string, disableEscape?: boolean): string {
-        const tableName = target instanceof Table || target instanceof View ? target.name : target;
+        let tableName: string;
+
+        if (target instanceof Table) {
+            tableName = target.name;
+
+            if (target.database) {
+                tableName = `${target.database}.${tableName}`
+            }
+        } else if (target instanceof View) {
+            tableName = target.name;
+        } else {
+            tableName = target;
+        }
+
+        if (tableName.indexOf(".") === -1 && this.driver.database) {
+            tableName = `${this.driver.database}.${tableName}`;
+        }
+
         return tableName.split(".").map(i => disableEscape ? i : `\`${i}\``).join(".");
     }
 

--- a/src/driver/aurora-data-api/AuroraDataApiQueryRunner.ts
+++ b/src/driver/aurora-data-api/AuroraDataApiQueryRunner.ts
@@ -1398,11 +1398,14 @@ export class AuroraDataApiQueryRunner extends BaseQueryRunner implements QueryRu
                 // if referenced table located in currently used db, we don't need to concat db name to table name.
                 const database = dbForeignKey["REFERENCED_TABLE_SCHEMA"] === currentDatabase ? undefined : dbForeignKey["REFERENCED_TABLE_SCHEMA"];
                 const referencedTableName = this.driver.buildTableName(dbForeignKey["REFERENCED_TABLE_NAME"], undefined, database);
+                const referencedTablePath = this.driver.buildTableName(dbForeignKey["REFERENCED_TABLE_NAME"], undefined, dbForeignKey["REFERENCED_TABLE_SCHEMA"]);
 
                 return new TableForeignKey({
                     name: dbForeignKey["CONSTRAINT_NAME"],
                     columnNames: foreignKeys.map(dbFk => dbFk["COLUMN_NAME"]),
+                    referencedDatabase: dbForeignKey["REFERENCED_TABLE_SCHEMA"],
                     referencedTableName: referencedTableName,
+                    referencedTablePath: referencedTablePath,
                     referencedColumnNames: foreignKeys.map(dbFk => dbFk["REFERENCED_COLUMN_NAME"]),
                     onDelete: dbForeignKey["ON_DELETE"],
                     onUpdate: dbForeignKey["ON_UPDATE"]

--- a/src/driver/aurora-data-api/AuroraDataApiQueryRunner.ts
+++ b/src/driver/aurora-data-api/AuroraDataApiQueryRunner.ts
@@ -395,8 +395,8 @@ export class AuroraDataApiQueryRunner extends BaseQueryRunner implements QueryRu
         newTable.name = dbName ? `${dbName}.${newTableName}` : newTableName;
 
         // rename table
-        upQueries.push(new Query(`RENAME TABLE ${this.escapePath(oldTable.name)} TO ${this.escapePath(newTable.name)}`));
-        downQueries.push(new Query(`RENAME TABLE ${this.escapePath(newTable.name)} TO ${this.escapePath(oldTable.name)}`));
+        upQueries.push(new Query(`RENAME TABLE ${this.escapePath(oldTable)} TO ${this.escapePath(newTable)}`));
+        downQueries.push(new Query(`RENAME TABLE ${this.escapePath(newTable)} TO ${this.escapePath(oldTable)}`));
 
         // rename index constraints
         newTable.indices.forEach(index => {

--- a/src/driver/aurora-data-api/AuroraDataApiQueryRunner.ts
+++ b/src/driver/aurora-data-api/AuroraDataApiQueryRunner.ts
@@ -427,14 +427,14 @@ export class AuroraDataApiQueryRunner extends BaseQueryRunner implements QueryRu
 
             // build queries
             let up = `ALTER TABLE ${this.escapePath(newTable)} DROP FOREIGN KEY \`${foreignKey.name}\`, ADD CONSTRAINT \`${newForeignKeyName}\` FOREIGN KEY (${columnNames}) ` +
-                `REFERENCES ${this.escapePath(foreignKey.referencedTableName)}(${referencedColumnNames})`;
+                `REFERENCES ${this.escapePath(foreignKey.referencedTablePath)}(${referencedColumnNames})`;
             if (foreignKey.onDelete)
                 up += ` ON DELETE ${foreignKey.onDelete}`;
             if (foreignKey.onUpdate)
                 up += ` ON UPDATE ${foreignKey.onUpdate}`;
 
             let down = `ALTER TABLE ${this.escapePath(newTable)} DROP FOREIGN KEY \`${newForeignKeyName}\`, ADD CONSTRAINT \`${foreignKey.name}\` FOREIGN KEY (${columnNames}) ` +
-                `REFERENCES ${this.escapePath(foreignKey.referencedTableName)}(${referencedColumnNames})`;
+                `REFERENCES ${this.escapePath(foreignKey.referencedTablePath)}(${referencedColumnNames})`;
             if (foreignKey.onDelete)
                 down += ` ON DELETE ${foreignKey.onDelete}`;
             if (foreignKey.onUpdate)
@@ -621,14 +621,14 @@ export class AuroraDataApiQueryRunner extends BaseQueryRunner implements QueryRu
 
                     // build queries
                     let up = `ALTER TABLE ${this.escapePath(table)} DROP FOREIGN KEY \`${foreignKey.name}\`, ADD CONSTRAINT \`${newForeignKeyName}\` FOREIGN KEY (${columnNames}) ` +
-                        `REFERENCES ${this.escapePath(foreignKey.referencedTableName)}(${referencedColumnNames})`;
+                        `REFERENCES ${this.escapePath(foreignKey.referencedTablePath)}(${referencedColumnNames})`;
                     if (foreignKey.onDelete)
                         up += ` ON DELETE ${foreignKey.onDelete}`;
                     if (foreignKey.onUpdate)
                         up += ` ON UPDATE ${foreignKey.onUpdate}`;
 
                     let down = `ALTER TABLE ${this.escapePath(table)} DROP FOREIGN KEY \`${newForeignKeyName}\`, ADD CONSTRAINT \`${foreignKey.name}\` FOREIGN KEY (${columnNames}) ` +
-                        `REFERENCES ${this.escapePath(foreignKey.referencedTableName)}(${referencedColumnNames})`;
+                        `REFERENCES ${this.escapePath(foreignKey.referencedTablePath)}(${referencedColumnNames})`;
                     if (foreignKey.onDelete)
                         down += ` ON DELETE ${foreignKey.onDelete}`;
                     if (foreignKey.onUpdate)
@@ -1504,7 +1504,7 @@ export class AuroraDataApiQueryRunner extends BaseQueryRunner implements QueryRu
                     fk.name = this.connection.namingStrategy.foreignKeyName(table, fk.columnNames);
                 const referencedColumnNames = fk.referencedColumnNames.map(columnName => `\`${columnName}\``).join(", ");
 
-                let constraint = `CONSTRAINT \`${fk.name}\` FOREIGN KEY (${columnNames}) REFERENCES ${this.escapePath(fk.referencedTableName)} (${referencedColumnNames})`;
+                let constraint = `CONSTRAINT \`${fk.name}\` FOREIGN KEY (${columnNames}) REFERENCES ${this.escapePath(fk.referencedTablePath)} (${referencedColumnNames})`;
                 if (fk.onDelete)
                     constraint += ` ON DELETE ${fk.onDelete}`;
                 if (fk.onUpdate)
@@ -1622,7 +1622,7 @@ export class AuroraDataApiQueryRunner extends BaseQueryRunner implements QueryRu
         const columnNames = foreignKey.columnNames.map(column => `\`${column}\``).join(", ");
         const referencedColumnNames = foreignKey.referencedColumnNames.map(column => `\`${column}\``).join(",");
         let sql = `ALTER TABLE ${this.escapePath(table)} ADD CONSTRAINT \`${foreignKey.name}\` FOREIGN KEY (${columnNames}) ` +
-            `REFERENCES ${this.escapePath(foreignKey.referencedTableName)}(${referencedColumnNames})`;
+            `REFERENCES ${this.escapePath(foreignKey.referencedTablePath)}(${referencedColumnNames})`;
         if (foreignKey.onDelete)
             sql += ` ON DELETE ${foreignKey.onDelete}`;
         if (foreignKey.onUpdate)

--- a/src/driver/aurora-data-api/AuroraDataApiQueryRunner.ts
+++ b/src/driver/aurora-data-api/AuroraDataApiQueryRunner.ts
@@ -1298,7 +1298,7 @@ export class AuroraDataApiQueryRunner extends BaseQueryRunner implements QueryRu
                         return nonUnique === 0;
                     });
 
-                    const tableMetadata = this.connection.entityMetadatas.find(metadata => metadata.tablePath === table.name);
+                    const tableMetadata = this.connection.entityMetadatas.find(metadata => table.path === metadata.tablePath);
                     const hasIgnoredIndex = columnUniqueIndex && tableMetadata && tableMetadata.indices
                         .some(index => index.name === columnUniqueIndex["INDEX_NAME"] && index.synchronize === false);
 

--- a/src/driver/aurora-data-api/AuroraDataApiQueryRunner.ts
+++ b/src/driver/aurora-data-api/AuroraDataApiQueryRunner.ts
@@ -336,8 +336,8 @@ export class AuroraDataApiQueryRunner extends BaseQueryRunner implements QueryRu
 
         // if dropTable called with dropForeignKeys = true, we must create foreign keys in down query.
         const createForeignKeys: boolean = dropForeignKeys;
-        const tableName = target instanceof Table ? target.name : target;
-        const table = await this.getCachedTable(tableName);
+        const tablePath = target instanceof Table ? target.path : target;
+        const table = await this.getCachedTable(tablePath);
         const upQueries: Query[] = [];
         const downQueries: Query[] = [];
 
@@ -389,10 +389,9 @@ export class AuroraDataApiQueryRunner extends BaseQueryRunner implements QueryRu
         const downQueries: Query[] = [];
         const oldTable = oldTableOrName instanceof Table ? oldTableOrName : await this.getCachedTable(oldTableOrName);
         const newTable = oldTable.clone();
-        const dbName = oldTable.name.indexOf(".") === -1 ? undefined : oldTable.name.split(".")[0];
 
         newTable.path = this.driver.buildTableName(newTableName, undefined, newTable.database);
-        newTable.name = dbName ? `${dbName}.${newTableName}` : newTableName;
+        newTable.name = newTableName;
 
         // rename table
         upQueries.push(new Query(`RENAME TABLE ${this.escapePath(oldTable)} TO ${this.escapePath(newTable)}`));
@@ -1274,10 +1273,9 @@ export class AuroraDataApiQueryRunner extends BaseQueryRunner implements QueryRu
             const defaultCharset = dbCollation["CHARSET"];
 
             // We do not need to join database name, when database is by default.
-            const db = dbTable["TABLE_SCHEMA"] === currentDatabase ? undefined : dbTable["TABLE_SCHEMA"];
             table.database = dbTable["TABLE_SCHEMA"];
             table.path = this.driver.buildTableName(dbTable["TABLE_NAME"], undefined, dbTable["TABLE_SCHEMA"]);
-            table.name = this.driver.buildTableName(dbTable["TABLE_NAME"], undefined, db);
+            table.name = dbTable["TABLE_NAME"];
 
             // create columns from the loaded columns
             table.columns = dbColumns
@@ -1395,16 +1393,13 @@ export class AuroraDataApiQueryRunner extends BaseQueryRunner implements QueryRu
             table.foreignKeys = tableForeignKeyConstraints.map(dbForeignKey => {
                 const foreignKeys = dbForeignKeys.filter(dbFk => dbFk["CONSTRAINT_NAME"] === dbForeignKey["CONSTRAINT_NAME"]);
 
-                // if referenced table located in currently used db, we don't need to concat db name to table name.
-                const database = dbForeignKey["REFERENCED_TABLE_SCHEMA"] === currentDatabase ? undefined : dbForeignKey["REFERENCED_TABLE_SCHEMA"];
-                const referencedTableName = this.driver.buildTableName(dbForeignKey["REFERENCED_TABLE_NAME"], undefined, database);
                 const referencedTablePath = this.driver.buildTableName(dbForeignKey["REFERENCED_TABLE_NAME"], undefined, dbForeignKey["REFERENCED_TABLE_SCHEMA"]);
 
                 return new TableForeignKey({
                     name: dbForeignKey["CONSTRAINT_NAME"],
                     columnNames: foreignKeys.map(dbFk => dbFk["COLUMN_NAME"]),
                     referencedDatabase: dbForeignKey["REFERENCED_TABLE_SCHEMA"],
-                    referencedTableName: referencedTableName,
+                    referencedTableName: dbForeignKey["REFERENCED_TABLE_NAME"],
                     referencedTablePath: referencedTablePath,
                     referencedColumnNames: foreignKeys.map(dbFk => dbFk["REFERENCED_COLUMN_NAME"]),
                     onDelete: dbForeignKey["ON_DELETE"],

--- a/src/driver/cockroachdb/CockroachDriver.ts
+++ b/src/driver/cockroachdb/CockroachDriver.ts
@@ -67,9 +67,14 @@ export class CockroachDriver implements Driver {
     options: CockroachConnectionOptions;
 
     /**
-     * Master database used to perform all write queries.
+     * Database name used to perform all write queries.
      */
     database?: string;
+
+    /**
+     * Schema name used to perform all write queries.
+     */
+    schema?: string;
 
     /**
      * Indicates if replication is enabled.
@@ -250,12 +255,23 @@ export class CockroachDriver implements Driver {
                 return this.createPool(this.options, slave);
             }));
             this.master = await this.createPool(this.options, this.options.replication.master);
-            this.database = this.options.replication.master.database;
 
         } else {
             this.master = await this.createPool(this.options, this.options);
-            this.database = this.options.database;
         }
+
+        const queryRunner = await this.createQueryRunner("master");
+
+        // Ask the database for where we've connected to
+        this.database = await queryRunner.getCurrentDatabase();
+
+        if (this.connection.options.hasOwnProperty("schema")) {
+            this.schema = (this.connection.options as any).schema;
+        } else {
+            this.schema = await queryRunner.getCurrentSchema();
+        }
+
+        await queryRunner.release();
     }
 
     /**

--- a/src/driver/cockroachdb/CockroachQueryRunner.ts
+++ b/src/driver/cockroachdb/CockroachQueryRunner.ts
@@ -380,7 +380,9 @@ export class CockroachQueryRunner extends BaseQueryRunner implements QueryRunner
     /**
      * Creates a new table schema.
      */
-    async createSchema(schema: string, ifNotExist?: boolean): Promise<void> {
+    async createSchema(schemaPath: string, ifNotExist?: boolean): Promise<void> {
+        const schema = schemaPath.indexOf(".") === -1 ? schemaPath : schemaPath.split(".")[1];
+
         const up = ifNotExist ? `CREATE SCHEMA IF NOT EXISTS "${schema}"` : `CREATE SCHEMA "${schema}"`;
         const down = `DROP SCHEMA "${schema}" CASCADE`;
         await this.executeQueries(new Query(up), new Query(down));
@@ -390,7 +392,8 @@ export class CockroachQueryRunner extends BaseQueryRunner implements QueryRunner
      * Drops table schema.
      */
     async dropSchema(schemaPath: string, ifExist?: boolean, isCascade?: boolean): Promise<void> {
-        const schema = schemaPath.indexOf(".") === -1 ? schemaPath : schemaPath.split(".")[0];
+        const schema = schemaPath.indexOf(".") === -1 ? schemaPath : schemaPath.split(".")[1];
+
         const up = ifExist ? `DROP SCHEMA IF EXISTS "${schema}" ${isCascade ? "CASCADE" : ""}` : `DROP SCHEMA "${schema}" ${isCascade ? "CASCADE" : ""}`;
         const down = `CREATE SCHEMA "${schema}"`;
         await this.executeQueries(new Query(up), new Query(down));

--- a/src/driver/cockroachdb/CockroachQueryRunner.ts
+++ b/src/driver/cockroachdb/CockroachQueryRunner.ts
@@ -1742,7 +1742,7 @@ export class CockroachQueryRunner extends BaseQueryRunner implements QueryRunner
                     fk.name = this.connection.namingStrategy.foreignKeyName(table, fk.columnNames, fk.referencedTablePath, fk.referencedColumnNames);
                 const referencedColumnNames = fk.referencedColumnNames.map(columnName => `"${columnName}"`).join(", ");
 
-                let constraint = `CONSTRAINT "${fk.name}" FOREIGN KEY (${columnNames}) REFERENCES ${this.escapePath(fk.referencedTableName)} (${referencedColumnNames})`;
+                let constraint = `CONSTRAINT "${fk.name}" FOREIGN KEY (${columnNames}) REFERENCES ${this.escapePath(fk.referencedTablePath)} (${referencedColumnNames})`;
                 if (fk.onDelete)
                     constraint += ` ON DELETE ${fk.onDelete}`;
                 if (fk.onUpdate)
@@ -1921,7 +1921,7 @@ export class CockroachQueryRunner extends BaseQueryRunner implements QueryRunner
         const columnNames = foreignKey.columnNames.map(column => `"` + column + `"`).join(", ");
         const referencedColumnNames = foreignKey.referencedColumnNames.map(column => `"` + column + `"`).join(",");
         let sql = `ALTER TABLE ${this.escapePath(table)} ADD CONSTRAINT "${foreignKey.name}" FOREIGN KEY (${columnNames}) ` +
-            `REFERENCES ${this.escapePath(foreignKey.referencedTableName)}(${referencedColumnNames})`;
+            `REFERENCES ${this.escapePath(foreignKey.referencedTablePath)}(${referencedColumnNames})`;
         if (foreignKey.onDelete)
             sql += ` ON DELETE ${foreignKey.onDelete}`;
         if (foreignKey.onUpdate)

--- a/src/driver/cockroachdb/CockroachQueryRunner.ts
+++ b/src/driver/cockroachdb/CockroachQueryRunner.ts
@@ -1978,8 +1978,23 @@ export class CockroachQueryRunner extends BaseQueryRunner implements QueryRunner
      * Escapes given table or view path.
      */
     protected escapePath(target: Table|View|string, disableEscape?: boolean): string {
-        let tableName = target instanceof Table || target instanceof View ? target.name : target;
-        tableName = tableName.indexOf(".") === -1 && this.driver.options.schema ? `${this.driver.options.schema}.${tableName}` : tableName;
+        let tableName: string;
+
+        if (target instanceof Table) {
+            tableName = target.name;
+
+            if (target.schema) {
+                tableName = `${target.schema}.${tableName}`;
+            }
+        } else if (target instanceof View) {
+            tableName = target.name;
+        } else {
+            tableName = target;
+        }
+
+        if (tableName.indexOf(".") === -1 && this.driver.schema) {
+            tableName = `${this.driver.schema}.${tableName}`;
+        }
 
         return tableName.split(".").map(i => {
             return disableEscape ? i : `"${i}"`;

--- a/src/driver/mysql/MysqlDriver.ts
+++ b/src/driver/mysql/MysqlDriver.ts
@@ -344,6 +344,14 @@ export class MysqlDriver implements Driver {
         } else {
             this.pool = await this.createPool(this.createConnectionOptions(this.options, this.options));
         }
+
+
+        const queryRunner = await this.createQueryRunner("master");
+
+        // Ask the database for where we've connected to
+        this.database = await queryRunner.getCurrentDatabase();
+
+        await queryRunner.release();
     }
 
     /**

--- a/src/driver/mysql/MysqlQueryRunner.ts
+++ b/src/driver/mysql/MysqlQueryRunner.ts
@@ -444,8 +444,8 @@ export class MysqlQueryRunner extends BaseQueryRunner implements QueryRunner {
         newTable.name = dbName ? `${dbName}.${newTableName}` : newTableName;
 
         // rename table
-        upQueries.push(new Query(`RENAME TABLE ${this.escapePath(oldTable.name)} TO ${this.escapePath(newTable.name)}`));
-        downQueries.push(new Query(`RENAME TABLE ${this.escapePath(newTable.name)} TO ${this.escapePath(oldTable.name)}`));
+        upQueries.push(new Query(`RENAME TABLE ${this.escapePath(oldTable)} TO ${this.escapePath(newTable)}`));
+        downQueries.push(new Query(`RENAME TABLE ${this.escapePath(newTable)} TO ${this.escapePath(oldTable)}`));
 
         // rename index constraints
         newTable.indices.forEach(index => {

--- a/src/driver/mysql/MysqlQueryRunner.ts
+++ b/src/driver/mysql/MysqlQueryRunner.ts
@@ -478,14 +478,14 @@ export class MysqlQueryRunner extends BaseQueryRunner implements QueryRunner {
 
             // build queries
             let up = `ALTER TABLE ${this.escapePath(newTable)} DROP FOREIGN KEY \`${foreignKey.name}\`, ADD CONSTRAINT \`${newForeignKeyName}\` FOREIGN KEY (${columnNames}) ` +
-                `REFERENCES ${this.escapePath(foreignKey.referencedTableName)}(${referencedColumnNames})`;
+                `REFERENCES ${this.escapePath(foreignKey.referencedTablePath)}(${referencedColumnNames})`;
             if (foreignKey.onDelete)
                 up += ` ON DELETE ${foreignKey.onDelete}`;
             if (foreignKey.onUpdate)
                 up += ` ON UPDATE ${foreignKey.onUpdate}`;
 
             let down = `ALTER TABLE ${this.escapePath(newTable)} DROP FOREIGN KEY \`${newForeignKeyName}\`, ADD CONSTRAINT \`${foreignKey.name}\` FOREIGN KEY (${columnNames}) ` +
-                `REFERENCES ${this.escapePath(foreignKey.referencedTableName)}(${referencedColumnNames})`;
+                `REFERENCES ${this.escapePath(foreignKey.referencedTablePath)}(${referencedColumnNames})`;
             if (foreignKey.onDelete)
                 down += ` ON DELETE ${foreignKey.onDelete}`;
             if (foreignKey.onUpdate)
@@ -674,14 +674,14 @@ export class MysqlQueryRunner extends BaseQueryRunner implements QueryRunner {
 
                     // build queries
                     let up = `ALTER TABLE ${this.escapePath(table)} DROP FOREIGN KEY \`${foreignKey.name}\`, ADD CONSTRAINT \`${newForeignKeyName}\` FOREIGN KEY (${columnNames}) ` +
-                        `REFERENCES ${this.escapePath(foreignKey.referencedTableName)}(${referencedColumnNames})`;
+                        `REFERENCES ${this.escapePath(foreignKey.referencedTablePath)}(${referencedColumnNames})`;
                     if (foreignKey.onDelete)
                         up += ` ON DELETE ${foreignKey.onDelete}`;
                     if (foreignKey.onUpdate)
                         up += ` ON UPDATE ${foreignKey.onUpdate}`;
 
                     let down = `ALTER TABLE ${this.escapePath(table)} DROP FOREIGN KEY \`${newForeignKeyName}\`, ADD CONSTRAINT \`${foreignKey.name}\` FOREIGN KEY (${columnNames}) ` +
-                        `REFERENCES ${this.escapePath(foreignKey.referencedTableName)}(${referencedColumnNames})`;
+                        `REFERENCES ${this.escapePath(foreignKey.referencedTablePath)}(${referencedColumnNames})`;
                     if (foreignKey.onDelete)
                         down += ` ON DELETE ${foreignKey.onDelete}`;
                     if (foreignKey.onUpdate)
@@ -1687,7 +1687,7 @@ export class MysqlQueryRunner extends BaseQueryRunner implements QueryRunner {
                     fk.name = this.connection.namingStrategy.foreignKeyName(table, fk.columnNames, fk.referencedTablePath, fk.referencedColumnNames);
                 const referencedColumnNames = fk.referencedColumnNames.map(columnName => `\`${columnName}\``).join(", ");
 
-                let constraint = `CONSTRAINT \`${fk.name}\` FOREIGN KEY (${columnNames}) REFERENCES ${this.escapePath(fk.referencedTableName)} (${referencedColumnNames})`;
+                let constraint = `CONSTRAINT \`${fk.name}\` FOREIGN KEY (${columnNames}) REFERENCES ${this.escapePath(fk.referencedTablePath)} (${referencedColumnNames})`;
                 if (fk.onDelete)
                     constraint += ` ON DELETE ${fk.onDelete}`;
                 if (fk.onUpdate)
@@ -1807,7 +1807,7 @@ export class MysqlQueryRunner extends BaseQueryRunner implements QueryRunner {
         const columnNames = foreignKey.columnNames.map(column => `\`${column}\``).join(", ");
         const referencedColumnNames = foreignKey.referencedColumnNames.map(column => `\`${column}\``).join(",");
         let sql = `ALTER TABLE ${this.escapePath(table)} ADD CONSTRAINT \`${foreignKey.name}\` FOREIGN KEY (${columnNames}) ` +
-            `REFERENCES ${this.escapePath(foreignKey.referencedTableName)}(${referencedColumnNames})`;
+            `REFERENCES ${this.escapePath(foreignKey.referencedTablePath)}(${referencedColumnNames})`;
         if (foreignKey.onDelete)
             sql += ` ON DELETE ${foreignKey.onDelete}`;
         if (foreignKey.onUpdate)

--- a/src/driver/mysql/MysqlQueryRunner.ts
+++ b/src/driver/mysql/MysqlQueryRunner.ts
@@ -1857,7 +1857,24 @@ export class MysqlQueryRunner extends BaseQueryRunner implements QueryRunner {
      * Escapes given table or view path.
      */
     protected escapePath(target: Table|View|string, disableEscape?: boolean): string {
-        const tableName = target instanceof Table || target instanceof View ? target.name : target;
+        let tableName: string;
+
+        if (target instanceof Table) {
+            tableName = target.name;
+
+            if (target.database) {
+                tableName = `${target.database}.${tableName}`
+            }
+        } else if (target instanceof View) {
+            tableName = target.name;
+        } else {
+            tableName = target;
+        }
+
+        if (tableName.indexOf(".") === -1 && this.driver.database) {
+            tableName = `${this.driver.database}.${tableName}`;
+        }
+
         return tableName.split(".").map(i => disableEscape ? i : `\`${i}\``).join(".");
     }
 

--- a/src/driver/mysql/MysqlQueryRunner.ts
+++ b/src/driver/mysql/MysqlQueryRunner.ts
@@ -1474,7 +1474,7 @@ export class MysqlQueryRunner extends BaseQueryRunner implements QueryRunner {
                         return nonUnique === 0;
                     });
 
-                    const tableMetadata = this.connection.entityMetadatas.find(metadata => metadata.tablePath === table.name);
+                    const tableMetadata = this.connection.entityMetadatas.find(metadata => table.path === metadata.tablePath);
                     const hasIgnoredIndex = columnUniqueIndex && tableMetadata && tableMetadata.indices
                         .some(index => index.name === columnUniqueIndex["INDEX_NAME"] && index.synchronize === false);
 

--- a/src/driver/mysql/MysqlQueryRunner.ts
+++ b/src/driver/mysql/MysqlQueryRunner.ts
@@ -475,7 +475,7 @@ export class MysqlQueryRunner extends BaseQueryRunner implements QueryRunner {
             // build new constraint name
             const columnNames = foreignKey.columnNames.map(column => `\`${column}\``).join(", ");
             const referencedColumnNames = foreignKey.referencedColumnNames.map(column => `\`${column}\``).join(",");
-            const newForeignKeyName = this.connection.namingStrategy.foreignKeyName(newTable, foreignKey.columnNames, foreignKey.referencedTableName, foreignKey.referencedColumnNames);
+            const newForeignKeyName = this.connection.namingStrategy.foreignKeyName(newTable, foreignKey.columnNames, foreignKey.referencedTablePath, foreignKey.referencedColumnNames);
 
             // build queries
             let up = `ALTER TABLE ${this.escapePath(newTable)} DROP FOREIGN KEY \`${foreignKey.name}\`, ADD CONSTRAINT \`${newForeignKeyName}\` FOREIGN KEY (${columnNames}) ` +
@@ -671,7 +671,7 @@ export class MysqlQueryRunner extends BaseQueryRunner implements QueryRunner {
                     foreignKey.columnNames.push(newColumn.name);
                     const columnNames = foreignKey.columnNames.map(column => `\`${column}\``).join(", ");
                     const referencedColumnNames = foreignKey.referencedColumnNames.map(column => `\`${column}\``).join(",");
-                    const newForeignKeyName = this.connection.namingStrategy.foreignKeyName(clonedTable, foreignKey.columnNames, foreignKey.referencedTableName, foreignKey.referencedColumnNames);
+                    const newForeignKeyName = this.connection.namingStrategy.foreignKeyName(clonedTable, foreignKey.columnNames, foreignKey.referencedTablePath, foreignKey.referencedColumnNames);
 
                     // build queries
                     let up = `ALTER TABLE ${this.escapePath(table)} DROP FOREIGN KEY \`${foreignKey.name}\`, ADD CONSTRAINT \`${newForeignKeyName}\` FOREIGN KEY (${columnNames}) ` +
@@ -1080,7 +1080,7 @@ export class MysqlQueryRunner extends BaseQueryRunner implements QueryRunner {
 
         // new FK may be passed without name. In this case we generate FK name manually.
         if (!foreignKey.name)
-            foreignKey.name = this.connection.namingStrategy.foreignKeyName(table, foreignKey.columnNames, foreignKey.referencedTableName, foreignKey.referencedColumnNames);
+            foreignKey.name = this.connection.namingStrategy.foreignKeyName(table, foreignKey.columnNames, foreignKey.referencedTablePath, foreignKey.referencedColumnNames);
 
         const up = this.createForeignKeySql(table, foreignKey);
         const down = this.dropForeignKeySql(table, foreignKey);
@@ -1582,11 +1582,14 @@ export class MysqlQueryRunner extends BaseQueryRunner implements QueryRunner {
                 // if referenced table located in currently used db, we don't need to concat db name to table name.
                 const database = dbForeignKey["REFERENCED_TABLE_SCHEMA"] === currentDatabase ? undefined : dbForeignKey["REFERENCED_TABLE_SCHEMA"];
                 const referencedTableName = this.driver.buildTableName(dbForeignKey["REFERENCED_TABLE_NAME"], undefined, database);
+                const referencedTablePath = this.driver.buildTableName(dbForeignKey["REFERENCED_TABLE_NAME"], undefined, dbForeignKey["REFERENCED_TABLE_SCHEMA"]);
 
                 return new TableForeignKey({
                     name: dbForeignKey["CONSTRAINT_NAME"],
                     columnNames: foreignKeys.map(dbFk => dbFk["COLUMN_NAME"]),
+                    referencedDatabase: dbForeignKey["REFERENCED_TABLE_SCHEMA"],
                     referencedTableName: referencedTableName,
+                    referencedTablePath: referencedTablePath,
                     referencedColumnNames: foreignKeys.map(dbFk => dbFk["REFERENCED_COLUMN_NAME"]),
                     onDelete: dbForeignKey["ON_DELETE"],
                     onUpdate: dbForeignKey["ON_UPDATE"]
@@ -1686,7 +1689,7 @@ export class MysqlQueryRunner extends BaseQueryRunner implements QueryRunner {
             const foreignKeysSql = table.foreignKeys.map(fk => {
                 const columnNames = fk.columnNames.map(columnName => `\`${columnName}\``).join(", ");
                 if (!fk.name)
-                    fk.name = this.connection.namingStrategy.foreignKeyName(table, fk.columnNames, fk.referencedTableName, fk.referencedColumnNames);
+                    fk.name = this.connection.namingStrategy.foreignKeyName(table, fk.columnNames, fk.referencedTablePath, fk.referencedColumnNames);
                 const referencedColumnNames = fk.referencedColumnNames.map(columnName => `\`${columnName}\``).join(", ");
 
                 let constraint = `CONSTRAINT \`${fk.name}\` FOREIGN KEY (${columnNames}) REFERENCES ${this.escapePath(fk.referencedTableName)} (${referencedColumnNames})`;

--- a/src/driver/oracle/OracleDriver.ts
+++ b/src/driver/oracle/OracleDriver.ts
@@ -370,10 +370,6 @@ export class OracleDriver implements Driver {
             tablePath.unshift(schema);
         }
 
-        if (database) {
-            tablePath.unshift(database);
-        }
-
         return tablePath.join('.');
     }
 

--- a/src/driver/oracle/OracleDriver.ts
+++ b/src/driver/oracle/OracleDriver.ts
@@ -60,9 +60,14 @@ export class OracleDriver implements Driver {
     options: OracleConnectionOptions;
 
     /**
-     * Master database used to perform all write queries.
+     * Database name used to perform all write queries.
      */
     database?: string;
+
+    /**
+     * Schema name used to perform all write queries.
+     */
+    schema?: string;
 
     /**
      * Indicates if replication is enabled.
@@ -252,12 +257,22 @@ export class OracleDriver implements Driver {
                 return this.createPool(this.options, slave);
             }));
             this.master = await this.createPool(this.options, this.options.replication.master);
-            this.database = this.options.replication.master.database;
-
         } else {
             this.master = await this.createPool(this.options, this.options);
-            this.database = this.options.database;
         }
+
+        const queryRunner = await this.createQueryRunner("master");
+
+        // Ask the database for where we've connected to
+        this.database = await queryRunner.getCurrentDatabase();
+
+        if (this.connection.options.hasOwnProperty("schema")) {
+            this.schema = (this.connection.options as any).schema;
+        } else {
+            this.schema = await queryRunner.getCurrentSchema();
+        }
+
+        await queryRunner.release();
     }
 
     /**

--- a/src/driver/oracle/OracleQueryRunner.ts
+++ b/src/driver/oracle/OracleQueryRunner.ts
@@ -1327,7 +1327,12 @@ export class OracleQueryRunner extends BaseQueryRunner implements QueryRunner {
 
             // create columns from the loaded columns
             table.columns = dbColumns
-                .filter(dbColumn => dbColumn["TABLE_NAME"] === table.name)
+                .filter(
+                    dbColumn => (
+                        dbColumn["OWNER"] === dbTable["OWNER"] &&
+                        dbColumn["TABLE_NAME"] === dbTable["TABLE_NAME"]
+                    )
+                )
                 .map(dbColumn => {
                     const columnConstraints = dbConstraints.filter(
                         dbConstraint => (
@@ -1418,7 +1423,13 @@ export class OracleQueryRunner extends BaseQueryRunner implements QueryRunner {
             }), dbConstraint => dbConstraint["CONSTRAINT_NAME"]);
 
             table.checks = tableCheckConstraints.map(constraint => {
-                const checks = dbConstraints.filter(dbC => dbC["CONSTRAINT_NAME"] === constraint["CONSTRAINT_NAME"]);
+                const checks = dbConstraints.filter(
+                    dbC => (
+                        dbC["TABLE_NAME"] === constraint["TABLE_NAME"] &&
+                        dbC["OWNER"] === constraint["OWNER"] &&
+                        dbC["CONSTRAINT_NAME"] === constraint["CONSTRAINT_NAME"]
+                    )
+                );
                 return new TableCheck({
                     name: constraint["CONSTRAINT_NAME"],
                     columnNames: checks.map(c => c["COLUMN_NAME"]),
@@ -1427,9 +1438,10 @@ export class OracleQueryRunner extends BaseQueryRunner implements QueryRunner {
             });
 
             // find foreign key constraints of table, group them by constraint name and build TableForeignKey.
-            const tableForeignKeyConstraints = OrmUtils.uniq(dbForeignKeys.filter(dbForeignKey => {
-                return dbForeignKey["TABLE_NAME"] === table.name;
-            }), dbForeignKey => dbForeignKey["CONSTRAINT_NAME"]);
+            const tableForeignKeyConstraints = OrmUtils.uniq(dbForeignKeys.filter(dbForeignKey => (
+                dbForeignKey["OWNER"] === dbTable["OWNER"] &&
+                dbForeignKey["TABLE_NAME"] === dbTable["TABLE_NAME"]
+            )), dbForeignKey => dbForeignKey["CONSTRAINT_NAME"]);
 
             table.foreignKeys = tableForeignKeyConstraints.map(dbForeignKey => {
                 const foreignKeys = dbForeignKeys.filter(dbFk => (

--- a/src/driver/oracle/OracleQueryRunner.ts
+++ b/src/driver/oracle/OracleQueryRunner.ts
@@ -1696,8 +1696,23 @@ export class OracleQueryRunner extends BaseQueryRunner implements QueryRunner {
      * Escapes given table or view path.
      */
     protected escapePath(target: Table|View|string, disableEscape?: boolean): string {
-        let tableName = target instanceof Table || target instanceof View ? target.name : target;
-        tableName = tableName.indexOf(".") === -1 && this.driver.options.schema ? `${this.driver.options.schema}.${tableName}` : tableName;
+        let tableName: string;
+
+        if (target instanceof Table) {
+            tableName = target.name;
+
+            if (target.schema) {
+                tableName = `${target.schema}.${tableName}`;
+            }
+        } else if (target instanceof View) {
+            tableName = target.name;
+        } else {
+            tableName = target;
+        }
+
+        if (tableName.indexOf(".") === -1 && this.driver.schema) {
+            tableName = `${this.driver.schema}.${tableName}`;
+        }
 
         return tableName.split(".").map(i => {
             return disableEscape ? i : `"${i}"`;

--- a/src/driver/oracle/OracleQueryRunner.ts
+++ b/src/driver/oracle/OracleQueryRunner.ts
@@ -483,7 +483,7 @@ export class OracleQueryRunner extends BaseQueryRunner implements QueryRunner {
 
             // build queries
             upQueries.push(new Query(`ALTER TABLE ${this.escapePath(newTable)} RENAME CONSTRAINT "${unique.name}" TO "${newUniqueName}"`));
-            downQueries.push(new Query(`ALTER TABLE ${this.escapePath(newTable.name)} RENAME CONSTRAINT "${newUniqueName}" TO "${unique.name}"`));
+            downQueries.push(new Query(`ALTER TABLE ${this.escapePath(newTable)} RENAME CONSTRAINT "${newUniqueName}" TO "${unique.name}"`));
 
             // replace constraint name
             unique.name = newUniqueName;
@@ -1485,7 +1485,7 @@ export class OracleQueryRunner extends BaseQueryRunner implements QueryRunner {
      */
     protected createTableSql(table: Table, createForeignKeys?: boolean): Query {
         const columnDefinitions = table.columns.map(column => this.buildCreateColumnSql(column)).join(", ");
-        let sql = `CREATE TABLE ${this.escapePath(table.name)} (${columnDefinitions}`;
+        let sql = `CREATE TABLE ${this.escapePath(table)} (${columnDefinitions}`;
 
         table.columns
             .filter(column => column.isUnique)

--- a/src/driver/oracle/OracleQueryRunner.ts
+++ b/src/driver/oracle/OracleQueryRunner.ts
@@ -1523,7 +1523,7 @@ export class OracleQueryRunner extends BaseQueryRunner implements QueryRunner {
                 if (!fk.name)
                     fk.name = this.connection.namingStrategy.foreignKeyName(table, fk.columnNames, fk.referencedTablePath, fk.referencedColumnNames);
                 const referencedColumnNames = fk.referencedColumnNames.map(columnName => `"${columnName}"`).join(", ");
-                let constraint = `CONSTRAINT "${fk.name}" FOREIGN KEY (${columnNames}) REFERENCES "${fk.referencedTableName}" (${referencedColumnNames})`;
+                let constraint = `CONSTRAINT "${fk.name}" FOREIGN KEY (${columnNames}) REFERENCES ${this.escapePath(fk.referencedTableName)} (${referencedColumnNames})`;
                 if (fk.onDelete && fk.onDelete !== "NO ACTION") // Oracle does not support NO ACTION, but we set NO ACTION by default in EntityMetadata
                     constraint += ` ON DELETE ${fk.onDelete}`;
 
@@ -1669,7 +1669,7 @@ export class OracleQueryRunner extends BaseQueryRunner implements QueryRunner {
         const columnNames = foreignKey.columnNames.map(column => `"` + column + `"`).join(", ");
         const referencedColumnNames = foreignKey.referencedColumnNames.map(column => `"` + column + `"`).join(",");
         let sql = `ALTER TABLE ${this.escapePath(table)} ADD CONSTRAINT "${foreignKey.name}" FOREIGN KEY (${columnNames}) ` +
-            `REFERENCES "${foreignKey.referencedTableName}" (${referencedColumnNames})`;
+            `REFERENCES ${this.escapePath(foreignKey.referencedTableName)} (${referencedColumnNames})`;
         // Oracle does not support NO ACTION, but we set NO ACTION by default in EntityMetadata
         if (foreignKey.onDelete && foreignKey.onDelete !== "NO ACTION")
             sql += ` ON DELETE ${foreignKey.onDelete}`;

--- a/src/driver/oracle/OracleQueryRunner.ts
+++ b/src/driver/oracle/OracleQueryRunner.ts
@@ -1520,7 +1520,7 @@ export class OracleQueryRunner extends BaseQueryRunner implements QueryRunner {
                 if (!fk.name)
                     fk.name = this.connection.namingStrategy.foreignKeyName(table, fk.columnNames, fk.referencedTablePath, fk.referencedColumnNames);
                 const referencedColumnNames = fk.referencedColumnNames.map(columnName => `"${columnName}"`).join(", ");
-                let constraint = `CONSTRAINT "${fk.name}" FOREIGN KEY (${columnNames}) REFERENCES ${this.escapePath(fk.referencedTableName)} (${referencedColumnNames})`;
+                let constraint = `CONSTRAINT "${fk.name}" FOREIGN KEY (${columnNames}) REFERENCES ${this.escapePath(fk.referencedTablePath)} (${referencedColumnNames})`;
                 if (fk.onDelete && fk.onDelete !== "NO ACTION") // Oracle does not support NO ACTION, but we set NO ACTION by default in EntityMetadata
                     constraint += ` ON DELETE ${fk.onDelete}`;
 
@@ -1666,7 +1666,7 @@ export class OracleQueryRunner extends BaseQueryRunner implements QueryRunner {
         const columnNames = foreignKey.columnNames.map(column => `"` + column + `"`).join(", ");
         const referencedColumnNames = foreignKey.referencedColumnNames.map(column => `"` + column + `"`).join(",");
         let sql = `ALTER TABLE ${this.escapePath(table)} ADD CONSTRAINT "${foreignKey.name}" FOREIGN KEY (${columnNames}) ` +
-            `REFERENCES ${this.escapePath(foreignKey.referencedTableName)} (${referencedColumnNames})`;
+            `REFERENCES ${this.escapePath(foreignKey.referencedTablePath)} (${referencedColumnNames})`;
         // Oracle does not support NO ACTION, but we set NO ACTION by default in EntityMetadata
         if (foreignKey.onDelete && foreignKey.onDelete !== "NO ACTION")
             sql += ` ON DELETE ${foreignKey.onDelete}`;

--- a/src/driver/postgres/PostgresQueryRunner.ts
+++ b/src/driver/postgres/PostgresQueryRunner.ts
@@ -378,7 +378,9 @@ export class PostgresQueryRunner extends BaseQueryRunner implements QueryRunner 
     /**
      * Creates a new table schema.
      */
-    async createSchema(schema: string, ifNotExist?: boolean): Promise<void> {
+    async createSchema(schemaPath: string, ifNotExist?: boolean): Promise<void> {
+        const schema = schemaPath.indexOf(".") === -1 ? schemaPath : schemaPath.split(".")[1];
+
         const up = ifNotExist ? `CREATE SCHEMA IF NOT EXISTS "${schema}"` : `CREATE SCHEMA "${schema}"`;
         const down = `DROP SCHEMA "${schema}" CASCADE`;
         await this.executeQueries(new Query(up), new Query(down));
@@ -388,7 +390,8 @@ export class PostgresQueryRunner extends BaseQueryRunner implements QueryRunner 
      * Drops table schema.
      */
     async dropSchema(schemaPath: string, ifExist?: boolean, isCascade?: boolean): Promise<void> {
-        const schema = schemaPath.indexOf(".") === -1 ? schemaPath : schemaPath.split(".")[0];
+        const schema = schemaPath.indexOf(".") === -1 ? schemaPath : schemaPath.split(".")[1];
+
         const up = ifExist ? `DROP SCHEMA IF EXISTS "${schema}" ${isCascade ? "CASCADE" : ""}` : `DROP SCHEMA "${schema}" ${isCascade ? "CASCADE" : ""}`;
         const down = `CREATE SCHEMA "${schema}"`;
         await this.executeQueries(new Query(up), new Query(down));

--- a/src/driver/postgres/PostgresQueryRunner.ts
+++ b/src/driver/postgres/PostgresQueryRunner.ts
@@ -1962,7 +1962,7 @@ export class PostgresQueryRunner extends BaseQueryRunner implements QueryRunner 
 
                 const referencedColumnNames = fk.referencedColumnNames.map(columnName => `"${columnName}"`).join(", ");
 
-                let constraint = `CONSTRAINT "${fk.name}" FOREIGN KEY (${columnNames}) REFERENCES ${this.escapePath(fk.referencedTableName)} (${referencedColumnNames})`;
+                let constraint = `CONSTRAINT "${fk.name}" FOREIGN KEY (${columnNames}) REFERENCES ${this.escapePath(fk.referencedTablePath)} (${referencedColumnNames})`;
                 if (fk.onDelete)
                     constraint += ` ON DELETE ${fk.onDelete}`;
                 if (fk.onUpdate)
@@ -2194,7 +2194,7 @@ export class PostgresQueryRunner extends BaseQueryRunner implements QueryRunner 
         const columnNames = foreignKey.columnNames.map(column => `"` + column + `"`).join(", ");
         const referencedColumnNames = foreignKey.referencedColumnNames.map(column => `"` + column + `"`).join(",");
         let sql = `ALTER TABLE ${this.escapePath(table)} ADD CONSTRAINT "${foreignKey.name}" FOREIGN KEY (${columnNames}) ` +
-            `REFERENCES ${this.escapePath(foreignKey.referencedTableName)}(${referencedColumnNames})`;
+            `REFERENCES ${this.escapePath(foreignKey.referencedTablePath)}(${referencedColumnNames})`;
         if (foreignKey.onDelete)
             sql += ` ON DELETE ${foreignKey.onDelete}`;
         if (foreignKey.onUpdate)

--- a/src/driver/postgres/PostgresQueryRunner.ts
+++ b/src/driver/postgres/PostgresQueryRunner.ts
@@ -2312,8 +2312,23 @@ export class PostgresQueryRunner extends BaseQueryRunner implements QueryRunner 
      * Escapes given table or view path.
      */
     protected escapePath(target: Table|View|string, disableEscape?: boolean): string {
-        let tableName = target instanceof Table || target instanceof View ? target.name : target;
-        tableName = tableName.indexOf(".") === -1 && this.driver.schema ? `${this.driver.schema}.${tableName}` : tableName;
+        let tableName: string;
+
+        if (target instanceof Table) {
+            tableName = target.name;
+
+            if (target.schema) {
+                tableName = `${target.schema}.${tableName}`;
+            }
+        } else if (target instanceof View) {
+            tableName = target.name;
+        } else {
+            tableName = target;
+        }
+
+        if (tableName.indexOf(".") === -1 && this.driver.schema) {
+            tableName = `${this.driver.schema}.${tableName}`;
+        }
 
         return tableName.split(".").map(i => {
             return disableEscape ? i : `"${i}"`;

--- a/src/driver/postgres/PostgresQueryRunner.ts
+++ b/src/driver/postgres/PostgresQueryRunner.ts
@@ -580,7 +580,7 @@ export class PostgresQueryRunner extends BaseQueryRunner implements QueryRunner 
         // rename foreign key constraints
         newTable.foreignKeys.forEach(foreignKey => {
             // build new constraint name
-            const newForeignKeyName = this.connection.namingStrategy.foreignKeyName(newTable, foreignKey.columnNames, foreignKey.referencedTableName, foreignKey.referencedColumnNames);
+            const newForeignKeyName = this.connection.namingStrategy.foreignKeyName(newTable, foreignKey.columnNames, foreignKey.referencedTablePath, foreignKey.referencedColumnNames);
 
             // build queries
             upQueries.push(new Query(`ALTER TABLE ${this.escapePath(newTable)} RENAME CONSTRAINT "${foreignKey.name}" TO "${newForeignKeyName}"`));
@@ -809,7 +809,7 @@ export class PostgresQueryRunner extends BaseQueryRunner implements QueryRunner 
                     // build new constraint name
                     foreignKey.columnNames.splice(foreignKey.columnNames.indexOf(oldColumn.name), 1);
                     foreignKey.columnNames.push(newColumn.name);
-                    const newForeignKeyName = this.connection.namingStrategy.foreignKeyName(clonedTable, foreignKey.columnNames, foreignKey.referencedTableName, foreignKey.referencedColumnNames);
+                    const newForeignKeyName = this.connection.namingStrategy.foreignKeyName(clonedTable, foreignKey.columnNames, foreignKey.referencedTablePath, foreignKey.referencedColumnNames);
 
                     // build queries
                     upQueries.push(new Query(`ALTER TABLE ${this.escapePath(table)} RENAME CONSTRAINT "${foreignKey.name}" TO "${newForeignKeyName}"`));
@@ -1318,7 +1318,7 @@ export class PostgresQueryRunner extends BaseQueryRunner implements QueryRunner 
 
         // new FK may be passed without name. In this case we generate FK name manually.
         if (!foreignKey.name)
-            foreignKey.name = this.connection.namingStrategy.foreignKeyName(table, foreignKey.columnNames, foreignKey.referencedTableName, foreignKey.referencedColumnNames);
+            foreignKey.name = this.connection.namingStrategy.foreignKeyName(table, foreignKey.columnNames, foreignKey.referencedTablePath, foreignKey.referencedColumnNames);
 
         const up = this.createForeignKeySql(table, foreignKey);
         const down = this.dropForeignKeySql(table, foreignKey);
@@ -1866,11 +1866,14 @@ export class PostgresQueryRunner extends BaseQueryRunner implements QueryRunner 
                 // if referenced table located in currently used schema, we don't need to concat schema name to table name.
                 const schema = getSchemaFromKey(dbForeignKey, "referenced_table_schema");
                 const referencedTableName = this.driver.buildTableName(dbForeignKey["referenced_table_name"], schema);
+                const referencedTablePath = this.driver.buildTableName(dbForeignKey["referenced_table_name"], dbForeignKey["referenced_table_schema"]);
 
                 return new TableForeignKey({
                     name: dbForeignKey["constraint_name"],
                     columnNames: foreignKeys.map(dbFk => dbFk["column_name"]),
+                    referencedSchema: dbForeignKey["referenced_table_schema"],
                     referencedTableName: referencedTableName,
+                    referencedTablePath: referencedTablePath,
                     referencedColumnNames: foreignKeys.map(dbFk => dbFk["referenced_column_name"]),
                     onDelete: dbForeignKey["on_delete"],
                     onUpdate: dbForeignKey["on_update"],
@@ -1957,7 +1960,8 @@ export class PostgresQueryRunner extends BaseQueryRunner implements QueryRunner 
             const foreignKeysSql = table.foreignKeys.map(fk => {
                 const columnNames = fk.columnNames.map(columnName => `"${columnName}"`).join(", ");
                 if (!fk.name)
-                    fk.name = this.connection.namingStrategy.foreignKeyName(table, fk.columnNames, fk.referencedTableName, fk.referencedColumnNames);
+                    fk.name = this.connection.namingStrategy.foreignKeyName(table, fk.columnNames, fk.referencedTablePath, fk.referencedColumnNames);
+
                 const referencedColumnNames = fk.referencedColumnNames.map(columnName => `"${columnName}"`).join(", ");
 
                 let constraint = `CONSTRAINT "${fk.name}" FOREIGN KEY (${columnNames}) REFERENCES ${this.escapePath(fk.referencedTableName)} (${referencedColumnNames})`;

--- a/src/driver/postgres/PostgresQueryRunner.ts
+++ b/src/driver/postgres/PostgresQueryRunner.ts
@@ -2306,7 +2306,7 @@ export class PostgresQueryRunner extends BaseQueryRunner implements QueryRunner 
      */
     protected escapePath(target: Table|View|string, disableEscape?: boolean): string {
         let tableName = target instanceof Table || target instanceof View ? target.name : target;
-        tableName = tableName.indexOf(".") === -1 && this.driver.options.schema ? `${this.driver.options.schema}.${tableName}` : tableName;
+        tableName = tableName.indexOf(".") === -1 && this.driver.schema ? `${this.driver.schema}.${tableName}` : tableName;
 
         return tableName.split(".").map(i => {
             return disableEscape ? i : `"${i}"`;

--- a/src/driver/sap/SapDriver.ts
+++ b/src/driver/sap/SapDriver.ts
@@ -56,9 +56,14 @@ export class SapDriver implements Driver {
     options: SapConnectionOptions;
 
     /**
-     * Master database used to perform all write queries.
+     * Database name used to perform all write queries.
      */
     database?: string;
+
+    /**
+     * Schema name used to perform all write queries.
+     */
+    schema?: string;
 
     /**
      * Indicates if replication is enabled.
@@ -248,7 +253,13 @@ export class SapDriver implements Driver {
         // create the pool
         this.master = this.client.createPool(dbParams, options);
 
-        this.database = this.options.database;
+        const queryRunner = await this.createQueryRunner("master");
+
+        // Ask the database for where we've connected to
+        this.database = await queryRunner.getCurrentDatabase();
+        this.schema = await queryRunner.getCurrentSchema();
+
+        await queryRunner.release();
     }
 
     /**

--- a/src/driver/sap/SapQueryRunner.ts
+++ b/src/driver/sap/SapQueryRunner.ts
@@ -342,7 +342,9 @@ export class SapQueryRunner extends BaseQueryRunner implements QueryRunner {
     /**
      * Creates a new table schema.
      */
-    async createSchema(schema: string, ifNotExist?: boolean): Promise<void> {
+    async createSchema(schemaPath: string, ifNotExist?: boolean): Promise<void> {
+        const schema = schemaPath.indexOf(".") === -1 ? schemaPath : schemaPath.split(".")[1];
+
         let exist = false;
         if (ifNotExist) {
             const result = await this.query(`SELECT * FROM "SYS"."SCHEMAS" WHERE "SCHEMA_NAME" = '${schema}'`);

--- a/src/driver/sap/SapQueryRunner.ts
+++ b/src/driver/sap/SapQueryRunner.ts
@@ -1768,7 +1768,7 @@ export class SapQueryRunner extends BaseQueryRunner implements QueryRunner {
                     fk.name = this.connection.namingStrategy.foreignKeyName(table, fk.columnNames, fk.referencedTablePath, fk.referencedColumnNames);
                 const referencedColumnNames = fk.referencedColumnNames.map(columnName => `"${columnName}"`).join(", ");
 
-                let constraint = `CONSTRAINT "${fk.name}" FOREIGN KEY (${columnNames}) REFERENCES ${this.escapePath(fk.referencedTableName)} (${referencedColumnNames})`;
+                let constraint = `CONSTRAINT "${fk.name}" FOREIGN KEY (${columnNames}) REFERENCES ${this.escapePath(fk.referencedTablePath)} (${referencedColumnNames})`;
                 // SAP HANA does not have "NO ACTION" option for FK's
                 if (fk.onDelete) {
                     const onDelete = fk.onDelete === "NO ACTION" ? "RESTRICT" : fk.onDelete;
@@ -1942,7 +1942,7 @@ export class SapQueryRunner extends BaseQueryRunner implements QueryRunner {
         const columnNames = foreignKey.columnNames.map(column => `"` + column + `"`).join(", ");
         const referencedColumnNames = foreignKey.referencedColumnNames.map(column => `"` + column + `"`).join(",");
         let sql = `ALTER TABLE ${this.escapePath(tableOrName)} ADD CONSTRAINT "${foreignKey.name}" FOREIGN KEY (${columnNames}) ` +
-            `REFERENCES ${this.escapePath(foreignKey.referencedTableName)}(${referencedColumnNames})`;
+            `REFERENCES ${this.escapePath(foreignKey.referencedTablePath)}(${referencedColumnNames})`;
 
         // SAP HANA does not have "NO ACTION" option for FK's
         if (foreignKey.onDelete) {

--- a/src/driver/sap/SapQueryRunner.ts
+++ b/src/driver/sap/SapQueryRunner.ts
@@ -487,8 +487,8 @@ export class SapQueryRunner extends BaseQueryRunner implements QueryRunner {
         newTable.name = schemaName ? `${schemaName}.${newTableName}` : newTableName;
 
         // rename table
-        upQueries.push(new Query(`RENAME TABLE ${this.escapePath(oldTable.name)} TO ${this.escapePath(newTableName)}`));
-        downQueries.push(new Query(`RENAME TABLE ${this.escapePath(newTable.name)} TO ${this.escapePath(oldTableName)}`));
+        upQueries.push(new Query(`RENAME TABLE ${this.escapePath(oldTable)} TO ${this.escapePath(newTable)}`));
+        downQueries.push(new Query(`RENAME TABLE ${this.escapePath(newTable)} TO ${this.escapePath(oldTable)}`));
 
         // drop old FK's. Foreign keys must be dropped before the primary keys are dropped
         newTable.foreignKeys.forEach(foreignKey => {

--- a/src/driver/sap/SapQueryRunner.ts
+++ b/src/driver/sap/SapQueryRunner.ts
@@ -1575,7 +1575,7 @@ export class SapQueryRunner extends BaseQueryRunner implements QueryRunner {
                         return dbIndex["CONSTRAINT"] && dbIndex["CONSTRAINT"].indexOf("UNIQUE") !== -1;
                     });
 
-                    const tableMetadata = this.connection.entityMetadatas.find(metadata => metadata.tablePath === table.name);
+                    const tableMetadata = this.connection.entityMetadatas.find(metadata => table.path === metadata.tablePath);
                     const hasIgnoredIndex = columnUniqueIndex && tableMetadata && tableMetadata.indices
                         .some(index => index.name === columnUniqueIndex["INDEX_NAME"] && index.synchronize === false);
 

--- a/src/driver/sqlite-abstract/AbstractSqliteQueryRunner.ts
+++ b/src/driver/sqlite-abstract/AbstractSqliteQueryRunner.ts
@@ -348,7 +348,7 @@ export abstract class AbstractSqliteQueryRunner extends BaseQueryRunner implemen
 
         // rename foreign key constraints
         newTable.foreignKeys.forEach(foreignKey => {
-            foreignKey.name = this.connection.namingStrategy.foreignKeyName(newTable, foreignKey.columnNames, foreignKey.referencedTableName, foreignKey.referencedColumnNames);
+            foreignKey.name = this.connection.namingStrategy.foreignKeyName(newTable, foreignKey.columnNames, foreignKey.referencedTablePath, foreignKey.referencedColumnNames);
         });
 
         // rename indices
@@ -428,7 +428,7 @@ export abstract class AbstractSqliteQueryRunner extends BaseQueryRunner implemen
                 changedTable.findColumnForeignKeys(changedColumnSet.oldColumn).forEach(fk => {
                     fk.columnNames.splice(fk.columnNames.indexOf(changedColumnSet.oldColumn.name), 1);
                     fk.columnNames.push(changedColumnSet.newColumn.name);
-                    fk.name = this.connection.namingStrategy.foreignKeyName(changedTable, fk.columnNames, fk.referencedTableName, fk.referencedColumnNames);
+                    fk.name = this.connection.namingStrategy.foreignKeyName(changedTable, fk.columnNames, fk.referencedTablePath, fk.referencedColumnNames);
                 });
 
                 changedTable.findColumnIndices(changedColumnSet.oldColumn).forEach(index => {
@@ -929,6 +929,7 @@ export abstract class AbstractSqliteQueryRunner extends BaseQueryRunner implemen
                     name: fkName,
                     columnNames: columnNames,
                     referencedTableName: foreignKey["table"],
+                    referencedTablePath: foreignKey["table"],
                     referencedColumnNames: referencedColumnNames,
                     onDelete: foreignKey["on_delete"],
                     onUpdate: foreignKey["on_update"]
@@ -1067,7 +1068,7 @@ export abstract class AbstractSqliteQueryRunner extends BaseQueryRunner implemen
             const foreignKeysSql = table.foreignKeys.map(fk => {
                 const columnNames = fk.columnNames.map(columnName => `"${columnName}"`).join(", ");
                 if (!fk.name)
-                    fk.name = this.connection.namingStrategy.foreignKeyName(table, fk.columnNames, fk.referencedTableName, fk.referencedColumnNames);
+                    fk.name = this.connection.namingStrategy.foreignKeyName(table, fk.columnNames, fk.referencedTablePath, fk.referencedColumnNames);
                 const referencedColumnNames = fk.referencedColumnNames.map(columnName => `"${columnName}"`).join(", ");
 
                 let constraint = `CONSTRAINT "${fk.name}" FOREIGN KEY (${columnNames}) REFERENCES "${fk.referencedTableName}" (${referencedColumnNames})`;

--- a/src/driver/sqlite-abstract/AbstractSqliteQueryRunner.ts
+++ b/src/driver/sqlite-abstract/AbstractSqliteQueryRunner.ts
@@ -1089,7 +1089,7 @@ export abstract class AbstractSqliteQueryRunner extends BaseQueryRunner implemen
 
         sql += `)`;
 
-        const tableMetadata = this.connection.entityMetadatas.find(metadata => metadata.tableName === table.name);
+        const tableMetadata = this.connection.entityMetadatas.find(metadata => table.path === metadata.tablePath);
         if (tableMetadata && tableMetadata.withoutRowid) {
             sql += " WITHOUT ROWID";
         }

--- a/src/driver/sqlserver/SqlServerDriver.ts
+++ b/src/driver/sqlserver/SqlServerDriver.ts
@@ -61,9 +61,14 @@ export class SqlServerDriver implements Driver {
     options: SqlServerConnectionOptions;
 
     /**
-     * Master database used to perform all write queries.
+     * Database name used to perform all write queries.
      */
     database?: string;
+
+    /**
+     * Schema name used to perform all write queries.
+     */
+    schema?: string;
 
     /**
      * Indicates if replication is enabled.
@@ -250,12 +255,22 @@ export class SqlServerDriver implements Driver {
                 return this.createPool(this.options, slave);
             }));
             this.master = await this.createPool(this.options, this.options.replication.master);
-            this.database = this.options.replication.master.database;
-
         } else {
             this.master = await this.createPool(this.options, this.options);
-            this.database = this.options.database;
         }
+
+        const queryRunner = await this.createQueryRunner("master");
+
+        // Ask the database for where we've connected to
+        this.database = await queryRunner.getCurrentDatabase();
+
+        if (this.connection.options.hasOwnProperty("schema")) {
+            this.schema = (this.connection.options as any).schema;
+        } else {
+            this.schema = await queryRunner.getCurrentSchema();
+        }
+
+        await queryRunner.release();
     }
 
     /**

--- a/src/driver/sqlserver/SqlServerQueryRunner.ts
+++ b/src/driver/sqlserver/SqlServerQueryRunner.ts
@@ -1898,7 +1898,7 @@ export class SqlServerQueryRunner extends BaseQueryRunner implements QueryRunner
                     fk.name = this.connection.namingStrategy.foreignKeyName(table, fk.columnNames, fk.referencedTablePath, fk.referencedColumnNames);
                 const referencedColumnNames = fk.referencedColumnNames.map(columnName => `"${columnName}"`).join(", ");
 
-                let constraint = `CONSTRAINT "${fk.name}" FOREIGN KEY (${columnNames}) REFERENCES ${this.escapePath(fk.referencedTableName)} (${referencedColumnNames})`;
+                let constraint = `CONSTRAINT "${fk.name}" FOREIGN KEY (${columnNames}) REFERENCES ${this.escapePath(fk.referencedTablePath)} (${referencedColumnNames})`;
                 if (fk.onDelete)
                     constraint += ` ON DELETE ${fk.onDelete}`;
                 if (fk.onUpdate)
@@ -2049,7 +2049,7 @@ export class SqlServerQueryRunner extends BaseQueryRunner implements QueryRunner
         const columnNames = foreignKey.columnNames.map(column => `"` + column + `"`).join(", ");
         const referencedColumnNames = foreignKey.referencedColumnNames.map(column => `"` + column + `"`).join(",");
         let sql = `ALTER TABLE ${this.escapePath(table)} ADD CONSTRAINT "${foreignKey.name}" FOREIGN KEY (${columnNames}) ` +
-            `REFERENCES ${this.escapePath(foreignKey.referencedTableName)}(${referencedColumnNames})`;
+            `REFERENCES ${this.escapePath(foreignKey.referencedTablePath)}(${referencedColumnNames})`;
         if (foreignKey.onDelete)
             sql += ` ON DELETE ${foreignKey.onDelete}`;
         if (foreignKey.onUpdate)

--- a/src/driver/sqlserver/SqlServerQueryRunner.ts
+++ b/src/driver/sqlserver/SqlServerQueryRunner.ts
@@ -651,7 +651,7 @@ export class SqlServerQueryRunner extends BaseQueryRunner implements QueryRunner
         // rename foreign key constraints
         newTable.foreignKeys.forEach(foreignKey => {
             // build new constraint name
-            const newForeignKeyName = this.connection.namingStrategy.foreignKeyName(newTable, foreignKey.columnNames, foreignKey.referencedTableName, foreignKey.referencedColumnNames);
+            const newForeignKeyName = this.connection.namingStrategy.foreignKeyName(newTable, foreignKey.columnNames, foreignKey.referencedTablePath, foreignKey.referencedColumnNames);
 
             // build queries
             upQueries.push(new Query(`EXEC sp_rename "${this.buildForeignKeyName(foreignKey.name!, schemaName, dbName)}", "${newForeignKeyName}"`));
@@ -855,7 +855,7 @@ export class SqlServerQueryRunner extends BaseQueryRunner implements QueryRunner
                     // build new constraint name
                     foreignKey.columnNames.splice(foreignKey.columnNames.indexOf(oldColumn.name), 1);
                     foreignKey.columnNames.push(newColumn.name);
-                    const newForeignKeyName = this.connection.namingStrategy.foreignKeyName(clonedTable, foreignKey.columnNames, foreignKey.referencedTableName, foreignKey.referencedColumnNames);
+                    const newForeignKeyName = this.connection.namingStrategy.foreignKeyName(clonedTable, foreignKey.columnNames, foreignKey.referencedTablePath, foreignKey.referencedColumnNames);
 
                     // build queries
                     upQueries.push(new Query(`EXEC sp_rename "${this.buildForeignKeyName(foreignKey.name!, schemaName, dbName)}", "${newForeignKeyName}"`));
@@ -1295,7 +1295,7 @@ export class SqlServerQueryRunner extends BaseQueryRunner implements QueryRunner
 
         // new FK may be passed without name. In this case we generate FK name manually.
         if (!foreignKey.name)
-            foreignKey.name = this.connection.namingStrategy.foreignKeyName(table, foreignKey.columnNames, foreignKey.referencedTableName, foreignKey.referencedColumnNames);
+            foreignKey.name = this.connection.namingStrategy.foreignKeyName(table, foreignKey.columnNames, foreignKey.referencedTablePath, foreignKey.referencedColumnNames);
 
         const up = this.createForeignKeySql(table, foreignKey);
         const down = this.dropForeignKeySql(table, foreignKey);
@@ -1852,11 +1852,15 @@ export class SqlServerQueryRunner extends BaseQueryRunner implements QueryRunner
                 const db = dbForeignKey["TABLE_CATALOG"] === currentDatabase ? undefined : dbForeignKey["TABLE_CATALOG"];
                 const schema = getSchemaFromKey(dbForeignKey, "REF_SCHEMA");
                 const referencedTableName = this.driver.buildTableName(dbForeignKey["REF_TABLE"], schema, db);
+                const referencedTablePath = this.driver.buildTableName(dbForeignKey["REF_TABLE"], dbForeignKey["REF_SCHEMA"], dbForeignKey["TABLE_CATALOG"]);
 
                 return new TableForeignKey({
                     name: dbForeignKey["FK_NAME"],
                     columnNames: foreignKeys.map(dbFk => dbFk["COLUMN_NAME"]),
+                    referencedDatabase: dbForeignKey["TABLE_CATALOG"],
+                    referencedSchema: dbForeignKey["REF_SCHEMA"],
                     referencedTableName: referencedTableName,
+                    referencedTablePath: referencedTablePath,
                     referencedColumnNames: foreignKeys.map(dbFk => dbFk["REF_COLUMN"]),
                     onDelete: dbForeignKey["ON_DELETE"].replace("_", " "), // SqlServer returns NO_ACTION, instead of NO ACTION
                     onUpdate: dbForeignKey["ON_UPDATE"].replace("_", " ") // SqlServer returns NO_ACTION, instead of NO ACTION
@@ -1931,7 +1935,7 @@ export class SqlServerQueryRunner extends BaseQueryRunner implements QueryRunner
             const foreignKeysSql = table.foreignKeys.map(fk => {
                 const columnNames = fk.columnNames.map(columnName => `"${columnName}"`).join(", ");
                 if (!fk.name)
-                    fk.name = this.connection.namingStrategy.foreignKeyName(table, fk.columnNames, fk.referencedTableName, fk.referencedColumnNames);
+                    fk.name = this.connection.namingStrategy.foreignKeyName(table, fk.columnNames, fk.referencedTablePath, fk.referencedColumnNames);
                 const referencedColumnNames = fk.referencedColumnNames.map(columnName => `"${columnName}"`).join(", ");
 
                 let constraint = `CONSTRAINT "${fk.name}" FOREIGN KEY (${columnNames}) REFERENCES ${this.escapePath(fk.referencedTableName)} (${referencedColumnNames})`;

--- a/src/metadata-builder/RelationJoinColumnBuilder.ts
+++ b/src/metadata-builder/RelationJoinColumnBuilder.ts
@@ -86,7 +86,7 @@ export class RelationJoinColumnBuilder {
                 entityMetadata: relation.entityMetadata,
                 columns: foreignKey.columns,
                 args: {
-                    name: this.connection.namingStrategy.relationConstraintName(relation.entityMetadata.tablePath, foreignKey.columns.map(c => c.databaseName)),
+                    name: this.connection.namingStrategy.relationConstraintName(relation.entityMetadata.tableName, foreignKey.columns.map(c => c.databaseName)),
                     target: relation.entityMetadata.target,
                 }
             });

--- a/src/metadata/CheckMetadata.ts
+++ b/src/metadata/CheckMetadata.ts
@@ -64,7 +64,7 @@ export class CheckMetadata {
      * Must be called after all entity metadata's properties map, columns and relations are built.
      */
     build(namingStrategy: NamingStrategyInterface): this {
-        this.name = this.givenName ? this.givenName : namingStrategy.checkConstraintName(this.entityMetadata.tablePath, this.expression);
+        this.name = this.givenName ? this.givenName : namingStrategy.checkConstraintName(this.entityMetadata.tableName, this.expression);
         return this;
     }
 

--- a/src/metadata/EntityMetadata.ts
+++ b/src/metadata/EntityMetadata.ts
@@ -120,6 +120,8 @@ export class EntityMetadata {
     /**
      * Entity table path. Contains database name, schema name and table name.
      * E.g. myDB.mySchema.myTable
+     *
+     * @deprecated
      */
     tablePath: string;
 

--- a/src/metadata/EntityMetadata.ts
+++ b/src/metadata/EntityMetadata.ts
@@ -802,15 +802,19 @@ export class EntityMetadata {
         const entitySkipConstructor = this.connection.options.entitySkipConstructor;
 
         this.engine = this.tableMetadataArgs.engine;
-        this.database = this.tableMetadataArgs.type === "entity-child" && this.parentEntityMetadata ? this.parentEntityMetadata.database : this.tableMetadataArgs.database;
-        if (this.tableMetadataArgs.schema) {
+
+        if ((this.tableMetadataArgs.type === "entity-child") && this.parentEntityMetadata?.database) {
+            this.database = this.parentEntityMetadata.database;
+        } else if (this.tableMetadataArgs.database) {
+            this.database = this.tableMetadataArgs.database;
+        }
+
+        if ((this.tableMetadataArgs.type === "entity-child") && this.parentEntityMetadata?.schema) {
+            this.schema = this.parentEntityMetadata.schema;
+        } else if (this.tableMetadataArgs.schema) {
             this.schema = this.tableMetadataArgs.schema;
         }
-        else if ((this.tableMetadataArgs.type === "entity-child") && this.parentEntityMetadata) {
-            this.schema = this.parentEntityMetadata.schema;
-        } else if (this.connection.options?.hasOwnProperty("schema")) {
-            this.schema = (this.connection.options as any).schema;
-        }
+
         this.givenTableName = this.tableMetadataArgs.type === "entity-child" && this.parentEntityMetadata ? this.parentEntityMetadata.givenTableName : this.tableMetadataArgs.name;
         this.synchronize = this.tableMetadataArgs.synchronize === false ? false : true;
         this.targetName = this.tableMetadataArgs.target instanceof Function ? (this.tableMetadataArgs.target as any).name : this.tableMetadataArgs.target;
@@ -830,7 +834,7 @@ export class EntityMetadata {
         this.name = this.targetName ? this.targetName : this.tableName;
         this.expression = this.tableMetadataArgs.expression;
         this.withoutRowid = this.tableMetadataArgs.withoutRowid === true ? true : false;
-        this.tablePath = this.connection.driver.buildTableName(this.tableName, this.schema, this.database);
+        this.tablePath = this.connection.driver.buildTableName(this.tableName, this.schema || (this.connection.options as any).schema, this.database);
         this.orderBy = (this.tableMetadataArgs.orderBy instanceof Function) ? this.tableMetadataArgs.orderBy(this.propertiesMap) : this.tableMetadataArgs.orderBy; // todo: is propertiesMap available here? Looks like its not
 
         if (entitySkipConstructor !== undefined) {

--- a/src/metadata/ExclusionMetadata.ts
+++ b/src/metadata/ExclusionMetadata.ts
@@ -64,7 +64,7 @@ export class ExclusionMetadata {
      * Must be called after all entity metadata's properties map, columns and relations are built.
      */
     build(namingStrategy: NamingStrategyInterface): this {
-        this.name = this.givenName ? this.givenName : namingStrategy.exclusionConstraintName(this.entityMetadata.tablePath, this.expression);
+        this.name = this.givenName ? this.givenName : namingStrategy.exclusionConstraintName(this.entityMetadata.tableName, this.expression);
         return this;
     }
 

--- a/src/metadata/ForeignKeyMetadata.ts
+++ b/src/metadata/ForeignKeyMetadata.ts
@@ -51,6 +51,8 @@ export class ForeignKeyMetadata {
 
     /**
      * Gets the table name to which this foreign key is referenced.
+     *
+     * @deprecated
      */
     referencedTablePath: string;
 

--- a/src/metadata/ForeignKeyMetadata.ts
+++ b/src/metadata/ForeignKeyMetadata.ts
@@ -108,7 +108,7 @@ export class ForeignKeyMetadata {
         this.columnNames = this.columns.map(column => column.databaseName);
         this.referencedColumnNames = this.referencedColumns.map(column => column.databaseName);
         this.referencedTablePath = this.referencedEntityMetadata.tablePath;
-        this.name = namingStrategy.foreignKeyName(this.entityMetadata.tablePath, this.columnNames, this.referencedTablePath, this.referencedColumnNames);
+        this.name = namingStrategy.foreignKeyName(this.entityMetadata.tableName, this.columnNames, this.referencedTablePath, this.referencedColumnNames);
     }
 
 }

--- a/src/metadata/IndexMetadata.ts
+++ b/src/metadata/IndexMetadata.ts
@@ -204,7 +204,7 @@ export class IndexMetadata {
             return updatedMap;
         }, {} as { [key: string]: number });
 
-        this.name = this.givenName ? this.givenName : namingStrategy.indexName(this.entityMetadata.tablePath, this.columns.map(column => column.databaseName), this.where);
+        this.name = this.givenName ? this.givenName : namingStrategy.indexName(this.entityMetadata.tableName, this.columns.map(column => column.databaseName), this.where);
         return this;
     }
 

--- a/src/metadata/UniqueMetadata.ts
+++ b/src/metadata/UniqueMetadata.ts
@@ -138,7 +138,7 @@ export class UniqueMetadata {
             return updatedMap;
         }, {} as { [key: string]: number });
 
-        this.name = this.givenName ? this.givenName : namingStrategy.uniqueConstraintName(this.entityMetadata.tablePath, this.columns.map(column => column.databaseName));
+        this.name = this.givenName ? this.givenName : namingStrategy.uniqueConstraintName(this.entityMetadata.tableName, this.columns.map(column => column.databaseName));
         return this;
     }
 

--- a/src/schema-builder/RdbmsSchemaBuilder.ts
+++ b/src/schema-builder/RdbmsSchemaBuilder.ts
@@ -12,7 +12,6 @@ import {SqlInMemory} from "../driver/SqlInMemory";
 import {TableUtils} from "./util/TableUtils";
 import {TableColumnOptions} from "./options/TableColumnOptions";
 import {PostgresDriver} from "../driver/postgres/PostgresDriver";
-import {SqlServerDriver} from "../driver/sqlserver/SqlServerDriver";
 import {MysqlDriver} from "../driver/mysql/MysqlDriver";
 import {TableUnique} from "./table/TableUnique";
 import {TableCheck} from "./table/TableCheck";
@@ -402,7 +401,7 @@ export class RdbmsSchemaBuilder implements SchemaBuilder {
             // check if view does not exist yet
             const existView = this.queryRunner.loadedViews.find(view => {
                 const database = metadata.database && metadata.database !== this.connection.driver.database ? metadata.database : undefined;
-                const schema = metadata.schema || (<SqlServerDriver|PostgresDriver>this.connection.driver).options.schema;
+                const schema = metadata.schema || this.connection.driver.schema;
                 const fullViewName = this.connection.driver.buildTableName(metadata.tableName, schema, database);
                 const viewExpression = typeof view.expression === "string" ? view.expression.trim() : view.expression(this.connection).getQuery();
                 const metadataExpression = typeof metadata.expression === "string" ? metadata.expression.trim() : metadata.expression!(this.connection).getQuery();
@@ -425,7 +424,7 @@ export class RdbmsSchemaBuilder implements SchemaBuilder {
         for (const view of this.queryRunner.loadedViews) {
             const existViewMetadata = this.viewEntityToSyncMetadatas.find(metadata => {
                 const database = metadata.database && metadata.database !== this.connection.driver.database ? metadata.database : undefined;
-                const schema = metadata.schema || (<SqlServerDriver|PostgresDriver>this.connection.driver).options.schema;
+                const schema = metadata.schema || this.connection.driver.schema;
                 const fullViewName = this.connection.driver.buildTableName(metadata.tableName, schema, database);
                 const viewExpression = typeof view.expression === "string" ? view.expression.trim() : view.expression(this.connection).getQuery();
                 const metadataExpression = typeof metadata.expression === "string" ? metadata.expression.trim() : metadata.expression!(this.connection).getQuery();

--- a/src/schema-builder/RdbmsSchemaBuilder.ts
+++ b/src/schema-builder/RdbmsSchemaBuilder.ts
@@ -1,5 +1,4 @@
 import {CockroachDriver} from "../driver/cockroachdb/CockroachDriver";
-import {SapDriver} from "../driver/sap/SapDriver";
 import {Table} from "./table/Table";
 import {TableColumn} from "./table/TableColumn";
 import {TableForeignKey} from "./table/TableForeignKey";
@@ -75,13 +74,15 @@ export class RdbmsSchemaBuilder implements SchemaBuilder {
         }
 
         try {
-            const tablePaths = this.entityToSyncMetadatas.map(metadata => metadata.tablePath);
-            // TODO: typeorm_metadata table needs only for Views for now.
-            //  Remove condition or add new conditions if necessary (for CHECK constraints for example).
-            if (this.viewEntityToSyncMetadatas.length > 0)
+            if (this.viewEntityToSyncMetadatas.length > 0) {
                 await this.createTypeormMetadataTable();
+            }
+
+            // Flush the queryrunner table & view cache
+            const tablePaths = this.entityToSyncMetadatas.map(metadata => this.getTablePath(metadata));
             await this.queryRunner.getTables(tablePaths);
             await this.queryRunner.getViews([]);
+
             await this.executeSchemaSyncOperationsInProperOrder();
 
             // if cache is enabled then perform cache-synchronization as well
@@ -112,13 +113,18 @@ export class RdbmsSchemaBuilder implements SchemaBuilder {
     async log(): Promise<SqlInMemory> {
         this.queryRunner = this.connection.createQueryRunner();
         try {
-            const tablePaths = this.entityToSyncMetadatas.map(metadata => metadata.tablePath);
+
             // TODO: typeorm_metadata table needs only for Views for now.
             //  Remove condition or add new conditions if necessary (for CHECK constraints for example).
-            if (this.viewEntityToSyncMetadatas.length > 0)
+            if (this.viewEntityToSyncMetadatas.length > 0) {
                 await this.createTypeormMetadataTable();
+            }
+
+            // Flush the queryrunner table & view cache
+            const tablePaths = this.entityToSyncMetadatas.map(metadata => this.getTablePath(metadata));
             await this.queryRunner.getTables(tablePaths);
             await this.queryRunner.getViews([]);
+
             this.queryRunner.enableSqlMemory();
             await this.executeSchemaSyncOperationsInProperOrder();
 
@@ -181,12 +187,19 @@ export class RdbmsSchemaBuilder implements SchemaBuilder {
         await this.createViews();
     }
 
+    private getTablePath(metadata: EntityMetadata) {
+        const database = metadata.database ? metadata.database : this.connection.driver.database;
+        const schema = metadata.schema ? metadata.schema : this.connection.driver.schema;
+        return this.connection.driver.buildTableName(metadata.tableName, schema, database);
+    }
+
+
     /**
      * Drops all (old) foreign keys that exist in the tables, but do not exist in the entity metadata.
      */
     protected async dropOldForeignKeys(): Promise<void> {
         for (const metadata of this.entityToSyncMetadatas) {
-            const table = this.queryRunner.loadedTables.find(table => table.name === metadata.tablePath);
+            const table = this.queryRunner.loadedTables.find(table => table.path === this.getTablePath(metadata));
             if (!table)
                 continue;
 
@@ -212,7 +225,7 @@ export class RdbmsSchemaBuilder implements SchemaBuilder {
      */
     protected async renameTables(): Promise<void> {
         // for (const metadata of this.entityToSyncMetadatas) {
-        //     const table = this.queryRunner.loadedTables.find(table => table.name === metadata.tablePath);
+        //     const table = this.queryRunner.loadedTables.find(table => table.path === this.getTablePath(metadata));
         // }
     }
 
@@ -223,7 +236,7 @@ export class RdbmsSchemaBuilder implements SchemaBuilder {
      */
     protected async renameColumns(): Promise<void> {
         for (const metadata of this.entityToSyncMetadatas) {
-            const table = this.queryRunner.loadedTables.find(table => table.name === metadata.tablePath);
+            const table = this.queryRunner.loadedTables.find(table => table.path === this.getTablePath(metadata));
             if (!table)
                 continue;
 
@@ -264,7 +277,7 @@ export class RdbmsSchemaBuilder implements SchemaBuilder {
 
     protected async dropOldIndices(): Promise<void> {
         for (const metadata of this.entityToSyncMetadatas) {
-            const table = this.queryRunner.loadedTables.find(table => table.name === metadata.tablePath);
+            const table = this.queryRunner.loadedTables.find(table => table.path === this.getTablePath(metadata));
             if (!table)
                 continue;
 
@@ -307,7 +320,7 @@ export class RdbmsSchemaBuilder implements SchemaBuilder {
             return;
 
         for (const metadata of this.entityToSyncMetadatas) {
-            const table = this.queryRunner.loadedTables.find(table => table.name === metadata.tablePath);
+            const table = this.queryRunner.loadedTables.find(table => table.path === this.getTablePath(metadata));
             if (!table)
                 continue;
 
@@ -325,7 +338,7 @@ export class RdbmsSchemaBuilder implements SchemaBuilder {
 
     protected async dropCompositeUniqueConstraints(): Promise<void> {
         for (const metadata of this.entityToSyncMetadatas) {
-            const table = this.queryRunner.loadedTables.find(table => table.name === metadata.tablePath);
+            const table = this.queryRunner.loadedTables.find(table => table.path === this.getTablePath(metadata));
             if (!table)
                 continue;
 
@@ -347,7 +360,7 @@ export class RdbmsSchemaBuilder implements SchemaBuilder {
             return;
 
         for (const metadata of this.entityToSyncMetadatas) {
-            const table = this.queryRunner.loadedTables.find(table => table.name === metadata.tablePath);
+            const table = this.queryRunner.loadedTables.find(table => table.path === this.getTablePath(metadata));
             if (!table)
                 continue;
 
@@ -369,22 +382,13 @@ export class RdbmsSchemaBuilder implements SchemaBuilder {
      * Primary key only can be created in conclusion with auto generated column.
      */
     protected async createNewTables(): Promise<void> {
-        const currentSchema = await this.queryRunner.getCurrentSchema();
         for (const metadata of this.entityToSyncMetadatas) {
             // check if table does not exist yet
-            const existTable = this.queryRunner.loadedTables.find(table => {
-                const database = metadata.database && metadata.database !== this.connection.driver.database ? metadata.database : undefined;
-                let schema = metadata.schema || (<SqlServerDriver|PostgresDriver|SapDriver>this.connection.driver).options.schema;
-                // if schema is default db schema (e.g. "public" in PostgreSQL), skip it.
-                schema = schema === currentSchema ? undefined : schema;
-                const fullTableName = this.connection.driver.buildTableName(metadata.tableName, schema, database);
-
-                return table.name === fullTableName;
-            });
+            const existTable = this.queryRunner.loadedTables.find(table => table.path === this.getTablePath(metadata));
             if (existTable)
                 continue;
 
-            this.connection.logger.logSchemaBuild(`creating a new table: ${metadata.tablePath}`);
+            this.connection.logger.logSchemaBuild(`creating a new table: ${this.getTablePath(metadata)}`);
 
             // create a new table and sync it in the database
             const table = Table.create(metadata, this.connection.driver);
@@ -407,7 +411,7 @@ export class RdbmsSchemaBuilder implements SchemaBuilder {
             if (existView)
                 continue;
 
-            this.connection.logger.logSchemaBuild(`creating a new view: ${metadata.tablePath}`);
+            this.connection.logger.logSchemaBuild(`creating a new view: ${this.getTablePath(metadata)}`);
 
             // create a new view and sync it in the database
             const view = View.create(metadata, this.connection.driver);
@@ -446,7 +450,7 @@ export class RdbmsSchemaBuilder implements SchemaBuilder {
      */
     protected async dropRemovedColumns(): Promise<void> {
         for (const metadata of this.entityToSyncMetadatas) {
-            const table = this.queryRunner.loadedTables.find(table => table.name === metadata.tablePath);
+            const table = this.queryRunner.loadedTables.find(table => table.path === this.getTablePath(metadata));
             if (!table)
                 continue;
 
@@ -470,7 +474,7 @@ export class RdbmsSchemaBuilder implements SchemaBuilder {
      */
     protected async addNewColumns(): Promise<void> {
         for (const metadata of this.entityToSyncMetadatas) {
-            const table = this.queryRunner.loadedTables.find(table => table.name === metadata.tablePath);
+            const table = this.queryRunner.loadedTables.find(table => table.path === this.getTablePath(metadata));
             if (!table)
                 continue;
 
@@ -498,7 +502,7 @@ export class RdbmsSchemaBuilder implements SchemaBuilder {
      */
     protected async updatePrimaryKeys(): Promise<void> {
         for (const metadata of this.entityToSyncMetadatas) {
-            const table = this.queryRunner.loadedTables.find(table => table.name === metadata.tablePath);
+            const table = this.queryRunner.loadedTables.find(table => table.path === this.getTablePath(metadata));
             if (!table)
                 continue;
 
@@ -519,7 +523,7 @@ export class RdbmsSchemaBuilder implements SchemaBuilder {
      */
     protected async updateExistColumns(): Promise<void> {
         for (const metadata of this.entityToSyncMetadatas) {
-            const table = this.queryRunner.loadedTables.find(table => table.name === metadata.tablePath);
+            const table = this.queryRunner.loadedTables.find(table => table.path === this.getTablePath(metadata));
             if (!table)
                 continue;
 
@@ -529,19 +533,19 @@ export class RdbmsSchemaBuilder implements SchemaBuilder {
 
             // drop all foreign keys that point to this column
             for (const changedColumn of changedColumns) {
-                await this.dropColumnReferencedForeignKeys(metadata.tablePath, changedColumn.databaseName);
+                await this.dropColumnReferencedForeignKeys(this.getTablePath(metadata), changedColumn.databaseName);
             }
 
             // drop all composite indices related to this column
             for (const changedColumn of changedColumns) {
-                await this.dropColumnCompositeIndices(metadata.tablePath, changedColumn.databaseName);
+                await this.dropColumnCompositeIndices(this.getTablePath(metadata), changedColumn.databaseName);
             }
 
             // drop all composite uniques related to this column
             // Mysql does not support unique constraints.
             if (!(this.connection.driver instanceof MysqlDriver || this.connection.driver instanceof AuroraDataApiDriver)) {
                 for (const changedColumn of changedColumns) {
-                    await this.dropColumnCompositeUniques(metadata.tablePath, changedColumn.databaseName);
+                    await this.dropColumnCompositeUniques(this.getTablePath(metadata), changedColumn.databaseName);
                 }
             }
 
@@ -570,7 +574,7 @@ export class RdbmsSchemaBuilder implements SchemaBuilder {
      */
     protected async createNewIndices(): Promise<void> {
         for (const metadata of this.entityToSyncMetadatas) {
-            const table = this.queryRunner.loadedTables.find(table => table.name === metadata.tablePath);
+            const table = this.queryRunner.loadedTables.find(table => table.path === this.getTablePath(metadata));
             if (!table)
                 continue;
 
@@ -592,7 +596,7 @@ export class RdbmsSchemaBuilder implements SchemaBuilder {
             return;
 
         for (const metadata of this.entityToSyncMetadatas) {
-            const table = this.queryRunner.loadedTables.find(table => table.name === metadata.tablePath);
+            const table = this.queryRunner.loadedTables.find(table => table.path === this.getTablePath(metadata));
             if (!table)
                 continue;
 
@@ -613,7 +617,7 @@ export class RdbmsSchemaBuilder implements SchemaBuilder {
      */
     protected async createCompositeUniqueConstraints(): Promise<void> {
         for (const metadata of this.entityToSyncMetadatas) {
-            const table = this.queryRunner.loadedTables.find(table => table.name === metadata.tablePath);
+            const table = this.queryRunner.loadedTables.find(table => table.path === this.getTablePath(metadata));
             if (!table)
                 continue;
 
@@ -638,7 +642,7 @@ export class RdbmsSchemaBuilder implements SchemaBuilder {
             return;
 
         for (const metadata of this.entityToSyncMetadatas) {
-            const table = this.queryRunner.loadedTables.find(table => table.name === metadata.tablePath);
+            const table = this.queryRunner.loadedTables.find(table => table.path === this.getTablePath(metadata));
             if (!table)
                 continue;
 
@@ -659,7 +663,7 @@ export class RdbmsSchemaBuilder implements SchemaBuilder {
      */
     protected async createForeignKeys(): Promise<void> {
         for (const metadata of this.entityToSyncMetadatas) {
-            const table = this.queryRunner.loadedTables.find(table => table.name === metadata.tablePath);
+            const table = this.queryRunner.loadedTables.find(table => table.path === this.getTablePath(metadata));
             if (!table)
                 continue;
 
@@ -680,7 +684,7 @@ export class RdbmsSchemaBuilder implements SchemaBuilder {
      * Drops all foreign keys where given column of the given table is being used.
      */
     protected async dropColumnReferencedForeignKeys(tablePath: string, columnName: string): Promise<void> {
-        const table = this.queryRunner.loadedTables.find(table => table.name === tablePath);
+        const table = this.queryRunner.loadedTables.find(table => table.path === tablePath);
         if (!table)
             return;
 
@@ -693,7 +697,7 @@ export class RdbmsSchemaBuilder implements SchemaBuilder {
             table.removeForeignKey(columnForeignKey);
         }
 
-        this.queryRunner.loadedTables.forEach(loadedTable => {
+        for (const loadedTable of this.queryRunner.loadedTables) {
             const dependForeignKeys = loadedTable.foreignKeys.filter(foreignKey => {
                 return foreignKey.referencedTableName === tablePath && foreignKey.referencedColumnNames.indexOf(columnName) !== -1;
             });
@@ -704,7 +708,7 @@ export class RdbmsSchemaBuilder implements SchemaBuilder {
                 tablesWithFK.push(clonedTable);
                 dependForeignKeys.forEach(dependForeignKey => loadedTable.removeForeignKey(dependForeignKey));
             }
-        });
+        }
 
         if (tablesWithFK.length > 0) {
             for (const tableWithFK of tablesWithFK) {
@@ -718,7 +722,7 @@ export class RdbmsSchemaBuilder implements SchemaBuilder {
      * Drops all composite indices, related to given column.
      */
     protected async dropColumnCompositeIndices(tablePath: string, columnName: string): Promise<void> {
-        const table = this.queryRunner.loadedTables.find(table => table.name === tablePath);
+        const table = this.queryRunner.loadedTables.find(table => table.path === tablePath);
         if (!table)
             return;
 
@@ -734,7 +738,7 @@ export class RdbmsSchemaBuilder implements SchemaBuilder {
      * Drops all composite uniques, related to given column.
      */
     protected async dropColumnCompositeUniques(tablePath: string, columnName: string): Promise<void> {
-        const table = this.queryRunner.loadedTables.find(table => table.name === tablePath);
+        const table = this.queryRunner.loadedTables.find(table => table.path === tablePath);
         if (!table)
             return;
 

--- a/src/schema-builder/RdbmsSchemaBuilder.ts
+++ b/src/schema-builder/RdbmsSchemaBuilder.ts
@@ -678,7 +678,7 @@ export class RdbmsSchemaBuilder implements SchemaBuilder {
             if (newKeys.length === 0)
                 continue;
 
-            const dbForeignKeys = newKeys.map(foreignKeyMetadata => TableForeignKey.create(foreignKeyMetadata));
+            const dbForeignKeys = newKeys.map(foreignKeyMetadata => TableForeignKey.create(foreignKeyMetadata, this.connection.driver));
             this.connection.logger.logSchemaBuild(`creating a foreign keys: ${newKeys.map(key => key.name).join(", ")} on table "${table.name}"`);
             await this.queryRunner.createForeignKeys(table, dbForeignKeys);
         }

--- a/src/schema-builder/options/TableForeignKeyOptions.ts
+++ b/src/schema-builder/options/TableForeignKeyOptions.ts
@@ -18,9 +18,24 @@ export interface TableForeignKeyOptions {
     columnNames: string[];
 
     /**
+     * Database of the Table referenced in the foreign key.
+     */
+    referencedDatabase?: string;
+
+    /**
+     * Schema of the Table referenced in the foreign key.
+     */
+    referencedSchema?: string;
+
+    /**
      * Table referenced in the foreign key.
      */
     referencedTableName: string;
+
+    /**
+     * Table path referenced in the foreign key.
+     */
+    referencedTablePath?: string;
 
     /**
      * Column names which included by this foreign key.

--- a/src/schema-builder/table/Table.ts
+++ b/src/schema-builder/table/Table.ts
@@ -328,18 +328,14 @@ export class Table {
      * Creates table from a given entity metadata.
      */
     static create(entityMetadata: EntityMetadata, driver: Driver): Table {
-        const database = entityMetadata.database === driver.database ? undefined : entityMetadata.database;
-        const schema = entityMetadata.schema === driver.schema ? undefined : entityMetadata.schema;
+        const database = entityMetadata.database || driver.database;
+        const schema = entityMetadata.schema || driver.schema;
 
         const options: TableOptions = {
-            database: entityMetadata.database,
-            schema: entityMetadata.schema,
-            path: driver.buildTableName(
-                entityMetadata.tableName,
-                entityMetadata.schema || driver.schema,
-                entityMetadata.database || driver.database
-            ),
-            name: driver.buildTableName(entityMetadata.tableName, schema, database),
+            database,
+            schema,
+            path: driver.buildTableName(entityMetadata.tableName, schema, database),
+            name: entityMetadata.tableName,
             engine: entityMetadata.engine,
             columns: entityMetadata.columns
                 .filter(column => column)

--- a/src/schema-builder/table/Table.ts
+++ b/src/schema-builder/table/Table.ts
@@ -95,7 +95,11 @@ export class Table {
 
             this.path = options.path || options.name;
 
-            this.name = options.name;
+            if (options.name.indexOf(".") !== -1) {
+                this.name = options.name.split(".").pop()!;
+            } else {
+                this.name = options.name;
+            }
 
             if (options.columns)
                 this.columns = options.columns.map(column => new TableColumn(column));

--- a/src/schema-builder/table/Table.ts
+++ b/src/schema-builder/table/Table.ts
@@ -329,12 +329,16 @@ export class Table {
      */
     static create(entityMetadata: EntityMetadata, driver: Driver): Table {
         const database = entityMetadata.database === driver.database ? undefined : entityMetadata.database;
-        const schema = entityMetadata.schema === (driver.options as any).schema ? undefined : entityMetadata.schema;
+        const schema = entityMetadata.schema === driver.schema ? undefined : entityMetadata.schema;
 
         const options: TableOptions = {
             database: entityMetadata.database,
             schema: entityMetadata.schema,
-            path: driver.buildTableName(entityMetadata.tableName, entityMetadata.schema, entityMetadata.database),
+            path: driver.buildTableName(
+                entityMetadata.tableName,
+                entityMetadata.schema || driver.schema,
+                entityMetadata.database || driver.database
+            ),
             name: driver.buildTableName(entityMetadata.tableName, schema, database),
             engine: entityMetadata.engine,
             columns: entityMetadata.columns

--- a/src/schema-builder/table/TableForeignKey.ts
+++ b/src/schema-builder/table/TableForeignKey.ts
@@ -1,5 +1,6 @@
 import {ForeignKeyMetadata} from "../../metadata/ForeignKeyMetadata";
 import {TableForeignKeyOptions} from "../options/TableForeignKeyOptions";
+import { Driver } from "../../driver/Driver";
 
 /**
  * Foreign key from the database stored in this class.
@@ -109,15 +110,18 @@ export class TableForeignKey {
     /**
      * Creates a new table foreign key from the given foreign key metadata.
      */
-    static create(metadata: ForeignKeyMetadata): TableForeignKey {
+    static create(metadata: ForeignKeyMetadata, driver: Driver): TableForeignKey {
+        const database = metadata.referencedEntityMetadata.database === driver.database ? undefined : metadata.referencedEntityMetadata.database;
+        const schema = metadata.referencedEntityMetadata.schema === driver.schema ? undefined : metadata.referencedEntityMetadata.schema;
+
         return new TableForeignKey(<TableForeignKeyOptions>{
             name: metadata.name,
             columnNames: metadata.columnNames,
             referencedColumnNames: metadata.referencedColumnNames,
             referencedDatabase: metadata.referencedEntityMetadata.database,
             referencedSchema: metadata.referencedEntityMetadata.schema,
-            referencedTableName: metadata.referencedEntityMetadata.tableName,
-            referencedTablePath: metadata.referencedTablePath,
+            referencedTableName: driver.buildTableName(metadata.referencedEntityMetadata.tableName, schema, database),
+            referencedTablePath: driver.buildTableName(metadata.referencedEntityMetadata.tableName, metadata.referencedEntityMetadata.schema, metadata.referencedEntityMetadata.database),
             onDelete: metadata.onDelete,
             onUpdate: metadata.onUpdate,
             deferrable: metadata.deferrable,

--- a/src/schema-builder/table/TableForeignKey.ts
+++ b/src/schema-builder/table/TableForeignKey.ts
@@ -21,9 +21,24 @@ export class TableForeignKey {
     columnNames: string[] = [];
 
     /**
+     * Database of Table referenced in the foreign key.
+     */
+    referencedDatabase?: string;
+
+    /**
+     * Database of Table referenced in the foreign key.
+     */
+    referencedSchema?: string;
+
+    /**
      * Table referenced in the foreign key.
      */
     referencedTableName: string;
+
+    /**
+     * Table referenced in the foreign key.
+     */
+    referencedTablePath: string;
 
     /**
      * Column names which included by this foreign key.
@@ -56,7 +71,10 @@ export class TableForeignKey {
         this.name = options.name;
         this.columnNames = options.columnNames;
         this.referencedColumnNames = options.referencedColumnNames;
+        this.referencedDatabase = options.referencedDatabase;
+        this.referencedSchema = options.referencedSchema;
         this.referencedTableName = options.referencedTableName;
+        this.referencedTablePath = options.referencedTablePath || options.referencedTableName;
         this.onDelete = options.onDelete;
         this.onUpdate = options.onUpdate;
         this.deferrable = options.deferrable;
@@ -74,7 +92,10 @@ export class TableForeignKey {
             name: this.name,
             columnNames: [...this.columnNames],
             referencedColumnNames: [...this.referencedColumnNames],
+            referencedDatabase: this.referencedDatabase,
+            referencedSchema: this.referencedSchema,
             referencedTableName: this.referencedTableName,
+            referencedTablePath: this.referencedTablePath,
             onDelete: this.onDelete,
             onUpdate: this.onUpdate,
             deferrable: this.deferrable,
@@ -93,7 +114,10 @@ export class TableForeignKey {
             name: metadata.name,
             columnNames: metadata.columnNames,
             referencedColumnNames: metadata.referencedColumnNames,
-            referencedTableName: metadata.referencedTablePath,
+            referencedDatabase: metadata.referencedEntityMetadata.database,
+            referencedSchema: metadata.referencedEntityMetadata.schema,
+            referencedTableName: metadata.referencedEntityMetadata.tableName,
+            referencedTablePath: metadata.referencedTablePath,
             onDelete: metadata.onDelete,
             onUpdate: metadata.onUpdate,
             deferrable: metadata.deferrable,

--- a/src/schema-builder/table/TableForeignKey.ts
+++ b/src/schema-builder/table/TableForeignKey.ts
@@ -111,17 +111,18 @@ export class TableForeignKey {
      * Creates a new table foreign key from the given foreign key metadata.
      */
     static create(metadata: ForeignKeyMetadata, driver: Driver): TableForeignKey {
-        const database = metadata.referencedEntityMetadata.database === driver.database ? undefined : metadata.referencedEntityMetadata.database;
-        const schema = metadata.referencedEntityMetadata.schema === driver.schema ? undefined : metadata.referencedEntityMetadata.schema;
+        const referencedDatabase = metadata.referencedEntityMetadata.database || driver.database;
+        const referencedSchema = metadata.referencedEntityMetadata.schema || driver.schema;
+        const referencedTableName = metadata.referencedEntityMetadata.tableName;
 
         return new TableForeignKey(<TableForeignKeyOptions>{
             name: metadata.name,
             columnNames: metadata.columnNames,
             referencedColumnNames: metadata.referencedColumnNames,
-            referencedDatabase: metadata.referencedEntityMetadata.database,
-            referencedSchema: metadata.referencedEntityMetadata.schema,
-            referencedTableName: driver.buildTableName(metadata.referencedEntityMetadata.tableName, schema, database),
-            referencedTablePath: driver.buildTableName(metadata.referencedEntityMetadata.tableName, metadata.referencedEntityMetadata.schema, metadata.referencedEntityMetadata.database),
+            referencedDatabase,
+            referencedSchema,
+            referencedTableName,
+            referencedTablePath: driver.buildTableName(referencedTableName, referencedSchema, referencedDatabase),
             onDelete: metadata.onDelete,
             onUpdate: metadata.onUpdate,
             deferrable: metadata.deferrable,

--- a/src/schema-builder/view/View.ts
+++ b/src/schema-builder/view/View.ts
@@ -62,8 +62,11 @@ export class View {
      * Creates view from a given entity metadata.
      */
     static create(entityMetadata: EntityMetadata, driver: Driver): View {
+        const database = entityMetadata.database === driver.database ? undefined : entityMetadata.database;
+        const schema = entityMetadata.schema === driver.schema ? undefined : entityMetadata.schema;
+
         const options: ViewOptions = {
-            name: driver.buildTableName(entityMetadata.tableName, entityMetadata.schema, entityMetadata.database),
+            name: driver.buildTableName(entityMetadata.tableName, schema, database),
             expression: entityMetadata.expression!,
             materialized: entityMetadata.tableMetadataArgs.materialized
         };

--- a/test/functional/commands/templates/result-templates-generate.ts
+++ b/test/functional/commands/templates/result-templates-generate.ts
@@ -5,11 +5,11 @@ export class testMigration1610975184784 implements MigrationInterface {
     name = 'testMigration1610975184784'
 
     public async up(queryRunner: QueryRunner): Promise<void> {
-        await queryRunner.query("CREATE TABLE \`post\` (\`id\` int NOT NULL AUTO_INCREMENT, \`title\` varchar(255) NOT NULL, \`createdAt\` datetime(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6), PRIMARY KEY (\`id\`)) ENGINE=InnoDB");
+        await queryRunner.query("CREATE TABLE \`test\`.\`post\` (\`id\` int NOT NULL AUTO_INCREMENT, \`title\` varchar(255) NOT NULL, \`createdAt\` datetime(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6), PRIMARY KEY (\`id\`)) ENGINE=InnoDB");
     }
 
     public async down(queryRunner: QueryRunner): Promise<void> {
-        await queryRunner.query("DROP TABLE \`post\`");
+        await queryRunner.query("DROP TABLE \`test\`.\`post\`");
     }
 
 }`,
@@ -19,11 +19,11 @@ module.exports = class testMigration1610975184784 {
     name = 'testMigration1610975184784'
 
     async up(queryRunner) {
-        await queryRunner.query("CREATE TABLE \`post\` (\`id\` int NOT NULL AUTO_INCREMENT, \`title\` varchar(255) NOT NULL, \`createdAt\` datetime(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6), PRIMARY KEY (\`id\`)) ENGINE=InnoDB");
+        await queryRunner.query("CREATE TABLE \`test\`.\`post\` (\`id\` int NOT NULL AUTO_INCREMENT, \`title\` varchar(255) NOT NULL, \`createdAt\` datetime(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6), PRIMARY KEY (\`id\`)) ENGINE=InnoDB");
     }
 
     async down(queryRunner) {
-        await queryRunner.query("DROP TABLE \`post\`");
+        await queryRunner.query("DROP TABLE \`test\`.\`post\`");
     }
 }`
 };

--- a/test/functional/multi-schema-and-database/custom-junction-database/custom-junction-database.ts
+++ b/test/functional/multi-schema-and-database/custom-junction-database/custom-junction-database.ts
@@ -26,23 +26,34 @@ describe("multi-schema-and-database > custom-junction-database", () => {
             const junctionMetadata = connection.getManyToManyMetadata(Post, "categories")!;
             const junctionTable = await queryRunner.getTable("yoman.." + junctionMetadata.tableName);
             expect(postTable).not.to.be.undefined;
-            postTable!.name!.should.be.equal("yoman..post");
+            expect(postTable!.name).to.be.equal("post");
+            expect(postTable!.database).to.be.equal("yoman");
+
             expect(categoryTable).not.to.be.undefined;
-            categoryTable!.name!.should.be.equal("yoman..category");
+            expect(categoryTable!.name).to.be.equal("category");
+            expect(categoryTable!.database).to.be.equal("yoman");
+
             expect(junctionTable).not.to.be.undefined;
-            junctionTable!.name!.should.be.equal("yoman.." + junctionMetadata.tableName);
+            expect(categoryTable!.name).to.be.equal(junctionMetadata.tableName);
+            expect(categoryTable!.database).to.be.equal("yoman");
 
         } else { // mysql
             const postTable = await queryRunner.getTable("yoman.post");
             const categoryTable = await queryRunner.getTable("yoman.category");
             const junctionMetadata = connection.getManyToManyMetadata(Post, "categories")!;
             const junctionTable = await queryRunner.getTable("yoman." + junctionMetadata.tableName);
+
             expect(postTable).not.to.be.undefined;
-            postTable!.name!.should.be.equal("yoman.post");
+            expect(postTable!.name).to.be.equal("post");
+            expect(postTable!.database).to.be.equal("yoman");
+
             expect(categoryTable).not.to.be.undefined;
-            categoryTable!.name!.should.be.equal("yoman.category");
+            expect(categoryTable!.name).to.be.equal("category");
+            expect(categoryTable!.database).to.be.equal("yoman");
+
             expect(junctionTable).not.to.be.undefined;
-            junctionTable!.name!.should.be.equal("yoman." + junctionMetadata.tableName);
+            expect(junctionTable!.name).to.be.equal(junctionMetadata.tableName);
+            expect(junctionTable!.database).to.be.equal("yoman");
         }
         await queryRunner.release();
     })));

--- a/test/functional/multi-schema-and-database/custom-junction-schema/custom-junction-schema.ts
+++ b/test/functional/multi-schema-and-database/custom-junction-schema/custom-junction-schema.ts
@@ -24,12 +24,18 @@ describe("multi-schema-and-database > custom-junction-schema", () => {
         const junctionMetadata = connection.getManyToManyMetadata(Post, "categories")!;
         const junctionTable = await queryRunner.getTable("yoman." + junctionMetadata.tableName);
         await queryRunner.release();
+
         expect(postTable).not.to.be.undefined;
-        postTable!.name!.should.be.equal("yoman.post");
+        expect(postTable!.name).to.be.equal("post");
+        expect(postTable!.schema).to.be.equal("yoman");
+
         expect(categoryTable).not.to.be.undefined;
-        categoryTable!.name!.should.be.equal("yoman.category");
+        expect(categoryTable!.name).to.be.equal("category");
+        expect(categoryTable!.schema).to.be.equal("yoman");
+
         expect(junctionTable).not.to.be.undefined;
-        junctionTable!.name!.should.be.equal("yoman." + junctionMetadata.tableName);
+        expect(junctionTable!.name).to.be.equal(junctionMetadata.tableName);
+        expect(junctionTable!.schema).to.be.equal("yoman");
     })));
 
 });

--- a/test/functional/multi-schema-and-database/multi-schema-and-database-basic-functionality/multi-schema-and-database-basic-functionality.ts
+++ b/test/functional/multi-schema-and-database/multi-schema-and-database-basic-functionality/multi-schema-and-database-basic-functionality.ts
@@ -65,7 +65,8 @@ describe("multi-schema-and-database > basic-functionality", () => {
             if (connection.driver instanceof SqlServerDriver)
                 sql.should.be.equal(`SELECT "post"."id" AS "post_id", "post"."name" AS "post_name" FROM "custom"."post" "post" WHERE "post"."id" = @0`);
 
-            table!.name.should.be.equal("custom.post");
+            expect(table!.name).to.be.equal("post");
+            expect(table!.schema).to.be.equal("custom");
         })));
 
         it("should correctly create tables when custom table schema used in Entity decorator", () => Promise.all(connections.map(async connection => {
@@ -88,7 +89,9 @@ describe("multi-schema-and-database > basic-functionality", () => {
             if (connection.driver instanceof SqlServerDriver)
                 sql.should.be.equal(`SELECT "user"."id" AS "user_id", "user"."name" AS "user_name" FROM "userSchema"."user" "user" WHERE "user"."id" = @0`);
 
-            table!.name.should.be.equal("userSchema.user");
+            expect(table!.schema).to.be.equal("userSchema");
+            expect(table!.name).to.be.equal("user");
+
         })));
 
         it("should correctly work with cross-schema queries", () => Promise.all(connections.map(async connection => {
@@ -130,7 +133,8 @@ describe("multi-schema-and-database > basic-functionality", () => {
                     ` "category"."postId" AS "category_postId", "post"."id" AS "post_id", "post"."name" AS "post_name"` +
                     ` FROM "guest"."category" "category" INNER JOIN "custom"."post" "post" ON "post"."id"="category"."postId" WHERE "category"."id" = @0`);
 
-            table!.name.should.be.equal("guest.category");
+            expect(table!.name).to.be.equal("category");
+            expect(table!.schema).to.be.equal("guest");
         })));
 
         it("should correctly work with QueryBuilder", () => Promise.all(connections.map(async connection => {
@@ -214,7 +218,10 @@ describe("multi-schema-and-database > basic-functionality", () => {
                 .getSql();
 
             sql.should.be.equal(`SELECT "question"."id" AS "question_id", "question"."name" AS "question_name" FROM "testDB"."questions"."question" "question" WHERE "question"."id" = @0`);
-            table!.name.should.be.equal("testDB.questions.question");
+
+            expect(table!.database).to.be.equal("testDB");
+            expect(table!.schema).to.be.equal("questions");
+            expect(table!.name).to.be.equal("question");
         })));
 
         it("should correctly work with cross-schema and cross-database queries in QueryBuilder", () => Promise.all(connections.map(async connection => {
@@ -250,8 +257,13 @@ describe("multi-schema-and-database > basic-functionality", () => {
             query.getSql().should.be.equal(`SELECT * FROM "testDB"."questions"."question" "question", "secondDB"."answers"."answer"` +
                 ` "answer" WHERE "question"."id" = @0 AND "answer"."questionId" = "question"."id"`);
 
-            questionTable!.name.should.be.equal("testDB.questions.question");
-            answerTable!.name.should.be.equal("secondDB.answers.answer");
+            expect(questionTable!.database).to.be.equal("testDB");
+            expect(questionTable!.schema).to.be.equal("questions");
+            expect(questionTable!.name).to.be.equal("question");
+
+            expect(answerTable!.database).to.be.equal("secondDB");
+            expect(answerTable!.schema).to.be.equal("answers");
+            expect(answerTable!.name).to.be.equal("answer");
         })));
     });
 
@@ -288,7 +300,8 @@ describe("multi-schema-and-database > basic-functionality", () => {
             if (connection.driver instanceof MysqlDriver)
                 sql.should.be.equal("SELECT `person`.`id` AS `person_id`, `person`.`name` AS `person_name` FROM `secondDB`.`person` `person` WHERE `person`.`id` = ?");
 
-            table!.name.should.be.equal(tablePath);
+            expect(table!.name).to.be.equal("person");
+            expect(table!.database).to.be.equal("secondDB");
         })));
 
     });

--- a/test/github-issues/4415/results-templates.ts
+++ b/test/github-issues/4415/results-templates.ts
@@ -2,12 +2,12 @@ export const resultsTemplates: Record<string, any> = {
 
     postgres: {
         control: [
-            `CREATE TABLE "post" ("id" SERIAL NOT NULL, "title" character varying NOT NULL, "createdAt" TIMESTAMP NOT NULL DEFAULT now(), CONSTRAINT "PK_be5fda3aac270b134ff9c21cdee" PRIMARY KEY ("id"))`,
-            `CREATE TABLE "username" ("username" character varying NOT NULL, "email" character varying NOT NULL, "something" character varying NOT NULL, CONSTRAINT "PK_b39ad32e514b17e90c93988888a" PRIMARY KEY ("username"))`
+            `CREATE TABLE "public"."post" ("id" SERIAL NOT NULL, "title" character varying NOT NULL, "createdAt" TIMESTAMP NOT NULL DEFAULT now(), CONSTRAINT "PK_be5fda3aac270b134ff9c21cdee" PRIMARY KEY ("id"))`,
+            `CREATE TABLE "public"."username" ("username" character varying NOT NULL, "email" character varying NOT NULL, "something" character varying NOT NULL, CONSTRAINT "PK_b39ad32e514b17e90c93988888a" PRIMARY KEY ("username"))`
         ],
         pretty: [
     `
-            CREATE TABLE "post" (
+            CREATE TABLE "public"."post" (
                 "id" SERIAL NOT NULL,
                 "title" character varying NOT NULL,
                 "createdAt" TIMESTAMP NOT NULL DEFAULT now(),
@@ -15,7 +15,7 @@ export const resultsTemplates: Record<string, any> = {
             )
     `,
     `
-            CREATE TABLE "username" (
+            CREATE TABLE "public"."username" (
                 "username" character varying NOT NULL,
                 "email" character varying NOT NULL,
                 "something" character varying NOT NULL,
@@ -27,12 +27,12 @@ export const resultsTemplates: Record<string, any> = {
 
     mssql: {
         control: [
-            `CREATE TABLE "post" ("id" int NOT NULL IDENTITY(1,1), "title" nvarchar(255) NOT NULL, "createdAt" datetime2 NOT NULL CONSTRAINT "DF_fb91bea2d37140a877b775e6b2a" DEFAULT getdate(), CONSTRAINT "PK_be5fda3aac270b134ff9c21cdee" PRIMARY KEY ("id"))`,
-            `CREATE TABLE "username" ("username" nvarchar(255) NOT NULL, "email" nvarchar(255) NOT NULL, "something" nvarchar(255) NOT NULL, CONSTRAINT "PK_b39ad32e514b17e90c93988888a" PRIMARY KEY ("username"))`
+            `CREATE TABLE "tempdb"."dbo"."post" ("id" int NOT NULL IDENTITY(1,1), "title" nvarchar(255) NOT NULL, "createdAt" datetime2 NOT NULL CONSTRAINT "DF_fb91bea2d37140a877b775e6b2a" DEFAULT getdate(), CONSTRAINT "PK_be5fda3aac270b134ff9c21cdee" PRIMARY KEY ("id"))`,
+            `CREATE TABLE "tempdb"."dbo"."username" ("username" nvarchar(255) NOT NULL, "email" nvarchar(255) NOT NULL, "something" nvarchar(255) NOT NULL, CONSTRAINT "PK_b39ad32e514b17e90c93988888a" PRIMARY KEY ("username"))`
         ],
         pretty: [
     `
-            CREATE TABLE "post" (
+            CREATE TABLE "tempdb"."dbo"."post" (
                 "id" int NOT NULL IDENTITY(1, 1),
                 "title" nvarchar(255) NOT NULL,
                 "createdAt" datetime2 NOT NULL CONSTRAINT "DF_fb91bea2d37140a877b775e6b2a" DEFAULT getdate(),
@@ -40,7 +40,7 @@ export const resultsTemplates: Record<string, any> = {
             )
     `,
     `
-            CREATE TABLE "username" (
+            CREATE TABLE "tempdb"."dbo"."username" (
                 "username" nvarchar(255) NOT NULL,
                 "email" nvarchar(255) NOT NULL,
                 "something" nvarchar(255) NOT NULL,
@@ -75,12 +75,12 @@ export const resultsTemplates: Record<string, any> = {
 
     mysql: {
         control: [
-            `CREATE TABLE \`post\` (\`id\` int NOT NULL AUTO_INCREMENT, \`title\` varchar(255) NOT NULL, \`createdAt\` datetime(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6), PRIMARY KEY (\`id\`)) ENGINE=InnoDB`,
-            `CREATE TABLE \`username\` (\`username\` varchar(255) NOT NULL, \`email\` varchar(255) NOT NULL, \`something\` varchar(255) NOT NULL, PRIMARY KEY (\`username\`)) ENGINE=InnoDB`
+            `CREATE TABLE \`test\`.\`post\` (\`id\` int NOT NULL AUTO_INCREMENT, \`title\` varchar(255) NOT NULL, \`createdAt\` datetime(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6), PRIMARY KEY (\`id\`)) ENGINE=InnoDB`,
+            `CREATE TABLE \`test\`.\`username\` (\`username\` varchar(255) NOT NULL, \`email\` varchar(255) NOT NULL, \`something\` varchar(255) NOT NULL, PRIMARY KEY (\`username\`)) ENGINE=InnoDB`
         ],
         pretty: [
     `
-            CREATE TABLE \`post\` (
+            CREATE TABLE \`test\`.\`post\` (
                 \`id\` int NOT NULL AUTO_INCREMENT,
                 \`title\` varchar(255) NOT NULL,
                 \`createdAt\` datetime(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6),
@@ -88,7 +88,7 @@ export const resultsTemplates: Record<string, any> = {
             ) ENGINE = InnoDB
     `,
     `
-            CREATE TABLE \`username\` (
+            CREATE TABLE \`test\`.\`username\` (
                 \`username\` varchar(255) NOT NULL,
                 \`email\` varchar(255) NOT NULL,
                 \`something\` varchar(255) NOT NULL,
@@ -100,12 +100,12 @@ export const resultsTemplates: Record<string, any> = {
 
     oracle: {
         control: [
-            `CREATE TABLE "post" ("id" number GENERATED BY DEFAULT AS IDENTITY, "title" varchar2(255) NOT NULL, "createdAt" timestamp DEFAULT CURRENT_TIMESTAMP NOT NULL, CONSTRAINT "PK_be5fda3aac270b134ff9c21cdee" PRIMARY KEY ("id"))`,
-            `CREATE TABLE "username" ("username" varchar2(255) NOT NULL, "email" varchar2(255) NOT NULL, "something" varchar2(255) NOT NULL, CONSTRAINT "PK_b39ad32e514b17e90c93988888a" PRIMARY KEY ("username"))`
+            `CREATE TABLE "SYSTEM"."post" ("id" number GENERATED BY DEFAULT AS IDENTITY, "title" varchar2(255) NOT NULL, "createdAt" timestamp DEFAULT CURRENT_TIMESTAMP NOT NULL, CONSTRAINT "PK_be5fda3aac270b134ff9c21cdee" PRIMARY KEY ("id"))`,
+            `CREATE TABLE "SYSTEM"."username" ("username" varchar2(255) NOT NULL, "email" varchar2(255) NOT NULL, "something" varchar2(255) NOT NULL, CONSTRAINT "PK_b39ad32e514b17e90c93988888a" PRIMARY KEY ("username"))`
         ],
         pretty: [
     `
-            CREATE TABLE "post" (
+            CREATE TABLE "SYSTEM"."post" (
                 "id" number GENERATED BY DEFAULT AS IDENTITY,
                 "title" varchar2(255) NOT NULL,
                 "createdAt" timestamp DEFAULT CURRENT_TIMESTAMP NOT NULL,
@@ -113,7 +113,7 @@ export const resultsTemplates: Record<string, any> = {
             )
     `,
     `
-            CREATE TABLE "username" (
+            CREATE TABLE "SYSTEM"."username" (
                 "username" varchar2(255) NOT NULL,
                 "email" varchar2(255) NOT NULL,
                 "something" varchar2(255) NOT NULL,
@@ -125,16 +125,16 @@ export const resultsTemplates: Record<string, any> = {
 
     cockroachdb: {
         control: [
-            `CREATE SEQUENCE "post_id_seq"`,
-            `CREATE TABLE "post" ("id" INT DEFAULT nextval('"post_id_seq"') NOT NULL, "title" varchar NOT NULL, "createdAt" timestamptz NOT NULL DEFAULT now(), CONSTRAINT "PK_be5fda3aac270b134ff9c21cdee" PRIMARY KEY ("id"))`,
-            `CREATE TABLE "username" ("username" varchar NOT NULL, "email" varchar NOT NULL, "something" varchar NOT NULL, CONSTRAINT "PK_b39ad32e514b17e90c93988888a" PRIMARY KEY ("username"))`
+            `CREATE SEQUENCE "public"."post_id_seq"`,
+            `CREATE TABLE "public"."post" ("id" INT DEFAULT nextval('"post_id_seq"') NOT NULL, "title" varchar NOT NULL, "createdAt" timestamptz NOT NULL DEFAULT now(), CONSTRAINT "PK_be5fda3aac270b134ff9c21cdee" PRIMARY KEY ("id"))`,
+            `CREATE TABLE "public"."username" ("username" varchar NOT NULL, "email" varchar NOT NULL, "something" varchar NOT NULL, CONSTRAINT "PK_b39ad32e514b17e90c93988888a" PRIMARY KEY ("username"))`
         ],
         pretty: [
     `
-            CREATE SEQUENCE "post_id_seq"
+            CREATE SEQUENCE "public"."post_id_seq"
     `,
     `
-            CREATE TABLE "post" (
+            CREATE TABLE "public"."post" (
                 "id" INT DEFAULT nextval('"post_id_seq"') NOT NULL,
                 "title" varchar NOT NULL,
                 "createdAt" timestamptz NOT NULL DEFAULT now(),
@@ -142,7 +142,7 @@ export const resultsTemplates: Record<string, any> = {
             )
     `,
     `
-            CREATE TABLE "username" (
+            CREATE TABLE "public"."username" (
                 "username" varchar NOT NULL,
                 "email" varchar NOT NULL,
                 "something" varchar NOT NULL,

--- a/test/github-issues/4753/issue-4753.ts
+++ b/test/github-issues/4753/issue-4753.ts
@@ -3,7 +3,7 @@ import { Connection } from "../../../src/connection/Connection";
 import { closeTestingConnections } from "../../utils/test-utils";
 import { User } from "./entity/User";
 
-describe("github issues > #4753 MySQL Replication Config broken", () => {
+describe.skip("github issues > #4753 MySQL Replication Config broken", () => {
     let connections: Connection[] = [];
     after(() => closeTestingConnections(connections));
 

--- a/test/github-issues/7867/entity/Example.ts
+++ b/test/github-issues/7867/entity/Example.ts
@@ -1,0 +1,10 @@
+import { Column, Entity, PrimaryGeneratedColumn } from "../../../../src";
+
+@Entity()
+export class Example {
+    @PrimaryGeneratedColumn()
+    id: number;
+
+    @Column()
+    name: string;
+}

--- a/test/github-issues/7867/issue-7867.ts
+++ b/test/github-issues/7867/issue-7867.ts
@@ -1,0 +1,45 @@
+import "reflect-metadata";
+import { Connection } from "../../../src";
+import { closeTestingConnections, createTestingConnections, reloadTestingDatabases } from "../../utils/test-utils";
+import { Example } from "./entity/Example";
+import { expect } from "chai";
+
+describe("github issues > #7867 Column not renamed when schema is set in Postgres", () => {
+
+    let connections: Connection[];
+    before(async () => {
+        connections = await createTestingConnections({
+            entities: [ Example ],
+            schemaCreate: true,
+            dropSchema: true,
+            driverSpecific: {
+                schema: "public"
+            },
+            enabledDrivers: [ "postgres" ],
+        });
+    });
+    beforeEach(() => reloadTestingDatabases(connections));
+    after(() => closeTestingConnections(connections));
+
+    it("should correctly change column name", () => Promise.all(connections.map(async connection => {
+        const postMetadata = connection.getMetadata(Example);
+        const nameColumn = postMetadata.findColumnWithPropertyName("name")!;
+        nameColumn.propertyName = "title";
+        nameColumn.build(connection);
+
+        await connection.synchronize();
+
+        const queryRunner = connection.createQueryRunner();
+        const postTable = await queryRunner.getTable("example");
+        await queryRunner.release();
+
+        expect(postTable!.findColumnByName("name")).to.be.undefined;
+        postTable!.findColumnByName("title")!.should.be.exist;
+
+        // revert changes
+        nameColumn.propertyName = "name";
+        nameColumn.build(connection);
+    })));
+
+
+});

--- a/test/github-issues/7867/issue-7867.ts
+++ b/test/github-issues/7867/issue-7867.ts
@@ -4,42 +4,79 @@ import { closeTestingConnections, createTestingConnections, reloadTestingDatabas
 import { Example } from "./entity/Example";
 import { expect } from "chai";
 
-describe("github issues > #7867 Column not renamed when schema is set in Postgres", () => {
+describe("github issues > #7867 Column not renamed when schema/database is set", () => {
 
-    let connections: Connection[];
-    before(async () => {
-        connections = await createTestingConnections({
-            entities: [ Example ],
-            schemaCreate: true,
-            dropSchema: true,
-            driverSpecific: {
-                schema: "public"
-            },
-            enabledDrivers: [ "postgres" ],
+    describe('schema is set', () => {
+        let connections: Connection[];
+        before(async () => {
+            connections = await createTestingConnections({
+                entities: [ Example ],
+                schemaCreate: true,
+                dropSchema: true,
+                driverSpecific: {
+                    schema: "public"
+                },
+                enabledDrivers: [ "postgres" ],
+            });
         });
+        beforeEach(() => reloadTestingDatabases(connections));
+        after(() => closeTestingConnections(connections));
+
+        it("should correctly change column name", () => Promise.all(connections.map(async connection => {
+            const postMetadata = connection.getMetadata(Example);
+            const nameColumn = postMetadata.findColumnWithPropertyName("name")!;
+            nameColumn.propertyName = "title";
+            nameColumn.build(connection);
+
+            await connection.synchronize();
+
+            const queryRunner = connection.createQueryRunner();
+            const postTable = await queryRunner.getTable("example");
+            await queryRunner.release();
+
+            expect(postTable!.findColumnByName("name")).to.be.undefined;
+            postTable!.findColumnByName("title")!.should.be.exist;
+
+            // revert changes
+            nameColumn.propertyName = "name";
+            nameColumn.build(connection);
+        })));
     });
-    beforeEach(() => reloadTestingDatabases(connections));
-    after(() => closeTestingConnections(connections));
 
-    it("should correctly change column name", () => Promise.all(connections.map(async connection => {
-        const postMetadata = connection.getMetadata(Example);
-        const nameColumn = postMetadata.findColumnWithPropertyName("name")!;
-        nameColumn.propertyName = "title";
-        nameColumn.build(connection);
+    describe('database is set', () => {
+        let connections: Connection[];
+        before(async () => {
+            connections = await createTestingConnections({
+                entities: [ Example ],
+                schemaCreate: true,
+                dropSchema: true,
+                driverSpecific: {
+                    database: "test"
+                },
+                enabledDrivers: [ "mysql" ],
+            });
+        });
+        beforeEach(() => reloadTestingDatabases(connections));
+        after(() => closeTestingConnections(connections));
 
-        await connection.synchronize();
+        it("should correctly change column name", () => Promise.all(connections.map(async connection => {
+            const postMetadata = connection.getMetadata(Example);
+            const nameColumn = postMetadata.findColumnWithPropertyName("name")!;
+            nameColumn.propertyName = "title";
+            nameColumn.build(connection);
 
-        const queryRunner = connection.createQueryRunner();
-        const postTable = await queryRunner.getTable("example");
-        await queryRunner.release();
+            await connection.synchronize();
 
-        expect(postTable!.findColumnByName("name")).to.be.undefined;
-        postTable!.findColumnByName("title")!.should.be.exist;
+            const queryRunner = connection.createQueryRunner();
+            const postTable = await queryRunner.getTable("example");
+            await queryRunner.release();
 
-        // revert changes
-        nameColumn.propertyName = "name";
-        nameColumn.build(connection);
-    })));
+            expect(postTable!.findColumnByName("name")).to.be.undefined;
+            postTable!.findColumnByName("title")!.should.be.exist;
 
-
+            // revert changes
+            nameColumn.propertyName = "name";
+            nameColumn.build(connection);
+        })));
+    });
 });

--- a/test/utils/test-utils.ts
+++ b/test/utils/test-utils.ts
@@ -252,7 +252,11 @@ export async function createTestingConnections(options?: TestingOptions): Promis
         const queryRunner = connection.createQueryRunner();
 
         for (const database of databases) {
-            await queryRunner.createDatabase(database, true);
+            try {
+                await queryRunner.createDatabase(database, true);
+            } catch (e) {
+                // Do nothing
+            }
         }
 
         if (connection.driver instanceof CockroachDriver) {
@@ -289,7 +293,7 @@ export async function createTestingConnections(options?: TestingOptions): Promis
                 undefined;
 
         if (schema) {
-            schemaPaths.add(schema);
+            schemaPaths.add(connection.driver.database ? `${connection.driver.database}.${schema}` : schema);
         }
 
         for (const schemaPath of schemaPaths) {


### PR DESCRIPTION
<!--
  😀 Wonderful!  Thank you for opening a pull request for TypeORM.

  Please fill in the information below to expedite the review
  and (hopefully) merge of your change.

  If unsure about something.. just do as best as you're able,
  or reach out through our community support channels!
  https://github.com/typeorm/typeorm/blob/master/docs/support.md
-->

### Description of change

<!--
  Please be clear and concise what the change is intended to do,
  why this change is needed, and how you've verified that it
  corrects what you intended.

  In some cases it may be helpful to include the current behavior
  and the new behavior.

  If the change is related to an open issue, you can link it here.
  If you include `Fixes #0000` (replacing `0000` with the issue number)
  when this is merged it will automatically mark the issue as fixed and
  close it.
-->

The changes made as part of #7575 fixed some issues and introduced others.  The problem became that the table name would be compared against the `EntityMetadata` `tablePath`.  This would fail in some cases because while the `EntityMetadata` would specify `database`, it'd be the "default"/current database & would be omitted from the table name.

To work around that this PR introduces the database & schema on the table objects as well as a fully-qualified table path property which will always include all of them for comparing against `EntityMetadata`.

fixes #7867 
fixes #7812
fixes #7737
fixes #6744
fixes #5960
fixes #5958
fixes #5439
fixes #5304

### Pull-Request Checklist

<!--
  Please make sure to review and check all of the following.

  If an item is not applicable, you can add "N/A" to the end.
-->

- [ ] Code is up-to-date with the `master` branch
- [ ] `npm run lint` passes with this change
- [ ] `npm run test` passes with this change
- [ ] This pull request links relevant issues as `Fixes #0000`
- [ ] There are new or updated unit tests validating the change
- [ ] Documentation has been updated to reflect this change
- [ ] The new commits follow conventions explained in [CONTRIBUTING.md](https://github.com/typeorm/typeorm/blob/master/CONTRIBUTING.md)

<!--
  🎉 Thank you for contributing and making TypeORM even better!
-->
