### PR TITLE
fix: support `require` to internal files without explicitly writing `.js` in the path

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,12 @@
       "import": "./index.mjs",
       "require": "./index.js"
     },
-    "./*": "./*"
+    "./browser": "./browser/index.js",
+    "./*.js": "./*.js",
+    "./*": {
+      "require": "./*.js",
+      "import": "./*"
+    }
   },
   "main": "./index.js",
   "module": "./index.mjs",


### PR DESCRIPTION
### Description of change
Support using `require` on internal module files without explicitly writing `.js` at the end of the path.

For example, this code would work now:
```js
// in ESM projects
import {snakeCase} from "typeorm/util/StringUtils.js";

// in CommonJS projects
const {snakeCase: snakeCase1} = require("typeorm/util/StringUtils"); // this line previously thrown an error, this PR fixes that
const {snakeCase: snakeCase2} = require("typeorm/util/StringUtils.js");

console.log(snakeCase === snakeCase1); // true
console.log(snakeCase === snakeCase2); // true
```

Closes #8656
Closes https://github.com/tonivj5/typeorm-naming-strategies/issues/16

### Pull-Request Checklist
- [x] Code is up-to-date with the `master` branch
- [x] `npm run lint` passes with this change
- [x] `npm run test` passes with this change
- [x] This pull request links relevant issues as `Fixes #0000`
- [ ] There are new or updated unit tests validating the change - _The change in this PR is hard to create a test for from within the module itself, since the `exports` property in `package.json` only reflects imports of the module from the outside, and does not affect internal file imports_
- [ ] Documentation has been updated to reflect this change - N/A
- [x] The new commits follow conventions explained in [CONTRIBUTING.md](https://github.com/typeorm/typeorm/blob/master/CONTRIBUTING.md)
