### PR TITLE
docs: correct mssql encrypt default value

### DIFF
--- a/docs/data-source-options.md
+++ b/docs/data-source-options.md
@@ -345,7 +345,7 @@ Different RDBMS-es have their own specific options.
     SQL Server Availability Group. For more information, see here. (default: `false`).
 
 -   `options.encrypt` - A boolean determining whether or not the connection will be encrypted. Set to true if you're
-    on Windows Azure. (default: `false`).
+    on Windows Azure. (default: `true`).
 
 -   `options.cryptoCredentialsDetails` - When encryption is used, an object may be supplied that will be used for the
     first argument when calling [tls.createSecurePair](http://nodejs.org/docs/latest/api/tls.html#tls_tls_createsecurepair_credentials_isserver_requestcert_rejectunauthorized)

--- a/docs/zh_CN/connection-options.md
+++ b/docs/zh_CN/connection-options.md
@@ -240,7 +240,7 @@
 
 - `options.readOnlyIntent` - 布尔值，确定连接是否将从SQL Server可用性组请求只读访问权限。 有关更多信息，请参阅此处。 （默认：`false`）。
 
-- `options.encrypt` - 确定连接是否将被加密的布尔值。 如果您使用的是Windows Azure，请设置为true。 （默认：`false`）。
+- `options.encrypt` - 确定连接是否将被加密的布尔值。 如果您使用的是Windows Azure，请设置为true。 （默认：`true`）。
 
 - `options.cryptoCredentialsDetails` - 使用加密时，可以提供一个对象，该对象在调用[tls.createSecurePair](http://nodejs.org/docs/latest/api/tls.html#tls_tls_createsecurepair_credentials_isserver_requestcert_rejectunauthorized)时将用于第一个参数（默认值：`{}`）。
 

--- a/src/driver/sqlserver/SqlServerConnectionOptions.ts
+++ b/src/driver/sqlserver/SqlServerConnectionOptions.ts
@@ -239,7 +239,7 @@ export interface SqlServerConnectionOptions
 
         /**
          * A boolean determining whether or not the connection will be encrypted. Set to true if you're on
-         * Windows Azure. (default: false).
+         * Windows Azure. (default: true).
          */
         readonly encrypt?: boolean
 


### PR DESCRIPTION
### Description of change

The [default value](https://github.com/tediousjs/node-mssql#tedious) is `true`.


### Pull-Request Checklist

- [x] Code is up-to-date with the `master` branch
- [ ] `npm run format` to apply prettier formatting
- [ ] `npm run test` passes with this change
- [ ] This pull request links relevant issues as `Fixes #0000`
- [ ] There are new or updated unit tests validating the change
- [x] Documentation has been updated to reflect this change
- [x] The new commits follow conventions explained in [CONTRIBUTING.md](https://github.com/typeorm/typeorm/blob/master/CONTRIBUTING.md)