### PR TITLE
fix: deep partial working with active records create and merge

### DIFF
--- a/src/common/DeepPartial.ts
+++ b/src/common/DeepPartial.ts
@@ -2,7 +2,7 @@
  * Same as Partial<T> but goes deeper and makes Partial<T> all its properties and sub-properties.
  */
 export type DeepPartial<T> =
-    | T
+    | Partial<T>
     | (T extends Array<infer U>
           ? DeepPartial<U>[]
           : T extends Map<infer K, infer V>

--- a/test/github-issues/8681/issue-8681.ts
+++ b/test/github-issues/8681/issue-8681.ts
@@ -25,7 +25,7 @@ describe("github issues > #8681 DeepPartial simplification breaks the .create() 
     it("should .save() and .create() complex deep partial entities", () =>
         Promise.all(
             connections.map(async (connection) => {
-                const myThing: DeepPartial<Thing> = {
+                const myThing = {
                     items: [{ id: 1 }, { id: 2 }],
                 }
 

--- a/test/github-issues/9150/entity/item.entity.ts
+++ b/test/github-issues/9150/entity/item.entity.ts
@@ -1,0 +1,10 @@
+import { BaseEntity, Column, Entity, PrimaryColumn } from "../../../../src"
+
+@Entity()
+export class Item extends BaseEntity {
+    @PrimaryColumn()
+    id: string
+
+    @Column()
+    value: number
+}

--- a/test/github-issues/9150/issue-9150.ts
+++ b/test/github-issues/9150/issue-9150.ts
@@ -1,0 +1,18 @@
+import { expect } from "chai"
+import "../../utils/test-setup"
+import { Item } from "./entity/item.entity"
+
+describe("github issues > #9150 DeepPartial update breaks Active Record create/merge", () => {
+    it("should create Item from a partial Item", async () => {
+        const input: Pick<Item, "value"> = { value: 42 }
+        const item = Item.create(input)
+        expect(item).deep.equals(input)
+    })
+
+    it("should merge Item with a partial Item", async () => {
+        const input: Pick<Item, "value"> = { value: 42 }
+        const item = Item.create()
+        const merge = Item.merge(item, input)
+        expect(merge).deep.equals(input)
+    })
+})


### PR DESCRIPTION
### Description of change

https://github.com/typeorm/typeorm/pull/8817 partially broke create & merge functions in Active Record setups.

```typescript
@Entity()
export class Item extends BaseEntity {
    @PrimaryColumn()
    id: string
    @Column()
    value: number
}

const input: Pick<Item, "value"> = { value: 42 }
const item = Item.create(input)
```

currently fails to compile because of

```
No overload matches this call.
  Overload 1 of 3, '(this: (new () => Item) & typeof BaseEntity, entityLikeArray: DeepPartial<Item>[]): Item[]', gave the following error.
    Argument of type 'Pick<Item, "value">' is not assignable to parameter of type 'DeepPartial<Item>[]'.
      Type 'Pick<Item, "value">' is missing the following properties from type 'DeepPartial<Item>[]': length, pop, push, concat, and 26 more.
  Overload 2 of 3, '(this: (new () => BaseEntity) & typeof BaseEntity, entityLike: DeepPartial<BaseEntity>): BaseEntity', gave the following error.
    Argument of type 'Pick<Item, "value">' is not assignable to parameter of type 'DeepPartial<BaseEntity>'.ts(2769)
BaseEntity.ts(185, 12): The call would have succeeded against this implementation, but implementation signatures of overloads are not externally visible.
```

### Pull-Request Checklist

- [x] Code is up-to-date with the `master` branch
- [x] `npm run format` to apply prettier formatting
- [x] `npm run test` passes with this change
- [x] This pull request links relevant issues as `Fixes #9150`
- [x] There are new or updated unit tests validating the change
- [ ] Documentation has been updated to reflect this change - N/A
- [x] The new commits follow conventions explained in [CONTRIBUTING.md](https://github.com/typeorm/typeorm/blob/master/CONTRIBUTING.md)

<!--
  🎉 Thank you for contributing and making TypeORM even better!
-->
