### PR TITLE
fix: resolve missing ConnectionOptions export in index.ts

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -131,6 +131,7 @@ export * from "./driver/sqlserver/MssqlParameter"
 // export * from "./data-source";
 
 export { ConnectionOptionsReader } from "./connection/ConnectionOptionsReader"
+export { ConnectionOptions } from "./connection/ConnectionOptions"
 export { DataSource } from "./data-source/DataSource"
 export { Connection } from "./connection/Connection"
 export { ConnectionManager } from "./connection/ConnectionManager"


### PR DESCRIPTION
Closes: #8837

### Description of change

Although `ConnectionOptions` is now deprecated and renamed to `DataSourceOptions`, the `ConnectionOptions` class still exists as an alias to maintain backwards compatibility. 

The issue however is that `ConnectionOptions` is not being exported from `src/index.ts`, resulting in broken backwards compatibility. 

This PR adds the appropriate `export` to the typings.

### Pull-Request Checklist

- [X] Code is up-to-date with the `master` branch
- [X] `npm run format` to apply prettier formatting
- [X] `npm run test` passes with this change
- [X] This pull request links relevant issues as `Fixes #0000`
- [N/A] There are new or updated unit tests validating the change
- [N/A] Documentation has been updated to reflect this change
- [X] The new commits follow conventions explained in [CONTRIBUTING.md](https://github.com/typeorm/typeorm/blob/master/CONTRIBUTING.md)

