### PR TITLE
fix: allow `FindOptionsWhere` to accept `LessThan` with Union

### DIFF
--- a/src/find-options/FindOptionsWhere.ts
+++ b/src/find-options/FindOptionsWhere.ts
@@ -4,38 +4,40 @@ import { EqualOperator } from "./EqualOperator"
 
 /**
  * A single property handler for FindOptionsWhere.
+ *
+ * The reason why we have both "PropertyToBeNarrowed" and "Property" is that Union is narrowed down when extends is used.
+ * It means the result of FindOptionsWhereProperty<1 | 2> doesn't include FindOperator<1 | 2> but FindOperator<1> | FindOperator<2>.
+ * So we keep the original Union as Original and pass it to the FindOperator too. Original remains Union as extends is not used for it.
  */
 export type FindOptionsWhereProperty<
-    Property,
-    Original = Property,
-> = Property extends Promise<infer I>
+    PropertyToBeNarrowed,
+    Property = PropertyToBeNarrowed,
+> = PropertyToBeNarrowed extends Promise<infer I>
     ? FindOptionsWhereProperty<NonNullable<I>>
-    : Property extends Array<infer I>
+    : PropertyToBeNarrowed extends Array<infer I>
     ? FindOptionsWhereProperty<NonNullable<I>>
-    : Property extends Function
+    : PropertyToBeNarrowed extends Function
     ? never
-    : Property extends Buffer
-    ? Property | FindOperator<Property> | FindOperator<Original>
-    : Property extends Date
-    ? Property | FindOperator<Property> | FindOperator<Original>
-    : Property extends ObjectID
-    ? Property | FindOperator<Property> | FindOperator<Original>
-    : Property extends string
-    ? Property | FindOperator<Property> | FindOperator<Original>
-    : Property extends number
-    ? Property | FindOperator<Property> | FindOperator<Original>
-    : Property extends boolean
-    ? Property | FindOperator<Property> | FindOperator<Original>
-    : Property extends object
+    : PropertyToBeNarrowed extends Buffer
+    ? Property | FindOperator<Property>
+    : PropertyToBeNarrowed extends Date
+    ? Property | FindOperator<Property>
+    : PropertyToBeNarrowed extends ObjectID
+    ? Property | FindOperator<Property>
+    : PropertyToBeNarrowed extends string
+    ? Property | FindOperator<Property>
+    : PropertyToBeNarrowed extends number
+    ? Property | FindOperator<Property>
+    : PropertyToBeNarrowed extends boolean
+    ? Property | FindOperator<Property>
+    : PropertyToBeNarrowed extends object
     ?
           | FindOptionsWhere<Property>
-          | FindOptionsWhere<Original>
           | FindOptionsWhere<Property>[]
           | EqualOperator<Property>
-          | EqualOperator<Original>
           | FindOperator<any>
           | boolean
-    : Property | FindOperator<Property> | FindOperator<Original>
+    : Property | FindOperator<Property>
 
 /**
  * Used for find operations.

--- a/src/find-options/FindOptionsWhere.ts
+++ b/src/find-options/FindOptionsWhere.ts
@@ -5,34 +5,37 @@ import { EqualOperator } from "./EqualOperator"
 /**
  * A single property handler for FindOptionsWhere.
  */
-export type FindOptionsWhereProperty<Property> = Property extends Promise<
-    infer I
->
+export type FindOptionsWhereProperty<
+    Property,
+    Original = Property,
+> = Property extends Promise<infer I>
     ? FindOptionsWhereProperty<NonNullable<I>>
     : Property extends Array<infer I>
     ? FindOptionsWhereProperty<NonNullable<I>>
     : Property extends Function
     ? never
     : Property extends Buffer
-    ? Property | FindOperator<Property>
+    ? Property | FindOperator<Property> | FindOperator<Original>
     : Property extends Date
-    ? Property | FindOperator<Property>
+    ? Property | FindOperator<Property> | FindOperator<Original>
     : Property extends ObjectID
-    ? Property | FindOperator<Property>
+    ? Property | FindOperator<Property> | FindOperator<Original>
     : Property extends string
-    ? Property | FindOperator<Property>
+    ? Property | FindOperator<Property> | FindOperator<Original>
     : Property extends number
-    ? Property | FindOperator<Property>
+    ? Property | FindOperator<Property> | FindOperator<Original>
     : Property extends boolean
-    ? Property | FindOperator<Property>
+    ? Property | FindOperator<Property> | FindOperator<Original>
     : Property extends object
     ?
           | FindOptionsWhere<Property>
+          | FindOptionsWhere<Original>
           | FindOptionsWhere<Property>[]
           | EqualOperator<Property>
+          | EqualOperator<Original>
           | FindOperator<any>
           | boolean
-    : Property | FindOperator<Property>
+    : Property | FindOperator<Property> | FindOperator<Original>
 
 /**
  * Used for find operations.

--- a/test/github-issues/9152/entity/Test.ts
+++ b/test/github-issues/9152/entity/Test.ts
@@ -1,0 +1,12 @@
+import { Column, Entity, PrimaryGeneratedColumn } from "../../../../src"
+
+export type ValueUnion = 1 | 2 | 3
+
+@Entity()
+export class Test {
+    @PrimaryGeneratedColumn({ unsigned: true })
+    id: number
+
+    @Column()
+    value: ValueUnion
+}

--- a/test/github-issues/9152/issue-9152.ts
+++ b/test/github-issues/9152/issue-9152.ts
@@ -1,0 +1,39 @@
+import "reflect-metadata"
+import { expect } from "chai"
+import { Test, ValueUnion } from "./entity/Test"
+import { DataSource } from "../../../src/data-source/DataSource"
+import {
+    closeTestingConnections,
+    createTestingConnections,
+    reloadTestingDatabases,
+} from "../../utils/test-utils"
+import { LessThan } from "../../../src"
+
+describe("github issues > #9152 Can't use LessThan for Union field", () => {
+    let connections: DataSource[]
+    before(
+        async () =>
+            (connections = await createTestingConnections({
+                entities: [Test],
+            })),
+    )
+    beforeEach(() => reloadTestingDatabases(connections))
+    after(() => closeTestingConnections(connections))
+
+    it("should not raise TypeScript error when LessThan with Union is passed to FindOptionsWhere", () =>
+        Promise.all(
+            connections.map(async (connection) => {
+                await connection.getRepository(Test).save({
+                    value: 1,
+                })
+
+                const value = 2 as ValueUnion
+
+                const count = await connection.getRepository(Test).countBy({
+                    value: LessThan(value),
+                })
+
+                expect(count).to.eq(1)
+            }),
+        ))
+})


### PR DESCRIPTION
<!--
  😀 Wonderful!  Thank you for opening a pull request for TypeORM.

  Please fill in the information below to expedite the review
  and (hopefully) merge of your change.

  If unsure about something.. just do as best as you're able,
  or reach out through our community support channels!
  https://github.com/typeorm/typeorm/blob/master/docs/support.md
-->

### Description of change

<!--
  Please be clear and concise what the change is intended to do,
  why this change is needed, and how you've verified that it
  corrects what you intended.

  In some cases it may be helpful to include the current behavior
  and the new behavior.

  If the change is related to an open issue, you can link it here.
  If you include `Fixes #0000` (replacing `0000` with the issue number)
  when this is merged it will automatically mark the issue as fixed and
  close it.
-->

Fixes #9152 

Some CI have failed (edited: now CI passed by re-run), but it seems there is no problem based on the following points:

- I made changes to the type definitions but not to the implementation
- `tsc` succeeds
- The added tests do not depend on the database, and there is a successful CI for Postgres, etc.

### Pull-Request Checklist

<!--
  Please make sure to review and check all of the following.

  If an item is not applicable, you can add "N/A" to the end.
-->

- [x] Code is up-to-date with the `master` branch
- [x] `npm run format` to apply prettier formatting
- [x] `npm run test` passes with this change
- [x] This pull request links relevant issues as `Fixes #0000`
- [x] There are new or updated unit tests validating the change
- [ ] Documentation has been updated to reflect this change
  - updates doesn't seem necessary
- [x] The new commits follow conventions explained in [CONTRIBUTING.md](https://github.com/typeorm/typeorm/blob/master/CONTRIBUTING.md)


<!--
  🎉 Thank you for contributing and making TypeORM even better!
-->
