### PR TITLE
feature: add comment param to FindOptions.

### DIFF
--- a/src/find-options/FindOneOptions.ts
+++ b/src/find-options/FindOneOptions.ts
@@ -9,6 +9,13 @@ import {FindConditions} from "./FindConditions";
 export interface FindOneOptions<Entity = any> {
 
     /**
+     * Includes a Query comment generated query.  This is helpful for debugging
+     * purposes, such as finding a specific query in the database server's logs,
+     * or for categorization using an APM product.
+     */
+    comment?: string;
+
+    /**
      * Specifies what columns should be retrieved.
      */
     select?: (keyof Entity)[];

--- a/src/find-options/FindOneOptions.ts
+++ b/src/find-options/FindOneOptions.ts
@@ -9,9 +9,9 @@ import {FindConditions} from "./FindConditions";
 export interface FindOneOptions<Entity = any> {
 
     /**
-     * Includes a Query comment generated query.  This is helpful for debugging
-     * purposes, such as finding a specific query in the database server's logs,
-     * or for categorization using an APM product.
+     * Adds a comment with the supplied string in the generated query.  This is
+     * helpful for debugging purposes, such as finding a specific query in the
+     * database server's logs, or for categorization using an APM product.
      */
     comment?: string;
 

--- a/src/find-options/FindOptionsUtils.ts
+++ b/src/find-options/FindOptionsUtils.ts
@@ -32,6 +32,7 @@ export class FindOptionsUtils {
                 possibleOptions.cache instanceof Object ||
                 typeof possibleOptions.cache === "boolean" ||
                 typeof possibleOptions.cache === "number" ||
+                typeof possibleOptions.comment === "string" ||
                 possibleOptions.lock instanceof Object ||
                 possibleOptions.loadRelationIds instanceof Object ||
                 typeof possibleOptions.loadRelationIds === "boolean" ||
@@ -97,6 +98,10 @@ export class FindOptionsUtils {
         const metadata = qb.expressionMap.mainAlias!.metadata;
 
         // apply all options from FindOptions
+        if (options.comment) {
+            qb.comment(options.comment);
+        }
+
         if (options.withDeleted) {
             qb.withDeleted();
         }

--- a/test/functional/repository/find-options/repository-find-options.ts
+++ b/test/functional/repository/find-options/repository-find-options.ts
@@ -7,8 +7,9 @@ import {Category} from "./entity/Category";
 import {Post} from "./entity/Post";
 import {Photo} from "./entity/Photo";
 import sinon from "sinon";
-import { FileLogger } from "../../../../src";
-import { readFile, unlink } from "fs/promises";
+import {FileLogger} from "../../../../src";
+import {promisify} from "util";
+import {readFile, unlink} from "fs";
 
 describe("repository > find options", () => {
 
@@ -210,14 +211,14 @@ describe("repository > find options > comment", () => {
     beforeEach(() => reloadTestingDatabases(connections));
     after(async () => {
         closeTestingConnections(connections);
-        await unlink(logPath);
+        await promisify(unlink)(logPath);
     });
 
     it("repository should insert comment", () => Promise.all(connections.map(async connection => {
         await connection.getRepository(User)
             .find({comment: "This is a query comment."});
 
-        const logs = await readFile(logPath);
+        const logs = await promisify(readFile)(logPath);
         const lines = logs.toString().split("\n");
         const lastLine = lines[lines.length - 2]; // last line is blank after newline
         // remove timestamp and prefix

--- a/test/functional/repository/find-options/repository-find-options.ts
+++ b/test/functional/repository/find-options/repository-find-options.ts
@@ -7,6 +7,8 @@ import {Category} from "./entity/Category";
 import {Post} from "./entity/Post";
 import {Photo} from "./entity/Photo";
 import sinon from "sinon";
+import { FileLogger } from "../../../../src";
+import { readFile, unlink } from "fs/promises";
 
 describe("repository > find options", () => {
 
@@ -190,6 +192,38 @@ describe("repository > find options", () => {
 
     })));
 
+});
+
+describe("repository > find options > comment", () => {
+    let connections: Connection[];
+    const logPath = "find_comment_test.log";
+
+    before(async () => {
+        // TODO: would be nice to be able to do this in memory with some kind of
+        // test logger that buffers messages.
+        const logger = new FileLogger(["query"], { logPath });
+        connections = await createTestingConnections({
+            entities: [__dirname + "/entity/*{.js,.ts}"],
+            createLogger: () => logger,
+        });
+    });
+    beforeEach(() => reloadTestingDatabases(connections));
+    after(async () => {
+        closeTestingConnections(connections);
+        await unlink(logPath);
+    });
+
+    it("repository should insert comment", () => Promise.all(connections.map(async connection => {
+        await connection.getRepository(User)
+            .find({comment: "This is a query comment."});
+
+        const logs = await readFile(logPath);
+        const lines = logs.toString().split("\n");
+        const lastLine = lines[lines.length - 2]; // last line is blank after newline
+        // remove timestamp and prefix
+        const sql = lastLine.replace(/^.*\[QUERY\]\: /, "");
+        expect(sql).to.match(/^\/\* This is a query comment. \*\//);
+    })));
 });
 
 


### PR DESCRIPTION
### Description of change

Allows users to pass in comments for queries issued through the entity manager
like they are for the query builder (added in #6892).

### Pull-Request Checklist

- [x] Code is up-to-date with the `master` branch
- [x] `npm run lint` passes with this change
- [x] `npm run test` passes with this change
- [x] This pull request links relevant issues as `Fixes #0000`
- [x] There are new or updated unit tests validating the change
- [x] Documentation has been updated to reflect this change
- [x] The new commits follow conventions explained in [CONTRIBUTING.md](https://github.com/typeorm/typeorm/blob/master/CONTRIBUTING.md)
