### PR TITLE
fix: the related entity from one-to-one relation should be sent to t…

### DIFF
--- a/src/persistence/subject-builder/OneToOneInverseSideSubjectBuilder.ts
+++ b/src/persistence/subject-builder/OneToOneInverseSideSubjectBuilder.ts
@@ -166,6 +166,7 @@ export class OneToOneInverseSideSubjectBuilder {
                     metadata: relation.inverseEntityMetadata,
                     canBeUpdated: true,
                     identifier: relationIdMap,
+                    entity: relatedEntity,
                 })
                 this.subjects.push(relatedEntitySubject)
             }

--- a/test/functional/entity-subscriber/relations/entity/Category.ts
+++ b/test/functional/entity-subscriber/relations/entity/Category.ts
@@ -1,0 +1,17 @@
+import {
+    Entity,
+    JoinColumn,
+    OneToOne,
+    PrimaryGeneratedColumn,
+} from "../../../../../src"
+import { Image } from "./Image"
+
+@Entity()
+export class Category {
+    @PrimaryGeneratedColumn()
+    id: number
+
+    @OneToOne(() => Image, (image) => image.defaultImageOf)
+    @JoinColumn()
+    image: Image
+}

--- a/test/functional/entity-subscriber/relations/entity/Image.ts
+++ b/test/functional/entity-subscriber/relations/entity/Image.ts
@@ -1,0 +1,11 @@
+import { Entity, OneToOne, PrimaryGeneratedColumn } from "../../../../../src"
+import { Category } from "./Category"
+
+@Entity()
+export class Image {
+    @PrimaryGeneratedColumn()
+    id: number
+
+    @OneToOne(() => Category, (category) => category.image)
+    defaultImageOf: Category
+}

--- a/test/functional/entity-subscriber/relations/relations.ts
+++ b/test/functional/entity-subscriber/relations/relations.ts
@@ -1,0 +1,41 @@
+import { DataSource } from "../../../../src"
+import {
+    closeTestingConnections,
+    createTestingConnections,
+} from "../../../utils/test-utils"
+import { expect } from "chai"
+import { CategorySubscriber } from "./subscribers/CategorySubscriber"
+import { Category } from "./entity/Category"
+import { Image } from "./entity/Image"
+
+describe("entity subscriber > one-to-one", () => {
+    let datasources: DataSource[]
+
+    before(async () => {
+        datasources = await createTestingConnections({
+            entities: [Category, Image],
+            subscribers: [CategorySubscriber],
+            dropSchema: true,
+            schemaCreate: true,
+            enabledDrivers: ["sqlite"],
+            logging: true,
+        })
+    })
+
+    after(() => closeTestingConnections(datasources))
+
+    it("passes related entity from one-to-one relation to subscriber", async () => {
+        if (!datasources.length) return
+
+        const subscriber = datasources[0].subscribers[0] as CategorySubscriber
+
+        const category = new Category()
+        await datasources[0].manager.save(category)
+
+        const image = new Image()
+        image.defaultImageOf = category
+        await datasources[0].manager.save(image)
+
+        expect(subscriber.events[0].entity).to.be.eql(category)
+    })
+})

--- a/test/functional/entity-subscriber/relations/subscribers/CategorySubscriber.ts
+++ b/test/functional/entity-subscriber/relations/subscribers/CategorySubscriber.ts
@@ -1,0 +1,19 @@
+import {
+    EntitySubscriberInterface,
+    EventSubscriber,
+    UpdateEvent,
+} from "../../../../../src"
+import { Category } from "../entity/Category"
+
+@EventSubscriber()
+export class CategorySubscriber implements EntitySubscriberInterface<Category> {
+    events: UpdateEvent<Category>[] = []
+
+    listenTo() {
+        return Category
+    }
+
+    afterUpdate(event: UpdateEvent<Category>): void {
+        this.events.push(event)
+    }
+}


### PR DESCRIPTION
…he entity subscriber on save, but it is not

### Description of change

Fix https://github.com/typeorm/typeorm/issues/9609
When saving an entity with a one-to-one relation, whose join column is set in the relation, the entity subscriber of the related entity is executed with the entity attribute of the update event as undefined

### Pull-Request Checklist

<!--
  Please make sure to review and check all of the following.

  If an item is not applicable, you can add "N/A" to the end.
-->

- [x] Code is up-to-date with the `master` branch
- [x] `npm run format` to apply prettier formatting
- [ ] `npm run test` passes with this change
- [x] This pull request links relevant issues as `Fixes #0000`
- [x] There are new or updated unit tests validating the change
- [ ] Documentation has been updated to reflect this change
- [x] The new commits follow conventions explained in [CONTRIBUTING.md](https://github.com/typeorm/typeorm/blob/master/CONTRIBUTING.md)

