### PR TITLE
fix: add missing await

### DIFF
--- a/src/migration/MigrationExecutor.ts
+++ b/src/migration/MigrationExecutor.ts
@@ -733,7 +733,7 @@ export class MigrationExecutor {
             this.queryRunner || this.connection.createQueryRunner()
 
         try {
-            return callback(queryRunner)
+            return await callback(queryRunner)
         } finally {
             if (!this.queryRunner) {
                 await queryRunner.release()


### PR DESCRIPTION
### Description
There was missing `await` that cause `QueryRunnerAlreadyReleasedError`.

### Pull-Request Checklist

- [X] Code is up-to-date with the `master` branch
- [ ] `npm run format` to apply prettier formatting
- [ ] `npm run test` passes with this change
- [X] This pull request links relevant issue  [MigrationExecutor - Query runner already released. #10083](https://github.com/typeorm/typeorm/issues/10083)
- [ ] There are new or updated unit tests validating the change
- [N/A] Documentation has been updated to reflect this change
- [X] The new commits follow conventions explained in [CONTRIBUTING.md](https://github.com/typeorm/typeorm/blob/master/CONTRIBUTING.md)
