### PR TITLE
fix: create a different cacheId if present for count query in getManyAndCount

### DIFF
--- a/src/query-builder/SelectQueryBuilder.ts
+++ b/src/query-builder/SelectQueryBuilder.ts
@@ -1199,6 +1199,10 @@ export class SelectQueryBuilder<Entity> extends QueryBuilder<Entity> implements 
             this.expressionMap.queryEntity = true;
             const entitiesAndRaw = await this.executeEntitiesAndRawResults(queryRunner);
             this.expressionMap.queryEntity = false;
+            const cacheId = this.expressionMap.cacheId;
+            // Creates a new cacheId for the count query, or it will retreive the above query results
+            // and count will return 0.
+            this.expressionMap.cacheId = (cacheId) ? `${cacheId}-count` : cacheId;
             const count = await this.executeCountQuery(queryRunner);
             const results: [Entity[], number] = [entitiesAndRaw.entities, count];
 

--- a/test/github-issues/4277/entity/User.ts
+++ b/test/github-issues/4277/entity/User.ts
@@ -1,0 +1,10 @@
+import {Entity, PrimaryGeneratedColumn, Column} from "../../../../src";
+
+@Entity()
+export class User {
+    @PrimaryGeneratedColumn({ type: "integer" })
+    id: number;
+    
+    @Column()
+    name: string;
+}

--- a/test/github-issues/4277/issue-4277.ts
+++ b/test/github-issues/4277/issue-4277.ts
@@ -1,0 +1,132 @@
+import "reflect-metadata";
+import {createTestingConnections, closeTestingConnections, reloadTestingDatabases} from "../../utils/test-utils";
+import {Connection} from "../../../src/connection/Connection";
+import {expect} from "chai";
+import {User} from "./entity/User";
+
+describe("github issues > #4277 Using cache in findAndCount and getManyAndCount returns 0 as count", () => {
+
+  let connections: Connection[];
+  before(async () => {
+    connections = await createTestingConnections({
+      entities: [__dirname + "/entity/*{.js,.ts}"],
+      schemaCreate: true,
+      dropSchema: true,
+      cache: {
+        type: "database",
+      },
+    });
+  });
+  beforeEach(async () => {
+    await reloadTestingDatabases(connections);
+    await Promise.all(connections.map((conn) => {
+      const repo = conn.getRepository(User);
+  
+      const usersToInsert = [...Array(10)].map((e) => {
+        const user = new User();
+        user.name = "Jeremy Clarkson";
+        return user;
+      });
+
+      return repo.save(usersToInsert);
+    }));
+  });
+  after(() => closeTestingConnections(connections));
+
+  it("getManyAndCount and findAndCount should count correctly when using cacheId", () => Promise.all(connections.map(async connection => {
+    const repo = connection.getRepository(User);
+
+    const getManyAndCount = () => repo.createQueryBuilder()
+      .cache("cache-id-1", 60000)
+      .getManyAndCount();
+
+    const findAndCount = () => repo.findAndCount({
+      cache: {
+        id: "cache-id-2",
+        milliseconds: 60000,
+      },
+    });
+
+
+    const [users, count] = await getManyAndCount();
+    expect(users.length).equal(10);
+    expect(count).equal(10);
+
+    const [users2, count2] = await findAndCount();
+    expect(users2.length).equal(10);
+    expect(count2).equal(10);
+
+    await repo.save({ name: "Jeremy Clarkson" });
+    
+    // After caching, both queries should be cached correctly. Save above should not affect results
+    const [_users, _count] = await getManyAndCount();
+    expect(_users.length).equal(10);
+    expect(_count).equal(10);
+
+    const [_users2, _count2] = await findAndCount();
+    expect(_users2.length).equal(10);
+    expect(_count2).equal(10);
+  })));
+
+  it("getManyAndCount and findAndCount should count correctly when NOT using cacheId", () => Promise.all(connections.map(async connection => {
+    const repo = connection.getRepository(User);
+
+    const getManyAndCount = () => repo.createQueryBuilder()
+      .cache(60000)
+      .getManyAndCount();
+
+    const findAndCount = () => repo.findAndCount({
+      cache: 60000,
+    });
+
+
+    const [users, count] = await getManyAndCount();
+    expect(users.length).equal(10);
+    expect(count).equal(10);
+
+    const [users2, count2] = await findAndCount();
+    expect(users2.length).equal(10);
+    expect(count2).equal(10);
+
+    await repo.save({ name: "Jeremy Clarkson" });
+    
+    // After caching, both queries should be cached correctly. Save above should not affect results
+    const [_users, _count] = await getManyAndCount();
+    expect(_users.length).equal(10);
+    expect(_count).equal(10);
+
+    const [_users2, _count2] = await findAndCount();
+    expect(_users2.length).equal(10);
+    expect(_count2).equal(10);
+  })));
+
+  it("getManyAndCount and findAndCount should count correctly when NOT using cache", () => Promise.all(connections.map(async connection => {
+    const repo = connection.getRepository(User);
+
+    const getManyAndCount = () => repo.createQueryBuilder()
+      .getManyAndCount();
+
+    const findAndCount = () => repo.findAndCount();
+
+
+    const [users, count] = await getManyAndCount();
+    expect(users.length).equal(10);
+    expect(count).equal(10);
+
+    const [users2, count2] = await findAndCount();
+    expect(users2.length).equal(10);
+    expect(count2).equal(10);
+
+    await repo.save({ name: "Jeremy Clarkson" });
+    
+    // After queries, both should NOT be cached. Save above SHOULD affect results
+    const [_users, _count] = await getManyAndCount();
+    expect(_users.length).equal(11);
+    expect(_count).equal(11);
+
+    const [_users2, _count2] = await findAndCount();
+    expect(_users2.length).equal(11);
+    expect(_count2).equal(11);
+  })));
+
+});


### PR DESCRIPTION
<!--
  😀 Wonderful!  Thank you for opening a pull request for TypeORM.

  Please fill in the information below to expedite the review
  and (hopefully) merge of your change.

  If unsure about something.. just do as best as you're able,
  or reach out through our community support channels!
  https://github.com/typeorm/typeorm/blob/master/docs/support.md
-->

### Description of change

Creates a different cacheId (if provided) for the count query in `getManyAndCount` so that it does not retreive the cache for the previous query (the select immediately above it). Previously, when providing a `cacheId` and using `getManyAndCount` or `findAndCount`, the count query would use the exact same `cacheId` as the select query above it, causing the `count` value to return as 0 (because it doesnt even exist in the select query result). Providing a different `cacheId` for the count query solves the problem. Only happens when explicitly defining a `cacheId`.

Fixes #4277 
<!--
  Please be clear and concise what the change is intended to do,
  why this change is needed, and how you've verified that it
  corrects what you intended.

  In some cases it may be helpful to include the current behavior
  and the new behavior.

  If the change is related to an open issue, you can link it here.
  If you include `Fixes #0000` (replacing `0000` with the issue number)
  when this is merged it will automatically mark the issue as fixed and
  close it.
-->


### Pull-Request Checklist

<!--
  Please make sure to review and check all of the following.

  If an item is not applicable, you can add "N/A" to the end.
-->

- [x] Code is up-to-date with the `master` branch
- [x] `npm run lint` passes with this change
- [x] `npm run test` passes with this change
- [x] This pull request links relevant issues as `Fixes #0000`
- [x] There are new or updated unit tests validating the change
- [ ] Documentation has been updated to reflect this change **N/A**
- [x] The new commits follow conventions explained in [CONTRIBUTING.md](https://github.com/typeorm/typeorm/blob/master/CONTRIBUTING.md)

<!--
  🎉 Thank you for contributing and making TypeORM even better!
-->
