### PR TITLE
Allow type FindOptionsOrderValue for order by object property (#9895)

### DIFF
--- a/src/find-options/FindOptionsOrder.ts
+++ b/src/find-options/FindOptionsOrder.ts
@@ -24,7 +24,7 @@ export type FindOptionsOrderProperty<Property> = Property extends Promise<
     : Property extends ObjectID
     ? FindOptionsOrderValue
     : Property extends object
-    ? FindOptionsOrder<Property>
+    ? FindOptionsOrder<Property> | FindOptionsOrderValue
     : FindOptionsOrderValue
 
 /**

--- a/test/github-issues/9895/entity/ExampleEntity.ts
+++ b/test/github-issues/9895/entity/ExampleEntity.ts
@@ -1,0 +1,31 @@
+import { Entity } from "../../../../src/decorator/entity/Entity"
+import { Column } from "../../../../src/decorator/columns/Column"
+import { PrimaryGeneratedColumn } from "../../../../src/decorator/columns/PrimaryGeneratedColumn"
+
+class ExampleBigNumber {
+    constructor(private value: string) {}
+
+    toFixed() {
+        return this.value
+    }
+}
+
+@Entity()
+export class ExampleEntity {
+    @PrimaryGeneratedColumn()
+    id: number
+
+    @Column({
+        type: "numeric",
+        nullable: false,
+        transformer: {
+            from: (value: any): ExampleBigNumber => {
+                return new ExampleBigNumber(value)
+            },
+            to: (value: any): string => {
+                return value.toFixed()
+            },
+        },
+    })
+    total: ExampleBigNumber
+}

--- a/test/github-issues/9895/issue-9895.ts
+++ b/test/github-issues/9895/issue-9895.ts
@@ -1,0 +1,33 @@
+import { DataSource } from "../../../src"
+import {
+    closeTestingConnections,
+    createTestingConnections,
+    reloadTestingDatabases,
+} from "../../utils/test-utils"
+import { ExampleEntity } from "./entity/ExampleEntity"
+
+describe("github issues > #9895", () => {
+    let dataSources: DataSource[]
+
+    before(async () => {
+        dataSources = await createTestingConnections({
+            entities: [ExampleEntity],
+            enabledDrivers: ["postgres"],
+        })
+    })
+
+    beforeEach(() => reloadTestingDatabases(dataSources))
+    after(() => closeTestingConnections(dataSources))
+
+    it("should allow find order on object property", async () => {
+        await Promise.all(
+            dataSources.map(async (dataSource) => {
+                await dataSource.manager.find(ExampleEntity, {
+                    order: {
+                        total: "DESC",
+                    },
+                })
+            }),
+        )
+    })
+})


### PR DESCRIPTION

<!--
  😀 Wonderful!  Thank you for opening a pull request for TypeORM.

  Please fill in the information below to expedite the review
  and (hopefully) merge of your change.

  If unsure about something.. just do as best as you're able,
  or reach out through our community support channels!
  https://github.com/typeorm/typeorm/blob/master/docs/support.md
-->

### Description of change

When using an Entity column transformer for an object type, the underlying database column may be sortable, despite the static TypeScript type being an object. The `FindOptionsOrder` typing should allow sorting on that object property and not require further nesting.

Fixes issue #9895. 

<!--
  Please be clear and concise what the change is intended to do,
  why this change is needed, and how you've verified that it
  corrects what you intended.

  In some cases it may be helpful to include the current behavior
  and the new behavior.

  If the change is related to an open issue, you can link it here.
  If you include `Fixes #0000` (replacing `0000` with the issue number)
  when this is merged it will automatically mark the issue as fixed and
  close it.
-->


### Pull-Request Checklist

<!--
  Please make sure to review and check all of the following.

  If an item is not applicable, you can add "N/A" to the end.
-->

- [x] Code is up-to-date with the `master` branch
- [x] `npm run format` to apply prettier formatting
- [x] `npm run test` passes with this change
- [x] This pull request links relevant issues as `Fixes #0000`
- [x] There are new or updated unit tests validating the change
- [ ] Documentation has been updated to reflect this change
- [x] The new commits follow conventions explained in [CONTRIBUTING.md](https://github.com/typeorm/typeorm/blob/master/CONTRIBUTING.md)

<!--
  🎉 Thank you for contributing and making TypeORM even better!
-->
