### PR TITLE
allow lock modes for cockroachdb

### DIFF
--- a/docs/find-options.md
+++ b/docs/find-options.md
@@ -239,6 +239,7 @@ Support of lock modes, and SQL statements they translate to, are listed in the t
 | Oracle          | FOR UPDATE               | FOR UPDATE              | (nothing)     |                             |                             |                     |
 | SQL Server      | WITH (HOLDLOCK, ROWLOCK) | WITH (UPDLOCK, ROWLOCK) | WITH (NOLOCK) |                             |                             |                     |
 | AuroraDataApi   | LOCK IN SHARE MODE       | FOR UPDATE              | (nothing)     |                             |                             |                     |
+| CockroachDB     |                          | FOR UPDATE              | (nothing)     |                             | FOR UPDATE NOWAIT           | FOR NO KEY UPDATE   |
 
 ```
 

--- a/src/query-builder/SelectQueryBuilder.ts
+++ b/src/query-builder/SelectQueryBuilder.ts
@@ -1679,7 +1679,7 @@ export class SelectQueryBuilder<Entity> extends QueryBuilder<Entity> implements 
         let lockTablesClause = "";
 
         if (this.expressionMap.lockTables) {
-            if (!(driver instanceof PostgresDriver)) {
+            if (!(driver instanceof PostgresDriver || driver instanceof CockroachDriver)) {
                 throw new TypeORMError("Lock tables not supported in selected driver");
             }
             if (this.expressionMap.lockTables.length < 1) {
@@ -1710,7 +1710,7 @@ export class SelectQueryBuilder<Entity> extends QueryBuilder<Entity> implements 
                     return " FOR UPDATE";
 
                 }
-                else if (driver instanceof PostgresDriver ) {
+                else if (driver instanceof PostgresDriver || driver instanceof CockroachDriver) {
                     return " FOR UPDATE" + lockTablesClause;
 
                 } else if (driver instanceof SqlServerDriver) {
@@ -1730,7 +1730,7 @@ export class SelectQueryBuilder<Entity> extends QueryBuilder<Entity> implements 
                     throw new LockNotSupportedOnGivenDriverError();
                 }
             case "pessimistic_write_or_fail":
-                if (driver instanceof PostgresDriver) {
+                if (driver instanceof PostgresDriver || driver instanceof CockroachDriver) {
                     return " FOR UPDATE" + lockTablesClause + " NOWAIT";
 
                 } else if (driver instanceof MysqlDriver) {
@@ -1741,7 +1741,7 @@ export class SelectQueryBuilder<Entity> extends QueryBuilder<Entity> implements 
                 }
 
             case "for_no_key_update":
-                if (driver instanceof PostgresDriver) {
+                if (driver instanceof PostgresDriver || driver instanceof CockroachDriver) {
                     return " FOR NO KEY UPDATE" + lockTablesClause;
                 } else {
                     throw new LockNotSupportedOnGivenDriverError();

--- a/test/functional/repository/find-options-locking/find-options-locking.ts
+++ b/test/functional/repository/find-options-locking/find-options-locking.ts
@@ -8,7 +8,7 @@ import {expect} from "chai";
 import {PostWithoutVersionAndUpdateDate} from "./entity/PostWithoutVersionAndUpdateDate";
 import {PostWithUpdateDate} from "./entity/PostWithUpdateDate";
 import {PostWithVersionAndUpdatedDate} from "./entity/PostWithVersionAndUpdatedDate";
-import {Post} from './entity/Post';
+import {Post} from "./entity/Post";
 import {OptimisticLockVersionMismatchError} from "../../../../src/error/OptimisticLockVersionMismatchError";
 import {OptimisticLockCanNotBeUsedError} from "../../../../src/error/OptimisticLockCanNotBeUsedError";
 import {NoVersionOrUpdateDateColumnError} from "../../../../src/error/NoVersionOrUpdateDateColumnError";
@@ -30,8 +30,17 @@ describe("repository > find options > locking", () => {
     after(() => closeTestingConnections(connections));
 
     it("should throw error if pessimistic lock used without transaction", () => Promise.all(connections.map(async connection => {
-        if (connection.driver instanceof AbstractSqliteDriver || connection.driver instanceof CockroachDriver || connection.driver instanceof SapDriver)
+        if (connection.driver instanceof AbstractSqliteDriver || connection.driver instanceof SapDriver)
             return;
+
+        if (connection.driver instanceof CockroachDriver) {
+            return Promise.all([
+                connection
+                    .getRepository(PostWithVersion)
+                    .findOne(1, { lock: { mode: "pessimistic_write" } })
+                    .should.be.rejectedWith(PessimisticLockTransactionRequiredError),
+            ]);
+        }
 
         return Promise.all([
             connection
@@ -47,8 +56,19 @@ describe("repository > find options > locking", () => {
     })));
 
     it("should not throw error if pessimistic lock used with transaction", () => Promise.all(connections.map(async connection => {
-        if (connection.driver instanceof AbstractSqliteDriver || connection.driver instanceof CockroachDriver || connection.driver instanceof SapDriver)
+        if (connection.driver instanceof AbstractSqliteDriver || connection.driver instanceof SapDriver)
             return;
+
+        if (connection.driver instanceof CockroachDriver) {
+            return connection.manager.transaction(entityManager => {
+                return Promise.all([
+                    entityManager
+                        .getRepository(PostWithVersion)
+                        .findOne(1, { lock: { mode: "pessimistic_write" } })
+                        .should.not.be.rejected
+                ]);
+            });
+        }
 
         return connection.manager.transaction(entityManager => {
             return Promise.all([
@@ -99,7 +119,7 @@ describe("repository > find options > locking", () => {
     })));
 
     it("should attach pessimistic write lock statement on query if locking enabled", () => Promise.all(connections.map(async connection => {
-        if (connection.driver instanceof AbstractSqliteDriver || connection.driver instanceof CockroachDriver || connection.driver instanceof SapDriver)
+        if (connection.driver instanceof AbstractSqliteDriver || connection.driver instanceof SapDriver)
             return;
 
         const executedSql: string[] = [];
@@ -251,7 +271,7 @@ describe("repository > find options > locking", () => {
     })));
 
     it("should throw error if pessimistic locking not supported by given driver", () => Promise.all(connections.map(async connection => {
-        if (connection.driver instanceof AbstractSqliteDriver || connection.driver instanceof CockroachDriver || connection.driver instanceof SapDriver)
+        if (connection.driver instanceof AbstractSqliteDriver || connection.driver instanceof SapDriver)
             return connection.manager.transaction(entityManager => {
                 return Promise.all([
                     entityManager
@@ -266,54 +286,80 @@ describe("repository > find options > locking", () => {
                 ]);
             });
 
+        if (connection.driver instanceof CockroachDriver)
+            return connection.manager.transaction(entityManager => {
+                return Promise.all([
+                    entityManager
+                        .getRepository(PostWithVersion)
+                        .findOne(1, { lock: { mode: "pessimistic_read" } })
+                        .should.be.rejectedWith(LockNotSupportedOnGivenDriverError),
+                ]);
+            });
+
         return;
     })));
 
     it("should not allow empty array for lockTables", () => Promise.all(connections.map(async connection => {
-        if (!(connection.driver instanceof PostgresDriver))
+        if (!(connection.driver instanceof PostgresDriver || connection.driver instanceof CockroachDriver))
             return;
 
         return connection.manager.transaction(entityManager => {
             return Promise.all([
                 entityManager.getRepository(Post)
                     .findOne({
-                        lock: {mode: 'pessimistic_write', tables: []}
-                    }).should.be.rejectedWith('lockTables cannot be an empty array'),
+                        lock: {mode: "pessimistic_write", tables: []}
+                    }).should.be.rejectedWith("lockTables cannot be an empty array"),
             ]);
         });
     })));
 
     it("should throw error when specifying a table that is not part of the query", () => Promise.all(connections.map(async connection => {
-        if (!(connection.driver instanceof PostgresDriver))
+        if (!(connection.driver instanceof PostgresDriver || connection.driver instanceof CockroachDriver))
             return;
 
         return connection.manager.transaction(entityManager => {
             return Promise.all([
                 entityManager.getRepository(Post)
                     .findOne({
-                        relations: ['author'],
-                        lock: {mode: 'pessimistic_write', tables: ['img']}
+                        relations: ["author"],
+                        lock: {mode: "pessimistic_write", tables: ["img"]}
                     }).should.be.rejectedWith('"img" is not part of this query')
             ]);
         });
     })));
 
     it("should allow on a left join", () => Promise.all(connections.map(async connection => {
-        if (!(connection.driver instanceof PostgresDriver))
-            return;
+        if (connection.driver instanceof CockroachDriver) {
+            return connection.manager.transaction(entityManager => {
+                return Promise.all([
+                    entityManager.getRepository(Post).findOne({
+                        relations: ["author"],
+                        lock: {mode: "pessimistic_write", tables: ["post"]}
+                    }),
+                    entityManager.getRepository(Post).findOne({
+                        relations: ["author"],
+                        lock: {mode: "pessimistic_write"}
+                    })
+                ]);
+            });
+        }
 
-        return connection.manager.transaction(entityManager => {
-            return Promise.all([
-                entityManager.getRepository(Post).findOne({
-                    relations: ['author'],
-                    lock: {mode: 'pessimistic_write', tables: ['post']}
-                }),
-                entityManager.getRepository(Post).findOne({
-                    relations: ['author'],
-                    lock: {mode: 'pessimistic_write'}
-                }).should.be.rejectedWith('FOR UPDATE cannot be applied to the nullable side of an outer join')
-            ]);
-        });
+        if (connection.driver instanceof PostgresDriver) {
+            return connection.manager.transaction(entityManager => {
+                return Promise.all([
+                    entityManager.getRepository(Post).findOne({
+                        relations: ["author"],
+                        lock: {mode: "pessimistic_write", tables: ["post"]}
+                    }),
+                    entityManager.getRepository(Post).findOne({
+                        relations: ["author"],
+                        lock: {mode: "pessimistic_write"}
+                    }).should.be.rejectedWith("FOR UPDATE cannot be applied to the nullable side of an outer join")
+                ]);
+            });
+        }
+
+        return;
     })));
 
     it("should allow using lockTables on all types of locking", () => Promise.all(connections.map(async connection => {
@@ -324,31 +370,31 @@ describe("repository > find options > locking", () => {
 
             return Promise.all([
                 entityManager.getRepository(Post).findOne({
-                    relations: ['author'],
-                    lock: {mode: 'pessimistic_read', tables: ['post']}
+                    relations: ["author"],
+                    lock: {mode: "pessimistic_read", tables: ["post"]}
                 }),
                 entityManager.getRepository(Post).findOne({
-                    relations: ['author'],
-                    lock: {mode: 'pessimistic_write', tables: ['post']}
+                    relations: ["author"],
+                    lock: {mode: "pessimistic_write", tables: ["post"]}
                 }),
                 entityManager.getRepository(Post).findOne({
-                    relations: ['author'],
-                    lock: {mode: 'pessimistic_partial_write', tables: ['post']}
+                    relations: ["author"],
+                    lock: {mode: "pessimistic_partial_write", tables: ["post"]}
                 }),
                 entityManager.getRepository(Post).findOne({
-                    relations: ['author'],
-                    lock: {mode: 'pessimistic_write_or_fail', tables: ['post']}
+                    relations: ["author"],
+                    lock: {mode: "pessimistic_write_or_fail", tables: ["post"]}
                 }),
                 entityManager.getRepository(Post).findOne({
-                    relations: ['author'],
-                    lock: {mode: 'for_no_key_update', tables: ['post']}
+                    relations: ["author"],
+                    lock: {mode: "for_no_key_update", tables: ["post"]}
                 }),
             ]);
         });
     })));
 
     it("should allow locking a relation of a relation", () => Promise.all(connections.map(async connection => {
-        if (!(connection.driver instanceof PostgresDriver))
+        if (!(connection.driver instanceof PostgresDriver || connection.driver instanceof CockroachDriver))
             return;
 
         return connection.manager.transaction(entityManager => {
@@ -356,13 +402,13 @@ describe("repository > find options > locking", () => {
             return Promise.all([
                 entityManager.getRepository(Post).findOne({
                     join: {
-                        alias: 'post',
+                        alias: "post",
                         innerJoinAndSelect: {
-                            categorys: 'post.categories',
-                            images: 'categorys.images'
+                            categorys: "post.categories",
+                            images: "categorys.images"
                         }
                     },
-                    lock: {mode: 'pessimistic_write', tables: ['image']}
+                    lock: {mode: "pessimistic_write", tables: ["image"]}
                 }),
             ]);
         });


### PR DESCRIPTION
fixes #8249

<!--
  😀 Wonderful!  Thank you for opening a pull request for TypeORM.

  Please fill in the information below to expedite the review
  and (hopefully) merge of your change.

  If unsure about something.. just do as best as you're able,
  or reach out through our community support channels!
  https://github.com/typeorm/typeorm/blob/master/docs/support.md
-->

### Description of change

allow the same lock modes as postgres - https://www.cockroachlabs.com/docs/stable/select-for-update.html


currently an exception is thrown when a lock is used in a transaction

Adds Support for:

* pessimistic_write
* pessimistic_write_or_fail
* for_no_key_update

<!--
  Please be clear and concise what the change is intended to do,
  why this change is needed, and how you've verified that it
  corrects what you intended.

  In some cases it may be helpful to include the current behavior
  and the new behavior.

  If the change is related to an open issue, you can link it here.
  If you include `Fixes #0000` (replacing `0000` with the issue number)
  when this is merged it will automatically mark the issue as fixed and
  close it.
-->


### Pull-Request Checklist

<!--
  Please make sure to review and check all of the following.

  If an item is not applicable, you can add "N/A" to the end.
-->

- [ ] Code is up-to-date with the `master` branch
- [ ] `npm run lint` passes with this change
- [ ] `npm run test` passes with this change
- [ ] This pull request links relevant issues as `Fixes #0000`
- [ ] There are new or updated unit tests validating the change
- [ ] Documentation has been updated to reflect this change
- [ ] The new commits follow conventions explained in [CONTRIBUTING.md](https://github.com/typeorm/typeorm/blob/master/CONTRIBUTING.md)

<!--
  🎉 Thank you for contributing and making TypeORM even better!
-->
