### PR TITLE
feat: add custom timestamp option in migration creation

### DIFF
--- a/docs/migrations.md
+++ b/docs/migrations.md
@@ -225,6 +225,16 @@ If you need to run/revert your migrations for another connection rather than the
 typeorm -c <your-config-name> migration:{run|revert}
 ```
 
+## Timestamp option
+If you need to specify a timestamp for the migration name, use the `-t` (alias for `--timestamp`) and pass the timestamp (should be a non-negative number)
+```
+typeorm -t <specific-timestamp> migration:{create|generate}
+```
+You can get a timestamp from:
+```js
+Date.now(); /* OR */ new Date().getTime();
+```
+
 ## Using migration API to write migrations
 
 In order to use an API to change a database schema you can use `QueryRunner`.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,11 @@
 {
   "name": "typeorm",
-  "version": "0.2.39",
+  "version": "0.2.41",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
-      "name": "typeorm",
-      "version": "0.2.39",
+      "version": "0.2.41",
       "license": "MIT",
       "dependencies": {
         "@sqltools/formatter": "^1.2.2",

--- a/src/commands/CommandUtils.ts
+++ b/src/commands/CommandUtils.ts
@@ -46,9 +46,9 @@ export class CommandUtils {
      * Gets migration timestamp and validates argument (if sent)
      */
     static getTimestamp(timestampOptionArgument: any): number {
-        if (timestampOptionArgument && isNaN(timestampOptionArgument)) {
-            throw new TypeORMError(`timestamp option should be a number. received: "${timestampOptionArgument}"`);
+        if (timestampOptionArgument && (isNaN(timestampOptionArgument) || timestampOptionArgument < 0)) {
+            throw new TypeORMError(`timestamp option should be a non-negative number. received: ${timestampOptionArgument}`);
         }
-        return (timestampOptionArgument ? new Date(Number(timestampOptionArgument)) : new Date()).getTime();
+        return timestampOptionArgument ? new Date(Number(timestampOptionArgument)).getTime() : Date.now();
     }
 }

--- a/src/commands/CommandUtils.ts
+++ b/src/commands/CommandUtils.ts
@@ -1,6 +1,7 @@
 import * as fs from "fs";
 import * as path from "path";
 import mkdirp from "mkdirp";
+import {TypeORMError} from "../error";
 
 /**
  * Command line utils functions.
@@ -39,5 +40,15 @@ export class CommandUtils {
 
     static async fileExists(filePath: string) {
         return fs.existsSync(filePath);
+    }
+
+    /**
+     * Gets migration timestamp and validates argument (if sent)
+     */
+    static getTimestamp(timestampOptionArgument: any): number {
+        if (timestampOptionArgument && isNaN(timestampOptionArgument)) {
+            throw new TypeORMError(`timestamp option should be a number. received: "${timestampOptionArgument}"`);
+        }
+        return (timestampOptionArgument ? new Date(Number(timestampOptionArgument)) : new Date()).getTime();
     }
 }

--- a/src/commands/MigrationCreateCommand.ts
+++ b/src/commands/MigrationCreateCommand.ts
@@ -39,6 +39,12 @@ export class MigrationCreateCommand implements yargs.CommandModule {
                 type: "boolean",
                 default: false,
                 describe: "Generate a migration file on Javascript instead of Typescript",
+            })
+            .option("t", {
+                alias: "timestamp",
+                type: "number",
+                default: false,
+                describe: "Custom timestamp for the migration name",
             });
     }
 
@@ -48,7 +54,7 @@ export class MigrationCreateCommand implements yargs.CommandModule {
         }
 
         try {
-            const timestamp = new Date().getTime();
+            const timestamp = CommandUtils.getTimestamp(args.timestamp);
             const fileContent = args.outputJs ?
                 MigrationCreateCommand.getJavascriptTemplate(args.name as any, timestamp)
                 : MigrationCreateCommand.getTemplate(args.name as any, timestamp);

--- a/src/commands/MigrationGenerateCommand.ts
+++ b/src/commands/MigrationGenerateCommand.ts
@@ -60,6 +60,12 @@ export class MigrationGenerateCommand implements yargs.CommandModule {
                 type: "boolean",
                 default: false,
                 describe: "Verifies that the current database is up to date and that no migrations are needed. Otherwise exits with code 1.",
+            })
+            .option("t", {
+                alias: "timestamp",
+                type: "number",
+                default: false,
+                describe: "Custom timestamp for the migration name",
             });
     }
 
@@ -68,7 +74,7 @@ export class MigrationGenerateCommand implements yargs.CommandModule {
             console.log("'migrations:generate' is deprecated, please use 'migration:generate' instead");
         }
 
-        const timestamp = new Date().getTime();
+        const timestamp = CommandUtils.getTimestamp(args.timestamp);
         const extension = args.outputJs ? ".js" : ".ts";
         const filename = timestamp + "-" + args.name + extension;
         let directory = args.dir as string | undefined;

--- a/test/functional/commands/templates/result-templates-create.ts
+++ b/test/functional/commands/templates/result-templates-create.ts
@@ -19,5 +19,16 @@ module.exports = class testMigration1610975184784 {
 
     async down(queryRunner) {
     }
-}`
+}`,
+    timestamp: `import {MigrationInterface, QueryRunner} from "typeorm";
+
+export class testMigration1641163894670 implements MigrationInterface {
+
+    public async up(queryRunner: QueryRunner): Promise<void> {
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<void> {
+    }
+
+}`,
 };

--- a/test/functional/commands/templates/result-templates-generate.ts
+++ b/test/functional/commands/templates/result-templates-generate.ts
@@ -25,5 +25,19 @@ module.exports = class testMigration1610975184784 {
     async down(queryRunner) {
         await queryRunner.query(\`DROP TABLE \\\`post\\\`\`);
     }
+}`,
+    timestamp: `import {MigrationInterface, QueryRunner} from "typeorm";
+
+export class testMigration1641163894670 implements MigrationInterface {
+    name = 'testMigration1641163894670'
+
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(\`CREATE TABLE \\\`post\\\` (\\\`id\\\` int NOT NULL AUTO_INCREMENT, \\\`title\\\` varchar(255) NOT NULL, \\\`createdAt\\\` datetime(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6), PRIMARY KEY (\\\`id\\\`)) ENGINE=InnoDB\`);
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(\`DROP TABLE \\\`post\\\`\`);
+    }
+
 }`
 };


### PR DESCRIPTION
An option in the CLI to specify a custom timestamp when creating or generating a migration.

Closes: #8500

<!--
  😀 Wonderful!  Thank you for opening a pull request for TypeORM.

  Please fill in the information below to expedite the review
  and (hopefully) merge of your change.

  If unsure about something.. just do as best as you're able,
  or reach out through our community support channels!
  https://github.com/typeorm/typeorm/blob/master/docs/support.md
-->

### Description of change

<!--
  Please be clear and concise what the change is intended to do,
  why this change is needed, and how you've verified that it
  corrects what you intended.

  In some cases it may be helpful to include the current behavior
  and the new behavior.

  If the change is related to an open issue, you can link it here.
  If you include `Fixes #0000` (replacing `0000` with the issue number)
  when this is merged it will automatically mark the issue as fixed and
  close it.
-->
An option in the CLI to specify a custom timestamp when creating / generating a migration.

### Pull-Request Checklist

<!--
  Please make sure to review and check all of the following.

  If an item is not applicable, you can add "N/A" to the end.
-->

- [x] Code is up-to-date with the `master` branch
- [x] `npm run lint` passes with this change
- [x] `npm run test` passes with this change
- [x] This pull request links relevant issues as `Fixes #0000`
- [x] There are new or updated unit tests validating the change
- [x] Documentation has been updated to reflect this change
- [x] The new commits follow conventions explained in [CONTRIBUTING.md](https://github.com/typeorm/typeorm/blob/master/CONTRIBUTING.md)

<!--
  🎉 Thank you for contributing and making TypeORM even better!
-->
