### PR TITLE
Test case to show issue/9395

### DIFF
--- a/test/functional/find-options/basic-usage/find-options-test-utils.ts
+++ b/test/functional/find-options/basic-usage/find-options-test-utils.ts
@@ -84,13 +84,13 @@ export async function prepareData(manager: EntityManager) {
     await manager.save(post3)
 
     const post4 = new Post()
-    post1.id = 4
-    post1.title = "Post #4"
-    post1.text = "About post #4"
-    post3.author = user1
-    post1.tags = []
-    post1.counters = new Counters()
-    post1.counters.likes = 1
-    post1.counters.likedUsers = [user1]
+    post4.id = 4
+    post4.title = "Post #4"
+    post4.text = "About post #4"
+    post4.author = user1
+    post4.tags = []
+    post4.counters = new Counters()
+    post4.counters.likes = 1
+    post4.counters.likedUsers = [user1]
     await manager.save(post4)
 }

--- a/test/functional/find-options/basic-usage/find-options-test-utils.ts
+++ b/test/functional/find-options/basic-usage/find-options-test-utils.ts
@@ -82,4 +82,15 @@ export async function prepareData(manager: EntityManager) {
     post3.counters.likes = 1
     post3.counters.likedUsers = [user2]
     await manager.save(post3)
+
+    const post4 = new Post()
+    post1.id = 4
+    post1.title = "Post #4"
+    post1.text = "About post #4"
+    post3.author = user1
+    post1.tags = []
+    post1.counters = new Counters()
+    post1.counters.likes = 1
+    post1.counters.likedUsers = [user1]
+    await manager.save(post4)
 }

--- a/test/functional/find-options/basic-usage/find-options-where.ts
+++ b/test/functional/find-options/basic-usage/find-options-where.ts
@@ -271,16 +271,18 @@ describe("find options > where", () => {
                 const posts = await connection
                     .createQueryBuilder(Post, "post")
                     .setFindOptions({
-                        where: [{
-                            author: {
-                                id: 1,
-                            }
-                        },
-                        {
-                            tags: {
-                                name: "category #1",
+                        where: [
+                            {
+                                author: {
+                                    id: 1,
+                                },
                             },
-                        }],
+                            {
+                                tags: {
+                                    name: "category #1",
+                                },
+                            },
+                        ],
                     })
                     .getMany()
                 posts.should.be.eql([

--- a/test/functional/find-options/basic-usage/find-options-where.ts
+++ b/test/functional/find-options/basic-usage/find-options-where.ts
@@ -263,6 +263,55 @@ describe("find options > where", () => {
             }),
         ))
 
+    it("where or + optional relations", () =>
+        Promise.all(
+            connections.map(async (connection) => {
+                await prepareData(connection.manager)
+
+                const posts = await connection
+                    .createQueryBuilder(Post, "post")
+                    .setFindOptions({
+                        where: [{
+                            author: {
+                                id: 1,
+                            }
+                        },
+                        {
+                            tags: {
+                                name: "category #1",
+                            },
+                        }],
+                    })
+                    .getMany()
+                posts.should.be.eql([
+                    {
+                        id: 1,
+                        title: "Post #1",
+                        text: "About post #1",
+                        counters: { likes: 1 },
+                    },
+                    {
+                        id: 2,
+                        title: "Post #2",
+                        text: "About post #2",
+                        counters: { likes: 1 },
+                    },
+                    {
+                        id: 3,
+                        title: "Post #3",
+                        text: "About post #3",
+                        counters: { likes: 2 },
+                    },
+                    {
+                        id: 4,
+                        title: "Post #4",
+                        text: "About post #4",
+                        counters: { likes: 1 },
+                    },
+                ])
+            }),
+        ))
+
     it("where column in embed", () =>
         Promise.all(
             connections.map(async (connection) => {


### PR DESCRIPTION
Proves #9395

### Description of change
Test case to showcase the bug.
From the docs https://typeorm.io/find-options, the following query 
```
userRepository.find({
    relations: {
        project: true,
    },
    where: {
        project: {
            name: "TypeORM",
            initials: "TORM",
        },
    },
})
```
should execute 

```
SELECT * FROM "user"
LEFT JOIN "project" ON "project"."id" = "user"."projectId"
WHERE "project"."name" = 'TypeORM' AND "project"."initials" = 'TORM'
```

But in reality in executing 

```
SELECT * FROM "user"
INNER JOIN "project" ON "project"."id" = "user"."projectId"
WHERE "project"."name" = 'TypeORM' AND "project"."initials" = 'TORM'
```
which is a problem for optional relations.

Further investigation showed `LEFT` is only replaced by `INNER` when we query by a relation property, eg if we query relation with `IsNull`, join in still of type `LEFT`.

### Pull-Request Checklist

<!--
  Please make sure to review and check all of the following.

  If an item is not applicable, you can add "N/A" to the end.
-->

- [x] Code is up-to-date with the `master` branch
- [x] `npm run format` to apply prettier formatting
- [ ] `npm run test` passes with this change
- [x] This pull request links relevant issues as `Fixes #0000`
- [x] There are new or updated unit tests validating the change
- [ ] Documentation has been updated to reflect this change
- [ ] The new commits follow conventions explained in [CONTRIBUTING.md](https://github.com/typeorm/typeorm/blob/master/CONTRIBUTING.md)

<!--
  🎉 Thank you for contributing and making TypeORM even better!
-->
