### PR TITLE
fix: use column database name in select queries

### DIFF
--- a/src/query-builder/SelectQueryBuilder.ts
+++ b/src/query-builder/SelectQueryBuilder.ts
@@ -2801,7 +2801,9 @@ export class SelectQueryBuilder<Entity extends ObjectLiteral>
                 return this.expressionMap.selects.some(
                     (select) =>
                         select.selection ===
-                        aliasName + "." + column.propertyPath,
+                            aliasName + "." + column.propertyPath ||
+                        select.selection ===
+                            aliasName + "." + column.databaseName,
                 )
             }),
         )
@@ -3849,7 +3851,8 @@ export class SelectQueryBuilder<Entity extends ObjectLiteral>
 
             const propertyPath = embedPrefix ? embedPrefix + "." + key : key
             const column =
-                metadata.findColumnWithPropertyPathStrict(propertyPath)
+                metadata.findColumnWithPropertyPathStrict(propertyPath) ||
+                metadata.findColumnWithDatabaseName(propertyPath)
             const embed = metadata.findEmbeddedWithPropertyPath(propertyPath)
             const relation = metadata.findRelationWithPropertyPath(propertyPath)
 
@@ -4094,7 +4097,8 @@ export class SelectQueryBuilder<Entity extends ObjectLiteral>
 
             const propertyPath = embedPrefix ? embedPrefix + "." + key : key
             const column =
-                metadata.findColumnWithPropertyPathStrict(propertyPath)
+                metadata.findColumnWithPropertyPathStrict(propertyPath) ||
+                metadata.findColumnWithDatabaseName(propertyPath)
             const embed = metadata.findEmbeddedWithPropertyPath(propertyPath)
             const relation = metadata.findRelationWithPropertyPath(propertyPath)
 
@@ -4219,7 +4223,8 @@ export class SelectQueryBuilder<Entity extends ObjectLiteral>
 
                 const propertyPath = embedPrefix ? embedPrefix + "." + key : key
                 const column =
-                    metadata.findColumnWithPropertyPathStrict(propertyPath)
+                    metadata.findColumnWithPropertyPathStrict(propertyPath) ||
+                    metadata.findColumnWithDatabaseName(propertyPath)
                 const embed =
                     metadata.findEmbeddedWithPropertyPath(propertyPath)
                 const relation =

--- a/src/query-builder/transformer/RawSqlResultsToEntityTransformer.ts
+++ b/src/query-builder/transformer/RawSqlResultsToEntityTransformer.ts
@@ -238,7 +238,9 @@ export class RawSqlResultsToEntityTransformer {
                     (select) =>
                         select.selection === alias.name ||
                         select.selection ===
-                            alias.name + "." + column.propertyPath,
+                            alias.name + "." + column.propertyPath ||
+                        select.selection ===
+                            alias.name + "." + column.databaseName,
                 )
             )
                 return

--- a/test/github-issues/9931/entity/User.ts
+++ b/test/github-issues/9931/entity/User.ts
@@ -1,0 +1,23 @@
+import {
+    Entity,
+    Column,
+    PrimaryGeneratedColumn,
+    BaseEntity,
+} from "../../../../src"
+
+@Entity()
+export class User extends BaseEntity {
+    @PrimaryGeneratedColumn({ name: "orderColumn" })
+    private _orderColumn: number
+
+    @Column()
+    name: string
+
+    get orderColumn() {
+        return this._orderColumn
+    }
+
+    set orderColumn(value: number) {
+        this._orderColumn = value
+    }
+}

--- a/test/github-issues/9931/issue-9931.ts
+++ b/test/github-issues/9931/issue-9931.ts
@@ -1,0 +1,40 @@
+import "reflect-metadata"
+import {
+    createTestingConnections,
+    closeTestingConnections,
+    reloadTestingDatabases,
+} from "../../utils/test-utils"
+import { DataSource } from "../../../src/data-source/DataSource"
+import { expect } from "chai"
+import { User } from "./entity/User"
+
+describe("github issues > #9931 EntityPropertyNotFound when using getters and setters in an Entity with column alias", () => {
+    let dataSources: DataSource[]
+    before(
+        async () =>
+            (dataSources = await createTestingConnections({
+                entities: [__dirname + "/entity/*{.js,.ts}"],
+                schemaCreate: true,
+                dropSchema: true,
+            })),
+    )
+    beforeEach(() => reloadTestingDatabases(dataSources))
+    after(() => closeTestingConnections(dataSources))
+
+    it("should find entity while using a key with a custom name", () =>
+        Promise.all(
+            dataSources.map(async (dataSource) => {
+                const user = new User()
+                user.name = "User 1"
+                const res = await user.save()
+
+                const users = await User.find({
+                    select: { orderColumn: true },
+                    order: { orderColumn: "ASC" },
+                    where: { orderColumn: res.orderColumn },
+                })
+
+                expect(users[0].orderColumn).to.equal(res.orderColumn)
+            }),
+        ))
+})


### PR DESCRIPTION
Fixes issues when naming a column something other than the variable in an entity class

Closes: #9931

<!--
  😀 Wonderful!  Thank you for opening a pull request for TypeORM.

  Please fill in the information below to expedite the review
  and (hopefully) merge of your change.

  If unsure about something.. just do as best as you're able,
  or reach out through our community support channels!
  https://github.com/typeorm/typeorm/blob/master/docs/support.md
-->

### Description of change

Uses both a column's `propertyPath` and `databaseName` when building
a select query to cover the case of using a column name that is
different than the internal class property name.

The newly created test gives an example of using a getter and setter
for accessing a key in a class that has a custom column name.

Fixes #9931

<!--
  Please be clear and concise what the change is intended to do,
  why this change is needed, and how you've verified that it
  corrects what you intended.

  In some cases it may be helpful to include the current behavior
  and the new behavior.

  If the change is related to an open issue, you can link it here.
  If you include `Fixes #0000` (replacing `0000` with the issue number)
  when this is merged it will automatically mark the issue as fixed and
  close it.
-->


### Pull-Request Checklist

<!--
  Please make sure to review and check all of the following.

  If an item is not applicable, you can add "N/A" to the end.
-->

- [x] Code is up-to-date with the `master` branch
- [x] `npm run format` to apply prettier formatting
- [x] `npm run test` passes with this change
- [x] This pull request links relevant issues as `Fixes #0000`
- [x] There are new or updated unit tests validating the change
- [ ] Documentation has been updated to reflect this change N/A
- [x] The new commits follow conventions explained in [CONTRIBUTING.md](https://github.com/typeorm/typeorm/blob/master/CONTRIBUTING.md)

<!--
  🎉 Thank you for contributing and making TypeORM even better!
-->
