### PR TITLE
feat: add relation options to all tree queries

### DIFF
--- a/docs/tree-entities.md
+++ b/docs/tree-entities.md
@@ -203,9 +203,6 @@ There are other special methods to work with tree entities through `TreeReposito
 ```typescript
 const treeCategories = await repository.findTrees();
 // returns root categories with sub categories inside
-
-const treeCategoriesWithRelations = await repository.findTrees({ relations: ["sites"] });
-// automatically joins the sites relation
 ```
 
 * `findRoots` - Roots are entities that have no ancestors. Finds them all.
@@ -272,4 +269,24 @@ const parents = await repository
 
 ```typescript
 const parentsCount = await repository.countAncestors(childCategory);
+```
+
+For the following methods, options can be passed:
+* findTrees
+* findRoots
+* findDescendants
+* findDescendantsTree
+* findAncestors
+* findAncestorsTree
+
+The following options are available: 
+* `relations` - Indicates what relations of entity should be loaded (simplified left join form).
+
+Examples: 
+```typescript
+const treeCategoriesWithRelations = await repository.findTrees({ relations: ["sites"] });
+// automatically joins the sites relation
+
+const parentsWithRelations = await repository.findAncestors(childCategory, { relations: ["members"] });
+// returns all direct childCategory's parent categories (without "parent of parents") and joins the 'members' relation
 ```

--- a/src/find-options/FindOptionsUtils.ts
+++ b/src/find-options/FindOptionsUtils.ts
@@ -5,6 +5,7 @@ import {FindRelationsNotFoundError} from "../error/FindRelationsNotFoundError";
 import {EntityMetadata} from "../metadata/EntityMetadata";
 import {DriverUtils} from "../driver/DriverUtils";
 import { TypeORMError } from "../error";
+import { FindTreeOptions } from "./FindTreeOptions";
 
 /**
  * Utilities to work with FindOptions.
@@ -21,23 +22,23 @@ export class FindOptionsUtils {
     static isFindOneOptions<Entity = any>(obj: any): obj is FindOneOptions<Entity> {
         const possibleOptions: FindOneOptions<Entity> = obj;
         return possibleOptions &&
-                (
-                    Array.isArray(possibleOptions.select) ||
-                    possibleOptions.where instanceof Object ||
-                    typeof possibleOptions.where === "string" ||
-                    Array.isArray(possibleOptions.relations) ||
-                    possibleOptions.join instanceof Object ||
-                    possibleOptions.order instanceof Object ||
-                    possibleOptions.cache instanceof Object ||
-                    typeof possibleOptions.cache === "boolean" ||
-                    typeof possibleOptions.cache === "number" ||
-                    possibleOptions.lock instanceof Object ||
-                    possibleOptions.loadRelationIds instanceof Object ||
-                    typeof possibleOptions.loadRelationIds === "boolean" ||
-                    typeof possibleOptions.loadEagerRelations === "boolean" ||
-                    typeof possibleOptions.withDeleted === "boolean" ||
-                    typeof possibleOptions.transaction === "boolean"
-                );
+            (
+                Array.isArray(possibleOptions.select) ||
+                possibleOptions.where instanceof Object ||
+                typeof possibleOptions.where === "string" ||
+                Array.isArray(possibleOptions.relations) ||
+                possibleOptions.join instanceof Object ||
+                possibleOptions.order instanceof Object ||
+                possibleOptions.cache instanceof Object ||
+                typeof possibleOptions.cache === "boolean" ||
+                typeof possibleOptions.cache === "number" ||
+                possibleOptions.lock instanceof Object ||
+                possibleOptions.loadRelationIds instanceof Object ||
+                typeof possibleOptions.loadRelationIds === "boolean" ||
+                typeof possibleOptions.loadEagerRelations === "boolean" ||
+                typeof possibleOptions.withDeleted === "boolean" ||
+                typeof possibleOptions.transaction === "boolean"
+            );
     }
 
     /**
@@ -211,6 +212,23 @@ export class FindOptionsUtils {
                         break;
                 }
             });
+
+        return qb;
+    }
+
+    static applyOptionsToTreeQueryBuilder<T>(qb: SelectQueryBuilder<T>, options?: FindTreeOptions): SelectQueryBuilder<T> {
+        if (options?.relations) {
+            // Copy because `applyRelationsRecursively` modifies it
+            const allRelations = [...options.relations];
+
+            FindOptionsUtils.applyRelationsRecursively(qb, allRelations, qb.expressionMap.mainAlias!.name, qb.expressionMap.mainAlias!.metadata, "");
+
+            // recursive removes found relations from allRelations array
+            // if there are relations left in this array it means those relations were not found in the entity structure
+            // so, we give an exception about not found relations
+            if (allRelations.length > 0)
+                throw new FindRelationsNotFoundError(allRelations);
+        }
 
         return qb;
     }

--- a/src/repository/TreeRepository.ts
+++ b/src/repository/TreeRepository.ts
@@ -4,7 +4,6 @@ import {ObjectLiteral} from "../common/ObjectLiteral";
 import {AbstractSqliteDriver} from "../driver/sqlite-abstract/AbstractSqliteDriver";
 import { TypeORMError } from "../error/TypeORMError";
 import { FindTreeOptions } from "../find-options/FindTreeOptions";
-import { FindRelationsNotFoundError } from "../error";
 import { FindOptionsUtils } from "../find-options/FindOptionsUtils";
 
 /**
@@ -38,19 +37,7 @@ export class TreeRepository<Entity> extends Repository<Entity> {
         );
 
         const qb = this.createQueryBuilder("treeEntity");
-
-        if (options?.relations) {
-            const allRelations = [...options.relations];
-
-            FindOptionsUtils.applyRelationsRecursively(qb, allRelations, qb.expressionMap.mainAlias!.name, qb.expressionMap.mainAlias!.metadata, "");
-
-            // recursive removes found relations from allRelations array
-            // if there are relations left in this array it means those relations were not found in the entity structure
-            // so, we give an exception about not found relations
-            if (allRelations.length > 0)
-                throw new FindRelationsNotFoundError(allRelations);
-        }
-
+        FindOptionsUtils.applyOptionsToTreeQueryBuilder(qb, options);
 
         return qb
             .where(`${escapeAlias("treeEntity")}.${escapeColumn(parentPropertyName)} IS NULL`)
@@ -60,10 +47,10 @@ export class TreeRepository<Entity> extends Repository<Entity> {
     /**
      * Gets all children (descendants) of the given entity. Returns them all in a flat array.
      */
-    findDescendants(entity: Entity): Promise<Entity[]> {
-        return this
-            .createDescendantsQueryBuilder("treeEntity", "treeClosure", entity)
-            .getMany();
+    findDescendants(entity: Entity, options?: FindTreeOptions): Promise<Entity[]> {
+        const qb = this.createDescendantsQueryBuilder("treeEntity", "treeClosure", entity);
+        FindOptionsUtils.applyOptionsToTreeQueryBuilder(qb, options);
+        return qb.getMany();
     }
 
     /**
@@ -73,19 +60,7 @@ export class TreeRepository<Entity> extends Repository<Entity> {
         // todo: throw exception if there is no column of this relation?
 
         const qb: SelectQueryBuilder<Entity> = this.createDescendantsQueryBuilder("treeEntity", "treeClosure", entity);
-
-        if (options?.relations) {
-            // Copy because `applyRelationsRecursively` modifies it
-            const allRelations = [...options.relations];
-
-            FindOptionsUtils.applyRelationsRecursively(qb, allRelations, qb.expressionMap.mainAlias!.name, qb.expressionMap.mainAlias!.metadata, "");
-
-            // recursive removes found relations from allRelations array
-            // if there are relations left in this array it means those relations were not found in the entity structure
-            // so, we give an exception about not found relations
-            if (allRelations.length > 0)
-                throw new FindRelationsNotFoundError(allRelations);
-        }
+        FindOptionsUtils.applyOptionsToTreeQueryBuilder(qb, options);
 
         const entities = await qb.getRawAndEntities();
         const relationMaps = this.createRelationMaps("treeEntity", entities.raw);
@@ -168,25 +143,24 @@ export class TreeRepository<Entity> extends Repository<Entity> {
     /**
      * Gets all parents (ancestors) of the given entity. Returns them all in a flat array.
      */
-    findAncestors(entity: Entity): Promise<Entity[]> {
-        return this
-            .createAncestorsQueryBuilder("treeEntity", "treeClosure", entity)
-            .getMany();
+    findAncestors(entity: Entity, options?: FindTreeOptions): Promise<Entity[]> {
+        const qb = this.createAncestorsQueryBuilder("treeEntity", "treeClosure", entity);
+        FindOptionsUtils.applyOptionsToTreeQueryBuilder(qb, options);
+        return qb.getMany();
     }
 
     /**
      * Gets all parents (ancestors) of the given entity. Returns them in a tree - nested into each other.
      */
-    findAncestorsTree(entity: Entity): Promise<Entity> {
+    async findAncestorsTree(entity: Entity, options?: FindTreeOptions): Promise<Entity> {
         // todo: throw exception if there is no column of this relation?
-        return this
-            .createAncestorsQueryBuilder("treeEntity", "treeClosure", entity)
-            .getRawAndEntities()
-            .then(entitiesAndScalars => {
-                const relationMaps = this.createRelationMaps("treeEntity", entitiesAndScalars.raw);
-                this.buildParentEntityTree(entity, entitiesAndScalars.entities, relationMaps);
-                return entity;
-            });
+        const qb = this.createAncestorsQueryBuilder("treeEntity", "treeClosure", entity);
+        FindOptionsUtils.applyOptionsToTreeQueryBuilder(qb, options);
+
+        const entities = await qb.getRawAndEntities();
+        const relationMaps = this.createRelationMaps("treeEntity", entities.raw);
+        this.buildParentEntityTree(entity, entities.entities, relationMaps);
+        return entity;
     }
 
     /**

--- a/test/github-issues/8076/entity/Category.ts
+++ b/test/github-issues/8076/entity/Category.ts
@@ -1,0 +1,29 @@
+import { BaseEntity, Column, Entity, OneToMany, PrimaryGeneratedColumn, Tree, TreeChildren, TreeParent } from "../../../../src";
+import { Site } from "./Site";
+import { Member } from "./Member";
+
+@Entity()
+@Tree("materialized-path")
+export class Category extends BaseEntity {
+
+  @PrimaryGeneratedColumn()
+  pk: number;
+
+  @Column({
+    length: 250,
+    nullable: false
+  })
+  title: string;
+
+  @TreeParent()
+  parentCategory: Category | null;
+
+  @TreeChildren()
+  childCategories: Category[];
+
+  @OneToMany(() => Site, site => site.parentCategory)
+  sites: Site[];
+
+  @OneToMany(() => Member, m => m.category)
+  members: Member[];
+}

--- a/test/github-issues/8076/entity/Member.ts
+++ b/test/github-issues/8076/entity/Member.ts
@@ -1,0 +1,18 @@
+import { BaseEntity, Column, Entity, ManyToOne, PrimaryGeneratedColumn } from "../../../../src";
+import { Category } from "./Category";
+
+@Entity()
+export class Member extends BaseEntity {
+
+  @PrimaryGeneratedColumn()
+  pk: number;
+
+  @Column({
+    length: 250,
+    nullable: false
+  })
+  title: string;
+
+  @ManyToOne(() => Category, c => c.members)
+  category: Category;
+}

--- a/test/github-issues/8076/entity/Site.ts
+++ b/test/github-issues/8076/entity/Site.ts
@@ -1,0 +1,21 @@
+import { BaseEntity, Column, CreateDateColumn, Entity, ManyToOne, PrimaryGeneratedColumn } from "../../../../src";
+import { Category } from "./Category";
+
+@Entity()
+export class Site extends BaseEntity {
+
+  @PrimaryGeneratedColumn()
+  pk: number;
+
+  @CreateDateColumn()
+  createdAt: Date;
+
+  @Column({
+    length: 250,
+    nullable: false
+  })
+  title: string;
+
+  @ManyToOne(() => Category)
+  parentCategory: Category;
+}

--- a/test/github-issues/8076/issue-8076.ts
+++ b/test/github-issues/8076/issue-8076.ts
@@ -1,0 +1,299 @@
+import { expect } from "chai";
+import "reflect-metadata";
+import { Connection } from "../../../src";
+import { closeTestingConnections, createTestingConnections, reloadTestingDatabases } from "../../utils/test-utils";
+import { Category } from "./entity/Category";
+import { Site } from "./entity/Site";
+import { Member } from "./entity/Member";
+
+describe("github issues > #8076 Add relation options to all tree queries (missing ones)", () => {
+
+  let connections: Connection[];
+
+  before(async () => connections = await createTestingConnections({
+    entities: [Category, Site, Member],
+    schemaCreate: true,
+    dropSchema: true
+  }));
+
+  beforeEach(async () => {
+    await reloadTestingDatabases(connections);
+    for (let connection of connections) {
+      let categoryRepo = connection.getRepository(Category);
+      let siteRepo = connection.getRepository(Site);
+      let memberRepo = connection.getRepository(Member);
+
+      let c1: Category = new Category();
+      c1.title = "Category 1";
+      c1.parentCategory = null;
+      c1.childCategories = [];
+      c1.sites = [];
+
+      let c2: Category = new Category();
+      c2.title = "Category 2";
+      c2.parentCategory = null;
+      c2.childCategories = [];
+      c2.sites = [];
+
+      let c3: Category = new Category();
+      c3.title = "Category 1.1";
+      c3.parentCategory = c1;
+      c3.childCategories = [];
+      c3.sites = [];
+
+      let c4: Category = new Category();
+      c4.title = "Category 1.1.1";
+      c4.parentCategory = c3;
+      c4.childCategories = [];
+      c4.sites = [];
+
+      c1.childCategories = [c3];
+      c3.childCategories = [c4];
+
+      let s1: Site = new Site();
+      s1.title = "Site of Category 1";
+      s1.parentCategory = c1;
+
+      let s2: Site = new Site();
+      s2.title = "Site of Category 1";
+      s2.parentCategory = c1;
+
+      let s3: Site = new Site();
+      s3.title = "Site of Category 1.1";
+      s3.parentCategory = c3;
+
+      let s4: Site = new Site();
+      s4.title = "Site of Category 1.1";
+      s4.parentCategory = c3;
+
+      let s5: Site = new Site();
+      s5.title = "Site of Category 1.1.1";
+      s5.parentCategory = c4;
+
+      let m1: Member = new Member();
+      m1.title = "Test";
+      m1.category = c1;
+
+      // Create the categories
+      c1 = await categoryRepo.save(c1);
+      c2 = await categoryRepo.save(c2);
+      c3 = await categoryRepo.save(c3);
+      c4 = await categoryRepo.save(c4);
+
+      // Create the sites
+      [s1, s2, s3, s4, s5] =
+        await Promise.all([
+          siteRepo.save(s1),
+          siteRepo.save(s2),
+          siteRepo.save(s3),
+          siteRepo.save(s4),
+          siteRepo.save(s5)
+        ]);
+
+      // Create the member relation
+      await memberRepo.save(m1);
+
+      // Set the just created relations correctly
+      c1.sites = [s1, s2];
+      c2.sites = [];
+      c3.sites = [s3, s4];
+      c4.sites = [s5];
+    }
+  });
+
+  after(() => closeTestingConnections(connections));
+
+  it("should return tree without sites relations", async () => await Promise.all(connections.map(async connection => {
+
+    let result = await connection.getTreeRepository(Category).findTrees();
+
+    // The complete tree should exist but other relations than the parent- / child-relations should not be loaded
+    expect(result).to.have.lengthOf(2);
+    expect(result[0].sites).equals(undefined);
+    expect(result[0].childCategories).to.have.lengthOf(1);
+    expect(result[0].childCategories[0].childCategories).to.have.lengthOf(1);
+    expect(result[0].childCategories[0].childCategories[0].sites).equal(undefined);
+
+  })));
+
+  it("should return tree with sites relations", async () => await Promise.all(connections.map(async connection => {
+
+    let result = await connection.getTreeRepository(Category).findTrees({ relations: ["sites"] });
+
+    // The complete tree should exist and site relations should not be loaded for every category
+    expect(result).to.have.lengthOf(2);
+    expect(result[0].sites).lengthOf(2);
+    expect(result[1].sites).to.be.an("array");
+    expect(result[1].sites).to.have.lengthOf(0);
+    expect(result[0].childCategories[0].sites).to.have.lengthOf(2);
+    expect(result[0].childCategories[0].childCategories[0].sites).to.have.lengthOf(1);
+    expect(result[0].childCategories[0].childCategories[0].sites).to.be.an("array");
+    expect(result[0].childCategories[0].childCategories[0].sites[0].title).to.be.equal("Site of Category 1.1.1");
+  })));
+
+  it("should return roots without member relations", async () => await Promise.all(connections.map(async connection => {
+
+    let result = await connection.getTreeRepository(Category).findRoots();
+
+    expect(result).to.have.lengthOf(2);
+    expect(result[0].sites).equals(undefined);
+    expect(result[0].members).equal(undefined);
+    expect(result[0].childCategories).equal(undefined);
+  })));
+
+  it("should return roots with member relations", async () => await Promise.all(connections.map(async connection => {
+
+    let result = await connection.getTreeRepository(Category).findRoots({ relations: ["members"] });
+
+    expect(result).to.have.lengthOf(2);
+    expect(result[0].sites).equals(undefined);
+    expect(result[0].members).to.have.lengthOf(1);
+    expect(result[0].members[0].title).to.be.equal("Test");
+    expect(result[0].childCategories).to.be.equal(undefined);
+  })));
+
+  it("should return descendants without member relations", async () => await Promise.all(connections.map(async connection => {
+
+    let c1 = await connection.getRepository(Category).findOne({ title: "Category 1" });
+    let result = await connection.getTreeRepository(Category).findDescendants(c1!);
+
+    expect(result).to.have.lengthOf(3);
+
+    expect(result[0].title).equals("Category 1");
+    expect(result[0].members).equals(undefined);
+    expect(result[0].sites).equals(undefined);
+
+    expect(result[1].title).equals("Category 1.1");
+    expect(result[1].members).equals(undefined);
+    expect(result[1].sites).equals(undefined);
+
+    expect(result[2].title).equals("Category 1.1.1");
+    expect(result[2].members).equals(undefined);
+    expect(result[2].sites).equals(undefined);
+  })));
+
+  it("should return descendants with member relations", async () => await Promise.all(connections.map(async connection => {
+
+    let c1 = await connection.getRepository(Category).findOne({ title: "Category 1" });
+    let result = await connection.getTreeRepository(Category).findDescendants(c1!, { relations: ["members"] });
+
+    expect(result).to.have.lengthOf(3);
+
+    expect(result[0].title).equals("Category 1");
+    expect(result[0].members).to.have.lengthOf(1);
+    expect(result[0].members[0].title).equals("Test");
+    expect(result[0].sites).equals(undefined);
+
+    expect(result[1].title).equals("Category 1.1");
+    expect(result[1].members).to.be.an("array");
+    expect(result[1].members).to.have.lengthOf(0);
+    expect(result[1].sites).equals(undefined);
+
+    expect(result[2].title).equals("Category 1.1.1");
+    expect(result[1].members).to.be.an("array");
+    expect(result[2].members).to.have.lengthOf(0);
+    expect(result[2].sites).equals(undefined);
+  })));
+
+  it("should return descendants tree without member relations", async () => await Promise.all(connections.map(async connection => {
+
+    let c1 = await connection.getRepository(Category).findOne({ title: "Category 1" });
+    let result = await connection.getTreeRepository(Category).findDescendantsTree(c1!);
+
+    expect(result.title).to.be.equal("Category 1");
+
+    expect(result.childCategories[0].title).equals("Category 1.1");
+    expect(result.childCategories[0].members).to.be.undefined;
+
+    expect(result.childCategories[0].childCategories[0].title).equals("Category 1.1.1");
+    expect(result.childCategories[0].childCategories[0].members).to.be.undefined;
+  })));
+
+  it("should return descendants tree with member relations", async () => await Promise.all(connections.map(async connection => {
+
+    let c1 = await connection.getRepository(Category).findOne({ title: "Category 1" });
+    let result = await connection.getTreeRepository(Category).findDescendantsTree(c1!, { relations: ["members"] });
+
+    expect(result.title).to.be.equal("Category 1");
+
+    expect(result.childCategories[0].title).equals("Category 1.1");
+    expect(result.childCategories[0].members).to.be.an("array");
+    expect(result.childCategories[0].members).to.have.lengthOf(0);
+
+    expect(result.childCategories[0].childCategories[0].title).equals("Category 1.1.1");
+    expect(result.childCategories[0].childCategories[0].members).to.be.an("array");
+    expect(result.childCategories[0].childCategories[0].members).to.have.lengthOf(0);
+  })));
+
+  it("should return ancestors without member relations", async () => await Promise.all(connections.map(async connection => {
+
+    let c3 = await connection.getRepository(Category).findOne({ title: "Category 1.1.1" });
+    let result = await connection.getTreeRepository(Category).findAncestors(c3!);
+
+    expect(result).to.have.lengthOf(3);
+
+    expect(result[0].title).equals("Category 1");
+    expect(result[0].members).equals(undefined);
+    expect(result[0].sites).equals(undefined);
+
+    expect(result[1].title).equals("Category 1.1");
+    expect(result[1].members).equals(undefined);
+    expect(result[1].sites).equals(undefined);
+
+    expect(result[2].title).equals("Category 1.1.1");
+    expect(result[2].members).equals(undefined);
+    expect(result[2].sites).equals(undefined);
+  })));
+
+  it("should return ancestors with member relations", async () => await Promise.all(connections.map(async connection => {
+
+    let c3 = await connection.getRepository(Category).findOne({ title: "Category 1.1.1" });
+    let result = await connection.getTreeRepository(Category).findAncestors(c3!, { relations: ["members"] });
+
+    expect(result[0].title).equals("Category 1");
+    expect(result[0].members).to.have.lengthOf(1);
+    expect(result[0].members[0].title).equals("Test");
+    expect(result[0].sites).equals(undefined);
+
+    expect(result[1].title).equals("Category 1.1");
+    expect(result[1].members).to.be.an("array");
+    expect(result[1].members).to.have.lengthOf(0);
+    expect(result[1].sites).equals(undefined);
+
+    expect(result[2].title).equals("Category 1.1.1");
+    expect(result[1].members).to.be.an("array");
+    expect(result[2].members).to.have.lengthOf(0);
+    expect(result[2].sites).equals(undefined);
+  })));
+
+  it("should return ancestors tree without member relations", async () => await Promise.all(connections.map(async connection => {
+
+    let c3 = await connection.getRepository(Category).findOne({ title: "Category 1.1.1" });
+    let result = await connection.getTreeRepository(Category).findAncestorsTree(c3!);
+
+    expect(result.title).to.be.equal("Category 1.1.1");
+
+    expect(result.parentCategory!.title).equals("Category 1.1");
+    expect(result.parentCategory!.members).to.be.undefined;
+
+    expect(result.parentCategory!.parentCategory!.title).equals("Category 1");
+    expect(result.parentCategory!.parentCategory!.members).to.be.undefined;
+  })));
+
+  it("should return ancestors tree with member relations", async () => await Promise.all(connections.map(async connection => {
+
+    let c3 = await connection.getRepository(Category).findOne({ title: "Category 1.1.1" });
+    let result = await connection.getTreeRepository(Category).findAncestorsTree(c3!, { relations: ["members"] });
+
+    expect(result.title).to.be.equal("Category 1.1.1");
+
+    expect(result.parentCategory!.title).equals("Category 1.1");
+    expect(result.parentCategory!.members).to.be.an("array");
+    expect(result.parentCategory!.members).to.have.lengthOf(0);
+
+    expect(result.parentCategory!.parentCategory!.title).equals("Category 1");
+    expect(result.parentCategory!.parentCategory!.members).to.be.an("array");
+    expect(result.parentCategory!.parentCategory!.members).to.have.lengthOf(1);
+    expect(result.parentCategory!.parentCategory!.members[0].title).equals("Test");
+  })));
+});

--- a/test/github-issues/8076/issue-8076.ts
+++ b/test/github-issues/8076/issue-8076.ts
@@ -231,6 +231,7 @@ describe("github issues > #8076 Add relation options to all tree queries (missin
 
     let c3 = await connection.getRepository(Category).findOne({ title: "Category 1.1.1" });
     let result = await connection.getTreeRepository(Category).findAncestors(c3!);
+    result.sort((a, b) => a.pk - b.pk);
 
     expect(result).to.have.lengthOf(3);
 
@@ -251,6 +252,7 @@ describe("github issues > #8076 Add relation options to all tree queries (missin
 
     let c3 = await connection.getRepository(Category).findOne({ title: "Category 1.1.1" });
     let result = await connection.getTreeRepository(Category).findAncestors(c3!, { relations: ["members"] });
+    result.sort((a, b) => a.pk - b.pk);
 
     expect(result[0].title).equals("Category 1");
     expect(result[0].members).to.have.lengthOf(1);

--- a/test/github-issues/8076/issue-8076.ts
+++ b/test/github-issues/8076/issue-8076.ts
@@ -156,6 +156,7 @@ describe("github issues > #8076 Add relation options to all tree queries (missin
 
     let c1 = await connection.getRepository(Category).findOne({ title: "Category 1" });
     let result = await connection.getTreeRepository(Category).findDescendants(c1!);
+    result.sort((a, b) => a.pk - b.pk);
 
     expect(result).to.have.lengthOf(3);
 
@@ -176,6 +177,7 @@ describe("github issues > #8076 Add relation options to all tree queries (missin
 
     let c1 = await connection.getRepository(Category).findOne({ title: "Category 1" });
     let result = await connection.getTreeRepository(Category).findDescendants(c1!, { relations: ["members"] });
+    result.sort((a, b) => a.pk - b.pk);
 
     expect(result).to.have.lengthOf(3);
 

--- a/test/github-issues/8076/issue-8076.ts
+++ b/test/github-issues/8076/issue-8076.ts
@@ -190,7 +190,7 @@ describe("github issues > #8076 Add relation options to all tree queries (missin
     expect(result[1].sites).equals(undefined);
 
     expect(result[2].title).equals("Category 1.1.1");
-    expect(result[1].members).to.be.an("array");
+    expect(result[2].members).to.be.an("array");
     expect(result[2].members).to.have.lengthOf(0);
     expect(result[2].sites).equals(undefined);
   })));


### PR DESCRIPTION
Closes: #8076

### Description of change
Added the `relations` option to all treeRepository methods.


### Pull-Request Checklist
- [x] Code is up-to-date with the `master` branch
- [x] `npm run lint` passes with this change
- [x] `npm run test` passes with this change
- [x] This pull request links relevant issues as `Fixes #0000`
- [x] There are new or updated unit tests validating the change
- [x] Documentation has been updated to reflect this change
- [x] The new commits follow conventions explained in [CONTRIBUTING.md](https://github.com/typeorm/typeorm/blob/master/CONTRIBUTING.md)

The changes are more or less the same I made in the previous pull request, just that I did it on all other methods too. I created test cases for each method, with and without the option set.
