### PR TITLE
docs: add ColumnOptions nullable default docs

### DIFF
--- a/src/decorator/options/ColumnOptions.ts
+++ b/src/decorator/options/ColumnOptions.ts
@@ -30,6 +30,7 @@ export interface ColumnOptions extends ColumnCommonOptions {
 
     /**
      * Indicates if column's value can be set to NULL.
+     * Default value is "false".
      */
     nullable?: boolean
 


### PR DESCRIPTION
### Description of change
Add ColumnOptions nullable default docs

### Pull-Request Checklist

- [✔] Code is up-to-date with the `master` branch
- [✔ ] `npm run format` to apply prettier formatting
- [✔ ] `npm run test` passes with this change
- [✔] This pull request links relevant issues as `Fixes #0000`
- [✔] There are new or updated unit tests validating the change
- [✔] Documentation has been updated to reflect this change
- [✔] The new commits follow conventions explained in [CONTRIBUTING.md](https://github.com/typeorm/typeorm/blob/master/CONTRIBUTING.md)
