### PR TITLE
Adding undocumented behavior to find-options doc

### DIFF
--- a/docs/find-options.md
+++ b/docs/find-options.md
@@ -266,6 +266,18 @@ userRepository.find({
 });
 ```
 
+If `undefined` is passed as an argument, find will return all items in the table, and findOne will return the first item in the table.
+```ts
+userRepository.find(undefined);
+
+```
+
+will execute following query:
+
+```sql
+SELECT * FROM "user"
+```
+
 ## Advanced options
 
 TypeORM provides a lot of built-in operators that can be used to create more complex comparisons:


### PR DESCRIPTION
### Description of change

Fixes #8495, adds documentation to find-options stating that when undefined is passed to find, all items in the table will be returned, and if undefined is passed to findOne the first item in the table will be returned. There is also an example SQL statement to give readers a better idea of what is being executed when undefined is passed.

### Pull-Request Checklist

- [x] Code is up-to-date with the `master` branch
- [ ] `npm run lint` passes with this change N/A (This change only modifies the documentation)
- [ ] `npm run test` passes with this change N/A (This change only modifies the documentation)
- [x] This pull request links relevant issues as `Fixes #0000`
- [ ] There are new or updated unit tests validating the change N/A (This change only modifies the documentation)
- [x] Documentation has been updated to reflect this change
- [x] The new commits follow conventions explained in [CONTRIBUTING.md](https://github.com/typeorm/typeorm/blob/master/CONTRIBUTING.md)