### PR TITLE
feat: relations: orphaned row action for one-to-one relation

### DIFF
--- a/test/functional/persistence/delete-orphans-one-to-one/delete-orphans-one-to-one.ts
+++ b/test/functional/persistence/delete-orphans-one-to-one/delete-orphans-one-to-one.ts
@@ -1,0 +1,75 @@
+import "reflect-metadata"
+import { DataSource, Repository } from "../../../../src/index"
+import {
+    closeTestingConnections,
+    createTestingConnections,
+    reloadTestingDatabases,
+} from "../../../utils/test-utils"
+import { expect } from "chai"
+import { Image } from "./entity/Image"
+import { File } from "./entity/File"
+
+describe("persistence > delete orphans in one-to-one relation", () => {
+    // -------------------------------------------------------------------------
+    // Configuration
+    // -------------------------------------------------------------------------
+
+    // connect to db
+    let connections: DataSource[] = []
+
+    before(
+        async () =>
+            (connections = await createTestingConnections({
+                entities: [__dirname + "/entity/*{.js,.ts}"],
+            })),
+    )
+    beforeEach(() => reloadTestingDatabases(connections))
+    after(() => closeTestingConnections(connections))
+
+    // -------------------------------------------------------------------------
+    // Specifications
+    // -------------------------------------------------------------------------
+
+    describe("when a File is removed from a Image", () => {
+        let imageRepository: Repository<Image>
+        let fileRepository: Repository<File>
+        let imageId: number
+
+        beforeEach(async () => {
+            await Promise.all(
+                connections.map(async (connection) => {
+                    imageRepository = connection.getRepository(Image)
+                    fileRepository = connection.getRepository(File)
+                }),
+            )
+
+            const imageToInsert = await imageRepository.save(new Image())
+            imageToInsert.file = new File()
+
+            await imageRepository.save(imageToInsert)
+            imageId = imageToInsert.id
+
+            const imageToUpdate = (await imageRepository.findOneBy({
+                id: imageId,
+            }))!
+            imageToUpdate.file = new File()
+
+            await imageRepository.save(imageToUpdate)
+        })
+
+        it("should retain a File on the Image", async () => {
+            console.log("before select")
+            const image = await imageRepository.findOneBy({
+                id: imageId,
+            })
+            console.log("image", image)
+            expect(image).not.to.be.undefined
+            expect(image!.fileId).not.to.be.undefined
+        })
+
+        it("should delete the orphaned File from the database", async () => {
+            const fileCount = await fileRepository.count()
+            expect(fileCount).to.equal(1)
+        })
+    })
+})

--- a/test/functional/persistence/delete-orphans-one-to-one/entity/File.ts
+++ b/test/functional/persistence/delete-orphans-one-to-one/entity/File.ts
@@ -1,0 +1,8 @@
+import { Entity } from "../../../../../src/decorator/entity/Entity"
+import { PrimaryGeneratedColumn } from "../../../../../src/decorator/columns/PrimaryGeneratedColumn"
+
+@Entity()
+export class File {
+    @PrimaryGeneratedColumn()
+    id: number
+}

--- a/test/functional/persistence/delete-orphans-one-to-one/entity/Image.ts
+++ b/test/functional/persistence/delete-orphans-one-to-one/entity/Image.ts
@@ -1,0 +1,23 @@
+import { File } from "./File"
+import { Entity } from "../../../../../src/decorator/entity/Entity"
+import { PrimaryGeneratedColumn } from "../../../../../src/decorator/columns/PrimaryGeneratedColumn"
+import { Column } from "../../../../../src/decorator/columns/Column"
+import { OneToOne } from "../../../../../src/decorator/relations/OneToOne"
+import { JoinColumn } from "../../../../../src/decorator/relations/JoinColumn"
+
+@Entity()
+export class Image {
+    @PrimaryGeneratedColumn()
+    id: number
+
+    @Column({ nullable: true })
+    fileId: string
+
+    @OneToOne(() => File, {
+        cascade: true,
+        nullable: true,
+        orphanedRowAction: "delete",
+    })
+    @JoinColumn({ name: "fileId" })
+    file: File
+}


### PR DESCRIPTION
First of all, hello and thank you for all the work you're doing on typeorm and the recent releases!

### Description of change

The goal is to change how related entities are handled on one-to-one relations.
Let's say we have an entity A which has a one-to-one relation with entity B,
and then we change and say we set the relation for entity A to entity C.
Currently, the entity B will stay in DB and will just be orphan.
This change uses the `orphanedRowAction` to delete or soft-delete the leftover entity, in this example entity B.

I tried to follow [#7105](https://github.com/typeorm/typeorm/pull/7105) changes as much as possible, but i don't really understand how the code really works, so you're welcome to rewrite the changes correctly.

Fixes #7453 

### Pull-Request Checklist

- [x] Code is up-to-date with the `master` branch
- [x] `npm run format` to apply prettier formatting
- [x] `npm run test` passes with this change
- [x] This pull request links relevant issues as `Fixes #0000`
- [x] There are new or updated unit tests validating the change
- [ ] Documentation has been updated to reflect this change N/A (i think?)
- [x] The new commits follow conventions explained in [CONTRIBUTING.md](https://github.com/typeorm/typeorm/blob/master/CONTRIBUTING.md)
