### PR TITLE
fix: fix "Cannot commit, no transaction is active" error in sql.js

### DIFF
--- a/src/driver/sqljs/SqljsDriver.ts
+++ b/src/driver/sqljs/SqljsDriver.ts
@@ -199,9 +199,10 @@ export class SqljsDriver extends AbstractSqliteDriver {
      * If a custom autoSaveCallback is specified, it get's called with the database as Uint8Array,
      * otherwise the save method is called which saves it to file (Node.js), local storage (browser)
      * or indexedDB (browser with enabled useLocalForage option).
+     * Don't auto-save when in transaction as the call to export will end the current transaction
      */
     async autoSave() {
-        if (this.options.autoSave) {
+        if (this.options.autoSave && !this.queryRunner?.isTransactionActive) {
             if (this.options.autoSaveCallback) {
                 await this.options.autoSaveCallback(this.export())
             } else {

--- a/src/driver/sqljs/SqljsQueryRunner.ts
+++ b/src/driver/sqljs/SqljsQueryRunner.ts
@@ -66,7 +66,9 @@ export class SqljsQueryRunner extends AbstractSqliteQueryRunner {
      */
     async commitTransaction(): Promise<void> {
         await super.commitTransaction()
-        await this.flush()
+        if (!this.isTransactionActive) {
+            await this.flush()
+        }
     }
 
     /**


### PR DESCRIPTION
Fixes: #9100

<!--
  😀 Wonderful!  Thank you for opening a pull request for TypeORM.

  Please fill in the information below to expedite the review
  and (hopefully) merge of your change.

  If unsure about something.. just do as best as you're able,
  or reach out through our community support channels!
  https://github.com/typeorm/typeorm/blob/master/docs/support.md
-->

### Description of change

When calling `autoSave` in a transaction, typeorm automatically closes the transaction in the `export` method. Therefore, when calling `commitTransaction`, the transaction is already committed and sqljs throws an exception "Cannot commit, no transaction is active".
This fix disables `autoSave` during the transaction to avoid this. Of course, `autoSave` is still called after the transaction, when calling commit. 

There was another PR for this issue (https://github.com/typeorm/typeorm/pull/9101) but this fix is not working when saving the database inside a transaction. If we call a `find` on the repository, typeorm releases the connection and it's calling `autoSave`. Waiting for the transaction to finish before saving was not working as we wait indefinitely.
<!--
  Please be clear and concise what the change is intended to do,
  why this change is needed, and how you've verified that it
  corrects what you intended.

  In some cases it may be helpful to include the current behavior
  and the new behavior.

  If the change is related to an open issue, you can link it here.
  If you include `Fixes #0000` (replacing `0000` with the issue number)
  when this is merged it will automatically mark the issue as fixed and
  close it.
-->


### Pull-Request Checklist

<!--
  Please make sure to review and check all of the following.

  If an item is not applicable, you can add "N/A" to the end.
-->

- [X] Code is up-to-date with the `master` branch
- [X] `npm run format` to apply prettier formatting
- [x] `npm run test` passes with this change
- [x] This pull request links relevant issues as `Fixes #0000`
- [ ] There are new or updated unit tests validating the change N/A
- [ ] Documentation has been updated to reflect this change N/A
- [X] The new commits follow conventions explained in [CONTRIBUTING.md](https://github.com/typeorm/typeorm/blob/master/CONTRIBUTING.md)

<!--
  🎉 Thank you for contributing and making TypeORM even better!
-->
