### PR TITLE
Fix documentations for migrations.

### DIFF
--- a/docs/migrations.md
+++ b/docs/migrations.md
@@ -243,7 +243,8 @@ export class QuestionRefactoringTIMESTAMP implements MigrationInterface {
                 {
                     name: "id",
                     type: "int",
-                    isPrimary: true
+                    isPrimary: true,
+                    isGenerated: true
                 },
                 {
                     name: "name",


### PR DESCRIPTION
Since the model claims `@PrimaryGeneratedColumn`, the migration should as well.


### Description of change
Documentation change for adding `isGenerated: true` to a migration that uses a schema with `@PrimaryGeneratedColumn`

### Pull-Request Checklist

- [ ] Code is up-to-date with the `master` branch **N/A**
- [ ] `npm run lint` passes with this change **N/A**
- [ ] `npm run test` passes with this change **N/A**
- [ ] This pull request links relevant issues as `Fixes #0000` **N/A**
- [ ] There are new or updated unit tests validating the change **N/A**
- [x] Documentation has been updated to reflect this change
- [x] The new commits follow conventions explained in [CONTRIBUTING.md](https://github.com/typeorm/typeorm/blob/master/CONTRIBUTING.md)
