### PR TITLE
Typo in docs where EntitySubscriberInterface is explained

### DIFF
--- a/docs/listeners-and-subscribers.md
+++ b/docs/listeners-and-subscribers.md
@@ -376,7 +376,7 @@ Make sure your `subscribers` property is set in your [DataSourceOptions](./data-
 
 Excluding `listenTo`, all `EntitySubscriberInterface` methods are passed an event object that has the following base properties:
 
--   `dataSource: DataSource` - DataSource used in the event.
+-   `connection: DataSource` - DataSource used in the event.
 -   `queryRunner: QueryRunner` - QueryRunner used in the event transaction.
 -   `manager: EntityManager` - EntityManager used in the event transaction.
 


### PR DESCRIPTION

There is a typo (according to https://github.com/typeorm/typeorm/blob/master/src/subscriber/event/InsertEvent.ts)