### PR TITLE
Fixes https://github.com/typeorm/typeorm/issues/8115

### DIFF
--- a/src/logger/AdvancedConsoleLogger.ts
+++ b/src/logger/AdvancedConsoleLogger.ts
@@ -1,4 +1,4 @@
-import {LoggerOptions} from "./LoggerOptions";
+import {LoggerOptions, shouldLog} from "./LoggerOptions";
 import {PlatformTools} from "../platform/PlatformTools";
 import {QueryRunner} from "../query-runner/QueryRunner";
 import {Logger} from "./Logger";
@@ -24,7 +24,7 @@ export class AdvancedConsoleLogger implements Logger {
      * Logs query and parameters used in it.
      */
     logQuery(query: string, parameters?: any[], queryRunner?: QueryRunner) {
-        if (this.options === "all" || this.options === true || (Array.isArray(this.options) && this.options.indexOf("query") !== -1)) {
+        if (shouldLog("query", this.options)) {
             const sql = query + (parameters && parameters.length ? " -- PARAMETERS: " + this.stringifyParams(parameters) : "");
             PlatformTools.logInfo("query:", PlatformTools.highlightSql(sql));
         }
@@ -34,7 +34,7 @@ export class AdvancedConsoleLogger implements Logger {
      * Logs query that is failed.
      */
     logQueryError(error: string, query: string, parameters?: any[], queryRunner?: QueryRunner) {
-        if (this.options === "all" || this.options === true || (Array.isArray(this.options) && this.options.indexOf("error") !== -1)) {
+        if (shouldLog("error", this.options)) {
             const sql = query + (parameters && parameters.length ? " -- PARAMETERS: " + this.stringifyParams(parameters) : "");
             PlatformTools.logError(`query failed:`, PlatformTools.highlightSql(sql));
             PlatformTools.logError(`error:`, error);
@@ -54,7 +54,7 @@ export class AdvancedConsoleLogger implements Logger {
      * Logs events from the schema build process.
      */
     logSchemaBuild(message: string, queryRunner?: QueryRunner) {
-        if (this.options === "all" || (Array.isArray(this.options) && this.options.indexOf("schema") !== -1)) {
+        if (shouldLog("schema", this.options)) {
             PlatformTools.log(message);
         }
     }
@@ -73,15 +73,15 @@ export class AdvancedConsoleLogger implements Logger {
     log(level: "log"|"info"|"warn", message: any, queryRunner?: QueryRunner) {
         switch (level) {
             case "log":
-                if (this.options === "all" || (Array.isArray(this.options) && this.options.indexOf("log") !== -1))
+                if (shouldLog("log", this.options))
                     PlatformTools.log(message);
                 break;
             case "info":
-                if (this.options === "all" || (Array.isArray(this.options) && this.options.indexOf("info") !== -1))
+                if (shouldLog("info", this.options))
                     PlatformTools.logInfo("INFO:", message);
                 break;
             case "warn":
-                if (this.options === "all" || (Array.isArray(this.options) && this.options.indexOf("warn") !== -1))
+                if (shouldLog("warn", this.options))
                     console.warn(PlatformTools.warn(message));
                 break;
         }

--- a/src/logger/FileLogger.ts
+++ b/src/logger/FileLogger.ts
@@ -1,4 +1,4 @@
-import {LoggerOptions, FileLoggerOptions} from "./LoggerOptions";
+import {LoggerOptions, FileLoggerOptions, shouldLog} from "./LoggerOptions";
 import appRootPath from "app-root-path";
 import {QueryRunner} from "../query-runner/QueryRunner";
 import {Logger} from "./Logger";
@@ -28,7 +28,7 @@ export class FileLogger implements Logger {
      * Logs query and parameters used in it.
      */
     logQuery(query: string, parameters?: any[], queryRunner?: QueryRunner) {
-        if (this.options === "all" || this.options === true || (Array.isArray(this.options) && this.options.indexOf("query") !== -1)) {
+        if (shouldLog("query", this.options)) {
             const sql = query + (parameters && parameters.length ? " -- PARAMETERS: " + this.stringifyParams(parameters) : "");
             this.write("[QUERY]: " + sql);
         }
@@ -38,7 +38,7 @@ export class FileLogger implements Logger {
      * Logs query that is failed.
      */
     logQueryError(error: string, query: string, parameters?: any[], queryRunner?: QueryRunner) {
-        if (this.options === "all" || this.options === true || (Array.isArray(this.options) && this.options.indexOf("error") !== -1)) {
+        if (shouldLog("error", this.options)) {
             const sql = query + (parameters && parameters.length ? " -- PARAMETERS: " + this.stringifyParams(parameters) : "");
             this.write([
                 `[FAILED QUERY]: ${sql}`,
@@ -59,7 +59,7 @@ export class FileLogger implements Logger {
      * Logs events from the schema build process.
      */
     logSchemaBuild(message: string, queryRunner?: QueryRunner) {
-        if (this.options === "all" || (Array.isArray(this.options) && this.options.indexOf("schema") !== -1)) {
+        if (shouldLog("schema", this.options)) {
             this.write(message);
         }
     }
@@ -78,15 +78,15 @@ export class FileLogger implements Logger {
     log(level: "log"|"info"|"warn", message: any, queryRunner?: QueryRunner) {
         switch (level) {
             case "log":
-                if (this.options === "all" || (Array.isArray(this.options) && this.options.indexOf("log") !== -1))
+                if (shouldLog("log", this.options))
                     this.write("[LOG]: " + message);
                 break;
             case "info":
-                if (this.options === "all" || (Array.isArray(this.options) && this.options.indexOf("info") !== -1))
+                if (shouldLog("info", this.options))
                     this.write("[INFO]: " + message);
                 break;
             case "warn":
-                if (this.options === "all" || (Array.isArray(this.options) && this.options.indexOf("warn") !== -1))
+                if (shouldLog("warn", this.options))
                     this.write("[WARN]: " + message);
                 break;
         }

--- a/src/logger/LoggerOptions.ts
+++ b/src/logger/LoggerOptions.ts
@@ -1,7 +1,8 @@
 /**
  * Logging options.
  */
-export type LoggerOptions = boolean|"all"|("query"|"schema"|"error"|"warn"|"info"|"log"|"migration")[];
+type LogLevel = ("query"|"schema"|"error"|"warn"|"info"|"log"|"migration");
+export type LoggerOptions = boolean|"all"|LogLevel[];
 
 /**
  * File logging option.
@@ -12,3 +13,17 @@ export type FileLoggerOptions = {
    */
   logPath: string;
 };
+
+/**
+ * Helper function to determine if a message at a particular log level should be logged given the options
+ */
+export function shouldLog(
+  logLevel: LogLevel,
+  options: LoggerOptions | undefined
+): boolean {
+  return (
+    options === "all" ||
+    options === true ||
+    (Array.isArray(options) && options.indexOf(logLevel) !== -1)
+  );
+}


### PR DESCRIPTION
<!--
  😀 Wonderful!  Thank you for opening a pull request for TypeORM.

  Please fill in the information below to expedite the review
  and (hopefully) merge of your change.

  If unsure about something.. just do as best as you're able,
  or reach out through our community support channels!
  https://github.com/typeorm/typeorm/blob/master/docs/support.md
-->

### Description of change

<!--
  Please be clear and concise what the change is intended to do,
  why this change is needed, and how you've verified that it
  corrects what you intended.

  In some cases it may be helpful to include the current behavior
  and the new behavior.

  If the change is related to an open issue, you can link it here.
  If you include `Fixes #0000` (replacing `0000` with the issue number)
  when this is merged it will automatically mark the issue as fixed and
  close it.
-->

I noticed that certain logging operations (namely `logSchemaBuild` and `log` would not work if the TypeORM logging option was set to `true`. *Some* of the functions (such as `logQuery` and `logQueryError`) explicitly checked for `this.options === true`, but others did not.

The documentation says:

> You can enable logging of all queries and errors by simply setting logging: true in your connection options

But certain logs are left out. I created a helper function called `shouldLog` to hold the logic, and shared the code between `AdvancedConsoleLogger` and `FileLogger` since they contained effectively identical checks. I believe the helper reduces some of the visual complexity and makes the code more readable. Sharing the checks in a common function hopefully helps prevent mismatches between these different logging behaviours in the future.

### Pull-Request Checklist

<!--
  Please make sure to review and check all of the following.

  If an item is not applicable, you can add "N/A" to the end.
-->

- [x] Code is up-to-date with the `master` branch
- [x] `npm run lint` passes with this change
- [x] `npm run test` passes with this change
- [x] This pull request links relevant issues as `Fixes #0000`
- [ ] There are new or updated unit tests validating the change
- [ ] Documentation has been updated to reflect this change
- [x] The new commits follow conventions explained in [CONTRIBUTING.md](https://github.com/typeorm/typeorm/blob/master/CONTRIBUTING.md)

<!--
  🎉 Thank you for contributing and making TypeORM even better!
-->
