### PR TITLE
fix: upsert should find unique index created by one-to-one relation

### DIFF
--- a/src/entity-manager/EntityManager.ts
+++ b/src/entity-manager/EntityManager.ts
@@ -39,7 +39,6 @@ import {ObjectLiteral} from "../common/ObjectLiteral";
 import {getMetadataArgsStorage} from "../globals";
 import {TypeORMError} from "../error";
 import {UpsertOptions} from "../repository/UpsertOptions";
-import { OrmUtils } from "../util/OrmUtils";
 
 /**
  * Entity manager supposed to work with any entity, automatically find its repository and call its methods,

--- a/src/entity-manager/EntityManager.ts
+++ b/src/entity-manager/EntityManager.ts
@@ -496,27 +496,6 @@ export class EntityManager {
             options = conflictPathsOrOptions;
         }
 
-        const relationMetadatas = metadata.relations.map(relation => (relation.embeddedMetadata ?? relation.entityMetadata));
-
-        const uniqueColumnConstraints = [
-            metadata.primaryColumns,
-            ...metadata.indices.filter(ix => ix.isUnique).map(ix => ix.columns),
-            ...metadata.uniques.map(uq => uq.columns),
-            ...OrmUtils.flatten([
-                ...relationMetadatas.map(rel => rel.indices.filter(ix => ix.isUnique).map(ix => ix.columns)),
-                ...relationMetadatas.map(rel => rel.uniques.map(ix => ix.columns)),
-            ])
-        ];
-
-        const useIndex = uniqueColumnConstraints.find((ix) =>
-            ix.length === options.conflictPaths.length &&
-            options.conflictPaths.every((conflictPropertyPath) => ix.some((col) => col.propertyPath === conflictPropertyPath))
-        );
-
-        if (useIndex == null) {
-            throw new TypeORMError(`An upsert requires conditions that have a unique constraint but none was found for conflict properties: ${options.conflictPaths.join(", ")}`);
-        }
-
         let entities: QueryDeepPartialEntity<Entity>[];
 
         if (!Array.isArray(entityOrEntities)) {

--- a/src/util/OrmUtils.ts
+++ b/src/util/OrmUtils.ts
@@ -15,10 +15,6 @@ export class OrmUtils {
         });
     }
 
-    static flatten<T>(deepArray: T[][]): T[] {
-        return ([] as T[]).concat(...deepArray);
-    }
-
     static splitClassesAndStrings<T>(clsesAndStrings: (string | T)[]): [T[], string[]] {
         return [
             (clsesAndStrings).filter((cls): cls is T => typeof cls !== "string"),

--- a/src/util/OrmUtils.ts
+++ b/src/util/OrmUtils.ts
@@ -15,6 +15,10 @@ export class OrmUtils {
         });
     }
 
+    static flatten<T>(deepArray: T[][]): T[] {
+        return ([] as T[]).concat(...deepArray);
+    }
+
     static splitClassesAndStrings<T>(clsesAndStrings: (string | T)[]): [T[], string[]] {
         return [
             (clsesAndStrings).filter((cls): cls is T => typeof cls !== "string"),

--- a/test/functional/repository/basic-methods/entity/OneToOneRelation.ts
+++ b/test/functional/repository/basic-methods/entity/OneToOneRelation.ts
@@ -1,0 +1,15 @@
+import { Column, Entity, JoinColumn, OneToOne, PrimaryGeneratedColumn } from "../../../../../src";
+import { Category } from "./Category";
+
+@Entity()
+export class OneToOneRelationEntity {
+    @PrimaryGeneratedColumn()
+    id: number;
+
+    @OneToOne(() => Category)
+    @JoinColumn()
+    category: Category;
+
+    @Column()
+    order: number;
+}

--- a/test/functional/repository/basic-methods/repository-basic-methods.ts
+++ b/test/functional/repository/basic-methods/repository-basic-methods.ts
@@ -14,6 +14,7 @@ import { ExternalIdPrimaryKeyEntity } from "./entity/ExternalIdPrimaryKeyEntity"
 import { EmbeddedUniqueConstraintEntity } from "./entity/EmbeddedUniqueConstraintEntity";
 import { RelationAsPrimaryKey } from "./entity/RelationAsPrimaryKey";
 import { TwoUniqueColumnsEntity } from "./entity/TwoUniqueColumns";
+import { OneToOneRelationEntity } from "./entity/OneToOneRelation";
 
 describe("repository > basic methods", () => {
 
@@ -41,7 +42,8 @@ describe("repository > basic methods", () => {
                     ExternalIdPrimaryKeyEntity,
                     EmbeddedUniqueConstraintEntity,
                     RelationAsPrimaryKey,
-                    TwoUniqueColumnsEntity
+                    TwoUniqueColumnsEntity,
+                    OneToOneRelationEntity
                 ],
             }))
     );
@@ -500,6 +502,31 @@ describe("repository > basic methods", () => {
             (await embeddedConstraintObjects.findOneOrFail({ embedded: { id: "bar1" } })).embedded.value.should.be.equal("foo 1");
             await embeddedConstraintObjects.upsert({ embedded: { id: "bar1", value: "foo 2" } }, ["embedded.id"]);
             (await embeddedConstraintObjects.findOneOrFail({ embedded: { id: "bar1" } })).embedded.value.should.be.equal("foo 2");
+        })));
+        it("should upsert on one-to-one relation", () => Promise.all(connections.map(async (connection) => {
+            if (connection.driver.supportedUpsertType == null) return;
+
+            const oneToOneRepository = connection.getRepository(OneToOneRelationEntity);
+            const categoryRepository = connection.getRepository(Category);
+
+            const category = await categoryRepository.save({
+                name: "Category"
+            });
+
+            await oneToOneRepository.upsert({
+                category,
+                order: 1
+            }, ["category.id"]);
+
+            (await oneToOneRepository.findOneOrFail({ category }))!.order.should.be.equal(1);
+
+            await oneToOneRepository.upsert({
+                category,
+                order: 2
+            }, ["category.id"]);
+
+            (await oneToOneRepository.findOneOrFail({ category }))!.order.should.be.equal(2);
+
         })));
         it("should bulk upsert with embedded columns", () => Promise.all(connections.map(async (connection) => {
             if (connection.driver.supportedUpsertType == null) return;

--- a/test/functional/repository/basic-methods/repository-basic-methods.ts
+++ b/test/functional/repository/basic-methods/repository-basic-methods.ts
@@ -551,14 +551,6 @@ describe("repository > basic methods", () => {
             (await embeddedConstraintObjects.findOneOrFail({ embedded: { id: "bar2" } })).embedded.value.should.be.equal("value2 2");
             (await embeddedConstraintObjects.findOneOrFail({ embedded: { id: "bar3" } })).embedded.value.should.be.equal("value3 2");
         })));
-        it("should throw if attempting to conflict on properties with no unique constraint", () => Promise.all(connections.map(async (connection) => {
-            if (connection.driver.supportedUpsertType == null) return;
-            
-            const externalIdObjects = connection.getRepository(ExternalIdPrimaryKeyEntity);
-            // cannot conflict on a column with no unique index
-            await externalIdObjects.upsert({ title: "foo"}, ["title"])
-                .should.be.rejectedWith(TypeORMError);
-        })));
         it("should throw if using an unsupported driver", () => Promise.all(connections.map(async (connection) => {
             if (connection.driver.supportedUpsertType != null) return;
             


### PR DESCRIPTION
<!--
  😀 Wonderful!  Thank you for opening a pull request for TypeORM.

  Please fill in the information below to expedite the review
  and (hopefully) merge of your change.

  If unsure about something.. just do as best as you're able,
  or reach out through our community support channels!
  https://github.com/typeorm/typeorm/blob/master/docs/support.md
-->

### Description of change

<!--
  Please be clear and concise what the change is intended to do,
  why this change is needed, and how you've verified that it
  corrects what you intended.

  In some cases it may be helpful to include the current behavior
  and the new behavior.

  If the change is related to an open issue, you can link it here.
  If you include `Fixes #0000` (replacing `0000` with the issue number)
  when this is merged it will automatically mark the issue as fixed and
  close it.
-->

Fixes #8587 

One-to-one relations create a unique index, that index should be suitable for an upsert conflict target.


### Pull-Request Checklist

<!--
  Please make sure to review and check all of the following.

  If an item is not applicable, you can add "N/A" to the end.
-->

- [x] Code is up-to-date with the `master` branch
- [x] `npm run lint` passes with this change
- [x] `npm run test` passes with this change
- [x] This pull request links relevant issues as `Fixes #0000`
- [x] There are new or updated unit tests validating the change
- [ ] Documentation has been updated to reflect this change
- [x] The new commits follow conventions explained in [CONTRIBUTING.md](https://github.com/typeorm/typeorm/blob/master/CONTRIBUTING.md)

<!--
  🎉 Thank you for contributing and making TypeORM even better!
-->
