### PR TITLE
Fix for operators not being assignable when using user defined types.

### DIFF
--- a/src/find-options/FindOneOptions.ts
+++ b/src/find-options/FindOneOptions.ts
@@ -10,7 +10,6 @@ import {
 } from "./FindOptionsRelations"
 import { FindOptionsOrder } from "./FindOptionsOrder"
 
-
 /**
  * Defines a special criteria to find specific entity.
  */

--- a/src/find-options/FindOneOptions.ts
+++ b/src/find-options/FindOneOptions.ts
@@ -10,6 +10,7 @@ import {
 } from "./FindOptionsRelations"
 import { FindOptionsOrder } from "./FindOptionsOrder"
 import { ObjectLiteral } from "../common/ObjectLiteral";
+
 /**
  * Defines a special criteria to find specific entity.
  */

--- a/src/find-options/FindOneOptions.ts
+++ b/src/find-options/FindOneOptions.ts
@@ -9,7 +9,7 @@ import {
     FindOptionsRelations,
 } from "./FindOptionsRelations"
 import { FindOptionsOrder } from "./FindOptionsOrder"
-import { ObjectLiteral } from "../common/ObjectLiteral";
+
 
 /**
  * Defines a special criteria to find specific entity.
@@ -30,7 +30,7 @@ export interface FindOneOptions<Entity = any> {
     /**
      * Simple condition that should be applied to match entities.
      */
-    where?: FindOptionsWhere<Entity>[] | FindOptionsWhere<Entity> | ObjectLiteral
+    where?: FindOptionsWhere<Entity>[] | FindOptionsWhere<Entity>
 
     /**
      * Indicates what relations of entity should be loaded (simplified left join form).

--- a/src/find-options/FindOneOptions.ts
+++ b/src/find-options/FindOneOptions.ts
@@ -9,7 +9,7 @@ import {
     FindOptionsRelations,
 } from "./FindOptionsRelations"
 import { FindOptionsOrder } from "./FindOptionsOrder"
-
+import { ObjectLiteral } from "../common/ObjectLiteral";
 /**
  * Defines a special criteria to find specific entity.
  */
@@ -29,7 +29,7 @@ export interface FindOneOptions<Entity = any> {
     /**
      * Simple condition that should be applied to match entities.
      */
-    where?: FindOptionsWhere<Entity>[] | FindOptionsWhere<Entity>
+    where?: FindOptionsWhere<Entity>[] | FindOptionsWhere<Entity> | ObjectLiteral
 
     /**
      * Indicates what relations of entity should be loaded (simplified left join form).

--- a/src/find-options/FindOptionsWhere.ts
+++ b/src/find-options/FindOptionsWhere.ts
@@ -37,8 +37,13 @@ export type FindOptionsWhereProperty<Property> = Property extends Promise<
 /**
  * Used for find operations.
  */
-export type FindOptionsWhere<Entity> = {
+export type FindOperatorObjectLiteral<Entity> = {
+    [P in keyof Entity]?: FindOperator<Entity[P]> | Entity[P];
+};
+
+export type FindOptionsWhere<Entity> = FindOperatorObjectLiteral<Entity> | {
     [P in keyof Entity]?: P extends "toString"
         ? unknown
         : FindOptionsWhereProperty<NonNullable<Entity[P]>>
-}
+};
+

--- a/src/find-options/FindOptionsWhere.ts
+++ b/src/find-options/FindOptionsWhere.ts
@@ -38,12 +38,13 @@ export type FindOptionsWhereProperty<Property> = Property extends Promise<
  * Used for find operations.
  */
 export type FindOperatorObjectLiteral<Entity> = {
-    [P in keyof Entity]?: FindOperator<Entity[P]> | Entity[P];
-};
+    [P in keyof Entity]?: FindOperator<Entity[P]> | Entity[P]
+}
 
-export type FindOptionsWhere<Entity> = FindOperatorObjectLiteral<Entity> | {
-    [P in keyof Entity]?: P extends "toString"
-        ? unknown
-        : FindOptionsWhereProperty<NonNullable<Entity[P]>>
-};
-
+export type FindOptionsWhere<Entity> =
+    | FindOperatorObjectLiteral<Entity>
+    | {
+          [P in keyof Entity]?: P extends "toString"
+              ? unknown
+              : FindOptionsWhereProperty<NonNullable<Entity[P]>>
+      }

--- a/test/functional/find-options/empty-properties/entity/Post.ts
+++ b/test/functional/find-options/empty-properties/entity/Post.ts
@@ -1,7 +1,6 @@
 import { Column, Entity, PrimaryGeneratedColumn } from "../../../../../src"
 
 export type MyCustomType = "A" | "B" | "C"
-
 @Entity()
 export class Post {
     @PrimaryGeneratedColumn()
@@ -12,7 +11,7 @@ export class Post {
 
     @Column()
     text: string
-   
+
     @Column()
     type: MyCustomType
 }

--- a/test/functional/find-options/empty-properties/entity/Post.ts
+++ b/test/functional/find-options/empty-properties/entity/Post.ts
@@ -1,5 +1,7 @@
 import { Column, Entity, PrimaryGeneratedColumn } from "../../../../../src"
 
+export type MyCustomType = "A" | "B" | "C"
+
 @Entity()
 export class Post {
     @PrimaryGeneratedColumn()
@@ -10,4 +12,7 @@ export class Post {
 
     @Column()
     text: string
+   
+    @Column()
+    type: MyCustomType
 }

--- a/test/functional/find-options/empty-properties/find-options-empty-properties.ts
+++ b/test/functional/find-options/empty-properties/find-options-empty-properties.ts
@@ -50,7 +50,7 @@ describe("find options > where", () => {
                     .getMany()
 
                 posts.should.be.eql([
-                    { id: 1, title: "Post #1", text: "About post #1" },
+                    { id: 1, title: "Post #1", text: "About post #1", type: "A" },
                 ])
             }),
         ))
@@ -105,7 +105,7 @@ describe("find options > where", () => {
                     .getMany()
 
                 posts2.should.be.eql([
-                    { id: 1, title: "Post #1", text: "About post #1", type: 'A' },
+                    { id: 1, title: "Post #1", text: "About post #1", type: "A" },
                     { id: 2, title: "Post #2", text: "About post #2", type: "B" },
                 ])
             }),

--- a/test/functional/find-options/empty-properties/find-options-empty-properties.ts
+++ b/test/functional/find-options/empty-properties/find-options-empty-properties.ts
@@ -21,11 +21,13 @@ describe("find options > where", () => {
         const post1 = new Post()
         post1.title = "Post #1"
         post1.text = "About post #1"
+        post1.type = "A"
         await connection.manager.save(post1)
 
         const post2 = new Post()
         post2.title = "Post #2"
         post2.text = "About post #2"
+        post2.type = "B"
         await connection.manager.save(post2)
     }
 

--- a/test/functional/find-options/empty-properties/find-options-empty-properties.ts
+++ b/test/functional/find-options/empty-properties/find-options-empty-properties.ts
@@ -50,7 +50,12 @@ describe("find options > where", () => {
                     .getMany()
 
                 posts.should.be.eql([
-                    { id: 1, title: "Post #1", text: "About post #1", type: "A" },
+                    {
+                        id: 1,
+                        title: "Post #1",
+                        text: "About post #1",
+                        type: "A",
+                    },
                 ])
             }),
         ))
@@ -88,7 +93,12 @@ describe("find options > where", () => {
                     .getMany()
 
                 posts1.should.be.eql([
-                    { id: 1, title: "Post #1", text: "About post #1", type: "A" },
+                    {
+                        id: 1,
+                        title: "Post #1",
+                        text: "About post #1",
+                        type: "A",
+                    },
                 ])
 
                 const posts2 = await connection
@@ -105,8 +115,18 @@ describe("find options > where", () => {
                     .getMany()
 
                 posts2.should.be.eql([
-                    { id: 1, title: "Post #1", text: "About post #1", type: "A" },
-                    { id: 2, title: "Post #2", text: "About post #2", type: "B" },
+                    {
+                        id: 1,
+                        title: "Post #1",
+                        text: "About post #1",
+                        type: "A",
+                    },
+                    {
+                        id: 2,
+                        title: "Post #2",
+                        text: "About post #2",
+                        type: "B",
+                    },
                 ])
             }),
         ))

--- a/test/functional/find-options/empty-properties/find-options-empty-properties.ts
+++ b/test/functional/find-options/empty-properties/find-options-empty-properties.ts
@@ -88,7 +88,7 @@ describe("find options > where", () => {
                     .getMany()
 
                 posts1.should.be.eql([
-                    { id: 1, title: "Post #1", text: "About post #1" },
+                    { id: 1, title: "Post #1", text: "About post #1", type: "A" },
                 ])
 
                 const posts2 = await connection
@@ -105,8 +105,8 @@ describe("find options > where", () => {
                     .getMany()
 
                 posts2.should.be.eql([
-                    { id: 1, title: "Post #1", text: "About post #1" },
-                    { id: 2, title: "Post #2", text: "About post #2" },
+                    { id: 1, title: "Post #1", text: "About post #1", type: 'A' },
+                    { id: 2, title: "Post #2", text: "About post #2", type: "B" },
                 ])
             }),
         ))

--- a/test/functional/find-options/empty-properties/find-options-empty-properties.ts
+++ b/test/functional/find-options/empty-properties/find-options-empty-properties.ts
@@ -1,6 +1,6 @@
 import "reflect-metadata"
 import "../../../utils/test-setup"
-import { DataSource } from "../../../../src"
+import { DataSource, Equal } from "../../../../src"
 import {
     closeTestingConnections,
     createTestingConnections,

--- a/test/functional/find-options/empty-properties/find-options-empty-properties.ts
+++ b/test/functional/find-options/empty-properties/find-options-empty-properties.ts
@@ -58,6 +58,19 @@ describe("find options > where", () => {
             connections.map(async (connection) => {
                 await prepareData(connection)
 
+                // Do not throw errors if the find operators are used with custom types.
+                await connection
+                    .createQueryBuilder(Post, "post")
+                    .setFindOptions({
+                        where: {
+                            type: Equal("B"),
+                        },
+                        order: {
+                            id: "asc",
+                        },
+                    })
+                    .getMany()
+                
                 const posts1 = await connection
                     .createQueryBuilder(Post, "post")
                     .setFindOptions({

--- a/test/functional/find-options/empty-properties/find-options-empty-properties.ts
+++ b/test/functional/find-options/empty-properties/find-options-empty-properties.ts
@@ -70,7 +70,7 @@ describe("find options > where", () => {
                         },
                     })
                     .getMany()
-                
+
                 const posts1 = await connection
                     .createQueryBuilder(Post, "post")
                     .setFindOptions({


### PR DESCRIPTION
### Description of change


Given the following model
```ts
export type MyCustomType = "A" | "B" | "C";

@Entity()
export class MyEntity
{
    @PrimaryGeneratedColumn()
    id: number

    @Column()
    data: MyCustomType = "A";

}
```
and the following code:
```ts
  const entity = new MyEntity()
  entity.data = "B";
  await connection.manager.save(entity)
  const foundEntity = await connection.manager.findOne(MyEntity, {
     where: {
            data: Equal("B")
     }
  });
```
User gets the following error message:
```
Type '{ data: EqualOperator<string>; }' is not assignable to type 'FindOptionsWhere<MyEntity> | FindOptionsWhere<MyEntity>[] | undefined'.
  Types of property 'data' are incompatible.
    Type 'EqualOperator<string>' is not assignable to type '"A" | "B" | "C" | FindOperator<"A"> | FindOperator<"B"> | FindOperator<"C"> | undefined'.
      Type 'EqualOperator<string>' is not assignable to type 'FindOperator<"C">'.
        Types of property '_value' are incompatible.
          Type 'string | FindOperator<string>' is not assignable to type '"C" | FindOperator<"C">'.
            Type 'string' is not assignable to type '"C" | FindOperator<"C">'.ts(2322)
```

The new signature broken and i don't really have the patience to untagle it, but by just allowing object literals the typings are still preserved and the code works.

<!--
  😀 Wonderful!  Thank you for opening a pull request for TypeORM.

  Please fill in the information below to expedite the review
  and (hopefully) merge of your change.

  If unsure about something.. just do as best as you're able,
  or reach out through our community support channels!
  https://github.com/typeorm/typeorm/blob/master/docs/support.md
-->



### Pull-Request Checklist

<!--
  Please make sure to review and check all of the following.

  If an item is not applicable, you can add "N/A" to the end.
-->

- [x] Code is up-to-date with the `master` branch
- [x] `npm run format` to apply prettier formatting
- [x] `npm run test` passes with this change
- [x] This pull request links relevant issues as `Fixes #0000`
- [x] There are new or updated unit tests validating the change
- [x] Documentation has been updated to reflect this change
- [x] The new commits follow conventions explained in [CONTRIBUTING.md](https://github.com/typeorm/typeorm/blob/master/CONTRIBUTING.md)

<!--
  🎉 Thank you for contributing and making TypeORM even better!
-->

Fixes:

https://github.com/typeorm/typeorm/issues/9671

https://github.com/typeorm/typeorm/issues/9508

https://github.com/typeorm/typeorm/issues/9350

https://github.com/typeorm/typeorm/issues/9346

https://github.com/typeorm/typeorm/issues/9269

https://github.com/typeorm/typeorm/issues/9251

https://github.com/typeorm/typeorm/issues/9223

https://github.com/typeorm/typeorm/issues/8939

And a bunch more.

full list pretty much can be found by searching for the error message.
https://github.com/typeorm/typeorm/issues?q=is+not+assignable+to+type+is%3Aopen

