### PR TITLE
feat: add ability to remove connections from ConnectionManager

### DIFF
--- a/src/connection/ConnectionManager.ts
+++ b/src/connection/ConnectionManager.ts
@@ -2,6 +2,7 @@ import {Connection} from "./Connection";
 import {ConnectionNotFoundError} from "../error/ConnectionNotFoundError";
 import {ConnectionOptions} from "./ConnectionOptions";
 import {AlreadyHasActiveConnectionError} from "../error/AlreadyHasActiveConnectionError";
+import { CannotRemoveActiveConnectionError } from "../error/CannotRemoveActiveConnectionError";
 
 /**
  * ConnectionManager is used to store and manage multiple orm connections.
@@ -18,7 +19,7 @@ export class ConnectionManager {
     /**
      * Internal lookup to quickly get from a connection name to the Connection object.
      */
-    private readonly connectionMap: Map<string, Connection> = new Map();
+    protected readonly connectionMap: Map<string, Connection> = new Map();
 
     // -------------------------------------------------------------------------
     // Public Methods
@@ -61,6 +62,21 @@ export class ConnectionManager {
         const connection = new Connection(options);
         this.connectionMap.set(connection.name, connection);
         return connection;
+    }
+
+    /**
+     * Removes registered connection with the given name from ConnectionManager.
+     * Throws error if connection name is not registered, or if the connection is still connected.
+     */
+    remove(connectionName: string = "unknown"): void {
+        // check if such connection is registered
+        const existConnection = this.get(connectionName);
+        // if connection is registered and its not closed then throw an error
+        if (existConnection && existConnection.isConnected) {
+            throw new CannotRemoveActiveConnectionError(existConnection.name);
+        }
+
+        this.connectionMap.delete(connectionName);
     }
 
 }

--- a/src/error/CannotRemoveActiveConnectionError.ts
+++ b/src/error/CannotRemoveActiveConnectionError.ts
@@ -1,0 +1,13 @@
+import { TypeORMError } from "./TypeORMError";
+
+/**
+ * Thrown when consumer tries to remove a connection from the ConnectionManager, but the connection was not closed yet.
+ */
+export class CannotRemoveActiveConnectionError extends TypeORMError {
+    constructor(connectionName: string) {
+        super(
+            `Cannot remove a connection named "${connectionName}" from ConnectionManager, ` +
+            `because the connection has not yet been closed.`
+        );
+    }
+}

--- a/test/functional/connection-manager/connection-manager.ts
+++ b/test/functional/connection-manager/connection-manager.ts
@@ -255,4 +255,41 @@ describe("ConnectionManager", () => {
 
     });
 
+    describe("remove", () => {
+
+        it("should remove a registered connection from the ConnectionManager", () => {
+            const options = setupSingleTestingConnection("mysql", {
+                name: "myMysqlConnection",
+                entities: []
+            });
+            if (!options)
+                return;
+            const connectionManager = new ConnectionManager();
+            const connection = connectionManager.create(options);
+            connectionManager.has(connection.name).should.be.true;
+            connectionManager.remove(connection.name);
+            connectionManager.has(connection.name).should.be.false;
+        });
+
+        it("should throw an error if the connectionName was not already registered", () => {
+            const connectionManager = new ConnectionManager();
+            expect(() => connectionManager.remove()).to.throw(Error);
+            expect(() => connectionManager.remove("someFakeConnectionName")).to.throw(Error);
+        });
+
+        it("should throw an error if the connection is not already closed", async () => {
+            const options = setupSingleTestingConnection("mysql", {
+                name: "myMysqlConnection",
+                entities: []
+            });
+            if (!options)
+                return;
+            const connectionManager = new ConnectionManager();
+            const connection = connectionManager.create(options);
+            await connection.connect();
+            expect(() => connectionManager.remove(connection.name)).to.throw(Error);
+        });
+
+    });
+
 });


### PR DESCRIPTION
### Description of change

<!--
  Please be clear and concise what the change is intended to do,
  why this change is needed, and how you've verified that it
  corrects what you intended.

  In some cases it may be helpful to include the current behavior
  and the new behavior.

  If the change is related to an open issue, you can link it here.
  If you include `Fixes #0000` (replacing `0000` with the issue number)
  when this is merged it will automatically mark the issue as fixed and
  close it.
-->
Fixes #8365 

Adds a `remove()` method to the `ConnectionManager` class. As described in #8365 this is useful when an app's infrastructure requires automatically rotating db credentials, which in turn results in new `Connection`s being created regularly. Currently there is no way to remove old, closed connections from the `ConnectionManager` and this PR adds a simple mechanism for client code to remove references to `Connection` objects that are no longer needed.

```
// Using the connection manager like normal...
getConnectionManager().create({ ...options, name: 'somewhatShortLivedConnection'});

// At a later point in time we no longer need the connection, so remove it from connection manager
getConnectionManager().remove('somewhatShortLivedConnection');
```

Also changes the `private readonly connectionMap` property to `protected` to improve extensibility.

### Pull-Request Checklist


- [x] Code is up-to-date with the `master` branch
- [x] `npm run lint` passes with this change
- [x] `npm run test` passes with this change
- [x] This pull request links relevant issues as `Fixes #0000`
- [x] There are new or updated unit tests validating the change
- [ ] Documentation has been updated to reflect this change - N/A
- [x] The new commits follow conventions explained in [CONTRIBUTING.md](https://github.com/typeorm/typeorm/blob/master/CONTRIBUTING.md)
