### PR TITLE
docs: fix wrong function used in entity documentation

### DIFF
--- a/docs/entities.md
+++ b/docs/entities.md
@@ -161,11 +161,11 @@ When you save entities using `save` it always tries to find an entity in the dat
 If id/ids are found then it will update this row in the database.
 If there is no row with the id/ids, a new row will be inserted.
 
-To find an entity by id you can use `manager.findOne` or `repository.findOne`. Example:
+To find an entity by id you can use `manager.findOneBy` or `repository.findOneBy`. Example:
 
 ```typescript
 // find one by id with single primary key
-const person = await dataSource.manager.findBy(Person, { id: 1 })
+const person = await dataSource.manager.findOneBy(Person, { id: 1 })
 const person = await dataSource.getRepository(Person).findOneBy({ id: 1 })
 
 // find one by id with composite primary keys


### PR DESCRIPTION
<!--
  😀 Wonderful!  Thank you for opening a pull request for TypeORM.

  Please fill in the information below to expedite the review
  and (hopefully) merge of your change.

  If unsure about something.. just do as best as you're able,
  or reach out through our community support channels!
  https://github.com/typeorm/typeorm/blob/master/docs/support.md
-->

### Description of change

Previously, the documentation said that it's using the `findOne`
function (see [here](https://github.com/typeorm/typeorm/blob/master/docs/entities.md?plain=1#L164)), but it used the `findBy` and `findOneBy` functions (see [here](https://github.com/typeorm/typeorm/blob/master/docs/entities.md?plain=1#L168) and [here](https://github.com/typeorm/typeorm/blob/master/docs/entities.md?plain=1#L169)). In order
to be coherent, this commit changes all those to `findOneBy`.

<!--
  Please be clear and concise what the change is intended to do,
  why this change is needed, and how you've verified that it
  corrects what you intended.

  In some cases it may be helpful to include the current behavior
  and the new behavior.

  If the change is related to an open issue, you can link it here.
  If you include `Fixes #0000` (replacing `0000` with the issue number)
  when this is merged it will automatically mark the issue as fixed and
  close it.
-->


### Pull-Request Checklist

<!--
  Please make sure to review and check all of the following.

  If an item is not applicable, you can add "N/A" to the end.
-->

- [X] Code is up-to-date with the `master` branch
- [x] `npm run format` to apply prettier formatting
- [x] `npm run test` passes with this change
- [x] This pull request links relevant issues as `Fixes #0000`
- [x] There are new or updated unit tests validating the change
- [X] Documentation has been updated to reflect this change
- [X] The new commits follow conventions explained in [CONTRIBUTING.md](https://github.com/typeorm/typeorm/blob/master/CONTRIBUTING.md)

<!--
  🎉 Thank you for contributing and making TypeORM even better!
-->
