### PR TITLE
Category do not accept any arguments, At line 167 it should be const …

### DIFF
--- a/docs/tree-entities.md
+++ b/docs/tree-entities.md
@@ -164,7 +164,7 @@ To bind tree entities to each other, it is required to set the parent in the chi
 for example:
 
 ```typescript
-const a1 = new Category("a1")
+const a1 = new Category()
 a1.name = "a1"
 await dataSource.manager.save(a1)
 


### PR DESCRIPTION
…a1 = new Category() insted of const a1 = new Category("a1")

At line 167 it should be const a1 = new Category() insted of const a1 = new Category("a1") 
Category do not accept any arguments

<!--
  😀 Wonderful!  Thank you for opening a pull request for TypeORM.

  Please fill in the information below to expedite the review
  and (hopefully) merge of your change.

  If unsure about something.. just do as best as you're able,
  or reach out through our community support channels!
  https://github.com/typeorm/typeorm/blob/master/docs/support.md
-->

### Description of change

<!--
  Please be clear and concise what the change is intended to do,
  why this change is needed, and how you've verified that it
  corrects what you intended.

  In some cases it may be helpful to include the current behavior
  and the new behavior.

  If the change is related to an open issue, you can link it here.
  If you include `Fixes #0000` (replacing `0000` with the issue number)
  when this is merged it will automatically mark the issue as fixed and
  close it.
-->


### Pull-Request Checklist

<!--
  Please make sure to review and check all of the following.

  If an item is not applicable, you can add "N/A" to the end.
-->

- [ ] Code is up-to-date with the `master` branch
- [ ] `npm run format` to apply prettier formatting
- [ ] `npm run test` passes with this change
- [ ] This pull request links relevant issues as `Fixes #0000`
- [ ] There are new or updated unit tests validating the change
- [ ] Documentation has been updated to reflect this change
- [ ] The new commits follow conventions explained in [CONTRIBUTING.md](https://github.com/typeorm/typeorm/blob/master/CONTRIBUTING.md)

<!--
  🎉 Thank you for contributing and making TypeORM even better!
-->
