### PR TITLE
fix: disable SQLite FK checks in synchronize / migrations

### DIFF
--- a/src/driver/better-sqlite3/BetterSqlite3QueryRunner.ts
+++ b/src/driver/better-sqlite3/BetterSqlite3QueryRunner.ts
@@ -59,6 +59,20 @@ export class BetterSqlite3QueryRunner extends AbstractSqliteQueryRunner {
     }
 
     /**
+     * Called before migrations are run.
+     */
+    async beforeMigration(): Promise<void> {
+        await this.query(`PRAGMA foreign_keys = OFF`);
+    }
+
+    /**
+     * Called after migrations are run.
+     */
+    async afterMigration(): Promise<void> {
+        await this.query(`PRAGMA foreign_keys = ON`);
+    }
+
+    /**
      * Executes a given SQL query.
      */
     async query(query: string, parameters?: any[], useStructuredResult = false): Promise<any> {

--- a/src/driver/capacitor/CapacitorQueryRunner.ts
+++ b/src/driver/capacitor/CapacitorQueryRunner.ts
@@ -26,6 +26,20 @@ export class CapacitorQueryRunner extends AbstractSqliteQueryRunner {
         this.broadcaster = new Broadcaster(this);
     }
 
+    /**
+     * Called before migrations are run.
+     */
+    async beforeMigration(): Promise<void> {
+        await this.query(`PRAGMA foreign_keys = OFF`);
+    }
+
+    /**
+     * Called after migrations are run.
+     */
+    async afterMigration(): Promise<void> {
+        await this.query(`PRAGMA foreign_keys = ON`);
+    }
+
     async executeSet(set: { statement: string; values?: any[] }[]) {
         if (this.isReleased) throw new QueryRunnerAlreadyReleasedError();
 

--- a/src/driver/cordova/CordovaQueryRunner.ts
+++ b/src/driver/cordova/CordovaQueryRunner.ts
@@ -29,6 +29,20 @@ export class CordovaQueryRunner extends AbstractSqliteQueryRunner {
     }
 
     /**
+     * Called before migrations are run.
+     */
+    async beforeMigration(): Promise<void> {
+        await this.query(`PRAGMA foreign_keys = OFF`);
+    }
+
+    /**
+     * Called after migrations are run.
+     */
+    async afterMigration(): Promise<void> {
+        await this.query(`PRAGMA foreign_keys = ON`);
+    }
+
+    /**
      * Executes a given SQL query.
      */
     async query(query: string, parameters?: any[], useStructuredResult = false): Promise<any> {

--- a/src/driver/expo/ExpoQueryRunner.ts
+++ b/src/driver/expo/ExpoQueryRunner.ts
@@ -127,6 +127,20 @@ export class ExpoQueryRunner extends AbstractSqliteQueryRunner {
     }
 
     /**
+     * Called before migrations are run.
+     */
+    async beforeMigration(): Promise<void> {
+        await this.query(`PRAGMA foreign_keys = OFF`);
+    }
+
+    /**
+     * Called after migrations are run.
+     */
+    async afterMigration(): Promise<void> {
+        await this.query(`PRAGMA foreign_keys = ON`);
+    }
+
+    /**
      * Executes a given SQL query.
      */
     async query(query: string, parameters?: any[], useStructuredResult = false): Promise<any> {

--- a/src/driver/mongodb/MongoQueryRunner.ts
+++ b/src/driver/mongodb/MongoQueryRunner.ts
@@ -121,6 +121,20 @@ export class MongoQueryRunner implements QueryRunner {
     // -------------------------------------------------------------------------
 
     /**
+     * Called before migrations are run.
+     */
+    async beforeMigration(): Promise<void> {
+        // Do nothing
+    }
+
+    /**
+     * Called after migrations are run.
+     */
+    async afterMigration(): Promise<void> {
+        // Do nothing
+    }
+
+    /**
      * Creates a cursor for a query that can be used to iterate over results from MongoDB.
      */
     cursor(collectionName: string, query?: ObjectLiteral): Cursor<any> {

--- a/src/driver/nativescript/NativescriptQueryRunner.ts
+++ b/src/driver/nativescript/NativescriptQueryRunner.ts
@@ -28,6 +28,20 @@ export class NativescriptQueryRunner extends AbstractSqliteQueryRunner {
     }
 
     /**
+     * Called before migrations are run.
+     */
+    async beforeMigration(): Promise<void> {
+        await this.query(`PRAGMA foreign_keys = OFF`);
+    }
+
+    /**
+     * Called after migrations are run.
+     */
+    async afterMigration(): Promise<void> {
+        await this.query(`PRAGMA foreign_keys = ON`);
+    }
+
+    /**
      * Executes a given SQL query.
      */
     async query(query: string, parameters?: any[], useStructuredResult = false): Promise<any> {

--- a/src/driver/react-native/ReactNativeQueryRunner.ts
+++ b/src/driver/react-native/ReactNativeQueryRunner.ts
@@ -28,6 +28,20 @@ export class ReactNativeQueryRunner extends AbstractSqliteQueryRunner {
     }
 
     /**
+     * Called before migrations are run.
+     */
+    async beforeMigration(): Promise<void> {
+        await this.query(`PRAGMA foreign_keys = OFF`);
+    }
+
+    /**
+     * Called after migrations are run.
+     */
+    async afterMigration(): Promise<void> {
+        await this.query(`PRAGMA foreign_keys = ON`);
+    }
+
+    /**
      * Executes a given SQL query.
      */
     query(query: string, parameters?: any[], useStructuredResult = false): Promise<any> {

--- a/src/driver/sqlite/SqliteQueryRunner.ts
+++ b/src/driver/sqlite/SqliteQueryRunner.ts
@@ -32,6 +32,20 @@ export class SqliteQueryRunner extends AbstractSqliteQueryRunner {
     }
 
     /**
+     * Called before migrations are run.
+     */
+    async beforeMigration(): Promise<void> {
+        await this.query(`PRAGMA foreign_keys = OFF`);
+    }
+
+    /**
+     * Called after migrations are run.
+     */
+    async afterMigration(): Promise<void> {
+        await this.query(`PRAGMA foreign_keys = ON`);
+    }
+
+    /**
      * Executes a given SQL query.
      */
     query(query: string, parameters?: any[], useStructuredResult = false): Promise<any> {

--- a/src/driver/sqljs/SqljsQueryRunner.ts
+++ b/src/driver/sqljs/SqljsQueryRunner.ts
@@ -35,6 +35,20 @@ export class SqljsQueryRunner extends AbstractSqliteQueryRunner {
     // Public methods
     // -------------------------------------------------------------------------
 
+    /**
+     * Called before migrations are run.
+     */
+    async beforeMigration(): Promise<void> {
+        await this.query(`PRAGMA foreign_keys = OFF`);
+    }
+
+    /**
+     * Called after migrations are run.
+     */
+    async afterMigration(): Promise<void> {
+        await this.query(`PRAGMA foreign_keys = ON`);
+    }
+
     private async flush() {
         if (this.isDirty) {
             await this.driver.autoSave();

--- a/src/migration/MigrationExecutor.ts
+++ b/src/migration/MigrationExecutor.ts
@@ -60,7 +60,9 @@ export class MigrationExecutor {
     public async executeMigration(migration: Migration): Promise<Migration> {
         return this.withQueryRunner(async (queryRunner) => {
             await this.createMigrationsTableIfNotExist(queryRunner);
+            await queryRunner.beforeMigration();
             await (migration.instance as any).up(queryRunner);
+            await queryRunner.afterMigration();
             await this.insertExecutedMigration(queryRunner, migration);
 
             return migration;
@@ -308,7 +310,10 @@ export class MigrationExecutor {
         }
 
         try {
+            await queryRunner.beforeMigration();
             await migrationToRevert.instance!.down(queryRunner);
+            await queryRunner.afterMigration();
+
             await this.deleteExecutedMigration(queryRunner, migrationToRevert);
             this.connection.logger.logSchemaBuild(`Migration ${migrationToRevert.name} has been reverted successfully.`);
 

--- a/src/query-runner/BaseQueryRunner.ts
+++ b/src/query-runner/BaseQueryRunner.ts
@@ -109,6 +109,20 @@ export abstract class BaseQueryRunner {
     // -------------------------------------------------------------------------
 
     /**
+     * Called before migrations are run.
+     */
+    async beforeMigration(): Promise<void> {
+        // Do nothing
+    }
+
+    /**
+     * Called after migrations are run.
+     */
+    async afterMigration(): Promise<void> {
+        // Do nothing
+    }
+
+    /**
      * Loads given table's data from the database.
      */
     async getTable(tablePath: string): Promise<Table|undefined> {

--- a/src/query-runner/QueryRunner.ts
+++ b/src/query-runner/QueryRunner.ts
@@ -73,6 +73,16 @@ export interface QueryRunner {
     connect(): Promise<any>;
 
     /**
+     * Called before migrations are run.
+     */
+    beforeMigration(): Promise<void>;
+
+    /**
+     * Called after migrations are run.
+     */
+    afterMigration(): Promise<void>;
+
+    /**
      * Releases used database connection.
      * You cannot use query runner methods after connection is released.
      */

--- a/src/schema-builder/RdbmsSchemaBuilder.ts
+++ b/src/schema-builder/RdbmsSchemaBuilder.ts
@@ -68,6 +68,8 @@ export class RdbmsSchemaBuilder implements SchemaBuilder {
             this.connection.options.migrationsTransactionMode !== "none"
         );
 
+        await this.queryRunner.beforeMigration();
+
         if (isUsingTransactions) {
             await this.queryRunner.startTransaction();
         }
@@ -102,6 +104,9 @@ export class RdbmsSchemaBuilder implements SchemaBuilder {
             throw error;
 
         } finally {
+
+            await this.queryRunner.afterMigration();
+
             await this.queryRunner.release();
         }
     }

--- a/test/functional/schema-builder/entity/Post.ts
+++ b/test/functional/schema-builder/entity/Post.ts
@@ -20,7 +20,7 @@ export class Post {
     @Column({ default: "My post" })
     name: string;
 
-    @Column()
+    @Column({ nullable: true })
     text: string;
 
     @Column()

--- a/test/functional/sqljs/auto-save.ts
+++ b/test/functional/sqljs/auto-save.ts
@@ -34,7 +34,7 @@ describe("sqljs driver > autosave", () => {
         await connection.createQueryBuilder().insert().into(Post).values(posts).execute();
         await connection.createQueryBuilder().update(Post).set({title: "Many posts"}).execute();
         await connection.createQueryBuilder().delete().from(Post).where("title = ?", {title: "third post"}).execute();
-        
+
         const repository = connection.getRepository(Post);
         let post = new Post();
         post.title = "A post";
@@ -52,7 +52,7 @@ describe("sqljs driver > autosave", () => {
 
         await connection.close();
 
-        expect(saves).to.be.equal(7);
+        expect(saves).to.be.equal(8);
     })));
 });
 


### PR DESCRIPTION
<!--
  😀 Wonderful!  Thank you for opening a pull request for TypeORM.

  Please fill in the information below to expedite the review
  and (hopefully) merge of your change.

  If unsure about something.. just do as best as you're able,
  or reach out through our community support channels!
  https://github.com/typeorm/typeorm/blob/master/docs/support.md
-->

### Description of change

<!--
  Please be clear and concise what the change is intended to do,
  why this change is needed, and how you've verified that it
  corrects what you intended.

  In some cases it may be helpful to include the current behavior
  and the new behavior.

  If the change is related to an open issue, you can link it here.
  If you include `Fixes #0000` (replacing `0000` with the issue number)
  when this is merged it will automatically mark the issue as fixed and
  close it.
-->

this moves the `PRAGMA` calls to where we need them in the sqlite migration generation / synchronize

fixes #2576

### Pull-Request Checklist

<!--
  Please make sure to review and check all of the following.

  If an item is not applicable, you can add "N/A" to the end.
-->

- [x] Code is up-to-date with the `master` branch
- [x] `npm run lint` passes with this change
- [x] `npm run test` passes with this change
- [x] This pull request links relevant issues as `Fixes #0000`
- [ ] There are new or updated unit tests validating the change
- [ ] Documentation has been updated to reflect this change
- [x] The new commits follow conventions explained in [CONTRIBUTING.md](https://github.com/typeorm/typeorm/blob/master/CONTRIBUTING.md)

<!--
  🎉 Thank you for contributing and making TypeORM even better!
-->
