### PR TITLE
Update select-query-builder.md

### DIFF
--- a/docs/select-query-builder.md
+++ b/docs/select-query-builder.md
@@ -1176,7 +1176,7 @@ const users = await connection.getRepository(User)
 Result values of `InsertQueryBuilder` or `UpdateQueryBuilder` can be used in Postgres:
 
 ```typescript
-const insertQueryBuilder = await connection.getRepository(User)
+const insertQueryBuilder = connection.getRepository(User)
     .createQueryBuilder()
     .insert({
         name: 'John Smith'


### PR DESCRIPTION
### Description of change

Update select-query-builder doc to reflect that InsertQueryBuilder should not `await`ed when passed into `addCommonTableExpression`.

### Pull-Request Checklist

<!--
  Please make sure to review and check all of the following.

  If an item is not applicable, you can add "N/A" to the end.
-->

- [x] Code is up-to-date with the `master` branch
- [ ] `npm run format` to apply prettier formatting "N/A"
- [ ] `npm run test` passes with this change "N/A"
- [ ] This pull request links relevant issues as `Fixes #0000` "N/A"
- [ ] There are new or updated unit tests validating the change "N/A"
- [ ] Documentation has been updated to reflect this change "N/A"
- [x] The new commits follow conventions explained in [CONTRIBUTING.md](https://github.com/typeorm/typeorm/blob/master/CONTRIBUTING.md)
