### PR TITLE
docs: Fix grammar error in the first paragraph.

### DIFF
--- a/docs/many-to-many-relations.md
+++ b/docs/many-to-many-relations.md
@@ -9,7 +9,7 @@
 
 ## What are many-to-many relations
 
-Many-to-many is a relation where A contains multiple instances of B, and B contain multiple instances of A.
+Many-to-many is a relation where A contains multiple instances of B, and B contains multiple instances of A.
 Let's take for example `Question` and `Category` entities.
 A question can have multiple categories, and each category can have multiple questions.
 


### PR DESCRIPTION
### Description of change
There's a grammar (verbal agreement) mistake in the first paragraph: "B contain multiple instances of A" instead of "B contains multiple instances of A".


### Pull-Request Checklist

<!--
  Please make sure to review and check all of the following.

  If an item is not applicable, you can add "N/A" to the end.
-->

- [x] Code is up-to-date with the `master` branch
- [ ] `npm run format` to apply prettier formatting
- [ ] N/A - `npm run test` passes with this change
- [ ] This pull request links relevant issues as `Fixes #0000`
- [ ] N/A - There are new or updated unit tests validating the change
- [ ] Documentation has been updated to reflect this change
- [x] The new commits follow conventions explained in [CONTRIBUTING.md](https://github.com/typeorm/typeorm/blob/master/CONTRIBUTING.md)
