### PR TITLE
fix: resolve entities correctly in datasource when globs are specified

### DIFF
--- a/src/data-source/DataSource.ts
+++ b/src/data-source/DataSource.ts
@@ -669,10 +669,11 @@ export class DataSource {
         )
 
         // set current data source to the entities
-        for (let entityKey in flattenedEntities) {
-            const entity = flattenedEntities[entityKey]
-            if (InstanceChecker.isBaseEntityConstructor(entity)) {
-                entity.useDataSource(this)
+        for (let entityMetadata of entityMetadatas) {
+            if (
+                InstanceChecker.isBaseEntityConstructor(entityMetadata.target)
+            ) {
+                entityMetadata.target.useDataSource(this)
             }
         }
     }

--- a/src/repository/BaseEntity.ts
+++ b/src/repository/BaseEntity.ts
@@ -27,8 +27,7 @@ export class BaseEntity {
     /**
      * DataSource used in all static methods of the BaseEntity.
      */
-    // @ts-ignore: Unused variable which is actually used
-    private static dataSource?: DataSource
+    private static dataSource: DataSource | null
 
     // -------------------------------------------------------------------------
     // Public Methods
@@ -95,7 +94,7 @@ export class BaseEntity {
     /**
      * Sets DataSource to be used by entity.
      */
-    static useDataSource(dataSource: DataSource) {
+    static useDataSource(dataSource: DataSource | null) {
         this.dataSource = dataSource
     }
 

--- a/test/functional/base-entity/base-entity.test.ts
+++ b/test/functional/base-entity/base-entity.test.ts
@@ -12,6 +12,31 @@ describe("base entity", () => {
         })
         if (!dataSourceOptions.length) return
 
+        // reset data source just to make sure inside DataSource it's really being set
+        User.useDataSource(null)
+
+        const dataSource = new DataSource(dataSourceOptions[0])
+        await dataSource.initialize()
+        await dataSource.synchronize(true)
+
+        await User.save({ name: "Timber Saw" })
+        const timber = await User.findOneByOrFail({ name: "Timber Saw" })
+        expect(timber).to.be.eql({
+            id: 1,
+            name: "Timber Saw",
+        })
+    })
+
+    it("test if DataSource calls `useDataSource` of the provided entities in the entities directory", async () => {
+        const dataSourceOptions = setupTestingConnections({
+            entities: [__dirname + "/entity/*{.js,.ts}"],
+            enabledDrivers: ["sqlite"],
+        })
+        if (!dataSourceOptions.length) return
+
+        // reset data source just to make sure inside DataSource it's really being set
+        User.useDataSource(null)
+
         const dataSource = new DataSource(dataSourceOptions[0])
         await dataSource.initialize()
         await dataSource.synchronize(true)


### PR DESCRIPTION
Closes: #8768

### Description of change

In the 0.3 release, DataSource stopped resolving entities correctly when specified as Globs. This results in the data source information not being set correctly into the entities. This PR fixes it by correctly importing the classes when globs are specified.