### PR TITLE
feat: add possibility to pass application_name via postgres specific config

### DIFF
--- a/docs/connection-options.md
+++ b/docs/connection-options.md
@@ -191,6 +191,8 @@ See [SSL options](https://github.com/mysqljs/mysql#ssl-options).
 
 * `installExtensions` - A boolean to control whether to install necessary postgres extensions automatically or not (default: `true`)
 
+* `applicationName` - A string visible in statistics and logs to help referencing an application to a connection (default: `undefined`)
+
 ## `sqlite` connection options
 
 * `database` - Database path. For example "./mydb.sql"

--- a/src/driver/postgres/PostgresConnectionOptions.ts
+++ b/src/driver/postgres/PostgresConnectionOptions.ts
@@ -67,4 +67,10 @@ export interface PostgresConnectionOptions extends BaseConnectionOptions, Postgr
      * Automatically install postgres extensions
      */
      readonly installExtensions?: boolean;
+
+    /**
+     * sets the application_name var to help db administrators identify
+     * the service using this connection. Defaults to 'undefined'
+     */
+    readonly applicationName?: string;
 }

--- a/src/driver/postgres/PostgresDriver.ts
+++ b/src/driver/postgres/PostgresDriver.ts
@@ -1101,7 +1101,8 @@ export class PostgresDriver implements Driver {
             database: credentials.database,
             port: credentials.port,
             ssl: credentials.ssl,
-            connectionTimeoutMillis: options.connectTimeoutMS
+            connectionTimeoutMillis: options.connectTimeoutMS,
+            application_name: options.applicationName
         }, options.extra || {});
 
         // create a connection pool

--- a/test/functional/driver/postgres/specific-options.ts
+++ b/test/functional/driver/postgres/specific-options.ts
@@ -1,0 +1,24 @@
+import "reflect-metadata";
+import { createTestingConnections, closeTestingConnections, reloadTestingDatabases } from "../../../utils/test-utils";
+import { Connection } from "../../../../src/connection/Connection";
+import { expect } from "chai";
+
+describe("postgres specific options", () => {
+  let connections: Connection[];
+  before(async () => connections = await createTestingConnections({
+    enabledDrivers: ["postgres"],
+    driverSpecific: {
+      applicationName: "some test name"
+    }
+  }));
+  beforeEach(() => reloadTestingDatabases(connections));
+  after(() => closeTestingConnections(connections));
+
+  it("should set application_name", () => Promise.all(connections.map(async connection => {
+    const result = await connection.query(
+      "select current_setting('application_name') as application_name"
+    );
+    expect(result.length).equals(1);
+    expect(result[0].application_name).equals("some test name");
+  })));
+});


### PR DESCRIPTION
<!--
  😀 Wonderful!  Thank you for opening a pull request for TypeORM.

  Please fill in the information below to expedite the review
  and (hopefully) merge of your change.

  If unsure about something.. just do as best as you're able,
  or reach out through our community support channels!
  https://github.com/typeorm/typeorm/blob/master/docs/support.md
-->

### Description of change

As the "extra" parameter should be deprecated in the future, the need for
passing driver specific options via the respective config objects is given.
The addition of the "applicationName" parameter is a step forward in this 
direction. This parameter is visible in logs and statistics and helps db
administrators to see which connection belongs to which application.
This change also enables the user to use code completion in case they
didn't even knew this options exists

<!--
  Please be clear and concise what the change is intended to do,
  why this change is needed, and how you've verified that it
  corrects what you intended.

  In some cases it may be helpful to include the current behavior
  and the new behavior.

  If the change is related to an open issue, you can link it here.
  If you include `Fixes #0000` (replacing `0000` with the issue number)
  when this is merged it will automatically mark the issue as fixed and
  close it.
-->


### Pull-Request Checklist

<!--
  Please make sure to review and check all of the following.

  If an item is not applicable, you can add "N/A" to the end.
-->

- [x] Code is up-to-date with the `master` branch
- [x] `npm run lint` passes with this change
- [x] `npm run test` passes with this change
- [ ] This pull request links relevant issues as `Fixes #0000` N/A
- [x] There are new or updated unit tests validating the change
- [x] Documentation has been updated to reflect this change
- [x] The new commits follow conventions explained in [CONTRIBUTING.md](https://github.com/typeorm/typeorm/blob/master/CONTRIBUTING.md)

<!--
  🎉 Thank you for contributing and making TypeORM even better!
-->
