### PR TITLE
fix: broken CLI in ESM projects since version 0.3

### DIFF
--- a/src/commands/CacheClearCommand.ts
+++ b/src/commands/CacheClearCommand.ts
@@ -25,7 +25,7 @@ export class CacheClearCommand implements yargs.CommandModule {
     async handler(args: yargs.Arguments) {
         let dataSource: DataSource | undefined = undefined
         try {
-            dataSource = CommandUtils.loadDataSource(
+            dataSource = await CommandUtils.loadDataSource(
                 path.resolve(process.cwd(), args.dataSource as string),
             )
             dataSource.setOptions({

--- a/src/commands/CommandUtils.ts
+++ b/src/commands/CommandUtils.ts
@@ -4,16 +4,20 @@ import mkdirp from "mkdirp"
 import { TypeORMError } from "../error"
 import { DataSource } from "../data-source"
 import { InstanceChecker } from "../util/InstanceChecker"
-import { importOrRequireFile } from "../util/ImportUtils";
+import { importOrRequireFile } from "../util/ImportUtils"
 
 /**
  * Command line utils functions.
  */
 export class CommandUtils {
-    static async loadDataSource(dataSourceFilePath: string): Promise<DataSource> {
+    static async loadDataSource(
+        dataSourceFilePath: string,
+    ): Promise<DataSource> {
         let dataSourceFileExports
         try {
-            [dataSourceFileExports] = await importOrRequireFile(dataSourceFilePath)
+            ;[dataSourceFileExports] = await importOrRequireFile(
+                dataSourceFilePath,
+            )
         } catch (err) {
             throw new Error(
                 `Invalid file path given: "${dataSourceFilePath}". File must contain a TypeScript / JavaScript code and export a DataSource instance.`,

--- a/src/commands/CommandUtils.ts
+++ b/src/commands/CommandUtils.ts
@@ -4,15 +4,16 @@ import mkdirp from "mkdirp"
 import { TypeORMError } from "../error"
 import { DataSource } from "../data-source"
 import { InstanceChecker } from "../util/InstanceChecker"
+import { importOrRequireFile } from "../util/ImportUtils";
 
 /**
  * Command line utils functions.
  */
 export class CommandUtils {
-    static loadDataSource(dataSourceFilePath: string): DataSource {
+    static async loadDataSource(dataSourceFilePath: string): Promise<DataSource> {
         let dataSourceFileExports
         try {
-            dataSourceFileExports = require(dataSourceFilePath)
+            [dataSourceFileExports] = await importOrRequireFile(dataSourceFilePath)
         } catch (err) {
             throw new Error(
                 `Invalid file path given: "${dataSourceFilePath}". File must contain a TypeScript / JavaScript code and export a DataSource instance.`,

--- a/src/commands/MigrationGenerateCommand.ts
+++ b/src/commands/MigrationGenerateCommand.ts
@@ -70,7 +70,7 @@ export class MigrationGenerateCommand implements yargs.CommandModule {
 
         let dataSource: DataSource | undefined = undefined
         try {
-            dataSource = CommandUtils.loadDataSource(
+            dataSource = await CommandUtils.loadDataSource(
                 path.resolve(process.cwd(), args.dataSource as string),
             )
             dataSource.setOptions({

--- a/src/commands/MigrationRevertCommand.ts
+++ b/src/commands/MigrationRevertCommand.ts
@@ -31,7 +31,7 @@ export class MigrationRevertCommand implements yargs.CommandModule {
     async handler(args: yargs.Arguments) {
         let dataSource: DataSource | undefined = undefined
         try {
-            dataSource = CommandUtils.loadDataSource(
+            dataSource = await CommandUtils.loadDataSource(
                 path.resolve(process.cwd(), args.dataSource as string),
             )
             dataSource.setOptions({

--- a/src/commands/MigrationRunCommand.ts
+++ b/src/commands/MigrationRunCommand.ts
@@ -31,7 +31,7 @@ export class MigrationRunCommand implements yargs.CommandModule {
     async handler(args: yargs.Arguments) {
         let dataSource: DataSource | undefined = undefined
         try {
-            dataSource = CommandUtils.loadDataSource(
+            dataSource = await CommandUtils.loadDataSource(
                 path.resolve(process.cwd(), args.dataSource as string),
             )
             dataSource.setOptions({

--- a/src/commands/MigrationShowCommand.ts
+++ b/src/commands/MigrationShowCommand.ts
@@ -24,7 +24,7 @@ export class MigrationShowCommand implements yargs.CommandModule {
     async handler(args: yargs.Arguments) {
         let dataSource: DataSource | undefined = undefined
         try {
-            dataSource = CommandUtils.loadDataSource(
+            dataSource = await CommandUtils.loadDataSource(
                 path.resolve(process.cwd(), args.dataSource as string),
             )
             dataSource.setOptions({

--- a/src/commands/QueryCommand.ts
+++ b/src/commands/QueryCommand.ts
@@ -33,7 +33,7 @@ export class QueryCommand implements yargs.CommandModule {
         let queryRunner: QueryRunner | undefined = undefined
         let dataSource: DataSource | undefined = undefined
         try {
-            dataSource = CommandUtils.loadDataSource(
+            dataSource = await CommandUtils.loadDataSource(
                 path.resolve(process.cwd(), args.dataSource as string),
             )
             dataSource.setOptions({

--- a/src/commands/SchemaDropCommand.ts
+++ b/src/commands/SchemaDropCommand.ts
@@ -27,7 +27,7 @@ export class SchemaDropCommand implements yargs.CommandModule {
     async handler(args: yargs.Arguments) {
         let dataSource: DataSource | undefined = undefined
         try {
-            dataSource = CommandUtils.loadDataSource(
+            dataSource = await CommandUtils.loadDataSource(
                 path.resolve(process.cwd(), args.dataSource as string),
             )
             dataSource.setOptions({

--- a/src/commands/SchemaLogCommand.ts
+++ b/src/commands/SchemaLogCommand.ts
@@ -28,7 +28,7 @@ export class SchemaLogCommand implements yargs.CommandModule {
     async handler(args: yargs.Arguments) {
         let dataSource: DataSource | undefined = undefined
         try {
-            dataSource = CommandUtils.loadDataSource(
+            dataSource = await CommandUtils.loadDataSource(
                 path.resolve(process.cwd(), args.dataSource as string),
             )
             dataSource.setOptions({

--- a/src/commands/SchemaSyncCommand.ts
+++ b/src/commands/SchemaSyncCommand.ts
@@ -27,7 +27,7 @@ export class SchemaSyncCommand implements yargs.CommandModule {
     async handler(args: yargs.Arguments) {
         let dataSource: DataSource | undefined = undefined
         try {
-            dataSource = CommandUtils.loadDataSource(
+            dataSource = await CommandUtils.loadDataSource(
                 path.resolve(process.cwd(), args.dataSource as string),
             )
             dataSource.setOptions({


### PR DESCRIPTION
### Description of change
Using the CLI in ESM projects is broken in version 0.3.1, this PR fixes that.
The CLI currently tries to `require( ... )` the `data-source.ts` file of the project regardless of the project type (CommonJS/ESM), the fix is to use the `importOrRequireFile` function instead.

### Pull-Request Checklist
- [x] Code is up-to-date with the `master` branch
- [x] `npm run format` to apply prettier formatting
- [x] `npm run test` passes with this change
- [x] This pull request links relevant issues as `Fixes #0000`
- [ ] There are new or updated unit tests validating the change - _This is problematic to test from within the module itself_
- [ ] Documentation has been updated to reflect this change
- [x] The new commits follow conventions explained in [CONTRIBUTING.md](https://github.com/typeorm/typeorm/blob/master/CONTRIBUTING.md)
