### PR TITLE
feat: add tagged template for executing raw SQL queries

### DIFF
--- a/src/data-source/DataSource.ts
+++ b/src/data-source/DataSource.ts
@@ -40,6 +40,7 @@ import { RelationIdLoader } from "../query-builder/RelationIdLoader"
 import { DriverUtils } from "../driver/DriverUtils"
 import { InstanceChecker } from "../util/InstanceChecker"
 import { ObjectLiteral } from "../common/ObjectLiteral"
+import { SqlTagUtils } from "../util/SqlTagUtils"
 
 /**
  * DataSource is a pre-defined connection configuration to a specific database.
@@ -533,6 +534,22 @@ export class DataSource {
         } finally {
             if (!queryRunner) await usedQueryRunner.release()
         }
+    }
+
+    /**
+     * A tagged template that executes raw SQL query and returns raw database results
+     */
+    async sql<T = any>(
+        strings: TemplateStringsArray,
+        ...values: unknown[]
+    ): Promise<T> {
+        const { query, variables } = SqlTagUtils.buildSqlTag({
+            databaseType: this.driver.options.type,
+            strings: strings,
+            expressions: values,
+        })
+
+        return await this.query(query, variables)
     }
 
     /**

--- a/src/entity-manager/EntityManager.ts
+++ b/src/entity-manager/EntityManager.ts
@@ -38,6 +38,7 @@ import { UpsertOptions } from "../repository/UpsertOptions"
 import { InstanceChecker } from "../util/InstanceChecker"
 import { ObjectLiteral } from "../common/ObjectLiteral"
 import { PickKeysByType } from "../common/PickKeysByType"
+import { SqlTagUtils } from "../util/SqlTagUtils"
 
 /**
  * Entity manager supposed to work with any entity, automatically find its repository and call its methods,
@@ -172,6 +173,22 @@ export class EntityManager {
      */
     async query<T = any>(query: string, parameters?: any[]): Promise<T> {
         return this.connection.query(query, parameters, this.queryRunner)
+    }
+
+    /**
+     * A tagged template that executes raw SQL query and returns raw database results
+     */
+    async sql<T = any>(
+        strings: TemplateStringsArray,
+        ...values: unknown[]
+    ): Promise<T> {
+        const { query, variables } = SqlTagUtils.buildSqlTag({
+            databaseType: this.connection.options.type,
+            strings: strings,
+            expressions: values,
+        })
+
+        return await this.query(query, variables)
     }
 
     /**

--- a/src/util/SqlTagUtils.ts
+++ b/src/util/SqlTagUtils.ts
@@ -1,0 +1,66 @@
+import { DatabaseType } from "../driver/types/DatabaseType"
+import { TypeORMError } from "../error"
+
+export class SqlTagUtils {
+    static buildSqlTag(params: {
+        databaseType: DatabaseType
+        strings: TemplateStringsArray
+        expressions: unknown[]
+    }): { query: string; variables: unknown[] } {
+        let idx = 0
+        let query = ""
+        const variables: unknown[] = []
+        const parameterStrategy = this.getParameterStrategy(params.databaseType)
+
+        for (const expression of params.expressions) {
+            query += params.strings[idx]
+
+            switch (parameterStrategy) {
+                case "dollar":
+                    query += "$" + ++idx
+                    break
+                case "at":
+                    query += "@" + ++idx
+                    break
+                case "colon":
+                    query += ":" + ++idx
+                    break
+                case "question-mark":
+                    query += "?"
+                    break
+                case "unknown":
+                    throw new TypeORMError(
+                        `This database engine does not support parameters`,
+                    )
+            }
+
+            variables.push(expression)
+        }
+
+        query += params.strings[idx]
+
+        return { query, variables }
+    }
+
+    static getParameterStrategy(
+        databaseType: DatabaseType,
+    ): "dollar" | "question-mark" | "colon" | "at" | "unknown" {
+        switch (databaseType) {
+            case "postgres":
+            case "cockroachdb":
+            case "aurora-postgres":
+            case "mariadb":
+                return "dollar"
+            case "mysql":
+            case "sqlite":
+            case "aurora-mysql":
+                return "question-mark"
+            case "oracle":
+                return "colon"
+            case "mssql":
+                return "at"
+            default:
+                return "unknown"
+        }
+    }
+}


### PR DESCRIPTION
*I'm aware that this PR won't be accepted until I add the appropriate tests and documentation. I first want to make sure that this feature is acceptable to the core maintainers.*

*My apologies for not writing a separate issue for that. If you believe sql tags should not exist in TypeORM, I will understand. Although, it would be harder for other tools (such as [SafeQL](https://github.com/ts-safeql/safeql)) to integrate with TypeORM.*

---

### Description of change

Adds a new tagged template to classes that execute raw SQL queries and return raw database results. The template takes a template string and an array of values as input and builds a SQL query using the appropriate parameter strategy based on

While SQL tags can be misleading to some people regarding SQL injections, they are, in fact, safer than splitting the query from the variables. With tagged template, you simply can't go wrong with accidently injecting unsafe values from variables due to the way of [how tagged templates work](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Template_literals).

As a plus, reading the query with the variables in place adds more clarity rather than trying to figure out what is the $23 parameter.

The new `sql` tag will split the templates from the expressions, parameterize the statement, and then map the statement and the variables back to the `query` method. (tag -> { query, variables } -> query method).

### Pull-Request Checklist

<!--
  Please make sure to review and check all of the following.

  If an item is not applicable, you can add "N/A" to the end.
-->

- [x] Code is up-to-date with the `master` branch
- [x] `npm run format` to apply prettier formatting
- [x] `npm run test` passes with this change
- [N/A] This pull request links relevant issues as `Fixes #0000`
- [ ] There are new or updated unit tests validating the change
- [ ] Documentation has been updated to reflect this change
- [x] The new commits follow conventions explained in [CONTRIBUTING.md](https://github.com/typeorm/typeorm/blob/master/CONTRIBUTING.md)