### PR TITLE
feat: mariadb uuid inet4 inet6 column data type support

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,7 +14,7 @@ services:
 
   # mariadb
   mariadb:
-    image: "mariadb:10.8.4"
+    image: "mariadb:10.10.3"
     container_name: "typeorm-mariadb"
     ports:
       - "3307:3306"

--- a/docs/entities.md
+++ b/docs/entities.md
@@ -371,8 +371,7 @@ or
 `json`, `binary`, `varbinary`, `geometry`, `point`, `linestring`, `polygon`, `multipoint`, `multilinestring`,
 `multipolygon`, `geometrycollection`, `uuid`, `inet4`, `inet6`
 
-> Note: UUID, INET4, and INET6 are only available for mariadb and for respective versions that made them available. If provided and
-> the current drive/version does not support the data type the default will be varchar
+> Note: UUID, INET4, and INET6 are only available for mariadb and for respective versions that made them available.
 
 
 ### Column types for `postgres`

--- a/docs/entities.md
+++ b/docs/entities.md
@@ -369,7 +369,11 @@ or
 `timestamp`, `time`, `year`, `char`, `nchar`, `national char`, `varchar`, `nvarchar`, `national varchar`,
 `text`, `tinytext`, `mediumtext`, `blob`, `longtext`, `tinyblob`, `mediumblob`, `longblob`, `enum`, `set`,
 `json`, `binary`, `varbinary`, `geometry`, `point`, `linestring`, `polygon`, `multipoint`, `multilinestring`,
-`multipolygon`, `geometrycollection`
+`multipolygon`, `geometrycollection`, `uuid`, `inet4`, `inet6`
+
+> Note: UUID, INET4, and INET6 are only available for mariadb and for respective versions that made them available. If provided and
+> the current drive/version does not support the data type the default will be varchar
+
 
 ### Column types for `postgres`
 

--- a/src/driver/mysql/MysqlDriver.ts
+++ b/src/driver/mysql/MysqlDriver.ts
@@ -863,8 +863,14 @@ export class MysqlDriver implements Driver {
 
         /**
          * fix https://github.com/typeorm/typeorm/issues/1139
+         * as part of adding uuid support for mariadb, we need to check that we aren't actually using the uuid type
+         * because this should not receive the length value by default
          */
-        if (column.generationStrategy === "uuid") return "36"
+        if (
+            this.columnTypeVersionSupportMap.uuid !== "uuid" &&
+            column.generationStrategy === "uuid"
+        )
+            return "36"
 
         switch (column.type) {
             case String:

--- a/src/driver/mysql/MysqlDriver.ts
+++ b/src/driver/mysql/MysqlDriver.ts
@@ -323,7 +323,6 @@ export class MysqlDriver implements Driver {
         inet6: "varchar",
     }
 
-
     /**
      * Max length allowed by MySQL for aliases.
      * @see https://dev.mysql.com/doc/refman/5.5/en/identifiers.html
@@ -440,21 +439,21 @@ export class MysqlDriver implements Driver {
              * @see https://mariadb.com/kb/en/uuid-data-type/
              */
             if (VersionUtils.isGreaterOrEqual(dbVersion, "10.7.0")) {
-                this.columnTypeVersionSupportMap.uuid = "uuid";
+                this.columnTypeVersionSupportMap.uuid = "uuid"
             }
             /**
              * MariaDb version 10.10.0 supports INET4 type
              * @see https://mariadb.com/kb/en/inet4/
              */
-            if (VersionUtils.isGreaterOrEqual(dbVersion,  "10.10.0")) {
-                this.columnTypeVersionSupportMap.inet4 = "inet4";
+            if (VersionUtils.isGreaterOrEqual(dbVersion, "10.10.0")) {
+                this.columnTypeVersionSupportMap.inet4 = "inet4"
             }
             /**
              * MariaDb version 10.5.0 supports INET6 type
              * @see https://mariadb.com/kb/en/inet6/
              */
             if (VersionUtils.isGreaterOrEqual(dbVersion, "10.5.0")) {
-                this.columnTypeVersionSupportMap.inet6 = "inet6";
+                this.columnTypeVersionSupportMap.inet6 = "inet6"
             }
         } else if (this.options.type === "mysql") {
             if (VersionUtils.isGreaterOrEqual(dbVersion, "8.0.0")) {
@@ -761,7 +760,7 @@ export class MysqlDriver implements Driver {
             return this.columnTypeVersionSupportMap.inet4
         } else if (column.type === "inet6") {
             return this.columnTypeVersionSupportMap.inet6
-        }else if (column.type === "json" && this.options.type === "mariadb") {
+        } else if (column.type === "json" && this.options.type === "mariadb") {
             /*
              * MariaDB implements this as a LONGTEXT rather, as the JSON data type contradicts the SQL standard,
              * and MariaDB's benchmarks indicate that performance is at least equivalent.

--- a/src/driver/mysql/MysqlDriver.ts
+++ b/src/driver/mysql/MysqlDriver.ts
@@ -335,6 +335,9 @@ export class MysqlDriver implements Driver {
             update: false,
         }
 
+    /** MariaDB supports uuid type for version 10.7.0 and up */
+    private uuidColumnTypeSuported = false
+
     // -------------------------------------------------------------------------
     // Constructor
     // -------------------------------------------------------------------------
@@ -424,6 +427,9 @@ export class MysqlDriver implements Driver {
             }
             if (VersionUtils.isGreaterOrEqual(dbVersion, "10.2.0")) {
                 this.cteCapabilities.enabled = true
+            }
+            if (VersionUtils.isGreaterOrEqual(dbVersion, "10.7.0")) {
+                this.uuidColumnTypeSuported = true
             }
         } else if (this.options.type === "mysql") {
             if (VersionUtils.isGreaterOrEqual(dbVersion, "8.0.0")) {
@@ -724,7 +730,7 @@ export class MysqlDriver implements Driver {
             return "blob"
         } else if (column.type === Boolean) {
             return "tinyint"
-        } else if (column.type === "uuid" && this.options.type === "mysql") {
+        } else if (column.type === "uuid" && !this.uuidColumnTypeSuported) {
             return "varchar"
         } else if (column.type === "json" && this.options.type === "mariadb") {
             /*
@@ -831,7 +837,7 @@ export class MysqlDriver implements Driver {
          * fix https://github.com/typeorm/typeorm/issues/1139
          * note that if the db did support uuid column type it wouldn't have been defaulted to varchar
          */
-        if (column.generationStrategy === "uuid" && column.type !== "uuid")
+        if (column.generationStrategy === "uuid" && column.type === "varchar")
             return "36"
 
         switch (column.type) {

--- a/src/driver/mysql/MysqlDriver.ts
+++ b/src/driver/mysql/MysqlDriver.ts
@@ -831,7 +831,8 @@ export class MysqlDriver implements Driver {
          * fix https://github.com/typeorm/typeorm/issues/1139
          * note that if the db did support uuid column type it wouldn't have been defaulted to varchar
          */
-        if (column.generationStrategy === "uuid" && column.type !== "uuid") return "36"
+        if (column.generationStrategy === "uuid" && column.type !== "uuid")
+            return "36"
 
         switch (column.type) {
             case String:

--- a/src/driver/types/ColumnTypes.ts
+++ b/src/driver/types/ColumnTypes.ts
@@ -177,13 +177,15 @@ export type SimpleColumnType =
     | "set" // mysql
     | "cidr" // postgres
     | "inet" // postgres, cockroachdb
+    | "inet4" // mariadb
+    | "inet6" // mariadb
     | "macaddr" // postgres
     | "bit" // postgres, mssql
     | "bit varying" // postgres
     | "varbit" // postgres
     | "tsvector" // postgres
     | "tsquery" // postgres
-    | "uuid" // postgres, cockroachdb
+    | "uuid" // postgres, cockroachdb, mariadb
     | "xml" // mssql, postgres
     | "json" // mysql, postgres, cockroachdb, spanner
     | "jsonb" // postgres, cockroachdb

--- a/src/metadata-builder/JunctionEntityMetadataBuilder.ts
+++ b/src/metadata-builder/JunctionEntityMetadataBuilder.ts
@@ -102,6 +102,10 @@ export class JunctionEntityMetadataBuilder {
                             ) ||
                                 this.connection.driver.options.type ===
                                     "aurora-mysql") &&
+                            // some versions of mariadb support the column type and should not try to provide the length property
+                            this.connection.driver.normalizeType(
+                                referencedColumn,
+                            ) !== "uuid" &&
                             (referencedColumn.generationStrategy === "uuid" ||
                                 referencedColumn.type === "uuid")
                                 ? "36"
@@ -166,6 +170,10 @@ export class JunctionEntityMetadataBuilder {
                                 ) ||
                                     this.connection.driver.options.type ===
                                         "aurora-mysql") &&
+                                // some versions of mariadb support the column type and should not try to provide the length property
+                                this.connection.driver.normalizeType(
+                                    inverseReferencedColumn,
+                                ) !== "uuid" &&
                                 (inverseReferencedColumn.generationStrategy ===
                                     "uuid" ||
                                     inverseReferencedColumn.type === "uuid")

--- a/src/metadata-builder/RelationJoinColumnBuilder.ts
+++ b/src/metadata-builder/RelationJoinColumnBuilder.ts
@@ -208,6 +208,10 @@ export class RelationJoinColumnBuilder {
                                 ) ||
                                     this.connection.driver.options.type ===
                                         "aurora-mysql") &&
+                                // some versions of mariadb support the column type and should not try to provide the length property
+                                this.connection.driver.normalizeType(
+                                    referencedColumn,
+                                ) !== "uuid" &&
                                 (referencedColumn.generationStrategy ===
                                     "uuid" ||
                                     referencedColumn.type === "uuid")

--- a/test/github-issues/6540/entity/order.entity.ts.ts
+++ b/test/github-issues/6540/entity/order.entity.ts.ts
@@ -16,7 +16,11 @@ export enum OrderStatus {
 
 @Entity()
 export class Order extends BaseEntity {
-    @PrimaryGeneratedColumn("uuid")
+    /**
+     * modified to remove the uuid since some versions of mariadb have uuid as a type
+     * which would create an additional upsert between the tests -> https://github.com/typeorm/typeorm/issues/8832
+     */
+    @PrimaryGeneratedColumn()
     id: string
 
     @Column({ type: "enum", enum: OrderStatus })

--- a/test/github-issues/6540/issue-6540.ts
+++ b/test/github-issues/6540/issue-6540.ts
@@ -38,6 +38,7 @@ describe("github issues > #6540 Enum not resolved if it is from an external file
                 const sqlInMemory = await connection.driver
                     .createSchemaBuilder()
                     .log()
+                console.log(connection.driver.options.type, sqlInMemory.upQueries)
                 sqlInMemory.upQueries.length.should.be.equal(0)
                 sqlInMemory.downQueries.length.should.be.equal(0)
             }),

--- a/test/github-issues/6540/issue-6540.ts
+++ b/test/github-issues/6540/issue-6540.ts
@@ -38,7 +38,10 @@ describe("github issues > #6540 Enum not resolved if it is from an external file
                 const sqlInMemory = await connection.driver
                     .createSchemaBuilder()
                     .log()
-                console.log(connection.driver.options.type, sqlInMemory.upQueries)
+                console.log(
+                    connection.driver.options.type,
+                    sqlInMemory.upQueries,
+                )
                 sqlInMemory.upQueries.length.should.be.equal(0)
                 sqlInMemory.downQueries.length.should.be.equal(0)
             }),

--- a/test/github-issues/6540/issue-6540.ts
+++ b/test/github-issues/6540/issue-6540.ts
@@ -38,10 +38,6 @@ describe("github issues > #6540 Enum not resolved if it is from an external file
                 const sqlInMemory = await connection.driver
                     .createSchemaBuilder()
                     .log()
-                console.log(
-                    connection.driver.options.type,
-                    sqlInMemory.upQueries,
-                )
                 sqlInMemory.upQueries.length.should.be.equal(0)
                 sqlInMemory.downQueries.length.should.be.equal(0)
             }),

--- a/test/github-issues/8832/badEntity/BadInet4.ts
+++ b/test/github-issues/8832/badEntity/BadInet4.ts
@@ -1,0 +1,10 @@
+import { Column, Entity, PrimaryGeneratedColumn } from "../../../../src"
+
+@Entity()
+export class BadInet4 {
+    @PrimaryGeneratedColumn("uuid")
+    id?: string
+
+    @Column({ type: "inet4", length: "36" })
+    inet4: string
+}

--- a/test/github-issues/8832/badEntity/BadInet6.ts
+++ b/test/github-issues/8832/badEntity/BadInet6.ts
@@ -1,0 +1,10 @@
+import { Column, Entity, PrimaryGeneratedColumn } from "../../../../src"
+
+@Entity()
+export class BadInet6 {
+    @PrimaryGeneratedColumn("uuid")
+    id?: string
+
+    @Column({ type: "inet6", length: "36" })
+    inet6: string
+}

--- a/test/github-issues/8832/badEntity/BadUuid.ts
+++ b/test/github-issues/8832/badEntity/BadUuid.ts
@@ -1,0 +1,10 @@
+import { Column, Entity, PrimaryGeneratedColumn } from "../../../../src"
+
+@Entity()
+export class BadUuid {
+    @PrimaryGeneratedColumn("uuid")
+    id?: string
+
+    @Column({ type: "uuid", length: "36" })
+    uuid: string
+}

--- a/test/github-issues/8832/entity/Address.ts
+++ b/test/github-issues/8832/entity/Address.ts
@@ -1,0 +1,22 @@
+import {
+    Entity,
+    PrimaryGeneratedColumn,
+    Column,
+    ManyToOne,
+} from "../../../../src"
+import { User } from "./User"
+
+@Entity()
+export class Address {
+    @PrimaryGeneratedColumn("increment")
+    id?: number
+
+    @Column()
+    city: string
+
+    @Column()
+    state: string
+
+    @ManyToOne(() => User, (user) => user.addresses)
+    user: User
+}

--- a/test/github-issues/8832/entity/User.ts
+++ b/test/github-issues/8832/entity/User.ts
@@ -17,5 +17,5 @@ export class User {
 
     /** testing generation */
     @Column({ type: "uuid", generated: "uuid" })
-    anotherUuid?: string;
+    anotherUuid?: string
 }

--- a/test/github-issues/8832/entity/User.ts
+++ b/test/github-issues/8832/entity/User.ts
@@ -1,0 +1,16 @@
+import { Column, Entity, PrimaryGeneratedColumn } from "../../../../src"
+
+@Entity()
+export class User {
+    @PrimaryGeneratedColumn("increment")
+    id?: number
+
+    @Column({ type: "uuid", precision: 16 })
+    uuid: string
+
+    @Column({ type: "inet4" })
+    inet4: string
+
+    @Column({ type: "inet6" })
+    inet6: string
+}

--- a/test/github-issues/8832/entity/User.ts
+++ b/test/github-issues/8832/entity/User.ts
@@ -1,12 +1,18 @@
-import { Column, Entity, PrimaryGeneratedColumn } from "../../../../src"
+import {
+    Column,
+    Entity,
+    OneToMany,
+    PrimaryGeneratedColumn,
+} from "../../../../src"
+import { Address } from "./Address"
 
 @Entity()
 export class User {
-    @PrimaryGeneratedColumn("increment")
-    id?: number
+    @PrimaryGeneratedColumn("uuid")
+    id?: string
 
     /** can use a default but testing against mysql since they're shared drivers */
-    @Column({ type: "uuid", precision: 16 })
+    @Column({ type: "uuid" })
     uuid: string
 
     @Column({ type: "inet4" })
@@ -17,5 +23,8 @@ export class User {
 
     /** testing generation */
     @Column({ type: "uuid", generated: "uuid" })
-    anotherUuid?: string
+    another_uuid_field?: string
+
+    @OneToMany(() => Address, (address) => address.user)
+    addresses?: Address[]
 }

--- a/test/github-issues/8832/entity/User.ts
+++ b/test/github-issues/8832/entity/User.ts
@@ -5,6 +5,7 @@ export class User {
     @PrimaryGeneratedColumn("increment")
     id?: number
 
+    /** can use a default but testing against mysql since they're shared drivers */
     @Column({ type: "uuid", precision: 16 })
     uuid: string
 
@@ -13,4 +14,8 @@ export class User {
 
     @Column({ type: "inet6" })
     inet6: string
+
+    /** testing generation */
+    @Column({ type: "uuid", generated: "uuid" })
+    anotherUuid?: string;
 }

--- a/test/github-issues/8832/entity/UuidEntity.ts
+++ b/test/github-issues/8832/entity/UuidEntity.ts
@@ -1,0 +1,7 @@
+import { Entity, PrimaryGeneratedColumn } from "../../../../src"
+
+@Entity()
+export class UuidEntity {
+    @PrimaryGeneratedColumn("uuid")
+    id?: string
+}

--- a/test/github-issues/8832/issue-8832.ts
+++ b/test/github-issues/8832/issue-8832.ts
@@ -116,20 +116,6 @@ describe("github issues > #8832 Add uuid, inet4, and inet6 types for mariadb", (
             ))
     })
 
-    describe("using new mariadb types with mysql driver", () => {
-        it("should throw an error when mysql attempts to use the uuid, inet4, inet6 database types", () =>
-            Promise.all(
-                ["mysql"].map(async (dbType: DatabaseType) => {
-                    return createTestingConnections({
-                        entities: [__dirname + "/entity/*{.js,.ts}"],
-                        schemaCreate: true,
-                        dropSchema: true,
-                        enabledDrivers: [dbType],
-                    }).should.be.rejected
-                }),
-            ))
-    })
-
     describe("entity-metadata-validator", () => {
         it("should throw error if mariadb uuid is supported and length is provided to property", async () => {
             Promise.all(

--- a/test/github-issues/8832/issue-8832.ts
+++ b/test/github-issues/8832/issue-8832.ts
@@ -57,9 +57,11 @@ describe("github issues > #8832 Add uuid, inet4, and inet6 types for mariadb", (
                 }
 
                 expect(foundUser[0].uuid).to.deep.equal(newUser.uuid)
+                expect(foundUser[0].inet4).to.deep.equal(newUser.inet4)
                 expect(foundUser[0].inet6).to.deep.equal(
                     allowsInet6Type ? expectedInet6 : newUser.inet6,
                 )
+                expect(foundUser[0].anotherUuid).to.not.be.undefined
 
                 const columnTypes: { COLUMN_NAME: string, DATA_TYPE: string}[] = await connection.query(`
                     SELECT 
@@ -69,17 +71,18 @@ describe("github issues > #8832 Add uuid, inet4, and inet6 types for mariadb", (
                     WHERE 
                         TABLE_NAME = ? 
                         AND COLUMN_NAME IN (?, ?, ?, ?)
-                `, ["user", "id", "uuid", "inet4", "inet6"]);
+                `, ["user", "id", "uuid", "inet4", "inet6", "anotherUuid"])
                 const expectedColumnTypes: Record<string, string> = {
                     "id": "int",
                     "uuid": allowsUuidType ? "uuid" : "varchar",
                     "inet4": allowsInet4Type ? "inet4" : "varchar",
-                    "inet6": allowsInet6Type ? "inet6" : "varchar"
-                };
+                    "inet6": allowsInet6Type ? "inet6" : "varchar",
+                    "anotherUuid": allowsUuidType ? "uuid" : "varchar",
+                }
 
                 columnTypes.forEach(({ COLUMN_NAME, DATA_TYPE }) => {
                     expect(DATA_TYPE).to.equal(expectedColumnTypes[COLUMN_NAME]);
-                });
+                })
             }),
         ))
 })

--- a/test/github-issues/8832/issue-8832.ts
+++ b/test/github-issues/8832/issue-8832.ts
@@ -18,7 +18,7 @@ describe("github issues > #8832 Add uuid, inet4, and inet6 types for mariadb", (
         inet6: "2001:0db8:0000:0000:0000:ff00:0042:8329",
     }
 
-    const expectedInet6 = "2001:db8::ff00:42:8329";
+    const expectedInet6 = "2001:db8::ff00:42:8329"
 
     before(
         async () =>
@@ -48,12 +48,15 @@ describe("github issues > #8832 Add uuid, inet4, and inet6 types for mariadb", (
                 } = connection
 
                 const { allowsUuidType, allowsInet4Type, allowsInet6Type } = {
-                    allowsUuidType: type === "mariadb" &&
-                    VersionUtils.isGreaterOrEqual(version, "10.7.0"),
-                    allowsInet4Type: type === "mariadb" &&
-                    VersionUtils.isGreaterOrEqual(version, "10.10.0"),
-                    allowsInet6Type: type === "mariadb" &&
-                    VersionUtils.isGreaterOrEqual(version, "10.5.0")
+                    allowsUuidType:
+                        type === "mariadb" &&
+                        VersionUtils.isGreaterOrEqual(version, "10.7.0"),
+                    allowsInet4Type:
+                        type === "mariadb" &&
+                        VersionUtils.isGreaterOrEqual(version, "10.10.0"),
+                    allowsInet6Type:
+                        type === "mariadb" &&
+                        VersionUtils.isGreaterOrEqual(version, "10.5.0"),
                 }
 
                 expect(foundUser[0].uuid).to.deep.equal(newUser.uuid)
@@ -63,7 +66,11 @@ describe("github issues > #8832 Add uuid, inet4, and inet6 types for mariadb", (
                 )
                 expect(foundUser[0].anotherUuid).to.not.be.undefined
 
-                const columnTypes: { COLUMN_NAME: string, DATA_TYPE: string}[] = await connection.query(`
+                const columnTypes: {
+                    COLUMN_NAME: string
+                    DATA_TYPE: string
+                }[] = await connection.query(
+                    `
                     SELECT 
                         COLUMN_NAME,
                         DATA_TYPE 
@@ -71,17 +78,19 @@ describe("github issues > #8832 Add uuid, inet4, and inet6 types for mariadb", (
                     WHERE 
                         TABLE_NAME = ? 
                         AND COLUMN_NAME IN (?, ?, ?, ?)
-                `, ["user", "id", "uuid", "inet4", "inet6", "anotherUuid"])
+                `,
+                    ["user", "id", "uuid", "inet4", "inet6", "anotherUuid"],
+                )
                 const expectedColumnTypes: Record<string, string> = {
-                    "id": "int",
-                    "uuid": allowsUuidType ? "uuid" : "varchar",
-                    "inet4": allowsInet4Type ? "inet4" : "varchar",
-                    "inet6": allowsInet6Type ? "inet6" : "varchar",
-                    "anotherUuid": allowsUuidType ? "uuid" : "varchar",
+                    id: "int",
+                    uuid: allowsUuidType ? "uuid" : "varchar",
+                    inet4: allowsInet4Type ? "inet4" : "varchar",
+                    inet6: allowsInet6Type ? "inet6" : "varchar",
+                    anotherUuid: allowsUuidType ? "uuid" : "varchar",
                 }
 
                 columnTypes.forEach(({ COLUMN_NAME, DATA_TYPE }) => {
-                    expect(DATA_TYPE).to.equal(expectedColumnTypes[COLUMN_NAME]);
+                    expect(DATA_TYPE).to.equal(expectedColumnTypes[COLUMN_NAME])
                 })
             }),
         ))

--- a/test/github-issues/8832/issue-8832.ts
+++ b/test/github-issues/8832/issue-8832.ts
@@ -1,0 +1,85 @@
+import "../../utils/test-setup"
+import {
+    createTestingConnections,
+    closeTestingConnections,
+    reloadTestingDatabases,
+} from "../../utils/test-utils"
+import { DataSource } from "../../../src/index"
+import { expect } from "chai"
+import { User } from "../8832/entity/User"
+import { VersionUtils } from "../../../src/util/VersionUtils"
+
+describe("github issues > #8832 Add uuid, inet4, and inet6 types for mariadb", () => {
+    let connections: DataSource[]
+
+    const newUser: User = {
+        uuid: "ceb2897c-a1cf-11ed-8dbd-040300000000",
+        inet4: "192.0.2.146",
+        inet6: "2001:0db8:0000:0000:0000:ff00:0042:8329",
+    }
+
+    const expectedInet6 = "2001:db8::ff00:42:8329";
+
+    before(
+        async () =>
+            (connections = await createTestingConnections({
+                entities: [__dirname + "/entity/*{.js,.ts}"],
+                schemaCreate: true,
+                dropSchema: true,
+                enabledDrivers: ["mysql", "mariadb"],
+            })),
+    )
+    beforeEach(() => reloadTestingDatabases(connections))
+    after(() => closeTestingConnections(connections))
+
+    it("should create table with uuid type set to column for relevant mariadb versions", () =>
+        Promise.all(
+            connections.map(async (connection) => {
+                const userRepository = connection.getRepository(User)
+
+                const savedUser = await userRepository.save(newUser)
+
+                const foundUser = await userRepository.find({
+                    where: { id: savedUser.id },
+                })
+                const {
+                    options: { type },
+                    driver: { version = "0.0.0" },
+                } = connection
+
+                const { allowsUuidType, allowsInet4Type, allowsInet6Type } = {
+                    allowsUuidType: type === "mariadb" &&
+                    VersionUtils.isGreaterOrEqual(version, "10.7.0"),
+                    allowsInet4Type: type === "mariadb" &&
+                    VersionUtils.isGreaterOrEqual(version, "10.10.0"),
+                    allowsInet6Type: type === "mariadb" &&
+                    VersionUtils.isGreaterOrEqual(version, "10.5.0")
+                }
+
+                expect(foundUser[0].uuid).to.deep.equal(newUser.uuid)
+                expect(foundUser[0].inet6).to.deep.equal(
+                    allowsInet6Type ? expectedInet6 : newUser.inet6,
+                )
+
+                const columnTypes: { COLUMN_NAME: string, DATA_TYPE: string}[] = await connection.query(`
+                    SELECT 
+                        COLUMN_NAME,
+                        DATA_TYPE 
+                    FROM INFORMATION_SCHEMA.COLUMNS 
+                    WHERE 
+                        TABLE_NAME = ? 
+                        AND COLUMN_NAME IN (?, ?, ?, ?)
+                `, ["user", "id", "uuid", "inet4", "inet6"]);
+                const expectedColumnTypes: Record<string, string> = {
+                    "id": "int",
+                    "uuid": allowsUuidType ? "uuid" : "varchar",
+                    "inet4": allowsInet4Type ? "inet4" : "varchar",
+                    "inet6": allowsInet6Type ? "inet6" : "varchar"
+                };
+
+                columnTypes.forEach(({ COLUMN_NAME, DATA_TYPE }) => {
+                    expect(DATA_TYPE).to.equal(expectedColumnTypes[COLUMN_NAME]);
+                });
+            }),
+        ))
+})

--- a/test/github-issues/8832/issue-8832.ts
+++ b/test/github-issues/8832/issue-8832.ts
@@ -4,94 +4,291 @@ import {
     closeTestingConnections,
     reloadTestingDatabases,
 } from "../../utils/test-utils"
-import { DataSource } from "../../../src/index"
+import {
+    Column,
+    DatabaseType,
+    DataSource,
+    Entity,
+    PrimaryGeneratedColumn,
+    TypeORMError,
+} from "../../../src/index"
 import { expect } from "chai"
 import { User } from "../8832/entity/User"
 import { VersionUtils } from "../../../src/util/VersionUtils"
+import { Address } from "./entity/Address"
+
+function getSupportedTypesMap(
+    type: DatabaseType,
+    version: string,
+): {
+    allowsUuidType: boolean
+    allowsInet4Type: boolean
+    allowsInet6Type: boolean
+} {
+    return {
+        allowsUuidType:
+            type === "mariadb" &&
+            VersionUtils.isGreaterOrEqual(version, "10.7.0"),
+        allowsInet4Type:
+            type === "mariadb" &&
+            VersionUtils.isGreaterOrEqual(version, "10.10.0"),
+        allowsInet6Type:
+            type === "mariadb" &&
+            VersionUtils.isGreaterOrEqual(version, "10.5.0"),
+    }
+}
 
 describe("github issues > #8832 Add uuid, inet4, and inet6 types for mariadb", () => {
     let connections: DataSource[]
 
-    const newUser: User = {
-        uuid: "ceb2897c-a1cf-11ed-8dbd-040300000000",
-        inet4: "192.0.2.146",
-        inet6: "2001:0db8:0000:0000:0000:ff00:0042:8329",
-    }
+    afterEach(() => closeTestingConnections(connections))
 
-    const expectedInet6 = "2001:db8::ff00:42:8329"
+    describe("basic use of new maria db types", () => {
+        const newUser: User = {
+            uuid: "ceb2897c-a1cf-11ed-8dbd-040300000000",
+            inet4: "192.0.2.146",
+            inet6: "2001:0db8:0000:0000:0000:ff00:0042:8329",
+        }
 
-    before(
-        async () =>
-            (connections = await createTestingConnections({
-                entities: [__dirname + "/entity/*{.js,.ts}"],
+        const expectedInet6 = "2001:db8::ff00:42:8329"
+
+        before(
+            async () =>
+                (connections = await createTestingConnections({
+                    entities: [__dirname + "/entity/*{.js,.ts}"],
+                    schemaCreate: true,
+                    dropSchema: true,
+                    enabledDrivers: ["mysql", "mariadb"],
+                })),
+        )
+        beforeEach(() => reloadTestingDatabases(connections))
+
+        it("should create table with uuid type set to column for relevant mariadb versions", () =>
+            Promise.all(
+                connections.map(async (connection) => {
+                    const userRepository = connection.getRepository(User)
+
+                    // seems there is an issue with the persisting id that crosses over from mysql to mariadb
+                    await userRepository.save(newUser)
+
+                    const savedUser = await userRepository.findOneOrFail({
+                        where: { uuid: newUser.uuid },
+                    })
+
+                    const foundUser = await userRepository.findOne({
+                        where: { id: savedUser.id },
+                    })
+
+                    const {
+                        options: { type },
+                        driver: { version = "0.0.0" },
+                    } = connection
+
+                    const { allowsUuidType, allowsInet4Type, allowsInet6Type } =
+                        getSupportedTypesMap(type, version)
+
+                    expect(foundUser).to.not.be.null
+                    expect(foundUser!.uuid).to.deep.equal(newUser.uuid)
+                    expect(foundUser!.inet4).to.deep.equal(newUser.inet4)
+                    expect(foundUser!.inet6).to.deep.equal(
+                        allowsInet6Type ? expectedInet6 : newUser.inet6,
+                    )
+                    expect(foundUser!.another_uuid_field).to.not.be.undefined
+
+                    const columnTypes: {
+                        COLUMN_NAME: string
+                        DATA_TYPE: string
+                    }[] = await connection.query(
+                        `
+                        SELECT 
+                            COLUMN_NAME,
+                            DATA_TYPE 
+                        FROM INFORMATION_SCHEMA.COLUMNS 
+                        WHERE
+                            TABLE_SCHEMA = ?
+                            AND TABLE_NAME = ? 
+                            AND COLUMN_NAME IN (?, ?, ?, ?)
+                    `,
+                        [
+                            connection.driver.database,
+                            "user",
+                            "id",
+                            "uuid",
+                            "inet4",
+                            "inet6",
+                            "anotherUuid",
+                        ],
+                    )
+                    const expectedColumnTypes: Record<string, string> = {
+                        id: allowsUuidType ? "uuid" : "varchar",
+                        uuid: allowsUuidType ? "uuid" : "varchar",
+                        inet4: allowsInet4Type ? "inet4" : "varchar",
+                        inet6: allowsInet6Type ? "inet6" : "varchar",
+                        another_uuid_field: allowsUuidType ? "uuid" : "varchar",
+                    }
+
+                    columnTypes.forEach(({ COLUMN_NAME, DATA_TYPE }) => {
+                        expect(DATA_TYPE).to.equal(
+                            expectedColumnTypes[COLUMN_NAME],
+                        )
+                    })
+
+                    // save a relation
+                    const addressRepository = connection.getRepository(Address)
+
+                    const newAddress: Address = {
+                        city: "Codersville",
+                        state: "Coderado",
+                        user: foundUser!,
+                    }
+
+                    await addressRepository.save(newAddress)
+
+                    const foundAddress = await addressRepository.findOne({
+                        where: { user: { id: foundUser!.id } },
+                    })
+
+                    expect(foundAddress).to.not.be.null
+                }),
+            ))
+    })
+
+    describe("errors using incorrect properties for maria db supported types", () => {
+        @Entity()
+        class BadUuidEntity {
+            @PrimaryGeneratedColumn("uuid")
+            id?: string
+
+            @Column({ type: "uuid", length: "36" })
+            badUuid: string
+        }
+
+        @Entity()
+        class BadInet4Entity {
+            @PrimaryGeneratedColumn("uuid")
+            id?: string
+
+            @Column({ type: "inet4", length: "28" })
+            badinet4: string
+        }
+
+        @Entity()
+        class BadInet6Entity {
+            @PrimaryGeneratedColumn("uuid")
+            id?: string
+
+            @Column({ type: "inet6", length: "28" })
+            badinet6: string
+        }
+
+        afterEach(() => closeTestingConnections(connections))
+
+        it("should throw error when validating uuid type with a length provided only for mariadb", async () => {
+            const expectedError = new TypeORMError(
+                `Column badUuid of Entity BadUuidEntity does not support length property.`,
+            )
+
+            await createTestingConnections({
+                entities: [BadUuidEntity],
                 schemaCreate: true,
                 dropSchema: true,
-                enabledDrivers: ["mysql", "mariadb"],
-            })),
-    )
-    beforeEach(() => reloadTestingDatabases(connections))
-    after(() => closeTestingConnections(connections))
-
-    it("should create table with uuid type set to column for relevant mariadb versions", () =>
-        Promise.all(
-            connections.map(async (connection) => {
-                const userRepository = connection.getRepository(User)
-
-                const savedUser = await userRepository.save(newUser)
-
-                const foundUser = await userRepository.find({
-                    where: { id: savedUser.id },
+                enabledDrivers: ["mariadb"],
+            })
+                .then(() => {
+                    expect.fail(
+                        null,
+                        null,
+                        "creating the connection did not reject with an error",
+                    )
                 })
-                const {
-                    options: { type },
-                    driver: { version = "0.0.0" },
-                } = connection
-
-                const { allowsUuidType, allowsInet4Type, allowsInet6Type } = {
-                    allowsUuidType:
-                        type === "mariadb" &&
-                        VersionUtils.isGreaterOrEqual(version, "10.7.0"),
-                    allowsInet4Type:
-                        type === "mariadb" &&
-                        VersionUtils.isGreaterOrEqual(version, "10.10.0"),
-                    allowsInet6Type:
-                        type === "mariadb" &&
-                        VersionUtils.isGreaterOrEqual(version, "10.5.0"),
-                }
-
-                expect(foundUser[0].uuid).to.deep.equal(newUser.uuid)
-                expect(foundUser[0].inet4).to.deep.equal(newUser.inet4)
-                expect(foundUser[0].inet6).to.deep.equal(
-                    allowsInet6Type ? expectedInet6 : newUser.inet6,
-                )
-                expect(foundUser[0].anotherUuid).to.not.be.undefined
-
-                const columnTypes: {
-                    COLUMN_NAME: string
-                    DATA_TYPE: string
-                }[] = await connection.query(
-                    `
-                    SELECT 
-                        COLUMN_NAME,
-                        DATA_TYPE 
-                    FROM INFORMATION_SCHEMA.COLUMNS 
-                    WHERE 
-                        TABLE_NAME = ? 
-                        AND COLUMN_NAME IN (?, ?, ?, ?)
-                `,
-                    ["user", "id", "uuid", "inet4", "inet6", "anotherUuid"],
-                )
-                const expectedColumnTypes: Record<string, string> = {
-                    id: "int",
-                    uuid: allowsUuidType ? "uuid" : "varchar",
-                    inet4: allowsInet4Type ? "inet4" : "varchar",
-                    inet6: allowsInet6Type ? "inet6" : "varchar",
-                    anotherUuid: allowsUuidType ? "uuid" : "varchar",
-                }
-
-                columnTypes.forEach(({ COLUMN_NAME, DATA_TYPE }) => {
-                    expect(DATA_TYPE).to.equal(expectedColumnTypes[COLUMN_NAME])
+                .catch((err) => {
+                    expect(err.message).to.equal(expectedError.message)
                 })
-            }),
-        ))
+
+            await createTestingConnections({
+                entities: [BadUuidEntity],
+                schemaCreate: true,
+                dropSchema: true,
+                enabledDrivers: ["mysql"],
+            }).catch(() => {
+                expect.fail(
+                    null,
+                    null,
+                    "creating the connection threw an unexpected error",
+                )
+            })
+        })
+
+        it("should throw error when validating inet4 type with a length provided only for mariadb", async () => {
+            const expectedError = new TypeORMError(
+                `Column badinet4 of Entity BadInet4Entity does not support length property.`,
+            )
+
+            await createTestingConnections({
+                entities: [BadInet4Entity],
+                schemaCreate: true,
+                dropSchema: true,
+                enabledDrivers: ["mariadb"],
+            })
+                .then(() => {
+                    expect.fail(
+                        null,
+                        null,
+                        "creating the connection did not reject with an error",
+                    )
+                })
+                .catch((err) => {
+                    expect(err.message).to.equal(expectedError.message)
+                })
+
+            connections = await createTestingConnections({
+                entities: [BadInet4Entity],
+                schemaCreate: true,
+                dropSchema: true,
+                enabledDrivers: ["mysql"],
+            }).catch(() => {
+                expect.fail(
+                    null,
+                    null,
+                    "creating the connection threw an unexpected error",
+                )
+            })
+        })
+
+        it("should throw error when validating inet6 type with a length provided", async () => {
+            const expectedError = new TypeORMError(
+                `Column badinet6 of Entity BadInet6Entity does not support length property.`,
+            )
+
+            await createTestingConnections({
+                entities: [BadInet6Entity],
+                schemaCreate: true,
+                dropSchema: true,
+                enabledDrivers: ["mariadb"],
+            })
+                .then(() => {
+                    expect.fail(
+                        null,
+                        null,
+                        "creating the connection did not reject with an error",
+                    )
+                })
+                .catch((err) => {
+                    expect(err.message).to.equal(expectedError.message)
+                })
+
+            connections = await createTestingConnections({
+                entities: [BadInet6Entity],
+                schemaCreate: true,
+                dropSchema: true,
+                enabledDrivers: ["mysql"],
+            }).catch(() => {
+                expect.fail(
+                    null,
+                    null,
+                    "creating the connection threw an unexpected error",
+                )
+            })
+        })
+    })
 })

--- a/test/github-issues/8832/issue-8832.ts
+++ b/test/github-issues/8832/issue-8832.ts
@@ -4,28 +4,14 @@ import {
     closeTestingConnections,
     reloadTestingDatabases,
 } from "../../utils/test-utils"
-import {
-    Column,
-    DatabaseType,
-    DataSource,
-    Entity,
-    PrimaryGeneratedColumn,
-    TypeORMError,
-} from "../../../src/index"
+import { Column, DatabaseType, DataSource, Entity, PrimaryGeneratedColumn, TypeORMError } from "../../../src/index"
 import { expect } from "chai"
 import { User } from "../8832/entity/User"
 import { VersionUtils } from "../../../src/util/VersionUtils"
 import { Address } from "./entity/Address"
 
-function getSupportedTypesMap(
-    type: DatabaseType,
-    version: string,
-): {
-    allowsUuidType: boolean
-    allowsInet4Type: boolean
-    allowsInet6Type: boolean
-} {
-    return {
+function getSupportedTypesMap(type: DatabaseType, version: string): { allowsUuidType: boolean, allowsInet4Type: boolean; allowsInet6Type: boolean} {
+   return {
         allowsUuidType:
             type === "mariadb" &&
             VersionUtils.isGreaterOrEqual(version, "10.7.0"),
@@ -36,6 +22,7 @@ function getSupportedTypesMap(
             type === "mariadb" &&
             VersionUtils.isGreaterOrEqual(version, "10.5.0"),
     }
+
 }
 
 describe("github issues > #8832 Add uuid, inet4, and inet6 types for mariadb", () => {
@@ -49,44 +36,44 @@ describe("github issues > #8832 Add uuid, inet4, and inet6 types for mariadb", (
             inet4: "192.0.2.146",
             inet6: "2001:0db8:0000:0000:0000:ff00:0042:8329",
         }
-
+    
         const expectedInet6 = "2001:db8::ff00:42:8329"
-
+    
         before(
             async () =>
                 (connections = await createTestingConnections({
                     entities: [__dirname + "/entity/*{.js,.ts}"],
                     schemaCreate: true,
                     dropSchema: true,
-                    enabledDrivers: ["mysql", "mariadb"],
+                    enabledDrivers: ["mysql", "mariadb"], 
                 })),
         )
         beforeEach(() => reloadTestingDatabases(connections))
-
+    
         it("should create table with uuid type set to column for relevant mariadb versions", () =>
             Promise.all(
                 connections.map(async (connection) => {
+                    
                     const userRepository = connection.getRepository(User)
-
+    
                     // seems there is an issue with the persisting id that crosses over from mysql to mariadb
                     await userRepository.save(newUser)
-
+    
                     const savedUser = await userRepository.findOneOrFail({
                         where: { uuid: newUser.uuid },
                     })
-
+    
                     const foundUser = await userRepository.findOne({
                         where: { id: savedUser.id },
                     })
-
+    
                     const {
                         options: { type },
                         driver: { version = "0.0.0" },
                     } = connection
 
-                    const { allowsUuidType, allowsInet4Type, allowsInet6Type } =
-                        getSupportedTypesMap(type, version)
-
+                    const { allowsUuidType, allowsInet4Type, allowsInet6Type } = getSupportedTypesMap(type, version);
+    
                     expect(foundUser).to.not.be.null
                     expect(foundUser!.uuid).to.deep.equal(newUser.uuid)
                     expect(foundUser!.inet4).to.deep.equal(newUser.inet4)
@@ -94,7 +81,7 @@ describe("github issues > #8832 Add uuid, inet4, and inet6 types for mariadb", (
                         allowsInet6Type ? expectedInet6 : newUser.inet6,
                     )
                     expect(foundUser!.another_uuid_field).to.not.be.undefined
-
+    
                     const columnTypes: {
                         COLUMN_NAME: string
                         DATA_TYPE: string
@@ -109,15 +96,7 @@ describe("github issues > #8832 Add uuid, inet4, and inet6 types for mariadb", (
                             AND TABLE_NAME = ? 
                             AND COLUMN_NAME IN (?, ?, ?, ?)
                     `,
-                        [
-                            connection.driver.database,
-                            "user",
-                            "id",
-                            "uuid",
-                            "inet4",
-                            "inet6",
-                            "anotherUuid",
-                        ],
+                        [connection.driver.database, "user", "id", "uuid", "inet4", "inet6", "anotherUuid"],
                     )
                     const expectedColumnTypes: Record<string, string> = {
                         id: allowsUuidType ? "uuid" : "varchar",
@@ -126,15 +105,13 @@ describe("github issues > #8832 Add uuid, inet4, and inet6 types for mariadb", (
                         inet6: allowsInet6Type ? "inet6" : "varchar",
                         another_uuid_field: allowsUuidType ? "uuid" : "varchar",
                     }
-
+    
                     columnTypes.forEach(({ COLUMN_NAME, DATA_TYPE }) => {
-                        expect(DATA_TYPE).to.equal(
-                            expectedColumnTypes[COLUMN_NAME],
-                        )
+                        expect(DATA_TYPE).to.equal(expectedColumnTypes[COLUMN_NAME])
                     })
 
                     // save a relation
-                    const addressRepository = connection.getRepository(Address)
+                    const addressRepository = connection.getRepository(Address);
 
                     const newAddress: Address = {
                         city: "Codersville",
@@ -152,14 +129,14 @@ describe("github issues > #8832 Add uuid, inet4, and inet6 types for mariadb", (
                 }),
             ))
     })
-
-    describe("errors using incorrect properties for maria db supported types", () => {
+    
+    describe("mariadb entity manager metadata validations for uuid, inet4, inet6 types", () => {
         @Entity()
         class BadUuidEntity {
             @PrimaryGeneratedColumn("uuid")
             id?: string
 
-            @Column({ type: "uuid", length: "36" })
+            @Column({ type: "uuid",  length: "36"})
             badUuid: string
         }
 
@@ -168,7 +145,7 @@ describe("github issues > #8832 Add uuid, inet4, and inet6 types for mariadb", (
             @PrimaryGeneratedColumn("uuid")
             id?: string
 
-            @Column({ type: "inet4", length: "28" })
+            @Column({ type: "inet4",  length: "28"})
             badinet4: string
         }
 
@@ -177,7 +154,7 @@ describe("github issues > #8832 Add uuid, inet4, and inet6 types for mariadb", (
             @PrimaryGeneratedColumn("uuid")
             id?: string
 
-            @Column({ type: "inet6", length: "28" })
+            @Column({ type: "inet6",  length: "28"})
             badinet6: string
         }
 
@@ -193,29 +170,23 @@ describe("github issues > #8832 Add uuid, inet4, and inet6 types for mariadb", (
                 schemaCreate: true,
                 dropSchema: true,
                 enabledDrivers: ["mariadb"],
+            }).then((conns) => {
+                if (conns.some((conn) => getSupportedTypesMap(conn.options.type, conn.driver.version ?? "0.0.0").allowsUuidType)) {
+                    expect.fail(null, null, 'creating the connection did not reject with an error')
+                }
             })
-                .then(() => {
-                    expect.fail(
-                        null,
-                        null,
-                        "creating the connection did not reject with an error",
-                    )
-                })
-                .catch((err) => {
-                    expect(err.message).to.equal(expectedError.message)
-                })
+            .catch((err) => {
+                expect(err.message).to.equal(expectedError.message)
+            })
 
             await createTestingConnections({
                 entities: [BadUuidEntity],
                 schemaCreate: true,
                 dropSchema: true,
                 enabledDrivers: ["mysql"],
-            }).catch(() => {
-                expect.fail(
-                    null,
-                    null,
-                    "creating the connection threw an unexpected error",
-                )
+            })
+            .catch(() => {
+                expect.fail(null, null, 'creating the connection threw an unexpected error')
             })
         })
 
@@ -229,29 +200,23 @@ describe("github issues > #8832 Add uuid, inet4, and inet6 types for mariadb", (
                 schemaCreate: true,
                 dropSchema: true,
                 enabledDrivers: ["mariadb"],
+            }).then((conns) => {
+                if (conns.some((conn) => getSupportedTypesMap(conn.options.type, conn.driver.version ?? "0.0.0").allowsInet4Type)) {
+                    expect.fail(null, null, 'creating the connection did not reject with an error')
+                }
             })
-                .then(() => {
-                    expect.fail(
-                        null,
-                        null,
-                        "creating the connection did not reject with an error",
-                    )
-                })
-                .catch((err) => {
-                    expect(err.message).to.equal(expectedError.message)
-                })
+            .catch((err) => {
+                expect(err.message).to.equal(expectedError.message)
+            })
 
             connections = await createTestingConnections({
                 entities: [BadInet4Entity],
                 schemaCreate: true,
                 dropSchema: true,
                 enabledDrivers: ["mysql"],
-            }).catch(() => {
-                expect.fail(
-                    null,
-                    null,
-                    "creating the connection threw an unexpected error",
-                )
+            })
+            .catch(() => {
+                expect.fail(null, null, 'creating the connection threw an unexpected error')
             })
         })
 
@@ -265,29 +230,23 @@ describe("github issues > #8832 Add uuid, inet4, and inet6 types for mariadb", (
                 schemaCreate: true,
                 dropSchema: true,
                 enabledDrivers: ["mariadb"],
+            }).then((conns) => {
+                if (conns.some((conn) => getSupportedTypesMap(conn.options.type, conn.driver.version ?? "0.0.0").allowsInet6Type)) {
+                    expect.fail(null, null, 'creating the connection did not reject with an error')
+                }
             })
-                .then(() => {
-                    expect.fail(
-                        null,
-                        null,
-                        "creating the connection did not reject with an error",
-                    )
-                })
-                .catch((err) => {
-                    expect(err.message).to.equal(expectedError.message)
-                })
+            .catch((err) => {
+                expect(err.message).to.equal(expectedError.message)
+            })
 
             connections = await createTestingConnections({
                 entities: [BadInet6Entity],
                 schemaCreate: true,
                 dropSchema: true,
                 enabledDrivers: ["mysql"],
-            }).catch(() => {
-                expect.fail(
-                    null,
-                    null,
-                    "creating the connection threw an unexpected error",
-                )
+            })
+            .catch(() => {
+                expect.fail(null, null, 'creating the connection threw an unexpected error')
             })
         })
     })

--- a/test/github-issues/8832/issue-8832.ts
+++ b/test/github-issues/8832/issue-8832.ts
@@ -4,7 +4,7 @@ import {
     closeTestingConnections,
     reloadTestingDatabases,
 } from "../../utils/test-utils"
-import { DatabaseType, DataSource } from "../../../src/index"
+import { DataSource } from "../../../src/index"
 import { expect } from "chai"
 import { User } from "../8832/entity/User"
 import { Address } from "./entity/Address"


### PR DESCRIPTION
<!--
  😀 Wonderful!  Thank you for opening a pull request for TypeORM.

  Please fill in the information below to expedite the review
  and (hopefully) merge of your change.

  If unsure about something.. just do as best as you're able,
  or reach out through our community support channels!
  https://github.com/typeorm/typeorm/blob/master/docs/support.md
-->

### Description of change

Fixes #8832

Adds uuid, inet4, inet6 column data types for appropriate mariadb versions
<!--
  Please be clear and concise what the change is intended to do,
  why this change is needed, and how you've verified that it
  corrects what you intended.

  In some cases it may be helpful to include the current behavior
  and the new behavior.

  If the change is related to an open issue, you can link it here.
  If you include `Fixes #8832` (replacing `0000` with the issue number)
  when this is merged it will automatically mark the issue as fixed and
  close it.
-->


### Pull-Request Checklist

<!--
  Please make sure to review and check all of the following.

  If an item is not applicable, you can add "N/A" to the end.
-->

- [x] Code is up-to-date with the `master` branch
- [x] `npm run format` to apply prettier formatting
- [x] `npm run test` passes with this change
- [x] This pull request links relevant issues as `Fixes #0000`
- [x] There are new or updated unit tests validating the change
- [x] Documentation has been updated to reflect this change
- [x] The new commits follow conventions explained in [CONTRIBUTING.md](https://github.com/typeorm/typeorm/blob/master/CONTRIBUTING.md)

<!--
  🎉 Thank you for contributing and making TypeORM even better!
-->
