### PR TITLE
chore: add a script to produce a packed tgz of the module

### DIFF
--- a/gulpfile.ts
+++ b/gulpfile.ts
@@ -116,6 +116,17 @@ export class Gulpfile {
                 "cd ./build/package && npm publish"
             ]));
     }
+    
+    /**
+     * Packs a .tgz from ./build/package directory.
+     */
+    @Task()
+    packagePack() {
+        return gulp.src("package.json", { read: false })
+            .pipe(shell([
+                "cd ./build/package && npm pack && mv -f typeorm-*.tgz .."
+            ]));
+    }
 
     /**
      * Publishes a package to npm from ./build/package directory with @next tag.
@@ -228,6 +239,14 @@ export class Gulpfile {
                 "packageCopyShims"
             ],
         ];
+    }
+
+    /**
+     * Creates a package .tgz
+     */
+    @SequenceTask()
+    pack() {
+        return ["package", "packagePack"];
     }
 
     /**

--- a/package.json
+++ b/package.json
@@ -209,6 +209,7 @@
     "compile": "rimraf ./build && tsc",
     "watch": "./node_modules/.bin/tsc -w",
     "package": "gulp package",
+    "pack": "gulp pack",
     "lint": "eslint -c ./.eslintrc.js src/**/*.ts test/**/*.ts sample/**/*.ts",
     "changelog": "conventional-changelog -p angular -i CHANGELOG.md -s -r 1"
   },


### PR DESCRIPTION
This makes it easier to install custom builds in local projects

<!--
  😀 Wonderful!  Thank you for opening a pull request for TypeORM.

  Please fill in the information below to expedite the review
  and (hopefully) merge of your change.

  If unsure about something.. just do as best as you're able,
  or reach out through our community support channels!
  https://github.com/typeorm/typeorm/blob/master/docs/support.md
-->

### Description of change

<!--
  Please be clear and concise what the change is intended to do,
  why this change is needed, and how you've verified that it
  corrects what you intended.

  In some cases it may be helpful to include the current behavior
  and the new behavior.

  If the change is related to an open issue, you can link it here.
  If you include `Fixes #0000` (replacing `0000` with the issue number)
  when this is merged it will automatically mark the issue as fixed and
  close it.
-->

Adds a "pack" script (similar to the "package" script) that produces a .tgz file in the ./build directory.


### Pull-Request Checklist

<!--
  Please make sure to review and check all of the following.

  If an item is not applicable, you can add "N/A" to the end.
-->

- [x] Code is up-to-date with the `master` branch
- [x] `npm run lint` passes with this change N/A
- [x] `npm run test` passes with this change N/A
- [x] This pull request links relevant issues as `Fixes #0000` N/A
- [x] There are new or updated unit tests validating the change N/A
- [x] Documentation has been updated to reflect this change N/A
- [x] The new commits follow conventions explained in [CONTRIBUTING.md](https://github.com/typeorm/typeorm/blob/master/CONTRIBUTING.md)

<!--
  🎉 Thank you for contributing and making TypeORM even better!
-->
