### PR TITLE
feat: add typeorm CLI variations that include `ts-node`

### DIFF
--- a/docs/faq.md
+++ b/docs/faq.md
@@ -160,13 +160,13 @@ make sure to use the `outDir` compiler option to prevent
 Also, if you want to use the ts-node CLI, you can execute TypeORM the following way:
 
 ```
-ts-node ./node_modules/.bin/typeorm schema:sync
+npx typeorm-ts-node-commonjs schema:sync
 ```
 
 For ESM projects use this instead:
 
 ```
-node --loader ts-node/esm ./node_modules/.bin/typeorm schema:sync
+npx typeorm-ts-node-esm schema:sync
 ```
 
 ## How to use Webpack for the backend?

--- a/docs/migrations.md
+++ b/docs/migrations.md
@@ -140,19 +140,13 @@ typeorm migration:run
 Example with `ts-node`:
 
 ```
-ts-node --transpile-only ./node_modules/typeorm/cli.js migration:run
+npx typeorm-ts-node-commonjs migration:run
 ```
 
 Example with `ts-node` in ESM projects:
 
 ```
-node --loader ts-node/esm ./node_modules/typeorm/cli.js migration:run
-```
-
-Example `ts-node` not using `node_modules` directly:
-
-```
-ts-node $(yarn bin typeorm) migration:run
+npx typeorm-ts-node-esm migration:run
 ```
 
 This command will execute all pending migrations and run them in a sequence ordered by their timestamps.

--- a/docs/using-cli.md
+++ b/docs/using-cli.md
@@ -42,7 +42,7 @@ Add typeorm command under scripts section in package.json
 ```
 "scripts": {
     ...
-    "typeorm": "node --require ts-node/register ./node_modules/typeorm/cli.js"
+    "typeorm": "typeorm-ts-node-commonjs"
 }
 ```
 
@@ -51,7 +51,7 @@ For ESM projects add this instead:
 ```
 "scripts": {
     ...
-    "typeorm": "node --loader ts-node/esm ./node_modules/typeorm/cli.js"
+    "typeorm": "typeorm-ts-node-esm"
 }
 ```
 

--- a/docs/zh_CN/faq.md
+++ b/docs/zh_CN/faq.md
@@ -168,7 +168,7 @@ createConnection({
 此外，如果要使用 ts-node CLI，可以通过以下方式执行 TypeORM：
 
 ```
-ts-node ./node_modules/bin/typeorm schema:sync
+npx typeorm-ts-node-commonjs schema:sync
 ```
 
 ## 后端如何使用Webpack？

--- a/docs/zh_CN/migrations.md
+++ b/docs/zh_CN/migrations.md
@@ -138,7 +138,7 @@ typeorm migration:run
 `ts-node`的示例：
 
 ```
-ts-node ./node_modules/typeorm/cli.js migration:run
+npx typeorm-ts-node-commonjs migration:run
 ```
 
 此命令将执行所有挂起的迁移，并按其时间戳排序的顺序运行它们。

--- a/docs/zh_CN/using-cli.md
+++ b/docs/zh_CN/using-cli.md
@@ -24,7 +24,7 @@
 你可以在项目中设置 ts-node 以简化操作，如下所示：
 
 ```
-npm install -g ts-node
+npm install ts-node --save-dev
 ```
 
 在 package.json 中的 scripts 下添加 typeorm 命令
@@ -32,7 +32,7 @@ npm install -g ts-node
 ```
 "script" {
     ...
-    "typeorm": "ts-node -r tsconfig-paths/register ./node_modules/typeorm/cli.js"
+    "typeorm": "typeorm-ts-node-commonjs"
 }
 ```
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "typeorm",
-  "version": "0.3.0-rc.38",
+  "version": "0.3.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "typeorm",
-      "version": "0.3.0-rc.38",
+      "version": "0.3.1",
       "license": "MIT",
       "dependencies": {
         "@sqltools/formatter": "^1.2.2",
@@ -28,6 +28,8 @@
         "yargs": "^17.3.1"
       },
       "bin": {
+        "typeorm-ts-node-commonjs": "./cli-ts-node-commonjs.js",
+        "typeorm-ts-node-esm": "./cli-ts-node-esm.js",
         "typeorm": "cli.js"
       },
       "devDependencies": {
@@ -79,7 +81,7 @@
         "source-map-support": "^0.5.19",
         "sql.js": "^1.4.0",
         "sqlite3": "^5.0.2",
-        "ts-node": "^9.1.1",
+        "ts-node": "^10.7.0",
         "typeorm-aurora-data-api-driver": "^2.0.0",
         "typescript": "^4.6.2"
       },
@@ -104,6 +106,7 @@
         "redis": "^3.1.1",
         "sql.js": "^1.4.0",
         "sqlite3": "^5.0.2",
+        "ts-node": "^10.7.0",
         "typeorm-aurora-data-api-driver": "^2.0.0"
       },
       "peerDependenciesMeta": {
@@ -147,6 +150,9 @@
           "optional": true
         },
         "sqlite3": {
+          "optional": true
+        },
+        "ts-node": {
           "optional": true
         },
         "typeorm-aurora-data-api-driver": {
@@ -667,6 +673,27 @@
         "node": ">=4"
       }
     },
+    "node_modules/@cspotcode/source-map-consumer": {
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/@cspotcode/source-map-consumer/-/source-map-consumer-0.8.0.tgz",
+      "integrity": "sha512-41qniHzTU8yAGbCp04ohlmSrZf8bkf/iJsl3V0dRGsQN/5GFfx+LbCSsCpp2gqrqjTVg/K6O8ycoV35JIwAzAg==",
+      "dev": true,
+      "engines": {
+        "node": ">= 12"
+      }
+    },
+    "node_modules/@cspotcode/source-map-support": {
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/@cspotcode/source-map-support/-/source-map-support-0.7.0.tgz",
+      "integrity": "sha512-X4xqRHqN8ACt2aHVe51OxeA2HjbcL4MqFqXkrmQszJ1NOUuUu5u6Vqx/0lZSVNku7velL5FC/s5uEAj1lsBMhA==",
+      "dev": true,
+      "dependencies": {
+        "@cspotcode/source-map-consumer": "0.8.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/@gulp-sourcemaps/identity-map": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/@gulp-sourcemaps/identity-map/-/identity-map-2.0.1.tgz",
@@ -853,6 +880,30 @@
       "engines": {
         "node": ">= 6"
       }
+    },
+    "node_modules/@tsconfig/node10": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node10/-/node10-1.0.8.tgz",
+      "integrity": "sha512-6XFfSQmMgq0CFLY1MslA/CPUfhIL919M1rMsa5lP2P097N2Wd1sSX0tx1u4olM16fLNhtHZpRhedZJphNJqmZg==",
+      "dev": true
+    },
+    "node_modules/@tsconfig/node12": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node12/-/node12-1.0.9.tgz",
+      "integrity": "sha512-/yBMcem+fbvhSREH+s14YJi18sp7J9jpuhYByADT2rypfajMZZN4WQ6zBGgBKp53NKmqI36wFYDb3yaMPurITw==",
+      "dev": true
+    },
+    "node_modules/@tsconfig/node14": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node14/-/node14-1.0.1.tgz",
+      "integrity": "sha512-509r2+yARFfHHE7T6Puu2jjkoycftovhXRqW328PDXTVGKihlb1P8Z9mMZH04ebyajfRY7dedfGynlrFHJUQCg==",
+      "dev": true
+    },
+    "node_modules/@tsconfig/node16": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node16/-/node16-1.0.2.tgz",
+      "integrity": "sha512-eZxlbI8GZscaGS7kkc/trHTT5xgrjH3/1n2JDwusC9iahPKWMRvRjJSAN5mCXviuTGQ/lHnhvv8Q1YTpnfz9gA==",
+      "dev": true
     },
     "node_modules/@types/app-root-path": {
       "version": "1.2.4",
@@ -1291,6 +1342,27 @@
       },
       "engines": {
         "node": ">=6.5"
+      }
+    },
+    "node_modules/acorn": {
+      "version": "8.7.0",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.7.0.tgz",
+      "integrity": "sha512-V/LGr1APy+PXIwKebEWrkZPwoeoF+w1jiOBUmuxuiUIaOHtob8Qc9BTrYo7VuI5fR8tqsy+buA2WFooR5olqvQ==",
+      "dev": true,
+      "bin": {
+        "acorn": "bin/acorn"
+      },
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/acorn-walk": {
+      "version": "8.2.0",
+      "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-8.2.0.tgz",
+      "integrity": "sha512-k+iyHEuPgSw6SbuDpGQM+06HQUa04DZ3o+F6CSzXMvvI5KMvnaEqXe+YVe555R9nn6GPt404fos4wcgpw12SDA==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.4.0"
       }
     },
     "node_modules/adal-node": {
@@ -11486,29 +11558,46 @@
       }
     },
     "node_modules/ts-node": {
-      "version": "9.1.1",
-      "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-9.1.1.tgz",
-      "integrity": "sha512-hPlt7ZACERQGf03M253ytLY3dHbGNGrAq9qIHWUY9XHYl1z7wYngSr3OQ5xmui8o2AaxsONxIzjafLUiWBo1Fg==",
+      "version": "10.7.0",
+      "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-10.7.0.tgz",
+      "integrity": "sha512-TbIGS4xgJoX2i3do417KSaep1uRAW/Lu+WAL2doDHC0D6ummjirVOXU5/7aiZotbQ5p1Zp9tP7U6cYhA0O7M8A==",
       "dev": true,
       "dependencies": {
+        "@cspotcode/source-map-support": "0.7.0",
+        "@tsconfig/node10": "^1.0.7",
+        "@tsconfig/node12": "^1.0.7",
+        "@tsconfig/node14": "^1.0.0",
+        "@tsconfig/node16": "^1.0.2",
+        "acorn": "^8.4.1",
+        "acorn-walk": "^8.1.1",
         "arg": "^4.1.0",
         "create-require": "^1.1.0",
         "diff": "^4.0.1",
         "make-error": "^1.1.1",
-        "source-map-support": "^0.5.17",
+        "v8-compile-cache-lib": "^3.0.0",
         "yn": "3.1.1"
       },
       "bin": {
         "ts-node": "dist/bin.js",
+        "ts-node-cwd": "dist/bin-cwd.js",
+        "ts-node-esm": "dist/bin-esm.js",
         "ts-node-script": "dist/bin-script.js",
         "ts-node-transpile-only": "dist/bin-transpile.js",
         "ts-script": "dist/bin-script-deprecated.js"
       },
-      "engines": {
-        "node": ">=10.0.0"
-      },
       "peerDependencies": {
+        "@swc/core": ">=1.2.50",
+        "@swc/wasm": ">=1.2.50",
+        "@types/node": "*",
         "typescript": ">=2.7"
+      },
+      "peerDependenciesMeta": {
+        "@swc/core": {
+          "optional": true
+        },
+        "@swc/wasm": {
+          "optional": true
+        }
       }
     },
     "node_modules/ts-node/node_modules/diff": {
@@ -11794,6 +11883,12 @@
       "bin": {
         "uuid": "dist/bin/uuid"
       }
+    },
+    "node_modules/v8-compile-cache-lib": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/v8-compile-cache-lib/-/v8-compile-cache-lib-3.0.0.tgz",
+      "integrity": "sha512-mpSYqfsFvASnSn5qMiwrr4VKfumbPyONLCOPmsR3A6pTY/r0+tSaVbgPWSAIuzbk3lCTa+FForeTiO+wBQGkjA==",
+      "dev": true
     },
     "node_modules/v8flags": {
       "version": "3.2.0",
@@ -12672,6 +12767,21 @@
         }
       }
     },
+    "@cspotcode/source-map-consumer": {
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/@cspotcode/source-map-consumer/-/source-map-consumer-0.8.0.tgz",
+      "integrity": "sha512-41qniHzTU8yAGbCp04ohlmSrZf8bkf/iJsl3V0dRGsQN/5GFfx+LbCSsCpp2gqrqjTVg/K6O8ycoV35JIwAzAg==",
+      "dev": true
+    },
+    "@cspotcode/source-map-support": {
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/@cspotcode/source-map-support/-/source-map-support-0.7.0.tgz",
+      "integrity": "sha512-X4xqRHqN8ACt2aHVe51OxeA2HjbcL4MqFqXkrmQszJ1NOUuUu5u6Vqx/0lZSVNku7velL5FC/s5uEAj1lsBMhA==",
+      "dev": true,
+      "requires": {
+        "@cspotcode/source-map-consumer": "0.8.0"
+      }
+    },
     "@gulp-sourcemaps/identity-map": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/@gulp-sourcemaps/identity-map/-/identity-map-2.0.1.tgz",
@@ -12828,6 +12938,30 @@
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/@tootallnate/once/-/once-1.1.2.tgz",
       "integrity": "sha512-RbzJvlNzmRq5c3O09UipeuXno4tA1FE6ikOjxZK0tuxVv3412l64l5t1W5pj4+rJq9vpkm/kwiR07aZXnsKPxw==",
+      "dev": true
+    },
+    "@tsconfig/node10": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node10/-/node10-1.0.8.tgz",
+      "integrity": "sha512-6XFfSQmMgq0CFLY1MslA/CPUfhIL919M1rMsa5lP2P097N2Wd1sSX0tx1u4olM16fLNhtHZpRhedZJphNJqmZg==",
+      "dev": true
+    },
+    "@tsconfig/node12": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node12/-/node12-1.0.9.tgz",
+      "integrity": "sha512-/yBMcem+fbvhSREH+s14YJi18sp7J9jpuhYByADT2rypfajMZZN4WQ6zBGgBKp53NKmqI36wFYDb3yaMPurITw==",
+      "dev": true
+    },
+    "@tsconfig/node14": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node14/-/node14-1.0.1.tgz",
+      "integrity": "sha512-509r2+yARFfHHE7T6Puu2jjkoycftovhXRqW328PDXTVGKihlb1P8Z9mMZH04ebyajfRY7dedfGynlrFHJUQCg==",
+      "dev": true
+    },
+    "@tsconfig/node16": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node16/-/node16-1.0.2.tgz",
+      "integrity": "sha512-eZxlbI8GZscaGS7kkc/trHTT5xgrjH3/1n2JDwusC9iahPKWMRvRjJSAN5mCXviuTGQ/lHnhvv8Q1YTpnfz9gA==",
       "dev": true
     },
     "@types/app-root-path": {
@@ -13227,6 +13361,18 @@
       "requires": {
         "event-target-shim": "^5.0.0"
       }
+    },
+    "acorn": {
+      "version": "8.7.0",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.7.0.tgz",
+      "integrity": "sha512-V/LGr1APy+PXIwKebEWrkZPwoeoF+w1jiOBUmuxuiUIaOHtob8Qc9BTrYo7VuI5fR8tqsy+buA2WFooR5olqvQ==",
+      "dev": true
+    },
+    "acorn-walk": {
+      "version": "8.2.0",
+      "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-8.2.0.tgz",
+      "integrity": "sha512-k+iyHEuPgSw6SbuDpGQM+06HQUa04DZ3o+F6CSzXMvvI5KMvnaEqXe+YVe555R9nn6GPt404fos4wcgpw12SDA==",
+      "dev": true
     },
     "adal-node": {
       "version": "0.2.3",
@@ -21261,16 +21407,23 @@
       "dev": true
     },
     "ts-node": {
-      "version": "9.1.1",
-      "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-9.1.1.tgz",
-      "integrity": "sha512-hPlt7ZACERQGf03M253ytLY3dHbGNGrAq9qIHWUY9XHYl1z7wYngSr3OQ5xmui8o2AaxsONxIzjafLUiWBo1Fg==",
+      "version": "10.7.0",
+      "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-10.7.0.tgz",
+      "integrity": "sha512-TbIGS4xgJoX2i3do417KSaep1uRAW/Lu+WAL2doDHC0D6ummjirVOXU5/7aiZotbQ5p1Zp9tP7U6cYhA0O7M8A==",
       "dev": true,
       "requires": {
+        "@cspotcode/source-map-support": "0.7.0",
+        "@tsconfig/node10": "^1.0.7",
+        "@tsconfig/node12": "^1.0.7",
+        "@tsconfig/node14": "^1.0.0",
+        "@tsconfig/node16": "^1.0.2",
+        "acorn": "^8.4.1",
+        "acorn-walk": "^8.1.1",
         "arg": "^4.1.0",
         "create-require": "^1.1.0",
         "diff": "^4.0.1",
         "make-error": "^1.1.1",
-        "source-map-support": "^0.5.17",
+        "v8-compile-cache-lib": "^3.0.0",
         "yn": "3.1.1"
       },
       "dependencies": {
@@ -21499,6 +21652,12 @@
       "version": "8.3.2",
       "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
       "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg=="
+    },
+    "v8-compile-cache-lib": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/v8-compile-cache-lib/-/v8-compile-cache-lib-3.0.0.tgz",
+      "integrity": "sha512-mpSYqfsFvASnSn5qMiwrr4VKfumbPyONLCOPmsR3A6pTY/r0+tSaVbgPWSAIuzbk3lCTa+FForeTiO+wBQGkjA==",
+      "dev": true
     },
     "v8flags": {
       "version": "3.2.0",

--- a/package.json
+++ b/package.json
@@ -129,7 +129,7 @@
     "source-map-support": "^0.5.19",
     "sql.js": "^1.4.0",
     "sqlite3": "^5.0.2",
-    "ts-node": "^9.1.1",
+    "ts-node": "^10.7.0",
     "typeorm-aurora-data-api-driver": "^2.0.0",
     "typescript": "^4.6.2",
     "prettier": "^2.5.1"
@@ -149,6 +149,7 @@
     "redis": "^3.1.1",
     "sql.js": "^1.4.0",
     "sqlite3": "^5.0.2",
+    "ts-node": "^10.7.0",
     "typeorm-aurora-data-api-driver": "^2.0.0"
   },
   "peerDependenciesMeta": {
@@ -194,6 +195,9 @@
     "sqlite3": {
       "optional": true
     },
+    "ts-node": {
+      "optional": true
+    },
     "typeorm-aurora-data-api-driver": {
       "optional": true
     }
@@ -228,7 +232,11 @@
     "format": "prettier --write \"./src/**/*.ts\" \"./test/**/*.ts\" \"./sample/**/*.ts\"",
     "changelog": "conventional-changelog -p angular -i CHANGELOG.md -s -r 2"
   },
-  "bin": "./cli.js",
+  "bin": {
+    "typeorm": "./cli.js",
+    "typeorm-ts-node-commonjs": "./cli-ts-node-commonjs.js",
+    "typeorm-ts-node-esm": "./cli-ts-node-esm.js"
+  },
   "funding": "https://opencollective.com/typeorm",
   "collective": {
     "type": "opencollective",

--- a/src/cli-ts-node-commonjs.ts
+++ b/src/cli-ts-node-commonjs.ts
@@ -1,0 +1,2 @@
+#!/usr/bin/env node --require ts-node/register
+import "./cli";

--- a/src/cli-ts-node-commonjs.ts
+++ b/src/cli-ts-node-commonjs.ts
@@ -1,2 +1,2 @@
 #!/usr/bin/env node --require ts-node/register
-import "./cli";
+import "./cli"

--- a/src/cli-ts-node-esm.ts
+++ b/src/cli-ts-node-esm.ts
@@ -1,0 +1,2 @@
+#!/usr/bin/env node --loader ts-node/esm --no-warnings
+import "./cli";

--- a/src/cli-ts-node-esm.ts
+++ b/src/cli-ts-node-esm.ts
@@ -1,2 +1,2 @@
 #!/usr/bin/env node --loader ts-node/esm --no-warnings
-import "./cli";
+import "./cli"

--- a/src/commands/InitCommand.ts
+++ b/src/commands/InitCommand.ts
@@ -691,14 +691,12 @@ Steps to run this project:
         if (projectIsEsm)
             Object.assign(packageJson.scripts, {
                 start: /*(docker ? "docker-compose up && " : "") + */ "node --loader ts-node/esm src/index.ts",
-                typeorm:
-                    "node --loader ts-node/esm ./node_modules/typeorm/cli.js",
+                typeorm: "typeorm-ts-node-esm",
             })
         else
             Object.assign(packageJson.scripts, {
                 start: /*(docker ? "docker-compose up && " : "") + */ "ts-node src/index.ts",
-                typeorm:
-                    "node --require ts-node/register ./node_modules/typeorm/cli.js",
+                typeorm: "typeorm-ts-node-commonjs",
             })
 
         return JSON.stringify(packageJson, undefined, 3)


### PR DESCRIPTION
### Description of change
Add `typeorm-ts-node-commonjs` and `typeorm-ts-node-esm` CLI commands.
This removes the need to manually write `node --require ts-node/register ./node_modules/typeorm/cli.js` or `node --loader ts-node/esm ./node_modules/typeorm/cli.js` in order to use TypeORM CLI without transpiling the code in advance.

This is more useful now than before since the new CLI in version 0.3 requires you to specify a file path instead of just a file name, so being able to `cd` to a folder and then run a simple and intuitive command is now more important.

Previous usage of the CLI in version 0.3:
```bash
cd src/db/migrations
node --loader ts-node/esm ../../../node_modules/typeorm/cli.js migration:generate -d ../data-source.ts --pretty SomeMigrationName
```

New possible usage of the CLI:
```bash
cd src/db/migrations
npx typeorm-ts-node-esm migration:generate -d ../data-source.ts --pretty SomeMigrationName
```

### Pull-Request Checklist
- [x] Code is up-to-date with the `master` branch
- [x] `npm run format` to apply prettier formatting
- [x] `npm run test` passes with this change
- [x] This pull request links relevant issues as `Fixes #0000`
- [ ] There are new or updated unit tests validating the change - N/A
- [x] Documentation has been updated to reflect this change
- [x] The new commits follow conventions explained in [CONTRIBUTING.md](https://github.com/typeorm/typeorm/blob/master/CONTRIBUTING.md)
