### PR TITLE
feat: add commentCallback

### DIFF
--- a/src/data-source/DataSource.ts
+++ b/src/data-source/DataSource.ts
@@ -536,20 +536,28 @@ export class DataSource {
         if (InstanceChecker.isMongoEntityManager(this.manager))
             throw new TypeORMError(`Query Builder is not supported by MongoDB.`)
 
+        let qb: SelectQueryBuilder<Entity>
         if (alias) {
             alias = DriverUtils.buildAlias(this.driver, alias)
             const metadata = this.getMetadata(
                 entityOrRunner as EntityTarget<Entity>,
             )
-            return new SelectQueryBuilder(this, queryRunner)
+            qb = new SelectQueryBuilder(this, queryRunner)
                 .select(alias)
                 .from(metadata.target, alias)
         } else {
-            return new SelectQueryBuilder(
+            qb = new SelectQueryBuilder(
                 this,
                 entityOrRunner as QueryRunner | undefined,
             )
         }
+        if (this.options.type === "postgres" && this.options.commentCallback) {
+            let comment = this.options.commentCallback()
+            if (comment) {
+                qb.comment(comment)
+            }
+        }
+        return qb
     }
 
     /**

--- a/src/driver/postgres/PostgresConnectionOptions.ts
+++ b/src/driver/postgres/PostgresConnectionOptions.ts
@@ -83,4 +83,10 @@ export interface PostgresConnectionOptions
      * the service using this connection. Defaults to 'undefined'
      */
     readonly applicationName?: string
+
+    /**
+     * Allow the application to dynamically insert a comment to SQL
+     * commands, to allow for advanced debugging.
+     */
+    readonly commentCallback?: () => string | undefined
 }


### PR DESCRIPTION
<!--
  😀 Wonderful!  Thank you for opening a pull request for TypeORM.

  Please fill in the information below to expedite the review
  and (hopefully) merge of your change.

  If unsure about something.. just do as best as you're able,
  or reach out through our community support channels!
  https://github.com/typeorm/typeorm/blob/master/docs/support.md
-->

### Description of change

<!--
  Please be clear and concise what the change is intended to do,
  why this change is needed, and how you've verified that it
  corrects what you intended.

  In some cases it may be helpful to include the current behavior
  and the new behavior.

  If the change is related to an open issue, you can link it here.
  If you include `Fixes #0000` (replacing `0000` with the issue number)
  when this is merged it will automatically mark the issue as fixed and
  close it.
-->

This adds a new configuration option, `commentCallback`, which allows an application to dynamically add a comment to SQL commands. This allows for advanced debugging, e.g. automatically inserting the source of all SQL commands (filename and line number).

Sidenote: In Ruby there's a gem called [marginalia](https://github.com/basecamp/marginalia) which accomplishes the same thing for Ruby/Rails applications.

**Note that this PR is not completely ready.** It is currently in a proof-of-concept stage, and it currently only works for code that uses `createQueryBuilder`. I'm not sure the best way to improve this to make sure the callback is called for everything (e.g. `QueryRunner`). Perhaps someone here would have a good idea of how to accomplish that?

If there's sufficient interest to mainline this and we manage to improve this so it works for all queries, then I can work on adding support for more engines (mysql, etc).

Here's an example of how I have used this in my testing:

```typescript
    commentCallback: () => {
      const cwd = process.cwd();
      const stackRegex = /at\s+(.*)\s+\((.*)\)/i;
      const stack = new Error().stack?.split('\n')?.slice(2);
      if (!stack) {
        return undefined;
      }
      for (const line of stack) {
        const parsed = stackRegex.exec(line);
        if (!parsed) {
          continue;
        }
        const functionName = parsed[1];
        const functionLocationLong = parsed[2];
        if (!functionLocationLong.startsWith(cwd) || functionLocationLong.startsWith(`${cwd}/node_modules/`)) {
          continue;
        }
        const functionLocation = functionLocationLong.substring(cwd.length + 1);
        return `${functionName} (${functionLocation})`;
      }
      return undefined;
    },
```

The end result is that I get these comments like this in my SQL server logs:

```
LOG:  statement: /* register (src/core/auth/auth.resolver.ts:263:23) */ SELECT "User"."id" AS "User_id", "User"."firstName" AS "User_firstName", "User"."lastName" AS "User_lastName", "User"."age" AS "User_age" FROM "user" "User"
```

So if I ever want to see where a query is coming from, the answer will be right there in my logs. 🎉 

I think this adds pretty good value to typeorm and the ability to debug large codebases. I'd love to know if this functionality is something that would be considered for inclusion and I'd love to hear if there's a better way to implement it. Thank you!


### Pull-Request Checklist

<!--
  Please make sure to review and check all of the following.

  If an item is not applicable, you can add "N/A" to the end.
-->

- [x] Code is up-to-date with the `master` branch
- [x] `npm run format` to apply prettier formatting
- [ ] `npm run test` passes with this change
- [ ] This pull request links relevant issues as `Fixes #0000`
- [ ] There are new or updated unit tests validating the change
- [ ] Documentation has been updated to reflect this change
- [ ] The new commits follow conventions explained in [CONTRIBUTING.md](https://github.com/typeorm/typeorm/blob/master/CONTRIBUTING.md)

<!--
  🎉 Thank you for contributing and making TypeORM even better!
-->
