### PR TITLE
docs: add link to react example

### DIFF
--- a/README.md
+++ b/README.md
@@ -1273,6 +1273,7 @@ There are a few repositories which you can clone and start with:
 * [Example how to use TypeORM with JavaScript](https://github.com/typeorm/javascript-example)
 * [Example how to use TypeORM with JavaScript and Babel](https://github.com/typeorm/babel-example)
 * [Example how to use TypeORM with TypeScript and SystemJS in Browser](https://github.com/typeorm/browser-example)
+* [Example how to use TypeORM with TypeScript and React in Browser](https://github.com/ItayGarin/typeorm-react-swc)
 * [Example how to use Express and TypeORM](https://github.com/typeorm/typescript-express-example)
 * [Example how to use Koa and TypeORM](https://github.com/typeorm/typescript-koa-example)
 * [Example how to use TypeORM with MongoDB](https://github.com/typeorm/mongo-typescript-example)


### PR DESCRIPTION
### Description of change

Hey! I've tried to get TypeORM (+sql.js) running in the browser the last couple of days.
Specifically, I wanted to build a browser-only React app that uses TypeORM as an embedded DB.

It turned out to be trickier than I imagined. Most of the current examples are a bit dated, and I couldn't find an example that uses the common `create-react-app` template project. 

Most of my issues were related to `emitDecoratorMetadata`. Seems like this option isn't supported by `create-react-app` and `vite` out of the box (esbuild/babel incompatibility?). Swapping out the Typescript transformer/loader to `swc` solved these issues for me.

hopefully, my sample repository can help others as well! 

Let me know if you have any questions,
Itay