### PR TITLE
fix: InitCommand AppDataSource Bug

### DIFF
--- a/src/commands/InitCommand.ts
+++ b/src/commands/InitCommand.ts
@@ -449,7 +449,7 @@ AppDataSource.initialize().then(async () => {
     )
 
     await AppDataSource.manager.save(
-        dataSource.manager.create(User, {
+        AppDataSource.manager.create(User, {
             firstName: "Phantom",
             lastName: "Assassin",
             age: 24


### PR DESCRIPTION
Use `AppDataSource` instead of `dataSource`. Looks like a bug introduced into the `InitCommand` from https://github.com/typeorm/typeorm/commit/3b8a031ece508820651a3a8f99f9cbf87319812c

<!--
  😀 Wonderful!  Thank you for opening a pull request for TypeORM.

  Please fill in the information below to expedite the review
  and (hopefully) merge of your change.

  If unsure about something.. just do as best as you're able,
  or reach out through our community support channels!
  https://github.com/typeorm/typeorm/blob/master/docs/support.md
-->

### Description of change

<!--
  Please be clear and concise what the change is intended to do,
  why this change is needed, and how you've verified that it
  corrects what you intended.

  In some cases it may be helpful to include the current behavior
  and the new behavior.

  If the change is related to an open issue, you can link it here.
  If you include `Fixes #0000` (replacing `0000` with the issue number)
  when this is merged it will automatically mark the issue as fixed and
  close it.
-->


### Pull-Request Checklist

<!--
  Please make sure to review and check all of the following.

  If an item is not applicable, you can add "N/A" to the end.
-->

- [x] Code is up-to-date with the `master` branch
- [ ] `npm run format` to apply prettier formatting
- [ ] `npm run test` passes with this change
- [ ] This pull request links relevant issues as `Fixes #0000`
- [ ] There are new or updated unit tests validating the change
- [ ] Documentation has been updated to reflect this change
- [ ] The new commits follow conventions explained in [CONTRIBUTING.md](https://github.com/typeorm/typeorm/blob/master/CONTRIBUTING.md)

<!--
  🎉 Thank you for contributing and making TypeORM even better!
-->
