### PR TITLE
fix: prevent flattening of `Brackets` so we get consistent queries

### DIFF
--- a/src/query-builder/QueryBuilder.ts
+++ b/src/query-builder/QueryBuilder.ts
@@ -813,7 +813,7 @@ export abstract class QueryBuilder<Entity> {
     /**
      * Computes given where argument - transforms to a where string all forms it can take.
      */
-    protected createWhereConditionExpression(condition: WhereClauseCondition): string {
+    protected createWhereConditionExpression(condition: WhereClauseCondition, alwaysWrap: boolean = false): string {
         if (typeof condition === "string")
             return condition;
 
@@ -822,7 +822,9 @@ export abstract class QueryBuilder<Entity> {
                 return "1=1";
             }
 
-            if (condition.length === 1) {
+            // In the future we should probably remove this entire condition
+            // but for now to prevent any breaking changes it exists.
+            if (condition.length === 1 && !alwaysWrap) {
                 return this.createWhereClausesExpression(condition);
             }
 
@@ -866,6 +868,8 @@ export abstract class QueryBuilder<Entity> {
 
             case "not":
                 return `NOT(${this.createWhereConditionExpression(condition.condition)})`;
+            case "brackets":
+                return `${this.createWhereConditionExpression(condition.condition, true)}`;
         }
 
         throw new TypeError(`Unsupported FindOperator ${FindOperator.constructor.name}`);
@@ -1178,7 +1182,10 @@ export abstract class QueryBuilder<Entity> {
 
             where.whereFactory(whereQueryBuilder as any);
 
-            return whereQueryBuilder.expressionMap.wheres;
+            return {
+                operator: "brackets",
+                condition: whereQueryBuilder.expressionMap.wheres
+            };
         }
 
         if (where instanceof Function) {

--- a/src/query-builder/WhereClause.ts
+++ b/src/query-builder/WhereClause.ts
@@ -1,4 +1,4 @@
-type WrappingOperator = "not";
+type WrappingOperator = "not" | "brackets";
 
 type PredicateOperator = "lessThan" | "lessThanOrEqual" | "moreThan" | "moreThanOrEqual" | "equal" | "notEqual" | "ilike" | "like" | "between" | "in" | "any" | "isNull";
 

--- a/test/functional/query-builder/select/query-builder-select.ts
+++ b/test/functional/query-builder/select/query-builder-select.ts
@@ -412,9 +412,9 @@ describe("query builder > select", () => {
 
             expect(sql).to.equal(
                 'SELECT post.id AS post_id FROM external_post post WHERE ' +
-                '((post.outlet = ? AND post.id = ?) OR ' +
-                '(post.outlet = ? AND post.id = ?) OR ' +
-                '(post.outlet = ? AND post.id = ?))'
+                '(((post.outlet = ? AND post.id = ?)) OR ' +
+                '((post.outlet = ? AND post.id = ?)) OR ' +
+                '((post.outlet = ? AND post.id = ?)))'
             )
             expect(params).to.eql([ "foo", 1, "bar", 2, "baz", 5 ])
         })))
@@ -428,9 +428,9 @@ describe("query builder > select", () => {
 
             expect(sql).to.equal(
                 'SELECT post.id AS post_id FROM external_post post WHERE ' +
-                '((post.outlet = ? AND post.id = ?) OR ' +
-                '(post.outlet = ? AND post.id = ?) OR ' +
-                'post.id = ?)'
+                '(((post.outlet = ? AND post.id = ?)) OR ' +
+                '((post.outlet = ? AND post.id = ?)) OR ' +
+                '(post.id = ?))'
             )
             expect(params).to.eql([ "foo", 1, "bar", 2, 5 ])
         })))


### PR DESCRIPTION
<!--
  😀 Wonderful!  Thank you for opening a pull request for TypeORM.

  Please fill in the information below to expedite the review
  and (hopefully) merge of your change.

  If unsure about something.. just do as best as you're able,
  or reach out through our community support channels!
  https://github.com/typeorm/typeorm/blob/master/docs/support.md
-->

### Description of change

<!--
  Please be clear and concise what the change is intended to do,
  why this change is needed, and how you've verified that it
  corrects what you intended.

  In some cases it may be helpful to include the current behavior
  and the new behavior.

  If the change is related to an open issue, you can link it here.
  If you include `Fixes #0000` (replacing `0000` with the issue number)
  when this is merged it will automatically mark the issue as fixed and
  close it.
-->

Fixes a regression where `Brackets` do not add parentheses if there's only one item in the condition

fixes #8043

### Pull-Request Checklist

<!--
  Please make sure to review and check all of the following.

  If an item is not applicable, you can add "N/A" to the end.
-->

- [x] Code is up-to-date with the `master` branch
- [x] `npm run lint` passes with this change
- [ ] `npm run test` passes with this change
- [x] This pull request links relevant issues as `Fixes #0000`
- [x] There are new or updated unit tests validating the change
- [ ] Documentation has been updated to reflect this change
- [x] The new commits follow conventions explained in [CONTRIBUTING.md](https://github.com/typeorm/typeorm/blob/master/CONTRIBUTING.md)

<!--
  🎉 Thank you for contributing and making TypeORM even better!
-->
