### PR TITLE
fix: parameter name compatibility broken in PostgresDriver

### DIFF
--- a/gulpfile.ts
+++ b/gulpfile.ts
@@ -116,6 +116,17 @@ export class Gulpfile {
                 "cd ./build/package && npm publish"
             ]));
     }
+    
+    /**
+     * Packs a .tgz from ./build/package directory.
+     */
+    @Task()
+    packagePack() {
+        return gulp.src("package.json", { read: false })
+            .pipe(shell([
+                "cd ./build/package && npm pack && mv -f typeorm-*.tgz .."
+            ]));
+    }
 
     /**
      * Publishes a package to npm from ./build/package directory with @next tag.
@@ -228,6 +239,14 @@ export class Gulpfile {
                 "packageCopyShims"
             ],
         ];
+    }
+
+    /**
+     * Creates a package .tgz
+     */
+    @SequenceTask()
+    pack() {
+        return ["package", "packagePack"];
     }
 
     /**

--- a/package.json
+++ b/package.json
@@ -208,6 +208,7 @@
     "compile": "rimraf ./build && tsc",
     "watch": "./node_modules/.bin/tsc -w",
     "package": "gulp package",
+    "pack": "gulp pack",
     "lint": "eslint -c ./.eslintrc.js src/**/*.ts test/**/*.ts sample/**/*.ts",
     "changelog": "conventional-changelog -p angular -i CHANGELOG.md -s -r 1"
   },


### PR DESCRIPTION
`Fixes #8339`
parameter name compatibility broken in PostgresDriver.ts -> escapeQueryWithParameters
For example, the parameter name cannot contain "@"