### PR TITLE
Fix: Call `dataSource.destroy` only on initialized dataSource in commands

### DIFF
--- a/src/commands/CacheClearCommand.ts
+++ b/src/commands/CacheClearCommand.ts
@@ -51,7 +51,8 @@ export class CacheClearCommand implements yargs.CommandModule {
         } catch (err) {
             PlatformTools.logCmdErr("Error during cache clear.", err)
 
-            if (dataSource) await (dataSource as DataSource).destroy()
+            if (dataSource && dataSource.isInitialized)
+                await (dataSource as DataSource).destroy()
 
             process.exit(1)
         }

--- a/src/commands/MigrationRevertCommand.ts
+++ b/src/commands/MigrationRevertCommand.ts
@@ -69,7 +69,8 @@ export class MigrationRevertCommand implements yargs.CommandModule {
         } catch (err) {
             PlatformTools.logCmdErr("Error during migration revert:", err)
 
-            if (dataSource) await dataSource.destroy()
+            if (dataSource && dataSource.isInitialized)
+                await dataSource.destroy()
 
             process.exit(1)
         }

--- a/src/commands/MigrationRunCommand.ts
+++ b/src/commands/MigrationRunCommand.ts
@@ -72,7 +72,8 @@ export class MigrationRunCommand implements yargs.CommandModule {
         } catch (err) {
             PlatformTools.logCmdErr("Error during migration run:", err)
 
-            if (dataSource) await dataSource.destroy()
+            if (dataSource && dataSource.isInitialized)
+                await dataSource.destroy()
 
             process.exit(1)
         }

--- a/src/commands/MigrationShowCommand.ts
+++ b/src/commands/MigrationShowCommand.ts
@@ -42,7 +42,8 @@ export class MigrationShowCommand implements yargs.CommandModule {
         } catch (err) {
             PlatformTools.logCmdErr("Error during migration show:", err)
 
-            if (dataSource) await dataSource.destroy()
+            if (dataSource && dataSource.isInitialized)
+                await dataSource.destroy()
 
             process.exit(1)
         }

--- a/src/commands/QueryCommand.ts
+++ b/src/commands/QueryCommand.ts
@@ -74,7 +74,8 @@ export class QueryCommand implements yargs.CommandModule {
             PlatformTools.logCmdErr("Error during query execution:", err)
 
             if (queryRunner) await (queryRunner as QueryRunner).release()
-            if (dataSource) await dataSource.destroy()
+            if (dataSource && dataSource.isInitialized)
+                await dataSource.destroy()
 
             process.exit(1)
         }

--- a/src/commands/SchemaDropCommand.ts
+++ b/src/commands/SchemaDropCommand.ts
@@ -46,7 +46,8 @@ export class SchemaDropCommand implements yargs.CommandModule {
         } catch (err) {
             PlatformTools.logCmdErr("Error during schema drop:", err)
 
-            if (dataSource) await dataSource.destroy()
+            if (dataSource && dataSource.isInitialized)
+                await dataSource.destroy()
 
             process.exit(1)
         }

--- a/src/commands/SchemaSyncCommand.ts
+++ b/src/commands/SchemaSyncCommand.ts
@@ -46,7 +46,8 @@ export class SchemaSyncCommand implements yargs.CommandModule {
         } catch (err) {
             PlatformTools.logCmdErr("Error during schema synchronization:", err)
 
-            if (dataSource) await dataSource.destroy()
+            if (dataSource && dataSource.isInitialized)
+                await dataSource.destroy()
 
             process.exit(1)
         }


### PR DESCRIPTION
<!--
  😀 Wonderful!  Thank you for opening a pull request for TypeORM.

  Please fill in the information below to expedite the review
  and (hopefully) merge of your change.

  If unsure about something.. just do as best as you're able,
  or reach out through our community support channels!
  https://github.com/typeorm/typeorm/blob/master/docs/support.md
-->

### Description of change

If there is some problem in the configuration options in DataSource (e.g wrong hostname), the dataSource is not initialized, so calling `dataSource.destroy()` will cause error `Cannot execute operation on "${connectionName}" connection because connection is not yet established.`. I add simple check if the dataSource is initialized, so this error will not occur and user can focues on the real problem.

<!--
  Please be clear and concise what the change is intended to do,
  why this change is needed, and how you've verified that it
  corrects what you intended.

  In some cases it may be helpful to include the current behavior
  and the new behavior.

  If the change is related to an open issue, you can link it here.
  If you include `Fixes #0000` (replacing `0000` with the issue number)
  when this is merged it will automatically mark the issue as fixed and
  close it.
-->


### Pull-Request Checklist

<!--
  Please make sure to review and check all of the following.

  If an item is not applicable, you can add "N/A" to the end.
-->

- [x] Code is up-to-date with the `master` branch
- [x] `npm run format` to apply prettier formatting
- [x] `npm run test` passes with this change
- [ ] This pull request links relevant issues as `Fixes #0000`
- [ ] There are new or updated unit tests validating the change
- [ ] Documentation has been updated to reflect this change (not needed)
- [x] The new commits follow conventions explained in [CONTRIBUTING.md](https://github.com/typeorm/typeorm/blob/master/CONTRIBUTING.md)

<!--
  🎉 Thank you for contributing and making TypeORM even better!
-->
