### PR TITLE
added instanceName to options

### DIFF
--- a/src/driver/sqlserver/SqlServerConnectionOptions.ts
+++ b/src/driver/sqlserver/SqlServerConnectionOptions.ts
@@ -120,6 +120,11 @@ export interface SqlServerConnectionOptions
      */
     readonly options?: {
         /**
+         * The named instance to connect to
+         */
+        readonly instanceName?: string
+        
+        /**
          * By default, if the database requestion by options.database cannot be accessed, the connection will fail with
          * an error. However, if options.fallbackToDefaultDb is set to true, then the user's default database will
          * be used instead (Default: false).

--- a/src/driver/sqlserver/SqlServerConnectionOptions.ts
+++ b/src/driver/sqlserver/SqlServerConnectionOptions.ts
@@ -123,7 +123,7 @@ export interface SqlServerConnectionOptions
          * The named instance to connect to
          */
         readonly instanceName?: string
-        
+
         /**
          * By default, if the database requestion by options.database cannot be accessed, the connection will fail with
          * an error. However, if options.fallbackToDefaultDb is set to true, then the user's default database will


### PR DESCRIPTION
### Description of change

Fixes #7686 
Added instanceName to SqlServerConnectionOtions.
This property was present in the docs (data-source-options.md) but missing in code.
The existing workarounds to put the instanceName in extra did not work for me.


### Pull-Request Checklist

<!--
  Please make sure to review and check all of the following.

  If an item is not applicable, you can add "N/A" to the end.
-->

- [X] Code is up-to-date with the `master` branch
- [x] `npm run format` to apply prettier formatting
- [ ] `npm run test` passes with this change
- [X] This pull request links relevant issues as `Fixes #7686`
- [ ] There are new or updated unit tests validating the change
- [ ] Documentation has been updated to reflect this change
- [ ] The new commits follow conventions explained in [CONTRIBUTING.md](https://github.com/typeorm/typeorm/blob/master/CONTRIBUTING.md)

<!--
  🎉 Thank you for contributing and making TypeORM even better!
-->
