### PR TITLE
Added a documentation section on debugging query builder

### DIFF
--- a/docs/select-query-builder.md
+++ b/docs/select-query-builder.md
@@ -1277,7 +1277,7 @@ For another supported timestamp arguments and additional information please refe
 
 ## Debugging
 
-You can get the generated SQL frome the query builder by calling `getQuery()` or `getQueryAndParameters()`.
+You can get the generated SQL from the query builder by calling `getQuery()` or `getQueryAndParameters()`.
 
 If you just want the query you can use `getQuery()`
 

--- a/docs/select-query-builder.md
+++ b/docs/select-query-builder.md
@@ -1282,7 +1282,7 @@ You can get the generated SQL frome the query builder by calling `getQuery()` or
 If you just want the query you can use `getQuery()`
 
 ```typescript
-const sql = dataSource
+const sql = await dataSource
     .getRepository(User)
     .createQueryBuilder("user")
     .where("user.id = :id", { id: 1 })
@@ -1298,7 +1298,7 @@ SELECT `user`.`id` as `userId`, `user`.`firstName` as `userFirstName`, `user`.`l
 Or if you want the query and the parameters you can get an array back using `getQueryAndParameters()`
 
 ```typescript
-const queryAndParams = dataSource
+const queryAndParams = await dataSource
     .getRepository(User)
     .createQueryBuilder("user")
     .where("user.id = :id", { id: 1 })

--- a/docs/select-query-builder.md
+++ b/docs/select-query-builder.md
@@ -28,6 +28,7 @@
 -   [Using subqueries](#using-subqueries)
 -   [Hidden Columns](#hidden-columns)
 -   [Querying Deleted rows](#querying-deleted-rows)
+-   [Debugging](#debugging)
 
 ## What is `QueryBuilder`
 
@@ -1273,3 +1274,43 @@ console.log(account)
 By default `timeTravelQuery()` uses `follower_read_timestamp()` function if no arguments passed.
 For another supported timestamp arguments and additional information please refer to
 [CockroachDB](https://www.cockroachlabs.com/docs/stable/as-of-system-time.html) docs.
+
+## Debugging
+
+You can get the generated SQL frome the query builder by calling `getQuery()` or `getQueryAndParameters()`.
+
+If you just want the query you can use `getQuery()`
+
+```typescript
+const sql = dataSource
+    .getRepository(User)
+    .createQueryBuilder("user")
+    .where("user.id = :id", { id: 1 })
+    .getQuery()
+```
+
+Which results in:
+
+```sql
+SELECT `user`.`id` as `userId`, `user`.`firstName` as `userFirstName`, `user`.`lastName` as `userLastName` FROM `users` `user` WHERE `user`.`id` = ?
+```
+
+Or if you want the query and the parameters you can get an array back using `getQueryAndParameters()`
+
+```typescript
+const queryAndParams = dataSource
+    .getRepository(User)
+    .createQueryBuilder("user")
+    .where("user.id = :id", { id: 1 })
+    .getQueryAndParameters()
+```
+
+Which results in:
+
+```typescript
+[
+ "SELECT `user`.`id` as `userId`, `user`.`firstName` as `userFirstName`, `user`.`lastName` as `userLastName` FROM `users` `user` WHERE `user`.`id` = ?",
+ [ 1 ]
+]
+```
+


### PR DESCRIPTION
### Description of change

It covers using getQuery() and getQueryAndParameters() which are both useful when trying to figure out why your query isn't doing what you might expect it should do.

I added it because I had to go digging through the source code to find out that these wonderful methods existed, and wanted to save future users the same hassle.


### Pull-Request Checklist

- [x] Code is up-to-date with the `master` branch
- [ ] `npm run format` to apply prettier formatting N/A
- [ ] `npm run test` passes with this change N/A
- [ ] This pull request links relevant issues as `Fixes #0000` N/A
- [ ] There are new or updated unit tests validating the change N/A
- [x] Documentation has been updated to reflect this change
- [x] The new commits follow conventions explained in [CONTRIBUTING.md](https://github.com/typeorm/typeorm/blob/master/CONTRIBUTING.md)


