### PR TITLE
fix: EntityNotFound error message in QueryBuilder.findOneOrFail

### DIFF
--- a/src/query-builder/SelectQueryBuilder.ts
+++ b/src/query-builder/SelectQueryBuilder.ts
@@ -1734,7 +1734,7 @@ export class SelectQueryBuilder<Entity extends ObjectLiteral>
         if (!entity) {
             throw new EntityNotFoundError(
                 this.expressionMap.mainAlias!.target,
-                this,
+                this.expressionMap.parameters,
             )
         }
 

--- a/test/functional/query-builder/select/query-builder-select.ts
+++ b/test/functional/query-builder/select/query-builder-select.ts
@@ -7,7 +7,6 @@ import {
 import { expect } from "chai"
 import {
     DataSource,
-    EntityNotFoundError,
     In,
     IsNull,
     Raw,

--- a/test/functional/query-builder/select/query-builder-select.ts
+++ b/test/functional/query-builder/select/query-builder-select.ts
@@ -5,12 +5,7 @@ import {
     reloadTestingDatabases,
 } from "../../../utils/test-utils"
 import { expect } from "chai"
-import {
-    DataSource,
-    In,
-    IsNull,
-    Raw,
-} from "../../../../src"
+import { DataSource, In, IsNull, Raw } from "../../../../src"
 import { Category } from "./entity/Category"
 import { Post } from "./entity/Post"
 import { Tag } from "./entity/Tag"

--- a/test/functional/query-builder/select/query-builder-select.ts
+++ b/test/functional/query-builder/select/query-builder-select.ts
@@ -522,7 +522,7 @@ describe("query builder > select", () => {
                             .createQueryBuilder(Post, "post")
                             .where("post.id = :id", { id: "2" })
                             .getOneOrFail(),
-                    ).to.be.rejectedWith(EntityNotFoundError)
+                    ).to.be.rejectedWith("")
                 }),
             ))
     })


### PR DESCRIPTION
### Description of change

Fixes the error message that is thrown on `QueryBuilder.findOneOrFail` if no entity is found.
Currently, a message like `Could not find any entity of type "Organization" matching: [object Object]` is displayed in that case.  This happens because `this` is passed to the error constructor, instead of the parameters that did not return a result.

### Pull-Request Checklist

<!--
  Please make sure to review and check all of the following.

  If an item is not applicable, you can add "N/A" to the end.
-->

- [x] Code is up-to-date with the `master` branch
- [x] `npm run format` to apply prettier formatting
- [x] `npm run test` passes with this change
- [ ] This pull request links relevant issues as `Fixes #0000` N/A
- [ ] There are new or updated unit tests validating the change N/A
- [ ] Documentation has been updated to reflect this change N/A
- [x] The new commits follow conventions explained in [CONTRIBUTING.md](https://github.com/typeorm/typeorm/blob/master/CONTRIBUTING.md)

