### PR TITLE
Fix bug with new nested where filters

### DIFF
--- a/test/functional/connection-options-reader/connection-options-reader.ts
+++ b/test/functional/connection-options-reader/connection-options-reader.ts
@@ -11,7 +11,7 @@ async function createDotenvFiles() {
 }
 
 async function createYamlFiles() {
-  await fs.mkdir(path.join(__dirname, "configs/yaml"));
+  await fs.mkdir(path.join(__dirname, "configs/yaml"), { recursive: true });
   await fs.writeFile(path.join(__dirname, "configs/yaml/test-yaml.yaml"), "- type: \"sqlite\"\n  name: \"file\"\n  database: \"test-yaml\"");
 }
 

--- a/test/functional/query-builder/select/query-builder-select.ts
+++ b/test/functional/query-builder/select/query-builder-select.ts
@@ -219,18 +219,24 @@ describe("query builder > select", () => {
 
         describe("many-to-many", () => {
             it("should craft query with exact value", () => Promise.all(connections.map(async connection => {
+                const [sql, params] = connection.createQueryBuilder(Post, "post")
+                    .select("post.id")
+                    .leftJoin("post.tags", "tags_join")
+                    .where({
+                        "tags": {
+                            "name": "Foo"
+                        }
+                    })
+                    .getQueryAndParameters();
 
-                expect(() => {
-                    connection.createQueryBuilder(Post, "post")
-                        .select("post.id")
-                        .leftJoin("post.tags", "tags_join")
-                        .where({
-                            "tags": {
-                                "name": "Foo"
-                            }
-                        })
-                        .getQueryAndParameters();
-                }).to.throw();
+                expect(sql).to.equal(
+                    'SELECT "post"."id" AS "post_id" FROM "post" "post" ' +
+                    'LEFT JOIN "post_tags_tag" "post_tags_join" ON "post_tags_join"."postId"="post"."id" ' +
+                    'LEFT JOIN "tag" "tags_join" ON "tags_join"."id"="post_tags_join"."tagId" ' +
+                    'WHERE "tags_join"."name" = ?'
+                );
+
+                expect(params).to.eql(["Foo"]);
             })));
 
             it("should craft query with FindOperator", () => Promise.all(connections.map(async connection => {

--- a/test/functional/query-builder/select/query-builder-select.ts
+++ b/test/functional/query-builder/select/query-builder-select.ts
@@ -342,6 +342,31 @@ describe("query builder > select", () => {
 
                 expect(params).to.eql(["Foo", "Bar", "Baz"]);
             })));
+
+            it("should craft query with FindOperator with nested primary/non-primary key", () => Promise.all(connections.map(async connection => {
+                const [sql, params] = connection.createQueryBuilder(HeroImage, "hero")
+                    .leftJoin("hero.post", "posts")
+                    .leftJoin("posts.category", "category")
+                    .where({
+                        post: {
+                            category: {
+                                id: In([1, 2, 3]),
+                                name: In(["Foo", "Bar", "Baz"]),
+                            }
+                        }
+                    })
+                    .getQueryAndParameters();
+
+                expect(sql).to.equal(
+                    'SELECT "hero"."id" AS "hero_id", "hero"."url" AS "hero_url" ' +
+                    'FROM "hero_image" "hero" ' +
+                    'LEFT JOIN "post" "posts" ON "posts"."heroImageId"="hero"."id"  ' +
+                    'LEFT JOIN "category" "category" ON "category"."id"="posts"."categoryId" ' +
+                    'WHERE ("category"."id" IN (?, ?, ?) AND "category"."name" IN (?, ?, ?))'
+                );
+
+                expect(params).to.eql([1, 2, 3, "Foo", "Bar", "Baz"]);
+            })));
         });
     });
 

--- a/test/functional/query-builder/select/query-builder-select.ts
+++ b/test/functional/query-builder/select/query-builder-select.ts
@@ -203,17 +203,23 @@ describe("query builder > select", () => {
             it("should craft query with FindOperator", () => Promise.all(connections.map(async connection => {
                 // For github issue #6647
 
-                expect(() => {
-                    connection.createQueryBuilder(Category, "category")
-                        .select("category.id")
-                        .leftJoin("category.posts", "posts")
-                        .where({
-                            posts: {
-                                id: IsNull()
-                            }
-                        })
-                        .getQueryAndParameters();
-                }).to.throw();
+                const [sql, params] = connection.createQueryBuilder(Category, "category")
+                    .select("category.id")
+                    .leftJoin("category.posts", "posts")
+                    .where({
+                        posts: {
+                            id: IsNull()
+                        }
+                    })
+                    .getQueryAndParameters();
+
+                expect(sql).to.equal(
+                    'SELECT "category"."id" AS "category_id" FROM "category" "category" ' +
+                    'LEFT JOIN "post" "posts" ON "posts"."categoryId"="category"."id" ' +
+                    'WHERE "posts"."id" IS NULL'
+                );
+
+                expect(params).to.eql([]);
             })));
         });
 
@@ -234,17 +240,24 @@ describe("query builder > select", () => {
             })));
 
             it("should craft query with FindOperator", () => Promise.all(connections.map(async connection => {
-                expect(() => {
-                    connection.createQueryBuilder(Post, "post")
-                        .select("post.id")
-                        .leftJoin("post.tags", "tags_join")
-                        .where({
-                            "tags": {
-                                "name": IsNull()
-                            }
-                        })
-                        .getQueryAndParameters();
-                }).to.throw();
+                const [sql, params] = connection.createQueryBuilder(Post, "post")
+                    .select("post.id")
+                    .leftJoin("post.tags", "tags_join")
+                    .where({
+                        "tags": {
+                            "name": IsNull()
+                        }
+                    })
+                    .getQueryAndParameters();
+
+                expect(sql).to.equal(
+                    'SELECT "post"."id" AS "post_id" FROM "post" "post" ' +
+                    'LEFT JOIN "post_tags_tag" "post_tags_join" ON "post_tags_join"."postId"="post"."id" ' +
+                    'LEFT JOIN "tag" "tags_join" ON "tags_join"."id"="post_tags_join"."tagId" ' +
+                    'WHERE "tags_join"."name" IS NULL'
+                );
+
+                expect(params).to.eql([]);
             })));
         });
 

--- a/test/functional/query-builder/select/query-builder-select.ts
+++ b/test/functional/query-builder/select/query-builder-select.ts
@@ -203,23 +203,17 @@ describe("query builder > select", () => {
             it("should craft query with FindOperator", () => Promise.all(connections.map(async connection => {
                 // For github issue #6647
 
-                const [sql, params] = connection.createQueryBuilder(Category, "category")
-                    .select("category.id")
-                    .leftJoin("category.posts", "posts")
-                    .where({
-                        posts: {
-                            id: IsNull()
-                        }
-                    })
-                    .getQueryAndParameters();
-
-                expect(sql).to.equal(
-                    'SELECT "category"."id" AS "category_id" FROM "category" "category" ' +
-                    'LEFT JOIN "post" "posts" ON "posts"."categoryId"="category"."id" ' +
-                    'WHERE "posts"."id" IS NULL'
-                );
-
-                expect(params).to.eql([]);
+                expect(() => {
+                    connection.createQueryBuilder(Category, "category")
+                        .select("category.id")
+                        .leftJoin("category.posts", "posts")
+                        .where({
+                            posts: {
+                                id: IsNull()
+                            }
+                        })
+                        .getQueryAndParameters();
+                }).to.throw();
             })));
         });
 


### PR DESCRIPTION
### Description of change
Found a bug in the most recent nested where filter feature:
https://github.com/typeorm/typeorm/pull/7805

When combining nested primary keys and non-primary keys the query builder would build an incorrect query.
Included a test case that illustrates the issue. 

 fixes #8082

### Pull-Request Checklist

- [x] Code is up-to-date with the `master` branch
- [x] `npm run lint` passes with this change
- [x] `npm run test` passes with this change
- [x] There are new or updated unit tests validating the change
- [x] The new commits follow conventions explained in [CONTRIBUTING.md](https://github.com/typeorm/typeorm/blob/master/CONTRIBUTING.md)
