### PR TITLE
fix: snakecase conversion for strings with numbers

### DIFF
--- a/src/util/StringUtils.ts
+++ b/src/util/StringUtils.ts
@@ -22,7 +22,7 @@ export function snakeCase(str: string): string{
         // ABc -> a_bc
         .replace(/([A-Z])([A-Z])([a-z])/g, "$1_$2$3")
         // aC -> a_c
-        .replace(/([a-z])([A-Z])/g, "$1_$2")
+        .replace(/([a-z0-9])([A-Z])/g, "$1_$2")
         .toLowerCase();
 }
 

--- a/test/functional/util/StringUtils.ts
+++ b/test/functional/util/StringUtils.ts
@@ -48,6 +48,14 @@ describe("StringUtils", () => {
             expect(actual).to.be.equal(expected, `Failed for Input: ${input}`);
         });
 
+        it("should correctly convert strings with numbers", () => {
+            const input = "device1Status";
+            const expected = "device1_status";
+            const actual = snakeCase(input);
+
+            expect(actual).to.be.equal(expected, `Failed for Input: ${input}`);
+        });
+
         it("should match the examples given in the older implementation", () => {
             // Pulled from https://regex101.com/r/QeSm2I/1
             const examples = {


### PR DESCRIPTION
Fix a specific case of converting device1Status -> device1_status

### Description of change

the change in eb680f99 has broke one case of how cammelCase is converted to snake_case, specifically:
device1Status -> device1status

this PR restores the correct behavior:
device1Status -> device1_status

### Pull-Request Checklist

- [x] Code is up-to-date with the `master` branch
- [x] `npm run lint` passes with this change
- [x] `npm run test` passes with this change
- [ ] This pull request links relevant issues as `Fixes #0000` (relevant issue not found)
- [x] There are new or updated unit tests validating the change
- [ ] Documentation has been updated to reflect this change (no change required)
- [x] The new commits follow conventions explained in [CONTRIBUTING.md](https://github.com/typeorm/typeorm/blob/master/CONTRIBUTING.md)
