### PR TITLE
fix: update date utils to parse year correctly for years 1-999

### DIFF
--- a/src/util/DateUtils.ts
+++ b/src/util/DateUtils.ts
@@ -28,11 +28,11 @@ export class DateUtils {
     static mixedDateToDateString(value: string | Date): string {
         if (value instanceof Date)
             return (
-                this.formatZerolessValue(value.getFullYear()) +
+                this.formatZerolessValue(value.getFullYear(), 4) +
                 "-" +
-                this.formatZerolessValue(value.getMonth() + 1) +
+                this.formatZerolessValue(value.getMonth() + 1, 2) +
                 "-" +
-                this.formatZerolessValue(value.getDate())
+                this.formatZerolessValue(value.getDate(), 2)
             )
 
         return value
@@ -88,11 +88,11 @@ export class DateUtils {
     ): string | any {
         if (value instanceof Date)
             return (
-                this.formatZerolessValue(value.getHours()) +
+                this.formatZerolessValue(value.getHours(), 2) +
                 ":" +
-                this.formatZerolessValue(value.getMinutes()) +
+                this.formatZerolessValue(value.getMinutes(), 2) +
                 (!skipSeconds
-                    ? ":" + this.formatZerolessValue(value.getSeconds())
+                    ? ":" + this.formatZerolessValue(value.getSeconds(), 2)
                     : "")
             )
 
@@ -151,17 +151,17 @@ export class DateUtils {
         }
         if (value instanceof Date) {
             let finalValue =
-                this.formatZerolessValue(value.getFullYear()) +
+                this.formatZerolessValue(value.getFullYear(), 4) +
                 "-" +
-                this.formatZerolessValue(value.getMonth() + 1) +
+                this.formatZerolessValue(value.getMonth() + 1, 2) +
                 "-" +
-                this.formatZerolessValue(value.getDate()) +
+                this.formatZerolessValue(value.getDate(), 2) +
                 " " +
-                this.formatZerolessValue(value.getHours()) +
+                this.formatZerolessValue(value.getHours(), 2) +
                 ":" +
-                this.formatZerolessValue(value.getMinutes()) +
+                this.formatZerolessValue(value.getMinutes(), 2) +
                 ":" +
-                this.formatZerolessValue(value.getSeconds())
+                this.formatZerolessValue(value.getSeconds(), 2)
 
             if (useMilliseconds)
                 finalValue += `.${this.formatMilliseconds(
@@ -183,17 +183,17 @@ export class DateUtils {
         }
         if (value instanceof Date) {
             return (
-                this.formatZerolessValue(value.getUTCFullYear()) +
+                this.formatZerolessValue(value.getUTCFullYear(), 4) +
                 "-" +
-                this.formatZerolessValue(value.getUTCMonth() + 1) +
+                this.formatZerolessValue(value.getUTCMonth() + 1, 2) +
                 "-" +
-                this.formatZerolessValue(value.getUTCDate()) +
+                this.formatZerolessValue(value.getUTCDate(), 2) +
                 " " +
-                this.formatZerolessValue(value.getUTCHours()) +
+                this.formatZerolessValue(value.getUTCHours(), 2) +
                 ":" +
-                this.formatZerolessValue(value.getUTCMinutes()) +
+                this.formatZerolessValue(value.getUTCMinutes(), 2) +
                 ":" +
-                this.formatZerolessValue(value.getUTCSeconds()) +
+                this.formatZerolessValue(value.getUTCSeconds(), 2) +
                 "." +
                 this.formatMilliseconds(value.getUTCMilliseconds())
             )
@@ -258,12 +258,15 @@ export class DateUtils {
     // -------------------------------------------------------------------------
 
     /**
-     * Formats given number to "0x" format, e.g. if it is 1 then it will return "01".
+     * Formats given number to "0x" format, e.g. if the totalLength = 2 and the value is 1 then it will return "01".
      */
-    private static formatZerolessValue(value: number): string {
-        if (value < 10) return "0" + value
+    private static formatZerolessValue(
+        value: number,
+        totalLength: number,
+    ): string {
+        const pad = "0".repeat(totalLength)
 
-        return String(value)
+        return String(`${pad}${value}`).slice(-totalLength)
     }
 
     /**

--- a/src/util/DateUtils.ts
+++ b/src/util/DateUtils.ts
@@ -30,9 +30,9 @@ export class DateUtils {
             return (
                 this.formatZerolessValue(value.getFullYear(), 4) +
                 "-" +
-                this.formatZerolessValue(value.getMonth() + 1, 2) +
+                this.formatZerolessValue(value.getMonth() + 1) +
                 "-" +
-                this.formatZerolessValue(value.getDate(), 2)
+                this.formatZerolessValue(value.getDate())
             )
 
         return value
@@ -88,11 +88,11 @@ export class DateUtils {
     ): string | any {
         if (value instanceof Date)
             return (
-                this.formatZerolessValue(value.getHours(), 2) +
+                this.formatZerolessValue(value.getHours()) +
                 ":" +
-                this.formatZerolessValue(value.getMinutes(), 2) +
+                this.formatZerolessValue(value.getMinutes()) +
                 (!skipSeconds
-                    ? ":" + this.formatZerolessValue(value.getSeconds(), 2)
+                    ? ":" + this.formatZerolessValue(value.getSeconds())
                     : "")
             )
 
@@ -153,15 +153,15 @@ export class DateUtils {
             let finalValue =
                 this.formatZerolessValue(value.getFullYear(), 4) +
                 "-" +
-                this.formatZerolessValue(value.getMonth() + 1, 2) +
+                this.formatZerolessValue(value.getMonth() + 1) +
                 "-" +
-                this.formatZerolessValue(value.getDate(), 2) +
+                this.formatZerolessValue(value.getDate()) +
                 " " +
-                this.formatZerolessValue(value.getHours(), 2) +
+                this.formatZerolessValue(value.getHours()) +
                 ":" +
-                this.formatZerolessValue(value.getMinutes(), 2) +
+                this.formatZerolessValue(value.getMinutes()) +
                 ":" +
-                this.formatZerolessValue(value.getSeconds(), 2)
+                this.formatZerolessValue(value.getSeconds())
 
             if (useMilliseconds)
                 finalValue += `.${this.formatMilliseconds(
@@ -185,15 +185,15 @@ export class DateUtils {
             return (
                 this.formatZerolessValue(value.getUTCFullYear(), 4) +
                 "-" +
-                this.formatZerolessValue(value.getUTCMonth() + 1, 2) +
+                this.formatZerolessValue(value.getUTCMonth() + 1) +
                 "-" +
-                this.formatZerolessValue(value.getUTCDate(), 2) +
+                this.formatZerolessValue(value.getUTCDate()) +
                 " " +
-                this.formatZerolessValue(value.getUTCHours(), 2) +
+                this.formatZerolessValue(value.getUTCHours()) +
                 ":" +
-                this.formatZerolessValue(value.getUTCMinutes(), 2) +
+                this.formatZerolessValue(value.getUTCMinutes()) +
                 ":" +
-                this.formatZerolessValue(value.getUTCSeconds(), 2) +
+                this.formatZerolessValue(value.getUTCSeconds()) +
                 "." +
                 this.formatMilliseconds(value.getUTCMilliseconds())
             )
@@ -260,10 +260,7 @@ export class DateUtils {
     /**
      * Formats given number to "0x" format, e.g. if the totalLength = 2 and the value is 1 then it will return "01".
      */
-    private static formatZerolessValue(
-        value: number,
-        totalLength: number,
-    ): string {
+    private static formatZerolessValue(value: number, totalLength = 2): string {
         const pad = "0".repeat(totalLength)
 
         return String(`${pad}${value}`).slice(-totalLength)

--- a/test/github-issues/9230/issue-9230.ts
+++ b/test/github-issues/9230/issue-9230.ts
@@ -1,0 +1,12 @@
+import { DateUtils } from "../../../src/util/DateUtils"
+import { expect } from "chai"
+
+describe("github issues > #9230 Incorrect date parsing for year 1-999", () => {
+    describe("mixedDateToDateString", () => {
+        it("should format a year less than 1000 with correct 0 padding", () => {
+            expect(
+                DateUtils.mixedDateToDateString(new Date("0202-01-01")),
+            ).to.eq("0202-01-01")
+        })
+    })
+})


### PR DESCRIPTION
<!--
  😀 Wonderful!  Thank you for opening a pull request for TypeORM.

  Please fill in the information below to expedite the review
  and (hopefully) merge of your change.

  If unsure about something.. just do as best as you're able,
  or reach out through our community support channels!
  https://github.com/typeorm/typeorm/blob/master/docs/support.md
-->

### Description of change

Update DateUtils to correctly handle years less than 999.  For instance, a date of 0999-01-01 should parse to the same string value with a leading 0 for the year.  Previously, the output would not contain the leading 0.

Fixes: #9230

<!--
  Please be clear and concise what the change is intended to do,
  why this change is needed, and how you've verified that it
  corrects what you intended.

  In some cases it may be helpful to include the current behavior
  and the new behavior.

  If the change is related to an open issue, you can link it here.
  If you include `Fixes #0000` (replacing `0000` with the issue number)
  when this is merged it will automatically mark the issue as fixed and
  close it.
-->


### Pull-Request Checklist

<!--
  Please make sure to review and check all of the following.

  If an item is not applicable, you can add "N/A" to the end.
-->

- [x] Code is up-to-date with the `master` branch
- [x] `npm run format` to apply prettier formatting
- [x] `npm run test` passes with this change
- [x] This pull request links relevant issues as `Fixes #0000`
- [x] There are new or updated unit tests validating the change
- [x] Documentation has been updated to reflect this change
- [x] The new commits follow conventions explained in [CONTRIBUTING.md](https://github.com/typeorm/typeorm/blob/master/CONTRIBUTING.md)

<!--
  🎉 Thank you for contributing and making TypeORM even better!
-->
