### PR TITLE
fix: Clarify error message on datasource loading

### DIFF
--- a/src/commands/CommandUtils.ts
+++ b/src/commands/CommandUtils.ts
@@ -20,7 +20,7 @@ export class CommandUtils {
             )
         } catch (err) {
             throw new Error(
-                `Invalid file path given: "${dataSourceFilePath}". File must contain a TypeScript / JavaScript code and export a DataSource instance.`,
+                `Unable to open file: "${dataSourceFilePath}". ${err.message}`,
             )
         }
 


### PR DESCRIPTION
### Description of change

Today, the error message is misleading. It states that the file does not export a datasource when it's juste trying to open the module.
Clarifying the error message and adding the root Exception message helps whith debugging.

### Pull-Request Checklist

<!--
  Please make sure to review and check all of the following.

  If an item is not applicable, you can add "N/A" to the end.
-->

- [X] Code is up-to-date with the `master` branch
- [X] `npm run format` to apply prettier formatting
- [ ] `npm run test` passes with this change N/A
- [X] This pull request links relevant issues as `Fixes #0000`
- [ ] There are new or updated unit tests validating the change N/A
- [ ] Documentation has been updated to reflect this change N/A
- [X] The new commits follow conventions explained in [CONTRIBUTING.md](https://github.com/typeorm/typeorm/blob/master/CONTRIBUTING.md)
