### PR TITLE
I think that now is better 😅 (Tiny modification in README.md file)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1000,7 +1000,7 @@ Let's change our photo's `@OneToOne` decorator a bit:
 
 ```typescript
 export class Photo {
-    /// ... other columns
+    // ... other columns
 
     @OneToOne(() => PhotoMetadata, (metadata) => metadata.photo, {
         cascade: true,
@@ -1155,7 +1155,7 @@ Now let's add the inverse side of our relation to the `Photo` class:
 
 ```typescript
 export class Photo {
-    /// ... other columns
+    // ... other columns
 
     @ManyToMany(() => Album, (album) => album.photos)
     albums: Album[]


### PR DESCRIPTION
### Description of change

I've just removed one `\` from the documentation. Comments are defined by `\\`, and the three slashes (`\\\`) are sometimes used for automatic documentation generation[^1].

[^1]: [What does the three slashes in javascript do?](https://stackoverflow.com/a/10423481)

### Pull-Request Checklist

- [x] Code is up-to-date with the `master` branch
- [x] `npm run format` to apply prettier formatting
- [x] `npm run test` passes with this change
- [ ] ~~This pull request links relevant issues as `Fixes #0000`~~ - N/A
- [ ] ~~There are new or updated unit tests validating the change~~ - N/A
- [x] Documentation has been updated to reflect this change
- [x] The new commits follow conventions explained in [CONTRIBUTING.md](https://github.com/typeorm/typeorm/blob/master/CONTRIBUTING.md)