### PR TITLE
fix: protection of the type of the default value of a column

### DIFF
--- a/src/decorator/options/ColumnOptions.ts
+++ b/src/decorator/options/ColumnOptions.ts
@@ -1,6 +1,7 @@
 import { ColumnType } from "../../driver/types/ColumnTypes"
 import { ValueTransformer } from "./ValueTransformer"
 import { ColumnCommonOptions } from "./ColumnCommonOptions"
+import { JSONValue } from "../../driver/types/JSONValue"
 
 /**
  * Describes all column's options.
@@ -67,7 +68,15 @@ export interface ColumnOptions extends ColumnCommonOptions {
     /**
      * Default database value.
      */
-    default?: any
+    default?:
+        | number
+        | boolean
+        | string
+        | null
+        | (number | boolean | string)[]
+        | Record<string, JSONValue>
+        | Array<Record<string, JSONValue>>
+        | (() => string | number)
 
     /**
      * ON UPDATE trigger. Works only for MySQL.

--- a/src/driver/aurora-mysql/AuroraMysqlDriver.ts
+++ b/src/driver/aurora-mysql/AuroraMysqlDriver.ts
@@ -732,7 +732,7 @@ export class AuroraMysqlDriver implements Driver {
         }
 
         if (typeof defaultValue === "function") {
-            return defaultValue()
+            return defaultValue().toString()
         }
 
         if (typeof defaultValue === "string") {

--- a/src/driver/cockroachdb/CockroachDriver.ts
+++ b/src/driver/cockroachdb/CockroachDriver.ts
@@ -723,7 +723,7 @@ export class CockroachDriver implements Driver {
         }
 
         if (typeof defaultValue === "function") {
-            const value = defaultValue()
+            const value = defaultValue().toString()
             if (value.toUpperCase() === "CURRENT_TIMESTAMP") {
                 return "current_timestamp()"
             } else if (value.toUpperCase() === "CURRENT_DATE") {

--- a/src/driver/mysql/MysqlDriver.ts
+++ b/src/driver/mysql/MysqlDriver.ts
@@ -794,7 +794,7 @@ export class MysqlDriver implements Driver {
         }
 
         if (typeof defaultValue === "function") {
-            const value = defaultValue()
+            const value = defaultValue().toString()
             return this.normalizeDatetimeFunction(value)
         }
 

--- a/src/driver/oracle/OracleDriver.ts
+++ b/src/driver/oracle/OracleDriver.ts
@@ -625,7 +625,7 @@ export class OracleDriver implements Driver {
         }
 
         if (typeof defaultValue === "function") {
-            return defaultValue()
+            return defaultValue().toString()
         }
 
         if (typeof defaultValue === "string") {

--- a/src/driver/postgres/PostgresDriver.ts
+++ b/src/driver/postgres/PostgresDriver.ts
@@ -1019,7 +1019,7 @@ export class PostgresDriver implements Driver {
         }
 
         if (typeof defaultValue === "function") {
-            const value = defaultValue()
+            const value = defaultValue().toString()
 
             return this.normalizeDatetimeFunction(value)
         }

--- a/src/driver/sap/SapDriver.ts
+++ b/src/driver/sap/SapDriver.ts
@@ -597,7 +597,7 @@ export class SapDriver implements Driver {
         }
 
         if (typeof defaultValue === "function") {
-            return defaultValue()
+            return defaultValue().toString()
         }
 
         if (typeof defaultValue === "string") {

--- a/src/driver/sqlite-abstract/AbstractSqliteDriver.ts
+++ b/src/driver/sqlite-abstract/AbstractSqliteDriver.ts
@@ -647,7 +647,7 @@ export abstract class AbstractSqliteDriver implements Driver {
         }
 
         if (typeof defaultValue === "function") {
-            return defaultValue()
+            return defaultValue().toString()
         }
 
         if (typeof defaultValue === "string") {

--- a/src/driver/sqlserver/SqlServerDriver.ts
+++ b/src/driver/sqlserver/SqlServerDriver.ts
@@ -642,7 +642,7 @@ export class SqlServerDriver implements Driver {
         }
 
         if (typeof defaultValue === "function") {
-            const value = defaultValue()
+            const value = defaultValue().toString()
             if (value.toUpperCase() === "CURRENT_TIMESTAMP") {
                 return "getdate()"
             }

--- a/src/driver/types/JSONValue.ts
+++ b/src/driver/types/JSONValue.ts
@@ -1,0 +1,6 @@
+export type JSONValue =
+    | string
+    | number
+    | boolean
+    | { [x: string]: JSONValue }
+    | Array<JSONValue>

--- a/src/metadata/ColumnMetadata.ts
+++ b/src/metadata/ColumnMetadata.ts
@@ -11,6 +11,7 @@ import { ApplyValueTransformers } from "../util/ApplyValueTransformers"
 import { ObjectUtils } from "../util/ObjectUtils"
 import { InstanceChecker } from "../util/InstanceChecker"
 import { VirtualColumnOptions } from "../decorator/options/VirtualColumnOptions"
+import { JSONValue } from "../driver/types/JSONValue"
 
 /**
  * This metadata contains all information about entity's column.
@@ -132,8 +133,9 @@ export class ColumnMetadata {
         | string
         | null
         | (number | boolean | string)[]
-        | Record<string, object>
-        | (() => string)
+        | Record<string, JSONValue>
+        | Array<JSONValue | Record<string, JSONValue>>
+        | (() => string | number)
 
     /**
      * ON UPDATE trigger. Works only for MySQL.

--- a/test/github-issues/9687/entity/Foo.ts
+++ b/test/github-issues/9687/entity/Foo.ts
@@ -1,0 +1,22 @@
+import { Entity, Column, PrimaryGeneratedColumn } from "../../../../src"
+
+@Entity({ name: "foo", schema: "SYSTEM" })
+export class Foo {
+    @PrimaryGeneratedColumn()
+    id: number
+
+    @Column({ name: "string", default: "string" })
+    string: number
+
+    @Column({ name: "number", default: 1 })
+    number: number
+
+    @Column({ name: "boolean", default: true })
+    boolean: number
+
+    @Column({ name: "date", default: Date.now })
+    date: number
+
+    @Column({ name: "function_string", default: () => "function" })
+    functionString: string
+}

--- a/test/github-issues/9687/issue-9687.ts
+++ b/test/github-issues/9687/issue-9687.ts
@@ -1,0 +1,43 @@
+import { DataSource } from "../../../src"
+import {
+    createTestingConnections,
+    closeTestingConnections,
+} from "../../utils/test-utils"
+import { Foo } from "./entity/Foo"
+
+describe("github issues > #9687 protect type for a default function in Column", () => {
+    let connections: DataSource[]
+    before(
+        async () =>
+            (connections = await createTestingConnections({
+                entities: [__dirname + "/entity/*{.js,.ts}"],
+                schemaCreate: false,
+                dropSchema: true,
+                enabledDrivers: ["oracle"],
+            })),
+    )
+    after(() => closeTestingConnections(connections))
+
+    it("should have default value column correctly", () => {
+        Promise.all(
+            connections.map(async (connection) => {
+                const fooRepository = connection.getTreeRepository(Foo)
+
+                const foo = new Foo()
+                await fooRepository.save(foo)
+
+                const savedFoo = await fooRepository.findOneBy({ id: foo.id })
+                if (!savedFoo) {
+                    throw new Error("foo not found")
+                }
+
+                savedFoo.should.be.instanceOf(Foo)
+                savedFoo.string.should.be.equal("string")
+                savedFoo.number.should.be.equal(1)
+                savedFoo.boolean.should.be.equal(true)
+                savedFoo.date.should.be.instanceOf(Date)
+                savedFoo.functionString.should.be.equal("function")
+            }),
+        )
+    })
+})


### PR DESCRIPTION
added the type of the `default` parameter of a column, because of some specificity, the numbers returned by the function are stringify

Closes: #9687

<!--
  😀 Wonderful!  Thank you for opening a pull request for TypeORM.

  Please fill in the information below to expedite the review
  and (hopefully) merge of your change.

  If unsure about something.. just do as best as you're able,
  or reach out through our community support channels!
  https://github.com/typeorm/typeorm/blob/master/docs/support.md
-->

### Description of change

<!--
  Please be clear and concise what the change is intended to do,
  why this change is needed, and how you've verified that it
  corrects what you intended.

  In some cases it may be helpful to include the current behavior
  and the new behavior.

  If the change is related to an open issue, you can link it here.
  If you include `Fixes #0000` (replacing `0000` with the issue number)
  when this is merged it will automatically mark the issue as fixed and
  close it.
-->


### Pull-Request Checklist

<!--
  Please make sure to review and check all of the following.

  If an item is not applicable, you can add "N/A" to the end.
-->

- [ x ] Code is up-to-date with the `master` branch
- [ x ] `npm run format` to apply prettier formatting
- [ x ] `npm run test` passes with this change
- [ x ] This pull request links relevant issues as `Fixes #0000`
- [ x ] There are new or updated unit tests validating the change
- [ x ] Documentation has been updated to reflect this change "N/A"
- [ x ] The new commits follow conventions explained in [CONTRIBUTING.md](https://github.com/typeorm/typeorm/blob/master/CONTRIBUTING.md)

<!--
  🎉 Thank you for contributing and making TypeORM even better!
-->
