### PR TITLE
docs: fix wrong upsert example

### DIFF
--- a/docs/repository-api.md
+++ b/docs/repository-api.md
@@ -157,7 +157,7 @@ await repository.update(1, { firstName: "Rizzrak" });
 * `upsert` - Inserts a new entity or array of entities unless they already exist in which case they are updated instead. Supported by AuroraDataApi, Cockroach, Mysql, Postgres, and Sqlite database drivers.
 
 ```typescript
-await repository.update([
+await repository.upsert([
     { externalId:"abc123", firstName: "Rizzrak" },
     { externalId:"bca321", firstName: "Karzzir" },
 ], ["externalId"]);


### PR DESCRIPTION
### Description of change
It seems like the wrong method(`update`) was used in the `upsert` example so I changed it to `upsert`.

### Pull-Request Checklist
- [X] Code is up-to-date with the `master` branch
- [ ] `npm run lint` passes with this change
- [ ] `npm run test` passes with this change
- [ ] This pull request links relevant issues as `Fixes #0000`
- [ ] There are new or updated unit tests validating the change
- [X] Documentation has been updated to reflect this change
- [X] The new commits follow conventions explained in [CONTRIBUTING.md](https://github.com/typeorm/typeorm/blob/master/CONTRIBUTING.md)
