### PR TITLE
fix #9318 change postgres driver version checking query

### DIFF
--- a/src/driver/postgres/PostgresDriver.ts
+++ b/src/driver/postgres/PostgresDriver.ts
@@ -375,13 +375,16 @@ export class PostgresDriver implements Driver {
 
         const results = (await this.executeQuery(
             connection,
-            "SHOW server_version;",
+            "SELECT version();",
         )) as {
             rows: {
-                server_version: string
+                version: string
             }[]
         }
-        const versionString = results.rows[0].server_version
+        const versionString = results.rows[0].version.replace(
+            /^PostgreSQL ([\d\.]+) .*$/,
+            "$1",
+        )
         this.isGeneratedColumnsSupported = VersionUtils.isGreaterOrEqual(
             versionString,
             "12.0",

--- a/src/driver/postgres/PostgresQueryRunner.ts
+++ b/src/driver/postgres/PostgresQueryRunner.ts
@@ -3989,8 +3989,8 @@ export class PostgresQueryRunner
      * Loads Postgres version.
      */
     protected async getVersion(): Promise<string> {
-        const result = await this.query(`SHOW SERVER_VERSION`)
-        return result[0]["server_version"]
+        const result = await this.query(`SELECT version()`)
+        return result[0]["version"].replace(/^PostgreSQL ([\d\.]+) .*$/, "$1")
     }
 
     /**

--- a/test/functional/cube/postgres/cube-postgres.ts
+++ b/test/functional/cube/postgres/cube-postgres.ts
@@ -109,10 +109,11 @@ describe("cube-postgres", () => {
                 // Get Postgres version because zero-length cubes are not legal
                 // on all Postgres versions. Zero-length cubes are only tested
                 // to be working on Postgres version >=10.6.
-                const [{ server_version }] = await connection.query(
-                    "SHOW server_version",
-                )
-                const semverArray = server_version.split(".").map(Number)
+                const [{ version }] = await connection.query("SELECT version()")
+                const semverArray = version
+                    .replace(/^PostgreSQL ([\d\.]+) .*$/, "$1")
+                    .split(".")
+                    .map(Number)
                 if (!(semverArray[0] >= 10 && semverArray[1] >= 6)) {
                     return
                 }

--- a/test/github-issues/9318/issue-9318.ts
+++ b/test/github-issues/9318/issue-9318.ts
@@ -1,8 +1,8 @@
 import "reflect-metadata"
 import {
-    createTestingConnections,
-    closeTestingConnections,
-    reloadTestingDatabases,
+  createTestingConnections,
+  closeTestingConnections,
+  reloadTestingDatabases,
 } from "../../utils/test-utils"
 import { DataSource } from "../../../src"
 
@@ -10,38 +10,36 @@ import { expect } from "chai"
 import { PostgresDriver } from "../../../src/driver/postgres/PostgresDriver"
 import { VersionUtils } from "../../../src/util/VersionUtils"
 
-describe.only("github issues > #9318 Change version query from SHOW server_version to SELECT version", () => {
-    let connections: DataSource[]
-    before(
-        async () =>
-            (connections = await createTestingConnections({
-                entities: [],
-                schemaCreate: false,
-                dropSchema: true,
-                enabledDrivers: ["postgres"],
-            })),
-    )
-    beforeEach(() => reloadTestingDatabases(connections))
-    after(() => closeTestingConnections(connections))
+describe("github issues > #9318 Change version query from SHOW server_version to SELECT version", () => {
+  let connections: DataSource[]
+  before(
+    async () =>
+      (connections = await createTestingConnections({
+        entities: [],
+        schemaCreate: false,
+        dropSchema: true,
+        enabledDrivers: ["postgres"],
+      })),
+  )
+  beforeEach(() => reloadTestingDatabases(connections))
+  after(() => closeTestingConnections(connections))
 
-    it("should have proper isGeneratedColumnsSupported value for postgres version", () =>
-        Promise.all(
-            connections.map(async (connection) => {
-                const { isGeneratedColumnsSupported } =
-                    connection.driver as PostgresDriver
-                const result = await connection.query("SELECT VERSION()")
-                const dbVersion = result[0]["version"].replace(
-                    /^PostgreSQL ([\d\.]+) .*$/,
-                    "$1",
-                )
-                const versionGreaterOfEqualTo12 = VersionUtils.isGreaterOrEqual(
-                    dbVersion,
-                    "12.0",
-                )
+  it("should have proper isGeneratedColumnsSupported value for postgres version", () =>
+    Promise.all(
+      connections.map(async (connection) => {
+        const { isGeneratedColumnsSupported } =
+          connection.driver as PostgresDriver
+        const result = await connection.query("SELECT VERSION()")
+        const dbVersion = result[0]["version"].replace(
+          /^PostgreSQL ([\d\.]+) .*$/,
+          "$1",
+        )
+        const versionGreaterOfEqualTo12 = VersionUtils.isGreaterOrEqual(
+          dbVersion,
+          "12.0",
+        )
 
-                expect(isGeneratedColumnsSupported).to.eq(
-                    versionGreaterOfEqualTo12,
-                )
-            }),
-        ))
+        expect(isGeneratedColumnsSupported).to.eq(versionGreaterOfEqualTo12)
+      }),
+    ))
 })

--- a/test/github-issues/9318/issue-9318.ts
+++ b/test/github-issues/9318/issue-9318.ts
@@ -1,0 +1,47 @@
+import "reflect-metadata"
+import {
+    createTestingConnections,
+    closeTestingConnections,
+    reloadTestingDatabases,
+} from "../../utils/test-utils"
+import { DataSource } from "../../../src"
+
+import { expect } from "chai"
+import { PostgresDriver } from "../../../src/driver/postgres/PostgresDriver"
+import { VersionUtils } from "../../../src/util/VersionUtils"
+
+describe.only("github issues > #9318 Change version query from SHOW server_version to SELECT version", () => {
+    let connections: DataSource[]
+    before(
+        async () =>
+            (connections = await createTestingConnections({
+                entities: [],
+                schemaCreate: false,
+                dropSchema: true,
+                enabledDrivers: ["postgres"],
+            })),
+    )
+    beforeEach(() => reloadTestingDatabases(connections))
+    after(() => closeTestingConnections(connections))
+
+    it("should have proper isGeneratedColumnsSupported value for postgres version", () =>
+        Promise.all(
+            connections.map(async (connection) => {
+                const { isGeneratedColumnsSupported } =
+                    connection.driver as PostgresDriver
+                const result = await connection.query("SELECT VERSION()")
+                const dbVersion = result[0]["version"].replace(
+                    /^PostgreSQL ([\d\.]+) .*$/,
+                    "$1",
+                )
+                const versionGreaterOfEqualTo12 = VersionUtils.isGreaterOrEqual(
+                    dbVersion,
+                    "12.0",
+                )
+
+                expect(isGeneratedColumnsSupported).to.eq(
+                    versionGreaterOfEqualTo12,
+                )
+            }),
+        ))
+})

--- a/test/github-issues/9318/issue-9318.ts
+++ b/test/github-issues/9318/issue-9318.ts
@@ -1,8 +1,8 @@
 import "reflect-metadata"
 import {
-  createTestingConnections,
-  closeTestingConnections,
-  reloadTestingDatabases,
+    createTestingConnections,
+    closeTestingConnections,
+    reloadTestingDatabases,
 } from "../../utils/test-utils"
 import { DataSource } from "../../../src"
 
@@ -11,35 +11,37 @@ import { PostgresDriver } from "../../../src/driver/postgres/PostgresDriver"
 import { VersionUtils } from "../../../src/util/VersionUtils"
 
 describe("github issues > #9318 Change version query from SHOW server_version to SELECT version", () => {
-  let connections: DataSource[]
-  before(
-    async () =>
-      (connections = await createTestingConnections({
-        entities: [],
-        schemaCreate: false,
-        dropSchema: true,
-        enabledDrivers: ["postgres"],
-      })),
-  )
-  beforeEach(() => reloadTestingDatabases(connections))
-  after(() => closeTestingConnections(connections))
+    let connections: DataSource[]
+    before(
+        async () =>
+            (connections = await createTestingConnections({
+                entities: [],
+                schemaCreate: false,
+                dropSchema: true,
+                enabledDrivers: ["postgres"],
+            })),
+    )
+    beforeEach(() => reloadTestingDatabases(connections))
+    after(() => closeTestingConnections(connections))
 
-  it("should have proper isGeneratedColumnsSupported value for postgres version", () =>
-    Promise.all(
-      connections.map(async (connection) => {
-        const { isGeneratedColumnsSupported } =
-          connection.driver as PostgresDriver
-        const result = await connection.query("SELECT VERSION()")
-        const dbVersion = result[0]["version"].replace(
-          /^PostgreSQL ([\d\.]+) .*$/,
-          "$1",
-        )
-        const versionGreaterOfEqualTo12 = VersionUtils.isGreaterOrEqual(
-          dbVersion,
-          "12.0",
-        )
+    it("should have proper isGeneratedColumnsSupported value for postgres version", () =>
+        Promise.all(
+            connections.map(async (connection) => {
+                const { isGeneratedColumnsSupported } =
+                    connection.driver as PostgresDriver
+                const result = await connection.query("SELECT VERSION()")
+                const dbVersion = result[0]["version"].replace(
+                    /^PostgreSQL ([\d\.]+) .*$/,
+                    "$1",
+                )
+                const versionGreaterOfEqualTo12 = VersionUtils.isGreaterOrEqual(
+                    dbVersion,
+                    "12.0",
+                )
 
-        expect(isGeneratedColumnsSupported).to.eq(versionGreaterOfEqualTo12)
-      }),
-    ))
+                expect(isGeneratedColumnsSupported).to.eq(
+                    versionGreaterOfEqualTo12,
+                )
+            }),
+        ))
 })


### PR DESCRIPTION
### Description of change

Change Postgres driver version checking query to add compatibility with the Postgres compatible AWS Redshift database.

When connecting using the Postgres driver, the afterConnect method is running the SQL `SHOW server_version;` as part of feature support detection. This command works on postgres and cockroachdb, but is incompatible with the postgres compatible redshift database.

This change adjusts the postgres `SHOW server_version` query to use `SELECT version()` which is supported by Postgres and CockroachDB, and gives compatibility with AWS Redshift database

Example command outputs:

**Redshift**
`SELECT version();`
PostgreSQL 8.0.2 on i686-pc-linux-gnu, compiled by GCC gcc (GCC) 3.4.2 20041017 (Red Hat 3.4.2-6.fc3), Redshift 1.0.40677



**Postgresql**
`SELECT version();`
PostgreSQL 14.5 (Debian 14.5-1.pgdg110+1) on x86_64-pc-linux-gnu, compiled by gcc (Debian 10.2.1-6) 10.2.1 20210110, 64-bit
PostgreSQL 11.16 (Debian 11.16-1.pgdg90+1) on x86_64-pc-linux-gnu, compiled by gcc (Debian 6.3.0-18+deb9u1) 6.3.0 20170516, 64-bit

`SHOW server_version;`
14.5 (Debian 14.5-1.pgdg110+1)
11.16 (Debian 11.16-1.pgdg90+1)


Fixes #9318

### Pull-Request Checklist

- [x] Code is up-to-date with the `master` branch
- [x] `npm run format` to apply prettier formatting
- [x] `npm run test` passes with this change
- [x] This pull request links relevant issues as `Fixes #0000`
- [x] There are new or updated unit tests validating the change
- [] Documentation has been updated to reflect this change N/A
- [x] The new commits follow conventions explained in [CONTRIBUTING.md](https://github.com/typeorm/typeorm/blob/master/CONTRIBUTING.md)