### PR TITLE
fix: find descendants of a non-existing tree parent

### DIFF
--- a/src/repository/TreeRepository.ts
+++ b/src/repository/TreeRepository.ts
@@ -137,7 +137,7 @@ export class TreeRepository<Entity> extends Repository<Entity> {
                     if (this.manager.connection.driver instanceof AbstractSqliteDriver) {
                         return `${alias}.${this.metadata.materializedPathColumn!.propertyPath} LIKE ${subQuery.getQuery()} || '%'`;
                     } else {
-                        return `${alias}.${this.metadata.materializedPathColumn!.propertyPath} LIKE CONCAT(${subQuery.getQuery()}, '%')`;
+                        return `${alias}.${this.metadata.materializedPathColumn!.propertyPath} LIKE NULLIF(CONCAT(${subQuery.getQuery()}, '%'), '%')`;
                     }
                 });
         }

--- a/test/github-issues/8556/entity/category.entity.ts
+++ b/test/github-issues/8556/entity/category.entity.ts
@@ -1,0 +1,19 @@
+import {Column, PrimaryGeneratedColumn, Tree, TreeParent, TreeChildren} from "../../../../src";
+import {Entity} from "../../../../src/decorator/entity/Entity";
+
+@Entity()
+@Tree("materialized-path")
+export class Category {
+
+    @PrimaryGeneratedColumn()
+    id: number;
+
+    @Column()
+    name: string;
+
+    @TreeChildren()
+    children: Category[];
+
+    @TreeParent()
+    parent: Category;
+}

--- a/test/github-issues/8556/issue-8556.ts
+++ b/test/github-issues/8556/issue-8556.ts
@@ -1,0 +1,53 @@
+import "reflect-metadata";
+import {createTestingConnections, closeTestingConnections, reloadTestingDatabases} from "../../utils/test-utils";
+import {Connection} from "../../../src/connection/Connection";
+import {expect} from "chai";
+import {Category} from "./entity/category.entity";
+import {TreeRepository} from "../../../src";
+
+describe("github issues > #8556 TreeRepository.findDescendants/Tree should return empty if tree parent entity does not exist", () => {
+    let connections: Connection[];
+    before(
+        async () =>
+        (connections = await createTestingConnections({
+            entities: [__dirname + "/entity/*{.js,.ts}"],
+            dropSchema: true,
+            schemaCreate: true
+        }))
+    );
+
+    beforeEach(() => reloadTestingDatabases(connections));
+    after(() => closeTestingConnections(connections));
+
+    it("should load descendants when findDescendants is called for a tree entity", () =>
+        Promise.all(
+            connections.map(async connection => {
+                const repo: TreeRepository<Category> = connection.getTreeRepository(Category);
+                const root: Category = await repo.save({ id: 1, name: "root" } as Category);
+                await repo.save({ id: 2, name: "child", parent: root } as Category);
+                const descendantsIncludingParent = await repo.findDescendants(root);
+                expect(descendantsIncludingParent.length).to.be.equal(2);
+                const descendantTree = await repo.findDescendantsTree(root);
+                expect(descendantTree.children.length).to.be.equal(1);
+                const countDescendantsIncludingParent = await repo.countDescendants(root)
+                expect(countDescendantsIncludingParent).to.be.equal(2);
+            })
+        )
+    );
+
+    it("should return empty when findDescendants is called for a non existing tree entity", () =>
+        Promise.all(
+            connections.map(async connection => {
+                const repo: TreeRepository<Category> = connection.getTreeRepository(Category);
+                const root: Category = await repo.save({ id: 1, name: "root" } as Category);
+                await repo.save({ id: 2, name: "child", parent: root } as Category);
+                const descendantsOfNonExistingParent = await repo.findDescendants({id: -1} as Category);
+                expect(descendantsOfNonExistingParent.length).to.be.equal(0);
+                const descendantTree = await repo.findDescendantsTree({id: -1} as Category);
+                expect(descendantTree.children.length).to.be.equal(0);
+                const countDescendantsIncludingParent = await repo.countDescendants({id: -1} as Category)
+                expect(countDescendantsIncludingParent).to.be.equal(0);
+            })
+        )
+    );
+});

--- a/test/github-issues/8556/issue-8556.ts
+++ b/test/github-issues/8556/issue-8556.ts
@@ -1,5 +1,10 @@
 import "reflect-metadata";
-import {createTestingConnections, closeTestingConnections, reloadTestingDatabases} from "../../utils/test-utils";
+import {
+    createTestingConnections,
+    closeTestingConnections,
+    reloadTestingDatabases,
+    generateRandomText
+} from "../../utils/test-utils";
 import {Connection} from "../../../src/connection/Connection";
 import {expect} from "chai";
 import {Category} from "./entity/category.entity";
@@ -12,7 +17,8 @@ describe("github issues > #8556 TreeRepository.findDescendants/Tree should retur
         (connections = await createTestingConnections({
             entities: [__dirname + "/entity/*{.js,.ts}"],
             dropSchema: true,
-            schemaCreate: true
+            schemaCreate: true,
+            name: generateRandomText(10)// Use a different name to avoid a random failure in build pipeline
         }))
     );
 


### PR DESCRIPTION
Closes: #8556

<!--
  😀 Wonderful!  Thank you for opening a pull request for TypeORM.

  Please fill in the information below to expedite the review
  and (hopefully) merge of your change.

  If unsure about something.. just do as best as you're able,
  or reach out through our community support channels!
  https://github.com/typeorm/typeorm/blob/master/docs/support.md
-->

### Description of change

<!--
  Please be clear and concise what the change is intended to do,
  why this change is needed, and how you've verified that it
  corrects what you intended.

  In some cases it may be helpful to include the current behavior
  and the new behavior.

  If the change is related to an open issue, you can link it here.
  If you include `Fixes #0000` (replacing `0000` with the issue number)
  when this is merged it will automatically mark the issue as fixed and
  close it.
-->
If subquery in findDescendants `CONCAT(${subQuery.getQuery()}, '%')` returns null when entity parent does not exist, the search string becomes `LIKE '%'`, because CONCAT ignores NULL. This `LIKE '%'` results on returning everything instead of nothing.
Now with `NULLIF` fix, search will be `LIKE NULL`, which returns nothing for a non existing tree parent.
In case of Sqlite, `LIKE ${subQuery.getQuery()} || '%'` is already evaluated as `LIKE NULL` when subquery returns null.


### Pull-Request Checklist

<!--
  Please make sure to review and check all of the following.

  If an item is not applicable, you can add "N/A" to the end.
-->

- [x ] Code is up-to-date with the `master` branch
- [ x] `npm run lint` passes with this change
- [ x] `npm run test` passes with this change
- [ x] This pull request links relevant issues as `Fixes #0000`
- [x ] There are new or updated unit tests validating the change
- [ ] Documentation has been updated to reflect this change
- [ x] The new commits follow conventions explained in [CONTRIBUTING.md](https://github.com/typeorm/typeorm/blob/master/CONTRIBUTING.md)

<!--
  🎉 Thank you for contributing and making TypeORM even better!
-->
