### PR TITLE
Feature/postgres primary and join column

### DIFF
--- a/src/metadata-builder/RelationJoinColumnBuilder.ts
+++ b/src/metadata-builder/RelationJoinColumnBuilder.ts
@@ -88,8 +88,11 @@ export class RelationJoinColumnBuilder {
         })
 
         // Oracle does not allow both primary and unique constraints on the same column
+        // Postgres can't take the unique und primary at once during create and primary key is unique anyway
         if (
-            this.connection.driver.options.type === "oracle" &&
+            ["oracle", "postgres"].includes(
+                this.connection.driver.options.type,
+            ) &&
             columns.every((column) => column.isPrimary)
         )
             return { foreignKey, columns, uniqueConstraint: undefined }

--- a/test/github-issues/8485/entity/User.ts
+++ b/test/github-issues/8485/entity/User.ts
@@ -1,0 +1,11 @@
+import { Entity, OneToOne, PrimaryGeneratedColumn } from "../../../../src"
+import { UserProfile } from "./UserProfile"
+
+@Entity()
+export class User {
+    @PrimaryGeneratedColumn()
+    public id: number
+
+    @OneToOne(() => UserProfile, (userProfile) => userProfile.user)
+    public profile: UserProfile
+}

--- a/test/github-issues/8485/entity/UserProfile.ts
+++ b/test/github-issues/8485/entity/UserProfile.ts
@@ -1,0 +1,12 @@
+import { Entity, JoinColumn, OneToOne, PrimaryColumn } from "../../../../src"
+import { User } from "./User"
+
+@Entity()
+export class UserProfile {
+    @PrimaryColumn()
+    public userId: number
+
+    @OneToOne(() => User, (user) => user.profile)
+    @JoinColumn()
+    public user: User
+}

--- a/test/github-issues/8485/issue-8485.ts
+++ b/test/github-issues/8485/issue-8485.ts
@@ -1,0 +1,36 @@
+import { DataSource } from "../../../src"
+import {
+    createTestingConnections,
+    closeTestingConnections,
+} from "../../utils/test-utils"
+import { UserProfile } from "./entity/UserProfile"
+import { User } from "./entity/User"
+import { expect } from "chai"
+
+describe("github issues > #8485 second migration is generated for a combination of PrimaryColumn and JoinColumn with Postgres", () => {
+    let dataSources: DataSource[]
+    before(
+        async () =>
+            (dataSources = await createTestingConnections({
+                entities: [User, UserProfile],
+                enabledDrivers: ["postgres"],
+                dropSchema: true,
+                schemaCreate: false,
+            })),
+    )
+    after(() => closeTestingConnections(dataSources))
+
+    it("should not create second migration", () =>
+        Promise.all(
+            dataSources.map(async (dataSource) => {
+                await dataSource.driver.createSchemaBuilder().build()
+
+                const sqlInMemory = await dataSource.driver
+                    .createSchemaBuilder()
+                    .log()
+
+                expect(sqlInMemory.upQueries).to.be.empty
+                expect(sqlInMemory.downQueries).to.be.empty
+            }),
+        ))
+})


### PR DESCRIPTION
### Description of change
Currently a Postgres column set as `PrimaryColumn` and `JoinColumn` of a `OneToOne` relation creates two consecutive migrations. The first migration contains the following up queries:
```sql
CREATE TABLE "user_profile" ("userId" integer NOT NULL, CONSTRAINT "REL_51cb79b5555effaf7d69ba1cff" UNIQUE ("userId"), CONSTRAINT "PK_51cb79b5555effaf7d69ba1cff9" PRIMARY KEY ("userId"))

CREATE TABLE "user" ("id" SERIAL NOT NULL, CONSTRAINT "PK_cace4a159ff9f2512dd42373760" PRIMARY KEY ("id"))

ALTER TABLE "user_profile" ADD CONSTRAINT "FK_51cb79b5555effaf7d69ba1cff9" FOREIGN KEY ("userId") REFERENCES "user"("id") ON DELETE NO ACTION ON UPDATE NO ACTION
```
After running this migration, another schema change is detected is by TypeORM. This migration contains the following queries:
```sql
ALTER TABLE "user_profile" DROP CONSTRAINT "FK_51cb79b5555effaf7d69ba1cff9"

ALTER TABLE "user_profile" ADD CONSTRAINT "UQ_51cb79b5555effaf7d69ba1cff9" UNIQUE ("userId")

ALTER TABLE "user_profile" ADD CONSTRAINT "FK_51cb79b5555effaf7d69ba1cff9" FOREIGN KEY ("userId") REFERENCES "user"("id") ON DELETE NO ACTION ON UPDATE NO ACTION
```

It seems like Postgres is choking up on the `UNIQUE` (added through `JoinColumn`/`OneToOne` relation) and `PRIMARY KEY` (added through `PrimaryColumn`) constraints beeing added in the initial `CREATE TABLE "user_profile"`. Therefore it tries to add the `UNIQUE` constraint in the second migration, which actually seems to work. This behavior only occurs with postgres. As `PRIMARY KEY` also make the column `UNIQUE` I suppose it should be fine to omit this `UNIQUE` added through `JoinColumn`.



* Fixes #8485
* Fixes #9229 
* Fixes #6670
* Fixes #3952
Picked up where #9282 stopped.


### Pull-Request Checklist

<!--
  Please make sure to review and check all of the following.

  If an item is not applicable, you can add "N/A" to the end.
-->

- [x] Code is up-to-date with the `master` branch
- [x] `npm run format` to apply prettier formatting
- [x] `npm run test` passes with this change
- [x] This pull request links relevant issues as `Fixes #0000`
- [x] There are new or updated unit tests validating the change
- [ ] Documentation has been updated to reflect this change
- [x] The new commits follow conventions explained in [CONTRIBUTING.md](https://github.com/typeorm/typeorm/blob/master/CONTRIBUTING.md)

<!--
  🎉 Thank you for contributing and making TypeORM even better!
-->
