### PR TITLE
fix: malformed query when selecting deeply nested embedded entities

### DIFF
--- a/src/query-builder/SelectQueryBuilder.ts
+++ b/src/query-builder/SelectQueryBuilder.ts
@@ -3683,7 +3683,7 @@ export class SelectQueryBuilder<Entity>
                     select[key] as FindOptionsSelect<any>,
                     metadata,
                     alias,
-                    key,
+                    propertyPath,
                 )
 
                 // } else if (relation) {

--- a/test/github-issues/9272/entity/User.ts
+++ b/test/github-issues/9272/entity/User.ts
@@ -1,0 +1,32 @@
+import { Entity, PrimaryGeneratedColumn, Column } from "../../../../src"
+
+export class LatLong {
+    @Column()
+    latitude: number
+
+    @Column()
+    longitude: number
+}
+
+export class Address {
+    @Column(() => LatLong)
+    latLong: LatLong
+}
+
+@Entity()
+export class User {
+    @PrimaryGeneratedColumn()
+    id: number
+
+    @Column()
+    firstName: string
+
+    @Column()
+    lastName: string
+
+    @Column(() => Address)
+    address: Address
+
+    @Column()
+    age: number
+}

--- a/test/github-issues/9272/issue-9272.ts
+++ b/test/github-issues/9272/issue-9272.ts
@@ -1,0 +1,88 @@
+import "reflect-metadata"
+import {
+    createTestingConnections,
+    closeTestingConnections,
+    reloadTestingDatabases,
+} from "../../utils/test-utils"
+import { DataSource } from "../../../src/data-source/DataSource"
+import { expect } from "chai"
+
+import { Address, LatLong, User } from "./entity/User"
+
+describe("github issues > #9272 Fix select on deeply nested embedded entities, using Repository API", () => {
+    let dataSources: DataSource[]
+    before(
+        async () =>
+            (dataSources = await createTestingConnections({
+                entities: [__dirname + "/entity/*{.js,.ts}"],
+                schemaCreate: true,
+                dropSchema: true,
+                enabledDrivers: [
+                    "better-sqlite3",
+                    "cockroachdb",
+                    "mariadb",
+                    "mssql",
+                    "mysql",
+                    "oracle",
+                    "postgres",
+                    "spanner",
+                    "sqlite",
+                ],
+            })),
+    )
+    beforeEach(() => reloadTestingDatabases(dataSources))
+    after(() => closeTestingConnections(dataSources))
+
+    it("should be able to pass select options for deeply nested embedded entities", () =>
+        Promise.all(
+            dataSources.map(async (dataSource) => {
+                // Arrange
+                const testUser = new User()
+                testUser.firstName = "Timber"
+                testUser.lastName = "Saw"
+                testUser.age = 25
+
+                const latLong = new LatLong()
+                latLong.latitude = -23
+                latLong.longitude = -46
+
+                const address = new Address()
+                address.latLong = latLong
+
+                testUser.address = address
+
+                await dataSource.manager.save(User, testUser)
+
+                // Act
+                const usersWithLatitudeOnly = await dataSource.manager.find(
+                    User,
+                    {
+                        select: {
+                            id: true,
+                            address: {
+                                latLong: {
+                                    latitude: true,
+                                },
+                            },
+                        },
+                    },
+                )
+
+                // Assert
+                expect(usersWithLatitudeOnly).to.have.length(1)
+
+                const [user] = usersWithLatitudeOnly
+
+                user.should.haveOwnProperty("id")
+                user.should.haveOwnProperty("address")
+                user.should.not.haveOwnProperty("firstName")
+                user.should.not.haveOwnProperty("lastName")
+                user.should.not.haveOwnProperty("age")
+
+                user.address.latLong.should.haveOwnProperty("latitude")
+                user.address.latLong.should.not.haveOwnProperty("longitude")
+
+                user.address.latLong.latitude.should.equal(-23)
+            }),
+        ))
+})


### PR DESCRIPTION
### Description of change

Fixes #9272

Update `SelectQueryBuilder.buildSelect` method to correctly build the property path for deeply nested embedded entities.

Previously, selecting a specific deeply nested embedded entity through the `FindOptionsSelect` object on the `find*` methods resulted in a runtime error, due to `SelectQueryBuilder.buildSelect` building the wrong property path for the embedded entity.

### Pull-Request Checklist

<!--
  Please make sure to review and check all of the following.

  If an item is not applicable, you can add "N/A" to the end.
-->

- [x] Code is up-to-date with the `master` branch
- [x] `npm run format` to apply prettier formatting
- [x] `npm run test` passes with this change
- [x] This pull request links relevant issues as `Fixes #0000`
- [x] There are new or updated unit tests validating the change
- [ ] Documentation has been updated to reflect this change (N/A)
- [x] The new commits follow conventions explained in [CONTRIBUTING.md](https://github.com/typeorm/typeorm/blob/master/CONTRIBUTING.md)
