### PR TITLE
tests: benchmark tests for cascade bulk operations

### DIFF
--- a/test/benchmark/bulk-save-cascade-case1/bulk-save-cascade-case1.ts
+++ b/test/benchmark/bulk-save-cascade-case1/bulk-save-cascade-case1.ts
@@ -1,0 +1,139 @@
+import "reflect-metadata"
+import { DataSource } from "../../../src/data-source/DataSource"
+import {
+    closeTestingConnections,
+    createTestingConnections,
+    reloadTestingDatabases,
+} from "../../utils/test-utils"
+import { One } from "./entity/One"
+import { Three } from "./entity/Three"
+import { Two } from "./entity/Two"
+
+describe("benchmark > bulk-save-cascade > case1", () => {
+    let connections: DataSource[]
+    before(
+        async () =>
+            (connections = await createTestingConnections({
+                __dirname,
+                enabledDrivers: ["postgres"],
+            })),
+    )
+    beforeEach(() => reloadTestingDatabases(connections))
+    after(() => closeTestingConnections(connections))
+
+    it("testing bulk save of 200 with two relations objects", () =>
+        Promise.all(
+            connections.map(async (connection) => {
+                const ones: One[] = []
+
+                for (let i = 1; i <= 200; i++) {
+                    const one = new One()
+                    const two = new Two()
+                    const three = new Three()
+                    one.text = `One #${i}`
+                    two.text = `Two #${i}`
+                    three.text = `Three #${i}`
+                    one.two = two
+                    one.three = three
+                    ones.push(one)
+                }
+
+                await connection.manager.save(ones)
+            }),
+        ))
+
+    it("testing bulk save of 500 with two relations objects", () =>
+        Promise.all(
+            connections.map(async (connection) => {
+                const ones: One[] = []
+
+                for (let i = 1; i <= 500; i++) {
+                    const one = new One()
+                    const two = new Two()
+                    const three = new Three()
+                    one.text = `One #${i}`
+                    two.text = `Two #${i}`
+                    three.text = `Three #${i}`
+                    one.two = two
+                    one.three = three
+                    ones.push(one)
+                }
+
+                await connection.manager.save(ones)
+            }),
+        ))
+
+    it("testing bulk save of 1000 with two relations objects", () =>
+        Promise.all(
+            connections.map(async (connection) => {
+                const ones: One[] = []
+
+                for (let i = 1; i <= 1000; i++) {
+                    const one = new One()
+                    const two = new Two()
+                    const three = new Three()
+                    one.text = `One #${i}`
+                    two.text = `Two #${i}`
+                    three.text = `Three #${i}`
+                    one.two = two
+                    one.three = three
+                    ones.push(one)
+                }
+
+                await connection.manager.save(ones)
+            }),
+        ))
+
+    it("testing bulk save of 5000 with two relations objects", () =>
+        Promise.all(
+            connections.map(async (connection) => {
+                const ones: One[] = []
+
+                for (let i = 1; i <= 5000; i++) {
+                    const one = new One()
+                    const two = new Two()
+                    const three = new Three()
+                    one.text = `One #${i}`
+                    two.text = `Two #${i}`
+                    three.text = `Three #${i}`
+                    one.two = two
+                    one.three = three
+                    ones.push(one)
+                }
+
+                await connection.manager.save(ones)
+            }),
+        ))
+
+    it("testing bulk save of 10000 with two relations objects", () =>
+        Promise.all(
+            connections.map(async (connection) => {
+                const ones: One[] = []
+
+                for (let i = 1; i <= 10000; i++) {
+                    const one = new One()
+                    const two = new Two()
+                    const three = new Three()
+                    one.text = `One #${i}`
+                    two.text = `Two #${i}`
+                    three.text = `Three #${i}`
+                    one.two = two
+                    one.three = three
+                    ones.push(one)
+                }
+
+                await connection.manager.save(ones)
+            }),
+        ))
+
+    /**
+     * Postgres
+     *
+     * ✓ testing bulk save of 200 with two relations objects (75ms)
+     * ✓ testing bulk save of 500 with two relations objects (135ms)
+     * ✓ testing bulk save of 1000 with two relations objects (211ms)
+     * ✓ testing bulk save of 5000 with two relations objects (2266ms)
+     * ✓ testing bulk save of 10000 with two relations objects (12210ms)
+     *
+     */
+})

--- a/test/benchmark/bulk-save-cascade-case1/entity/One.ts
+++ b/test/benchmark/bulk-save-cascade-case1/entity/One.ts
@@ -1,0 +1,30 @@
+import { DeleteDateColumn, OneToOne } from "../../../../src"
+import { Column } from "../../../../src/decorator/columns/Column"
+import { PrimaryGeneratedColumn } from "../../../../src/decorator/columns/PrimaryGeneratedColumn"
+import { Entity } from "../../../../src/decorator/entity/Entity"
+import { Three } from "./Three"
+import { Two } from "./Two"
+
+@Entity()
+export class One {
+    @PrimaryGeneratedColumn()
+    id: number
+
+    @OneToOne((type) => Two, (two) => two.one, {
+        cascade: ["insert", "soft-remove"],
+        orphanedRowAction: "soft-delete",
+    })
+    two: Two
+
+    @OneToOne((type) => Three, (three) => three.one, {
+        cascade: ["insert", "soft-remove"],
+        orphanedRowAction: "soft-delete",
+    })
+    three: Three
+
+    @Column({ type: "text" })
+    text: string
+
+    @DeleteDateColumn()
+    deleted_at: string
+}

--- a/test/benchmark/bulk-save-cascade-case1/entity/One.ts
+++ b/test/benchmark/bulk-save-cascade-case1/entity/One.ts
@@ -1,4 +1,4 @@
-import { DeleteDateColumn, OneToOne } from "../../../../src"
+import { DeleteDateColumn, JoinColumn, OneToOne } from "../../../../src"
 import { Column } from "../../../../src/decorator/columns/Column"
 import { PrimaryGeneratedColumn } from "../../../../src/decorator/columns/PrimaryGeneratedColumn"
 import { Entity } from "../../../../src/decorator/entity/Entity"
@@ -10,19 +10,27 @@ export class One {
     @PrimaryGeneratedColumn()
     id: number
 
+    @Column({ name: "two_id" })
+    twoId: number
+
+    @Column({ name: "three_id" })
+    threeId: number
+
     @OneToOne((type) => Two, (two) => two.one, {
         cascade: ["insert", "soft-remove"],
         orphanedRowAction: "soft-delete",
     })
+    @JoinColumn({ name: "two_id" })
     two: Two
 
     @OneToOne((type) => Three, (three) => three.one, {
         cascade: ["insert", "soft-remove"],
         orphanedRowAction: "soft-delete",
     })
+    @JoinColumn({ name: "three_id" })
     three: Three
 
-    @Column({ type: "text" })
+    @Column({ type: "text", nullable: true })
     text: string
 
     @DeleteDateColumn()

--- a/test/benchmark/bulk-save-cascade-case1/entity/Three.ts
+++ b/test/benchmark/bulk-save-cascade-case1/entity/Three.ts
@@ -1,0 +1,20 @@
+import { DeleteDateColumn, OneToOne } from "../../../../src"
+import { Column } from "../../../../src/decorator/columns/Column"
+import { PrimaryGeneratedColumn } from "../../../../src/decorator/columns/PrimaryGeneratedColumn"
+import { Entity } from "../../../../src/decorator/entity/Entity"
+import { One } from "./One"
+
+@Entity()
+export class Three {
+    @PrimaryGeneratedColumn()
+    id: number
+
+    @OneToOne((type) => One)
+    one: One
+
+    @Column({ type: "text" })
+    text: string
+
+    @DeleteDateColumn()
+    deleted_at: string
+}

--- a/test/benchmark/bulk-save-cascade-case1/entity/Two.ts
+++ b/test/benchmark/bulk-save-cascade-case1/entity/Two.ts
@@ -1,0 +1,20 @@
+import { DeleteDateColumn, OneToOne } from "../../../../src"
+import { Column } from "../../../../src/decorator/columns/Column"
+import { PrimaryGeneratedColumn } from "../../../../src/decorator/columns/PrimaryGeneratedColumn"
+import { Entity } from "../../../../src/decorator/entity/Entity"
+import { One } from "./One"
+
+@Entity()
+export class Two {
+    @PrimaryGeneratedColumn()
+    id: number
+
+    @OneToOne((type) => One)
+    one: One
+
+    @Column({ type: "text" })
+    text: string
+
+    @DeleteDateColumn()
+    deleted_at: string
+}

--- a/test/benchmark/bulk-save-soft-remove-cascade-case1/bulk-save-soft-remove-cascade-case1.ts
+++ b/test/benchmark/bulk-save-soft-remove-cascade-case1/bulk-save-soft-remove-cascade-case1.ts
@@ -1,0 +1,122 @@
+import "reflect-metadata"
+import { DataSource } from "../../../src/data-source/DataSource"
+import {
+    closeTestingConnections,
+    createTestingConnections,
+    reloadTestingDatabases,
+} from "../../utils/test-utils"
+import { One } from "./entity/One"
+import { Three } from "./entity/Three"
+import { Two } from "./entity/Two"
+
+describe("benchmark > bulk-save-soft-remove-cascade > case1", () => {
+    let connections: DataSource[]
+    before(
+        async () =>
+            (connections = await createTestingConnections({
+                __dirname,
+                enabledDrivers: ["postgres"],
+            })),
+    )
+    beforeEach(() => reloadTestingDatabases(connections))
+    after(() => closeTestingConnections(connections))
+
+    it("testing bulk cascade save then cascade soft remove of 200 objects", () =>
+        Promise.all(
+            connections.map(async (connection) => {
+                const ones: One[] = []
+
+                for (let i = 1; i <= 200; i++) {
+                    const one = new One()
+                    const two = new Two()
+                    const three = new Three()
+                    one.text = `One #${i}`
+                    two.text = `Two #${i}`
+                    three.text = `Three #${i}`
+                    one.two = two
+                    one.three = three
+                    ones.push(one)
+                }
+
+                await connection.manager.save(ones)
+                await connection.manager.softRemove(ones)
+            }),
+        ))
+
+    it("testing bulk cascade save then cascade soft remove of 500 objects", () =>
+        Promise.all(
+            connections.map(async (connection) => {
+                const ones: One[] = []
+
+                for (let i = 1; i <= 500; i++) {
+                    const one = new One()
+                    const two = new Two()
+                    const three = new Three()
+                    one.text = `One #${i}`
+                    two.text = `Two #${i}`
+                    three.text = `Three #${i}`
+                    one.two = two
+                    one.three = three
+                    ones.push(one)
+                }
+
+                await connection.manager.save(ones)
+                await connection.manager.softRemove(ones)
+            }),
+        ))
+
+    it("testing bulk cascade save then cascade soft remove of 5000 objects", () =>
+        Promise.all(
+            connections.map(async (connection) => {
+                const ones: One[] = []
+
+                for (let i = 1; i <= 5000; i++) {
+                    const one = new One()
+                    const two = new Two()
+                    const three = new Three()
+                    one.text = `One #${i}`
+                    two.text = `Two #${i}`
+                    three.text = `Three #${i}`
+                    one.two = two
+                    one.three = three
+                    ones.push(one)
+                }
+
+                await connection.manager.save(ones)
+                await connection.manager.softRemove(ones)
+            }),
+        ))
+
+    it("testing bulk cascade save then cascade soft remove of 10000 objects", () =>
+        Promise.all(
+            connections.map(async (connection) => {
+                const ones: One[] = []
+
+                for (let i = 1; i <= 10000; i++) {
+                    const one = new One()
+                    const two = new Two()
+                    const three = new Three()
+                    one.text = `One #${i}`
+                    two.text = `Two #${i}`
+                    three.text = `Three #${i}`
+                    one.two = two
+                    one.three = three
+                    ones.push(one)
+                }
+
+                await connection.manager.save(ones)
+                await connection.manager.softRemove(ones)
+            }),
+        ))
+
+    /**
+     * Postgres
+     *
+     * ✓ testing bulk cascade save then cascade soft remove of 200 objects (700ms)
+     * ✓ testing bulk cascade save then cascade soft remove of 500 objects (2610ms)
+     * 1) testing bulk cascade save then cascade soft remove of 5000 objects
+     * 2 passing (3m)
+     * 1 failing
+     *
+     */
+})

--- a/test/benchmark/bulk-save-soft-remove-cascade-case1/entity/One.ts
+++ b/test/benchmark/bulk-save-soft-remove-cascade-case1/entity/One.ts
@@ -1,0 +1,30 @@
+import { DeleteDateColumn, OneToOne } from "../../../../src"
+import { Column } from "../../../../src/decorator/columns/Column"
+import { PrimaryGeneratedColumn } from "../../../../src/decorator/columns/PrimaryGeneratedColumn"
+import { Entity } from "../../../../src/decorator/entity/Entity"
+import { Three } from "./Three"
+import { Two } from "./Two"
+
+@Entity()
+export class One {
+    @PrimaryGeneratedColumn()
+    id: number
+
+    @OneToOne((type) => Two, (two) => two.one, {
+        cascade: ["insert", "soft-remove"],
+        orphanedRowAction: "soft-delete",
+    })
+    two: Two
+
+    @OneToOne((type) => Three, (three) => three.one, {
+        cascade: ["insert", "soft-remove"],
+        orphanedRowAction: "soft-delete",
+    })
+    three: Three
+
+    @Column({ type: "text" })
+    text: string
+
+    @DeleteDateColumn()
+    deleted_at: string
+}

--- a/test/benchmark/bulk-save-soft-remove-cascade-case1/entity/One.ts
+++ b/test/benchmark/bulk-save-soft-remove-cascade-case1/entity/One.ts
@@ -1,4 +1,4 @@
-import { DeleteDateColumn, OneToOne } from "../../../../src"
+import { DeleteDateColumn, JoinColumn, OneToOne } from "../../../../src"
 import { Column } from "../../../../src/decorator/columns/Column"
 import { PrimaryGeneratedColumn } from "../../../../src/decorator/columns/PrimaryGeneratedColumn"
 import { Entity } from "../../../../src/decorator/entity/Entity"
@@ -10,19 +10,27 @@ export class One {
     @PrimaryGeneratedColumn()
     id: number
 
+    @Column({ name: "two_id" })
+    twoId: number
+
+    @Column({ name: "three_id" })
+    threeId: number
+
     @OneToOne((type) => Two, (two) => two.one, {
         cascade: ["insert", "soft-remove"],
         orphanedRowAction: "soft-delete",
     })
+    @JoinColumn({ name: "two_id" })
     two: Two
 
     @OneToOne((type) => Three, (three) => three.one, {
         cascade: ["insert", "soft-remove"],
         orphanedRowAction: "soft-delete",
     })
+    @JoinColumn({ name: "three_id" })
     three: Three
 
-    @Column({ type: "text" })
+    @Column({ type: "text", nullable: true })
     text: string
 
     @DeleteDateColumn()

--- a/test/benchmark/bulk-save-soft-remove-cascade-case1/entity/Three.ts
+++ b/test/benchmark/bulk-save-soft-remove-cascade-case1/entity/Three.ts
@@ -1,0 +1,20 @@
+import { DeleteDateColumn, OneToOne } from "../../../../src"
+import { Column } from "../../../../src/decorator/columns/Column"
+import { PrimaryGeneratedColumn } from "../../../../src/decorator/columns/PrimaryGeneratedColumn"
+import { Entity } from "../../../../src/decorator/entity/Entity"
+import { One } from "./One"
+
+@Entity()
+export class Three {
+    @PrimaryGeneratedColumn()
+    id: number
+
+    @OneToOne((type) => One)
+    one: One
+
+    @Column({ type: "text" })
+    text: string
+
+    @DeleteDateColumn()
+    deleted_at: string
+}

--- a/test/benchmark/bulk-save-soft-remove-cascade-case1/entity/Two.ts
+++ b/test/benchmark/bulk-save-soft-remove-cascade-case1/entity/Two.ts
@@ -1,0 +1,20 @@
+import { DeleteDateColumn, OneToOne } from "../../../../src"
+import { Column } from "../../../../src/decorator/columns/Column"
+import { PrimaryGeneratedColumn } from "../../../../src/decorator/columns/PrimaryGeneratedColumn"
+import { Entity } from "../../../../src/decorator/entity/Entity"
+import { One } from "./One"
+
+@Entity()
+export class Two {
+    @PrimaryGeneratedColumn()
+    id: number
+
+    @OneToOne((type) => One)
+    one: One
+
+    @Column({ type: "text" })
+    text: string
+
+    @DeleteDateColumn()
+    deleted_at: string
+}

--- a/test/benchmark/bulk-save-soft-remove-cascade-case2/bulk-save-soft-remove-cascade-case2.ts
+++ b/test/benchmark/bulk-save-soft-remove-cascade-case2/bulk-save-soft-remove-cascade-case2.ts
@@ -1,0 +1,55 @@
+import "reflect-metadata"
+import { DataSource } from "../../../src/data-source/DataSource"
+import {
+    closeTestingConnections,
+    createTestingConnections,
+} from "../../utils/test-utils"
+import { One } from "./entity/One"
+import { Three } from "./entity/Three"
+import { Two } from "./entity/Two"
+
+describe("benchmark > bulk-save-soft-remove-cascade > case2", () => {
+    let connections: DataSource[]
+    let ones: One[] = []
+    before(
+        async () =>
+            (connections = await createTestingConnections({
+                __dirname,
+                enabledDrivers: ["postgres"],
+            })),
+    )
+    beforeEach(() =>
+        Promise.all(
+            connections.map(async (connection) => {
+                for (let i = 1; i <= 2500; i++) {
+                    const one = new One()
+                    const two = new Two()
+                    const three = new Three()
+                    one.text = `One #${i}`
+                    two.text = `Two #${i}`
+                    three.text = `Three #${i}`
+                    one.two = two
+                    one.three = three
+                    ones.push(one)
+                }
+
+                await connection.manager.save(ones)
+            }),
+        ),
+    )
+    after(() => closeTestingConnections(connections))
+
+    it("testing bulk soft remove of 2500 with relations objects", () =>
+        Promise.all(
+            connections.map(async (connection) => {
+                await connection.manager.softRemove(ones)
+            }),
+        ))
+
+    /**
+     * Postgres
+     *
+     * ✓ testing bulk soft remove of 2500 with relations objects (55972ms)
+     *
+     */
+})

--- a/test/benchmark/bulk-save-soft-remove-cascade-case2/entity/One.ts
+++ b/test/benchmark/bulk-save-soft-remove-cascade-case2/entity/One.ts
@@ -1,0 +1,30 @@
+import { DeleteDateColumn, OneToOne } from "../../../../src"
+import { Column } from "../../../../src/decorator/columns/Column"
+import { PrimaryGeneratedColumn } from "../../../../src/decorator/columns/PrimaryGeneratedColumn"
+import { Entity } from "../../../../src/decorator/entity/Entity"
+import { Three } from "./Three"
+import { Two } from "./Two"
+
+@Entity()
+export class One {
+    @PrimaryGeneratedColumn()
+    id: number
+
+    @OneToOne((type) => Two, (two) => two.one, {
+        cascade: ["insert", "soft-remove"],
+        orphanedRowAction: "soft-delete",
+    })
+    two: Two
+
+    @OneToOne((type) => Three, (three) => three.one, {
+        cascade: ["insert", "soft-remove"],
+        orphanedRowAction: "soft-delete",
+    })
+    three: Three
+
+    @Column({ type: "text" })
+    text: string
+
+    @DeleteDateColumn()
+    deleted_at: string
+}

--- a/test/benchmark/bulk-save-soft-remove-cascade-case2/entity/One.ts
+++ b/test/benchmark/bulk-save-soft-remove-cascade-case2/entity/One.ts
@@ -1,4 +1,4 @@
-import { DeleteDateColumn, OneToOne } from "../../../../src"
+import { DeleteDateColumn, JoinColumn, OneToOne } from "../../../../src"
 import { Column } from "../../../../src/decorator/columns/Column"
 import { PrimaryGeneratedColumn } from "../../../../src/decorator/columns/PrimaryGeneratedColumn"
 import { Entity } from "../../../../src/decorator/entity/Entity"
@@ -10,19 +10,27 @@ export class One {
     @PrimaryGeneratedColumn()
     id: number
 
+    @Column({ name: "two_id" })
+    twoId: number
+
+    @Column({ name: "three_id" })
+    threeId: number
+
     @OneToOne((type) => Two, (two) => two.one, {
         cascade: ["insert", "soft-remove"],
         orphanedRowAction: "soft-delete",
     })
+    @JoinColumn({ name: "two_id" })
     two: Two
 
     @OneToOne((type) => Three, (three) => three.one, {
         cascade: ["insert", "soft-remove"],
         orphanedRowAction: "soft-delete",
     })
+    @JoinColumn({ name: "three_id" })
     three: Three
 
-    @Column({ type: "text" })
+    @Column({ type: "text", nullable: true })
     text: string
 
     @DeleteDateColumn()

--- a/test/benchmark/bulk-save-soft-remove-cascade-case2/entity/Three.ts
+++ b/test/benchmark/bulk-save-soft-remove-cascade-case2/entity/Three.ts
@@ -1,0 +1,20 @@
+import { DeleteDateColumn, OneToOne } from "../../../../src"
+import { Column } from "../../../../src/decorator/columns/Column"
+import { PrimaryGeneratedColumn } from "../../../../src/decorator/columns/PrimaryGeneratedColumn"
+import { Entity } from "../../../../src/decorator/entity/Entity"
+import { One } from "./One"
+
+@Entity()
+export class Three {
+    @PrimaryGeneratedColumn()
+    id: number
+
+    @OneToOne((type) => One)
+    one: One
+
+    @Column({ type: "text" })
+    text: string
+
+    @DeleteDateColumn()
+    deleted_at: string
+}

--- a/test/benchmark/bulk-save-soft-remove-cascade-case2/entity/Two.ts
+++ b/test/benchmark/bulk-save-soft-remove-cascade-case2/entity/Two.ts
@@ -1,0 +1,20 @@
+import { DeleteDateColumn, OneToOne } from "../../../../src"
+import { Column } from "../../../../src/decorator/columns/Column"
+import { PrimaryGeneratedColumn } from "../../../../src/decorator/columns/PrimaryGeneratedColumn"
+import { Entity } from "../../../../src/decorator/entity/Entity"
+import { One } from "./One"
+
+@Entity()
+export class Two {
+    @PrimaryGeneratedColumn()
+    id: number
+
+    @OneToOne((type) => One)
+    one: One
+
+    @Column({ type: "text" })
+    text: string
+
+    @DeleteDateColumn()
+    deleted_at: string
+}


### PR DESCRIPTION
<!--
  😀 Wonderful!  Thank you for opening a pull request for TypeORM.

  Please fill in the information below to expedite the review
  and (hopefully) merge of your change.

  If unsure about something.. just do as best as you're able,
  or reach out through our community support channels!
  https://github.com/typeorm/typeorm/blob/master/docs/support.md
-->


### Description of change
Creates benchmark tests for actions being done in bulk with cascaded inserts and soft-removal.

The following cases are covered:
- Cascade bulk save
- Two cases of bulk soft-removal (including and not including cascade bulk insert)

Theses tests aim to show the lack of performance for the soft-remove operation, that fails fairly early in the tests due to how long it takes.
<!--
  Please be clear and concise what the change is intended to do,
  why this change is needed, and how you've verified that it
  corrects what you intended.

  In some cases it may be helpful to include the current behavior
  and the new behavior.

  If the change is related to an open issue, you can link it here.
  If you include `Fixes #0000` (replacing `0000` with the issue number)
  when this is merged it will automatically mark the issue as fixed and
  close it.
-->


### Pull-Request Checklist

<!--
  Please make sure to review and check all of the following.

  If an item is not applicable, you can add "N/A" to the end.
-->

- [X] Code is up-to-date with the `master` branch
- [X] `npm run format` to apply prettier formatting
- [ ] `npm run test` passes with this change
- [ ] This pull request links relevant issues as `Fixes #0000`
- [ ] There are new or updated unit tests validating the change
- [ ] Documentation has been updated to reflect this change
- [X] The new commits follow conventions explained in [CONTRIBUTING.md](https://github.com/typeorm/typeorm/blob/master/CONTRIBUTING.md)

<!--
  🎉 Thank you for contributing and making TypeORM even better!
-->
