### PR TITLE
fix: force web bundlers to ignore `index.mjs` and use the browser ESM version directly

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,7 +51,8 @@
     "./browser/platform/PlatformTools.js": "./browser/platform/BrowserPlatformTools.js",
     "./browser/repository/MongoRepository.js": "./browser/platform/BrowserDisabledDriversDummy.js",
     "./browser/util/DirectoryExportedClassesLoader.js": "./browser/platform/BrowserDirectoryExportedClassesLoader.js",
-    "./index.js": "./browser/index.js"
+    "./index.js": "./browser/index.js",
+    "./index.mjs": "./browser/index.js"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
### Description of change
Force web bundlers to ignore `index.mjs` and use `browser/index.js` instead

Closes #8709

### Pull-Request Checklist
- [x] Code is up-to-date with the `master` branch
- [x] `npm run lint` passes with this change
- [x] `npm run test` passes with this change
- [x] This pull request links relevant issues as `Fixes #0000`
- [ ] There are new or updated unit tests validating the change - _Testing the way the module is imported is problematic to do from within the module itself_
- [ ] Documentation has been updated to reflect this change - N/A
- [x] The new commits follow conventions explained in [CONTRIBUTING.md](https://github.com/typeorm/typeorm/blob/master/CONTRIBUTING.md)
