### PR TITLE
Fix parameter escape in SQLiteDriver

### DIFF
--- a/src/driver/better-sqlite3/BetterSqlite3QueryRunner.ts
+++ b/src/driver/better-sqlite3/BetterSqlite3QueryRunner.ts
@@ -83,13 +83,6 @@ export class BetterSqlite3QueryRunner extends AbstractSqliteQueryRunner {
 
         const connection = this.driver.connection
 
-        parameters = parameters || []
-        for (let i = 0; i < parameters.length; i++) {
-            // in "where" clauses the parameters are not escaped by the driver
-            if (typeof parameters[i] === "boolean")
-                parameters[i] = +parameters[i]
-        }
-
         this.driver.connection.logger.logQuery(query, parameters, this)
         const queryStartTime = +new Date()
 

--- a/src/driver/sqlite-abstract/AbstractSqliteDriver.ts
+++ b/src/driver/sqlite-abstract/AbstractSqliteDriver.ts
@@ -480,6 +480,16 @@ export abstract class AbstractSqliteDriver implements Driver {
                     return String(value)
                 }
 
+                // Sqlite does not have a boolean data type so we have to transform
+                // it to 1 or 0
+                if (typeof value === "boolean") {
+                    escapedParameters.push(+value)
+                    return this.createParameter(
+                        key,
+                        escapedParameters.length - 1,
+                    )
+                }
+
                 if (value instanceof Date) {
                     escapedParameters.push(
                         DateUtils.mixedDateToUtcDatetimeString(value),

--- a/test/functional/driver/abstract-sqlite/abstract-sqlite-escape-query-parameters.ts
+++ b/test/functional/driver/abstract-sqlite/abstract-sqlite-escape-query-parameters.ts
@@ -17,7 +17,7 @@ describe("escape sqlite query parameters", () => {
     beforeEach(() => reloadTestingDatabases(connections))
     after(() => closeTestingConnections(connections))
 
-    it("should transform booelan parameters with value `true` into `1`", () =>
+    it("should transform boolean parameters with value `true` into `1`", () =>
         Promise.all(
             connections.map((connection) => {
                 const [_, parameters] =
@@ -31,7 +31,7 @@ describe("escape sqlite query parameters", () => {
             }),
         ))
 
-    it("should transform booelan parameters with value `false` into `0`", () =>
+    it("should transform boolean parameters with value `false` into `0`", () =>
         Promise.all(
             connections.map((connection) => {
                 const [_, parameters] =
@@ -45,7 +45,7 @@ describe("escape sqlite query parameters", () => {
             }),
         ))
 
-    it("should transform booelan nativeParameters with value `true` into `1`", () =>
+    it("should transform boolean nativeParameters with value `true` into `1`", () =>
         Promise.all(
             connections.map((connection) => {
                 const [_, parameters] =
@@ -59,7 +59,7 @@ describe("escape sqlite query parameters", () => {
             }),
         ))
 
-    it("should transform booelan nativeParameters with value `false` into 0", () =>
+    it("should transform boolean nativeParameters with value `false` into 0", () =>
         Promise.all(
             connections.map((connection) => {
                 const [_, parameters] =

--- a/test/functional/driver/abstract-sqlite/abstract-sqlite-escape-query-parameters.ts
+++ b/test/functional/driver/abstract-sqlite/abstract-sqlite-escape-query-parameters.ts
@@ -1,0 +1,75 @@
+import { DataSource } from "../../../../src"
+import {
+    createTestingConnections,
+    reloadTestingDatabases,
+    closeTestingConnections,
+} from "../../../utils/test-utils"
+
+describe("escape sqlite query parameters", () => {
+    let connections: DataSource[]
+    before(
+        async () =>
+            (connections = await createTestingConnections({
+                entities: [__dirname + "/entity/*{.js,.ts}"],
+                enabledDrivers: ["sqlite", "better-sqlite3"],
+            })),
+    )
+    beforeEach(() => reloadTestingDatabases(connections))
+    after(() => closeTestingConnections(connections))
+
+    it("should transform booelan parameters with value `true` into `1`", () =>
+        Promise.all(
+            connections.map((connection) => {
+                const [_, parameters] =
+                    connection.driver.escapeQueryWithParameters(
+                        "SELECT nothing FROM irrelevant WHERE a = :param1",
+                        { param1: true },
+                        {},
+                    )
+
+                parameters.should.eql([1])
+            }),
+        ))
+
+    it("should transform booelan parameters with value `false` into `0`", () =>
+        Promise.all(
+            connections.map((connection) => {
+                const [_, parameters] =
+                    connection.driver.escapeQueryWithParameters(
+                        "SELECT nothing FROM irrelevant WHERE a = :param1",
+                        { param1: false },
+                        {},
+                    )
+
+                parameters.should.eql([0])
+            }),
+        ))
+
+    it("should transform booelan nativeParameters with value `true` into `1`", () =>
+        Promise.all(
+            connections.map((connection) => {
+                const [_, parameters] =
+                    connection.driver.escapeQueryWithParameters(
+                        "SELECT nothing FROM irrelevant",
+                        {},
+                        { nativeParam1: true },
+                    )
+
+                parameters.should.eql([1])
+            }),
+        ))
+
+    it("should transform booelan nativeParameters with value `false` into 0", () =>
+        Promise.all(
+            connections.map((connection) => {
+                const [_, parameters] =
+                    connection.driver.escapeQueryWithParameters(
+                        "SELECT nothing FROM irrelevant",
+                        {},
+                        { nativeParam1: false },
+                    )
+
+                parameters.should.eql([0])
+            }),
+        ))
+})


### PR DESCRIPTION
### Description of change

(Re-)Fixes: #1981

The issue in #1981 re-occurred after 0.3.0 because `nativeParameters` became deprecated and new `find` methods use `parmeters` instead which where not fixed in #7122. This PR adds the boolean parameter escape for all kind of parameters and also makes additional transformations as implemented in the `BetterSqlite3QueryRunner` obsolete. 

The problem seems to be mainly related to the `CordovaDriver` where I also encountered this problem after migration to > 0.3.0. However, I think it's appropriate to have this fixed in the `AbstractSqliteDriver` because it is obviously affecting `BetterSqlite3` too and a correct way of handling boolean properties in SQLite anyways :). 

A similar approach was already submitted via: #9009 which was closed unfortunately but I added test-cases in addition and instead of just converting the boolean values to strings this PR will pass them as numeric query parameters.  

### Pull-Request Checklist
- [x] Code is up-to-date with the `master` branch
- [x] `npm run format` to apply prettier formatting
- [x] `npm run test` passes with this change
- [x] This pull request links relevant issues as `Fixes #0000`
- [x] There are new or updated unit tests validating the change
- [ ] Documentation has been updated to reflect this change N/A
- [x] The new commits follow conventions explained in [CONTRIBUTING.md](https://github.com/typeorm/typeorm/blob/master/CONTRIBUTING.md)