### PR TITLE
fix: add SET TRANSACTION AUTOCOMMIT DDL statements (SAP HANA)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -93,7 +93,7 @@
       },
       "peerDependencies": {
         "@google-cloud/spanner": "^5.18.0",
-        "@sap/hana-client": "^2.11.14",
+        "@sap/hana-client": "^2.12.25",
         "better-sqlite3": "^7.1.2",
         "hdb-pool": "^0.1.6",
         "ioredis": "^4.28.3",
@@ -829,6 +829,36 @@
       "engines": {
         "node": ">=8.0.0"
       }
+    },
+    "node_modules/@sap/hana-client": {
+      "version": "2.12.25",
+      "resolved": "https://registry.npmjs.org/@sap/hana-client/-/hana-client-2.12.25.tgz",
+      "integrity": "sha512-Jn76aKTXryJmKbZaZdtUt2oLN3EQXyBi9gHK2hs+cTIK2Eb0popYvQu0M/9d2YXFGAtsfD14cXgh621m+NhRJA==",
+      "hasInstallScript": true,
+      "hasShrinkwrap": true,
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "debug": "3.1.0"
+      },
+      "engines": {
+        "node": ">=4.0.0"
+      }
+    },
+    "node_modules/@sap/hana-client/node_modules/debug": {
+      "version": "3.1.0",
+      "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "ms": "2.0.0"
+      }
+    },
+    "node_modules/@sap/hana-client/node_modules/ms": {
+      "version": "2.0.0",
+      "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+      "optional": true,
+      "peer": true
     },
     "node_modules/@sinonjs/commons": {
       "version": "1.8.3",
@@ -5607,6 +5637,16 @@
       },
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/hdb-pool": {
+      "version": "0.1.6",
+      "resolved": "https://registry.npmjs.org/hdb-pool/-/hdb-pool-0.1.6.tgz",
+      "integrity": "sha512-8VZOLn1EHamm1NmTFQj2iqjVcfonYIsD7F5DU2bz2N+gF+knp6/MbAVeRXkJtya717IBkPeA5iv0/1iPuYo4ZA==",
+      "optional": true,
+      "peer": true,
+      "engines": {
+        "node": ">= 8"
       }
     },
     "node_modules/he": {
@@ -12892,6 +12932,33 @@
       "integrity": "sha512-BuJuXRSJNQ3QoKA6GWWDyuLpOUck+9hAXNMCnrloc1aWVoy6Xq6t9PUV08aBZ4Lutqq2LEHM486bpZqoViScog==",
       "dev": true
     },
+    "@sap/hana-client": {
+      "version": "2.12.25",
+      "resolved": "https://registry.npmjs.org/@sap/hana-client/-/hana-client-2.12.25.tgz",
+      "integrity": "sha512-Jn76aKTXryJmKbZaZdtUt2oLN3EQXyBi9gHK2hs+cTIK2Eb0popYvQu0M/9d2YXFGAtsfD14cXgh621m+NhRJA==",
+      "optional": true,
+      "peer": true,
+      "requires": {
+        "debug": "3.1.0"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "3.1.0",
+          "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+          "optional": true,
+          "peer": true,
+          "requires": {
+            "ms": "2.0.0"
+          }
+        },
+        "ms": {
+          "version": "2.0.0",
+          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+          "optional": true,
+          "peer": true
+        }
+      }
+    },
     "@sinonjs/commons": {
       "version": "1.8.3",
       "resolved": "https://registry.npmjs.org/@sinonjs/commons/-/commons-1.8.3.tgz",
@@ -16737,6 +16804,13 @@
           }
         }
       }
+    },
+    "hdb-pool": {
+      "version": "0.1.6",
+      "resolved": "https://registry.npmjs.org/hdb-pool/-/hdb-pool-0.1.6.tgz",
+      "integrity": "sha512-8VZOLn1EHamm1NmTFQj2iqjVcfonYIsD7F5DU2bz2N+gF+knp6/MbAVeRXkJtya717IBkPeA5iv0/1iPuYo4ZA==",
+      "optional": true,
+      "peer": true
     },
     "he": {
       "version": "1.2.0",

--- a/package.json
+++ b/package.json
@@ -140,7 +140,7 @@
   },
   "peerDependencies": {
     "@google-cloud/spanner": "^5.18.0",
-    "@sap/hana-client": "^2.11.14",
+    "@sap/hana-client": "^2.12.25",
     "better-sqlite3": "^7.1.2",
     "hdb-pool": "^0.1.6",
     "ioredis": "^4.28.3",

--- a/src/driver/sap/SapQueryRunner.ts
+++ b/src/driver/sap/SapQueryRunner.ts
@@ -26,6 +26,7 @@ import { QueryResult } from "../../query-runner/QueryResult"
 import { QueryLock } from "../../query-runner/QueryLock"
 import { MetadataTableType } from "../types/MetadataTableType"
 import { InstanceChecker } from "../../util/InstanceChecker"
+import { promisify } from "util"
 
 /**
  * Runs queries on a single SQL Server database connection.
@@ -109,6 +110,12 @@ export class SapQueryRunner extends BaseQueryRunner implements QueryRunner {
 
         this.isTransactionActive = true
 
+        /**
+         * Disable AUTOCOMMIT while running transaction.
+         *  Otherwise, COMMIT/ROLLBACK doesn't work in autocommit mode.
+         */
+        await this.setAutoCommit({ status: "off" })
+
         if (isolationLevel) {
             await this.query(
                 `SET TRANSACTION ISOLATION LEVEL ${isolationLevel || ""}`,
@@ -132,6 +139,7 @@ export class SapQueryRunner extends BaseQueryRunner implements QueryRunner {
         await this.query("COMMIT")
         this.isTransactionActive = false
 
+        await this.setAutoCommit({ status: "on" })
         await this.broadcaster.broadcast("AfterTransactionCommit")
     }
 
@@ -149,7 +157,26 @@ export class SapQueryRunner extends BaseQueryRunner implements QueryRunner {
         await this.query("ROLLBACK")
         this.isTransactionActive = false
 
+        await this.setAutoCommit({ status: "on" })
         await this.broadcaster.broadcast("AfterTransactionRollback")
+    }
+
+    /**
+     * Switches on/off AUTOCOMMIT mode
+     */
+    async setAutoCommit(options: { status: "on" | "off" }) {
+        const connection = await this.connect()
+
+        const execute = promisify(connection.exec.bind(connection))
+
+        connection.setAutoCommit(options.status === "on")
+
+        const query = `SET TRANSACTION AUTOCOMMIT DDL ${options.status.toUpperCase()};`
+        try {
+            await execute(query)
+        } catch (error) {
+            throw new QueryFailedError(query, [], error)
+        }
     }
 
     /**
@@ -169,8 +196,7 @@ export class SapQueryRunner extends BaseQueryRunner implements QueryRunner {
 
         try {
             const databaseConnection = await this.connect()
-            // we disable autocommit because ROLLBACK does not work in autocommit mode
-            databaseConnection.setAutoCommit(!this.isTransactionActive)
+
             this.driver.connection.logger.logQuery(query, parameters, this)
             const queryStartTime = +new Date()
             const isInsertQuery = query.substr(0, 11) === "INSERT INTO"


### PR DESCRIPTION
Hello TypeORM team!

_Summary_: I have fixed the issue happening for SAP HANA database when transaction, run during TypeORM synchronize, failed and rollback action is executed but updated Table structure is not reverted.

### Description of change

Current _TypeORM version (0.3.5)_ doesn't support **_SQL Transactions_** for **_DDL_** expressions executed on **_SAP HANA_** database.

The issue why it doesn't work is due to missed part for setting AUTOCOMMIT flag to OFF as described on [this SAP Help page](https://help.sap.com/docs/HANA_SERVICE_CF/7c78579ce9b14a669c1f3295b0d8ca16/d538d11053bd4f3f847ec5ce817a3d4c.html?locale=en-US).

Current Pull Request fixes this issue and allows to execute DDL scripts in transactional mode with working "commit" and "rollback" actions.

### Pull-Request Checklist

- [x] Code is up-to-date with the `master` branch
- [x] `npm run format` to apply prettier formatting
- [x] `npm run test` passes with this change
- [x] This pull request links relevant issues as `Fixes #0000`
- [ ] There are new or updated unit tests validating the change
- [ ] Documentation has been updated to reflect this change
- [x] The new commits follow conventions explained in [CONTRIBUTING.md](https://github.com/typeorm/typeorm/blob/master/CONTRIBUTING.md)
