### PR TITLE
fix: prevent unique index identical to primary key (all sql dialects) fixes #8485

### DIFF
--- a/test/github-issues/8485/issue-8485.ts
+++ b/test/github-issues/8485/issue-8485.ts
@@ -7,13 +7,13 @@ import { UserProfile } from "./entity/UserProfile"
 import { User } from "./entity/User"
 import { expect } from "chai"
 
-describe("github issues > #8485 second migration is generated for a combination of PrimaryColumn and JoinColumn with Postgres", () => {
+describe("github issues > #8485 second migration is generated for a combination of PrimaryColumn and JoinColumn", () => {
     let dataSources: DataSource[]
     before(
         async () =>
             (dataSources = await createTestingConnections({
                 entities: [User, UserProfile],
-                enabledDrivers: ["postgres"],
+                enabledDrivers: ["mariadb", "mysql", "oracle", "postgres"],
                 dropSchema: true,
                 schemaCreate: false,
             })),


### PR DESCRIPTION
### Description of change

As described in #8485, a relation creates besides the foreign key on the main entity, also an unique index on the referenced entity. This happens even though the column (or combination of columns) already is the primary of the referenced entity. Until now, exceptions have been made for certain dialects, however, as discussed in https://github.com/typeorm/typeorm/pull/9677#issuecomment-1422963665, this is not necessary.

This PR fixes #8485 for all SQL dialects (including MySQL and SAP HANA), not just Oracle.

### Pull-Request Checklist

- [X] Code is up-to-date with the `master` branch
- [X] `npm run format` to apply prettier formatting
- [X] `npm run test` passes with this change
- [X] This pull request links relevant issues as `Fixes #0000`
- [X] There are new or updated unit tests validating the change
- [ ] Documentation has been updated to reflect this change
- [X] The new commits follow conventions explained in [CONTRIBUTING.md](https://github.com/typeorm/typeorm/blob/master/CONTRIBUTING.md)