### PR TITLE
fix: Prevent TS from making `FindOptionsWhereProperty` distributive

### DIFF
--- a/src/find-options/FindOptionsWhere.ts
+++ b/src/find-options/FindOptionsWhere.ts
@@ -5,26 +5,28 @@ import { EqualOperator } from "./EqualOperator"
 /**
  * A single property handler for FindOptionsWhere.
  */
-export type FindOptionsWhereProperty<Property> = Property extends Promise<
+export type FindOptionsWhereProperty<Property> = FindOptionsWherePropertyInternal<Property, FindOperator<Property>>;
+
+type FindOptionsWherePropertyInternal<Property, PropertyOperator> = Property extends Promise<
     infer I
 >
-    ? FindOptionsWhereProperty<NonNullable<I>>
+    ? FindOptionsWhereProperty<I & {}>
     : Property extends Array<infer I>
-    ? FindOptionsWhereProperty<NonNullable<I>>
+    ? FindOptionsWhereProperty<I & {}>
     : Property extends Function
     ? never
     : Property extends Buffer
-    ? Property | FindOperator<Property>
+    ? Property | PropertyOperator
     : Property extends Date
-    ? Property | FindOperator<Property>
+    ? Property | PropertyOperator
     : Property extends ObjectID
-    ? Property | FindOperator<Property>
+    ? Property | PropertyOperator
     : Property extends string
-    ? Property | FindOperator<Property>
+    ? Property | PropertyOperator
     : Property extends number
-    ? Property | FindOperator<Property>
+    ? Property | PropertyOperator
     : Property extends boolean
-    ? Property | FindOperator<Property>
+    ? Property | PropertyOperator
     : Property extends object
     ?
           | FindOptionsWhere<Property>
@@ -32,7 +34,7 @@ export type FindOptionsWhereProperty<Property> = Property extends Promise<
           | EqualOperator<Property>
           | FindOperator<any>
           | boolean
-    : Property | FindOperator<Property>
+    : Property | PropertyOperator
 
 /**
  * Used for find operations.
@@ -40,5 +42,5 @@ export type FindOptionsWhereProperty<Property> = Property extends Promise<
 export type FindOptionsWhere<Entity> = {
     [P in keyof Entity]?: P extends "toString"
         ? unknown
-        : FindOptionsWhereProperty<NonNullable<Entity[P]>>
+        : FindOptionsWhereProperty<Entity[P] & {}>
 }


### PR DESCRIPTION
### Description of change

By hoisting `FindOperator<Property>` into the signature, it stops TypeScript from making `FindOperator` distributive. This makes `where` work with `FindOperator` and TypeScripts enums.

(Also convert `NonNullable` to `& {}` so the type hints don't show up as `FindOperator<NonNullable<xxxx | null>>`.)
Fixes: #9745

### Pull-Request Checklist


- [x] Code is up-to-date with the `master` branch
- [ ] `npm run format` to apply prettier formatting
- [ ] `npm run test` passes with this change
- [x] This pull request links relevant issues as `Fixes #0000`
- [ ] There are new or updated unit tests validating the change
- [ ] Documentation has been updated to reflect this change
- [x] The new commits follow conventions explained in [CONTRIBUTING.md](https://github.com/typeorm/typeorm/blob/master/CONTRIBUTING.md)

I'm not quite sure how to write a test for this, as this only involves type changes.

```
    enum Status { CONFIRMED = 'confirmed', PENDING = 'pending', BLOCKED = 'blocked' }
    // should not have TS error
    const _unused: FindOptionsWhere<{ status: Status }> = {
      status: Any([Status.CONFIRMED, Status.PENDING])
    };
```