### PR TITLE
fix: allow periods in parameter identifiers

### DIFF
--- a/src/driver/aurora-data-api/AuroraDataApiDriver.ts
+++ b/src/driver/aurora-data-api/AuroraDataApiDriver.ts
@@ -384,7 +384,7 @@ export class AuroraDataApiDriver implements Driver {
         if (!parameters || !Object.keys(parameters).length)
             return [sql, escapedParameters];
 
-        sql = sql.replace(/:(\.\.\.)?([A-Za-z0-9_]+)/g, (full, isArray: string, key: string): string => {
+        sql = sql.replace(/:(\.\.\.)?([A-Za-z0-9_.]+)/g, (full, isArray: string, key: string): string => {
             if (!parameters.hasOwnProperty(key)) {
                 return full;
             }

--- a/src/driver/cockroachdb/CockroachDriver.ts
+++ b/src/driver/cockroachdb/CockroachDriver.ts
@@ -388,7 +388,7 @@ export class CockroachDriver implements Driver {
         if (!parameters || !Object.keys(parameters).length)
             return [sql, escapedParameters];
 
-        sql = sql.replace(/:(\.\.\.)?([A-Za-z0-9_]+)/g, (full, isArray: string, key: string): string => {
+        sql = sql.replace(/:(\.\.\.)?([A-Za-z0-9_.]+)/g, (full, isArray: string, key: string): string => {
             if (!parameters.hasOwnProperty(key)) {
                 return full;
             }

--- a/src/driver/mysql/MysqlDriver.ts
+++ b/src/driver/mysql/MysqlDriver.ts
@@ -403,7 +403,7 @@ export class MysqlDriver implements Driver {
         if (!parameters || !Object.keys(parameters).length)
             return [sql, escapedParameters];
 
-        sql = sql.replace(/:(\.\.\.)?([A-Za-z0-9_]+)/g, (full, isArray: string, key: string): string => {
+        sql = sql.replace(/:(\.\.\.)?([A-Za-z0-9_.]+)/g, (full, isArray: string, key: string): string => {
             if (!parameters.hasOwnProperty(key)) {
                 return full;
             }

--- a/src/driver/oracle/OracleDriver.ts
+++ b/src/driver/oracle/OracleDriver.ts
@@ -311,7 +311,7 @@ export class OracleDriver implements Driver {
         if (!parameters || !Object.keys(parameters).length)
             return [sql, escapedParameters];
 
-        sql = sql.replace(/:(\.\.\.)?([A-Za-z0-9_]+)/g, (full, isArray: string, key: string): string => {
+        sql = sql.replace(/:(\.\.\.)?([A-Za-z0-9_.]+)/g, (full, isArray: string, key: string): string => {
             if (!parameters.hasOwnProperty(key)) {
                 return full;
             }

--- a/src/driver/postgres/PostgresDriver.ts
+++ b/src/driver/postgres/PostgresDriver.ts
@@ -628,7 +628,7 @@ export class PostgresDriver implements Driver {
         if (!parameters || !Object.keys(parameters).length)
             return [sql, escapedParameters];
 
-        sql = sql.replace(/:(\.\.\.)?([A-Za-z0-9_]+)/g, (full, isArray: string, key: string): string => {
+        sql = sql.replace(/:(\.\.\.)?([A-Za-z0-9_.]+)/g, (full, isArray: string, key: string): string => {
             if (!parameters.hasOwnProperty(key)) {
                 return full;
             }

--- a/src/driver/sap/SapDriver.ts
+++ b/src/driver/sap/SapDriver.ts
@@ -307,7 +307,7 @@ export class SapDriver implements Driver {
         if (!parameters || !Object.keys(parameters).length)
             return [sql, escapedParameters];
 
-        sql = sql.replace(/:(\.\.\.)?([A-Za-z0-9_]+)/g, (full, isArray: string, key: string): string => {
+        sql = sql.replace(/:(\.\.\.)?([A-Za-z0-9_.]+)/g, (full, isArray: string, key: string): string => {
             if (!parameters.hasOwnProperty(key)) {
                 return full;
             }

--- a/src/driver/sqlite-abstract/AbstractSqliteDriver.ts
+++ b/src/driver/sqlite-abstract/AbstractSqliteDriver.ts
@@ -372,7 +372,7 @@ export abstract class AbstractSqliteDriver implements Driver {
         if (!parameters || !Object.keys(parameters).length)
             return [sql, escapedParameters];
 
-        sql = sql.replace(/:(\.\.\.)?([A-Za-z0-9_]+)/g, (full, isArray: string, key: string): string => {
+        sql = sql.replace(/:(\.\.\.)?([A-Za-z0-9_.]+)/g, (full, isArray: string, key: string): string => {
             if (!parameters.hasOwnProperty(key)) {
                 return full;
             }

--- a/src/driver/sqlserver/SqlServerDriver.ts
+++ b/src/driver/sqlserver/SqlServerDriver.ts
@@ -316,7 +316,7 @@ export class SqlServerDriver implements Driver {
         if (!parameters || !Object.keys(parameters).length)
             return [sql, escapedParameters];
 
-        sql = sql.replace(/:(\.\.\.)?([A-Za-z0-9_]+)/g, (full, isArray: string, key: string): string => {
+        sql = sql.replace(/:(\.\.\.)?([A-Za-z0-9_.]+)/g, (full, isArray: string, key: string): string => {
             if (!parameters.hasOwnProperty(key)) {
                 return full;
             }

--- a/src/query-builder/QueryBuilder.ts
+++ b/src/query-builder/QueryBuilder.ts
@@ -339,10 +339,16 @@ export abstract class QueryBuilder<Entity> {
 
     /**
      * Sets parameter name and its value.
+     *
+     * The key for this parametere may contain numbers, letters, underscores, or periods.
      */
     setParameter(key: string, value: any): this {
         if (value instanceof Function) {
             throw new TypeORMError(`Function parameter isn't supported in the parameters. Please check "${key}" parameter.`);
+        }
+
+        if (!key.match(/^([A-Za-z0-9_.]+)$/)) {
+            throw new TypeORMError("QueryBuilder parameter keys may only contain numbers, letters, underscores, or periods.");
         }
 
         if (this.parentQueryBuilder) {

--- a/test/functional/query-builder/parameters/entity/Example.ts
+++ b/test/functional/query-builder/parameters/entity/Example.ts
@@ -1,0 +1,7 @@
+import { Entity, PrimaryColumn } from "../../../../../src";
+
+@Entity()
+export class Example {
+    @PrimaryColumn()
+    id: string
+}

--- a/test/functional/query-builder/parameters/query-builder-parameters.ts
+++ b/test/functional/query-builder/parameters/query-builder-parameters.ts
@@ -1,0 +1,53 @@
+import "reflect-metadata";
+import { Example } from "./entity/Example";
+import {closeTestingConnections, createTestingConnections, reloadTestingDatabases} from "../../../utils/test-utils";
+import {expect} from "chai";
+import { Connection } from "../../../../src";
+
+describe("query builder > parameters", () => {
+
+    let connections: Connection[];
+    before(async () => connections = await createTestingConnections({
+        entities: [ Example ],
+        enabledDrivers: [ "sqlite" ]
+
+    }));
+    beforeEach(() => reloadTestingDatabases(connections));
+    after(() => closeTestingConnections(connections));
+
+    it("should replace basic parameters when executing", () => Promise.all(connections.map(async connection => {
+        const repo = connection.getRepository(Example);
+
+        await repo.save({ id: 'bar' });
+
+        const example = await repo.createQueryBuilder()
+            .setParameter('foo', 'bar')
+            .where('example.id = :foo')
+            .getOne();
+
+        expect(example?.id).to.be.equal('bar')
+    })))
+
+    it("should prevent invalid characters from being used as identifiers", () => Promise.all(connections.map(async connection => {
+        const b = connection.createQueryBuilder();
+
+        expect(() => b.setParameter(':foo', 'bar')).to.throw();
+        expect(() => b.setParameter('@foo', 'bar')).to.throw();
+        expect(() => b.setParameter('😋', 'bar')).to.throw();
+        expect(() => b.setParameter('foo bar', 'bar')).to.throw();
+    })))
+
+    it("should allow periods in parameters", () => Promise.all(connections.map(async connection => {
+        const repo = connection.getRepository(Example);
+
+        await repo.save({ id: 'bar' });
+
+        const example = await repo.createQueryBuilder()
+            .setParameter('f.o.o', 'bar')
+            .where('example.id = :f.o.o')
+            .getOne();
+
+        expect(example?.id).to.be.equal('bar')
+    })))
+
+});


### PR DESCRIPTION
<!--
  😀 Wonderful!  Thank you for opening a pull request for TypeORM.

  Please fill in the information below to expedite the review
  and (hopefully) merge of your change.

  If unsure about something.. just do as best as you're able,
  or reach out through our community support channels!
  https://github.com/typeorm/typeorm/blob/master/docs/support.md
-->

### Description of change

<!--
  Please be clear and concise what the change is intended to do,
  why this change is needed, and how you've verified that it
  corrects what you intended.

  In some cases it may be helpful to include the current behavior
  and the new behavior.

  If the change is related to an open issue, you can link it here.
  If you include `Fixes #0000` (replacing `0000` with the issue number)
  when this is merged it will automatically mark the issue as fixed and
  close it.
-->

updates the character set for parameter identifiers to include
periods.  also update the `setParameter` function on query builder
to validate these identifiers to ensure have explicit failures
when invalid keys are used

fixes #8015

### Pull-Request Checklist

<!--
  Please make sure to review and check all of the following.

  If an item is not applicable, you can add "N/A" to the end.
-->

- [x] Code is up-to-date with the `master` branch
- [x] `npm run lint` passes with this change
- [ ] `npm run test` passes with this change
- [x] This pull request links relevant issues as `Fixes #0000`
- [x] There are new or updated unit tests validating the change
- [ ] Documentation has been updated to reflect this change
- [x] The new commits follow conventions explained in [CONTRIBUTING.md](https://github.com/typeorm/typeorm/blob/master/CONTRIBUTING.md)

<!--
  🎉 Thank you for contributing and making TypeORM even better!
-->
