### PR TITLE
fix: handle inherited relations insert order

### DIFF
--- a/src/persistence/SubjectTopoligicalSorter.ts
+++ b/src/persistence/SubjectTopoligicalSorter.ts
@@ -67,7 +67,9 @@ export class SubjectTopoligicalSorter {
         // add those sorted targets and remove them from original array of targets
         sortedNonNullableEntityTargets.forEach((sortedEntityTarget) => {
             const entityTargetSubjects = this.subjects.filter(
-                (subject) => subject.metadata.targetName === sortedEntityTarget,
+                (subject) =>
+                    subject.metadata.targetName === sortedEntityTarget ||
+                    subject.metadata.parentEntityMetadata?.targetName,
             )
             sortedSubjects.push(...entityTargetSubjects)
             this.removeAlreadySorted(entityTargetSubjects)

--- a/test/github-issues/9241/entity/Employee.ts
+++ b/test/github-issues/9241/entity/Employee.ts
@@ -1,0 +1,9 @@
+import { Column, ChildEntity } from "../../../../src"
+
+import { User } from "./User"
+
+@ChildEntity()
+export class Employee extends User {
+    @Column()
+    salary: number
+}

--- a/test/github-issues/9241/entity/Photo.ts
+++ b/test/github-issues/9241/entity/Photo.ts
@@ -1,0 +1,22 @@
+import {
+    OneToMany,
+    Entity,
+    PrimaryGeneratedColumn,
+    Column,
+} from "../../../../src"
+
+import { UserPhoto } from "./UserPhoto"
+
+@Entity()
+export class Photo {
+    @PrimaryGeneratedColumn()
+    id: number
+
+    @Column()
+    name: string
+
+    @OneToMany(() => UserPhoto, (userPhoto) => userPhoto.photo, {
+        cascade: true,
+    })
+    userPhotos: UserPhoto[]
+}

--- a/test/github-issues/9241/entity/User.ts
+++ b/test/github-issues/9241/entity/User.ts
@@ -1,0 +1,24 @@
+import {
+    Entity,
+    PrimaryGeneratedColumn,
+    OneToMany,
+    Column,
+    TableInheritance,
+} from "../../../../src"
+
+import { UserPhoto } from "./UserPhoto"
+
+@Entity()
+@TableInheritance({ column: { type: "varchar", name: "type" } })
+export class User {
+    @PrimaryGeneratedColumn()
+    id: number
+
+    @Column()
+    name: string
+
+    @OneToMany(() => UserPhoto, (userPhoto) => userPhoto.user, {
+        cascade: true,
+    })
+    userPhotos: UserPhoto[]
+}

--- a/test/github-issues/9241/entity/UserPhoto.ts
+++ b/test/github-issues/9241/entity/UserPhoto.ts
@@ -1,0 +1,22 @@
+import { Column, PrimaryColumn, ManyToOne, Entity } from "../../../../src"
+
+import { User } from "./User"
+import { Photo } from "./Photo"
+
+@Entity()
+export class UserPhoto {
+    @Column()
+    isProfilePhoto: boolean
+
+    @ManyToOne(() => User, (user) => user.userPhotos, { nullable: false })
+    user: User
+
+    @PrimaryColumn()
+    userId: User["id"]
+
+    @ManyToOne(() => Photo, (photo) => photo.userPhotos, { nullable: false })
+    photo: Photo
+
+    @PrimaryColumn()
+    photoId: Photo["id"]
+}

--- a/test/github-issues/9241/issue-9241.ts
+++ b/test/github-issues/9241/issue-9241.ts
@@ -1,0 +1,58 @@
+import "reflect-metadata"
+import { expect } from "chai"
+import {
+    createTestingConnections,
+    closeTestingConnections,
+    reloadTestingDatabases,
+} from "../../utils/test-utils"
+import { DataSource, DeepPartial } from "../../../src"
+
+import { Employee } from "./entity/Employee"
+import { Photo } from "./entity/Photo"
+
+describe("github issues > #9241 Incorrect insert order when cascade inserting parent inherited relations", () => {
+    let connections: DataSource[]
+    before(
+        async () =>
+            (connections = await createTestingConnections({
+                entities: [__dirname + "/entity/*{.js,.ts}"],
+                enabledDrivers: ["sqlite", "better-sqlite3"],
+                schemaCreate: true,
+                dropSchema: true,
+            })),
+    )
+    beforeEach(() => reloadTestingDatabases(connections))
+    after(() => closeTestingConnections(connections))
+
+    it("should save entities properly", async () => {
+        for (const connection of connections) {
+            const photos: DeepPartial<Photo>[] = [
+                { name: "Photo 1" },
+                { name: "Photo 2" },
+            ]
+
+            await connection.getRepository(Photo).save(photos)
+
+            const employee: DeepPartial<Employee> = {
+                name: "test name",
+                salary: 12345,
+                userPhotos: [
+                    {
+                        photo: photos[0],
+                        isProfilePhoto: true,
+                    },
+                    {
+                        photo: photos[1],
+                        isProfilePhoto: false,
+                    },
+                ],
+            }
+
+            const employeeRepository = connection.getRepository(Employee)
+            const createdEmployee = employeeRepository.create(employee)
+
+            await expect(employeeRepository.save(createdEmployee)).to.eventually
+                .be.fulfilled
+        }
+    })
+})


### PR DESCRIPTION
Take inheritance into consideration when sorting insert commands

Closes: #9241

<!--
  😀 Wonderful!  Thank you for opening a pull request for TypeORM.

  Please fill in the information below to expedite the review
  and (hopefully) merge of your change.

  If unsure about something.. just do as best as you're able,
  or reach out through our community support channels!
  https://github.com/typeorm/typeorm/blob/master/docs/support.md
-->

### Description of change

<!--
  Please be clear and concise what the change is intended to do,
  why this change is needed, and how you've verified that it
  corrects what you intended.

  In some cases it may be helpful to include the current behavior
  and the new behavior.

  If the change is related to an open issue, you can link it here.
  If you include `Fixes #0000` (replacing `0000` with the issue number)
  when this is merged it will automatically mark the issue as fixed and
  close it.
-->

The insert commands are executed in correct order when an entity has nested relation inherited from a parent entity through @TableInheritance


### Pull-Request Checklist

<!--
  Please make sure to review and check all of the following.

  If an item is not applicable, you can add "N/A" to the end.
-->

- [x] Code is up-to-date with the `master` branch
- [x] `npm run format` to apply prettier formatting
- [ ] `npm run test` passes with this change
- [x] This pull request links relevant issues as `Fixes #9241 `
- [x] There are new or updated unit tests validating the change
- [ ] Documentation has been updated to reflect this change N/A
- [x] The new commits follow conventions explained in [CONTRIBUTING.md](https://github.com/typeorm/typeorm/blob/master/CONTRIBUTING.md)

<!--
  🎉 Thank you for contributing and making TypeORM even better!
-->
