### PR TITLE
fix: allow clearing database inside a transaction

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "typeorm",
-  "version": "0.2.39",
+  "version": "0.2.41",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "typeorm",
-      "version": "0.2.39",
+      "version": "0.2.41",
       "license": "MIT",
       "dependencies": {
         "@sqltools/formatter": "^1.2.2",

--- a/src/driver/mysql/MysqlQueryRunner.ts
+++ b/src/driver/mysql/MysqlQueryRunner.ts
@@ -1176,7 +1176,9 @@ export class MysqlQueryRunner extends BaseQueryRunner implements QueryRunner {
             throw new TypeORMError(`Can not clear database. No database is specified`);
         }
 
-        await this.startTransaction();
+        const isAnotherTransactionActive = this.isTransactionActive;
+        if (!isAnotherTransactionActive)
+            await this.startTransaction();
         try {
 
             const selectViewDropsQuery = `SELECT concat('DROP VIEW IF EXISTS \`', table_schema, '\`.\`', table_name, '\`') AS \`query\` FROM \`INFORMATION_SCHEMA\`.\`VIEWS\` WHERE \`TABLE_SCHEMA\` = '${dbName}'`;
@@ -1192,11 +1194,13 @@ export class MysqlQueryRunner extends BaseQueryRunner implements QueryRunner {
             await Promise.all(dropQueries.map(query => this.query(query["query"])));
             await this.query(enableForeignKeysCheckQuery);
 
-            await this.commitTransaction();
+            if (!isAnotherTransactionActive)
+                await this.commitTransaction();
 
         } catch (error) {
             try { // we throw original error even if rollback thrown an error
-                await this.rollbackTransaction();
+                if (!isAnotherTransactionActive)
+                    await this.rollbackTransaction();
             } catch (rollbackError) { }
             throw error;
         }

--- a/src/driver/postgres/PostgresQueryRunner.ts
+++ b/src/driver/postgres/PostgresQueryRunner.ts
@@ -1559,8 +1559,8 @@ export class PostgresQueryRunner extends BaseQueryRunner implements QueryRunner 
             return name === "current_schema()" ? name : "'" + name + "'";
         }).join(", ");
 
-        const anotherTransactionRunning = this.isTransactionActive;
-        if (!anotherTransactionRunning)
+        const isAnotherTransactionActive = this.isTransactionActive;
+        if (!isAnotherTransactionActive)
             await this.startTransaction();
         try {
             const version = await this.getVersion()
@@ -1590,12 +1590,12 @@ export class PostgresQueryRunner extends BaseQueryRunner implements QueryRunner 
             // drop enum types
             await this.dropEnumTypes(schemaNamesString);
 
-            if (!anotherTransactionRunning)
+            if (!isAnotherTransactionActive)
                 await this.commitTransaction();
 
         } catch (error) {
             try { // we throw original error even if rollback thrown an error
-                if (!anotherTransactionRunning)
+                if (!isAnotherTransactionActive)
                     await this.rollbackTransaction();
             } catch (rollbackError) { }
             throw error;

--- a/src/driver/sqlite-abstract/AbstractSqliteQueryRunner.ts
+++ b/src/driver/sqlite-abstract/AbstractSqliteQueryRunner.ts
@@ -729,7 +729,10 @@ export abstract class AbstractSqliteQueryRunner extends BaseQueryRunner implemen
      */
     async clearDatabase(): Promise<void> {
         await this.query(`PRAGMA foreign_keys = OFF;`);
-        await this.startTransaction();
+        
+        const isAnotherTransactionActive = this.isTransactionActive;
+        if (!isAnotherTransactionActive)
+            await this.startTransaction();
         try {
             const selectViewDropsQuery = `SELECT 'DROP VIEW "' || name || '";' as query FROM "sqlite_master" WHERE "type" = 'view'`;
             const dropViewQueries: ObjectLiteral[] = await this.query(selectViewDropsQuery);
@@ -738,11 +741,13 @@ export abstract class AbstractSqliteQueryRunner extends BaseQueryRunner implemen
             const selectTableDropsQuery = `SELECT 'DROP TABLE "' || name || '";' as query FROM "sqlite_master" WHERE "type" = 'table' AND "name" != 'sqlite_sequence'`;
             const dropTableQueries: ObjectLiteral[] = await this.query(selectTableDropsQuery);
             await Promise.all(dropTableQueries.map(q => this.query(q["query"])));
-            await this.commitTransaction();
-
+            
+            if (!isAnotherTransactionActive)
+                await this.commitTransaction();
         } catch (error) {
             try { // we throw original error even if rollback thrown an error
-                await this.rollbackTransaction();
+                if (!isAnotherTransactionActive)
+                    await this.rollbackTransaction();
             } catch (rollbackError) { }
             throw error;
 

--- a/test/github-issues/8527/entity/TestEntity.ts
+++ b/test/github-issues/8527/entity/TestEntity.ts
@@ -1,0 +1,12 @@
+import {Entity} from "../../../../src/decorator/entity/Entity";
+import {Column} from "../../../../src/decorator/columns/Column";
+import {PrimaryGeneratedColumn} from "../../../../src/decorator/columns/PrimaryGeneratedColumn";
+
+@Entity()
+export class TestEntity {
+    @PrimaryGeneratedColumn()
+    id: number;
+
+    @Column()
+    name: string;
+}

--- a/test/github-issues/8527/issue-8527.ts
+++ b/test/github-issues/8527/issue-8527.ts
@@ -1,0 +1,24 @@
+import "reflect-metadata";
+import { closeTestingConnections, createTestingConnections, reloadTestingDatabases } from "../../utils/test-utils";
+import { Connection } from "../../../src/connection/Connection";
+import { expect } from "chai";
+import { TestEntity } from "./entity/TestEntity";
+
+describe("github issues > #8527 cannot clear database inside a transaction.", () => {
+    let connections: Connection[];
+
+    before(async () => connections = await createTestingConnections({
+        entities: [TestEntity],
+        enabledDrivers: ["postgres"]
+    }));
+    beforeEach(() => reloadTestingDatabases(connections));
+    after(() => closeTestingConnections(connections));
+
+    it("should not fail when clearing a database inside a transaction", () => Promise.all(connections.map(async (connection) => {
+        const queryRunner = connection.createQueryRunner();
+        await queryRunner.startTransaction();
+        await expect(queryRunner.clearDatabase()).not.to.be.rejected;
+        await queryRunner.commitTransaction();
+        await queryRunner.release();
+    })));
+});

--- a/test/github-issues/8527/issue-8527.ts
+++ b/test/github-issues/8527/issue-8527.ts
@@ -9,7 +9,13 @@ describe("github issues > #8527 cannot clear database inside a transaction.", ()
 
     before(async () => connections = await createTestingConnections({
         entities: [TestEntity],
-        enabledDrivers: ["postgres"]
+        enabledDrivers: [
+            "postgres",
+            "sqlite",
+            "mysql"
+        ],
+        dropSchema: true,
+        schemaCreate: true
     }));
     beforeEach(() => reloadTestingDatabases(connections));
     after(() => closeTestingConnections(connections));


### PR DESCRIPTION
Possible fix for: #8527

<!--
  😀 Wonderful!  Thank you for opening a pull request for TypeORM.

  Please fill in the information below to expedite the review
  and (hopefully) merge of your change.

  If unsure about something.. just do as best as you're able,
  or reach out through our community support channels!
  https://github.com/typeorm/typeorm/blob/master/docs/support.md
-->

### Description of change

<!--
  Please be clear and concise what the change is intended to do,
  why this change is needed, and how you've verified that it
  corrects what you intended.

  In some cases it may be helpful to include the current behavior
  and the new behavior.

  If the change is related to an open issue, you can link it here.
  If you include `Fixes #0000` (replacing `0000` with the issue number)
  when this is merged it will automatically mark the issue as fixed and
  close it.
-->

This is one of the possible fixes for the issue #8527

It allows to run `clearDatabase` inside a transaction by making `clearDatabase` to check if another transaction is already running and not creating a new transaction in that case

It currently is only developed for/tested with Postgres, if this is the right direction same fix could be applied for other query runners

### Pull-Request Checklist

<!--
  Please make sure to review and check all of the following.

  If an item is not applicable, you can add "N/A" to the end.
-->

- [x] Code is up-to-date with the `master` branch
- [x] `npm run lint` passes with this change
- [x] `npm run test` passes with this change
- [x] This pull request links relevant issues as `Fixes #0000`
- [x] There are new or updated unit tests validating the change
- [ ] Documentation has been updated to reflect this change
- [x] The new commits follow conventions explained in [CONTRIBUTING.md](https://github.com/typeorm/typeorm/blob/master/CONTRIBUTING.md)

<!--
  🎉 Thank you for contributing and making TypeORM even better!
-->
