### PR TITLE
Add support for Oracle Implicit Results

### DIFF
--- a/src/driver/oracle/OracleQueryRunner.ts
+++ b/src/driver/oracle/OracleQueryRunner.ts
@@ -201,7 +201,7 @@ export class OracleQueryRunner extends BaseQueryRunner implements QueryRunner {
 
             const result = new QueryResult();
 
-            result.raw = raw.rows || raw.outBinds || raw.rowsAffected;
+            result.raw = raw.rows || raw.outBinds || raw.rowsAffected || raw.implicitResults;
 
             if (raw?.hasOwnProperty('rows') && Array.isArray(raw.rows)) {
                 result.records = raw.rows;
@@ -209,6 +209,10 @@ export class OracleQueryRunner extends BaseQueryRunner implements QueryRunner {
 
             if (raw?.hasOwnProperty('outBinds') && Array.isArray(raw.outBinds)) {
                 result.records = raw.outBinds;
+            }
+
+            if (raw?.hasOwnProperty('implicitResults') && Array.isArray(raw.implicitResults)) {
+                result.records = raw.implicitResults;
             }
 
             if (raw?.hasOwnProperty('rowsAffected')) {

--- a/test/functional/query-runner/implicit-results.ts
+++ b/test/functional/query-runner/implicit-results.ts
@@ -3,7 +3,7 @@ import { Connection } from "../../../src";
 import { closeTestingConnections, createTestingConnections } from "../../utils/test-utils";
 import { expect } from "chai";
 
-describe.only("query runner > implicit results", () => {
+describe("query runner > implicit results", () => {
 
     let connections: Connection[];
     before(async () => {

--- a/test/functional/query-runner/implicit-results.ts
+++ b/test/functional/query-runner/implicit-results.ts
@@ -1,0 +1,57 @@
+import "reflect-metadata";
+import { Connection } from "../../../src";
+import { closeTestingConnections, createTestingConnections } from "../../utils/test-utils";
+import { expect } from "chai";
+
+describe.only("query runner > implicit results", () => {
+
+    let connections: Connection[];
+    before(async () => {
+        connections = await createTestingConnections({
+            entities: [__dirname + "/view/*{.js,.ts}"],
+            enabledDrivers: ["oracle"],
+            schemaCreate: true,
+            dropSchema: true,
+        });
+    });
+    after(() => closeTestingConnections(connections));
+
+    it("should return results for Oracle Stored Procedure with Implicit Results", () => Promise.all(connections.map(async connection => {
+        const queryRunner = connection.createQueryRunner();
+        
+        // Create sample procedure with implicit results
+        await connection.query(`
+          CREATE OR REPLACE PROCEDURE TEST_IMPLICIT_RESULTS
+          AS
+            test_array dbms_sql.varchar2_table;
+            cur1 sys_refcursor;
+          BEGIN
+            test_array(1) := 'First';
+            test_array(2) := 'Second';
+            test_array(3) := 'Third';
+            OPEN cur1 FOR SELECT * FROM TABLE(test_array);
+            DBMS_SQL.return_result(cur1);
+          END;
+        `);
+
+        const result = await queryRunner.query(`
+          BEGIN
+            TEST_IMPLICIT_RESULTS;
+          END;
+        `);
+
+        expect(result).to.be.an('array');
+        expect(result).to.eql(
+          [
+            [
+              { COLUMN_VALUE: 'First' },
+              { COLUMN_VALUE: 'Second' },
+              { COLUMN_VALUE: 'Third' },
+            ]
+          ]
+        );
+
+        await queryRunner.release();
+    })));
+
+});


### PR DESCRIPTION
### Description of change

Add support for Oracle Implicit Results (please see issue #8046 )

### Pull-Request Checklist

- [x] Code is up-to-date with the `master` branch
- [x] `npm run lint` passes with this change
- [x] `npm run test` passes with this change
- [x] This pull request links relevant issues as `Fixes #0000`
- [x] There are new or updated unit tests validating the change
- [ ] Documentation has been updated to reflect this change
- [x] The new commits follow conventions explained in [CONTRIBUTING.md](https://github.com/typeorm/typeorm/blob/master/CONTRIBUTING.md)

@imnotjames sorry I have to recreate the PR, but this time with unit test