### PR TITLE
fix: explicitly define property for entity relation as enumerable

### DIFF
--- a/src/query-builder/RelationLoader.ts
+++ b/src/query-builder/RelationLoader.ts
@@ -448,6 +448,7 @@ export class RelationLoader {
                 }
             },
             configurable: true,
+            enumerable: false,
         })
     }
 }


### PR DESCRIPTION
### Description of change
Change to makes properties for entity relation explicitly non-enumerable, which resolves a "rare" issue that leads to a memory leak.

In some environments it seems like an entity object was created with column values set to undefined, thus Object.defineProperty uses already defined value for enumerable - true. This leads to RawSqlResultsToEntityTransformer.transform() run-getters on relation fields (as they were enumerable) resolving the promises - running queries which eventually leads to the Free memory exhaustion on the machine :)

Closes: #6631 

### Pull-Request Checklist

<!--
  Please make sure to review and check all of the following.

  If an item is not applicable, you can add "N/A" to the end.
-->

- [x] Code is up-to-date with the `master` branch
- [x] `npm run format` to apply prettier formatting
- [x] `npm run test` passes with this change
- [x] This pull request links relevant issues as `Fixes #0000`
- [ ] There are new or updated unit tests validating the change
- [ ] Documentation has been updated to reflect this change
- [x] The new commits follow conventions explained in [CONTRIBUTING.md](https://github.com/typeorm/typeorm/blob/master/CONTRIBUTING.md)

Unfortunately while trying to find a way to replicate the issue in a couple of ways:

- Trying to make entity class derivative of BaseEntity
- Trying to run compiled tests
- Replicating my project entities in close to 1:1 way

I wasn't able to replicate the same behavior in the test case, but while debugging I found exactly the same behavior in my code as other users reported in the issue.

Making `enumerable: false` explicitly stated shouldn't regress any code and seems like running tests locally confirmed that, however ~~single test did fail:~~

UP: I see that on CI tests worked just fine