### PR TITLE
fix: mongodb repository.find filters soft deleted rows

### DIFF
--- a/test/github-issues/7113/entity/Configuration.ts
+++ b/test/github-issues/7113/entity/Configuration.ts
@@ -1,0 +1,10 @@
+import { DeleteDateColumn, Entity, ObjectID, ObjectIdColumn } from "../../../../src";
+
+@Entity()
+export class Configuration {
+    @ObjectIdColumn()
+    _id: ObjectID;
+
+    @DeleteDateColumn()
+    deletedAt?: Date;
+}

--- a/test/github-issues/7113/issue-7113.ts
+++ b/test/github-issues/7113/issue-7113.ts
@@ -1,0 +1,104 @@
+import "reflect-metadata";
+import { createTestingConnections, closeTestingConnections, reloadTestingDatabases } from "../../utils/test-utils";
+import { Connection } from "../../../src/connection/Connection";
+import { expect } from "chai";
+import { Configuration } from "./entity/Configuration";
+import { ConfigurationRepository } from "./repository/ConfigurationRepository";
+
+describe("github issues > #7113 Soft deleted docs still being pulled in Mongodb", () => {
+
+    let connections: Connection[];
+    before(async () => connections = await createTestingConnections({
+        entities: [__dirname + "/entity/*{.js,.ts}"],
+        schemaCreate: true,
+        dropSchema: true,
+        enabledDrivers: ["mongodb"],
+    }));
+    beforeEach(() => reloadTestingDatabases(connections));
+    after(() => closeTestingConnections(connections));
+
+    it("should not pull soft deleted docs with find", () => Promise.all(connections.map(async connection => {
+
+        const repository = connection.getCustomRepository(ConfigurationRepository);
+        const configuration = new Configuration();
+        
+        await repository.save(configuration);
+
+        await repository.deleteConfiguration(configuration);
+
+        const withoutDeleted = await repository.findAllConfigurations();        
+        expect(withoutDeleted.length).to.be.eq(0);
+
+        const withDeleted = await repository.find({ withDeleted: true });
+        expect(withDeleted.length).to.be.eq(1);
+
+        const withOtherOption = await repository.find({order: { _id: "ASC" }});
+        expect(withOtherOption.length).to.be.eq(0);
+
+    })));
+
+    it("should not pull soft deleted docs with findAndCount", () => Promise.all(connections.map(async connection => {
+
+        const repository = connection.getCustomRepository(ConfigurationRepository);
+        const configuration = new Configuration();
+        
+        await repository.save(configuration);
+
+        await repository.softRemove(configuration);
+
+        const withoutDeletedAndCount = await repository.findAndCount();        
+        expect(withoutDeletedAndCount[0].length).to.be.eq(0);
+
+        const withDeletedAndCount = await repository.findAndCount({ withDeleted: true });
+        expect(withDeletedAndCount[0].length).to.be.eq(1);
+
+        const withOtherOptionAndCount = await repository.findAndCount({order: { _id: "ASC" }});
+        expect(withOtherOptionAndCount[0].length).to.be.eq(0);
+
+    })));
+
+    it("should not pull soft deleted docs with findByIds", () => Promise.all(connections.map(async connection => {
+
+        const repository = connection.getCustomRepository(ConfigurationRepository);
+        const configuration = new Configuration();
+        
+        await repository.save(configuration);
+
+        await repository.softRemove(configuration);
+
+        const withoutDeletedById = await repository.findByIds([configuration._id]);
+        expect(withoutDeletedById.length).to.be.eq(0);
+
+        const withDeletedById = await repository.findByIds([configuration._id],
+            { withDeleted: true });
+        expect(withDeletedById.length).to.be.eq(1);
+
+        const withOtherOptionById = await repository.findByIds([configuration._id],
+            { cache: true });
+        expect(withOtherOptionById.length).to.be.eq(0);
+
+    })));
+
+    it("should not pull soft deleted docs with findOne", () => Promise.all(connections.map(async connection => {
+
+        const repository = connection.getCustomRepository(ConfigurationRepository);
+        const configuration = new Configuration();
+        
+        await repository.save(configuration);
+
+        await repository.softRemove(configuration);
+
+        const withoutDeletedOne = await repository.findOne(configuration._id);        
+        expect(withoutDeletedOne).to.be.undefined;
+
+        const withDeletedOne = await repository.findOne(configuration._id,
+            { withDeleted: true });
+        expect(withDeletedOne).not.to.be.undefined;
+
+        const withOtherOptionOne = await repository.findOne(configuration._id,
+            { cache: true });
+        expect(withOtherOptionOne).to.be.undefined;
+
+    })));
+
+});

--- a/test/github-issues/7113/repository/ConfigurationRepository.ts
+++ b/test/github-issues/7113/repository/ConfigurationRepository.ts
@@ -1,0 +1,18 @@
+import { EntityRepository, MongoRepository, ObjectID } from "../../../../src";
+import { Configuration } from "../entity/Configuration";
+
+@EntityRepository(Configuration)
+export class ConfigurationRepository extends MongoRepository<Configuration> {
+
+  async findAllConfigurations(): Promise<Configuration[]> {
+    const configurations = await this.find();
+    return configurations;
+  }
+
+  async deleteConfiguration(
+    configuration: Configuration
+  ): Promise<ObjectID> {
+    await this.softRemove(configuration);
+    return configuration._id;
+  }
+}


### PR DESCRIPTION
Closes: #7113

<!--
  😀 Wonderful!  Thank you for opening a pull request for TypeORM.

  Please fill in the information below to expedite the review
  and (hopefully) merge of your change.

  If unsure about something.. just do as best as you're able,
  or reach out through our community support channels!
  https://github.com/typeorm/typeorm/blob/master/docs/support.md
-->

### Description of change

<!--
  Please be clear and concise what the change is intended to do,
  why this change is needed, and how you've verified that it
  corrects what you intended.

  In some cases it may be helpful to include the current behavior
  and the new behavior.

  If the change is related to an open issue, you can link it here.
  If you include `Fixes #0000` (replacing `0000` with the issue number)
  when this is merged it will automatically mark the issue as fixed and
  close it.
-->
`MongoRepository` `find`, `findAndCount`, `findByIds`, `findOne` methods do not select rows that was soft deleted.

### Pull-Request Checklist

<!--
  Please make sure to review and check all of the following.

  If an item is not applicable, you can add "N/A" to the end.
-->

- [x] Code is up-to-date with the `master` branch
- [x] `npm run lint` passes with this change
- [x] `npm run test` passes with this change
- [ ] This pull request links relevant issues as `Fixes #0000`
- [x] There are new or updated unit tests validating the change
- [ ] Documentation has been updated to reflect this change
- [x] The new commits follow conventions explained in [CONTRIBUTING.md](https://github.com/typeorm/typeorm/blob/master/CONTRIBUTING.md)

<!--
  🎉 Thank you for contributing and making TypeORM even better!
-->
