### PR TITLE
fixed full path requirement in migration:create command

### DIFF
--- a/docs/migrations.md
+++ b/docs/migrations.md
@@ -78,7 +78,8 @@ Here we setup three options:
 Once you setup connection options you can create a new migration using CLI:
 
 ```
-typeorm migration:create -n PostRefactoring
+typeorm migration:create /path-to-migrations-dir/PostRefactoring
+
 ```
 
 Here, `PostRefactoring` is the name of the migration - you can specify any name you want.

--- a/docs/migrations.md
+++ b/docs/migrations.md
@@ -78,7 +78,7 @@ Here we setup three options:
 Once you setup connection options you can create a new migration using CLI:
 
 ```
-typeorm migration:create /path-to-migrations-dir/PostRefactoring
+typeorm migration:create ./path-to-migrations-dir/PostRefactoring
 
 ```
 


### PR DESCRIPTION


The current documentation of the migration:create command uses the old cli syntax
```
typeorm migration:create -n PostRefactoring
```

This throws an error as newer versions greater than 0.30 require the full path to be passed.
![error_migrations_create](https://user-images.githubusercontent.com/59575776/173980507-6eb426ca-28aa-4bd8-9e37-8970bb01cde9.png)

```
typeorm migration:create /path-to-migrations-dir/PostRefactoring

```

The above command creates the migration in the path with the name {timestamp}-PostRefactoring.ts successfully.
![successful_migrations_create](https://user-images.githubusercontent.com/59575776/173985282-7c1a17af-f646-46f8-8588-732f25f9f246.png)




### Pull-Request Checklist

<!--
  Please make sure to review and check all of the following.

  If an item is not applicable, you can add "N/A" to the end.
-->

- [x] Code is up-to-date with the `master` branch
- [x] `npm run format` to apply prettier formatting N/A
- [x] `npm run test` passes with this change N/A 
- [x] This pull request links relevant issues as `Fixes #0000` N/A
- [x] There are new or updated unit tests validating the change N/A
- [x] Documentation has been updated to reflect this change
- [x] The new commits follow conventions explained in [CONTRIBUTING.md] N/A
- [x] (https://github.com/typeorm/typeorm/blob/master/CONTRIBUTING.md)

<!--
  🎉 Thank you for contributing and making TypeORM even better!
-->



