### PR TITLE
Option to set Postgres connection's search_path

### DIFF
--- a/docs/connection-options.md
+++ b/docs/connection-options.md
@@ -195,6 +195,8 @@ See [SSL options](https://github.com/mysqljs/mysql#ssl-options).
 
 * `applicationName` - A string visible in statistics and logs to help referencing an application to a connection (default: `undefined`)
 
+* `updateSearchPath` - A boolean to control whether to update the connection's search path to prioritize the connection's schema (default: `false`)
+
 ## `sqlite` connection options
 
 * `database` - Database path. For example "./mydb.sql"

--- a/src/driver/postgres/PostgresConnectionOptions.ts
+++ b/src/driver/postgres/PostgresConnectionOptions.ts
@@ -73,4 +73,10 @@ export interface PostgresConnectionOptions extends BaseConnectionOptions, Postgr
      * the service using this connection. Defaults to 'undefined'
      */
     readonly applicationName?: string;
+
+    /**
+     * Update connection's search_path to prepand the working schema,
+     * if available.
+     */
+    readonly updateSearchPath?: boolean;
 }

--- a/test/functional/driver/postgres/specific-options.ts
+++ b/test/functional/driver/postgres/specific-options.ts
@@ -8,7 +8,9 @@ describe("postgres specific options", () => {
   before(async () => connections = await createTestingConnections({
     enabledDrivers: ["postgres"],
     driverSpecific: {
-      applicationName: "some test name"
+      schema: "my_schema",
+      applicationName: "some test name",
+      updateSearchPath: true
     }
   }));
   beforeEach(() => reloadTestingDatabases(connections));
@@ -20,5 +22,13 @@ describe("postgres specific options", () => {
     );
     expect(result.length).equals(1);
     expect(result[0].application_name).equals("some test name");
+  })));
+
+  it("should set search_path", () => Promise.all(connections.map(async connection => {
+    const result = await connection.query(
+      "show search_path"
+    );
+    expect(result.length).equals(1);
+    expect(result[0].search_path).equals("my_schema, public");
   })));
 });


### PR DESCRIPTION
<!--
  😀 Wonderful!  Thank you for opening a pull request for TypeORM.

  Please fill in the information below to expedite the review
  and (hopefully) merge of your change.

  If unsure about something.. just do as best as you're able,
  or reach out through our community support channels!
  https://github.com/typeorm/typeorm/blob/master/docs/support.md
-->

### Description of change

<!--
  Please be clear and concise what the change is intended to do,
  why this change is needed, and how you've verified that it
  corrects what you intended.

  In some cases it may be helpful to include the current behavior
  and the new behavior.

  If the change is related to an open issue, you can link it here.
  If you include `Fixes #0000` (replacing `0000` with the issue number)
  when this is merged it will automatically mark the issue as fixed and
  close it.
-->

Adds a Postgres driver-specific option to update the `search_path` of opened connections. This will enable query runners to work in the connection's schema by default, fall backing to the `default` schema (to use some extensions for instance, as uuid_generate_v4 is enabled on the default schema).

### Pull-Request Checklist

<!--
  Please make sure to review and check all of the following.

  If an item is not applicable, you can add "N/A" to the end.
-->

- [x] Code is up-to-date with the `master` branch
- [x] `npm run lint` passes with this change
- [x] `npm run test` passes with this change
- [x] This pull request links relevant issues as `Fixes #0000` N/A
- [x] There are new or updated unit tests validating the change
- [x] Documentation has been updated to reflect this change
- [x] The new commits follow conventions explained in [CONTRIBUTING.md](https://github.com/typeorm/typeorm/blob/master/CONTRIBUTING.md)

<!--
  🎉 Thank you for contributing and making TypeORM even better!
-->
