### PR TITLE
Doc: Improve comprehension of update repository API

### DIFF
--- a/docs/entity-manager-api.md
+++ b/docs/entity-manager-api.md
@@ -136,8 +136,8 @@ await manager.insert(User, [
 -   `update` - Partially updates entity by a given update options or entity id.
 
 ```typescript
-await manager.update(User, { firstName: "Timber" }, { firstName: "Rizzrak" })
-// executes UPDATE user SET firstName = Rizzrak WHERE firstName = Timber
+await manager.update(User, { age: 18 }, { category: "ADULT" })
+// executes UPDATE user SET category = ADULT WHERE age = 18
 
 await manager.update(User, 1, { firstName: "Rizzrak" })
 // executes UPDATE user SET firstName = Rizzrak WHERE id = 1

--- a/docs/repository-api.md
+++ b/docs/repository-api.md
@@ -143,8 +143,8 @@ await repository.insert([
 -   `update` - Partially updates entity by a given update options or entity id.
 
 ```typescript
-await repository.update({ firstName: "Timber" }, { firstName: "Rizzrak" })
-// executes UPDATE user SET firstName = Rizzrak WHERE firstName = Timber
+await repository.update({ age: 18 }, { category: "ADULT" })
+// executes UPDATE user SET category = ADULT WHERE age = 18
 
 await repository.update(1, { firstName: "Rizzrak" })
 // executes UPDATE user SET firstName = Rizzrak WHERE id = 1


### PR DESCRIPTION
### Description of change

This is a suggestion to improve the documentation.

In the [Repository API section](https://typeorm.io/repository-api), under the `update` API documentation, the first usage example is the following:

```typescript
await repository.update({ firstName: "Timber" }, { firstName: "Rizzrak" })
// executes UPDATE user SET firstName = Rizzrak WHERE firstName = Timber
```

Because of the use of 2 "`firstName`" in the API, I got confused and reversed the **WHERE** condition and the actual **change**.
Thus, this doc change PR is just a suggestion to avoid that kind of confusion.

### Pull-Request Checklist

- [x] Code is up-to-date with the `master` branch
- [ ] `npm run format` to apply prettier formatting -> N/A
- [ ] `npm run test` passes with this change -> N/A
- [ ] This pull request links relevant issues as `Fixes #0000` -> N/A
- [ ] There are new or updated unit tests validating the change -> N/A
- [x] Documentation has been updated to reflect this change
- [x] The new commits follow conventions explained in [CONTRIBUTING.md](https://github.com/typeorm/typeorm/blob/master/CONTRIBUTING.md)