### PR TITLE
[ISSUE#9528] quering PRAGMA table_info & table_xinfo both to access c…

### DIFF
--- a/test/github-issues/9528/entity/Example.ts
+++ b/test/github-issues/9528/entity/Example.ts
@@ -1,0 +1,12 @@
+import { Entity } from "../../../../src/decorator/entity/Entity"
+import { PrimaryColumn } from "../../../../src/decorator/columns/PrimaryColumn"
+import { Column } from "../../../../src/decorator/columns/Column"
+
+@Entity('example')
+export class Example {
+    @PrimaryColumn()
+    id: Date
+
+    @Column()
+    text: string
+}

--- a/test/github-issues/9528/issue-9528.ts
+++ b/test/github-issues/9528/issue-9528.ts
@@ -1,0 +1,45 @@
+import "reflect-metadata"
+import {
+    createTestingConnections,
+    closeTestingConnections,
+    reloadTestingDatabases,
+} from "../../utils/test-utils"
+import { DataSource } from "../../../src/data-source/DataSource"
+import { expect } from "chai"
+import { Example } from "./entity/Example"
+
+describe("github issues > #9528 In the old version, Huawei PRAGMA table_xinfo is incompatible", () => {
+    let connections: DataSource[]
+    before(
+        async () =>
+            (connections = await createTestingConnections({
+                entities: [Example],
+                schemaCreate: true,
+                dropSchema: true,
+                /* Test not eligible for better-sql where binding Dates is impossible */
+                enabledDrivers: ["sqlite"],
+            })),
+    )
+    beforeEach(() => reloadTestingDatabases(connections))
+
+    after(() => closeTestingConnections(connections))
+
+    it("should has columns", () =>
+        Promise.all(
+            connections.map(async (connection) => {
+                const qr = connection.createQueryRunner();
+
+                expect(await qr.hasColumn('example', 'id')).to.be.true
+                expect(await qr.hasColumn('example', 'text')).to.be.true
+            }),
+        ))
+
+    it("should not has columns", () =>
+        Promise.all(
+            connections.map(async (connection) => {
+                const qr = connection.createQueryRunner();
+
+                expect(await qr.hasColumn('example', 'invalidColumn')).to.be.false
+            }),
+        ))
+})


### PR DESCRIPTION
…olumns in sqlite

<!--
  😀 Wonderful!  Thank you for opening a pull request for TypeORM.

  Please fill in the information below to expedite the review
  and (hopefully) merge of your change.

  If unsure about something.. just do as best as you're able,
  or reach out through our community support channels!
  https://github.com/typeorm/typeorm/blob/master/docs/support.md
-->

### Description of change

<!--
  Please be clear and concise what the change is intended to do,
  why this change is needed, and how you've verified that it
  corrects what you intended.

  In some cases it may be helpful to include the current behavior
  and the new behavior.

  If the change is related to an open issue, you can link it here.
  If you include `Fixes #0000` (replacing `0000` with the issue number)
  when this is merged it will automatically mark the issue as fixed and
  close it.
-->

Fixes #9528 

It queryies PRAGMA table_info & table_xinfo BOTH to access columns in SQLITE.

### Pull-Request Checklist

<!--
  Please make sure to review and check all of the following.

  If an item is not applicable, you can add "N/A" to the end.
-->

- [v] Code is up-to-date with the `master` branch
- [v] `npm run format` to apply prettier formatting
- [v] `npm run test` passes with this change > 
- [v] This pull request links relevant issues as `Fixes #9528`
- [v] There are new or updated unit tests validating the change
- [v] Documentation has been updated to reflect this change
- [v] The new commits follow conventions explained in [CONTRIBUTING.md](https://github.com/typeorm/typeorm/blob/master/CONTRIBUTING.md)

<!--
  🎉 Thank you for contributing and making TypeORM even better!
-->
