### PR TITLE
fix: fix entityManager.getId for custom join table

### DIFF
--- a/src/metadata/ColumnMetadata.ts
+++ b/src/metadata/ColumnMetadata.ts
@@ -570,7 +570,12 @@ export class ColumnMetadata {
             return Object.keys(map).length > 0 ? map : undefined;
 
         } else { // no embeds - no problems. Simply return column property name and its value of the entity
-            if (this.relationMetadata && entity[this.relationMetadata.propertyName] && entity[this.relationMetadata.propertyName] instanceof Object) {
+            /**
+             * Object.getOwnPropertyDescriptor checks if the relation is lazy, in which case value is a Promise
+             * DO NOT use `entity[this.relationMetadata.propertyName] instanceof Promise`, which will invoke property getter and make unwanted DB request
+             * refer: https://github.com/typeorm/typeorm/pull/8676#issuecomment-1049906331
+             */
+            if (this.relationMetadata && !Object.getOwnPropertyDescriptor(entity, this.relationMetadata.propertyName)?.get && entity[this.relationMetadata.propertyName] && entity[this.relationMetadata.propertyName] instanceof Object) {
                 const map = this.relationMetadata.joinColumns.reduce((map, joinColumn) => {
                     const value = joinColumn.referencedColumn!.getEntityValueMap(entity[this.relationMetadata!.propertyName]);
                     if (value === undefined) return map;

--- a/test/other-issues/get-id-for-composite-primary-key/entity/Category.ts
+++ b/test/other-issues/get-id-for-composite-primary-key/entity/Category.ts
@@ -1,0 +1,10 @@
+import { Column, Entity, PrimaryGeneratedColumn } from "../../../../src";
+
+@Entity()
+export class Category {
+    @PrimaryGeneratedColumn("increment")
+    id!: number;
+
+    @Column()
+    name!: string;
+}

--- a/test/other-issues/get-id-for-composite-primary-key/entity/Post.ts
+++ b/test/other-issues/get-id-for-composite-primary-key/entity/Post.ts
@@ -1,0 +1,10 @@
+import { Column, Entity, PrimaryGeneratedColumn } from "../../../../src";
+
+@Entity()
+export class Post {
+    @PrimaryGeneratedColumn("increment")
+    id!: number;
+
+    @Column()
+    content!: string;
+}

--- a/test/other-issues/get-id-for-composite-primary-key/entity/PostCategory.ts
+++ b/test/other-issues/get-id-for-composite-primary-key/entity/PostCategory.ts
@@ -1,0 +1,24 @@
+import {
+    CreateDateColumn,
+    Entity,
+    ManyToOne,
+    PrimaryColumn,
+} from "../../../../src";
+import { Category } from "./Category";
+import { Post } from "./Post";
+
+@Entity()
+export class PostCategory {
+    @ManyToOne(() => Post)
+    post!: Promise<Post>;
+    @PrimaryColumn()
+    postId!: Post["id"];
+
+    @ManyToOne(() => Category)
+    category!: Promise<Category>;
+    @PrimaryColumn()
+    categoryId!: Category["id"];
+
+    @CreateDateColumn()
+    added!: Date;
+}

--- a/test/other-issues/get-id-for-composite-primary-key/get-id-for-composite-primary-key.ts
+++ b/test/other-issues/get-id-for-composite-primary-key/get-id-for-composite-primary-key.ts
@@ -1,0 +1,47 @@
+import { expect } from "chai";
+import "reflect-metadata";
+import { Connection } from "../../../src/connection/Connection";
+import {
+    closeTestingConnections,
+    createTestingConnections,
+    reloadTestingDatabases,
+} from "../../utils/test-utils";
+import { Category } from "./entity/Category";
+import { Post } from "./entity/Post";
+import { PostCategory } from "./entity/PostCategory";
+
+describe("other issues > getId should not return undefined for composite primary keys with lazy relations", () => {
+    let connections: Connection[];
+    before(
+        async () =>
+            (connections = await createTestingConnections({
+                entities: [__dirname + "/entity/*{.js,.ts}"],
+            }))
+    );
+    beforeEach(() => reloadTestingDatabases(connections));
+    after(() => closeTestingConnections(connections));
+
+    it("getId should not return undefined", () =>
+        Promise.all(
+            connections.map(async ({ manager }) => {
+                const post = manager.create(Post, {
+                    content: "Sample Post",
+                });
+                await manager.save(post);
+
+                const category = manager.create(Category, {
+                    name: "javascript",
+                });
+                await manager.save(category);
+
+                const postCategory = manager.create(PostCategory, {});
+                postCategory.post = Promise.resolve(post);
+                postCategory.category = Promise.resolve(category);
+                await manager.save(postCategory);
+
+                expect(manager.getId(post)).not.to.be.undefined;
+                expect(manager.getId(category)).not.to.be.undefined;
+                expect(manager.getId(postCategory)).not.to.be.undefined;
+            })
+        ));
+});


### PR DESCRIPTION


<!--
  😀 Wonderful!  Thank you for opening a pull request for TypeORM.

  Please fill in the information below to expedite the review
  and (hopefully) merge of your change.

  If unsure about something.. just do as best as you're able,
  or reach out through our community support channels!
  https://github.com/typeorm/typeorm/blob/master/docs/support.md
-->

### Description of change

`entityManager.getId` currently returns undefined for an entity with composite primary key if primary key columns are also foreign keys with lazy relations, for e.g., in a custom join table. This commit tries to fix that.

The reason for `getId` returning `undefined` is that `columnMetadata.getEntityValueMap` doesn't take into account the fact that the value for lazy-relations is a getter which returns a `Promise`. This PR adds a check for this condition.

To reproduce the issue, refer https://github.com/ranjan-purbey/typeorm-composite-primary-key-test

Closes: #7736 (maybe)

### Pull-Request Checklist

- [x] Code is up-to-date with the `master` branch
- [x] `npm run lint` passes with this change
- [x] `npm run test` passes with this change
- [x] This pull request links relevant issues as `Fixes #0000`
- [ ] There are new or updated unit tests validating the change
- [ ] Documentation has been updated to reflect this change - N/A
- [x] The new commits follow conventions explained in [CONTRIBUTING.md](https://github.com/typeorm/typeorm/blob/master/CONTRIBUTING.md)

<!--
  🎉 Thank you for contributing and making TypeORM even better!
-->
