### PR TITLE
Fix typo in migrations doc

### DIFF
--- a/docs/migrations.md
+++ b/docs/migrations.md
@@ -238,7 +238,7 @@ module.exports = class PostRefactoringTIMESTAMP {
 See, you don't need to write the queries on your own.
 The rule of thumb for generating migrations is that you generate them after **each** change you made to your models. To apply multi-line formatting to your generated migration queries, use the `p` (alias for `--pretty`) flag.
 
-## DataSoure option
+## DataSource option
 
 If you need to run/revert/generate/show your migrations use the `-d` (alias for `--dataSource`) and pass the path to the file where your DataSource instance is defined as an argument
 


### PR DESCRIPTION
docs: fixed typo 
Datasoure ==> Datasource

### Description of change

Fixed a typo in docs

Datasoure => Datasource

### Pull-Request Checklist

- [x] Code is up-to-date with the `master` branch
- [NA] `npm run format` to apply prettier formatting
- [NA] `npm run test` passes with this change
- [NA] This pull request links relevant issues as `Fixes #0000`
- [NA] There are new or updated unit tests validating the change
- [x] Documentation has been updated to reflect this change
- [x] The new commits follow conventions explained in [CONTRIBUTING.md](https://github.com/typeorm/typeorm/blob/master/CONTRIBUTING.md)
