### PR TITLE
fix: find() throws error while using mongodb

### DIFF
--- a/src/entity-manager/MongoEntityManager.ts
+++ b/src/entity-manager/MongoEntityManager.ts
@@ -683,7 +683,8 @@ export class MongoEntityManager extends EntityManager {
      * Overrides cursor's toArray and next methods to convert results to entity automatically.
      */
     protected applyEntityTransformationToCursor<Entity>(metadata: EntityMetadata, cursor: Cursor<Entity> | AggregationCursor<Entity>) {
-        const ParentCursor = PlatformTools.load("mongodb").Cursor;
+        // mongdb-3.7 exports Cursor, mongodb-4.2 exports FindCursor, provide support for both.
+        const ParentCursor = PlatformTools.load("mongodb").Cursor || PlatformTools.load("mongodb").FindCursor;
         const queryRunner = this.mongoQueryRunner;
         cursor.toArray = function (callback?: MongoCallback<Entity[]>) {
             if (callback) {


### PR DESCRIPTION
Add support for mongodb 4.2

Closes: 8146

### Description of change

mongodb@4.2 does not export a Cursor, instead it exports a FindCursor. This change provides compatibility support to TypeORM so it works with both mongodb@3.6.4 and mongodb@4.2

Some notes on the tests:
- test/functional/commands/migration-create.ts
- test/functional/commands/migration-generate.ts
- test/functional/connection-options-reader/connection-options-reader.ts
- test/functional/persistence/delete-orphans/delete-orphans.ts

These tests were not passing prior to any changes and were disabled to complete the other tests. The remaining tests were ran successfully for both MongoDB version 4.4.10 using mongdb@4.2 driver and using MongoDB version 3.7 (using the docker image) and mongodb@3.6.4 driver.

### Pull-Request Checklist

- [X] Code is up-to-date with the `master` branch
- [X] `npm run lint` passes with this change
- [X] `npm run test` passes with this change
- [X] This pull request links relevant issues as `Fixes #0000`
- [X] There are new or updated unit tests validating the change - N/A
- [X] Documentation has been updated to reflect this change - N/A
- [X] The new commits follow conventions explained in [CONTRIBUTING.md](https://github.com/typeorm/typeorm/blob/master/CONTRIBUTING.md)

