### PR TITLE
Repository replaced by dataSource.manager.getTreeRepository(Category)

### DIFF
--- a/docs/tree-entities.md
+++ b/docs/tree-entities.md
@@ -231,10 +231,10 @@ There are other special methods to work with tree entities through `TreeReposito
 -   `findTrees` - Returns all trees in the database with all their children, children of children, etc.
 
 ```typescript
-const treeCategories = await repository.findTrees()
+const treeCategories = await dataSource.manager.getTreeRepository(Category).findTrees()
 // returns root categories with sub categories inside
 
-const treeCategoriesWithLimitedDepth = await repository.findTrees({ depth: 2 })
+const treeCategoriesWithLimitedDepth = await dataSource.manager.getTreeRepository(Category).findTrees({ depth: 2 })
 // returns root categories with sub categories inside, up to depth 2
 ```
 
@@ -242,14 +242,14 @@ const treeCategoriesWithLimitedDepth = await repository.findTrees({ depth: 2 })
     Does not load children leafs.
 
 ```typescript
-const rootCategories = await repository.findRoots()
+const rootCategories = await dataSource.manager.getTreeRepository(Category).findRoots()
 // returns root categories without sub categories inside
 ```
 
 -   `findDescendants` - Gets all children (descendants) of the given entity. Returns them all in a flat array.
 
 ```typescript
-const children = await repository.findDescendants(parentCategory)
+const children = await dataSource.manager.getTreeRepository(Category).findDescendants(parentCategory)
 // returns all direct subcategories (without its nested categories) of a parentCategory
 ```
 
@@ -281,7 +281,7 @@ const children = await repository
 -   `countDescendants` - Gets number of descendants of the entity.
 
 ```typescript
-const childrenCount = await repository.countDescendants(parentCategory)
+const childrenCount = await dataSource.manager.getTreeRepository(Category).countDescendants(parentCategory)
 ```
 
 -   `findAncestors` - Gets all parent (ancestors) of the given entity. Returns them all in a flat array.
@@ -294,7 +294,7 @@ const parents = await repository.findAncestors(childCategory)
 -   `findAncestorsTree` - Gets all parent (ancestors) of the given entity. Returns them in a tree - nested into each other.
 
 ```typescript
-const parentsTree = await repository.findAncestorsTree(childCategory)
+const parentsTree = await dataSource.manager.getTreeRepository(Category).findAncestorsTree(childCategory)
 // returns all direct childCategory's parent categories (with "parent of parents")
 ```
 
@@ -310,7 +310,7 @@ const parents = await repository
 -   `countAncestors` - Gets the number of ancestors of the entity.
 
 ```typescript
-const parentsCount = await repository.countAncestors(childCategory)
+const parentsCount = await dataSource.manager.getTreeRepository(Category).countAncestors(childCategory)
 ```
 
 For the following methods, options can be passed:
@@ -329,12 +329,12 @@ The following options are available:
 Examples:
 
 ```typescript
-const treeCategoriesWithRelations = await repository.findTrees({
+const treeCategoriesWithRelations = await dataSource.manager.getTreeRepository(Category).findTrees({
     relations: ["sites"],
 })
 // automatically joins the sites relation
 
-const parentsWithRelations = await repository.findAncestors(childCategory, {
+const parentsWithRelations = await dataSource.manager.getTreeRepository(Category).findAncestors(childCategory, {
     relations: ["members"],
 })
 // returns all direct childCategory's parent categories (without "parent of parents") and joins the 'members' relation


### PR DESCRIPTION
Repository should be replaced by dataSource.manager.getTreeRepository(Category)

<!--
  😀 Wonderful!  Thank you for opening a pull request for TypeORM.

  Please fill in the information below to expedite the review
  and (hopefully) merge of your change.

  If unsure about something.. just do as best as you're able,
  or reach out through our community support channels!
  https://github.com/typeorm/typeorm/blob/master/docs/support.md
-->

### Description of change

<!--
  Please be clear and concise what the change is intended to do,
  why this change is needed, and how you've verified that it
  corrects what you intended.

  In some cases it may be helpful to include the current behavior
  and the new behavior.

  If the change is related to an open issue, you can link it here.
  If you include `Fixes #0000` (replacing `0000` with the issue number)
  when this is merged it will automatically mark the issue as fixed and
  close it.
-->


### Pull-Request Checklist

<!--
  Please make sure to review and check all of the following.

  If an item is not applicable, you can add "N/A" to the end.
-->

- [ ] Code is up-to-date with the `master` branch
- [ ] `npm run format` to apply prettier formatting
- [ ] `npm run test` passes with this change
- [ ] This pull request links relevant issues as `Fixes #0000`
- [ ] There are new or updated unit tests validating the change
- [ ] Documentation has been updated to reflect this change
- [ ] The new commits follow conventions explained in [CONTRIBUTING.md](https://github.com/typeorm/typeorm/blob/master/CONTRIBUTING.md)

<!--
  🎉 Thank you for contributing and making TypeORM even better!
-->
