### PR TITLE
Typeorm creates migration that creates already existing unique constraint

### DIFF
--- a/src/driver/postgres/PostgresQueryRunner.ts
+++ b/src/driver/postgres/PostgresQueryRunner.ts
@@ -1791,9 +1791,9 @@ export class PostgresQueryRunner extends BaseQueryRunner implements QueryRunner 
                     tableColumn.isPrimary = !!columnConstraints.find(constraint => constraint["constraint_type"] === "PRIMARY");
 
                     /* Find all contraints that are not composite one for specific column and take first one */
-                    const uniqueConstraint = columnConstraints.filter(constraint => constraint["constraint_type"] === "UNIQUE").map(constraint => {
+                    const uniqueConstraint: ObjectLiteral | undefined = columnConstraints.filter(constraint => constraint["constraint_type"] === "UNIQUE").filter(constraint => {
                         return !dbConstraints.find(dbConstraint => dbConstraint["constraint_type"] === "UNIQUE"
-                            && dbConstraint["constraint_name"] === uniqueConstraint["constraint_name"]
+                            && dbConstraint["constraint_name"] === constraint["constraint_name"]
                             && dbConstraint["column_name"] !== dbColumn["column_name"])
                     })[0];
                     tableColumn.isUnique = !!uniqueConstraint;

--- a/src/driver/postgres/PostgresQueryRunner.ts
+++ b/src/driver/postgres/PostgresQueryRunner.ts
@@ -1790,13 +1790,13 @@ export class PostgresQueryRunner extends BaseQueryRunner implements QueryRunner 
                     tableColumn.isNullable = dbColumn["is_nullable"] === "YES";
                     tableColumn.isPrimary = !!columnConstraints.find(constraint => constraint["constraint_type"] === "PRIMARY");
 
-                    const uniqueConstraint = columnConstraints.find(constraint => constraint["constraint_type"] === "UNIQUE");
-                    const isConstraintComposite = uniqueConstraint
-                        ? !!dbConstraints.find(dbConstraint => dbConstraint["constraint_type"] === "UNIQUE"
+                    /* Find all contraints that are not composite one for specific column and take first one */
+                    const uniqueConstraint = columnConstraints.filter(constraint => constraint["constraint_type"] === "UNIQUE").map(constraint => {
+                        return !dbConstraints.find(dbConstraint => dbConstraint["constraint_type"] === "UNIQUE"
                             && dbConstraint["constraint_name"] === uniqueConstraint["constraint_name"]
                             && dbConstraint["column_name"] !== dbColumn["column_name"])
-                        : false;
-                    tableColumn.isUnique = !!uniqueConstraint && !isConstraintComposite;
+                    })[0];
+                    tableColumn.isUnique = !!uniqueConstraint;
 
                     if (dbColumn["column_default"] !== null && dbColumn["column_default"] !== undefined) {
                         const serialDefaultName = `nextval('${this.buildSequenceName(table, dbColumn["column_name"])}'::regclass)`;


### PR DESCRIPTION
<!--
  😀 Wonderful!  Thank you for opening a pull request for TypeORM.

  Please fill in the information below to expedite the review
  and (hopefully) merge of your change.

  If unsure about something.. just do as best as you're able,
  or reach out through our community support channels!
  https://github.com/typeorm/typeorm/blob/master/docs/support.md
-->

### Description of change

<!--
  Please be clear and concise what the change is intended to do,
  why this change is needed, and how you've verified that it
  corrects what you intended.

  In some cases it may be helpful to include the current behavior
  and the new behavior.

  If the change is related to an open issue, you can link it here.
  If you include `Fixes #0000` (replacing `0000` with the issue number)
  when this is merged it will automatically mark the issue as fixed and
  close it.
-->

Fixes #8158

Typeorm was detecting whether unique constraint exists on column by using `find()` on all constraints for column (finding one with type `UNIQUE`) and then checking whether the constraint is a composite one. This is not a valid approach, because in case there's more than one constraint for a column and the first one is composite the code will not detect the column is in fact unique.

The code was adapted to use filter:
1. Select all constraints for column with type `UNIQUE`
2. Filter all composite constraints
3. Select first result

This approach will correctly handle situation in which there are many unique keys for a column and some of them are composite and are ordered randomly.


### Pull-Request Checklist

<!--
  Please make sure to review and check all of the following.

  If an item is not applicable, you can add "N/A" to the end.
-->

- [x] Code is up-to-date with the `master` branch
- [x] `npm run lint` passes with this change
- [x] `npm run test` passes with this change
- [x] This pull request links relevant issues as `Fixes #0000`
- [ ] There are new or updated unit tests validating the change
- [ ] Documentation has been updated to reflect this change
- [ ] The new commits follow conventions explained in [CONTRIBUTING.md](https://github.com/typeorm/typeorm/blob/master/CONTRIBUTING.md)

<!--
  🎉 Thank you for contributing and making TypeORM even better!
-->
