### PR TITLE
docs: migration from .sql file

### DIFF
--- a/docs/migrations.md
+++ b/docs/migrations.md
@@ -401,6 +401,32 @@ export class QuestionRefactoringTIMESTAMP implements MigrationInterface {
 }
 ```
 
+## Executing .sql files
+
+If your .sql file contains multiple statements per file, which is common with most standard sql tooling, you will first need to enable the `multipleStatements` option in the applicable `DataSource`.
+
+Then, in your migrations, you can just import the file as a string and execute it!
+
+```ts
+import { MigrationInterface, QueryRunner } from "typeorm"
+import fs from 'node:fs/promises'
+
+export class ExampleMigrationFromFile implements MigrationInterface {
+   public async up(queryRunner: QueryRunner): Promise<void> {
+      // be sure to specify some form of encoding on readFile/readFileSync/etc
+      // as queryRunner.query() expects a string, and by default readFile returns a Buffer
+      let queries = await fs.readFile('./data/example_table_dump.sql', { encoding: 'utf-8' })
+      await queryRunner.query(queries);
+  }
+  public async down(queryRunner: QueryRunner): Promise<void> {
+     await queryRunner.dropTable("example_table_dump")
+  }
+}
+
+```
+
+This approach can be used by `QueryRunner` at runtime as well, however - depending on your usage of typeorm, there may be security implications for leaving `multipleStatements` enabled in production.
+
 ---
 
 ```ts


### PR DESCRIPTION
to polish off #1366 for good. noticing that users created a whole npm library for this problem to work around `multipleStatements` option

I wasn't sure whether to put this in the `QueryRunner` docs or here - it seems this should ideally only be used in migrations. Perhaps there are runtime applications for a psuedo-ETL type scenario, but it seems ill advised to even document the ability to do this at runtime?

There may be other edge cases where this fails, I've only tested it with standard pgdump style files with multi-statement, single statement-per-line

<!--
  😀 Wonderful!  Thank you for opening a pull request for TypeORM.

  Please fill in the information below to expedite the review
  and (hopefully) merge of your change.

  If unsure about something.. just do as best as you're able,
  or reach out through our community support channels!
  https://github.com/typeorm/typeorm/blob/master/docs/support.md
-->

### Description of change

<!--
  Please be clear and concise what the change is intended to do,
  why this change is needed, and how you've verified that it
  corrects what you intended.

  In some cases it may be helpful to include the current behavior
  and the new behavior.

  If the change is related to an open issue, you can link it here.
  If you include `Fixes #0000` (replacing `0000` with the issue number)
  when this is merged it will automatically mark the issue as fixed and
  close it.
-->


### Pull-Request Checklist

<!--
  Please make sure to review and check all of the following.

  If an item is not applicable, you can add "N/A" to the end.
-->

- [ ] Code is up-to-date with the `master` branch
- [ ] `npm run format` to apply prettier formatting
- [ ] `npm run test` passes with this change
- [ ] This pull request links relevant issues as `Fixes #0000`
- [ ] There are new or updated unit tests validating the change
- [ ] Documentation has been updated to reflect this change
- [ ] The new commits follow conventions explained in [CONTRIBUTING.md](https://github.com/typeorm/typeorm/blob/master/CONTRIBUTING.md)

<!--
  🎉 Thank you for contributing and making TypeORM even better!
-->
