### PR TITLE
fix: correctly return insertId for react-native

### DIFF
--- a/src/driver/react-native/ReactNativeQueryRunner.ts
+++ b/src/driver/react-native/ReactNativeQueryRunner.ts
@@ -76,11 +76,6 @@ export class ReactNativeQueryRunner extends AbstractSqliteQueryRunner {
 
                     const result = new QueryResult()
 
-                    // return id of inserted row, if query was insert statement.
-                    if (query.substr(0, 11) === "INSERT INTO") {
-                        result.raw = raw.insertId
-                    }
-
                     if (raw?.hasOwnProperty("rowsAffected")) {
                         result.affected = raw.rowsAffected
                     }
@@ -93,6 +88,11 @@ export class ReactNativeQueryRunner extends AbstractSqliteQueryRunner {
 
                         result.raw = records
                         result.records = records
+                    }
+
+                    // return id of inserted row, if query was insert statement.
+                    if (query.substr(0, 11) === "INSERT INTO") {
+                        result.raw = raw.insertId
                     }
 
                     if (useStructuredResult) {


### PR DESCRIPTION
<!--
  😀 Wonderful!  Thank you for opening a pull request for TypeORM.

  Please fill in the information below to expedite the review
  and (hopefully) merge of your change.

  If unsure about something.. just do as best as you're able,
  or reach out through our community support channels!
  https://github.com/typeorm/typeorm/blob/master/docs/support.md
-->

### Description of change

Correctly return the `insertId` in `ReactNativeQueryRunner.ts`, thus returning the updated entity with `save()` when inserting.

I've just re-ordered the code. Previously, the `insertId` was overwritten a few lines below.

Fixes #9482 


### Pull-Request Checklist

<!--
  Please make sure to review and check all of the following.

  If an item is not applicable, you can add "N/A" to the end.
-->

- [x] Code is up-to-date with the `master` branch
- [x] `npm run format` to apply prettier formatting
- [x] `npm run test` passes with this change
- [x] This pull request links relevant issues as `Fixes #9482`
- [ ] There are new or updated unit tests validating the change
- [ ] Documentation has been updated to reflect this change
- [x] The new commits follow conventions explained in [CONTRIBUTING.md](https://github.com/typeorm/typeorm/blob/master/CONTRIBUTING.md)

<!--
  🎉 Thank you for contributing and making TypeORM even better!
-->
