### PR TITLE
Fix typo of 'upsert'

### DIFF
--- a/docs/repository-api.md
+++ b/docs/repository-api.md
@@ -157,7 +157,7 @@ await repository.update(1, { firstName: "Rizzrak" });
 * `upsert` - Inserts a new entity or array of entities unless they already exist in which case they are updated instead. Supported by AuroraDataApi, Cockroach, Mysql, Postgres, and Sqlite database drivers.
 
 ```typescript
-await repository.update([
+await repository.upsert([
     { externalId:"abc123", firstName: "Rizzrak" },
     { externalId:"bca321", firstName: "Karzzir" },
 ], ["externalId"]);


### PR DESCRIPTION
Fix documentation with correct function name

### Description of change
Fixes a typo in an example in documentation that used `update` instead of `upsert`


### Pull-Request Checklist
- [x] Code is up-to-date with the `master` branch
- [x] `npm run lint` passes with this change
- [x] `npm run test` passes with this change
- [x] This pull request links relevant issues as `Fixes #0000`
- [x] There are new or updated unit tests validating the change
- [x] Documentation has been updated to reflect this change
- [x] The new commits follow conventions explained in [CONTRIBUTING.md](https://github.com/typeorm/typeorm/blob/master/CONTRIBUTING.md)
