### PR TITLE
fix: Use concrete subclass for saving with single table inheritance

### DIFF
--- a/src/persistence/EntityPersistExecutor.ts
+++ b/src/persistence/EntityPersistExecutor.ts
@@ -81,10 +81,28 @@ export class EntityPersistExecutor {
                         if (entityTarget === Object)
                             throw new CannotDetermineEntityError(this.mode)
 
+                        let metadata = this.connection.getMetadata(entityTarget)
+
+                        // Check for single table inheritance and find the correct metadata in that case.
+                        // Goal is to use the correct discriminator as we could have a repository
+                        // for an (abstract) base class and thus the target would not match.
+                        if (
+                            metadata.inheritancePattern === "STI" &&
+                            metadata.childEntityMetadatas.length > 0
+                        ) {
+                            const matchingChildMetadata =
+                                metadata.childEntityMetadatas.find(
+                                    (meta) =>
+                                        entity.constructor === meta.target,
+                                )
+                            if (matchingChildMetadata) {
+                                metadata = matchingChildMetadata
+                            }
+                        }
+
                         subjects.push(
                             new Subject({
-                                metadata:
-                                    this.connection.getMetadata(entityTarget),
+                                metadata,
                                 entity: entity,
                                 canBeInserted: this.mode === "save",
                                 canBeUpdated: this.mode === "save",

--- a/test/github-issues/2927/entity/Content.ts
+++ b/test/github-issues/2927/entity/Content.ts
@@ -1,0 +1,28 @@
+import {
+    Column,
+    Entity,
+    PrimaryGeneratedColumn,
+    TableInheritance,
+} from "../../../../src"
+
+export enum ContentType {
+    Photo = "photo",
+    Post = "post",
+    SpecialPhoto = "special_photo",
+}
+
+@Entity()
+@TableInheritance({
+    pattern: "STI",
+    column: { type: "enum", name: "content_type", enum: ContentType },
+})
+export class Content {
+    @PrimaryGeneratedColumn()
+    id: number
+
+    @Column()
+    title: string
+
+    @Column()
+    description: string
+}

--- a/test/github-issues/2927/entity/Photo.ts
+++ b/test/github-issues/2927/entity/Photo.ts
@@ -1,0 +1,8 @@
+import { ChildEntity, Column } from "../../../../src"
+import { Content, ContentType } from "./Content"
+
+@ChildEntity(ContentType.Photo)
+export class Photo extends Content {
+    @Column()
+    size: number
+}

--- a/test/github-issues/2927/entity/Post.ts
+++ b/test/github-issues/2927/entity/Post.ts
@@ -1,0 +1,8 @@
+import { ChildEntity, Column } from "../../../../src"
+import { Content, ContentType } from "./Content"
+
+@ChildEntity(ContentType.Post)
+export class Post extends Content {
+    @Column()
+    viewCount: number
+}

--- a/test/github-issues/2927/entity/SpecialPhoto.ts
+++ b/test/github-issues/2927/entity/SpecialPhoto.ts
@@ -1,0 +1,9 @@
+import { ChildEntity, Column } from "../../../../src"
+import { ContentType } from "./Content"
+import { Photo } from "./Photo"
+
+@ChildEntity(ContentType.SpecialPhoto)
+export class SpecialPhoto extends Photo {
+    @Column()
+    specialProperty: number
+}

--- a/test/github-issues/2927/issue-2927.ts
+++ b/test/github-issues/2927/issue-2927.ts
@@ -1,0 +1,103 @@
+import "reflect-metadata"
+import {
+    createTestingConnections,
+    closeTestingConnections,
+    reloadTestingDatabases,
+} from "../../utils/test-utils"
+import { DataSource } from "../../../src/data-source/index"
+import { expect } from "chai"
+import { Content } from "./entity/Content"
+import { Photo } from "./entity/Photo"
+import { SpecialPhoto } from "./entity/SpecialPhoto"
+import { Post } from "./entity/Post"
+
+describe("github issues > #2927 When using base class' custom repository, the discriminator is ignored", () => {
+    let dataSources: DataSource[]
+    before(
+        async () =>
+            (dataSources = await createTestingConnections({
+                entities: [__dirname + "/entity/*{.js,.ts}"],
+                schemaCreate: true,
+                dropSchema: true,
+            })),
+    )
+    beforeEach(() => reloadTestingDatabases(dataSources))
+    after(() => closeTestingConnections(dataSources))
+
+    it("should use the correct subclass for inheritance when saving and retrieving concrete instance", () =>
+        Promise.all(
+            dataSources.map(async (dataSource) => {
+                const entityManager = dataSource.createEntityManager()
+                const repository = entityManager.getRepository(Content)
+
+                // Create and save a new Photo.
+                const photo = new Photo()
+                photo.title = "some title"
+                photo.description = "some description"
+                photo.size = 42
+                await repository.save(photo)
+
+                // Retrieve it back from the DB.
+                const contents = await repository.find()
+                expect(contents.length).to.equal(1)
+                expect(contents[0] instanceof Photo).to.equal(true)
+                const fetchedPhoto = contents[0] as Photo
+                expect(fetchedPhoto).to.eql(photo)
+            }),
+        ))
+
+    it("should work for deeply nested classes", () =>
+        Promise.all(
+            dataSources.map(async (dataSource) => {
+                const entityManager = dataSource.createEntityManager()
+                const repository = entityManager.getRepository(Content)
+
+                // Create and save a new SpecialPhoto.
+                const specialPhoto = new SpecialPhoto()
+                specialPhoto.title = "some title"
+                specialPhoto.description = "some description"
+                specialPhoto.size = 42
+                specialPhoto.specialProperty = 420
+                await repository.save(specialPhoto)
+
+                // Retrieve it back from the DB.
+                const contents = await repository.find()
+                expect(contents.length).to.equal(1)
+                expect(contents[0] instanceof SpecialPhoto).to.equal(true)
+                const fetchedSpecialPhoto = contents[0] as SpecialPhoto
+                expect(fetchedSpecialPhoto).to.eql(specialPhoto)
+            }),
+        ))
+
+    it("should work for saving and fetching different subclasses", () =>
+        Promise.all(
+            dataSources.map(async (dataSource) => {
+                const entityManager = dataSource.createEntityManager()
+                const repository = entityManager.getRepository(Content)
+
+                // Create and save a new Post.
+                const post = new Post()
+                post.title = "some title"
+                post.description = "some description"
+                post.viewCount = 69
+
+                // Create and save a new SpecialPhoto.
+                const specialPhoto = new SpecialPhoto()
+                specialPhoto.title = "some title"
+                specialPhoto.description = "some description"
+                specialPhoto.size = 42
+                specialPhoto.specialProperty = 420
+
+                await repository.save([post, specialPhoto])
+
+                // Retrieve them back from the DB.
+                const contents = await repository.find()
+                expect(contents.length).to.equal(2)
+                expect(contents.find((content) => content instanceof Post)).not
+                    .to.be.undefined
+                expect(
+                    contents.find((content) => content instanceof SpecialPhoto),
+                ).not.to.be.undefined
+            }),
+        ))
+})


### PR DESCRIPTION
<!--
  😀 Wonderful!  Thank you for opening a pull request for TypeORM.

  Please fill in the information below to expedite the review
  and (hopefully) merge of your change.

  If unsure about something.. just do as best as you're able,
  or reach out through our community support channels!
  https://github.com/typeorm/typeorm/blob/master/docs/support.md
-->

### Description of change

When using a STI scheme and an EntityManager or Repository with base class target, the wrong discriminator was written to the database despite giving a concrete entity.
This was because of the entity's target being ignored in favour of the target of the Repository or the EntityManager, which then is the (abstract) base class.

This PR introduces a fix by **figuring out the concrete subclass of an entity when saving**.

Further questions from my side:

* Currently, it allows for subclass entities to be found by querying the class from `childEntityMetadatas` for every entity. What about performance problems?
* Should this behaviour be deactivatable?
* Is there any documentation that has to be updated?

This PR fixes #2927 (which was closed by the author without the problem being resolved).

<!--
  Please be clear and concise what the change is intended to do,
  why this change is needed, and how you've verified that it
  corrects what you intended.

  In some cases it may be helpful to include the current behavior
  and the new behavior.

  If the change is related to an open issue, you can link it here.
  If you include `Fixes #0000` (replacing `0000` with the issue number)
  when this is merged it will automatically mark the issue as fixed and
  close it.
-->


### Pull-Request Checklist

<!--
  Please make sure to review and check all of the following.

  If an item is not applicable, you can add "N/A" to the end.
-->

- [x] Code is up-to-date with the `master` branch
- [x] `npm run format` to apply prettier formatting
- [x] `npm run test` passes with this change
- [x] This pull request links relevant issues as `Fixes #0000`
- [x] There are new or updated unit tests validating the change
- [ ] Documentation has been updated to reflect this change
- [x] The new commits follow conventions explained in [CONTRIBUTING.md](https://github.com/typeorm/typeorm/blob/master/CONTRIBUTING.md)

<!--
  🎉 Thank you for contributing and making TypeORM even better!
-->