### PR TITLE
Use forward slashes when normalizing path on Windows

### DIFF
--- a/src/platform/PlatformTools.ts
+++ b/src/platform/PlatformTools.ts
@@ -140,10 +140,13 @@ export class PlatformTools {
     }
 
     /**
-     * Normalizes given path. Does "path.normalize".
+     * Normalizes given path. Does "path.normalize" and replaces backslashes with forward slashes on Windows.
      */
     static pathNormalize(pathStr: string): string {
-        return path.normalize(pathStr)
+        let normalizedPath = path.normalize(pathStr)
+        if (process.platform === "win32")
+            normalizedPath = normalizedPath.replace(/\\/g, "/")
+        return normalizedPath
     }
 
     /**


### PR DESCRIPTION
Fixes #9766

### Description of change
Replace backslashes with forward slashes when normalizing a path on Windows, in order to make the path work for glob pattern resolving.