### PR TITLE
fix: add `retryWrites` to `MongoConnectionOptions`

### DIFF
--- a/src/driver/mongodb/MongoConnectionOptions.ts
+++ b/src/driver/mongodb/MongoConnectionOptions.ts
@@ -343,4 +343,9 @@ export interface MongoConnectionOptions extends BaseConnectionOptions {
      * Automatic Client-Side Field Level Encryption configuration.
      */
     readonly autoEncryption?: any;
+
+    /**
+     * Enables or disables the ability to retry writes upon encountering transient network errors.
+     */
+    readonly retryWrites?: boolean;
 }


### PR DESCRIPTION

### Description of change

Add `retryWrites` property to `MongoConnectionOptions` to match change to `MongoDriver` made in #7869.
I encountered this missing type when using `TypeOrmModuleOptions` from `@nestjs/typeorm`, which is based on the `MongoConnectionOptions` interface.

The doc string is taken from https://docs.mongodb.com/v4.0/reference/method/Mongo.startSession/.

### Pull-Request Checklist

- [x] Code is up-to-date with the `master` branch
- [x] `npm run lint` passes with this change
- [ ] `npm run test` passes with this change
- [ ] This pull request links relevant issues as `Fixes #0000`
- [ ] There are new or updated unit tests validating the change
- [ ] Documentation has been updated to reflect this change
- [x] The new commits follow conventions explained in [CONTRIBUTING.md](https://github.com/typeorm/typeorm/blob/master/CONTRIBUTING.md)

