### PR TITLE
fix: multiple select queries during db sync in sqlite

### DIFF
--- a/src/driver/sqlite-abstract/AbstractSqliteQueryRunner.ts
+++ b/src/driver/sqlite-abstract/AbstractSqliteQueryRunner.ts
@@ -1318,7 +1318,9 @@ export abstract class AbstractSqliteQueryRunner
                 if (tableNamesWithoutDot.length) {
                     promises.push(
                         this.query(
-                            `SELECT * FROM "sqlite_master" WHERE "type" = '${type}' AND "name" IN (${tableNamesWithoutDot})`,
+                            `SELECT * FROM "sqlite_master" WHERE "type" = '${type}' AND "${
+                                type === "table" ? "name" : "tbl_name"
+                            }" IN (${tableNamesWithoutDot})`,
                         ),
                     )
                 }

--- a/src/driver/sqlite-abstract/AbstractSqliteQueryRunner.ts
+++ b/src/driver/sqlite-abstract/AbstractSqliteQueryRunner.ts
@@ -1311,7 +1311,7 @@ export abstract class AbstractSqliteQueryRunner
             const queryPromises = (type: "table" | "index") => {
                 const promises = [
                     ...tableNamesWithDot.map((tableName) =>
-                        this.loadTableRecords(tableName, "table"),
+                        this.loadTableRecords(tableName, type),
                     ),
                 ]
 

--- a/src/driver/sqlite-abstract/AbstractSqliteQueryRunner.ts
+++ b/src/driver/sqlite-abstract/AbstractSqliteQueryRunner.ts
@@ -1257,7 +1257,7 @@ export abstract class AbstractSqliteQueryRunner
             database =
                 this.driver.getAttachedDatabasePathRelativeByHandle(schema)
         }
-        const res = await this.query(
+        return this.query(
             `SELECT ${database ? `'${database}'` : null} as database, ${
                 schema ? `'${schema}'` : null
             } as schema, * FROM ${
@@ -1268,12 +1268,11 @@ export abstract class AbstractSqliteQueryRunner
                 tableOrIndex === "table" ? "name" : "tbl_name"
             }" IN ('${tableName}')`,
         )
-        return res
     }
+
     protected async loadPragmaRecords(tablePath: string, pragma: string) {
         const [, tableName] = this.splitTablePath(tablePath)
-        const res = await this.query(`PRAGMA ${pragma}("${tableName}")`)
-        return res
+        return this.query(`PRAGMA ${pragma}("${tableName}")`)
     }
 
     /**
@@ -1299,22 +1298,37 @@ export abstract class AbstractSqliteQueryRunner
                 `SELECT * FROM "sqlite_master" WHERE "type" = 'index' AND "tbl_name" IN (${tableNamesString})`,
             )
         } else {
-            dbTables = (
-                await Promise.all(
-                    tableNames.map((tableName) =>
+            const tableNamesWithoutDot = tableNames
+                .filter((tableName) => {
+                    return tableName.split(".").length === 1
+                })
+                .map((tableName) => `'${tableName}'`)
+
+            const tableNamesWithDot = tableNames.filter((tableName) => {
+                return tableName.split(".").length > 1
+            })
+
+            const queryPromises = (type: "table" | "index") => {
+                const promises = [
+                    ...tableNamesWithDot.map((tableName) =>
                         this.loadTableRecords(tableName, "table"),
                     ),
-                )
-            )
+                ]
+
+                if (tableNamesWithoutDot.length) {
+                    promises.push(
+                        this.query(
+                            `SELECT * FROM "sqlite_master" WHERE "type" = '${type}' AND "name" IN (${tableNamesWithoutDot})`,
+                        ),
+                    )
+                }
+
+                return promises
+            }
+            dbTables = (await Promise.all(queryPromises("table")))
                 .reduce((acc, res) => [...acc, ...res], [])
                 .filter(Boolean)
-            dbIndicesDef = (
-                await Promise.all(
-                    (tableNames ?? []).map((tableName) =>
-                        this.loadTableRecords(tableName, "index"),
-                    ),
-                )
-            )
+            dbIndicesDef = (await Promise.all(queryPromises("index")))
                 .reduce((acc, res) => [...acc, ...res], [])
                 .filter(Boolean)
         }

--- a/test/functional/multi-database/multi-database-basic-functionality/multi-database-basic-functionality.ts
+++ b/test/functional/multi-database/multi-database-basic-functionality/multi-database-basic-functionality.ts
@@ -1,6 +1,6 @@
 import "../../../utils/test-setup"
 import { expect } from "chai"
-import { DataSource } from "../../../../src/data-source/DataSource"
+import { DataSource } from "../../../../src/index.js"
 import {
     closeTestingConnections,
     createTestingConnections,

--- a/test/functional/multi-database/multi-database-basic-functionality/multi-database-basic-functionality.ts
+++ b/test/functional/multi-database/multi-database-basic-functionality/multi-database-basic-functionality.ts
@@ -1,6 +1,6 @@
 import "../../../utils/test-setup"
 import { expect } from "chai"
-import { DataSource } from "../../../../src/index.js"
+import { DataSource } from "../../../../src/data-source/DataSource"
 import {
     closeTestingConnections,
     createTestingConnections,


### PR DESCRIPTION


### Description of change

Optimized DDL queries during DB synchronization in SQLite.

Before:

```sql
SELECT * FROM "sqlite_master" WHERE "type" = 'table' AND "name" IN ('user')
SELECT * FROM "sqlite_master" WHERE "type" = 'table' AND "name" IN ('question')
SELECT * FROM "sqlite_master" WHERE "type" = 'table' AND "name" IN ('answer')
SELECT * FROM "sqlite_master" WHERE "type" = 'table' AND "name" IN ('category')
```

After:

```sql
SELECT * FROM "sqlite_master" WHERE "type" = 'table' AND "name" IN ('user', 'question', 'answer', 'category')
```

### Pull-Request Checklist

<!--
  Please make sure to review and check all of the following.

  If an item is not applicable, you can add "N/A" to the end.
-->

- [x] Code is up-to-date with the `master` branch
- [x] `npm run format` to apply prettier formatting
- [x] `npm run test` passes with this change
- [ ] This pull request links relevant issues as `Fixes #0000`
- [ ] There are new or updated unit tests validating the change
- [ ] Documentation has been updated to reflect this change
- [x] The new commits follow conventions explained in [CONTRIBUTING.md](https://github.com/typeorm/typeorm/blob/master/CONTRIBUTING.md)

<!--
  🎉 Thank you for contributing and making TypeORM even better!
-->
