### PR TITLE
Clarify deprecation or orUpdate

### DIFF
--- a/src/query-builder/InsertQueryBuilder.ts
+++ b/src/query-builder/InsertQueryBuilder.ts
@@ -335,7 +335,7 @@ export class InsertQueryBuilder<Entity> extends QueryBuilder<Entity> {
     }
 
     /**
-     * @deprecated
+     * @deprecated Use new call signature instead.
      */
     orUpdate(statement?: {
         columns?: string[]


### PR DESCRIPTION
It would look like both onConflict and orUpdate were deprecated with no description on what to use or why

### Description of change

With [this change](https://github.com/typeorm/typeorm/pull/7880/files#diff-f12ef5527b9bc2971ab7a8247c71dd735a43cd7a1c859bd206b61dee8c7f617d) `onConflict` was deprecated in favour of `orUpdate`, but at the same time the "old" call signature of `orUpdate` was also deprecated. For people that are using the old call signature of `orUpdate` it now looks like both functions are deprecated with no explanation or alternative offered. This PR introduces a small message to clarify that it is only the one call signature that is deprecated, the function should still be used.

### Pull-Request Checklist

<!--
  Please make sure to review and check all of the following.

  If an item is not applicable, you can add "N/A" to the end.
-->

- [x] Code is up-to-date with the `master` branch
- [x] `npm run format` to apply prettier formatting
- [x] `npm run test` passes with this change
- [ ] This pull request links relevant issues as `Fixes #0000` (N/A)
- [ ] There are new or updated unit tests validating the change (N/A)
- [x] Documentation has been updated to reflect this change
- [x] The new commits follow conventions explained in [CONTRIBUTING.md](https://github.com/typeorm/typeorm/blob/master/CONTRIBUTING.md)