### PR TITLE
fix: loading tables with fk in sqlite query runner

### DIFF
--- a/src/driver/sqlite-abstract/AbstractSqliteQueryRunner.ts
+++ b/src/driver/sqlite-abstract/AbstractSqliteQueryRunner.ts
@@ -1570,7 +1570,7 @@ export abstract class AbstractSqliteQueryRunner
                         )
 
                         return new TableForeignKey({
-                            name: fkMapping!.name,
+                            name: fkMapping?.name,
                             columnNames: columnNames,
                             referencedTableName: foreignKey["table"],
                             referencedColumnNames: referencedColumnNames,

--- a/test/github-issues/9266/issue-9266.ts
+++ b/test/github-issues/9266/issue-9266.ts
@@ -1,0 +1,33 @@
+import { expect } from "chai"
+import "reflect-metadata"
+import { DataSource } from "../../../src/data-source/DataSource"
+import {
+    closeTestingConnections,
+    createTestingConnections,
+    reloadTestingDatabases,
+} from "../../utils/test-utils"
+
+describe("github issues > #9266 queryRunner.getTable() fails if Foreign Key is set in target table", () => {
+    let connections: DataSource[]
+    before(async () => {
+        connections = await createTestingConnections({
+            migrations: [__dirname + "/migrations/*{.js,.ts}"],
+            enabledDrivers: ["sqlite", "better-sqlite3"],
+        })
+    })
+    beforeEach(() => reloadTestingDatabases(connections))
+    after(() => closeTestingConnections(connections))
+
+    it("should be able to load tables", () =>
+        Promise.all(
+            connections.map(async (connection) => {
+                await connection.runMigrations()
+                const queryRunner = connection.createQueryRunner()
+                const tables = await queryRunner.getTables()
+                const tableNames = tables.map((table) => table.name)
+                expect(tableNames).to.include("author")
+                expect(tableNames).to.include("post")
+                await queryRunner.release()
+            }),
+        ))
+})

--- a/test/github-issues/9266/migrations/init.ts
+++ b/test/github-issues/9266/migrations/init.ts
@@ -1,0 +1,15 @@
+import { MigrationInterface, QueryRunner } from "../../../../src"
+
+export class CreateDatabase implements MigrationInterface {
+    name = "CreateDatabase1623518107000"
+    async up(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(
+            `CREATE TABLE "author" ("id" integer PRIMARY KEY AUTOINCREMENT NOT NULL, "name" varchar NOT NULL)`,
+        )
+        await queryRunner.query(
+            `CREATE TABLE "post" ("id" integer PRIMARY KEY AUTOINCREMENT NOT NULL, "text" varchar NOT NULL, "authorId" integer NOT NULL REFERENCES author(id) ON DELETE CASCADE ON UPDATE NO ACTION)`,
+        )
+    }
+
+    async down(queryRunner: QueryRunner): Promise<void> {}
+}


### PR DESCRIPTION
Closes: #9266

### Description of change

Currently, the AbstractSQLiteQuerryRunner expects the FK to be defined as `CONSTRAINT "FK_ID" FOREIGN KEY  ("columnName") REFERENCES  "table"("id")`. 
However, this is also a valid way to declare a FK:  `columnName TEXT REFERENCES table(id)`.
In that case, there is no foreign key id and the code was throwing an exception on this line: https://github.com/typeorm/typeorm/blob/58fc08840a4a64ca1935391f4709a784c3f0b373/src/driver/sqlite-abstract/AbstractSqliteQueryRunner.ts#L1573

### Pull-Request Checklist

<!--
  Please make sure to review and check all of the following.

  If an item is not applicable, you can add "N/A" to the end.
-->

- [x] Code is up-to-date with the `master` branch
- [x] `npm run format` to apply prettier formatting
- [x] `npm run test` passes with this change
- [x] This pull request links relevant issues as `Fixes #0000`
- [x] There are new or updated unit tests validating the change
- [x] Documentation has been updated to reflect this change N/A
- [x] The new commits follow conventions explained in [CONTRIBUTING.md](https://github.com/typeorm/typeorm/blob/master/CONTRIBUTING.md)

<!--
  🎉 Thank you for contributing and making TypeORM even better!
-->
