### PR TITLE
docs: migration replace `Connection` with `DataSource` option

### DIFF
--- a/docs/migrations.md
+++ b/docs/migrations.md
@@ -221,12 +221,12 @@ module.exports = class PostRefactoringTIMESTAMP {
 See, you don't need to write the queries on your own.
 The rule of thumb for generating migrations is that you generate them after **each** change you made to your models. To apply multi-line formatting to your generated migration queries, use the `p` (alias for `--pretty`) flag.
 
-## Connection option
+## DataSoure option
 
-If you need to run/revert your migrations for another connection rather than the default, use the `-c` (alias for `--connection`) and pass the config name as an argument
+If you need to run/revert your migrations use the `-d` (alias for `--dataSource`) and pass the path to the file where your DataSource instance is defined as an argument
 
 ```
-typeorm -c <your-config-name> migration:{run|revert}
+typeorm -d <your-dataSource-path> migration:{run|revert}
 ```
 
 ## Timestamp option

--- a/docs/migrations.md
+++ b/docs/migrations.md
@@ -223,10 +223,10 @@ The rule of thumb for generating migrations is that you generate them after **ea
 
 ## DataSoure option
 
-If you need to run/revert your migrations use the `-d` (alias for `--dataSource`) and pass the path to the file where your DataSource instance is defined as an argument
+If you need to run/revert/generate/show your migrations use the `-d` (alias for `--dataSource`) and pass the path to the file where your DataSource instance is defined as an argument
 
 ```
-typeorm -d <your-dataSource-path> migration:{run|revert}
+typeorm -d <your-data-source-path> migration:{run|revert}
 ```
 
 ## Timestamp option


### PR DESCRIPTION
### Description of change

The current migration documentation still reveres to the option `-c` (for `Connection`):
https://github.com/typeorm/typeorm/blob/15f90e0be897f5bd2f4dac1d1e8d24f539a842a8/docs/migrations.md?plain=1#L224-L230
This option was replaced by `-d` (for `DataSource`) in [v0.3.0](https://github.com/typeorm/typeorm/commit/3b8a031ece508820651a3a8f99f9cbf87319812c). 

This PR updates the documentation for this option.

### Pull-Request Checklist

<!--
  Please make sure to review and check all of the following.

  If an item is not applicable, you can add "N/A" to the end.
-->

- [x] Code is up-to-date with the `master` branch
- [x] `npm run format` to apply prettier formatting
- [ ] `npm run test` passes with this change "N/A"
- [ ] This pull request links relevant issues as `Fixes #0000` "N/A"
- [ ] There are new or updated unit tests validating the change "N/A"
- [x] Documentation has been updated to reflect this change
- [x] The new commits follow conventions explained in [CONTRIBUTING.md](https://github.com/typeorm/typeorm/blob/master/CONTRIBUTING.md)

<!--
  🎉 Thank you for contributing and making TypeORM even better!
-->
