### PR TITLE
fix: use object create if entity skip constructor is set

### DIFF
--- a/src/metadata/EmbeddedMetadata.ts
+++ b/src/metadata/EmbeddedMetadata.ts
@@ -199,10 +199,10 @@ export class EmbeddedMetadata {
             return {}
         }
 
-        if (!options?.fromDeserializer || this.isAlwaysUsingConstructor) {
-            return new (this.type as any)()
-        } else {
+        if (options?.fromDeserializer || !this.isAlwaysUsingConstructor) {
             return Object.create(this.type.prototype)
+        } else {
+            return new (this.type as any)()
         }
     }
 


### PR DESCRIPTION
<!--
  😀 Wonderful!  Thank you for opening a pull request for TypeORM.

  Please fill in the information below to expedite the review
  and (hopefully) merge of your change.

  If unsure about something.. just do as best as you're able,
  or reach out through our community support channels!
  https://github.com/typeorm/typeorm/blob/master/docs/support.md
-->

### Description of change

<!--
  Please be clear and concise what the change is intended to do,
  why this change is needed, and how you've verified that it
  corrects what you intended.

  In some cases it may be helpful to include the current behavior
  and the new behavior.

  If the change is related to an open issue, you can link it here.
  If you include `Fixes #0000` (replacing `0000` with the issue number)
  when this is merged it will automatically mark the issue as fixed and
  close it.
-->

Fixes #9824. Allows embedded entities to skip constructor when entitySkipConstructor is set.

### Pull-Request Checklist

<!--
  Please make sure to review and check all of the following.

  If an item is not applicable, you can add "N/A" to the end.
-->

- [x] Code is up-to-date with the `master` branch
- [x] `npm run format` to apply prettier formatting
- [x] `npm run test` passes with this change
- [x] This pull request links relevant issues as `Fixes #0000`
- [x] There are new or updated unit tests validating the change
- [x] Documentation has been updated to reflect this change
- [x] The new commits follow conventions explained in [CONTRIBUTING.md](https://github.com/typeorm/typeorm/blob/master/CONTRIBUTING.md)

<!--
  🎉 Thank you for contributing and making TypeORM even better!
-->
