### PR TITLE
docs: Correct relation decorator name in faq doc

### DIFF
--- a/docs/faq.md
+++ b/docs/faq.md
@@ -289,7 +289,7 @@ module.exports = {
 
 Make sure to add `"type": "module"` in the `package.json` of your project so TypeORM will know to use `import( ... )` on files.
 
-To avoid circular dependency import issues use the `Related` wrapper type for relation type definitions in entities:
+To avoid circular dependency import issues use the `Relation` wrapper type for relation type definitions in entities:
 
 ```typescript
 @Entity()
@@ -305,4 +305,4 @@ Doing this prevents the type of the property from being saved in the transpiled 
 
 Since the type of the column is already defined using the `@OneToOne` decorator, there's no use of the additional type metadata saved by TypeScript.
 
-> Important: Do not use `Related` on non-relation column types
+> Important: Do not use `Relation` on non-relation column types


### PR DESCRIPTION
### Description of change

Correct relation decorator name in faq doc


### Pull-Request Checklist

- [x] Code is up-to-date with the `master` branch
- [x] `npm run lint` passes with this change
- [x] `npm run test` passes with this change
- [ ] This pull request links relevant issues as `Fixes #0000`
- [ ] There are new or updated unit tests validating the change
- [x] Documentation has been updated to reflect this change
- [x] The new commits follow conventions explained in [CONTRIBUTING.md](https://github.com/typeorm/typeorm/blob/master/CONTRIBUTING.md)