### PR TITLE
Synchronizing view with schema broken for oracle

### DIFF
--- a/src/driver/oracle/OracleQueryRunner.ts
+++ b/src/driver/oracle/OracleQueryRunner.ts
@@ -2848,7 +2848,7 @@ export class OracleQueryRunner extends BaseQueryRunner implements QueryRunner {
         const type = view.materialized
             ? MetadataTableType.MATERIALIZED_VIEW
             : MetadataTableType.VIEW
-        const { schema, tableName } = this.driver.parseTableName(view);
+        const { schema, tableName } = this.driver.parseTableName(view)
         return this.insertTypeormMetadataSql({
             type: type,
             name: tableName,

--- a/src/driver/oracle/OracleQueryRunner.ts
+++ b/src/driver/oracle/OracleQueryRunner.ts
@@ -2242,17 +2242,25 @@ export class OracleQueryRunner extends BaseQueryRunner implements QueryRunner {
         const currentDatabase = await this.getCurrentDatabase()
         const currentSchema = await this.getCurrentSchema()
 
-        const viewNamesString = viewNames
-            .map((name) => "'" + name + "'")
-            .join(", ")
+        const viewsCondition = viewNames
+            .map((viewName) => this.driver.parseTableName(viewName))
+            .map(({ schema, tableName }) => {
+                if (!schema) {
+                    schema = this.driver.options.schema || currentSchema
+                }
+
+                return `("T"."schema" = '${schema}' AND "T"."name" = '${tableName}')`
+            })
+            .join(" OR ")
+
         let query =
             `SELECT "T".* FROM ${this.escapePath(
                 this.getTypeormMetadataTableName(),
             )} "T" ` +
             `INNER JOIN "USER_OBJECTS" "O" ON "O"."OBJECT_NAME" = "T"."name" AND "O"."OBJECT_TYPE" IN ( 'MATERIALIZED VIEW', 'VIEW' ) ` +
-            `WHERE "T"."type" IN ( '${MetadataTableType.MATERIALIZED_VIEW}', '${MetadataTableType.VIEW}' )`
-        if (viewNamesString.length > 0)
-            query += ` AND "T"."name" IN (${viewNamesString})`
+            `WHERE "T"."type" IN ('${MetadataTableType.MATERIALIZED_VIEW}', '${MetadataTableType.VIEW}')`
+        if (viewsCondition.length > 0) query += ` AND ${viewsCondition}`
+
         const dbViews = await this.query(query)
         return dbViews.map((dbView: any) => {
             const parsedName = this.driver.parseTableName(dbView["name"])

--- a/src/driver/oracle/OracleQueryRunner.ts
+++ b/src/driver/oracle/OracleQueryRunner.ts
@@ -2848,9 +2848,11 @@ export class OracleQueryRunner extends BaseQueryRunner implements QueryRunner {
         const type = view.materialized
             ? MetadataTableType.MATERIALIZED_VIEW
             : MetadataTableType.VIEW
+        const { schema, tableName } = this.driver.parseTableName(view);
         return this.insertTypeormMetadataSql({
             type: type,
-            name: view.name,
+            name: tableName,
+            schema: schema,
             value: expression,
         })
     }

--- a/test/github-issues/9601/entity/Foo.ts
+++ b/test/github-issues/9601/entity/Foo.ts
@@ -1,0 +1,14 @@
+import {
+    Entity,
+    PrimaryGeneratedColumn,
+    UpdateDateColumn,
+} from "../../../../src"
+
+@Entity({ name: "foo", schema: "SYSTEM" })
+export class Foo {
+    @PrimaryGeneratedColumn({ name: "id" })
+    id: number
+
+    @UpdateDateColumn({ name: "updated_at" })
+    updatedAt: Date
+}

--- a/test/github-issues/9601/entity/FooView.ts
+++ b/test/github-issues/9601/entity/FooView.ts
@@ -1,0 +1,13 @@
+import { DataSource, ViewColumn, ViewEntity } from "../../../../src"
+import { Foo } from "./Foo"
+
+@ViewEntity({
+    name: "foo_view",
+    schema: "SYSTEM",
+    expression: (connection: DataSource) =>
+        connection.createQueryBuilder(Foo, "foo").select(`foo.updatedAt`),
+})
+export class FooView {
+    @ViewColumn()
+    updatedAt: Date
+}

--- a/test/github-issues/9601/issue-9601.ts
+++ b/test/github-issues/9601/issue-9601.ts
@@ -1,0 +1,43 @@
+import "reflect-metadata"
+import { DataSource } from "../../../src/index"
+import {
+    closeTestingConnections,
+    createTestingConnections,
+} from "../../utils/test-utils"
+
+describe.only("github issues > #9601 view+schema+synchronize broken for oracle", () => {
+    let connections: DataSource[]
+    before(
+        async () =>
+            (connections = await createTestingConnections({
+                entities: [__dirname + "/entity/*{.js,.ts}"],
+                schemaCreate: false,
+                dropSchema: true,
+                enabledDrivers: ["oracle"],
+            })),
+    )
+    after(() => closeTestingConnections(connections))
+
+    it("should recognize model changes", () =>
+        Promise.all(
+            connections.map(async (connection) => {
+                const sqlInMemory = await connection.driver
+                    .createSchemaBuilder()
+                    .log()
+                sqlInMemory.upQueries.length.should.be.greaterThan(0)
+                sqlInMemory.downQueries.length.should.be.greaterThan(0)
+            }),
+        ))
+
+    it("should not generate queries when no model changes", () =>
+        Promise.all(
+            connections.map(async (connection) => {
+                await connection.driver.createSchemaBuilder().build()
+                const sqlInMemory = await connection.driver
+                    .createSchemaBuilder()
+                    .log()
+                sqlInMemory.upQueries.length.should.be.equal(0)
+                sqlInMemory.downQueries.length.should.be.equal(0)
+            }),
+        ))
+})

--- a/test/github-issues/9601/issue-9601.ts
+++ b/test/github-issues/9601/issue-9601.ts
@@ -5,7 +5,7 @@ import {
     createTestingConnections,
 } from "../../utils/test-utils"
 
-describe.only("github issues > #9601 view+schema+synchronize broken for oracle", () => {
+describe("github issues > #9601 view+schema+synchronize broken for oracle", () => {
     let connections: DataSource[]
     before(
         async () =>


### PR DESCRIPTION
### Description of change

Modify OracleQueryRunner to workaround potentially bad inputs to insertViewDefinitionSql(), where the View object passed in does not have schema defined, but the name of the view already has the schema as a prefix. Use parseTableName() to separate the schema and the view name.

Fixes #9601

### Pull-Request Checklist

- [x] Code is up-to-date with the `master` branch
- [x] `npm run format` to apply prettier formatting
- [ ] `npm run test` passes with this change
- [x] This pull request links relevant issues as `Fixes #0000`
- [ ] There are new or updated unit tests validating the change
- [N/A] Documentation has been updated to reflect this change
- [ ] The new commits follow conventions explained in [CONTRIBUTING.md](https://github.com/typeorm/typeorm/blob/master/CONTRIBUTING.md)