### PR TITLE
fix: typings for Repository.extend function

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,12 @@
 {
   "name": "typeorm",
-  "version": "0.3.9",
+  "version": "0.3.10",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
-      "version": "0.3.9",
+      "name": "typeorm",
+      "version": "0.3.10",
       "license": "MIT",
       "dependencies": {
         "@sqltools/formatter": "^1.2.2",

--- a/src/repository/Repository.ts
+++ b/src/repository/Repository.ts
@@ -627,9 +627,8 @@ export class Repository<Entity extends ObjectLiteral> {
      * Extends repository with provided functions.
      */
     extend<CustomRepository>(
-        custom: CustomRepository &
-            ThisType<Repository<Entity> & CustomRepository>,
-    ): Repository<Entity> & CustomRepository {
+        custom: CustomRepository & ThisType<this & CustomRepository>,
+    ): this & CustomRepository {
         // return {
         //     ...this,
         //     ...custom

--- a/src/repository/TreeRepository.ts
+++ b/src/repository/TreeRepository.ts
@@ -409,24 +409,6 @@ export class TreeRepository<
     }
 
     /**
-     * Extends tree repository with provided functions.
-     */
-    extend<CustomRepository>(
-        custom: CustomRepository &
-            ThisType<TreeRepository<Entity> & CustomRepository>,
-    ): TreeRepository<Entity> & CustomRepository {
-        const thisRepo = this.constructor as new (...args: any[]) => typeof this
-        const { target, manager, queryRunner } = this
-        const cls = new (class extends thisRepo {})(
-            target,
-            manager,
-            queryRunner,
-        )
-        Object.assign(cls, custom)
-        return cls as any
-    }
-
-    /**
      * Moves entity to the children of then given entity.
      *
     move(entity: Entity, to: Entity): Promise<void> {


### PR DESCRIPTION
additionally remove duplicated TreeRepository.extend method

<!--
  😀 Wonderful!  Thank you for opening a pull request for TypeORM.

  Please fill in the information below to expedite the review
  and (hopefully) merge of your change.

  If unsure about something.. just do as best as you're able,
  or reach out through our community support channels!
  https://github.com/typeorm/typeorm/blob/master/docs/support.md
-->

### Description of change

For example, if you use 
```typescript
dataSource.getMongoRepository(Foo).extend({ findSomething: () => {} })
``` 
right now it will returns typing like this
```typescript
Repository<Foo> & { findSomething: (): void }
```

with this fix it will return 
```typescript
MongoRepository<Entity> & { findSomething: (): void }
```

<!--
  Please be clear and concise what the change is intended to do,
  why this change is needed, and how you've verified that it
  corrects what you intended.

  In some cases it may be helpful to include the current behavior
  and the new behavior.

  If the change is related to an open issue, you can link it here.
  If you include `Fixes #0000` (replacing `0000` with the issue number)
  when this is merged it will automatically mark the issue as fixed and
  close it.
-->


### Pull-Request Checklist

<!--
  Please make sure to review and check all of the following.

  If an item is not applicable, you can add "N/A" to the end.
-->

- [ ] Code is up-to-date with the `master` branch
- [x] `npm run format` to apply prettier formatting
- [x] `npm run test` passes with this change
- [ ] This pull request links relevant issues as `Fixes #0000`
- [ ] There are new or updated unit tests validating the change
- [ ] Documentation has been updated to reflect this change
- [ ] The new commits follow conventions explained in [CONTRIBUTING.md](https://github.com/typeorm/typeorm/blob/master/CONTRIBUTING.md)

<!--
  🎉 Thank you for contributing and making TypeORM even better!
-->
