### PR TITLE
fix: don't use temporary table name to create foreign key, unique, check constraint with SQLite

### DIFF
--- a/test/github-issues/9176/entity/Author.ts
+++ b/test/github-issues/9176/entity/Author.ts
@@ -1,0 +1,10 @@
+import { Column, Entity, PrimaryGeneratedColumn } from "../../../../src"
+
+@Entity()
+export class Author {
+    @PrimaryGeneratedColumn()
+    id: number
+
+    @Column()
+    name: string
+}

--- a/test/github-issues/9176/entity/Post.ts
+++ b/test/github-issues/9176/entity/Post.ts
@@ -1,0 +1,22 @@
+import {
+    Column,
+    Entity,
+    ManyToOne,
+    PrimaryGeneratedColumn,
+} from "../../../../src"
+import { Author } from "./Author"
+
+@Entity()
+export class Post {
+    @PrimaryGeneratedColumn()
+    id: number
+
+    @Column()
+    title: string
+
+    @Column()
+    text: string
+
+    @ManyToOne((type) => Author, { cascade: true, nullable: false })
+    author: Author
+}

--- a/test/github-issues/9176/entity/User.ts
+++ b/test/github-issues/9176/entity/User.ts
@@ -1,0 +1,33 @@
+import {
+    Check,
+    Column,
+    Entity,
+    PrimaryGeneratedColumn,
+    Unique,
+} from "../../../../src"
+
+@Entity()
+@Unique(["firstName", "lastName", "middleName"])
+export class User {
+    @PrimaryGeneratedColumn()
+    id: number
+
+    @Column()
+    firstName: string
+
+    @Column()
+    lastName: string
+
+    @Column()
+    middleName: string
+}
+
+@Entity()
+@Check(`"age" > 18`)
+export class CheckedUser {
+    @PrimaryGeneratedColumn()
+    id: number
+
+    @Column()
+    age: number
+}

--- a/test/github-issues/9176/issue-9176.ts
+++ b/test/github-issues/9176/issue-9176.ts
@@ -1,0 +1,113 @@
+import "reflect-metadata"
+import {
+    createTestingConnections,
+    closeTestingConnections,
+} from "../../utils/test-utils"
+import { DataSource } from "../../../src/data-source/DataSource"
+import { Author } from "./entity/Author"
+import { Post } from "./entity/Post"
+import { CheckedUser, User } from "./entity/User"
+import { CreatePostTable1656926770819 } from "./migration/1656926770819-CreatePostTable"
+import { CreateAuthorTable1656939116999 } from "./migration/1656939116999-CreateAuthorTable"
+import { AddAuthorIdColumn1656939646470 } from "./migration/1656939646470-AddAuthorIdColumn"
+import { CreateUserTable1657066872930 } from "./migration/1657066872930-CreateUserTable"
+import { CreateUniqueConstraintToUser1657067039714 } from "./migration/1657067039714-CreateUniqueConstraintToUser"
+import { CreateCheckedUserTable1657067039715 } from "./migration/1657067039715-CreateCheckedUserTable"
+import { CreateCheckConstraintToUser1657067039716 } from "./migration/1657067039716-CreateCheckConstraintToUser"
+import { expect } from "chai"
+
+describe("github issues > #9176 The names of foreign keys created by queryRunner.createForeignKey and schema:sync are different with SQLite", () => {
+    describe("github issues > #9176 foreign keys", () => {
+        let dataSources: DataSource[]
+        before(
+            async () =>
+                (dataSources = await createTestingConnections({
+                    entities: [Author, Post],
+                    enabledDrivers: ["sqlite" /*, "better-sqlite3"*/],
+                    migrations: [
+                        CreatePostTable1656926770819,
+                        CreateAuthorTable1656939116999,
+                        AddAuthorIdColumn1656939646470,
+                    ],
+                    schemaCreate: false,
+                    dropSchema: true,
+                })),
+        )
+        after(() => closeTestingConnections(dataSources))
+
+        it("should not generate queries when created foreign key with queryRunnner.createForeignKey", () =>
+            Promise.all(
+                dataSources.map(async (dataSource) => {
+                    await dataSource.runMigrations()
+                    const sqlInMemory = await dataSource.driver
+                        .createSchemaBuilder()
+                        .log()
+
+                    expect(sqlInMemory.upQueries).to.empty
+                    expect(sqlInMemory.downQueries).to.empty
+                }),
+            ))
+    })
+
+    describe("github issues > #9176 unique constraint", () => {
+        let dataSources: DataSource[]
+        before(
+            async () =>
+                (dataSources = await createTestingConnections({
+                    entities: [User],
+                    enabledDrivers: ["sqlite" /*, "better-sqlite3"*/],
+                    migrations: [
+                        CreateUserTable1657066872930,
+                        CreateUniqueConstraintToUser1657067039714,
+                    ],
+                    schemaCreate: false,
+                    dropSchema: true,
+                })),
+        )
+        after(() => closeTestingConnections(dataSources))
+
+        it("should not generate queries when created unique constraint with queryRunnner.createUniqueConstraint", () =>
+            Promise.all(
+                dataSources.map(async (dataSource) => {
+                    await dataSource.runMigrations()
+                    const sqlInMemory = await dataSource.driver
+                        .createSchemaBuilder()
+                        .log()
+
+                    expect(sqlInMemory.upQueries).to.empty
+                    expect(sqlInMemory.downQueries).to.empty
+                }),
+            ))
+    })
+
+    describe("github issues > #9176 check constraint", () => {
+        let dataSources: DataSource[]
+        before(
+            async () =>
+                (dataSources = await createTestingConnections({
+                    entities: [CheckedUser],
+                    enabledDrivers: ["sqlite" /*, "better-sqlite3"*/],
+                    migrations: [
+                        CreateCheckedUserTable1657067039715,
+                        CreateCheckConstraintToUser1657067039716,
+                    ],
+                    schemaCreate: false,
+                    dropSchema: true,
+                })),
+        )
+        after(() => closeTestingConnections(dataSources))
+
+        it("should not generate queries when created check constraint with queryRunnner.createCheckConstraint", () =>
+            Promise.all(
+                dataSources.map(async (dataSource) => {
+                    await dataSource.runMigrations()
+                    const sqlInMemory = await dataSource.driver
+                        .createSchemaBuilder()
+                        .log()
+
+                    expect(sqlInMemory.upQueries).to.empty
+                    expect(sqlInMemory.downQueries).to.empty
+                }),
+            ))
+    })
+})

--- a/test/github-issues/9176/issue-9176.ts
+++ b/test/github-issues/9176/issue-9176.ts
@@ -23,7 +23,7 @@ describe("github issues > #9176 The names of foreign keys created by queryRunner
             async () =>
                 (dataSources = await createTestingConnections({
                     entities: [Author, Post],
-                    enabledDrivers: ["sqlite" /*, "better-sqlite3"*/],
+                    enabledDrivers: ["sqlite"],
                     migrations: [
                         CreatePostTable1656926770819,
                         CreateAuthorTable1656939116999,
@@ -55,7 +55,7 @@ describe("github issues > #9176 The names of foreign keys created by queryRunner
             async () =>
                 (dataSources = await createTestingConnections({
                     entities: [User],
-                    enabledDrivers: ["sqlite" /*, "better-sqlite3"*/],
+                    enabledDrivers: ["sqlite"],
                     migrations: [
                         CreateUserTable1657066872930,
                         CreateUniqueConstraintToUser1657067039714,
@@ -86,7 +86,7 @@ describe("github issues > #9176 The names of foreign keys created by queryRunner
             async () =>
                 (dataSources = await createTestingConnections({
                     entities: [CheckedUser],
-                    enabledDrivers: ["sqlite" /*, "better-sqlite3"*/],
+                    enabledDrivers: ["sqlite"],
                     migrations: [
                         CreateCheckedUserTable1657067039715,
                         CreateCheckConstraintToUser1657067039716,

--- a/test/github-issues/9176/migration/1656926770819-CreatePostTable.ts
+++ b/test/github-issues/9176/migration/1656926770819-CreatePostTable.ts
@@ -1,0 +1,35 @@
+import { MigrationInterface, QueryRunner, Table } from "../../../../src"
+
+export class CreatePostTable1656926770819 implements MigrationInterface {
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.createTable(
+            new Table({
+                name: "post",
+                columns: [
+                    {
+                        name: "id",
+                        type: "integer",
+                        isPrimary: true,
+                        isGenerated: true,
+                        generationStrategy: "increment",
+                    },
+                    {
+                        name: "title",
+                        type: "varchar",
+                    },
+                    {
+                        name: "text",
+                        type: "varchar",
+                    },
+                ],
+            }),
+            true,
+            true,
+            true,
+        )
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.dropTable("post")
+    }
+}

--- a/test/github-issues/9176/migration/1656939116999-CreateAuthorTable.ts
+++ b/test/github-issues/9176/migration/1656939116999-CreateAuthorTable.ts
@@ -1,0 +1,31 @@
+import { MigrationInterface, QueryRunner, Table } from "../../../../src"
+
+export class CreateAuthorTable1656939116999 implements MigrationInterface {
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.createTable(
+            new Table({
+                name: "author",
+                columns: [
+                    {
+                        name: "id",
+                        type: "integer",
+                        isPrimary: true,
+                        isGenerated: true,
+                        generationStrategy: "increment",
+                    },
+                    {
+                        name: "name",
+                        type: "varchar",
+                    },
+                ],
+            }),
+            true,
+            true,
+            true,
+        )
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.dropTable("author")
+    }
+}

--- a/test/github-issues/9176/migration/1656939646470-AddAuthorIdColumn.ts
+++ b/test/github-issues/9176/migration/1656939646470-AddAuthorIdColumn.ts
@@ -1,0 +1,38 @@
+import {
+    MigrationInterface,
+    QueryRunner,
+    TableColumn,
+    TableForeignKey,
+} from "../../../../src"
+
+export class AddAuthorIdColumn1656939646470 implements MigrationInterface {
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.addColumn(
+            "post",
+            new TableColumn({
+                name: "authorId",
+                type: "integer",
+            }),
+        )
+        await queryRunner.createForeignKey(
+            "post",
+            new TableForeignKey({
+                columnNames: ["authorId"],
+                referencedTableName: "author",
+                referencedColumnNames: ["id"],
+            }),
+        )
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.dropForeignKey(
+            "post",
+            new TableForeignKey({
+                columnNames: ["authorId"],
+                referencedTableName: "author",
+                referencedColumnNames: ["id"],
+            }),
+        )
+        await queryRunner.dropColumn("post", "authorId")
+    }
+}

--- a/test/github-issues/9176/migration/1657066872930-CreateUserTable.ts
+++ b/test/github-issues/9176/migration/1657066872930-CreateUserTable.ts
@@ -1,0 +1,39 @@
+import { MigrationInterface, QueryRunner, Table } from "../../../../src"
+
+export class CreateUserTable1657066872930 implements MigrationInterface {
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.createTable(
+            new Table({
+                name: "user",
+                columns: [
+                    {
+                        name: "id",
+                        type: "integer",
+                        isPrimary: true,
+                        isGenerated: true,
+                        generationStrategy: "increment",
+                    },
+                    {
+                        name: "firstName",
+                        type: "varchar",
+                    },
+                    {
+                        name: "lastName",
+                        type: "varchar",
+                    },
+                    {
+                        name: "middleName",
+                        type: "varchar",
+                    },
+                ],
+            }),
+            true,
+            true,
+            true,
+        )
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.dropTable("user")
+    }
+}

--- a/test/github-issues/9176/migration/1657067039714-CreateUniqueConstraintToUser.ts
+++ b/test/github-issues/9176/migration/1657067039714-CreateUniqueConstraintToUser.ts
@@ -1,0 +1,23 @@
+import { MigrationInterface, QueryRunner, TableUnique } from "../../../../src"
+
+export class CreateUniqueConstraintToUser1657067039714
+    implements MigrationInterface
+{
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.createUniqueConstraint(
+            "user",
+            new TableUnique({
+                columnNames: ["firstName", "lastName", "middleName"],
+            }),
+        )
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.dropUniqueConstraint(
+            "user",
+            new TableUnique({
+                columnNames: ["firstName", "lastName", "middleName"],
+            }),
+        )
+    }
+}

--- a/test/github-issues/9176/migration/1657067039715-CreateCheckedUserTable.ts
+++ b/test/github-issues/9176/migration/1657067039715-CreateCheckedUserTable.ts
@@ -1,0 +1,31 @@
+import { MigrationInterface, QueryRunner, Table } from "../../../../src"
+
+export class CreateCheckedUserTable1657067039715 implements MigrationInterface {
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.createTable(
+            new Table({
+                name: "checked_user",
+                columns: [
+                    {
+                        name: "id",
+                        type: "integer",
+                        isPrimary: true,
+                        isGenerated: true,
+                        generationStrategy: "increment",
+                    },
+                    {
+                        name: "age",
+                        type: "integer",
+                    },
+                ],
+            }),
+            true,
+            true,
+            true,
+        )
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.dropTable("checked_user")
+    }
+}

--- a/test/github-issues/9176/migration/1657067039716-CreateCheckConstraintToUser.ts
+++ b/test/github-issues/9176/migration/1657067039716-CreateCheckConstraintToUser.ts
@@ -1,0 +1,23 @@
+import { MigrationInterface, QueryRunner, TableCheck } from "../../../../src"
+
+export class CreateCheckConstraintToUser1657067039716
+    implements MigrationInterface
+{
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.createCheckConstraint(
+            "checked_user",
+            new TableCheck({
+                expression: `"age" > 18`,
+            }),
+        )
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.dropCheckConstraint(
+            "checked_user",
+            new TableCheck({
+                expression: `"age" > 18`,
+            }),
+        )
+    }
+}

--- a/test/utils/test-utils.ts
+++ b/test/utils/test-utils.ts
@@ -61,7 +61,7 @@ export interface TestingOptions {
     /**
      * Migrations needs to be included in connection for the given test suite.
      */
-    migrations?: string[]
+    migrations?: (string | Function)[]
 
     /**
      * Subscribers needs to be included in the connection for the given test suite.


### PR DESCRIPTION
<!--
  😀 Wonderful!  Thank you for opening a pull request for TypeORM.

  Please fill in the information below to expedite the review
  and (hopefully) merge of your change.

  If unsure about something.. just do as best as you're able,
  or reach out through our community support channels!
  https://github.com/typeorm/typeorm/blob/master/docs/support.md
-->

### Description of change

In migration steps, finally temporary table name is renamed to original table name. these constraints name should be created from original table name not temporary table name.

<!--
  Please be clear and concise what the change is intended to do,
  why this change is needed, and how you've verified that it
  corrects what you intended.

  In some cases it may be helpful to include the current behavior
  and the new behavior.

  If the change is related to an open issue, you can link it here.
  If you include `Fixes #0000` (replacing `0000` with the issue number)
  when this is merged it will automatically mark the issue as fixed and
  close it.
-->

Fixes #9176


### Pull-Request Checklist

<!--
  Please make sure to review and check all of the following.

  If an item is not applicable, you can add "N/A" to the end.
-->

- [x] Code is up-to-date with the `master` branch
- [x] `npm run format` to apply prettier formatting
- [x] `npm run test` passes with this change
- [x] This pull request links relevant issues as `Fixes #9176`
- [x] There are new or updated unit tests validating the change
- [x] Documentation has been updated to reflect this change - N/A
- [x] The new commits follow conventions explained in [CONTRIBUTING.md](https://github.com/typeorm/typeorm/blob/master/CONTRIBUTING.md)

<!--
  🎉 Thank you for contributing and making TypeORM even better!
-->
