### PR TITLE
fix: Exit process on successful migration revert via cli

### DIFF
--- a/src/commands/MigrationRevertCommand.ts
+++ b/src/commands/MigrationRevertCommand.ts
@@ -74,6 +74,8 @@ export class MigrationRevertCommand implements yargs.CommandModule {
 
             await connection.undoLastMigration(options);
             await connection.close();
+            // exit process if no errors
+            process.exit(0);
 
         } catch (err) {
             if (connection) await (connection as Connection).close();


### PR DESCRIPTION
### Description of change

Add process exit after successfully reverting a migration via cli

**Motivation**

Currently, process is not exited after successfully reverting a migration via cli, so it is unclear if everything is OK 

**Current behavior**

Process is not exited after successfully reverting a migration via cli

**New behavior**

Process is exited with code `0` after successfully reverting a migration via cli

### Pull-Request Checklist

- [x] Code is up-to-date with the `master` branch
- [x] `npm run lint` passes with this change
- [x] `npm run test` passes with this change
- [ ] This pull request links relevant issues as `Fixes #0000`
- [ ] There are new or updated unit tests validating the change
- [ ] Documentation has been updated to reflect this change
- [x] The new commits follow conventions explained in [CONTRIBUTING.md](https://github.com/typeorm/typeorm/blob/master/CONTRIBUTING.md)
