### PR TITLE
fix: Allow special keyword as column name for simple-enum type on sqlite

### DIFF
--- a/src/driver/sqlite-abstract/AbstractSqliteQueryRunner.ts
+++ b/src/driver/sqlite-abstract/AbstractSqliteQueryRunner.ts
@@ -859,7 +859,7 @@ export abstract class AbstractSqliteQueryRunner extends BaseQueryRunner implemen
 
                 if (tableColumn.type === "varchar") {
                     // Check if this is an enum
-                    const enumMatch = sql.match(new RegExp("\"(" + tableColumn.name + ")\" varchar CHECK\\s*\\(\\s*\\1\\s+IN\\s*\\(('[^']+'(?:\\s*,\\s*'[^']+')+)\\s*\\)\\s*\\)"));
+                    const enumMatch = sql.match(new RegExp("\"(" + tableColumn.name + ")\" varchar CHECK\\s*\\(\\s*\"\\1\"\\s+IN\\s*\\(('[^']+'(?:\\s*,\\s*'[^']+')+)\\s*\\)\\s*\\)"));
                     if (enumMatch) {
                         // This is an enum
                         tableColumn.enum = enumMatch[2].substr(1, enumMatch[2].length - 2).split("','");
@@ -1147,7 +1147,7 @@ export abstract class AbstractSqliteQueryRunner extends BaseQueryRunner implemen
         }
 
         if (column.enum)
-            c += ' CHECK( "' + column.name + '" IN (' + column.enum.map(val => "'" + val + "'").join(",") + ") )";
+            c += " CHECK( \"" + column.name + "\" IN (" + column.enum.map(val => "'" + val + "'").join(",") + ") )";
         if (column.isPrimary && !skipPrimary)
             c += " PRIMARY KEY";
         if (column.isGenerated === true && column.generationStrategy === "increment") // don't use skipPrimary here since updates can update already exist primary without auto inc.

--- a/src/driver/sqlite-abstract/AbstractSqliteQueryRunner.ts
+++ b/src/driver/sqlite-abstract/AbstractSqliteQueryRunner.ts
@@ -1147,7 +1147,7 @@ export abstract class AbstractSqliteQueryRunner extends BaseQueryRunner implemen
         }
 
         if (column.enum)
-            c += " CHECK( " + column.name + " IN (" + column.enum.map(val => "'" + val + "'").join(",") + ") )";
+            c += ' CHECK( "' + column.name + '" IN (' + column.enum.map(val => "'" + val + "'").join(",") + ") )";
         if (column.isPrimary && !skipPrimary)
             c += " PRIMARY KEY";
         if (column.isGenerated === true && column.generationStrategy === "increment") // don't use skipPrimary here since updates can update already exist primary without auto inc.

--- a/test/github-issues/8644/entity/my-table.entity.ts
+++ b/test/github-issues/8644/entity/my-table.entity.ts
@@ -1,0 +1,16 @@
+import {Column, PrimaryGeneratedColumn} from "../../../../src";
+import {Entity} from "../../../../src/decorator/entity/Entity";
+
+export enum Limit {
+    Foo = "foo",
+    Bar = "bar",
+}
+
+@Entity()
+export class MyTable {
+    @PrimaryGeneratedColumn()
+    id: number;
+
+    @Column({ type: "simple-enum", enum: Limit })
+    limit: Limit;
+}

--- a/test/github-issues/8644/issue-8644.ts
+++ b/test/github-issues/8644/issue-8644.ts
@@ -1,0 +1,29 @@
+import { Connection } from "../../../src";
+import {
+    closeTestingConnections,
+    createTestingConnections,
+    reloadTestingDatabases,
+} from "../../utils/test-utils";
+import { Limit, MyTable } from "./entity/my-table.entity";
+
+describe("github issues > #8644 BUG - Special keyword column name for simple-enum in sqlite", () => {
+    let connections: Connection[];
+
+    before(
+        async () =>
+            (connections = await createTestingConnections({
+                entities: [__dirname + "/entity/*{.js,.ts}"],
+            }))
+    );
+    beforeEach(() => reloadTestingDatabases(connections));
+    after(() => closeTestingConnections(connections));
+
+    it("it should be able to set special keyword as column name for simple-enum types", () =>
+        Promise.all(
+            connections.map(async (connection) => {
+                const repository = connection.getRepository(MyTable);
+
+                await repository.insert({ limit: Limit.Bar });
+            })
+        ));
+});

--- a/test/github-issues/8644/issue-8644.ts
+++ b/test/github-issues/8644/issue-8644.ts
@@ -13,6 +13,9 @@ describe("github issues > #8644 BUG - Special keyword column name for simple-enu
         async () =>
             (connections = await createTestingConnections({
                 entities: [__dirname + "/entity/*{.js,.ts}"],
+                enabledDrivers: ["sqlite", "better-sqlite3"],
+                schemaCreate: true,
+                dropSchema: true,
             }))
     );
     beforeEach(() => reloadTestingDatabases(connections));


### PR DESCRIPTION
### Description of change

Fixes: #8644 
