### PR TITLE
docs: add the documentation site as `homepage` in `package.json`

### DIFF
--- a/package.json
+++ b/package.json
@@ -64,6 +64,7 @@
   "bugs": {
     "url": "https://github.com/typeorm/typeorm/issues"
   },
+  "homepage": "https://typeorm.io",
   "tags": [
     "orm",
     "typescript",


### PR DESCRIPTION
### Description of change
Add the documentation site as `homepage` in `package.json`.
This way the npm module page will also link to the documentation site, instead of displaying 2 links to the same github page.

### Pull-Request Checklist
- [x] Code is up-to-date with the `master` branch
- [ ] `npm run format` to apply prettier formatting - N/A
- [ ] `npm run test` passes with this change - N/A
- [ ] This pull request links relevant issues as `Fixes #0000` - N/A
- [ ] There are new or updated unit tests validating the change - N/A
- [ ] Documentation has been updated to reflect this change - N/A
- [x] The new commits follow conventions explained in [CONTRIBUTING.md](https://github.com/typeorm/typeorm/blob/master/CONTRIBUTING.md)
