### PR TITLE
docs: update TableForeignKeyOptions.name description

### DIFF
--- a/src/schema-builder/options/TableForeignKeyOptions.ts
+++ b/src/schema-builder/options/TableForeignKeyOptions.ts
@@ -7,7 +7,7 @@ export interface TableForeignKeyOptions {
     // -------------------------------------------------------------------------
 
     /**
-     * Name of the table which contains this foreign key.
+     * Name of the foreign key.
      */
     name?: string
 


### PR DESCRIPTION
### Description of change
`TableForeignKeyOptions.name` reflects the name of the foreign key. The name of the table where this foreign key resides is actually referenced by `referencedTableName`.


### Pull-Request Checklist

- [x] Code is up-to-date with the `master` branch
- [ ] `npm run format` to apply prettier formatting N/A
- [ ] `npm run test` passes with this change N/A
- [ ] This pull request links relevant issues as `Fixes #0000` N/A
- [ ] There are new or updated unit tests validating the change N/A
- [x] Documentation has been updated to reflect this change
- [x] The new commits follow conventions explained in [CONTRIBUTING.md](https://github.com/typeorm/typeorm/blob/master/CONTRIBUTING.md)
