### PR TITLE
fix: add WITH (lock) clause for MSSQL select with join queries

### DIFF
--- a/src/query-builder/SelectQueryBuilder.ts
+++ b/src/query-builder/SelectQueryBuilder.ts
@@ -1437,21 +1437,6 @@ export class SelectQueryBuilder<Entity> extends QueryBuilder<Entity> implements 
         if (allSelects.length === 0)
             allSelects.push({ selection: "*" });
 
-        let lock: string = "";
-        if (this.connection.driver instanceof SqlServerDriver) {
-            switch (this.expressionMap.lockMode) {
-                case "pessimistic_read":
-                    lock = " WITH (HOLDLOCK, ROWLOCK)";
-                    break;
-                case "pessimistic_write":
-                    lock = " WITH (UPDLOCK, ROWLOCK)";
-                    break;
-                case "dirty_read":
-                    lock = " WITH (NOLOCK)";
-                    break;
-            }
-        }
-
         // Use certain index
         let useIndex: string = "";
         if (this.expressionMap.useIndex) {
@@ -1473,7 +1458,7 @@ export class SelectQueryBuilder<Entity> extends QueryBuilder<Entity> implements 
         const select = this.createSelectDistinctExpression();
         const selection = allSelects.map(select => select.selection + (select.aliasName ? " AS " + this.escape(select.aliasName) : "")).join(", ");
 
-        return select + selection + " FROM " + froms.join(", ") + lock + useIndex;
+        return select + selection + " FROM " + froms.join(", ") + this.createSqlServerSelectLockExpression() + useIndex;
     }
 
     /**
@@ -1528,7 +1513,7 @@ export class SelectQueryBuilder<Entity> extends QueryBuilder<Entity> implements 
             // table to join, without junction table involved. This means we simply join direct table.
             if (!parentAlias || !relation) {
                 const destinationJoin = joinAttr.alias.subQuery ? joinAttr.alias.subQuery : this.getTableName(destinationTableName);
-                return " " + joinAttr.direction + " JOIN " + destinationJoin + " " + this.escape(destinationTableAlias) +
+                return " " + joinAttr.direction + " JOIN " + destinationJoin + " " + this.escape(destinationTableAlias) + this.createSqlServerSelectLockExpression() +
                     (joinAttr.condition ? " ON " + this.replacePropertyNames(joinAttr.condition) : "");
             }
 
@@ -1541,7 +1526,7 @@ export class SelectQueryBuilder<Entity> extends QueryBuilder<Entity> implements 
                         parentAlias + "." + relation.propertyPath + "." + joinColumn.referencedColumn!.propertyPath;
                 }).join(" AND ");
 
-                return " " + joinAttr.direction + " JOIN " + this.getTableName(destinationTableName) + " " + this.escape(destinationTableAlias) + " ON " + this.replacePropertyNames(condition + appendedCondition);
+                return " " + joinAttr.direction + " JOIN " + this.getTableName(destinationTableName) + " " + this.escape(destinationTableAlias) + this.createSqlServerSelectLockExpression() + " ON " + this.replacePropertyNames(condition + appendedCondition);
 
             } else if (relation.isOneToMany || relation.isOneToOneNotOwner) {
 
@@ -1555,7 +1540,7 @@ export class SelectQueryBuilder<Entity> extends QueryBuilder<Entity> implements 
                         parentAlias + "." + joinColumn.referencedColumn!.propertyPath;
                 }).join(" AND ");
 
-                return " " + joinAttr.direction + " JOIN " + this.getTableName(destinationTableName) + " " + this.escape(destinationTableAlias) + " ON " + this.replacePropertyNames(condition + appendedCondition);
+                return " " + joinAttr.direction + " JOIN " + this.getTableName(destinationTableName) + " " + this.escape(destinationTableAlias) + this.createSqlServerSelectLockExpression() + " ON " + this.replacePropertyNames(condition + appendedCondition);
 
             } else { // means many-to-many
                 const junctionTableName = relation.junctionEntityMetadata!.tablePath;
@@ -1587,8 +1572,8 @@ export class SelectQueryBuilder<Entity> extends QueryBuilder<Entity> implements 
                     }).join(" AND ");
                 }
 
-                return " " + joinAttr.direction + " JOIN " + this.getTableName(junctionTableName) + " " + this.escape(junctionAlias) + " ON " + this.replacePropertyNames(junctionCondition) +
-                    " " + joinAttr.direction + " JOIN " + this.getTableName(destinationTableName) + " " + this.escape(destinationTableAlias) + " ON " + this.replacePropertyNames(destinationCondition + appendedCondition);
+                return " " + joinAttr.direction + " JOIN " + this.getTableName(junctionTableName) + " " + this.escape(junctionAlias) + this.createSqlServerSelectLockExpression() + " ON "  + this.replacePropertyNames(junctionCondition) +
+                    " " + joinAttr.direction + " JOIN " + this.getTableName(destinationTableName) + " " + this.escape(destinationTableAlias) + this.createSqlServerSelectLockExpression() + " ON " + this.replacePropertyNames(destinationCondition + appendedCondition);
 
             }
         });
@@ -1691,6 +1676,28 @@ export class SelectQueryBuilder<Entity> extends QueryBuilder<Entity> implements 
         }
 
         return "";
+    }
+
+    /**
+     * Creates "LOCK" part of SELECT Query
+     */
+    private createSqlServerSelectLockExpression(): string {
+        let lock = "";
+        if(this.connection.driver instanceof SqlServerDriver) {
+            switch (this.expressionMap.lockMode) {
+                case "pessimistic_read":
+                    lock = " WITH (HOLDLOCK, ROWLOCK)";
+                    break;
+                case "pessimistic_write":
+                    lock = " WITH (UPDLOCK, ROWLOCK)";
+                    break;
+                case "dirty_read":
+                    lock = " WITH (NOLOCK)";
+                    break;
+            }
+        }
+
+        return lock;
     }
 
     /**

--- a/src/query-builder/SelectQueryBuilder.ts
+++ b/src/query-builder/SelectQueryBuilder.ts
@@ -1458,7 +1458,7 @@ export class SelectQueryBuilder<Entity> extends QueryBuilder<Entity> implements 
         const select = this.createSelectDistinctExpression();
         const selection = allSelects.map(select => select.selection + (select.aliasName ? " AS " + this.escape(select.aliasName) : "")).join(", ");
 
-        return select + selection + " FROM " + froms.join(", ") + this.createSqlServerSelectLockExpression() + useIndex;
+        return select + selection + " FROM " + froms.join(", ") + this.createTableLockExpression() + useIndex;
     }
 
     /**
@@ -1513,7 +1513,7 @@ export class SelectQueryBuilder<Entity> extends QueryBuilder<Entity> implements 
             // table to join, without junction table involved. This means we simply join direct table.
             if (!parentAlias || !relation) {
                 const destinationJoin = joinAttr.alias.subQuery ? joinAttr.alias.subQuery : this.getTableName(destinationTableName);
-                return " " + joinAttr.direction + " JOIN " + destinationJoin + " " + this.escape(destinationTableAlias) + this.createSqlServerSelectLockExpression() +
+                return " " + joinAttr.direction + " JOIN " + destinationJoin + " " + this.escape(destinationTableAlias) + this.createTableLockExpression() +
                     (joinAttr.condition ? " ON " + this.replacePropertyNames(joinAttr.condition) : "");
             }
 
@@ -1526,7 +1526,7 @@ export class SelectQueryBuilder<Entity> extends QueryBuilder<Entity> implements 
                         parentAlias + "." + relation.propertyPath + "." + joinColumn.referencedColumn!.propertyPath;
                 }).join(" AND ");
 
-                return " " + joinAttr.direction + " JOIN " + this.getTableName(destinationTableName) + " " + this.escape(destinationTableAlias) + this.createSqlServerSelectLockExpression() + " ON " + this.replacePropertyNames(condition + appendedCondition);
+                return " " + joinAttr.direction + " JOIN " + this.getTableName(destinationTableName) + " " + this.escape(destinationTableAlias) + this.createTableLockExpression() + " ON " + this.replacePropertyNames(condition + appendedCondition);
 
             } else if (relation.isOneToMany || relation.isOneToOneNotOwner) {
 
@@ -1540,7 +1540,7 @@ export class SelectQueryBuilder<Entity> extends QueryBuilder<Entity> implements 
                         parentAlias + "." + joinColumn.referencedColumn!.propertyPath;
                 }).join(" AND ");
 
-                return " " + joinAttr.direction + " JOIN " + this.getTableName(destinationTableName) + " " + this.escape(destinationTableAlias) + this.createSqlServerSelectLockExpression() + " ON " + this.replacePropertyNames(condition + appendedCondition);
+                return " " + joinAttr.direction + " JOIN " + this.getTableName(destinationTableName) + " " + this.escape(destinationTableAlias) + this.createTableLockExpression() + " ON " + this.replacePropertyNames(condition + appendedCondition);
 
             } else { // means many-to-many
                 const junctionTableName = relation.junctionEntityMetadata!.tablePath;
@@ -1572,8 +1572,8 @@ export class SelectQueryBuilder<Entity> extends QueryBuilder<Entity> implements 
                     }).join(" AND ");
                 }
 
-                return " " + joinAttr.direction + " JOIN " + this.getTableName(junctionTableName) + " " + this.escape(junctionAlias) + this.createSqlServerSelectLockExpression() + " ON "  + this.replacePropertyNames(junctionCondition) +
-                    " " + joinAttr.direction + " JOIN " + this.getTableName(destinationTableName) + " " + this.escape(destinationTableAlias) + this.createSqlServerSelectLockExpression() + " ON " + this.replacePropertyNames(destinationCondition + appendedCondition);
+                return " " + joinAttr.direction + " JOIN " + this.getTableName(junctionTableName) + " " + this.escape(junctionAlias) + this.createTableLockExpression() + " ON "  + this.replacePropertyNames(junctionCondition) +
+                    " " + joinAttr.direction + " JOIN " + this.getTableName(destinationTableName) + " " + this.escape(destinationTableAlias) + this.createTableLockExpression() + " ON " + this.replacePropertyNames(destinationCondition + appendedCondition);
 
             }
         });
@@ -1679,25 +1679,26 @@ export class SelectQueryBuilder<Entity> extends QueryBuilder<Entity> implements 
     }
 
     /**
-     * Creates "LOCK" part of SELECT Query
+     * Creates "LOCK" part of SELECT Query after table Clause
+     * ex.
+     *  SELECT 1
+     *  FROM USER U WITH (NOLOCK)
+     *  JOIN ORDER O WITH (NOLOCK)
+     *      ON U.ID=O.OrderID
      */
-    private createSqlServerSelectLockExpression(): string {
-        let lock = "";
+    private createTableLockExpression(): string {
         if(this.connection.driver instanceof SqlServerDriver) {
             switch (this.expressionMap.lockMode) {
                 case "pessimistic_read":
-                    lock = " WITH (HOLDLOCK, ROWLOCK)";
-                    break;
+                    return " WITH (HOLDLOCK, ROWLOCK)";
                 case "pessimistic_write":
-                    lock = " WITH (UPDLOCK, ROWLOCK)";
-                    break;
+                    return " WITH (UPDLOCK, ROWLOCK)";
                 case "dirty_read":
-                    lock = " WITH (NOLOCK)";
-                    break;
+                    return " WITH (NOLOCK)";
             }
         }
 
-        return lock;
+        return "";
     }
 
     /**

--- a/test/github-issues/4764/entity/Cart.ts
+++ b/test/github-issues/4764/entity/Cart.ts
@@ -1,5 +1,13 @@
-import { Column, Entity, OneToMany, PrimaryGeneratedColumn } from "../../../../src";
+import {
+    Column,
+    Entity,
+    JoinColumn,
+    OneToMany,
+    OneToOne,
+    PrimaryGeneratedColumn,
+} from "../../../../src";
 import { CartItems } from "./CartItems";
+import { User } from "./User";
 
 @Entity()
 export class Cart {
@@ -26,4 +34,8 @@ export class Cart {
 
     @OneToMany((type) => CartItems, (t) => t.Cart)
     CartItems?: CartItems[];
+
+    @OneToOne((type) => User, (t) => t.Cart)
+    @JoinColumn({ name: "UNID" })
+    User?: User;
 }

--- a/test/github-issues/4764/entity/Cart.ts
+++ b/test/github-issues/4764/entity/Cart.ts
@@ -1,0 +1,29 @@
+import { Column, Entity, OneToMany, PrimaryGeneratedColumn } from "../../../../src";
+import { CartItems } from "./CartItems";
+
+@Entity()
+export class Cart {
+    @PrimaryGeneratedColumn()
+    ID!: number;
+
+    @Column()
+    UNID!: number;
+
+    @Column()
+    Type!: string;
+
+    @Column()
+    Cycle?: number;
+
+    @Column()
+    Term?: string;
+
+    @Column()
+    RegDate!: Date;
+
+    @Column()
+    ModifiedDate!: Date;
+
+    @OneToMany((type) => CartItems, (t) => t.Cart)
+    CartItems?: CartItems[];
+}

--- a/test/github-issues/4764/entity/CartItems.ts
+++ b/test/github-issues/4764/entity/CartItems.ts
@@ -1,0 +1,30 @@
+import { Column, Entity, JoinColumn, ManyToOne, PrimaryGeneratedColumn } from "../../../../src";
+import { Cart } from "./Cart";
+
+@Entity()
+export class CartItems {
+    @PrimaryGeneratedColumn()
+    ID!: number;
+
+    @Column()
+    CartID!: number;
+
+    @Column()
+    ItemID!: number;
+
+    @Column()
+    OptionID!: number;
+
+    @Column()
+    Quantity!: number;
+
+    @Column()
+    RegDate!: Date;
+
+    @Column()
+    ModifiedDate!: Date;
+
+    @ManyToOne((type) => Cart, (t) => t.CartItems)
+    @JoinColumn({ name: "CartID" })
+    Cart?: Cart;
+}

--- a/test/github-issues/4764/entity/User.ts
+++ b/test/github-issues/4764/entity/User.ts
@@ -1,0 +1,25 @@
+import {
+    Column,
+    Entity,
+    OneToOne,
+    PrimaryGeneratedColumn,
+} from "../../../../src";
+import { Cart } from "./Cart";
+
+@Entity()
+export class User {
+    @PrimaryGeneratedColumn()
+    ID!: number;
+
+    @Column()
+    name!: string;
+
+    @Column()
+    RegDate!: Date;
+
+    @Column()
+    ModifiedDate!: Date;
+
+    @OneToOne((type) => Cart, (t) => t.User)
+    Cart?: Cart;
+}

--- a/test/github-issues/4764/issue-4764.ts
+++ b/test/github-issues/4764/issue-4764.ts
@@ -1,0 +1,158 @@
+import { expect } from "chai";
+import "reflect-metadata";
+import { Connection } from "../../../src/index";
+import {
+    closeTestingConnections,
+    createTestingConnections,
+    reloadTestingDatabases,
+} from "../../utils/test-utils";
+import { Cart } from "./entity/Cart";
+
+describe("mssql > add lock clause for MSSQL select with join clause", () => {
+    // -------------------------------------------------------------------------
+    // Configuration
+    // -------------------------------------------------------------------------
+
+    // connect to db
+    let connections: Connection[];
+
+    before(
+        async () =>
+            (connections = await createTestingConnections({
+                enabledDrivers: ["mssql"],
+                entities: [__dirname + "/entity/*{.js,.ts}"],
+                schemaCreate: true,
+                dropSchema: true,
+            }))
+    );
+    beforeEach(() => reloadTestingDatabases(connections));
+    after(() => closeTestingConnections(connections));
+
+    // -------------------------------------------------------------------------
+    // Specifications
+    // -------------------------------------------------------------------------
+    it("should not have Lock clause", async () => {
+        Promise.all(
+            connections.map(async (connection) => {
+                const lock = " WITH (NOLOCK)";
+                const selectQuery = connection
+                    .createQueryBuilder()
+                    .select("cart")
+                    .from(Cart, "cart")
+                    .where("1=1")
+                    .getQuery();
+
+                console.log(selectQuery);
+                expect(selectQuery.includes(lock)).not.to.equal(true);
+
+                await connection.query(selectQuery);
+            })
+        );
+    });
+
+    it("should have WITH (NOLOCK) clause", async () => {
+        Promise.all(
+            connections.map(async (connection) => {
+                const lock = " WITH (NOLOCK)";
+                const selectQuery = connection
+                    .createQueryBuilder()
+                    .select("cart")
+                    .from(Cart, "cart")
+                    .setLock("dirty_read")
+                    .where("1=1")
+                    .getQuery();
+
+                console.log(selectQuery);
+                expect(selectQuery.includes(lock)).to.equal(true);
+
+                await connection.query(selectQuery);
+            })
+        );
+    });
+
+    it("should have two WITH (NOLOCK) clause", async () => {
+        Promise.all(
+            connections.map(async (connection) => {
+                const lock = " WITH (NOLOCK)";
+                const selectQuery = connection
+                    .createQueryBuilder()
+                    .select("cart")
+                    .from(Cart, "cart")
+                    .innerJoinAndSelect("cart.CartItems", "cartItems")
+                    .setLock("dirty_read")
+                    .where("1=1")
+                    .getQuery();
+
+                console.log(selectQuery);
+                expect(countInstances(selectQuery, lock)).to.equal(2);
+
+                await connection.query(selectQuery);
+            })
+        );
+    });
+
+    it("should have WITH (HOLDLOCK, ROWLOCK) clause", async () => {
+        Promise.all(
+            connections.map(async (connection) => {
+                const lock = " WITH (HOLDLOCK, ROWLOCK)";
+                const selectQuery = connection
+                    .createQueryBuilder()
+                    .select("cart")
+                    .from(Cart, "cart")
+                    .setLock("pessimistic_read")
+                    .where("1=1")
+                    .getQuery();
+
+                console.log(selectQuery);
+                expect(selectQuery.includes(lock)).to.equal(true);
+
+                await connection.query(selectQuery);
+            })
+        );
+    });
+
+    it("should have WITH (UPLOCK, ROWLOCK) clause", async () => {
+        Promise.all(
+            connections.map(async (connection) => {
+                const lock = " WITH (UPDLOCK, ROWLOCK)";
+                const selectQuery = connection
+                    .createQueryBuilder()
+                    .select("cart")
+                    .from(Cart, "cart")
+                    .setLock("pessimistic_write")
+                    .where("1=1")
+                    .getQuery();
+
+                console.log(selectQuery);
+                expect(selectQuery.includes(lock)).to.equal(true);
+
+                await connection.query(selectQuery);
+            })
+        );
+    });
+
+    it("should have two WITH (UPDLOCK, ROWLOCK) clause", async () => {
+        Promise.all(
+            connections.map(async (connection) => {
+                const lock = " WITH (UPDLOCK, ROWLOCK)";
+                const selectQuery = connection
+                    .createQueryBuilder()
+                    .select("cart")
+                    .from(Cart, "cart")
+                    .innerJoinAndSelect("cart.CartItems", "cartItems")
+                    .setLock("pessimistic_write")
+                    .where("1=1")
+                    .getQuery();
+
+                console.log(selectQuery);
+                expect(countInstances(selectQuery, lock)).to.equal(2);
+
+                await connection.query(selectQuery);
+            })
+        );
+    });
+
+    function countInstances(str: string, word: string) {
+        return str.split(word).length - 1;
+    }
+});


### PR DESCRIPTION
Typeorm didn't supported LOCK clause in MSSQL SELECT + JOIN query. 

For example, when we write code with typeorm like this
```typescript
await getConnection()
        .createQueryBuilder()
        .select("order")
        .setLock("dirty_read")
        .from(Order, "order")
        .innerJoinAndSelect("order", "order.OrderItems")
        .where("1=1")
        .getMany()
```
we would expect the corresponding SQL of this statement is 
```sql
SELECT      *
FROM        Order O     WITH (NOLOCK)
LEFT JOIN   OrderItems  WITH (NOLOCK)
WHERE       1=1
```
but typeorm generates SQL like this 
```sql
SELECT      *
FROM        Order O     WITH (NOLOCK)
LEFT JOIN   OrderItems  
WHERE       1=1
```

This pull request enables LOCK with SELECT + JOIN sql query.
This pull request will prevent deadlock situations while querying SELECT statements during transactions. (in case of MSSQL Driver)

Closes: #4764

<!--
  😀 Wonderful!  Thank you for opening a pull request for TypeORM.

  Please fill in the information below to expedite the review
  and (hopefully) merge of your change.

  If unsure about something.. just do as best as you're able,
  or reach out through our community support channels!
  https://github.com/typeorm/typeorm/blob/master/docs/support.md
-->

### Description of change

<!--
  Please be clear and concise what the change is intended to do,
  why this change is needed, and how you've verified that it
  corrects what you intended.

  In some cases it may be helpful to include the current behavior
  and the new behavior.

  If the change is related to an open issue, you can link it here.
  If you include `Fixes #0000` (replacing `0000` with the issue number)
  when this is merged it will automatically mark the issue as fixed and
  close it.
-->


### Pull-Request Checklist

<!--
  Please make sure to review and check all of the following.

  If an item is not applicable, you can add "N/A" to the end.
-->

- [x] Code is up-to-date with the `master` branch
- [x] `npm run lint` passes with this change
- [x] `npm run test` passes with this change
- [x] This pull request links relevant issues as `Fixes #0000`
- [x] There are new or updated unit tests validating the change
- [x] `(N/A)` Documentation has been updated to reflect this change 
- [x] The new commits follow conventions explained in [CONTRIBUTING.md](https://github.com/typeorm/typeorm/blob/master/CONTRIBUTING.md)

<!--
  🎉 Thank you for contributing and making TypeORM even better!
-->
