### PR TITLE
chore: support TS 4.7+ node16/nodenext module mode

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
   },
   "exports": {
     ".": {
+      "types": "./index.d.ts",
       "node": {
         "import": "./index.mjs",
         "require": "./index.js"
@@ -24,7 +25,10 @@
         "default": "./index.js"
       }
     },
-    "./browser": "./browser/index.js",
+    "./browser": {
+      "types": "./index.d.ts",
+      "default": "./browser/index.js"
+    },
     "./*.js": "./*.js",
     "./*": {
       "require": "./*.js",


### PR DESCRIPTION
<!--
  😀 Wonderful!  Thank you for opening a pull request for TypeORM.

  Please fill in the information below to expedite the review
  and (hopefully) merge of your change.

  If unsure about something.. just do as best as you're able,
  or reach out through our community support channels!
  https://github.com/typeorm/typeorm/blob/master/docs/support.md
-->

### Description of change

in node16/nodenext module mode of TyepScript 4.7+, If package has `exports` entry on package.json, needs "types" field in `exports.*` for typings.

without this change, TypeScript 4.7+ (on node16/nodenext module mode) can't find typings.

```
src/backend/db/entities/local-user.ts:1:69 - error TS7016: Could not find a declaration file for module 'typeorm'. '/Users/user/work/github.com/rinsuki/alice/node_modules/typeorm/index.mjs' implicitly has an 'any' type.
  If the 'typeorm' package actually exposes this module, try adding a new declaration (.d.ts) file containing `declare module 'typeorm';`

1 import { Column, Entity, JoinColumn, OneToOne, PrimaryColumn } from "typeorm";
```

so just I added it.

ref. https://devblogs.microsoft.com/typescript/announcing-typescript-4-7/


### Pull-Request Checklist

<!--
  Please make sure to review and check all of the following.

  If an item is not applicable, you can add "N/A" to the end.
-->

- [x] Code is up-to-date with the `master` branch
- [x] `npm run format` to apply prettier formatting
- [x] `npm run test` passes with this change
- [ ] This pull request links relevant issues as `Fixes #0000` N/A
- [ ] There are new or updated unit tests validating the change N/A
- [ ] Documentation has been updated to reflect this change N/A
- [x] The new commits follow conventions explained in [CONTRIBUTING.md](https://github.com/typeorm/typeorm/blob/master/CONTRIBUTING.md)

<!--
  🎉 Thank you for contributing and making TypeORM even better!
-->
