### PR TITLE
feat: Allow custom update expression in InsertQueryBuilder's `orUpdate` method

### DIFF
--- a/src/query-builder/InsertQueryBuilder.ts
+++ b/src/query-builder/InsertQueryBuilder.ts
@@ -371,8 +371,8 @@ export class InsertQueryBuilder<Entity> extends QueryBuilder<Entity> {
                 if (Array.isArray(overwrite)) {
                     query += ` ${conflictTarget} DO UPDATE SET `;
                     query += overwrite?.map((val: string | {column: string, expression?: string}) => {
-                        const column = this.escape(typeof val === 'string' ? val : val.column);
-                        const expression = typeof val !== 'string' && val.expression ? val.expression :  `EXCLUDED.${column}`
+                        const column = this.escape(typeof val === "string" ? val : val.column);
+                        const expression = typeof val !== "string" && val.expression ? val.expression :  `EXCLUDED.${column}`;
 
                         return `${column} = ${expression}`;
                     }).join(", ");
@@ -392,8 +392,8 @@ export class InsertQueryBuilder<Entity> extends QueryBuilder<Entity> {
                 if (Array.isArray(overwrite)) {
                     query += " ON DUPLICATE KEY UPDATE ";
                     query += overwrite?.map((val: string | {column: string, expression?: string}) => {
-                        const column = this.escape(typeof val === 'string' ? val : val.column);
-                        const expression = typeof val !== 'string' && val.expression ? val.expression :  `VALUES(${column})`
+                        const column = this.escape(typeof val === "string" ? val : val.column);
+                        const expression = typeof val !== "string" && val.expression ? val.expression :  `VALUES(${column})`;
 
                         return `${column} = ${expression}`;
                     }).join(", ");

--- a/src/query-builder/QueryExpressionMap.ts
+++ b/src/query-builder/QueryExpressionMap.ts
@@ -99,7 +99,7 @@ export class QueryExpressionMap {
     onUpdate: {
         conflict?: string | string[],
         columns?: string[],
-        overwrite?: string[],
+        overwrite?: (string | {column: string; expression?: string})[],
     };
 
     /**

--- a/test/github-issues/8125/entity/DailyStats.ts
+++ b/test/github-issues/8125/entity/DailyStats.ts
@@ -1,0 +1,15 @@
+import {Entity} from "../../../../src/decorator/entity/Entity";
+import {Column} from "../../../../src/decorator/columns/Column";
+import { PrimaryColumn } from "../../../../src/decorator/columns/PrimaryColumn";
+
+@Entity()
+export class DailyStats {
+    @PrimaryColumn()
+    public feedItemId: number;
+
+    @PrimaryColumn('date')
+    public date: string;
+
+    @Column()
+    public views: number;
+}

--- a/test/github-issues/8125/issue-8125.ts
+++ b/test/github-issues/8125/issue-8125.ts
@@ -1,0 +1,150 @@
+import "reflect-metadata";
+import {createTestingConnections, closeTestingConnections, reloadTestingDatabases} from "../../utils/test-utils";
+import {Connection} from "../../../src/connection/Connection";
+import {expect} from "chai";
+import {DailyStats} from "./entity/DailyStats";
+import {MysqlDriver} from "../../../src/driver/mysql/MysqlDriver";
+import {PostgresDriver} from "../../../src/driver/postgres/PostgresDriver";
+import {AbstractSqliteDriver} from "../../../src/driver/sqlite-abstract/AbstractSqliteDriver";
+
+describe("github issues > #8125 - Mysql, Postgres & SQLite - on duplicate key update using custom expression", () => {
+    let connections: Connection[];
+
+    before(async () => connections = await createTestingConnections({
+        entities: [DailyStats],
+        schemaCreate: true,
+        dropSchema: true,
+    }));
+
+    beforeEach(() => reloadTestingDatabases(connections));
+
+    after(() => closeTestingConnections(connections));
+
+    it("should overwrite using custom expression in MySQL/MariaDB", () => Promise.all(connections.map(async connection => {
+        try {
+            if (connection.driver instanceof MysqlDriver) {
+                const DailyStatsRepository = connection.manager.getRepository(DailyStats);
+
+                await DailyStatsRepository
+                    .createQueryBuilder()
+                    .insert()
+                    .into(DailyStats)
+                    .values({feedItemId: 1, date: '2021-01-01', views: 1})
+                    .execute();
+
+                await DailyStatsRepository
+                    .createQueryBuilder()
+                    .insert()
+                    .into(DailyStats)
+                    .values({feedItemId: 1, date: '2021-01-01', views: 2})
+                    .orUpdate([{column: 'views', expression: 'views + VALUES(views)'}], ['feedItemId', 'date'])
+                    .execute();
+
+                expect(await DailyStatsRepository.count()).to.be.eql(1);
+                expect(await DailyStatsRepository.findOneOrFail()).to.be.eql({
+                    feedItemId: 1,
+                    date: '2021-01-01',
+                    views: 3 // Overwritten by existing value + new value (using custom expression)
+                });
+            }
+        } catch (err) {
+            throw new Error(err);
+        }
+    })));
+
+    it("should default to existing behaviour when no expression given in MySQL/MariaDB", () => Promise.all(connections.map(async connection => {
+        try {
+            if (connection.driver instanceof MysqlDriver) {
+                const DailyStatsRepository = connection.manager.getRepository(DailyStats);
+
+                await DailyStatsRepository
+                    .createQueryBuilder()
+                    .insert()
+                    .into(DailyStats)
+                    .values({feedItemId: 1, date: '2021-01-01', views: 1})
+                    .execute();
+
+                await DailyStatsRepository
+                    .createQueryBuilder()
+                    .insert()
+                    .into(DailyStats)
+                    .values({feedItemId: 1, date: '2021-01-01', views: 2})
+                    .orUpdate([{column: 'views'}], ['feedItemId', 'date'])
+                    .execute();
+
+                expect(await DailyStatsRepository.count()).to.be.eql(1);
+                expect(await DailyStatsRepository.findOneOrFail()).to.be.eql({
+                    feedItemId: 1,
+                    date: '2021-01-01',
+                    views: 2 // Overwritten by value (no custom expression)
+                });
+            }
+        } catch (err) {
+            throw new Error(err);
+        }
+    })));
+
+    it("should overwrite using current value in PostgreSQL and SQLite", () => Promise.all(connections.map(async connection => {
+        try {
+            if (connection.driver instanceof PostgresDriver || connection.driver instanceof AbstractSqliteDriver) {
+                const DailyStatsRepository = connection.manager.getRepository(DailyStats);
+
+                await DailyStatsRepository
+                    .createQueryBuilder()
+                    .insert()
+                    .into(DailyStats)
+                    .values({feedItemId: 1, date: '2021-01-01', views: 1})
+                    .execute();
+
+                await DailyStatsRepository
+                    .createQueryBuilder()
+                    .insert()
+                    .into(DailyStats)
+                    .values({feedItemId: 1, date: '2021-01-01', views: 2})
+                    .orUpdate([{column: 'views', expression: 'views + EXCLUDED.views'}], ['feedItemId', 'date'])
+                    .execute();
+
+                expect(await DailyStatsRepository.count()).to.be.eql(1);
+                expect(await DailyStatsRepository.findOneOrFail()).to.be.eql({
+                    feedItemId: 1,
+                    date: '2021-01-01',
+                    views: 3 // Overwritten by existing value + new value (using custom expression)
+                });
+            }
+        } catch (err) {
+            throw new Error(err);
+        }
+    })));
+
+    it("should default to existing behaviour when no expression given in PostgreSQL and SQLite", () => Promise.all(connections.map(async connection => {
+        try {
+            if (connection.driver instanceof PostgresDriver || connection.driver instanceof AbstractSqliteDriver) {
+                const DailyStatsRepository = connection.manager.getRepository(DailyStats);
+
+                await DailyStatsRepository
+                    .createQueryBuilder()
+                    .insert()
+                    .into(DailyStats)
+                    .values({feedItemId: 1, date: '2021-01-01', views: 1})
+                    .execute();
+
+                await DailyStatsRepository
+                    .createQueryBuilder()
+                    .insert()
+                    .into(DailyStats)
+                    .values({feedItemId: 1, date: '2021-01-01', views: 2})
+                    .orUpdate([{column: 'views'}], ['feedItemId', 'date'])
+                    .execute();
+
+                expect(await DailyStatsRepository.count()).to.be.eql(1); // Ensure no new row added
+                expect(await DailyStatsRepository.findOneOrFail()).to.be.eql({
+                    feedItemId: 1,
+                    date: '2021-01-01',
+                    views: 2 // Overwritten by value (no custom expression)
+                });
+            }
+        } catch (err) {
+            throw new Error(err);
+        }
+    })));
+});


### PR DESCRIPTION
Closes #8125 

### Description of change

This PR improves the existing `orUpdate` function within InsertQueryBuilder for MySQL, SQLite & Postgres. It allows a custom expression to be used rather that simply overriding the value.

Existing functionality allows the following:
```
await DailyStatsRepository
    .createQueryBuilder()
    .insert()
    .into(DailyStats)
    .values({feedItemId: 1, date: '2021-01-01', views: 2})
    .orUpdate(['views'], ['feedItemId', 'date'])
    .execute();
```

Which will produce a query as follows:

```
INSERT INTO daily_stats ( ... ) VALUES ( ... )
ON DUPLICATE KEY UPDATE views = VALUES(views)
```

My use case (and I have hit this in past projects also, hence the issue and PR this time), involves needing to append to an existing value, rather than simple replace it, so my solution allows the following:

```
await DailyStatsRepository
    .createQueryBuilder()
    .insert()
    .into(DailyStats)
    .values({feedItemId: 1, date: '2021-01-01', views: 2})
    .orUpdate([{column: 'views', expression: 'views + VALUES(views)'}], ['feedItemId', 'date'])
    .execute();
```

Which will produce a query as follows:

```
INSERT INTO daily_stats ( ... ) VALUES ( ... )
ON DUPLICATE KEY UPDATE views = views + VALUES(views)
```

This allows me to do a single query to update the rows, without the need to first read the data, manually update the `views` column and then insert/update. This would be fine in most instances, but this feature I am working on is going to receive high traffic and has the potential to lead to race conditions, hence being able to do this in a single insert/update is what I need.

Happy to re-work as desired to get this in, the code changes themselves aren't significant so wont take long to rework.

### Pull-Request Checklist

- [x] Code is up-to-date with the `master` branch
- [x] `npm run lint` passes with this change
- [x] `npm run test` passes with this change
- [x] This pull request links relevant issues as `Fixes #0000`
- [x] There are new or updated unit tests validating the change
- [ ] Documentation has been updated to reflect this change
- [x] The new commits follow conventions explained in [CONTRIBUTING.md](https://github.com/typeorm/typeorm/blob/master/CONTRIBUTING.md)
