### PR TITLE
Allow custom driver to a connection of type react-native

### DIFF
--- a/src/driver/react-native/ReactNativeConnectionOptions.ts
+++ b/src/driver/react-native/ReactNativeConnectionOptions.ts
@@ -19,4 +19,9 @@ export interface ReactNativeConnectionOptions extends BaseConnectionOptions {
      * Storage Location
      */
     readonly location: string;
+
+    /**
+     * Driver
+     */
+    readonly driver?: any;
 }

--- a/src/driver/react-native/ReactNativeDriver.ts
+++ b/src/driver/react-native/ReactNativeDriver.ts
@@ -90,7 +90,11 @@ export class ReactNativeDriver extends AbstractSqliteDriver {
      */
     protected loadDependencies(): void {
         try {
+          if(!this.options.driver) {
             this.sqlite = require("react-native-sqlite-storage");
+          } else {
+            this.sqlite = this.options.driver
+          }
 
         } catch (e) {
             throw new DriverPackageNotInstalledError("React-Native", "react-native-sqlite-storage");

--- a/src/platform/PlatformTools.ts
+++ b/src/platform/PlatformTools.ts
@@ -124,6 +124,12 @@ export class PlatformTools {
                  */
                 case "react-native-sqlite-storage":
                     return require("react-native-sqlite-storage");
+
+                /**
+                 * react-native-quick-sqlite
+                 */
+                case "react-native-quick-sqlite":
+                  return require("react-native-quick-sqlite");
             }
 
         } catch (err) {


### PR DESCRIPTION

### Description of change

Hi!

I created a new [sqlite package for react-native](https://github.com/ospfranco/react-native-quick-sqlite) this package is much faster than all the previous implementations

TypeORM already supports react-native-sqlite-storage as a driver, taken this into consideration I implemented the same API on my package, so it's meant to be a drop-in replacement

Before this PR I got typeORM to work just fine by just replacing the `react-native-sqlite-storage` string with my own package name `react-native-quick-sqlite`, everything works fine.

On this PR however I'm not sure how many files I was supposed to change (too many I guess) so I did the next best option, the ability to pass a driver object directly.

Any help getting the PR approved is much appreciated :)

### Pull-Request Checklist

<!--
  Please make sure to review and check all of the following.

  If an item is not applicable, you can add "N/A" to the end.
-->

- [x] Code is up-to-date with the `master` branch
- [x] `npm run lint` passes with this change
- [x] `npm run test` passes with this change
- [x] This pull request links relevant issues as `Fixes #0000`
- [ ] There are new or updated unit tests validating the change
- [ ] Documentation has been updated to reflect this change
- [x] The new commits follow conventions explained in [CONTRIBUTING.md](https://github.com/typeorm/typeorm/blob/master/CONTRIBUTING.md)