### PR TITLE
SQLite Driver: Add Open DB Flags and URI DB Name

### DIFF
--- a/src/driver/sqlite/SqliteConnectionOptions.ts
+++ b/src/driver/sqlite/SqliteConnectionOptions.ts
@@ -44,13 +44,13 @@ export interface SqliteConnectionOptions extends BaseDataSourceOptions {
      * @see https://www.sqlite.org/wal.html
      */
     readonly enableWAL?: boolean
-    
+
     /**
      * Specifies the open file flags. By default its undefined.
      * @see https://www.sqlite.org/c3ref/c_open_autoproxy.html
      * @see https://github.com/TryGhost/node-sqlite3/blob/master/test/open_close.test.js
      */
-    readonly flags?: number;
+    readonly flags?: number
 
     readonly poolSize?: never
 }

--- a/src/driver/sqlite/SqliteConnectionOptions.ts
+++ b/src/driver/sqlite/SqliteConnectionOptions.ts
@@ -44,6 +44,13 @@ export interface SqliteConnectionOptions extends BaseDataSourceOptions {
      * @see https://www.sqlite.org/wal.html
      */
     readonly enableWAL?: boolean
+    
+    /**
+     * Specifies the open file flags. By default its undefined.
+     * @see https://www.sqlite.org/c3ref/c_open_autoproxy.html
+     * @see https://github.com/TryGhost/node-sqlite3/blob/master/test/open_close.test.js
+     */
+    readonly flags?: number;
 
     readonly poolSize?: never
 }

--- a/src/driver/sqlite/SqliteDriver.ts
+++ b/src/driver/sqlite/SqliteDriver.ts
@@ -134,13 +134,24 @@ export class SqliteDriver extends AbstractSqliteDriver {
         await this.createDatabaseDirectory(this.options.database)
 
         const databaseConnection: any = await new Promise((ok, fail) => {
-            const connection = new this.sqlite.Database(
-                this.options.database,
-                (err: any) => {
-                    if (err) return fail(err)
-                    ok(connection)
-                },
-            )
+            if (this.options.flags === undefined) {
+                const connection = new this.sqlite.Database(
+                    this.options.database,
+                    (err: any) => {
+                        if (err) return fail(err)
+                        ok(connection)
+                    },
+                )
+            } else {
+                const connection = new this.sqlite.Database(
+                    this.options.database,
+                    this.options.flags,
+                    (err: any) => {
+                        if (err) return fail(err)
+                        ok(connection)
+                    },
+                )
+            }
         })
 
         // Internal function to run a command on the connection and fail if an error occured.

--- a/src/driver/sqlite/SqliteDriver.ts
+++ b/src/driver/sqlite/SqliteDriver.ts
@@ -130,8 +130,10 @@ export class SqliteDriver extends AbstractSqliteDriver {
     /**
      * Creates connection with the database.
      */
-    protected async createDatabaseConnection() {
-        await this.createDatabaseDirectory(this.options.database)
+  protected async createDatabaseConnection() {
+        if (this.options.flags === undefined || !(this.options.flags & this.sqlite.OPEN_URI)) {
+            await this.createDatabaseDirectory(this.options.database)
+        }
 
         const databaseConnection: any = await new Promise((ok, fail) => {
             if (this.options.flags === undefined) {

--- a/src/driver/sqlite/SqliteDriver.ts
+++ b/src/driver/sqlite/SqliteDriver.ts
@@ -130,8 +130,11 @@ export class SqliteDriver extends AbstractSqliteDriver {
     /**
      * Creates connection with the database.
      */
-  protected async createDatabaseConnection() {
-        if (this.options.flags === undefined || !(this.options.flags & this.sqlite.OPEN_URI)) {
+    protected async createDatabaseConnection() {
+        if (
+            this.options.flags === undefined ||
+            !(this.options.flags & this.sqlite.OPEN_URI)
+        ) {
             await this.createDatabaseDirectory(this.options.database)
         }
 

--- a/test/functional/sqlite/file-open-flags.ts
+++ b/test/functional/sqlite/file-open-flags.ts
@@ -6,7 +6,7 @@ import {
     createTestingConnections,
     reloadTestingDatabases,
 } from "../../utils/test-utils"
-const sqlite3 = require ("sqlite3");
+const sqlite3 = require("sqlite3")
 
 describe("sqlite driver > file open flags", () => {
     let connections: DataSource[]
@@ -17,7 +17,11 @@ describe("sqlite driver > file open flags", () => {
                 entities: [],
                 enabledDrivers: ["sqlite"],
                 driverSpecific: {
-                    flags: sqlite3.OPEN_URI | sqlite3.OPEN_SHAREDCACHE | sqlite3.OPEN_READWRITE | sqlite3.OPEN_CREATE
+                    flags:
+                        sqlite3.OPEN_URI |
+                        sqlite3.OPEN_SHAREDCACHE |
+                        sqlite3.OPEN_READWRITE |
+                        sqlite3.OPEN_CREATE,
                 },
             })),
     )

--- a/test/functional/sqlite/file-open-flags.ts
+++ b/test/functional/sqlite/file-open-flags.ts
@@ -1,0 +1,36 @@
+import "reflect-metadata"
+import { expect } from "chai"
+import { DataSource } from "../../../src/data-source/DataSource"
+import {
+    closeTestingConnections,
+    createTestingConnections,
+    reloadTestingDatabases,
+} from "../../utils/test-utils"
+const sqlite3 = require ("sqlite3");
+
+describe("sqlite driver > file open flags", () => {
+    let connections: DataSource[]
+    before(
+        async () =>
+            (connections = await createTestingConnections({
+                name: "file:./temp/sqlitedb-memory.db?mode=memory",
+                entities: [],
+                enabledDrivers: ["sqlite"],
+                driverSpecific: {
+                    flags: sqlite3.OPEN_URI | sqlite3.OPEN_SHAREDCACHE | sqlite3.OPEN_READWRITE | sqlite3.OPEN_CREATE
+                },
+            })),
+    )
+    beforeEach(() => reloadTestingDatabases(connections))
+    after(() => closeTestingConnections(connections))
+
+    it("should open a DB with flags as expected", () =>
+        Promise.all(
+            connections.map(async (connection) => {
+                // if we come this far, test was successful as a connection was established
+                const result = await connection.query("PRAGMA journal_mode")
+
+                expect(result).to.eql([{ journal_mode: "wal" }])
+            }),
+        ))
+})


### PR DESCRIPTION
### Description of change
Add the ability to pass in open DB connection flags and DB URI's for the sqlite3 driver.  This allows for sharing of the drive/in-memory DB between threads. 

Unfortunately, the better-sqlite3 driver isn't yet able to do this:
https://github.com/WiseLibs/better-sqlite3/issues/483
https://github.com/WiseLibs/better-sqlite3/pull/735

Here is where it was added in the sqlite3 upstream driver:
https://github.com/TryGhost/node-sqlite3/issues/1032
https://github.com/TryGhost/node-sqlite3/pull/1078

Example usage in sqlite:
https://github.com/TryGhost/node-sqlite3/blob/master/test/open_close.test.js

Flags:
https://www.sqlite.org/c3ref/c_open_autoproxy.html

Example usage of this fix:
https://github.com/WeWatchWall/stark-db

- [x] Code is up-to-date with the `master` branch
- [x] `npm run format` to apply prettier formatting
- [x] `npm run test` passes with this change
- [ ] This pull request links relevant issues as `Fixes #0000`. N/A
- [x] There are new or updated unit tests validating the change
- [ ] Documentation has been updated to reflect this change. N/A
- [x] The new commits follow conventions explained in [CONTRIBUTING.md](https://github.com/typeorm/typeorm/blob/master/CONTRIBUTING.md)
