### PR TITLE
feat: add --quiet option to migration:show command (Fixes #7349)

### DIFF
--- a/src/commands/MigrationShowCommand.ts
+++ b/src/commands/MigrationShowCommand.ts
@@ -24,6 +24,9 @@ export class MigrationShowCommand implements yargs.CommandModule {
         alias: "f",
         default: "ormconfig",
         describe: "Name of the file with connection configuration."
+      })
+      .option("quiet", {
+        describe: "Silences the error exit code if there are unapplied migrations"
       });
   }
 
@@ -46,8 +49,9 @@ export class MigrationShowCommand implements yargs.CommandModule {
       const unappliedMigrations = await connection.showMigrations();
       await connection.close();
 
-      // return error code if there are unapplied migrations for CI
-      process.exit(unappliedMigrations ? 1 : 0);
+      const silenceError = args.quiet !== undefined ? true : false;
+      // return error code if there are unapplied migrations
+      process.exit(unappliedMigrations && !silenceError ? 1 : 0);
 
     } catch (err) {
       if (connection) await (connection as Connection).close();

--- a/src/commands/MigrationShowCommand.ts
+++ b/src/commands/MigrationShowCommand.ts
@@ -24,9 +24,6 @@ export class MigrationShowCommand implements yargs.CommandModule {
         alias: "f",
         default: "ormconfig",
         describe: "Name of the file with connection configuration."
-      })
-      .option("quiet", {
-        describe: "Silences the error exit code if there are unapplied migrations"
       });
   }
 
@@ -49,9 +46,7 @@ export class MigrationShowCommand implements yargs.CommandModule {
       const unappliedMigrations = await connection.showMigrations();
       await connection.close();
 
-      const silenceError = args.quiet !== undefined ? true : false;
-      // return error code if there are unapplied migrations
-      process.exit(unappliedMigrations && !silenceError ? 1 : 0);
+      process.exit(0);
 
     } catch (err) {
       if (connection) await (connection as Connection).close();

--- a/src/commands/MigrationShowCommand.ts
+++ b/src/commands/MigrationShowCommand.ts
@@ -43,7 +43,7 @@ export class MigrationShowCommand implements yargs.CommandModule {
         logging: ["query", "error", "schema"]
       });
       connection = await createConnection(connectionOptions);
-      const unappliedMigrations = await connection.showMigrations();
+      await connection.showMigrations();
       await connection.close();
 
       process.exit(0);


### PR DESCRIPTION
### Description of change

Currently `typeorm migration:show` prints out a list of migrations, and returns an error exit code if there are any unapplied migrations. 

The error code is useful in CI contexts, to assert that all migrations have been applied, perhaps before a code deploy.

Issue #7349 points out that this error code is noisy/annoying for local development. This PR introduces a `--quiet` flag to supress that exit code.

### Pull-Request Checklist

- [x] Code is up-to-date with the `master` branch
- [x] `npm run lint` passes with this change
- [ ] `npm run test` passes with this change
- [x] This pull request links relevant issues as `Fixes #0000`
- [ ] There are new or updated unit tests validating the change
- [ ] Documentation has been updated to reflect this change
- [x] The new commits follow conventions explained in [CONTRIBUTING.md](https://github.com/typeorm/typeorm/blob/master/CONTRIBUTING.md)
