### PR TITLE
SelectQueryBuilder.getRawOneOrFail

### DIFF
--- a/src/query-builder/SelectQueryBuilder.ts
+++ b/src/query-builder/SelectQueryBuilder.ts
@@ -1531,6 +1531,20 @@ export class SelectQueryBuilder<Entity>
     }
 
     /**
+     * Gets first raw result returned by execution of generated query builder sql or rejects the returned promise on error.
+     */
+    async getRawOneOrFail<T = any>(): Promise<T> {
+        const result = await this.getRawOne<T>()
+        if (!result) {
+            throw new EntityNotFoundError(
+                this.expressionMap.mainAlias!.target,
+                this,
+            )
+        }
+        return result
+    }
+
+    /**
      * Gets all raw results returned by execution of generated query builder sql.
      */
     async getRawMany<T = any>(): Promise<T[]> {


### PR DESCRIPTION
### Description of change

Added `getRawOneOrFail` method on `SelectQueryBuilder` and this method is exactly the same as `getOneOrFail`.

```typescript


async getOneOrFail(): Promise<Entity> {
    const entity = await this.getOne()
    if (!entity) {
        throw new EntityNotFoundError(
            this.expressionMap.mainAlias!.target,
            this,
        )
    }
    return entity
}


async getRawOneOrFail<T = any>(): Promise<T> {
    const result = await this.getRawOne<T>()
    if (!result) {
        throw new EntityNotFoundError(
            this.expressionMap.mainAlias!.target,
            this,
        )
    }
    return result
}

```

### Pull-Request Checklist

<!--
  Please make sure to review and check all of the following.

  If an item is not applicable, you can add "N/A" to the end.
-->

- [x] Code is up-to-date with the `master` branch
- [x] `npm run format` to apply prettier formatting
- [x] `npm run test` passes with this change
- [ ] This pull request links relevant issues as `Fixes #0000` N/A
- [ ] There are new or updated unit tests validating the change N/A
- [ ] Documentation has been updated to reflect this change
- [x] The new commits follow conventions explained in [CONTRIBUTING.md](https://github.com/typeorm/typeorm/blob/master/CONTRIBUTING.md)

<!--
  🎉 Thank you for contributing and making TypeORM even better!
-->
