### PR TITLE
fix: Expo query runner never committing a transaction

### DIFF
--- a/src/driver/expo/ExpoQueryRunner.ts
+++ b/src/driver/expo/ExpoQueryRunner.ts
@@ -250,9 +250,12 @@ export class ExpoQueryRunner extends AbstractSqliteQueryRunner {
                     await this.rollbackTransaction()
                     fail(err)
                 },
-                () => {
-                    this.isTransactionActive = false
-                    this.transaction = undefined
+                async () => {
+                    try {
+                        await this.commitTransaction()
+                    } catch (e) {
+                        fail(e)
+                    }
                 },
             )
         })


### PR DESCRIPTION

### Description of change

`startTransaction()` is called  every time `query(query, parameters, useStructuredResult)` provided that the `transaction` object is `undefined`. 

Taking a look at  `databaseConnection.transaction(callback, errorCallback, successCallback)` `errorCallback` properly calls `rollbackTransaction`, decreasing `transactionDepth` but `successCallback ` doesn't call `commitTransaction` causing `transactionDepth` to never decrease unless a transaction fails.

`commitTransaction` is now called on the expo-sqlite` transaction(callback, errorCallback, successCallback)` `successCallback `. Properly decreasing `transactionDepth` and deleting the `transaction` object to set stage for the next transaction.

Fixes #8742 

- [x] Code is up-to-date with the `master` branch
- [x] `npm run format` to apply prettier formatting
- [x] `npm run test` passes with this change
- [x] This pull request links relevant issues as `Fixes #0000`
- [ ] There are new or updated unit tests validating the change. N/A
- [ ] Documentation has been updated to reflect this change. N/A
- [x] The new commits follow conventions explained in [CONTRIBUTING.md](https://github.com/typeorm/typeorm/blob/master/CONTRIBUTING.md)

