### PR TITLE
feat: Add support for insert with alias #4003

### DIFF
--- a/src/query-builder/InsertQueryBuilder.ts
+++ b/src/query-builder/InsertQueryBuilder.ts
@@ -410,6 +410,13 @@ export class InsertQueryBuilder<Entity> extends QueryBuilder<Entity> {
 
         query += `INTO ${tableName}`
 
+        if (
+            this.alias !== this.getMainTableName() &&
+            this.connection.driver.options.type === "postgres"
+        ) {
+            query += ` AS "${this.alias}"`
+        }
+
         // add columns expression
         if (columnsExpression) {
             query += `(${columnsExpression})`


### PR DESCRIPTION
### Description of change

Adds support for alias on insertQueryBuilder. This is particularly useful when dealing with `ON CONFLICT` as you can reference the original table to do an update or nothing based on a condition.

Fixes #4003 

As an aside question - would it be possible to un-deprecate `onConflict` as it is still useful for this sort of complex `ON CONFLICT` work which isn't possible with `orUpdate` or `orIgnore`

### Pull-Request Checklist

- [x] Code is up-to-date with the `master` branch
- [x] `npm run format` to apply prettier formatting
- [x] `npm run test` passes with this change (*tests for the code I changed at least)
- [x] This pull request links relevant issues as `Fixes #0000`
- [x] There are new or updated unit tests validating the change
- [ ] Documentation has been updated to reflect this change (See above - `onConflict` has no docs right now)
- [x] The new commits follow conventions explained in [CONTRIBUTING.md](https://github.com/typeorm/typeorm/blob/master/CONTRIBUTING.md)

