### PR TITLE
feat: Add support for SQL aggregate functions SUM, AVG, MIN, and MAX to the Repository API

### DIFF
--- a/docs/repository-api.md
+++ b/docs/repository-api.md
@@ -273,6 +273,30 @@ const count = await repository.count({
 const count = await repository.countBy({ firstName: "Timber" })
 ```
 
+-   `sum` - Returns the sum of a numeric field for all entities that match `FindOptionsWhere`.
+
+```typescript
+const sum = await repository.sum("age", { firstName: "Timber" })
+```
+
+-   `average` - Returns the average of a numeric field for all entities that match `FindOptionsWhere`.
+
+```typescript
+const average = await repository.average("age", { firstName: "Timber" })
+```
+
+-   `minimum` - Returns the minimum of a numeric field for all entities that match `FindOptionsWhere`.
+
+```typescript
+const minimum = await repository.minimum("age", { firstName: "Timber" })
+```
+
+-   `maximum` - Returns the maximum of a numeric field for all entities that match `FindOptionsWhere`.
+
+```typescript
+const maximum = await repository.maximum("age", { firstName: "Timber" })
+```
+
 -   `find` - Finds entities that match given `FindOptions`.
 
 ```typescript

--- a/src/common/PickKeysByType.ts
+++ b/src/common/PickKeysByType.ts
@@ -1,0 +1,6 @@
+/**
+ * Pick only the keys that match the Type `U`
+ */
+export type PickKeysByType<T, U> = keyof {
+    [P in keyof T as T[P] extends U ? P : never]: T[P]
+}

--- a/src/common/PickKeysByType.ts
+++ b/src/common/PickKeysByType.ts
@@ -1,6 +1,7 @@
 /**
  * Pick only the keys that match the Type `U`
  */
-export type PickKeysByType<T, U> = keyof {
-    [P in keyof T as T[P] extends U ? P : never]: T[P]
-}
+export type PickKeysByType<T, U> = string &
+    keyof {
+        [P in keyof T as T[P] extends U ? P : never]: T[P]
+    }

--- a/src/entity-manager/EntityManager.ts
+++ b/src/entity-manager/EntityManager.ts
@@ -1025,7 +1025,7 @@ export class EntityManager {
     }
 
     /**
-     * Return the AVG of a column
+     * Return the MIN of a column
      */
     minimum<Entity extends ObjectLiteral>(
         entityClass: EntityTarget<Entity>,
@@ -1036,7 +1036,7 @@ export class EntityManager {
     }
 
     /**
-     * Return the AVG of a column
+     * Return the MAX of a column
      */
     maximum<Entity extends ObjectLiteral>(
         entityClass: EntityTarget<Entity>,

--- a/src/entity-manager/EntityManager.ts
+++ b/src/entity-manager/EntityManager.ts
@@ -1056,7 +1056,9 @@ export class EntityManager {
         const result = await this.createQueryBuilder(entityClass, metadata.name)
             .setFindOptions({ where })
             .select(
-                `${fnName}(${this.connection.driver.escape(String(columnName))})`,
+                `${fnName}(${this.connection.driver.escape(
+                    String(columnName),
+                )})`,
                 fnName,
             )
             .getRawOne()

--- a/src/entity-manager/EntityManager.ts
+++ b/src/entity-manager/EntityManager.ts
@@ -1053,17 +1053,14 @@ export class EntityManager {
         where: FindOptionsWhere<Entity> | FindOptionsWhere<Entity>[] = {},
     ): Promise<number | null> {
         const metadata = this.connection.getMetadata(entityClass)
-        const { [fnName]: result } = await this.createQueryBuilder(
-            entityClass,
-            metadata.name,
-        )
+        const result = await this.createQueryBuilder(entityClass, metadata.name)
             .setFindOptions({ where })
             .select(
-                `${fnName}(${this.connection.driver.escape(columnName)})`,
+                `${fnName}(${this.connection.driver.escape(String(columnName))})`,
                 fnName,
             )
             .getRawOne()
-        return result === null ? null : parseFloat(result)
+        return result[fnName] === null ? null : parseFloat(result[fnName])
     }
 
     /**

--- a/src/entity-manager/EntityManager.ts
+++ b/src/entity-manager/EntityManager.ts
@@ -1007,10 +1007,10 @@ export class EntityManager {
      */
     sum<Entity extends ObjectLiteral>(
         entityClass: EntityTarget<Entity>,
-        field: PickKeysByType<Entity, number>,
+        columnName: PickKeysByType<Entity, number>,
         where?: FindOptionsWhere<Entity> | FindOptionsWhere<Entity>[],
     ): Promise<number | null> {
-        return this.callAggregateFun(entityClass, "SUM", field, where)
+        return this.callAggregateFun(entityClass, "SUM", columnName, where)
     }
 
     /**
@@ -1018,10 +1018,10 @@ export class EntityManager {
      */
     average<Entity extends ObjectLiteral>(
         entityClass: EntityTarget<Entity>,
-        field: PickKeysByType<Entity, number>,
+        columnName: PickKeysByType<Entity, number>,
         where?: FindOptionsWhere<Entity> | FindOptionsWhere<Entity>[],
     ): Promise<number | null> {
-        return this.callAggregateFun(entityClass, "AVG", field, where)
+        return this.callAggregateFun(entityClass, "AVG", columnName, where)
     }
 
     /**
@@ -1029,10 +1029,10 @@ export class EntityManager {
      */
     minimum<Entity extends ObjectLiteral>(
         entityClass: EntityTarget<Entity>,
-        field: PickKeysByType<Entity, number>,
+        columnName: PickKeysByType<Entity, number>,
         where?: FindOptionsWhere<Entity> | FindOptionsWhere<Entity>[],
     ): Promise<number | null> {
-        return this.callAggregateFun(entityClass, "MIN", field, where)
+        return this.callAggregateFun(entityClass, "MIN", columnName, where)
     }
 
     /**
@@ -1040,16 +1040,16 @@ export class EntityManager {
      */
     maximum<Entity extends ObjectLiteral>(
         entityClass: EntityTarget<Entity>,
-        field: PickKeysByType<Entity, number>,
+        columnName: PickKeysByType<Entity, number>,
         where?: FindOptionsWhere<Entity> | FindOptionsWhere<Entity>[],
     ): Promise<number | null> {
-        return this.callAggregateFun(entityClass, "MAX", field, where)
+        return this.callAggregateFun(entityClass, "MAX", columnName, where)
     }
 
     private async callAggregateFun<Entity extends ObjectLiteral>(
         entityClass: EntityTarget<Entity>,
         fnName: "SUM" | "AVG" | "MIN" | "MAX",
-        field: PickKeysByType<Entity, number>,
+        columnName: PickKeysByType<Entity, number>,
         where: FindOptionsWhere<Entity> | FindOptionsWhere<Entity>[] = {},
     ): Promise<number | null> {
         const metadata = this.connection.getMetadata(entityClass)
@@ -1058,7 +1058,10 @@ export class EntityManager {
             metadata.name,
         )
             .setFindOptions({ where })
-            .select(`${fnName}(${field.toString()})`, fnName)
+            .select(
+                `${fnName}(${this.connection.driver.escape(columnName)})`,
+                fnName,
+            )
             .getRawOne()
         return result === null ? null : parseFloat(result)
     }

--- a/src/repository/BaseEntity.ts
+++ b/src/repository/BaseEntity.ts
@@ -414,10 +414,10 @@ export class BaseEntity {
      */
     static sum<T extends BaseEntity>(
         this: { new (): T } & typeof BaseEntity,
-        field: PickKeysByType<T, number>,
+        columnName: PickKeysByType<T, number>,
         where: FindOptionsWhere<T>,
     ): Promise<number | null> {
-        return this.getRepository<T>().sum(field, where)
+        return this.getRepository<T>().sum(columnName, where)
     }
 
     /**
@@ -425,10 +425,10 @@ export class BaseEntity {
      */
     static average<T extends BaseEntity>(
         this: { new (): T } & typeof BaseEntity,
-        field: PickKeysByType<T, number>,
+        columnName: PickKeysByType<T, number>,
         where: FindOptionsWhere<T>,
     ): Promise<number | null> {
-        return this.getRepository<T>().average(field, where)
+        return this.getRepository<T>().average(columnName, where)
     }
 
     /**
@@ -436,10 +436,10 @@ export class BaseEntity {
      */
     static minimum<T extends BaseEntity>(
         this: { new (): T } & typeof BaseEntity,
-        field: PickKeysByType<T, number>,
+        columnName: PickKeysByType<T, number>,
         where: FindOptionsWhere<T>,
     ): Promise<number | null> {
-        return this.getRepository<T>().minimum(field, where)
+        return this.getRepository<T>().minimum(columnName, where)
     }
 
     /**
@@ -447,10 +447,10 @@ export class BaseEntity {
      */
     static maximum<T extends BaseEntity>(
         this: { new (): T } & typeof BaseEntity,
-        field: PickKeysByType<T, number>,
+        columnName: PickKeysByType<T, number>,
         where: FindOptionsWhere<T>,
     ): Promise<number | null> {
-        return this.getRepository<T>().maximum(field, where)
+        return this.getRepository<T>().maximum(columnName, where)
     }
 
     /**

--- a/src/repository/BaseEntity.ts
+++ b/src/repository/BaseEntity.ts
@@ -15,6 +15,7 @@ import { ObjectUtils } from "../util/ObjectUtils"
 import { QueryDeepPartialEntity } from "../query-builder/QueryPartialEntity"
 import { UpsertOptions } from "./UpsertOptions"
 import { EntityTarget } from "../common/EntityTarget"
+import { PickKeysByType } from "../common/PickKeysByType"
 
 /**
  * Base abstract entity for all entities, used in ActiveRecord patterns.
@@ -406,6 +407,50 @@ export class BaseEntity {
         where: FindOptionsWhere<T>,
     ): Promise<number> {
         return this.getRepository<T>().countBy(where)
+    }
+
+    /**
+     * Return the SUM of a column
+     */
+    static sum<T extends BaseEntity>(
+        this: { new (): T } & typeof BaseEntity,
+        field: PickKeysByType<T, number>,
+        where: FindOptionsWhere<T>,
+    ): Promise<number | null> {
+        return this.getRepository<T>().sum(field, where)
+    }
+
+    /**
+     * Return the AVG of a column
+     */
+    static average<T extends BaseEntity>(
+        this: { new (): T } & typeof BaseEntity,
+        field: PickKeysByType<T, number>,
+        where: FindOptionsWhere<T>,
+    ): Promise<number | null> {
+        return this.getRepository<T>().average(field, where)
+    }
+
+    /**
+     * Return the MIN of a column
+     */
+    static minimum<T extends BaseEntity>(
+        this: { new (): T } & typeof BaseEntity,
+        field: PickKeysByType<T, number>,
+        where: FindOptionsWhere<T>,
+    ): Promise<number | null> {
+        return this.getRepository<T>().minimum(field, where)
+    }
+
+    /**
+     * Return the MAX of a column
+     */
+    static maximum<T extends BaseEntity>(
+        this: { new (): T } & typeof BaseEntity,
+        field: PickKeysByType<T, number>,
+        where: FindOptionsWhere<T>,
+    ): Promise<number | null> {
+        return this.getRepository<T>().maximum(field, where)
     }
 
     /**

--- a/src/repository/Repository.ts
+++ b/src/repository/Repository.ts
@@ -481,40 +481,40 @@ export class Repository<Entity extends ObjectLiteral> {
      * Return the SUM of a column
      */
     sum(
-        field: PickKeysByType<Entity, number>,
+        columnName: PickKeysByType<Entity, number>,
         where?: FindOptionsWhere<Entity> | FindOptionsWhere<Entity>[],
     ): Promise<number | null> {
-        return this.manager.sum(this.metadata.target, field, where)
+        return this.manager.sum(this.metadata.target, columnName, where)
     }
 
     /**
      * Return the AVG of a column
      */
     average(
-        field: PickKeysByType<Entity, number>,
+        columnName: PickKeysByType<Entity, number>,
         where?: FindOptionsWhere<Entity> | FindOptionsWhere<Entity>[],
     ): Promise<number | null> {
-        return this.manager.average(this.metadata.target, field, where)
+        return this.manager.average(this.metadata.target, columnName, where)
     }
 
     /**
      * Return the MIN of a column
      */
     minimum(
-        field: PickKeysByType<Entity, number>,
+        columnName: PickKeysByType<Entity, number>,
         where?: FindOptionsWhere<Entity> | FindOptionsWhere<Entity>[],
     ): Promise<number | null> {
-        return this.manager.minimum(this.metadata.target, field, where)
+        return this.manager.minimum(this.metadata.target, columnName, where)
     }
 
     /**
      * Return the MAX of a column
      */
     maximum(
-        field: PickKeysByType<Entity, number>,
+        columnName: PickKeysByType<Entity, number>,
         where?: FindOptionsWhere<Entity> | FindOptionsWhere<Entity>[],
     ): Promise<number | null> {
-        return this.manager.maximum(this.metadata.target, field, where)
+        return this.manager.maximum(this.metadata.target, columnName, where)
     }
 
     /**

--- a/src/repository/Repository.ts
+++ b/src/repository/Repository.ts
@@ -498,7 +498,7 @@ export class Repository<Entity extends ObjectLiteral> {
     }
 
     /**
-     * Return the AVG of a column
+     * Return the MIN of a column
      */
     minimum(
         field: PickKeysByType<Entity, number>,
@@ -508,7 +508,7 @@ export class Repository<Entity extends ObjectLiteral> {
     }
 
     /**
-     * Return the AVG of a column
+     * Return the MAX of a column
      */
     maximum(
         field: PickKeysByType<Entity, number>,

--- a/src/repository/Repository.ts
+++ b/src/repository/Repository.ts
@@ -15,6 +15,7 @@ import { ObjectID } from "../driver/mongodb/typings"
 import { FindOptionsWhere } from "../find-options/FindOptionsWhere"
 import { UpsertOptions } from "./UpsertOptions"
 import { EntityTarget } from "../common/EntityTarget"
+import { PickKeysByType } from "../common/PickKeysByType"
 
 /**
  * Repository is supposed to work with your entity objects. Find entities, insert, update, delete, etc.
@@ -474,6 +475,46 @@ export class Repository<Entity extends ObjectLiteral> {
         where: FindOptionsWhere<Entity> | FindOptionsWhere<Entity>[],
     ): Promise<number> {
         return this.manager.countBy(this.metadata.target, where)
+    }
+
+    /**
+     * Return the SUM of a column
+     */
+    sum(
+        field: PickKeysByType<Entity, number>,
+        where?: FindOptionsWhere<Entity> | FindOptionsWhere<Entity>[],
+    ): Promise<number | null> {
+        return this.manager.sum(this.metadata.target, field, where)
+    }
+
+    /**
+     * Return the AVG of a column
+     */
+    average(
+        field: PickKeysByType<Entity, number>,
+        where?: FindOptionsWhere<Entity> | FindOptionsWhere<Entity>[],
+    ): Promise<number | null> {
+        return this.manager.average(this.metadata.target, field, where)
+    }
+
+    /**
+     * Return the AVG of a column
+     */
+    minimum(
+        field: PickKeysByType<Entity, number>,
+        where?: FindOptionsWhere<Entity> | FindOptionsWhere<Entity>[],
+    ): Promise<number | null> {
+        return this.manager.minimum(this.metadata.target, field, where)
+    }
+
+    /**
+     * Return the AVG of a column
+     */
+    maximum(
+        field: PickKeysByType<Entity, number>,
+        where?: FindOptionsWhere<Entity> | FindOptionsWhere<Entity>[],
+    ): Promise<number | null> {
+        return this.manager.maximum(this.metadata.target, field, where)
     }
 
     /**

--- a/test/functional/repository/aggregate-methods/entity/Post.ts
+++ b/test/functional/repository/aggregate-methods/entity/Post.ts
@@ -8,5 +8,5 @@ export class Post {
     id: number
 
     @Column()
-    value: number
+    counter: number
 }

--- a/test/functional/repository/aggregate-methods/entity/Post.ts
+++ b/test/functional/repository/aggregate-methods/entity/Post.ts
@@ -1,0 +1,12 @@
+import { Entity } from "../../../../../src/decorator/entity/Entity"
+import { Column } from "../../../../../src/decorator/columns/Column"
+import { PrimaryColumn } from "../../../../../src/decorator/columns/PrimaryColumn"
+
+@Entity()
+export class Post {
+    @PrimaryColumn()
+    id: number
+
+    @Column()
+    value: number
+}

--- a/test/functional/repository/aggregate-methods/repository-aggregate-methods.ts
+++ b/test/functional/repository/aggregate-methods/repository-aggregate-methods.ts
@@ -1,0 +1,87 @@
+import "reflect-metadata"
+import {
+    closeTestingConnections,
+    createTestingConnections,
+} from "../../../utils/test-utils"
+import { Repository } from "../../../../src/repository/Repository"
+import { DataSource } from "../../../../src/data-source/DataSource"
+import { Post } from "./entity/Post"
+import { LessThan } from "../../../../src"
+import { expect } from "chai"
+
+describe("repository > aggregate methods", () => {
+    debugger
+    let connections: DataSource[]
+    let repository: Repository<Post>
+
+    before(async () => {
+        connections = await createTestingConnections({
+            entities: [Post],
+            schemaCreate: true,
+            dropSchema: true,
+        })
+        repository = connections[0].getRepository(Post)
+        for (let i = 0; i < 100; i++) {
+            const post = new Post()
+            post.id = i
+            post.value = i + 1
+            await repository.save(post)
+        }
+    })
+
+    after(() => closeTestingConnections(connections))
+
+    describe("sum", () => {
+        it("should return the aggregate sum", async () => {
+            const sum = await repository.sum("value")
+            expect(sum).to.equal(5050)
+        })
+
+        it("should return null when 0 rows match the query", async () => {
+            const sum = await repository.sum("value", { id: LessThan(0) })
+            expect(sum).to.be.null
+        })
+    })
+
+    describe("average", () => {
+        it("should return the aggregate average", async () => {
+            const average = await repository.average("value")
+            expect(average).to.equal(50.5)
+        })
+
+        it("should return null when 0 rows match the query", async () => {
+            const average = await repository.average("value", {
+                id: LessThan(0),
+            })
+            expect(average).to.be.null
+        })
+    })
+
+    describe("minimum", () => {
+        it("should return the aggregate minimum", async () => {
+            const minimum = await repository.minimum("value")
+            expect(minimum).to.equal(1)
+        })
+
+        it("should return null when 0 rows match the query", async () => {
+            const minimum = await repository.minimum("value", {
+                id: LessThan(0),
+            })
+            expect(minimum).to.be.null
+        })
+    })
+
+    describe("maximum", () => {
+        it("should return the aggregate maximum", async () => {
+            const maximum = await repository.maximum("value")
+            expect(maximum).to.equal(100)
+        })
+
+        it("should return null when 0 rows match the query", async () => {
+            const maximum = await repository.maximum("value", {
+                id: LessThan(0),
+            })
+            expect(maximum).to.be.null
+        })
+    })
+})

--- a/test/functional/repository/aggregate-methods/repository-aggregate-methods.ts
+++ b/test/functional/repository/aggregate-methods/repository-aggregate-methods.ts
@@ -24,7 +24,7 @@ describe("repository > aggregate methods", () => {
         for (let i = 0; i < 100; i++) {
             const post = new Post()
             post.id = i
-            post.value = i + 1
+            post.counter = i + 1
             await repository.save(post)
         }
     })
@@ -33,24 +33,24 @@ describe("repository > aggregate methods", () => {
 
     describe("sum", () => {
         it("should return the aggregate sum", async () => {
-            const sum = await repository.sum("value")
+            const sum = await repository.sum("counter")
             expect(sum).to.equal(5050)
         })
 
         it("should return null when 0 rows match the query", async () => {
-            const sum = await repository.sum("value", { id: LessThan(0) })
+            const sum = await repository.sum("counter", { id: LessThan(0) })
             expect(sum).to.be.null
         })
     })
 
     describe("average", () => {
         it("should return the aggregate average", async () => {
-            const average = await repository.average("value")
+            const average = await repository.average("counter")
             expect(average).to.equal(50.5)
         })
 
         it("should return null when 0 rows match the query", async () => {
-            const average = await repository.average("value", {
+            const average = await repository.average("counter", {
                 id: LessThan(0),
             })
             expect(average).to.be.null
@@ -59,12 +59,12 @@ describe("repository > aggregate methods", () => {
 
     describe("minimum", () => {
         it("should return the aggregate minimum", async () => {
-            const minimum = await repository.minimum("value")
+            const minimum = await repository.minimum("counter")
             expect(minimum).to.equal(1)
         })
 
         it("should return null when 0 rows match the query", async () => {
-            const minimum = await repository.minimum("value", {
+            const minimum = await repository.minimum("counter", {
                 id: LessThan(0),
             })
             expect(minimum).to.be.null
@@ -73,12 +73,12 @@ describe("repository > aggregate methods", () => {
 
     describe("maximum", () => {
         it("should return the aggregate maximum", async () => {
-            const maximum = await repository.maximum("value")
+            const maximum = await repository.maximum("counter")
             expect(maximum).to.equal(100)
         })
 
         it("should return null when 0 rows match the query", async () => {
-            const maximum = await repository.maximum("value", {
+            const maximum = await repository.maximum("counter", {
                 id: LessThan(0),
             })
             expect(maximum).to.be.null


### PR DESCRIPTION
### Description of change
This addresses #673, and adds a convenient way to call aggregate functions via the repository API.

### Pull-Request Checklist

- [x] Code is up-to-date with the `master` branch
- [x] `npm run format` to apply prettier formatting
- [x] `npm run test` passes with this change
- [x] This pull request links relevant issues
- [x] There are new or updated unit tests validating the change
- [x] Documentation has been updated to reflect this change
- [x] The new commits follow conventions explained in [CONTRIBUTING.md](https://github.com/typeorm/typeorm/blob/master/CONTRIBUTING.md)
