### PR TITLE
Soft delete recursive cascade

### DIFF
--- a/src/persistence/SubjectExecutor.ts
+++ b/src/persistence/SubjectExecutor.ts
@@ -647,7 +647,6 @@ export class SubjectExecutor {
         if (relation.isCascadeSoftRemove){
             let primaryPropertyName = relation.inverseEntityMetadata.primaryColumns[0].propertyName;
             let updateResult: UpdateResult;
-            let parentIds: any[] = [];
             let softDeleteQueryBuilder = this.queryRunner
                 .manager
                 .createQueryBuilder()
@@ -658,9 +657,7 @@ export class SubjectExecutor {
                 .callListeners(false);
             softDeleteQueryBuilder.where(`${relation.inverseSidePropertyPath} in (:...ids)`, {ids: ids});
             updateResult = await softDeleteQueryBuilder.execute();
-            for (const row of updateResult.raw) {
-                parentIds.push(row[Object.keys(row)[0]]);
-            }
+            const parentIds = updateResult.raw.map((row: any) => row[Object.keys(row)[0]]);
             if (parentIds.length) {
                 for (const subRelation of relation.inverseEntityMetadata.relations) {
                     await this.executeSoftRemoveRecursive(subRelation, parentIds);

--- a/src/persistence/SubjectExecutor.ts
+++ b/src/persistence/SubjectExecutor.ts
@@ -645,6 +645,7 @@ export class SubjectExecutor {
 
     protected async executeSoftRemoveRecursive(relation: RelationMetadata, ids: any[]): Promise<void> {
         if (relation.isCascadeSoftRemove){
+            console.log(this.queryRunner.connection.driver.isReturningSqlSupported());
             let primaryPropertyName = relation.inverseEntityMetadata.primaryColumns[0].propertyName;
             let updateResult: UpdateResult;
             let softDeleteQueryBuilder = this.queryRunner
@@ -652,10 +653,12 @@ export class SubjectExecutor {
                 .createQueryBuilder()
                 .softDelete()
                 .from(relation.inverseEntityMetadata.target)
-                .returning(primaryPropertyName)
+                .returning([primaryPropertyName])
                 .updateEntity(this.options && this.options.reload === false ? false : true)
                 .callListeners(false);
             softDeleteQueryBuilder.where(`${relation.inverseSidePropertyPath} in (:...ids)`, {ids: ids});
+            console.log(softDeleteQueryBuilder.getQuery());
+            console.log(ids);
             updateResult = await softDeleteQueryBuilder.execute();
             const parentIds = updateResult.raw.map((row: any) => row[Object.keys(row)[0]]);
             if (parentIds.length) {

--- a/src/persistence/SubjectExecutor.ts
+++ b/src/persistence/SubjectExecutor.ts
@@ -611,7 +611,7 @@ export class SubjectExecutor {
                 updateResult = await softDeleteQueryBuilder.execute();
 
                 for (const relation of subject.metadata.relations) {
-                    await this.executeSoftRemoveRecursive(relation, [Reflect.get(subject.entity!, subject.metadata.primaryColumns[0].propertyName)]);
+                    await this.executeSoftRemoveRecursive(relation, [Reflect.get(subject.identifier, subject.metadata.primaryColumns[0].propertyName)]);
                 }
             }
 

--- a/src/persistence/SubjectExecutor.ts
+++ b/src/persistence/SubjectExecutor.ts
@@ -609,8 +609,9 @@ export class SubjectExecutor {
                     softDeleteQueryBuilder.where(subject.identifier);
                 }
                 updateResult = await softDeleteQueryBuilder.execute();
-
+                // Move throw all the relation of the subject
                 for (const relation of subject.metadata.relations) {
+                    // Call recursive function that get the parents primary keys that in used on the inverse side in all one to many relations
                     await this.executeSoftRemoveRecursive(relation, [Reflect.get(subject.identifier, subject.metadata.primaryColumns[0].propertyName)]);
                 }
             }
@@ -644,7 +645,9 @@ export class SubjectExecutor {
      */
 
     protected async executeSoftRemoveRecursive(relation: RelationMetadata, ids: any[]): Promise<void> {
+        // We want to delete the entities just when the relation is cascade soft remove
         if (relation.isCascadeSoftRemove){
+
             let primaryPropertyName = relation.inverseEntityMetadata.primaryColumns[0].propertyName;
             let updateResult: UpdateResult;
             let softDeleteQueryBuilder = this.queryRunner
@@ -652,9 +655,11 @@ export class SubjectExecutor {
                 .createQueryBuilder()
                 .softDelete()
                 .from(relation.inverseEntityMetadata.target)
+                // We get back list of the affected rows primary keys for call again
                 .returning([primaryPropertyName])
                 .updateEntity(this.options && this.options.reload === false ? false : true)
                 .callListeners(false);
+            // soft remove only where parent id is in the list
             softDeleteQueryBuilder.where(`${relation.inverseSidePropertyPath} in (:...ids)`, {ids: ids});
             updateResult = await softDeleteQueryBuilder.execute();
             let parentIds;
@@ -666,6 +671,7 @@ export class SubjectExecutor {
                 parentIds = updateResult.raw.map((row: any) => row[Object.keys(row)[0]]);
             }
             if (parentIds.length) {
+                // This is the recursive - check the relations of the relation
                 for (const subRelation of relation.inverseEntityMetadata.relations) {
                     await this.executeSoftRemoveRecursive(subRelation, parentIds);
                 }

--- a/test/github-issues/8416/8416.ts
+++ b/test/github-issues/8416/8416.ts
@@ -1,0 +1,75 @@
+import "reflect-metadata";
+import { Connection, Repository } from "../../../src/index";
+import { reloadTestingDatabases, createTestingConnections, closeTestingConnections } from "../../utils/test-utils";
+import { expect } from "chai";
+import { Category } from "./entity/Category";
+import { Post } from "./entity/Post";
+import {Author} from "./entity/Author";
+
+describe.only("Soft Delete Recursive cascade", () => {
+
+    // -------------------------------------------------------------------------
+    // Configuration
+    // -------------------------------------------------------------------------
+
+    // connect to db
+    let connections: Connection[] = [];
+
+    before(async () => connections = await createTestingConnections({
+        entities: [__dirname + "/entity/*{.js,.ts}"],
+
+    }));
+    beforeEach(() => reloadTestingDatabases(connections));
+    after(() => closeTestingConnections(connections));
+
+    // -------------------------------------------------------------------------
+    // Specifications
+    // -------------------------------------------------------------------------
+
+    describe("when a Post is removed from a Category", () => {
+        let categoryRepository: Repository<Category>;
+        let postRepository: Repository<Post>;
+        let authorRepository: Repository<Author>;
+
+        beforeEach(async () => {
+            await Promise.all(connections.map(async connection => {
+                categoryRepository = connection.getRepository(Category);
+                postRepository = connection.getRepository(Post);
+                authorRepository = connection.getRepository(Author);
+            }));
+            const firstPost: Post = new Post();
+            firstPost.authors = [
+                new Author(),
+                new Author()
+            ];
+            const secondPost: Post = new Post();
+            secondPost.authors = [
+                new Author(),
+                new Author()
+            ];
+            const categoryToInsert = await categoryRepository.save(new Category());
+            categoryToInsert.posts = [
+                firstPost,
+                secondPost
+            ];
+
+            await categoryRepository.save(categoryToInsert);
+            let insertedCategory: Category = await categoryRepository.findOneOrFail();
+            await categoryRepository.softRemove(insertedCategory);
+        });
+
+        it("should delete the category", async () => {
+            const categoryCount = await categoryRepository.count();
+            expect(categoryCount).to.equal(0);
+        });
+
+        it("should delete the all the posts", async () => {
+            const postCount = await postRepository.count();
+            expect(postCount).to.equal(0);
+        });
+        it("should delete the all the authors", async () => {
+            const authorsCount = await authorRepository.count();
+            expect(authorsCount).to.equal(0);
+        });
+    });
+});

--- a/test/github-issues/8416/8416.ts
+++ b/test/github-issues/8416/8416.ts
@@ -47,7 +47,7 @@ describe("Soft Delete Recursive cascade", () => {
                 new Author(),
                 new Author()
             ];
-            const categoryToInsert = await categoryRepository.save(new Category());
+            const categoryToInsert = new Category();
             categoryToInsert.posts = [
                 firstPost,
                 secondPost

--- a/test/github-issues/8416/8416.ts
+++ b/test/github-issues/8416/8416.ts
@@ -6,7 +6,7 @@ import { Category } from "./entity/Category";
 import { Post } from "./entity/Post";
 import {Author} from "./entity/Author";
 
-describe.only("Soft Delete Recursive cascade", () => {
+describe("Soft Delete Recursive cascade", () => {
 
     // -------------------------------------------------------------------------
     // Configuration

--- a/test/github-issues/8416/entity/Author.ts
+++ b/test/github-issues/8416/entity/Author.ts
@@ -1,0 +1,24 @@
+import {Entity} from "../../../../src/decorator/entity/Entity";
+import {PrimaryGeneratedColumn} from "../../../../src/decorator/columns/PrimaryGeneratedColumn";
+import {Column} from "../../../../src/decorator/columns/Column";
+import {ManyToOne} from "../../../../src/decorator/relations/ManyToOne";
+import {JoinColumn} from "../../../../src/decorator/relations/JoinColumn";
+import {DeleteDateColumn} from "../../../../src";
+import {Post} from "./Post";
+
+@Entity()
+export class Author {
+
+    @PrimaryGeneratedColumn()
+    id: number;
+
+    @Column()
+    postId: string;
+
+    @ManyToOne(() => Post, post => post.authors)
+    @JoinColumn({ name: "postId" })
+    post: Post;
+
+    @DeleteDateColumn()
+    deletedAt?: Date;
+}

--- a/test/github-issues/8416/entity/Author.ts
+++ b/test/github-issues/8416/entity/Author.ts
@@ -10,7 +10,7 @@ import {Post} from "./Post";
 export class Author {
 
     @PrimaryGeneratedColumn()
-    id: number;
+    idkey: number;
 
     @Column()
     postId: string;

--- a/test/github-issues/8416/entity/Author.ts
+++ b/test/github-issues/8416/entity/Author.ts
@@ -10,7 +10,7 @@ import {Post} from "./Post";
 export class Author {
 
     @PrimaryGeneratedColumn()
-    idkey: number;
+    id: number;
 
     @Column()
     postId: string;

--- a/test/github-issues/8416/entity/Category.ts
+++ b/test/github-issues/8416/entity/Category.ts
@@ -1,0 +1,20 @@
+import {Entity} from "../../../../src/decorator/entity/Entity";
+import {PrimaryGeneratedColumn} from "../../../../src/decorator/columns/PrimaryGeneratedColumn";
+import {Post} from "./Post";
+import {OneToMany} from "../../../../src/decorator/relations/OneToMany";
+import {DeleteDateColumn} from "../../../../src";
+
+@Entity()
+export class Category {
+
+    @PrimaryGeneratedColumn()
+    id: number;
+
+    @OneToMany(() => Post, post => post.category, {
+        cascade: true
+    })
+    posts: Post[];
+
+    @DeleteDateColumn()
+    deletedAt?: Date;
+}

--- a/test/github-issues/8416/entity/Category.ts
+++ b/test/github-issues/8416/entity/Category.ts
@@ -8,7 +8,7 @@ import {DeleteDateColumn} from "../../../../src";
 export class Category {
 
     @PrimaryGeneratedColumn()
-    id: number;
+    idkey: number;
 
     @OneToMany(() => Post, post => post.category, {
         cascade: true

--- a/test/github-issues/8416/entity/Category.ts
+++ b/test/github-issues/8416/entity/Category.ts
@@ -8,7 +8,7 @@ import {DeleteDateColumn} from "../../../../src";
 export class Category {
 
     @PrimaryGeneratedColumn()
-    idkey: number;
+    id: number;
 
     @OneToMany(() => Post, post => post.category, {
         cascade: true

--- a/test/github-issues/8416/entity/Post.ts
+++ b/test/github-issues/8416/entity/Post.ts
@@ -1,0 +1,30 @@
+import {Category} from "./Category";
+import {Entity} from "../../../../src/decorator/entity/Entity";
+import {PrimaryGeneratedColumn} from "../../../../src/decorator/columns/PrimaryGeneratedColumn";
+import {Column} from "../../../../src/decorator/columns/Column";
+import {ManyToOne} from "../../../../src/decorator/relations/ManyToOne";
+import {JoinColumn} from "../../../../src/decorator/relations/JoinColumn";
+import {DeleteDateColumn, OneToMany} from "../../../../src";
+import {Author} from "./Author";
+
+@Entity()
+export class Post {
+
+    @PrimaryGeneratedColumn()
+    id: number;
+
+    @Column()
+    categoryId: string;
+
+    @ManyToOne(() => Category, category => category.posts)
+    @JoinColumn({ name: "categoryId" })
+    category: Category;
+
+    @OneToMany(() => Author, author => author.post, {
+        cascade: true
+    })
+    authors: Author[];
+
+    @DeleteDateColumn()
+    deletedAt?: Date;
+}

--- a/test/github-issues/8416/entity/Post.ts
+++ b/test/github-issues/8416/entity/Post.ts
@@ -11,7 +11,7 @@ import {Author} from "./Author";
 export class Post {
 
     @PrimaryGeneratedColumn()
-    id: number;
+    idkey: number;
 
     @Column()
     categoryId: string;

--- a/test/github-issues/8416/entity/Post.ts
+++ b/test/github-issues/8416/entity/Post.ts
@@ -11,7 +11,7 @@ import {Author} from "./Author";
 export class Post {
 
     @PrimaryGeneratedColumn()
-    idkey: number;
+    id: number;
 
     @Column()
     categoryId: string;


### PR DESCRIPTION
The soft-delete would update recursively the related entities without loading them

related to - https://github.com/typeorm/typeorm/issues/8416

### Description of change

The Problem
Today, the cascade soft delete update the related entities just if we would load all the entities that we want to soft-remove
This behavior is bad in term of performance and in addition, don't work recursively
Because there is no feature like that today, a lot of developers write soft delete flow for every entity that includes a lot of code because they need to kill the children as well, and that causes a lot of bugs

The Solution
Change the soft-remove flow to soft-remove all related entities recursively and automatically
- soft remove the entity
- get the entity relations and soft remove the inverse entities where the parent id is the first entity id
- move recursively throw the relations and soft-delete by the parent ids

I prefer to soft remove without loading all the entities and create subject to each of them because it's more efficient

Other option
Add a flag to the soft-remove function that declares that the operation should do the new logic instead of the old one

### Pull-Request Checklist


- [x] Code is up-to-date with the `master` branch
- [x] `npm run lint` passes with this change
- [x] `npm run test` passes with this change
- [x] This pull request links relevant issues as `Fixes #0000`
- [x] There are new or updated unit tests validating the change
- [x] Documentation has been updated to reflect this change
- [x] The new commits follow conventions explained in [CONTRIBUTING.md](https://github.com/typeorm/typeorm/blob/master/CONTRIBUTING.md)