### PR TITLE
fix: resolve duplicate subscriber updateed columns

### DIFF
--- a/src/persistence/SubjectChangedColumnsComputer.ts
+++ b/src/persistence/SubjectChangedColumnsComputer.ts
@@ -166,7 +166,10 @@ export class SubjectChangedColumnsComputer {
                     if (normalizedValue === databaseValue) return
                 }
             }
-            subject.diffColumns.push(column)
+
+            if (!subject.diffColumns.includes(column))
+                subject.diffColumns.push(column)
+
             subject.changeMaps.push({
                 column: column,
                 value: entityValue,

--- a/test/github-issues/9948/entity/Post.ts
+++ b/test/github-issues/9948/entity/Post.ts
@@ -1,0 +1,13 @@
+import { Column, Entity, PrimaryGeneratedColumn } from "../../../../src"
+
+@Entity()
+export class Post {
+    @PrimaryGeneratedColumn()
+    id: number
+
+    @Column()
+    name: string
+
+    @Column({ default: 0 })
+    updatedNameColumnsCount: number
+}

--- a/test/github-issues/9948/issue-9948.ts
+++ b/test/github-issues/9948/issue-9948.ts
@@ -1,0 +1,40 @@
+import "reflect-metadata"
+import {
+    createTestingConnections,
+    closeTestingConnections,
+    reloadTestingDatabases,
+} from "../../utils/test-utils"
+import { DataSource } from "../../../src/data-source/DataSource"
+import { expect } from "chai"
+import { Post } from "./entity/Post"
+
+describe("github issues > #9948 Subscribers with both 'beforeUpdate' and 'afterUpdate' methods defined cause duplicate 'updatedColumn' entries", () => {
+    let dataSources: DataSource[]
+    before(
+        async () =>
+            (dataSources = await createTestingConnections({
+                entities: [__dirname + "/entity/*{.js,.ts}"],
+                subscribers: [__dirname + "/subscriber/*{.js,.ts}"],
+                schemaCreate: true,
+                dropSchema: true,
+            })),
+    )
+    beforeEach(() => reloadTestingDatabases(dataSources))
+    after(() => closeTestingConnections(dataSources))
+
+    it("should not duplicate update column", () =>
+        Promise.all(
+            dataSources.map(async (dataSource) => {
+                const manager = dataSource.manager
+
+                const initialPost = new Post()
+                initialPost.name = "post-init"
+                await manager.save(initialPost)
+
+                initialPost.name = "post-update"
+                const updatedPost = await manager.save(initialPost)
+
+                expect(updatedPost.updatedNameColumnsCount).to.be.eq(1)
+            }),
+        ))
+})

--- a/test/github-issues/9948/subscriber/PostSubscriber.ts
+++ b/test/github-issues/9948/subscriber/PostSubscriber.ts
@@ -1,0 +1,31 @@
+import {
+    EntitySubscriberInterface,
+    EventSubscriber,
+    UpdateEvent,
+} from "../../../../src"
+import { Post } from "../entity/Post"
+
+@EventSubscriber()
+export class PostSubscriber implements EntitySubscriberInterface {
+    listenTo(): string | Function {
+        return Post
+    }
+
+    beforeUpdate(event: UpdateEvent<Post>): void | Promise<Post> {
+        event.entity!.updatedNameColumnsCount = event.updatedColumns.reduce(
+            (p, c) => {
+                return p + (c.propertyName === "name" ? 1 : 0)
+            },
+            0,
+        )
+    }
+
+    afterUpdate(event: UpdateEvent<Post>): void | Promise<Post> {
+        event.entity!.updatedNameColumnsCount = event.updatedColumns.reduce(
+            (p, c) => {
+                return p + (c.propertyName === "name" ? 1 : 0)
+            },
+            0,
+        )
+    }
+}


### PR DESCRIPTION
Closes: #9948

<!--
  😀 Wonderful!  Thank you for opening a pull request for TypeORM.

  Please fill in the information below to expedite the review
  and (hopefully) merge of your change.

  If unsure about something.. just do as best as you're able,
  or reach out through our community support channels!
  https://github.com/typeorm/typeorm/blob/master/docs/support.md
-->

### Description of change

<!--
  Please be clear and concise what the change is intended to do,
  why this change is needed, and how you've verified that it
  corrects what you intended.

  In some cases it may be helpful to include the current behavior
  and the new behavior.

  If the change is related to an open issue, you can link it here.
  If you include `Fixes #0000` (replacing `0000` with the issue number)
  when this is merged it will automatically mark the issue as fixed and
  close it.
-->
Fixes issue #9948 with duplicate update columns in after update subscriber method if before update method is defined by filtering `Subject.diffColumns`

### Pull-Request Checklist

<!--
  Please make sure to review and check all of the following.

  If an item is not applicable, you can add "N/A" to the end.
-->

- [x] Code is up-to-date with the `master` branch
- [x] `npm run format` to apply prettier formatting
- [ ] `npm run test` passes with this change
- [x] This pull request links relevant issues as `Fixes #0000`
- [x] There are new or updated unit tests validating the change
- [ ] Documentation has been updated to reflect this change
- [x] The new commits follow conventions explained in [CONTRIBUTING.md](https://github.com/typeorm/typeorm/blob/master/CONTRIBUTING.md)

<!--
  🎉 Thank you for contributing and making TypeORM even better!
-->
