### PR TITLE
fix: Make id retrieval for relation ids consistent

### DIFF
--- a/src/metadata/ColumnMetadata.ts
+++ b/src/metadata/ColumnMetadata.ts
@@ -691,6 +691,7 @@ export class ColumnMetadata {
                     entity,
                     this.relationMetadata.propertyName,
                 )?.get &&
+                this.propertyName === this.relationMetadata.propertyName &&
                 entity[this.relationMetadata.propertyName] &&
                 ObjectUtils.isObject(entity[this.relationMetadata.propertyName])
             ) {

--- a/test/github-issues/9656/entity/CompositeEntity.ts
+++ b/test/github-issues/9656/entity/CompositeEntity.ts
@@ -1,0 +1,22 @@
+import { Entity } from "../../../../src/decorator/entity/Entity"
+import { Column, ManyToOne, PrimaryColumn } from "../../../../src"
+import { ReferencedEntityOne } from "./ReferencedEntityOne"
+import { ReferencedEntityTwo } from "./ReferencedEntityTwo"
+
+@Entity()
+export class CompositeEntity {
+    @ManyToOne(() => ReferencedEntityOne, (one) => one.composites)
+    referencedEntityOne: ReferencedEntityOne
+
+    @PrimaryColumn("uuid")
+    referencedEntityOneId: string
+
+    @ManyToOne(() => ReferencedEntityTwo, (one) => one.composites)
+    referencedEntityTwo: ReferencedEntityTwo
+
+    @PrimaryColumn("uuid")
+    referencedEntityTwoId: string
+
+    @Column("text")
+    description: string
+}

--- a/test/github-issues/9656/entity/ReferencedEntityOne.ts
+++ b/test/github-issues/9656/entity/ReferencedEntityOne.ts
@@ -1,0 +1,22 @@
+import { Entity } from "../../../../src/decorator/entity/Entity"
+import { PrimaryGeneratedColumn } from "../../../../src/decorator/columns/PrimaryGeneratedColumn"
+import { Column, OneToMany } from "../../../../src"
+import { CompositeEntity } from "./CompositeEntity"
+
+@Entity()
+export class ReferencedEntityOne {
+    @PrimaryGeneratedColumn("uuid")
+    id: string
+
+    @OneToMany(
+        () => CompositeEntity,
+        (composite) => composite.referencedEntityOne,
+        {
+            cascade: true,
+        },
+    )
+    composites: CompositeEntity[]
+
+    @Column("text")
+    name: string
+}

--- a/test/github-issues/9656/entity/ReferencedEntityTwo.ts
+++ b/test/github-issues/9656/entity/ReferencedEntityTwo.ts
@@ -1,0 +1,19 @@
+import { Entity } from "../../../../src/decorator/entity/Entity"
+import { PrimaryGeneratedColumn } from "../../../../src/decorator/columns/PrimaryGeneratedColumn"
+import { Column, OneToMany } from "../../../../src"
+import { CompositeEntity } from "./CompositeEntity"
+
+@Entity()
+export class ReferencedEntityTwo {
+    @PrimaryGeneratedColumn("uuid")
+    id: string
+
+    @OneToMany(
+        () => CompositeEntity,
+        (composite) => composite.referencedEntityTwo,
+    )
+    composites: CompositeEntity[]
+
+    @Column("int")
+    num: number
+}

--- a/test/github-issues/9656/issue-9656.ts
+++ b/test/github-issues/9656/issue-9656.ts
@@ -1,0 +1,138 @@
+import "reflect-metadata"
+import {
+    createTestingConnections,
+    closeTestingConnections,
+    reloadTestingDatabases,
+} from "../../utils/test-utils"
+import { DataSource } from "../../../src/data-source/DataSource"
+import { expect } from "chai"
+import { ReferencedEntityOne } from "./entity/ReferencedEntityOne"
+import { ReferencedEntityTwo } from "./entity/ReferencedEntityTwo"
+import { CompositeEntity } from "./entity/CompositeEntity"
+
+describe("github issues > #9656 Cascading OneToMany with composite key fails on update", () => {
+    let dataSources: DataSource[]
+    before(
+        async () =>
+            (dataSources = await createTestingConnections({
+                entities: [__dirname + "/entity/*{.js,.ts}"],
+                schemaCreate: true,
+                dropSchema: true,
+            })),
+    )
+    beforeEach(() => reloadTestingDatabases(dataSources))
+    after(() => closeTestingConnections(dataSources))
+
+    function makeReferencedEntityOne() {
+        const one = new ReferencedEntityOne()
+        one.composites = []
+        one.name = "the default name"
+        return one
+    }
+
+    function makeReferencedEntityTwo() {
+        const two = new ReferencedEntityTwo()
+        two.composites = []
+        two.num = Math.floor(Math.random() * 10000)
+        return two
+    }
+
+    function makeComposite(oneId: string, twoId: string) {
+        const composite = new CompositeEntity()
+
+        composite.referencedEntityOne = new ReferencedEntityOne()
+        composite.referencedEntityOne.id = oneId
+        composite.referencedEntityOneId = oneId
+
+        composite.referencedEntityTwo = new ReferencedEntityTwo()
+        composite.referencedEntityTwo.id = twoId
+        composite.referencedEntityTwoId = twoId
+
+        composite.description = `The description: ${oneId} ${twoId}`
+
+        return composite
+    }
+
+    function getReferencedEntityOne(dataSource: DataSource, id: string) {
+        return dataSource.getRepository(ReferencedEntityOne).findOneOrFail({
+            where: { id },
+            relations: {
+                composites: {
+                    referencedEntityTwo: true,
+                },
+            },
+        })
+    }
+
+    it("should allow inserting records one by one", () =>
+        Promise.all(
+            dataSources.map(async (dataSource) => {
+                const oneRepo = dataSource.getRepository(ReferencedEntityOne)
+                const twoRepo = dataSource.getRepository(ReferencedEntityTwo)
+                // const compositeRepo = dataSource.getRepository(CompositeEntity);
+
+                const ones = [
+                    makeReferencedEntityOne(),
+                    makeReferencedEntityOne(),
+                    makeReferencedEntityOne(),
+                    makeReferencedEntityOne(),
+                ]
+
+                for (const one of ones) {
+                    await oneRepo.save(one)
+                }
+
+                const twos = [
+                    makeReferencedEntityTwo(),
+                    makeReferencedEntityTwo(),
+                    makeReferencedEntityTwo(),
+                    makeReferencedEntityTwo(),
+                ]
+
+                for (const two of twos) {
+                    await twoRepo.save(two)
+                }
+
+                let loadedOne = await getReferencedEntityOne(
+                    dataSource,
+                    ones[0].id,
+                )
+
+                expect(loadedOne.composites).length(0)
+
+                loadedOne.composites.push(
+                    makeComposite(loadedOne.id, twos[0].id),
+                )
+
+                await oneRepo.save(loadedOne)
+
+                loadedOne = await getReferencedEntityOne(
+                    dataSource,
+                    loadedOne.id,
+                )
+
+                expect(loadedOne.composites).length(1)
+                expect(loadedOne.composites[0].referencedEntityTwo.id).equals(
+                    twos[0].id,
+                )
+                expect(loadedOne.composites[0].referencedEntityTwo.num).equals(
+                    twos[0].num,
+                )
+
+                loadedOne.composites.push(
+                    makeComposite(loadedOne.id, twos[1].id),
+                )
+
+                await oneRepo.save(loadedOne)
+
+                loadedOne = await getReferencedEntityOne(
+                    dataSource,
+                    loadedOne.id,
+                )
+
+                expect(loadedOne.composites).length(2)
+            }),
+        ))
+
+    // you can add additional tests if needed
+})


### PR DESCRIPTION
Closes: #9656

### Description of change
When investigating this, I realized that when we were looking for `getEntityValue` for the id property from the primary column, it was accidentally retrieving the relation property name instead. This change makes sure only to do the relation logic if the property we are asking for and the relation property name are the same. 



### Pull-Request Checklist


- [X] Code is up-to-date with the `master` branch
- [X] `npm run format` to apply prettier formatting
- [X] `npm run test` passes with this change
- [X] This pull request links relevant issues as `Fixes #0000`
- [X] There are new or updated unit tests validating the change
- [X] Documentation has been updated to reflect this change
- [X] The new commits follow conventions explained in [CONTRIBUTING.md](https://github.com/typeorm/typeorm/blob/master/CONTRIBUTING.md)

<!--
  🎉 Thank you for contributing and making TypeORM even better!
-->
