### PR TITLE
fix: release newly created runner when no runner provided

### DIFF
--- a/src/cache/DbQueryResultCache.ts
+++ b/src/cache/DbQueryResultCache.ts
@@ -298,12 +298,10 @@ export class DbQueryResultCache implements QueryResultCache {
         identifiers: string[],
         queryRunner?: QueryRunner,
     ): Promise<void> {
+        let _queryRunner: QueryRunner = queryRunner || this.getQueryRunner()
         await Promise.all(
             identifiers.map((identifier) => {
-                const qb =
-                    this.getQueryRunner(
-                        queryRunner,
-                    ).manager.createQueryBuilder()
+                const qb = _queryRunner.manager.createQueryBuilder()
                 return qb
                     .delete()
                     .from(this.queryResultCacheTable)
@@ -313,6 +311,10 @@ export class DbQueryResultCache implements QueryResultCache {
                     .execute()
             }),
         )
+
+        if (!queryRunner) {
+            await _queryRunner.release()
+        }
     }
 
     // -------------------------------------------------------------------------
@@ -322,9 +324,7 @@ export class DbQueryResultCache implements QueryResultCache {
     /**
      * Gets a query runner to work with.
      */
-    protected getQueryRunner(
-        queryRunner: QueryRunner | undefined,
-    ): QueryRunner {
+    protected getQueryRunner(queryRunner?: QueryRunner): QueryRunner {
         if (queryRunner) return queryRunner
 
         return this.connection.createQueryRunner()


### PR DESCRIPTION
<!--
  😀 Wonderful!  Thank you for opening a pull request for TypeORM.

  Please fill in the information below to expedite the review
  and (hopefully) merge of your change.

  If unsure about something.. just do as best as you're able,
  or reach out through our community support channels!
  https://github.com/typeorm/typeorm/blob/master/docs/support.md
-->

### Description of change

Fixes #4866

When calling `DbQueryResultCache.remove`, if the optional `queryRunner` is not provided, currently, a new runner is created.
This new runner is not released after executing the query.

<!--
  Please be clear and concise what the change is intended to do,
  why this change is needed, and how you've verified that it
  corrects what you intended.

  In some cases it may be helpful to include the current behavior
  and the new behavior.

  If the change is related to an open issue, you can link it here.
  If you include `Fixes #4866` (replacing `0000` with the issue number)
  when this is merged it will automatically mark the issue as fixed and
  close it.
-->


### Pull-Request Checklist

<!--
  Please make sure to review and check all of the following.

  If an item is not applicable, you can add "N/A" to the end.
-->

- [x] Code is up-to-date with the `master` branch
- [x] `npm run format` to apply prettier formatting
- [x] `npm run test` passes with this change
- [x] This pull request links relevant issues as `Fixes #0000`
- [ ] There are new or updated unit tests validating the change
- [ ] Documentation has been updated to reflect this change
- [x] The new commits follow conventions explained in [CONTRIBUTING.md](https://github.com/typeorm/typeorm/blob/master/CONTRIBUTING.md)

<!--
  🎉 Thank you for contributing and making TypeORM even better!
-->
