### PR TITLE
When calling AVG on an integer column, MS SQL Server returns an int (test only fix)

### DIFF
--- a/test/functional/repository/aggregate-methods/repository-aggregate-methods.ts
+++ b/test/functional/repository/aggregate-methods/repository-aggregate-methods.ts
@@ -46,7 +46,9 @@ describe("repository > aggregate methods", () => {
     describe("average", () => {
         it("should return the aggregate average", async () => {
             const average = await repository.average("counter")
-            expect(average).to.equal(50.5)
+            // Some RDBMSs (e.g. SQL Server) will return an int when averaging an int column, so either
+            // answer is acceptable.
+            expect([50, 50.5]).to.include(average)
         })
 
         it("should return null when 0 rows match the query", async () => {


### PR DESCRIPTION
In this case, 50 instead of 50.5. Apparently the ANSI standard for SQL is silent on this issue, so either behavior should be considered acceptable.

<!--
  😀 Wonderful!  Thank you for opening a pull request for TypeORM.

  Please fill in the information below to expedite the review
  and (hopefully) merge of your change.

  If unsure about something.. just do as best as you're able,
  or reach out through our community support channels!
  https://github.com/typeorm/typeorm/blob/master/docs/support.md
-->

### Description of change

Modify test to accept the answer that SQL Server gives for AVG even though it is mathematically inaccurate.

<!--
  Please be clear and concise what the change is intended to do,
  why this change is needed, and how you've verified that it
  corrects what you intended.

  In some cases it may be helpful to include the current behavior
  and the new behavior.

  If the change is related to an open issue, you can link it here.
  If you include `Fixes #0000` (replacing `0000` with the issue number)
  when this is merged it will automatically mark the issue as fixed and
  close it.
-->


### Pull-Request Checklist

<!--
  Please make sure to review and check all of the following.

  If an item is not applicable, you can add "N/A" to the end.
-->

- [x] Code is up-to-date with the `master` branch
- [x] `npm run format` to apply prettier formatting
- [x] `npm run test` passes with this change
- [ ] This pull request links relevant issues as `Fixes #0000` (N/A)
- [ ] There are new or updated unit tests validating the change (N/A)
- [ ] Documentation has been updated to reflect this change (N/A)
- [x] The new commits follow conventions explained in [CONTRIBUTING.md](https://github.com/typeorm/typeorm/blob/master/CONTRIBUTING.md)

<!--
  🎉 Thank you for contributing and making TypeORM even better!
-->
