### PR TITLE
feat: allows user to specify which mysql package should be used

### DIFF
--- a/src/driver/mysql/MysqlConnectionOptions.ts
+++ b/src/driver/mysql/MysqlConnectionOptions.ts
@@ -103,6 +103,12 @@ export interface MysqlConnectionOptions
     readonly flags?: string[]
 
     /**
+     * TypeORM will automatically use package found in your node_modules, prioritizing mysql over mysql2,
+     * but you can specify it manually
+     */
+    readonly connectorPackage?: "mysql" | "mysql2"
+
+    /**
      * Replication setup.
      */
     readonly replication?: {


### PR DESCRIPTION
### Description of change

In attempt to resolve  #8534, I'm cherry-picking this small change.

This is necessary to eventually resolve #8713

This allows user using `ormconfig.json` to specify connector package.

### Pull-Request Checklist

- [x] Code is up-to-date with the `master` branch
- [x] `npm run format` to apply prettier formatting
- [x] `npm run test` passes with this change
- [ ] This pull request links relevant issues as `Fixes #0000`
- [ ] There are new or updated unit tests validating the change
- [ ] Documentation has been updated to reflect this change
- [x] The new commits follow conventions explained in [CONTRIBUTING.md](https://github.com/typeorm/typeorm/blob/master/CONTRIBUTING.md)
