### PR TITLE
feat: allow users to specify custom column types

### DIFF
--- a/src/decorator/columns/Column.ts
+++ b/src/decorator/columns/Column.ts
@@ -8,6 +8,7 @@ import {
     WithWidthColumnType,
 } from "../../driver/types/ColumnTypes"
 import { ColumnMetadataArgs } from "../../metadata-args/ColumnMetadataArgs"
+import { isCustomColumnType } from "../../util/IsCustomColumnType"
 import { ColumnCommonOptions } from "../options/ColumnCommonOptions"
 import { SpatialColumnOptions } from "../options/SpatialColumnOptions"
 import { ColumnWithLengthOptions } from "../options/ColumnWithLengthOptions"
@@ -143,12 +144,13 @@ export function Column(
         let type: ColumnType | undefined
         if (
             typeof typeOrOptions === "string" ||
-            typeof typeOrOptions === "function"
+            typeof typeOrOptions === "function" ||
+            isCustomColumnType(typeOrOptions)
         ) {
             type = <ColumnType>typeOrOptions
         } else if (typeOrOptions) {
             options = <ColumnOptions>typeOrOptions
-            type = typeOrOptions.type
+            type = options.type
         }
         if (!options) options = {} as ColumnOptions
 

--- a/src/driver/cockroachdb/CockroachDriver.ts
+++ b/src/driver/cockroachdb/CockroachDriver.ts
@@ -1,3 +1,4 @@
+import { isCustomColumnType } from "../../util/IsCustomColumnType"
 import { Driver } from "../Driver"
 import { ConnectionIsNotSetError } from "../../error/ConnectionIsNotSetError"
 import { ObjectLiteral } from "../../common/ObjectLiteral"
@@ -620,6 +621,8 @@ export class CockroachDriver implements Driver {
             return "char"
         } else if (column.type === "json") {
             return "jsonb"
+        } else if (isCustomColumnType(column.type)) {
+            return column.type.getDatabaseIdentifier(this)
         } else {
             return (column.type as string) || ""
         }

--- a/src/driver/mysql/MysqlDriver.ts
+++ b/src/driver/mysql/MysqlDriver.ts
@@ -1,3 +1,4 @@
+import { isCustomColumnType } from "../../util/IsCustomColumnType"
 import { Driver, ReturningType } from "../Driver"
 import { ConnectionIsNotSetError } from "../../error/ConnectionIsNotSetError"
 import { DriverPackageNotInstalledError } from "../../error/DriverPackageNotInstalledError"
@@ -744,6 +745,8 @@ export class MysqlDriver implements Driver {
             return "varchar"
         } else if (column.type === "nchar" || column.type === "national char") {
             return "char"
+        } else if (isCustomColumnType(column.type)) {
+            return column.type.getDatabaseIdentifier(this)
         } else {
             return (column.type as string) || ""
         }

--- a/src/driver/oracle/OracleDriver.ts
+++ b/src/driver/oracle/OracleDriver.ts
@@ -1,3 +1,4 @@
+import { isCustomColumnType } from "../../util/IsCustomColumnType"
 import { Driver } from "../Driver"
 import { ConnectionIsNotSetError } from "../../error/ConnectionIsNotSetError"
 import { DriverPackageNotInstalledError } from "../../error/DriverPackageNotInstalledError"
@@ -594,6 +595,8 @@ export class OracleDriver implements Driver {
             return "clob"
         } else if (column.type === "simple-json") {
             return "clob"
+        } else if (isCustomColumnType(column.type)) {
+            return column.type.getDatabaseIdentifier(this)
         } else {
             return (column.type as string) || ""
         }

--- a/src/driver/postgres/PostgresDriver.ts
+++ b/src/driver/postgres/PostgresDriver.ts
@@ -10,6 +10,7 @@ import { RdbmsSchemaBuilder } from "../../schema-builder/RdbmsSchemaBuilder"
 import { TableColumn } from "../../schema-builder/table/TableColumn"
 import { ApplyValueTransformers } from "../../util/ApplyValueTransformers"
 import { DateUtils } from "../../util/DateUtils"
+import { isCustomColumnType } from "../../util/IsCustomColumnType"
 import { OrmUtils } from "../../util/OrmUtils"
 import { Driver } from "../Driver"
 import { ColumnType } from "../types/ColumnTypes"
@@ -972,6 +973,8 @@ export class PostgresDriver implements Driver {
             return "character"
         } else if (column.type === "varbit") {
             return "bit varying"
+        } else if (isCustomColumnType(column.type)) {
+            return column.type.getDatabaseIdentifier(this)
         } else {
             return (column.type as string) || ""
         }

--- a/src/driver/sqlite-abstract/AbstractSqliteDriver.ts
+++ b/src/driver/sqlite-abstract/AbstractSqliteDriver.ts
@@ -1,3 +1,4 @@
+import { isCustomColumnType } from "../../util/IsCustomColumnType"
 import { Driver } from "../Driver"
 import { ObjectLiteral } from "../../common/ObjectLiteral"
 import { ColumnMetadata } from "../../metadata/ColumnMetadata"
@@ -613,6 +614,8 @@ export abstract class AbstractSqliteDriver implements Driver {
             return "text"
         } else if (column.type === "simple-enum") {
             return "varchar"
+        } else if (isCustomColumnType(column.type)) {
+            return column.type.getDatabaseIdentifier(this)
         } else {
             return (column.type as string) || ""
         }

--- a/src/driver/types/ColumnTypes.ts
+++ b/src/driver/types/ColumnTypes.ts
@@ -1,6 +1,8 @@
 /**
  * Column types used for @PrimaryGeneratedColumn() decorator.
  */
+import { CustomColumnType } from "./CustomColumnType"
+
 export type PrimaryGeneratedColumnType =
     | "int" // mysql, mssql, oracle, sqlite, sap
     | "int2" // postgres, sqlite, cockroachdb
@@ -210,3 +212,4 @@ export type ColumnType =
     | DateConstructor
     | NumberConstructor
     | StringConstructor
+    | CustomColumnType

--- a/src/driver/types/CustomColumnType.ts
+++ b/src/driver/types/CustomColumnType.ts
@@ -1,0 +1,5 @@
+import { Driver } from "../Driver"
+
+export interface CustomColumnType {
+    getDatabaseIdentifier(driver: Driver): string
+}

--- a/src/metadata-builder/EntityMetadataValidator.ts
+++ b/src/metadata-builder/EntityMetadataValidator.ts
@@ -9,6 +9,7 @@ import { NoConnectionOptionError } from "../error/NoConnectionOptionError"
 import { InitializedRelationError } from "../error/InitializedRelationError"
 import { TypeORMError } from "../error"
 import { DriverUtils } from "../driver/DriverUtils"
+import { isCustomColumnType } from "../util/IsCustomColumnType"
 
 /// todo: add check if there are multiple tables with the same name
 /// todo: add checks when generated column / table names are too long for the specific driver
@@ -109,6 +110,9 @@ export class EntityMetadataValidator {
 
         if (!(driver.options.type === "mongodb")) {
             entityMetadata.columns.forEach((column) => {
+                if (isCustomColumnType(column.type)) {
+                    return
+                }
                 const normalizedColumn = driver.normalizeType(
                     column,
                 ) as ColumnType

--- a/src/util/IsCustomColumnType.ts
+++ b/src/util/IsCustomColumnType.ts
@@ -1,0 +1,9 @@
+import { CustomColumnType } from "../driver/types/CustomColumnType"
+
+export function isCustomColumnType(type: any): type is CustomColumnType {
+    return !!(
+        type &&
+        typeof type === "object" &&
+        typeof type.getDatabaseIdentifier === "function"
+    )
+}


### PR DESCRIPTION
Resolves #8407

### Description of change

Allows to specify object of interface `CustomColumnType` wherever `ColumnType` is required.

This allows users to define arbitrary column types without monkey patching library internals. 

TODO: add docs and tests.

### Pull-Request Checklist

<!--
  Please make sure to review and check all of the following.

  If an item is not applicable, you can add "N/A" to the end.
-->

- [x] Code is up-to-date with the `master` branch
- [x] `npm run lint` passes with this change
- [x] `npm run test` passes with this change
- [x ] This pull request links relevant issues as `Fixes #0000`
- [ ] There are new or updated unit tests validating the change
- [ ] Documentation has been updated to reflect this change
- [ ] The new commits follow conventions explained in [CONTRIBUTING.md](https://github.com/typeorm/typeorm/blob/master/CONTRIBUTING.md)

<!--
  🎉 Thank you for contributing and making TypeORM even better!
-->
