### PR TITLE
feat: applicationName parameter for CockroachDB

### DIFF
--- a/src/driver/cockroachdb/CockroachConnectionOptions.ts
+++ b/src/driver/cockroachdb/CockroachConnectionOptions.ts
@@ -44,6 +44,12 @@ export interface CockroachConnectionOptions
         readonly slaves: CockroachConnectionCredentialsOptions[]
     }
 
+    /**
+     * sets the application_name var to help db administrators identify
+     * the service using this connection. Defaults to 'undefined'
+     */
+    readonly applicationName?: string
+
     /*
      * Function handling errors thrown by drivers pool.
      * Defaults to logging error with `warn` level.

--- a/src/driver/cockroachdb/CockroachDriver.ts
+++ b/src/driver/cockroachdb/CockroachDriver.ts
@@ -923,6 +923,7 @@ export class CockroachDriver implements Driver {
                 database: credentials.database,
                 port: credentials.port,
                 ssl: credentials.ssl,
+                application_name: options.applicationName,
             },
             options.extra || {},
         )


### PR DESCRIPTION
<!--
  😀 Wonderful!  Thank you for opening a pull request for TypeORM.

  Please fill in the information below to expedite the review
  and (hopefully) merge of your change.

  If unsure about something.. just do as best as you're able,
  or reach out through our community support channels!
  https://github.com/typeorm/typeorm/blob/master/docs/support.md
-->

### Description of change
Add `applicationName` parameter in connection option that is missed for CockroachDB. This parameter is supported and tested that the "Application Name" value can be seen in the CockroachDB's console web UI.
<!--
  Please be clear and concise what the change is intended to do,
  why this change is needed, and how you've verified that it
  corrects what you intended.

  In some cases it may be helpful to include the current behavior
  and the new behavior.

  If the change is related to an open issue, you can link it here.
  If you include `Fixes #0000` (replacing `0000` with the issue number)
  when this is merged it will automatically mark the issue as fixed and
  close it.
-->


### Pull-Request Checklist

<!--
  Please make sure to review and check all of the following.

  If an item is not applicable, you can add "N/A" to the end.
-->

- [x] Code is up-to-date with the `master` branch
- [x] `npm run format` to apply prettier formatting
- [x] `npm run test` passes with this change
- [ ] This pull request links relevant issues as `Fixes #0000`
- [ ] There are new or updated unit tests validating the change
- [ ] Documentation has been updated to reflect this change
- [ ] The new commits follow conventions explained in [CONTRIBUTING.md](https://github.com/typeorm/typeorm/blob/master/CONTRIBUTING.md)

<!--
  🎉 Thank you for contributing and making TypeORM even better!
-->
