### PR TITLE
fix: add missing support for `primaryKeyConstraintName` property in EntitySchema

### DIFF
--- a/src/entity-schema/EntitySchemaColumnOptions.ts
+++ b/src/entity-schema/EntitySchemaColumnOptions.ts
@@ -203,4 +203,9 @@ export interface EntitySchemaColumnOptions extends SpatialColumnOptions {
      * this column when reading or writing to the database.
      */
     transformer?: ValueTransformer | ValueTransformer[]
+
+    /**
+     * Name of the primary key constraint.
+     */
+    primaryKeyConstraintName?: string
 }

--- a/src/entity-schema/EntitySchemaTransformer.ts
+++ b/src/entity-schema/EntitySchemaTransformer.ts
@@ -81,6 +81,8 @@ export class EntitySchemaTransformer {
                 options: {
                     type: regularColumn.type,
                     name: regularColumn.objectId ? "_id" : regularColumn.name,
+                    primaryKeyConstraintName:
+                        regularColumn.primaryKeyConstraintName,
                     length: regularColumn.length,
                     width: regularColumn.width,
                     nullable: regularColumn.nullable,

--- a/test/functional/entity-schema/custom-constraint-names/foreign-key/entity/Animal.ts
+++ b/test/functional/entity-schema/custom-constraint-names/foreign-key/entity/Animal.ts
@@ -1,0 +1,49 @@
+import { EntitySchema } from "../../../../../../src"
+
+export const AnimalSchema = new EntitySchema<any>({
+    name: "animal",
+    columns: {
+        id: {
+            primary: true,
+            type: Number,
+            generated: "increment",
+        },
+    },
+    relations: {
+        categories: {
+            type: "many-to-many",
+            target: "category",
+            joinTable: {
+                name: "animal_category",
+                joinColumn: {
+                    name: "categoryId",
+                    referencedColumnName: "id",
+                    foreignKeyConstraintName: "fk_animal_category_categoryId",
+                },
+                inverseJoinColumn: {
+                    name: "animalId",
+                    referencedColumnName: "id",
+                    foreignKeyConstraintName: "fk_animal_category_animalId",
+                },
+            },
+        },
+        breed: {
+            type: "many-to-one",
+            target: "breed",
+            joinColumn: {
+                name: "breedId",
+                referencedColumnName: "id",
+                foreignKeyConstraintName: "fk_animal_breedId",
+            },
+        },
+        name: {
+            type: "one-to-one",
+            target: "name",
+            joinColumn: {
+                name: "nameId",
+                referencedColumnName: "id",
+                foreignKeyConstraintName: "fk_animal_nameId",
+            },
+        },
+    },
+})

--- a/test/functional/entity-schema/custom-constraint-names/foreign-key/entity/Breed.ts
+++ b/test/functional/entity-schema/custom-constraint-names/foreign-key/entity/Breed.ts
@@ -1,0 +1,12 @@
+import { EntitySchema } from "../../../../../../src"
+
+export const BreedSchema = new EntitySchema<any>({
+    name: "breed",
+    columns: {
+        id: {
+            primary: true,
+            type: Number,
+            generated: "increment",
+        },
+    },
+})

--- a/test/functional/entity-schema/custom-constraint-names/foreign-key/entity/Category.ts
+++ b/test/functional/entity-schema/custom-constraint-names/foreign-key/entity/Category.ts
@@ -1,0 +1,12 @@
+import { EntitySchema } from "../../../../../../src"
+
+export const CategorySchema = new EntitySchema<any>({
+    name: "category",
+    columns: {
+        id: {
+            primary: true,
+            type: Number,
+            generated: "increment",
+        },
+    },
+})

--- a/test/functional/entity-schema/custom-constraint-names/foreign-key/entity/Name.ts
+++ b/test/functional/entity-schema/custom-constraint-names/foreign-key/entity/Name.ts
@@ -1,0 +1,12 @@
+import { EntitySchema } from "../../../../../../src"
+
+export const NameSchema = new EntitySchema<any>({
+    name: "name",
+    columns: {
+        id: {
+            primary: true,
+            type: Number,
+            generated: "increment",
+        },
+    },
+})

--- a/test/functional/entity-schema/custom-constraint-names/foreign-key/foreign-key.ts
+++ b/test/functional/entity-schema/custom-constraint-names/foreign-key/foreign-key.ts
@@ -1,0 +1,208 @@
+import "reflect-metadata"
+import { expect } from "chai"
+import {
+    closeTestingConnections,
+    createTestingConnections,
+    reloadTestingDatabases,
+} from "../../../../utils/test-utils"
+import { DataSource } from "../../../../../src"
+import { AnimalSchema } from "./entity/Animal"
+
+describe("entity schema > custom constraint names > foreign key", () => {
+    let dataSources: DataSource[]
+
+    before(
+        async () =>
+            (dataSources = await createTestingConnections({
+                entities: [__dirname + "/entity/*{.js,.ts}"],
+            })),
+    )
+    beforeEach(() => reloadTestingDatabases(dataSources))
+    after(() => closeTestingConnections(dataSources))
+
+    it("should set custom constraint names", () =>
+        Promise.all(
+            dataSources.map(async (dataSource) => {
+                let metadata = dataSource.getMetadata(AnimalSchema)
+
+                // check ManyToMany constraints
+                const joinTable = metadata.ownRelations[0]
+                const mtmFk1 = joinTable.foreignKeys.find(
+                    (fk) => fk.name === "fk_animal_category_categoryId",
+                )
+                const mtmFk2 = joinTable.foreignKeys.find(
+                    (fk) => fk.name === "fk_animal_category_animalId",
+                )
+
+                expect(mtmFk1).to.exist
+                expect(mtmFk2).to.exist
+
+                // check ManyToOne constraint
+                const mtoFk = metadata.foreignKeys.find(
+                    (fk) => fk.name === "fk_animal_breedId",
+                )
+                expect(mtoFk).to.exist
+
+                // check OneToOne constraint
+                const otoFk = metadata.foreignKeys.find(
+                    (fk) => fk.name === "fk_animal_nameId",
+                )
+                expect(otoFk).to.exist
+            }),
+        ))
+
+    it("should load constraints with custom names", () =>
+        Promise.all(
+            dataSources.map(async (dataSource) => {
+                const queryRunner = dataSource.createQueryRunner()
+                const table = await queryRunner.getTable("animal")
+                const joinTable = await queryRunner.getTable("animal_category")
+                await queryRunner.release()
+
+                // check ManyToMany constraints
+                const mtmFk1 = joinTable!.foreignKeys.find(
+                    (fk) => fk.name === "fk_animal_category_categoryId",
+                )
+                const mtmFk2 = joinTable!.foreignKeys.find(
+                    (fk) => fk.name === "fk_animal_category_animalId",
+                )
+
+                expect(mtmFk1).to.exist
+                expect(mtmFk2).to.exist
+
+                // check ManyToOne constraint
+                const mtoFk = table!.foreignKeys.find(
+                    (fk) => fk.name === "fk_animal_breedId",
+                )
+                expect(mtoFk).to.exist
+
+                // check OneToOne constraint
+                const otoFk = table!.foreignKeys.find(
+                    (fk) => fk.name === "fk_animal_nameId",
+                )
+                expect(otoFk).to.exist
+            }),
+        ))
+
+    it("should not change constraint names when table renamed", () =>
+        Promise.all(
+            dataSources.map(async (dataSource) => {
+                const queryRunner = dataSource.createQueryRunner()
+                await queryRunner.renameTable("animal", "animal_renamed")
+                await queryRunner.renameTable(
+                    "animal_category",
+                    "animal_category_renamed",
+                )
+
+                const table = await queryRunner.getTable("animal_renamed")
+                const joinTable = await queryRunner.getTable(
+                    "animal_category_renamed",
+                )
+
+                await queryRunner.release()
+
+                // check ManyToMany constraints
+                const mtmFk1 = joinTable!.foreignKeys.find(
+                    (fk) => fk.name === "fk_animal_category_categoryId",
+                )
+                const mtmFk2 = joinTable!.foreignKeys.find(
+                    (fk) => fk.name === "fk_animal_category_animalId",
+                )
+
+                expect(mtmFk1).to.exist
+                expect(mtmFk2).to.exist
+
+                // check ManyToOne constraint
+                const mtoFk = table!.foreignKeys.find(
+                    (fk) => fk.name === "fk_animal_breedId",
+                )
+                expect(mtoFk).to.exist
+
+                // check OneToOne constraint
+                const otoFk = table!.foreignKeys.find(
+                    (fk) => fk.name === "fk_animal_nameId",
+                )
+                expect(otoFk).to.exist
+            }),
+        ))
+
+    it("should not change constraint names when column renamed", () =>
+        Promise.all(
+            dataSources.map(async (dataSource) => {
+                // in SqlServer we can't change column that is used in FK.
+                if (dataSource.driver.options.type === "mssql") return
+
+                const queryRunner = dataSource.createQueryRunner()
+
+                let table = await queryRunner.getTable("animal")
+
+                const breedIdColumn = table!.findColumnByName("breedId")!
+                const changedBreedIdColumn = breedIdColumn.clone()
+                changedBreedIdColumn.name = "breedId_renamed"
+
+                const nameIdColumn = table!.findColumnByName("nameId")!
+                const changedNameIdColumn = nameIdColumn.clone()
+                changedNameIdColumn.name = "nameId_renamed"
+
+                await queryRunner.changeColumns(table!, [
+                    {
+                        oldColumn: breedIdColumn,
+                        newColumn: changedBreedIdColumn,
+                    },
+                    {
+                        oldColumn: nameIdColumn,
+                        newColumn: changedNameIdColumn,
+                    },
+                ])
+
+                let joinTable = await queryRunner.getTable("animal_category")
+                const categoryIdColumn =
+                    joinTable!.findColumnByName("categoryId")!
+                const changedCategoryIdColumn = categoryIdColumn.clone()
+                changedCategoryIdColumn.name = "categoryId_renamed"
+
+                const animalIdColumn = joinTable!.findColumnByName("animalId")!
+                const changedAnimalIdColumn = animalIdColumn.clone()
+                changedAnimalIdColumn.name = "animalId_renamed"
+
+                await queryRunner.changeColumns(joinTable!, [
+                    {
+                        oldColumn: categoryIdColumn,
+                        newColumn: changedCategoryIdColumn,
+                    },
+                    {
+                        oldColumn: animalIdColumn,
+                        newColumn: changedAnimalIdColumn,
+                    },
+                ])
+
+                table = await queryRunner.getTable("animal")
+                joinTable = await queryRunner.getTable("animal_category")
+
+                await queryRunner.release()
+
+                // check ManyToMany constraints
+                const mtmFk1 = joinTable!.foreignKeys.find(
+                    (fk) => fk.name === "fk_animal_category_categoryId",
+                )
+                const mtmFk2 = joinTable!.foreignKeys.find(
+                    (fk) => fk.name === "fk_animal_category_animalId",
+                )
+
+                expect(mtmFk1).to.exist
+                expect(mtmFk2).to.exist
+
+                // check ManyToOne constraint
+                const mtoFk = table!.foreignKeys.find(
+                    (fk) => fk.name === "fk_animal_breedId",
+                )
+                expect(mtoFk).to.exist
+
+                // check OneToOne constraint
+                const otoFk = table!.foreignKeys.find(
+                    (fk) => fk.name === "fk_animal_nameId",
+                )
+                expect(otoFk).to.exist
+            }),
+        ))
+})

--- a/test/functional/entity-schema/custom-constraint-names/index/entity/Post.ts
+++ b/test/functional/entity-schema/custom-constraint-names/index/entity/Post.ts
@@ -1,0 +1,28 @@
+import { EntitySchema } from "../../../../../../src"
+
+export const PostSchema = new EntitySchema<any>({
+    name: "post",
+    columns: {
+        id: {
+            primary: true,
+            type: Number,
+            generated: "increment",
+        },
+        name: {
+            type: String,
+        },
+        header: {
+            type: String,
+        },
+    },
+    indices: [
+        {
+            name: "IDX_NAME",
+            columns: ["name"],
+        },
+        {
+            name: "IDX_HEADER",
+            columns: ["header"],
+        },
+    ],
+})

--- a/test/functional/entity-schema/custom-constraint-names/index/index.ts
+++ b/test/functional/entity-schema/custom-constraint-names/index/index.ts
@@ -1,0 +1,114 @@
+import "reflect-metadata"
+import { expect } from "chai"
+import {
+    closeTestingConnections,
+    createTestingConnections,
+    reloadTestingDatabases,
+} from "../../../../utils/test-utils"
+import { DataSource } from "../../../../../src"
+import { PostSchema } from "./entity/Post"
+
+describe("entity schema > custom constraint names > index", () => {
+    let dataSources: DataSource[]
+
+    before(
+        async () =>
+            (dataSources = await createTestingConnections({
+                entities: [__dirname + "/entity/*{.js,.ts}"],
+            })),
+    )
+    beforeEach(() => reloadTestingDatabases(dataSources))
+    after(() => closeTestingConnections(dataSources))
+
+    it("should set custom constraint names", () =>
+        Promise.all(
+            dataSources.map(async (dataSource) => {
+                let metadata = dataSource.getMetadata(PostSchema)
+
+                const nameIndex = metadata.indices.find(
+                    (it) => it.name === "IDX_NAME",
+                )
+                const headerIndex = metadata.indices.find(
+                    (it) => it.name === "IDX_HEADER",
+                )
+
+                expect(nameIndex).to.exist
+                expect(headerIndex).to.exist
+            }),
+        ))
+
+    it("should load constraints with custom names", () =>
+        Promise.all(
+            dataSources.map(async (dataSource) => {
+                const queryRunner = dataSource.createQueryRunner()
+                const table = await queryRunner.getTable("post")
+                await queryRunner.release()
+
+                const nameIndex = table!.indices.find(
+                    (it) => it.name === "IDX_NAME",
+                )
+                const headerIndex = table!.indices.find(
+                    (it) => it.name === "IDX_HEADER",
+                )
+
+                expect(nameIndex).to.exist
+                expect(headerIndex).to.exist
+            }),
+        ))
+
+    it("should not change constraint names when table renamed", () =>
+        Promise.all(
+            dataSources.map(async (dataSource) => {
+                const queryRunner = dataSource.createQueryRunner()
+                await queryRunner.renameTable("post", "post_renamed")
+
+                const table = await queryRunner.getTable("post_renamed")
+
+                await queryRunner.release()
+
+                const nameIndex = table!.indices.find(
+                    (it) => it.name === "IDX_NAME",
+                )
+                const headerIndex = table!.indices.find(
+                    (it) => it.name === "IDX_HEADER",
+                )
+
+                expect(nameIndex).to.exist
+                expect(headerIndex).to.exist
+            }),
+        ))
+
+    it("should not change constraint names when column renamed", () =>
+        Promise.all(
+            dataSources.map(async (dataSource) => {
+                const queryRunner = dataSource.createQueryRunner()
+
+                let table = await queryRunner.getTable("post")
+
+                const nameColumn = table!.findColumnByName("name")!
+                const changedNameColumn = nameColumn.clone()
+                changedNameColumn.name = "name_renamed"
+
+                await queryRunner.changeColumns(table!, [
+                    {
+                        oldColumn: nameColumn,
+                        newColumn: changedNameColumn,
+                    },
+                ])
+
+                table = await queryRunner.getTable("post")
+
+                await queryRunner.release()
+
+                const nameIndex = table!.indices.find(
+                    (it) => it.name === "IDX_NAME",
+                )
+                const headerIndex = table!.indices.find(
+                    (it) => it.name === "IDX_HEADER",
+                )
+
+                expect(nameIndex).to.exist
+                expect(headerIndex).to.exist
+            }),
+        ))
+})

--- a/test/functional/entity-schema/custom-constraint-names/primary-key/entity/Post.ts
+++ b/test/functional/entity-schema/custom-constraint-names/primary-key/entity/Post.ts
@@ -1,0 +1,17 @@
+import { EntitySchema } from "../../../../../../src"
+
+export const PostSchema = new EntitySchema<any>({
+    name: "post",
+    columns: {
+        name: {
+            primary: true,
+            type: String,
+            primaryKeyConstraintName: "PK_NAME_HEADER",
+        },
+        header: {
+            primary: true,
+            type: String,
+            primaryKeyConstraintName: "PK_NAME_HEADER",
+        },
+    },
+})

--- a/test/functional/entity-schema/custom-constraint-names/primary-key/entity/User.ts
+++ b/test/functional/entity-schema/custom-constraint-names/primary-key/entity/User.ts
@@ -1,0 +1,12 @@
+import { EntitySchema } from "../../../../../../src"
+
+export const UserSchema = new EntitySchema<any>({
+    name: "user",
+    columns: {
+        name: {
+            primary: true,
+            type: String,
+            primaryKeyConstraintName: "PK_ID",
+        },
+    },
+})

--- a/test/functional/entity-schema/custom-constraint-names/primary-key/primary-key.ts
+++ b/test/functional/entity-schema/custom-constraint-names/primary-key/primary-key.ts
@@ -1,0 +1,132 @@
+import "reflect-metadata"
+import { expect } from "chai"
+import {
+    closeTestingConnections,
+    createTestingConnections,
+    reloadTestingDatabases,
+} from "../../../../utils/test-utils"
+import { DataSource } from "../../../../../src"
+import { PostSchema } from "./entity/Post"
+import { UserSchema } from "./entity/User"
+
+describe("database schema > custom constraint names > primary key", () => {
+    let dataSources: DataSource[]
+
+    before(
+        async () =>
+            (dataSources = await createTestingConnections({
+                entities: [__dirname + "/entity/*{.js,.ts}"],
+                enabledDrivers: ["postgres", "cockroachdb", "mssql", "oracle"],
+            })),
+    )
+    beforeEach(() => reloadTestingDatabases(dataSources))
+    after(() => closeTestingConnections(dataSources))
+
+    it("should set custom constraint names", () =>
+        Promise.all(
+            dataSources.map(async (dataSource) => {
+                let post = dataSource.getMetadata(PostSchema)
+                let user = dataSource.getMetadata(UserSchema)
+
+                const idPK = user.primaryColumns.find(
+                    (it) => it.primaryKeyConstraintName === "PK_ID",
+                )
+                const namePK = post.primaryColumns.find(
+                    (it) => it.primaryKeyConstraintName === "PK_NAME_HEADER",
+                )
+                const headerPK = post.primaryColumns.find(
+                    (it) => it.primaryKeyConstraintName === "PK_NAME_HEADER",
+                )
+
+                expect(idPK).to.exist
+                expect(namePK).to.exist
+                expect(headerPK).to.exist
+            }),
+        ))
+
+    it("should load constraints with custom names", () =>
+        Promise.all(
+            dataSources.map(async (dataSource) => {
+                const queryRunner = dataSource.createQueryRunner()
+                const postTable = await queryRunner.getTable("post")
+                const userTable = await queryRunner.getTable("user")
+                await queryRunner.release()
+
+                const idPK = userTable!.primaryColumns.find(
+                    (it) => it.primaryKeyConstraintName === "PK_ID",
+                )
+                const namePK = postTable!.primaryColumns.find(
+                    (it) => it.primaryKeyConstraintName === "PK_NAME_HEADER",
+                )
+                const headerPK = postTable!.primaryColumns.find(
+                    (it) => it.primaryKeyConstraintName === "PK_NAME_HEADER",
+                )
+
+                expect(idPK).to.exist
+                expect(namePK).to.exist
+                expect(headerPK).to.exist
+            }),
+        ))
+
+    it("should not change constraint names when table renamed", () =>
+        Promise.all(
+            dataSources.map(async (dataSource) => {
+                const queryRunner = dataSource.createQueryRunner()
+                await queryRunner.renameTable("post", "post_renamed")
+                await queryRunner.renameTable("user", "user_renamed")
+
+                const postTable = await queryRunner.getTable("post_renamed")
+                const userTable = await queryRunner.getTable("user_renamed")
+
+                await queryRunner.release()
+
+                const idPK = userTable!.primaryColumns.find(
+                    (it) => it.primaryKeyConstraintName === "PK_ID",
+                )
+                const namePK = postTable!.primaryColumns.find(
+                    (it) => it.primaryKeyConstraintName === "PK_NAME_HEADER",
+                )
+                const headerPK = postTable!.primaryColumns.find(
+                    (it) => it.primaryKeyConstraintName === "PK_NAME_HEADER",
+                )
+
+                expect(idPK).to.exist
+                expect(namePK).to.exist
+                expect(headerPK).to.exist
+            }),
+        ))
+
+    it("should not change constraint names when column renamed", () =>
+        Promise.all(
+            dataSources.map(async (dataSource) => {
+                const queryRunner = dataSource.createQueryRunner()
+
+                let table = await queryRunner.getTable("post")
+
+                const nameColumn = table!.findColumnByName("name")!
+                const changedNameColumn = nameColumn.clone()
+                changedNameColumn.name = "name_renamed"
+
+                await queryRunner.changeColumns(table!, [
+                    {
+                        oldColumn: nameColumn,
+                        newColumn: changedNameColumn,
+                    },
+                ])
+
+                table = await queryRunner.getTable("post")
+
+                await queryRunner.release()
+
+                const namePK = table!.primaryColumns.find(
+                    (it) => it.primaryKeyConstraintName === "PK_NAME_HEADER",
+                )
+                const headerPK = table!.primaryColumns.find(
+                    (it) => it.primaryKeyConstraintName === "PK_NAME_HEADER",
+                )
+
+                expect(namePK).to.exist
+                expect(headerPK).to.exist
+            }),
+        ))
+})

--- a/test/functional/entity-schema/custom-constraint-names/unique/entity/Post.ts
+++ b/test/functional/entity-schema/custom-constraint-names/unique/entity/Post.ts
@@ -1,0 +1,21 @@
+import { EntitySchema } from "../../../../../../src"
+
+export const PostSchema = new EntitySchema<any>({
+    name: "post",
+    columns: {
+        id: {
+            primary: true,
+            type: Number,
+            generated: "increment",
+        },
+        name: {
+            type: String,
+        },
+    },
+    uniques: [
+        {
+            name: "UQ_NAME",
+            columns: ["name"],
+        },
+    ],
+})

--- a/test/functional/entity-schema/custom-constraint-names/unique/unique.ts
+++ b/test/functional/entity-schema/custom-constraint-names/unique/unique.ts
@@ -1,0 +1,147 @@
+import "reflect-metadata"
+import { expect } from "chai"
+import {
+    closeTestingConnections,
+    createTestingConnections,
+    reloadTestingDatabases,
+} from "../../../../utils/test-utils"
+import { DataSource } from "../../../../../src"
+import { PostSchema } from "./entity/Post"
+import { DriverUtils } from "../../../../../src/driver/DriverUtils"
+
+describe("database schema > custom constraint names > unique", () => {
+    let dataSources: DataSource[]
+
+    before(
+        async () =>
+            (dataSources = await createTestingConnections({
+                entities: [__dirname + "/entity/*{.js,.ts}"],
+            })),
+    )
+    beforeEach(() => reloadTestingDatabases(dataSources))
+    after(() => closeTestingConnections(dataSources))
+
+    it("should set custom constraint names", () =>
+        Promise.all(
+            dataSources.map(async (dataSource) => {
+                let metadata = dataSource.getMetadata(PostSchema)
+
+                // This drivers stores unique constraints as unique indices.
+                if (
+                    DriverUtils.isMySQLFamily(dataSource.driver) ||
+                    dataSource.driver.options.type === "aurora-mysql" ||
+                    dataSource.driver.options.type === "sap" ||
+                    dataSource.driver.options.type === "spanner"
+                ) {
+                    const uniqueIndex = metadata.indices.find(
+                        (it) => it.name === "UQ_NAME",
+                    )
+                    expect(uniqueIndex).to.exist
+                } else {
+                    const unique = metadata.uniques.find(
+                        (it) => it.name === "UQ_NAME",
+                    )
+                    expect(unique).to.exist
+                }
+            }),
+        ))
+
+    it("should load constraints with custom names", () =>
+        Promise.all(
+            dataSources.map(async (dataSource) => {
+                const queryRunner = dataSource.createQueryRunner()
+                const table = await queryRunner.getTable("post")
+                await queryRunner.release()
+
+                // This drivers stores unique constraints as unique indices.
+                if (
+                    DriverUtils.isMySQLFamily(dataSource.driver) ||
+                    dataSource.driver.options.type === "aurora-mysql" ||
+                    dataSource.driver.options.type === "sap" ||
+                    dataSource.driver.options.type === "spanner"
+                ) {
+                    const uniqueIndex = table!.indices.find(
+                        (it) => it.name === "UQ_NAME",
+                    )
+                    expect(uniqueIndex).to.exist
+                } else {
+                    const unique = table!.uniques.find(
+                        (it) => it.name === "UQ_NAME",
+                    )
+                    expect(unique).to.exist
+                }
+            }),
+        ))
+
+    it("should not change constraint names when table renamed", () =>
+        Promise.all(
+            dataSources.map(async (dataSource) => {
+                const queryRunner = dataSource.createQueryRunner()
+                await queryRunner.renameTable("post", "post_renamed")
+
+                const table = await queryRunner.getTable("post_renamed")
+
+                await queryRunner.release()
+
+                // This drivers stores unique constraints as unique indices.
+                if (
+                    DriverUtils.isMySQLFamily(dataSource.driver) ||
+                    dataSource.driver.options.type === "aurora-mysql" ||
+                    dataSource.driver.options.type === "sap" ||
+                    dataSource.driver.options.type === "spanner"
+                ) {
+                    const uniqueIndex = table!.indices.find(
+                        (it) => it.name === "UQ_NAME",
+                    )
+                    expect(uniqueIndex).to.exist
+                } else {
+                    const unique = table!.uniques.find(
+                        (it) => it.name === "UQ_NAME",
+                    )
+                    expect(unique).to.exist
+                }
+            }),
+        ))
+
+    it("should not change constraint names when column renamed", () =>
+        Promise.all(
+            dataSources.map(async (dataSource) => {
+                const queryRunner = dataSource.createQueryRunner()
+
+                let table = await queryRunner.getTable("post")
+
+                const nameColumn = table!.findColumnByName("name")!
+                const changedNameColumn = nameColumn.clone()
+                changedNameColumn.name = "name_renamed"
+
+                await queryRunner.changeColumns(table!, [
+                    {
+                        oldColumn: nameColumn,
+                        newColumn: changedNameColumn,
+                    },
+                ])
+
+                table = await queryRunner.getTable("post")
+
+                await queryRunner.release()
+
+                // This drivers stores unique constraints as unique indices.
+                if (
+                    DriverUtils.isMySQLFamily(dataSource.driver) ||
+                    dataSource.driver.options.type === "aurora-mysql" ||
+                    dataSource.driver.options.type === "sap" ||
+                    dataSource.driver.options.type === "spanner"
+                ) {
+                    const uniqueIndex = table!.indices.find(
+                        (it) => it.name === "UQ_NAME",
+                    )
+                    expect(uniqueIndex).to.exist
+                } else {
+                    const unique = table!.uniques.find(
+                        (it) => it.name === "UQ_NAME",
+                    )
+                    expect(unique).to.exist
+                }
+            }),
+        ))
+})


### PR DESCRIPTION
### Description of change

* adds missing support for `primaryKeyConstraintName` property in EntitySchema definition
* adds tests for another custom constraint names in EntitySchema definition

Fixes #9309

### Pull-Request Checklist

<!--
  Please make sure to review and check all of the following.

  If an item is not applicable, you can add "N/A" to the end.
-->

- [ ] Code is up-to-date with the `master` branch
- [ ] `npm run format` to apply prettier formatting
- [ ] `npm run test` passes with this change
- [ ] This pull request links relevant issues as `Fixes #0000`
- [ ] There are new or updated unit tests validating the change
- [ ] Documentation has been updated to reflect this change
- [ ] The new commits follow conventions explained in [CONTRIBUTING.md](https://github.com/typeorm/typeorm/blob/master/CONTRIBUTING.md)

<!--
  🎉 Thank you for contributing and making TypeORM even better!
-->
