### PR TITLE
fix: materialized hints support for cte

### DIFF
--- a/src/query-builder/QueryBuilder.ts
+++ b/src/query-builder/QueryBuilder.ts
@@ -1117,17 +1117,21 @@ export abstract class QueryBuilder<Entity extends ObjectLiteral> {
                     cte.options.recursive && databaseRequireRecusiveHint
                         ? "RECURSIVE"
                         : ""
-                const materializeClause =
-                    cte.options.materialized &&
-                    this.connection.driver.cteCapabilities.materializedHint
+                let materializeClause = ""
+                if (
+                    this.connection.driver.cteCapabilities.materializedHint &&
+                    cte.options.materialized !== undefined
+                ) {
+                    materializeClause = cte.options.materialized
                         ? "MATERIALIZED"
-                        : ""
+                        : "NOT MATERIALIZED"
+                }
 
                 return [
                     recursiveClause,
                     cteHeader,
-                    materializeClause,
                     "AS",
+                    materializeClause,
                     `(${cteBodyExpression})`,
                 ]
                     .filter(Boolean)

--- a/test/functional/query-builder/cte/materialized-cte.ts
+++ b/test/functional/query-builder/cte/materialized-cte.ts
@@ -1,0 +1,140 @@
+import "reflect-metadata"
+import { expect } from "chai"
+import {
+    createTestingConnections,
+    closeTestingConnections,
+    reloadTestingDatabases,
+} from "../../../utils/test-utils"
+import { Connection } from "../../../../src/connection/Connection"
+import { Foo } from "./entity/foo"
+import { filterByCteCapabilities } from "./helpers"
+import { QueryBuilderCteOptions } from "../../../../src/query-builder/QueryBuilderCte"
+
+describe("query builder > cte > materialized", () => {
+    let connections: Connection[]
+    before(
+        async () =>
+            (connections = await createTestingConnections({
+                entities: [__dirname + "/entity/*{.js,.ts}"],
+                schemaCreate: true,
+                dropSchema: true,
+                // enabledDrivers: [']
+            })),
+    )
+    beforeEach(() => reloadTestingDatabases(connections))
+    after(() => closeTestingConnections(connections))
+
+    it("should allow MATERIALIZED hint", () =>
+        Promise.all(
+            connections
+                .filter(filterByCteCapabilities("enabled"))
+                .filter(filterByCteCapabilities("materializedHint"))
+                .map(async (connection) => {
+                    await connection
+                        .getRepository(Foo)
+                        .insert(
+                            [1, 2, 3].map((i) => ({ id: i, bar: String(i) })),
+                        )
+                    const cteQuery = connection
+                        .createQueryBuilder()
+                        .select()
+                        .addSelect(`foo.bar`, "bar")
+                        .from(Foo, "foo")
+                        .where(`foo.bar = :value`, { value: "2" })
+
+                    const cteOptions: QueryBuilderCteOptions = {
+                        columnNames: ["raz"],
+                        materialized: true,
+                    }
+
+                    const cteSelection = "qaz.raz"
+
+                    const qb = await connection
+                        .createQueryBuilder()
+                        .addCommonTableExpression(cteQuery, "qaz", cteOptions)
+                        .from("qaz", "qaz")
+                        .select([])
+                        .addSelect(cteSelection, "raz")
+
+                    expect(qb.getQuery()).to.contain(
+                        `WITH "qaz"("raz") AS MATERIALIZED (`,
+                    )
+                    expect(await qb.getRawMany()).to.deep.equal([{ raz: "2" }])
+                }),
+        ))
+
+    it("should allow NOT MATERIALIZED hint", () =>
+        Promise.all(
+            connections
+                .filter(filterByCteCapabilities("enabled"))
+                .filter(filterByCteCapabilities("materializedHint"))
+                .map(async (connection) => {
+                    await connection
+                        .getRepository(Foo)
+                        .insert(
+                            [1, 2, 3].map((i) => ({ id: i, bar: String(i) })),
+                        )
+                    const cteQuery = connection
+                        .createQueryBuilder()
+                        .select()
+                        .addSelect(`foo.bar`, "bar")
+                        .from(Foo, "foo")
+                        .where(`foo.bar = :value`, { value: "2" })
+
+                    const cteOptions: QueryBuilderCteOptions = {
+                        columnNames: ["raz"],
+                        materialized: false,
+                    }
+
+                    const cteSelection = "qaz.raz"
+
+                    const qb = await connection
+                        .createQueryBuilder()
+                        .addCommonTableExpression(cteQuery, "qaz", cteOptions)
+                        .from("qaz", "qaz")
+                        .select([])
+                        .addSelect(cteSelection, "raz")
+
+                    expect(qb.getQuery()).to.contain(
+                        `WITH "qaz"("raz") AS NOT MATERIALIZED (`,
+                    )
+                    expect(await qb.getRawMany()).to.deep.equal([{ raz: "2" }])
+                }),
+        ))
+
+    it("should omit hint if materialized option is not set", () =>
+        Promise.all(
+            connections
+                .filter(filterByCteCapabilities("enabled"))
+                .filter(filterByCteCapabilities("materializedHint"))
+                .map(async (connection) => {
+                    await connection
+                        .getRepository(Foo)
+                        .insert(
+                            [1, 2, 3].map((i) => ({ id: i, bar: String(i) })),
+                        )
+                    const cteQuery = connection
+                        .createQueryBuilder()
+                        .select()
+                        .addSelect(`foo.bar`, "bar")
+                        .from(Foo, "foo")
+                        .where(`foo.bar = :value`, { value: "2" })
+
+                    const cteOptions: QueryBuilderCteOptions = {
+                        columnNames: ["raz"],
+                    }
+
+                    const cteSelection = "qaz.raz"
+
+                    const qb = await connection
+                        .createQueryBuilder()
+                        .addCommonTableExpression(cteQuery, "qaz", cteOptions)
+                        .from("qaz", "qaz")
+                        .select([])
+                        .addSelect(cteSelection, "raz")
+
+                    expect(qb.getQuery()).to.contain(`WITH "qaz"("raz") AS (`)
+                    expect(await qb.getRawMany()).to.deep.equal([{ raz: "2" }])
+                }),
+        ))
+})


### PR DESCRIPTION
<!--
  😀 Wonderful!  Thank you for opening a pull request for TypeORM.

  Please fill in the information below to expedite the review
  and (hopefully) merge of your change.

  If unsure about something.. just do as best as you're able,
  or reach out through our community support channels!
  https://github.com/typeorm/typeorm/blob/master/docs/support.md
-->

### Description of change

Fix implementation of materialized hints in common table expressions.

Previous behavior did not account for NOT MATERIALIZED hints, also placed materialized hints in wrong place (before "AS").
This change only affects drivers that support materialized hints (currently, postgres and cockroachdb)
I stumbled upon this while using your excellent library at work and trying to optimize queries using CTEs with postgres.
I'm sorry if I skipped opening an issue first. If it is necessary I'll do that and move the tests to an issue folder.

<!--
  Please be clear and concise what the change is intended to do,
  why this change is needed, and how you've verified that it
  corrects what you intended.

  In some cases it may be helpful to include the current behavior
  and the new behavior.

  If the change is related to an open issue, you can link it here.
  If you include `Fixes #0000` (replacing `0000` with the issue number)
  when this is merged it will automatically mark the issue as fixed and
  close it.
-->


### Pull-Request Checklist

<!--
  Please make sure to review and check all of the following.

  If an item is not applicable, you can add "N/A" to the end.
-->

- [x] Code is up-to-date with the `master` branch
- [x] `npm run format` to apply prettier formatting
- [x] `npm run test` passes with this change
- [ ] This pull request links relevant issues as `Fixes #0000` N/A
- [x] There are new or updated unit tests validating the change
- [ ] Documentation has been updated to reflect this change
- [x] The new commits follow conventions explained in [CONTRIBUTING.md](https://github.com/typeorm/typeorm/blob/master/CONTRIBUTING.md)

<!--
  🎉 Thank you for contributing and making TypeORM even better!
-->
