### PR TITLE
WIP: Add BeforeQuery and AfterQuery events

### DIFF
--- a/src/driver/cockroachdb/CockroachQueryRunner.ts
+++ b/src/driver/cockroachdb/CockroachQueryRunner.ts
@@ -236,7 +236,11 @@ export class CockroachQueryRunner
         const broadcasterResult = new BroadcasterResult()
 
         this.driver.connection.logger.logQuery(query, parameters, this)
-        this.broadcaster.broadcastBeforeQueryEvent(broadcasterResult, query, parameters)
+        this.broadcaster.broadcastBeforeQueryEvent(
+            broadcasterResult,
+            query,
+            parameters,
+        )
 
         const queryStartTime = +new Date()
 
@@ -266,7 +270,7 @@ export class CockroachQueryRunner
                 true,
                 queryExecutionTime,
                 raw,
-                undefined
+                undefined,
             )
 
             if (
@@ -321,7 +325,7 @@ export class CockroachQueryRunner
                 false,
                 undefined,
                 undefined,
-                err
+                err,
             )
 
             throw new QueryFailedError(query, parameters, err)

--- a/src/driver/cordova/CordovaQueryRunner.ts
+++ b/src/driver/cordova/CordovaQueryRunner.ts
@@ -6,6 +6,7 @@ import { CordovaDriver } from "./CordovaDriver"
 import { Broadcaster } from "../../subscriber/Broadcaster"
 import { TypeORMError } from "../../error"
 import { QueryResult } from "../../query-runner/QueryResult"
+import { BroadcasterResult } from "../../subscriber/BroadcasterResult"
 
 /**
  * Runs queries on a single sqlite database connection.
@@ -52,7 +53,11 @@ export class CordovaQueryRunner extends AbstractSqliteQueryRunner {
         if (this.isReleased) throw new QueryRunnerAlreadyReleasedError()
 
         const databaseConnection = await this.connect()
+        const broadcasterResult = new BroadcasterResult()
+
         this.driver.connection.logger.logQuery(query, parameters, this)
+        this.broadcaster.broadcastBeforeQueryEvent(broadcasterResult, query, parameters)
+
         const queryStartTime = +new Date()
 
         try {
@@ -70,6 +75,17 @@ export class CordovaQueryRunner extends AbstractSqliteQueryRunner {
                 this.driver.options.maxQueryExecutionTime
             const queryEndTime = +new Date()
             const queryExecutionTime = queryEndTime - queryStartTime
+
+            this.broadcaster.broadcastAfterQueryEvent(
+                broadcasterResult,
+                query,
+                parameters,
+                true,
+                queryExecutionTime,
+                raw,
+                undefined
+            )
+
             if (
                 maxQueryExecutionTime &&
                 queryExecutionTime > maxQueryExecutionTime
@@ -108,7 +124,20 @@ export class CordovaQueryRunner extends AbstractSqliteQueryRunner {
                 parameters,
                 this,
             )
+            this.broadcaster.broadcastAfterQueryEvent(
+                broadcasterResult,
+                query,
+                parameters,
+                false,
+                undefined,
+                undefined,
+                err
+            )
+
             throw new QueryFailedError(query, parameters, err)
+        } finally {
+            if (broadcasterResult.promises.length > 0)
+                await Promise.all(broadcasterResult.promises)
         }
     }
 

--- a/src/driver/cordova/CordovaQueryRunner.ts
+++ b/src/driver/cordova/CordovaQueryRunner.ts
@@ -56,7 +56,11 @@ export class CordovaQueryRunner extends AbstractSqliteQueryRunner {
         const broadcasterResult = new BroadcasterResult()
 
         this.driver.connection.logger.logQuery(query, parameters, this)
-        this.broadcaster.broadcastBeforeQueryEvent(broadcasterResult, query, parameters)
+        this.broadcaster.broadcastBeforeQueryEvent(
+            broadcasterResult,
+            query,
+            parameters,
+        )
 
         const queryStartTime = +new Date()
 
@@ -83,7 +87,7 @@ export class CordovaQueryRunner extends AbstractSqliteQueryRunner {
                 true,
                 queryExecutionTime,
                 raw,
-                undefined
+                undefined,
             )
 
             if (
@@ -131,7 +135,7 @@ export class CordovaQueryRunner extends AbstractSqliteQueryRunner {
                 false,
                 undefined,
                 undefined,
-                err
+                err,
             )
 
             throw new QueryFailedError(query, parameters, err)

--- a/src/driver/expo/ExpoQueryRunner.ts
+++ b/src/driver/expo/ExpoQueryRunner.ts
@@ -168,7 +168,11 @@ export class ExpoQueryRunner extends AbstractSqliteQueryRunner {
             const broadcasterResult = new BroadcasterResult()
 
             this.driver.connection.logger.logQuery(query, parameters, this)
-            this.broadcaster.broadcastBeforeQueryEvent(broadcasterResult, query, parameters)
+            this.broadcaster.broadcastBeforeQueryEvent(
+                broadcasterResult,
+                query,
+                parameters,
+            )
 
             const queryStartTime = +new Date()
             // All Expo SQL queries are executed in a transaction context
@@ -196,7 +200,7 @@ export class ExpoQueryRunner extends AbstractSqliteQueryRunner {
                                 true,
                                 queryExecutionTime,
                                 raw,
-                                undefined
+                                undefined,
                             )
 
                             if (
@@ -255,7 +259,7 @@ export class ExpoQueryRunner extends AbstractSqliteQueryRunner {
                                 false,
                                 undefined,
                                 undefined,
-                                err
+                                err,
                             )
                             if (broadcasterResult.promises.length > 0)
                                 await Promise.all(broadcasterResult.promises)

--- a/src/driver/expo/ExpoQueryRunner.ts
+++ b/src/driver/expo/ExpoQueryRunner.ts
@@ -5,6 +5,7 @@ import { TransactionNotStartedError } from "../../error/TransactionNotStartedErr
 import { ExpoDriver } from "./ExpoDriver"
 import { Broadcaster } from "../../subscriber/Broadcaster"
 import { QueryResult } from "../../query-runner/QueryResult"
+import { BroadcasterResult } from "../../subscriber/BroadcasterResult"
 
 // Needed to satisfy the Typescript compiler
 interface IResultSet {
@@ -164,7 +165,11 @@ export class ExpoQueryRunner extends AbstractSqliteQueryRunner {
 
         return new Promise<any>(async (ok, fail) => {
             const databaseConnection = await this.connect()
+            const broadcasterResult = new BroadcasterResult()
+
             this.driver.connection.logger.logQuery(query, parameters, this)
+            this.broadcaster.broadcastBeforeQueryEvent(broadcasterResult, query, parameters)
+
             const queryStartTime = +new Date()
             // All Expo SQL queries are executed in a transaction context
             databaseConnection.transaction(
@@ -176,13 +181,24 @@ export class ExpoQueryRunner extends AbstractSqliteQueryRunner {
                     this.transaction.executeSql(
                         query,
                         parameters,
-                        (t: ITransaction, raw: IResultSet) => {
+                        async (t: ITransaction, raw: IResultSet) => {
                             // log slow queries if maxQueryExecution time is set
                             const maxQueryExecutionTime =
                                 this.driver.options.maxQueryExecutionTime
                             const queryEndTime = +new Date()
                             const queryExecutionTime =
                                 queryEndTime - queryStartTime
+
+                            this.broadcaster.broadcastAfterQueryEvent(
+                                broadcasterResult,
+                                query,
+                                parameters,
+                                true,
+                                queryExecutionTime,
+                                raw,
+                                undefined
+                            )
+
                             if (
                                 maxQueryExecutionTime &&
                                 queryExecutionTime > maxQueryExecutionTime
@@ -216,19 +232,34 @@ export class ExpoQueryRunner extends AbstractSqliteQueryRunner {
                                 result.raw = raw.insertId
                             }
 
+                            if (broadcasterResult.promises.length > 0)
+                                await Promise.all(broadcasterResult.promises)
+
                             if (useStructuredResult) {
                                 ok(result)
                             } else {
                                 ok(result.raw)
                             }
                         },
-                        (t: ITransaction, err: any) => {
+                        async (t: ITransaction, err: any) => {
                             this.driver.connection.logger.logQueryError(
                                 err,
                                 query,
                                 parameters,
                                 this,
                             )
+                            this.broadcaster.broadcastAfterQueryEvent(
+                                broadcasterResult,
+                                query,
+                                parameters,
+                                false,
+                                undefined,
+                                undefined,
+                                err
+                            )
+                            if (broadcasterResult.promises.length > 0)
+                                await Promise.all(broadcasterResult.promises)
+
                             fail(new QueryFailedError(query, parameters, err))
                         },
                     )

--- a/src/driver/mysql/MysqlQueryRunner.ts
+++ b/src/driver/mysql/MysqlQueryRunner.ts
@@ -193,7 +193,11 @@ export class MysqlQueryRunner extends BaseQueryRunner implements QueryRunner {
                 const broadcasterResult = new BroadcasterResult()
 
                 this.driver.connection.logger.logQuery(query, parameters, this)
-                this.broadcaster.broadcastBeforeQueryEvent(broadcasterResult, query, parameters)
+                this.broadcaster.broadcastBeforeQueryEvent(
+                    broadcasterResult,
+                    query,
+                    parameters,
+                )
 
                 const queryStartTime = +new Date()
                 databaseConnection.query(
@@ -231,7 +235,7 @@ export class MysqlQueryRunner extends BaseQueryRunner implements QueryRunner {
                                 false,
                                 undefined,
                                 undefined,
-                                err
+                                err,
                             )
                             if (broadcasterResult.promises.length > 0)
                                 await Promise.all(broadcasterResult.promises)
@@ -247,7 +251,7 @@ export class MysqlQueryRunner extends BaseQueryRunner implements QueryRunner {
                                 true,
                                 queryExecutionTime,
                                 raw,
-                                undefined
+                                undefined,
                             )
                             if (broadcasterResult.promises.length > 0)
                                 await Promise.all(broadcasterResult.promises)

--- a/src/driver/mysql/MysqlQueryRunner.ts
+++ b/src/driver/mysql/MysqlQueryRunner.ts
@@ -26,6 +26,7 @@ import { ReplicationMode } from "../types/ReplicationMode"
 import { TypeORMError } from "../../error"
 import { MetadataTableType } from "../types/MetadataTableType"
 import { InstanceChecker } from "../../util/InstanceChecker"
+import { BroadcasterResult } from "../../subscriber/BroadcasterResult"
 
 /**
  * Runs queries on a single mysql database connection.
@@ -189,17 +190,22 @@ export class MysqlQueryRunner extends BaseQueryRunner implements QueryRunner {
         return new Promise(async (ok, fail) => {
             try {
                 const databaseConnection = await this.connect()
+                const broadcasterResult = new BroadcasterResult()
+
                 this.driver.connection.logger.logQuery(query, parameters, this)
+                this.broadcaster.broadcastBeforeQueryEvent(broadcasterResult, query, parameters)
+
                 const queryStartTime = +new Date()
                 databaseConnection.query(
                     query,
                     parameters,
-                    (err: any, raw: any) => {
+                    async (err: any, raw: any) => {
                         // log slow queries if maxQueryExecution time is set
                         const maxQueryExecutionTime =
                             this.driver.options.maxQueryExecutionTime
                         const queryEndTime = +new Date()
                         const queryExecutionTime = queryEndTime - queryStartTime
+
                         if (
                             maxQueryExecutionTime &&
                             queryExecutionTime > maxQueryExecutionTime
@@ -218,9 +224,33 @@ export class MysqlQueryRunner extends BaseQueryRunner implements QueryRunner {
                                 parameters,
                                 this,
                             )
+                            this.broadcaster.broadcastAfterQueryEvent(
+                                broadcasterResult,
+                                query,
+                                parameters,
+                                false,
+                                undefined,
+                                undefined,
+                                err
+                            )
+                            if (broadcasterResult.promises.length > 0)
+                                await Promise.all(broadcasterResult.promises)
+
                             return fail(
                                 new QueryFailedError(query, parameters, err),
                             )
+                        } else {
+                            this.broadcaster.broadcastAfterQueryEvent(
+                                broadcasterResult,
+                                query,
+                                parameters,
+                                true,
+                                queryExecutionTime,
+                                raw,
+                                undefined
+                            )
+                            if (broadcasterResult.promises.length > 0)
+                                await Promise.all(broadcasterResult.promises)
                         }
 
                         const result = new QueryResult()

--- a/src/driver/oracle/OracleQueryRunner.ts
+++ b/src/driver/oracle/OracleQueryRunner.ts
@@ -24,6 +24,7 @@ import { TypeORMError } from "../../error"
 import { QueryResult } from "../../query-runner/QueryResult"
 import { MetadataTableType } from "../types/MetadataTableType"
 import { InstanceChecker } from "../../util/InstanceChecker"
+import { BroadcasterResult } from "../../subscriber/BroadcasterResult"
 
 /**
  * Runs queries on a single oracle database connection.
@@ -197,8 +198,11 @@ export class OracleQueryRunner extends BaseQueryRunner implements QueryRunner {
         if (this.isReleased) throw new QueryRunnerAlreadyReleasedError()
 
         const databaseConnection = await this.connect()
+        const broadcasterResult = new BroadcasterResult()
 
         this.driver.connection.logger.logQuery(query, parameters, this)
+        this.broadcaster.broadcastBeforeQueryEvent(broadcasterResult, query, parameters)
+
         const queryStartTime = +new Date()
 
         try {
@@ -218,6 +222,17 @@ export class OracleQueryRunner extends BaseQueryRunner implements QueryRunner {
                 this.driver.options.maxQueryExecutionTime
             const queryEndTime = +new Date()
             const queryExecutionTime = queryEndTime - queryStartTime
+
+            this.broadcaster.broadcastAfterQueryEvent(
+                broadcasterResult,
+                query,
+                parameters,
+                true,
+                queryExecutionTime,
+                raw,
+                undefined
+            )
+
             if (
                 maxQueryExecutionTime &&
                 queryExecutionTime > maxQueryExecutionTime
@@ -271,7 +286,20 @@ export class OracleQueryRunner extends BaseQueryRunner implements QueryRunner {
                 parameters,
                 this,
             )
+            this.broadcaster.broadcastAfterQueryEvent(
+                broadcasterResult,
+                query,
+                parameters,
+                false,
+                undefined,
+                undefined,
+                err
+            )
+
             throw new QueryFailedError(query, parameters, err)
+        } finally {
+            if (broadcasterResult.promises.length > 0)
+                await Promise.all(broadcasterResult.promises)
         }
     }
 

--- a/src/driver/oracle/OracleQueryRunner.ts
+++ b/src/driver/oracle/OracleQueryRunner.ts
@@ -201,7 +201,11 @@ export class OracleQueryRunner extends BaseQueryRunner implements QueryRunner {
         const broadcasterResult = new BroadcasterResult()
 
         this.driver.connection.logger.logQuery(query, parameters, this)
-        this.broadcaster.broadcastBeforeQueryEvent(broadcasterResult, query, parameters)
+        this.broadcaster.broadcastBeforeQueryEvent(
+            broadcasterResult,
+            query,
+            parameters,
+        )
 
         const queryStartTime = +new Date()
 
@@ -230,7 +234,7 @@ export class OracleQueryRunner extends BaseQueryRunner implements QueryRunner {
                 true,
                 queryExecutionTime,
                 raw,
-                undefined
+                undefined,
             )
 
             if (
@@ -293,7 +297,7 @@ export class OracleQueryRunner extends BaseQueryRunner implements QueryRunner {
                 false,
                 undefined,
                 undefined,
-                err
+                err,
             )
 
             throw new QueryFailedError(query, parameters, err)

--- a/src/driver/postgres/PostgresQueryRunner.ts
+++ b/src/driver/postgres/PostgresQueryRunner.ts
@@ -26,6 +26,7 @@ import { TypeORMError } from "../../error"
 import { QueryResult } from "../../query-runner/QueryResult"
 import { MetadataTableType } from "../types/MetadataTableType"
 import { InstanceChecker } from "../../util/InstanceChecker"
+import { BroadcasterResult } from "../../subscriber/BroadcasterResult"
 
 /**
  * Runs queries on a single postgres database connection.
@@ -242,8 +243,11 @@ export class PostgresQueryRunner
         if (this.isReleased) throw new QueryRunnerAlreadyReleasedError()
 
         const databaseConnection = await this.connect()
+        const broadcasterResult = new BroadcasterResult()
 
         this.driver.connection.logger.logQuery(query, parameters, this)
+        this.broadcaster.broadcastBeforeQueryEvent(broadcasterResult, query, parameters)
+
         try {
             const queryStartTime = +new Date()
             const raw = await databaseConnection.query(query, parameters)
@@ -252,6 +256,17 @@ export class PostgresQueryRunner
                 this.driver.options.maxQueryExecutionTime
             const queryEndTime = +new Date()
             const queryExecutionTime = queryEndTime - queryStartTime
+
+            this.broadcaster.broadcastAfterQueryEvent(
+                broadcasterResult,
+                query,
+                parameters,
+                true,
+                queryExecutionTime,
+                raw,
+                undefined
+            )
+
             if (
                 maxQueryExecutionTime &&
                 queryExecutionTime > maxQueryExecutionTime
@@ -296,7 +311,20 @@ export class PostgresQueryRunner
                 parameters,
                 this,
             )
+            this.broadcaster.broadcastAfterQueryEvent(
+                broadcasterResult,
+                query,
+                parameters,
+                false,
+                undefined,
+                undefined,
+                err
+            )
+
             throw new QueryFailedError(query, parameters, err)
+        } finally {
+            if (broadcasterResult.promises.length > 0)
+                await Promise.all(broadcasterResult.promises)
         }
     }
 

--- a/src/driver/postgres/PostgresQueryRunner.ts
+++ b/src/driver/postgres/PostgresQueryRunner.ts
@@ -246,7 +246,11 @@ export class PostgresQueryRunner
         const broadcasterResult = new BroadcasterResult()
 
         this.driver.connection.logger.logQuery(query, parameters, this)
-        this.broadcaster.broadcastBeforeQueryEvent(broadcasterResult, query, parameters)
+        this.broadcaster.broadcastBeforeQueryEvent(
+            broadcasterResult,
+            query,
+            parameters,
+        )
 
         try {
             const queryStartTime = +new Date()
@@ -264,7 +268,7 @@ export class PostgresQueryRunner
                 true,
                 queryExecutionTime,
                 raw,
-                undefined
+                undefined,
             )
 
             if (
@@ -318,7 +322,7 @@ export class PostgresQueryRunner
                 false,
                 undefined,
                 undefined,
-                err
+                err,
             )
 
             throw new QueryFailedError(query, parameters, err)

--- a/src/driver/react-native/ReactNativeQueryRunner.ts
+++ b/src/driver/react-native/ReactNativeQueryRunner.ts
@@ -56,7 +56,11 @@ export class ReactNativeQueryRunner extends AbstractSqliteQueryRunner {
             const broadcasterResult = new BroadcasterResult()
 
             this.driver.connection.logger.logQuery(query, parameters, this)
-            this.broadcaster.broadcastBeforeQueryEvent(broadcasterResult, query, parameters)
+            this.broadcaster.broadcastBeforeQueryEvent(
+                broadcasterResult,
+                query,
+                parameters,
+            )
 
             const queryStartTime = +new Date()
             databaseConnection.executeSql(
@@ -76,7 +80,7 @@ export class ReactNativeQueryRunner extends AbstractSqliteQueryRunner {
                         true,
                         queryExecutionTime,
                         raw,
-                        undefined
+                        undefined,
                     )
 
                     if (
@@ -134,7 +138,7 @@ export class ReactNativeQueryRunner extends AbstractSqliteQueryRunner {
                         false,
                         undefined,
                         undefined,
-                        err
+                        err,
                     )
                     if (broadcasterResult.promises.length > 0)
                         await Promise.all(broadcasterResult.promises)

--- a/src/driver/react-native/ReactNativeQueryRunner.ts
+++ b/src/driver/react-native/ReactNativeQueryRunner.ts
@@ -5,6 +5,7 @@ import { AbstractSqliteQueryRunner } from "../sqlite-abstract/AbstractSqliteQuer
 import { ReactNativeDriver } from "./ReactNativeDriver"
 import { Broadcaster } from "../../subscriber/Broadcaster"
 import { QueryResult } from "../../query-runner/QueryResult"
+import { BroadcasterResult } from "../../subscriber/BroadcasterResult"
 
 /**
  * Runs queries on a single sqlite database connection.
@@ -52,17 +53,32 @@ export class ReactNativeQueryRunner extends AbstractSqliteQueryRunner {
 
         return new Promise(async (ok, fail) => {
             const databaseConnection = await this.connect()
+            const broadcasterResult = new BroadcasterResult()
+
             this.driver.connection.logger.logQuery(query, parameters, this)
+            this.broadcaster.broadcastBeforeQueryEvent(broadcasterResult, query, parameters)
+
             const queryStartTime = +new Date()
             databaseConnection.executeSql(
                 query,
                 parameters,
-                (raw: any) => {
+                async (raw: any) => {
                     // log slow queries if maxQueryExecution time is set
                     const maxQueryExecutionTime =
                         this.driver.options.maxQueryExecutionTime
                     const queryEndTime = +new Date()
                     const queryExecutionTime = queryEndTime - queryStartTime
+
+                    this.broadcaster.broadcastAfterQueryEvent(
+                        broadcasterResult,
+                        query,
+                        parameters,
+                        true,
+                        queryExecutionTime,
+                        raw,
+                        undefined
+                    )
+
                     if (
                         maxQueryExecutionTime &&
                         queryExecutionTime > maxQueryExecutionTime
@@ -73,6 +89,9 @@ export class ReactNativeQueryRunner extends AbstractSqliteQueryRunner {
                             parameters,
                             this,
                         )
+
+                    if (broadcasterResult.promises.length > 0)
+                        await Promise.all(broadcasterResult.promises)
 
                     const result = new QueryResult()
 
@@ -101,13 +120,25 @@ export class ReactNativeQueryRunner extends AbstractSqliteQueryRunner {
                         ok(result.raw)
                     }
                 },
-                (err: any) => {
+                async (err: any) => {
                     this.driver.connection.logger.logQueryError(
                         err,
                         query,
                         parameters,
                         this,
                     )
+                    this.broadcaster.broadcastAfterQueryEvent(
+                        broadcasterResult,
+                        query,
+                        parameters,
+                        false,
+                        undefined,
+                        undefined,
+                        err
+                    )
+                    if (broadcasterResult.promises.length > 0)
+                        await Promise.all(broadcasterResult.promises)
+
                     fail(new QueryFailedError(query, parameters, err))
                 },
             )

--- a/src/driver/sap/SapQueryRunner.ts
+++ b/src/driver/sap/SapQueryRunner.ts
@@ -27,6 +27,7 @@ import { QueryLock } from "../../query-runner/QueryLock"
 import { MetadataTableType } from "../types/MetadataTableType"
 import { InstanceChecker } from "../../util/InstanceChecker"
 import { promisify } from "util"
+import { BroadcasterResult } from "../../subscriber/BroadcasterResult"
 
 /**
  * Runs queries on a single SQL Server database connection.
@@ -194,11 +195,14 @@ export class SapQueryRunner extends BaseQueryRunner implements QueryRunner {
 
         let statement: any
         const result = new QueryResult()
+        const broadcasterResult = new BroadcasterResult()
 
         try {
             const databaseConnection = await this.connect()
 
             this.driver.connection.logger.logQuery(query, parameters, this)
+            this.broadcaster.broadcastBeforeQueryEvent(broadcasterResult, query, parameters)
+
             const queryStartTime = +new Date()
             const isInsertQuery = query.substr(0, 11) === "INSERT INTO"
 
@@ -217,6 +221,17 @@ export class SapQueryRunner extends BaseQueryRunner implements QueryRunner {
                 this.driver.connection.options.maxQueryExecutionTime
             const queryEndTime = +new Date()
             const queryExecutionTime = queryEndTime - queryStartTime
+
+            this.broadcaster.broadcastAfterQueryEvent(
+                broadcasterResult,
+                query,
+                parameters,
+                true,
+                queryExecutionTime,
+                raw,
+                undefined
+            )
+
             if (
                 maxQueryExecutionTime &&
                 queryExecutionTime > maxQueryExecutionTime
@@ -261,19 +276,31 @@ export class SapQueryRunner extends BaseQueryRunner implements QueryRunner {
                 result.raw = identityValueResult[0]["CURRENT_IDENTITY_VALUE()"]
                 result.records = identityValueResult
             }
-        } catch (e) {
+        } catch (err) {
             this.driver.connection.logger.logQueryError(
-                e,
+                err,
                 query,
                 parameters,
                 this,
             )
-            throw e
+            this.broadcaster.broadcastAfterQueryEvent(
+                broadcasterResult,
+                query,
+                parameters,
+                false,
+                undefined,
+                undefined,
+                err
+            )
+            throw err
         } finally {
             // Never forget to drop the statement we reserved
             if (statement?.drop) {
                 await new Promise<void>((ok) => statement.drop(() => ok()))
             }
+
+            if (broadcasterResult.promises.length > 0)
+                await Promise.all(broadcasterResult.promises)
 
             // Always release the lock.
             release()

--- a/src/driver/sap/SapQueryRunner.ts
+++ b/src/driver/sap/SapQueryRunner.ts
@@ -201,7 +201,11 @@ export class SapQueryRunner extends BaseQueryRunner implements QueryRunner {
             const databaseConnection = await this.connect()
 
             this.driver.connection.logger.logQuery(query, parameters, this)
-            this.broadcaster.broadcastBeforeQueryEvent(broadcasterResult, query, parameters)
+            this.broadcaster.broadcastBeforeQueryEvent(
+                broadcasterResult,
+                query,
+                parameters,
+            )
 
             const queryStartTime = +new Date()
             const isInsertQuery = query.substr(0, 11) === "INSERT INTO"
@@ -229,7 +233,7 @@ export class SapQueryRunner extends BaseQueryRunner implements QueryRunner {
                 true,
                 queryExecutionTime,
                 raw,
-                undefined
+                undefined,
             )
 
             if (
@@ -290,7 +294,7 @@ export class SapQueryRunner extends BaseQueryRunner implements QueryRunner {
                 false,
                 undefined,
                 undefined,
-                err
+                err,
             )
             throw err
         } finally {

--- a/src/driver/spanner/SpannerQueryRunner.ts
+++ b/src/driver/spanner/SpannerQueryRunner.ts
@@ -185,7 +185,11 @@ export class SpannerQueryRunner extends BaseQueryRunner implements QueryRunner {
 
             try {
                 this.driver.connection.logger.logQuery(query, parameters, this)
-                this.broadcaster.broadcastBeforeQueryEvent(broadcasterResult, query, parameters)
+                this.broadcaster.broadcastBeforeQueryEvent(
+                    broadcasterResult,
+                    query,
+                    parameters,
+                )
 
                 rawResult = await executor.run({
                     sql: query,
@@ -222,7 +226,7 @@ export class SpannerQueryRunner extends BaseQueryRunner implements QueryRunner {
                 true,
                 queryExecutionTime,
                 rawResult,
-                undefined
+                undefined,
             )
 
             if (
@@ -263,7 +267,7 @@ export class SpannerQueryRunner extends BaseQueryRunner implements QueryRunner {
                 false,
                 undefined,
                 undefined,
-                err
+                err,
             )
             throw new QueryFailedError(query, parameters, err)
         } finally {

--- a/src/driver/spanner/SpannerQueryRunner.ts
+++ b/src/driver/spanner/SpannerQueryRunner.ts
@@ -24,6 +24,7 @@ import { TypeORMError } from "../../error"
 import { QueryResult } from "../../query-runner/QueryResult"
 import { MetadataTableType } from "../types/MetadataTableType"
 import { SpannerDriver } from "./SpannerDriver"
+import { BroadcasterResult } from "../../subscriber/BroadcasterResult"
 
 /**
  * Runs queries on a single postgres database connection.
@@ -155,6 +156,8 @@ export class SpannerQueryRunner extends BaseQueryRunner implements QueryRunner {
     ): Promise<any> {
         if (this.isReleased) throw new QueryRunnerAlreadyReleasedError()
 
+        const broadcasterResult = new BroadcasterResult()
+
         try {
             const queryStartTime = +new Date()
             await this.connect()
@@ -182,6 +185,8 @@ export class SpannerQueryRunner extends BaseQueryRunner implements QueryRunner {
 
             try {
                 this.driver.connection.logger.logQuery(query, parameters, this)
+                this.broadcaster.broadcastBeforeQueryEvent(broadcasterResult, query, parameters)
+
                 rawResult = await executor.run({
                     sql: query,
                     params: parameters
@@ -209,6 +214,17 @@ export class SpannerQueryRunner extends BaseQueryRunner implements QueryRunner {
                 this.driver.options.maxQueryExecutionTime
             const queryEndTime = +new Date()
             const queryExecutionTime = queryEndTime - queryStartTime
+
+            this.broadcaster.broadcastAfterQueryEvent(
+                broadcasterResult,
+                query,
+                parameters,
+                true,
+                queryExecutionTime,
+                rawResult,
+                undefined
+            )
+
             if (
                 maxQueryExecutionTime &&
                 queryExecutionTime > maxQueryExecutionTime
@@ -240,8 +256,19 @@ export class SpannerQueryRunner extends BaseQueryRunner implements QueryRunner {
                 parameters,
                 this,
             )
+            this.broadcaster.broadcastAfterQueryEvent(
+                broadcasterResult,
+                query,
+                parameters,
+                false,
+                undefined,
+                undefined,
+                err
+            )
             throw new QueryFailedError(query, parameters, err)
         } finally {
+            if (broadcasterResult.promises.length > 0)
+                await Promise.all(broadcasterResult.promises)
         }
     }
 

--- a/src/driver/sqljs/SqljsQueryRunner.ts
+++ b/src/driver/sqljs/SqljsQueryRunner.ts
@@ -86,7 +86,11 @@ export class SqljsQueryRunner extends AbstractSqliteQueryRunner {
         const broadcasterResult = new BroadcasterResult()
 
         this.driver.connection.logger.logQuery(query, parameters, this)
-        this.broadcaster.broadcastBeforeQueryEvent(broadcasterResult, query, parameters)
+        this.broadcaster.broadcastBeforeQueryEvent(
+            broadcasterResult,
+            query,
+            parameters,
+        )
 
         const queryStartTime = +new Date()
         let statement: any
@@ -130,7 +134,7 @@ export class SqljsQueryRunner extends AbstractSqliteQueryRunner {
                 true,
                 queryExecutionTime,
                 records,
-                undefined
+                undefined,
             )
 
             const result = new QueryResult()
@@ -168,7 +172,7 @@ export class SqljsQueryRunner extends AbstractSqliteQueryRunner {
                 false,
                 undefined,
                 undefined,
-                err
+                err,
             )
 
             throw new QueryFailedError(query, parameters, err)

--- a/src/driver/sqljs/SqljsQueryRunner.ts
+++ b/src/driver/sqljs/SqljsQueryRunner.ts
@@ -4,6 +4,7 @@ import { SqljsDriver } from "./SqljsDriver"
 import { Broadcaster } from "../../subscriber/Broadcaster"
 import { QueryFailedError } from "../../error/QueryFailedError"
 import { QueryResult } from "../../query-runner/QueryResult"
+import { BroadcasterResult } from "../../subscriber/BroadcasterResult"
 
 /**
  * Runs queries on a single sqlite database connection.
@@ -82,7 +83,11 @@ export class SqljsQueryRunner extends AbstractSqliteQueryRunner {
         const command = query.trim().split(" ", 1)[0]
 
         const databaseConnection = this.driver.databaseConnection
+        const broadcasterResult = new BroadcasterResult()
+
         this.driver.connection.logger.logQuery(query, parameters, this)
+        this.broadcaster.broadcastBeforeQueryEvent(broadcasterResult, query, parameters)
+
         const queryStartTime = +new Date()
         let statement: any
         try {
@@ -100,6 +105,7 @@ export class SqljsQueryRunner extends AbstractSqliteQueryRunner {
                 this.driver.options.maxQueryExecutionTime
             const queryEndTime = +new Date()
             const queryExecutionTime = queryEndTime - queryStartTime
+
             if (
                 maxQueryExecutionTime &&
                 queryExecutionTime > maxQueryExecutionTime
@@ -116,6 +122,16 @@ export class SqljsQueryRunner extends AbstractSqliteQueryRunner {
             while (statement.step()) {
                 records.push(statement.getAsObject())
             }
+
+            this.broadcaster.broadcastAfterQueryEvent(
+                broadcasterResult,
+                query,
+                parameters,
+                true,
+                queryExecutionTime,
+                records,
+                undefined
+            )
 
             const result = new QueryResult()
 
@@ -134,18 +150,31 @@ export class SqljsQueryRunner extends AbstractSqliteQueryRunner {
             } else {
                 return result.raw
             }
-        } catch (e) {
+        } catch (err) {
             if (statement) {
                 statement.free()
             }
 
             this.driver.connection.logger.logQueryError(
-                e,
+                err,
                 query,
                 parameters,
                 this,
             )
-            throw new QueryFailedError(query, parameters, e)
+            this.broadcaster.broadcastAfterQueryEvent(
+                broadcasterResult,
+                query,
+                parameters,
+                false,
+                undefined,
+                undefined,
+                err
+            )
+
+            throw new QueryFailedError(query, parameters, err)
+        } finally {
+            if (broadcasterResult.promises.length > 0)
+                await Promise.all(broadcasterResult.promises)
         }
     }
 }

--- a/src/driver/sqlserver/SqlServerQueryRunner.ts
+++ b/src/driver/sqlserver/SqlServerQueryRunner.ts
@@ -213,7 +213,11 @@ export class SqlServerQueryRunner
 
         try {
             this.driver.connection.logger.logQuery(query, parameters, this)
-            this.broadcaster.broadcastBeforeQueryEvent(broadcasterResult, query, parameters)
+            this.broadcaster.broadcastBeforeQueryEvent(
+                broadcasterResult,
+                query,
+                parameters,
+            )
 
             const pool = await (this.mode === "slave"
                 ? this.driver.obtainSlaveConnection()
@@ -258,7 +262,7 @@ export class SqlServerQueryRunner
                         true,
                         queryExecutionTime,
                         raw,
-                        undefined
+                        undefined,
                     )
 
                     if (
@@ -320,7 +324,7 @@ export class SqlServerQueryRunner
                 false,
                 undefined,
                 undefined,
-                err
+                err,
             )
 
             throw err

--- a/src/driver/sqlserver/SqlServerQueryRunner.ts
+++ b/src/driver/sqlserver/SqlServerQueryRunner.ts
@@ -27,6 +27,7 @@ import { TypeORMError } from "../../error"
 import { QueryLock } from "../../query-runner/QueryLock"
 import { MetadataTableType } from "../types/MetadataTableType"
 import { InstanceChecker } from "../../util/InstanceChecker"
+import { BroadcasterResult } from "../../subscriber/BroadcasterResult"
 
 /**
  * Runs queries on a single SQL Server database connection.
@@ -208,8 +209,12 @@ export class SqlServerQueryRunner
 
         const release = await this.lock.acquire()
 
+        const broadcasterResult = new BroadcasterResult()
+
         try {
             this.driver.connection.logger.logQuery(query, parameters, this)
+            this.broadcaster.broadcastBeforeQueryEvent(broadcasterResult, query, parameters)
+
             const pool = await (this.mode === "slave"
                 ? this.driver.obtainSlaveConnection()
                 : this.driver.obtainMasterConnection())
@@ -245,6 +250,17 @@ export class SqlServerQueryRunner
                         this.driver.options.maxQueryExecutionTime
                     const queryEndTime = +new Date()
                     const queryExecutionTime = queryEndTime - queryStartTime
+
+                    this.broadcaster.broadcastAfterQueryEvent(
+                        broadcasterResult,
+                        query,
+                        parameters,
+                        true,
+                        queryExecutionTime,
+                        raw,
+                        undefined
+                    )
+
                     if (
                         maxQueryExecutionTime &&
                         queryExecutionTime > maxQueryExecutionTime
@@ -297,8 +313,21 @@ export class SqlServerQueryRunner
                 parameters,
                 this,
             )
+            this.broadcaster.broadcastAfterQueryEvent(
+                broadcasterResult,
+                query,
+                parameters,
+                false,
+                undefined,
+                undefined,
+                err
+            )
+
             throw err
         } finally {
+            if (broadcasterResult.promises.length > 0)
+                await Promise.all(broadcasterResult.promises)
+
             release()
         }
     }

--- a/src/metadata/EntityMetadata.ts
+++ b/src/metadata/EntityMetadata.ts
@@ -458,7 +458,7 @@ export class EntityMetadata {
     afterLoadListeners: EntityListenerMetadata[] = []
 
     /**
-     * Listener metadatas with "AFTER INSERT" type.
+     * Listener metadatas with "BEFORE INSERT" type.
      */
     beforeInsertListeners: EntityListenerMetadata[] = []
 
@@ -468,7 +468,7 @@ export class EntityMetadata {
     afterInsertListeners: EntityListenerMetadata[] = []
 
     /**
-     * Listener metadatas with "AFTER UPDATE" type.
+     * Listener metadatas with "BEFORE UPDATE" type.
      */
     beforeUpdateListeners: EntityListenerMetadata[] = []
 
@@ -478,7 +478,7 @@ export class EntityMetadata {
     afterUpdateListeners: EntityListenerMetadata[] = []
 
     /**
-     * Listener metadatas with "AFTER REMOVE" type.
+     * Listener metadatas with "BEFORE REMOVE" type.
      */
     beforeRemoveListeners: EntityListenerMetadata[] = []
 

--- a/src/subscriber/Broadcaster.ts
+++ b/src/subscriber/Broadcaster.ts
@@ -422,7 +422,7 @@ export class Broadcaster {
     /**
      * Broadcasts "AFTER_QUERY" event.
      */
-     broadcastAfterQueryEvent(
+    broadcastAfterQueryEvent(
         result: BroadcasterResult,
         query: string,
         parameters: undefined | any[],

--- a/src/subscriber/Broadcaster.ts
+++ b/src/subscriber/Broadcaster.ts
@@ -8,6 +8,9 @@ import { RelationMetadata } from "../metadata/RelationMetadata"
 import { ObjectUtils } from "../util/ObjectUtils"
 
 interface BroadcasterEvents {
+    BeforeQuery: () => void
+    AfterQuery: () => void
+
     BeforeTransactionCommit: () => void
     AfterTransactionCommit: () => void
     BeforeTransactionStart: () => void
@@ -381,6 +384,66 @@ export class Broadcaster {
                         manager: this.queryRunner.manager,
                         entity: entity,
                         metadata: metadata,
+                    })
+                    if (executionResult instanceof Promise)
+                        result.promises.push(executionResult)
+                    result.count++
+                }
+            })
+        }
+    }
+
+    /**
+     * Broadcasts "BEFORE_QUERY" event.
+     */
+    broadcastBeforeQueryEvent(
+        result: BroadcasterResult,
+        query: string,
+        parameters: undefined | any[],
+    ): void {
+        if (this.queryRunner.connection.subscribers.length) {
+            this.queryRunner.connection.subscribers.forEach((subscriber) => {
+                if (subscriber.beforeQuery) {
+                    const executionResult = subscriber.beforeQuery({
+                        connection: this.queryRunner.connection,
+                        queryRunner: this.queryRunner,
+                        manager: this.queryRunner.manager,
+                        query: query,
+                        parameters: parameters,
+                    })
+                    if (executionResult instanceof Promise)
+                        result.promises.push(executionResult)
+                    result.count++
+                }
+            })
+        }
+    }
+
+    /**
+     * Broadcasts "AFTER_QUERY" event.
+     */
+     broadcastAfterQueryEvent(
+        result: BroadcasterResult,
+        query: string,
+        parameters: undefined | any[],
+        success: boolean,
+        executionTime: undefined | number,
+        rawResults: undefined | any,
+        error: undefined | any,
+    ): void {
+        if (this.queryRunner.connection.subscribers.length) {
+            this.queryRunner.connection.subscribers.forEach((subscriber) => {
+                if (subscriber.afterQuery) {
+                    const executionResult = subscriber.afterQuery({
+                        connection: this.queryRunner.connection,
+                        queryRunner: this.queryRunner,
+                        manager: this.queryRunner.manager,
+                        query: query,
+                        parameters: parameters,
+                        success: success,
+                        executionTime: executionTime,
+                        rawResults: rawResults,
+                        error: error,
                     })
                     if (executionResult instanceof Promise)
                         result.promises.push(executionResult)

--- a/src/subscriber/EntitySubscriberInterface.ts
+++ b/src/subscriber/EntitySubscriberInterface.ts
@@ -7,6 +7,7 @@ import { InsertEvent } from "./event/InsertEvent"
 import { LoadEvent } from "./event/LoadEvent"
 import { SoftRemoveEvent } from "./event/SoftRemoveEvent"
 import { RecoverEvent } from "./event/RecoverEvent"
+import { AfterQueryEvent, BeforeQueryEvent } from "./event/QueryEvent"
 
 /**
  * Classes that implement this interface are subscribers that subscribe for the specific events in the ORM.
@@ -27,6 +28,16 @@ export interface EntitySubscriberInterface<Entity = any> {
      * compilation for existing subscribers).
      */
     afterLoad?(entity: Entity, event?: LoadEvent<Entity>): Promise<any> | void
+
+    /**
+     * Called before query is executed.
+     */
+    beforeQuery?(event: BeforeQueryEvent<Entity>): Promise<any> | void
+
+    /**
+     * Called after query is executed.
+     */
+    afterQuery?(event: AfterQueryEvent<Entity>): Promise<any> | void
 
     /**
      * Called before entity is inserted to the database.

--- a/src/subscriber/event/QueryEvent.ts
+++ b/src/subscriber/event/QueryEvent.ts
@@ -26,12 +26,12 @@ export interface QueryEvent<Entity> {
     /**
      * Query that is being executed.
      */
-    query: string;
+    query: string
 
     /**
      * Parameters used in the query.
      */
-    parameters?: any[];
+    parameters?: any[]
 }
 
 export interface BeforeQueryEvent<Entity> extends QueryEvent<Entity> {}
@@ -40,20 +40,20 @@ export interface AfterQueryEvent<Entity> extends QueryEvent<Entity> {
     /**
      * Whether the query was successful.
      */
-    success: boolean;
+    success: boolean
 
     /**
      * The duration of the query execution.
      */
-    executionTime?: number;
+    executionTime?: number
 
     /**
      * The raw results from the database if the query was successful.
      */
-    rawResults?: any;
+    rawResults?: any
 
     /**
      * The error thrown if the query was unsuccessful.
      */
-    error?: any;
+    error?: any
 }

--- a/src/subscriber/event/QueryEvent.ts
+++ b/src/subscriber/event/QueryEvent.ts
@@ -1,0 +1,59 @@
+import { EntityManager } from "../../entity-manager/EntityManager"
+import { DataSource } from "../../data-source/DataSource"
+import { QueryRunner } from "../../query-runner/QueryRunner"
+
+/**
+ * BeforeQueryEvent is an object that broadcaster sends to the entity subscriber before query is ran against the database.
+ */
+export interface QueryEvent<Entity> {
+    /**
+     * Connection used in the event.
+     */
+    connection: DataSource
+
+    /**
+     * QueryRunner used in the event transaction.
+     * All database operations in the subscribed event listener should be performed using this query runner instance.
+     */
+    queryRunner: QueryRunner
+
+    /**
+     * EntityManager used in the event transaction.
+     * All database operations in the subscribed event listener should be performed using this entity manager instance.
+     */
+    manager: EntityManager
+
+    /**
+     * Query that is being executed.
+     */
+    query: string;
+
+    /**
+     * Parameters used in the query.
+     */
+    parameters?: any[];
+}
+
+export interface BeforeQueryEvent<Entity> extends QueryEvent<Entity> {}
+
+export interface AfterQueryEvent<Entity> extends QueryEvent<Entity> {
+    /**
+     * Whether the query was successful.
+     */
+    success: boolean;
+
+    /**
+     * The duration of the query execution.
+     */
+    executionTime?: number;
+
+    /**
+     * The raw results from the database if the query was successful.
+     */
+    rawResults?: any;
+
+    /**
+     * The error thrown if the query was unsuccessful.
+     */
+    error?: any;
+}


### PR DESCRIPTION
Fixes #3302 (see https://github.com/typeorm/typeorm/issues/3302#issuecomment-449422542)

### Description of change

This PR adds `BeforeQuery` and `AfterQuery` events, which provide data about the queries run against the database immediately before and after execution. The events include the raw queries and parameters, and, for the `AfterQuery` event, the success status, raw result, execution time and possible error.

This feature enables better integration with a wide range of providers, such as logging and tracing utilities. Although similar functionality exists with custom loggers, only one custom logger can be used at once making multiple integrations cumbersome. Additionally, access to the query execution time is available for all queries only after manually setting [`maxQueryExecutionTime: -1`](https://orkhan.gitbook.io/typeorm/docs/logging#log-long-running-queries) -- setting this config value incorrectly could cause unexpected behavior with external connections.

I'm submitting this PR as a WIP for now to get feedback on my implementation as I finish updating the tests and documentation. If anyone has a better solution in mind, I'm open to suggestions!

<!--
  Please be clear and concise what the change is intended to do,
  why this change is needed, and how you've verified that it
  corrects what you intended.

  In some cases it may be helpful to include the current behavior
  and the new behavior.

  If the change is related to an open issue, you can link it here.
  If you include `Fixes #0000` (replacing `0000` with the issue number)
  when this is merged it will automatically mark the issue as fixed and
  close it.
-->


### Pull-Request Checklist

<!--
  Please make sure to review and check all of the following.

  If an item is not applicable, you can add "N/A" to the end.
-->

- [x] Code is up-to-date with the `master` branch
- [x] `npm run format` to apply prettier formatting
- [x] `npm run test` passes with this change
- [x] This pull request links relevant issues as `Fixes #0000`
- [ ] There are new or updated unit tests validating the change
- [ ] Documentation has been updated to reflect this change
- [x] The new commits follow conventions explained in [CONTRIBUTING.md](https://github.com/typeorm/typeorm/blob/master/CONTRIBUTING.md)

<!--
  🎉 Thank you for contributing and making TypeORM even better!
-->
