### PR TITLE
perf: don't recompile escapeRegExp for every query

### DIFF
--- a/src/query-builder/QueryBuilder.ts
+++ b/src/query-builder/QueryBuilder.ts
@@ -24,6 +24,7 @@ import { EntityPropertyNotFoundError } from "../error/EntityPropertyNotFoundErro
 import { ReturningType } from "../driver/Driver"
 import { OracleDriver } from "../driver/oracle/OracleDriver"
 import { InstanceChecker } from "../util/InstanceChecker"
+import { escapeRegExp } from "../util/escapeRegExp"
 
 // todo: completely cover query builder with tests
 // todo: entityOrProperty can be target name. implement proper behaviour if it is.
@@ -701,12 +702,8 @@ export abstract class QueryBuilder<Entity> {
     /**
      * Replaces all entity's propertyName to name in the given statement.
      */
-    protected replacePropertyNames(statement: string) {
-        // Escape special characters in regular expressions
-        // Per https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Regular_Expressions#Escaping
-        const escapeRegExp = (s: String) =>
-            s.replace(/[.*+\-?^${}()|[\]\\]/g, "\\$&")
 
+    protected replacePropertyNames(statement: string) {
         for (const alias of this.expressionMap.aliases) {
             if (!alias.hasMetadata) continue
             const replaceAliasNamePrefix = this.expressionMap

--- a/src/util/escapeRegExp.ts
+++ b/src/util/escapeRegExp.ts
@@ -1,0 +1,4 @@
+// Escape special characters in regular expressions
+// Per https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Regular_Expressions#Escaping
+const ESCAPE_REGEXP = /[.*+\-?^${}()|[\]\\]/g
+export const escapeRegExp = (s: String) => s.replace(ESCAPE_REGEXP, "\\$&")


### PR DESCRIPTION
### Description of change

Context: the query builder is pretty CPU intensive, and can be slow -
e.g. https://github.com/typeorm/typeorm/issues/3857

One of the things which makes this slow is `escapeRegExp` in the query
builder: we freshly construct the same RegExp once per
`replacePropertyName` invocation (many times per overall query!) and
since the RegExp itself is constant -- we can lift it out and construct
it once.

Over-all this saves about 5% on our query build times as measured by
 #8955.

### Pull-Request Checklist

- [x] Code is up-to-date with the `master` branch
- [x] `npm run format` to apply prettier formatting
- [x] `npm run test` passes with this change
- [x] This pull request links relevant issues as `Fixes #0000`
- [x] There are new or updated unit tests validating the change
- [x] Documentation has been updated to reflect this change
- [x] The new commits follow conventions explained in [CONTRIBUTING.md](https://github.com/typeorm/typeorm/blob/master/CONTRIBUTING.md)

<!--
  🎉 Thank you for contributing and making TypeORM even better!
-->
