### PR TITLE
fix: discard duplicated columns on update

### DIFF
--- a/src/query-builder/UpdateQueryBuilder.ts
+++ b/src/query-builder/UpdateQueryBuilder.ts
@@ -394,7 +394,8 @@ export class UpdateQueryBuilder<Entity> extends QueryBuilder<Entity> implements 
                 }
 
                 columns.forEach(column => {
-                    if (!column.isUpdate) { return; }
+                    if (!column.isUpdate || updatedColumns.includes(column)) { return; }
+                    
                     updatedColumns.push(column);
 
                     //

--- a/test/github-issues/8723/entity/Photo.ts
+++ b/test/github-issues/8723/entity/Photo.ts
@@ -1,0 +1,21 @@
+import { 
+  Column, 
+  Entity,
+  OneToOne, 
+  JoinColumn, 
+  PrimaryColumn,
+} from "../../../../src";
+import { User } from "./User";
+
+@Entity()
+export class Photo {
+  @PrimaryColumn({ type: "int", nullable: false })
+  id: number;
+
+  @OneToOne(() => User, { nullable: true })
+  @JoinColumn({ name: "user_id" })
+  public user?: User;
+
+  @Column({ name: "user_id", nullable: true })
+  public userId?: number;
+}

--- a/test/github-issues/8723/entity/User.ts
+++ b/test/github-issues/8723/entity/User.ts
@@ -1,0 +1,14 @@
+import { 
+  Column, 
+  Entity,
+  PrimaryColumn,
+} from "../../../../src";
+
+@Entity()
+export class User {
+  @PrimaryColumn({ type: "int", nullable: false })
+  id: number;
+
+  @Column()
+  name: string;
+}

--- a/test/github-issues/8723/issue-8723.ts
+++ b/test/github-issues/8723/issue-8723.ts
@@ -1,0 +1,28 @@
+import "reflect-metadata";
+import { createTestingConnections, closeTestingConnections, reloadTestingDatabases } from "../../utils/test-utils";
+import { Connection } from "../../../src/connection/Connection";
+import { User } from "./entity/User";
+import { Photo } from "./entity/Photo";
+
+describe("github issues > #8723 Fail on Update when reference exists together with FK: multiple assignments to same column ", () => {
+
+    let connections: Connection[];
+    before(async () => connections = await createTestingConnections({
+        entities: [__dirname + "/entity/*{.js,.ts}"],
+        schemaCreate: true,
+        dropSchema: true,
+    }));
+    beforeEach(() => reloadTestingDatabases(connections));
+    after(() => closeTestingConnections(connections));
+
+    it("should able to update when both reference and the id exist in the update object", () => Promise.all(connections.map(async connection => {
+        const photoRepository = connection.getRepository(Photo);
+        const userRepository = connection.getRepository(User);
+
+        const user = await userRepository.save({ id: 1, name: "Test" });
+        const photo = await photoRepository.save({ id: 1 });
+
+        await photoRepository.update({ id: photo.id }, { user, userId: user.id });
+    })));
+
+});


### PR DESCRIPTION
Closes: #8723

<!--
  😀 Wonderful!  Thank you for opening a pull request for TypeORM.

  Please fill in the information below to expedite the review
  and (hopefully) merge of your change.

  If unsure about something.. just do as best as you're able,
  or reach out through our community support channels!
  https://github.com/typeorm/typeorm/blob/master/docs/support.md
-->

### Description of change

<!--
  Please be clear and concise what the change is intended to do,
  why this change is needed, and how you've verified that it
  corrects what you intended.

  In some cases it may be helpful to include the current behavior
  and the new behavior.

  If the change is related to an open issue, you can link it here.
  If you include `Fixes #0000` (replacing `0000` with the issue number)
  when this is merged it will automatically mark the issue as fixed and
  close it.
-->

This change is to discard duplicated columns when building an update query. 
Fixes #8723

### Pull-Request Checklist

<!--
  Please make sure to review and check all of the following.

  If an item is not applicable, you can add "N/A" to the end.
-->

- [x] Code is up-to-date with the `master` branch
- [x] `npm run lint` passes with this change
- [x] `npm run test` passes with this change
- [x] This pull request links relevant issues as `Fixes #0000`
- [x] There are new or updated unit tests validating the change
- [N/A] Documentation has been updated to reflect this change
- [x] The new commits follow conventions explained in [CONTRIBUTING.md](https://github.com/typeorm/typeorm/blob/master/CONTRIBUTING.md)

<!--
  🎉 Thank you for contributing and making TypeORM even better!
-->
