### PR TITLE
docs: missing argument at migration:generate

### DIFF
--- a/docs/migrations.md
+++ b/docs/migrations.md
@@ -149,6 +149,10 @@ Example with `ts-node` in ESM projects:
 npx typeorm-ts-node-esm migration:run
 ```
 
+```
+npx typeorm-ts-node-esm migration:generate ./src/migrations/update-post-table -d ./src/data-source.ts
+```
+
 This command will execute all pending migrations and run them in a sequence ordered by their timestamps.
 This means all sql queries written in the `up` methods of your created migrations will be executed.
 That's all! Now you have your database schema up-to-date.


### PR DESCRIPTION
### Description of change

`migration:generate` requires data-source path as argument and was not provided at doc.

### Pull-Request Checklist

- [x] Code is up-to-date with the `master` branch
- [ ] `npm run format` to apply prettier formatting
- [ ] `npm run test` passes with this change
- [ ] This pull request links relevant issues as `Fixes #0000`
- [ ] There are new or updated unit tests validating the change
- [x] Documentation has been updated to reflect this change
- [x] The new commits follow conventions explained in [CONTRIBUTING.md](https://github.com/typeorm/typeorm/blob/master/CONTRIBUTING.md)
