### PR TITLE
fix: child entities as an object not being saved correctly with cascade

### DIFF
--- a/src/metadata/EntityMetadata.ts
+++ b/src/metadata/EntityMetadata.ts
@@ -849,7 +849,11 @@ export class EntityMetadata {
     ): EntityMetadata {
         const childEntityMetadata =
             relation.inverseEntityMetadata.childEntityMetadatas.find(
-                (metadata) => metadata.target === value.constructor,
+                (metadata) =>
+                    metadata.target === value.constructor ||
+                    (metadata.discriminatorColumn &&
+                        value[metadata.discriminatorColumn.propertyName] ===
+                            metadata.discriminatorValue),
             )
         return childEntityMetadata
             ? childEntityMetadata


### PR DESCRIPTION
### Description of change
Based on this fix: https://github.com/typeorm/typeorm/pull/6219
For child entities, if we pass an object in the `save` function, they are not correctly created. The `getInverseEntityMetadata` function only supports class instances.

### Pull-Request Checklist
- [x] Code is up-to-date with the `master` branch
- [x] `npm run format` to apply prettier formatting
- [x] `npm run test` passes with this change
- [x] The new commits follow conventions explained in [CONTRIBUTING.md](https://github.com/typeorm/typeorm/blob/master/CONTRIBUTING.md)