### PR TITLE
feat: fix for database, schema and table names with dots (".")

### DIFF
--- a/src/query-builder/QueryBuilder.ts
+++ b/src/query-builder/QueryBuilder.ts
@@ -622,6 +622,9 @@ export abstract class QueryBuilder<Entity> {
      * schema name, otherwise returns escaped table name.
      */
     protected getTableName(tablePath: string): string {
+        if (this.expressionMap.mainAlias?.hasMetadata){
+            return this.getTableNameFromMetadata()
+        }
         return tablePath
             .split(".")
             .map((i) => {
@@ -645,6 +648,24 @@ export abstract class QueryBuilder<Entity> {
             return this.expressionMap.mainAlias.metadata.tablePath
 
         return this.expressionMap.mainAlias.tablePath!
+    }
+
+    /**
+     * Gets escaped table from the metadata, instead of the tablePath string.
+     * Allows for custom names containing dots (".")
+     */
+    protected getTableNameFromMetadata(): string {
+        const database = this.expressionMap.mainAlias?.metadata.database;
+        const schema = this.expressionMap.mainAlias?.metadata.schema;
+        const tablePath = [
+            this.escape(this.expressionMap.mainAlias!.metadata.tableName),
+        ]
+        if (schema)
+            tablePath.unshift(this.escape(schema));
+        if (database)
+            tablePath.unshift(this.escape(database));
+
+        return tablePath.join(".")
     }
 
     /**


### PR DESCRIPTION
<!--
  😀 Wonderful!  Thank you for opening a pull request for TypeORM.

  Please fill in the information below to expedite the review
  and (hopefully) merge of your change.

  If unsure about something.. just do as best as you're able,
  or reach out through our community support channels!
  https://github.com/typeorm/typeorm/blob/master/docs/support.md
-->

### Description of change
The current QueryBuilder method for creating escaped table paths (getTableName) uses `split(".")`, which doesn't allow for database, schemas, or table names that contain dots. This PR aims to partially fix #8918 , due to the problem still persisting during the synchronization process (if synchronize is set to true). From my understanding, during the synchronization process, there are methods for each specific driver to deploy the schema. I guess this would be hard to solve.

`Fixes #8918`
<!--
  Please be clear and concise what the change is intended to do,
  why this change is needed, and how you've verified that it
  corrects what you intended.

  In some cases, it may be helpful to include the current behavior
  and the new behavior.

  If the change is related to an open issue, you can link it here.
  If you include `Fixes #0000` (replacing `0000` with the issue number)
  when this is merged it will automatically mark the issue as fixed and
  close it.
-->


### Pull-Request Checklist

<!--
  Please make sure to review and check all of the following.

  If an item is not applicable, you can add "N/A" to the end.
-->

- [x] Code is up-to-date with the `master` branch
- [x] `npm run format` to apply prettier formatting
- [ ] `npm run test` passes with this change
- [x] This pull request links relevant issues as `Fixes #8918`
- [x] There are new or updated unit tests validating the change
- [ ] Documentation has been updated to reflect this change
- [x] The new commits follow conventions explained in [CONTRIBUTING.md](https://github.com/typeorm/typeorm/blob/master/CONTRIBUTING.md)

<!--
  🎉 Thank you for contributing and making TypeORM even better!
-->
