### PR TITLE
docs: fix cli create command

### DIFF
--- a/docs/using-cli.md
+++ b/docs/using-cli.md
@@ -128,90 +128,57 @@ typeorm init --docker
 
 ## Create a new entity
 
-You can create a new entity using CLI:
+You can create a new entity on root project folder using CLI:
 
 ```
 typeorm entity:create -n User
 ```
 
 where `User` is an entity file and class name.
-Running the command will create a new empty entity in `entitiesDir` of the project.
-To set up the `entitiesDir` of the project you must add it in data source options:
 
-```
-{
-    cli: {
-        entitiesDir: "src/entity"
-    }
-}
-```
-
-Learn more about [data source options](./data-source-options.md).
 If you have a multi-module project structure with multiple entities in different directories
 you can provide the path to the CLI command where you want to generate an entity:
 
 ```
-typeorm entity:create -n User -d src/user/entity
+typeorm entity:create -d src/user/entity/User
 ```
 
 Learn more about [entities](./entities.md).
 
 ## Create a new subscriber
 
-You can create a new subscriber using CLI:
+You can create a new subscriber on root project folder using CLI:
 
 ```
 typeorm subscriber:create -n UserSubscriber
 ```
 
 where `UserSubscriber` is a subscriber file and class name.
-Running the following command will create a new empty subscriber in the `subscribersDir` of the project.
-To setup `subscribersDir` you must add it in data source options:
 
-```
-{
-    cli: {
-        subscribersDir: "src/subscriber"
-    }
-}
-```
-
-Learn more about [data source options](./data-source-options.md).
 If you have a multi-module project structure with multiple subscribers in different directories
 you can provide a path to the CLI command where you want to generate a subscriber:
 
 ```
-typeorm subscriber:create -n UserSubscriber -d src/user/subscriber
+typeorm subscriber:create -d src/user/subscriber/UserSubscriber 
 ```
 
 Learn more about [Subscribers](./listeners-and-subscribers.md).
 
 ## Create a new migration
 
-You can create a new migration using CLI:
+You can create a new migration on root project folder using CLI:
 
 ```
 typeorm migration:create -n UserMigration
 ```
 
 where `UserMigration` is a migration file and class name.
-Running the command will create a new empty migration in the `migrationsDir` of the project.
-To setup `migrationsDir` you must add it in data source options:
 
-```
-{
-    cli: {
-        migrationsDir: "src/migration"
-    }
-}
-```
-
-Learn more about [data source options](./data-source-options.md).
 If you have a multi-module project structure with multiple migrations in different directories
 you can provide a path to the CLI command where you want to generate a migration:
 
 ```
-typeorm migration:create -n UserMigration -d src/user/migration
+typeorm migration:create -d src/user/migration/UserMigration 
 ```
 
 Learn more about [Migrations](./migrations.md).


### PR DESCRIPTION
### Description of change

Tried to fix the docs cause it was causing some misunderstanding about the cli create command like #8783 and #8762.

### Pull-Request Checklist

- [x] Code is up-to-date with the `master` branch
- [x] `npm run format` to apply prettier formatting
- [x] `npm run test` passes with this change
- [x] This pull request links relevant issues as `Fixes #0000`
- [ ] There are new or updated unit tests validating the change
- [x] Documentation has been updated to reflect this change
- [x] The new commits follow conventions explained in [CONTRIBUTING.md](https://github.com/typeorm/typeorm/blob/master/CONTRIBUTING.md)