### PR TITLE
fix: disable loading of eager relations recursively

### DIFF
--- a/src/query-builder/RelationLoader.ts
+++ b/src/query-builder/RelationLoader.ts
@@ -150,11 +150,16 @@ export class RelationLoader {
             qb.where(condition)
         }
 
-        FindOptionsUtils.joinEagerRelations(
-            qb,
-            qb.alias,
-            qb.expressionMap.mainAlias!.metadata,
-        )
+        if (
+            qb.loadEagerRelations !== false &&
+            qb.expressionMap.relationLoadStrategy === "join"
+        ) {
+            FindOptionsUtils.joinEagerRelations(
+                qb,
+                qb.alias,
+                qb.expressionMap.mainAlias!.metadata,
+            )
+        }
 
         return qb.getMany()
         // return qb.getOne(); todo: fix all usages
@@ -234,11 +239,16 @@ export class RelationLoader {
             qb.where(condition)
         }
 
-        FindOptionsUtils.joinEagerRelations(
-            qb,
-            qb.alias,
-            qb.expressionMap.mainAlias!.metadata,
-        )
+        if (
+            qb.loadEagerRelations !== false &&
+            qb.expressionMap.relationLoadStrategy === "join"
+        ) {
+            FindOptionsUtils.joinEagerRelations(
+                qb,
+                qb.alias,
+                qb.expressionMap.mainAlias!.metadata,
+            )
+        }
 
         return qb.getMany()
         // return relation.isOneToMany ? qb.getMany() : qb.getOne(); todo: fix all usages
@@ -302,11 +312,16 @@ export class RelationLoader {
             ),
         ).setParameters(parameters)
 
-        FindOptionsUtils.joinEagerRelations(
-            qb,
-            qb.alias,
-            qb.expressionMap.mainAlias!.metadata,
-        )
+        if (
+            qb.loadEagerRelations !== false &&
+            qb.expressionMap.relationLoadStrategy === "join"
+        ) {
+            FindOptionsUtils.joinEagerRelations(
+                qb,
+                qb.alias,
+                qb.expressionMap.mainAlias!.metadata,
+            )
+        }
 
         return qb.getMany()
     }
@@ -370,11 +385,16 @@ export class RelationLoader {
             ),
         ).setParameters(parameters)
 
-        FindOptionsUtils.joinEagerRelations(
-            qb,
-            qb.alias,
-            qb.expressionMap.mainAlias!.metadata,
-        )
+        if (
+            qb.loadEagerRelations !== false &&
+            qb.expressionMap.relationLoadStrategy === "join"
+        ) {
+            FindOptionsUtils.joinEagerRelations(
+                qb,
+                qb.alias,
+                qb.expressionMap.mainAlias!.metadata,
+            )
+        }
 
         return qb.getMany()
     }

--- a/test/github-issues/9006/entity/comment.entity.ts
+++ b/test/github-issues/9006/entity/comment.entity.ts
@@ -1,0 +1,11 @@
+import { Entity, ManyToOne, PrimaryGeneratedColumn } from "../../../../src"
+import { Post } from "./post.entity"
+
+@Entity()
+export class Comment {
+    @PrimaryGeneratedColumn()
+    id: number
+
+    @ManyToOne(() => Post, (post) => post.comments)
+    post: Post;
+}

--- a/test/github-issues/9006/entity/post.entity.ts
+++ b/test/github-issues/9006/entity/post.entity.ts
@@ -1,0 +1,14 @@
+import { Comment } from "./comment.entity"
+import { Entity, OneToMany, PrimaryGeneratedColumn } from "../../../../src"
+
+@Entity()
+export class Post {
+    @PrimaryGeneratedColumn()
+    id: number
+
+    @OneToMany(() => Comment, (comment) => comment.post, {
+        eager: true,
+        cascade: true,
+    })
+    comments: Comment[]
+}

--- a/test/github-issues/9006/issue-9006.ts
+++ b/test/github-issues/9006/issue-9006.ts
@@ -1,0 +1,45 @@
+import "reflect-metadata"
+import {
+    createTestingConnections,
+    closeTestingConnections,
+    reloadTestingDatabases,
+} from "../../utils/test-utils"
+import { DataSource } from "../../../src"
+import { Post } from "./entity/post.entity"
+import { Comment } from "./entity/comment.entity"
+import { expect } from "chai"
+
+describe("github issues > #9006 Eager relations do not respect relationLoadStrategy", () => {
+    let dataSources: DataSource[]
+    before(
+        async () =>
+            (dataSources = await createTestingConnections({
+                entities: [__dirname + "/entity/*{.js,.ts}"],
+                schemaCreate: true,
+                dropSchema: true,
+            })),
+    )
+    beforeEach(() => reloadTestingDatabases(dataSources))
+    after(() => closeTestingConnections(dataSources))
+
+    it("should load eager relation in separate query", async () => {
+        for (const dataSource of dataSources) {
+            const postRepository = await dataSource.getRepository(Post)
+            const post = new Post()
+            post.comments = [new Comment()]
+
+            await postRepository.save(post)
+
+            const queryBuilder = postRepository
+                .createQueryBuilder()
+                .setFindOptions({ relationLoadStrategy: "query" })
+
+            const query = queryBuilder.getSql()
+
+            const loadedPost = await queryBuilder.getMany()
+
+            expect(query).to.not.contain("LEFT JOIN")
+            expect(loadedPost).to.deep.equal([{ id: 1, comments: [{ id: 1 }] }])
+        }
+    })
+})


### PR DESCRIPTION
Closes: #9006

<!--
  😀 Wonderful!  Thank you for opening a pull request for TypeORM.

  Please fill in the information below to expedite the review
  and (hopefully) merge of your change.

  If unsure about something.. just do as best as you're able,
  or reach out through our community support channels!
  https://github.com/typeorm/typeorm/blob/master/docs/support.md
-->

### Description of change

<!--
  Please be clear and concise what the change is intended to do,
  why this change is needed, and how you've verified that it
  corrects what you intended.

  In some cases it may be helpful to include the current behavior
  and the new behavior.

  If the change is related to an open issue, you can link it here.
  If you include `Fixes #0000` (replacing `0000` with the issue number)
  when this is merged it will automatically mark the issue as fixed and
  close it.
-->
A check was added to all relevant methods in `RelationLoader` which ensures that nested eager relations are only loaded, if the loading of eager relations was not disabled explicitly in the findOptions. That way, the option `loadEagerRelations` applies recursively and not only to the first hierarchy level of relations.

Issue #9006 is fixed by adding the same check in the `applyFindOptions` method of the `SelectQueryBuilder` before calling `FindOptionsUtils.joinEagerRelations`. In order to load the eager relations using the `query` strategy, the eager relations are added to the `relations` object of `FindOptions`.

### Pull-Request Checklist

<!--
  Please make sure to review and check all of the following.

  If an item is not applicable, you can add "N/A" to the end.
-->

- [x] Code is up-to-date with the `master` branch
- [x] `npm run format` to apply prettier formatting
- [x] `npm run test` passes with this change
- [x] This pull request links relevant issues as `Fixes #0000`
- [x] There are new or updated unit tests validating the change
- [x] Documentation has been updated to reflect this change
- [x] The new commits follow conventions explained in [CONTRIBUTING.md](https://github.com/typeorm/typeorm/blob/master/CONTRIBUTING.md)

<!--
  🎉 Thank you for contributing and making TypeORM even better!
-->
