### PR TITLE
fix: mysql default value change detection for NULL columns (#8576)

### DIFF
--- a/src/driver/mysql/MysqlDriver.ts
+++ b/src/driver/mysql/MysqlDriver.ts
@@ -653,6 +653,19 @@ export class MysqlDriver implements Driver {
     }
 
     /**
+     * Return undefined in case the "default" value of a table column is 'NULL'
+     */
+    nullDefault(tableMetadata: Pick<TableColumn, 'default'>): TableColumn['default'] | undefined {
+      const defaultValue = tableMetadata.default;
+
+      if (defaultValue === "'NULL'") {
+        return undefined;
+      }
+
+      return defaultValue;
+    }
+
+    /**
      * Normalizes "default" value of the column.
      */
     normalizeDefault(columnMetadata: ColumnMetadata): string | undefined {
@@ -833,7 +846,7 @@ export class MysqlDriver implements Driver {
                 || tableColumn.asExpression !== columnMetadata.asExpression
                 || tableColumn.generatedType !== columnMetadata.generatedType
                 || tableColumn.comment !== this.escapeComment(columnMetadata.comment)
-                || !this.compareDefaultValues(this.normalizeDefault(columnMetadata), tableColumn.default)
+                || !this.compareDefaultValues(this.normalizeDefault(columnMetadata), this.nullDefault(tableColumn))
                 || (tableColumn.enum && columnMetadata.enum && !OrmUtils.isArraysEqual(tableColumn.enum, columnMetadata.enum.map(val => val + "")))
                 || tableColumn.onUpdate !== this.normalizeDatetimeFunction(columnMetadata.onUpdate)
                 || tableColumn.isPrimary !== columnMetadata.isPrimary
@@ -857,7 +870,7 @@ export class MysqlDriver implements Driver {
             //     console.log("comment:", tableColumn.comment, this.escapeComment(columnMetadata.comment));
             //     console.log("default:", tableColumn.default, this.normalizeDefault(columnMetadata));
             //     console.log("enum:", tableColumn.enum, columnMetadata.enum);
-            //     console.log("default changed:", !this.compareDefaultValues(this.normalizeDefault(columnMetadata), tableColumn.default));
+            //     console.log("default changed:", !this.compareDefaultValues(this.normalizeDefault(columnMetadata), this.nullDefault(tableColumn.default)));
             //     console.log("onUpdate:", tableColumn.onUpdate, this.normalizeOnUpdate(columnMetadata.onUpdate));
             //     console.log("isPrimary:", tableColumn.isPrimary, columnMetadata.isPrimary);
             //     console.log("isNullable:", tableColumn.isNullable, columnMetadata.isNullable);


### PR DESCRIPTION
<!--
  😀 Wonderful!  Thank you for opening a pull request for TypeORM.

  Please fill in the information below to expedite the review
  and (hopefully) merge of your change.

  If unsure about something.. just do as best as you're able,
  or reach out through our community support channels!
  https://github.com/typeorm/typeorm/blob/master/docs/support.md
-->

### Description of change

<!--
  Please be clear and concise what the change is intended to do,
  why this change is needed, and how you've verified that it
  corrects what you intended.

  In some cases it may be helpful to include the current behavior
  and the new behavior.

  If the change is related to an open issue, you can link it here.
  If you include `Fixes #0000` (replacing `0000` with the issue number)
  when this is merged it will automatically mark the issue as fixed and
  close it.
-->
Fixes #8576 

Add a new function `nullDefault` to src/driver/mysql/MysqlDriver.ts which "normalizes" a TableColumn's default value to `undefined` if it is `"'NULL'"`. Use this function on the existing table's column data when comparing against entity column metadata to find changed columns.

### Pull-Request Checklist

<!--
  Please make sure to review and check all of the following.

  If an item is not applicable, you can add "N/A" to the end.
-->

- [x] Code is up-to-date with the `master` branch
- [x] `npm run lint` passes with this change
- [ ] `npm run test` passes with this change
- [x] This pull request links relevant issues as `Fixes #0000`
- [ ] There are new or updated unit tests validating the change
- [x] Documentation has been updated to reflect this change
- [x] The new commits follow conventions explained in [CONTRIBUTING.md](https://github.com/typeorm/typeorm/blob/master/CONTRIBUTING.md)

<!--
  🎉 Thank you for contributing and making TypeORM even better!
-->
