### PR TITLE
fix: add SQLite boolean escaping

### DIFF
--- a/src/driver/sqlite-abstract/AbstractSqliteDriver.ts
+++ b/src/driver/sqlite-abstract/AbstractSqliteDriver.ts
@@ -476,6 +476,10 @@ export abstract class AbstractSqliteDriver implements Driver {
                 } else if (typeof value === "number") {
                     return String(value)
                 }
+                
+                if (typeof value === "boolean") {
+                    return value ? "1" : "0";
+                }
 
                 if (value instanceof Date) {
                     escapedParameters.push(


### PR DESCRIPTION
Fixes #1981 (again).


### Description of change

When using `someRepository.findOneBy({ someField: true })`, `nativeParameters` has no keys and the query doesn't work properly, returning empty array. We updated to last TypeORM version (from 0.2.30) and this seems to solve it, but I don't really understand why booleans worked and now don't. If it means anything, we are using Cordova to develop and Android app. Anyways, this commit fixes it.


### Pull-Request Checklist

- [x] Code is up-to-date with the `master` branch
- [ ] `npm run format` to apply prettier formatting
- [ ] `npm run test` passes with this change
- [x] This pull request links relevant issues as `Fixes #0000`
- [ ] There are new or updated unit tests validating the change
- [ ] Documentation has been updated to reflect this change
- [x] The new commits follow conventions explained in [CONTRIBUTING.md](https://github.com/typeorm/typeorm/blob/master/CONTRIBUTING.md)
