### PR TITLE
fix: ordering by joined columns for PostgreSQL (#3736)

### DIFF
--- a/src/query-builder/SelectQueryBuilder.ts
+++ b/src/query-builder/SelectQueryBuilder.ts
@@ -1951,7 +1951,7 @@ export class SelectQueryBuilder<Entity> extends QueryBuilder<Entity> implements 
 
             // we are skipping order by here because its not working in subqueries anyway
             // to make order by working we need to apply it on a distinct query
-            const [selects, orderBys] = this.createOrderByCombinedWithSelectExpression("distinctAlias");
+            const [selects, orderBys, subquerySelect] = this.createOrderByCombinedWithSelectExpression("distinctAlias");
             const metadata = this.expressionMap.mainAlias.metadata;
             const mainAliasName = this.expressionMap.mainAlias.name;
 
@@ -1973,7 +1973,7 @@ export class SelectQueryBuilder<Entity> extends QueryBuilder<Entity> implements 
             rawResults = await new SelectQueryBuilder(this.connection, queryRunner)
                 .select(`DISTINCT ${querySelects.join(", ")}`)
                 .addSelect(selects)
-                .from(`(${this.clone().orderBy().getQuery()})`, "distinctAlias")
+                .from(`(${this.clone().orderBy().addSelect(subquerySelect).getQuery()})`, "distinctAlias")
                 .offset(this.expressionMap.skip)
                 .limit(this.expressionMap.take)
                 .orderBy(orderBys)
@@ -2042,7 +2042,7 @@ export class SelectQueryBuilder<Entity> extends QueryBuilder<Entity> implements 
         };
     }
 
-    protected createOrderByCombinedWithSelectExpression(parentAlias: string): [ string, OrderByCondition] {
+    protected createOrderByCombinedWithSelectExpression(parentAlias: string): [ string, OrderByCondition, string] {
 
         // if table has a default order then apply it
         const orderBys = this.expressionMap.allOrderBys;
@@ -2082,7 +2082,24 @@ export class SelectQueryBuilder<Entity> extends QueryBuilder<Entity> implements 
             }
         });
 
-        return [selectString, orderByObject];
+        const subquerySelectString = Object.keys(orderBys)
+            .filter(orderCriteria => orderCriteria.includes("."))
+            .map(orderCriteria => {
+                const criteriaParts = orderCriteria.split(".");
+                const aliasName = criteriaParts[0];
+                const propertyPath = criteriaParts.slice(1).join(".");
+                const alias = this.expressionMap.findAliasByName(aliasName);
+                if (alias.type !== "join") {
+                    return "";
+                }
+                const column = alias.metadata.findColumnWithPropertyPath(propertyPath);
+                const property = this.escape(alias.name) + "." + this.escape(column!.databaseName);
+                const propertyAlias = this.escape(DriverUtils.buildAlias(this.connection.driver, aliasName, column!.databaseName));
+                return [property, "AS", propertyAlias].join(" ");
+            })
+            .join(", ");
+
+        return [selectString, orderByObject, subquerySelectString];
     }
 
     /**

--- a/test/github-issues/3736/entity/Photo.ts
+++ b/test/github-issues/3736/entity/Photo.ts
@@ -1,0 +1,16 @@
+import {Entity, PrimaryGeneratedColumn, Column, ManyToOne} from "../../../../src";
+import {User} from "./User";
+
+@Entity()
+export class Photo {
+
+    @PrimaryGeneratedColumn()
+    id: number;
+
+    @Column()
+    url: string;
+
+    @ManyToOne(() => User, user => user.photos)
+    user: User;
+
+}

--- a/test/github-issues/3736/entity/User.ts
+++ b/test/github-issues/3736/entity/User.ts
@@ -1,0 +1,16 @@
+import {Entity, PrimaryGeneratedColumn, Column, OneToMany} from "../../../../src";
+import {Photo} from "./Photo";
+
+@Entity()
+export class User {
+
+    @PrimaryGeneratedColumn()
+    id: number;
+
+    @Column()
+    name: string;
+
+    @OneToMany(() => Photo, photo => photo.user)
+    photos: Photo[];
+
+}

--- a/test/github-issues/3736/issue-3736.ts
+++ b/test/github-issues/3736/issue-3736.ts
@@ -1,0 +1,40 @@
+import "reflect-metadata";
+import { createTestingConnections, closeTestingConnections, reloadTestingDatabases } from "../../utils/test-utils";
+import { Connection } from "../../../src/connection/Connection";
+import { expect } from "chai";
+import { Photo } from "./entity/Photo";
+import { User } from "./entity/User";
+import { SelectQueryBuilder } from "../../../src";
+
+
+describe("github issues > #3736 Order by joined column broken in Postgres", () => {
+    let connections: Connection[];
+    before(async () => connections = await createTestingConnections({
+        entities: [__dirname + "/entity/*{.js,.ts}"],
+        schemaCreate: true,
+        dropSchema: true,
+        logging: true
+    }));
+    beforeEach(() => reloadTestingDatabases(connections));
+    after(() => closeTestingConnections(connections));
+
+    it("should return photos ordered by user.name", () => Promise.all(connections.map(async connection => {
+        const [user1, user2]  = await connection.getRepository(User).save([
+            { name: "userA" },
+            { name: "userB" },
+        ]);
+        const [photo1, photo2] = await connection.getRepository(Photo).save([
+            { url: "https://example.com", user: user2 },
+            { url: "https://example.com", user: user1 },
+        ]);
+        const queryBuilder: SelectQueryBuilder<Photo> = await connection.getRepository(Photo).createQueryBuilder("photo");
+        const [results] = await queryBuilder
+            .select()
+            .leftJoin("photo.user", "user")
+            .take(5)
+            .orderBy("user.name")
+            .getManyAndCount();
+        expect(results[0].id).to.equal(photo2.id);
+        expect(results[1].id).to.equal(photo1.id);
+    })));
+})


### PR DESCRIPTION
### Description of change

Fixes #3736

This PR adds the missing column to the select clause inside the sub query when ordering is done by a property of a related entity.

Example:

```typescript
const queryBuilder: SelectQueryBuilder<Photo> = await connection.getRepository(Photo).createQueryBuilder("photo");
await queryBuilder
    .select()
    .leftJoin("photo.user", "user")
    .take(5)
    .orderBy("user.name")
    .getManyAndCount();
```

Generates the following valid SQL query:

```diff
SELECT
	DISTINCT "distinctAlias"."photo_id" AS "ids_photo_id",
	"distinctAlias"."user_name"
FROM
	(
		SELECT "photo"."id" AS "photo_id",
		"photo"."url" AS "photo_url",
		"photo"."userId" AS "photo_userId",
+		"user"."name" AS "user_name" 
	FROM
		"photo" "photo"
	LEFT JOIN "user" "user" ON
		"user"."id" = "photo"."userId") "distinctAlias"
ORDER BY
	"distinctAlias"."user_name" ASC,
	"photo_id" ASC
LIMIT 5
```

Without the fix `"user"."name" AS "user_name"` line is missing and query fails with error:
```
error: column distinctAlias.user_name does not exist
```

### Pull-Request Checklist

- [x] Code is up-to-date with the `master` branch
- [x] `npm run lint` passes with this change
- [x] `npm run test` passes with this change
- [x] This pull request links relevant issues as `Fixes #0000`
- [x] There are new or updated unit tests validating the change
- [ ] Documentation has been updated to reflect this change
- [x] The new commits follow conventions explained in [CONTRIBUTING.md](https://github.com/typeorm/typeorm/blob/master/CONTRIBUTING.md)