### PR TITLE
feat: add depth limiter optional parameter when loading nested trees

### DIFF
--- a/docs/tree-entities.md
+++ b/docs/tree-entities.md
@@ -203,6 +203,9 @@ There are other special methods to work with tree entities through `TreeReposito
 ```typescript
 const treeCategories = await repository.findTrees();
 // returns root categories with sub categories inside
+
+const treeCategoriesWithLimitedDepth = await repository.findTrees({ depth: 2 });
+// returns root categories with sub categories inside, up to depth 2
 ```
 
 * `findRoots` - Roots are entities that have no ancestors. Finds them all.
@@ -225,6 +228,8 @@ const children = await repository.findDescendants(parentCategory);
 ```typescript
 const childrenTree = await repository.findDescendantsTree(parentCategory);
 // returns all direct subcategories (with its nested categories) of a parentCategory
+const childrenTreeWithLimitedDepth = await repository.findDescendantsTree(parentCategory, { depth: 2 });
+// returns all direct subcategories (with its nested categories) of a parentCategory, up to depth 2
 ```
 
 * `createDescendantsQueryBuilder` - Creates a query builder used to get descendants of the entities in a tree.
@@ -279,10 +284,10 @@ For the following methods, options can be passed:
 * findAncestors
 * findAncestorsTree
 
-The following options are available: 
+The following options are available:
 * `relations` - Indicates what relations of entity should be loaded (simplified left join form).
 
-Examples: 
+Examples:
 ```typescript
 const treeCategoriesWithRelations = await repository.findTrees({ relations: ["sites"] });
 // automatically joins the sites relation

--- a/src/find-options/FindTreeOptions.ts
+++ b/src/find-options/FindTreeOptions.ts
@@ -3,9 +3,14 @@
  */
 export interface FindTreeOptions {
 
-  /**
-    * Indicates what relations of entity should be loaded (simplified left join form).
-   */
-  relations?: string[];
+    /**
+     * Indicates what relations of entity should be loaded (simplified left join form).
+     */
+    relations?: string[];
+
+    /**
+     * When loading a tree from a TreeRepository, limits the depth of the descendents loaded
+     */
+    depth?: number;
 
 }

--- a/src/repository/FindTreesOptions.ts
+++ b/src/repository/FindTreesOptions.ts
@@ -1,0 +1,11 @@
+/**
+ * Special options passed to TreeRepository#findTrees
+ */
+export interface FindTreesOptions {
+
+    /**
+     * When loading a tree from a TreeRepository, limits the depth of the descendents loaded
+     */
+    depth?: number;
+
+}

--- a/test/functional/tree-tables/closure-table/closure-table.ts
+++ b/test/functional/tree-tables/closure-table/closure-table.ts
@@ -1,7 +1,7 @@
 import "reflect-metadata";
-import {Category} from "./entity/Category";
-import {Connection} from "../../../../src/connection/Connection";
-import {closeTestingConnections, createTestingConnections, reloadTestingDatabases} from "../../../utils/test-utils";
+import { Category } from "./entity/Category";
+import { Connection } from "../../../../src/connection/Connection";
+import { closeTestingConnections, createTestingConnections, reloadTestingDatabases } from "../../../utils/test-utils";
 
 describe("tree tables > closure-table", () => {
 
@@ -188,4 +188,414 @@ describe("tree tables > closure-table", () => {
         // a1ChildrenNames2.should.deep.include("a12");
     })));
 
+    describe("findTrees() tests", () => {
+        it("findTrees should load all category roots and attached children", () => Promise.all(connections.map(async connection => {
+            const categoryRepository = connection.getTreeRepository(Category);
+
+            const a1 = new Category();
+            a1.name = "a1";
+
+            const a11 = new Category();
+            a11.name = "a11";
+
+            const a12 = new Category();
+            a12.name = "a12";
+
+            const a111 = new Category();
+            a111.name = "a111";
+
+            const a112 = new Category();
+            a112.name = "a112";
+
+            a1.childCategories = [a11, a12];
+            a11.childCategories = [a111, a112];
+            await categoryRepository.save(a1);
+
+            const categoriesTree = await categoryRepository.findTrees();
+            categoriesTree.should.be.eql([
+                {
+                    id: a1.id,
+                    name: "a1",
+                    childCategories: [
+                        {
+                            id: a11.id,
+                            name: "a11",
+                            childCategories: [
+                                {
+                                    id: a111.id,
+                                    name: "a111",
+                                    childCategories: []
+                                },
+                                {
+                                    id: a112.id,
+                                    name: "a112",
+                                    childCategories: []
+                                }
+                            ]
+                        },
+                        {
+                            id: a12.id,
+                            name: "a12",
+                            childCategories: []
+                        }
+                    ]
+                }
+            ]);
+        })));
+
+        it("findTrees should load multiple category roots if they exist", () => Promise.all(connections.map(async connection => {
+            const categoryRepository = connection.getTreeRepository(Category);
+
+            const a1 = new Category();
+            a1.name = "a1";
+
+            const a11 = new Category();
+            a11.name = "a11";
+
+            const a12 = new Category();
+            a12.name = "a12";
+
+            const a111 = new Category();
+            a111.name = "a111";
+
+            const a112 = new Category();
+            a112.name = "a112";
+
+            a1.childCategories = [a11, a12];
+            a11.childCategories = [a111, a112];
+            await categoryRepository.save(a1);
+
+            const b1 = new Category();
+            b1.name = "b1";
+
+            const b11 = new Category();
+            b11.name = "b11";
+
+            const b12 = new Category();
+            b12.name = "b12";
+
+            b1.childCategories = [b11, b12];
+            await categoryRepository.save(b1);
+
+            const categoriesTree = await categoryRepository.findTrees();
+            categoriesTree.should.be.eql([
+                {
+                    id: a1.id,
+                    name: "a1",
+                    childCategories: [
+                        {
+                            id: a11.id,
+                            name: "a11",
+                            childCategories: [
+                                {
+                                    id: a111.id,
+                                    name: "a111",
+                                    childCategories: []
+                                },
+                                {
+                                    id: a112.id,
+                                    name: "a112",
+                                    childCategories: []
+                                }
+                            ]
+                        },
+                        {
+                            id: a12.id,
+                            name: "a12",
+                            childCategories: []
+                        }
+                    ]
+                }, {
+                    id: b1.id,
+                    name: "b1",
+                    childCategories: [
+                        {
+                            id: b11.id,
+                            name: "b11",
+                            childCategories: []
+                        },
+                        {
+                            id: b12.id,
+                            name: "b12",
+                            childCategories: []
+                        }
+                    ]
+                }
+            ]);
+        })));
+
+        it("findTrees should filter by depth if optionally provided", () => Promise.all(connections.map(async connection => {
+            const categoryRepository = connection.getTreeRepository(Category);
+
+            const a1 = new Category();
+            a1.name = "a1";
+
+            const a11 = new Category();
+            a11.name = "a11";
+
+            const a12 = new Category();
+            a12.name = "a12";
+
+            const a111 = new Category();
+            a111.name = "a111";
+
+            const a112 = new Category();
+            a112.name = "a112";
+
+            a1.childCategories = [a11, a12];
+            a11.childCategories = [a111, a112];
+            await categoryRepository.save(a1);
+
+            const categoriesTree = await categoryRepository.findTrees();
+            categoriesTree.should.be.eql([
+                {
+                    id: a1.id,
+                    name: "a1",
+                    childCategories: [
+                        {
+                            id: a11.id,
+                            name: "a11",
+                            childCategories: [
+                                {
+                                    id: a111.id,
+                                    name: "a111",
+                                    childCategories: []
+                                },
+                                {
+                                    id: a112.id,
+                                    name: "a112",
+                                    childCategories: []
+                                }
+                            ]
+                        },
+                        {
+                            id: a12.id,
+                            name: "a12",
+                            childCategories: []
+                        }
+                    ]
+                }
+            ]);
+
+            const categoriesTreeWithEmptyOptions = await categoryRepository.findTrees({});
+            categoriesTreeWithEmptyOptions.should.be.eql([
+                {
+                    id: a1.id,
+                    name: "a1",
+                    childCategories: [
+                        {
+                            id: a11.id,
+                            name: "a11",
+                            childCategories: [
+                                {
+                                    id: a111.id,
+                                    name: "a111",
+                                    childCategories: []
+                                },
+                                {
+                                    id: a112.id,
+                                    name: "a112",
+                                    childCategories: []
+                                }
+                            ]
+                        },
+                        {
+                            id: a12.id,
+                            name: "a12",
+                            childCategories: []
+                        }
+                    ]
+                }
+            ]);
+
+            const categoriesTreeWithDepthZero = await categoryRepository.findTrees({ depth: 0 });
+            categoriesTreeWithDepthZero.should.be.eql([
+                {
+                    id: a1.id,
+                    name: "a1",
+                    childCategories: []
+                }
+            ]);
+
+            const categoriesTreeWithDepthOne = await categoryRepository.findTrees({ depth: 1 });
+            categoriesTreeWithDepthOne.should.be.eql([
+                {
+                    id: a1.id,
+                    name: "a1",
+                    childCategories: [
+                        {
+                            id: a11.id,
+                            name: "a11",
+                            childCategories: []
+                        },
+                        {
+                            id: a12.id,
+                            name: "a12",
+                            childCategories: []
+                        }
+                    ]
+                }
+            ]);
+        })));
+    });
+
+    describe("findDescendantsTree() tests", () => {
+        it("findDescendantsTree should load all category descendents and nested children", () => Promise.all(connections.map(async connection => {
+            const categoryRepository = connection.getTreeRepository(Category);
+
+            const a1 = new Category();
+            a1.name = "a1";
+
+            const a11 = new Category();
+            a11.name = "a11";
+
+            const a12 = new Category();
+            a12.name = "a12";
+
+            const a111 = new Category();
+            a111.name = "a111";
+
+            const a112 = new Category();
+            a112.name = "a112";
+
+            a1.childCategories = [a11, a12];
+            a11.childCategories = [a111, a112];
+            await categoryRepository.save(a1);
+
+            const categoriesTree = await categoryRepository.findDescendantsTree(a1);
+            categoriesTree.should.be.eql({
+                id: a1.id,
+                name: "a1",
+                childCategories: [
+                    {
+                        id: a11.id,
+                        name: "a11",
+                        childCategories: [
+                            {
+                                id: a111.id,
+                                name: "a111",
+                                childCategories: []
+                            },
+                            {
+                                id: a112.id,
+                                name: "a112",
+                                childCategories: []
+                            }
+                        ]
+                    },
+                    {
+                        id: a12.id,
+                        name: "a12",
+                        childCategories: []
+                    }
+                ]
+            });
+        })));
+
+        it("findDescendantsTree should filter by depth if optionally provided", () => Promise.all(connections.map(async connection => {
+            const categoryRepository = connection.getTreeRepository(Category);
+
+            const a1 = new Category();
+            a1.name = "a1";
+
+            const a11 = new Category();
+            a11.name = "a11";
+
+            const a12 = new Category();
+            a12.name = "a12";
+
+            const a111 = new Category();
+            a111.name = "a111";
+
+            const a112 = new Category();
+            a112.name = "a112";
+
+            a1.childCategories = [a11, a12];
+            a11.childCategories = [a111, a112];
+            await categoryRepository.save(a1);
+
+            const categoriesTree = await categoryRepository.findDescendantsTree(a1);
+            categoriesTree.should.be.eql({
+                id: a1.id,
+                name: "a1",
+                childCategories: [
+                    {
+                        id: a11.id,
+                        name: "a11",
+                        childCategories: [
+                            {
+                                id: a111.id,
+                                name: "a111",
+                                childCategories: []
+                            },
+                            {
+                                id: a112.id,
+                                name: "a112",
+                                childCategories: []
+                            }
+                        ]
+                    },
+                    {
+                        id: a12.id,
+                        name: "a12",
+                        childCategories: []
+                    }
+                ]
+            });
+
+            const categoriesTreeWithEmptyOptions = await categoryRepository.findDescendantsTree(a1, {});
+            categoriesTreeWithEmptyOptions.should.be.eql({
+                id: a1.id,
+                name: "a1",
+                childCategories: [
+                    {
+                        id: a11.id,
+                        name: "a11",
+                        childCategories: [
+                            {
+                                id: a111.id,
+                                name: "a111",
+                                childCategories: []
+                            },
+                            {
+                                id: a112.id,
+                                name: "a112",
+                                childCategories: []
+                            }
+                        ]
+                    },
+                    {
+                        id: a12.id,
+                        name: "a12",
+                        childCategories: []
+                    }
+                ]
+            });
+
+            const categoriesTreeWithDepthZero = await categoryRepository.findDescendantsTree(a1, { depth: 0 });
+            categoriesTreeWithDepthZero.should.be.eql({
+                id: a1.id,
+                name: "a1",
+                childCategories: []
+            });
+
+            const categoriesTreeWithDepthOne = await categoryRepository.findDescendantsTree(a1, { depth: 1 });
+            categoriesTreeWithDepthOne.should.be.eql({
+                id: a1.id,
+                name: "a1",
+                childCategories: [
+                    {
+                        id: a11.id,
+                        name: "a11",
+                        childCategories: []
+                    },
+                    {
+                        id: a12.id,
+                        name: "a12",
+                        childCategories: []
+                    }
+                ]
+            });
+        })));
+    });
 });

--- a/test/functional/tree-tables/materialized-path/materialized-path.ts
+++ b/test/functional/tree-tables/materialized-path/materialized-path.ts
@@ -1,7 +1,7 @@
 import "reflect-metadata";
-import {Category} from "./entity/Category";
-import {Connection} from "../../../../src/connection/Connection";
-import {closeTestingConnections, createTestingConnections, reloadTestingDatabases} from "../../../utils/test-utils";
+import { Category } from "./entity/Category";
+import { Connection } from "../../../../src/connection/Connection";
+import { closeTestingConnections, createTestingConnections, reloadTestingDatabases } from "../../../utils/test-utils";
 
 describe("tree tables > materialized-path", () => {
 
@@ -164,4 +164,414 @@ describe("tree tables > materialized-path", () => {
         a1ChildrenNames.should.deep.include("a112");
     })));
 
+    describe("findTrees() tests", () => {
+        it("findTrees should load all category roots and attached children", () => Promise.all(connections.map(async connection => {
+            const categoryRepository = connection.getTreeRepository(Category);
+
+            const a1 = new Category();
+            a1.name = "a1";
+
+            const a11 = new Category();
+            a11.name = "a11";
+
+            const a12 = new Category();
+            a12.name = "a12";
+
+            const a111 = new Category();
+            a111.name = "a111";
+
+            const a112 = new Category();
+            a112.name = "a112";
+
+            a1.childCategories = [a11, a12];
+            a11.childCategories = [a111, a112];
+            await categoryRepository.save(a1);
+
+            const categoriesTree = await categoryRepository.findTrees();
+            categoriesTree.should.be.eql([
+                {
+                    id: a1.id,
+                    name: "a1",
+                    childCategories: [
+                        {
+                            id: a11.id,
+                            name: "a11",
+                            childCategories: [
+                                {
+                                    id: a111.id,
+                                    name: "a111",
+                                    childCategories: []
+                                },
+                                {
+                                    id: a112.id,
+                                    name: "a112",
+                                    childCategories: []
+                                }
+                            ]
+                        },
+                        {
+                            id: a12.id,
+                            name: "a12",
+                            childCategories: []
+                        }
+                    ]
+                }
+            ]);
+        })));
+
+        it("findTrees should load multiple category roots if they exist", () => Promise.all(connections.map(async connection => {
+            const categoryRepository = connection.getTreeRepository(Category);
+
+            const a1 = new Category();
+            a1.name = "a1";
+
+            const a11 = new Category();
+            a11.name = "a11";
+
+            const a12 = new Category();
+            a12.name = "a12";
+
+            const a111 = new Category();
+            a111.name = "a111";
+
+            const a112 = new Category();
+            a112.name = "a112";
+
+            a1.childCategories = [a11, a12];
+            a11.childCategories = [a111, a112];
+            await categoryRepository.save(a1);
+
+            const b1 = new Category();
+            b1.name = "b1";
+
+            const b11 = new Category();
+            b11.name = "b11";
+
+            const b12 = new Category();
+            b12.name = "b12";
+
+            b1.childCategories = [b11, b12];
+            await categoryRepository.save(b1);
+
+            const categoriesTree = await categoryRepository.findTrees();
+            categoriesTree.should.be.eql([
+                {
+                    id: a1.id,
+                    name: "a1",
+                    childCategories: [
+                        {
+                            id: a11.id,
+                            name: "a11",
+                            childCategories: [
+                                {
+                                    id: a111.id,
+                                    name: "a111",
+                                    childCategories: []
+                                },
+                                {
+                                    id: a112.id,
+                                    name: "a112",
+                                    childCategories: []
+                                }
+                            ]
+                        },
+                        {
+                            id: a12.id,
+                            name: "a12",
+                            childCategories: []
+                        }
+                    ]
+                }, {
+                    id: b1.id,
+                    name: "b1",
+                    childCategories: [
+                        {
+                            id: b11.id,
+                            name: "b11",
+                            childCategories: []
+                        },
+                        {
+                            id: b12.id,
+                            name: "b12",
+                            childCategories: []
+                        }
+                    ]
+                }
+            ]);
+        })));
+
+        it("findTrees should filter by depth if optionally provided", () => Promise.all(connections.map(async connection => {
+            const categoryRepository = connection.getTreeRepository(Category);
+
+            const a1 = new Category();
+            a1.name = "a1";
+
+            const a11 = new Category();
+            a11.name = "a11";
+
+            const a12 = new Category();
+            a12.name = "a12";
+
+            const a111 = new Category();
+            a111.name = "a111";
+
+            const a112 = new Category();
+            a112.name = "a112";
+
+            a1.childCategories = [a11, a12];
+            a11.childCategories = [a111, a112];
+            await categoryRepository.save(a1);
+
+            const categoriesTree = await categoryRepository.findTrees();
+            categoriesTree.should.be.eql([
+                {
+                    id: a1.id,
+                    name: "a1",
+                    childCategories: [
+                        {
+                            id: a11.id,
+                            name: "a11",
+                            childCategories: [
+                                {
+                                    id: a111.id,
+                                    name: "a111",
+                                    childCategories: []
+                                },
+                                {
+                                    id: a112.id,
+                                    name: "a112",
+                                    childCategories: []
+                                }
+                            ]
+                        },
+                        {
+                            id: a12.id,
+                            name: "a12",
+                            childCategories: []
+                        }
+                    ]
+                }
+            ]);
+
+            const categoriesTreeWithEmptyOptions = await categoryRepository.findTrees({});
+            categoriesTreeWithEmptyOptions.should.be.eql([
+                {
+                    id: a1.id,
+                    name: "a1",
+                    childCategories: [
+                        {
+                            id: a11.id,
+                            name: "a11",
+                            childCategories: [
+                                {
+                                    id: a111.id,
+                                    name: "a111",
+                                    childCategories: []
+                                },
+                                {
+                                    id: a112.id,
+                                    name: "a112",
+                                    childCategories: []
+                                }
+                            ]
+                        },
+                        {
+                            id: a12.id,
+                            name: "a12",
+                            childCategories: []
+                        }
+                    ]
+                }
+            ]);
+
+            const categoriesTreeWithDepthZero = await categoryRepository.findTrees({ depth: 0 });
+            categoriesTreeWithDepthZero.should.be.eql([
+                {
+                    id: a1.id,
+                    name: "a1",
+                    childCategories: []
+                }
+            ]);
+
+            const categoriesTreeWithDepthOne = await categoryRepository.findTrees({ depth: 1 });
+            categoriesTreeWithDepthOne.should.be.eql([
+                {
+                    id: a1.id,
+                    name: "a1",
+                    childCategories: [
+                        {
+                            id: a11.id,
+                            name: "a11",
+                            childCategories: []
+                        },
+                        {
+                            id: a12.id,
+                            name: "a12",
+                            childCategories: []
+                        }
+                    ]
+                }
+            ]);
+        })));
+    });
+
+    describe("findDescendantsTree() tests", () => {
+        it("findDescendantsTree should load all category descendents and nested children", () => Promise.all(connections.map(async connection => {
+            const categoryRepository = connection.getTreeRepository(Category);
+
+            const a1 = new Category();
+            a1.name = "a1";
+
+            const a11 = new Category();
+            a11.name = "a11";
+
+            const a12 = new Category();
+            a12.name = "a12";
+
+            const a111 = new Category();
+            a111.name = "a111";
+
+            const a112 = new Category();
+            a112.name = "a112";
+
+            a1.childCategories = [a11, a12];
+            a11.childCategories = [a111, a112];
+            await categoryRepository.save(a1);
+
+            const categoriesTree = await categoryRepository.findDescendantsTree(a1);
+            categoriesTree.should.be.eql({
+                id: a1.id,
+                name: "a1",
+                childCategories: [
+                    {
+                        id: a11.id,
+                        name: "a11",
+                        childCategories: [
+                            {
+                                id: a111.id,
+                                name: "a111",
+                                childCategories: []
+                            },
+                            {
+                                id: a112.id,
+                                name: "a112",
+                                childCategories: []
+                            }
+                        ]
+                    },
+                    {
+                        id: a12.id,
+                        name: "a12",
+                        childCategories: []
+                    }
+                ]
+            });
+        })));
+
+        it("findDescendantsTree should filter by depth if optionally provided", () => Promise.all(connections.map(async connection => {
+            const categoryRepository = connection.getTreeRepository(Category);
+
+            const a1 = new Category();
+            a1.name = "a1";
+
+            const a11 = new Category();
+            a11.name = "a11";
+
+            const a12 = new Category();
+            a12.name = "a12";
+
+            const a111 = new Category();
+            a111.name = "a111";
+
+            const a112 = new Category();
+            a112.name = "a112";
+
+            a1.childCategories = [a11, a12];
+            a11.childCategories = [a111, a112];
+            await categoryRepository.save(a1);
+
+            const categoriesTree = await categoryRepository.findDescendantsTree(a1);
+            categoriesTree.should.be.eql({
+                id: a1.id,
+                name: "a1",
+                childCategories: [
+                    {
+                        id: a11.id,
+                        name: "a11",
+                        childCategories: [
+                            {
+                                id: a111.id,
+                                name: "a111",
+                                childCategories: []
+                            },
+                            {
+                                id: a112.id,
+                                name: "a112",
+                                childCategories: []
+                            }
+                        ]
+                    },
+                    {
+                        id: a12.id,
+                        name: "a12",
+                        childCategories: []
+                    }
+                ]
+            });
+
+            const categoriesTreeWithEmptyOptions = await categoryRepository.findDescendantsTree(a1, {});
+            categoriesTreeWithEmptyOptions.should.be.eql({
+                id: a1.id,
+                name: "a1",
+                childCategories: [
+                    {
+                        id: a11.id,
+                        name: "a11",
+                        childCategories: [
+                            {
+                                id: a111.id,
+                                name: "a111",
+                                childCategories: []
+                            },
+                            {
+                                id: a112.id,
+                                name: "a112",
+                                childCategories: []
+                            }
+                        ]
+                    },
+                    {
+                        id: a12.id,
+                        name: "a12",
+                        childCategories: []
+                    }
+                ]
+            });
+
+            const categoriesTreeWithDepthZero = await categoryRepository.findDescendantsTree(a1, { depth: 0 });
+            categoriesTreeWithDepthZero.should.be.eql({
+                id: a1.id,
+                name: "a1",
+                childCategories: []
+            });
+
+            const categoriesTreeWithDepthOne = await categoryRepository.findDescendantsTree(a1, { depth: 1 });
+            categoriesTreeWithDepthOne.should.be.eql({
+                id: a1.id,
+                name: "a1",
+                childCategories: [
+                    {
+                        id: a11.id,
+                        name: "a11",
+                        childCategories: []
+                    },
+                    {
+                        id: a12.id,
+                        name: "a12",
+                        childCategories: []
+                    }
+                ]
+            });
+        })));
+    });
 });


### PR DESCRIPTION
### Description of change

feat: add depth limiter optional parameter when loading nested trees when using TreeRepository's findTrees() and findDescendantsTree()

Modified TreeRepository's findTrees() and findDescendantsTree() public methods to now accept an optional object with config options.
For now, said object contains a depth parameter that, if set, will limit how far down the tree those methods will crawl and retrieve nested entities.

BREAKING CHANGE: TreeRepository's protected method buildChildrenEntityTree() now requires a 4th argument. Anyone affected by this break should also review and update their implementation, otherwise this feature will not work.

Closes: #3909

### Pull-Request Checklist


- [x] Code is up-to-date with the `master` branch
- [x] `npm run lint` passes with this change
- [ ] `npm run test` passes with this change
- [x] This pull request links relevant issues as `Fixes #0000`
- [x] There are new or updated unit tests validating the change
- [x] Documentation has been updated to reflect this change
- [x] The new commits follow conventions explained in [CONTRIBUTING.md](https://github.com/typeorm/typeorm/blob/master/CONTRIBUTING.md)

Unrelated tests are failing for me both on the branch and on master. I ran the individual tests I added to cover my changes, and hopefully CI will take care of the rest.