### PR TITLE
fix: ng webpack default import

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,8 +11,15 @@
   },
   "exports": {
     ".": {
-      "import": "./index.mjs",
-      "require": "./index.js"
+      "node": {
+        "import": "./index.mjs",
+        "require": "./index.js"
+      },
+      "browser": {
+        "require": "./index.js",
+        "import": "./browser/index.js",
+        "default": "./index.js"
+      }
     },
     "./browser": "./browser/index.js",
     "./*.js": "./*.js",
@@ -24,7 +31,6 @@
   "main": "./index.js",
   "module": "./index.mjs",
   "types": "./index.d.ts",
-  "type": "commonjs",
   "browser": {
     "./browser/connection/ConnectionOptionsReader.js": "./browser/platform/BrowserConnectionOptionsReaderDummy.js",
     "./browser/connection/options-reader/ConnectionOptionsXmlReader.js": "./browser/platform/BrowserConnectionOptionsReaderDummy.js",


### PR DESCRIPTION
### Description of change
Instruct Webpack to import the CommonJS version or browser-native ESM version of TypeORM directly when using TypeORM's default import, ignoring `index.mjs` file meant for nodejs ESM projects.

In nodejs the `index.mjs` file is used to refer to the same loaded instance of TypeORM from both ESM and CommonJS imports, it's needed in order to maintain the same state across ESM and CommonJS imports that may occur in different places in the same project.
When using Webpack, only one module system can be used to import the same library, so providing different import methods should not cause state problems.

Closes #8674


### Pull-Request Checklist
- [x] Code is up-to-date with the `master` branch
- [x] `npm run lint` passes with this change
- [x] `npm run test` passes with this change
- [x] This pull request links relevant issues as `Fixes #0000`
- [ ] There are new or updated unit tests validating the change - _Testing the way the module is imported is problematic to do from within the module itself_
- [ ] Documentation has been updated to reflect this change - N/A
- [x] The new commits follow conventions explained in [CONTRIBUTING.md](https://github.com/typeorm/typeorm/blob/master/CONTRIBUTING.md)
