### PR TITLE
fix: correct encode mongodb auth credentials

### DIFF
--- a/src/driver/mongodb/MongoDriver.ts
+++ b/src/driver/mongodb/MongoDriver.ts
@@ -528,7 +528,9 @@ export class MongoDriver implements Driver {
         const schemaUrlPart = options.type.toLowerCase()
         const credentialsUrlPart =
             options.username && options.password
-                ? `${options.username}:${options.password}@`
+                ? `${encodeURIComponent(options.username)}:${encodeURIComponent(
+                      options.password,
+                  )}@`
                 : ""
 
         const portUrlPart =

--- a/test/github-issues/9885/issue-9885.ts
+++ b/test/github-issues/9885/issue-9885.ts
@@ -1,0 +1,22 @@
+import { expect } from "chai"
+import { DataSource } from "../../../src"
+import { createTestingConnections } from "../../utils/test-utils"
+
+describe("github issues > #9885", () => {
+    let dataSources: DataSource[]
+
+    before(async () => {
+        dataSources = await createTestingConnections({
+            entities: [],
+            enabledDrivers: ["mongodb"],
+        })
+    })
+
+    it("should be connected", async () => {
+        await Promise.all(
+            dataSources.map(async (dataSource) => {
+                expect(dataSource.isInitialized).true
+            }),
+        )
+    })
+})

--- a/test/github-issues/9885/issue-9885.ts
+++ b/test/github-issues/9885/issue-9885.ts
@@ -1,7 +1,7 @@
 import { expect } from "chai"
 import { DataSource } from "../../../src"
 import { createTestingConnections } from "../../utils/test-utils"
-import { closeTestingConnections } from "../../test/utils/test-utils.js"
+import { closeTestingConnections } from "../../test/utils/test-utils"
 
 describe("github issues > #9885", () => {
     let dataSources: DataSource[]

--- a/test/github-issues/9885/issue-9885.ts
+++ b/test/github-issues/9885/issue-9885.ts
@@ -1,7 +1,9 @@
 import { expect } from "chai"
 import { DataSource } from "../../../src"
-import { closeTestingConnections, createTestingConnections } from "../../utils/test-utils"
-
+import {
+    closeTestingConnections,
+    createTestingConnections,
+} from "../../utils/test-utils"
 
 describe("github issues > #9885", () => {
     let dataSources: DataSource[]

--- a/test/github-issues/9885/issue-9885.ts
+++ b/test/github-issues/9885/issue-9885.ts
@@ -1,6 +1,7 @@
 import { expect } from "chai"
 import { DataSource } from "../../../src"
 import { createTestingConnections } from "../../utils/test-utils"
+import { closeTestingConnections } from "../../test/utils/test-utils.js"
 
 describe("github issues > #9885", () => {
     let dataSources: DataSource[]
@@ -11,12 +12,11 @@ describe("github issues > #9885", () => {
             enabledDrivers: ["mongodb"],
         })
     })
+    after(() => closeTestingConnections(dataSources))
 
-    it("should be connected", async () => {
-        await Promise.all(
-            dataSources.map(async (dataSource) => {
-                expect(dataSource.isInitialized).true
-            }),
-        )
+    it("should be connected", () => {
+        dataSources.forEach((dataSource) => {
+            expect(dataSource.isInitialized).true
+        })
     })
 })

--- a/test/github-issues/9885/issue-9885.ts
+++ b/test/github-issues/9885/issue-9885.ts
@@ -1,7 +1,7 @@
 import { expect } from "chai"
 import { DataSource } from "../../../src"
-import { createTestingConnections } from "../../utils/test-utils"
-import { closeTestingConnections } from "../../test/utils/test-utils"
+import { closeTestingConnections, createTestingConnections } from "../../utils/test-utils"
+
 
 describe("github issues > #9885", () => {
     let dataSources: DataSource[]


### PR DESCRIPTION
### Description of change

It fix an unauthorized error when connecting to mongodb using the character `@` in the credentials

### Pull-Request Checklist

- [x] Code is up-to-date with the `master` branch
- [x] `npm run format` to apply prettier formatting
- [x] `npm run test` passes with this change
- [x] This pull request links relevant issues as `Fixes #0000`
- [x] There are new or updated unit tests validating the change
- [ ] Documentation has been updated to reflect this change
- [x] The new commits follow conventions explained in [CONTRIBUTING.md](https://github.com/typeorm/typeorm/blob/master/CONTRIBUTING.md)

<!--
  🎉 Thank you for contributing and making TypeORM even better!
-->
