### PR TITLE
fix: firstCapital=true not working in camelCase() function

### DIFF
--- a/src/util/StringUtils.ts
+++ b/src/util/StringUtils.ts
@@ -6,14 +6,11 @@ import shajs from "sha.js"
  * @see http://stackoverflow.com/questions/2970525/converting-any-string-into-camel-case
  */
 export function camelCase(str: string, firstCapital: boolean = false): string {
-    return str.replace(
-        /^([A-Z])|[\s-_](\w)/g,
-        function (match, p1, p2, offset) {
-            if (firstCapital === true && offset === 0) return p1
-            if (p2) return p2.toUpperCase()
-            return p1.toLowerCase()
-        },
-    )
+    if (firstCapital) str = " " + str
+    return str.replace(/^([A-Z])|[\s-_](\w)/g, function (match, p1, p2) {
+        if (p2) return p2.toUpperCase()
+        return p1.toLowerCase()
+    })
 }
 
 /**

--- a/test/functional/util/StringUtils.ts
+++ b/test/functional/util/StringUtils.ts
@@ -1,5 +1,5 @@
 import { expect } from "chai"
-import { snakeCase } from "../../../src/util/StringUtils"
+import { camelCase, snakeCase } from "../../../src/util/StringUtils"
 
 describe("StringUtils", () => {
     describe("snakeCase", () => {
@@ -75,6 +75,48 @@ describe("StringUtils", () => {
                     `Failed for Input: ${input}`,
                 )
             }
+        })
+    })
+
+    describe("camelCase", () => {
+        it("should convert snakecase to camelcase", () => {
+            const input = "camel_case_string_here"
+            const expected = "camelCaseStringHere"
+            const actual = camelCase(input)
+
+            expect(actual).to.be.equal(expected, `Failed for Input: ${input}`)
+        })
+
+        it("should convert with first capital letter", () => {
+            const input = "camel_case_string_here"
+            const expected = "CamelCaseStringHere"
+            const actual = camelCase(input, true)
+
+            expect(actual).to.be.equal(expected, `Failed for Input: ${input}`)
+        })
+
+        it("should correctly convert repeating snakecase groups", () => {
+            const input = "option_a_or_b_or_c"
+            const expected = "optionAOrBOrC"
+            const actual = camelCase(input)
+
+            expect(actual).to.be.equal(expected, `Failed for Input: ${input}`)
+        })
+
+        it("should do nothing with strings that are already camelcase", () => {
+            const expected1 = "camelCaseStringHere"
+            expect(camelCase(expected1)).to.be.equal(expected1, expected1)
+
+            const expected2 = "CamelCaseStringHere"
+            expect(camelCase(expected2, true)).to.be.equal(expected2, expected2)
+        })
+
+        it("should correctly convert strings with numbers", () => {
+            const input = "device1_status"
+            const expected = "device1Status"
+            const actual = camelCase(input)
+
+            expect(actual).to.be.equal(expected, `Failed for Input: ${input}`)
         })
     })
 })


### PR DESCRIPTION

<!--
  😀 Wonderful!  Thank you for opening a pull request for TypeORM.

  Please fill in the information below to expedite the review
  and (hopefully) merge of your change.

  If unsure about something.. just do as best as you're able,
  or reach out through our community support channels!
  https://github.com/typeorm/typeorm/blob/master/docs/support.md
-->

### Description of change

<!--
  Please be clear and concise what the change is intended to do,
  why this change is needed, and how you've verified that it
  corrects what you intended.

  In some cases it may be helpful to include the current behavior
  and the new behavior.

  If the change is related to an open issue, you can link it here.
  If you include `Fixes #0000` (replacing `0000` with the issue number)
  when this is merged it will automatically mark the issue as fixed and
  close it.
-->

Fixed `firstCapital` parameter in `camelCase` function.

```ts
// before
camelCase("test_string", true) // testString

// after
camelCase("test_string", true) // TestString
```

* fixes #7331
* closes #9720
* closes #9837


### Pull-Request Checklist

<!--
  Please make sure to review and check all of the following.

  If an item is not applicable, you can add "N/A" to the end.
-->

- [x] Code is up-to-date with the `master` branch
- [x] `npm run format` to apply prettier formatting
- [x] `npm run test` passes with this change
- [x] This pull request links relevant issues as `Fixes #0000`
- [x] There are new or updated unit tests validating the change
- n/a Documentation has been updated to reflect this change
- [x] The new commits follow conventions explained in [CONTRIBUTING.md](https://github.com/typeorm/typeorm/blob/master/CONTRIBUTING.md)

<!--
  🎉 Thank you for contributing and making TypeORM even better!
-->
