### PR TITLE
fix: sql expression when `where` parameter is empty array

### DIFF
--- a/src/query-builder/SelectQueryBuilder.ts
+++ b/src/query-builder/SelectQueryBuilder.ts
@@ -4125,14 +4125,14 @@ export class SelectQueryBuilder<Entity extends ObjectLiteral>
     }
 
     protected buildWhere(
-        where: FindOptionsWhere<any>,
+        where: FindOptionsWhere<any>[] | FindOptionsWhere<any>,
         metadata: EntityMetadata,
         alias: string,
         embedPrefix?: string,
     ) {
         let condition: string = ""
         // let parameterIndex = Object.keys(this.expressionMap.nativeParameters).length;
-        if (Array.isArray(where)) {
+        if (Array.isArray(where) && where.length) {
             condition =
                 "(" +
                 where

--- a/test/github-issues/9690/entity/Foo.ts
+++ b/test/github-issues/9690/entity/Foo.ts
@@ -1,0 +1,7 @@
+import { Entity, PrimaryGeneratedColumn } from "../../../../src"
+
+@Entity()
+export class Foo {
+    @PrimaryGeneratedColumn({ name: "id" })
+    id: number
+}

--- a/test/github-issues/9690/issue-9690.ts
+++ b/test/github-issues/9690/issue-9690.ts
@@ -1,0 +1,30 @@
+import "reflect-metadata"
+import { DataSource } from "../../../src"
+import {
+    closeTestingConnections,
+    createTestingConnections,
+} from "../../utils/test-utils"
+import { Foo } from "./entity/Foo"
+
+describe("github issues > #9690 Incorrect SQL expression if `where` parameter is empty array", () => {
+    let dataSources: DataSource[]
+    before(async () => {
+        dataSources = await createTestingConnections({
+            enabledDrivers: ["postgres"],
+            entities: [Foo],
+            schemaCreate: true,
+            dropSchema: true,
+        })
+    })
+    after(() => closeTestingConnections(dataSources))
+
+    it("should run without throw error", () =>
+        Promise.all(
+            dataSources.map(async (dataSource) => {
+                const repository = dataSource.getRepository(Foo)
+                await repository.find({
+                    where: [],
+                })
+            }),
+        ))
+})


### PR DESCRIPTION
Closes: #9690

<!--
  😀 Wonderful!  Thank you for opening a pull request for TypeORM.

  Please fill in the information below to expedite the review
  and (hopefully) merge of your change.

  If unsure about something.. just do as best as you're able,
  or reach out through our community support channels!
  https://github.com/typeorm/typeorm/blob/master/docs/support.md
-->

### Description of change

- fix sql expression when `where` parameter is empty array

<!--
  Please be clear and concise what the change is intended to do,
  why this change is needed, and how you've verified that it
  corrects what you intended.

  In some cases it may be helpful to include the current behavior
  and the new behavior.

  If the change is related to an open issue, you can link it here.
  If you include `Fixes #0000` (replacing `0000` with the issue number)
  when this is merged it will automatically mark the issue as fixed and
  close it.
-->


### Pull-Request Checklist

<!--
  Please make sure to review and check all of the following.

  If an item is not applicable, you can add "N/A" to the end.
-->

- [x] Code is up-to-date with the `master` branch
- [x] `npm run format` to apply prettier formatting
- [ ] `npm run test` passes with this change
- [x] This pull request links relevant issues as `Fixes #9690 `
- [x] There are new or updated unit tests validating the change
- [ ] Documentation has been updated to reflect this change
- [x] The new commits follow conventions explained in [CONTRIBUTING.md](https://github.com/typeorm/typeorm/blob/master/CONTRIBUTING.md)

<!--
  🎉 Thank you for contributing and making TypeORM even better!
-->
