### PR TITLE
fix: resolve issue delete column null on after update event subscriber

### DIFF
--- a/src/persistence/SubjectExecutor.ts
+++ b/src/persistence/SubjectExecutor.ts
@@ -735,11 +735,11 @@ export class SubjectExecutor {
             this.updateSpecialColumnsInInsertedAndUpdatedEntities(this.updateSubjects);
 
         // update soft-removed entity properties
-        if (this.updateSubjects.length)
+        if (this.softRemoveSubjects.length)
             this.updateSpecialColumnsInInsertedAndUpdatedEntities(this.softRemoveSubjects);
 
         // update recovered entity properties
-        if (this.updateSubjects.length)
+        if (this.recoverSubjects.length)
             this.updateSpecialColumnsInInsertedAndUpdatedEntities(this.recoverSubjects);
 
         // remove ids from the entities that were removed

--- a/src/query-builder/ReturningResultsEntityUpdator.ts
+++ b/src/query-builder/ReturningResultsEntityUpdator.ts
@@ -50,7 +50,7 @@ export class ReturningResultsEntityUpdator {
             } else {
 
                 // for driver which do not support returning/output statement we need to perform separate query and load what we need
-                const updationColumns = this.getUpdationReturningColumns();
+                const updationColumns = this.expressionMap.extraReturningColumns;
                 if (updationColumns.length > 0) {
 
                     // get entity id by which we will get needed data
@@ -62,9 +62,10 @@ export class ReturningResultsEntityUpdator {
                     const loadedReturningColumns = await this.queryRunner.manager
                         .createQueryBuilder()
                         .select(metadata.primaryColumns.map(column => metadata.targetName + "." + column.propertyPath))
-                        .addSelect(this.getUpdationReturningColumns().map(column => metadata.targetName + "." + column.propertyPath))
+                        .addSelect(updationColumns.map(column => metadata.targetName + "." + column.propertyPath))
                         .from(metadata.target, metadata.targetName)
                         .where(entityId)
+                        .withDeleted()
                         .setOption("create-pojo") // use POJO because created object can contain default values, e.g. property = null and those properties maight be overridden by merge process
                         .getOne() as any;
 
@@ -163,60 +164,6 @@ export class ReturningResultsEntityUpdator {
             insertResult.identifiers.push(entityId);
             insertResult.generatedMaps.push(generatedMaps[entityIndex]);
         });
-    }
-
-    /**
-     * Updates entities with a special columns after soft delete and restore query execution.
-     */
-    async softDelete(updateResult: UpdateResult, entities: ObjectLiteral[]): Promise<void> {
-        const metadata = this.expressionMap.mainAlias!.metadata;
-
-        await Promise.all(entities.map(async (entity, entityIndex) => {
-
-            // if database supports returning/output statement then we already should have updating values in the raw data returned by insert query
-            if (this.queryRunner.connection.driver.isReturningSqlSupported()) {
-                if (this.queryRunner.connection.driver instanceof OracleDriver && Array.isArray(updateResult.raw) && this.expressionMap.extraReturningColumns.length > 0) {
-                    updateResult.raw = updateResult.raw.reduce((newRaw, rawItem, rawItemIndex) => {
-                        newRaw[this.expressionMap.extraReturningColumns[rawItemIndex].databaseName] = rawItem[0];
-                        return newRaw;
-                    }, {} as ObjectLiteral);
-                }
-                const result = Array.isArray(updateResult.raw) ? updateResult.raw[entityIndex] : updateResult.raw;
-                const returningColumns = this.queryRunner.connection.driver.createGeneratedMap(metadata, result);
-                if (returningColumns) {
-                    this.queryRunner.manager.merge(metadata.target as any, entity, returningColumns);
-                    updateResult.generatedMaps.push(returningColumns);
-                }
-
-            } else {
-
-                // for driver which do not support returning/output statement we need to perform separate query and load what we need
-                const updationColumns = this.getSoftDeletionReturningColumns();
-                if (updationColumns.length > 0) {
-
-                    // get entity id by which we will get needed data
-                    const entityId = this.expressionMap.mainAlias!.metadata.getEntityIdMap(entity);
-                    if (!entityId)
-                        throw new TypeORMError(`Cannot update entity because entity id is not set in the entity.`);
-
-                    // execute query to get needed data
-                    const loadedReturningColumns = await this.queryRunner.manager
-                        .createQueryBuilder()
-                        .select(metadata.primaryColumns.map(column => metadata.targetName + "." + column.propertyPath))
-                        .addSelect(this.getSoftDeletionReturningColumns().map(column => metadata.targetName + "." + column.propertyPath))
-                        .from(metadata.target, metadata.targetName)
-                        .where(entityId)
-                        .withDeleted()
-                        .setOption("create-pojo") // use POJO because created object can contain default values, e.g. property = null and those properties maight be overridden by merge process
-                        .getOne() as any;
-
-                    if (loadedReturningColumns) {
-                        this.queryRunner.manager.merge(metadata.target as any, entity, loadedReturningColumns);
-                        updateResult.generatedMaps.push(loadedReturningColumns);
-                    }
-                }
-            }
-        }));
     }
 
     /**

--- a/src/query-builder/SoftDeleteQueryBuilder.ts
+++ b/src/query-builder/SoftDeleteQueryBuilder.ts
@@ -73,7 +73,7 @@ export class SoftDeleteQueryBuilder<Entity> extends QueryBuilder<Entity> impleme
             if (this.expressionMap.updateEntity === true &&
                 this.expressionMap.mainAlias!.hasMetadata &&
                 this.expressionMap.whereEntities.length > 0) {
-                this.expressionMap.extraReturningColumns = returningResultsEntityUpdator.getUpdationReturningColumns();
+                this.expressionMap.extraReturningColumns = returningResultsEntityUpdator.getSoftDeletionReturningColumns();
             }
 
             // execute update query
@@ -86,7 +86,7 @@ export class SoftDeleteQueryBuilder<Entity> extends QueryBuilder<Entity> impleme
             if (this.expressionMap.updateEntity === true &&
                 this.expressionMap.mainAlias!.hasMetadata &&
                 this.expressionMap.whereEntities.length > 0) {
-                await returningResultsEntityUpdator.update(updateResult, this.expressionMap.whereEntities);
+                await returningResultsEntityUpdator.softDelete(updateResult, this.expressionMap.whereEntities);
             }
 
             // call after updation methods in listeners and subscribers

--- a/src/query-builder/SoftDeleteQueryBuilder.ts
+++ b/src/query-builder/SoftDeleteQueryBuilder.ts
@@ -86,7 +86,7 @@ export class SoftDeleteQueryBuilder<Entity> extends QueryBuilder<Entity> impleme
             if (this.expressionMap.updateEntity === true &&
                 this.expressionMap.mainAlias!.hasMetadata &&
                 this.expressionMap.whereEntities.length > 0) {
-                await returningResultsEntityUpdator.softDelete(updateResult, this.expressionMap.whereEntities);
+                await returningResultsEntityUpdator.update(updateResult, this.expressionMap.whereEntities);
             }
 
             // call after updation methods in listeners and subscribers

--- a/test/github-issues/6327/entity/Post.ts
+++ b/test/github-issues/6327/entity/Post.ts
@@ -1,0 +1,13 @@
+import { DeleteDateColumn, Entity, PrimaryGeneratedColumn, UpdateDateColumn } from "../../../../src";
+
+@Entity()
+export class Post {
+    @PrimaryGeneratedColumn()
+    id: number;
+
+    @UpdateDateColumn()
+    updatedAt: Date;
+
+    @DeleteDateColumn()
+    deletedAt: Date;
+}

--- a/test/github-issues/6327/issue-6327.ts
+++ b/test/github-issues/6327/issue-6327.ts
@@ -1,5 +1,5 @@
 import "reflect-metadata";
-import { createTestingConnections, closeTestingConnections, reloadTestingDatabases, sleep } from "../../utils/test-utils";
+import { createTestingConnections, closeTestingConnections, reloadTestingDatabases } from "../../utils/test-utils";
 import { Connection } from "../../../src/connection/Connection";
 import { Post } from "./entity/Post";
 
@@ -23,11 +23,8 @@ describe("github issues > #6327 softRemove DeleteDateColumn is null at Susbscrib
         await manager.save(entity);
 
         const deletedEntity = await manager.softRemove(entity, { data: { action: "soft-delete" } });
-        const softDeleteDate = deletedEntity!.updatedAt;
 
-        await sleep(1000);
-
-        await manager.recover(deletedEntity, { data: { action: "restore", softDeleteDate } });
+        await manager.recover(deletedEntity, { data: { action: "restore" } });
 
     })));
 

--- a/test/github-issues/6327/issue-6327.ts
+++ b/test/github-issues/6327/issue-6327.ts
@@ -1,0 +1,34 @@
+import "reflect-metadata";
+import { createTestingConnections, closeTestingConnections, reloadTestingDatabases, sleep } from "../../utils/test-utils";
+import { Connection } from "../../../src/connection/Connection";
+import { Post } from "./entity/Post";
+
+describe("github issues > #6327 softRemove DeleteDateColumn is null at Susbscriber's AfterUpdate method", () => {
+
+    let connections: Connection[];
+    before(async () => connections = await createTestingConnections({
+        entities: [__dirname + "/entity/*{.js,.ts}"],
+        subscribers: [__dirname + "/subscriber/*{.js,.ts}"],
+        schemaCreate: true,
+        dropSchema: true,
+    }));
+    beforeEach(() => reloadTestingDatabases(connections));
+    after(() => closeTestingConnections(connections));
+
+    it("should send correct update and delete date columns to after update subscriber", () => Promise.all(connections.map(async connection => {
+
+        const manager = connection.manager;
+
+        const entity = new Post();
+        await manager.save(entity);
+
+        const deletedEntity = await manager.softRemove(entity, { data: { action: "soft-delete" } });
+        const softDeleteDate = deletedEntity!.updatedAt;
+
+        await sleep(1000);
+
+        await manager.recover(deletedEntity, { data: { action: "restore", softDeleteDate } });
+
+    })));
+
+});

--- a/test/github-issues/6327/issue-6327.ts
+++ b/test/github-issues/6327/issue-6327.ts
@@ -1,9 +1,5 @@
 import "reflect-metadata";
-<<<<<<< HEAD
 import { createTestingConnections, closeTestingConnections, reloadTestingDatabases } from "../../utils/test-utils";
-=======
-import { createTestingConnections, closeTestingConnections, reloadTestingDatabases, sleep } from "../../utils/test-utils";
->>>>>>> e99369cead3f73172f18969ee74d306c91032c9c
 import { Connection } from "../../../src/connection/Connection";
 import { Post } from "./entity/Post";
 
@@ -27,16 +23,8 @@ describe("github issues > #6327 softRemove DeleteDateColumn is null at Susbscrib
         await manager.save(entity);
 
         const deletedEntity = await manager.softRemove(entity, { data: { action: "soft-delete" } });
-<<<<<<< HEAD
 
         await manager.recover(deletedEntity, { data: { action: "restore" } });
-=======
-        const softDeleteDate = deletedEntity!.updatedAt;
-
-        await sleep(1000);
-
-        await manager.recover(deletedEntity, { data: { action: "restore", softDeleteDate } });
->>>>>>> e99369cead3f73172f18969ee74d306c91032c9c
 
     })));
 

--- a/test/github-issues/6327/subscriber/PostSubscriber.ts
+++ b/test/github-issues/6327/subscriber/PostSubscriber.ts
@@ -1,0 +1,25 @@
+import { expect } from "chai";
+import { EntitySubscriberInterface, EventSubscriber, UpdateEvent } from "../../../../src";
+import { Post } from "../entity/Post";
+
+@EventSubscriber()
+export class PostSubscriber implements EntitySubscriberInterface<Post> {
+    listenTo() {
+        return Post;
+    }
+
+    afterUpdate(event: UpdateEvent<Post>): void {
+        const { entity, queryRunner: { data } } = event;
+
+        expect(["soft-delete", "restore"]).to.include(data!.action);
+
+        if (data!.action === "soft-delete") {
+            expect(Object.prototype.toString.call(entity!.deletedAt)).to.be.eq("[object Date]");
+        }
+
+        if (data!.action === "restore") {
+            expect(entity!.deletedAt).to.be.null;
+            expect(entity!.updatedAt.getTime()).not.to.be.eq(data!.softDeleteDate.getTime());
+        }
+    }
+}

--- a/test/github-issues/6327/subscriber/PostSubscriber.ts
+++ b/test/github-issues/6327/subscriber/PostSubscriber.ts
@@ -19,7 +19,6 @@ export class PostSubscriber implements EntitySubscriberInterface<Post> {
 
         if (data!.action === "restore") {
             expect(entity!.deletedAt).to.be.null;
-            expect(entity!.updatedAt.getTime()).not.to.be.eq(data!.softDeleteDate.getTime());
         }
     }
 }

--- a/test/github-issues/6327/subscriber/PostSubscriber.ts
+++ b/test/github-issues/6327/subscriber/PostSubscriber.ts
@@ -19,10 +19,6 @@ export class PostSubscriber implements EntitySubscriberInterface<Post> {
 
         if (data!.action === "restore") {
             expect(entity!.deletedAt).to.be.null;
-<<<<<<< HEAD
-=======
-            expect(entity!.updatedAt.getTime()).not.to.be.eq(data!.softDeleteDate.getTime());
->>>>>>> e99369cead3f73172f18969ee74d306c91032c9c
         }
     }
 }


### PR DESCRIPTION
Fixes: #6327
Fixes: #6349

<!--
  😀 Wonderful!  Thank you for opening a pull request for TypeORM.

  Please fill in the information below to expedite the review
  and (hopefully) merge of your change.

  If unsure about something.. just do as best as you're able,
  or reach out through our community support channels!
  https://github.com/typeorm/typeorm/blob/master/docs/support.md
-->

### Description of change

<!--
  Please be clear and concise what the change is intended to do,
  why this change is needed, and how you've verified that it
  corrects what you intended.

  In some cases it may be helpful to include the current behavior
  and the new behavior.

  If the change is related to an open issue, you can link it here.
  If you include `Fixes #0000` (replacing `0000` with the issue number)
  when this is merged it will automatically mark the issue as fixed and
  close it.
-->

Subscriber `afterUpdate` now gets entity with changed delete and update date column.

Adds `softDelete`, `getSoftDeletionReturningColumns` methods to `ReturningResultsEntityUpdator` class to get right returning columns and search for entity `withDeleted()`. Resolves bug in `SubjectExecutor` class. Adds tests for the issue.

### Pull-Request Checklist

<!--
  Please make sure to review and check all of the following.

  If an item is not applicable, you can add "N/A" to the end.
-->

- [x] Code is up-to-date with the `master` branch
- [x] `npm run lint` passes with this change
- [x] `npm run test` passes with this change
- [x] This pull request links relevant issues as `Fixes #0000`
- [x] There are new or updated unit tests validating the change
- [ ] Documentation has been updated to reflect this change
- [x] The new commits follow conventions explained in [CONTRIBUTING.md](https://github.com/typeorm/typeorm/blob/master/CONTRIBUTING.md)

<!--
  🎉 Thank you for contributing and making TypeORM even better!
-->
