### PR TITLE
fix: broken shebang parameters of `cli-ts-node-commonjs` and `cli-ts-node-esm` on some linux distros

### DIFF
--- a/src/cli-ts-node-commonjs.ts
+++ b/src/cli-ts-node-commonjs.ts
@@ -1,2 +1,3 @@
-#!/usr/bin/env node --require ts-node/register
+#!/usr/bin/env node
+require("ts-node").register()
 import "./cli"

--- a/src/cli-ts-node-esm.ts
+++ b/src/cli-ts-node-esm.ts
@@ -1,2 +1,20 @@
-#!/usr/bin/env node --loader ts-node/esm --no-warnings
-import "./cli"
+#!/usr/bin/env node
+import { spawnSync } from "child_process"
+
+if ((process.env["NODE_OPTIONS"] || "").includes("--loader ts-node"))
+    require("./cli")
+else
+    spawnSync(process.argv[0], process.argv.slice(1), {
+        stdio: "inherit",
+        env: {
+            ...process.env,
+            NODE_OPTIONS: [
+                process.env["NODE_OPTIONS"],
+                "--loader ts-node/esm",
+                "--no-warnings",
+            ]
+                .filter((item) => !!item)
+                .join(" "),
+        },
+        windowsHide: true,
+    })


### PR DESCRIPTION
### Description of change
Added a workaround in nodejs itself to use `ts-node` instead of relying on shebang parameters, as they seem to work a bit differently on some linux distros, and using the `-S` parameter (`#!/usr/bin/env -S node <parameters>`) breaks the CLI on Windows.

Closes #8818

### Pull-Request Checklist
- [x] Code is up-to-date with the `master` branch
- [x] `npm run format` to apply prettier formatting
- [x] `npm run test` passes with this change
- [x] This pull request links relevant issues as `Fixes #0000`
- [ ] There are new or updated unit tests validating the change - N/A
- [ ] Documentation has been updated to reflect this change - N/A
- [x] The new commits follow conventions explained in [CONTRIBUTING.md](https://github.com/typeorm/typeorm/blob/master/CONTRIBUTING.md)
