### PR TITLE
perf: partially lift matching from regexp to js

### DIFF
--- a/test/benchmark/multiple-joins-querybuilder/multiple-joins-querybuilder.ts
+++ b/test/benchmark/multiple-joins-querybuilder/multiple-joins-querybuilder.ts
@@ -47,11 +47,11 @@ describe("benchmark > QueryBuilder > wide join", () => {
 
         /**
          * On a M1 macbook air, 5 runs:
-         * 3501ms
-         * 3574ms
-         * 3575ms
-         * 3563ms
-         * 3567ms
+         * 1861ms
+         * 1850ms
+         * 1859ms
+         * 1859ms
+         * 1884ms
          */
     })
 })


### PR DESCRIPTION
### Description of change

Digging further into #3857.

See also #8955, #8956.

As [previously discussed](https://github.com/typeorm/typeorm/issues/3857#issuecomment-699505893), the query builder currently suffers from poor performance in two ways:

1. quadratic numbers of operations with respect to total table/column
counts
2.  poor constant factor performance (regexps can be expensive
to build/run!)

The constant-factor performance is the more tractable problem: no longer
quadratically looping would be a chunky rewrite of the query builder,
but we can locally refactor to be a bunch cheaper in terms of regexp
operations.

This change cuts the benchmark time here in ~half (yay!).

We achieve this by simplifying the overall replacement regexp (we don't
need our column names in there, since we already have a plain object
where they're the keys to match against) so compilation of that is much
cheaper, plus skipping the need to `escapeRegExp` every column as a
result.

### Pull-Request Checklist

<!--
  Please make sure to review and check all of the following.

  If an item is not applicable, you can add "N/A" to the end.
-->

- [x] Code is up-to-date with the `master` branch
- [x] `npm run format` to apply prettier formatting
- [x] `npm run test` passes with this change
- [x] This pull request links relevant issues as `Fixes #0000`
- [x] There are new or updated unit tests validating the change
- [x] Documentation has been updated to reflect this change
- [x] The new commits follow conventions explained in [CONTRIBUTING.md](https://github.com/typeorm/typeorm/blob/master/CONTRIBUTING.md)

<!--
  🎉 Thank you for contributing and making TypeORM even better!
-->
