### PR TITLE
fix: allow hstore type to use transformers in driver postgres

### DIFF
--- a/src/driver/postgres/PostgresDriver.ts
+++ b/src/driver/postgres/PostgresDriver.ts
@@ -723,9 +723,7 @@ export class PostgresDriver implements Driver {
                         return ""
                     },
                 )
-                return object
-            } else {
-                return value
+                value = object
             }
         } else if (columnMetadata.type === "simple-array") {
             value = DateUtils.stringToSimpleArray(value)

--- a/test/other-issues/hstore-allow-transformer/entity/hstore-entity.ts
+++ b/test/other-issues/hstore-allow-transformer/entity/hstore-entity.ts
@@ -1,0 +1,13 @@
+import { Entity } from "../../../../src/decorator/entity/Entity"
+import { Column } from "../../../../src/decorator/columns/Column"
+import { PrimaryGeneratedColumn } from "../../../../src/decorator/columns/PrimaryGeneratedColumn"
+import { testTransformer } from "../test-transformer"
+
+@Entity()
+export class DummyHSTOREEntity {
+    @PrimaryGeneratedColumn()
+    id: number
+
+    @Column({ type: "hstore", transformer: testTransformer })
+    translation: object
+}

--- a/test/other-issues/hstore-allow-transformer/hstore-allow-transformer.ts
+++ b/test/other-issues/hstore-allow-transformer/hstore-allow-transformer.ts
@@ -1,0 +1,47 @@
+import "../../utils/test-setup"
+import {
+    createTestingConnections,
+    closeTestingConnections,
+    reloadTestingDatabases,
+} from "../../utils/test-utils"
+import { DataSource } from "../../../src"
+import { expect } from "chai"
+import { DummyHSTOREEntity } from "./entity/hstore-entity"
+
+describe("other issues > allow HSTORE column type to use transformers", () => {
+    let connections: DataSource[]
+    before(
+        async () =>
+            (connections = await createTestingConnections({
+                entities: [__dirname + "/entity/*{.js,.ts}"],
+                schemaCreate: true,
+                dropSchema: true,
+                enabledDrivers: ["postgres"],
+            })),
+    )
+    beforeEach(() => reloadTestingDatabases(connections))
+    after(() => closeTestingConnections(connections))
+
+    it("should use the transformer set in the column options", () =>
+        Promise.all(
+            connections.map(async (connection) => {
+                const repository = connection.getRepository(DummyHSTOREEntity)
+
+                const translation = {
+                    en_US: "hello",
+                    fr_FR: "salut",
+                }
+
+                const dummy = repository.create({
+                    translation,
+                })
+
+                await repository.save(dummy)
+
+                const dummyEntity = await repository.findOneByOrFail({
+                    id: dummy.id,
+                })
+                expect(dummyEntity.translation).to.equal("hello")
+            }),
+        ))
+})

--- a/test/other-issues/hstore-allow-transformer/test-transformer.ts
+++ b/test/other-issues/hstore-allow-transformer/test-transformer.ts
@@ -1,0 +1,8 @@
+export const testTransformer = {
+    to(data: any) {
+        return data
+    },
+    from(data: any) {
+        return data.en_US
+    },
+}


### PR DESCRIPTION
### Description of change

The HSTORE type is the only type bypassing the transformer
column options.

This fix makes the option available to this column type as well.

If the current behavior was intentional then the documentation should be updated to inform developers that transformers are not applicable to the HSTORE type in Postgres.



### Pull-Request Checklist

<!--
  Please make sure to review and check all of the following.

  If an item is not applicable, you can add "N/A" to the end.
-->

- [x] Code is up-to-date with the `master` branch
- [x] `npm run format` to apply prettier formatting
- [x] `npm run test` passes with this change
- [ ] This pull request links relevant issues as `Fixes #0000` N/A
- [x] There are new or updated unit tests validating the change
- [ ] Documentation has been updated to reflect this change N/A
- [x] The new commits follow conventions explained in [CONTRIBUTING.md](https://github.com/typeorm/typeorm/blob/master/CONTRIBUTING.md)

<!--
  🎉 Thank you for contributing and making TypeORM even better!
-->
