### PR TITLE
fix: Convert the join table ID to the referenceColumn ID type

### DIFF
--- a/src/query-builder/transformer/RawSqlResultsToEntityTransformer.ts
+++ b/src/query-builder/transformer/RawSqlResultsToEntityTransformer.ts
@@ -490,7 +490,7 @@ export class RawSqlResultsToEntityTransformer {
                                     column.referencedColumn!.databaseName,
                                 )
                             ],
-                            column,
+                            column.referencedColumn!,
                         )
                 }
             })

--- a/test/other-issues/auto-increment-id-as-string/auto-increment-id-as-string.ts
+++ b/test/other-issues/auto-increment-id-as-string/auto-increment-id-as-string.ts
@@ -1,0 +1,48 @@
+import "reflect-metadata"
+import {
+    closeTestingConnections,
+    createTestingConnections,
+    reloadTestingDatabases,
+} from "../../utils/test-utils"
+import { DataSource } from "../../../src/data-source/DataSource"
+import { User } from "./entity/User"
+import { Role } from "./entity/Role"
+
+describe("other issues > auto-increment id as string", () => {
+    let connections: DataSource[]
+    before(
+        async () =>
+            (connections = await createTestingConnections({
+                entities: [__dirname + "/entity/*{.js,.ts}"],
+            })),
+    )
+    beforeEach(() => reloadTestingDatabases(connections))
+    after(() => closeTestingConnections(connections))
+
+    it("should relationIds exist", () =>
+        Promise.all(
+            connections.map(async function (connection) {
+                const role1 = new Role();
+                role1.roleName = '#role 1';
+                const role2 = new Role();
+                role2.roleName = '#role 2';
+
+                const user = new User();
+                user.userName = '#user 1';
+                user.roles = [
+                    await connection.manager.save(role1),
+                    await connection.manager.save(role2),
+                ];
+
+                const user2 = await connection.manager.save(user);
+
+                const user3 = await connection.manager.findOne(User, {
+                    where: {
+                        userId: user2.userId,
+                    },
+                    loadRelationIds: true,
+                });
+                user3!.roles.length.should.be.equal(2);
+            }),
+        ))
+})

--- a/test/other-issues/auto-increment-id-as-string/auto-increment-id-as-string.ts
+++ b/test/other-issues/auto-increment-id-as-string/auto-increment-id-as-string.ts
@@ -22,27 +22,27 @@ describe("other issues > auto-increment id as string", () => {
     it("should relationIds exist", () =>
         Promise.all(
             connections.map(async function (connection) {
-                const role1 = new Role();
-                role1.roleName = '#role 1';
-                const role2 = new Role();
-                role2.roleName = '#role 2';
+                const role1 = new Role()
+                role1.roleName = "#role 1"
+                const role2 = new Role()
+                role2.roleName = "#role 2"
 
-                const user = new User();
-                user.userName = '#user 1';
+                const user = new User()
+                user.userName = "#user 1"
                 user.roles = [
                     await connection.manager.save(role1),
                     await connection.manager.save(role2),
-                ];
+                ]
 
-                const user2 = await connection.manager.save(user);
+                const user2 = await connection.manager.save(user)
 
                 const user3 = await connection.manager.findOne(User, {
                     where: {
                         userId: user2.userId,
                     },
                     loadRelationIds: true,
-                });
-                user3!.roles.length.should.be.equal(2);
+                })
+                user3!.roles.length.should.be.equal(2)
             }),
         ))
 })

--- a/test/other-issues/auto-increment-id-as-string/entity/Role.ts
+++ b/test/other-issues/auto-increment-id-as-string/entity/Role.ts
@@ -1,0 +1,24 @@
+import { Column } from "../../../../src/decorator/columns/Column";
+import { Entity } from "../../../../src/decorator/entity/Entity";
+
+@Entity()
+export class Role {
+    @Column({
+        name: "role_id",
+        primary: true,
+        type: 'int',
+        generated: 'increment',
+        transformer: {
+            to(value: object) {
+                return value?.toString();
+            },
+            from(value: object) {
+                return value?.toString();
+            },
+        }
+    })
+    roleId: string;
+
+    @Column({ name: "role_name" })
+    roleName: string;
+}

--- a/test/other-issues/auto-increment-id-as-string/entity/Role.ts
+++ b/test/other-issues/auto-increment-id-as-string/entity/Role.ts
@@ -1,24 +1,24 @@
-import { Column } from "../../../../src/decorator/columns/Column";
-import { Entity } from "../../../../src/decorator/entity/Entity";
+import { Column } from "../../../../src/decorator/columns/Column"
+import { Entity } from "../../../../src/decorator/entity/Entity"
 
 @Entity()
 export class Role {
     @Column({
         name: "role_id",
         primary: true,
-        type: 'int',
-        generated: 'increment',
+        type: "int",
+        generated: "increment",
         transformer: {
             to(value: object) {
-                return value?.toString();
+                return value?.toString()
             },
             from(value: object) {
-                return value?.toString();
+                return value?.toString()
             },
-        }
+        },
     })
-    roleId: string;
+    roleId: string
 
     @Column({ name: "role_name" })
-    roleName: string;
+    roleName: string
 }

--- a/test/other-issues/auto-increment-id-as-string/entity/User.ts
+++ b/test/other-issues/auto-increment-id-as-string/entity/User.ts
@@ -1,0 +1,38 @@
+import { JoinTable, ManyToMany } from "../../../../src";
+import { Column } from "../../../../src/decorator/columns/Column";
+import { Entity } from "../../../../src/decorator/entity/Entity";
+import { Role } from "./Role";
+
+@Entity()
+export class User {
+    @Column({
+        name: 'user_id',
+        primary: true,
+        type: 'int',
+        generated: 'increment',
+        transformer: {
+            to(value: object) {
+                return value?.toString();
+            },
+            from(value: object) {
+                return value?.toString();
+            },
+        }
+    })
+    userId: string;
+
+    @Column({ name: "user_name" })
+    userName: string;
+
+    @ManyToMany(type => Role)
+    @JoinTable({
+        name: 'user_role', joinColumn: {
+            name: 'user_id',
+            referencedColumnName: 'userId'
+        }, inverseJoinColumn: {
+            name: 'role_id',
+            referencedColumnName: 'roleId'
+        }
+    })
+    roles: Role[];
+}

--- a/test/other-issues/auto-increment-id-as-string/entity/User.ts
+++ b/test/other-issues/auto-increment-id-as-string/entity/User.ts
@@ -1,38 +1,40 @@
-import { JoinTable, ManyToMany } from "../../../../src";
-import { Column } from "../../../../src/decorator/columns/Column";
-import { Entity } from "../../../../src/decorator/entity/Entity";
-import { Role } from "./Role";
+import { JoinTable, ManyToMany } from "../../../../src"
+import { Column } from "../../../../src/decorator/columns/Column"
+import { Entity } from "../../../../src/decorator/entity/Entity"
+import { Role } from "./Role"
 
 @Entity()
 export class User {
     @Column({
-        name: 'user_id',
+        name: "user_id",
         primary: true,
-        type: 'int',
-        generated: 'increment',
+        type: "int",
+        generated: "increment",
         transformer: {
             to(value: object) {
-                return value?.toString();
+                return value?.toString()
             },
             from(value: object) {
-                return value?.toString();
+                return value?.toString()
             },
-        }
+        },
     })
-    userId: string;
+    userId: string
 
     @Column({ name: "user_name" })
-    userName: string;
+    userName: string
 
-    @ManyToMany(type => Role)
+    @ManyToMany((type) => Role)
     @JoinTable({
-        name: 'user_role', joinColumn: {
-            name: 'user_id',
-            referencedColumnName: 'userId'
-        }, inverseJoinColumn: {
-            name: 'role_id',
-            referencedColumnName: 'roleId'
-        }
+        name: "user_role",
+        joinColumn: {
+            name: "user_id",
+            referencedColumnName: "userId",
+        },
+        inverseJoinColumn: {
+            name: "role_id",
+            referencedColumnName: "roleId",
+        },
     })
-    roles: Role[];
+    roles: Role[]
 }


### PR DESCRIPTION
<!--
  😀 Wonderful!  Thank you for opening a pull request for TypeORM.

  Please fill in the information below to expedite the review
  and (hopefully) merge of your change.

  If unsure about something.. just do as best as you're able,
  or reach out through our community support channels!
  https://github.com/typeorm/typeorm/blob/master/docs/support.md
-->

### Description of change

When I use auto-incremented id as a string and call findOne with the "loadRelationIds:true" option, I get an empty array for the "relationIds" property, even though the relation exists.

### Pull-Request Checklist

<!--
  Please make sure to review and check all of the following.

  If an item is not applicable, you can add "N/A" to the end.
-->

- [ ] Code is up-to-date with the `master` branch
- [ ] `npm run format` to apply prettier formatting
- [ ] `npm run test` passes with this change
- [ ] This pull request links relevant issues as `Fixes #0000`
- [ ] There are new or updated unit tests validating the change
- [ ] Documentation has been updated to reflect this change
- [ ] The new commits follow conventions explained in [CONTRIBUTING.md](https://github.com/typeorm/typeorm/blob/master/CONTRIBUTING.md)

<!--
  🎉 Thank you for contributing and making TypeORM even better!
-->
