### PR TITLE
fix: add DataSource findMetadata support for functions/classes

### DIFF
--- a/src/data-source/DataSource.ts
+++ b/src/data-source/DataSource.ts
@@ -641,6 +641,16 @@ export class DataSource {
                     )
                 }
             }
+            if (
+                target !== null &&
+                typeof target === "function" &&
+                typeof target.name === "string"
+            ) {
+                return (
+                    metadata.name === target.name ||
+                    metadata.tableName === target.name
+                )
+            }
 
             return false
         })


### PR DESCRIPTION
<!--
  😀 Wonderful!  Thank you for opening a pull request for TypeORM.

  Please fill in the information below to expedite the review
  and (hopefully) merge of your change.

  If unsure about something.. just do as best as you're able,
  or reach out through our community support channels!
  https://github.com/typeorm/typeorm/blob/master/docs/support.md
-->

### Description of change

Implemented to support inline imports of `Class` for `DataSource` entities.

The current implementation would fail

```ts
if (metadata.target === target) return true
```

My goal was to continue to use single imports for `getRepository()` but dynamically import all files in entities folder instead of relying on [`importClassesFromDirectories`](https://github.com/typeorm/typeorm/blob/bb33cd0f23d566c0d87fcb57e42bd611761cc106/src/util/DirectoryExportedClassesLoader.ts#L11).

For example:

```ts
let entities

function importSth(toImport: string[]) {
  return toImport.map(((f) => import('./entities/' + f).then((res) => Object.values(res))))
}

if (isNext() !== undefined) {
  entitiesPath = join(process.cwd(), `src/entities`, `*.ts`)

  const dir = dirname(fileURLToPath(import.meta.url))

  const toImport = readdirSync(resolve(dir, './entities')).filter((f) => {
    return f.endsWith(`.ts`)
  })

  entities = (await Promise.all(importSth(toImport))).flat()
}
```

<!--
  Please be clear and concise what the change is intended to do,
  why this change is needed, and how you've verified that it
  corrects what you intended.

  In some cases it may be helpful to include the current behavior
  and the new behavior.

  If the change is related to an open issue, you can link it here.
  If you include `Fixes #0000` (replacing `0000` with the issue number)
  when this is merged it will automatically mark the issue as fixed and
  close it.
-->


### Pull-Request Checklist

<!--
  Please make sure to review and check all of the following.

  If an item is not applicable, you can add "N/A" to the end.
-->

- [x] Code is up-to-date with the `master` branch
- [x] `npm run format` to apply prettier formatting
- [x] `npm run test` passes with this change
- [x] This pull request links relevant issues as `Fixes #0000` N/A
- [x] There are new or updated unit tests validating the change N/A
- [x] Documentation has been updated to reflect this change N/A
- [x] The new commits follow conventions explained in [CONTRIBUTING.md](https://github.com/typeorm/typeorm/blob/master/CONTRIBUTING.md)

<!--
  🎉 Thank you for contributing and making TypeORM even better!
-->
