### PR TITLE
fix: add `trustServerCertificate` option to `SqlServerConnectionOptions`

### DIFF
--- a/docs/data-source-options.md
+++ b/docs/data-source-options.md
@@ -378,6 +378,8 @@ Different RDBMS-es have their own specific options.
 
 -   `options.appName` - Application name used for identifying a specific application in profiling, logging or tracing tools of SQL Server. (default: `node-mssql`)
 
+-   `options.trustServerCertificate` - A boolean, controlling whether encryption occurs if there is no verifiable server certificate. (default: `false`)
+
 -   `options.debug.packet` - A boolean, controlling whether `debug` events will be emitted with text describing packet
     details (default: `false`).
 

--- a/src/driver/sqlserver/SqlServerConnectionOptions.ts
+++ b/src/driver/sqlserver/SqlServerConnectionOptions.ts
@@ -278,6 +278,12 @@ export interface SqlServerConnectionOptions
          * (default: node-mssql)
          */
         readonly appName?: string
+
+        /**
+         * A boolean, that specifies whether encryption occurs if there is no verifiable server certificate. 
+         * (default: false)
+         */
+        readonly trustServerCertificate?: boolean
     }
 
     /**

--- a/src/driver/sqlserver/SqlServerConnectionOptions.ts
+++ b/src/driver/sqlserver/SqlServerConnectionOptions.ts
@@ -280,7 +280,7 @@ export interface SqlServerConnectionOptions
         readonly appName?: string
 
         /**
-         * A boolean, that specifies whether encryption occurs if there is no verifiable server certificate. 
+         * A boolean, that specifies whether encryption occurs if there is no verifiable server certificate.
          * (default: false)
          */
         readonly trustServerCertificate?: boolean

--- a/src/driver/sqlserver/SqlServerConnectionOptions.ts
+++ b/src/driver/sqlserver/SqlServerConnectionOptions.ts
@@ -280,7 +280,7 @@ export interface SqlServerConnectionOptions
         readonly appName?: string
 
         /**
-         * A boolean, that specifies whether encryption occurs if there is no verifiable server certificate.
+         * A boolean, controlling whether encryption occurs if there is no verifiable server certificate.
          * (default: false)
          */
         readonly trustServerCertificate?: boolean


### PR DESCRIPTION
<!--
  😀 Wonderful!  Thank you for opening a pull request for TypeORM.

  Please fill in the information below to expedite the review
  and (hopefully) merge of your change.

  If unsure about something.. just do as best as you're able,
  or reach out through our community support channels!
  https://github.com/typeorm/typeorm/blob/master/docs/support.md
-->

### Description of change

Add `trustServerCertificate` option to `SqlServerConnectionOptions` interface. No updates to driver code are necessary since the entire `options` object is passed to the driver.

Closes #8093

<!--
  Please be clear and concise what the change is intended to do,
  why this change is needed, and how you've verified that it
  corrects what you intended.

  In some cases it may be helpful to include the current behavior
  and the new behavior.

  If the change is related to an open issue, you can link it here.
  If you include `Fixes #0000` (replacing `0000` with the issue number)
  when this is merged it will automatically mark the issue as fixed and
  close it.
-->


### Pull-Request Checklist

<!--
  Please make sure to review and check all of the following.

  If an item is not applicable, you can add "N/A" to the end.
-->

- [x] Code is up-to-date with the `master` branch
- [x] `npm run format` to apply prettier formatting
- [x] `npm run test` passes with this change
- [x] This pull request links relevant issues as `Fixes #0000`
- [ ] There are new or updated unit tests validating the change
- [x] Documentation has been updated to reflect this change
- [x] The new commits follow conventions explained in [CONTRIBUTING.md](https://github.com/typeorm/typeorm/blob/master/CONTRIBUTING.md)

<!--
  🎉 Thank you for contributing and making TypeORM even better!
-->
