### PR TITLE
fix: for running cli-ts-node-esm use exit code from child process

### DIFF
--- a/src/cli-ts-node-esm.ts
+++ b/src/cli-ts-node-esm.ts
@@ -3,8 +3,8 @@ import { spawnSync } from "child_process"
 
 if ((process.env["NODE_OPTIONS"] || "").includes("--loader ts-node"))
     require("./cli")
-else
-    spawnSync(process.argv[0], process.argv.slice(1), {
+else {
+    const childProcess = spawnSync(process.argv[0], process.argv.slice(1), {
         stdio: "inherit",
         env: {
             ...process.env,
@@ -18,3 +18,6 @@ else
         },
         windowsHide: true,
     })
+
+    process.exit(childProcess.status || 0)
+}


### PR DESCRIPTION



### Description of change

Use child process exit code in parent process to properly indicate that child process (migration running) fails. Previously parent process always exists with code 0.

Closes: #10029

### Pull-Request Checklist

- [x] Code is up-to-date with the `master` branch
- [x] `npm run format` to apply prettier formatting
- [x] `npm run test` passes with this change
- [x] This pull request links relevant issues as `Fixes #0000`
- [ ] There are new or updated unit tests validating the change (N/A)
- [ ] Documentation has been updated to reflect this change (N/A)
- [x] The new commits follow conventions explained in [CONTRIBUTING.md](https://github.com/typeorm/typeorm/blob/master/CONTRIBUTING.md)
