### PR TITLE
fix: prevent foreign key support during migration batch under sqlite

### DIFF
--- a/src/migration/MigrationExecutor.ts
+++ b/src/migration/MigrationExecutor.ts
@@ -333,7 +333,6 @@ export class MigrationExecutor {
                     transactionStartedByUs = true
                 }
 
-                this.connection.logger.log("info", "--start migration--")
                 await migration
                     .instance!.up(queryRunner)
                     .catch((error) => {

--- a/test/functional/migrations/show-command/command.ts
+++ b/test/functional/migrations/show-command/command.ts
@@ -12,7 +12,7 @@ describe("migrations > show command", () => {
         async () =>
             (connections = await createTestingConnections({
                 migrations: [__dirname + "/migration/*.js"],
-                enabledDrivers: ["postgres"],
+                enabledDrivers: ["postgres", "sqlite"],
                 schemaCreate: true,
                 dropSchema: true,
             })),
@@ -31,7 +31,12 @@ describe("migrations > show command", () => {
     it("can recognise no pending migrations", () =>
         Promise.all(
             connections.map(async (connection) => {
-                await connection.runMigrations()
+                const m = await connection.runMigrations()
+                /*
+                    .catch((err) => { console.log(`error: ${err}`)})
+                    .then(() => { console.log('migrations done')})
+                */
+                console.log(`have performe ${m.length} migrations`)
                 const migrations = await connection.showMigrations()
                 migrations.should.be.equal(false)
             }),

--- a/test/functional/migrations/show-command/command.ts
+++ b/test/functional/migrations/show-command/command.ts
@@ -31,12 +31,7 @@ describe("migrations > show command", () => {
     it("can recognise no pending migrations", () =>
         Promise.all(
             connections.map(async (connection) => {
-                const m = await connection.runMigrations()
-                /*
-                    .catch((err) => { console.log(`error: ${err}`)})
-                    .then(() => { console.log('migrations done')})
-                */
-                console.log(`have performe ${m.length} migrations`)
+                await connection.runMigrations()
                 const migrations = await connection.showMigrations()
                 migrations.should.be.equal(false)
             }),

--- a/test/github-issues/9770/entity/Bar.ts
+++ b/test/github-issues/9770/entity/Bar.ts
@@ -1,0 +1,26 @@
+import {
+    Entity,
+    Column,
+    ManyToOne,
+    JoinColumn,
+    PrimaryGeneratedColumn,
+} from "../../../../src"
+
+import { Foo } from "./Foo"
+
+@Entity()
+export class Bar {
+    @PrimaryGeneratedColumn()
+    id: number
+
+    @ManyToOne(() => Foo, {
+        cascade: true,
+        onDelete: "CASCADE",
+        nullable: false,
+    })
+    @JoinColumn()
+    foo!: Foo
+
+    @Column()
+    data: string
+}

--- a/test/github-issues/9770/entity/Foo.ts
+++ b/test/github-issues/9770/entity/Foo.ts
@@ -1,0 +1,9 @@
+import { Entity, Column, PrimaryGeneratedColumn } from "../../../../src"
+
+@Entity()
+export class Foo {
+    @PrimaryGeneratedColumn() id: number
+
+    @Column()
+    data: string
+}

--- a/test/github-issues/9770/issue-9770.ts
+++ b/test/github-issues/9770/issue-9770.ts
@@ -1,0 +1,87 @@
+import "reflect-metadata"
+import { expect } from "chai"
+
+import { DataSource } from "../../../src"
+//import { DataSource, TableColumn } from "../../../src"
+import {
+    closeTestingConnections,
+    createTestingConnections,
+    reloadTestingDatabases,
+} from "../../utils/test-utils"
+
+import { Foo } from "./entity/Foo"
+import { Bar } from "./entity/Bar"
+
+describe("github issues > #9770 check for referencing foreign keys when altering a table using sqlite", () => {
+    let dataSources: DataSource[]
+    before(async () => {
+        dataSources = await createTestingConnections({
+            entities: [__dirname + "/entity/*{.js,.ts}"],
+            migrations: [__dirname + "/migration/*{.js,.ts}"],
+            enabledDrivers: ["sqlite", "better-sqlite3"],
+            schemaCreate: true,
+            dropSchema: true,
+            logging: true,
+        })
+    })
+    beforeEach(() => reloadTestingDatabases(dataSources))
+    after(() => closeTestingConnections(dataSources))
+
+    it("shouldn't loose dependant table data", () =>
+        Promise.all(
+            dataSources.map(async (dataSource) => {
+                const manager = dataSource.manager
+
+                // Insert records in the tables
+                const foo = new Foo()
+                foo.data = "foo"
+                await manager.save(foo)
+                const foundFoo = await manager.findOne(Foo, {
+                    where: {
+                        id: 1,
+                    },
+                })
+                expect(foundFoo).not.to.be.null
+
+                if (!foundFoo) return
+
+                const bar = new Bar()
+                bar.foo = foundFoo
+                bar.data = "bar"
+                await manager.save(bar)
+
+                const foundBar = await manager.findOne(Bar, {
+                    where: {
+                        foo: {
+                            id: foundFoo.id,
+                        },
+                    },
+                })
+                expect(foundBar).not.to.be.null
+
+                // check current state (migrations pending and entries in db)
+                const migrations = await dataSource.showMigrations()
+                migrations.should.be.equal(true)
+
+                const queryRunner = dataSource.createQueryRunner()
+                let barRecords = await queryRunner.query(`SELECT * FROM "bar"`)
+                expect(barRecords).to.have.lengthOf.above(0)
+
+                // run migrations which contains a table drop
+                await dataSource.runMigrations()
+
+                // check post migration (no more pending migration and data still in db)
+                const migrations2 = await dataSource.showMigrations()
+                migrations2.should.be.equal(false)
+
+                // check if data still exists in dependant table
+                barRecords = await queryRunner.query(`SELECT * FROM "bar"`)
+                expect(barRecords).to.have.lengthOf.above(0)
+
+                // revert changes
+                await queryRunner.executeMemoryDownSql()
+
+                await queryRunner.release()
+            }),
+        ))
+})

--- a/test/github-issues/9770/migration/1675779246631-amendFoo.ts
+++ b/test/github-issues/9770/migration/1675779246631-amendFoo.ts
@@ -1,0 +1,19 @@
+import { MigrationInterface, QueryRunner, TableColumn } from "../../../../src"
+
+export class amendFoo1675779246631 implements MigrationInterface {
+    public async up(q: QueryRunner): Promise<void> {
+        await q.addColumn(
+            "foo",
+            new TableColumn({
+                name: "comment",
+                type: "varchar",
+                isNullable: true,
+                default: null,
+            }),
+        )
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.dropColumn("foo", "comment")
+    }
+}


### PR DESCRIPTION
Schema changes in migrations batch cannot be done on table which has referring
 foreign keys with ON DELETE CASCADE without deleting its content.

Closes: #9770
Closes: #2584

<!--
  😀 Wonderful!  Thank you for opening a pull request for TypeORM.

  Please fill in the information below to expedite the review
  and (hopefully) merge of your change.

  If unsure about something.. just do as best as you're able,
  or reach out through our community support channels!
  https://github.com/typeorm/typeorm/blob/master/docs/support.md
-->

### Description of change
Complemente the PR #7922 by executing beforeMigration before each migration and execting afterMigration after each migration right before Transaction is started and right after transaction is being commited.
As specified in [sqlite doc](https://www.sqlite.org/pragma.html#pragma_foreign_keys) : 

> This pragma is a no-op within a transaction; foreign key constraint enforcement may only be enabled or disabled when there is no pending [BEGIN](https://www.sqlite.org/lang_transaction.html) or [SAVEPOINT](https://www.sqlite.org/lang_savepoint.html).

So the change is to run PRAGMA foreign_keys = OFF before starting the migration and the transaction that contains it and to set it back to ON right after once commited.

This change will avoid to trigger CASCADE events as well as constraint check on foreign keys.
Hence avoiding to have some deleted data unexpectedly because any table change is managed throught a clone creation and original table drop.

<!--
  Please be clear and concise what the change is intended to do,
  why this change is needed, and how you've verified that it
  corrects what you intended.

  In some cases it may be helpful to include the current behavior
  and the new behavior.

  If the change is related to an open issue, you can link it here.
  If you include `Fixes #0000` (replacing `0000` with the issue number)
  when this is merged it will automatically mark the issue as fixed and
  close it.
-->


### Pull-Request Checklist

<!--
  Please make sure to review and check all of the following.

  If an item is not applicable, you can add "N/A" to the end.
-->

- [X] Code is up-to-date with the `master` branch
- [X] `npm run format` to apply prettier formatting
- [X] `npm run test` passes with this change (well actually it breaks at same place than without he change)
- [X] This pull request links relevant issues as `Fixes #9770 #2584`
- [X] There are new or updated unit tests validating the change
- [ ] Documentation has been updated to reflect this change (no change of interface)
- [X] The new commits follow conventions explained in [CONTRIBUTING.md](https://github.com/typeorm/typeorm/blob/master/CONTRIBUTING.md)

<!--
  🎉 Thank you for contributing and making TypeORM even better!
-->
