### PR TITLE
fix: attach FOR NO KEY UPDATE lock to query if required

### DIFF
--- a/src/find-options/FindOptionsUtils.ts
+++ b/src/find-options/FindOptionsUtils.ts
@@ -155,7 +155,14 @@ export class FindOptionsUtils {
         if (options.lock) {
             if (options.lock.mode === "optimistic") {
                 qb.setLock(options.lock.mode, options.lock.version);
-            } else if (options.lock.mode === "pessimistic_read" || options.lock.mode === "pessimistic_write" || options.lock.mode === "dirty_read" || options.lock.mode === "pessimistic_partial_write" || options.lock.mode === "pessimistic_write_or_fail") {
+            } else if (
+                options.lock.mode === "pessimistic_read" ||
+                options.lock.mode === "pessimistic_write" ||
+                options.lock.mode === "dirty_read" ||
+                options.lock.mode === "pessimistic_partial_write" ||
+                options.lock.mode === "pessimistic_write_or_fail" ||
+                options.lock.mode === "for_no_key_update"
+            ) {
                 const tableNames = options.lock.tables ? options.lock.tables.map((table) => {
                     const tableAlias = qb.expressionMap.aliases.find((alias) => {
                         return alias.metadata.tableNameWithoutPrefix === table;


### PR DESCRIPTION
<!--
  😀 Wonderful!  Thank you for opening a pull request for TypeORM.

  Please fill in the information below to expedite the review
  and (hopefully) merge of your change.

  If unsure about something.. just do as best as you're able,
  or reach out through our community support channels!
  https://github.com/typeorm/typeorm/blob/master/docs/support.md
-->

### Description of change

FOR NO KEY UPDATE was introduced in typeorm 0.2.25 but the relevant query
part was never added due to missing check in FindOptionUtils as @ykovalenko-gentech
stated out. I've added a test to ensure this behaviour will not change in the future.

Fixes #7717

<!--
  Please be clear and concise what the change is intended to do,
  why this change is needed, and how you've verified that it
  corrects what you intended.

  In some cases it may be helpful to include the current behavior
  and the new behavior.

  If the change is related to an open issue, you can link it here.
  If you include `Fixes #0000` (replacing `0000` with the issue number)
  when this is merged it will automatically mark the issue as fixed and
  close it.
-->


### Pull-Request Checklist

<!--
  Please make sure to review and check all of the following.

  If an item is not applicable, you can add "N/A" to the end.
-->

- [x] Code is up-to-date with the `master` branch
- [x] `npm run lint` passes with this change
- [x] `npm run test` passes with this change
- [x] This pull request links relevant issues as `Fixes #0000`
- [x] There are new or updated unit tests validating the change
- [x] Documentation has been updated to reflect this change *N/A*
- [x] The new commits follow conventions explained in [CONTRIBUTING.md](https://github.com/typeorm/typeorm/blob/master/CONTRIBUTING.md)

<!--
  🎉 Thank you for contributing and making TypeORM even better!
-->
