### PR TITLE
docs: update listeners/subscribers documentation

### DIFF
--- a/docs/listeners-and-subscribers.md
+++ b/docs/listeners-and-subscribers.md
@@ -9,11 +9,14 @@
     * [`@BeforeRemove`](#beforeremove)
     * [`@AfterRemove`](#afterremove)
 * [What is a Subscriber](#what-is-a-subscriber)
+    * [`Event Object`](#event-object)
 
 ## What is an Entity Listener
 
 Any of your entities can have methods with custom logic that listen to specific entity events.
 You must mark those methods with special decorators depending on what event you want to listen to.
+
+**Note:** Do not make any database calls within a listener, opt for [subscribers](#what-is-a-subscriber) instead.
 
 ### `@AfterLoad`
 
@@ -266,3 +269,15 @@ export class PostSubscriber implements EntitySubscriberInterface {
 ```
 
 Make sure your `subscribers` property is set in your [Connection Options](./connection-options.md#common-connection-options) so TypeORM loads your subscriber.
+
+### `Event Object`
+
+Excluding `listenTo`, all `EntitySubscriberInterface` methods are passed an event object that has the following base properties:
+
+- `connection: Connection` - Connection used in the event.
+- `queryRunner: QueryRunner` - QueryRunner used in the event transaction.
+- `manager: EntityManager` - EntityManager used in the event transaction.
+
+See each [Event's interface](https://github.com/typeorm/typeorm/tree/master/src/subscriber/event) for additional properties.
+
+**Note:** All database operations in the subscribed event listeners should be performed using the event object's `queryRunner` or `manager` instance.


### PR DESCRIPTION
Add documentation on base properties for subscriber's event object.
Add note to listeners about not running database calls.

<!--
  😀 Wonderful!  Thank you for opening a pull request for TypeORM.

  Please fill in the information below to expedite the review
  and (hopefully) merge of your change.

  If unsure about something.. just do as best as you're able,
  or reach out through our community support channels!
  https://github.com/typeorm/typeorm/blob/master/docs/support.md
-->

### Description of change

<!--
  Please be clear and concise what the change is intended to do,
  why this change is needed, and how you've verified that it
  corrects what you intended.

  In some cases it may be helpful to include the current behavior
  and the new behavior.

  If the change is related to an open issue, you can link it here.
  If you include `Fixes #0000` (replacing `0000` with the issue number)
  when this is merged it will automatically mark the issue as fixed and
  close it.
-->

I have seen people incorrectly use database calls inside listeners, including myself, leading to unresponsiveness. This is because the original QueryRunner used in the event that triggers the listeners is not released until after the broadcasting methods are finished.

This might be obvious to some, but I didn't realize this until after exploring the TypeORM code base further. This PR updates the documentation to add a note not to make database calls in listeners and instead opt for subscribers. The subscriber event methods all receive the event object that contains the original QueryRunner/EntityManager instance which when used  solves the race condition issue. 

The reason listeners don't get the event object is explained here: https://github.com/typeorm/typeorm/issues/319

Example of issue: (an express api)

- Your application has a connection limit of 10. 
- Route A uses QueryBuilder to load a single Post entity that has a listener which makes a database call.

You put Route A under a heavy load and there is a race condition to when 10 connections are being used to load the Post entity, each then trying to call the listener which attempts to fetch a new connection from the pool but there is none available, thus putting TypeORM/the application into an unresponsive state.

I am only familiar with MySQL and I don't believe there is a timeout for connection requests in the queue, so other drivers might solve this issue (although a timeout error doesn't seem like a solution). 

Related issue: https://github.com/typeorm/typeorm/issues/6779

### Pull-Request Checklist

<!--
  Please make sure to review and check all of the following.

  If an item is not applicable, you can add "N/A" to the end.
-->

- [x] Code is up-to-date with the `master` branch
- [] `npm run lint` passes with this change
- [] `npm run test` passes with this change
- [] This pull request links relevant issues as `Fixes #0000`
- [] There are new or updated unit tests validating the change
- [x] Documentation has been updated to reflect this change
- [x] The new commits follow conventions explained in [CONTRIBUTING.md](https://github.com/typeorm/typeorm/blob/master/CONTRIBUTING.md)

<!--
  🎉 Thank you for contributing and making TypeORM even better!
-->
