### PR TITLE
fix: use correct query for cross-database mssql identity check

### DIFF
--- a/src/driver/sqlserver/SqlServerQueryRunner.ts
+++ b/src/driver/sqlserver/SqlServerQueryRunner.ts
@@ -1639,7 +1639,7 @@ export class SqlServerQueryRunner extends BaseQueryRunner implements QueryRunner
             return `SELECT "TABLE_CATALOG", "TABLE_SCHEMA", "COLUMN_NAME", "TABLE_NAME" ` +
                 `FROM "${TABLE_CATALOG}"."INFORMATION_SCHEMA"."COLUMNS" ` +
                 `WHERE ` +
-                `COLUMNPROPERTY(object_id("TABLE_CATALOG" + '.' + "TABLE_SCHEMA" + '.' + "TABLE_NAME"), "COLUMN_NAME", 'IsIdentity') = 1 AND ` +
+                `EXISTS(SELECT 1 FROM "${TABLE_CATALOG}"."SYS"."COLUMNS" "S" WHERE OBJECT_ID("TABLE_CATALOG" + '.' + "TABLE_SCHEMA" + '.' + "TABLE_NAME") = "S"."OBJECT_ID" AND "COLUMN_NAME" = "S"."NAME" AND "S"."is_identity" = 1) AND ` +
                 `(${conditions})`;
         }).join(" UNION ALL ");
 

--- a/test/functional/multi-schema-and-database/multi-schema-and-database-basic-functionality/multi-schema-and-database-basic-functionality.ts
+++ b/test/functional/multi-schema-and-database/multi-schema-and-database-basic-functionality/multi-schema-and-database-basic-functionality.ts
@@ -27,6 +27,15 @@ describe("multi-schema-and-database > basic-functionality", () => {
         beforeEach(() => reloadTestingDatabases(connections));
         after(() => closeTestingConnections(connections));
 
+        it("should correctly get the table primary keys when custom table schema used", () => Promise.all(connections.map(async connection => {
+            const queryRunner = connection.createQueryRunner();
+            const table = (await queryRunner.getTable("post"))!;
+            await queryRunner.release();
+
+            expect(table.primaryColumns).to.have.length(1);
+            expect(table.findColumnByName("id")?.isGenerated).to.be.true;
+        })));
+
         it("should correctly create tables when custom table schema used", () => Promise.all(connections.map(async connection => {
 
             const queryRunner = connection.createQueryRunner();
@@ -161,6 +170,15 @@ describe("multi-schema-and-database > basic-functionality", () => {
         });
         beforeEach(() => reloadTestingDatabases(connections));
         after(() => closeTestingConnections(connections));
+
+        it("should correctly get the table primary keys when custom table schema used", () => Promise.all(connections.map(async connection => {
+            const queryRunner = connection.createQueryRunner();
+            const table = (await queryRunner.getTable("testDB.questions.question"))!;
+            await queryRunner.release();
+
+            expect(table.primaryColumns).to.have.length(1);
+            expect(table.findColumnByName("id")?.isGenerated).to.be.true;
+        })));
 
         it("should correctly create tables when custom database and custom schema used in Entity decorator", () => Promise.all(connections.map(async connection => {
 


### PR DESCRIPTION
<!--
  😀 Wonderful!  Thank you for opening a pull request for TypeORM.

  Please fill in the information below to expedite the review
  and (hopefully) merge of your change.

  If unsure about something.. just do as best as you're able,
  or reach out through our community support channels!
  https://github.com/typeorm/typeorm/blob/master/docs/support.md
-->

### Description of change

<!--
  Please be clear and concise what the change is intended to do,
  why this change is needed, and how you've verified that it
  corrects what you intended.

  In some cases it may be helpful to include the current behavior
  and the new behavior.

  If the change is related to an open issue, you can link it here.
  If you include `Fixes #0000` (replacing `0000` with the issue number)
  when this is merged it will automatically mark the issue as fixed and
  close it.
-->

COLUMNPROPERTY only works in the same database so this query was
always incorrect.  instead, use `SYS.COLUMNS` and the `is_identity`
field to check for idenitty columns

### Pull-Request Checklist

<!--
  Please make sure to review and check all of the following.

  If an item is not applicable, you can add "N/A" to the end.
-->

- [x] Code is up-to-date with the `master` branch
- [x] `npm run lint` passes with this change
- [x] `npm run test` passes with this change
- [ ] This pull request links relevant issues as `Fixes #0000`
- [x] There are new or updated unit tests validating the change
- [ ] Documentation has been updated to reflect this change
- [x] The new commits follow conventions explained in [CONTRIBUTING.md](https://github.com/typeorm/typeorm/blob/master/CONTRIBUTING.md)

<!--
  🎉 Thank you for contributing and making TypeORM even better!
-->
