### PR TITLE
feat: add `for_key_share` ("FOR KEY SHARE") lock mode for postgres

### DIFF
--- a/docs/find-options.md
+++ b/docs/find-options.md
@@ -221,7 +221,8 @@ or
         "dirty_read" |
         "pessimistic_partial_write" |
         "pessimistic_write_or_fail" |
-        "for_no_key_update"
+        "for_no_key_update" |
+        "for_key_share"
 }
 ```
 
@@ -239,14 +240,14 @@ userRepository.findOne({
 Support of lock modes, and SQL statements they translate to, are listed in the table below (blank cell denotes unsupported). When specified lock mode is not supported, a `LockNotSupportedOnGivenDriverError` error will be thrown.
 
 ```text
-|                 | pessimistic_read         | pessimistic_write       | dirty_read    | pessimistic_partial_write   | pessimistic_write_or_fail   | for_no_key_update   |
-| --------------- | --------------------     | ----------------------- | ------------- | --------------------------- | --------------------------- | ------------------- |
-| MySQL           | LOCK IN SHARE MODE       | FOR UPDATE              | (nothing)     | FOR UPDATE SKIP LOCKED      | FOR UPDATE NOWAIT           |                     |
-| Postgres        | FOR SHARE                | FOR UPDATE              | (nothing)     | FOR UPDATE SKIP LOCKED      | FOR UPDATE NOWAIT           | FOR NO KEY UPDATE   |
-| Oracle          | FOR UPDATE               | FOR UPDATE              | (nothing)     |                             |                             |                     |
-| SQL Server      | WITH (HOLDLOCK, ROWLOCK) | WITH (UPDLOCK, ROWLOCK) | WITH (NOLOCK) |                             |                             |                     |
-| AuroraDataApi   | LOCK IN SHARE MODE       | FOR UPDATE              | (nothing)     |                             |                             |                     |
-| CockroachDB     |                          | FOR UPDATE              | (nothing)     |                             | FOR UPDATE NOWAIT           | FOR NO KEY UPDATE   |
+|                 | pessimistic_read         | pessimistic_write       | dirty_read    | pessimistic_partial_write   | pessimistic_write_or_fail   | for_no_key_update   | for_key_share |
+| --------------- | --------------------     | ----------------------- | ------------- | --------------------------- | --------------------------- | ------------------- | ------------- |
+| MySQL           | LOCK IN SHARE MODE       | FOR UPDATE              | (nothing)     | FOR UPDATE SKIP LOCKED      | FOR UPDATE NOWAIT           |                     |               |
+| Postgres        | FOR SHARE                | FOR UPDATE              | (nothing)     | FOR UPDATE SKIP LOCKED      | FOR UPDATE NOWAIT           | FOR NO KEY UPDATE   | FOR KEY SHARE |
+| Oracle          | FOR UPDATE               | FOR UPDATE              | (nothing)     |                             |                             |                     |               |
+| SQL Server      | WITH (HOLDLOCK, ROWLOCK) | WITH (UPDLOCK, ROWLOCK) | WITH (NOLOCK) |                             |                             |                     |               |
+| AuroraDataApi   | LOCK IN SHARE MODE       | FOR UPDATE              | (nothing)     |                             |                             |                     |               |
+| CockroachDB     |                          | FOR UPDATE              | (nothing)     |                             | FOR UPDATE NOWAIT           | FOR NO KEY UPDATE   |               |
 
 ```
 

--- a/src/find-options/FindOneOptions.ts
+++ b/src/find-options/FindOneOptions.ts
@@ -77,6 +77,7 @@ export interface FindOneOptions<Entity = any> {
                   | "pessimistic_partial_write"
                   | "pessimistic_write_or_fail"
                   | "for_no_key_update"
+                  | "for_key_share"
               tables?: string[]
           }
 

--- a/src/find-options/FindOptionsUtils.ts
+++ b/src/find-options/FindOptionsUtils.ts
@@ -181,7 +181,8 @@ export class FindOptionsUtils {
                 options.lock.mode === "dirty_read" ||
                 options.lock.mode === "pessimistic_partial_write" ||
                 options.lock.mode === "pessimistic_write_or_fail" ||
-                options.lock.mode === "for_no_key_update"
+                options.lock.mode === "for_no_key_update" ||
+                options.lock.mode === "for_key_share"
             ) {
                 const tableNames = options.lock.tables ? options.lock.tables.map((table) => {
                     const tableAlias = qb.expressionMap.aliases.find((alias) => {

--- a/src/query-builder/QueryExpressionMap.ts
+++ b/src/query-builder/QueryExpressionMap.ts
@@ -189,6 +189,7 @@ export class QueryExpressionMap {
         | "pessimistic_partial_write"
         | "pessimistic_write_or_fail"
         | "for_no_key_update"
+        | "for_key_share"
 
     /**
      * Current version of the entity, used for locking.

--- a/src/query-builder/SelectQueryBuilder.ts
+++ b/src/query-builder/SelectQueryBuilder.ts
@@ -1487,7 +1487,8 @@ export class SelectQueryBuilder<Entity>
             | "dirty_read"
             | "pessimistic_partial_write"
             | "pessimistic_write_or_fail"
-            | "for_no_key_update",
+            | "for_no_key_update"
+            | "for_key_share",
         lockVersion?: undefined,
         lockTables?: string[],
     ): this
@@ -1503,7 +1504,8 @@ export class SelectQueryBuilder<Entity>
             | "dirty_read"
             | "pessimistic_partial_write"
             | "pessimistic_write_or_fail"
-            | "for_no_key_update",
+            | "for_no_key_update"
+            | "for_key_share",
         lockVersion?: number | Date,
         lockTables?: string[],
     ): this {
@@ -2564,6 +2566,14 @@ export class SelectQueryBuilder<Entity>
                 } else {
                     throw new LockNotSupportedOnGivenDriverError()
                 }
+
+            case "for_key_share":
+                if (driver.options.type === "postgres") {
+                    return " FOR KEY SHARE" + lockTablesClause
+                } else {
+                    throw new LockNotSupportedOnGivenDriverError()
+                }
+
             default:
                 return ""
         }
@@ -3061,7 +3071,8 @@ export class SelectQueryBuilder<Entity>
                         "pessimistic_partial_write" ||
                     this.findOptions.lock.mode ===
                         "pessimistic_write_or_fail" ||
-                    this.findOptions.lock.mode === "for_no_key_update"
+                    this.findOptions.lock.mode === "for_no_key_update" ||
+                    this.findOptions.lock.mode === "for_key_share"
                 ) {
                     const tableNames = this.findOptions.lock.tables
                         ? this.findOptions.lock.tables.map((table) => {
@@ -3140,7 +3151,8 @@ export class SelectQueryBuilder<Entity>
                 this.expressionMap.lockMode === "pessimistic_write" ||
                 this.expressionMap.lockMode === "pessimistic_partial_write" ||
                 this.expressionMap.lockMode === "pessimistic_write_or_fail" ||
-                this.expressionMap.lockMode === "for_no_key_update") &&
+                this.expressionMap.lockMode === "for_no_key_update" ||
+                this.expressionMap.lockMode === "for_key_share") &&
             !queryRunner.isTransactionActive
         )
             throw new PessimisticLockTransactionRequiredError()


### PR DESCRIPTION
<!--
  😀 Wonderful!  Thank you for opening a pull request for TypeORM.

  Please fill in the information below to expedite the review
  and (hopefully) merge of your change.

  If unsure about something.. just do as best as you're able,
  or reach out through our community support channels!
  https://github.com/typeorm/typeorm/blob/master/docs/support.md
-->

### Description of change

<!--
  Please be clear and concise what the change is intended to do,
  why this change is needed, and how you've verified that it
  corrects what you intended.

  In some cases it may be helpful to include the current behavior
  and the new behavior.

  If the change is related to an open issue, you can link it here.
  If you include `Fixes #0000` (replacing `0000` with the issue number)
  when this is merged it will automatically mark the issue as fixed and
  close it.
-->

Adds support for new lock mode `for_key_share` - generating FOR KEY SHARE lock. 
Lock applies only to driver type postgres. Otherwise LockNotSupportedOnGivenDriverError error is thrown.

Closes: #8878


### Pull-Request Checklist

<!--
  Please make sure to review and check all of the following.

  If an item is not applicable, you can add "N/A" to the end.
-->

- [x] Code is up-to-date with the `master` branch
- [x] `npm run format` to apply prettier formatting
- [x] `npm run test` passes with this change
- [x] This pull request links relevant issues as `Fixes #8878`
- [x] There are new or updated unit tests validating the change
- [x] Documentation has been updated to reflect this change
- [x] The new commits follow conventions explained in [CONTRIBUTING.md](https://github.com/typeorm/typeorm/blob/master/CONTRIBUTING.md)

<!--
  🎉 Thank you for contributing and making TypeORM even better!
-->
