### PR TITLE
fix: mysql2 processes incorrectly with JSON column

### DIFF
--- a/test/github-issues/8319/entity/JsonTest.ts
+++ b/test/github-issues/8319/entity/JsonTest.ts
@@ -1,0 +1,13 @@
+import {Entity} from "../../../../src/decorator/entity/Entity";
+import {Column} from "../../../../src/decorator/columns/Column";
+import { PrimaryGeneratedColumn } from "../../../../src/decorator/columns/PrimaryGeneratedColumn";
+
+@Entity()
+export class JsonTest {
+
+    @PrimaryGeneratedColumn()
+    public id!: number;
+
+    @Column("json")
+    public jvalue!: any;
+}

--- a/test/github-issues/8319/issue-8319.ts
+++ b/test/github-issues/8319/issue-8319.ts
@@ -1,0 +1,59 @@
+import "reflect-metadata";
+import {closeTestingConnections, createTestingConnections, reloadTestingDatabases} from "../../utils/test-utils";
+import {Connection} from "../../../src/connection/Connection";
+import {expect} from "chai";
+import {JsonTest} from "./entity/JsonTest";
+
+describe("github issues > #8319 JSON string value will be parsed twice with mysql2", () => {
+
+    let connections: Connection[];
+    before(async () => connections = await createTestingConnections({
+        entities: [__dirname + "/entity/*{.js,.ts}"],
+        enabledDrivers: ["mysql"]
+    }));
+    beforeEach(() => reloadTestingDatabases(connections));
+    after(() => closeTestingConnections(connections));
+
+    it("should read output as input", async () => {
+
+        for (const connection of connections) {
+            const test = new JsonTest();
+
+            test.jvalue = "hello";
+
+            await connection.manager.save(test);
+
+            expect((await connection.getRepository(JsonTest).findOne(test.id))!.jvalue).to.be.equal("hello");
+
+            test.jvalue = 123;
+
+            await connection.manager.save(test);
+
+            expect((await connection.getRepository(JsonTest).findOne(test.id))!.jvalue).to.be.equal(123);
+
+            test.jvalue = false;
+
+            await connection.manager.save(test);
+
+            expect((await connection.getRepository(JsonTest).findOne(test.id))!.jvalue).to.be.equal(false);
+
+            test.jvalue = { name: "Mick" };
+
+            await connection.manager.save(test);
+
+            expect((await connection.getRepository(JsonTest).findOne(test.id))!.jvalue.name).to.be.equal("Mick");
+
+            test.jvalue = null;
+
+            await connection.manager.save(test);
+
+            expect((await connection.getRepository(JsonTest).findOne(test.id))!.jvalue).to.be.equal(null);
+
+            test.jvalue = [123, null, "Lot"];
+
+            await connection.manager.save(test);
+
+            expect((await connection.getRepository(JsonTest).findOne(test.id))!.jvalue[2]).to.be.equal("Lot");
+        }
+    });
+});


### PR DESCRIPTION
This PR does:
- fix: the JSON column with JSON encoded string value like `row.column1 = "text"` should not be parsed twice using driver `mysql2`.
- fix: the JSON column should be allowed to save `null` in JSON encoding, even if it's not a nullable column.
- feat: allow using `{ "driver": "mysql2" }` in connection options to select driver explicitly.

Closes: #8319

<!--
  😀 Wonderful!  Thank you for opening a pull request for TypeORM.

  Please fill in the information below to expedite the review
  and (hopefully) merge of your change.

  If unsure about something.. just do as best as you're able,
  or reach out through our community support channels!
  https://github.com/typeorm/typeorm/blob/master/docs/support.md
-->

### Description of change

<!--
  Please be clear and concise what the change is intended to do,
  why this change is needed, and how you've verified that it
  corrects what you intended.

  In some cases it may be helpful to include the current behavior
  and the new behavior.

  If the change is related to an open issue, you can link it here.
  If you include `Fixes #0000` (replacing `0000` with the issue number)
  when this is merged it will automatically mark the issue as fixed and
  close it.
-->


### Pull-Request Checklist

<!--
  Please make sure to review and check all of the following.

  If an item is not applicable, you can add "N/A" to the end.
-->

- [x] Code is up-to-date with the `master` branch
- [x] `npm run lint` passes with this change
- [x] `npm run test` passes with this change
- [x] This pull request links relevant issues as `Fixes #0000`
- [x] There are new or updated unit tests validating the change
- [ ] Documentation has been updated to reflect this change
- [x] The new commits follow conventions explained in [CONTRIBUTING.md](https://github.com/typeorm/typeorm/blob/master/CONTRIBUTING.md)

<!--
  🎉 Thank you for contributing and making TypeORM even better!
-->
