### PR TITLE
feat: add `typeorm` command wrapper to package.json in project template

### DIFF
--- a/src/commands/InitCommand.ts
+++ b/src/commands/InitCommand.ts
@@ -601,6 +601,7 @@ Steps to run this project:
         if (!packageJson.scripts) packageJson.scripts = {};
         Object.assign(packageJson.scripts, {
             start: /*(docker ? "docker-compose up && " : "") + */"ts-node src/index.ts"
+            , typeorm: "node --require ts-node/register ./node_modules/typeorm/cli.js"
         });
         return JSON.stringify(packageJson, undefined, 3);
     }

--- a/src/commands/InitCommand.ts
+++ b/src/commands/InitCommand.ts
@@ -600,8 +600,8 @@ Steps to run this project:
 
         if (!packageJson.scripts) packageJson.scripts = {};
         Object.assign(packageJson.scripts, {
-            start: /*(docker ? "docker-compose up && " : "") + */"ts-node src/index.ts"
-            , typeorm: "node --require ts-node/register ./node_modules/typeorm/cli.js"
+            start: /*(docker ? "docker-compose up && " : "") + */"ts-node src/index.ts",
+            typeorm: "node --require ts-node/register ./node_modules/typeorm/cli.js"
         });
         return JSON.stringify(packageJson, undefined, 3);
     }


### PR DESCRIPTION
### Description of change

This small feature addition is to reduce beginner stumbling when initializing a project with the `typeorm init` command.

When someone runs the `typeorm init` command using the current TypeORM CLI, the `scripts` section of the package.json generated at that time looks like this:

```
   "scripts": {
      "start": "ts-node src/index.ts"
   }
```

Also, the `entities`, `migrations` and `subscribers` section of ormconfig.json looks like this:

```
   "entities": [
      "src/entity/**/*.ts"
   ],
   "migrations": [
      "src/migration/**/*.ts"
   ],
   "subscribers": [
      "src/subscriber/**/*.ts"
   ],
```

In this project, when I run a command like `typeorm schema:log` or `npm run typeorm schema:log`, I will get the following error:

```
$ typeorm schema:log
/tmp/typeorm-newproject/src/entity/User.ts:1
import {Entity, PrimaryGeneratedColumn, Column} from "typeorm";
^^^^^^

SyntaxError: Cannot use import statement outside a module
    at wrapSafe (internal/modules/cjs/loader.js:1001:16)
    at Module._compile (internal/modules/cjs/loader.js:1049:27)
    at Object.Module._extensions..js (internal/modules/cjs/loader.js:1114:10)
```

This is because the wrapper for the `typeorm` command described in <https://typeorm.io/#/using-cli/if-entities-files-are-in-typescript>  is not added to the `scripts` section of the package.json of this project. This error can be a stumbling block for beginners. Because it seems that the settings in ormconfig.json and the settings in package.json don't match.

So I suggest adding the above command wrapper to the project template to make it easier for beginners to get in.

### Environment

Node: 14.17.3
npm: 7.20.3

### Pull-Request Checklist

<!--
  Please make sure to review and check all of the following.

  If an item is not applicable, you can add "N/A" to the end.
-->

- [x] Code is up-to-date with the `master` branch
- [x] `npm run lint` passes with this change - (No error in InitCommand.ts)
- [ ] `npm run test` passes with this change - N/A (There are no tests for InitCommand in the current TypeORM)
- [ ] This pull request links relevant issues as `Fixes #0000` - N/A
- [ ] There are new or updated unit tests validating the change - N/A (There are no tests for InitCommand in the current TypeORM)
- [ ] Documentation has been updated to reflect this change - N/A
- [x] The new commits follow conventions explained in [CONTRIBUTING.md](https://github.com/typeorm/typeorm/blob/master/CONTRIBUTING.md)
