### PR TITLE
docs: fix incorrect docs for whereInIds()

### DIFF
--- a/src/query-builder/DeleteQueryBuilder.ts
+++ b/src/query-builder/DeleteQueryBuilder.ts
@@ -144,7 +144,9 @@ export class DeleteQueryBuilder<Entity> extends QueryBuilder<Entity> implements 
     }
 
     /**
-     * Adds new AND WHERE with conditions for the given ids.
+     * Sets WHERE condition in the query builder with a condition for the given ids.
+     * If you had previously WHERE expression defined,
+     * calling this function will override previously set WHERE conditions.
      */
     whereInIds(ids: any|any[]): this {
         return this.where(this.getWhereInIdsCondition(ids));

--- a/src/query-builder/UpdateQueryBuilder.ts
+++ b/src/query-builder/UpdateQueryBuilder.ts
@@ -197,7 +197,9 @@ export class UpdateQueryBuilder<Entity> extends QueryBuilder<Entity> implements 
     }
 
     /**
-     * Adds new AND WHERE with conditions for the given ids.
+     * Sets WHERE condition in the query builder with a condition for the given ids.
+     * If you had previously WHERE expression defined,
+     * calling this function will override previously set WHERE conditions.
      */
     whereInIds(ids: any|any[]): this {
         return this.where(this.getWhereInIdsCondition(ids));

--- a/src/query-builder/WhereExpressionBuilder.ts
+++ b/src/query-builder/WhereExpressionBuilder.ts
@@ -107,7 +107,9 @@ export interface WhereExpressionBuilder {
     orWhere(subQuery: (qb: this) => string, parameters?: ObjectLiteral): this;
 
     /**
-     * Adds new AND WHERE with conditions for the given ids.
+     * Sets WHERE condition in the query builder with a condition for the given ids.
+     * If you had previously WHERE expression defined,
+     * calling this function will override previously set WHERE conditions.
      *
      * Ids are mixed.
      * It means if you have single primary key you can pass a simple id values, for example [1, 2, 3].


### PR DESCRIPTION
### Description of change

![ss](https://user-images.githubusercontent.com/4450814/151265306-a84f61d9-4c37-4af7-9168-92abac072824.png)

`whereInIds()` has incorrect documentation identical to `andWhereInIds()`, indicating that it performs an `AND WHERE`, when in fact it does not. Instead, it performs a `WHERE`, totally overwriting any previous set of conditions.

Several of us have tripped on this due to this improper documentation so I'd like to remedy with this pull request please.

### Pull-Request Checklist

<!--
  Please make sure to review and check all of the following.

  If an item is not applicable, you can add "N/A" to the end.
-->

- [x] Code is up-to-date with the `master` branch
- [x] `npm run lint` passes with this change
- [x] `npm run test` passes with this change
- [x] ~This pull request links relevant issues as `Fixes #0000`~ (N/A)
- [x] ~There are new or updated unit tests validating the change~ (N/A)
- [x] Documentation has been updated to reflect this change
- [x] The new commits follow conventions explained in [CONTRIBUTING.md](https://github.com/typeorm/typeorm/blob/master/CONTRIBUTING.md)
