### PR TITLE
fix: add setter method to 'metadata' property in src/repository/Repository.d.ts

### DIFF
--- a/src/repository/Repository.ts
+++ b/src/repository/Repository.ts
@@ -51,6 +51,7 @@ export class Repository<Entity extends ObjectLiteral> {
     get metadata() {
         return this.manager.connection.getMetadata(this.target)
     }
+    set metadata(newMetadata) {}
 
     // -------------------------------------------------------------------------
     // Constructor


### PR DESCRIPTION
Fixes: #8883

### Description of change

Adds a `set()` method to the `metadata` property in the type definition file for the `Repository` class. This fixes the compiler error: `Cannot set property metadata of #<Repository> which has only a getter`


### Pull-Request Checklist

- [x] Code is up-to-date with the `master` branch
- [x] `npm run format` to apply prettier formatting
- [x] `npm run test` passes with this change
- [x] This pull request links relevant issues as `Fixes #0000`
- [x] There are new or updated unit tests validating the change
- [x] Documentation has been updated to reflect this change
- [x] The new commits follow conventions explained in [CONTRIBUTING.md](https://github.com/typeorm/typeorm/blob/master/CONTRIBUTING.md)
