### PR TITLE
docs: update entitymanager definition

### DIFF
--- a/docs/working-with-entity-manager.md
+++ b/docs/working-with-entity-manager.md
@@ -7,11 +7,11 @@ You can access the entity manager via DataSource's manager.
 Example how to use it:
  
 ```typescript
-import {Manager} from "./config/DataSource";
+import {DataSource} from "typeorm";
 import {User} from "./entity/User";
 
-const entityManager = Manager;
-const user = await entityManager.findOne(User, 1);
+const myDataSource = new DataSource({ /*...*/ });
+const user = await myDataSource.manager.findOne(User, 1);
 user.name = "Umed";
 await entityManager.save(user);
 ```

--- a/docs/working-with-entity-manager.md
+++ b/docs/working-with-entity-manager.md
@@ -3,14 +3,14 @@
 Using `EntityManager` you can manage (insert, update, delete, load, etc.) any entity. 
 EntityManager is just like a collection of all entity repositories in a single place.
  
-You can access the entity manager via `getManager()` or from `Connection`.
+You can access the entity manager via DataSource's manager.
 Example how to use it:
  
 ```typescript
-import {getManager} from "typeorm";
+import {Manager} from "./config/DataSource";
 import {User} from "./entity/User";
 
-const entityManager = getManager(); // you can also get it via getConnection().manager
+const entityManager = Manager;
 const user = await entityManager.findOne(User, 1);
 user.name = "Umed";
 await entityManager.save(user);


### PR DESCRIPTION
<!--
  😀 Wonderful!  Thank you for opening a pull request for TypeORM.

  Please fill in the information below to expedite the review
  and (hopefully) merge of your change.

  If unsure about something.. just do as best as you're able,
  or reach out through our community support channels!
  https://github.com/typeorm/typeorm/blob/master/docs/support.md
-->

### Description of change

change the "What is EntityManager?" page to be up-to-date with v 0.3.0

1. line 6 changes from
`You can access the entity manager via 'getManager()' or from 'Connection'.`
to 
`You can access the entity manager via DataSource's manager.`

2. the import on `getManager` in line 10 becomes `DataSource`  directly imported from typeorm:
`import {getManager} from "typeorm";`
becomes 
`import {DataSource} from "typeorm";`

3. change entityManager definition in line 13 and user load in line 14:
from
`const entityManager = getManager(); // you can also get it via getConnection().manager`
`const user = await entityManager.findOne(User, 1);`
to
`const myDataSource = new DataSource({ /*...*/ });`
`const user = await myDataSource.manager.findOne(User, 1);`

<!--
  Please be clear and concise what the change is intended to do,
  why this change is needed, and how you've verified that it
  corrects what you intended.

  In some cases it may be helpful to include the current behavior
  and the new behavior.

  If the change is related to an open issue, you can link it here.
  If you include `Fixes #0000` (replacing `0000` with the issue number)
  when this is merged it will automatically mark the issue as fixed and
  close it.
-->


### Pull-Request Checklist

<!--
  Please make sure to review and check all of the following.

  If an item is not applicable, you can add "N/A" to the end.
-->

- [ ] Code is up-to-date with the `master` branch
- [ ] `npm run lint` passes with this change
- [ ] `npm run test` passes with this change
- [ ] This pull request links relevant issues as `Fixes #0000`
- [ ] There are new or updated unit tests validating the change
- [ ] Documentation has been updated to reflect this change
- [x] The new commits follow conventions explained in [CONTRIBUTING.md](https://github.com/typeorm/typeorm/blob/master/CONTRIBUTING.md)

<!--
  🎉 Thank you for contributing and making TypeORM even better!
-->
