### PR TITLE
feat: consistent parsing and escaping of table names in QueryRunners

### DIFF
--- a/src/driver/aurora-data-api/AuroraDataApiQueryRunner.ts
+++ b/src/driver/aurora-data-api/AuroraDataApiQueryRunner.ts
@@ -1639,11 +1639,30 @@ export class AuroraDataApiQueryRunner extends BaseQueryRunner implements QueryRu
         return new Query(`ALTER TABLE ${this.escapePath(table)} DROP FOREIGN KEY \`${foreignKeyName}\``);
     }
 
-    protected parseTableName(target: Table|string) {
-        const tableName = target instanceof Table ? target.name : target;
+    protected parseTableName(target: Table | View | string): { database?: string, schema?: string, tableName: string } {
+        const driverDatabase = this.driver.database;
+        const driverSchema = undefined;
+
+        if (target instanceof Table) {
+            const parsed = this.parseTableName(target.name);
+
+            return {
+                database: target.database || parsed.database || driverDatabase,
+                schema: target.schema || parsed.schema || driverSchema,
+                tableName: parsed.tableName
+            };
+        }
+
+        if (target instanceof View) {
+            return this.parseTableName(target.name);
+        }
+
+        const parts = target.split(".")
+
         return {
-            database: tableName.indexOf(".") !== -1 ? tableName.split(".")[0] : this.driver.database,
-            tableName: tableName.indexOf(".") !== -1 ? tableName.split(".")[1] : tableName
+            database: (parts.length > 1 ? parts[0] : undefined) || driverDatabase,
+            schema: driverSchema,
+            tableName: parts.length > 1 ? parts[1] : parts[0]
         };
     }
 
@@ -1666,9 +1685,14 @@ export class AuroraDataApiQueryRunner extends BaseQueryRunner implements QueryRu
     /**
      * Escapes given table or view path.
      */
-    protected escapePath(target: Table|View|string, disableEscape?: boolean): string {
-        const tableName = target instanceof Table || target instanceof View ? target.name : target;
-        return tableName.split(".").map(i => disableEscape ? i : `\`${i}\``).join(".");
+    protected escapePath(target: Table|View|string): string {
+        const { database, tableName } = this.parseTableName(target);
+
+        if (database) {
+            return `\`${database}\`.\`${tableName}\``;
+        }
+
+        return `\`${tableName}\``;
     }
 
     /**

--- a/src/driver/sap/SapQueryRunner.ts
+++ b/src/driver/sap/SapQueryRunner.ts
@@ -2004,31 +2004,46 @@ export class SapQueryRunner extends BaseQueryRunner implements QueryRunner {
     /**
      * Escapes given table or view path.
      */
-    protected escapePath(target: Table|View|string, disableEscape?: boolean): string {
-        let tableName = target instanceof Table || target instanceof View ? target.name : target;
-        tableName = tableName.indexOf(".") === -1 && this.driver.options.schema ? `${this.driver.options.schema}.${tableName}` : tableName;
+    protected escapePath(target: Table|View|string): string {
+        const { schema, tableName } = this.parseTableName(target);
 
-        return tableName.split(".").map(i => {
-            return disableEscape ? i : `"${i}"`;
-        }).join(".");
+        if (schema) {
+            return `"${schema}"."${tableName}"`;
+        }
+
+        return `"${tableName}"`;
     }
 
     /**
      * Returns object with table schema and table name.
      */
-    protected parseTableName(target: Table|string) {
-        const tableName = target instanceof Table ? target.name : target;
-        if (tableName.indexOf(".") === -1) {
+    protected parseTableName(target: Table | View | string): { database?: string, schema?: string, tableName: string } {
+        const driverDatabase = this.driver.database;
+
+        // This really should be abstracted into the driver as well..
+        const driverSchema = this.driver.options.schema;
+
+        if (target instanceof Table) {
+            const parsed = this.parseTableName(target.name);
+
             return {
-                schema: this.driver.options.schema,
-                tableName: tableName
-            };
-        } else {
-            return {
-                schema: tableName.split(".")[0],
-                tableName: tableName.split(".")[1]
-            };
+                database: target.database || parsed.database || driverDatabase,
+                schema: target.schema || parsed.schema || driverSchema,
+                tableName: parsed.tableName
+            }
         }
+
+        if (target instanceof View) {
+            return this.parseTableName(target.name);
+        }
+
+        const parts = target.split(".")
+
+        return {
+            database: driverDatabase,
+            schema: (parts.length > 1 ? parts[0] : undefined) || driverSchema,
+            tableName: parts.length > 1 ? parts[1] : parts[0]
+        };
     }
 
     /**

--- a/src/metadata-builder/RelationJoinColumnBuilder.ts
+++ b/src/metadata-builder/RelationJoinColumnBuilder.ts
@@ -86,7 +86,7 @@ export class RelationJoinColumnBuilder {
                 entityMetadata: relation.entityMetadata,
                 columns: foreignKey.columns,
                 args: {
-                    name: this.connection.namingStrategy.relationConstraintName(relation.entityMetadata.tablePath, foreignKey.columns.map(c => c.databaseName)),
+                    name: this.connection.namingStrategy.relationConstraintName(relation.entityMetadata.tableName, foreignKey.columns.map(c => c.databaseName)),
                     target: relation.entityMetadata.target,
                 }
             });

--- a/src/metadata/CheckMetadata.ts
+++ b/src/metadata/CheckMetadata.ts
@@ -64,7 +64,7 @@ export class CheckMetadata {
      * Must be called after all entity metadata's properties map, columns and relations are built.
      */
     build(namingStrategy: NamingStrategyInterface): this {
-        this.name = this.givenName ? this.givenName : namingStrategy.checkConstraintName(this.entityMetadata.tablePath, this.expression);
+        this.name = this.givenName ? this.givenName : namingStrategy.checkConstraintName(this.entityMetadata.tableName, this.expression);
         return this;
     }
 

--- a/src/metadata/ExclusionMetadata.ts
+++ b/src/metadata/ExclusionMetadata.ts
@@ -64,7 +64,7 @@ export class ExclusionMetadata {
      * Must be called after all entity metadata's properties map, columns and relations are built.
      */
     build(namingStrategy: NamingStrategyInterface): this {
-        this.name = this.givenName ? this.givenName : namingStrategy.exclusionConstraintName(this.entityMetadata.tablePath, this.expression);
+        this.name = this.givenName ? this.givenName : namingStrategy.exclusionConstraintName(this.entityMetadata.tableName, this.expression);
         return this;
     }
 

--- a/src/metadata/ForeignKeyMetadata.ts
+++ b/src/metadata/ForeignKeyMetadata.ts
@@ -106,7 +106,7 @@ export class ForeignKeyMetadata {
         this.columnNames = this.columns.map(column => column.databaseName);
         this.referencedColumnNames = this.referencedColumns.map(column => column.databaseName);
         this.referencedTablePath = this.referencedEntityMetadata.tablePath;
-        this.name = namingStrategy.foreignKeyName(this.entityMetadata.tablePath, this.columnNames, this.referencedTablePath, this.referencedColumnNames);
+        this.name = namingStrategy.foreignKeyName(this.entityMetadata.tableName, this.columnNames, this.referencedEntityMetadata.tableName, this.referencedColumnNames);
     }
 
 }

--- a/src/metadata/IndexMetadata.ts
+++ b/src/metadata/IndexMetadata.ts
@@ -204,7 +204,7 @@ export class IndexMetadata {
             return updatedMap;
         }, {} as { [key: string]: number });
 
-        this.name = this.givenName ? this.givenName : namingStrategy.indexName(this.entityMetadata.tablePath, this.columns.map(column => column.databaseName), this.where);
+        this.name = this.givenName ? this.givenName : namingStrategy.indexName(this.entityMetadata.tableName, this.columns.map(column => column.databaseName), this.where);
         return this;
     }
 

--- a/src/metadata/UniqueMetadata.ts
+++ b/src/metadata/UniqueMetadata.ts
@@ -138,7 +138,7 @@ export class UniqueMetadata {
             return updatedMap;
         }, {} as { [key: string]: number });
 
-        this.name = this.givenName ? this.givenName : namingStrategy.uniqueConstraintName(this.entityMetadata.tablePath, this.columns.map(column => column.databaseName));
+        this.name = this.givenName ? this.givenName : namingStrategy.uniqueConstraintName(this.entityMetadata.tableName, this.columns.map(column => column.databaseName));
         return this;
     }
 

--- a/src/naming-strategy/DefaultNamingStrategy.ts
+++ b/src/naming-strategy/DefaultNamingStrategy.ts
@@ -7,7 +7,13 @@ import {Table} from "../schema-builder/table/Table";
  * Naming strategy that is used by default.
  */
 export class DefaultNamingStrategy implements NamingStrategyInterface {
+    private getTableName(tableOrName: Table | string): string {
+        if (tableOrName instanceof Table) {
+            tableOrName = tableOrName.name;
+        }
 
+        return tableOrName.split(".").pop()!;
+    }
     /**
      * Normalizes table name.
      *
@@ -44,7 +50,7 @@ export class DefaultNamingStrategy implements NamingStrategyInterface {
         // sort incoming column names to avoid issue when ["id", "name"] and ["name", "id"] arrays
         const clonedColumnNames = [...columnNames];
         clonedColumnNames.sort();
-        const tableName = tableOrName instanceof Table ? tableOrName.name : tableOrName;
+        const tableName = this.getTableName(tableOrName);
         const replacedTableName = tableName.replace(".", "_");
         const key = `${replacedTableName}_${clonedColumnNames.join("_")}`;
         return "PK_" + RandomGenerator.sha1(key).substr(0, 27);
@@ -54,7 +60,7 @@ export class DefaultNamingStrategy implements NamingStrategyInterface {
         // sort incoming column names to avoid issue when ["id", "name"] and ["name", "id"] arrays
         const clonedColumnNames = [...columnNames];
         clonedColumnNames.sort();
-        const tableName = tableOrName instanceof Table ? tableOrName.name : tableOrName;
+        const tableName = this.getTableName(tableOrName);
         const replacedTableName = tableName.replace(".", "_");
         const key = `${replacedTableName}_${clonedColumnNames.join("_")}`;
         return "UQ_" + RandomGenerator.sha1(key).substr(0, 27);
@@ -64,7 +70,7 @@ export class DefaultNamingStrategy implements NamingStrategyInterface {
         // sort incoming column names to avoid issue when ["id", "name"] and ["name", "id"] arrays
         const clonedColumnNames = [...columnNames];
         clonedColumnNames.sort();
-        const tableName = tableOrName instanceof Table ? tableOrName.name : tableOrName;
+        const tableName = this.getTableName(tableOrName);
         const replacedTableName = tableName.replace(".", "_");
         let key = `${replacedTableName}_${clonedColumnNames.join("_")}`;
         if (where)
@@ -74,7 +80,7 @@ export class DefaultNamingStrategy implements NamingStrategyInterface {
     }
 
     defaultConstraintName(tableOrName: Table|string, columnName: string): string {
-        const tableName = tableOrName instanceof Table ? tableOrName.name : tableOrName;
+        const tableName = this.getTableName(tableOrName);
         const replacedTableName = tableName.replace(".", "_");
         const key = `${replacedTableName}_${columnName}`;
         return "DF_" + RandomGenerator.sha1(key).substr(0, 27);
@@ -84,7 +90,7 @@ export class DefaultNamingStrategy implements NamingStrategyInterface {
         // sort incoming column names to avoid issue when ["id", "name"] and ["name", "id"] arrays
         const clonedColumnNames = [...columnNames];
         clonedColumnNames.sort();
-        const tableName = tableOrName instanceof Table ? tableOrName.name : tableOrName;
+        const tableName = this.getTableName(tableOrName);
         const replacedTableName = tableName.replace(".", "_");
         const key = `${replacedTableName}_${clonedColumnNames.join("_")}`;
         return "FK_" + RandomGenerator.sha1(key).substr(0, 27);
@@ -94,7 +100,7 @@ export class DefaultNamingStrategy implements NamingStrategyInterface {
         // sort incoming column names to avoid issue when ["id", "name"] and ["name", "id"] arrays
         const clonedColumnNames = [...columnNames];
         clonedColumnNames.sort();
-        const tableName = tableOrName instanceof Table ? tableOrName.name : tableOrName;
+        const tableName = this.getTableName(tableOrName);
         const replacedTableName = tableName.replace(".", "_");
         let key = `${replacedTableName}_${clonedColumnNames.join("_")}`;
         if (where)
@@ -104,7 +110,7 @@ export class DefaultNamingStrategy implements NamingStrategyInterface {
     }
 
     checkConstraintName(tableOrName: Table|string, expression: string, isEnum?: boolean): string {
-        const tableName = tableOrName instanceof Table ? tableOrName.name : tableOrName;
+        const tableName = this.getTableName(tableOrName);
         const replacedTableName = tableName.replace(".", "_");
         const key = `${replacedTableName}_${expression}`;
         const name = "CHK_" + RandomGenerator.sha1(key).substr(0, 26);
@@ -112,7 +118,7 @@ export class DefaultNamingStrategy implements NamingStrategyInterface {
     }
 
     exclusionConstraintName(tableOrName: Table|string, expression: string): string {
-        const tableName = tableOrName instanceof Table ? tableOrName.name : tableOrName;
+        const tableName = this.getTableName(tableOrName);
         const replacedTableName = tableName.replace(".", "_");
         const key = `${replacedTableName}_${expression}`;
         return "XCL_" + RandomGenerator.sha1(key).substr(0, 26);

--- a/test/functional/commands/templates/result-templates-generate.ts
+++ b/test/functional/commands/templates/result-templates-generate.ts
@@ -5,11 +5,11 @@ export class testMigration1610975184784 implements MigrationInterface {
     name = 'testMigration1610975184784'
 
     public async up(queryRunner: QueryRunner): Promise<void> {
-        await queryRunner.query("CREATE TABLE \`post\` (\`id\` int NOT NULL AUTO_INCREMENT, \`title\` varchar(255) NOT NULL, \`createdAt\` datetime(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6), PRIMARY KEY (\`id\`)) ENGINE=InnoDB");
+        await queryRunner.query("CREATE TABLE \`test\`.\`post\` (\`id\` int NOT NULL AUTO_INCREMENT, \`title\` varchar(255) NOT NULL, \`createdAt\` datetime(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6), PRIMARY KEY (\`id\`)) ENGINE=InnoDB");
     }
 
     public async down(queryRunner: QueryRunner): Promise<void> {
-        await queryRunner.query("DROP TABLE \`post\`");
+        await queryRunner.query("DROP TABLE \`test\`.\`post\`");
     }
 
 }`,
@@ -19,11 +19,11 @@ module.exports = class testMigration1610975184784 {
     name = 'testMigration1610975184784'
 
     async up(queryRunner) {
-        await queryRunner.query("CREATE TABLE \`post\` (\`id\` int NOT NULL AUTO_INCREMENT, \`title\` varchar(255) NOT NULL, \`createdAt\` datetime(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6), PRIMARY KEY (\`id\`)) ENGINE=InnoDB");
+        await queryRunner.query("CREATE TABLE \`test\`.\`post\` (\`id\` int NOT NULL AUTO_INCREMENT, \`title\` varchar(255) NOT NULL, \`createdAt\` datetime(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6), PRIMARY KEY (\`id\`)) ENGINE=InnoDB");
     }
 
     async down(queryRunner) {
-        await queryRunner.query("DROP TABLE \`post\`");
+        await queryRunner.query("DROP TABLE \`test\`.\`post\`");
     }
 }`
 };

--- a/test/functional/schema-builder/create-foreign-key.ts
+++ b/test/functional/schema-builder/create-foreign-key.ts
@@ -39,7 +39,7 @@ describe("schema builder > create foreign key", () => {
                 entityMetadata: categoryMetadata,
                 columns: fkMetadata.columns,
                 args: {
-                    name: connection.namingStrategy.relationConstraintName(categoryMetadata.tablePath, fkMetadata.columns.map(c => c.databaseName)),
+                    name: connection.namingStrategy.relationConstraintName(categoryMetadata.tableName, fkMetadata.columns.map(c => c.databaseName)),
                     target: categoryMetadata.target,
                 }
             });

--- a/test/github-issues/4415/results-templates.ts
+++ b/test/github-issues/4415/results-templates.ts
@@ -27,12 +27,12 @@ export const resultsTemplates: Record<string, any> = {
 
     mssql: {
         control: [
-            `CREATE TABLE "post" ("id" int NOT NULL IDENTITY(1,1), "title" nvarchar(255) NOT NULL, "createdAt" datetime2 NOT NULL CONSTRAINT "DF_fb91bea2d37140a877b775e6b2a" DEFAULT getdate(), CONSTRAINT "PK_be5fda3aac270b134ff9c21cdee" PRIMARY KEY ("id"))`,
-            `CREATE TABLE "username" ("username" nvarchar(255) NOT NULL, "email" nvarchar(255) NOT NULL, "something" nvarchar(255) NOT NULL, CONSTRAINT "PK_b39ad32e514b17e90c93988888a" PRIMARY KEY ("username"))`
+            `CREATE TABLE "tempdb".."post" ("id" int NOT NULL IDENTITY(1,1), "title" nvarchar(255) NOT NULL, "createdAt" datetime2 NOT NULL CONSTRAINT "DF_fb91bea2d37140a877b775e6b2a" DEFAULT getdate(), CONSTRAINT "PK_be5fda3aac270b134ff9c21cdee" PRIMARY KEY ("id"))`,
+            `CREATE TABLE "tempdb".."username" ("username" nvarchar(255) NOT NULL, "email" nvarchar(255) NOT NULL, "something" nvarchar(255) NOT NULL, CONSTRAINT "PK_b39ad32e514b17e90c93988888a" PRIMARY KEY ("username"))`
         ],
         pretty: [
     `
-            CREATE TABLE "post" (
+            CREATE TABLE "tempdb".."post" (
                 "id" int NOT NULL IDENTITY(1, 1),
                 "title" nvarchar(255) NOT NULL,
                 "createdAt" datetime2 NOT NULL CONSTRAINT "DF_fb91bea2d37140a877b775e6b2a" DEFAULT getdate(),
@@ -40,7 +40,7 @@ export const resultsTemplates: Record<string, any> = {
             )
     `,
     `
-            CREATE TABLE "username" (
+            CREATE TABLE "tempdb".."username" (
                 "username" nvarchar(255) NOT NULL,
                 "email" nvarchar(255) NOT NULL,
                 "something" nvarchar(255) NOT NULL,
@@ -75,12 +75,12 @@ export const resultsTemplates: Record<string, any> = {
 
     mysql: {
         control: [
-            `CREATE TABLE \`post\` (\`id\` int NOT NULL AUTO_INCREMENT, \`title\` varchar(255) NOT NULL, \`createdAt\` datetime(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6), PRIMARY KEY (\`id\`)) ENGINE=InnoDB`,
-            `CREATE TABLE \`username\` (\`username\` varchar(255) NOT NULL, \`email\` varchar(255) NOT NULL, \`something\` varchar(255) NOT NULL, PRIMARY KEY (\`username\`)) ENGINE=InnoDB`
+            `CREATE TABLE \`test\`.\`post\` (\`id\` int NOT NULL AUTO_INCREMENT, \`title\` varchar(255) NOT NULL, \`createdAt\` datetime(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6), PRIMARY KEY (\`id\`)) ENGINE=InnoDB`,
+            `CREATE TABLE \`test\`.\`username\` (\`username\` varchar(255) NOT NULL, \`email\` varchar(255) NOT NULL, \`something\` varchar(255) NOT NULL, PRIMARY KEY (\`username\`)) ENGINE=InnoDB`
         ],
         pretty: [
     `
-            CREATE TABLE \`post\` (
+            CREATE TABLE \`test\`.\`post\` (
                 \`id\` int NOT NULL AUTO_INCREMENT,
                 \`title\` varchar(255) NOT NULL,
                 \`createdAt\` datetime(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6),
@@ -88,7 +88,7 @@ export const resultsTemplates: Record<string, any> = {
             ) ENGINE = InnoDB
     `,
     `
-            CREATE TABLE \`username\` (
+            CREATE TABLE \`test\`.\`username\` (
                 \`username\` varchar(255) NOT NULL,
                 \`email\` varchar(255) NOT NULL,
                 \`something\` varchar(255) NOT NULL,

--- a/test/github-issues/5119/issue-5119.ts
+++ b/test/github-issues/5119/issue-5119.ts
@@ -49,16 +49,16 @@ describe("github issues > #5119 migration with foreign key that changes target",
                         query => query.query
                     );
                     upQueries.should.eql([
-                        `ALTER TABLE "post" DROP CONSTRAINT "FK_4490d00e1925ca046a1f52ddf04"`,
+                        `ALTER TABLE "public"."post" DROP CONSTRAINT "FK_4490d00e1925ca046a1f52ddf04"`,
                         `CREATE TABLE "account" ("id" SERIAL NOT NULL, "userId" integer, CONSTRAINT "PK_54115ee388cdb6d86bb4bf5b2ea" PRIMARY KEY ("id"))`,
                         `ALTER TABLE "account" ADD CONSTRAINT "FK_60328bf27019ff5498c4b977421" FOREIGN KEY ("userId") REFERENCES "user"("id") ON DELETE NO ACTION ON UPDATE NO ACTION`,
-                        `ALTER TABLE "post" ADD CONSTRAINT "FK_4490d00e1925ca046a1f52ddf04" FOREIGN KEY ("ownerId") REFERENCES "account"("id") ON DELETE NO ACTION ON UPDATE NO ACTION`
+                        `ALTER TABLE "public"."post" ADD CONSTRAINT "FK_4490d00e1925ca046a1f52ddf04" FOREIGN KEY ("ownerId") REFERENCES "account"("id") ON DELETE NO ACTION ON UPDATE NO ACTION`
                     ]);
                     downQueries.should.eql([
-                        `ALTER TABLE "post" ADD CONSTRAINT "FK_4490d00e1925ca046a1f52ddf04" FOREIGN KEY ("ownerId") REFERENCES "user"("id") ON DELETE NO ACTION ON UPDATE NO ACTION`,
+                        `ALTER TABLE "public"."post" ADD CONSTRAINT "FK_4490d00e1925ca046a1f52ddf04" FOREIGN KEY ("ownerId") REFERENCES "user"("id") ON DELETE NO ACTION ON UPDATE NO ACTION`,
                         `DROP TABLE "account"`,
                         `ALTER TABLE "account" DROP CONSTRAINT "FK_60328bf27019ff5498c4b977421"`,
-                        `ALTER TABLE "post" DROP CONSTRAINT "FK_4490d00e1925ca046a1f52ddf04"`
+                        `ALTER TABLE "public"."post" DROP CONSTRAINT "FK_4490d00e1925ca046a1f52ddf04"`
                     ]);
                 } finally {
                     connection.close();

--- a/test/github-issues/6442/issue-6442.ts
+++ b/test/github-issues/6442/issue-6442.ts
@@ -53,9 +53,9 @@ describe("github issues > #6442 JoinTable does not respect inverseJoinColumns re
                 );
 
                 upQueries.should.eql([
-                    "CREATE TABLE `foo_bars` (`foo_id` int(10) UNSIGNED NOT NULL, `bar_id` int(10) UNSIGNED NOT NULL, INDEX `IDX_319290776f044043e3ef3ba5a8` (`foo_id`), INDEX `IDX_b7fd4be386fa7cdb87ef8b12b6` (`bar_id`), PRIMARY KEY (`foo_id`, `bar_id`)) ENGINE=InnoDB",
-                    "ALTER TABLE `foo_bars` ADD CONSTRAINT `FK_319290776f044043e3ef3ba5a8d` FOREIGN KEY (`foo_id`) REFERENCES `foo_entity`(`id`) ON DELETE CASCADE ON UPDATE CASCADE",
-                    "ALTER TABLE `foo_bars` ADD CONSTRAINT `FK_b7fd4be386fa7cdb87ef8b12b69` FOREIGN KEY (`bar_id`) REFERENCES `bar_entity`(`id`) ON DELETE CASCADE ON UPDATE CASCADE"
+                    "CREATE TABLE `test`.`foo_bars` (`foo_id` int(10) UNSIGNED NOT NULL, `bar_id` int(10) UNSIGNED NOT NULL, INDEX `IDX_319290776f044043e3ef3ba5a8` (`foo_id`), INDEX `IDX_b7fd4be386fa7cdb87ef8b12b6` (`bar_id`), PRIMARY KEY (`foo_id`, `bar_id`)) ENGINE=InnoDB",
+                    "ALTER TABLE `test`.`foo_bars` ADD CONSTRAINT `FK_319290776f044043e3ef3ba5a8d` FOREIGN KEY (`foo_id`) REFERENCES `test`.`foo_entity`(`id`) ON DELETE CASCADE ON UPDATE CASCADE",
+                    "ALTER TABLE `test`.`foo_bars` ADD CONSTRAINT `FK_b7fd4be386fa7cdb87ef8b12b69` FOREIGN KEY (`bar_id`) REFERENCES `test`.`bar_entity`(`id`) ON DELETE CASCADE ON UPDATE CASCADE"
                 ]);
 
             } finally {


### PR DESCRIPTION
<!--
  😀 Wonderful!  Thank you for opening a pull request for TypeORM.

  Please fill in the information below to expedite the review
  and (hopefully) merge of your change.

  If unsure about something.. just do as best as you're able,
  or reach out through our community support channels!
  https://github.com/typeorm/typeorm/blob/master/docs/support.md
-->

### Description of change

<!--
  Please be clear and concise what the change is intended to do,
  why this change is needed, and how you've verified that it
  corrects what you intended.

  In some cases it may be helpful to include the current behavior
  and the new behavior.

  If the change is related to an open issue, you can link it here.
  If you include `Fixes #0000` (replacing `0000` with the issue number)
  when this is merged it will automatically mark the issue as fixed and
  close it.
-->

this refactors `escapePath` and `parseTableName` so that when we parse
and serialize the table names they should work the same between the two

### Pull-Request Checklist

<!--
  Please make sure to review and check all of the following.

  If an item is not applicable, you can add "N/A" to the end.
-->

- [x] Code is up-to-date with the `master` branch
- [x] `npm run lint` passes with this change
- [x] `npm run test` passes with this change
- [ ] This pull request links relevant issues as `Fixes #0000`
- [ ] There are new or updated unit tests validating the change
- [ ] Documentation has been updated to reflect this change
- [x] The new commits follow conventions explained in [CONTRIBUTING.md](https://github.com/typeorm/typeorm/blob/master/CONTRIBUTING.md)

<!--
  🎉 Thank you for contributing and making TypeORM even better!
-->
