### PR TITLE
fix: allow space and no-space syntaxes for SQLite constraints

### DIFF
--- a/src/driver/sqlite-abstract/AbstractSqliteQueryRunner.ts
+++ b/src/driver/sqlite-abstract/AbstractSqliteQueryRunner.ts
@@ -1499,7 +1499,7 @@ export abstract class AbstractSqliteQueryRunner
                     }),
                 )
 
-                // find unique constraints from CREATE TABLE sql
+                // find foreign key constraints from CREATE TABLE sql
                 let fkResult
                 const fkMappings: {
                     name: string
@@ -1507,7 +1507,7 @@ export abstract class AbstractSqliteQueryRunner
                     referencedTableName: string
                 }[] = []
                 const fkRegex =
-                    /CONSTRAINT "([^"]*)" FOREIGN KEY \((.*?)\) REFERENCES "([^"]*)" /g
+                    /CONSTRAINT "([^"]*)" FOREIGN KEY ?\((.*?)\) REFERENCES "([^"]*)"/g
                 while ((fkResult = fkRegex.exec(sql)) !== null) {
                     fkMappings.push({
                         name: fkResult[1],
@@ -1563,7 +1563,7 @@ export abstract class AbstractSqliteQueryRunner
                 // find unique constraints from CREATE TABLE sql
                 let uniqueRegexResult
                 const uniqueMappings: { name: string; columns: string[] }[] = []
-                const uniqueRegex = /CONSTRAINT "([^"]*)" UNIQUE \((.*?)\)/g
+                const uniqueRegex = /CONSTRAINT "([^"]*)" UNIQUE ?\((.*?)\)/g
                 while ((uniqueRegexResult = uniqueRegex.exec(sql)) !== null) {
                     uniqueMappings.push({
                         name: uniqueRegexResult[1],
@@ -1627,7 +1627,8 @@ export abstract class AbstractSqliteQueryRunner
 
                 // build checks
                 let result
-                const regexp = /CONSTRAINT "([^"]*)" CHECK (\(.*?\))([,]|[)]$)/g
+                const regexp =
+                    /CONSTRAINT "([^"]*)" CHECK ?(\(.*?\))([,]|[)]$)/g
                 while ((result = regexp.exec(sql)) !== null) {
                     table.checks.push(
                         new TableCheck({


### PR DESCRIPTION
<!--
  😀 Wonderful!  Thank you for opening a pull request for TypeORM.

  Please fill in the information below to expedite the review
  and (hopefully) merge of your change.

  If unsure about something.. just do as best as you're able,
  or reach out through our community support channels!
  https://github.com/typeorm/typeorm/blob/master/docs/support.md
-->

### Description of change

Fixes #9237

The regex for SQLite constraints now accepts both space and no-space syntaxes for `FOREIGN KEY`, `CHECK` and `UNIQUE` constraints.
Both syntaxes exist on the web:
- no-space: https://www.sqlite.org/foreignkeys.html
- space: https://www.sqlitetutorial.net/sqlite-foreign-key/
<!--
  Please be clear and concise what the change is intended to do,
  why this change is needed, and how you've verified that it
  corrects what you intended.

  In some cases it may be helpful to include the current behavior
  and the new behavior.

  If the change is related to an open issue, you can link it here.
  If you include `Fixes #0000` (replacing `0000` with the issue number)
  when this is merged it will automatically mark the issue as fixed and
  close it.
-->


### Pull-Request Checklist

<!--
  Please make sure to review and check all of the following.

  If an item is not applicable, you can add "N/A" to the end.
-->

- [X] Code is up-to-date with the `master` branch
- [X] `npm run format` to apply prettier formatting
- [X] `npm run test` passes with this change
- [X] This pull request links relevant issues as `Fixes #0000`
- [ ] There are new or updated unit tests validating the change N/A
- [ ] Documentation has been updated to reflect this change N/A
- [X] The new commits follow conventions explained in [CONTRIBUTING.md](https://github.com/typeorm/typeorm/blob/master/CONTRIBUTING.md)

<!--
  🎉 Thank you for contributing and making TypeORM even better!
-->
