### PR TITLE
 fix: use full path for table lookups 

### DIFF
--- a/test/github-issues/7867/entity/Example.ts
+++ b/test/github-issues/7867/entity/Example.ts
@@ -1,0 +1,10 @@
+import { Column, Entity, PrimaryGeneratedColumn } from "../../../../src";
+
+@Entity()
+export class Example {
+    @PrimaryGeneratedColumn()
+    id: number;
+
+    @Column()
+    name: string;
+}

--- a/test/github-issues/7867/issue-7867.ts
+++ b/test/github-issues/7867/issue-7867.ts
@@ -1,0 +1,82 @@
+import "reflect-metadata";
+import { Connection } from "../../../src";
+import { closeTestingConnections, createTestingConnections, reloadTestingDatabases } from "../../utils/test-utils";
+import { Example } from "./entity/Example";
+import { expect } from "chai";
+
+describe("github issues > #7867 Column not renamed when schema/database is set", () => {
+
+    describe('schema is set', () => {
+        let connections: Connection[];
+        before(async () => {
+            connections = await createTestingConnections({
+                entities: [ Example ],
+                schemaCreate: true,
+                dropSchema: true,
+                driverSpecific: {
+                    schema: "public"
+                },
+                enabledDrivers: [ "postgres" ],
+            });
+        });
+        beforeEach(() => reloadTestingDatabases(connections));
+        after(() => closeTestingConnections(connections));
+
+        it("should correctly change column name", () => Promise.all(connections.map(async connection => {
+            const postMetadata = connection.getMetadata(Example);
+            const nameColumn = postMetadata.findColumnWithPropertyName("name")!;
+            nameColumn.propertyName = "title";
+            nameColumn.build(connection);
+
+            await connection.synchronize();
+
+            const queryRunner = connection.createQueryRunner();
+            const postTable = await queryRunner.getTable("example");
+            await queryRunner.release();
+
+            expect(postTable!.findColumnByName("name")).to.be.undefined;
+            postTable!.findColumnByName("title")!.should.be.exist;
+
+            // revert changes
+            nameColumn.propertyName = "name";
+            nameColumn.build(connection);
+        })));
+    });
+
+    describe('database is set', () => {
+        let connections: Connection[];
+        before(async () => {
+            connections = await createTestingConnections({
+                entities: [ Example ],
+                schemaCreate: true,
+                dropSchema: true,
+                driverSpecific: {
+                    database: "test"
+                },
+                enabledDrivers: [ "mysql" ],
+            });
+        });
+        beforeEach(() => reloadTestingDatabases(connections));
+        after(() => closeTestingConnections(connections));
+
+        it("should correctly change column name", () => Promise.all(connections.map(async connection => {
+            const postMetadata = connection.getMetadata(Example);
+            const nameColumn = postMetadata.findColumnWithPropertyName("name")!;
+            nameColumn.propertyName = "title";
+            nameColumn.build(connection);
+
+            await connection.synchronize();
+
+            const queryRunner = connection.createQueryRunner();
+            const postTable = await queryRunner.getTable("example");
+            await queryRunner.release();
+
+            expect(postTable!.findColumnByName("name")).to.be.undefined;
+            postTable!.findColumnByName("title")!.should.be.exist;
+
+            // revert changes
+            nameColumn.propertyName = "name";
+            nameColumn.build(connection);
+        })));
+    });
+});


### PR DESCRIPTION
<!--
  😀 Wonderful!  Thank you for opening a pull request for TypeORM.

  Please fill in the information below to expedite the review
  and (hopefully) merge of your change.

  If unsure about something.. just do as best as you're able,
  or reach out through our community support channels!
  https://github.com/typeorm/typeorm/blob/master/docs/support.md
-->

### Description of change

<!--
  Please be clear and concise what the change is intended to do,
  why this change is needed, and how you've verified that it
  corrects what you intended.

  In some cases it may be helpful to include the current behavior
  and the new behavior.

  If the change is related to an open issue, you can link it here.
  If you include `Fixes #0000` (replacing `0000` with the issue number)
  when this is merged it will automatically mark the issue as fixed and
  close it.
-->

The changes made as part of #7575 fixed some issues and introduced others.  The problem became that the table name would be compared against the `EntityMetadata` `tablePath`.  This would fail in some cases because while the `EntityMetadata` would specify `database`, it'd be the "default"/current database & would be omitted from the table name.

To work around that this PR introduces the database & schema on the table objects as well as a fully-qualified table path property which will always include all of them for comparing against `EntityMetadata`.

fixes #8109
fixes #8102 
fixes #7867 
fixes #7812
fixes #7737
fixes #6744
fixes #5960
fixes #5958
fixes #5439
fixes #5304

### Pull-Request Checklist

<!--
  Please make sure to review and check all of the following.

  If an item is not applicable, you can add "N/A" to the end.
-->

- [x] Code is up-to-date with the `master` branch
- [x] `npm run lint` passes with this change
- [x] `npm run test` passes with this change
- [x] This pull request links relevant issues as `Fixes #0000`
- [x] There are new or updated unit tests validating the change
- [ ] Documentation has been updated to reflect this change
- [x] The new commits follow conventions explained in [CONTRIBUTING.md](https://github.com/typeorm/typeorm/blob/master/CONTRIBUTING.md)

<!--
  🎉 Thank you for contributing and making TypeORM even better!
-->
