### PR TITLE
fix: use last item in value array in the case of duplicate columns (mssql)

### DIFF
--- a/src/driver/sqlserver/SqlServerQueryRunner.ts
+++ b/src/driver/sqlserver/SqlServerQueryRunner.ts
@@ -269,6 +269,22 @@ export class SqlServerQueryRunner
 
             if (raw?.hasOwnProperty("recordset")) {
                 result.records = raw.recordset
+                // mssql driver will return an array if duplicate columns exist
+                // The following will search for properties that return as an array, and then update the property with the last value
+                if (result.records?.length > 0) {
+                    const propsToTakeForDuplicate = []
+                    for (let prop in result.records[0]) {
+                        if (Array.isArray(result.records[0][prop])) {
+                            propsToTakeForDuplicate.push(prop)
+                        }
+                    }
+                    for (let record of result.records) {
+                        for (let prop of propsToTakeForDuplicate) {
+                            const lastIdx = record[prop].length - 1
+                            record[prop] = record[prop][lastIdx]
+                        }
+                    }
+                }
             }
 
             if (raw?.hasOwnProperty("rowsAffected")) {

--- a/test/github-issues/7775/entities/test.ts
+++ b/test/github-issues/7775/entities/test.ts
@@ -1,0 +1,26 @@
+import {
+    Entity,
+    JoinColumn,
+    ManyToOne,
+    OneToMany,
+    PrimaryGeneratedColumn,
+} from "../../../../src"
+
+@Entity("parent")
+export class Parent {
+    @PrimaryGeneratedColumn()
+    id: number
+
+    @OneToMany((type) => Child, (child) => child.parent)
+    children: Child[]
+}
+
+@Entity("child")
+export class Child {
+    @PrimaryGeneratedColumn()
+    id: number
+
+    @ManyToOne((type) => Parent, (parent) => parent.children)
+    @JoinColumn({ name: "parent_id" })
+    parent: Parent
+}

--- a/test/github-issues/7775/issue-7775.ts
+++ b/test/github-issues/7775/issue-7775.ts
@@ -1,0 +1,72 @@
+import { expect } from "chai"
+import "reflect-metadata"
+import { DataSource } from "../../../src"
+import {
+    closeTestingConnections,
+    createTestingConnections,
+    reloadTestingDatabases,
+} from "../../utils/test-utils"
+import { Child, Parent } from "./entities/test"
+
+describe("github issues > #7775 MSSQL: Duplicate columns names return as an array, potentially breaking mapping", () => {
+    let connections: DataSource[]
+    before(async () => {
+        connections = await createTestingConnections({
+            enabledDrivers: ["mssql"],
+            entities: [Parent, Child],
+            dropSchema: true,
+            schemaCreate: true,
+        })
+    })
+    beforeEach(() => reloadTestingDatabases(connections))
+    after(() => closeTestingConnections(connections))
+
+    it("should take the last column as the value, consistent with other drivers", () =>
+        Promise.all(
+            connections.map(async (connection) => {
+                const results = await connection.manager.query(
+                    `SELECT 1 as id, 2 as id UNION SELECT 5, NULL`,
+                )
+                expect(results.length).to.be.eql(2)
+                expect(results[0].id).to.be.eql(2)
+                expect(results[1].id).to.be.eql(null)
+            }),
+        ))
+
+    it("should map the data properly if duplicate columns are present", () =>
+        Promise.all(
+            connections.map(async (connection) => {
+                const parentRepo = await connection.getRepository(Parent)
+                const childRepo = await connection.getRepository(Child)
+
+                const parent = new Parent()
+                parent.id = 1
+
+                await parentRepo.save(parent)
+
+                const child = new Child()
+                child.id = 1
+                child.parent = parent
+
+                await childRepo.save(child)
+
+                const results = await connection
+                    .getRepository(Child)
+                    .createQueryBuilder("child")
+                    .andWhere("parent.id = :p0")
+                    .setParameters({ p0: 1 })
+                    .select(
+                        "child.id, child.parent"
+                            .split(",")
+                            .map((i) => i.trim()),
+                    )
+                    .leftJoinAndSelect("child.parent", "parent", "1 = 1")
+                    .getMany()
+
+                expect(results.length).to.be.eql(1)
+                expect(results[0]).to.be.instanceOf(Child)
+                expect(results[0].parent).to.be.instanceOf(Parent)
+                expect(results[0].parent.id).to.be.eq(1)
+            }),
+        ))
+})


### PR DESCRIPTION
<!--
  😀 Wonderful!  Thank you for opening a pull request for TypeORM.

  Please fill in the information below to expedite the review
  and (hopefully) merge of your change.

  If unsure about something.. just do as best as you're able,
  or reach out through our community support channels!
  https://github.com/typeorm/typeorm/blob/master/docs/support.md
-->

### Description of change

Closes #7775

<!--
  Please be clear and concise what the change is intended to do,
  why this change is needed, and how you've verified that it
  corrects what you intended.

  In some cases it may be helpful to include the current behavior
  and the new behavior.

  If the change is related to an open issue, you can link it here.
  If you include `Fixes #0000` (replacing `0000` with the issue number)
  when this is merged it will automatically mark the issue as fixed and
  close it.
-->

The `mssql` driver, by default, returns an array when the resultset has duplicate columns. For example:

`SELECT 1 as id, 2 as id` would restult in `{id: [1, 2]}`

See https://github.com/tediousjs/node-mssql/issues/1384 upstream issue for more information and discussion. While I can understand the intent behind it, this is in contrast to how other drivers handle duplicate columns (in which they return, by default, the last column value). It seems that `mssql` is hesitant to introduce an option to automatically select for this behavior, citing data loss.

For TypeORM, tho, we need drivers that return data in similar fashion consistently. This change will look for any arrays that `mssql` returns, and then loop over the resultset and replace that property with the last value.

This is a fairly edge-case scenario - It's not normal for TypeORM to generate a query with duplicate columns, but it can happen (see test case entities for example), and this protects the mapper from returning odd results.

Please also see the issue in which this closes, #7775

### Pull-Request Checklist

<!--
  Please make sure to review and check all of the following.

  If an item is not applicable, you can add "N/A" to the end.
-->

- [x] Code is up-to-date with the `master` branch
- [x] `npm run format` to apply prettier formatting
- [x] `npm run test` passes with this change
       * Note: there is one failing test case, but it seems to be happening in master as well, so not related to this PR. I only ran tests using `mssql` in ormconfig
- [x] This pull request links relevant issues as `Fixes #0000`
- [x] There are new or updated unit tests validating the change
- [ ] Documentation has been updated to reflect this change
      * Unsure if this is needed?
- [x] The new commits follow conventions explained in [CONTRIBUTING.md](https://github.com/typeorm/typeorm/blob/master/CONTRIBUTING.md)

<!--
  🎉 Thank you for contributing and making TypeORM even better!
-->
