### PR TITLE
fix: DataSource.setOptions doesn't properly update the database in the drivers

### DIFF
--- a/src/data-source/DataSource.ts
+++ b/src/data-source/DataSource.ts
@@ -215,6 +215,17 @@ export class DataSource {
             this.queryResultCache = new QueryResultCacheFactory(this).create()
         }
 
+        // todo: we must update the database in the driver as well, if it was set by setOptions method
+        //  in the future we need to refactor the code and remove "database" from the driver, and instead
+        //  use database (and options) from a single place - data source.
+        if (options.database) {
+            this.driver.database = DriverUtils.buildDriverOptions(
+                this.options,
+            ).database
+        }
+
+        // todo: need to take a look if we need to update schema and other "poor" properties
+
         return this
     }
 

--- a/src/driver/better-sqlite3/BetterSqlite3Driver.ts
+++ b/src/driver/better-sqlite3/BetterSqlite3Driver.ts
@@ -1,7 +1,6 @@
 import mkdirp from "mkdirp"
 import path from "path"
 import { DriverPackageNotInstalledError } from "../../error"
-import { DriverOptionNotSetError } from "../../error"
 import { PlatformTools } from "../../platform/PlatformTools"
 import { DataSource } from "../../data-source"
 import { ColumnType } from "../types/ColumnTypes"
@@ -40,10 +39,6 @@ export class BetterSqlite3Driver extends AbstractSqliteDriver {
         this.connection = connection
         this.options = connection.options as BetterSqlite3ConnectionOptions
         this.database = this.options.database
-
-        // validate options to make sure everything is set
-        if (!this.options.database)
-            throw new DriverOptionNotSetError("database")
 
         // load sqlite package
         this.loadDependencies()

--- a/src/driver/capacitor/CapacitorDriver.ts
+++ b/src/driver/capacitor/CapacitorDriver.ts
@@ -3,10 +3,7 @@ import { CapacitorConnectionOptions } from "./CapacitorConnectionOptions"
 import { CapacitorQueryRunner } from "./CapacitorQueryRunner"
 import { QueryRunner } from "../../query-runner/QueryRunner"
 import { DataSource } from "../../data-source/DataSource"
-import {
-    DriverOptionNotSetError,
-    DriverPackageNotInstalledError,
-} from "../../error"
+import { DriverPackageNotInstalledError } from "../../error"
 import { ReplicationMode } from "../types/ReplicationMode"
 
 export class CapacitorDriver extends AbstractSqliteDriver {
@@ -22,12 +19,6 @@ export class CapacitorDriver extends AbstractSqliteDriver {
 
         this.database = this.options.database
         this.driver = this.options.driver
-
-        // validate options to make sure everything is set
-        if (!this.options.database)
-            throw new DriverOptionNotSetError("database")
-
-        if (!this.options.driver) throw new DriverOptionNotSetError("driver")
 
         // load sqlite package
         this.sqlite = this.options.driver

--- a/src/driver/cordova/CordovaDriver.ts
+++ b/src/driver/cordova/CordovaDriver.ts
@@ -3,7 +3,6 @@ import { CordovaConnectionOptions } from "./CordovaConnectionOptions"
 import { CordovaQueryRunner } from "./CordovaQueryRunner"
 import { QueryRunner } from "../../query-runner/QueryRunner"
 import { DataSource } from "../../data-source/DataSource"
-import { DriverOptionNotSetError } from "../../error/DriverOptionNotSetError"
 import { DriverPackageNotInstalledError } from "../../error/DriverPackageNotInstalledError"
 import { ReplicationMode } from "../types/ReplicationMode"
 
@@ -29,13 +28,6 @@ export class CordovaDriver extends AbstractSqliteDriver {
         // this.connection = connection;
         // this.options = connection.options as CordovaConnectionOptions;
         this.database = this.options.database
-
-        // validate options to make sure everything is set
-        if (!this.options.database)
-            throw new DriverOptionNotSetError("database")
-
-        if (!this.options.location)
-            throw new DriverOptionNotSetError("location")
 
         // load sqlite package
         this.loadDependencies()

--- a/src/driver/expo/ExpoDriver.ts
+++ b/src/driver/expo/ExpoDriver.ts
@@ -3,7 +3,6 @@ import { ExpoConnectionOptions } from "./ExpoConnectionOptions"
 import { ExpoQueryRunner } from "./ExpoQueryRunner"
 import { QueryRunner } from "../../query-runner/QueryRunner"
 import { DataSource } from "../../data-source/DataSource"
-import { DriverOptionNotSetError } from "../../error/DriverOptionNotSetError"
 import { ReplicationMode } from "../types/ReplicationMode"
 
 export class ExpoDriver extends AbstractSqliteDriver {
@@ -17,12 +16,6 @@ export class ExpoDriver extends AbstractSqliteDriver {
         super(connection)
 
         this.database = this.options.database
-
-        // validate options to make sure everything is set
-        if (!this.options.database)
-            throw new DriverOptionNotSetError("database")
-
-        if (!this.options.driver) throw new DriverOptionNotSetError("driver")
 
         // load sqlite package
         this.sqlite = this.options.driver

--- a/src/driver/nativescript/NativescriptDriver.ts
+++ b/src/driver/nativescript/NativescriptDriver.ts
@@ -3,7 +3,6 @@ import { NativescriptConnectionOptions } from "./NativescriptConnectionOptions"
 import { NativescriptQueryRunner } from "./NativescriptQueryRunner"
 import { QueryRunner } from "../../query-runner/QueryRunner"
 import { DataSource } from "../../data-source/DataSource"
-import { DriverOptionNotSetError } from "../../error/DriverOptionNotSetError"
 import { DriverPackageNotInstalledError } from "../../error/DriverPackageNotInstalledError"
 import { ColumnType } from "../types/ColumnTypes"
 import { ReplicationMode } from "../types/ReplicationMode"
@@ -39,11 +38,6 @@ export class NativescriptDriver extends AbstractSqliteDriver {
         this.options = connection.options as NativescriptConnectionOptions
         this.database = this.options.database
         this.driver = this.options.driver
-
-        // validate options to make sure everything is set
-        if (!this.options.database) {
-            throw new DriverOptionNotSetError("database")
-        }
 
         // load sqlite package
         this.loadDependencies()

--- a/src/driver/react-native/ReactNativeDriver.ts
+++ b/src/driver/react-native/ReactNativeDriver.ts
@@ -3,7 +3,6 @@ import { ReactNativeConnectionOptions } from "./ReactNativeConnectionOptions"
 import { ReactNativeQueryRunner } from "./ReactNativeQueryRunner"
 import { QueryRunner } from "../../query-runner/QueryRunner"
 import { DataSource } from "../../data-source/DataSource"
-import { DriverOptionNotSetError } from "../../error/DriverOptionNotSetError"
 import { DriverPackageNotInstalledError } from "../../error/DriverPackageNotInstalledError"
 import { ReplicationMode } from "../types/ReplicationMode"
 
@@ -18,13 +17,6 @@ export class ReactNativeDriver extends AbstractSqliteDriver {
         super(connection)
 
         this.database = this.options.database
-
-        // validate options to make sure everything is set
-        if (!this.options.database)
-            throw new DriverOptionNotSetError("database")
-
-        if (!this.options.location)
-            throw new DriverOptionNotSetError("location")
 
         // load sqlite package
         this.loadDependencies()

--- a/src/driver/sqlite/SqliteDriver.ts
+++ b/src/driver/sqlite/SqliteDriver.ts
@@ -2,7 +2,6 @@ import mkdirp from "mkdirp"
 import path from "path"
 import { DriverPackageNotInstalledError } from "../../error/DriverPackageNotInstalledError"
 import { SqliteQueryRunner } from "./SqliteQueryRunner"
-import { DriverOptionNotSetError } from "../../error/DriverOptionNotSetError"
 import { PlatformTools } from "../../platform/PlatformTools"
 import { DataSource } from "../../data-source/DataSource"
 import { SqliteConnectionOptions } from "./SqliteConnectionOptions"
@@ -40,10 +39,6 @@ export class SqliteDriver extends AbstractSqliteDriver {
         this.connection = connection
         this.options = connection.options as SqliteConnectionOptions
         this.database = this.options.database
-
-        // validate options to make sure everything is set
-        if (!this.options.database)
-            throw new DriverOptionNotSetError("database")
 
         // load sqlite package
         this.loadDependencies()


### PR DESCRIPTION
* make sure we update database in the driver if it was dynamically set via dataSource.setOptions
* removed validation for database since we definitely shouldn't have it in the constructor, database can be set later on (e.g. datasource.setOptions)

`DataSource.setOptions` doesn't work properly if we update database name using it, e.g.

```ts
dataSource.setOptions({ database: "database-defined-later" })
```

This PR fixes this problem.