### PR TITLE
fix: must invoke key pragma before do any other interaction with the sqlite

### DIFF
--- a/src/driver/sqlite/SqliteDriver.ts
+++ b/src/driver/sqlite/SqliteDriver.ts
@@ -107,6 +107,11 @@ export class SqliteDriver extends AbstractSqliteDriver {
                 });
             });
         }
+        // in the options, if encryption key for SQLCipher is setted.
+        // Must invoke key pragma before trying to do any other interaction with the database.
+        if (this.options.key) {
+            await run(`PRAGMA key = ${JSON.stringify(this.options.key)};`);
+        }
 
         if (this.options.enableWAL) {
             await run(`PRAGMA journal_mode = WAL;`);
@@ -115,11 +120,6 @@ export class SqliteDriver extends AbstractSqliteDriver {
         // we need to enable foreign keys in sqlite to make sure all foreign key related features
         // working properly. this also makes onDelete to work with sqlite.
         await run(`PRAGMA foreign_keys = ON;`);
-
-        // in the options, if encryption key for SQLCipher is setted.
-        if (this.options.key) {
-            await run(`PRAGMA key = ${JSON.stringify(this.options.key)};`);
-        }
 
         return databaseConnection;
     }


### PR DESCRIPTION
fix: must invoke key pragma before trying to do any other interaction with the sqlite

See documentation: [SQLite Encryption Extension](https://www.sqlite.org/see/doc/release/www/readme.wiki)

> Using the "key" PRAGMA
> You must invoke this pragma before trying to do any other interaction with the database. 

Closed: #8475

<!--
  😀 Wonderful!  Thank you for opening a pull request for TypeORM.

  Please fill in the information below to expedite the review
  and (hopefully) merge of your change.

  If unsure about something.. just do as best as you're able,
  or reach out through our community support channels!
  https://github.com/typeorm/typeorm/blob/master/docs/support.md
-->

### Description of change

<!--
  Please be clear and concise what the change is intended to do,
  why this change is needed, and how you've verified that it
  corrects what you intended.

  In some cases it may be helpful to include the current behavior
  and the new behavior.

  If the change is related to an open issue, you can link it here.
  If you include `Fixes #0000` (replacing `0000` with the issue number)
  when this is merged it will automatically mark the issue as fixed and
  close it.
-->


### Pull-Request Checklist

<!--
  Please make sure to review and check all of the following.

  If an item is not applicable, you can add "N/A" to the end.
-->

- [x] Code is up-to-date with the `master` branch
- [x] `npm run lint` passes with this change
- [x] `npm run test` passes with this change
- [x] This pull request links relevant issues as `Fixes #8475`
- [x] There are new or updated unit tests validating the change
- [x] Documentation has been updated to reflect this change
- [x] The new commits follow conventions explained in [CONTRIBUTING.md](https://github.com/typeorm/typeorm/blob/master/CONTRIBUTING.md)

<!--
  🎉 Thank you for contributing and making TypeORM even better!
-->
