### PR TITLE
Pass fake argument to undoLastMigration Fixes #9561

### DIFF
--- a/src/commands/MigrationRevertCommand.ts
+++ b/src/commands/MigrationRevertCommand.ts
@@ -53,6 +53,7 @@ export class MigrationRevertCommand implements yargs.CommandModule {
                 transaction:
                     dataSource.options.migrationsTransactionMode ??
                     ("all" as "all" | "none" | "each"),
+                fake: !!args.f,
             }
 
             switch (args.t) {


### PR DESCRIPTION
Closes #9561

### Description of change
passed fake argument to `undoLastMigration` in `MigrationRevertCommand`

### Pull-Request Checklist

- [x]  Code is up-to-date with the `master` branch
- [x] `npm run format` to apply prettier formatting
- [ ] `npm run test` passes with this change -- **I don't have the required setup to run all these tests**
- [x] This pull request links relevant issues as `Fixes #0000`
- [ ] There are new or updated unit tests validating the change
- [ ] Documentation has been updated to reflect this change -- N/A no change
- [x] The new commits follow conventions explained in [CONTRIBUTING.md](https://github.com/typeorm/typeorm/blob/master/CONTRIBUTING.md)

