### PR TITLE
Change getRepository for AppDataSource.getRepository when run the cli…

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,12 @@
 {
   "name": "typeorm",
-  "version": "0.3.9",
+  "version": "0.3.10",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
-      "version": "0.3.9",
+      "name": "typeorm",
+      "version": "0.3.10",
       "license": "MIT",
       "dependencies": {
         "@sqltools/formatter": "^1.2.2",

--- a/src/commands/InitCommand.ts
+++ b/src/commands/InitCommand.ts
@@ -377,13 +377,13 @@ export const Routes = [{
      * Gets contents of the user controller file (used when express is enabled).
      */
     protected static getControllerTemplate(isEsm: boolean): string {
-        return `import { getRepository } from "typeorm"
+        return `import { AppDataSource } from '../data-source'
 import { NextFunction, Request, Response } from "express"
 import { User } from "../entity/User${isEsm ? ".js" : ""}"
 
 export class UserController {
 
-    private userRepository = getRepository(User)
+    private userRepository = AppDataSource.getRepository(User)
 
     async all(request: Request, response: Response, next: NextFunction) {
         return this.userRepository.find()


### PR DESCRIPTION
… init command

### Description of change

 When run "cli init" command, it crate a file called UserController.ts using getRepository(User) instead AppDataSource.getRepository(User). Into file InitCommand.ts I changed this file using the AppDataSource according to the current version of typeorm. 



### Pull-Request Checklist

<!--
  Please make sure to review and check all of the following.

  If an item is not applicable, you can add "N/A" to the end.
-->

- [ ] Code is up-to-date with the `master` branch N/A
- [ ] `npm run format` to apply prettier formatting N/A
- [ ] `npm run test` passes with this change N/A
- [ ] This pull request links relevant issues as `Fixes #0000` N/A
- [ ] There are new or updated unit tests validating the change N/A
- [ ] Documentation has been updated to reflect this change N/A
- [ ] The new commits follow conventions explained in [CONTRIBUTING.md](https://github.com/typeorm/typeorm/blob/master/CONTRIBUTING.md) N/A

<!--
  🎉 Thank you for contributing and making TypeORM even better!
-->
