### PR TITLE
fix: allow json as alias for longtext in applicable mariadb versions

### DIFF
--- a/test/github-issues/9903/entity/User.ts
+++ b/test/github-issues/9903/entity/User.ts
@@ -1,0 +1,10 @@
+import { Column, Entity, PrimaryGeneratedColumn } from "../../../../src"
+
+@Entity()
+export class User {
+    @PrimaryGeneratedColumn("increment")
+    id?: number
+
+    @Column({ type: "json" })
+    jsonData: string
+}

--- a/test/github-issues/9903/issue-9903.ts
+++ b/test/github-issues/9903/issue-9903.ts
@@ -1,0 +1,83 @@
+import "../../utils/test-setup"
+import {
+    createTestingConnections,
+    closeTestingConnections,
+    reloadTestingDatabases,
+} from "../../utils/test-utils"
+import { DataSource } from "../../../src/index"
+import { expect } from "chai"
+import { User } from "./entity/User"
+
+describe("github issues > #9903 json data type", () => {
+    let connections: DataSource[]
+
+    afterEach(() => closeTestingConnections(connections))
+
+    describe("json supported type for mariadb", () => {
+        const expectedJsonString = JSON.stringify({
+            firstName: "Quality",
+            lastName: "Tester",
+        })
+        const newUser: User = {
+            jsonData: expectedJsonString,
+        }
+
+        const badJsonUser: User = {
+            jsonData: `'''faux---'''`,
+        }
+
+        before(
+            async () =>
+                (connections = await createTestingConnections({
+                    entities: [__dirname + "/entity/*{.js,.ts}"],
+                    schemaCreate: true,
+                    dropSchema: true,
+                    enabledDrivers: ["mariadb"],
+                })),
+        )
+        beforeEach(() => reloadTestingDatabases(connections))
+
+        it("should create table with json constraint", () =>
+            Promise.all(
+                connections.map(async (connection) => {
+                    const userRepository = connection.getRepository(User)
+
+                    await userRepository.save(newUser)
+
+                    const savedUser = await userRepository.findOneOrFail({
+                        where: { id: newUser.id },
+                    })
+
+                    expect(savedUser).to.not.be.null
+                    expect(savedUser.jsonData).to.equal(expectedJsonString)
+
+                    // trying to save bad json
+                    // here when executing the save the value is passed to JSON.stringify(),
+                    // this will ensure its json valid in mariadb so this won't break the constraint
+                    try {
+                        await userRepository.save(badJsonUser)
+                    } catch (err) {
+                        expect.fail(
+                            null,
+                            null,
+                            "Should have not thrown an error",
+                        )
+                    }
+
+                    try {
+                        await userRepository.query(
+                            "INSERT INTO user values (?, ?)",
+                            [3, badJsonUser.jsonData],
+                        )
+                        expect.fail(null, null, "Should have thrown an error")
+                    } catch (err) {
+                        expect(err).not.to.be.undefined
+                        expect(err.sqlMessage).not.to.be.undefined
+                        expect(err.sqlMessage).to.equal(
+                            "CONSTRAINT `user.jsonData` failed for `test`.`user`",
+                        )
+                    }
+                }),
+            ))
+    })
+})


### PR DESCRIPTION
<!--
  😀 Wonderful!  Thank you for opening a pull request for TypeORM.

  Please fill in the information below to expedite the review
  and (hopefully) merge of your change.

  If unsure about something.. just do as best as you're able,
  or reach out through our community support channels!
  https://github.com/typeorm/typeorm/blob/master/docs/support.md
-->

### Description of change

<!--
  Please be clear and concise what the change is intended to do,
  why this change is needed, and how you've verified that it
  corrects what you intended.

  In some cases it may be helpful to include the current behavior
  and the new behavior.

  If the change is related to an open issue, you can link it here.
  If you include `Fixes #0000` (replacing `0000` with the issue number)
  when this is merged it will automatically mark the issue as fixed and
  close it.
-->

This addresses the defaulting of json to longtext where users of later versions are unable to use the alias of JSON for the column type which creates an automatic JSON check constraint.

Fixes #9903 

### Pull-Request Checklist

<!--
  Please make sure to review and check all of the following.

  If an item is not applicable, you can add "N/A" to the end.
-->

- [x] Code is up-to-date with the `master` branch
- [x] `npm run format` to apply prettier formatting
- [x] `npm run test` passes with this change
- [x] This pull request links relevant issues as `Fixes #0000`
- [x] There are new or updated unit tests validating the change
- [ ] Documentation has been updated to reflect this change
- [x] The new commits follow conventions explained in [CONTRIBUTING.md](https://github.com/typeorm/typeorm/blob/master/CONTRIBUTING.md)

<!--
  🎉 Thank you for contributing and making TypeORM even better!
-->
