### PR TITLE
test: fix test from #9034 with STI for Oracle

### DIFF
--- a/test/github-issues/7558/entity/Animal.ts
+++ b/test/github-issues/7558/entity/Animal.ts
@@ -19,7 +19,7 @@ export class AnimalEntity {
 
     @ManyToOne(() => PersonEntity, ({ pets }) => pets, {
         onDelete: "CASCADE",
-        onUpdate: "CASCADE",
+        onUpdate: "NO ACTION", // cascade would not work here as ORACLE does not have that action
     })
     person: PersonEntity
 }


### PR DESCRIPTION
<!--
  😀 Wonderful!  Thank you for opening a pull request for TypeORM.

  Please fill in the information below to expedite the review
  and (hopefully) merge of your change.

  If unsure about something.. just do as best as you're able,
  or reach out through our community support channels!
  https://github.com/typeorm/typeorm/blob/master/docs/support.md
-->

### Description of change

Oracle does not have a `onUpdate: 'CASCADE'` option. Thus, the test fixtures had to be adapted.
Checking for the correct `onUpdate` actions for Oracle was introduced in #9786.

Related To #9034

<!--
  Please be clear and concise what the change is intended to do,
  why this change is needed, and how you've verified that it
  corrects what you intended.

  In some cases it may be helpful to include the current behavior
  and the new behavior.

  If the change is related to an open issue, you can link it here.
  If you include `Fixes #0000` (replacing `0000` with the issue number)
  when this is merged it will automatically mark the issue as fixed and
  close it.
-->


### Pull-Request Checklist

<!--
  Please make sure to review and check all of the following.

  If an item is not applicable, you can add "N/A" to the end.
-->

- [x] Code is up-to-date with the `master` branch
- [x] `npm run format` to apply prettier formatting
- [x] `npm run test` passes with this change
- [x] This pull request links relevant issues as `Fixes #0000`
- [x] There are new or updated unit tests validating the change
- [ ] Documentation has been updated to reflect this change
- [x] The new commits follow conventions explained in [CONTRIBUTING.md](https://github.com/typeorm/typeorm/blob/master/CONTRIBUTING.md)

<!--
  🎉 Thank you for contributing and making TypeORM even better!
-->
