### PR TITLE
fix: support of multi-depth self-reference relation-based properties in where clauses (#8205)

### DIFF
--- a/src/query-builder/QueryBuilder.ts
+++ b/src/query-builder/QueryBuilder.ts
@@ -921,6 +921,7 @@ export abstract class QueryBuilder<Entity> {
         let alias = this.expressionMap.mainAlias;
         const root: string[] = [];
         const propertyPathParts = propertyPath.split(".");
+        const joinedAliasNames: string[] = [];
 
         while (propertyPathParts.length > 1) {
             const part = propertyPathParts[0];
@@ -946,7 +947,7 @@ export abstract class QueryBuilder<Entity> {
                 // that match the relation & then continue further down
                 // the property path
                 const joinAttr = this.expressionMap.joinAttributes.find(
-                    (joinAttr) => joinAttr.relationPropertyPath === part
+                    (joinAttr) => joinAttr.relationPropertyPath === part && !joinedAliasNames.includes(joinAttr.alias.name)
                 );
 
                 if (!joinAttr?.alias) {
@@ -955,6 +956,7 @@ export abstract class QueryBuilder<Entity> {
                 }
 
                 alias = joinAttr.alias;
+                joinedAliasNames.push(alias.name);
                 root.push(...part.split("."));
                 propertyPathParts.shift();
                 continue;

--- a/test/github-issues/8205/entity/Account.ts
+++ b/test/github-issues/8205/entity/Account.ts
@@ -1,0 +1,16 @@
+import { Entity, BaseEntity, PrimaryGeneratedColumn, Column, ManyToOne, OneToMany } from "../../../../src";
+
+@Entity({ name: "account" })
+export class AccountEntity extends BaseEntity {
+  @PrimaryGeneratedColumn("increment")
+  id: number;
+
+  @Column({ type: "varchar", length: 255 })
+  title: string;
+
+  @ManyToOne((type) => AccountEntity, (account) => account.childAccounts)
+  parentAccount: AccountEntity;
+
+  @OneToMany((type) => AccountEntity, (account) => account.parentAccount)
+  childAccounts: AccountEntity[];
+}

--- a/test/github-issues/8205/issue-8205.ts
+++ b/test/github-issues/8205/issue-8205.ts
@@ -1,0 +1,95 @@
+import "reflect-metadata";
+import { createTestingConnections, closeTestingConnections, reloadTestingDatabases } from "../../utils/test-utils";
+import { Connection } from "../../../src/connection/Connection";
+import { expect } from "chai";
+import { AccountEntity } from "./entity/Account";
+
+describe("github issues > #8205 Bug in self referencing relation-based properties in where clauses", () => {
+
+    let connections: Connection[];
+    before(async () => connections = await createTestingConnections({
+        entities: [__dirname + "/entity/*{.js,.ts}"],
+        schemaCreate: true,
+        dropSchema: true,
+    }));
+    beforeEach(() => reloadTestingDatabases(connections));
+    after(() => closeTestingConnections(connections));
+
+    it("should work properly when using 2-depth self reference where clause", () => Promise.all(connections.map(async connection => {
+		const repository = connection.getRepository(AccountEntity);
+		let grandParent = new AccountEntity();
+		grandParent.title = "grandParent";
+		grandParent = await repository.save(grandParent);
+		let Parent1 = new AccountEntity();
+		Parent1.title = "Parent1";
+		Parent1.parentAccount = grandParent;
+		Parent1 = await repository.save(Parent1);
+		let Child1 = new AccountEntity();
+		Child1.title = "Child1";
+		Child1.parentAccount = Parent1;
+		Child1 = await repository.save(Child1);
+
+		const expectedResult = await repository.find({
+			where: {
+				title: "Child1"
+			},
+			relations: ['parentAccount', 'parentAccount.parentAccount']
+		})
+
+		const queryResult = await repository.find({
+			where: {
+				parentAccount: {
+					parentAccount: {
+						title: "grandParent"
+					}
+				}
+			},
+			relations: ['parentAccount', 'parentAccount.parentAccount']
+		})
+
+		expect(queryResult).to.be.eql(expectedResult);
+    })));
+
+	it("should work properly when using 3-depth self reference where clause", () => Promise.all(connections.map(async connection => {
+		const repository = connection.getRepository(AccountEntity);
+		let grandParent = new AccountEntity();
+		grandParent.title = "grandParent";
+		grandParent = await repository.save(grandParent);
+		let Parent1 = new AccountEntity();
+		Parent1.title = "Parent1";
+		Parent1.parentAccount = grandParent;
+		Parent1 = await repository.save(Parent1);
+		let Child1 = new AccountEntity();
+		Child1.title = "Child1";
+		Child1.parentAccount = Parent1;
+		Child1 = await repository.save(Child1);
+		let grandChild1 = new AccountEntity();
+		grandChild1.title = "grandChild1";
+		grandChild1.parentAccount = Child1;
+		grandChild1 = await repository.save(grandChild1);
+
+		const expectedResult = await repository.find({
+			where: {
+				title: "grandChild1"
+			},
+			relations: ["parentAccount", "parentAccount.parentAccount", "parentAccount.parentAccount.parentAccount"]
+		})
+
+		const queryResult = await repository.find({
+			where: {
+				parentAccount: {
+					parentAccount: {
+						parentAccount: {
+							title: "grandParent"
+						}
+					}
+				}
+			},
+			relations: ["parentAccount", "parentAccount.parentAccount", "parentAccount.parentAccount.parentAccount"]
+		})
+
+		expect(queryResult).to.be.eql(expectedResult);
+    })));
+
+
+});


### PR DESCRIPTION
<!--
  😀 Wonderful!  Thank you for opening a pull request for TypeORM.

  Please fill in the information below to expedite the review
  and (hopefully) merge of your change.

  If unsure about something.. just do as best as you're able,
  or reach out through our community support channels!
  https://github.com/typeorm/typeorm/blob/master/docs/support.md
-->

### Description of change

Fixes #8205 

This PR updates function `findColumnsForPropertyPath` in `QueryBuilder.ts`

In `findColumnsForPropertyPath` function, it find the `alias` that matched join column. 

there can exist multiple joinAttributes that `joinAttr.relationPropertyPath` is same when using multi-depth self-reference in where clauses.

In that situation, funciton must select appropriate `joinAttribute` referred to the existing joined status.


### EXAMPLE

1. In `findColumnsForPropertyPath`
```
const joinAttr = this.expression.find((joinAttr) => joinAttr.relationPropertyPath === part);
// this selects only first element that matched. 
// but, there can exists many elements that matched. 
// this code should select appropriate joinAttr.
```

<!--
  Please be clear and concise what the change is intended to do,
  why this change is needed, and how you've verified that it
  corrects what you intended.

  In some cases it may be helpful to include the current behavior
  and the new behavior.

  If the change is related to an open issue, you can link it here.
  If you include `Fixes #0000` (replacing `0000` with the issue number)
  when this is merged it will automatically mark the issue as fixed and
  close it.
-->


### Pull-Request Checklist

<!--
  Please make sure to review and check all of the following.

  If an item is not applicable, you can add "N/A" to the end.
-->

- [x] Code is up-to-date with the `master` branch
- [x] `npm run lint` passes with this change
- [x] `npm run test` passes with this change
- [x] This pull request links relevant issues as `Fixes #0000`
- [ ] There are new or updated unit tests validating the change
- [ ] Documentation has been updated to reflect this change
- [x] The new commits follow conventions explained in [CONTRIBUTING.md](https://github.com/typeorm/typeorm/blob/master/CONTRIBUTING.md)

<!--
  🎉 Thank you for contributing and making TypeORM even better!
-->
