### PR TITLE
fix: use ObjectLiteral in UpdateEvent rather than `Entity`

### DIFF
--- a/src/subscriber/event/UpdateEvent.ts
+++ b/src/subscriber/event/UpdateEvent.ts
@@ -4,6 +4,7 @@ import {EntityManager} from "../../entity-manager/EntityManager";
 import {QueryRunner} from "../../query-runner/QueryRunner";
 import {Connection} from "../../connection/Connection";
 import { EntityMetadata } from "../../metadata/EntityMetadata";
+import { ObjectLiteral } from "../../common/ObjectLiteral";
 
 /**
  * UpdateEvent is an object that broadcaster sends to the entity subscriber when entity is being updated in the database.
@@ -30,7 +31,7 @@ export interface UpdateEvent<Entity> {
     /**
      * Updating entity.
      */
-    entity: Partial<Entity> | undefined;
+    entity: ObjectLiteral | undefined;
 
     /**
      * Metadata of the entity.


### PR DESCRIPTION
<!--
  😀 Wonderful!  Thank you for opening a pull request for TypeORM.

  Please fill in the information below to expedite the review
  and (hopefully) merge of your change.

  If unsure about something.. just do as best as you're able,
  or reach out through our community support channels!
  https://github.com/typeorm/typeorm/blob/master/docs/support.md
-->

### Description of change

<!--
  Please be clear and concise what the change is intended to do,
  why this change is needed, and how you've verified that it
  corrects what you intended.

  In some cases it may be helpful to include the current behavior
  and the new behavior.

  If the change is related to an open issue, you can link it here.
  If you include `Fixes #0000` (replacing `0000` with the issue number)
  when this is merged it will automatically mark the issue as fixed and
  close it.
-->

The typing going into `UpdateEvent.entity` is always an `ObjectLiteral`, so update the typing on the `UpdateEvent` to match.


### Pull-Request Checklist

<!--
  Please make sure to review and check all of the following.

  If an item is not applicable, you can add "N/A" to the end.
-->

- [x] Code is up-to-date with the `master` branch
- [x] `npm run lint` passes with this change
- [x] `npm run test` passes with this change
- [ ] This pull request links relevant issues as `Fixes #0000`
- [ ] There are new or updated unit tests validating the change
- [ ] Documentation has been updated to reflect this change
- [x] The new commits follow conventions explained in [CONTRIBUTING.md](https://github.com/typeorm/typeorm/blob/master/CONTRIBUTING.md)

<!--
  🎉 Thank you for contributing and making TypeORM even better!
-->
