### PR TITLE
fix: adds entity-schema support for withoutRowid

### DIFF
--- a/src/entity-schema/EntitySchemaOptions.ts
+++ b/src/entity-schema/EntitySchemaOptions.ts
@@ -95,6 +95,13 @@ export class EntitySchemaOptions<T> {
     synchronize?: boolean;
 
     /**
+     * If set to 'true' this option disables Sqlite's default behaviour of secretly creating
+     * an integer primary key column named 'rowid' on table creation. 
+     * @see https://www.sqlite.org/withoutrowid.html. 
+     */
+    withoutRowid?: boolean;
+
+    /**
      * View expression.
      */
     expression?: string|((connection: Connection) => SelectQueryBuilder<any>);

--- a/src/entity-schema/EntitySchemaTransformer.ts
+++ b/src/entity-schema/EntitySchemaTransformer.ts
@@ -42,6 +42,7 @@ export class EntitySchemaTransformer {
                 type: options.type || "regular",
                 orderBy: options.orderBy,
                 synchronize: options.synchronize,
+                withoutRowid: !!options.withoutRowid,
                 expression: options.expression
             };
             metadataArgsStorage.tables.push(tableMetadata);


### PR DESCRIPTION
### Description of change

A previous pull request (#4688) added support for `withoutRowid` to `EntityOptions` but did not extend this support all the way into `EntitySchemaOptions`

This PR adds this missing piece.

Fixes: #8429

### Pull-Request Checklist

- [X] Code is up-to-date with the `master` branch
- [X] `npm run lint` passes with this change
- [X] `npm run test` passes with this change
- [X] This pull request links relevant issues as `Fixes #0000`
- [X] There are new or updated unit tests validating the change **N/A**
- [X] Documentation has been updated to reflect this change **N/A**
- [X] The new commits follow conventions explained in [CONTRIBUTING.md](https://github.com/typeorm/typeorm/blob/master/CONTRIBUTING.md)
