### PR TITLE
fix: ignore redis connect error when ignoreErrors:true

### DIFF
--- a/src/cache/RedisQueryResultCache.ts
+++ b/src/cache/RedisQueryResultCache.ts
@@ -61,9 +61,13 @@ export class RedisQueryResultCache implements QueryResultCache {
                 this.client.on("error", (err: any) => {
                     this.connection.logger.log("warn", err)
                 })
-            }
-            if ("connect" in this.client) {
-                await this.client.connect()
+
+                try {
+                    // Try to connect, but ignore errors if not possible
+                    await this.client.connect?.()
+                } catch (_) {}
+            } else {
+                await this.client.connect?.()
             }
         } else if (this.clientType === "ioredis") {
             if (cacheOptions && cacheOptions.port) {


### PR DESCRIPTION
<!--
  😀 Wonderful!  Thank you for opening a pull request for TypeORM.

  Please fill in the information below to expedite the review
  and (hopefully) merge of your change.

  If unsure about something.. just do as best as you're able,
  or reach out through our community support channels!
  https://github.com/typeorm/typeorm/blob/master/docs/support.md
-->

### Description of change

If ormconfig settings as follows and try to connect while Redis is down, the DB connection will not work.

```ts
const config: DataSourceOptions = {
  ...
  cache: {
    type: 'redis',
    options: {
      socket: {
        host: process.env.REDIS_HOST,
        port: +process.env.REDIS_PORT,
        reconnectStrategy: false,
      },
    },
    ignoreErrors: true,
  },
}
```

In the previous issue #926 I saw that even though Redis is down, if the value of `ignoreErrors` is true then the connection should be established.

Since the redis library is emitting Error, it had to be wrapped in try to make it work.

<details><summary><b>redis library code</b></summary>
<p>

```ts
// https://github.com/redis/node-redis/blob/3273c8540d8354119e2e07d81e1913bb1bd9cbe4/packages/client/lib/client/index.ts#L429-L433
connect(): Promise<void> {
    // see comment in constructor
    this.#isolationPool ??= this.#initiateIsolationPool();
    return this.#socket.connect();
}
```


```ts
// https://github.com/redis/node-redis/blob/3273c8540d8354119e2e07d81e1913bb1bd9cbe4/packages/client/lib/client/socket.ts#L138C1-L175
// #socket.connect()
async connect(): Promise<null> {
    if (this.#isOpen) {
        throw new Error('Socket already opened');
    }

    this.#isOpen = true;
    return this.#connect();
}

async #connect(): Promise<null> {
    let retries = 0;
    do {
        try {
            this.#socket = await this.#createSocket();
            this.#writableNeedDrain = false;
            this.emit('connect');

            try {
                await this.#initiator();
            } catch (err) {
                this.#socket.destroy();
                this.#socket = undefined;
                throw err;
            }
            this.#isReady = true;
            this.emit('ready');
        } catch (err) {
            const retryIn = this.#shouldReconnect(retries++, err as Error);
            if (typeof retryIn !== 'number') {
                throw retryIn;
            }

            this.emit('error', err);
            await promiseTimeout(retryIn);
            this.emit('reconnecting');
        }
    } while (this.#isOpen && !this.#isReady);
}
```

`throw retryIn;` <--  throw error because of this code.

</p>
</details> 





<!--
  Please be clear and concise what the change is intended to do,
  why this change is needed, and how you've verified that it
  corrects what you intended.

  In some cases it may be helpful to include the current behavior
  and the new behavior.

  If the change is related to an open issue, you can link it here.
  If you include `Fixes #0000` (replacing `0000` with the issue number)
  when this is merged it will automatically mark the issue as fixed and
  close it.
-->


### Pull-Request Checklist

<!--
  Please make sure to review and check all of the following.

  If an item is not applicable, you can add "N/A" to the end.
-->

- [x] Code is up-to-date with the `master` branch
- [x] `npm run format` to apply prettier formatting
- [x] `npm run test` passes with this change
- [ ] This pull request links relevant issues as `Fixes #0000`
- [ ] There are new or updated unit tests validating the change
- [ ] Documentation has been updated to reflect this change
- [x] The new commits follow conventions explained in [CONTRIBUTING.md](https://github.com/typeorm/typeorm/blob/master/CONTRIBUTING.md)

<!--
  🎉 Thank you for contributing and making TypeORM even better!
-->
