### PR TITLE
fix: resolve numbers loose decimals when read from the database

### DIFF
--- a/src/driver/aurora-mysql/AuroraMysqlDriver.ts
+++ b/src/driver/aurora-mysql/AuroraMysqlDriver.ts
@@ -636,7 +636,7 @@ export class AuroraMysqlDriver implements Driver {
             value = parseInt(value)
         } else if (columnMetadata.type === Number) {
             // convert to number if number
-            value = !isNaN(+value) ? parseInt(value) : value
+            value = !isNaN(+value) ? parseFloat(value) : value
         }
 
         if (columnMetadata.transformer)

--- a/src/driver/mysql/MysqlDriver.ts
+++ b/src/driver/mysql/MysqlDriver.ts
@@ -647,7 +647,7 @@ export class MysqlDriver implements Driver {
             return DateUtils.simpleArrayToString(value)
         } else if (columnMetadata.type === Number) {
             // convert to number if number
-            value = !isNaN(+value) ? parseInt(value) : value
+            value = !isNaN(+value) ? parseFloat(value) : value
         }
 
         return value
@@ -699,7 +699,7 @@ export class MysqlDriver implements Driver {
             value = DateUtils.stringToSimpleArray(value)
         } else if (columnMetadata.type === Number) {
             // convert to number if number
-            value = !isNaN(+value) ? parseInt(value) : value
+            value = !isNaN(+value) ? parseFloat(value) : value
         }
 
         if (columnMetadata.transformer)

--- a/src/driver/oracle/OracleDriver.ts
+++ b/src/driver/oracle/OracleDriver.ts
@@ -555,7 +555,7 @@ export class OracleDriver implements Driver {
             value = DateUtils.stringToSimpleJson(value)
         } else if (columnMetadata.type === Number) {
             // convert to number if number
-            value = !isNaN(+value) ? parseInt(value) : value
+            value = !isNaN(+value) ? parseFloat(value) : value
         }
 
         if (columnMetadata.transformer)

--- a/src/driver/postgres/PostgresDriver.ts
+++ b/src/driver/postgres/PostgresDriver.ts
@@ -804,7 +804,7 @@ export class PostgresDriver implements Driver {
             }
         } else if (columnMetadata.type === Number) {
             // convert to number if number
-            value = !isNaN(+value) ? parseInt(value) : value
+            value = !isNaN(+value) ? parseFloat(value) : value
         }
 
         if (columnMetadata.transformer)

--- a/src/driver/react-native/ReactNativeDriver.ts
+++ b/src/driver/react-native/ReactNativeDriver.ts
@@ -418,7 +418,7 @@ export class ReactNativeDriver implements Driver {
             value = DateUtils.stringToSimpleEnum(value, columnMetadata)
         } else if (columnMetadata.type === Number) {
             // convert to number if number
-            value = !isNaN(+value) ? parseInt(value) : value
+            value = !isNaN(+value) ? parseFloat(value) : value
         }
 
         if (columnMetadata.transformer)

--- a/src/driver/sap/SapDriver.ts
+++ b/src/driver/sap/SapDriver.ts
@@ -537,7 +537,7 @@ export class SapDriver implements Driver {
             value = DateUtils.stringToSimpleEnum(value, columnMetadata)
         } else if (columnMetadata.type === Number) {
             // convert to number if number
-            value = !isNaN(+value) ? parseInt(value) : value
+            value = !isNaN(+value) ? parseFloat(value) : value
         }
 
         if (columnMetadata.transformer)

--- a/src/driver/spanner/SpannerDriver.ts
+++ b/src/driver/spanner/SpannerDriver.ts
@@ -442,7 +442,7 @@ export class SpannerDriver implements Driver {
             value = typeof value === "string" ? JSON.parse(value) : value
         } else if (columnMetadata.type === Number) {
             // convert to number if number
-            value = !isNaN(+value) ? parseInt(value) : value
+            value = !isNaN(+value) ? parseFloat(value) : value
         }
 
         if (columnMetadata.transformer)

--- a/src/driver/sqlite-abstract/AbstractSqliteDriver.ts
+++ b/src/driver/sqlite-abstract/AbstractSqliteDriver.ts
@@ -420,7 +420,7 @@ export abstract class AbstractSqliteDriver implements Driver {
             value = DateUtils.stringToSimpleEnum(value, columnMetadata)
         } else if (columnMetadata.type === Number) {
             // convert to number if number
-            value = !isNaN(+value) ? parseInt(value) : value
+            value = !isNaN(+value) ? parseFloat(value) : value
         }
 
         if (columnMetadata.transformer)

--- a/src/driver/sqlserver/SqlServerDriver.ts
+++ b/src/driver/sqlserver/SqlServerDriver.ts
@@ -576,7 +576,7 @@ export class SqlServerDriver implements Driver {
             value = DateUtils.stringToSimpleEnum(value, columnMetadata)
         } else if (columnMetadata.type === Number) {
             // convert to number if number
-            value = !isNaN(+value) ? parseInt(value) : value
+            value = !isNaN(+value) ? parseFloat(value) : value
         }
 
         if (columnMetadata.transformer)


### PR DESCRIPTION
Closes: #10026

### Description of change
Fixes #10026 
Resolve issue that decimals were lost during database read.
Replaced the `parseInt` by `parseFloat`


### Pull-Request Checklist

- [x ] Code is up-to-date with the `master` branch
- [ x] `npm run format` to apply prettier formatting
- [no test databases available ] `npm run test` passes with this change 
- [x ] This pull request links relevant issues as `Fixes #0000`
- [ ] There are new or updated unit tests validating the change
- [ ] Documentation has been updated to reflect this change
- [ x] The new commits follow conventions explained in [CONTRIBUTING.md](https://github.com/typeorm/typeorm/blob/master/CONTRIBUTING.md)
