### PR TITLE
fix: correct a typo

### DIFF
--- a/src/driver/postgres/PostgresDriver.ts
+++ b/src/driver/postgres/PostgresDriver.ts
@@ -485,7 +485,7 @@ export class PostgresDriver implements Driver {
             } catch (_) {
                 logger.log(
                     "warn",
-                    "At least one of the entities has a cube column, but the 'ltree' extension cannot be installed automatically. Please install it manually using superuser rights",
+                    "At least one of the entities has a ltree column, but the 'ltree' extension cannot be installed automatically. Please install it manually using superuser rights",
                 )
             }
         if (hasExclusionConstraints)


### PR DESCRIPTION
### Description of change

Correct a typo in an error message, where it shows there is an error creating ltree extension, the original error message mentions a cube type column instead of ltree.

### Pull-Request Checklist

- [x] Code is up-to-date with the `master` branch
- [x] `npm run format` to apply prettier formatting
- [x] `npm run test` passes with this change
- [ ] This pull request links relevant issues as `Fixes #0000`
- [ ] There are new or updated unit tests validating the change
- [ ] Documentation has been updated to reflect this change
- [x] The new commits follow conventions explained in [CONTRIBUTING.md](https://github.com/typeorm/typeorm/blob/master/CONTRIBUTING.md)