### PR TITLE
fix: support imports of absolute paths of ESM files on Windows

### DIFF
--- a/src/util/ImportUtils.ts
+++ b/src/util/ImportUtils.ts
@@ -1,11 +1,14 @@
 import fs from "fs";
 import path from "path";
+import {pathToFileURL} from "url";
 
 export async function importOrRequireFile(filePath: string): Promise<[result: any, moduleType: "esm" | "commonjs"]> {
     const tryToImport = async (): Promise<[any, "esm"]> => {
         // `Function` is required to make sure the `import` statement wil stay `import` after
         // transpilation and won't be converted to `require`
-        return [await Function("return filePath => import(filePath)")()(filePath), "esm"];
+        return [await Function("return filePath => import(filePath)")()(
+            filePath.startsWith("file://") ? filePath : pathToFileURL(filePath).toString()
+        ), "esm"];
     };
     const tryToRequire = async (): Promise<[any, "commonjs"]> => {
         return [require(filePath), "commonjs"];


### PR DESCRIPTION
### Description of change
Support importing absolute paths of ESM file on Windows.

For example, this code would work now:
```js
import {importOrRequireFile} from "./util/ImportUtils";

await importOrRequireFile("./index.mjs");
await importOrRequireFile("./index.cjs");

// on macOS / Linux
await importOrRequireFile("/Users/user/Documents/index.mjs");
await importOrRequireFile("/Users/user/Documents/index.cjs");

// on Windows
await importOrRequireFile("C:\\Users\\user\\Documents\\index.mjs"); // this line previously thrown an error, this PR fixes that
await importOrRequireFile("C:\\Users\\user\\Documents\\index.cjs");
```

Closes #8651

### Pull-Request Checklist
- [x] Code is up-to-date with the `master` branch
- [x] `npm run lint` passes with this change
- [x] `npm run test` passes with this change
- [x] This pull request links relevant issues as `Fixes #0000`
- [ ] There are new or updated unit tests validating the change - _The best way to test this code would be to run tests also on a Windows machine which would catch issue like this one, but I guess this is out of scope for the issue_
- [ ] Documentation has been updated to reflect this change
- [x] The new commits follow conventions explained in [CONTRIBUTING.md](https://github.com/typeorm/typeorm/blob/master/CONTRIBUTING.md)
