### PR TITLE
fix: always generate migrations with template string literals

### DIFF
--- a/src/commands/MigrationGenerateCommand.ts
+++ b/src/commands/MigrationGenerateCommand.ts
@@ -1,10 +1,8 @@
 import {ConnectionOptionsReader} from "../connection/ConnectionOptionsReader";
 import {CommandUtils} from "./CommandUtils";
 import {createConnection} from "../globals";
-import {MysqlDriver} from "../driver/mysql/MysqlDriver";
 import {camelCase} from "../util/StringUtils";
 import * as yargs from "yargs";
-import {AuroraDataApiDriver} from "../driver/aurora-data-api/AuroraDataApiDriver";
 import chalk from "chalk";
 import { format } from "@sqltools/formatter/lib/sqlFormatter";
 
@@ -115,23 +113,12 @@ export class MigrationGenerateCommand implements yargs.CommandModule {
                     });
                 }
 
-                // mysql is exceptional here because it uses ` character in to escape names in queries, that's why for mysql
-                // we are using simple quoted string instead of template string syntax
-                if (connection.driver instanceof MysqlDriver || connection.driver instanceof AuroraDataApiDriver) {
-                    sqlInMemory.upQueries.forEach(upQuery => {
-                        upSqls.push("        await queryRunner.query(\"" + upQuery.query.replace(new RegExp(`"`, "g"), `\\"`) + "\"" + MigrationGenerateCommand.queryParams(upQuery.parameters) + ");");
-                    });
-                    sqlInMemory.downQueries.forEach(downQuery => {
-                        downSqls.push("        await queryRunner.query(\"" + downQuery.query.replace(new RegExp(`"`, "g"), `\\"`) + "\"" + MigrationGenerateCommand.queryParams(downQuery.parameters) + ");");
-                    });
-                } else {
-                    sqlInMemory.upQueries.forEach(upQuery => {
-                        upSqls.push("        await queryRunner.query(`" + upQuery.query.replace(new RegExp("`", "g"), "\\`") + "`" + MigrationGenerateCommand.queryParams(upQuery.parameters) + ");");
-                    });
-                    sqlInMemory.downQueries.forEach(downQuery => {
-                        downSqls.push("        await queryRunner.query(`" + downQuery.query.replace(new RegExp("`", "g"), "\\`") + "`" + MigrationGenerateCommand.queryParams(downQuery.parameters) + ");");
-                    });
-                }
+                sqlInMemory.upQueries.forEach(upQuery => {
+                    upSqls.push("        await queryRunner.query(`" + upQuery.query.replace(new RegExp("`", "g"), "\\`") + "`" + MigrationGenerateCommand.queryParams(upQuery.parameters) + ");");
+                });
+                sqlInMemory.downQueries.forEach(downQuery => {
+                    downSqls.push("        await queryRunner.query(`" + downQuery.query.replace(new RegExp("`", "g"), "\\`") + "`" + MigrationGenerateCommand.queryParams(downQuery.parameters) + ");");
+                });
             } finally {
                 await connection.close();
             }

--- a/test/functional/commands/templates/result-templates-generate.ts
+++ b/test/functional/commands/templates/result-templates-generate.ts
@@ -5,11 +5,11 @@ export class testMigration1610975184784 implements MigrationInterface {
     name = 'testMigration1610975184784'
 
     public async up(queryRunner: QueryRunner): Promise<void> {
-        await queryRunner.query("CREATE TABLE \`test\`.\`post\` (\`id\` int NOT NULL AUTO_INCREMENT, \`title\` varchar(255) NOT NULL, \`createdAt\` datetime(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6), PRIMARY KEY (\`id\`)) ENGINE=InnoDB");
+        await queryRunner.query(\`CREATE TABLE \\\`test\\\`.\\\`post\\\` (\\\`id\\\` int NOT NULL AUTO_INCREMENT, \\\`title\\\` varchar(255) NOT NULL, \\\`createdAt\\\` datetime(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6), PRIMARY KEY (\\\`id\\\`)) ENGINE=InnoDB\`);
     }
 
     public async down(queryRunner: QueryRunner): Promise<void> {
-        await queryRunner.query("DROP TABLE \`test\`.\`post\`");
+        await queryRunner.query(\`DROP TABLE \\\`test\\\`.\\\`post\\\`\`);
     }
 
 }`,
@@ -19,11 +19,11 @@ module.exports = class testMigration1610975184784 {
     name = 'testMigration1610975184784'
 
     async up(queryRunner) {
-        await queryRunner.query("CREATE TABLE \`test\`.\`post\` (\`id\` int NOT NULL AUTO_INCREMENT, \`title\` varchar(255) NOT NULL, \`createdAt\` datetime(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6), PRIMARY KEY (\`id\`)) ENGINE=InnoDB");
+        await queryRunner.query(\`CREATE TABLE \\\`test\\\`.\\\`post\\\` (\\\`id\\\` int NOT NULL AUTO_INCREMENT, \\\`title\\\` varchar(255) NOT NULL, \\\`createdAt\\\` datetime(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6), PRIMARY KEY (\\\`id\\\`)) ENGINE=InnoDB\`);
     }
 
     async down(queryRunner) {
-        await queryRunner.query("DROP TABLE \`test\`.\`post\`");
+        await queryRunner.query(\`DROP TABLE \\\`test\\\`.\\\`post\\\`\`);
     }
 }`
 };

--- a/test/github-issues/4415/results-templates.ts
+++ b/test/github-issues/4415/results-templates.ts
@@ -75,24 +75,24 @@ export const resultsTemplates: Record<string, any> = {
 
     mysql: {
         control: [
-            `CREATE TABLE \`test\`.\`post\` (\`id\` int NOT NULL AUTO_INCREMENT, \`title\` varchar(255) NOT NULL, \`createdAt\` datetime(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6), PRIMARY KEY (\`id\`)) ENGINE=InnoDB`,
-            `CREATE TABLE \`test\`.\`username\` (\`username\` varchar(255) NOT NULL, \`email\` varchar(255) NOT NULL, \`something\` varchar(255) NOT NULL, PRIMARY KEY (\`username\`)) ENGINE=InnoDB`
+            `CREATE TABLE \\\`test\\\`.\\\`post\\\` (\\\`id\\\` int NOT NULL AUTO_INCREMENT, \\\`title\\\` varchar(255) NOT NULL, \\\`createdAt\\\` datetime(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6), PRIMARY KEY (\\\`id\\\`)) ENGINE=InnoDB`,
+            `CREATE TABLE \\\`test\\\`.\\\`username\\\` (\\\`username\\\` varchar(255) NOT NULL, \\\`email\\\` varchar(255) NOT NULL, \\\`something\\\` varchar(255) NOT NULL, PRIMARY KEY (\\\`username\\\`)) ENGINE=InnoDB`
         ],
         pretty: [
     `
-            CREATE TABLE \`test\`.\`post\` (
-                \`id\` int NOT NULL AUTO_INCREMENT,
-                \`title\` varchar(255) NOT NULL,
-                \`createdAt\` datetime(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6),
-                PRIMARY KEY (\`id\`)
+            CREATE TABLE \\\`test\\\`.\\\`post\\\` (
+                \\\`id\\\` int NOT NULL AUTO_INCREMENT,
+                \\\`title\\\` varchar(255) NOT NULL,
+                \\\`createdAt\\\` datetime(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6),
+                PRIMARY KEY (\\\`id\\\`)
             ) ENGINE = InnoDB
     `,
     `
-            CREATE TABLE \`test\`.\`username\` (
-                \`username\` varchar(255) NOT NULL,
-                \`email\` varchar(255) NOT NULL,
-                \`something\` varchar(255) NOT NULL,
-                PRIMARY KEY (\`username\`)
+            CREATE TABLE \\\`test\\\`.\\\`username\\\` (
+                \\\`username\\\` varchar(255) NOT NULL,
+                \\\`email\\\` varchar(255) NOT NULL,
+                \\\`something\\\` varchar(255) NOT NULL,
+                PRIMARY KEY (\\\`username\\\`)
             ) ENGINE = InnoDB
     `
         ]


### PR DESCRIPTION
<!--
  😀 Wonderful!  Thank you for opening a pull request for TypeORM.

  Please fill in the information below to expedite the review
  and (hopefully) merge of your change.

  If unsure about something.. just do as best as you're able,
  or reach out through our community support channels!
  https://github.com/typeorm/typeorm/blob/master/docs/support.md
-->

### Description of change

<!--
  Please be clear and concise what the change is intended to do,
  why this change is needed, and how you've verified that it
  corrects what you intended.

  In some cases it may be helpful to include the current behavior
  and the new behavior.

  If the change is related to an open issue, you can link it here.
  If you include `Fixes #0000` (replacing `0000` with the issue number)
  when this is merged it will automatically mark the issue as fixed and
  close it.
-->

because we escape the backticks in template string literals we can use
them for mysql.  this is important because standard strings cannot cross
multiple lines when you do `pretty` + migrations

fixes #6968

### Pull-Request Checklist

<!--
  Please make sure to review and check all of the following.

  If an item is not applicable, you can add "N/A" to the end.
-->

- [x] Code is up-to-date with the `master` branch
- [x] `npm run lint` passes with this change
- [x] `npm run test` passes with this change
- [ ] This pull request links relevant issues as `Fixes #0000`
- [ ] There are new or updated unit tests validating the change
- [ ] Documentation has been updated to reflect this change
- [x] The new commits follow conventions explained in [CONTRIBUTING.md](https://github.com/typeorm/typeorm/blob/master/CONTRIBUTING.md)

<!--
  🎉 Thank you for contributing and making TypeORM even better!
-->
