### PR TITLE
fix: make cache optional fields optional

### DIFF
--- a/src/cache/DbQueryResultCache.ts
+++ b/src/cache/DbQueryResultCache.ts
@@ -131,7 +131,7 @@ export class DbQueryResultCache implements QueryResultCache {
     }
 
     /**
-     * Caches given query result.
+     * Get data from cache.
      * Returns cache result if found.
      * Returns undefined if result is not cached.
      */

--- a/src/cache/QueryResultCacheOptions.ts
+++ b/src/cache/QueryResultCacheOptions.ts
@@ -6,7 +6,7 @@ export interface QueryResultCacheOptions {
      * Cache identifier set by user.
      * Can be empty.
      */
-    identifier: string
+    identifier?: string
 
     /**
      * Time, when cache was created.
@@ -21,7 +21,7 @@ export interface QueryResultCacheOptions {
     /**
      * Cached query.
      */
-    query: string
+    query?: string
 
     /**
      * Query result that will be cached.

--- a/src/cache/RedisQueryResultCache.ts
+++ b/src/cache/RedisQueryResultCache.ts
@@ -123,7 +123,7 @@ export class RedisQueryResultCache implements QueryResultCache {
     async synchronize(queryRunner: QueryRunner): Promise<void> {}
 
     /**
-     * Caches given query result.
+     * Get data from cache.
      * Returns cache result if found.
      * Returns undefined if result is not cached.
      */


### PR DESCRIPTION
<!--
  😀 Wonderful!  Thank you for opening a pull request for TypeORM.

  Please fill in the information below to expedite the review
  and (hopefully) merge of your change.

  If unsure about something.. just do as best as you're able,
  or reach out through our community support channels!
  https://github.com/typeorm/typeorm/blob/master/docs/support.md
-->

### Description of change
This patch allows the `getFromCache` caller to only pass in `identifier` or `query` field, as `getFromCache`only needs **either, or neither** `identifier` or `query` to be present.

Currently as a caller of `getFromCache`, one is required to pass both `identifier` and `query` value, which is unnecessary because only one will be used for execution, with `identifier` taking precedence.
<!--
  Please be clear and concise what the change is intended to do,
  why this change is needed, and how you've verified that it
  corrects what you intended.

  In some cases it may be helpful to include the current behavior
  and the new behavior.

  If the change is related to an open issue, you can link it here.
  If you include `Fixes #0000` (replacing `0000` with the issue number)
  when this is merged it will automatically mark the issue as fixed and
  close it.
-->


### Pull-Request Checklist

<!--
  Please make sure to review and check all of the following.

  If an item is not applicable, you can add "N/A" to the end.
-->

- [x] Code is up-to-date with the `master` branch
- [x] `npm run format` to apply prettier formatting
- [x] `npm run test` passes with this change
- [ ] This pull request links relevant issues as `Fixes #0000`
- [ ] There are new or updated unit tests validating the change
- [x] Documentation has been updated to reflect this change
- [x] The new commits follow conventions explained in [CONTRIBUTING.md](https://github.com/typeorm/typeorm/blob/master/CONTRIBUTING.md)

<!--
  🎉 Thank you for contributing and making TypeORM even better!
-->
