### PR TITLE
Fixes #8796

### DIFF
--- a/src/query-builder/SelectQueryBuilder.ts
+++ b/src/query-builder/SelectQueryBuilder.ts
@@ -3582,7 +3582,7 @@ export class SelectQueryBuilder<Entity>
         embedPrefix?: string,
     ) {
         for (let key in select) {
-            if (select[key] === undefined) continue
+            if (select[key] === undefined || select[key] === false) continue
 
             const propertyPath = embedPrefix ? embedPrefix + "." + key : key
             const column =

--- a/test/github-issues/8796/entity/User.ts
+++ b/test/github-issues/8796/entity/User.ts
@@ -1,0 +1,16 @@
+import { Column, Entity, PrimaryColumn } from "../../../../src"
+
+@Entity()
+export class User {
+    @PrimaryColumn({ type: "int", nullable: false })
+    id: number
+
+    @Column()
+    firstName: string
+
+    @Column()
+    lastName: string
+
+    @Column()
+    github: string
+}

--- a/test/github-issues/8796/issue-8796.ts
+++ b/test/github-issues/8796/issue-8796.ts
@@ -34,7 +34,7 @@ describe('github issues > #8796 New find select object api should support false 
     beforeEach(() => reloadTestingDatabases(connections));
     after(() => closeTestingConnections(connections));
 
-    it('should <put a detailed description of what it should do here>', () =>
+    it('should suport false value when selecting fields', () =>
         Promise.all(
             connections.map(async (connection) => {
                 const userRepository = connection.getRepository(User);

--- a/test/github-issues/8796/issue-8796.ts
+++ b/test/github-issues/8796/issue-8796.ts
@@ -1,0 +1,57 @@
+import 'reflect-metadata';
+import {
+    createTestingConnections,
+    closeTestingConnections,
+    reloadTestingDatabases,
+} from '../../utils/test-utils';
+import { Connection } from '../../../src/connection/Connection';
+import { expect } from 'chai';
+import { User } from '../8796/entity/User';
+
+describe('github issues > #8796 New find select object api should support false values as expected', () => {
+    let connections: Connection[];
+
+    const user: User = {
+        id: 1,
+        firstName: 'Christian',
+        lastName: 'Fleury',
+        github: 'chfleury',
+    };
+
+    const expectedUser: Partial<User> = {
+        id: 1,
+        firstName: 'Christian',
+    };
+
+    before(
+        async () =>
+            (connections = await createTestingConnections({
+                entities: [__dirname + '/entity/*{.js,.ts}'],
+                schemaCreate: true,
+                dropSchema: true,
+            }))
+    );
+    beforeEach(() => reloadTestingDatabases(connections));
+    after(() => closeTestingConnections(connections));
+
+    it('should <put a detailed description of what it should do here>', () =>
+        Promise.all(
+            connections.map(async (connection) => {
+                const userRepository = connection.getRepository(User);
+
+                await userRepository.save(user);
+
+                const foundUser = await userRepository.find({
+                    where: { id: 1 },
+                    select: {
+                        id: true,
+                        firstName: true,
+                        lastName: undefined,
+                        github: false,
+                    },
+                });
+
+                expect(foundUser[0]).to.deep.equal(expectedUser);
+            })
+        ));
+});

--- a/test/github-issues/8796/issue-8796.ts
+++ b/test/github-issues/8796/issue-8796.ts
@@ -1,45 +1,45 @@
-import 'reflect-metadata';
+import "reflect-metadata"
 import {
     createTestingConnections,
     closeTestingConnections,
     reloadTestingDatabases,
-} from '../../utils/test-utils';
-import { Connection } from '../../../src/connection/Connection';
-import { expect } from 'chai';
-import { User } from '../8796/entity/User';
+} from "../../utils/test-utils"
+import { Connection } from "../../../src/connection/Connection"
+import { expect } from "chai"
+import { User } from "../8796/entity/User"
 
-describe('github issues > #8796 New find select object api should support false values as expected', () => {
-    let connections: Connection[];
+describe("github issues > #8796 New find select object api should support false values as expected", () => {
+    let connections: Connection[]
 
     const user: User = {
         id: 1,
-        firstName: 'Christian',
-        lastName: 'Fleury',
-        github: 'chfleury',
-    };
+        firstName: "Christian",
+        lastName: "Fleury",
+        github: "chfleury",
+    }
 
     const expectedUser: Partial<User> = {
         id: 1,
-        firstName: 'Christian',
-    };
+        firstName: "Christian",
+    }
 
     before(
         async () =>
             (connections = await createTestingConnections({
-                entities: [__dirname + '/entity/*{.js,.ts}'],
+                entities: [__dirname + "/entity/*{.js,.ts}"],
                 schemaCreate: true,
                 dropSchema: true,
-            }))
-    );
-    beforeEach(() => reloadTestingDatabases(connections));
-    after(() => closeTestingConnections(connections));
+            })),
+    )
+    beforeEach(() => reloadTestingDatabases(connections))
+    after(() => closeTestingConnections(connections))
 
-    it('should suport false value when selecting fields', () =>
+    it("should suport false value when selecting fields", () =>
         Promise.all(
             connections.map(async (connection) => {
-                const userRepository = connection.getRepository(User);
+                const userRepository = connection.getRepository(User)
 
-                await userRepository.save(user);
+                await userRepository.save(user)
 
                 const foundUser = await userRepository.find({
                     where: { id: 1 },
@@ -49,9 +49,9 @@ describe('github issues > #8796 New find select object api should support false 
                         lastName: undefined,
                         github: false,
                     },
-                });
+                })
 
-                expect(foundUser[0]).to.deep.equal(expectedUser);
-            })
-        ));
-});
+                expect(foundUser[0]).to.deep.equal(expectedUser)
+            }),
+        ))
+})


### PR DESCRIPTION
### Description of change
If you pass false to a field in the select object, it will not select that field.
Before this PR, it would select fields marked as false.

<br>

Example:
```
userRepository.find({
    select: {
        firstName: true,
        lastName: false, // note false
    },
})
```
**would return even properties marked as false** 
```
{
    firstName:  'foo',
    lastName:  'bar',
},
```
**now returns**
 
```
{
    firstName:  'foo',
},
```


This PR Fixes https://github.com/typeorm/typeorm/issues/8796


I wasn't able to run all the tests, but I ran mine, and it passed.

### Pull-Request Checklist

- [X] Code is up-to-date with the `master` branch
- [X] `npm run format` to apply prettier formatting
- [ ] `npm run test` passes with this change
- [X] This pull request links relevant issues as `Fixes #0000`
- [X] There are new or updated unit tests validating the change
- [ ] Documentation has been updated to reflect this change
- [X] The new commits follow conventions explained in [CONTRIBUTING.md](https://github.com/typeorm/typeorm/blob/master/CONTRIBUTING.md)

PS: this is my first PR ever.