### PR TITLE
feat: Introduce TYPEORM_DATASOURCE env var as default datasource file

### DIFF
--- a/src/commands/CacheClearCommand.ts
+++ b/src/commands/CacheClearCommand.ts
@@ -19,6 +19,7 @@ export class CacheClearCommand implements yargs.CommandModule {
             describe:
                 "Path to the file where your DataSource instance is defined.",
             demandOption: true,
+            default: process.env.TYPEORM_DATASOURCE,
         })
     }
 

--- a/src/commands/MigrationShowCommand.ts
+++ b/src/commands/MigrationShowCommand.ts
@@ -18,6 +18,7 @@ export class MigrationShowCommand implements yargs.CommandModule {
             describe:
                 "Path to the file where your DataSource instance is defined.",
             demandOption: true,
+            default: process.env.TYPEORM_DATASOURCE,
         })
     }
 

--- a/src/commands/SchemaDropCommand.ts
+++ b/src/commands/SchemaDropCommand.ts
@@ -21,6 +21,7 @@ export class SchemaDropCommand implements yargs.CommandModule {
             describe:
                 "Path to the file where your DataSource instance is defined.",
             demandOption: true,
+            default: process.env.TYPEORM_DATASOURCE,
         })
     }
 

--- a/src/commands/SchemaLogCommand.ts
+++ b/src/commands/SchemaLogCommand.ts
@@ -22,6 +22,7 @@ export class SchemaLogCommand implements yargs.CommandModule {
             describe:
                 "Path to the file where your DataSource instance is defined.",
             demandOption: true,
+            default: process.env.TYPEORM_DATASOURCE,
         })
     }
 

--- a/src/commands/SchemaSyncCommand.ts
+++ b/src/commands/SchemaSyncCommand.ts
@@ -21,6 +21,7 @@ export class SchemaSyncCommand implements yargs.CommandModule {
             describe:
                 "Path to the file where your DataSource instance is defined.",
             demandOption: true,
+            default: process.env.TYPEORM_DATASOURCE,
         })
     }
 


### PR DESCRIPTION
<!--
  😀 Wonderful!  Thank you for opening a pull request for TypeORM.

  Please fill in the information below to expedite the review
  and (hopefully) merge of your change.

  If unsure about something.. just do as best as you're able,
  or reach out through our community support channels!
  https://github.com/typeorm/typeorm/blob/master/docs/support.md
-->

### Description of change

** This is currently in draft, looking for feedback **

This PR adds a new TYPEORM_DATASOURCE environment variable that is used as a default value for the `-d` cli option.

The reasoning behind this is using the typeorm cli in a project. Without this option, defining a `typeorm` command in package.json with a default datasource becomes cumbersome because not all sub-commands accept the datasource option leading to `Unknown argument: d` errors, whereas passing it as env variable makes it much easier.

Right now I made the minimum edits to show this as a proof of concept, but if you feel this could be a good PR I can work on it further (documentation, etc...). Let me know!


### Pull-Request Checklist

<!--
  Please make sure to review and check all of the following.

  If an item is not applicable, you can add "N/A" to the end.
-->

- [x] Code is up-to-date with the `master` branch
- [x] `npm run format` to apply prettier formatting
- [ ] `npm run test` passes with this change
- [N/A] This pull request links relevant issues as `Fixes #0000`
- [ ] There are new or updated unit tests validating the change
- [ ] Documentation has been updated to reflect this change
- [x] The new commits follow conventions explained in [CONTRIBUTING.md](https://github.com/typeorm/typeorm/blob/master/CONTRIBUTING.md)

<!--
  🎉 Thank you for contributing and making TypeORM even better!
-->
