### PR TITLE
Disable transactionSupport option for CordovaDriver

### DIFF
--- a/docs/supported-platforms.md
+++ b/docs/supported-platforms.md
@@ -56,7 +56,7 @@ In your main html page, you need to include reflect-metadata:
 TypeORM is able to run on Cordova, PhoneGap, Ionic apps using the
 [cordova-sqlite-storage](https://github.com/litehelpers/Cordova-sqlite-storage) plugin
 You have the option to choose between module loaders just like in browser package.
-For an example how to use TypeORM in Cordova see [typeorm/cordova-example](https://github.com/typeorm/cordova-example) and for Ionic see [typeorm/ionic-example](https://github.com/typeorm/ionic-example). **Important**: For use with Ionic, a custom webpack config file is needed! Please checkout the example to see the needed changes.
+For an example how to use TypeORM in Cordova see [typeorm/cordova-example](https://github.com/typeorm/cordova-example) and for Ionic see [typeorm/ionic-example](https://github.com/typeorm/ionic-example). **Important**: For use with Ionic, a custom webpack config file is needed! Please checkout the example to see the needed changes. Note that there is currently no support for transactions when using the [cordova-sqlite-storage](https://github.com/litehelpers/Cordova-sqlite-storage) plugin. See https://github.com/storesafe/cordova-sqlite-storage#other-limitations for more information.
 
 ## React Native
 

--- a/src/driver/cordova/CordovaDriver.ts
+++ b/src/driver/cordova/CordovaDriver.ts
@@ -17,6 +17,8 @@ declare let window: Window
 export class CordovaDriver extends AbstractSqliteDriver {
     options: CordovaConnectionOptions
 
+    transactionSupport = "none" as const
+
     // -------------------------------------------------------------------------
     // Constructor
     // -------------------------------------------------------------------------

--- a/src/persistence/EntityPersistExecutor.ts
+++ b/src/persistence/EntityPersistExecutor.ts
@@ -181,7 +181,10 @@ export class EntityPersistExecutor {
             try {
                 // open transaction if its not opened yet
                 if (!queryRunner.isTransactionActive) {
-                    if (!this.options || this.options.transaction !== false) {
+                    if (
+                        this.connection.driver.transactionSupport !== "none" &&
+                        (!this.options || this.options.transaction !== false)
+                    ) {
                         // start transaction until it was not explicitly disabled
                         isTransactionStartedByUs = true
                         await queryRunner.startTransaction()


### PR DESCRIPTION
### Description of change

The [cordova-sqlite-storage](https://github.com/litehelpers/Cordova-sqlite-storage) plugin does not support regular transactions at the moment.

See: https://github.com/storesafe/cordova-sqlite-storage#other-limitations
> User-defined savepoints are not supported and not expected to be compatible with the transaction locking mechanism used by this plugin. In addition, the use of BEGIN/COMMIT/ROLLBACK statements is not supported.

This conflicts with the way typeORM is handling save / remove operations via the `EntityPersistExecutor` by default leading to errors when not explicitly disabling the transaction on each method call via the respective option (e.g. `connection.manager.save(ExampleEntity, { transaction: false })`. Prior version 0.2.34 this was not a problem since the transaction was basically just ignored but with fc4133c the `start|commit|rollbackTransaction` call will throw an error to indicate that transactions aren't supported which is totally correct in my opinion but is pretty hard to work with the current behavior of the `EntityPersistExecutor`. This PR will set the `transactionSupport` property of the `CordovaDriver` to `none` and also respect this setting in the `EntityPersistExecutor`. 

Relates to:
- https://github.com/typeorm/ionic-example/issues/44 
- https://github.com/typeorm/typeorm/issues/4075#issuecomment-933715081
- https://github.com/storesafe/cordova-sqlite-storage/issues/865

### Pull-Request Checklist

- [x] Code is up-to-date with the `master` branch
- [x] `npm run format` to apply prettier formatting
- [x] `npm run test` passes with this change
- [ ] This pull request links relevant issues as `Fixes #0000` N/A
- [x] There are new or updated unit tests validating the change
- [x] Documentation has been updated to reflect this change
- [x] The new commits follow conventions explained in [CONTRIBUTING.md](https://github.com/typeorm/typeorm/blob/master/CONTRIBUTING.md)