### PR TITLE
feat: Add synchronize to @JoinTable

### DIFF
--- a/docs/decorator-reference.md
+++ b/docs/decorator-reference.md
@@ -539,6 +539,7 @@ Used for `many-to-many` relations and describes join columns of the "junction" t
 Junction table is a special, separate table created automatically by TypeORM with columns referenced to the related entities.
 You can change the name of the generated "junction" table, the column names inside the junction table, their referenced
 columns with the `joinColumn`- and `inverseJoinColumn` attributes, and the created foreign keys names.
+You can also set parameter `synchronize` to false to skip schema update(same way as in @Entity)
 
 Example:
 
@@ -558,6 +559,7 @@ export class Post {
             referencedColumnName: "id",
             foreignKeyConstraintName: "fk_question_categories_categoryId"
         },
+        synchronize: false,
     })
     categories: Category[]
 }

--- a/src/decorator/options/JoinTableMultipleColumnsOptions.ts
+++ b/src/decorator/options/JoinTableMultipleColumnsOptions.ts
@@ -31,4 +31,11 @@ export interface JoinTableMultipleColumnsOptions {
      * Works only in some databases (like postgres and mssql).
      */
     schema?: string
+
+    /**
+     * Indicates if schema synchronization is enabled or disabled junction table.
+     * If it will be set to false then schema sync will and migrations ignores junction table.
+     * By default schema synchronization is enabled.
+     */
+    readonly synchronize?: boolean
 }

--- a/src/decorator/options/JoinTableOptions.ts
+++ b/src/decorator/options/JoinTableOptions.ts
@@ -31,4 +31,11 @@ export interface JoinTableOptions {
      * Works only in some databases (like postgres and mssql).
      */
     schema?: string
+
+    /**
+     * Indicates if schema synchronization is enabled or disabled junction table.
+     * If it will be set to false then schema sync will and migrations ignores junction table.
+     * By default schema synchronization is enabled.
+     */
+    synchronize?: boolean
 }

--- a/src/decorator/relations/JoinTable.ts
+++ b/src/decorator/relations/JoinTable.ts
@@ -50,6 +50,7 @@ export function JoinTable(
             schema: options && options.schema ? options.schema : undefined,
             database:
                 options && options.database ? options.database : undefined,
+            synchronize: !(options && options.synchronize === false),
         } as JoinTableMetadataArgs)
     }
 }

--- a/src/metadata-args/JoinTableMetadataArgs.ts
+++ b/src/metadata-args/JoinTableMetadataArgs.ts
@@ -41,4 +41,11 @@ export interface JoinTableMetadataArgs {
      * Works only in some databases (like postgres and mssql).
      */
     readonly schema?: string
+
+    /**
+     * Indicates if schema synchronization is enabled or disabled junction table.
+     * If it will be set to false then schema sync will and migrations ignores junction table.
+     * By default schema synchronization is enabled.
+     */
+    readonly synchronize?: boolean
 }

--- a/src/metadata-builder/JunctionEntityMetadataBuilder.ts
+++ b/src/metadata-builder/JunctionEntityMetadataBuilder.ts
@@ -59,6 +59,7 @@ export class JunctionEntityMetadataBuilder {
                 database:
                     joinTable.database || relation.entityMetadata.database,
                 schema: joinTable.schema || relation.entityMetadata.schema,
+                synchronize: joinTable.synchronize,
             },
         })
         entityMetadata.build()

--- a/test/github-issues/3443/entity/category.ts
+++ b/test/github-issues/3443/entity/category.ts
@@ -1,0 +1,11 @@
+import { Entity, ManyToMany, PrimaryGeneratedColumn } from "../../../../src"
+import { Product } from "./product"
+
+@Entity({ name: "category" })
+export class Category {
+    @PrimaryGeneratedColumn()
+    id: string
+
+    @ManyToMany(() => Product, (product) => product.categories)
+    products: Product[]
+}

--- a/test/github-issues/3443/entity/product.ts
+++ b/test/github-issues/3443/entity/product.ts
@@ -1,0 +1,17 @@
+import {
+    Entity,
+    JoinTable,
+    ManyToMany,
+    PrimaryGeneratedColumn,
+} from "../../../../src"
+import { Category } from "./category"
+
+@Entity({ name: "product" })
+export class Product {
+    @PrimaryGeneratedColumn()
+    id: string
+
+    @ManyToMany(() => Category, (category) => category.products)
+    @JoinTable({ name: "product_category", synchronize: false })
+    categories: Category[]
+}

--- a/test/github-issues/3443/issue-3443.ts
+++ b/test/github-issues/3443/issue-3443.ts
@@ -1,0 +1,47 @@
+import "reflect-metadata"
+import {
+    createTestingConnections,
+    closeTestingConnections,
+    reloadTestingDatabases,
+} from "../../utils/test-utils"
+import { DataSource } from "../../../src/data-source/DataSource"
+import { expect } from "chai"
+
+describe.only("github issues > #3443 @JoinTable on entities without synchronization", () => {
+    let dataSources: DataSource[]
+    before(
+        async () =>
+            (dataSources = await createTestingConnections({
+                entities: [__dirname + "/entity/*{.js,.ts}"],
+                schemaCreate: true,
+                dropSchema: true,
+            })),
+    )
+    beforeEach(() => reloadTestingDatabases(dataSources))
+    after(() => closeTestingConnections(dataSources))
+
+    it("Should set synchronize: false for @JoinTable when passed to options", () =>
+        Promise.all(
+            dataSources.map(async (dataSource) => {
+                const PRODUCT_TABLE_NAME = "product"
+                const CATEGORY_TABLE_NAME = "category"
+                const PRODUCT_CATEGORY_TABLE_NAME = "product_category"
+
+                expect(() =>
+                    dataSource.getMetadata(PRODUCT_TABLE_NAME),
+                ).not.to.throw()
+                expect(() =>
+                    dataSource.getMetadata(CATEGORY_TABLE_NAME),
+                ).not.to.throw()
+                expect(() =>
+                    dataSource.getMetadata(PRODUCT_CATEGORY_TABLE_NAME),
+                ).not.to.throw()
+                expect(
+                    dataSource.getMetadata(PRODUCT_CATEGORY_TABLE_NAME)
+                        .synchronize,
+                ).to.equal(false)
+            }),
+        ))
+
+    // you can add additional tests if needed
+})


### PR DESCRIPTION
Add synchronize option to JoinTable. It allows ignoring JoinTable when syncing and generating migrations.

Closes #3443

- [x] Code is up-to-date with the `master` branch
- [x] `npm run format` to apply prettier formatting
- [x] `npm run test` passes with this change
- [x] This pull request links relevant issues as `Fixes #0000`
- [x] There are new or updated unit tests validating the change
- [x] Documentation has been updated to reflect this change
- [x] The new commits follow conventions explained in [CONTRIBUTING.md](https://github.com/typeorm/typeorm/blob/master/CONTRIBUTING.md)
