### PR TITLE
Fix #6573 (beforeUpdate has no entity data included when detaching a oneToMany-related entity)

### DIFF
--- a/test/github-issues/6573/entity/Setting.ts
+++ b/test/github-issues/6573/entity/Setting.ts
@@ -1,25 +1,36 @@
-import { BaseEntity, Column, Entity, ManyToOne, PrimaryColumn } from "../../../../src";
-import {User} from "./User";
+import {
+    BaseEntity,
+    Column,
+    Entity,
+    ManyToOne,
+    PrimaryColumn,
+} from "../../../../src"
+import { User } from "./User"
 
 @Entity()
 export class Setting extends BaseEntity {
-	@PrimaryColumn("int")
-	assetId?: number;
+    @PrimaryColumn("int")
+    assetId?: number
 
-	@ManyToOne("User","settings",{ cascade:false , orphanedRowAction: "delete", nullable:false, onDelete:"CASCADE", onUpdate:"RESTRICT" })
-	asset?: User;
+    @ManyToOne("User", "settings", {
+        cascade: false,
+        orphanedRowAction: "delete",
+        nullable: false,
+        onDelete: "CASCADE",
+        onUpdate: "RESTRICT",
+    })
+    asset?: User
 
-	@PrimaryColumn("varchar")
-	name: string;
+    @PrimaryColumn("varchar")
+    name: string
 
-	@Column()
-	value: string;
+    @Column()
+    value: string
 
-	constructor(id: number, name: string, value: string) {
-		super();
-		this.assetId = id;
-		this.name = name;
-		this.value = value;
-	}
-
+    constructor(id: number, name: string, value: string) {
+        super()
+        this.assetId = id
+        this.name = name
+        this.value = value
+    }
 }

--- a/test/github-issues/6573/entity/Setting.ts
+++ b/test/github-issues/6573/entity/Setting.ts
@@ -1,0 +1,25 @@
+import { BaseEntity, Column, Entity, ManyToOne, PrimaryColumn } from "../../../../src";
+import {User} from "./User";
+
+@Entity()
+export class Setting extends BaseEntity {
+	@PrimaryColumn("int")
+	assetId?: number;
+
+	@ManyToOne("User","settings",{ cascade:false , orphanedRowAction: "delete", nullable:false, onDelete:"CASCADE", onUpdate:"RESTRICT" })
+	asset?: User;
+
+	@PrimaryColumn("varchar")
+	name: string;
+
+	@Column()
+	value: string;
+
+	constructor(id: number, name: string, value: string) {
+		super();
+		this.assetId = id;
+		this.name = name;
+		this.value = value;
+	}
+
+}

--- a/test/github-issues/6573/entity/User.ts
+++ b/test/github-issues/6573/entity/User.ts
@@ -1,20 +1,26 @@
-import { BaseEntity, Column, Entity, OneToMany, PrimaryColumn } from "../../../../src";
-import {Setting} from "./Setting";
+import {
+    BaseEntity,
+    Column,
+    Entity,
+    OneToMany,
+    PrimaryColumn,
+} from "../../../../src"
+import { Setting } from "./Setting"
 
 @Entity()
 export class User extends BaseEntity {
     @PrimaryColumn()
-    id: number;
+    id: number
 
-	@Column()
-	name: string;
+    @Column()
+    name: string
 
-	@OneToMany("Setting","asset",{ cascade:true })
-	settings: Setting[];
+    @OneToMany("Setting", "asset", { cascade: true })
+    settings: Setting[]
 
-	constructor(id: number, name: string) {
-		super();
-		this.id = id;
-		this.name = name;
-	}
+    constructor(id: number, name: string) {
+        super()
+        this.id = id
+        this.name = name
+    }
 }

--- a/test/github-issues/6573/entity/User.ts
+++ b/test/github-issues/6573/entity/User.ts
@@ -1,0 +1,20 @@
+import { BaseEntity, Column, Entity, OneToMany, PrimaryColumn } from "../../../../src";
+import {Setting} from "./Setting";
+
+@Entity()
+export class User extends BaseEntity {
+    @PrimaryColumn()
+    id: number;
+
+	@Column()
+	name: string;
+
+	@OneToMany("Setting","asset",{ cascade:true })
+	settings: Setting[];
+
+	constructor(id: number, name: string) {
+		super();
+		this.id = id;
+		this.name = name;
+	}
+}

--- a/test/github-issues/6573/issue-6573.ts
+++ b/test/github-issues/6573/issue-6573.ts
@@ -1,4 +1,3 @@
-import { Connection } from "../../../src"
 import {
     closeTestingConnections,
     createTestingConnections,
@@ -8,9 +7,10 @@ import { MockSubscriber } from "./subscribers/MockSubscriber"
 import "reflect-metadata"
 import { User } from "./entity/User"
 import { Setting } from "./entity/Setting"
+import { DataSource } from "../../../src/data-source/DataSource"
 
-describe("custom > bugfix-missing-entity-data-in-before-remove", () => {
-    let connections: Connection[]
+describe("github issues > #6573 bugfix-missing-entity-data-in-before-remove", () => {
+    let connections: DataSource[]
 
     before(
         async () =>
@@ -24,7 +24,7 @@ describe("custom > bugfix-missing-entity-data-in-before-remove", () => {
 
     after(() => closeTestingConnections(connections))
 
-    function insertTestData(connection: Connection) {
+    function insertTestData(connection: DataSource) {
         const userRepo = connection.getRepository(User)
         // const settingRepo = connection.getRepository(Setting);
 

--- a/test/github-issues/6573/issue-6573.ts
+++ b/test/github-issues/6573/issue-6573.ts
@@ -1,0 +1,53 @@
+import { Connection } from "../../../src";
+import {closeTestingConnections, createTestingConnections} from "../../utils/test-utils";
+import {expect} from "chai";
+import { MockSubscriber } from "./subscribers/MockSubscriber";
+import "reflect-metadata";
+import { User } from "./entity/User";
+import { Setting } from "./entity/Setting";
+
+describe("custom > bugfix-missing-entity-data-in-before-remove", () => {
+	let connections: Connection[];
+
+	before(async () => connections = await createTestingConnections({
+		entities: [User,Setting],
+		subscribers: [MockSubscriber],
+		schemaCreate: true,
+		dropSchema: true
+	}));
+
+	after(() => closeTestingConnections(connections));
+
+	function insertTestData(connection: Connection) {
+		const userRepo = connection.getRepository(User);
+		// const settingRepo = connection.getRepository(Setting);
+
+		const user = new User(1, "FooGuy");
+		const settingA = new Setting(1, "A", "foo");
+		const settingB = new Setting(1, "B", "");
+		user.settings = [settingA,settingB];
+
+		return userRepo.save(user);
+	}
+
+	it("entity data (partial) should be available when related items are being deleted", () => Promise.all(connections.map(async connection => {
+
+		await insertTestData(connection);
+		const userRepo = connection.getRepository(User);
+		const subscriber = connection.subscribers[0] as MockSubscriber;
+		subscriber.clear();
+
+		// resave with empty settings list, relation is configurated to delete them in this case
+		await userRepo.save([{
+			id:1,
+			settings:[]
+		}]);
+
+		expect(subscriber.calledData).to.be.eql([
+			{ assetId: 1, name: "A" },
+			{ assetId: 1, name: "B" }
+		]);
+
+	})));
+
+});

--- a/test/github-issues/6573/subscribers/MockSubscriber.ts
+++ b/test/github-issues/6573/subscribers/MockSubscriber.ts
@@ -1,19 +1,23 @@
-import { EntitySubscriberInterface, EventSubscriber, UpdateEvent } from "../../../../src";
-import { Setting } from "../entity/Setting";
+import {
+    EntitySubscriberInterface,
+    EventSubscriber,
+    UpdateEvent,
+} from "../../../../src"
+import { Setting } from "../entity/Setting"
 
 @EventSubscriber()
 export class MockSubscriber implements EntitySubscriberInterface {
-    calledData: any[] = [];
+    calledData: any[] = []
 
-	listenTo() {
-		return Setting;
-	}
-
-    beforeRemove(event: UpdateEvent<any>): void {
-        this.calledData.push(event.databaseEntity);
+    listenTo() {
+        return Setting
     }
 
-	clear() {
-		this.calledData = [];
-	}
+    beforeRemove(event: UpdateEvent<any>): void {
+        this.calledData.push(event.databaseEntity)
+    }
+
+    clear() {
+        this.calledData = []
+    }
 }

--- a/test/github-issues/6573/subscribers/MockSubscriber.ts
+++ b/test/github-issues/6573/subscribers/MockSubscriber.ts
@@ -1,0 +1,19 @@
+import { EntitySubscriberInterface, EventSubscriber, UpdateEvent } from "../../../../src";
+import { Setting } from "../entity/Setting";
+
+@EventSubscriber()
+export class MockSubscriber implements EntitySubscriberInterface {
+    calledData: any[] = [];
+
+	listenTo() {
+		return Setting;
+	}
+
+    beforeRemove(event: UpdateEvent<any>): void {
+        this.calledData.push(event.databaseEntity);
+    }
+
+	clear() {
+		this.calledData = [];
+	}
+}


### PR DESCRIPTION


### Description of change

Fixes https://github.com/typeorm/typeorm/issues/6573

Until now, when updating a relation, the beforeUpdate event was called for relation items,
but info about the modified entity was not available because event.entity/event.databaseEntity both were empty.

This fix adds a few lines to OneToManySubjectBuilder and populates beforeUpdate.databaseEntity with loaded entity information.


### Pull-Request Checklist

<!--
  Please make sure to review and check all of the following.

  If an item is not applicable, you can add "N/A" to the end.
-->

- [x] Code is up-to-date with the `master` branch
- [x] `npm run format` to apply prettier formatting
- [x] `npm run test` passes with this change
- [x] This pull request links relevant issues as `Fixes #0000`
- [x] There are new or updated unit tests validating the change
- [ ] Documentation has been updated to reflect this change
- [x] The new commits follow conventions explained in [CONTRIBUTING.md](https://github.com/typeorm/typeorm/blob/master/CONTRIBUTING.md)

<!--
  🎉 Thank you for contributing and making TypeORM even better!
-->
