### PR TITLE
fix: reverted json/jsonb changes introduced in 0.3.1

### DIFF
--- a/src/driver/postgres/PostgresDriver.ts
+++ b/src/driver/postgres/PostgresDriver.ts
@@ -622,7 +622,7 @@ export class PostgresDriver implements Driver {
                 columnMetadata.type,
             ) >= 0
         ) {
-            return value // JSON.stringify()
+            return JSON.stringify(value)
         } else if (columnMetadata.type === "hstore") {
             if (typeof value === "string") {
                 return value

--- a/test/benchmark/bulk-save-case2/entity/Document.ts
+++ b/test/benchmark/bulk-save-case2/entity/Document.ts
@@ -16,7 +16,7 @@ export class Document {
     @Column("text")
     context: string
 
-    @Column({ type: "jsonb", array: true })
+    @Column({ type: "jsonb" })
     distributions: Distribution[]
 
     @Column({ type: "timestamp with time zone" })

--- a/test/functional/find-options/array-contained-by-operator/array-contained-by-operator.test.ts
+++ b/test/functional/find-options/array-contained-by-operator/array-contained-by-operator.test.ts
@@ -25,21 +25,18 @@ describe("find options > find operators > ArrayContainedBy", () => {
         const post1 = new Post()
         post1.title = "Post #1"
         post1.authors = ["dmitry", "olimjon"]
-        post1.categories = [{ name: "typescript" }, { name: "programming" }]
         post1.statuses = [PostStatus.draft, PostStatus.published]
         await manager.save(post1)
 
         const post2 = new Post()
         post2.title = "Post #2"
         post2.authors = ["olimjon"]
-        post2.categories = [{ name: "programming" }]
         post2.statuses = [PostStatus.published]
         await manager.save(post2)
 
         const post3 = new Post()
         post3.title = "Post #3"
         post3.authors = []
-        post3.categories = []
         post3.statuses = []
         await manager.save(post3)
     }
@@ -62,24 +59,18 @@ describe("find options > find operators > ArrayContainedBy", () => {
                         id: 1,
                         title: "Post #1",
                         authors: ["dmitry", "olimjon"],
-                        categories: [
-                            { name: "typescript" },
-                            { name: "programming" },
-                        ],
                         statuses: [PostStatus.draft, PostStatus.published],
                     },
                     {
                         id: 2,
                         title: "Post #2",
                         authors: ["olimjon"],
-                        categories: [{ name: "programming" }],
                         statuses: [PostStatus.published],
                     },
                     {
                         id: 3,
                         title: "Post #3",
                         authors: [],
-                        categories: [],
                         statuses: [],
                     },
                 ])
@@ -97,84 +88,12 @@ describe("find options > find operators > ArrayContainedBy", () => {
                         id: 2,
                         title: "Post #2",
                         authors: ["olimjon"],
-                        categories: [{ name: "programming" }],
                         statuses: [PostStatus.published],
                     },
                     {
                         id: 3,
                         title: "Post #3",
                         authors: [],
-                        categories: [],
-                        statuses: [],
-                    },
-                ])
-            }),
-        ))
-
-    it("should find entries in jsonb", () =>
-        Promise.all(
-            connections.map(async (connection) => {
-                await prepareData(connection.manager)
-
-                const loadedPost1 = await connection.manager.find(Post, {
-                    where: {
-                        categories: ArrayContainedBy([
-                            { name: "typescript" },
-                            { name: "programming" },
-                        ]),
-                    },
-                    order: {
-                        id: "asc",
-                    },
-                })
-                loadedPost1.should.be.eql([
-                    {
-                        id: 1,
-                        title: "Post #1",
-                        authors: ["dmitry", "olimjon"],
-                        categories: [
-                            { name: "typescript" },
-                            { name: "programming" },
-                        ],
-                        statuses: [PostStatus.draft, PostStatus.published],
-                    },
-                    {
-                        id: 2,
-                        title: "Post #2",
-                        authors: ["olimjon"],
-                        categories: [{ name: "programming" }],
-                        statuses: [PostStatus.published],
-                    },
-                    {
-                        id: 3,
-                        title: "Post #3",
-                        authors: [],
-                        categories: [],
-                        statuses: [],
-                    },
-                ])
-
-                const loadedPost2 = await connection.manager.find(Post, {
-                    where: {
-                        categories: ArrayContainedBy([{ name: "programming" }]),
-                    },
-                    order: {
-                        id: "asc",
-                    },
-                })
-                loadedPost2.should.be.eql([
-                    {
-                        id: 2,
-                        title: "Post #2",
-                        authors: ["olimjon"],
-                        categories: [{ name: "programming" }],
-                        statuses: [PostStatus.published],
-                    },
-                    {
-                        id: 3,
-                        title: "Post #3",
-                        authors: [],
-                        categories: [],
                         statuses: [],
                     },
                 ])
@@ -202,24 +121,18 @@ describe("find options > find operators > ArrayContainedBy", () => {
                         id: 1,
                         title: "Post #1",
                         authors: ["dmitry", "olimjon"],
-                        categories: [
-                            { name: "typescript" },
-                            { name: "programming" },
-                        ],
                         statuses: [PostStatus.draft, PostStatus.published],
                     },
                     {
                         id: 2,
                         title: "Post #2",
                         authors: ["olimjon"],
-                        categories: [{ name: "programming" }],
                         statuses: [PostStatus.published],
                     },
                     {
                         id: 3,
                         title: "Post #3",
                         authors: [],
-                        categories: [],
                         statuses: [],
                     },
                 ])
@@ -237,14 +150,12 @@ describe("find options > find operators > ArrayContainedBy", () => {
                         id: 2,
                         title: "Post #2",
                         authors: ["olimjon"],
-                        categories: [{ name: "programming" }],
                         statuses: [PostStatus.published],
                     },
                     {
                         id: 3,
                         title: "Post #3",
                         authors: [],
-                        categories: [],
                         statuses: [],
                     },
                 ])

--- a/test/functional/find-options/array-contains-operator/array-contains-operator.test.ts
+++ b/test/functional/find-options/array-contains-operator/array-contains-operator.test.ts
@@ -25,21 +25,18 @@ describe("find options > find operators > ArrayContains", () => {
         const post1 = new Post()
         post1.title = "Post #1"
         post1.authors = ["dmitry", "olimjon"]
-        post1.categories = [{ name: "typescript" }, { name: "programming" }]
         post1.statuses = [PostStatus.draft, PostStatus.published]
         await manager.save(post1)
 
         const post2 = new Post()
         post2.title = "Post #2"
         post2.authors = ["olimjon"]
-        post2.categories = [{ name: "programming" }]
         post2.statuses = [PostStatus.published]
         await manager.save(post2)
 
         const post3 = new Post()
         post3.title = "Post #3"
         post3.authors = []
-        post3.categories = []
         post3.statuses = []
         await manager.save(post3)
     }
@@ -62,10 +59,6 @@ describe("find options > find operators > ArrayContains", () => {
                         id: 1,
                         title: "Post #1",
                         authors: ["dmitry", "olimjon"],
-                        categories: [
-                            { name: "typescript" },
-                            { name: "programming" },
-                        ],
                         statuses: [PostStatus.draft, PostStatus.published],
                     },
                 ])
@@ -83,73 +76,12 @@ describe("find options > find operators > ArrayContains", () => {
                         id: 1,
                         title: "Post #1",
                         authors: ["dmitry", "olimjon"],
-                        categories: [
-                            { name: "typescript" },
-                            { name: "programming" },
-                        ],
                         statuses: [PostStatus.draft, PostStatus.published],
                     },
                     {
                         id: 2,
                         title: "Post #2",
                         authors: ["olimjon"],
-                        categories: [{ name: "programming" }],
-                        statuses: [PostStatus.published],
-                    },
-                ])
-            }),
-        ))
-
-    it("should find entries in jsonb", () =>
-        Promise.all(
-            connections.map(async (connection) => {
-                await prepareData(connection.manager)
-
-                const loadedPost1 = await connection.manager.find(Post, {
-                    where: {
-                        categories: ArrayContains([{ name: "typescript" }]),
-                    },
-                    order: {
-                        id: "asc",
-                    },
-                })
-                loadedPost1.should.be.eql([
-                    {
-                        id: 1,
-                        title: "Post #1",
-                        authors: ["dmitry", "olimjon"],
-                        categories: [
-                            { name: "typescript" },
-                            { name: "programming" },
-                        ],
-                        statuses: [PostStatus.draft, PostStatus.published],
-                    },
-                ])
-
-                const loadedPost2 = await connection.manager.find(Post, {
-                    where: {
-                        categories: ArrayContains([{ name: "programming" }]),
-                    },
-                    order: {
-                        id: "asc",
-                    },
-                })
-                loadedPost2.should.be.eql([
-                    {
-                        id: 1,
-                        title: "Post #1",
-                        authors: ["dmitry", "olimjon"],
-                        categories: [
-                            { name: "typescript" },
-                            { name: "programming" },
-                        ],
-                        statuses: [PostStatus.draft, PostStatus.published],
-                    },
-                    {
-                        id: 2,
-                        title: "Post #2",
-                        authors: ["olimjon"],
-                        categories: [{ name: "programming" }],
                         statuses: [PostStatus.published],
                     },
                 ])
@@ -174,10 +106,6 @@ describe("find options > find operators > ArrayContains", () => {
                         id: 1,
                         title: "Post #1",
                         authors: ["dmitry", "olimjon"],
-                        categories: [
-                            { name: "typescript" },
-                            { name: "programming" },
-                        ],
                         statuses: [PostStatus.draft, PostStatus.published],
                     },
                 ])
@@ -195,17 +123,12 @@ describe("find options > find operators > ArrayContains", () => {
                         id: 1,
                         title: "Post #1",
                         authors: ["dmitry", "olimjon"],
-                        categories: [
-                            { name: "typescript" },
-                            { name: "programming" },
-                        ],
                         statuses: [PostStatus.draft, PostStatus.published],
                     },
                     {
                         id: 2,
                         title: "Post #2",
                         authors: ["olimjon"],
-                        categories: [{ name: "programming" }],
                         statuses: [PostStatus.published],
                     },
                 ])

--- a/test/functional/find-options/array-contains-operator/entity/Post.ts
+++ b/test/functional/find-options/array-contains-operator/entity/Post.ts
@@ -25,12 +25,6 @@ export class Post {
     authors: string[]
 
     @Column({
-        type: "jsonb",
-        array: true,
-    })
-    categories: PostCategory[]
-
-    @Column({
         type: "enum",
         enum: PostStatus,
         array: true,

--- a/test/functional/find-options/array-overlap/array-overlap-operator.test.ts
+++ b/test/functional/find-options/array-overlap/array-overlap-operator.test.ts
@@ -25,21 +25,18 @@ describe("find options > find operators > ArrayOverlap", () => {
         const post1 = new Post()
         post1.title = "Post #1"
         post1.authors = ["dmitry", "olimjon"]
-        post1.categories = [{ name: "typescript" }, { name: "programming" }]
         post1.statuses = [PostStatus.draft, PostStatus.published]
         await manager.save(post1)
 
         const post2 = new Post()
         post2.title = "Post #2"
         post2.authors = ["olimjon"]
-        post2.categories = [{ name: "programming" }]
         post2.statuses = [PostStatus.published]
         await manager.save(post2)
 
         const post3 = new Post()
         post3.title = "Post #3"
         post3.authors = []
-        post3.categories = []
         post3.statuses = []
         await manager.save(post3)
     }
@@ -62,10 +59,6 @@ describe("find options > find operators > ArrayOverlap", () => {
                         id: 1,
                         title: "Post #1",
                         authors: ["dmitry", "olimjon"],
-                        categories: [
-                            { name: "typescript" },
-                            { name: "programming" },
-                        ],
                         statuses: [PostStatus.draft, PostStatus.published],
                     },
                 ])
@@ -83,79 +76,12 @@ describe("find options > find operators > ArrayOverlap", () => {
                         id: 1,
                         title: "Post #1",
                         authors: ["dmitry", "olimjon"],
-                        categories: [
-                            { name: "typescript" },
-                            { name: "programming" },
-                        ],
                         statuses: [PostStatus.draft, PostStatus.published],
                     },
                     {
                         id: 2,
                         title: "Post #2",
                         authors: ["olimjon"],
-                        categories: [{ name: "programming" }],
-                        statuses: [PostStatus.published],
-                    },
-                ])
-            }),
-        ))
-
-    it("should find entries in jsonb", () =>
-        Promise.all(
-            connections.map(async (connection) => {
-                await prepareData(connection.manager)
-
-                const loadedPost1 = await connection.manager.find(Post, {
-                    where: {
-                        categories: ArrayOverlap([
-                            { name: "typescript" },
-                            { name: "python" },
-                        ]),
-                    },
-                    order: {
-                        id: "asc",
-                    },
-                })
-                loadedPost1.should.be.eql([
-                    {
-                        id: 1,
-                        title: "Post #1",
-                        authors: ["dmitry", "olimjon"],
-                        categories: [
-                            { name: "typescript" },
-                            { name: "programming" },
-                        ],
-                        statuses: [PostStatus.draft, PostStatus.published],
-                    },
-                ])
-
-                const loadedPost2 = await connection.manager.find(Post, {
-                    where: {
-                        categories: ArrayOverlap([
-                            { name: "programming" },
-                            { name: "python" },
-                        ]),
-                    },
-                    order: {
-                        id: "asc",
-                    },
-                })
-                loadedPost2.should.be.eql([
-                    {
-                        id: 1,
-                        title: "Post #1",
-                        authors: ["dmitry", "olimjon"],
-                        categories: [
-                            { name: "typescript" },
-                            { name: "programming" },
-                        ],
-                        statuses: [PostStatus.draft, PostStatus.published],
-                    },
-                    {
-                        id: 2,
-                        title: "Post #2",
-                        authors: ["olimjon"],
-                        categories: [{ name: "programming" }],
                         statuses: [PostStatus.published],
                     },
                 ])
@@ -183,10 +109,6 @@ describe("find options > find operators > ArrayOverlap", () => {
                         id: 1,
                         title: "Post #1",
                         authors: ["dmitry", "olimjon"],
-                        categories: [
-                            { name: "typescript" },
-                            { name: "programming" },
-                        ],
                         statuses: [PostStatus.draft, PostStatus.published],
                     },
                 ])
@@ -207,17 +129,12 @@ describe("find options > find operators > ArrayOverlap", () => {
                         id: 1,
                         title: "Post #1",
                         authors: ["dmitry", "olimjon"],
-                        categories: [
-                            { name: "typescript" },
-                            { name: "programming" },
-                        ],
                         statuses: [PostStatus.draft, PostStatus.published],
                     },
                     {
                         id: 2,
                         title: "Post #2",
                         authors: ["olimjon"],
-                        categories: [{ name: "programming" }],
                         statuses: [PostStatus.published],
                     },
                 ])

--- a/test/functional/find-options/array-overlap/entity/Post.ts
+++ b/test/functional/find-options/array-overlap/entity/Post.ts
@@ -25,12 +25,6 @@ export class Post {
     authors: string[]
 
     @Column({
-        type: "jsonb",
-        array: true,
-    })
-    categories: PostCategory[]
-
-    @Column({
         type: "enum",
         enum: PostStatus,
         array: true,

--- a/test/functional/json/basic-jsonb/basic-jsonb.test.ts
+++ b/test/functional/json/basic-jsonb/basic-jsonb.test.ts
@@ -1,12 +1,12 @@
-import "../../utils/test-setup"
+import "../../../utils/test-setup"
 import { expect } from "chai"
 import { Record } from "./entity/Record"
-import { DataSource } from "../../../src"
+import { DataSource } from "../../../../src"
 import {
     closeTestingConnections,
     createTestingConnections,
     reloadTestingDatabases,
-} from "../../utils/test-utils"
+} from "../../../utils/test-utils"
 
 describe("jsonb type", () => {
     let connections: DataSource[]
@@ -86,7 +86,7 @@ describe("jsonb type", () => {
             connections.map(async (connection) => {
                 let recordRepo = connection.getRepository(Record)
                 let record = new Record()
-                record.data = `"foo"`
+                record.data = `foo`
                 let persistedRecord = await recordRepo.save(record)
                 let foundRecord = await recordRepo.findOneBy({
                     id: persistedRecord.id,
@@ -102,13 +102,13 @@ describe("jsonb type", () => {
             connections.map(async (connection) => {
                 let recordRepo = connection.getRepository(Record)
                 let record = new Record()
-                record.data2 = [1, `"2"`, { a: 3 }]
+                record.data = [1, `2`, { a: 3 }]
                 let persistedRecord = await recordRepo.save(record)
                 let foundRecord = await recordRepo.findOneBy({
                     id: persistedRecord.id,
                 })
                 expect(foundRecord).to.be.not.undefined
-                expect(foundRecord!.data2).to.deep.include.members([
+                expect(foundRecord!.data).to.deep.include.members([
                     1,
                     "2",
                     { a: 3 },

--- a/test/functional/json/basic-jsonb/entity/Record.ts
+++ b/test/functional/json/basic-jsonb/entity/Record.ts
@@ -1,4 +1,4 @@
-import { Column, Entity, PrimaryGeneratedColumn } from "../../../../src"
+import { Column, Entity, PrimaryGeneratedColumn } from "../../../../../src"
 
 /**
  * For testing Postgres jsonb
@@ -13,9 +13,6 @@ export class Record {
 
     @Column({ type: "jsonb", nullable: true })
     data: any
-
-    @Column({ type: "jsonb", nullable: true, array: true })
-    data2: any
 
     @Column({
         type: "jsonb",

--- a/test/functional/json/jsonb-defaults/entity/Post.ts
+++ b/test/functional/json/jsonb-defaults/entity/Post.ts
@@ -4,12 +4,6 @@ export type PostCategory = {
     name: string
 }
 
-export enum PostStatus {
-    draft = "draft",
-    published = "published",
-    unknown = "unknown",
-}
-
 @Entity()
 export class Post {
     @PrimaryGeneratedColumn()
@@ -19,15 +13,20 @@ export class Post {
     title: string
 
     @Column({
-        type: "varchar",
-        array: true,
+        type: "jsonb",
+        default: ["Dmitry", "Olimjon"],
     })
     authors: string[]
 
     @Column({
-        type: "enum",
-        enum: PostStatus,
-        array: true,
+        type: "jsonb",
+        default: { name: "TypeScript" },
     })
-    statuses: PostStatus[]
+    category: PostCategory
+
+    @Column({
+        type: "jsonb",
+        default: [{ name: "TypeScript" }],
+    })
+    categories: PostCategory[]
 }

--- a/test/functional/json/jsonb-defaults/jsonb-defaults.test.ts
+++ b/test/functional/json/jsonb-defaults/jsonb-defaults.test.ts
@@ -1,0 +1,70 @@
+import "../../../utils/test-setup"
+import { Post } from "./entity/Post"
+import { DataSource } from "../../../../src"
+import {
+    closeTestingConnections,
+    createTestingConnections,
+    reloadTestingDatabases,
+} from "../../../utils/test-utils"
+
+describe("json > defaults", () => {
+    let connections: DataSource[]
+    before(
+        async () =>
+            (connections = await createTestingConnections({
+                entities: [Post],
+                enabledDrivers: ["postgres"], // because only postgres supports jsonb type
+                // logging: true,
+            })),
+    )
+    beforeEach(() => reloadTestingDatabases(connections))
+    after(() => closeTestingConnections(connections))
+
+    it("should insert default values properly", () =>
+        Promise.all(
+            connections.map(async (connection) => {
+                const post1 = new Post()
+                post1.title = "Post #1"
+                await connection.manager.save(post1)
+
+                const loadedPost1 = await connection.manager.findBy(Post, {
+                    title: "Post #1",
+                })
+                loadedPost1.should.be.eql([
+                    {
+                        id: 1,
+                        title: "Post #1",
+                        authors: ["Dmitry", "Olimjon"],
+                        category: { name: "TypeScript" },
+                        categories: [{ name: "TypeScript" }],
+                    },
+                ])
+
+                const post2 = new Post()
+                post2.title = "Post #2"
+                post2.authors = [`Umed`, `Dmitry`]
+                post2.category = { name: "JavaScript" }
+                post2.categories = [
+                    { name: "JavaScript" },
+                    { name: "ECMAScript" },
+                ]
+                await connection.manager.save(post2)
+
+                const loadedPost2 = await connection.manager.findBy(Post, {
+                    title: "Post #2",
+                })
+                loadedPost2.should.be.eql([
+                    {
+                        id: 2,
+                        title: "Post #2",
+                        authors: ["Umed", "Dmitry"],
+                        category: { name: "JavaScript" },
+                        categories: [
+                            { name: "JavaScript" },
+                            { name: "ECMAScript" },
+                        ],
+                    },
+                ])
+            }),
+        ))
+})

--- a/test/github-issues/204/entity/Record.ts
+++ b/test/github-issues/204/entity/Record.ts
@@ -7,9 +7,9 @@ export class Record {
     @PrimaryGeneratedColumn()
     id: number
 
-    @Column({ type: "json", array: true })
+    @Column({ type: "json" })
     configs: RecordConfig[]
 
-    @Column({ type: "jsonb", array: true })
+    @Column({ type: "jsonb" })
     datas: RecordData[]
 }

--- a/test/github-issues/3496/entity/Post.ts
+++ b/test/github-issues/3496/entity/Post.ts
@@ -10,6 +10,6 @@ export class Post {
     @VersionColumn()
     version: number
 
-    @Column({ type: "jsonb", array: true })
+    @Column({ type: "jsonb" })
     problems: object
 }


### PR DESCRIPTION
I have to revert breaking changes introduced in #8766

My assumptions were wrong regarding on how `json`/`jsonb` arrays work in postgres.
Also I faced issue that `node-pg` (underlying package used by TypeORM for postgres support) doesn't really plays well with JSON arrays, so we **must** call `JSON.stringify` to properly support all JSON use cases (see https://github.com/brianc/node-postgres/issues/374 and https://github.com/brianc/node-postgres/issues/442) for more details.

So, this change reverts all breaking changes introduced in 0.3.1 back to how they were in 0.3.0 and earlier versions.

fixes #8772