### PR TITLE
Mark array arguments to find operators as read-only

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,12 @@
 {
   "name": "typeorm",
-  "version": "0.3.9",
+  "version": "0.3.10",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
-      "version": "0.3.9",
+      "name": "typeorm",
+      "version": "0.3.10",
       "license": "MIT",
       "dependencies": {
         "@sqltools/formatter": "^1.2.2",

--- a/src/find-options/operator/Any.ts
+++ b/src/find-options/operator/Any.ts
@@ -4,6 +4,6 @@ import { FindOperator } from "../FindOperator"
  * Find Options Operator.
  * Example: { someField: Any([...]) }
  */
-export function Any<T>(value: T[] | FindOperator<T>): FindOperator<T> {
+export function Any<T>(value: readonly T[] | FindOperator<T>): FindOperator<T> {
     return new FindOperator("any", value as any)
 }

--- a/src/find-options/operator/ArrayContainedBy.ts
+++ b/src/find-options/operator/ArrayContainedBy.ts
@@ -5,7 +5,7 @@ import { FindOperator } from "../FindOperator"
  * Example: { someField: ArrayContainedBy([...]) }
  */
 export function ArrayContainedBy<T>(
-    value: T[] | FindOperator<T>,
+    value: readonly T[] | FindOperator<T>,
 ): FindOperator<any> {
     return new FindOperator("arrayContainedBy", value as any)
 }

--- a/src/find-options/operator/ArrayContains.ts
+++ b/src/find-options/operator/ArrayContains.ts
@@ -5,7 +5,7 @@ import { FindOperator } from "../FindOperator"
  * Example: { someField: ArrayContains([...]) }
  */
 export function ArrayContains<T>(
-    value: T[] | FindOperator<T>,
+    value: readonly T[] | FindOperator<T>,
 ): FindOperator<any> {
     return new FindOperator("arrayContains", value as any)
 }

--- a/src/find-options/operator/ArrayOverlap.ts
+++ b/src/find-options/operator/ArrayOverlap.ts
@@ -5,7 +5,7 @@ import { FindOperator } from "../FindOperator"
  * Example: { someField: ArrayOverlap([...]) }
  */
 export function ArrayOverlap<T>(
-    value: T[] | FindOperator<T>,
+    value: readonly T[] | FindOperator<T>,
 ): FindOperator<any> {
     return new FindOperator("arrayOverlap", value as any)
 }

--- a/src/find-options/operator/In.ts
+++ b/src/find-options/operator/In.ts
@@ -4,6 +4,8 @@ import { FindOperator } from "../FindOperator"
  * Find Options Operator.
  * Example: { someField: In([...]) }
  */
-export function In<T>(value: T[] | FindOperator<T>): FindOperator<any> {
+export function In<T>(
+    value: readonly T[] | FindOperator<T>,
+): FindOperator<any> {
     return new FindOperator("in", value as any, true, true)
 }


### PR DESCRIPTION
<!--
  😀 Wonderful!  Thank you for opening a pull request for TypeORM.

  Please fill in the information below to expedite the review
  and (hopefully) merge of your change.

  If unsure about something.. just do as best as you're able,
  or reach out through our community support channels!
  https://github.com/typeorm/typeorm/blob/master/docs/support.md
-->

### Description of change

Mark the array arguments to find operators like `In` and `ArrayContains` as `readonly`. This makes it possible to use them with readonly arrays as parameters without casting or having to make copies.

<!--
  Please be clear and concise what the change is intended to do,
  why this change is needed, and how you've verified that it
  corrects what you intended.

  In some cases it may be helpful to include the current behavior
  and the new behavior.

  If the change is related to an open issue, you can link it here.
  If you include `Fixes #0000` (replacing `0000` with the issue number)
  when this is merged it will automatically mark the issue as fixed and
  close it.
-->


### Pull-Request Checklist

<!--
  Please make sure to review and check all of the following.

  If an item is not applicable, you can add "N/A" to the end.
-->

- [x] Code is up-to-date with the `master` branch
- [x] `npm run format` to apply prettier formatting
- [x] `npm run test` passes with this change
- [ ] This pull request links relevant issues as `Fixes #0000` N/A
- [ ] There are new or updated unit tests validating the change N/A
- [ ] Documentation has been updated to reflect this change N/A
- [x] The new commits follow conventions explained in [CONTRIBUTING.md](https://github.com/typeorm/typeorm/blob/master/CONTRIBUTING.md)

<!--
  🎉 Thank you for contributing and making TypeORM even better!
-->
