### PR TITLE
fix: include asExpression columns in returning clause

### DIFF
--- a/src/metadata/ColumnMetadata.ts
+++ b/src/metadata/ColumnMetadata.ts
@@ -81,7 +81,7 @@ export class ColumnMetadata {
     isPrimary: boolean = false;
 
     /**
-     * Indicates if this column is generated (auto increment or generated other way).
+     * Indicates if this column is generated (auto increment or other `generationStrategy`).
      */
     isGenerated: boolean = false;
 

--- a/src/query-builder/ReturningResultsEntityUpdator.ts
+++ b/src/query-builder/ReturningResultsEntityUpdator.ts
@@ -178,7 +178,10 @@ export class ReturningResultsEntityUpdator {
         // filter out the columns of which we need database inserted values to update our entity
         return this.expressionMap.mainAlias!.metadata.columns.filter(column => {
             return  column.default !== undefined ||
-                    (needToCheckGenerated && column.isGenerated)  ||
+                    (needToCheckGenerated &&
+                        column.isGenerated ||
+                        !!column.asExpression
+                    ) ||
                     column.isCreateDate ||
                     column.isUpdateDate ||
                     column.isDeleteDate ||

--- a/src/schema-builder/table/TableColumn.ts
+++ b/src/schema-builder/table/TableColumn.ts
@@ -35,7 +35,7 @@ export class TableColumn {
     isNullable: boolean = false;
 
     /**
-     * Indicates if column is auto-generated sequence.
+     * Indicates if column is generated (auto increment or other `generationStrategy`).
      */
     isGenerated: boolean = false;
 

--- a/test/github-issues/8450/entity/UserEntity.ts
+++ b/test/github-issues/8450/entity/UserEntity.ts
@@ -1,11 +1,11 @@
 import {Entity} from "../../../../src/decorator/entity/Entity";
-import {PrimaryGeneratedColumn} from "../../../../src/decorator/columns/PrimaryGeneratedColumn";
+import {PrimaryColumn} from "../../../../src/decorator/columns/PrimaryColumn";
 import {Column} from "../../../../src/decorator/columns/Column";
 
 @Entity("user")
 export class UserEntity {
 
-    @PrimaryGeneratedColumn()
+    @PrimaryColumn("int")
     id: number;
 
     @Column({

--- a/test/github-issues/8450/entity/UserEntity.ts
+++ b/test/github-issues/8450/entity/UserEntity.ts
@@ -1,0 +1,18 @@
+import {Entity} from "../../../../src/decorator/entity/Entity";
+import {PrimaryGeneratedColumn} from "../../../../src/decorator/columns/PrimaryGeneratedColumn";
+import {Column} from "../../../../src/decorator/columns/Column";
+
+@Entity("user")
+export class UserEntity {
+
+    @PrimaryGeneratedColumn()
+    id: number;
+
+    @Column({
+        type: "int",
+        generatedType: "STORED",
+        asExpression: "id * 2",
+    })
+    generated: number;
+
+}

--- a/test/github-issues/8450/issue-8450.ts
+++ b/test/github-issues/8450/issue-8450.ts
@@ -4,17 +4,19 @@ import {Connection} from "../../../src/connection/Connection";
 import {UserEntity} from "./entity/UserEntity";
 import {expect} from "chai";
 
-describe("github issues > #8450 Generated column not in RETURNING clause on save - PostgreSQL database", () => {
+describe("github issues > #8450 Generated column not in RETURNING clause on save", () => {
 
     let connections: Connection[];
     before(async () => connections = await createTestingConnections({
         entities: [__dirname + "/entity/*{.js,.ts}"],
+        enabledDrivers: ["postgres", "mysql"]
     }));
     beforeEach(() => reloadTestingDatabases(connections));
     after(() => closeTestingConnections(connections));
 
     it("should populate an object with generated column values after saving", () => Promise.all(connections.map(async connection => {
         const user = new UserEntity();
+        user.id = 100;
 
         expect(user.generated).to.be.undefined;
 

--- a/test/github-issues/8450/issue-8450.ts
+++ b/test/github-issues/8450/issue-8450.ts
@@ -1,0 +1,29 @@
+import "reflect-metadata";
+import {closeTestingConnections, createTestingConnections, reloadTestingDatabases} from "../../utils/test-utils";
+import {Connection} from "../../../src/connection/Connection";
+import {UserEntity} from "./entity/UserEntity";
+import {expect} from "chai";
+
+describe("github issues > #8450 Generated column not in RETURNING clause on save - PostgreSQL database", () => {
+
+    let connections: Connection[];
+    before(async () => connections = await createTestingConnections({
+        entities: [__dirname + "/entity/*{.js,.ts}"],
+    }));
+    beforeEach(() => reloadTestingDatabases(connections));
+    after(() => closeTestingConnections(connections));
+
+    it("should populate an object with generated column values after saving", () => Promise.all(connections.map(async connection => {
+        const user = new UserEntity();
+
+        expect(user.generated).to.be.undefined;
+
+        await connection.manager.save(user);
+
+        expect(user.id).not.to.be.undefined;
+        expect(user.id).to.be.a("number");
+        expect(user.generated).to.be.a("number");
+        expect(user.generated).to.be.equal(user.id * 2);
+    })));
+
+});

--- a/test/github-issues/8450/issue-8450.ts
+++ b/test/github-issues/8450/issue-8450.ts
@@ -22,8 +22,6 @@ describe("github issues > #8450 Generated column not in RETURNING clause on save
 
         await connection.manager.save(user);
 
-        expect(user.id).not.to.be.undefined;
-        expect(user.id).to.be.a("number");
         expect(user.generated).to.be.a("number");
         expect(user.generated).to.be.equal(user.id * 2);
     })));


### PR DESCRIPTION
<!--
  😀 Wonderful!  Thank you for opening a pull request for TypeORM.

  Please fill in the information below to expedite the review
  and (hopefully) merge of your change.

  If unsure about something.. just do as best as you're able,
  or reach out through our community support channels!
  https://github.com/typeorm/typeorm/blob/master/docs/support.md
-->

### Description

Fixes #8450 

It is a bit unclear wether the `isGenerated` property on `TableColumn` and `ColumnMetadata` (and possibly in more places) should be set _only_ if `generationStrategy` is defined as well. The property description in the `ColumnMetadata` class mentions it is meant for columns of "generated other way" (I read this as "any type of generation", including `asExpression`), but most of the code that utilizes the `isGenerated` field often does not adhere to this.
https://github.com/typeorm/typeorm/blob/cefddd95c550191d6a18cb53c8ea4995d0c219ca/src/metadata/ColumnMetadata.ts#L83-L86
Perhaps this comment refers only to _other generation strategies_, like `uuid`?

I could think of two ways to solve the issue:
1. If the `isGenerated` property is not restricted to generation strategies: go through all references of `isGenerated` and confirm or rewrite parts to make `isGenerated` a universal indicator for columns that are generated in some way.
2. Make it clear that `isGenerated` should only be used for generation strategies. The fix to the actual issue would then be simple: change line 181 of the condition below to
```ts
(needToCheckGenerated && (column.isGenerated || !!column.asExpression))  ||
```
https://github.com/typeorm/typeorm/blob/90a8deb6383c31686965893cdea96151f40be396/src/query-builder/ReturningResultsEntityUpdator.ts#L172-L187
This makes it such that columns with an `asExpression` are also included in the `RETURNING` clause when saving an entity.

<!--
  Please be clear and concise what the change is intended to do,
  why this change is needed, and how you've verified that it
  corrects what you intended.

  In some cases it may be helpful to include the current behavior
  and the new behavior.

  If the change is related to an open issue, you can link it here.
  If you include `Fixes #0000` (replacing `0000` with the issue number)
  when this is merged it will automatically mark the issue as fixed and
  close it.
-->


### Pull-Request Checklist

<!--
  Please make sure to review and check all of the following.

  If an item is not applicable, you can add "N/A" to the end.
-->

- [X] Code is up-to-date with the `master` branch
- [x] `npm run lint` passes with this change
- [ ] `npm run test` passes with this change
- [X] This pull request links relevant issues as `Fixes #0000`
- [X] There are new or updated unit tests validating the change
- [X] Documentation has been updated to reflect this change 
  (I updated documentation in the source files, not docs directory)
- [x] The new commits follow conventions explained in [CONTRIBUTING.md](https://github.com/typeorm/typeorm/blob/master/CONTRIBUTING.md)

<!--
  🎉 Thank you for contributing and making TypeORM even better!
-->
