### PR TITLE
fix: resolve entities correctly in datasource when globs are specified

### DIFF
--- a/src/data-source/DataSource.ts
+++ b/src/data-source/DataSource.ts
@@ -37,6 +37,7 @@ import { TypeORMError } from "../error/TypeORMError"
 import { RelationIdLoader } from "../query-builder/RelationIdLoader"
 import { DriverUtils } from "../driver/DriverUtils"
 import { InstanceChecker } from "../util/InstanceChecker"
+import { importClassesFromDirectories } from "../util/DirectoryExportedClassesLoader"
 
 /**
  * DataSource is a pre-defined connection configuration to a specific database.
@@ -645,6 +646,17 @@ export class DataSource {
         const flattenedEntities = ObjectUtils.mixedListToArray(
             this.options.entities || [],
         )
+
+        // resolve globs to the respective entity classes
+        flattenedEntities.push(
+            ...(await importClassesFromDirectories(
+                this.logger,
+                flattenedEntities.filter(
+                    (it) => typeof it === "string",
+                ) as string[],
+            )),
+        )
+
         const entityMetadatas =
             await connectionMetadataBuilder.buildEntityMetadatas(
                 flattenedEntities,


### PR DESCRIPTION
Closes: #8768

<!--
  😀 Wonderful!  Thank you for opening a pull request for TypeORM.

  Please fill in the information below to expedite the review
  and (hopefully) merge of your change.

  If unsure about something.. just do as best as you're able,
  or reach out through our community support channels!
  https://github.com/typeorm/typeorm/blob/master/docs/support.md
-->

### Description of change

In the 0.3 release, DataSource stopped resolving entities correctly when specified as Globs. This results in the data source information not being set correctly into the entities. This PR fixes it by correctly importing the classes when globs are specified. 

### Pull-Request Checklist

<!--
  Please make sure to review and check all of the following.

  If an item is not applicable, you can add "N/A" to the end.
-->

- [x] Code is up-to-date with the `master` branch
- [x] `npm run format` to apply prettier formatting
- [x] `npm run test` passes with this change
- [x] This pull request links relevant issues as `Fixes #0000`
- [ ] There are new or updated unit tests validating the change
- [ ] Documentation has been updated to reflect this change - N/A
- [x] The new commits follow conventions explained in [CONTRIBUTING.md](https://github.com/typeorm/typeorm/blob/master/CONTRIBUTING.md)

<!--
  🎉 Thank you for contributing and making TypeORM even better!
-->
