### PR TITLE
Add support for node-redis v4.0.0 and newer

### DIFF
--- a/docs/caching.md
+++ b/docs/caching.md
@@ -149,8 +149,7 @@ Example:
 }
 ```
 
-"options" can be [node_redis specific options](https://github.com/NodeRedis/node_redis#options-object-properties) or [ioredis specific options](https://github.com/luin/ioredis/blob/master/API.md#new-redisport-host-options) depending on what type you're using.
-
+"options" can be [node_redis specific options](https://github.com/redis/node-redis/blob/master/docs/client-configuration.md) or [ioredis specific options](https://github.com/luin/ioredis/blob/master/API.md#new-redisport-host-options) depending on what type you're using.
 
 In case you want to connect to a redis-cluster using IORedis's cluster functionality, you can do that as well by doing the following:
 

--- a/src/cache/RedisQueryResultCache.ts
+++ b/src/cache/RedisQueryResultCache.ts
@@ -50,10 +50,12 @@ export class RedisQueryResultCache implements QueryResultCache {
     async connect(): Promise<void> {
         const cacheOptions: any = this.connection.options.cache;
         if (this.clientType === "redis") {
-            if (cacheOptions && cacheOptions.options) {
-                this.client = this.redis.createClient(cacheOptions.options);
-            } else {
-                this.client = this.redis.createClient();
+            this.client = this.redis.createClient({
+                ...cacheOptions?.options,
+                legacyMode: true
+            });
+            if ("connect" in this.client) {
+                await this.client.connect();
             }
         } else if (this.clientType === "ioredis") {
             if (cacheOptions && cacheOptions.port) {


### PR DESCRIPTION
- Fixes https://github.com/typeorm/typeorm/issues/8420
- v4.0.0 and newer of node-redis will no longer auto-connect, so we need to add that step
- For backwards compatibility, we check for the existence of a "v4" property so we don't try to call `connect` on older versions of the client
- A `legacyMode` flag exists in the new v4.0.0 of node-redis to keep a similar calling style without having to change any code
- This option can be passed via the createClient options, so I've added documentation to indicate that this is required if users would like to use v4.0.0 of node-redis
- Note that the legacyMode flag is **required** to be passed if the calling code isn't going to be changed

<!--
  😀 Wonderful!  Thank you for opening a pull request for TypeORM.

  Please fill in the information below to expedite the review
  and (hopefully) merge of your change.

  If unsure about something.. just do as best as you're able,
  or reach out through our community support channels!
  https://github.com/typeorm/typeorm/blob/master/docs/support.md
-->

### Description of change

<!--
  Please be clear and concise what the change is intended to do,
  why this change is needed, and how you've verified that it
  corrects what you intended.

  In some cases it may be helpful to include the current behavior
  and the new behavior.

  If the change is related to an open issue, you can link it here.
  If you include `Fixes #0000` (replacing `0000` with the issue number)
  when this is merged it will automatically mark the issue as fixed and
  close it.
-->


### Pull-Request Checklist

<!--
  Please make sure to review and check all of the following.

  If an item is not applicable, you can add "N/A" to the end.
-->

- [x] Code is up-to-date with the `master` branch
- [x] `npm run lint` passes with this change
- [ ] `npm run test` passes with this change
- [x] This pull request links relevant issues as `Fixes #0000`
- [ ] There are new or updated unit tests validating the change
- [x] Documentation has been updated to reflect this change
- [ ] The new commits follow conventions explained in [CONTRIBUTING.md](https://github.com/typeorm/typeorm/blob/master/CONTRIBUTING.md)

<!--
  🎉 Thank you for contributing and making TypeORM even better!
-->
