### PR TITLE
feat: add nativeBinding option to better-sqlite3 driver

### DIFF
--- a/docs/data-source-options.md
+++ b/docs/data-source-options.md
@@ -202,6 +202,8 @@ Different RDBMS-es have their own specific options.
 
 -   `prepareDatabase` - Function to run before a database is used in typeorm. You can access original better-sqlite3 Database object here.
 
+-   `nativeBinding` - Relative or absolute path to the native addon (better_sqlite3.node).
+
 ## `capacitor` data source options
 
 -   `database` - Database name (capacitor-sqlite will add the suffix `SQLite.db`)

--- a/src/driver/better-sqlite3/BetterSqlite3ConnectionOptions.ts
+++ b/src/driver/better-sqlite3/BetterSqlite3ConnectionOptions.ts
@@ -62,4 +62,9 @@ export interface BetterSqlite3ConnectionOptions extends BaseDataSourceOptions {
      * Provide a function that gets called with every SQL string executed by the database connection.
      */
     readonly verbose?: Function
+
+    /**
+     * Relative or absolute path to the native addon (better_sqlite3.node).
+     */
+    readonly nativeBinding?: string
 }

--- a/src/driver/better-sqlite3/BetterSqlite3Driver.ts
+++ b/src/driver/better-sqlite3/BetterSqlite3Driver.ts
@@ -1,9 +1,9 @@
 import mkdirp from "mkdirp"
 import path from "path"
-import { DriverPackageNotInstalledError } from '../../error'
-import { DriverOptionNotSetError } from '../../error'
+import { DriverPackageNotInstalledError } from "../../error"
+import { DriverOptionNotSetError } from "../../error"
 import { PlatformTools } from "../../platform/PlatformTools"
-import { DataSource } from '../../data-source'
+import { DataSource } from "../../data-source"
 import { ColumnType } from "../types/ColumnTypes"
 import { QueryRunner } from "../../query-runner/QueryRunner"
 import { AbstractSqliteDriver } from "../sqlite-abstract/AbstractSqliteDriver"
@@ -148,7 +148,7 @@ export class BetterSqlite3Driver extends AbstractSqliteDriver {
             fileMustExist,
             timeout,
             verbose,
-            nativeBinding
+            nativeBinding,
         })
         // in the options, if encryption key for SQLCipher is setted.
         // Must invoke key pragma before trying to do any other interaction with the database.

--- a/src/driver/better-sqlite3/BetterSqlite3Driver.ts
+++ b/src/driver/better-sqlite3/BetterSqlite3Driver.ts
@@ -1,9 +1,9 @@
 import mkdirp from "mkdirp"
 import path from "path"
-import { DriverPackageNotInstalledError } from "../../error/DriverPackageNotInstalledError"
-import { DriverOptionNotSetError } from "../../error/DriverOptionNotSetError"
+import { DriverPackageNotInstalledError } from '../../error'
+import { DriverOptionNotSetError } from '../../error'
 import { PlatformTools } from "../../platform/PlatformTools"
-import { DataSource } from "../../data-source/DataSource"
+import { DataSource } from '../../data-source'
 import { ColumnType } from "../types/ColumnTypes"
 import { QueryRunner } from "../../query-runner/QueryRunner"
 import { AbstractSqliteDriver } from "../sqlite-abstract/AbstractSqliteDriver"
@@ -140,6 +140,7 @@ export class BetterSqlite3Driver extends AbstractSqliteDriver {
             fileMustExist = false,
             timeout = 5000,
             verbose = null,
+            nativeBinding = null,
             prepareDatabase,
         } = this.options
         const databaseConnection = this.sqlite(database, {
@@ -147,6 +148,7 @@ export class BetterSqlite3Driver extends AbstractSqliteDriver {
             fileMustExist,
             timeout,
             verbose,
+            nativeBinding
         })
         // in the options, if encryption key for SQLCipher is setted.
         // Must invoke key pragma before trying to do any other interaction with the database.

--- a/test/functional/driver/better-sqlite3/better-sqlite3-native-binding.ts
+++ b/test/functional/driver/better-sqlite3/better-sqlite3-native-binding.ts
@@ -1,0 +1,28 @@
+import 'reflect-metadata';
+import {closeTestingConnections, createTestingConnections, reloadTestingDatabases} from '../../../utils/test-utils';
+import {expect} from 'chai';
+import {join} from 'path';
+import {DataSource} from '../../../../src';
+
+const pathToBetterSqliteNode = join(__dirname, '../../../../../../node_modules/better-sqlite3/build/Release/better_sqlite3.node');
+
+describe.only('option nativeBinding for better-sqlite3', () => {
+
+    let connections: DataSource[];
+    before(async () => connections = await createTestingConnections({
+        entities: [],
+        enabledDrivers: ['better-sqlite3'],
+        driverSpecific: {
+            nativeBinding: pathToBetterSqliteNode,
+        },
+    }));
+    beforeEach(() => reloadTestingDatabases(connections));
+    after(() => closeTestingConnections(connections));
+
+    it('should use a the path set in nativeBindings to the node file', () => Promise.all(connections.map(async connection => {
+        expect((connection.options as any).nativeBinding).to.be.eql(pathToBetterSqliteNode);
+        // how to test if driver works?
+    })));
+
+    // you can add additional tests if needed
+});

--- a/test/functional/driver/better-sqlite3/better-sqlite3-native-binding.ts
+++ b/test/functional/driver/better-sqlite3/better-sqlite3-native-binding.ts
@@ -33,9 +33,11 @@ describe.only("option nativeBinding for better-sqlite3", () => {
         Promise.all(
             connections.map(async (connection) => {
                 expect(
-                    (connection.driver.options as BetterSqlite3ConnectionOptions)
-                        .nativeBinding,
-                ).to.be.eql(pathToBetterSqliteNode);
+                    (
+                        connection.driver
+                            .options as BetterSqlite3ConnectionOptions
+                    ).nativeBinding,
+                ).to.be.eql(pathToBetterSqliteNode)
             }),
         ))
 })

--- a/test/functional/driver/better-sqlite3/better-sqlite3-native-binding.ts
+++ b/test/functional/driver/better-sqlite3/better-sqlite3-native-binding.ts
@@ -14,7 +14,7 @@ const pathToBetterSqliteNode = join(
     "../../../../../../node_modules/better-sqlite3/build/Release/better_sqlite3.node",
 )
 
-describe.only("option nativeBinding for better-sqlite3", () => {
+describe("option nativeBinding for better-sqlite3", () => {
     let connections: DataSource[]
     before(
         async () =>

--- a/test/functional/driver/better-sqlite3/better-sqlite3-native-binding.ts
+++ b/test/functional/driver/better-sqlite3/better-sqlite3-native-binding.ts
@@ -1,28 +1,41 @@
-import 'reflect-metadata';
-import {closeTestingConnections, createTestingConnections, reloadTestingDatabases} from '../../../utils/test-utils';
-import {expect} from 'chai';
-import {join} from 'path';
-import {DataSource} from '../../../../src';
+import "reflect-metadata"
+import {
+    closeTestingConnections,
+    createTestingConnections,
+    reloadTestingDatabases,
+} from "../../../utils/test-utils"
+import { expect } from "chai"
+import { join } from "path"
+import { DataSource } from "../../../../src"
+import { BetterSqlite3ConnectionOptions } from "../../../../src/driver/better-sqlite3/BetterSqlite3ConnectionOptions"
 
-const pathToBetterSqliteNode = join(__dirname, '../../../../../../node_modules/better-sqlite3/build/Release/better_sqlite3.node');
+const pathToBetterSqliteNode = join(
+    __dirname,
+    "../../../../../../node_modules/better-sqlite3/build/Release/better_sqlite3.node",
+)
 
-describe.only('option nativeBinding for better-sqlite3', () => {
+describe.only("option nativeBinding for better-sqlite3", () => {
+    let connections: DataSource[]
+    before(
+        async () =>
+            (connections = await createTestingConnections({
+                entities: [],
+                enabledDrivers: ["better-sqlite3"],
+                driverSpecific: {
+                    nativeBinding: pathToBetterSqliteNode,
+                },
+            })),
+    )
+    beforeEach(() => reloadTestingDatabases(connections))
+    after(() => closeTestingConnections(connections))
 
-    let connections: DataSource[];
-    before(async () => connections = await createTestingConnections({
-        entities: [],
-        enabledDrivers: ['better-sqlite3'],
-        driverSpecific: {
-            nativeBinding: pathToBetterSqliteNode,
-        },
-    }));
-    beforeEach(() => reloadTestingDatabases(connections));
-    after(() => closeTestingConnections(connections));
-
-    it('should use a the path set in nativeBindings to the node file', () => Promise.all(connections.map(async connection => {
-        expect((connection.options as any).nativeBinding).to.be.eql(pathToBetterSqliteNode);
-        // how to test if driver works?
-    })));
-
-    // you can add additional tests if needed
-});
+    it("should use a the path set in nativeBindings to the node file", () =>
+        Promise.all(
+            connections.map(async (connection) => {
+                expect(
+                    (connection.driver.options as BetterSqlite3ConnectionOptions)
+                        .nativeBinding,
+                ).to.be.eql(pathToBetterSqliteNode);
+            }),
+        ))
+})


### PR DESCRIPTION
### Description of change

better-sqlite3 allows to set the `nativeBinding` option since version v7.5.0. It allows to define a custom path for the native api binary `better_sqlite3.node`. This feature is very important for developers who want to create binaries of their node apps for different platforms (e.g. with pkg). [More information](https://github.com/WiseLibs/better-sqlite3/blob/master/docs/api.md#new-databasepath-options=).

### Remarks

- The test just checks if the `nativeBinding` option was set to the driver options.
- I tested the new build in my project with better-sqlite3 v7.5.3, it works fine.
- The `nativeBinding` option is only available in better-sqlite3 >= v7.5.0. Because "^7.1.2" already includes the latest package, I did not update the package.json. If someone uses < v7.5.0 setting `nativeBinding` does not affect anything.

### Pull-Request Checklist

- [x] Code is up-to-date with the `master` branch
- [x] `npm run format` to apply prettier formatting
- [x] `npm run test` passes with this change SEE REMARKS
- [x] This pull request links relevant issues as `Fixes #0000` N/A
- [x] There are new or updated unit tests validating the change
- [x] Documentation has been updated to reflect this change N/A
- [x] The new commits follow conventions explained in [CONTRIBUTING.md](https://github.com/typeorm/typeorm/blob/master/CONTRIBUTING.md)