### PR TITLE
optional JSON/JSONB passthrough for postgres

### DIFF
--- a/docs/decorator-reference.md
+++ b/docs/decorator-reference.md
@@ -196,6 +196,7 @@ You can specify array of values or specify a enum class.
 * `asExpression: string` - Generated column expression. Used only in [MySQL](https://dev.mysql.com/doc/refman/5.7/en/create-table-generated-columns.html).
 * `generatedType: "VIRTUAL"|"STORED"` - Generated column type. Used only in [MySQL](https://dev.mysql.com/doc/refman/5.7/en/create-table-generated-columns.html).
 * `hstoreType: "object"|"string"` - Return type of `HSTORE` column. Returns value as string or as object. Used only in [Postgres](https://www.postgresql.org/docs/9.6/static/hstore.html).
+* `jsonType: "object"|"string"` - Return type of `JSON` or `JSONB` column. Returns value as string or as object. Used only in Postgres
 * `array: boolean` - Used for postgres and cockroachdb column types which can be array (for example int[]).
 * `transformer: ValueTransformer|ValueTransformer[]` - Specifies a value transformer (or array of value transformers) that is to be used to (un)marshal this column when reading or writing to the database. In case of an array, the value transformers will be applied in the natural order from entityValue to databaseValue, and in reverse order from databaseValue to entityValue.
 * `spatialFeatureType: string` - Optional feature type (`Point`, `Polygon`, `LineString`, `Geometry`) used as a constraint on a spatial column. If not specified, it will behave as though `Geometry` was provided. Used only in PostgreSQL.

--- a/docs/entities.md
+++ b/docs/entities.md
@@ -573,7 +573,7 @@ You can change it by specifying your own name.
 * `asExpression: string` - Generated column expression. Used only in [MySQL](https://dev.mysql.com/doc/refman/5.7/en/create-table-generated-columns.html).
 * `generatedType: "VIRTUAL"|"STORED"` - Generated column type. Used only in [MySQL](https://dev.mysql.com/doc/refman/5.7/en/create-table-generated-columns.html).
 * `hstoreType: "object"|"string"` - Return type of `HSTORE` column. Returns value as string or as object. Used only in [Postgres](https://www.postgresql.org/docs/9.6/static/hstore.html).
-* `array: boolean` - Used for postgres and cockroachdb column types which can be array (for example int[])
+* `jsonType: "object"|"string"` - Return type of `JSON` or `JSONB` column. Returns value as string or as object. Used only in Postgres* `array: boolean` - Used for postgres and cockroachdb column types which can be array (for example int[])
 * `transformer: { from(value: DatabaseType): EntityType, to(value: EntityType): DatabaseType }` - Used to marshal properties of arbitrary type `EntityType` into a type `DatabaseType` supported by the database. Array of transformers are also supported and will be applied in natural order when writing, and in reverse order when reading. e.g. `[lowercase, encrypt]` will first lowercase the string then encrypt it when writing, and will decrypt then do nothing when reading.
 
 Note: most of those column options are RDBMS-specific and aren't available in `MongoDB`.

--- a/docs/entities.md
+++ b/docs/entities.md
@@ -573,7 +573,8 @@ You can change it by specifying your own name.
 * `asExpression: string` - Generated column expression. Used only in [MySQL](https://dev.mysql.com/doc/refman/5.7/en/create-table-generated-columns.html).
 * `generatedType: "VIRTUAL"|"STORED"` - Generated column type. Used only in [MySQL](https://dev.mysql.com/doc/refman/5.7/en/create-table-generated-columns.html).
 * `hstoreType: "object"|"string"` - Return type of `HSTORE` column. Returns value as string or as object. Used only in [Postgres](https://www.postgresql.org/docs/9.6/static/hstore.html).
-* `jsonType: "object"|"string"` - Return type of `JSON` or `JSONB` column. Returns value as string or as object. Used only in Postgres* `array: boolean` - Used for postgres and cockroachdb column types which can be array (for example int[])
+* `jsonType: "object"|"string"` - Return type of `JSON` or `JSONB` column. Returns value as string or as object. Used only in Postgres
+* `array: boolean` - Used for postgres and cockroachdb column types which can be array (for example int[])
 * `transformer: { from(value: DatabaseType): EntityType, to(value: EntityType): DatabaseType }` - Used to marshal properties of arbitrary type `EntityType` into a type `DatabaseType` supported by the database. Array of transformers are also supported and will be applied in natural order when writing, and in reverse order when reading. e.g. `[lowercase, encrypt]` will first lowercase the string then encrypt it when writing, and will decrypt then do nothing when reading.
 
 Note: most of those column options are RDBMS-specific and aren't available in `MongoDB`.

--- a/src/decorator/columns/Column.ts
+++ b/src/decorator/columns/Column.ts
@@ -17,6 +17,7 @@ import {ColumnEmbeddedOptions} from "../options/ColumnEmbeddedOptions";
 import {EmbeddedMetadataArgs} from "../../metadata-args/EmbeddedMetadataArgs";
 import {ColumnTypeUndefinedError} from "../../error/ColumnTypeUndefinedError";
 import {ColumnHstoreOptions} from "../options/ColumnHstoreOptions";
+import {ColumnJsonOptions} from "../options/ColumnJsonOptions";
 import {ColumnWithWidthOptions} from "../options/ColumnWithWidthOptions";
 import {GeneratedMetadataArgs} from "../../metadata-args/GeneratedMetadataArgs";
 import {ColumnOptions} from "../options/ColumnOptions";
@@ -90,6 +91,18 @@ export function Column(type: "hstore", options?: ColumnCommonOptions & ColumnHst
 /**
  * Column decorator is used to mark a specific class property as a table column.
  * Only properties decorated with this decorator will be persisted to the database when entity be saved.
+ */
+export function Column(type: "json", options?: ColumnCommonOptions & ColumnJsonOptions): PropertyDecorator;
+
+/**
+ * Column decorator is used to mark a specific class property as a table column.
+ * Only properties decorated with this decorator will be persisted to the database when entity be saved.
+ */
+export function Column(type: "jsonb", options?: ColumnCommonOptions & ColumnJsonOptions): PropertyDecorator;
+
+/**
+ * Column decorator is used to mark a specific class property as a table column.
+ * Only properties decorated with this decorator will be persisted to the database when entity be saved.
  *
  * Property in entity can be marked as Embedded, and on persist all columns from the embedded are mapped to the
  * single table of the entity where Embedded is used. And on hydration all columns which supposed to be in the
@@ -127,6 +140,18 @@ export function Column(typeOrOptions?: ((type?: any) => Function)|ColumnType|(Co
         // specify HSTORE type if column is HSTORE
         if (options.type === "hstore" && !options.hstoreType)
             options.hstoreType = reflectMetadataType === Object ? "object" : "string";
+
+        if (options.type === "json" && !options.jsonType) 
+            options.jsonType = reflectMetadataType === String ? "string" : "object";
+        
+        if (options.type === "jsonb" && !options.jsonType) 
+            options.jsonType = reflectMetadataType === String ? "string" : "object";
+        
+        if (options.type === "geometry" && !options.jsonType) 
+            options.jsonType = reflectMetadataType === String ? "string" : "object";
+        
+        if (options.type === "geography" && !options.jsonType) 
+            options.jsonType = reflectMetadataType === String ? "string" : "object";
 
         if (typeOrOptions instanceof Function) { // register an embedded
             getMetadataArgsStorage().embeddeds.push({

--- a/src/decorator/columns/PrimaryColumn.ts
+++ b/src/decorator/columns/PrimaryColumn.ts
@@ -1,8 +1,8 @@
-import {getMetadataArgsStorage} from "../../globals";
-import {ColumnTypeUndefinedError} from "../../error/ColumnTypeUndefinedError";
-import {PrimaryColumnCannotBeNullableError} from "../../error/PrimaryColumnCannotBeNullableError";
-import {ColumnMetadataArgs} from "../../metadata-args/ColumnMetadataArgs";
-import {GeneratedMetadataArgs} from "../../metadata-args/GeneratedMetadataArgs";
+import { getMetadataArgsStorage } from "../../globals";
+import { ColumnTypeUndefinedError } from "../../error/ColumnTypeUndefinedError";
+import { PrimaryColumnCannotBeNullableError } from "../../error/PrimaryColumnCannotBeNullableError";
+import { ColumnMetadataArgs } from "../../metadata-args/ColumnMetadataArgs";
+import { GeneratedMetadataArgs } from "../../metadata-args/GeneratedMetadataArgs";
 import { ColumnOptions } from "../options/ColumnOptions";
 import { ColumnType } from "../../driver/types/ColumnTypes";
 
@@ -31,15 +31,15 @@ export function PrimaryColumn(type?: ColumnType, options?: PrimaryColumnOptions)
  * Only properties decorated with this decorator will be persisted to the database when entity be saved.
  * Primary columns also creates a PRIMARY KEY for this column in a db.
  */
-export function PrimaryColumn(typeOrOptions?: ColumnType|PrimaryColumnOptions, options?: PrimaryColumnOptions): PropertyDecorator {
+export function PrimaryColumn(typeOrOptions?: ColumnType | PrimaryColumnOptions, options?: PrimaryColumnOptions): PropertyDecorator {
     return function (object: Object, propertyName: string) {
 
         // normalize parameters
-        let type: ColumnType|undefined;
+        let type: ColumnType | undefined;
         if (typeof typeOrOptions === "string") {
             type = typeOrOptions;
         } else {
-            options = Object.assign({}, <PrimaryColumnOptions> typeOrOptions);
+            options = Object.assign({}, <PrimaryColumnOptions>typeOrOptions);
         }
         if (!options) options = {} as PrimaryColumnOptions;
 
@@ -55,6 +55,18 @@ export function PrimaryColumn(typeOrOptions?: ColumnType|PrimaryColumnOptions, o
         // if we still don't have a type then we need to give error to user that type is required
         if (!options.type)
             throw new ColumnTypeUndefinedError(object, propertyName);
+
+        if (options.type === "json" && !options.jsonType)
+            options.jsonType = reflectMetadataType === String ? "string" : "object";
+
+        if (options.type === "jsonb" && !options.jsonType)
+            options.jsonType = reflectMetadataType === String ? "string" : "object";
+
+        if (options.type === "geometry" && !options.jsonType)
+            options.jsonType = reflectMetadataType === String ? "string" : "object";
+
+        if (options.type === "geography" && !options.jsonType)
+            options.jsonType = reflectMetadataType === String ? "string" : "object";
 
         // check if column is not nullable, because we cannot allow a primary key to be nullable
         if (options.nullable)

--- a/src/decorator/columns/PrimaryColumn.ts
+++ b/src/decorator/columns/PrimaryColumn.ts
@@ -1,10 +1,10 @@
-import { getMetadataArgsStorage } from "../../globals";
-import { ColumnTypeUndefinedError } from "../../error/ColumnTypeUndefinedError";
-import { PrimaryColumnCannotBeNullableError } from "../../error/PrimaryColumnCannotBeNullableError";
-import { ColumnMetadataArgs } from "../../metadata-args/ColumnMetadataArgs";
-import { GeneratedMetadataArgs } from "../../metadata-args/GeneratedMetadataArgs";
-import { ColumnOptions } from "../options/ColumnOptions";
-import { ColumnType } from "../../driver/types/ColumnTypes";
+import {getMetadataArgsStorage} from "../../globals";
+import {ColumnTypeUndefinedError} from "../../error/ColumnTypeUndefinedError";
+import {PrimaryColumnCannotBeNullableError} from "../../error/PrimaryColumnCannotBeNullableError";
+import {ColumnMetadataArgs} from "../../metadata-args/ColumnMetadataArgs";
+import {GeneratedMetadataArgs} from "../../metadata-args/GeneratedMetadataArgs";
+import {ColumnOptions} from "../options/ColumnOptions";
+import {ColumnType} from "../../driver/types/ColumnTypes";
 
 /**
  * Describes all primary key column's options.
@@ -31,15 +31,15 @@ export function PrimaryColumn(type?: ColumnType, options?: PrimaryColumnOptions)
  * Only properties decorated with this decorator will be persisted to the database when entity be saved.
  * Primary columns also creates a PRIMARY KEY for this column in a db.
  */
-export function PrimaryColumn(typeOrOptions?: ColumnType | PrimaryColumnOptions, options?: PrimaryColumnOptions): PropertyDecorator {
+export function PrimaryColumn(typeOrOptions?: ColumnType|PrimaryColumnOptions, options?: PrimaryColumnOptions): PropertyDecorator {
     return function (object: Object, propertyName: string) {
 
         // normalize parameters
-        let type: ColumnType | undefined;
+        let type: ColumnType|undefined;
         if (typeof typeOrOptions === "string") {
             type = typeOrOptions;
         } else {
-            options = Object.assign({}, <PrimaryColumnOptions>typeOrOptions);
+            options = Object.assign({}, <PrimaryColumnOptions> typeOrOptions);
         }
         if (!options) options = {} as PrimaryColumnOptions;
 

--- a/src/decorator/options/ColumnJsonOptions.ts
+++ b/src/decorator/options/ColumnJsonOptions.ts
@@ -1,5 +1,5 @@
 /**
- * Column options for enum-typed columns.
+ * Column options for JSON-typed columns.
  */
 export interface ColumnJsonOptions {
 

--- a/src/decorator/options/ColumnJsonOptions.ts
+++ b/src/decorator/options/ColumnJsonOptions.ts
@@ -1,0 +1,12 @@
+/**
+ * Column options for enum-typed columns.
+ */
+export interface ColumnJsonOptions {
+
+    /**
+     * Return type of HSTORE column.
+     * Returns value as string or as object.
+     */
+    jsonType?: string;
+
+}

--- a/src/decorator/options/ColumnOptions.ts
+++ b/src/decorator/options/ColumnOptions.ts
@@ -150,6 +150,12 @@ export interface ColumnOptions extends ColumnCommonOptions {
     hstoreType?: "object"|"string";
 
     /**
+     * Return type of JSON/JSONB column.
+     * Returns value as string or as object.
+     */
+    jsonType?: "object"|"string";
+
+    /**
      * Indicates if this column is an array.
      * Can be simply set to true or array length can be specified.
      * Supported only by postgres.

--- a/src/decorator/options/ColumnOptions.ts
+++ b/src/decorator/options/ColumnOptions.ts
@@ -151,7 +151,9 @@ export interface ColumnOptions extends ColumnCommonOptions {
 
     /**
      * Return type of JSON/JSONB column.
-     * Returns value as string or as object.
+     * 
+     * Determines whether value is passed to/returned from the database as a string or object.
+     * Supported only by postgres.
      */
     jsonType?: "object"|"string";
 

--- a/src/driver/postgres/PostgresDriver.ts
+++ b/src/driver/postgres/PostgresDriver.ts
@@ -45,11 +45,6 @@ export class PostgresDriver implements Driver {
     postgres: any;
 
     /**
-     * Postgres type mapper
-     */
-    types: any;
-
-    /**
      * Pool for master database.
      */
     master: any;

--- a/src/driver/postgres/PostgresDriver.ts
+++ b/src/driver/postgres/PostgresDriver.ts
@@ -1200,9 +1200,7 @@ export class PostgresDriver implements Driver {
     /**
      * Executes given query.
      */
-    protected executeQuery(connection: any, query: string) {
-        this.connection.logger.logQuery(query);
-
+    protected executeQuery(connection: any, query: string) {        
         return new Promise((ok, fail) => {
             this.connection.logger.logQuery(query);
             connection.query(

--- a/src/driver/postgres/PostgresDriver.ts
+++ b/src/driver/postgres/PostgresDriver.ts
@@ -45,6 +45,11 @@ export class PostgresDriver implements Driver {
     postgres: any;
 
     /**
+     * Postgres type mapper
+     */
+    types: any;
+
+    /**
      * Pool for master database.
      */
     master: any;
@@ -355,6 +360,15 @@ export class PostgresDriver implements Driver {
         }
     }
 
+    getTypeParser(oid: number, ...rest: any[]) : (param: string) => any {
+        const baseTypes = this.postgres.types;        
+        if (oid === baseTypes.builtins.JSON || oid === baseTypes.builtins.JSONB) {
+            return (v : any) => v;
+        } else {
+          return baseTypes.getTypeParser(oid, ...rest);
+        }
+    }      
+
     protected async enableExtensions(extensionsMetadata: any, connection: any) {
         const { logger } = this.connection;
 
@@ -502,8 +516,11 @@ export class PostgresDriver implements Driver {
             return DateUtils.mixedDateToDate(value);
 
         } else if (["json", "jsonb", ...this.spatialTypes].indexOf(columnMetadata.type) >= 0) {
-            return JSON.stringify(value);
-
+            if (columnMetadata.jsonType === 'object') {
+                return JSON.stringify(value);
+            } else {
+                return value;
+            }
         } else if (columnMetadata.type === "hstore") {
             if (typeof value === "string") {
                 return value;
@@ -586,7 +603,10 @@ export class PostgresDriver implements Driver {
             } else {
                 return value;
             }
-
+        } else if (["json", "jsonb", ...this.spatialTypes].indexOf(columnMetadata.type) >= 0) {
+            if (columnMetadata.jsonType === 'object') {
+                value = JSON.parse(value);
+            } 
         } else if (columnMetadata.type === "simple-array") {
             value = DateUtils.stringToSimpleArray(value);
 
@@ -1189,7 +1209,13 @@ export class PostgresDriver implements Driver {
         this.connection.logger.logQuery(query);
 
         return new Promise((ok, fail) => {
-            connection.query(query, (err: any, result: any) => err ? fail(err) : ok(result));
+            this.connection.logger.logQuery(query);
+            connection.query(
+                { text: query, types: { getTypeParser : (oid : number, ...rest: any[]) => this.getTypeParser(oid, ...rest)}  }, 
+                (err: any, result: any) => {
+                if (err) return fail(err);
+                ok(result);
+            });
         });
     }
 

--- a/src/driver/postgres/PostgresQueryRunner.ts
+++ b/src/driver/postgres/PostgresQueryRunner.ts
@@ -205,9 +205,10 @@ export class PostgresQueryRunner extends BaseQueryRunner implements QueryRunner 
         const databaseConnection = await this.connect();
 
         this.driver.connection.logger.logQuery(query, parameters, this);
+
         try {
             const queryStartTime = +new Date();
-            const raw = await databaseConnection.query(query, parameters);
+            const raw = await databaseConnection.query({ text: query, values: parameters, types: { getTypeParser : (oid : number, ...rest: any[]) => this.driver.getTypeParser(oid, ...rest)} });
             // log slow queries if maxQueryExecution time is set
             const maxQueryExecutionTime = this.driver.options.maxQueryExecutionTime;
             const queryEndTime = +new Date();

--- a/src/entity-schema/EntitySchemaColumnOptions.ts
+++ b/src/entity-schema/EntitySchemaColumnOptions.ts
@@ -188,6 +188,12 @@ export interface EntitySchemaColumnOptions extends SpatialColumnOptions {
     hstoreType?: "object"|"string";
 
     /**
+     * Return type of JSON/JSONB column.
+     * Returns value as string or as object.
+     */
+    jsonType?: "object"|"string";
+
+    /**
      * Indicates if this column is an array.
      * Can be simply set to true or array length can be specified.
      * Supported only by postgres.

--- a/src/entity-schema/EntitySchemaTransformer.ts
+++ b/src/entity-schema/EntitySchemaTransformer.ts
@@ -94,6 +94,7 @@ export class EntitySchemaTransformer {
                         asExpression: column.asExpression,
                         generatedType: column.generatedType,
                         hstoreType: column.hstoreType,
+                        jsonType: column.jsonType,
                         array: column.array,
                         transformer: column.transformer,
                         spatialFeatureType: column.spatialFeatureType,

--- a/src/metadata/ColumnMetadata.ts
+++ b/src/metadata/ColumnMetadata.ts
@@ -179,6 +179,12 @@ export class ColumnMetadata {
     hstoreType?: "object"|"string";
 
     /**
+     * Return type of JSON/JSONB column.
+     * Returns value as string or as object.
+     */
+    jsonType?: "object"|"string";
+
+    /**
      * Indicates if this column is an array.
      */
     isArray: boolean = false;
@@ -396,6 +402,8 @@ export class ColumnMetadata {
         }
         if (options.args.options.hstoreType)
             this.hstoreType = options.args.options.hstoreType;
+        if (options.args.options.jsonType)
+            this.jsonType = options.args.options.jsonType;            
         if (options.args.options.array)
             this.isArray = options.args.options.array;
         if (options.args.mode) {

--- a/test/github-issues/8128/entity/Record.ts
+++ b/test/github-issues/8128/entity/Record.ts
@@ -1,0 +1,33 @@
+import {Entity} from "../../../../src/decorator/entity/Entity";
+import {PrimaryGeneratedColumn} from "../../../../src/decorator/columns/PrimaryGeneratedColumn";
+import {Column} from "../../../../src/decorator/columns/Column";
+
+const JSON_TRANSFORMER = {
+    from: (value : string) => JSON.parse(value),
+    to: (value: any) => JSON.stringify(value)
+}
+
+/**
+ * For testing Postgres jsonb
+ */
+@Entity()
+export class Record {
+
+    @PrimaryGeneratedColumn()
+    id: number;
+
+    @Column({ type: "json", nullable: true, jsonType: 'string', transformer: JSON_TRANSFORMER })
+    config: any;
+
+    @Column({ type: "jsonb", nullable: true, jsonType: 'string', transformer: JSON_TRANSFORMER })
+    data: any;
+
+    @Column({ type: "jsonb", nullable: true, default: { hello: "world", foo: "bar" }, jsonType: 'string', transformer: JSON_TRANSFORMER })
+    dataWithDefaultObject: any;
+
+    @Column({ type: "jsonb", nullable: true, default: null, jsonType: 'string', transformer: JSON_TRANSFORMER })
+    dataWithDefaultNull: any;
+
+    @Column({ type: "jsonb", nullable: true })
+    raw: string;
+}

--- a/test/github-issues/8128/issue-8128.ts
+++ b/test/github-issues/8128/issue-8128.ts
@@ -1,0 +1,104 @@
+import "reflect-metadata";
+import {expect} from "chai";
+import {Record} from "./entity/Record";
+import {Connection} from "../../../src/connection/Connection";
+import {closeTestingConnections, createTestingConnections} from "../../utils/test-utils";
+
+describe("github issues > #8128 postgres/pass through JSON as string", () => {
+
+    let connections: Connection[];
+    before(async () => connections = await createTestingConnections({
+        entities: [Record],
+        enabledDrivers: ["postgres"] // because only postgres supports jsonb type
+    }));
+    // beforeEach(() => reloadTestingDatabases(connections));
+    after(() => closeTestingConnections(connections));
+
+    it("should make correct schema with Postgres' jsonb type", () => Promise.all(connections.map(async connection => {
+        await connection.synchronize(true);
+        const queryRunner = connection.createQueryRunner();
+        let schema = await queryRunner.getTable("record");
+        await queryRunner.release();
+        expect(schema).not.to.be.undefined;
+        expect(schema!.columns.find(tableColumn => tableColumn.name === "config" && tableColumn.type === "json")).to.be.not.empty;
+        expect(schema!.columns.find(tableColumn => tableColumn.name === "data" && tableColumn.type === "jsonb")).to.be.not.empty;
+        expect(schema!.columns.find(tableColumn => tableColumn.name === "dataWithDefaultObject" && tableColumn.type === "jsonb")).to.be.not.empty;
+        expect(schema!.columns.find(tableColumn => tableColumn.name === "dataWithDefaultNull" && tableColumn.type === "jsonb")).to.be.not.empty;
+        expect(schema!.columns.find(tableColumn => tableColumn.name === "raw" && tableColumn.type === "jsonb")).to.be.not.empty;
+    })));
+
+    it("should persist jsonb correctly", () => Promise.all(connections.map(async connection => {
+        await connection.synchronize(true);
+        let recordRepo = connection.getRepository(Record);
+        let record = new Record();
+        record.data = { foo: "bar" };
+        record.raw = JSON.stringify(record.data);
+        let persistedRecord = await recordRepo.save(record);
+        let foundRecord = await recordRepo.findOne(persistedRecord.id);
+        expect(foundRecord).to.be.not.undefined;
+        expect(foundRecord!.data.foo).to.eq("bar");
+        expect(foundRecord!.raw).to.eq("{\"foo\": \"bar\"}");
+        expect(foundRecord!.dataWithDefaultNull).to.be.null;
+        expect(foundRecord!.dataWithDefaultObject).to.eql({ hello: "world", foo: "bar" });
+    })));
+
+    it("should persist jsonb string correctly", () => Promise.all(connections.map(async connection => {
+        let recordRepo = connection.getRepository(Record);
+        let record = new Record();
+        record.data = "foo";
+        record.raw = "\"foo\"";
+        let persistedRecord = await recordRepo.save(record);
+        let foundRecord = await recordRepo.findOne(persistedRecord.id);
+        expect(foundRecord).to.be.not.undefined;
+        expect(foundRecord!.data).to.be.a("string");
+        expect(foundRecord!.data).to.eq("foo");
+        expect(foundRecord!.raw).to.eq("\"foo\"");
+    })));
+
+    it("should persist jsonb array correctly", () => Promise.all(connections.map(async connection => {
+        let recordRepo = connection.getRepository(Record);
+        let record = new Record();
+        record.data = [1, "2", { a: 3 }];
+        record.raw = JSON.stringify([1, "2", { a: 3 }]);
+        let persistedRecord = await recordRepo.save(record);
+        let foundRecord = await recordRepo.findOne(persistedRecord.id);
+        expect(foundRecord).to.be.not.undefined;
+        expect(foundRecord!.data).to.deep.include.members([1, "2", { a: 3 }]);
+        expect(JSON.parse(foundRecord!.raw)).to.deep.include.members([1, "2", { a: 3 }]);
+    })));
+
+    it("should persist jsonb large integers correctly", () => Promise.all(connections.map(async connection => {
+        let recordRepo = connection.getRepository(Record);
+        let record = new Record();
+        record.raw = "{ \"foo\": 12312342345234534984732495807234233453453452234 }";
+        let persistedRecord = await recordRepo.save(record);
+        let foundRecord = await recordRepo.findOne(persistedRecord.id);
+        expect(foundRecord).to.be.not.undefined;
+        expect(foundRecord!.raw).to.eq("{\"foo\": 12312342345234534984732495807234233453453452234}");
+    })));    
+
+    it("should create updates when changing object", () => Promise.all(connections.map(async connection => {
+        await connection.query(`ALTER TABLE record ALTER COLUMN "dataWithDefaultObject" SET DEFAULT '{"foo":"baz","hello": "earth"}';`)
+
+        const sqlInMemory = await connection.driver.createSchemaBuilder().log();
+
+        expect(sqlInMemory.upQueries).not.to.eql([]);
+        expect(sqlInMemory.downQueries).not.to.eql([]);
+    })))
+
+    it("should not create updates when resorting object", () => Promise.all(connections.map(async connection => {
+        await connection.query(`ALTER TABLE record ALTER COLUMN "dataWithDefaultObject" SET DEFAULT '{"foo":"bar", "hello": "world"}';`)
+
+        const sqlInMemory = await connection.driver.createSchemaBuilder().log();
+
+        expect(sqlInMemory.upQueries).to.eql([]);
+        expect(sqlInMemory.downQueries).to.eql([]);
+    })));
+
+    it("should not create new migrations when everything is equivalent", () => Promise.all(connections.map(async connection => {
+        const sqlInMemory = await connection.driver.createSchemaBuilder().log();
+
+        expect(sqlInMemory.upQueries).to.eql([]);
+        expect(sqlInMemory.downQueries).to.eql([]);
+    })));
+});


### PR DESCRIPTION
### Description of change

Fixes #8128 - though better than originally proposed. Implements mechanism for postgres JSON/JSONB types similar to HSTORE. Permits developers to use their own JSON parser which is essential for supporting high precision/scale in JSON, while maintaining backward compatibility.

### Pull-Request Checklist

- [X] Code is up-to-date with the `master` branch
- [X] `npm run lint` passes with this change
- [X] `npm run test` passes with this change (though I've only run for postgres)
- [X] This pull request links relevant issues as `Fixes #0000`
- [X] There are new or updated unit tests validating the change
- [X] Documentation has been updated to reflect this change (only english)
- [X] The new commits follow conventions explained in [CONTRIBUTING.md](https://github.com/typeorm/typeorm/blob/master/CONTRIBUTING.md)

