### PR TITLE
fix: Update RelationIdLoader to use DriverUtils.getAlias

### DIFF
--- a/src/query-builder/RelationIdLoader.ts
+++ b/src/query-builder/RelationIdLoader.ts
@@ -3,6 +3,7 @@ import { ColumnMetadata } from "../metadata/ColumnMetadata"
 import { DataSource } from "../data-source/DataSource"
 import { ObjectLiteral } from "../common/ObjectLiteral"
 import { SelectQueryBuilder } from "./SelectQueryBuilder"
+import { DriverUtils } from "../driver/DriverUtils"
 
 /**
  * Loads relation ids for the given entities.
@@ -158,11 +159,17 @@ export class RelationIdLoader {
                         return column.compareEntityValue(
                             relatedEntity,
                             relationId[
-                                column.entityMetadata.name +
-                                    "_" +
-                                    relation.propertyPath.replace(".", "_") +
-                                    "_" +
-                                    column.propertyPath.replace(".", "_")
+                                DriverUtils.buildAlias(
+                                    this.connection.driver,
+                                    column.entityMetadata.name +
+                                        "_" +
+                                        relation.propertyPath.replace(
+                                            ".",
+                                            "_",
+                                        ) +
+                                        "_" +
+                                        column.propertyPath.replace(".", "_"),
+                                )
                             ],
                         )
                     })
@@ -238,19 +245,23 @@ export class RelationIdLoader {
 
         // select all columns from junction table
         columns.forEach((column) => {
-            const columnName =
+            const columnName = DriverUtils.buildAlias(
+                this.connection.driver,
                 column.referencedColumn!.entityMetadata.name +
-                "_" +
-                column.referencedColumn!.propertyPath.replace(".", "_")
+                    "_" +
+                    column.referencedColumn!.propertyPath.replace(".", "_"),
+            )
             qb.addSelect(mainAlias + "." + column.propertyPath, columnName)
         })
         inverseColumns.forEach((column) => {
-            const columnName =
+            const columnName = DriverUtils.buildAlias(
+                this.connection.driver,
                 column.referencedColumn!.entityMetadata.name +
-                "_" +
-                relation.propertyPath.replace(".", "_") +
-                "_" +
-                column.referencedColumn!.propertyPath.replace(".", "_")
+                    "_" +
+                    relation.propertyPath.replace(".", "_") +
+                    "_" +
+                    column.referencedColumn!.propertyPath.replace(".", "_"),
+            )
             qb.addSelect(mainAlias + "." + column.propertyPath, columnName)
         })
 
@@ -474,22 +485,26 @@ export class RelationIdLoader {
         // select all columns we need
         const qb = this.connection.createQueryBuilder()
         relation.entityMetadata.primaryColumns.forEach((primaryColumn) => {
-            const columnName =
+            const columnName = DriverUtils.buildAlias(
+                this.connection.driver,
                 primaryColumn.entityMetadata.name +
-                "_" +
-                primaryColumn.propertyPath.replace(".", "_")
+                    "_" +
+                    primaryColumn.propertyPath.replace(".", "_"),
+            )
             qb.addSelect(
                 mainAlias + "." + primaryColumn.propertyPath,
                 columnName,
             )
         })
         relation.joinColumns.forEach((column) => {
-            const columnName =
+            const columnName = DriverUtils.buildAlias(
+                this.connection.driver,
                 column.referencedColumn!.entityMetadata.name +
-                "_" +
-                relation.propertyPath.replace(".", "_") +
-                "_" +
-                column.referencedColumn!.propertyPath.replace(".", "_")
+                    "_" +
+                    relation.propertyPath.replace(".", "_") +
+                    "_" +
+                    column.referencedColumn!.propertyPath.replace(".", "_"),
+            )
             qb.addSelect(mainAlias + "." + column.propertyPath, columnName)
         })
 
@@ -607,22 +622,26 @@ export class RelationIdLoader {
         // select all columns we need
         const qb = this.connection.createQueryBuilder()
         relation.entityMetadata.primaryColumns.forEach((primaryColumn) => {
-            const columnName =
+            const columnName = DriverUtils.buildAlias(
+                this.connection.driver,
                 primaryColumn.entityMetadata.name +
-                "_" +
-                relation.inverseRelation!.propertyPath.replace(".", "_") +
-                "_" +
-                primaryColumn.propertyPath.replace(".", "_")
+                    "_" +
+                    relation.inverseRelation!.propertyPath.replace(".", "_") +
+                    "_" +
+                    primaryColumn.propertyPath.replace(".", "_"),
+            )
             qb.addSelect(
                 mainAlias + "." + primaryColumn.propertyPath,
                 columnName,
             )
         })
         relation.joinColumns.forEach((column) => {
-            const columnName =
+            const columnName = DriverUtils.buildAlias(
+                this.connection.driver,
                 column.referencedColumn!.entityMetadata.name +
-                "_" +
-                column.referencedColumn!.propertyPath.replace(".", "_")
+                    "_" +
+                    column.referencedColumn!.propertyPath.replace(".", "_"),
+            )
             qb.addSelect(mainAlias + "." + column.propertyPath, columnName)
         })
 

--- a/test/github-issues/9379/entity/SuperLongTableName.ts
+++ b/test/github-issues/9379/entity/SuperLongTableName.ts
@@ -1,0 +1,22 @@
+import {
+    Entity,
+    PrimaryGeneratedColumn,
+    Column,
+    OneToMany,
+} from "../../../../src"
+import { SuperLongTableNameWhichIsRelatedToOriginalTable } from "./SuperLongTableNameIsRelatedToOriginal"
+
+@Entity()
+export class SuperLongTableName {
+    @PrimaryGeneratedColumn()
+    id: number
+
+    @Column()
+    name: string
+
+    @OneToMany(
+        () => SuperLongTableNameWhichIsRelatedToOriginalTable,
+        (table) => table.superLongTableName,
+    )
+    relatedToOriginal: SuperLongTableNameWhichIsRelatedToOriginalTable[]
+}

--- a/test/github-issues/9379/entity/SuperLongTableNameIsRelatedToOriginal.ts
+++ b/test/github-issues/9379/entity/SuperLongTableNameIsRelatedToOriginal.ts
@@ -1,0 +1,21 @@
+import {
+    Entity,
+    PrimaryGeneratedColumn,
+    Column,
+    ManyToOne,
+    JoinColumn,
+} from "../../../../src"
+import { SuperLongTableName } from "./SuperLongTableName"
+
+@Entity()
+export class SuperLongTableNameWhichIsRelatedToOriginalTable {
+    @PrimaryGeneratedColumn()
+    id: number
+
+    @Column()
+    superLongTableNameId: number
+
+    @ManyToOne(() => SuperLongTableName, (table) => table.relatedToOriginal)
+    @JoinColumn({ name: "superLongTableNameId" })
+    superLongTableName: SuperLongTableName
+}

--- a/test/github-issues/9379/issue-9379.ts
+++ b/test/github-issues/9379/issue-9379.ts
@@ -1,0 +1,47 @@
+import "reflect-metadata"
+import { expect } from "chai"
+import { DataSource } from "../../../src/data-source/DataSource"
+import {
+    closeTestingConnections,
+    createTestingConnections,
+    reloadTestingDatabases,
+} from "../../utils/test-utils"
+import { SuperLongTableName } from "./entity/SuperLongTableName"
+import { SuperLongTableNameWhichIsRelatedToOriginalTable } from "./entity/SuperLongTableNameIsRelatedToOriginal"
+
+describe.only("github issues > #9379 RelationIdLoader is not respecting maxAliasLength", () => {
+    let connections: DataSource[]
+    before(
+        async () =>
+            (connections = await createTestingConnections({
+                entities: [__dirname + "/entity/*{.js,.ts}"],
+                enabledDrivers: ["postgres"],
+            })),
+    )
+    beforeEach(() => reloadTestingDatabases(connections))
+    after(() => closeTestingConnections(connections))
+
+    it("should fetch related entities properly", async () => {
+        for (const connection of connections) {
+            const origin = await connection
+                .getRepository(SuperLongTableName)
+                .save({ name: "test" })
+
+            await connection
+                .getRepository(SuperLongTableNameWhichIsRelatedToOriginalTable)
+                .save({
+                    superLongTableNameId: origin.id,
+                })
+
+            const result = await connection
+                .getRepository(SuperLongTableName)
+                .findOne({
+                    where: { id: origin.id },
+                    relations: { relatedToOriginal: true },
+                    relationLoadStrategy: "query",
+                })
+
+            expect(result?.relatedToOriginal.length).to.eq(1)
+        }
+    })
+})


### PR DESCRIPTION
Update RelationIdLoader to use DriverUtils.getAlias to prevent aliases being possibly trimmed by database.

Closes: #9379

<!--
  😀 Wonderful!  Thank you for opening a pull request for TypeORM.

  Please fill in the information below to expedite the review
  and (hopefully) merge of your change.

  If unsure about something.. just do as best as you're able,
  or reach out through our community support channels!
  https://github.com/typeorm/typeorm/blob/master/docs/support.md
-->

### Description of change

Updates `RelationIdLoader` class to use `DriverUtils.getAlias` to generate column aliases. This resolves issues with databases that have hard limit on column aliases such as Postgres.

**I've never contributed to this project so I'm definitely not sure if this fix is correct**, but it did resolve the issue with `relationLoadStrategy: query` I was having. There may be other places that don't use this util? Maybe this breaks some other behaviour that expects the columns to be properly named?

### Pull-Request Checklist

<!--
  Please make sure to review and check all of the following.

  If an item is not applicable, you can add "N/A" to the end.
-->

- [x] Code is up-to-date with the `master` branch
- [x] `npm run format` to apply prettier formatting
- [x] `npm run test` passes with this change
- [x] This pull request links relevant issues as `Fixes #0000`
- [x] There are new or updated unit tests validating the change
- [ ] Documentation has been updated to reflect this change
- [x] The new commits follow conventions explained in [CONTRIBUTING.md](https://github.com/typeorm/typeorm/blob/master/CONTRIBUTING.md)

<!--
  🎉 Thank you for contributing and making TypeORM even better!
-->
