### PR TITLE
fix: resolve get entity value for date columns that are related

### DIFF
--- a/src/metadata/ColumnMetadata.ts
+++ b/src/metadata/ColumnMetadata.ts
@@ -615,7 +615,7 @@ export class ColumnMetadata {
                     if (relatedEntity && relatedEntity instanceof Object && !(relatedEntity instanceof FindOperator) && !(relatedEntity instanceof Buffer)) {
                         value = this.referencedColumn.getEntityValue(relatedEntity);
 
-                    } else if (embeddedObject[this.propertyName] && embeddedObject[this.propertyName] instanceof Object && !(embeddedObject[this.propertyName] instanceof FindOperator) && !(embeddedObject[this.propertyName] instanceof Buffer)) {
+                    } else if (embeddedObject[this.propertyName] && embeddedObject[this.propertyName] instanceof Object && !(embeddedObject[this.propertyName] instanceof FindOperator) && !(embeddedObject[this.propertyName] instanceof Buffer) && !(embeddedObject[this.propertyName] instanceof Date)) {
                         value = this.referencedColumn.getEntityValue(embeddedObject[this.propertyName]);
 
                     } else {
@@ -639,7 +639,7 @@ export class ColumnMetadata {
                 if (relatedEntity && relatedEntity instanceof Object && !(relatedEntity instanceof FindOperator) && !(relatedEntity instanceof Function) && !(relatedEntity instanceof Buffer)) {
                     value = this.referencedColumn.getEntityValue(relatedEntity);
 
-                } else if (entity[this.propertyName] && entity[this.propertyName] instanceof Object && !(entity[this.propertyName] instanceof FindOperator) && !(entity[this.propertyName] instanceof Function) && !(entity[this.propertyName] instanceof Buffer)) {
+                } else if (entity[this.propertyName] && entity[this.propertyName] instanceof Object && !(entity[this.propertyName] instanceof FindOperator) && !(entity[this.propertyName] instanceof Function) && !(entity[this.propertyName] instanceof Buffer) && !(entity[this.propertyName] instanceof Date)) {
                     value = this.referencedColumn.getEntityValue(entity[this.propertyName]);
 
                 } else {

--- a/test/github-issues/8026/entity/Sailing.ts
+++ b/test/github-issues/8026/entity/Sailing.ts
@@ -1,0 +1,23 @@
+import { BaseEntity, Column, Entity, Index, JoinColumn, OneToMany, PrimaryColumn } from "../../../../src";
+import { ScheduledSailing } from "./ScheduledSailing";
+
+@Entity()
+@Index(["scheduled_departure_time", "departure_terminal_id", "vessel_position_number"], { unique: true })
+export class Sailing extends BaseEntity {
+    @PrimaryColumn()
+    departure_terminal_id: number;
+
+    @PrimaryColumn()
+    scheduled_departure_time: Date;
+
+    @Column()
+    vessel_position_number: number;
+
+    @OneToMany(() => ScheduledSailing, (scheduledSailing) => scheduledSailing.sailing)
+    @JoinColumn([
+        { referencedColumnName: "departure_terminal_id", name: "departure_terminal_id" },
+        { referencedColumnName: "vessel_position_number", name: "vessel_position_number" },
+        { referencedColumnName: "scheduled_departure_time", name: "scheduled_departure_time" }
+    ])
+    scheduled_sailings: ScheduledSailing[];
+}

--- a/test/github-issues/8026/entity/Sailing.ts
+++ b/test/github-issues/8026/entity/Sailing.ts
@@ -1,22 +1,13 @@
-import { BaseEntity, Column, Entity, Index, JoinColumn, OneToMany, PrimaryColumn } from "../../../../src";
+import { BaseEntity, Entity, JoinColumn, OneToMany, PrimaryColumn } from "../../../../src";
 import { ScheduledSailing } from "./ScheduledSailing";
 
 @Entity()
-@Index(["scheduled_departure_time", "departure_terminal_id", "vessel_position_number"], { unique: true })
 export class Sailing extends BaseEntity {
-    @PrimaryColumn()
-    departure_terminal_id: number;
-
     @PrimaryColumn()
     scheduled_departure_time: Date;
 
-    @Column()
-    vessel_position_number: number;
-
     @OneToMany(() => ScheduledSailing, (scheduledSailing) => scheduledSailing.sailing)
     @JoinColumn([
-        { referencedColumnName: "departure_terminal_id", name: "departure_terminal_id" },
-        { referencedColumnName: "vessel_position_number", name: "vessel_position_number" },
         { referencedColumnName: "scheduled_departure_time", name: "scheduled_departure_time" }
     ])
     scheduled_sailings: ScheduledSailing[];

--- a/test/github-issues/8026/entity/ScheduledSailing.ts
+++ b/test/github-issues/8026/entity/ScheduledSailing.ts
@@ -4,21 +4,13 @@ import { Sailing } from "./Sailing";
 @Entity()
 export class ScheduledSailing extends BaseEntity {
     @PrimaryColumn()
-    departure_terminal_id: number;
-
-    @PrimaryColumn()
     scheduled_departure_time: Date;
 
     @Column()
     scheduled_arrival_time: Date;
 
-    @Column()
-    vessel_position_number: number;
-
     @ManyToOne(() => Sailing, (sailing) => sailing.scheduled_sailings)
         @JoinColumn([
-        { referencedColumnName: "departure_terminal_id", name: "departure_terminal_id" },
-        { referencedColumnName: "vessel_position_number", name: "vessel_position_number" },
         { referencedColumnName: "scheduled_departure_time", name: "scheduled_departure_time" }
     ])
     sailing: Sailing;

--- a/test/github-issues/8026/entity/ScheduledSailing.ts
+++ b/test/github-issues/8026/entity/ScheduledSailing.ts
@@ -1,0 +1,25 @@
+import { BaseEntity, Column, Entity, JoinColumn, ManyToOne, PrimaryColumn } from "../../../../src";
+import { Sailing } from "./Sailing";
+
+@Entity()
+export class ScheduledSailing extends BaseEntity {
+    @PrimaryColumn()
+    departure_terminal_id: number;
+
+    @PrimaryColumn()
+    scheduled_departure_time: Date;
+
+    @Column()
+    scheduled_arrival_time: Date;
+
+    @Column()
+    vessel_position_number: number;
+
+    @ManyToOne(() => Sailing, (sailing) => sailing.scheduled_sailings)
+        @JoinColumn([
+        { referencedColumnName: "departure_terminal_id", name: "departure_terminal_id" },
+        { referencedColumnName: "vessel_position_number", name: "vessel_position_number" },
+        { referencedColumnName: "scheduled_departure_time", name: "scheduled_departure_time" }
+    ])
+    sailing: Sailing;
+}

--- a/test/github-issues/8026/issue-8026.ts
+++ b/test/github-issues/8026/issue-8026.ts
@@ -1,0 +1,44 @@
+import { expect } from "chai";
+import "reflect-metadata";
+import { Connection } from "../../../src";
+import { closeTestingConnections, createTestingConnections } from "../../utils/test-utils";
+import { Sailing } from "./entity/Sailing";
+import { ScheduledSailing } from "./entity/ScheduledSailing";
+
+describe("github issues > #8026 Inserting a value for a column that has a relation, and is also a date, results in the value being inserted as DEFAULT", () => {
+
+  let connections: Connection[];
+
+  before(async () => connections = await createTestingConnections({
+    entities: [Sailing, ScheduledSailing],
+    schemaCreate: true,
+    dropSchema: true
+  }));
+
+  after(() => closeTestingConnections(connections));
+
+  it("it should include a related date column in the constructed query", async () => await Promise.all(connections.map(async connection => {
+
+    let queryBuilder = await connection.createQueryBuilder();
+    
+    const insertValue = {
+      departure_terminal_id: 1,
+      scheduled_departure_time: new Date(),
+      scheduled_arrival_time: new Date(),
+      vessel_position_number: 3,
+    }
+
+    const [query, params] = await queryBuilder
+      .insert()
+      .into(ScheduledSailing)
+      .values([insertValue])
+      .getQueryAndParameters()
+      
+    expect(query.includes("DEFAULT")).to.be.false;
+    expect(params).length(4);
+    expect(params[1]).to.be.an.instanceOf(Date);
+    expect(params[2]).to.be.an.instanceOf(Date);
+
+  })));
+
+});

--- a/test/github-issues/8026/issue-8026.ts
+++ b/test/github-issues/8026/issue-8026.ts
@@ -22,10 +22,8 @@ describe("github issues > #8026 Inserting a value for a column that has a relati
     let queryBuilder = await connection.createQueryBuilder();
     
     const insertValue = {
-      departure_terminal_id: 1,
       scheduled_departure_time: new Date(),
       scheduled_arrival_time: new Date(),
-      vessel_position_number: 3,
     }
 
     const [query, params] = await queryBuilder
@@ -35,9 +33,9 @@ describe("github issues > #8026 Inserting a value for a column that has a relati
       .getQueryAndParameters()
       
     expect(query.includes("DEFAULT")).to.be.false;
-    expect(params).length(4);
+    expect(params).length(2);
+    expect(params[0]).to.be.an.instanceOf(Date);
     expect(params[1]).to.be.an.instanceOf(Date);
-    expect(params[2]).to.be.an.instanceOf(Date);
 
   })));
 

--- a/test/github-issues/8026/issue-8026.ts
+++ b/test/github-issues/8026/issue-8026.ts
@@ -34,8 +34,6 @@ describe("github issues > #8026 Inserting a value for a column that has a relati
       
     expect(query.includes("DEFAULT")).to.be.false;
     expect(params).length(2);
-    expect(params[0]).to.be.an.instanceOf(Date);
-    expect(params[1]).to.be.an.instanceOf(Date);
 
   })));
 


### PR DESCRIPTION
Closes: #8026

### Description of change

Allows for date columns that are part of a relation to have data inserted into them.

Fixes: #8026 

### Pull-Request Checklist

<!--
  Please make sure to review and check all of the following.

  If an item is not applicable, you can add "N/A" to the end.
-->

- [x] Code is up-to-date with the `master` branch
- [x] `npm run lint` passes with this change
- [x] `npm run test` passes with this change
- [x] This pull request links relevant issues as `Fixes #0000`
- [x] There are new or updated unit tests validating the change
- [x] Documentation has been updated to reflect this change N/A
- [x] The new commits follow conventions explained in [CONTRIBUTING.md](https://github.com/typeorm/typeorm/blob/master/CONTRIBUTING.md)
