### PR TITLE
Update QueryBuilder.ts

### DIFF
--- a/src/query-builder/QueryBuilder.ts
+++ b/src/query-builder/QueryBuilder.ts
@@ -623,14 +623,19 @@ export abstract class QueryBuilder<Entity> {
      * schema name, otherwise returns escaped table name.
      */
     protected getTableName(tablePath: string): string {
-        return tablePath
-            .split(".")
-            .map((i) => {
-                // this condition need because in SQL Server driver when custom database name was specified and schema name was not, we got `dbName..tableName` string, and doesn't need to escape middle empty string
-                if (i === "") return i
-                return this.escape(i)
-            })
-            .join(".")
+        const tablePathArray = tablePath.split(".");
+        if (this.connection.driver.options.type === 'oracle' && tablePathArray.length == 2) {
+            // do not escape schema name in oracle
+            return tablePathArray[0] + "." + this.escape(tablePathArray[1]);
+        } else {
+            return tablePathArray
+                .map((i) => {
+                    // this condition need because in SQL Server driver when custom database name was specified and schema name was not, we got `dbName..tableName` string, and doesn't need to escape middle empty string
+                    if (i === "") return i
+                    return this.escape(i)
+                })
+                .join(".")
+        }
     }
 
     /**


### PR DESCRIPTION
fix: do not escape schema name for oracle

closes: #9194

<!--
  😀 Wonderful!  Thank you for opening a pull request for TypeORM.

  Please fill in the information below to expedite the review
  and (hopefully) merge of your change.

  If unsure about something.. just do as best as you're able,
  or reach out through our community support channels!
  https://github.com/typeorm/typeorm/blob/master/docs/support.md
-->

### Description of change

<!--
  Please be clear and concise what the change is intended to do,
  why this change is needed, and how you've verified that it
  corrects what you intended.

  In some cases it may be helpful to include the current behavior
  and the new behavior.

  If the change is related to an open issue, you can link it here.
  If you include `Fixes #0000` (replacing `0000` with the issue number)
  when this is merged it will automatically mark the issue as fixed and
  close it.
-->

The fix does not escape schema names for oracle, when a schema is configured.
So the generated queries look like `SELECT * FROM SCHEMA."TABLE"`.

Without the fix, the generated statements `SELECT * FROM "SCHEMA"."TABLE"` threw an error.

### Pull-Request Checklist

<!--
  Please make sure to review and check all of the following.

  If an item is not applicable, you can add "N/A" to the end.
-->

- [x] Code is up-to-date with the `master` branch
- [ ] `npm run format` to apply prettier formatting
- [ ] `npm run test` passes with this change
- [x] This pull request links relevant issues as `Fixes #0000`
- [ ] There are new or updated unit tests validating the change
- [ ] Documentation has been updated to reflect this change
- [x] The new commits follow conventions explained in [CONTRIBUTING.md](https://github.com/typeorm/typeorm/blob/master/CONTRIBUTING.md)

<!--
  🎉 Thank you for contributing and making TypeORM even better!
-->
