### PR TITLE
fix: allow char and varchar cases to fall through when creating parameters

### DIFF
--- a/src/driver/sqlserver/SqlServerQueryRunner.ts
+++ b/src/driver/sqlserver/SqlServerQueryRunner.ts
@@ -2244,15 +2244,12 @@ export class SqlServerQueryRunner extends BaseQueryRunner implements QueryRunner
             case "tinyint":
                 return this.driver.mssql.TinyInt;
             case "char":
-                return this.driver.mssql.Char(...parameter.params);
             case "nchar":
                 return this.driver.mssql.NChar(...parameter.params);
             case "text":
-                return this.driver.mssql.Text;
             case "ntext":
                 return this.driver.mssql.Ntext;
             case "varchar":
-                return this.driver.mssql.VarChar(...parameter.params);
             case "nvarchar":
                 return this.driver.mssql.NVarChar(...parameter.params);
             case "xml":

--- a/test/github-issues/7932/entity/Example.ts
+++ b/test/github-issues/7932/entity/Example.ts
@@ -1,0 +1,22 @@
+import {
+    Entity,
+    PrimaryGeneratedColumn,
+    Column,
+    CreateDateColumn
+} from '../../../../src';
+
+@Entity()
+export class Example {
+
+    @PrimaryGeneratedColumn('uuid')
+    id?: string;
+
+    @CreateDateColumn({ type: 'datetime' })
+    created?: Date;
+
+    @Column('varchar', { length: 10 })
+    content: string = '';
+
+    @Column('char', { length: 10 })
+    fixedLengthContent: string = '';
+}

--- a/test/github-issues/7932/issue-7932.ts
+++ b/test/github-issues/7932/issue-7932.ts
@@ -1,0 +1,56 @@
+import "reflect-metadata";
+import { expect } from "chai";
+import { Connection } from "../../../src";
+import { closeTestingConnections, createTestingConnections, reloadTestingDatabases } from "../../utils/test-utils";
+import { Example } from "./entity/Example";
+
+describe("github issues > #7932  non-ascii characters assigned to var/char columns in SQL are truncated to one byte", () => {
+
+    let connections: Connection[];
+    before(async () => {
+        connections = await createTestingConnections({
+            enabledDrivers: ["mssql"],
+            entities: [Example],
+            schemaCreate: false,
+            dropSchema: true
+        });
+    });
+    beforeEach(() => reloadTestingDatabases(connections));
+    after(() => closeTestingConnections(connections));
+
+    it("should store non-ascii characters in var/char without data loss", () => Promise.all(connections.map(async connection => {
+        const repo = connection.getRepository(Example);
+
+        const entity = new Example();
+        entity.content = '\u2021';
+        entity.fixedLengthContent = '\u2022';
+
+        await repo.save(entity);
+        const savedEntity =
+            await repo.findOne({ order: { created: 'DESC' } });
+
+        expect(savedEntity?.content).to.be.equal(entity.content);
+        expect(savedEntity?.fixedLengthContent).to.be.equal('\u2022         ');
+    })));
+
+    it("should throw an error if characters in a string are too long to store", () => Promise.all(connections.map(async connection => {
+        const repo = connection.getRepository(Example);
+
+        const entity = new Example();
+        entity.content = '💖';
+        entity.fixedLengthContent = '🏍';
+
+        expect(repo.save(entity)).to.eventually.be.rejectedWith(Error);
+    })));
+
+    it("should not change char or varchar column types to nchar or nvarchar", () => Promise.all(connections.map(async connection => {
+        const repo = connection.getRepository(Example);
+
+        const columnMetadata = repo.metadata.ownColumns;
+        const contentColumnType = columnMetadata.find(m => m.propertyName === 'content')?.type;
+        const fixedLengthContentColumnType = columnMetadata.find(m => m.propertyName === 'fixedLengthContent')?.type;
+
+        expect(contentColumnType).to.be.equal('varchar');
+        expect(fixedLengthContentColumnType).to.be.equal('char');
+    })));
+});


### PR DESCRIPTION
<!--
  😀 Wonderful!  Thank you for opening a pull request for TypeORM.

  Please fill in the information below to expedite the review
  and (hopefully) merge of your change.

  If unsure about something.. just do as best as you're able,
  or reach out through our community support channels!
  https://github.com/typeorm/typeorm/blob/master/docs/support.md
-->

### Description of change
When we are converting MS-SQL parameters from typeorm's to native, we allow the `varchar` case to fall through to `nvarchar`, and `char` to `nchar`, in order to correctly enable saving strings to columns of those types that contain characters longer than one byte.
<!--
  Please be clear and concise what the change is intended to do,
  why this change is needed, and how you've verified that it
  corrects what you intended.

  In some cases it may be helpful to include the current behavior
  and the new behavior.

  If the change is related to an open issue, you can link it here.
  If you include `Fixes #0000` (replacing `0000` with the issue number)
  when this is merged it will automatically mark the issue as fixed and
  close it.
-->

Fixes #7932

### Pull-Request Checklist

<!--
  Please make sure to review and check all of the following.

  If an item is not applicable, you can add "N/A" to the end.
-->

- [x] Code is up-to-date with the `master` branch
- [x] `npm run lint` passes with this change
- [x] `npm run test` passes with this change
- [x] This pull request links relevant issues as `Fixes #0000`
- [x] There are new or updated unit tests validating the change
- [ ] Documentation has been updated to reflect this change
- [x] The new commits follow conventions explained in [CONTRIBUTING.md](https://github.com/typeorm/typeorm/blob/master/CONTRIBUTING.md)

<!--
  🎉 Thank you for contributing and making TypeORM even better!
-->
