### PR TITLE
fix: resolve issue EventSubscribers beforeInsert and afterInsert missing data for junction tables

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "typeorm",
-  "version": "0.3.15",
+  "version": "0.3.14",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "typeorm",
-      "version": "0.3.15",
+      "version": "0.3.14",
       "license": "MIT",
       "dependencies": {
         "@sqltools/formatter": "^1.2.5",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "typeorm",
-  "version": "0.3.14",
+  "version": "0.3.15",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "typeorm",
-      "version": "0.3.14",
+      "version": "0.3.15",
       "license": "MIT",
       "dependencies": {
         "@sqltools/formatter": "^1.2.5",

--- a/src/persistence/Subject.ts
+++ b/src/persistence/Subject.ts
@@ -234,9 +234,8 @@ export class Subject {
     /**
      * Creates a value set needs to be inserted / updated in the database.
      * Value set is based on the entity and change maps of the subject.
-     * Important note: this method pops data from this subject's change maps.
      */
-    createValueSetAndPopChangeMap(): ObjectLiteral {
+    createValueSetAndChangeMapsWithoutValues() {
         const changeMapsWithoutValues: SubjectChangeMap[] = []
         const changeSet = this.changeMaps.reduce((updateMap, changeMap) => {
             let value = changeMap.value
@@ -296,6 +295,16 @@ export class Subject {
             OrmUtils.mergeDeep(updateMap, valueMap)
             return updateMap
         }, {} as ObjectLiteral)
+        return [changeSet, changeMapsWithoutValues] as const
+    }
+
+    /**
+     * Creates a value set needs to be inserted / updated in the database.
+     * Value set is based on the entity and change maps of the subject.
+     * Important note: this method pops data from this subject's change maps.
+     */
+    createValueSetAndPopChangeMap(): ObjectLiteral {
+        const [changeSet, changeMapsWithoutValues] = this.createValueSetAndChangeMapsWithoutValues();
         this.changeMaps = changeMapsWithoutValues
         return changeSet
     }

--- a/src/persistence/Subject.ts
+++ b/src/persistence/Subject.ts
@@ -235,7 +235,10 @@ export class Subject {
      * Creates a value set needs to be inserted / updated in the database.
      * Value set is based on the entity and change maps of the subject.
      */
-    createValueSetAndChangeMapsWithoutValues() {
+    createValueSetAndChangeMapsWithoutValues(): [
+        ObjectLiteral,
+        SubjectChangeMap[],
+    ] {
         const changeMapsWithoutValues: SubjectChangeMap[] = []
         const changeSet = this.changeMaps.reduce((updateMap, changeMap) => {
             let value = changeMap.value
@@ -295,7 +298,7 @@ export class Subject {
             OrmUtils.mergeDeep(updateMap, valueMap)
             return updateMap
         }, {} as ObjectLiteral)
-        return [changeSet, changeMapsWithoutValues] as const
+        return [changeSet, changeMapsWithoutValues]
     }
 
     /**

--- a/src/persistence/Subject.ts
+++ b/src/persistence/Subject.ts
@@ -304,7 +304,8 @@ export class Subject {
      * Important note: this method pops data from this subject's change maps.
      */
     createValueSetAndPopChangeMap(): ObjectLiteral {
-        const [changeSet, changeMapsWithoutValues] = this.createValueSetAndChangeMapsWithoutValues();
+        const [changeSet, changeMapsWithoutValues] =
+            this.createValueSetAndChangeMapsWithoutValues()
         this.changeMaps = changeMapsWithoutValues
         return changeSet
     }

--- a/src/persistence/SubjectExecutor.ts
+++ b/src/persistence/SubjectExecutor.ts
@@ -240,7 +240,7 @@ export class SubjectExecutor {
                 this.queryRunner.broadcaster.broadcastBeforeInsertEvent(
                     result,
                     subject.metadata,
-                    subject.entity!,
+                    subject.entity ?? subject.createValueSetAndChangeMapsWithoutValues()[0],
                 ),
             )
         if (this.updateSubjects.length)
@@ -299,7 +299,7 @@ export class SubjectExecutor {
                 this.queryRunner.broadcaster.broadcastAfterInsertEvent(
                     result,
                     subject.metadata,
-                    subject.entity!,
+                    subject.entity ?? subject.insertedValueSet,
                 ),
             )
         if (this.updateSubjects.length)

--- a/src/persistence/SubjectExecutor.ts
+++ b/src/persistence/SubjectExecutor.ts
@@ -240,7 +240,8 @@ export class SubjectExecutor {
                 this.queryRunner.broadcaster.broadcastBeforeInsertEvent(
                     result,
                     subject.metadata,
-                    subject.entity ?? subject.createValueSetAndChangeMapsWithoutValues()[0],
+                    subject.entity ??
+                        subject.createValueSetAndChangeMapsWithoutValues()[0],
                 ),
             )
         if (this.updateSubjects.length)

--- a/test/github-issues/9974/entity/Author.ts
+++ b/test/github-issues/9974/entity/Author.ts
@@ -1,20 +1,29 @@
-import {Column, Entity, JoinTable, ManyToMany, PrimaryGeneratedColumn} from "../../../../src";
-import {Post} from "./Post";
-import {PostWithCascade} from "./PostWithCascade";
+import {
+    Column,
+    Entity,
+    JoinTable,
+    ManyToMany,
+    PrimaryGeneratedColumn,
+} from "../../../../src"
+import { Post } from "./Post"
+import { PostWithCascade } from "./PostWithCascade"
 
 @Entity()
-export class Author{
+export class Author {
     @PrimaryGeneratedColumn()
     id: number
 
     @Column()
     name: string
 
-    @ManyToMany(() => Post, post => post.authors)
+    @ManyToMany(() => Post, (post) => post.authors)
     @JoinTable()
     posts: Post[]
 
-    @ManyToMany(() => PostWithCascade, postWithCascade => postWithCascade.authors)
+    @ManyToMany(
+        () => PostWithCascade,
+        (postWithCascade) => postWithCascade.authors,
+    )
     @JoinTable()
     postsWithCascade: PostWithCascade[]
 }

--- a/test/github-issues/9974/entity/Author.ts
+++ b/test/github-issues/9974/entity/Author.ts
@@ -1,0 +1,20 @@
+import {Column, Entity, JoinTable, ManyToMany, PrimaryGeneratedColumn} from "../../../../src";
+import {Post} from "./Post";
+import {PostWithCascade} from "./PostWithCascade";
+
+@Entity()
+export class Author{
+    @PrimaryGeneratedColumn()
+    id: number
+
+    @Column()
+    name: string
+
+    @ManyToMany(() => Post, post => post.authors)
+    @JoinTable()
+    posts: Post[]
+
+    @ManyToMany(() => PostWithCascade, postWithCascade => postWithCascade.authors)
+    @JoinTable()
+    postsWithCascade: PostWithCascade[]
+}

--- a/test/github-issues/9974/entity/Post.ts
+++ b/test/github-issues/9974/entity/Post.ts
@@ -1,5 +1,10 @@
-import {Column, Entity, ManyToMany, PrimaryGeneratedColumn} from "../../../../src"
-import {Author} from "./Author";
+import {
+    Column,
+    Entity,
+    ManyToMany,
+    PrimaryGeneratedColumn,
+} from "../../../../src"
+import { Author } from "./Author"
 
 @Entity()
 export class Post {
@@ -9,6 +14,6 @@ export class Post {
     @Column()
     name: string
 
-    @ManyToMany(() => Author, author => author.posts)
+    @ManyToMany(() => Author, (author) => author.posts)
     authors: Author[]
 }

--- a/test/github-issues/9974/entity/Post.ts
+++ b/test/github-issues/9974/entity/Post.ts
@@ -1,0 +1,14 @@
+import {Column, Entity, ManyToMany, PrimaryGeneratedColumn} from "../../../../src"
+import {Author} from "./Author";
+
+@Entity()
+export class Post {
+    @PrimaryGeneratedColumn()
+    id: number
+
+    @Column()
+    name: string
+
+    @ManyToMany(() => Author, author => author.posts)
+    authors: Author[]
+}

--- a/test/github-issues/9974/entity/PostWithCascade.ts
+++ b/test/github-issues/9974/entity/PostWithCascade.ts
@@ -1,0 +1,14 @@
+import {Column, Entity, ManyToMany, PrimaryGeneratedColumn} from "../../../../src"
+import {Author} from "./Author";
+
+@Entity()
+export class PostWithCascade {
+    @PrimaryGeneratedColumn()
+    id: number
+
+    @Column()
+    name: string
+
+    @ManyToMany(() => Author, author => author.postsWithCascade, {cascade: true})
+    authors: Author[]
+}

--- a/test/github-issues/9974/entity/PostWithCascade.ts
+++ b/test/github-issues/9974/entity/PostWithCascade.ts
@@ -1,5 +1,10 @@
-import {Column, Entity, ManyToMany, PrimaryGeneratedColumn} from "../../../../src"
-import {Author} from "./Author";
+import {
+    Column,
+    Entity,
+    ManyToMany,
+    PrimaryGeneratedColumn,
+} from "../../../../src"
+import { Author } from "./Author"
 
 @Entity()
 export class PostWithCascade {
@@ -9,6 +14,8 @@ export class PostWithCascade {
     @Column()
     name: string
 
-    @ManyToMany(() => Author, author => author.postsWithCascade, {cascade: true})
+    @ManyToMany(() => Author, (author) => author.postsWithCascade, {
+        cascade: true,
+    })
     authors: Author[]
 }

--- a/test/github-issues/9974/issue-9974.ts
+++ b/test/github-issues/9974/issue-9974.ts
@@ -4,13 +4,13 @@ import {
     closeTestingConnections,
     reloadTestingDatabases,
 } from "../../utils/test-utils"
-import {DataSource} from "../../../src/data-source/DataSource"
-import {expect} from "chai"
-import {Post} from "./entity/Post"
-import {Author} from "./entity/Author";
-import {AuthorPostSubscriber} from "./subscriber/AuthorPostSubscriber";
-import {PostWithCascade} from "./entity/PostWithCascade";
-import {AuthorPostWithCascadeSubscriber} from "./subscriber/AuthorPostWithCascadeSubscriber";
+import { DataSource } from "../../../src/data-source/DataSource"
+import { expect } from "chai"
+import { Post } from "./entity/Post"
+import { Author } from "./entity/Author"
+import { AuthorPostSubscriber } from "./subscriber/AuthorPostSubscriber"
+import { PostWithCascade } from "./entity/PostWithCascade"
+import { AuthorPostWithCascadeSubscriber } from "./subscriber/AuthorPostWithCascadeSubscriber"
 
 describe("github issues > #9974 EventSubscriber beforeInsert, afterInsert missing data for junctionTables", () => {
     let dataSources: DataSource[]
@@ -18,17 +18,20 @@ describe("github issues > #9974 EventSubscriber beforeInsert, afterInsert missin
         async () =>
             (dataSources = await createTestingConnections({
                 entities: [__dirname + "/entity/*{.js,.ts}"],
-                subscribers: [AuthorPostSubscriber, AuthorPostWithCascadeSubscriber],
+                subscribers: [
+                    AuthorPostSubscriber,
+                    AuthorPostWithCascadeSubscriber,
+                ],
                 schemaCreate: true,
                 dropSchema: true,
             })),
     )
     beforeEach(() => {
-        AuthorPostSubscriber.beforeInsertEntity = undefined;
-        AuthorPostSubscriber.afterInsertEntity = undefined;
+        AuthorPostSubscriber.beforeInsertEntity = undefined
+        AuthorPostSubscriber.afterInsertEntity = undefined
 
-        AuthorPostWithCascadeSubscriber.beforeInsertEntity = undefined;
-        AuthorPostWithCascadeSubscriber.afterInsertEntity = undefined;
+        AuthorPostWithCascadeSubscriber.beforeInsertEntity = undefined
+        AuthorPostWithCascadeSubscriber.afterInsertEntity = undefined
 
         return reloadTestingDatabases(dataSources)
     })
@@ -39,9 +42,9 @@ describe("github issues > #9974 EventSubscriber beforeInsert, afterInsert missin
             dataSources.map(async (dataSource) => {
                 const manager = dataSource.manager
 
-                const author = new Author();
+                const author = new Author()
                 author.name = "author"
-                await manager.save(author);
+                await manager.save(author)
 
                 const post = new Post()
                 post.name = "post"
@@ -49,8 +52,14 @@ describe("github issues > #9974 EventSubscriber beforeInsert, afterInsert missin
                 await manager.save(post)
 
                 // Before is undefined since post is not saved yet and has no ID in beforeInsert
-                expect(AuthorPostSubscriber.beforeInsertEntity).to.be.eql({authorId: 1, postId: undefined})
-                expect(AuthorPostSubscriber.afterInsertEntity).to.be.eql({authorId: 1, postId: 1})
+                expect(AuthorPostSubscriber.beforeInsertEntity).to.be.eql({
+                    authorId: 1,
+                    postId: undefined,
+                })
+                expect(AuthorPostSubscriber.afterInsertEntity).to.be.eql({
+                    authorId: 1,
+                    postId: 1,
+                })
             }),
         ))
 
@@ -59,7 +68,7 @@ describe("github issues > #9974 EventSubscriber beforeInsert, afterInsert missin
             dataSources.map(async (dataSource) => {
                 const manager = dataSource.manager
 
-                const author = new Author();
+                const author = new Author()
                 author.name = "author"
 
                 const post = new PostWithCascade()
@@ -68,8 +77,15 @@ describe("github issues > #9974 EventSubscriber beforeInsert, afterInsert missin
                 await manager.save(post)
 
                 // Before is undefined since post and author are not saved yet and have no ID in beforeInsert
-                expect(AuthorPostWithCascadeSubscriber.beforeInsertEntity).to.be.eql({authorId: undefined, postWithCascadeId: undefined})
-                expect(AuthorPostWithCascadeSubscriber.afterInsertEntity).to.be.eql({authorId: 1, postWithCascadeId: 1})
+                expect(
+                    AuthorPostWithCascadeSubscriber.beforeInsertEntity,
+                ).to.be.eql({
+                    authorId: undefined,
+                    postWithCascadeId: undefined,
+                })
+                expect(
+                    AuthorPostWithCascadeSubscriber.afterInsertEntity,
+                ).to.be.eql({ authorId: 1, postWithCascadeId: 1 })
             }),
         ))
 
@@ -78,7 +94,7 @@ describe("github issues > #9974 EventSubscriber beforeInsert, afterInsert missin
             dataSources.map(async (dataSource) => {
                 const manager = dataSource.manager
 
-                const author = new Author();
+                const author = new Author()
                 author.name = "author"
                 await manager.save(author)
 
@@ -86,10 +102,20 @@ describe("github issues > #9974 EventSubscriber beforeInsert, afterInsert missin
                 post.name = "post"
                 await manager.save(post)
 
-                await dataSource.createQueryBuilder().relation(Post, "authors").of(1).add(1);
+                await dataSource
+                    .createQueryBuilder()
+                    .relation(Post, "authors")
+                    .of(1)
+                    .add(1)
 
-                expect(AuthorPostSubscriber.beforeInsertEntity).to.be.eql({authorId: 1, postId: 1})
-                expect(AuthorPostSubscriber.afterInsertEntity).to.be.eql({authorId: 1, postId: 1})
+                expect(AuthorPostSubscriber.beforeInsertEntity).to.be.eql({
+                    authorId: 1,
+                    postId: 1,
+                })
+                expect(AuthorPostSubscriber.afterInsertEntity).to.be.eql({
+                    authorId: 1,
+                    postId: 1,
+                })
             }),
         ))
 })

--- a/test/github-issues/9974/issue-9974.ts
+++ b/test/github-issues/9974/issue-9974.ts
@@ -1,0 +1,95 @@
+import "reflect-metadata"
+import {
+    createTestingConnections,
+    closeTestingConnections,
+    reloadTestingDatabases,
+} from "../../utils/test-utils"
+import {DataSource} from "../../../src/data-source/DataSource"
+import {expect} from "chai"
+import {Post} from "./entity/Post"
+import {Author} from "./entity/Author";
+import {AuthorPostSubscriber} from "./subscriber/AuthorPostSubscriber";
+import {PostWithCascade} from "./entity/PostWithCascade";
+import {AuthorPostWithCascadeSubscriber} from "./subscriber/AuthorPostWithCascadeSubscriber";
+
+describe("github issues > #9974 EventSubscriber beforeInsert, afterInsert missing data for junctionTables", () => {
+    let dataSources: DataSource[]
+    before(
+        async () =>
+            (dataSources = await createTestingConnections({
+                entities: [__dirname + "/entity/*{.js,.ts}"],
+                subscribers: [AuthorPostSubscriber, AuthorPostWithCascadeSubscriber],
+                schemaCreate: true,
+                dropSchema: true,
+            })),
+    )
+    beforeEach(() => {
+        AuthorPostSubscriber.beforeInsertEntity = undefined;
+        AuthorPostSubscriber.afterInsertEntity = undefined;
+
+        AuthorPostWithCascadeSubscriber.beforeInsertEntity = undefined;
+        AuthorPostWithCascadeSubscriber.afterInsertEntity = undefined;
+
+        return reloadTestingDatabases(dataSources)
+    })
+    after(() => closeTestingConnections(dataSources))
+
+    it("should have entity set inside subscriber", () =>
+        Promise.all(
+            dataSources.map(async (dataSource) => {
+                const manager = dataSource.manager
+
+                const author = new Author();
+                author.name = "author"
+                await manager.save(author);
+
+                const post = new Post()
+                post.name = "post"
+                post.authors = [author]
+                await manager.save(post)
+
+                // Before is undefined since post is not saved yet and has no ID in beforeInsert
+                expect(AuthorPostSubscriber.beforeInsertEntity).to.be.eql({authorId: 1, postId: undefined})
+                expect(AuthorPostSubscriber.afterInsertEntity).to.be.eql({authorId: 1, postId: 1})
+            }),
+        ))
+
+    it("should have entity set inside subscriber with cascade", () =>
+        Promise.all(
+            dataSources.map(async (dataSource) => {
+                const manager = dataSource.manager
+
+                const author = new Author();
+                author.name = "author"
+
+                const post = new PostWithCascade()
+                post.name = "post"
+                post.authors = [author]
+                await manager.save(post)
+
+                // Before is undefined since post and author are not saved yet and have no ID in beforeInsert
+                expect(AuthorPostWithCascadeSubscriber.beforeInsertEntity).to.be.eql({authorId: undefined, postWithCascadeId: undefined})
+                expect(AuthorPostWithCascadeSubscriber.afterInsertEntity).to.be.eql({authorId: 1, postWithCascadeId: 1})
+            }),
+        ))
+
+    it("should have entity set inside subscriber with queryBuilder", () =>
+        Promise.all(
+            dataSources.map(async (dataSource) => {
+                const manager = dataSource.manager
+
+                const author = new Author();
+                author.name = "author"
+                await manager.save(author)
+
+                const post = new Post()
+                post.name = "post"
+                await manager.save(post)
+
+                await dataSource.createQueryBuilder().relation(Post, "authors").of(1).add(1);
+
+                expect(AuthorPostSubscriber.beforeInsertEntity).to.be.eql({authorId: 1, postId: 1})
+                expect(AuthorPostSubscriber.afterInsertEntity).to.be.eql({authorId: 1, postId: 1})
+            }),
+        ))
+})

--- a/test/github-issues/9974/subscriber/AuthorPostSubscriber.ts
+++ b/test/github-issues/9974/subscriber/AuthorPostSubscriber.ts
@@ -1,11 +1,11 @@
 import {
     EntitySubscriberInterface,
-    EventSubscriber, InsertEvent,
+    EventSubscriber,
+    InsertEvent,
 } from "../../../../src"
 
 @EventSubscriber()
 export class AuthorPostSubscriber implements EntitySubscriberInterface {
-
     static beforeInsertEntity: any
     static afterInsertEntity: any
 
@@ -13,11 +13,11 @@ export class AuthorPostSubscriber implements EntitySubscriberInterface {
         return "author_posts_post"
     }
 
-    beforeInsert({entity}: InsertEvent<any>) {
+    beforeInsert({ entity }: InsertEvent<any>) {
         AuthorPostSubscriber.beforeInsertEntity = entity
     }
 
-    afterInsert({entity}: InsertEvent<any>) {
+    afterInsert({ entity }: InsertEvent<any>) {
         AuthorPostSubscriber.afterInsertEntity = entity
     }
 }

--- a/test/github-issues/9974/subscriber/AuthorPostSubscriber.ts
+++ b/test/github-issues/9974/subscriber/AuthorPostSubscriber.ts
@@ -1,0 +1,23 @@
+import {
+    EntitySubscriberInterface,
+    EventSubscriber, InsertEvent,
+} from "../../../../src"
+
+@EventSubscriber()
+export class AuthorPostSubscriber implements EntitySubscriberInterface {
+
+    static beforeInsertEntity: any
+    static afterInsertEntity: any
+
+    listenTo(): Function | string {
+        return "author_posts_post"
+    }
+
+    beforeInsert({entity}: InsertEvent<any>) {
+        AuthorPostSubscriber.beforeInsertEntity = entity
+    }
+
+    afterInsert({entity}: InsertEvent<any>) {
+        AuthorPostSubscriber.afterInsertEntity = entity
+    }
+}

--- a/test/github-issues/9974/subscriber/AuthorPostWithCascadeSubscriber.ts
+++ b/test/github-issues/9974/subscriber/AuthorPostWithCascadeSubscriber.ts
@@ -1,0 +1,23 @@
+import {
+    EntitySubscriberInterface,
+    EventSubscriber, InsertEvent,
+} from "../../../../src"
+
+@EventSubscriber()
+export class AuthorPostWithCascadeSubscriber implements EntitySubscriberInterface {
+
+    static beforeInsertEntity: any
+    static afterInsertEntity: any
+
+    listenTo(): Function | string {
+        return "author_posts_with_cascade_post_with_cascade"
+    }
+
+    beforeInsert({metadata, entity}: InsertEvent<any>) {
+        AuthorPostWithCascadeSubscriber.beforeInsertEntity = entity
+    }
+
+    afterInsert({metadata, entity}: InsertEvent<any>) {
+        AuthorPostWithCascadeSubscriber.afterInsertEntity = entity
+    }
+}

--- a/test/github-issues/9974/subscriber/AuthorPostWithCascadeSubscriber.ts
+++ b/test/github-issues/9974/subscriber/AuthorPostWithCascadeSubscriber.ts
@@ -1,11 +1,13 @@
 import {
     EntitySubscriberInterface,
-    EventSubscriber, InsertEvent,
+    EventSubscriber,
+    InsertEvent,
 } from "../../../../src"
 
 @EventSubscriber()
-export class AuthorPostWithCascadeSubscriber implements EntitySubscriberInterface {
-
+export class AuthorPostWithCascadeSubscriber
+    implements EntitySubscriberInterface
+{
     static beforeInsertEntity: any
     static afterInsertEntity: any
 
@@ -13,11 +15,11 @@ export class AuthorPostWithCascadeSubscriber implements EntitySubscriberInterfac
         return "author_posts_with_cascade_post_with_cascade"
     }
 
-    beforeInsert({metadata, entity}: InsertEvent<any>) {
+    beforeInsert({ metadata, entity }: InsertEvent<any>) {
         AuthorPostWithCascadeSubscriber.beforeInsertEntity = entity
     }
 
-    afterInsert({metadata, entity}: InsertEvent<any>) {
+    afterInsert({ metadata, entity }: InsertEvent<any>) {
         AuthorPostWithCascadeSubscriber.afterInsertEntity = entity
     }
 }


### PR DESCRIPTION

<!--
  😀 Wonderful!  Thank you for opening a pull request for TypeORM.

  Please fill in the information below to expedite the review
  and (hopefully) merge of your change.

  If unsure about something.. just do as best as you're able,
  or reach out through our community support channels!
  https://github.com/typeorm/typeorm/blob/master/docs/support.md
-->

### Description of change

Fixes #9974


When data is inserted into a junctionTable (through updating Many-To-Many-Relations) the EventSubscriber's beforeInsert and afterInsert methods are called, but without data. This MR changes that.

<!--
  Please be clear and concise what the change is intended to do,
  why this change is needed, and how you've verified that it
  corrects what you intended.

  In some cases it may be helpful to include the current behavior
  and the new behavior.

  If the change is related to an open issue, you can link it here.
  If you include `Fixes #0000` (replacing `0000` with the issue number)
  when this is merged it will automatically mark the issue as fixed and
  close it.
-->


### Pull-Request Checklist

<!--
  Please make sure to review and check all of the following.

  If an item is not applicable, you can add "N/A" to the end.
-->

- [x] Code is up-to-date with the `master` branch
- [x] `npm run format` to apply prettier formatting
- [x] `npm run test` passes with this change
- [x] This pull request links relevant issues as `Fixes #0000`
- [x] There are new or updated unit tests validating the change
- [ ] Documentation has been updated to reflect this change
- [x] The new commits follow conventions explained in [CONTRIBUTING.md](https://github.com/typeorm/typeorm/blob/master/CONTRIBUTING.md)

<!--
  🎉 Thank you for contributing and making TypeORM even better!
-->
