### PR TITLE
fix: Resolve undefined fields created when in ES2022 mode

### DIFF
--- a/src/metadata/EntityMetadata.ts
+++ b/src/metadata/EntityMetadata.ts
@@ -569,6 +569,12 @@ export class EntityMetadata {
             ret = {}
         }
 
+        // Cleaning up any undefined keys to make it work consistent
+        // with TS useDefineForClassFields option being true or false.
+        Object.keys(ret).forEach(
+            (key) => ret[key] === undefined && delete ret[key],
+        )
+
         // add "typename" property
         if (this.connection.options.typename) {
             ret[this.connection.options.typename] = this.targetName

--- a/test/github-issues/9118/entity/Test.ts
+++ b/test/github-issues/9118/entity/Test.ts
@@ -1,0 +1,10 @@
+import { Column, Entity, PrimaryGeneratedColumn } from "../../../../src"
+
+@Entity()
+export class Test {
+    @PrimaryGeneratedColumn("uuid")
+    id: string
+
+    @Column("varchar")
+    name: string
+}

--- a/test/github-issues/9118/issue-9118.ts
+++ b/test/github-issues/9118/issue-9118.ts
@@ -1,0 +1,38 @@
+// @ts
+import "../../utils/test-setup"
+import {
+    createTestingConnections,
+    closeTestingConnections,
+    reloadTestingDatabases,
+} from "../../utils/test-utils"
+import { DataSource } from "../../../src"
+import { Test } from "./entity/Test"
+import { expect } from "chai"
+
+describe("github issues > #9118 ES2022 Repository create method include undefined field that breaks DB update", () => {
+    let connections: DataSource[]
+    before(
+        async () =>
+            (connections = await createTestingConnections({
+                entities: [__dirname + "/entity/*{.js,.ts}"],
+                enabledDrivers: ["postgres"],
+                schemaCreate: true,
+            })),
+    )
+    beforeEach(() => reloadTestingDatabases(connections))
+    after(() => closeTestingConnections(connections))
+
+    it("it should not create undefined fields", () =>
+        Promise.all(
+            connections.map(async (connection) => {
+                const testRepository = connection.getRepository(Test)
+                const result = testRepository.create({
+                    name: "test name",
+                })
+
+                expect(Object.getOwnPropertyNames(result)).to.have.same.members(
+                    ["name"],
+                )
+            }),
+        ))
+})


### PR DESCRIPTION
Closes: #9118

<!--
  😀 Wonderful!  Thank you for opening a pull request for TypeORM.

  Please fill in the information below to expedite the review
  and (hopefully) merge of your change.

  If unsure about something.. just do as best as you're able,
  or reach out through our community support channels!
  https://github.com/typeorm/typeorm/blob/master/docs/support.md
-->

### Description of change

<!--
  Please be clear and concise what the change is intended to do,
  why this change is needed, and how you've verified that it
  corrects what you intended.

  In some cases it may be helpful to include the current behavior
  and the new behavior.

  If the change is related to an open issue, you can link it here.
  If you include `Fixes #0000` (replacing `0000` with the issue number)
  when this is merged it will automatically mark the issue as fixed and
  close it.
-->

When compiling in ES2022 mode, Typescript option `useDefineForClassFields` is set to `true`. It leads to fields with undefined values being generated in entity metadata.

This changes fixes it by cleaning up any undefined fields in metadata so undefined fields are not generated and behaviour is the same when `useDefineForClassFields` is set to either `true` or `false`


### Pull-Request Checklist

<!--
  Please make sure to review and check all of the following.

  If an item is not applicable, you can add "N/A" to the end.
-->

- [x] Code is up-to-date with the `master` branch
- [x] `npm run format` to apply prettier formatting
- [x] `npm run test` passes with this change
- [x] This pull request links relevant issues as `Fixes #0000`
- [x] There are new or updated unit tests validating the change
- [x] Documentation has been updated to reflect this change
- [x] The new commits follow conventions explained in [CONTRIBUTING.md](https://github.com/typeorm/typeorm/blob/master/CONTRIBUTING.md)

<!--
  🎉 Thank you for contributing and making TypeORM even better!
-->
