### PR TITLE
fix: object with null properties on many to many relation when join query

### DIFF
--- a/src/query-builder/transformer/RawSqlResultsToEntityTransformer.ts
+++ b/src/query-builder/transformer/RawSqlResultsToEntityTransformer.ts
@@ -47,7 +47,7 @@ export class RawSqlResultsToEntityTransformer {
         const entities: any[] = [];
         group.forEach(results => {
             const entity = this.transformRawResultsGroup(results, alias);
-            if (entity !== undefined && !Object.values(entity).every((value) => value === null))
+            if (entity !== undefined && !Object.values(entity).every((value) => value === null || value === undefined))
                 entities.push(entity);
         });
         return entities;

--- a/test/github-issues/8692/entity/Student.entity.ts
+++ b/test/github-issues/8692/entity/Student.entity.ts
@@ -1,0 +1,25 @@
+import { Column, Entity, OneToMany, PrimaryColumn } from "../../../../src";
+import { SubjectStudent } from "./SubjectStudent.entity";
+
+@Entity("students")
+export class Student {
+
+    @PrimaryColumn()
+    id!: string;
+
+    @Column()
+    name!: string;
+
+    @OneToMany(() => SubjectStudent, subjectStudents => subjectStudents.student)
+    subjectStudents!: SubjectStudent[];
+
+    constructor(
+        id: string,
+        name: string,
+    ) {
+        this.id = id;
+        this.name = name;
+    }
+
+}
+

--- a/test/github-issues/8692/entity/Subject.entity.ts
+++ b/test/github-issues/8692/entity/Subject.entity.ts
@@ -1,0 +1,24 @@
+import { Column, Entity, OneToMany, PrimaryColumn } from "../../../../src";
+import { SubjectStudent } from "./SubjectStudent.entity";
+
+@Entity("subjects")
+export class Subject {
+
+    @PrimaryColumn()
+    id!: string;
+
+    @Column()
+    name!: string;
+
+    @OneToMany(() => SubjectStudent, subjectStudents => subjectStudents.subject)
+    subjectStudents!: SubjectStudent[];
+
+    constructor(
+        id: string,
+        name: string,
+    ) {
+        this.id = id;
+        this.name = name;
+    }
+
+}

--- a/test/github-issues/8692/entity/SubjectStudent.entity.ts
+++ b/test/github-issues/8692/entity/SubjectStudent.entity.ts
@@ -1,0 +1,28 @@
+import { Column, Entity, ManyToOne } from "../../../../src";
+import { Student } from "./Student.entity";
+import { Subject } from "./Subject.entity";
+
+@Entity("students_subjects")
+export class SubjectStudent {
+
+    @ManyToOne(() => Subject, subject => subject.subjectStudents, { primary: true })
+    subject!: Subject;
+
+    @ManyToOne(() => Student, student => student.subjectStudents, { primary: true })
+    student!: Student;
+
+    @Column()
+    mark!: number;
+
+    constructor(
+        subject: Subject,
+        student: Student,
+        mark: number,
+    ) {
+        this.subject = subject;
+        this.student = student;
+        this.mark = mark;
+    }
+
+}
+

--- a/test/github-issues/8692/issue-8692.ts
+++ b/test/github-issues/8692/issue-8692.ts
@@ -1,0 +1,40 @@
+import { expect } from "chai";
+import { Connection } from "../../../src";
+import {
+    closeTestingConnections,
+    createTestingConnections,
+    reloadTestingDatabases,
+} from "../../utils/test-utils";
+import { Subject } from "./entity/Subject.entity";
+
+describe("github issues > #8692 BUG - join with no results produces entity with nulled properties on many to many relation with custom properties", () => {
+    let connections: Connection[];
+
+    before(
+        async () =>
+        (connections = await createTestingConnections({
+            entities: [__dirname + "/entity/*{.js,.ts}"],
+            enabledDrivers: ["postgres"],
+            schemaCreate: true,
+            dropSchema: true,
+        }))
+    );
+    beforeEach(() => reloadTestingDatabases(connections));
+    after(() => closeTestingConnections(connections));
+
+    it("should return empty array if not have data relation", () =>
+        Promise.all(
+            connections.map(async (connection) => {
+                const repository = connection.getRepository(Subject);
+                await repository.save(new Subject("id", "maths"));
+
+                const data = await repository
+                    .createQueryBuilder("subject")
+                    .leftJoinAndSelect("subject.subjectStudents", "subjectStudent")
+                    .leftJoinAndSelect("subjectStudent.student", "student")
+                    .getMany();
+
+                expect(data[0].subjectStudents.length).to.be.equal(0);
+            })
+        ));
+});


### PR DESCRIPTION
Check undefined on property relation for many to many

fix: join with no results produces entity with null properties on many to many relation with custom properties
Closes: #8692

### Description of change

Check undefined on property relation for many to many

### Pull-Request Checklist

- [x] Code is up-to-date with the `master` branch
- [x] `npm run lint` passes with this change
- [x] `npm run test` passes with this change
- [x] This pull request links relevant issues as `Fixes #8692`
- [x] There are new or updated unit tests validating the change
- [ ] Documentation has been updated to reflect this change
- [x] The new commits follow conventions explained in [CONTRIBUTING.md](https://github.com/typeorm/typeorm/blob/master/CONTRIBUTING.md)
