### PR TITLE
default enum value when creating migrations

### DIFF
--- a/src/driver/postgres/PostgresQueryRunner.ts
+++ b/src/driver/postgres/PostgresQueryRunner.ts
@@ -3717,7 +3717,7 @@ export class PostgresQueryRunner
                                 } else {
                                     tableColumn.default = dbColumn[
                                         "column_default"
-                                    ].replace(/::[\w\s\.\[\]\"]+/g, "")
+                                    ].replace(/::.+/g, "")
                                     tableColumn.default =
                                         tableColumn.default.replace(
                                             /^(-?\d+)$/,

--- a/test/github-issues/9684/entity/Foo.ts
+++ b/test/github-issues/9684/entity/Foo.ts
@@ -1,19 +1,15 @@
-import {
-    Column,
-    Entity,
-    PrimaryGeneratedColumn,
-} from "../../../../src"
+import { Column, Entity, PrimaryGeneratedColumn } from "../../../../src"
 
 export enum EnumStatus {
     DRAFT = "draft",
     PUBLISHED = "published",
 }
 
-@Entity('module-foo_table_x')
+@Entity("module-foo_table_x")
 export class Foo {
     @PrimaryGeneratedColumn({ name: "id" })
     id: number
 
-    @Column({ type: 'enum', enum: EnumStatus, default: EnumStatus.DRAFT })
+    @Column({ type: "enum", enum: EnumStatus, default: EnumStatus.DRAFT })
     enumStatus: Date
 }

--- a/test/github-issues/9684/entity/Foo.ts
+++ b/test/github-issues/9684/entity/Foo.ts
@@ -1,0 +1,19 @@
+import {
+    Column,
+    Entity,
+    PrimaryGeneratedColumn,
+} from "../../../../src"
+
+export enum EnumStatus {
+    DRAFT = "draft",
+    PUBLISHED = "published",
+}
+
+@Entity('module-foo_table_x')
+export class Foo {
+    @PrimaryGeneratedColumn({ name: "id" })
+    id: number
+
+    @Column({ type: 'enum', enum: EnumStatus, default: EnumStatus.DRAFT })
+    enumStatus: Date
+}

--- a/test/github-issues/9684/issue-9684.ts
+++ b/test/github-issues/9684/issue-9684.ts
@@ -1,0 +1,31 @@
+import "reflect-metadata"
+import { DataSource } from "../../../src/index"
+import {
+    closeTestingConnections,
+    createTestingConnections,
+} from "../../utils/test-utils"
+import { Foo } from "./entity/Foo"
+
+describe("github issues > #9684 Incorrect enum default value when table name contains dash character", () => {
+    let connections: DataSource[]
+    before(
+        async () =>
+            (connections = await createTestingConnections({
+                entities: [Foo],
+                schemaCreate: true,
+                dropSchema: true,
+                enabledDrivers: ["postgres"],
+            })),
+    )
+    after(() => closeTestingConnections(connections))
+    it("should get default enum value", () =>
+        Promise.all(
+            connections.map(async (connection) => {
+                const queryRunner = connection.createQueryRunner()
+                let table = await queryRunner.getTable("module-foo_table_x")
+
+                const nameColumn = table!.findColumnByName("enumStatus")!
+                nameColumn!.default!.should.be.equal("'draft'")
+            }),
+        ))
+})


### PR DESCRIPTION
### Description of change

This PR is to get the default enum value when creating migrations correctly. 
Closes: https://github.com/typeorm/typeorm/issues/9684
expected enum default value `UNPAID` from `'UNPAID'::module-payment_order_entity_enum` constraint, but the return was incorrect `'UNPAID'-payment_order_entity_enum"` 
### Pull-Request Checklist

<!--
  Please make sure to review and check all of the following.

  If an item is not applicable, you can add "N/A" to the end.
-->

- [x] Code is up-to-date with the `master` branch
- [x] `npm run format` to apply prettier formatting
- [x] `npm run test` passes with this change
- [x] This pull request links relevant issues as `Fixes #9684 `
- [x] There are new or updated unit tests validating the change 
- [ ] Documentation has been updated to reflect this change "
- [x] The new commits follow conventions explained in [CONTRIBUTING.md](https://github.com/typeorm/typeorm/blob/master/CONTRIBUTING.md)

<!--
  🎉 Thank you for contributing and making TypeORM even better!
-->
