### PR TITLE
feat: add relations option to tree queries

### DIFF
--- a/docs/tree-entities.md
+++ b/docs/tree-entities.md
@@ -204,7 +204,7 @@ There are other special methods to work with tree entities through `TreeReposito
 const treeCategories = await repository.findTrees();
 // returns root categories with sub categories inside
 
-const treeCategories = await repository.findTrees({ relations: ["sites"] });
+const treeCategoriesWithRelations = await repository.findTrees({ relations: ["sites"] });
 // automatically joins the sites relation
 ```
 

--- a/docs/tree-entities.md
+++ b/docs/tree-entities.md
@@ -203,6 +203,9 @@ There are other special methods to work with tree entities through `TreeReposito
 ```typescript
 const treeCategories = await repository.findTrees();
 // returns root categories with sub categories inside
+
+const treeCategories = await repository.findTrees({ relations: ["sites"] });
+// automatically joins the sites relation
 ```
 
 * `findRoots` - Roots are entities that have no ancestors. Finds them all.

--- a/src/find-options/FindOptionsUtils.ts
+++ b/src/find-options/FindOptionsUtils.ts
@@ -4,7 +4,7 @@ import {SelectQueryBuilder} from "../query-builder/SelectQueryBuilder";
 import {FindRelationsNotFoundError} from "../error/FindRelationsNotFoundError";
 import {EntityMetadata} from "../metadata/EntityMetadata";
 import {DriverUtils} from "../driver/DriverUtils";
-import {TypeORMError} from "../error";
+import { TypeORMError } from "../error";
 
 /**
  * Utilities to work with FindOptions.
@@ -38,7 +38,6 @@ export class FindOptionsUtils {
                     typeof possibleOptions.withDeleted === "boolean" ||
                     typeof possibleOptions.transaction === "boolean"
                 );
-  
     }
 
     /**

--- a/src/find-options/FindOptionsUtils.ts
+++ b/src/find-options/FindOptionsUtils.ts
@@ -1,10 +1,10 @@
-import { FindManyOptions } from "./FindManyOptions";
-import { FindOneOptions } from "./FindOneOptions";
-import { SelectQueryBuilder } from "../query-builder/SelectQueryBuilder";
-import { FindRelationsNotFoundError } from "../error/FindRelationsNotFoundError";
-import { EntityMetadata } from "../metadata/EntityMetadata";
-import { DriverUtils } from "../driver/DriverUtils";
-import { TypeORMError } from "../error";
+import {FindManyOptions} from "./FindManyOptions";
+import {FindOneOptions} from "./FindOneOptions";
+import {SelectQueryBuilder} from "../query-builder/SelectQueryBuilder";
+import {FindRelationsNotFoundError} from "../error/FindRelationsNotFoundError";
+import {EntityMetadata} from "../metadata/EntityMetadata";
+import {DriverUtils} from "../driver/DriverUtils";
+import {TypeORMError} from "../error";
 
 /**
  * Utilities to work with FindOptions.
@@ -21,23 +21,24 @@ export class FindOptionsUtils {
     static isFindOneOptions<Entity = any>(obj: any): obj is FindOneOptions<Entity> {
         const possibleOptions: FindOneOptions<Entity> = obj;
         return possibleOptions &&
-            (
-                Array.isArray(possibleOptions.select) ||
-                possibleOptions.where instanceof Object ||
-                typeof possibleOptions.where === "string" ||
-                Array.isArray(possibleOptions.relations) ||
-                possibleOptions.join instanceof Object ||
-                possibleOptions.order instanceof Object ||
-                possibleOptions.cache instanceof Object ||
-                typeof possibleOptions.cache === "boolean" ||
-                typeof possibleOptions.cache === "number" ||
-                possibleOptions.lock instanceof Object ||
-                possibleOptions.loadRelationIds instanceof Object ||
-                typeof possibleOptions.loadRelationIds === "boolean" ||
-                typeof possibleOptions.loadEagerRelations === "boolean" ||
-                typeof possibleOptions.withDeleted === "boolean" ||
-                typeof possibleOptions.transaction === "boolean"
-            );
+                (
+                    Array.isArray(possibleOptions.select) ||
+                    possibleOptions.where instanceof Object ||
+                    typeof possibleOptions.where === "string" ||
+                    Array.isArray(possibleOptions.relations) ||
+                    possibleOptions.join instanceof Object ||
+                    possibleOptions.order instanceof Object ||
+                    possibleOptions.cache instanceof Object ||
+                    typeof possibleOptions.cache === "boolean" ||
+                    typeof possibleOptions.cache === "number" ||
+                    possibleOptions.lock instanceof Object ||
+                    possibleOptions.loadRelationIds instanceof Object ||
+                    typeof possibleOptions.loadRelationIds === "boolean" ||
+                    typeof possibleOptions.loadEagerRelations === "boolean" ||
+                    typeof possibleOptions.withDeleted === "boolean" ||
+                    typeof possibleOptions.transaction === "boolean"
+                );
+  
     }
 
     /**
@@ -57,7 +58,7 @@ export class FindOptionsUtils {
     /**
      * Checks if given object is really instance of FindOptions interface.
      */
-    static extractFindManyOptionsAlias(object: any): string | undefined {
+    static extractFindManyOptionsAlias(object: any): string|undefined {
         if (this.isFindManyOptions(object) && object.join)
             return object.join.alias;
 
@@ -67,7 +68,7 @@ export class FindOptionsUtils {
     /**
      * Applies give find many options to the given query builder.
      */
-    static applyFindManyOptionsOrConditionsToQueryBuilder<T>(qb: SelectQueryBuilder<T>, options: FindManyOptions<T> | Partial<T> | undefined): SelectQueryBuilder<T> {
+    static applyFindManyOptionsOrConditionsToQueryBuilder<T>(qb: SelectQueryBuilder<T>, options: FindManyOptions<T>|Partial<T>|undefined): SelectQueryBuilder<T> {
         if (this.isFindManyOptions(options))
             return this.applyOptionsToQueryBuilder(qb, options);
 
@@ -80,7 +81,7 @@ export class FindOptionsUtils {
     /**
      * Applies give find options to the given query builder.
      */
-    static applyOptionsToQueryBuilder<T>(qb: SelectQueryBuilder<T>, options: FindOneOptions<T> | FindManyOptions<T> | undefined): SelectQueryBuilder<T> {
+    static applyOptionsToQueryBuilder<T>(qb: SelectQueryBuilder<T>, options: FindOneOptions<T>|FindManyOptions<T>|undefined): SelectQueryBuilder<T> {
 
         // if options are not set then simply return query builder. This is made for simplicity of usage.
         if (!options || (!this.isFindOneOptions(options) && !this.isFindManyOptions(options)))

--- a/src/find-options/FindOptionsUtils.ts
+++ b/src/find-options/FindOptionsUtils.ts
@@ -1,9 +1,9 @@
-import {FindManyOptions} from "./FindManyOptions";
-import {FindOneOptions} from "./FindOneOptions";
-import {SelectQueryBuilder} from "../query-builder/SelectQueryBuilder";
-import {FindRelationsNotFoundError} from "../error/FindRelationsNotFoundError";
-import {EntityMetadata} from "../metadata/EntityMetadata";
-import {DriverUtils} from "../driver/DriverUtils";
+import { FindManyOptions } from "./FindManyOptions";
+import { FindOneOptions } from "./FindOneOptions";
+import { SelectQueryBuilder } from "../query-builder/SelectQueryBuilder";
+import { FindRelationsNotFoundError } from "../error/FindRelationsNotFoundError";
+import { EntityMetadata } from "../metadata/EntityMetadata";
+import { DriverUtils } from "../driver/DriverUtils";
 import { TypeORMError } from "../error";
 
 /**
@@ -21,23 +21,23 @@ export class FindOptionsUtils {
     static isFindOneOptions<Entity = any>(obj: any): obj is FindOneOptions<Entity> {
         const possibleOptions: FindOneOptions<Entity> = obj;
         return possibleOptions &&
-                (
-                    Array.isArray(possibleOptions.select) ||
-                    possibleOptions.where instanceof Object ||
-                    typeof possibleOptions.where === "string" ||
-                    Array.isArray(possibleOptions.relations) ||
-                    possibleOptions.join instanceof Object ||
-                    possibleOptions.order instanceof Object ||
-                    possibleOptions.cache instanceof Object ||
-                    typeof possibleOptions.cache === "boolean" ||
-                    typeof possibleOptions.cache === "number" ||
-                    possibleOptions.lock instanceof Object ||
-                    possibleOptions.loadRelationIds instanceof Object ||
-                    typeof possibleOptions.loadRelationIds === "boolean" ||
-                    typeof possibleOptions.loadEagerRelations === "boolean" ||
-                    typeof possibleOptions.withDeleted === "boolean" ||
-                    typeof possibleOptions.transaction === "boolean"
-                );
+            (
+                Array.isArray(possibleOptions.select) ||
+                possibleOptions.where instanceof Object ||
+                typeof possibleOptions.where === "string" ||
+                Array.isArray(possibleOptions.relations) ||
+                possibleOptions.join instanceof Object ||
+                possibleOptions.order instanceof Object ||
+                possibleOptions.cache instanceof Object ||
+                typeof possibleOptions.cache === "boolean" ||
+                typeof possibleOptions.cache === "number" ||
+                possibleOptions.lock instanceof Object ||
+                possibleOptions.loadRelationIds instanceof Object ||
+                typeof possibleOptions.loadRelationIds === "boolean" ||
+                typeof possibleOptions.loadEagerRelations === "boolean" ||
+                typeof possibleOptions.withDeleted === "boolean" ||
+                typeof possibleOptions.transaction === "boolean"
+            );
     }
 
     /**
@@ -57,7 +57,7 @@ export class FindOptionsUtils {
     /**
      * Checks if given object is really instance of FindOptions interface.
      */
-    static extractFindManyOptionsAlias(object: any): string|undefined {
+    static extractFindManyOptionsAlias(object: any): string | undefined {
         if (this.isFindManyOptions(object) && object.join)
             return object.join.alias;
 
@@ -67,7 +67,7 @@ export class FindOptionsUtils {
     /**
      * Applies give find many options to the given query builder.
      */
-    static applyFindManyOptionsOrConditionsToQueryBuilder<T>(qb: SelectQueryBuilder<T>, options: FindManyOptions<T>|Partial<T>|undefined): SelectQueryBuilder<T> {
+    static applyFindManyOptionsOrConditionsToQueryBuilder<T>(qb: SelectQueryBuilder<T>, options: FindManyOptions<T> | Partial<T> | undefined): SelectQueryBuilder<T> {
         if (this.isFindManyOptions(options))
             return this.applyOptionsToQueryBuilder(qb, options);
 
@@ -80,7 +80,7 @@ export class FindOptionsUtils {
     /**
      * Applies give find options to the given query builder.
      */
-    static applyOptionsToQueryBuilder<T>(qb: SelectQueryBuilder<T>, options: FindOneOptions<T>|FindManyOptions<T>|undefined): SelectQueryBuilder<T> {
+    static applyOptionsToQueryBuilder<T>(qb: SelectQueryBuilder<T>, options: FindOneOptions<T> | FindManyOptions<T> | undefined): SelectQueryBuilder<T> {
 
         // if options are not set then simply return query builder. This is made for simplicity of usage.
         if (!options || (!this.isFindOneOptions(options) && !this.isFindManyOptions(options)))
@@ -222,7 +222,7 @@ export class FindOptionsUtils {
     /**
      * Adds joins for all relations and sub-relations of the given relations provided in the find options.
      */
-    protected static applyRelationsRecursively(qb: SelectQueryBuilder<any>, allRelations: string[], alias: string, metadata: EntityMetadata, prefix: string): void {
+    public static applyRelationsRecursively(qb: SelectQueryBuilder<any>, allRelations: string[], alias: string, metadata: EntityMetadata, prefix: string): void {
 
         // find all relations that match given prefix
         let matchedBaseRelations: string[] = [];

--- a/src/find-options/FindTreeOptions.ts
+++ b/src/find-options/FindTreeOptions.ts
@@ -1,7 +1,7 @@
 /**
  * Defines a special criteria to find specific entities.
  */
-export interface FindTreeOptions<Entity = any> {
+export interface FindTreeOptions {
 
   /**
     * Indicates what relations of entity should be loaded (simplified left join form).

--- a/src/find-options/FindTreeOptions.ts
+++ b/src/find-options/FindTreeOptions.ts
@@ -1,0 +1,11 @@
+/**
+ * Defines a special criteria to find specific entities.
+ */
+export interface FindTreeOptions<Entity = any> {
+
+  /**
+    * Indicates what relations of entity should be loaded (simplified left join form).
+   */
+  relations?: string[];
+
+}

--- a/src/repository/TreeRepository.ts
+++ b/src/repository/TreeRepository.ts
@@ -1,8 +1,11 @@
-import {Repository} from "./Repository";
-import {SelectQueryBuilder} from "../query-builder/SelectQueryBuilder";
-import {ObjectLiteral} from "../common/ObjectLiteral";
-import {AbstractSqliteDriver} from "../driver/sqlite-abstract/AbstractSqliteDriver";
+import { Repository } from "./Repository";
+import { SelectQueryBuilder } from "../query-builder/SelectQueryBuilder";
+import { ObjectLiteral } from "../common/ObjectLiteral";
+import { AbstractSqliteDriver } from "../driver/sqlite-abstract/AbstractSqliteDriver";
 import { TypeORMError } from "../error/TypeORMError";
+import { FindTreeOptions } from "../find-options/FindTreeOptions";
+import { FindRelationsNotFoundError } from "../error";
+import { FindOptionsUtils } from "../find-options/FindOptionsUtils";
 
 /**
  * Repository with additional functions to work with trees.
@@ -18,23 +21,38 @@ export class TreeRepository<Entity> extends Repository<Entity> {
     /**
      * Gets complete trees for all roots in the table.
      */
-    async findTrees(): Promise<Entity[]> {
-        const roots = await this.findRoots();
-        await Promise.all(roots.map(root => this.findDescendantsTree(root)));
+    async findTrees(options?: FindTreeOptions): Promise<Entity[]> {
+        const roots = await this.findRoots(options);
+        await Promise.all(roots.map(root => this.findDescendantsTree(root, options)));
         return roots;
     }
 
     /**
      * Roots are entities that have no ancestors. Finds them all.
      */
-    findRoots(): Promise<Entity[]> {
+    findRoots(options?: FindTreeOptions): Promise<Entity[]> {
         const escapeAlias = (alias: string) => this.manager.connection.driver.escape(alias);
         const escapeColumn = (column: string) => this.manager.connection.driver.escape(column);
         const parentPropertyName = this.manager.connection.namingStrategy.joinColumnName(
             this.metadata.treeParentRelation!.propertyName, this.metadata.primaryColumns[0].propertyName
         );
 
-        return this.createQueryBuilder("treeEntity")
+        const qb = this.createQueryBuilder("treeEntity");
+
+        if (options?.relations) {
+            const allRelations = [...options.relations];
+
+            FindOptionsUtils.applyRelationsRecursively(qb, allRelations, qb.expressionMap.mainAlias!.name, qb.expressionMap.mainAlias!.metadata, "");
+
+            // recursive removes found relations from allRelations array
+            // if there are relations left in this array it means those relations were not found in the entity structure
+            // so, we give an exception about not found relations
+            if (allRelations.length > 0)
+                throw new FindRelationsNotFoundError(allRelations);
+        }
+
+
+        return qb
             .where(`${escapeAlias("treeEntity")}.${escapeColumn(parentPropertyName)} IS NULL`)
             .getMany();
     }
@@ -51,16 +69,29 @@ export class TreeRepository<Entity> extends Repository<Entity> {
     /**
      * Gets all children (descendants) of the given entity. Returns them in a tree - nested into each other.
      */
-    findDescendantsTree(entity: Entity): Promise<Entity> {
+    async findDescendantsTree(entity: Entity, options?: FindTreeOptions): Promise<Entity> {
         // todo: throw exception if there is no column of this relation?
-        return this
-            .createDescendantsQueryBuilder("treeEntity", "treeClosure", entity)
-            .getRawAndEntities()
-            .then(entitiesAndScalars => {
-                const relationMaps = this.createRelationMaps("treeEntity", entitiesAndScalars.raw);
-                this.buildChildrenEntityTree(entity, entitiesAndScalars.entities, relationMaps);
-                return entity;
-            });
+
+        const qb: SelectQueryBuilder<Entity> = this.createDescendantsQueryBuilder("treeEntity", "treeClosure", entity);
+
+        if (options?.relations) {
+            // Copy because `applyRelationsRecursively` modifies it
+            const allRelations = [...options.relations];
+
+            FindOptionsUtils.applyRelationsRecursively(qb, allRelations, qb.expressionMap.mainAlias!.name, qb.expressionMap.mainAlias!.metadata, "");
+
+            // recursive removes found relations from allRelations array
+            // if there are relations left in this array it means those relations were not found in the entity structure
+            // so, we give an exception about not found relations
+            if (allRelations.length > 0)
+                throw new FindRelationsNotFoundError(allRelations);
+        }
+
+        const entities = await qb.getRawAndEntities();
+        const relationMaps = this.createRelationMaps("treeEntity", entities.raw);
+        this.buildChildrenEntityTree(entity, entities.entities, relationMaps);
+
+        return entity;
     }
 
     /**

--- a/src/repository/TreeRepository.ts
+++ b/src/repository/TreeRepository.ts
@@ -1,7 +1,7 @@
-import { Repository } from "./Repository";
-import { SelectQueryBuilder } from "../query-builder/SelectQueryBuilder";
-import { ObjectLiteral } from "../common/ObjectLiteral";
-import { AbstractSqliteDriver } from "../driver/sqlite-abstract/AbstractSqliteDriver";
+import {Repository} from "./Repository";
+import {SelectQueryBuilder} from "../query-builder/SelectQueryBuilder";
+import {ObjectLiteral} from "../common/ObjectLiteral";
+import {AbstractSqliteDriver} from "../driver/sqlite-abstract/AbstractSqliteDriver";
 import { TypeORMError } from "../error/TypeORMError";
 import { FindTreeOptions } from "../find-options/FindTreeOptions";
 import { FindRelationsNotFoundError } from "../error";

--- a/test/github-issues/7974/entity/Category.ts
+++ b/test/github-issues/7974/entity/Category.ts
@@ -1,0 +1,25 @@
+import { BaseEntity, Column, Entity, OneToMany, PrimaryGeneratedColumn, Tree, TreeChildren, TreeParent } from "../../../../src";
+import { Site } from "./Site";
+
+@Entity()
+@Tree("materialized-path")
+export class Category extends BaseEntity {
+
+  @PrimaryGeneratedColumn()
+  pk: number;
+
+  @Column({
+    length: 250,
+    nullable: false
+  })
+  title: string;
+
+  @TreeParent()
+  parentCategory: Category | null;
+
+  @TreeChildren()
+  childCategories: Category[];
+
+  @OneToMany(() => Site, site => site.parentCategory)
+  sites: Site[];
+}

--- a/test/github-issues/7974/entity/Site.ts
+++ b/test/github-issues/7974/entity/Site.ts
@@ -1,0 +1,21 @@
+import { BaseEntity, Column, CreateDateColumn, Entity, ManyToOne, PrimaryGeneratedColumn } from "../../../../src";
+import { Category } from "./Category";
+
+@Entity()
+export class Site extends BaseEntity {
+
+  @PrimaryGeneratedColumn()
+  pk: number;
+
+  @CreateDateColumn()
+  createdAt: Date;
+
+  @Column({
+    length: 250,
+    nullable: false
+  })
+  title: string;
+
+  @ManyToOne(() => Category)
+  parentCategory: Category;
+}

--- a/test/github-issues/7974/issue-7974.ts
+++ b/test/github-issues/7974/issue-7974.ts
@@ -12,8 +12,7 @@ describe("github issues > #7974 Adding relations option to findTrees()", () => {
   before(async () => connections = await createTestingConnections({
     entities: [Category, Site],
     schemaCreate: true,
-    dropSchema: true,
-    enabledDrivers: ["mssql", "mariadb"]
+    dropSchema: true
   }));
 
   beforeEach(async () => {

--- a/test/github-issues/7974/issue-7974.ts
+++ b/test/github-issues/7974/issue-7974.ts
@@ -1,0 +1,126 @@
+import { expect } from "chai";
+import "reflect-metadata";
+import { Connection } from "../../../src";
+import { closeTestingConnections, createTestingConnections, reloadTestingDatabases } from "../../utils/test-utils";
+import { Category } from "./entity/Category";
+import { Site } from "./entity/Site";
+
+describe("github issues > #7974 Adding relations option to findTrees()", () => {
+
+  let connections: Connection[];
+
+  before(async () => connections = await createTestingConnections({
+    entities: [Category, Site],
+    schemaCreate: true,
+    dropSchema: true,
+    enabledDrivers: ["mssql", "mariadb"]
+  }));
+
+  beforeEach(async () => {
+    await reloadTestingDatabases(connections);
+    for (let connection of connections) {
+      let categoryRepo = connection.getRepository(Category);
+      let siteRepo = connection.getRepository(Site);
+
+      let c1: Category = new Category();
+      c1.title = "Category 1";
+      c1.parentCategory = null;
+      c1.childCategories = [];
+      c1.sites = [];
+
+      let c2: Category = new Category();
+      c2.title = "Category 2";
+      c2.parentCategory = null;
+      c2.childCategories = [];
+      c2.sites = [];
+
+      let c3: Category = new Category();
+      c3.title = "Category 1.1";
+      c3.parentCategory = c1;
+      c3.childCategories = [];
+      c3.sites = [];
+
+      let c4: Category = new Category();
+      c4.title = "Category 1.1.1";
+      c4.parentCategory = c3;
+      c4.childCategories = [];
+      c4.sites = [];
+
+      c1.childCategories = [c3];
+      c3.childCategories = [c4];
+
+      let s1: Site = new Site();
+      s1.title = "Site of Category 1";
+      s1.parentCategory = c1;
+
+      let s2: Site = new Site();
+      s2.title = "Site of Category 1";
+      s2.parentCategory = c1;
+
+      let s3: Site = new Site();
+      s3.title = "Site of Category 1.1";
+      s3.parentCategory = c3;
+
+      let s4: Site = new Site();
+      s4.title = "Site of Category 1.1";
+      s4.parentCategory = c3;
+
+      let s5: Site = new Site();
+      s5.title = "Site of Category 1.1.1";
+      s5.parentCategory = c4;
+
+      // Create the categories
+      c1 = await categoryRepo.save(c1);
+      c2 = await categoryRepo.save(c2);
+      c3 = await categoryRepo.save(c3);
+      c4 = await categoryRepo.save(c4);
+
+      // Create the sites
+      [s1, s2, s3, s4, s5] =
+        await Promise.all([
+          siteRepo.save(s1),
+          siteRepo.save(s2),
+          siteRepo.save(s3),
+          siteRepo.save(s4),
+          siteRepo.save(s5)
+        ]);
+
+      // Set the just created relations correctly
+      c1.sites = [s1, s2];
+      c2.sites = [];
+      c3.sites = [s3, s4];
+      c4.sites = [s5];
+    }
+  });
+
+  after(() => closeTestingConnections(connections));
+
+  it("should return tree without sites relations", async () => await Promise.all(connections.map(async connection => {
+
+    let result = await connection.getTreeRepository(Category).findTrees();
+
+    // The complete tree should exist but other relations than the parent- / child-relations should not be loaded
+    expect(result).to.have.lengthOf(2);
+    expect(result[0].sites).equals(undefined);
+    expect(result[0].childCategories).to.have.lengthOf(1);
+    expect(result[0].childCategories[0].childCategories).to.have.lengthOf(1);
+    expect(result[0].childCategories[0].childCategories[0].sites).equal(undefined);
+
+  })));
+
+  it("should return tree with sites relations", async () => await Promise.all(connections.map(async connection => {
+
+    let result = await connection.getTreeRepository(Category).findTrees({ relations: ["sites"] });
+
+    // The complete tree should exist and site relations should not be loaded for every category
+    expect(result).to.have.lengthOf(2);
+    expect(result[0].sites).lengthOf(2);
+    expect(result[1].sites).to.be.an("array");
+    expect(result[1].sites).to.have.lengthOf(0);
+    expect(result[0].childCategories[0].sites).to.have.lengthOf(2);
+    expect(result[0].childCategories[0].childCategories[0].sites).to.have.lengthOf(1);
+    expect(result[0].childCategories[0].childCategories[0].sites).to.be.an("array");
+    expect(result[0].childCategories[0].childCategories[0].sites[0].title).to.be.equal("Site of Category 1.1.1");
+  })));
+
+});


### PR DESCRIPTION
Add possibility to load relations of tree entities

### Description of change

The change adds an optional `options` parameter to the findTrees() function. 
The only option that can currently be set is `relations` which is an array of all relations that should be loaded for the entities. It works the same way as the `relations` array for the find() method.

**Example:** 
```typescript
await connection.getTreeRepository(Category).findTrees({ relations: ["sites"] });
```
Results in: 
```
[
  Category {
    pk: 1,
    title: 'Category 1',
    sites: [ [Site], [Site] ],
    childCategories: [ [Category] ]
  },
  Category {
    pk: 2,
    title: 'Category 2',
    sites: [],
    childCategories: []
  }
]
```
Because findTrees() is depending on the findDescendantsTree() and findRoots() functions those two also implement this new optional `options` parameter.

Currently it is not possible to load relations for tree entities in a single query. This is a much requested and needed feature, it would be great if it could be merged very soon!

I created test cases to ensure the functionality.

Closes: #7974 #4564

### Pull-Request Checklist

<!--
  Please make sure to review and check all of the following.

  If an item is not applicable, you can add "N/A" to the end.
-->

- [x] Code is up-to-date with the `master` branch
- [x] `npm run lint` passes with this change
- [x] `npm run test` passes with this change
- [x] This pull request links relevant issues as `Fixes #0000`
- [x] There are new or updated unit tests validating the change
- [x] Documentation has been updated to reflect this change
- [x] The new commits follow conventions explained in [CONTRIBUTING.md](https://github.com/typeorm/typeorm/blob/master/CONTRIBUTING.md)

Could you please tell me when you are planning to merge this pull request? Thank you!