### PR TITLE
fix: allow entity listeners to fire when saving plain objects

### DIFF
--- a/package.json
+++ b/package.json
@@ -227,6 +227,7 @@
   },
   "scripts": {
     "test": "rimraf ./build && tsc && mocha --file ./build/compiled/test/utils/test-setup.js --bail --recursive --timeout 60000 ./build/compiled/test",
+    "test-nobail": "rimraf ./build && tsc && mocha --file ./build/compiled/test/utils/test-setup.js --recursive --timeout 60000 ./build/compiled/test",
     "test-fast": "mocha --file ./build/compiled/test/utils/test-setup.js --bail --recursive --timeout 60000 ./build/compiled/test",
     "compile": "rimraf ./build && tsc",
     "watch": "./node_modules/.bin/tsc -w",

--- a/src/subscriber/Broadcaster.ts
+++ b/src/subscriber/Broadcaster.ts
@@ -74,15 +74,12 @@ export class Broadcaster {
      * Note: this method has a performance-optimized code organization, do not change code structure.
      */
     broadcastBeforeInsertEvent(result: BroadcasterResult, metadata: EntityMetadata, entity: undefined | ObjectLiteral): void {
-
         if (entity && metadata.beforeInsertListeners.length) {
             metadata.beforeInsertListeners.forEach(listener => {
-                if (listener.isAllowed(entity)) {
-                    const executionResult = listener.execute(entity);
-                    if (executionResult instanceof Promise)
-                        result.promises.push(executionResult);
-                    result.count++;
-                }
+                const executionResult = listener.execute(entity);
+                if (executionResult instanceof Promise)
+                    result.promises.push(executionResult);
+                result.count++;
             });
         }
 
@@ -115,12 +112,10 @@ export class Broadcaster {
     broadcastBeforeUpdateEvent(result: BroadcasterResult, metadata: EntityMetadata, entity?: ObjectLiteral, databaseEntity?: ObjectLiteral, updatedColumns?: ColumnMetadata[], updatedRelations?: RelationMetadata[]): void { // todo: send relations too?
         if (entity && metadata.beforeUpdateListeners.length) {
             metadata.beforeUpdateListeners.forEach(listener => {
-                if (listener.isAllowed(entity)) {
-                    const executionResult = listener.execute(entity);
-                    if (executionResult instanceof Promise)
-                        result.promises.push(executionResult);
-                    result.count++;
-                }
+                const executionResult = listener.execute(entity);
+                if (executionResult instanceof Promise)
+                    result.promises.push(executionResult);
+                result.count++;
             });
         }
 
@@ -156,12 +151,10 @@ export class Broadcaster {
     broadcastBeforeRemoveEvent(result: BroadcasterResult, metadata: EntityMetadata, entity?: ObjectLiteral, databaseEntity?: ObjectLiteral): void {
         if (entity && metadata.beforeRemoveListeners.length) {
             metadata.beforeRemoveListeners.forEach(listener => {
-                if (listener.isAllowed(entity)) {
-                    const executionResult = listener.execute(entity);
-                    if (executionResult instanceof Promise)
-                        result.promises.push(executionResult);
-                    result.count++;
-                }
+                const executionResult = listener.execute(entity);
+                if (executionResult instanceof Promise)
+                    result.promises.push(executionResult);
+                result.count++;
             });
         }
 
@@ -196,12 +189,10 @@ export class Broadcaster {
     broadcastBeforeSoftRemoveEvent(result: BroadcasterResult, metadata: EntityMetadata, entity?: ObjectLiteral, databaseEntity?: ObjectLiteral): void {
         if (entity && metadata.beforeSoftRemoveListeners.length) {
             metadata.beforeSoftRemoveListeners.forEach(listener => {
-                if (listener.isAllowed(entity)) {
-                    const executionResult = listener.execute(entity);
-                    if (executionResult instanceof Promise)
-                        result.promises.push(executionResult);
-                    result.count++;
-                }
+                const executionResult = listener.execute(entity);
+                if (executionResult instanceof Promise)
+                    result.promises.push(executionResult);
+                result.count++;
             });
         }
 
@@ -236,12 +227,10 @@ export class Broadcaster {
     broadcastBeforeRecoverEvent(result: BroadcasterResult, metadata: EntityMetadata, entity?: ObjectLiteral, databaseEntity?: ObjectLiteral): void {
         if (entity && metadata.beforeRecoverListeners.length) {
             metadata.beforeRecoverListeners.forEach(listener => {
-                if (listener.isAllowed(entity)) {
-                    const executionResult = listener.execute(entity);
-                    if (executionResult instanceof Promise)
-                        result.promises.push(executionResult);
-                    result.count++;
-                }
+                const executionResult = listener.execute(entity);
+                if (executionResult instanceof Promise)
+                    result.promises.push(executionResult);
+                result.count++;
             });
         }
 
@@ -277,12 +266,10 @@ export class Broadcaster {
 
         if (entity && metadata.afterInsertListeners.length) {
             metadata.afterInsertListeners.forEach(listener => {
-                if (listener.isAllowed(entity)) {
-                    const executionResult = listener.execute(entity);
-                    if (executionResult instanceof Promise)
-                        result.promises.push(executionResult);
-                    result.count++;
-                }
+                const executionResult = listener.execute(entity);
+                if (executionResult instanceof Promise)
+                    result.promises.push(executionResult);
+                result.count++;
             });
         }
 
@@ -436,12 +423,10 @@ export class Broadcaster {
 
         if (entity && metadata.afterUpdateListeners.length) {
             metadata.afterUpdateListeners.forEach(listener => {
-                if (listener.isAllowed(entity)) {
-                    const executionResult = listener.execute(entity);
-                    if (executionResult instanceof Promise)
-                        result.promises.push(executionResult);
-                    result.count++;
-                }
+                const executionResult = listener.execute(entity);
+                if (executionResult instanceof Promise)
+                    result.promises.push(executionResult);
+                result.count++;
             });
         }
 
@@ -478,12 +463,10 @@ export class Broadcaster {
 
         if (entity && metadata.afterRemoveListeners.length) {
             metadata.afterRemoveListeners.forEach(listener => {
-                if (listener.isAllowed(entity)) {
-                    const executionResult = listener.execute(entity);
-                    if (executionResult instanceof Promise)
-                        result.promises.push(executionResult);
-                    result.count++;
-                }
+                const executionResult = listener.execute(entity);
+                if (executionResult instanceof Promise)
+                    result.promises.push(executionResult);
+                result.count++;
             });
         }
 
@@ -519,12 +502,10 @@ export class Broadcaster {
 
         if (entity && metadata.afterSoftRemoveListeners.length) {
             metadata.afterSoftRemoveListeners.forEach(listener => {
-                if (listener.isAllowed(entity)) {
-                    const executionResult = listener.execute(entity);
-                    if (executionResult instanceof Promise)
-                        result.promises.push(executionResult);
-                    result.count++;
-                }
+                const executionResult = listener.execute(entity);
+                if (executionResult instanceof Promise)
+                    result.promises.push(executionResult);
+                result.count++;
             });
         }
 
@@ -560,12 +541,10 @@ export class Broadcaster {
 
         if (entity && metadata.afterRecoverListeners.length) {
             metadata.afterRecoverListeners.forEach(listener => {
-                if (listener.isAllowed(entity)) {
-                    const executionResult = listener.execute(entity);
-                    if (executionResult instanceof Promise)
-                        result.promises.push(executionResult);
-                    result.count++;
-                }
+                const executionResult = listener.execute(entity);
+                if (executionResult instanceof Promise)
+                    result.promises.push(executionResult);
+                result.count++;
             });
         }
 
@@ -628,11 +607,9 @@ export class Broadcaster {
             if (metadata.afterLoadListeners.length) {
                 metadata.afterLoadListeners.forEach(listener => {
                     nonPromiseEntities.forEach(entity => {
-                        if (listener.isAllowed(entity)) {
-                            const executionResult = listener.execute(entity);
-                            if (executionResult instanceof Promise) result.promises.push(executionResult);
-                            result.count++;
-                        }
+                        const executionResult = listener.execute(entity);
+                        if (executionResult instanceof Promise) result.promises.push(executionResult);
+                        result.count++;
                     });
                 });
             }

--- a/test/functional/entity-listeners/entity-listeners.ts
+++ b/test/functional/entity-listeners/entity-listeners.ts
@@ -12,6 +12,16 @@ describe("entity-listeners", () => {
     }));
     after(() => closeTestingConnections(connections));
 
+    it("entity listeners work when saving a plain object", () => Promise.all(connections.map(async connection => {
+        const plainObjectPost = {
+            title: "post title",
+            text: "post text"
+        };
+        const insertedPost = await connection.getRepository(Post).save(plainObjectPost);
+        let loadedPost = await connection.getRepository(Post).findOne(insertedPost.id);
+        loadedPost!.title.should.be.equal("new: post title");
+    })));
+
     it("beforeUpdate", () => Promise.all(connections.map(async connection => {
         const post = new Post();
         post.title = "post title";

--- a/test/functional/entity-listeners/entity/Post.ts
+++ b/test/functional/entity-listeners/entity/Post.ts
@@ -1,4 +1,4 @@
-import {BeforeUpdate} from "../../../../src";
+import {BeforeInsert, BeforeUpdate} from "../../../../src";
 import {Column} from "../../../../src/decorator/columns/Column";
 import {PrimaryGeneratedColumn} from "../../../../src/decorator/columns/PrimaryGeneratedColumn";
 import {Entity} from "../../../../src/decorator/entity/Entity";
@@ -14,6 +14,11 @@ export class Post {
 
     @Column()
     text: string;
+
+    @BeforeInsert()
+    beforeInsert() {
+        this.title = `new: ${this.title.trim()}`;
+    }
 
     @BeforeUpdate()
     beforeUpdate() {


### PR DESCRIPTION
<!--
  😀 Wonderful!  Thank you for opening a pull request for TypeORM.

  Please fill in the information below to expedite the review
  and (hopefully) merge of your change.

  If unsure about something.. just do as best as you're able,
  or reach out through our community support channels!
  https://github.com/typeorm/typeorm/blob/master/docs/support.md
-->

### Description of change

<!--
  Please be clear and concise what the change is intended to do,
  why this change is needed, and how you've verified that it
  corrects what you intended.

  In some cases it may be helpful to include the current behavior
  and the new behavior.

  If the change is related to an open issue, you can link it here.
  If you include `Fixes #0000` (replacing `0000` with the issue number)
  when this is merged it will automatically mark the issue as fixed and
  close it.
-->

Fixes #8706

`@BeforeInsert()` (etc) listeners on Entities are not called when saving plain objects ie: 
```
class Entity {
  @Column() title: string;

  @BeforeInsert() beforeInsert() {
    // not called for plain object saves
  }
}
...
getReposity<Entity>.save({ title: "foo" })
```

This change allows those listeners to be run against plain objects.

### Pull-Request Checklist

<!--
  Please make sure to review and check all of the following.

  If an item is not applicable, you can add "N/A" to the end.
-->

- [x] Code is up-to-date with the `master` branch
- [x] `npm run lint` passes with this change
- [x] `npm run test` passes with this change
- [x] This pull request links relevant issues as `Fixes #0000`
- [x] There are new or updated unit tests validating the change
- [ ] Documentation has been updated to reflect this change
- [x] The new commits follow conventions explained in [CONTRIBUTING.md](https://github.com/typeorm/typeorm/blob/master/CONTRIBUTING.md)

<!--
  🎉 Thank you for contributing and making TypeORM even better!
-->
