### PR TITLE
feature: support enableWal for the better-sqlite3 driver

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "typeorm",
-  "version": "0.3.10",
+  "version": "0.3.11",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "typeorm",
-      "version": "0.3.10",
+      "version": "0.3.11",
       "license": "MIT",
       "dependencies": {
         "@sqltools/formatter": "^1.2.2",

--- a/src/driver/better-sqlite3/BetterSqlite3ConnectionOptions.ts
+++ b/src/driver/better-sqlite3/BetterSqlite3ConnectionOptions.ts
@@ -69,4 +69,11 @@ export interface BetterSqlite3ConnectionOptions extends BaseDataSourceOptions {
     readonly nativeBinding?: string
 
     readonly poolSize?: never
+
+    /**
+     * Enables WAL mode. By default its disabled.
+     *
+     * @see https://www.sqlite.org/wal.html
+     */
+    readonly enableWAL?: boolean
 }

--- a/src/driver/better-sqlite3/BetterSqlite3Driver.ts
+++ b/src/driver/better-sqlite3/BetterSqlite3Driver.ts
@@ -168,7 +168,9 @@ export class BetterSqlite3Driver extends AbstractSqliteDriver {
         databaseConnection.exec(`PRAGMA foreign_keys = ON`)
 
         // turn on WAL mode to enhance performance
-        databaseConnection.exec(`PRAGMA journal_mode = WAL`)
+        if (this.options.enableWAL) {
+            databaseConnection.exec(`PRAGMA journal_mode = WAL`)
+        }
 
         return databaseConnection
     }

--- a/test/github-issues/9410/issue-9410.ts
+++ b/test/github-issues/9410/issue-9410.ts
@@ -1,0 +1,33 @@
+import "reflect-metadata"
+import { expect } from "chai"
+import { DataSource } from "../../../src/data-source/DataSource"
+import {
+    closeTestingConnections,
+    createTestingConnections,
+    reloadTestingDatabases,
+} from "../../utils/test-utils"
+
+describe("better-sqlite3 driver > enable wal", () => {
+    let connections: DataSource[]
+    before(
+        async () =>
+            (connections = await createTestingConnections({
+                entities: [],
+                enabledDrivers: ["better-sqlite3"],
+                driverSpecific: {
+                    enableWAL: true,
+                },
+            })),
+    )
+    beforeEach(() => reloadTestingDatabases(connections))
+    after(() => closeTestingConnections(connections))
+
+    it("github issues > #9410 The better-sqlite3 driver should support the enableWal flag", () =>
+        Promise.all(
+            connections.map(async (connection) => {
+                const result = await connection.query("PRAGMA journal_mode")
+
+                expect(result).to.eql([{ journal_mode: "wal" }])
+            }),
+        ))
+})


### PR DESCRIPTION
### Support the enableWal flag for the better-sqlite3 driver

Fixes #9410 

The better sqlite3 driver lacks the enableWal flag in its options. Moreover, the WAL mode always gets enabled, since this configuration is hardcoded in the [driver itself](https://github.com/typeorm/typeorm/blob/master/src/driver/better-sqlite3/BetterSqlite3Driver.ts#L171). Neither the [sqlite driver](https://github.com/typeorm/typeorm/blob/master/src/driver/sqlite/SqliteDriver.ts#L177) nor the better-sqlite3 library itself enable this mode by themselves, so I see no reason to have it always enabled.

The `enableWal` flag will force the WAL mode when turned on, but keeps the existing default for the database if not set or set to false. This guarantees backwards compatibility with existing databases.


### Pull-Request Checklist

- [x] Code is up-to-date with the `master` branch
- [x] `npm run format` to apply prettier formatting
- [x] `npm run test` passes with this change
- [x] This pull request links relevant issues as `Fixes #0000`
- [x] There are new or updated unit tests validating the change
- [ ] Documentation has been updated to reflect this change
- [x] The new commits follow conventions explained in [CONTRIBUTING.md](https://github.com/typeorm/typeorm/blob/master/CONTRIBUTING.md)
