### PR TITLE
fix: resolves issue with mssql column recreation

### DIFF
--- a/src/driver/sqlserver/SqlServerDriver.ts
+++ b/src/driver/sqlserver/SqlServerDriver.ts
@@ -1035,7 +1035,10 @@ export class SqlServerDriver implements Driver {
         // of data type precedence to the expressions specified in the formula.
         if (columnMetadata.asExpression) return false
 
-        return tableColumn.length !== this.getColumnLength(columnMetadata)
+        return (
+            tableColumn.length?.toUpperCase() !==
+            this.getColumnLength(columnMetadata)?.toUpperCase()
+        )
     }
 
     protected lowerDefaultValueIfNecessary(value: string | undefined) {

--- a/src/driver/sqlserver/SqlServerDriver.ts
+++ b/src/driver/sqlserver/SqlServerDriver.ts
@@ -1036,8 +1036,8 @@ export class SqlServerDriver implements Driver {
         if (columnMetadata.asExpression) return false
 
         return (
-            tableColumn.length?.toUpperCase() !==
-            this.getColumnLength(columnMetadata)?.toUpperCase()
+            tableColumn.length.toUpperCase() !==
+            this.getColumnLength(columnMetadata).toUpperCase()
         )
     }
 

--- a/test/github-issues/9399/entity/ExampleEntity.ts
+++ b/test/github-issues/9399/entity/ExampleEntity.ts
@@ -1,0 +1,13 @@
+import { Entity, Generated } from "../../../../src"
+import { PrimaryGeneratedColumn } from "../../../../src"
+import { Column } from "../../../../src"
+
+@Entity()
+export class ExampleEntity {
+    @Generated("increment")
+    @PrimaryGeneratedColumn()
+    id: number
+
+    @Column({ type: "nvarchar", length: "max" })
+    value: string
+}

--- a/test/github-issues/9399/issue-9399.ts
+++ b/test/github-issues/9399/issue-9399.ts
@@ -27,9 +27,8 @@ describe("github issues > #9399 mssql: Column is dropped and recreated in every 
                     .createSchemaBuilder()
                     .log()
 
-                expect(sqlInMemory.upQueries).to.eql([])
-                expect(sqlInMemory.downQueries).to.eql([])
+                expect(sqlInMemory.upQueries.length).to.eql(0)
+                expect(sqlInMemory.downQueries.length).to.eql(0)
             }),
         ))
-    // you can add additional tests if needed
 })

--- a/test/github-issues/9399/issue-9399.ts
+++ b/test/github-issues/9399/issue-9399.ts
@@ -1,0 +1,35 @@
+import "reflect-metadata"
+import {
+    createTestingConnections,
+    closeTestingConnections,
+} from "../../utils/test-utils"
+import { DataSource } from "../../../src"
+import { expect } from "chai"
+
+describe("github issues > #9399 mssql: Column is dropped and recreated in every migration", () => {
+    let dataSources: DataSource[]
+    before(
+        async () =>
+            (dataSources = await createTestingConnections({
+                entities: [__dirname + "/entity/*{.js,.ts}"],
+                schemaCreate: true,
+                dropSchema: true,
+                enabledDrivers: ["mssql"],
+            })),
+    )
+    after(() => closeTestingConnections(dataSources))
+
+    it("No migration should be created", () =>
+        Promise.all(
+            dataSources.map(async (dataSource) => {
+                await dataSource.runMigrations()
+                const sqlInMemory = await dataSource.driver
+                    .createSchemaBuilder()
+                    .log()
+
+                expect(sqlInMemory.upQueries).to.eql([])
+                expect(sqlInMemory.downQueries).to.eql([])
+            }),
+        ))
+    // you can add additional tests if needed
+})


### PR DESCRIPTION
Resolves issue with mssql column recreation when length max is i)n lower case

Fixes: #9399 

<!--
  😀 Wonderful!  Thank you for opening a pull request for TypeORM.

  Please fill in the information below to expedite the review
  and (hopefully) merge of your change.

  If unsure about something.. just do as best as you're able,
  or reach out through our community support channels!
  https://github.com/typeorm/typeorm/blob/master/docs/support.md
-->

### Description of change

<!--
  Please be clear and concise what the change is intended to do,
  why this change is needed, and how you've verified that it
  corrects what you intended.

  In some cases it may be helpful to include the current behavior
  and the new behavior.

  If the change is related to an open issue, you can link it here.
  If you include `Fixes #0000` (replacing `0000` with the issue number)
  when this is merged it will automatically mark the issue as fixed and
  close it.
-->


### Pull-Request Checklist

<!--
  Please make sure to review and check all of the following.

  If an item is not applicable, you can add "N/A" to the end.
-->

- [x] Code is up-to-date with the `master` branch
- [x] `npm run format` to apply prettier formatting
- [x] `npm run test` passes with this change
- [x] This pull request links relevant issues as `Fixes #0000`
- [x] There are new or updated unit tests validating the change
 [~] Documentation has been updated to reflect this change
- [x] The new commits follow conventions explained in [CONTRIBUTING.md](https://github.com/typeorm/typeorm/blob/master/CONTRIBUTING.md)

<!--
  🎉 Thank you for contributing and making TypeORM even better!
-->
