### PR TITLE
fix: postgres enum in schema regenerated migrations

### DIFF
--- a/src/driver/postgres/PostgresQueryRunner.ts
+++ b/src/driver/postgres/PostgresQueryRunner.ts
@@ -1800,7 +1800,7 @@ export class PostgresQueryRunner extends BaseQueryRunner implements QueryRunner 
                         } else if (dbColumn["column_default"] === "now()" || dbColumn["column_default"].indexOf("'now'::text") !== -1) {
                             tableColumn.default = dbColumn["column_default"];
                         } else {
-                            tableColumn.default = dbColumn["column_default"].replace(/::[\w\s\[\]\"]+/g, "");
+                            tableColumn.default = dbColumn["column_default"].replace(/::[\w\s\.\[\]\"]+/g, "");
                             tableColumn.default = tableColumn.default.replace(/^(-?\d+)$/, "'$1'");
                         }
                     }

--- a/test/github-issues/3076/entity/SomeEntity.ts
+++ b/test/github-issues/3076/entity/SomeEntity.ts
@@ -1,0 +1,26 @@
+import {Column, PrimaryGeneratedColumn} from "../../../../src";
+import {Entity} from "../../../../src";
+
+export enum CreationMechanism {
+    SOURCE_A = 'SOURCE_A',
+    SOURCE_B = 'SOURCE_B',
+    SOURCE_C = 'SOURCE_C',
+    SOURCE_D = 'SOURCE_D'
+}
+
+@Entity({ name: 'some_entity', schema: 'some_schema', })
+export class SomeEntity {
+    @PrimaryGeneratedColumn()
+    id: number;
+
+    @Column({
+        type     : 'enum',
+        enumName : 'creation_mechanism_enum',
+        enum     : CreationMechanism,
+        default  : CreationMechanism.SOURCE_A,
+    })
+    creationMechanism: CreationMechanism;
+
+    @Column({ nullable: false, default: () => 'now()' })
+    createdAt: Date;
+}

--- a/test/github-issues/3076/issue-3076.ts
+++ b/test/github-issues/3076/issue-3076.ts
@@ -1,0 +1,40 @@
+import "reflect-metadata";
+import {Connection} from "../../../src";
+import {createTestingConnections, closeTestingConnections} from "../../utils/test-utils";
+import {SomeEntity, CreationMechanism} from "./entity/SomeEntity";
+
+describe("github issues > #3076 Postgres enum in schema with default is recreated in every new generated migration", () => {
+    let connections: Connection[];
+    before(async () => connections = await createTestingConnections({
+        migrations: [],
+        enabledDrivers: ["postgres"],
+        schemaCreate: false,
+        dropSchema: true,
+        entities: [SomeEntity],
+    }));
+    after(() => closeTestingConnections(connections));
+
+    it("should recognize model changes", () => Promise.all(connections.map(async connection => {
+        const sqlInMemory = await connection.driver.createSchemaBuilder().log();
+        sqlInMemory.upQueries.length.should.be.greaterThan(0);
+        sqlInMemory.downQueries.length.should.be.greaterThan(0);
+    })));
+
+    it("should not generate queries when no model changes", () => Promise.all(connections.map(async connection => {
+        await connection.driver.createSchemaBuilder().build();
+
+        const sqlInMemory = await connection.driver.createSchemaBuilder().log();
+        sqlInMemory.upQueries.length.should.be.equal(0);
+        sqlInMemory.downQueries.length.should.be.equal(0);
+    })));
+
+    it("should handle `enumName` default change", () => Promise.all(connections.map(async connection => {
+        const entityMetadata = connection.getMetadata(SomeEntity);
+        const columnMetadata = entityMetadata.columns.find(column => column.databaseName === "creationMechanism")
+        columnMetadata!.default = CreationMechanism.SOURCE_B;
+
+        const sqlInMemory = await connection.driver.createSchemaBuilder().log();
+        sqlInMemory.upQueries.length.should.be.greaterThan(0);
+        sqlInMemory.downQueries.length.should.be.greaterThan(0);
+    })));
+});


### PR DESCRIPTION
### Description of change
added "/." to PostgresQueryRunner regex for default value retrieving to prevent regenerating migrations for enum columns with default type when the object is within a schema.

**Previous Behaviour:**
on any migration generation, a new migration has been created for enum default values when the object is within a named schema

**Expected Behaviour:**
no migration as long as the default value is not changed

A broader discussion around the issue: https://github.com/typeorm/typeorm/issues/3076 for which it extends the current workaround

### Pull-Request Checklist

- [x] Code is up-to-date with the `master` branch
- [x] `npm run lint` passes with this change
- [x] `npm run test` passes with this change
- [x] This pull request links relevant issues as `Fixes #0000`
- [x] There are new or updated unit tests validating the change
- [x] Documentation has been updated to reflect this change
- [x] The new commits follow conventions explained in [CONTRIBUTING.md](https://github.com/typeorm/typeorm/blob/master/CONTRIBUTING.md)

