### PR TITLE
fix: cacheId not used when loading relations with take

### DIFF
--- a/src/query-builder/SelectQueryBuilder.ts
+++ b/src/query-builder/SelectQueryBuilder.ts
@@ -3309,9 +3309,9 @@ export class SelectQueryBuilder<Entity extends ObjectLiteral>
                 .limit(this.expressionMap.take)
                 .orderBy(orderBys)
                 .cache(
-                    this.expressionMap.cache
-                        ? this.expressionMap.cache
-                        : this.expressionMap.cacheId,
+                    this.expressionMap.cache && this.expressionMap.cacheId
+                        ? `${this.expressionMap.cacheId}-pagination`
+                        : this.expressionMap.cache,
                     this.expressionMap.cacheDuration,
                 )
                 .setParameters(this.getParameters())

--- a/test/functional/cache/custom-cache-provider.ts
+++ b/test/functional/cache/custom-cache-provider.ts
@@ -9,6 +9,7 @@ import {
 import { DataSource } from "../../../src/data-source/DataSource"
 import { User } from "./entity/User"
 import { MockQueryResultCache } from "./provider/MockQueryResultCache"
+import { Address } from "./entity/Address"
 
 describe("custom cache provider", () => {
     let connections: DataSource[]
@@ -274,6 +275,60 @@ describe("custom cache provider", () => {
                     .cache("user_admins", 2000)
                     .getMany()
                 expect(users4.length).to.be.equal(2)
+            }),
+        ))
+
+    it.only("should cache results with pagination enabled properly and custom id and loaded relations", () =>
+        Promise.all(
+            connections.map(async (connection) => {
+                if (connection.driver.options.type === "spanner") {
+                    return
+                }
+
+                const noUser = await connection.manager
+                    .getRepository(User)
+                    .findOne({
+                        where: { isAdmin: false },
+                        relations: { addresses: true },
+                        cache: { id: "user-address", milliseconds: 2000 },
+                    })
+
+                expect(noUser).to.be.null
+
+                // first prepare data - insert users
+                const user1 = new User()
+                user1.firstName = "Timber"
+                user1.lastName = "Saw"
+                user1.isAdmin = false
+                await connection.manager.save(user1)
+
+                const user1Address = new Address()
+                user1Address.address = "1 random street"
+                user1Address.user = user1
+                await connection.manager.save(user1Address)
+
+                const user1Cached = await connection.manager
+                    .getRepository(User)
+                    .findOne({
+                        relations: { addresses: true },
+                        where: { isAdmin: false },
+                        cache: { id: "user-address", milliseconds: 2000 },
+                    })
+                expect(user1Cached).to.be.null
+
+                const user1WithAddressWithOtherCacheId =
+                    await connection.manager.getRepository(User).findOne({
+                        relations: { addresses: true },
+                        where: { isAdmin: false },
+                        cache: {
+                            id: "user-1-different-cache-id",
+                            milliseconds: 2000,
+                        },
+                    })
+
+                expect(
+                    user1WithAddressWithOtherCacheId?.addresses,
+                ).to.have.length(1)
             }),
         ))
 

--- a/test/functional/cache/custom-cache-provider.ts
+++ b/test/functional/cache/custom-cache-provider.ts
@@ -278,7 +278,7 @@ describe("custom cache provider", () => {
             }),
         ))
 
-    it.only("should cache results with pagination enabled properly and custom id and loaded relations", () =>
+    it("should cache results with pagination enabled properly and custom id and loaded relations", () =>
         Promise.all(
             connections.map(async (connection) => {
                 if (connection.driver.options.type === "spanner") {

--- a/test/functional/cache/entity/Address.ts
+++ b/test/functional/cache/entity/Address.ts
@@ -1,0 +1,19 @@
+import {
+    Column,
+    Entity,
+    ManyToOne,
+    PrimaryGeneratedColumn,
+} from "../../../../src"
+import { User } from "./User"
+
+@Entity()
+export class Address {
+    @PrimaryGeneratedColumn()
+    id: number
+
+    @Column()
+    address: string
+
+    @ManyToOne(() => User)
+    user: User
+}

--- a/test/functional/cache/entity/User.ts
+++ b/test/functional/cache/entity/User.ts
@@ -1,6 +1,8 @@
 import { Entity } from "../../../../src/decorator/entity/Entity"
 import { PrimaryGeneratedColumn } from "../../../../src/decorator/columns/PrimaryGeneratedColumn"
 import { Column } from "../../../../src/decorator/columns/Column"
+import { OneToMany } from "../../../../src"
+import { Address } from "./Address"
 
 @Entity()
 export class User {
@@ -15,4 +17,7 @@ export class User {
 
     @Column()
     isAdmin: boolean
+
+    @OneToMany(() => Address, (a) => a.user)
+    addresses: Address[]
 }


### PR DESCRIPTION
<!--
  😀 Wonderful!  Thank you for opening a pull request for TypeORM.

  Please fill in the information below to expedite the review
  and (hopefully) merge of your change.

  If unsure about something.. just do as best as you're able,
  or reach out through our community support channels!
  https://github.com/typeorm/typeorm/blob/master/docs/support.md
-->

### Description of change
The cacheId is set to undefined when finding entities with relations and the pagination(s) option(s) is/are set (take/skip).

It seems the cacheId is set to undefined for the main request used for pagination when we load related entities.

I appended a `-pagination` to the identifier of the pagination request.

Related #5983

### Pull-Request Checklist

<!--
  Please make sure to review and check all of the following.

  If an item is not applicable, you can add "N/A" to the end.
-->

- [x] Code is up-to-date with the `master` branch
- [x] `npm run format` to apply prettier formatting
- [x] `npm run test` passes with this change
- [x] This pull request links relevant issues as `Fixes #0000`
- [x] There are new or updated unit tests validating the change
- [x] Documentation has been updated to reflect this change
- [x] The new commits follow conventions explained in [CONTRIBUTING.md](https://github.com/typeorm/typeorm/blob/master/CONTRIBUTING.md)

<!--
  🎉 Thank you for contributing and making TypeORM even better!
-->
