### PR TITLE
fix: cli drops migrations in cwd

### DIFF
--- a/docs/data-source-options.md
+++ b/docs/data-source-options.md
@@ -50,6 +50,9 @@ Different RDBMS-es have their own specific options.
     Example: `migrations: [FirstMigration, SecondMigration, "migration/*.js", "modules/**/migration/*.js"]`.
     Learn more about [Migrations](migrations.md).
 
+-   `migrationsOutDir` - Migration output directory for CLI commands (Relative)
+    Example: `migrationsOutDir: 'database/migrations'`.
+
 -   `logging` - Indicates if logging is enabled or not.
     If set to `true` then query and error logging will be enabled.
     You can also specify different types of logging to be enabled, for example `["query", "error", "schema"]`.

--- a/docs/migrations.md
+++ b/docs/migrations.md
@@ -56,8 +56,9 @@ This place is called "migrations".
 
 Before creating a new migration you need to setup your data source options properly:
 
+`data-source.ts`
 ```ts
-{
+export const dataSource = new DataSource({
     type: "mysql",
     host: "localhost",
     port: 3306,
@@ -67,6 +68,7 @@ Before creating a new migration you need to setup your data source options prope
     entities: [/*...*/],
     migrations: [/*...*/],
     migrationsTableName: "custom_migration_table",
+    migrationsOutDir: 'database/migrations',
 }
 ```
 
@@ -78,11 +80,17 @@ Here we setup three options:
 Once you setup connection options you can create a new migration using CLI:
 
 ```
-typeorm migration:create -n PostRefactoring
+typeorm migration:create PostRefactoring
+```
+
+To use the data source options configured above, run with the `-d` arg:
+
+```
+typeorm migration:create PostRefactoring -d data-source.ts
 ```
 
 Here, `PostRefactoring` is the name of the migration - you can specify any name you want.
-After you run the command you can see a new file generated in the "migration" directory
+After you run the command you can see a new file generated in the migrations directory
 named `{TIMESTAMP}-PostRefactoring.ts` where `{TIMESTAMP}` is the current timestamp when the migration was generated.
 Now you can open the file and add your migration sql queries there.
 
@@ -174,7 +182,7 @@ Let's say you have a `Post` entity with a `title` column, and you have changed t
 You can run following command:
 
 ```
-typeorm migration:generate -n PostRefactoring
+typeorm migration:generate PostRefactoring -d data-source.ts
 ```
 
 And it will generate a new migration called `{TIMESTAMP}-PostRefactoring.ts` with the following content:

--- a/src/commands/MigrationGenerateCommand.ts
+++ b/src/commands/MigrationGenerateCommand.ts
@@ -63,10 +63,6 @@ export class MigrationGenerateCommand implements yargs.CommandModule {
     async handler(args: yargs.Arguments) {
         const timestamp = CommandUtils.getTimestamp(args.timestamp)
         const extension = args.outputJs ? ".js" : ".ts"
-        const fullPath = (args.path as string).startsWith("/")
-            ? (args.path as string)
-            : path.resolve(process.cwd(), args.path as string)
-        const filename = timestamp + "-" + path.basename(fullPath) + extension
 
         let dataSource: DataSource | undefined = undefined
         try {
@@ -80,6 +76,17 @@ export class MigrationGenerateCommand implements yargs.CommandModule {
                 logging: false,
             })
             await dataSource.initialize()
+
+            const migrationsDir = dataSource?.options.migrationsOutDir || ""
+            const fullPath = (args.path as string).startsWith("/")
+                ? (args.path as string)
+                : path.resolve(
+                      process.cwd(),
+                      migrationsDir,
+                      args.path as string,
+                  )
+            const filename =
+                timestamp + "-" + path.basename(fullPath) + extension
 
             const upSqls: string[] = [],
                 downSqls: string[] = []

--- a/src/data-source/BaseDataSourceOptions.ts
+++ b/src/data-source/BaseDataSourceOptions.ts
@@ -45,6 +45,11 @@ export interface BaseDataSourceOptions {
     readonly migrations?: MixedList<Function | string>
 
     /**
+     * Migration output directory for CLI commands (Relative)
+     */
+    readonly migrationsOutDir?: string
+
+    /**
      * Migrations table name, in case of different name from "migrations".
      * Accepts single string name.
      */


### PR DESCRIPTION
- Reintroduce option to set the migrations output directory on DataSource
- Update broken migration:create and migration:generate documentation
- Add (optional) dataSource option on migration:create
- migrations.md instructions "setup your data source options properly" was incomplete and misleading

Closes #9085

<!--
  😀 Wonderful!  Thank you for opening a pull request for TypeORM.

  Please fill in the information below to expedite the review
  and (hopefully) merge of your change.

  If unsure about something.. just do as best as you're able,
  or reach out through our community support channels!
  https://github.com/typeorm/typeorm/blob/master/docs/support.md
-->

### Description of change

<!--
  Please be clear and concise what the change is intended to do,
  why this change is needed, and how you've verified that it
  corrects what you intended.

  In some cases it may be helpful to include the current behavior
  and the new behavior.

  If the change is related to an open issue, you can link it here.
  If you include `Fixes #0000` (replacing `0000` with the issue number)
  when this is merged it will automatically mark the issue as fixed and
  close it.
-->


### Pull-Request Checklist

<!--
  Please make sure to review and check all of the following.

  If an item is not applicable, you can add "N/A" to the end.
-->

- [x] Code is up-to-date with the `master` branch
- [x] `npm run format` to apply prettier formatting
- [x] `npm run test` passes with this change
- [x] This pull request links relevant issues as `Fixes #0000`
- [n/a] There are new or updated unit tests validating the change
- [x] Documentation has been updated to reflect this change _also fixes documentation regressions from v0.3.0_
- [x] The new commits follow conventions explained in [CONTRIBUTING.md](https://github.com/typeorm/typeorm/blob/master/CONTRIBUTING.md)

<!--
  🎉 Thank you for contributing and making TypeORM even better!
-->
