### PR TITLE
feat: log command error prior to calling destroy

### DIFF
--- a/src/commands/CacheClearCommand.ts
+++ b/src/commands/CacheClearCommand.ts
@@ -49,9 +49,9 @@ export class CacheClearCommand implements yargs.CommandModule {
 
             await dataSource.destroy()
         } catch (err) {
-            if (dataSource) await (dataSource as DataSource).destroy()
-
             PlatformTools.logCmdErr("Error during cache clear.", err)
+
+            if (dataSource) await (dataSource as DataSource).destroy()
 
             process.exit(1)
         }

--- a/src/commands/MigrationRevertCommand.ts
+++ b/src/commands/MigrationRevertCommand.ts
@@ -67,9 +67,10 @@ export class MigrationRevertCommand implements yargs.CommandModule {
             await dataSource.undoLastMigration(options)
             await dataSource.destroy()
         } catch (err) {
+            PlatformTools.logCmdErr("Error during migration revert:", err)
+
             if (dataSource) await dataSource.destroy()
 
-            PlatformTools.logCmdErr("Error during migration revert:", err)
             process.exit(1)
         }
     }

--- a/src/commands/MigrationRunCommand.ts
+++ b/src/commands/MigrationRunCommand.ts
@@ -70,9 +70,10 @@ export class MigrationRunCommand implements yargs.CommandModule {
             // exit process if no errors
             process.exit(0)
         } catch (err) {
+            PlatformTools.logCmdErr("Error during migration run:", err)
+
             if (dataSource) await dataSource.destroy()
 
-            PlatformTools.logCmdErr("Error during migration run:", err)
             process.exit(1)
         }
     }

--- a/src/commands/MigrationShowCommand.ts
+++ b/src/commands/MigrationShowCommand.ts
@@ -40,8 +40,10 @@ export class MigrationShowCommand implements yargs.CommandModule {
 
             process.exit(0)
         } catch (err) {
-            if (dataSource) await dataSource.destroy()
             PlatformTools.logCmdErr("Error during migration show:", err)
+
+            if (dataSource) await dataSource.destroy()
+
             process.exit(1)
         }
     }

--- a/src/commands/QueryCommand.ts
+++ b/src/commands/QueryCommand.ts
@@ -71,10 +71,11 @@ export class QueryCommand implements yargs.CommandModule {
             await queryRunner.release()
             await dataSource.destroy()
         } catch (err) {
+            PlatformTools.logCmdErr("Error during query execution:", err)
+
             if (queryRunner) await (queryRunner as QueryRunner).release()
             if (dataSource) await dataSource.destroy()
 
-            PlatformTools.logCmdErr("Error during query execution:", err)
             process.exit(1)
         }
     }

--- a/src/commands/SchemaDropCommand.ts
+++ b/src/commands/SchemaDropCommand.ts
@@ -44,8 +44,10 @@ export class SchemaDropCommand implements yargs.CommandModule {
                 chalk.green("Database schema has been successfully dropped."),
             )
         } catch (err) {
-            if (dataSource) await dataSource.destroy()
             PlatformTools.logCmdErr("Error during schema drop:", err)
+
+            if (dataSource) await dataSource.destroy()
+
             process.exit(1)
         }
     }

--- a/src/commands/SchemaSyncCommand.ts
+++ b/src/commands/SchemaSyncCommand.ts
@@ -44,9 +44,10 @@ export class SchemaSyncCommand implements yargs.CommandModule {
                 chalk.green("Schema synchronization finished successfully."),
             )
         } catch (err) {
+            PlatformTools.logCmdErr("Error during schema synchronization:", err)
+
             if (dataSource) await dataSource.destroy()
 
-            PlatformTools.logCmdErr("Error during schema synchronization:", err)
             process.exit(1)
         }
     }


### PR DESCRIPTION
### Description of change

Fixes https://github.com/typeorm/typeorm/issues/8885.

The issue can be reproduced here:

https://gist.github.com/gillepsi-swyftx/d595a281ec08c019ea12abbfa20ea058

Most of the CLI commands currently run `dataSource.destroy()` in a `catch {}` block when an error occurs during the command ([see here](https://github.com/typeorm/typeorm/blob/506133e2179529bf3add2b0b982613835d321af6/src/commands/MigrationRunCommand.ts#L73)). This call to `destroy()` is throwing, which masks the underlying issue. The error caught in the `catch {}` block should be logged regardless of whether `destroy()` throws.

This PR moves the log entries in the `catch {}` block above the call to `destroy()`. This ensures that the error will be logged regardless of whether `destroy()` throws.

### Pull-Request Checklist

- [x] Code is up-to-date with the `master` branch
- [x] `npm run format` to apply prettier formatting
- [x] `npm run test` passes with this change
- [x] This pull request links relevant issues as `Fixes #0000`
- [ ] There are new or updated unit tests validating the change
- [ ] Documentation has been updated to reflect this change
- [x] The new commits follow conventions explained in [CONTRIBUTING.md](https://github.com/typeorm/typeorm/blob/master/CONTRIBUTING.md)
