### PR TITLE
Quick - backwards compatible fix for supporting mongo v4

### DIFF
--- a/src/entity-manager/MongoEntityManager.ts
+++ b/src/entity-manager/MongoEntityManager.ts
@@ -130,7 +130,7 @@ export class MongoEntityManager extends EntityManager {
     async findByIds<Entity>(entityClassOrName: EntityTarget<Entity>, ids: any[], optionsOrConditions?: FindManyOptions<Entity> | Partial<Entity>): Promise<Entity[]> {
         const metadata = this.connection.getMetadata(entityClassOrName);
         const query = this.convertFindManyOptionsOrConditionsToMongodbQuery(optionsOrConditions) || {};
-        const objectIdInstance = PlatformTools.load("mongodb").ObjectID;
+        const objectIdInstance = PlatformTools.load("mongodb").ObjectID || PlatformTools.load("mongodb").ObjectId;
         query["_id"] = {
             $in: ids.map(id => {
                 if (typeof id === "string") {
@@ -171,7 +171,7 @@ export class MongoEntityManager extends EntityManager {
     async findOne<Entity>(entityClassOrName: EntityTarget<Entity>,
                           optionsOrConditions?: string | string[] | number | number[] | Date | Date[] | ObjectID | ObjectID[] | FindOneOptions<Entity> | DeepPartial<Entity>,
                           maybeOptions?: FindOneOptions<Entity>): Promise<Entity | undefined> {
-        const objectIdInstance = PlatformTools.load("mongodb").ObjectID;
+        const objectIdInstance = PlatformTools.load("mongodb").ObjectID || PlatformTools.load("mongodb").ObjectId;
         const id = (optionsOrConditions instanceof objectIdInstance) || typeof optionsOrConditions === "string" ? optionsOrConditions : undefined;
         const findOneOptionsOrConditions = (id ? maybeOptions : optionsOrConditions) as any;
         const query = this.convertFindOneOptionsOrConditionsToMongodbQuery(findOneOptionsOrConditions) || {};
@@ -592,8 +592,8 @@ export class MongoEntityManager extends EntityManager {
             return undefined;
 
         if (FindOptionsUtils.isFindManyOptions<Entity>(optionsOrConditions))
-        // If where condition is passed as a string which contains sql we have to ignore
-        // as mongo is not a sql database
+            // If where condition is passed as a string which contains sql we have to ignore
+            // as mongo is not a sql database
             return typeof optionsOrConditions.where === "string"
                 ? {}
                 : optionsOrConditions.where;
@@ -609,8 +609,8 @@ export class MongoEntityManager extends EntityManager {
             return undefined;
 
         if (FindOptionsUtils.isFindOneOptions<Entity>(optionsOrConditions))
-        // If where condition is passed as a string which contains sql we have to ignore
-        // as mongo is not a sql database
+            // If where condition is passed as a string which contains sql we have to ignore
+            // as mongo is not a sql database
             return typeof optionsOrConditions.where === "string"
                 ? {}
                 : optionsOrConditions.where;
@@ -651,7 +651,7 @@ export class MongoEntityManager extends EntityManager {
      * Ensures given id is an id for query.
      */
     protected convertMixedCriteria(metadata: EntityMetadata, idMap: any): ObjectLiteral {
-        const objectIdInstance = PlatformTools.load("mongodb").ObjectID;
+        const objectIdInstance = PlatformTools.load("mongodb").ObjectID || PlatformTools.load("mongodb").ObjectId;
 
         // check first if it's ObjectId compatible:
         // string, number, Buffer, ObjectId or ObjectId-like
@@ -684,7 +684,7 @@ export class MongoEntityManager extends EntityManager {
      * Overrides cursor's toArray and next methods to convert results to entity automatically.
      */
     protected applyEntityTransformationToCursor<Entity>(metadata: EntityMetadata, cursor: Cursor<Entity> | AggregationCursor<Entity>) {
-        const ParentCursor = PlatformTools.load("mongodb").Cursor;
+        const ParentCursor = PlatformTools.load("mongodb").Cursor || PlatformTools.load("mongodb").FindCursor;
         const queryRunner = this.mongoQueryRunner;
         cursor.toArray = function (callback?: MongoCallback<Entity[]>) {
             if (callback) {
@@ -751,3 +751,4 @@ export class MongoEntityManager extends EntityManager {
     }
 
 }
+


### PR DESCRIPTION
### Description of change
While integrating `next-auth` into a full stack next project, I noticed that the type orm implementation of mongo v4 was breaking.  

There is another [much larger PR, and more complete PR](https://github.com/typeorm/typeorm/pull/7909) open to upgrade to mongo v4.

But, with the fix I added here, I was able to leverage the core functionality of the MongoEntity Manager without causing any regressions. 


### Pull-Request Checklist

- [x] Code is up-to-date with the `master` branch
- [ ] `npm run lint` passes with this change
- [ ] `npm run test` passes with this change
- [ ] This pull request links relevant issues as `Fixes #0000`
- [ ] There are new or updated unit tests validating the change
- [ ] Documentation has been updated to reflect this change
- [ ] The new commits follow conventions explained in [CONTRIBUTING.md](https://github.com/typeorm/typeorm/blob/master/CONTRIBUTING.md)

