### PR TITLE
fix: materialized path being computed as "undefined1."

### DIFF
--- a/src/persistence/tree/MaterializedPathSubjectExecutor.ts
+++ b/src/persistence/tree/MaterializedPathSubjectExecutor.ts
@@ -97,13 +97,13 @@ export class MaterializedPathSubjectExecutor {
             .execute();
     }
 
-    private getEntityPath(subject: Subject, id: ObjectLiteral): Promise<any> {
+    private getEntityPath(subject: Subject, id: ObjectLiteral): Promise<string> {
         return this.queryRunner.manager
             .createQueryBuilder()
             .select(subject.metadata.targetName + "." + subject.metadata.materializedPathColumn!.propertyPath, "path")
             .from(subject.metadata.target, subject.metadata.targetName)
             .whereInIds(id)
             .getRawOne()
-            .then(result => result ? result["path"] : undefined);
+            .then(result => result ? result["path"] : "");
     }
 }

--- a/test/functional/tree-tables/materialized-path/entity/Category.ts
+++ b/test/functional/tree-tables/materialized-path/entity/Category.ts
@@ -4,8 +4,11 @@ import {TreeParent} from "../../../../../src/decorator/tree/TreeParent";
 import {TreeChildren} from "../../../../../src/decorator/tree/TreeChildren";
 import {Entity} from "../../../../../src/decorator/entity/Entity";
 import {Tree} from "../../../../../src/decorator/tree/Tree";
+import {ManyToOne} from "../../../../../src/decorator/relations/ManyToOne";
+import {JoinColumn} from "../../../../../src/decorator/relations/JoinColumn";
+import {Product} from "./Product";
 
-@Entity()
+@Entity({ name: "categories" })
 @Tree("materialized-path")
 export class Category {
 
@@ -21,7 +24,14 @@ export class Category {
     @TreeChildren({ cascade: true })
     childCategories: Category[];
 
-    // @TreeLevelColumn()
-    // level: number;
+    @ManyToOne(
+        () => Product,
+        (product) => product.categories,
+    )
+    @JoinColumn()
+    product: Product;
+
+    @Column({ nullable: true })
+    productId: number;
 
 }

--- a/test/functional/tree-tables/materialized-path/entity/Category.ts
+++ b/test/functional/tree-tables/materialized-path/entity/Category.ts
@@ -31,7 +31,4 @@ export class Category {
     @JoinColumn()
     product: Product;
 
-    @Column({ nullable: true })
-    productId: number;
-
 }

--- a/test/functional/tree-tables/materialized-path/entity/Product.ts
+++ b/test/functional/tree-tables/materialized-path/entity/Product.ts
@@ -1,0 +1,23 @@
+import {PrimaryGeneratedColumn} from "../../../../../src/decorator/columns/PrimaryGeneratedColumn";
+import {Entity} from "../../../../../src/decorator/entity/Entity";
+import {Category} from "./Category";
+import {OneToMany} from "../../../../../src/decorator/relations/OneToMany";
+import {Column} from "../../../../../src/decorator/columns/Column";
+
+@Entity()
+export class Product {
+
+    @PrimaryGeneratedColumn()
+    id: number;
+
+    @Column()
+    name: string;
+
+    @OneToMany(
+        () => Category,
+        (category) => category.product,
+        { cascade: true },
+    )
+    categories: Category[];
+
+}

--- a/test/functional/tree-tables/materialized-path/materialized-path.ts
+++ b/test/functional/tree-tables/materialized-path/materialized-path.ts
@@ -574,7 +574,6 @@ describe("tree tables > materialized-path", () => {
     })));
 
     it("should compute path correctly when tree is implicitly saved (cascade: true) through related entity", () => Promise.all(connections.map(async connection => {
-        const categoryMetadata = connection.getMetadata(Category);
         const categoryRepository = connection.getRepository(Category);
         const productRepository = connection.getRepository(Product);
 

--- a/test/functional/tree-tables/materialized-path/materialized-path.ts
+++ b/test/functional/tree-tables/materialized-path/materialized-path.ts
@@ -2,12 +2,14 @@ import "reflect-metadata";
 import {Category} from "./entity/Category";
 import {Connection} from "../../../../src/connection/Connection";
 import {closeTestingConnections, createTestingConnections, reloadTestingDatabases} from "../../../utils/test-utils";
+import {Product} from "./entity/Product";
 
 describe("tree tables > materialized-path", () => {
 
     let connections: Connection[];
     before(async () => connections = await createTestingConnections({
-        entities: [Category],
+        entities: [Product, Category],
+        logging: true,
     }));
     beforeEach(() => reloadTestingDatabases(connections));
     after(() => closeTestingConnections(connections));
@@ -569,5 +571,38 @@ describe("tree tables > materialized-path", () => {
                 }
             ]
         });
+    })));
+
+    it.only("should compute path correctly when tree is implicitly saved (cascade: true) through related entity", () => Promise.all(connections.map(async connection => {
+        const categoryRepository = connection.getRepository(Category);
+        const productRepository = connection.getRepository(Product);
+
+        // first increment the category primary id once by saving and removing an item
+        // this is necessary to reproduce the bug behaviour
+        const existingCategory = new Category();
+        existingCategory.name = "irrelevant";
+        await categoryRepository.save(existingCategory);
+        await categoryRepository.delete(existingCategory);
+
+        // set up a product with category tree `{name: "My product", categories: [{name: "root", children: [{name: "child"}]}]}`
+        const childCategory = new Category();
+        childCategory.name = "child";
+        const rootCategory = new Category();
+        rootCategory.name = "root";
+        rootCategory.childCategories = [childCategory];
+        const product = new Product();
+        product.name = "My product";
+        product.categories = [rootCategory];
+
+        // save it alongside its categories ( cascade )
+        const savedProduct = await productRepository.save(product);
+
+        const pathResult = await connection.createQueryBuilder()
+            .select("mpath", "path")
+            .from("categories", "categories")
+            .where({ productId: savedProduct.id })
+            .getRawOne();
+
+        pathResult.path.should.not.match(/^undefined/);
     })));
 });

--- a/test/functional/tree-tables/materialized-path/materialized-path.ts
+++ b/test/functional/tree-tables/materialized-path/materialized-path.ts
@@ -574,6 +574,8 @@ describe("tree tables > materialized-path", () => {
     })));
 
     it("should compute path correctly when tree is implicitly saved (cascade: true) through related entity", () => Promise.all(connections.map(async connection => {
+        const categoryMetadata = connection.getMetadata(Category);
+        const mpathColumn = categoryMetadata.materializedPathColumn!.databasePath;
         const categoryRepository = connection.getRepository(Category);
         const productRepository = connection.getRepository(Product);
 
@@ -596,9 +598,8 @@ describe("tree tables > materialized-path", () => {
 
         // save it alongside its categories ( cascade )
         const savedProduct = await productRepository.save(product);
-
         const pathResult = await connection.createQueryBuilder()
-            .select("mpath", "path")
+            .select(mpathColumn, "path")
             .from("categories", "categories")
             .where({ product: { id: savedProduct.id } })
             .getRawOne();

--- a/test/functional/tree-tables/materialized-path/materialized-path.ts
+++ b/test/functional/tree-tables/materialized-path/materialized-path.ts
@@ -603,6 +603,6 @@ describe("tree tables > materialized-path", () => {
             .setParameters({ id: savedProduct.id })
             .getRawOne();
 
-        pathResult.path.should.not.match(/^undefined/);
+        pathResult.mpath.should.not.match(/^undefined/);
     })));
 });

--- a/test/functional/tree-tables/materialized-path/materialized-path.ts
+++ b/test/functional/tree-tables/materialized-path/materialized-path.ts
@@ -599,9 +599,10 @@ describe("tree tables > materialized-path", () => {
         // save it alongside its categories ( cascade )
         const savedProduct = await productRepository.save(product);
         const pathResult = await connection.createQueryBuilder()
-            .select(mpathColumn, "path")
-            .from("categories", "categories")
-            .where({ product: { id: savedProduct.id } })
+            .select(mpathColumn, "category.path")
+            .from("categories", "category")
+            .where("category.product = :id")
+            .setParameters({ id: savedProduct.id })
             .getRawOne();
 
         pathResult.path.should.not.match(/^undefined/);

--- a/test/functional/tree-tables/materialized-path/materialized-path.ts
+++ b/test/functional/tree-tables/materialized-path/materialized-path.ts
@@ -573,7 +573,7 @@ describe("tree tables > materialized-path", () => {
         });
     })));
 
-    it.only("should compute path correctly when tree is implicitly saved (cascade: true) through related entity", () => Promise.all(connections.map(async connection => {
+    it("should compute path correctly when tree is implicitly saved (cascade: true) through related entity", () => Promise.all(connections.map(async connection => {
         const categoryRepository = connection.getRepository(Category);
         const productRepository = connection.getRepository(Product);
 

--- a/test/functional/tree-tables/materialized-path/materialized-path.ts
+++ b/test/functional/tree-tables/materialized-path/materialized-path.ts
@@ -600,7 +600,7 @@ describe("tree tables > materialized-path", () => {
         const pathResult = await connection.createQueryBuilder()
             .select("mpath", "path")
             .from("categories", "categories")
-            .where({ productId: savedProduct.id })
+            .where({ product: { id: savedProduct.id } })
             .getRawOne();
 
         pathResult.path.should.not.match(/^undefined/);

--- a/test/functional/tree-tables/materialized-path/materialized-path.ts
+++ b/test/functional/tree-tables/materialized-path/materialized-path.ts
@@ -597,7 +597,7 @@ describe("tree tables > materialized-path", () => {
         // save it alongside its categories ( cascade )
         const savedProduct = await productRepository.save(product);
         const pathResult = await connection.createQueryBuilder()
-            .select("category.path", "mpath")
+            .select("category.mpath", "mpath")
             .from("categories", "category")
             .where("category.product = :id")
             .setParameters({ id: savedProduct.id })

--- a/test/functional/tree-tables/materialized-path/materialized-path.ts
+++ b/test/functional/tree-tables/materialized-path/materialized-path.ts
@@ -575,7 +575,6 @@ describe("tree tables > materialized-path", () => {
 
     it("should compute path correctly when tree is implicitly saved (cascade: true) through related entity", () => Promise.all(connections.map(async connection => {
         const categoryMetadata = connection.getMetadata(Category);
-        const mpathColumn = categoryMetadata.materializedPathColumn!.databasePath;
         const categoryRepository = connection.getRepository(Category);
         const productRepository = connection.getRepository(Product);
 

--- a/test/functional/tree-tables/materialized-path/materialized-path.ts
+++ b/test/functional/tree-tables/materialized-path/materialized-path.ts
@@ -599,7 +599,7 @@ describe("tree tables > materialized-path", () => {
         // save it alongside its categories ( cascade )
         const savedProduct = await productRepository.save(product);
         const pathResult = await connection.createQueryBuilder()
-            .select(mpathColumn, "category.path")
+            .select("category.path", "mpath")
             .from("categories", "category")
             .where("category.product = :id")
             .setParameters({ id: savedProduct.id })


### PR DESCRIPTION
### Description of change
When tree entities are saved implicitly (through another related entity which hasMany tree-entities and "cascade" set to true) the ORM generates materialized-path strings prefixed with `undefined`. Resulting in materialized paths like `undefined1.2.3`. This pull request fixes that. Root cause was that the materialized path always relies on the previously inserted entity mpath which is `undefined` for the root-tree-entity.


### Pull-Request Checklist

- [x] Code is up-to-date with the `master` branch
- [x] `npm run lint` passes with this change
- [x] `npm run test` passes with this change
- [ ] This pull request links relevant issues as `Fixes #0000` N/A
- [x] There are new or updated unit tests validating the change
- [ ] Documentation has been updated to reflect this change N/A
- [ x] The new commits follow conventions explained in [CONTRIBUTING.md](https://github.com/typeorm/typeorm/blob/master/CONTRIBUTING.md)
