### PR TITLE
fix: For MS SQL Server use lowercase "sys"."columns" reference. (#8400)

### DIFF
--- a/src/driver/sqlserver/SqlServerQueryRunner.ts
+++ b/src/driver/sqlserver/SqlServerQueryRunner.ts
@@ -1672,7 +1672,7 @@ export class SqlServerQueryRunner extends BaseQueryRunner implements QueryRunner
             return `SELECT "TABLE_CATALOG", "TABLE_SCHEMA", "COLUMN_NAME", "TABLE_NAME" ` +
                 `FROM "${TABLE_CATALOG}"."INFORMATION_SCHEMA"."COLUMNS" ` +
                 `WHERE ` +
-                `EXISTS(SELECT 1 FROM "${TABLE_CATALOG}"."SYS"."COLUMNS" "S" WHERE OBJECT_ID("TABLE_CATALOG" + '.' + "TABLE_SCHEMA" + '.' + "TABLE_NAME") = "S"."OBJECT_ID" AND "COLUMN_NAME" = "S"."NAME" AND "S"."is_identity" = 1) AND ` +
+                `EXISTS(SELECT 1 FROM "${TABLE_CATALOG}"."sys"."columns" "S" WHERE OBJECT_ID("TABLE_CATALOG" + '.' + "TABLE_SCHEMA" + '.' + "TABLE_NAME") = "S"."OBJECT_ID" AND "COLUMN_NAME" = "S"."NAME" AND "S"."is_identity" = 1) AND ` +
                 `(${conditions})`;
         }).join(" UNION ALL ");
 


### PR DESCRIPTION
For MS SQL Server change uppercase table reference "SYS"."COLUMNS" to lowercase "sys"."columns" to avoid table name mismatch when database collation is ALTER'ed to a case-sensitive collation.

### Description of change

Per issue #8400 changed the only occurrence of uppercase reference `"SYS"."COLUMNS"` to lowercase `"sys".columns"`.

### Pull-Request Checklist

_I am a contractor and due to resource constraints of only having one shared MS SQL Server DB instance I was unable to implement/run any tests!_

- [x] Code is up-to-date with the `master` branch
- [ ] `npm run lint` passes with this change
- [ ] `npm run test` passes with this change
- [x] This pull request links relevant issues as `Fixes #8400`
- [ ] There are new or updated unit tests validating the change
- [ ] Documentation has been updated to reflect this change
- [x] The new commits follow conventions explained in [CONTRIBUTING.md]
