### PR TITLE
fix: NativescriptQueryRunner's query method fails when targeting es2017

### DIFF
--- a/src/driver/nativescript/NativescriptQueryRunner.ts
+++ b/src/driver/nativescript/NativescriptQueryRunner.ts
@@ -42,6 +42,7 @@ export class NativescriptQueryRunner extends AbstractSqliteQueryRunner {
 
             const databaseConnection = await this.connect();
             const isInsertQuery = query.substr(0, 11) === "INSERT INTO";
+            connection.logger.logQuery(query, parameters, this);
 
             const handler = (err: any, raw: any) => {
 

--- a/src/driver/nativescript/NativescriptQueryRunner.ts
+++ b/src/driver/nativescript/NativescriptQueryRunner.ts
@@ -31,51 +31,55 @@ export class NativescriptQueryRunner extends AbstractSqliteQueryRunner {
      * Executes a given SQL query.
      */
     async query(query: string, parameters?: any[], useStructuredResult = false): Promise<any> {
-        if (this.isReleased)
+
+        if (this.isReleased) {
             throw new QueryRunnerAlreadyReleasedError();
+        }
 
         const connection = this.driver.connection;
 
-        return new Promise( (ok, fail) => {
+        return new Promise(async (ok, fail) => {
+
+            const databaseConnection = await this.connect();
             const isInsertQuery = query.substr(0, 11) === "INSERT INTO";
 
-            const handler = function (err: any, raw: any) {
+            const handler = (err: any, raw: any) => {
 
                 // log slow queries if maxQueryExecution time is set
                 const maxQueryExecutionTime = this.driver.options.maxQueryExecutionTime;
                 const queryEndTime = +new Date();
                 const queryExecutionTime = queryEndTime - queryStartTime;
-                if (maxQueryExecutionTime && queryExecutionTime > maxQueryExecutionTime)
+                
+                if (maxQueryExecutionTime && queryExecutionTime > maxQueryExecutionTime) {
                     connection.logger.logQuerySlow(queryExecutionTime, query, parameters, this);
-
+                }
+                
                 if (err) {
                     connection.logger.logQueryError(err, query, parameters, this);
                     fail(new QueryFailedError(query, parameters, err));
-                } else {
-                    const result = new QueryResult();
-
-                    result.raw = raw;
-
-                    if (!isInsertQuery && Array.isArray(raw)) {
-                        result.records = raw;
-                    }
-
-                    if (useStructuredResult) {
-                        ok(result);
-                    } else {
-                        ok(result.raw);
-                    }
                 }
+
+                const result = new QueryResult();
+                result.raw = raw;
+
+                if (!isInsertQuery && Array.isArray(raw)) {
+                    result.records = raw;
+                }
+
+                if (useStructuredResult) {
+                    ok(result);
+                } else {
+                    ok(result.raw);
+                }
+                
             };
-            this.driver.connection.logger.logQuery(query, parameters, this);
             const queryStartTime = +new Date();
-            this.connect().then(databaseConnection => {
-                if (isInsertQuery) {
-                    databaseConnection.execSQL(query, parameters, handler);
-                } else {
-                    databaseConnection.all(query, parameters, handler);
-                }
-            });
+
+            if (isInsertQuery) {
+                databaseConnection.execSQL(query, parameters, handler);
+            } else {
+                databaseConnection.all(query, parameters, handler);
+            } 
         });
     }
 


### PR DESCRIPTION
Making the promise async now correctly scopes the handler. this.driver is now defined.
Additional corrections were made to the syntax, eg conditionals.

Closes #8180

### Description of change
I believe making the promise async will now correctly scope `this` in the handler function. When it references this.driver, on running a query the app would throw an exception stating that driver was undefined. 

Tested this change with NS8 projects and it doesn't throw the error anymore.

### Pull-Request Checklist

- [x] Code is up-to-date with the `master` branch
- [x] `npm run lint` passes with this change
- [x] `npm run test` passes with this change
- [x] This pull request links relevant issues as `Fixes #0000`
- [ ] There are new or updated unit tests validating the change N/A
- [ ] Documentation has been updated to reflect this change N/A
- [x] The new commits follow conventions explained in [CONTRIBUTING.md](https://github.com/typeorm/typeorm/blob/master/CONTRIBUTING.md)