### PR TITLE
fix: add lock clause for MSSQL select, select with join clause

### DIFF
--- a/src/query-builder/SelectQueryBuilder.ts
+++ b/src/query-builder/SelectQueryBuilder.ts
@@ -1437,21 +1437,6 @@ export class SelectQueryBuilder<Entity> extends QueryBuilder<Entity> implements 
         if (allSelects.length === 0)
             allSelects.push({ selection: "*" });
 
-        let lock: string = "";
-        if (this.connection.driver instanceof SqlServerDriver) {
-            switch (this.expressionMap.lockMode) {
-                case "pessimistic_read":
-                    lock = " WITH (HOLDLOCK, ROWLOCK)";
-                    break;
-                case "pessimistic_write":
-                    lock = " WITH (UPDLOCK, ROWLOCK)";
-                    break;
-                case "dirty_read":
-                    lock = " WITH (NOLOCK)";
-                    break;
-            }
-        }
-
         // Use certain index
         let useIndex: string = "";
         if (this.expressionMap.useIndex) {
@@ -1473,7 +1458,7 @@ export class SelectQueryBuilder<Entity> extends QueryBuilder<Entity> implements 
         const select = this.createSelectDistinctExpression();
         const selection = allSelects.map(select => select.selection + (select.aliasName ? " AS " + this.escape(select.aliasName) : "")).join(", ");
 
-        return select + selection + " FROM " + froms.join(", ") + lock + useIndex;
+        return select + selection + " FROM " + froms.join(", ") + this.createSqlServerSelectLockExpression() + useIndex;
     }
 
     /**
@@ -1528,7 +1513,7 @@ export class SelectQueryBuilder<Entity> extends QueryBuilder<Entity> implements 
             // table to join, without junction table involved. This means we simply join direct table.
             if (!parentAlias || !relation) {
                 const destinationJoin = joinAttr.alias.subQuery ? joinAttr.alias.subQuery : this.getTableName(destinationTableName);
-                return " " + joinAttr.direction + " JOIN " + destinationJoin + " " + this.escape(destinationTableAlias) +
+                return " " + joinAttr.direction + " JOIN " + destinationJoin + " " + this.escape(destinationTableAlias) + this.createSqlServerSelectLockExpression() +
                     (joinAttr.condition ? " ON " + this.replacePropertyNames(joinAttr.condition) : "");
             }
 
@@ -1541,7 +1526,7 @@ export class SelectQueryBuilder<Entity> extends QueryBuilder<Entity> implements 
                         parentAlias + "." + relation.propertyPath + "." + joinColumn.referencedColumn!.propertyPath;
                 }).join(" AND ");
 
-                return " " + joinAttr.direction + " JOIN " + this.getTableName(destinationTableName) + " " + this.escape(destinationTableAlias) + " ON " + this.replacePropertyNames(condition + appendedCondition);
+                return " " + joinAttr.direction + " JOIN " + this.getTableName(destinationTableName) + " " + this.escape(destinationTableAlias) + this.createSqlServerSelectLockExpression() + " ON " + this.replacePropertyNames(condition + appendedCondition);
 
             } else if (relation.isOneToMany || relation.isOneToOneNotOwner) {
 
@@ -1555,7 +1540,7 @@ export class SelectQueryBuilder<Entity> extends QueryBuilder<Entity> implements 
                         parentAlias + "." + joinColumn.referencedColumn!.propertyPath;
                 }).join(" AND ");
 
-                return " " + joinAttr.direction + " JOIN " + this.getTableName(destinationTableName) + " " + this.escape(destinationTableAlias) + " ON " + this.replacePropertyNames(condition + appendedCondition);
+                return " " + joinAttr.direction + " JOIN " + this.getTableName(destinationTableName) + " " + this.escape(destinationTableAlias) + this.createSqlServerSelectLockExpression() + " ON " + this.replacePropertyNames(condition + appendedCondition);
 
             } else { // means many-to-many
                 const junctionTableName = relation.junctionEntityMetadata!.tablePath;
@@ -1587,8 +1572,8 @@ export class SelectQueryBuilder<Entity> extends QueryBuilder<Entity> implements 
                     }).join(" AND ");
                 }
 
-                return " " + joinAttr.direction + " JOIN " + this.getTableName(junctionTableName) + " " + this.escape(junctionAlias) + " ON " + this.replacePropertyNames(junctionCondition) +
-                    " " + joinAttr.direction + " JOIN " + this.getTableName(destinationTableName) + " " + this.escape(destinationTableAlias) + " ON " + this.replacePropertyNames(destinationCondition + appendedCondition);
+                return " " + joinAttr.direction + " JOIN " + this.getTableName(junctionTableName) + " " + this.escape(junctionAlias) + this.createSqlServerSelectLockExpression() + " ON "  + this.replacePropertyNames(junctionCondition) +
+                    " " + joinAttr.direction + " JOIN " + this.getTableName(destinationTableName) + " " + this.escape(destinationTableAlias) + this.createSqlServerSelectLockExpression() + " ON " + this.replacePropertyNames(destinationCondition + appendedCondition);
 
             }
         });
@@ -1691,6 +1676,28 @@ export class SelectQueryBuilder<Entity> extends QueryBuilder<Entity> implements 
         }
 
         return "";
+    }
+
+    /**
+     * Creates "LOCK" part of SELECT Query
+     */
+    private createSqlServerSelectLockExpression(): string {
+        let lock = "";
+        if(this.connection.driver instanceof SqlServerDriver) {
+            switch (this.expressionMap.lockMode) {
+                case "pessimistic_read":
+                    lock = " WITH (HOLDLOCK, ROWLOCK)";
+                    break;
+                case "pessimistic_write":
+                    lock = " WITH (UPDLOCK, ROWLOCK)";
+                    break;
+                case "dirty_read":
+                    lock = " WITH (NOLOCK)";
+                    break;
+            }
+        }
+
+        return lock;
     }
 
     /**

--- a/test/github-issues/4764/entity/AdminUser.ts
+++ b/test/github-issues/4764/entity/AdminUser.ts
@@ -1,0 +1,19 @@
+import { Column, Entity, PrimaryGeneratedColumn } from "../../../../src";
+
+@Entity()
+export class AdminUser {
+    @PrimaryGeneratedColumn()
+    id!: number;
+
+    @Column()
+    email!: number;
+
+    @Column()
+    scopes!: string;
+
+    @Column()
+    name!: string;
+
+    @Column()
+    unid!: number;
+}

--- a/test/github-issues/4764/entity/Cart.ts
+++ b/test/github-issues/4764/entity/Cart.ts
@@ -1,0 +1,29 @@
+import { Column, Entity, OneToMany, PrimaryGeneratedColumn } from "../../../../src";
+import { CartItems } from "./CartItems";
+
+@Entity()
+export class Cart {
+    @PrimaryGeneratedColumn()
+    ID!: number;
+
+    @Column()
+    UNID!: number;
+
+    @Column()
+    Type!: string;
+
+    @Column()
+    Cycle?: number;
+
+    @Column()
+    Term?: string;
+
+    @Column()
+    RegDate!: Date;
+
+    @Column()
+    ModifiedDate!: Date;
+
+    @OneToMany((type) => CartItems, (t) => t.Cart)
+    CartItems?: CartItems[];
+}

--- a/test/github-issues/4764/entity/CartItems.ts
+++ b/test/github-issues/4764/entity/CartItems.ts
@@ -1,0 +1,30 @@
+import { Column, Entity, JoinColumn, ManyToOne, PrimaryGeneratedColumn } from "../../../../src";
+import { Cart } from "./Cart";
+
+@Entity()
+export class CartItems {
+    @PrimaryGeneratedColumn()
+    ID!: number;
+
+    @Column()
+    CartID!: number;
+
+    @Column()
+    ItemID!: number;
+
+    @Column()
+    OptionID!: number;
+
+    @Column()
+    Quantity!: number;
+
+    @Column()
+    RegDate!: Date;
+
+    @Column()
+    ModifiedDate!: Date;
+
+    @ManyToOne((type) => Cart, (t) => t.CartItems)
+    @JoinColumn({ name: "CartID" })
+    Cart?: Cart;
+}

--- a/test/github-issues/4764/issue-4764.ts
+++ b/test/github-issues/4764/issue-4764.ts
@@ -1,0 +1,222 @@
+import "reflect-metadata";
+import { Connection } from "../../../src/index";
+import {
+    reloadTestingDatabases,
+    createTestingConnections,
+    closeTestingConnections,
+} from "../../utils/test-utils";
+import { expect } from "chai";
+import { Cart } from "./entity/Cart";
+import { AdminUser } from "./entity/AdminUser";
+
+describe("mssql > add with(nolock) on select with join", () => {
+    describe("mssql", () => {
+        // -------------------------------------------------------------------------
+        // Configuration
+        // -------------------------------------------------------------------------
+
+        // connect to db
+        let mssqlConnection: Connection;
+
+        before(
+            async () =>
+                ([mssqlConnection] = await createTestingConnections({
+                    enabledDrivers: ["mssql"],
+                    entities: [__dirname + "/entity/*{.js,.ts}"],
+                }))
+        );
+        beforeEach(() => reloadTestingDatabases([mssqlConnection]));
+        after(() => closeTestingConnections([mssqlConnection]));
+
+        // -------------------------------------------------------------------------
+        // Specifications
+        // -------------------------------------------------------------------------
+        it("should not have Lock clause", async () => {
+            const lock = " WITH (NOLOCK)";
+            const selectQuery = mssqlConnection
+                .createQueryBuilder()
+                .select("cart")
+                .from(Cart, "cart")
+                .where("1=1")
+                .getQuery();
+
+            console.log(selectQuery);
+            expect(selectQuery.includes(lock)).not.to.equal(true);
+
+            await mssqlConnection.query(selectQuery);
+        });
+
+        it("should have WITH (NOLOCK) clause", async () => {
+            const lock = " WITH (NOLOCK)";
+            const selectQuery = mssqlConnection
+                .createQueryBuilder()
+                .select("cart")
+                .from(Cart, "cart")
+                .setLock("dirty_read")
+                .where("1=1")
+                .getQuery();
+
+            console.log(selectQuery);
+            expect(selectQuery.includes(lock)).to.equal(true);
+
+            await mssqlConnection.query(selectQuery);
+        });
+
+        it("should have two WITH (NOLOCK) clause", async () => {
+            const lock = " WITH (NOLOCK)";
+            const selectQuery = mssqlConnection
+                .createQueryBuilder()
+                .select("cart")
+                .from(Cart, "cart")
+                .innerJoinAndSelect("cart.CartItems", "cartItems")
+                .setLock("dirty_read")
+                .where("1=1")
+                .getQuery();
+
+            console.log(selectQuery);
+            expect(countInstances(selectQuery, lock)).to.equal(2);
+
+            await mssqlConnection.query(selectQuery);
+        });
+
+        it("should have WITH (HOLDLOCK, ROWLOCK) clause", async () => {
+            const lock = " WITH (HOLDLOCK, ROWLOCK)";
+            const selectQuery = mssqlConnection
+                .createQueryBuilder()
+                .select("cart")
+                .from(Cart, "cart")
+                .setLock("pessimistic_read")
+                .where("1=1")
+                .getQuery();
+
+            console.log(selectQuery);
+            expect(selectQuery.includes(lock)).to.equal(true);
+
+            await mssqlConnection.query(selectQuery);
+        });
+
+        it("should have WITH (UPLOCK, ROWLOCK) clause", async () => {
+            const lock = " WITH (UPDLOCK, ROWLOCK)";
+            const selectQuery = mssqlConnection
+                .createQueryBuilder()
+                .select("cart")
+                .from(Cart, "cart")
+                .setLock("pessimistic_write")
+                .where("1=1")
+                .getQuery();
+
+            console.log(selectQuery);
+            expect(selectQuery.includes(lock)).to.equal(true);
+
+            await mssqlConnection.query(selectQuery);
+        });
+
+        it("should have two WITH (UPDLOCK, ROWLOCK) clause", async () => {
+            const lock = " WITH (UPDLOCK, ROWLOCK)";
+            const selectQuery = mssqlConnection
+                .createQueryBuilder()
+                .select("cart")
+                .from(Cart, "cart")
+                .innerJoinAndSelect("cart.CartItems", "cartItems")
+                .setLock("pessimistic_write")
+                .where("1=1")
+                .getQuery();
+
+            console.log(selectQuery);
+            expect(countInstances(selectQuery, lock)).to.equal(2);
+
+            await mssqlConnection.query(selectQuery);
+        });
+
+        function countInstances(str: string, word: string) {
+            return str.split(word).length - 1;
+        }
+    });
+
+    describe("postgres", () => {
+        // -------------------------------------------------------------------------
+        // Configuration
+        // -------------------------------------------------------------------------
+
+        // connect to db
+        let postgresConnection: Connection;
+
+        it("should not have WITH (NOLOCK) clause", async () => {
+            const lock = " WITH (NOLOCK)";
+            const selectQuery = postgresConnection
+                .createQueryBuilder()
+                .select("admin")
+                .from(AdminUser, "admin")
+                .setLock("dirty_read")
+                .where("1=1")
+                .getQuery();
+
+            console.log(selectQuery);
+            expect(selectQuery.includes(lock)).not.to.equal(true);
+
+            await postgresConnection.query(selectQuery);
+        });
+
+        it("should not have Lock clause", async () => {
+            const lock = " WITH (NOLOCK)";
+            const selectQuery = postgresConnection
+                .createQueryBuilder()
+                .select("admin")
+                .from(AdminUser, "admin")
+                .where("1=1")
+                .getQuery();
+
+            console.log(selectQuery);
+            expect(selectQuery.includes(lock)).not.to.equal(true);
+
+            await postgresConnection.query(selectQuery);
+        });
+
+        it("should not have WITH (HOLDLOCK, ROWLOCK) clause", async () => {
+            const lock = " WITH (HOLDLOCK, ROWLOCK)";
+            const selectQuery = postgresConnection
+                .createQueryBuilder()
+                .select("admin")
+                .from(AdminUser, "admin")
+                .setLock("pessimistic_read")
+                .where("1=1")
+                .getQuery();
+
+            console.log(selectQuery);
+            expect(selectQuery.includes(lock)).not.to.equal(true);
+
+            await postgresConnection.query(selectQuery);
+        });
+
+        it("should not have WITH (UPLOCK, ROWLOCK) clause", async () => {
+            const lock = " WITH (UPDLOCK, ROWLOCK)";
+            const selectQuery = postgresConnection
+                .createQueryBuilder()
+                .select("admin")
+                .from(AdminUser, "admin")
+                .setLock("pessimistic_write")
+                .where("1=1")
+                .getQuery();
+
+            console.log(selectQuery);
+            expect(selectQuery.includes(lock)).not.to.equal(true);
+
+            await postgresConnection.query(selectQuery);
+        });
+        it("should have  FOR SHARE clause", async () => {
+            const lock = " FOR SHARE";
+            const selectQuery = postgresConnection
+                .createQueryBuilder()
+                .select("admin")
+                .from(AdminUser, "admin")
+                .setLock("pessimistic_read")
+                .where("1=1")
+                .getQuery();
+
+            console.log(selectQuery);
+            expect(selectQuery.includes(lock)).to.equal(true);
+
+            await postgresConnection.query(selectQuery);
+        });
+    });
+});


### PR DESCRIPTION
typeorm didn't supported LOCK clause in SELECT + JOIN query. For example, we cannot buld SQL such as "SELECT * FROM USER U WITH(NOLOCK) INNER JOIN ORDER WITH(NOLOCK) O ON U.ID=O.UserID". This pull request enables LOCK with SELECT + JOIN sql query.

Closes: #4764

<!--
  😀 Wonderful!  Thank you for opening a pull request for TypeORM.

  Please fill in the information below to expedite the review
  and (hopefully) merge of your change.

  If unsure about something.. just do as best as you're able,
  or reach out through our community support channels!
  https://github.com/typeorm/typeorm/blob/master/docs/support.md
-->

### Description of change

<!--
  Please be clear and concise what the change is intended to do,
  why this change is needed, and how you've verified that it
  corrects what you intended.

  In some cases it may be helpful to include the current behavior
  and the new behavior.

  If the change is related to an open issue, you can link it here.
  If you include `Fixes #0000` (replacing `0000` with the issue number)
  when this is merged it will automatically mark the issue as fixed and
  close it.
-->


### Pull-Request Checklist

<!--
  Please make sure to review and check all of the following.

  If an item is not applicable, you can add "N/A" to the end.
-->

- [x] Code is up-to-date with the `master` branch
- [x] `npm run lint` passes with this change
- [ ] `npm run test` passes with this change
- [x] This pull request links relevant issues as `Fixes #0000`
- [x] There are new or updated unit tests validating the change
- [ ] Documentation has been updated to reflect this change (N/A)
- [x] The new commits follow conventions explained in [CONTRIBUTING.md](https://github.com/typeorm/typeorm/blob/master/CONTRIBUTING.md)

<!--
  🎉 Thank you for contributing and making TypeORM even better!
-->
