### PR TITLE
fix: ISO date parsing

### DIFF
--- a/test/github-issues/9941/entity/A.ts
+++ b/test/github-issues/9941/entity/A.ts
@@ -1,0 +1,10 @@
+import { Column, Entity, PrimaryGeneratedColumn } from "../../../../src"
+
+@Entity()
+export class A {
+    @PrimaryGeneratedColumn("uuid")
+    id: string
+
+    @Column("timestamp with time zone")
+    date: Date
+}

--- a/test/github-issues/9941/issue-9941.ts
+++ b/test/github-issues/9941/issue-9941.ts
@@ -1,0 +1,91 @@
+import "reflect-metadata"
+import {
+    createTestingConnections,
+    closeTestingConnections,
+    reloadTestingDatabases,
+} from "../../utils/test-utils"
+import { DataSource } from "../../../src/data-source/DataSource"
+import { expect } from "chai"
+import { A } from "./entity/A"
+
+describe("github issues > #9941 ISO DateTime parsing returning wrong Date value", () => {
+    let tzBefore: string | undefined = undefined
+    let dataSources: DataSource[]
+    before(async () => {
+        dataSources = await createTestingConnections({
+            entities: [__dirname + "/entity/*{.js,.ts}"],
+            schemaCreate: true,
+            dropSchema: true,
+            enabledDrivers: ["postgres"],
+        })
+    })
+    beforeEach(() => {
+        // Mock timezones.
+        tzBefore = process.env.TZ
+        process.env.TZ = "America/Montreal"
+        return reloadTestingDatabases(dataSources)
+    })
+    afterEach(() => {
+        // Reset date timezone mock.
+        if (tzBefore === undefined) {
+            delete process.env.TZ
+        } else {
+            process.env.TZ = tzBefore
+        }
+    })
+    after(() => {
+        closeTestingConnections(dataSources)
+    })
+
+    it("should parse and save ISO date-time strings with given zero timezone offset (UTC) correctly", () =>
+        Promise.all(
+            dataSources.map(async (dataSource) => {
+                const entityManager = dataSource.createEntityManager()
+
+                const dateString = "2023-05-02T01:01:01.000Z"
+                const dateStringExpected = "2023-05-02T01:01:01.000Z"
+                const savedA = await entityManager.save(
+                    entityManager.create(A, { date: dateString }),
+                )
+                const fetchedA = (
+                    await entityManager.find(A, { where: { id: savedA.id } })
+                )[0]
+                expect(fetchedA.date.toISOString()).eq(dateStringExpected)
+            }),
+        ))
+
+    it("should parse and save ISO date strings without given time(-zone) correctly", () =>
+        Promise.all(
+            dataSources.map(async (dataSource) => {
+                const entityManager = dataSource.createEntityManager()
+
+                // This should be parsed as local time (with 2h offset because mocking the timezone).
+                const dateString = "2023-05-02"
+                const dateStringExpected = "2023-05-02T04:00:00.000Z"
+                const savedA = await entityManager.save(
+                    entityManager.create(A, { date: dateString }),
+                )
+                const fetchedA = (
+                    await entityManager.find(A, { where: { id: savedA.id } })
+                )[0]
+                expect(fetchedA.date.toISOString()).eq(dateStringExpected)
+            }),
+        ))
+
+    it("should parse and save ISO date-time strings with non-zero timezone correctly", () =>
+        Promise.all(
+            dataSources.map(async (dataSource) => {
+                const entityManager = dataSource.createEntityManager()
+                // With some offset.
+                const dateString = "2023-05-02T07:01:01+06:30"
+                let dateStringExpected = "2023-05-02T00:31:01.000Z"
+                const savedA = await entityManager.save(
+                    entityManager.create(A, { date: dateString }),
+                )
+                const fetchedA = (
+                    await entityManager.find(A, { where: { id: savedA.id } })
+                )[0]
+                expect(fetchedA.date.toISOString()).eq(dateStringExpected)
+            }),
+        ))
+})


### PR DESCRIPTION
<!--
  😀 Wonderful!  Thank you for opening a pull request for TypeORM.

  Please fill in the information below to expedite the review
  and (hopefully) merge of your change.

  If unsure about something.. just do as best as you're able,
  or reach out through our community support channels!
  https://github.com/typeorm/typeorm/blob/master/docs/support.md
-->

### Description of change

Fix date parsing ignoring time zones.
In the code there's a explanation with link to the ECMA-script specification on why that happens.
The error was introduced when removing `date-fns` from typeorm in #9634.

### Discussion

**However:** I wonder if it is even intended to deviate from the standard (even if the distinction between date and date-times seems a little bit... odd). Currently, the parse function always assumes local time unless there's a timezone given. This could be confusing.

During testing I also noticed that there are some tests that relied on another date format.
Maybe it would be wise to decide which date standard to go for (RFC3339 or ISO8601, see [this website for comparison](https://ijmacd.github.io/rfc3339-iso8601/)).
Furthermore, not sure if it makes sense to handle this by code in typeorm itself.
There are other people who really already invested time into figuring dates out in JS.

Fixes #9941

<!--
  Please be clear and concise what the change is intended to do,
  why this change is needed, and how you've verified that it
  corrects what you intended.

  In some cases it may be helpful to include the current behavior
  and the new behavior.

  If the change is related to an open issue, you can link it here.
  If you include `Fixes #0000` (replacing `0000` with the issue number)
  when this is merged it will automatically mark the issue as fixed and
  close it.
-->


### Pull-Request Checklist

<!--
  Please make sure to review and check all of the following.

  If an item is not applicable, you can add "N/A" to the end.
-->

- [x] Code is up-to-date with the `master` branch
- [x] `npm run format` to apply prettier formatting
- [ ] `npm run test` passes with this change
- [x] This pull request links relevant issues as `Fixes #0000`
- [x] There are new or updated unit tests validating the change
- [ ] Documentation has been updated to reflect this change
- [x] The new commits follow conventions explained in [CONTRIBUTING.md](https://github.com/typeorm/typeorm/blob/master/CONTRIBUTING.md)

<!--
  🎉 Thank you for contributing and making TypeORM even better!
-->
