### PR TITLE
feat: allow `{delete,insert}().returning()` on MariaDB

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -26,7 +26,7 @@ services:
 
   # mariadb
   mariadb:
-    image: "mariadb:10.4.8"
+    image: "mariadb:10.5.13"
     container_name: "typeorm-mariadb"
     ports:
       - "3307:3306"

--- a/src/driver/Driver.ts
+++ b/src/driver/Driver.ts
@@ -9,10 +9,12 @@ import {BaseConnectionOptions} from "../connection/BaseConnectionOptions";
 import {TableColumn} from "../schema-builder/table/TableColumn";
 import {EntityMetadata} from "../metadata/EntityMetadata";
 import {ReplicationMode} from "./types/ReplicationMode";
-import { Table } from "../schema-builder/table/Table";
-import { View } from "../schema-builder/view/View";
-import { TableForeignKey } from "../schema-builder/table/TableForeignKey";
-import { UpsertType } from "./types/UpsertType";
+import {Table} from "../schema-builder/table/Table";
+import {View} from "../schema-builder/view/View";
+import {TableForeignKey} from "../schema-builder/table/TableForeignKey";
+import {UpsertType} from "./types/UpsertType";
+
+export type ReturningType = "insert" | "update" | "delete";
 
 /**
  * Driver organizes TypeORM communication with specific database management system.
@@ -206,7 +208,7 @@ export interface Driver {
     /**
      * Returns true if driver supports RETURNING / OUTPUT statement.
      */
-    isReturningSqlSupported(): boolean;
+    isReturningSqlSupported(returningType: ReturningType): boolean;
 
     /**
      * Returns true if driver supports uuid values generation on its own.

--- a/src/driver/mysql/MysqlDriver.ts
+++ b/src/driver/mysql/MysqlDriver.ts
@@ -19,10 +19,10 @@ import {EntityMetadata} from "../../metadata/EntityMetadata";
 import {OrmUtils} from "../../util/OrmUtils";
 import {ApplyValueTransformers} from "../../util/ApplyValueTransformers";
 import {ReplicationMode} from "../types/ReplicationMode";
-import { TypeORMError } from "../../error";
-import { Table } from "../../schema-builder/table/Table";
-import { View } from "../../schema-builder/view/View";
-import { TableForeignKey } from "../../schema-builder/table/TableForeignKey";
+import {TypeORMError} from "../../error";
+import {Table} from "../../schema-builder/table/Table";
+import {View} from "../../schema-builder/view/View";
+import {TableForeignKey} from "../../schema-builder/table/TableForeignKey";
 
 /**
  * Organizes communication with MySQL DBMS.
@@ -875,7 +875,8 @@ export class MysqlDriver implements Driver {
      * Returns true if driver supports RETURNING / OUTPUT statement.
      */
     isReturningSqlSupported(): boolean {
-        return false;
+        const isMariaDb = this.connection.driver.options.type === "mariadb";
+        return isMariaDb;
     }
 
     /**
@@ -961,8 +962,8 @@ export class MysqlDriver implements Driver {
             socketPath: credentials.socketPath
         },
         options.acquireTimeout === undefined
-          ? {}
-          : { acquireTimeout: options.acquireTimeout },
+            ? {}
+            : { acquireTimeout: options.acquireTimeout },
         options.extra || {});
     }
 
@@ -994,8 +995,8 @@ export class MysqlDriver implements Driver {
     private prepareDbConnection(connection: any): any {
         const { logger } = this.connection;
         /*
-          Attaching an error handler to connection errors is essential, as, otherwise, errors raised will go unhandled and
-          cause the hosting app to crash.
+         * Attaching an error handler to connection errors is essential, as, otherwise, errors raised will go unhandled and
+         * cause the hosting app to crash.
          */
         if (connection.listeners("error").length === 0) {
             connection.on("error", (error: any) => logger.log("warn", `MySQL connection raised an error. ${error}`));

--- a/src/error/ReturningStatementNotSupportedError.ts
+++ b/src/error/ReturningStatementNotSupportedError.ts
@@ -7,7 +7,7 @@ import {TypeORMError} from "./TypeORMError";
 export class ReturningStatementNotSupportedError extends TypeORMError {
     constructor() {
         super(
-            `OUTPUT or RETURNING clause only supported by Microsoft SQL Server or PostgreSQL databases.`
+            `OUTPUT or RETURNING clause only supported by Microsoft SQL Server or PostgreSQL or MariaDB databases.`
         );
     }
 }

--- a/src/persistence/SubjectExecutor.ts
+++ b/src/persistence/SubjectExecutor.ts
@@ -832,7 +832,8 @@ export class SubjectExecutor {
     protected groupBulkSubjects(subjects: Subject[], type: "insert" | "delete"): [{ [key: string]: Subject[] }, string[]] {
         const group: { [key: string]: Subject[] } = {};
         const keys: string[] = [];
-        const groupingAllowed = type === "delete" || this.queryRunner.connection.driver.isReturningSqlSupported();
+        const groupingAllowed = type === "delete" ||
+            this.queryRunner.connection.driver.isReturningSqlSupported("insert");
 
         subjects.forEach((subject, index) => {
             const key = groupingAllowed || subject.metadata.isJunction ? subject.metadata.name : subject.metadata.name + "_" + index;

--- a/src/query-builder/DeleteQueryBuilder.ts
+++ b/src/query-builder/DeleteQueryBuilder.ts
@@ -1,12 +1,9 @@
-import {CockroachDriver} from "../driver/cockroachdb/CockroachDriver";
 import {QueryBuilder} from "./QueryBuilder";
 import {ObjectLiteral} from "../common/ObjectLiteral";
 import {EntityTarget} from "../common/EntityTarget";
 import {Connection} from "../connection/Connection";
 import {QueryRunner} from "../query-runner/QueryRunner";
 import {SqlServerDriver} from "../driver/sqlserver/SqlServerDriver";
-import {PostgresDriver} from "../driver/postgres/PostgresDriver";
-import {MysqlDriver} from "./../driver/mysql/MysqlDriver";
 import {WhereExpressionBuilder} from "./WhereExpressionBuilder";
 import {Brackets} from "./Brackets";
 import {DeleteResult} from "./result/DeleteResult";
@@ -213,8 +210,9 @@ export class DeleteQueryBuilder<Entity> extends QueryBuilder<Entity> implements 
     returning(returning: string|string[]): this {
 
         // not all databases support returning/output cause
-        if (!this.connection.driver.isReturningSqlSupported())
+        if (!this.connection.driver.isReturningSqlSupported("delete")) {
             throw new ReturningStatementNotSupportedError();
+        }
 
         this.expressionMap.returning = returning;
         return this;
@@ -230,21 +228,15 @@ export class DeleteQueryBuilder<Entity> extends QueryBuilder<Entity> implements 
     protected createDeleteExpression() {
         const tableName = this.getTableName(this.getMainTableName());
         const whereExpression = this.createWhereExpression();
-        const returningExpression = this.createReturningExpression();
+        const returningExpression = this.createReturningExpression("delete");
 
-        if (
-            returningExpression &&
-            (this.connection.driver instanceof PostgresDriver ||
-                this.connection.driver instanceof CockroachDriver ||
-                this.connection.driver instanceof MysqlDriver)
-        ) {
-            return `DELETE FROM ${tableName}${whereExpression} RETURNING ${returningExpression}`;
-        } else if (returningExpression !== "" && this.connection.driver instanceof SqlServerDriver) {
-            return `DELETE FROM ${tableName} OUTPUT ${returningExpression}${whereExpression}`;
-
-        } else {
+        if (returningExpression === "") {
             return `DELETE FROM ${tableName}${whereExpression}`;
         }
+        if (this.connection.driver instanceof SqlServerDriver) {
+            return `DELETE FROM ${tableName} OUTPUT ${returningExpression}${whereExpression}`;
+        }
+        return `DELETE FROM ${tableName}${whereExpression} RETURNING ${returningExpression}`;
     }
 
 }

--- a/src/query-builder/DeleteQueryBuilder.ts
+++ b/src/query-builder/DeleteQueryBuilder.ts
@@ -6,6 +6,7 @@ import {Connection} from "../connection/Connection";
 import {QueryRunner} from "../query-runner/QueryRunner";
 import {SqlServerDriver} from "../driver/sqlserver/SqlServerDriver";
 import {PostgresDriver} from "../driver/postgres/PostgresDriver";
+import {MysqlDriver} from "./../driver/mysql/MysqlDriver";
 import {WhereExpressionBuilder} from "./WhereExpressionBuilder";
 import {Brackets} from "./Brackets";
 import {DeleteResult} from "./result/DeleteResult";
@@ -231,9 +232,13 @@ export class DeleteQueryBuilder<Entity> extends QueryBuilder<Entity> implements 
         const whereExpression = this.createWhereExpression();
         const returningExpression = this.createReturningExpression();
 
-        if (returningExpression && (this.connection.driver instanceof PostgresDriver || this.connection.driver instanceof CockroachDriver)) {
+        if (
+            returningExpression &&
+            (this.connection.driver instanceof PostgresDriver ||
+                this.connection.driver instanceof CockroachDriver ||
+                this.connection.driver instanceof MysqlDriver)
+        ) {
             return `DELETE FROM ${tableName}${whereExpression} RETURNING ${returningExpression}`;
-
         } else if (returningExpression !== "" && this.connection.driver instanceof SqlServerDriver) {
             return `DELETE FROM ${tableName} OUTPUT ${returningExpression}${whereExpression}`;
 

--- a/src/query-builder/InsertQueryBuilder.ts
+++ b/src/query-builder/InsertQueryBuilder.ts
@@ -17,8 +17,8 @@ import {BroadcasterResult} from "../subscriber/BroadcasterResult";
 import {EntitySchema} from "../entity-schema/EntitySchema";
 import {OracleDriver} from "../driver/oracle/OracleDriver";
 import {AuroraDataApiDriver} from "../driver/aurora-data-api/AuroraDataApiDriver";
-import { TypeORMError } from "../error";
-import { v4 as uuidv4 } from "uuid";
+import {TypeORMError} from "../error";
+import {v4 as uuidv4} from "uuid";
 
 /**
  * Allows to build complex sql queries in a fashion way and execute those queries.
@@ -321,7 +321,7 @@ export class InsertQueryBuilder<Entity> extends QueryBuilder<Entity> {
         let query = "INSERT ";
 
         if (this.connection.driver instanceof MysqlDriver || this.connection.driver instanceof AuroraDataApiDriver) {
-          query += `${this.expressionMap.onIgnore ? " IGNORE " : ""}`;
+            query += `${this.expressionMap.onIgnore ? " IGNORE " : ""}`;
         }
 
         query += `INTO ${tableName}`;
@@ -400,7 +400,13 @@ export class InsertQueryBuilder<Entity> extends QueryBuilder<Entity> {
         }
 
         // add RETURNING expression
-        if (returningExpression && (this.connection.driver instanceof PostgresDriver || this.connection.driver instanceof OracleDriver || this.connection.driver instanceof CockroachDriver)) {
+        if (
+            returningExpression &&
+            (this.connection.driver instanceof PostgresDriver ||
+                this.connection.driver instanceof OracleDriver ||
+                this.connection.driver instanceof CockroachDriver ||
+                this.connection.driver instanceof MysqlDriver)
+        ) {
             query += ` RETURNING ${returningExpression}`;
         }
 
@@ -504,7 +510,7 @@ export class InsertQueryBuilder<Entity> extends QueryBuilder<Entity> {
 
                     if (!(value instanceof Function)) {
                       // make sure our value is normalized by a driver
-                      value = this.connection.driver.preparePersistentValue(value, column);
+                        value = this.connection.driver.preparePersistentValue(value, column);
                     }
 
                     // newly inserted entities always have a version equal to 1 (first version)
@@ -584,9 +590,9 @@ export class InsertQueryBuilder<Entity> extends QueryBuilder<Entity> {
                             }
                         } else if (this.connection.driver instanceof PostgresDriver && this.connection.driver.spatialTypes.indexOf(column.type) !== -1) {
                             if (column.srid != null) {
-                              expression += `ST_SetSRID(ST_GeomFromGeoJSON(${paramName}), ${column.srid})::${column.type}`;
+                                expression += `ST_SetSRID(ST_GeomFromGeoJSON(${paramName}), ${column.srid})::${column.type}`;
                             } else {
-                              expression += `ST_GeomFromGeoJSON(${paramName})::${column.type}`;
+                                expression += `ST_GeomFromGeoJSON(${paramName})::${column.type}`;
                             }
                         } else if (this.connection.driver instanceof SqlServerDriver && this.connection.driver.spatialTypes.indexOf(column.type) !== -1) {
                             expression += column.type + "::STGeomFromText(" + paramName + ", " + (column.srid || "0") + ")";

--- a/src/query-builder/InsertQueryBuilder.ts
+++ b/src/query-builder/InsertQueryBuilder.ts
@@ -244,8 +244,9 @@ export class InsertQueryBuilder<Entity> extends QueryBuilder<Entity> {
     returning(returning: string|string[]): this {
 
         // not all databases support returning/output cause
-        if (!this.connection.driver.isReturningSqlSupported())
+        if (!this.connection.driver.isReturningSqlSupported("insert")) {
             throw new ReturningStatementNotSupportedError();
+        }
 
         this.expressionMap.returning = returning;
         return this;
@@ -316,7 +317,10 @@ export class InsertQueryBuilder<Entity> extends QueryBuilder<Entity> {
     protected createInsertExpression() {
         const tableName = this.getTableName(this.getMainTableName());
         const valuesExpression = this.createValuesExpression(); // its important to get values before returning expression because oracle rely on native parameters and ordering of them is important
-        const returningExpression = (this.connection.driver instanceof OracleDriver && this.getValueSets().length > 1) ? null : this.createReturningExpression(); // oracle doesnt support returning with multi-row insert
+        const returningExpression =
+            (this.connection.driver instanceof OracleDriver && this.getValueSets().length > 1)
+                ? null
+                : this.createReturningExpression("insert"); // oracle doesnt support returning with multi-row insert
         const columnsExpression = this.createColumnNamesExpression();
         let query = "INSERT ";
 

--- a/src/query-builder/QueryBuilder.ts
+++ b/src/query-builder/QueryBuilder.ts
@@ -22,9 +22,10 @@ import {EntitySchema} from "../entity-schema/EntitySchema";
 import {FindOperator} from "../find-options/FindOperator";
 import {In} from "../find-options/operator/In";
 import {EntityColumnNotFound} from "../error/EntityColumnNotFound";
-import { TypeORMError } from "../error";
-import { WhereClause, WhereClauseCondition } from "./WhereClause";
+import {TypeORMError} from "../error";
+import {WhereClause, WhereClauseCondition} from "./WhereClause";
 import {NotBrackets} from "./NotBrackets";
+import {ReturningType} from "../driver/Driver";
 
 // todo: completely cover query builder with tests
 // todo: entityOrProperty can be target name. implement proper behaviour if it is.
@@ -737,7 +738,7 @@ export abstract class QueryBuilder<Entity> {
     /**
      * Creates "RETURNING" / "OUTPUT" expression.
      */
-    protected createReturningExpression(): string {
+    protected createReturningExpression(returningType: ReturningType): string {
         const columns = this.getReturningColumns();
         const driver = this.connection.driver;
 
@@ -745,7 +746,7 @@ export abstract class QueryBuilder<Entity> {
         // if user gave his own returning
         if (typeof this.expressionMap.returning !== "string" &&
             this.expressionMap.extraReturningColumns.length > 0 &&
-            driver.isReturningSqlSupported()) {
+            driver.isReturningSqlSupported(returningType)) {
             columns.push(...this.expressionMap.extraReturningColumns.filter(column => {
                 return columns.indexOf(column) === -1;
             }));

--- a/test/github-issues/7235/entity/Animal.ts
+++ b/test/github-issues/7235/entity/Animal.ts
@@ -1,0 +1,10 @@
+import {Column, Entity, PrimaryGeneratedColumn} from "../../../../src";
+
+@Entity()
+export class Animal {
+    @PrimaryGeneratedColumn()
+    id: number;
+
+    @Column({ type: "varchar" })
+    name: string;
+}

--- a/test/github-issues/7235/issue-7235.ts
+++ b/test/github-issues/7235/issue-7235.ts
@@ -3,8 +3,18 @@ import {createTestingConnections, closeTestingConnections, reloadTestingDatabase
 import {Animal} from "./entity/Animal";
 import {Connection} from "../../../src/connection/Connection";
 import {expect} from "chai";
+import {VersionUtils} from "../../../src/util/VersionUtils";
 
 describe('github issues > #7235 Use "INSERT...RETURNING" in MariaDB.', () => {
+    const runOnSpecificVersion = (version: string, fn: Function) =>
+        async () => Promise.all(connections.map(async (connection) => {
+            const result = await connection.query(`SELECT VERSION() AS \`version\``);
+            const dbVersion = result[0]["version"];
+            if (VersionUtils.isGreaterOrEqual(dbVersion, version)) {
+                await fn(connection);
+            }
+        }));
+
     let connections: Connection[];
 
     before(async () => connections = await createTestingConnections({
@@ -16,32 +26,56 @@ describe('github issues > #7235 Use "INSERT...RETURNING" in MariaDB.', () => {
     beforeEach(() => reloadTestingDatabases(connections));
     after(() => closeTestingConnections(connections));
 
-    it("should allow `{insert,delete}().returning()` on MariaDB >= 10.5.0", () =>
-        Promise.all(connections.map(async (connection) => {
+    it("should allow `DELETE...RETURNING` on MariaDB >= 10.0.5",
+        runOnSpecificVersion("10.0.5", async (connection: Connection) => {
             const animalRepository = connection.getRepository(Animal);
-            const insertCat = await animalRepository
+
+            await animalRepository
                 .createQueryBuilder()
                 .insert()
-                .values({ name: "Cat" })
-                .returning("name")
+                .values([{ name: "Cat" }, { name: "Wolf" }])
                 .execute();
-            expect(insertCat.raw[0]).to.deep.equal({ name: "Cat" });
 
-            const insertDog = await animalRepository
-                .createQueryBuilder()
-                .insert()
-                .values({ name: "Dog" })
-                .returning(["id", "name"])
-                .execute();
-            expect(insertDog.raw[0]).to.deep.equal({ id: 2, name: "Dog" });
-
-            const deleteDog = await animalRepository
+            const deleteCat = await animalRepository
                 .createQueryBuilder()
                 .delete()
-                .where({ name: "Dog" })
+                .where({ name: "Cat" })
                 .returning(["id", "name"])
                 .execute();
-            expect(deleteDog.raw[0]).to.deep.equal({ id: 2, name: "Dog" });
-        }))
+            expect(deleteCat.raw[0]).to.deep.equal({ id: 1, name: "Cat" });
+            const deleteWolf = await animalRepository
+                .createQueryBuilder()
+                .delete()
+                .where({ name: "Wolf" })
+                .returning("name")
+                .execute();
+            expect(deleteWolf.raw[0]).to.deep.equal({ name: "Wolf" });
+        })
+    );
+
+    it("should allow `INSERT...RETURNING` on MariaDB >= 10.5.0",
+        runOnSpecificVersion("10.5.0", async (connection: Connection) => {
+            const animalRepository = connection.getRepository(Animal);
+            const insertDogFox = await animalRepository
+                .createQueryBuilder()
+                .insert()
+                .values([{ name: "Dog" }, { name: "Fox" }])
+                .returning("name")
+                .execute();
+            expect(insertDogFox.raw).to.deep.equal([
+                { name: "Dog" },
+                { name: "Fox" },
+            ]);
+
+            const insertUnicorn = await animalRepository
+                .createQueryBuilder()
+                .insert()
+                .values({ name: "Unicorn" })
+                .returning(["id", "name"])
+                .execute();
+            expect(insertUnicorn.raw[0]).to.deep.equal(
+                { id: 3, name: "Unicorn" },
+            );
+        })
     );
 });

--- a/test/github-issues/7235/issue-7235.ts
+++ b/test/github-issues/7235/issue-7235.ts
@@ -1,0 +1,47 @@
+import "reflect-metadata";
+import {createTestingConnections, closeTestingConnections, reloadTestingDatabases} from "../../utils/test-utils";
+import {Animal} from "./entity/Animal";
+import {Connection} from "../../../src/connection/Connection";
+import {expect} from "chai";
+
+describe('github issues > #7235 Use "INSERT...RETURNING" in MariaDB.', () => {
+    let connections: Connection[];
+
+    before(async () => connections = await createTestingConnections({
+        entities: [__dirname + "/entity/*{.js,.ts}"],
+        schemaCreate: true,
+        dropSchema: true,
+        enabledDrivers: ["mariadb"],
+    }));
+    beforeEach(() => reloadTestingDatabases(connections));
+    after(() => closeTestingConnections(connections));
+
+    it("should allow `{insert,delete}().returning()` on MariaDB >= 10.5.0", () =>
+        Promise.all(connections.map(async (connection) => {
+            const animalRepository = connection.getRepository(Animal);
+            const insertCat = await animalRepository
+                .createQueryBuilder()
+                .insert()
+                .values({ name: "Cat" })
+                .returning("name")
+                .execute();
+            expect(insertCat.raw[0]).to.deep.equal({ name: "Cat" });
+
+            const insertDog = await animalRepository
+                .createQueryBuilder()
+                .insert()
+                .values({ name: "Dog" })
+                .returning(["id", "name"])
+                .execute();
+            expect(insertDog.raw[0]).to.deep.equal({ id: 2, name: "Dog" });
+
+            const deleteDog = await animalRepository
+                .createQueryBuilder()
+                .delete()
+                .where({ name: "Dog" })
+                .returning(["id", "name"])
+                .execute();
+            expect(deleteDog.raw[0]).to.deep.equal({ id: 2, name: "Dog" });
+        }))
+    );
+});


### PR DESCRIPTION
Closes: #7235

### Description of change

- Allow `delete().returning()` on MariaDB >= 10.0.5
- Allow `insert().returning()` on MariaDB >= 10.5.0
- Can check DML type(ex: `select`, `update`, `delete`) on
  `Driver.isReturningSqlSupported()` and `QueryBuilder.createReturningExpression()`

### Pull-Request Checklist

- [x] Code is up-to-date with the `master` branch
- [x] `npm run lint` passes with this change
- [x] `npm run test` passes with this change
- [x] This pull request links relevant issues as `Fixes #0000`
- [x] There are new or updated unit tests validating the change
- [ ] Documentation has been updated to reflect this change
- [x] The new commits follow conventions explained in [CONTRIBUTING.md](https://github.com/typeorm/typeorm/blob/master/CONTRIBUTING.md)
