### PR TITLE
fix: old name fixed in test case name

### DIFF
--- a/test/functional/connection/connection.ts
+++ b/test/functional/connection/connection.ts
@@ -202,7 +202,7 @@ describe("Connection", () => {
         // }));
     })
 
-    describe("generate a schema when connection.syncSchema is called", function () {
+    describe("generate a schema when connection.synchronize is called", function () {
         let connections: DataSource[]
         before(() =>
             createTestingConnections({


### PR DESCRIPTION
syncSchema was renamed to synchronize but nobody updated the test case name.

### Description of change
Consistency of terminology helps especially newcomers to work on the project.
This change does not affect behavior, just replaces the earlier name with the current one.

### Pull-Request Checklist

- [x] Code is up-to-date with the `master` branch
- [x] `npm run format` to apply prettier formatting
- [x] `npm run test` passes with this change
- [N/A] This pull request links relevant issues as `Fixes #0000`
- [N/A] There are new or updated unit tests validating the change
- [N/A] Documentation has been updated to reflect this change
- [x] The new commits follow conventions explained in [CONTRIBUTING.md](https://github.com/typeorm/typeorm/blob/master/CONTRIBUTING.md)

