### PR TITLE
ci: wait if oracle db is enabled in test suite

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -151,8 +151,9 @@ jobs:
                     map(select(.skip == false)
                       | select(.host)
                       | select(.port)
-                      | "nc -z " + .host + " " + (.port|tostring) + " && echo " + .host + " " + (.port|tostring) + " is up")
-                      | join(" && ")
+                      | "nc -z " + .host + " " + (.port|tostring) + " && echo " + .host + " " + (.port|tostring) + " is up"
+                    )
+                    | join(" && ")
                   '
             )
             echo "Running '$COMMANDS'"
@@ -162,6 +163,24 @@ jobs:
               --tty \
               ubuntu:trusty \
               timeout 60 sh -c "until ($COMMANDS); do echo \"Waiting for Services to be Available ...\"; sleep 5; done"
+      - run:
+          name: "Wait for OracleDB to be Available"
+          command: |
+            COMMANDS=$(
+                cat ormconfig.json \
+                  | jq -r '
+                    map(select(.skip == false)
+                      | select(.name == "oracle")
+                      | "sleep 60"
+                    )
+                    | join(" && ")
+                  '
+            )
+            if [ ! -z "$COMMANDS" ]; then
+              echo "$COMMANDS seconds to wait for oracledb";
+              $COMMANDS
+            fi
+
       # Download and cache dependencies
       - run:
           name: "Run Tests with Coverage"


### PR DESCRIPTION
<!--
  😀 Wonderful!  Thank you for opening a pull request for TypeORM.

  Please fill in the information below to expedite the review
  and (hopefully) merge of your change.

  If unsure about something.. just do as best as you're able,
  or reach out through our community support channels!
  https://github.com/typeorm/typeorm/blob/master/docs/support.md
-->

### Description of change

Fixes ci error 
```
ORA-12514: TNS:listener does not currently know of service requested in connect descriptor
```
because port-scan is not enough to determine wether oracledb is ready to handle connections.

<!--
  Please be clear and concise what the change is intended to do,
  why this change is needed, and how you've verified that it
  corrects what you intended.

  In some cases it may be helpful to include the current behavior
  and the new behavior.

  If the change is related to an open issue, you can link it here.
  If you include `Fixes #0000` (replacing `0000` with the issue number)
  when this is merged it will automatically mark the issue as fixed and
  close it.
-->


### Pull-Request Checklist

<!--
  Please make sure to review and check all of the following.

  If an item is not applicable, you can add "N/A" to the end.
-->

- [X] Code is up-to-date with the `master` branch
- [X] `npm run format` to apply prettier formatting
- [X] `npm run test` passes with this change N/A
- [X] This pull request links relevant issues as `Fixes #0000`
  [this comment](https://github.com/typeorm/typeorm/pull/9926#issuecomment-1505815061)
- [X] There are new or updated unit tests validating the change
- [X] Documentation has been updated to reflect this change N/A
- [X] The new commits follow conventions explained in [CONTRIBUTING.md](https://github.com/typeorm/typeorm/blob/master/CONTRIBUTING.md)

<!--
  🎉 Thank you for contributing and making TypeORM even better!
-->
