### PR TITLE
feat: implement separate fetch relations in findOptions

### DIFF
--- a/src/find-options/FindOneOptions.ts
+++ b/src/find-options/FindOneOptions.ts
@@ -65,6 +65,10 @@ export interface FindOneOptions<Entity = any> {
     /**
      * If this is set to true, SELECT query in a `find` method will be executed in a transaction.
      */
-    transaction?: boolean
+    transaction?: boolean;
 
+    /**
+     * Indicates if this query going fetch relations in separated queries.
+     */
+    separateFetchRelations?: string[];
 }

--- a/src/find-options/FindOptionsUtils.ts
+++ b/src/find-options/FindOptionsUtils.ts
@@ -5,6 +5,7 @@ import {FindRelationsNotFoundError} from "../error/FindRelationsNotFoundError";
 import {EntityMetadata} from "../metadata/EntityMetadata";
 import {DriverUtils} from "../driver/DriverUtils";
 import { TypeORMError } from "../error";
+import { RelationSeparateAttributes } from "../query-builder/relation-separate/RelationSeparateAttributes";
 
 /**
  * Utilities to work with FindOptions.
@@ -123,6 +124,11 @@ export class FindOptionsUtils {
             // so, we give an exception about not found relations
             if (allRelations.length > 0)
                 throw new FindRelationsNotFoundError(allRelations);
+        }
+
+        if (options.separateFetchRelations) {
+            const separateRelations = [...options.separateFetchRelations];
+            separateRelations.map((relation)=>qb.expressionMap.relationSeparateAttributes.push(new RelationSeparateAttributes({relationPath:relation})));
         }
 
         if (options.join) {

--- a/src/query-builder/QueryExpressionMap.ts
+++ b/src/query-builder/QueryExpressionMap.ts
@@ -12,6 +12,7 @@ import {RelationMetadata} from "../metadata/RelationMetadata";
 import {SelectQueryBuilderOption} from "./SelectQueryBuilderOption";
 import { TypeORMError } from "../error";
 import { WhereClause } from "./WhereClause";
+import { RelationSeparateAttributes } from "./relation-separate/RelationSeparateAttributes";
 
 /**
  * Contains all properties of the QueryBuilder that needs to be build a final query.
@@ -116,6 +117,12 @@ export class QueryExpressionMap {
      * Relation count queries.
      */
     relationCountAttributes: RelationCountAttribute[] = [];
+
+    /**
+     *  Relation separately queries
+     */
+
+    relationSeparateAttributes: RelationSeparateAttributes[] = [];
 
     /**
      * WHERE queries.

--- a/src/query-builder/relation-separate/RelationSeparateAttributes.ts
+++ b/src/query-builder/relation-separate/RelationSeparateAttributes.ts
@@ -1,0 +1,17 @@
+import {ObjectUtils} from "../../util/ObjectUtils";
+
+export class RelationSeparateAttributes {
+
+    /**
+     * Path of relation. e.g. "post.category" for User entity
+     */
+    relationPath: string;
+
+    // -------------------------------------------------------------------------
+    // Constructor
+    // -------------------------------------------------------------------------
+
+    constructor(relationSeparateAttribute?: Partial<RelationSeparateAttributes>) {
+        ObjectUtils.assign(this, relationSeparateAttribute || {});
+    }
+}

--- a/src/query-builder/relation-separate/RelationSeparateLoader.ts
+++ b/src/query-builder/relation-separate/RelationSeparateLoader.ts
@@ -1,0 +1,57 @@
+import {Connection} from "../../connection/Connection";
+import {QueryRunner} from "../../query-runner/QueryRunner";
+import { TypeORMError } from "../../error/TypeORMError";
+import { RelationSeparateAttributes } from "./RelationSeparateAttributes";
+import { RelationLoader } from "../RelationLoader";
+
+export class RelationSeparateLoader {
+
+    // -------------------------------------------------------------------------
+    // Constructor
+    // -------------------------------------------------------------------------
+
+    protected relationLoader;
+
+    constructor(protected connection: Connection,
+                protected queryRunner: QueryRunner|undefined,
+                protected relationSeparateAttributes: RelationSeparateAttributes[]) {
+        this.relationLoader = new RelationLoader(this.connection);
+    }
+
+    // -------------------------------------------------------------------------
+    // Public Methods
+    // -------------------------------------------------------------------------
+
+    async load(entities: any[]): Promise<void> {
+        if(entities.length<=0){
+            return;
+        }
+        await Promise.all(this.relationSeparateAttributes.map(async (attr)=>{
+            await Promise.all(entities.map(async (entity)=>{
+                await this.loadRelation(attr.relationPath, entity);
+            }));
+        }));
+        return;
+    }
+
+    private async loadRelation(relationPath: string, entity: any) {
+        const entityMetadata = this.connection.getMetadata(entity.constructor);
+        const pathSegments = relationPath.split(".");
+        const targetRelation = pathSegments[0];
+        const relation = entityMetadata.findRelationWithPropertyPath(targetRelation);
+        if(!relation){
+            throw new TypeORMError(`Relation with property path ${targetRelation} in ${entityMetadata.name} was not found.`);
+        }
+        const result = await this.relationLoader.load(relation, entity, this.queryRunner);
+        if(pathSegments.length>1){
+            await Promise.all(result.map(async (entity)=>{
+                await this.loadRelation(pathSegments.splice(1).join("."),entity);
+            }));
+        }
+        if (["one-to-one", "many-to-one"].includes(relation.relationType)) {
+            entity[relation.propertyName] = result[0];
+        } else {
+            entity[relation.propertyName] = result;
+        }
+    }
+}

--- a/src/query-builder/transformer/RawSqlResultsToEntityTransformer.ts
+++ b/src/query-builder/transformer/RawSqlResultsToEntityTransformer.ts
@@ -97,7 +97,7 @@ export class RawSqlResultsToEntityTransformer {
         if (metadata.discriminatorColumn) {
             const discriminatorValues = rawResults.map(result => result[DriverUtils.buildAlias(this.driver, alias.name, alias.metadata.discriminatorColumn!.databaseName)]);
             const discriminatorMetadata = metadata.childEntityMetadatas.find(childEntityMetadata => {
-                return typeof discriminatorValues.find(value => value === childEntityMetadata.discriminatorValue) !== 'undefined';
+                return typeof discriminatorValues.find(value => value === childEntityMetadata.discriminatorValue) !== "undefined";
             });
             if (discriminatorMetadata)
                 metadata = discriminatorMetadata;

--- a/test/functional/relations/separate-fetch-relations/entity/Author.ts
+++ b/test/functional/relations/separate-fetch-relations/entity/Author.ts
@@ -1,0 +1,18 @@
+import {Entity} from "../../../../../src/decorator/entity/Entity";
+import {Column} from "../../../../../src/decorator/columns/Column";
+import {OneToMany} from "../../../../../src/decorator/relations/OneToMany";
+import { PrimaryGeneratedColumn } from "../../../../../src";
+import { Post } from "./Post";
+
+@Entity()
+export class Author {
+
+    @PrimaryGeneratedColumn()
+    id: number;
+
+    @Column()
+    name: string;
+
+    @OneToMany(()=>Post,(post)=>post.author)
+    post: Post;
+}

--- a/test/functional/relations/separate-fetch-relations/entity/Category.ts
+++ b/test/functional/relations/separate-fetch-relations/entity/Category.ts
@@ -1,0 +1,19 @@
+import {Entity} from "../../../../../src/decorator/entity/Entity";
+import {PrimaryGeneratedColumn} from "../../../../../src/decorator/columns/PrimaryGeneratedColumn";
+import {Column} from "../../../../../src/decorator/columns/Column";
+import {Post} from "./Post";
+import {OneToMany} from "../../../../../src/decorator/relations/OneToMany";
+
+@Entity()
+export class Category {
+
+    @PrimaryGeneratedColumn()
+    id: number;
+
+    @Column()
+    name: string;
+
+    @OneToMany(type => Post, post => post.category)
+    posts: Post[];
+
+}

--- a/test/functional/relations/separate-fetch-relations/entity/Post.ts
+++ b/test/functional/relations/separate-fetch-relations/entity/Post.ts
@@ -1,0 +1,22 @@
+import {Entity} from "../../../../../src/decorator/entity/Entity";
+import {Column} from "../../../../../src/decorator/columns/Column";
+import {ManyToOne} from "../../../../../src/decorator/relations/ManyToOne";
+import {Category} from "./Category";
+import {Author} from "./Author";
+import {JoinColumn} from "../../../../../src/decorator/relations/JoinColumn";
+
+@Entity()
+export class Post {
+
+    @ManyToOne(type => Category, category => category.posts, {
+        primary: true
+    })
+    category: Category;
+
+    @Column()
+    title: string;
+
+    @ManyToOne(()=>Author,(author)=>author.post)
+    @JoinColumn()
+    author: Author;
+}

--- a/test/functional/relations/separate-fetch-relations/separate-fetch-relations.ts
+++ b/test/functional/relations/separate-fetch-relations/separate-fetch-relations.ts
@@ -1,0 +1,78 @@
+import "reflect-metadata";
+import {closeTestingConnections, createTestingConnections, reloadTestingDatabases} from "../../../utils/test-utils";
+import {Connection} from "../../../../src";
+import {Post} from "./entity/Post";
+import {Category} from "./entity/Category";
+import { Author } from "./entity/Author";
+
+describe("relations > separate-fetch-relations", () => {
+
+    let connections: Connection[];
+    before(async () => connections = await createTestingConnections({
+        entities: [__dirname + "/entity/*{.js,.ts}"],
+    }));
+    beforeEach(() => reloadTestingDatabases(connections));
+    after(() => closeTestingConnections(connections));
+
+    describe("Separate fetch relation provided in finding options", function() {
+
+        it("should work with join relations perfectly", () => Promise.all(connections.map(async connection => {
+
+            const category1 = new Category();
+            category1.name = "Category #1";
+            await connection.manager.save(category1);
+
+            const author1 = new Author();
+            author1.name = "Hello author";
+            await connection.manager.save(author1);
+
+            const post1 = new Post();
+            post1.title = "Hello Post #1";
+            post1.category = category1;
+            post1.author = author1;
+
+            await connection.manager.save(post1);
+
+            const category2 = new Category();
+            category2.name = "Category #2";
+            await connection.manager.save(category2);
+
+            const post2 = new Post();
+            post2.title = "Hello Post #2";
+            post2.category = category2;
+            post2.author = author1;
+
+            await connection.manager.save(post2);
+
+            // Should work with join relations
+            const posts = await connection.manager.find(Post, {
+                relations: ["category"],
+                where: {category:{name: "Category #2"}},
+                separateFetchRelations: ["author","author.post"]
+            });
+
+            posts.should.be.eql([{
+                title: "Hello Post #2",
+                category: {
+                    id: 2,
+                    name: "Category #2"
+                },
+                author: {
+                    id: 1,
+                    name: "Hello author",
+                    post: [
+                        {
+                            title: "Hello Post #1"
+                        },
+                        {
+                            title: "Hello Post #2"
+                        }
+                    ]
+
+                }
+            }]);
+        })));
+
+    });
+
+});


### PR DESCRIPTION
This new feature allow fetch relations in separated sql query, that  will fix memory running out when .find() called with multiple join relations. This issue is described in #5829 & #3857


Fixes: #5829

<!--
  😀 Wonderful!  Thank you for opening a pull request for TypeORM.

  Please fill in the information below to expedite the review
  and (hopefully) merge of your change.

  If unsure about something.. just do as best as you're able,
  or reach out through our community support channels!
  https://github.com/typeorm/typeorm/blob/master/docs/support.md
-->

### Description of change

This new feature allow fetch relations in separated sql query, that  will fix memory running out when .find() called with multiple join relations. This issue is described in #5829 & #3857

You can fetch relations by using:
```typescript
    const posts = await connection.manager.find(Post, {
        relations: ["category"],
        where: {category:{name: "Category #2"}},
        separateFetchRelations: ["author","author.post"]
    });
```
Then the relation `author` and `post` of `author` will be queried in separated sql:
```sql
SELECT * FROM post 
LEFT JOIN category on category.post_id = post.id
WHERE category.name = 'Category #2';

SELECT * FROM author
WHERE author.post_id = post_id; --post's id just fetched

SELECT * FROM post
WHERE post.author_id = author_id; --author's id just fetched
```


<!--
  Please be clear and concise what the change is intended to do,
  why this change is needed, and how you've verified that it
  corrects what you intended.

  In some cases it may be helpful to include the current behavior
  and the new behavior.

  If the change is related to an open issue, you can link it here.
  If you include `Fixes #0000` (replacing `0000` with the issue number)
  when this is merged it will automatically mark the issue as fixed and
  close it.
-->


### Pull-Request Checklist

<!--
  Please make sure to review and check all of the following.

  If an item is not applicable, you can add "N/A" to the end.
-->

- [x] Code is up-to-date with the `master` branch
- [x] `npm run lint` passes with this change
- [x] `npm run test` passes with this change
- [x] This pull request links relevant issues as `Fixes #0000`
- [x] There are new or updated unit tests validating the change
- [x] Documentation has been updated to reflect this change
- [x] The new commits follow conventions explained in [CONTRIBUTING.md](https://github.com/typeorm/typeorm/blob/master/CONTRIBUTING.md)

<!--
  🎉 Thank you for contributing and making TypeORM even better!
-->
