### PR TITLE
Improve DeepPartial using recursive types

### DIFF
--- a/src/common/DeepPartial.ts
+++ b/src/common/DeepPartial.ts
@@ -1,15 +1,6 @@
 /**
  * Same as Partial<T> but goes deeper and makes Partial<T> all its properties and sub-properties.
  */
-type DeepPartialPrimitive = undefined | null | boolean | string | number | Function;
-
-export type DeepPartial<T> =
-    T extends DeepPartialPrimitive ? T :
-        T extends Array<infer U> ? DeepPartialArray<U> :
-            T extends Map<infer K, infer V> ? DeepPartialMap<K, V> :
-                T extends Set<infer M> ? DeepPartialSet<M> : DeepPartialObject<T>;
-
-export type DeepPartialArray<T> = Array<DeepPartial<T>>;
-export type DeepPartialMap<K, V> = Map<DeepPartial<K>, DeepPartial<V>>;
-export type DeepPartialSet<T> = Set<DeepPartial<T>>;
-export type DeepPartialObject<T> = {[K in keyof T]?: DeepPartial<T[K]>};
+export type DeepPartial<T> = T extends object ? {
+    [P in keyof T]?: DeepPartial<T[P]>;
+} : T;

--- a/src/common/DeepPartial.ts
+++ b/src/common/DeepPartial.ts
@@ -1,9 +1,15 @@
 /**
  * Same as Partial<T> but goes deeper and makes Partial<T> all its properties and sub-properties.
  */
-export type DeepPartial<T> = {
-    [P in keyof T]?:
-        T[P] extends Array<infer U> ? Array<DeepPartial<U>> :
-        T[P] extends ReadonlyArray<infer U> ? ReadonlyArray<DeepPartial<U>> :
-        DeepPartial<T[P]> | T[P]
-};
+type DeepPartialPrimitive = undefined | null | boolean | string | number | Function;
+
+export type DeepPartial<T> =
+    T extends DeepPartialPrimitive ? T :
+        T extends Array<infer U> ? DeepPartialArray<U> :
+            T extends Map<infer K, infer V> ? DeepPartialMap<K, V> :
+                T extends Set<infer M> ? DeepPartialSet<M> : DeepPartialObject<T>;
+
+export type DeepPartialArray<T> = Array<DeepPartial<T>>;
+export type DeepPartialMap<K, V> = Map<DeepPartial<K>, DeepPartial<V>>;
+export type DeepPartialSet<T> = Set<DeepPartial<T>>;
+export type DeepPartialObject<T> = {[K in keyof T]?: DeepPartial<T[K]>};

--- a/src/entity-manager/EntityManager.ts
+++ b/src/entity-manager/EntityManager.ts
@@ -246,7 +246,7 @@ export class EntityManager {
             return metadata.create(this.queryRunner);
 
         if (Array.isArray(plainObjectOrObjects))
-            return plainObjectOrObjects.map(plainEntityLike => this.create(entityClass as any, plainEntityLike));
+            return (plainObjectOrObjects as DeepPartial<Entity>[]).map(plainEntityLike => this.create(entityClass, plainEntityLike));
 
         const mergeIntoEntity = metadata.create(this.queryRunner);
         this.plainObjectToEntityTransformer.transform(mergeIntoEntity, plainObjectOrObjects, metadata, true);

--- a/test/github-issues/2904/entity/Comment.ts
+++ b/test/github-issues/2904/entity/Comment.ts
@@ -1,0 +1,12 @@
+import {
+    Column,
+    CreateDateColumn,
+} from "../../../../src";
+
+export class Comment {
+    @CreateDateColumn()
+    createdAt: Date;
+
+    @Column()
+    savedBy: string;
+}

--- a/test/github-issues/2904/issue-2904.ts
+++ b/test/github-issues/2904/issue-2904.ts
@@ -1,0 +1,14 @@
+import {DeepPartial} from "../../../src";
+import {Comment} from "./entity/Comment";
+
+describe("github issues > #2904 Type DeepPartial issue when used with generics", () => {
+
+    it("DeepPartial should correctly handle generics", () => {
+        function commentFactory<E extends Comment>(entity: DeepPartial<E>) {
+            entity.createdAt = new Date();
+            entity.savedBy = 'SomeUSer';
+        }
+
+        commentFactory({});
+    });
+});

--- a/test/github-issues/7079/issue-7079.ts
+++ b/test/github-issues/7079/issue-7079.ts
@@ -30,22 +30,22 @@ describe("github issues > #7079 Error when sorting by an embedded entity while u
                 id: 1,
                 text: "Happy Holidays",
                 userId: 1,
-                blog: { date: new Date().toISOString() },
-                newsletter: { date: new Date().toISOString() }
+                blog: { date: new Date() },
+                newsletter: { date: new Date() }
             },
             {
                 id: 2,
                 text: "My Vacation",
                 userId: 1,
-                blog: { date: new Date().toISOString() },
-                newsletter: { date: new Date().toISOString() }
+                blog: { date: new Date() },
+                newsletter: { date: new Date() }
             },
             {
                 id: 3,
                 text: "Working with TypeORM",
                 userId: 2,
-                blog: { date: new Date().toISOString() },
-                newsletter: { date: new Date().toISOString() }
+                blog: { date: new Date() },
+                newsletter: { date: new Date() }
             }
         ]
         await postRepo.save(posts);


### PR DESCRIPTION
### Description of change
Fixes #2904.

This change improves the DeepPartial check and prevents TypeScript from errorring unnecessarily in cases described in the aforementioned issue. On the flipside, it now errors on `.save()` in case a string property is passed instead of a `Date`. As such this PR will be a breaking change. I created a second commit that highlights what resolving the breaking change would look like.

What are your thoughts?

### Pull-Request Checklist

- [x] Code is up-to-date with the `master` branch
- [x] `npm run lint` passes with this change
- [x] `npm run test` passes with this change
- [x] This pull request links relevant issues as `Fixes #0000`
- [x] There are new or updated unit tests validating the change
- [ ] Documentation has been updated to reflect this change
- [x] The new commits follow conventions explained in [CONTRIBUTING.md](https://github.com/typeorm/typeorm/blob/master/CONTRIBUTING.md)