### PR TITLE
fix: find query mongodb properly with @DeleteDateColumn()

### DIFF
--- a/src/entity-manager/MongoEntityManager.ts
+++ b/src/entity-manager/MongoEntityManager.ts
@@ -1170,12 +1170,13 @@ export class MongoEntityManager extends EntityManager {
         deleteDateColumn: ColumnMetadata,
         query?: ObjectLiteral,
     ) {
+        const { $or, ...restQuery } = query ?? {}
         cursor.filter({
             $or: [
-                { [deleteDateColumn.propertyName]: { $exists: false } },
                 { [deleteDateColumn.propertyName]: { $eq: null } },
+                ...(Array.isArray($or) ? $or : []),
             ],
-            ...query,
+            ...restQuery,
         })
     }
 

--- a/src/entity-manager/MongoEntityManager.ts
+++ b/src/entity-manager/MongoEntityManager.ts
@@ -180,10 +180,10 @@ export class MongoEntityManager extends EntityManager {
                     ),
                 )
             if (deleteDateColumn && !optionsOrConditions.withDeleted) {
-                this.filterSoftDeleted(cursor, deleteDateColumn)
+                this.filterSoftDeleted(cursor, deleteDateColumn, query)
             }
         } else if (deleteDateColumn) {
-            this.filterSoftDeleted(cursor, deleteDateColumn)
+            this.filterSoftDeleted(cursor, deleteDateColumn, query)
         }
         return await cursor.toArray()
     }
@@ -1168,8 +1168,9 @@ export class MongoEntityManager extends EntityManager {
     protected filterSoftDeleted<Entity>(
         cursor: Cursor<Entity>,
         deleteDateColumn: ColumnMetadata,
+        query?: ObjectLiteral,
     ) {
-        cursor.filter({ $where: `this.${deleteDateColumn.propertyName}==null` })
+        cursor.filter({ $or: [ {[deleteDateColumn.propertyName]: {$exists: false}}, {[deleteDateColumn.propertyName]: {$eq: null}} ], ...query} )
     }
 
     /**
@@ -1214,10 +1215,10 @@ export class MongoEntityManager extends EntityManager {
                     ),
                 )
             if (deleteDateColumn && !findOneOptionsOrConditions.withDeleted) {
-                this.filterSoftDeleted(cursor, deleteDateColumn)
+                this.filterSoftDeleted(cursor, deleteDateColumn, query)
             }
         } else if (deleteDateColumn) {
-            this.filterSoftDeleted(cursor, deleteDateColumn)
+            this.filterSoftDeleted(cursor, deleteDateColumn, query)
         }
 
         // const result = await cursor.limit(1).next();
@@ -1256,10 +1257,10 @@ export class MongoEntityManager extends EntityManager {
                     ),
                 )
             if (deleteDateColumn && !optionsOrConditions.withDeleted) {
-                this.filterSoftDeleted(cursor, deleteDateColumn)
+                this.filterSoftDeleted(cursor, deleteDateColumn, query)
             }
         } else if (deleteDateColumn) {
-            this.filterSoftDeleted(cursor, deleteDateColumn)
+            this.filterSoftDeleted(cursor, deleteDateColumn, query)
         }
         return cursor.toArray()
     }
@@ -1295,10 +1296,10 @@ export class MongoEntityManager extends EntityManager {
                     ),
                 )
             if (deleteDateColumn && !optionsOrConditions.withDeleted) {
-                this.filterSoftDeleted(cursor, deleteDateColumn)
+                this.filterSoftDeleted(cursor, deleteDateColumn, query)
             }
         } else if (deleteDateColumn) {
-            this.filterSoftDeleted(cursor, deleteDateColumn)
+            this.filterSoftDeleted(cursor, deleteDateColumn, query)
         }
         const [results, count] = await Promise.all<any>([
             cursor.toArray(),

--- a/src/entity-manager/MongoEntityManager.ts
+++ b/src/entity-manager/MongoEntityManager.ts
@@ -1170,7 +1170,13 @@ export class MongoEntityManager extends EntityManager {
         deleteDateColumn: ColumnMetadata,
         query?: ObjectLiteral,
     ) {
-        cursor.filter({ $or: [ {[deleteDateColumn.propertyName]: {$exists: false}}, {[deleteDateColumn.propertyName]: {$eq: null}} ], ...query} )
+        cursor.filter({
+            $or: [
+                { [deleteDateColumn.propertyName]: { $exists: false } },
+                { [deleteDateColumn.propertyName]: { $eq: null } },
+            ],
+            ...query,
+        })
     }
 
     /**

--- a/test/functional/mongodb/basic/mongo-repository/entity/Post.ts
+++ b/test/functional/mongodb/basic/mongo-repository/entity/Post.ts
@@ -2,6 +2,7 @@ import { Entity } from "../../../../../../src/decorator/entity/Entity"
 import { Column } from "../../../../../../src/decorator/columns/Column"
 import { ObjectIdColumn } from "../../../../../../src/decorator/columns/ObjectIdColumn"
 import { ObjectID } from "../../../../../../src/driver/mongodb/typings"
+import { DeleteDateColumn } from "../../../../../../src"
 
 @Entity()
 export class Post {
@@ -16,4 +17,19 @@ export class Post {
 
     // @Column(() => Counters)
     // counters: Counters;
+}
+
+@Entity()
+export class PostWithDeleted {
+    @ObjectIdColumn()
+    id: ObjectID
+
+    @Column()
+    title: string
+
+    @Column()
+    text: string
+
+    @DeleteDateColumn()
+    deletedAt: Date | null
 }

--- a/test/functional/mongodb/basic/mongo-repository/mongo-repository.ts
+++ b/test/functional/mongodb/basic/mongo-repository/mongo-repository.ts
@@ -189,6 +189,21 @@ describe("mongodb > MongoRepository", () => {
 
     // Github issue #9250
     describe("with DeletedDataColumn", () => {
+        it("with $or query", () =>
+            Promise.all(
+                connections.map(async (connection) => {
+                    const postRepository =
+                        connection.getMongoRepository(PostWithDeleted)
+                    await seedPosts(postRepository)
+                    const loadedPosts = await postRepository.find({
+                        where: {
+                            $or: [{ deletedAt: { $ne: null } }],
+                        },
+                    })
+                    expect(loadedPosts).to.have.length(3)
+                }),
+            ))
+
         it("filter delete data", () =>
             Promise.all(
                 connections.map(async (connection) => {

--- a/test/functional/mongodb/basic/mongo-repository/mongo-repository.ts
+++ b/test/functional/mongodb/basic/mongo-repository/mongo-repository.ts
@@ -6,7 +6,7 @@ import {
     createTestingConnections,
     reloadTestingDatabases,
 } from "../../../../utils/test-utils"
-import { Post } from "./entity/Post"
+import { Post, PostWithDeleted } from "./entity/Post"
 import { MongoRepository } from "../../../../../src/repository/MongoRepository"
 
 describe("mongodb > MongoRepository", () => {
@@ -14,7 +14,7 @@ describe("mongodb > MongoRepository", () => {
     before(
         async () =>
             (connections = await createTestingConnections({
-                entities: [Post],
+                entities: [Post, PostWithDeleted],
                 enabledDrivers: ["mongodb"],
             })),
     )
@@ -186,4 +186,85 @@ describe("mongodb > MongoRepository", () => {
                 expect(loadedPosts[0]).to.not.have.property("unreal")
             }),
         ))
+
+    // Github issue #9250
+    describe("with DeletedDataColumn", () => {
+        it("filter delete data", () =>
+            Promise.all(
+                connections.map(async (connection) => {
+                    const postRepository =
+                        connection.getMongoRepository(PostWithDeleted)
+                    await seedPosts(postRepository)
+
+                    const loadedPosts = await postRepository.find()
+                    const filteredPost = loadedPosts.find(
+                        (post) => post.title === "deleted",
+                    )
+
+                    expect(filteredPost).to.be.undefined
+                    expect(loadedPosts).to.have.length(2)
+                }),
+            ))
+
+        describe("findOne filtered data properly", () => {
+            it("findOne()", () =>
+                Promise.all(
+                    connections.map(async (connection) => {
+                        const postRepository =
+                            connection.getMongoRepository(PostWithDeleted)
+                        await seedPosts(postRepository)
+
+                        const loadedPost = await postRepository.findOne({
+                            where: { title: "notDeleted" },
+                        })
+                        const loadedPostWithDeleted =
+                            await postRepository.findOne({
+                                where: { title: "deleted" },
+                                withDeleted: true,
+                            })
+
+                        expect(loadedPost?.title).to.eql("notDeleted")
+                        expect(loadedPostWithDeleted?.title).to.eql("deleted")
+                    }),
+                ))
+
+            it("findOneBy()", () =>
+                Promise.all(
+                    connections.map(async (connection) => {
+                        const postRepository =
+                            connection.getMongoRepository(PostWithDeleted)
+                        await seedPosts(postRepository)
+
+                        const loadedPost = await postRepository.findOneBy({
+                            where: { title: "notDeleted" },
+                        })
+                        const loadedPostWithDeleted =
+                            await postRepository.findOne({
+                                where: { title: "deleted" },
+                                withDeleted: true,
+                            })
+
+                        expect(loadedPost?.title).to.eql("notDeleted")
+                        expect(loadedPostWithDeleted?.title).to.eql("deleted")
+                    }),
+                ))
+        })
+    })
 })
+
+async function seedPosts(postRepository: MongoRepository<PostWithDeleted>) {
+    await postRepository.save({
+        title: "withoutDeleted",
+        text: "withoutDeleted",
+    })
+    await postRepository.save({
+        title: "notDeleted",
+        text: "notDeleted",
+        deletedAt: null,
+    })
+    await postRepository.save({
+        title: "deleted",
+        text: "deleted",
+        deletedAt: new Date(),
+    })
+}


### PR DESCRIPTION
<!--
  😀 Wonderful!  Thank you for opening a pull request for TypeORM.

  Please fill in the information below to expedite the review
  and (hopefully) merge of your change.

  If unsure about something.. just do as best as you're able,
  or reach out through our community support channels!
  https://github.com/typeorm/typeorm/blob/master/docs/support.md
-->

### Description of change

<!--
  Please be clear and concise what the change is intended to do,
  why this change is needed, and how you've verified that it
  corrects what you intended.

  In some cases it may be helpful to include the current behavior
  and the new behavior.

  If the change is related to an open issue, you can link it here.
  If you include `Fixes #0000` (replacing `0000` with the issue number)
  when this is merged it will automatically mark the issue as fixed and
  close it.
-->

Fixes #9250 

Fix `filterSoftDelted` of `MongoEntityManager` not to reset query filter.
Previous version replaced cursor query filter with `where this.deletedDateColumn.propertyName == null`. 
So there is a bug that the cursor queries all of not deleted data if the entity has DeletedDateColumn.

### Pull-Request Checklist

<!--
  Please make sure to review and check all of the following.

  If an item is not applicable, you can add "N/A" to the end.
-->

- [x] Code is up-to-date with the `master` branch
- [x] `npm run format` to apply prettier formatting
- [x] `npm run test` passes with this change
- [x] This pull request links relevant issues as `Fixes #0000`
- [x] There are new or updated unit tests validating the change
- [x] Documentation has been updated to reflect this change (interface was not changed)
- [x] The new commits follow conventions explained in [CONTRIBUTING.md](https://github.com/typeorm/typeorm/blob/master/CONTRIBUTING.md)

<!--
  🎉 Thank you for contributing and making TypeORM even better!
-->
