### PR TITLE
docs: Adjust grammatical error

### DIFF
--- a/docs/relations-faq.md
+++ b/docs/relations-faq.md
@@ -197,7 +197,7 @@ Question {
 
 Now when you save this object `categories` inside it won't be touched - because it is unset.
 
-But if you have initializer, the loaded object will look like as follow:
+But if you have an initializer, the loaded object will look as follows:
 
 ```javascript
 Question {


### PR DESCRIPTION
The following grammatical adjustments are related to the `Avoid relation property initializers` section, found in the relations-faq [page](https://typeorm.io/#/relations-faq/avoid-relation-property-initializers);

1.  Adjust the grammatical error found in the following phrase `But if you have initializer` by **adding** `an` before the word `initializer`.
2.  Adjust the grammatical error found in the following phrase `the loaded object will look like as follow` by **removing** the `like` word and **adding** an `s` to `follow`.

<!--
  😀 Wonderful!  Thank you for opening a pull request for TypeORM.

  Please fill in the information below to expedite the review
  and (hopefully) merge of your change.

  If unsure about something.. just do as best as you're able,
  or reach out through our community support channels!
  https://github.com/typeorm/typeorm/blob/master/docs/support.md
-->

### Description of change

<!--
  Please be clear and concise what the change is intended to do,
  why this change is needed, and how you've verified that it
  corrects what you intended.

  In some cases it may be helpful to include the current behavior
  and the new behavior.

  If the change is related to an open issue, you can link it here.
  If you include `Fixes #0000` (replacing `0000` with the issue number)
  when this is merged it will automatically mark the issue as fixed and
  close it.
-->


### Pull-Request Checklist

<!--
  Please make sure to review and check all of the following.

  If an item is not applicable, you can add "N/A" to the end.
-->

- [ ] Code is up-to-date with the `master` branch `N/A`
- [x] `npm run lint` passes with this change 
- [x] `npm run test` passes with this change `N/A`
- [ ] This pull request links relevant issues as `Fixes #0000` `N/A`
- [ ] There are new or updated unit tests validating the change `N/A`
- [ ] Documentation has been updated to reflect this change `N/A`
- [x] The new commits follow conventions explained in [CONTRIBUTING.md](https://github.com/typeorm/typeorm/blob/master/CONTRIBUTING.md)

<!--
  🎉 Thank you for contributing and making TypeORM even better!
-->
