### PR TITLE
catch JSON parse error

### DIFF
--- a/src/driver/mysql/MysqlDriver.ts
+++ b/src/driver/mysql/MysqlDriver.ts
@@ -568,8 +568,13 @@ export class MysqlDriver implements Driver {
             value = DateUtils.mixedDateToDateString(value);
 
         } else if (columnMetadata.type === "json") {
-            value = typeof value === "string" ? JSON.parse(value) : value;
-
+            if(typeof value === "string"){
+                try{
+                    return JSON.parse(value);
+                } catch(e) {
+                }
+            }
+            return value;
         } else if (columnMetadata.type === "time") {
             value = DateUtils.mixedTimeToString(value);
 


### PR DESCRIPTION
### Catch JSON.parse exception in MysqlDriver.prepareHydratedValue
  I saved a string in mysql json field, then got an exception when I tried to retrieve that string. The string fed to JSON.parse doesn't have double quote around it. It looks like the string had been parsed before reaching prepareHydratedValue. By catching the exception, the value will be returned when it is a string and can not be parsed by JSON.parse.


### Pull-Request Checklist

<!--
  Please make sure to review and check all of the following.

  If an item is not applicable, you can add "N/A" to the end.
-->

- [ X ] Code is up-to-date with the `master` branch
- [ X ] `npm run lint` passes with this change
- [ ] `npm run test` passes with this change
- [ ] This pull request links relevant issues as `Fixes #0000`
- [ ] There are new or updated unit tests validating the change
- [ N/A ] Documentation has been updated to reflect this change
- [ X ] The new commits follow conventions explained in [CONTRIBUTING.md](https://github.com/typeorm/typeorm/blob/master/CONTRIBUTING.md)

<!--
  🎉 Thank you for contributing and making TypeORM even better!
-->
