### PR TITLE
Sync schema not drop columns

### DIFF
--- a/src/decorator/options/RelationOptions.ts
+++ b/src/decorator/options/RelationOptions.ts
@@ -74,6 +74,6 @@ export interface RelationOptions {
     /**
      * When a child row is removed from its parent, determines if the child row should be orphaned (default) or deleted.
      */
-    orphanedRowAction?: "nullify" | "delete";
+    orphanedRowAction?: "nullify" | "delete" | "soft-delete";
 
 }

--- a/src/entity-schema/EntitySchemaRelationOptions.ts
+++ b/src/entity-schema/EntitySchemaRelationOptions.ts
@@ -102,5 +102,5 @@ export interface EntitySchemaRelationOptions {
     /**
      * When a child row is removed from its parent, determines if the child row should be orphaned (default) or deleted.
      */
-    orphanedRowAction?: "nullify" | "delete";
+    orphanedRowAction?: "nullify" | "delete" | "soft-delete";
 }

--- a/src/metadata/RelationMetadata.ts
+++ b/src/metadata/RelationMetadata.ts
@@ -113,7 +113,7 @@ export class RelationMetadata {
     /**
      * When a child row is removed from its parent, determines if the child row should be orphaned (default) or deleted.
      */
-    orphanedRowAction?: "nullify" | "delete";
+    orphanedRowAction?: "nullify" | "delete" | "soft-delete";
 
     /**
      * If set to true then related objects are allowed to be inserted to the database.

--- a/src/persistence/subject-builder/OneToManySubjectBuilder.ts
+++ b/src/persistence/subject-builder/OneToManySubjectBuilder.ts
@@ -184,7 +184,10 @@ export class OneToManySubjectBuilder {
                 } else if (relation.inverseRelation.orphanedRowAction === "delete") {
                     removedRelatedEntitySubject.mustBeRemoved = true;
                 }
-
+                else if (relation.inverseRelation.orphanedRowAction === "soft-delete") {
+                    removedRelatedEntitySubject.canBeSoftRemoved = true;
+                }
+                
                 this.subjects.push(removedRelatedEntitySubject);
             });
     }

--- a/test/github-issues/8408/delete-orphans.ts
+++ b/test/github-issues/8408/delete-orphans.ts
@@ -1,0 +1,73 @@
+import "reflect-metadata";
+import { Connection, Repository } from "../../../src/index";
+import { reloadTestingDatabases, createTestingConnections, closeTestingConnections } from "../../utils/test-utils";
+import { expect } from "chai";
+import { Category } from "./entity/Category";
+import { Post } from "./entity/Post";
+
+describe("persistence > delete orphans", () => {
+
+    // -------------------------------------------------------------------------
+    // Configuration
+    // -------------------------------------------------------------------------
+
+    // connect to db
+    let connections: Connection[] = [];
+
+    before(async () => connections = await createTestingConnections({
+        entities: [__dirname + "/entity/*{.js,.ts}"],
+
+    }));
+    beforeEach(() => reloadTestingDatabases(connections));
+    after(() => closeTestingConnections(connections));
+
+    // -------------------------------------------------------------------------
+    // Specifications
+    // -------------------------------------------------------------------------
+
+    describe("when a Post is removed from a Category", () => {
+        let categoryRepository: Repository<Category>;
+        let postRepository: Repository<Post>;
+        let categoryId: number;
+
+        beforeEach(async () => {
+            await Promise.all(connections.map(async connection => {
+                categoryRepository = connection.getRepository(Category);
+                postRepository = connection.getRepository(Post);
+            }));
+
+            const categoryToInsert = await categoryRepository.save(new Category());
+            categoryToInsert.posts = [
+                new Post(),
+                new Post()
+            ];
+
+            await categoryRepository.save(categoryToInsert);
+            categoryId = categoryToInsert.id;
+
+            const categoryToUpdate = (await categoryRepository.findOne(categoryId))!;
+            categoryToUpdate.posts = categoryToInsert.posts.filter(p => p.id === 1); // Keep the first post
+
+            await categoryRepository.save(categoryToUpdate);
+        });
+
+        it("should retain a Post on the Category", async () => {
+            const category = await categoryRepository.findOne(categoryId);
+            expect(category).not.to.be.undefined;
+            expect(category!.posts).to.have.lengthOf(1);
+            expect(category!.posts[0].id).to.equal(1);
+        });
+
+        it("should delete the orphaned Post from the database", async () => {
+            const postCount = await postRepository.count();
+            expect(postCount).to.equal(1);
+        });
+
+        it("should retain foreign keys on remaining Posts", async () => {
+            const postsWithoutForeignKeys = (await postRepository.find())
+                .filter(p => !p.categoryId);
+            expect(postsWithoutForeignKeys).to.have.lengthOf(0);
+        });
+    });
+
+});

--- a/test/github-issues/8408/entity/Category.ts
+++ b/test/github-issues/8408/entity/Category.ts
@@ -1,0 +1,18 @@
+import {Entity} from "../../../../src/decorator/entity/Entity";
+import {PrimaryGeneratedColumn} from "../../../../src/decorator/columns/PrimaryGeneratedColumn";
+import {Post} from "./Post";
+import {OneToMany} from "../../../../src/decorator/relations/OneToMany";
+
+@Entity()
+export class Category {
+
+    @PrimaryGeneratedColumn()
+    id: number;
+
+    @OneToMany(() => Post, post => post.category, {
+        cascade: true,
+        eager: true
+    })
+    posts: Post[];
+
+}

--- a/test/github-issues/8408/entity/Post.ts
+++ b/test/github-issues/8408/entity/Post.ts
@@ -1,0 +1,21 @@
+import {Category} from "./Category";
+import {Entity} from "../../../../src/decorator/entity/Entity";
+import {PrimaryGeneratedColumn} from "../../../../src/decorator/columns/PrimaryGeneratedColumn";
+import {Column} from "../../../../src/decorator/columns/Column";
+import {ManyToOne} from "../../../../src/decorator/relations/ManyToOne";
+import {JoinColumn} from "../../../../src/decorator/relations/JoinColumn";
+
+@Entity()
+export class Post {
+
+    @PrimaryGeneratedColumn()
+    id: number;
+
+    @Column()
+    categoryId: string;
+
+    @ManyToOne(() => Category, category => category.posts, { orphanedRowAction: "soft-delete" })
+    @JoinColumn({ name: "categoryId" })
+    category: Category;
+
+}


### PR DESCRIPTION
### Description of change

set synchronization option to not drop columns but only add columns when initializing

related to - https://github.com/typeorm/typeorm/issues/2196

It is very easy to get this wrong and/or make a mistake. synchronization should not drop columns - especially with existing data

Alternatively, we can give an option to the user to decide what to do and what not in the synchronization

### Pull-Request Checklist


- [X] Code is up-to-date with the `master` branch
- [X] `npm run lint` passes with this change
- [X] `npm run test` passes with this change
- [X] This pull request links relevant issues as `Fixes #0000`
- [X] There are new or updated unit tests validating the change
- [X] Documentation has been updated to reflect this change
- [X] The new commits follow conventions explained in [CONTRIBUTING.md]