### PR TITLE
[Postgres]fix: proper default value on generating migration when a default value is a function calling

### DIFF
--- a/src/driver/postgres/PostgresQueryRunner.ts
+++ b/src/driver/postgres/PostgresQueryRunner.ts
@@ -3717,7 +3717,7 @@ export class PostgresQueryRunner
                                 } else {
                                     tableColumn.default = dbColumn[
                                         "column_default"
-                                    ].replace(/::.+/g, "")
+                                    ].replace(/::[\w\s.\[\]\-"]+/g, "")
                                     tableColumn.default =
                                         tableColumn.default.replace(
                                             /^(-?\d+)$/,

--- a/test/github-issues/9829/entity/ExampleEntity.ts
+++ b/test/github-issues/9829/entity/ExampleEntity.ts
@@ -1,0 +1,17 @@
+import { Entity } from "../../../../src/decorator/entity/Entity"
+import { Column } from "../../../../src/decorator/columns/Column"
+import { PrimaryGeneratedColumn } from "../../../../src/decorator/columns/PrimaryGeneratedColumn"
+
+@Entity()
+export class ExampleEntity {
+    @PrimaryGeneratedColumn()
+    id: number
+
+    @Column({
+        type: "varchar",
+        length: 3,
+        unique: true,
+        default: () => "('AA'|| COALESCE(NULL, '1'))",
+    })
+    someValue: string
+}

--- a/test/github-issues/9829/issue-9829.ts
+++ b/test/github-issues/9829/issue-9829.ts
@@ -1,0 +1,33 @@
+import "reflect-metadata"
+import { DataSource } from "../../../src/index"
+import {
+    closeTestingConnections,
+    createTestingConnections,
+} from "../../utils/test-utils"
+import { ExampleEntity } from "./entity/ExampleEntity"
+
+describe("github issues > #9829 Incorrect default value with concat value of function", () => {
+    let connections: DataSource[]
+    before(
+        async () =>
+            (connections = await createTestingConnections({
+                entities: [ExampleEntity],
+                schemaCreate: true,
+                dropSchema: true,
+                enabledDrivers: ["postgres"],
+            })),
+    )
+    after(() => closeTestingConnections(connections))
+    it("should get default concat value", () =>
+        Promise.all(
+            connections.map(async (connection) => {
+                const queryRunner = connection.createQueryRunner()
+                let table = await queryRunner.getTable("example_entity")
+
+                const nameColumn = table!.findColumnByName("someValue")!
+                nameColumn!.default!.should.be.equal(
+                    "('AA'|| COALESCE(NULL, '1'))",
+                )
+            }),
+        ))
+})


### PR DESCRIPTION
<!--
  😀 Wonderful!  Thank you for opening a pull request for TypeORM.

  Please fill in the information below to expedite the review
  and (hopefully) merge of your change.

  If unsure about something.. just do as best as you're able,
  or reach out through our community support channels!
  https://github.com/typeorm/typeorm/blob/master/docs/support.md
-->

### Description of change
Closes: https://github.com/typeorm/typeorm/issues/9829

<!--
  Please be clear and concise what the change is intended to do,
  why this change is needed, and how you've verified that it
  corrects what you intended.

  In some cases it may be helpful to include the current behavior
  and the new behavior.

  If the change is related to an open issue, you can link it here.
  If you include `Fixes #0000` (replacing `0000` with the issue number)
  when this is merged it will automatically mark the issue as fixed and
  close it.
-->


### Pull-Request Checklist

<!--
  Please make sure to review and check all of the following.

  If an item is not applicable, you can add "N/A" to the end.
-->

- [x] Code is up-to-date with the `master` branch
- [x] `npm run format` to apply prettier formatting
- [x] `npm run test` passes with this change
- [x] This pull request links relevant issues as `Fixes #9829`
- [x] There are new or updated unit tests validating the change
- [x] Documentation has been updated to reflect this change
- [x] The new commits follow conventions explained in [CONTRIBUTING.md](https://github.com/typeorm/typeorm/blob/master/CONTRIBUTING.md)

<!--
  🎉 Thank you for contributing and making TypeORM even better!
-->
