### PR TITLE
Fix - remove extension when importing file

### DIFF
--- a/src/driver/cockroachdb/CockroachQueryRunner.ts
+++ b/src/driver/cockroachdb/CockroachQueryRunner.ts
@@ -25,7 +25,7 @@ import { ReplicationMode } from "../types/ReplicationMode"
 import { TypeORMError } from "../../error"
 import { MetadataTableType } from "../types/MetadataTableType"
 import { InstanceChecker } from "../../util/InstanceChecker"
-import { VersionUtils } from "../../util/VersionUtils.js"
+import { VersionUtils } from "../../util/VersionUtils"
 
 /**
  * Runs queries on a single postgres database connection.

--- a/src/index.ts
+++ b/src/index.ts
@@ -127,7 +127,7 @@ export * from "./schema-builder/options/TableUniqueOptions"
 export * from "./schema-builder/options/ViewOptions"
 export * from "./driver/mongodb/typings"
 export * from "./driver/types/DatabaseType"
-export * from "./driver/types/GeoJsonTypes.js"
+export * from "./driver/types/GeoJsonTypes"
 export * from "./driver/types/ReplicationMode"
 export * from "./driver/sqlserver/MssqlParameter"
 

--- a/test/functional/query-builder/time-travel-query/entity/Person.ts
+++ b/test/functional/query-builder/time-travel-query/entity/Person.ts
@@ -4,7 +4,7 @@ import {
     OneToOne,
     PrimaryGeneratedColumn,
 } from "../../../../../src/index"
-import { Account } from "./Account.js"
+import { Account } from "./Account"
 
 @Entity()
 export class Person {

--- a/test/functional/query-builder/time-travel-query/time-travel-query.ts
+++ b/test/functional/query-builder/time-travel-query/time-travel-query.ts
@@ -6,8 +6,8 @@ import {
     sleep,
 } from "../../../utils/test-utils"
 import { DataSource } from "../../../../src/index"
-import { Account } from "./entity/Account.js"
-import { Person } from "./entity/Person.js"
+import { Account } from "./entity/Account"
+import { Person } from "./entity/Person"
 
 describe("query builder > time-travel-query", () => {
     // -------------------------------------------------------------------------


### PR DESCRIPTION
### Description of change
fixed: #9712 

I can't run test code because file importing grammar error

I saw the below errors
```
# Case1
Error: Cannot find module '../../util/VersionUtils.js'
...

# Case2
Error: Cannot find module './driver/types/GeoJsonTypes.js'
...
```

So I removed file extensions when file importing. (It's not not a js file.)

### Pull-Request Checklist
- [x] Code is up-to-date with the `master` branch
- [X] `npm run format` to apply prettier formatting
- [X] `npm run test` passes with this change
- [X] This pull request links relevant issues as `Fixes #0000`
- [x] There are new or updated unit tests validating the change
- [x] Documentation has been updated to reflect this change
- [x] The new commits follow conventions explained in [CONTRIBUTING.md](https://github.com/typeorm/typeorm/blob/master/CONTRIBUTING.md)