### PR TITLE
query methods should accept generic for return type

### DIFF
--- a/src/data-source/DataSource.ts
+++ b/src/data-source/DataSource.ts
@@ -515,11 +515,11 @@ export class DataSource {
     /**
      * Executes raw SQL query and returns raw database results.
      */
-    async query(
+    async query<T = any>(
         query: string,
         parameters?: any[],
         queryRunner?: QueryRunner,
-    ): Promise<any> {
+    ): Promise<T> {
         if (InstanceChecker.isMongoEntityManager(this.manager))
             throw new TypeORMError(`Queries aren't supported by MongoDB.`)
 

--- a/src/entity-manager/EntityManager.ts
+++ b/src/entity-manager/EntityManager.ts
@@ -170,7 +170,7 @@ export class EntityManager {
     /**
      * Executes raw SQL query and returns raw database results.
      */
-    async query(query: string, parameters?: any[]): Promise<any> {
+    async query<T = any>(query: string, parameters?: any[]): Promise<T> {
         return this.connection.query(query, parameters, this.queryRunner)
     }
 


### PR DESCRIPTION
<!--
  😀 Wonderful!  Thank you for opening a pull request for TypeORM.

  Please fill in the information below to expedite the review
  and (hopefully) merge of your change.

  If unsure about something.. just do as best as you're able,
  or reach out through our community support channels!
  https://github.com/typeorm/typeorm/blob/master/docs/support.md
-->

### Description of change

the query methods can now accept a generic type that is used as the return type. If no generic were passed, it will default to any (the current behavior). This way it allows the consumer of the library to decide what should be the return type without type casting (`as`). 

I wrote an ESLint plugin ([SafeQL](https://github.com/ts-safeql/safeql)) that helps validate the return type of a raw query based on the generic type, which is the main reason I raised this PR. Currently, type augmentation is the only way to integrate TypeORM with SafeQL which hurts DX (which I'm trying to avoid) 🙂.

<!--
  Please be clear and concise what the change is intended to do,
  why this change is needed, and how you've verified that it
  corrects what you intended.

  In some cases it may be helpful to include the current behavior
  and the new behavior.

  If the change is related to an open issue, you can link it here.
  If you include `Fixes #0000` (replacing `0000` with the issue number)
  when this is merged it will automatically mark the issue as fixed and
  close it.
-->


### Pull-Request Checklist

<!--
  Please make sure to review and check all of the following.

  If an item is not applicable, you can add "N/A" to the end.
-->

- [x] Code is up-to-date with the `master` branch
- [x] `npm run format` to apply prettier formatting
- [x] `npm run test` passes with this change
- [ ] This pull request links relevant issues as `Fixes #0000`
- [ ] There are new or updated unit tests validating the change
- [ ] Documentation has been updated to reflect this change
- [x] The new commits follow conventions explained in [CONTRIBUTING.md](https://github.com/typeorm/typeorm/blob/master/CONTRIBUTING.md)

<!--
  🎉 Thank you for contributing and making TypeORM even better!
-->
