### PR TITLE
fix: keep junction aliases short

### DIFF
--- a/test/github-issues/8627/entity/long-name.entity.ts
+++ b/test/github-issues/8627/entity/long-name.entity.ts
@@ -1,0 +1,17 @@
+import {PrimaryGeneratedColumn, ManyToMany, JoinTable} from "../../../../src";
+import {Entity} from "../../../../src/decorator/entity/Entity";
+import {AnotherReallyLongNameForAnEntityBecauseThisIsNecessaryB, AnotherRealLongNameForAnEntityBecauseThisIsNecessaryC} from "./other-long-name.entity";
+
+@Entity()
+export class ThisIsARealLongNameForAnEntityBecauseThisIsNecessary {
+    @PrimaryGeneratedColumn()
+    id: number;
+
+    @ManyToMany(() => AnotherReallyLongNameForAnEntityBecauseThisIsNecessaryB, { eager: true })
+    @JoinTable({name: 'junction_b'})
+    long_name_for_bs!: AnotherReallyLongNameForAnEntityBecauseThisIsNecessaryB[];
+
+    @ManyToMany(() => AnotherRealLongNameForAnEntityBecauseThisIsNecessaryC, { eager: true })
+    @JoinTable({name: 'junction_c'})
+    long_name_for_cs!: AnotherRealLongNameForAnEntityBecauseThisIsNecessaryC[];
+}

--- a/test/github-issues/8627/entity/other-long-name.entity.ts
+++ b/test/github-issues/8627/entity/other-long-name.entity.ts
@@ -1,0 +1,14 @@
+import {PrimaryGeneratedColumn} from "../../../../src";
+import {Entity} from "../../../../src/decorator/entity/Entity";
+
+@Entity()
+export class AnotherReallyLongNameForAnEntityBecauseThisIsNecessaryB {
+    @PrimaryGeneratedColumn()
+    id: number;
+}
+
+@Entity()
+export class AnotherRealLongNameForAnEntityBecauseThisIsNecessaryC {
+    @PrimaryGeneratedColumn()
+    id: number;
+}

--- a/test/github-issues/8627/issue-8627.ts
+++ b/test/github-issues/8627/issue-8627.ts
@@ -1,0 +1,37 @@
+import "reflect-metadata";
+import {
+    createTestingConnections,
+    closeTestingConnections,
+    reloadTestingDatabases,
+    generateRandomText
+} from "../../utils/test-utils";
+import {Connection} from "../../../src/connection/Connection";
+import {expect} from "chai";
+import {ThisIsARealLongNameForAnEntityBecauseThisIsNecessary} from "./entity/long-name.entity";
+
+describe("github issues > #8627 junction aliases are not unique", () => {
+    let connections: Connection[];
+    before(
+        async () =>
+        (connections = await createTestingConnections({
+            entities: [__dirname + "/entity/*{.js,.ts}"],
+            dropSchema: true,
+            schemaCreate: true,
+            name: generateRandomText(10)// Use a different name to avoid a random failure in build pipeline
+        }))
+    );
+
+    beforeEach(() => reloadTestingDatabases(connections));
+    after(() => closeTestingConnections(connections));
+
+    it("should not fail querying many-to-many-relation", () =>
+        Promise.all(
+            connections.map(async connection => {
+                const manager = connection.createEntityManager()
+                // Nothing special to be checked here, just the query shouldn't fail.
+                const result = await manager.find(ThisIsARealLongNameForAnEntityBecauseThisIsNecessary)
+                expect(result).to.eql([])
+            })
+        )
+    );
+});


### PR DESCRIPTION
<!--
  😀 Wonderful!  Thank you for opening a pull request for TypeORM.

  Please fill in the information below to expedite the review
  and (hopefully) merge of your change.

  If unsure about something.. just do as best as you're able,
  or reach out through our community support channels!
  https://github.com/typeorm/typeorm/blob/master/docs/support.md
-->

### Description of change

Currently, when having really long names for entities (in the code, not the table name) or deeply nested structures, joins do not work correctly because it can be that junction aliases do not get shortened. In the driver (e.g. Postgres has a limit of 63 characters), they will be truncated and then two different junction aliases map to the same string, resulting in the query failing because of aliases not being unique.

~~With this fix, junction aliases are being hashed and thus are short enough.~~

See below... **tl;dr: The fix was already implemented in 0.3.0. This PR adds a test for that fix.**

*Note that this does worsen the ability to read the query as the shortened / hashed aliases are harder to read.*
If you have suggestions on how to now loose the readability while still fixing the issue of junction names being too long, I'd be happy to change the behaviour.

<!--
  Please be clear and concise what the change is intended to do,
  why this change is needed, and how you've verified that it
  corrects what you intended.

  In some cases it may be helpful to include the current behavior
  and the new behavior.

  If the change is related to an open issue, you can link it here.
  If you include `Fixes #0000` (replacing `0000` with the issue number)
  when this is merged it will automatically mark the issue as fixed and
  close it.
-->

Fixes #8627


### Pull-Request Checklist

Is there documentation that needs to be updated?

<!--
  Please make sure to review and check all of the following.

  If an item is not applicable, you can add "N/A" to the end.
-->

- [x] Code is up-to-date with the `master` branch
- [x] `npm run lint` passes with this change
- [x] `npm run test` passes with this change
- [x] This pull request links relevant issues as `Fixes #0000`
- [x] There are new or updated unit tests validating the change
- [ ] Documentation has been updated to reflect this change
- [x] The new commits follow conventions explained in [CONTRIBUTING.md](https://github.com/typeorm/typeorm/blob/master/CONTRIBUTING.md)

<!--
  🎉 Thank you for contributing and making TypeORM even better!
-->
