### PR TITLE
fix: use datetime2 as type of sqlserver query parameter

### DIFF
--- a/src/driver/sqlserver/SqlServerQueryRunner.ts
+++ b/src/driver/sqlserver/SqlServerQueryRunner.ts
@@ -232,7 +232,15 @@ export class SqlServerQueryRunner
                             request.input(parameterName, parameter.value)
                         }
                     } else {
-                        request.input(parameterName, parameter)
+                        if (parameter instanceof Date) {
+                            request.input(
+                                parameterName,
+                                this.driver.mssql.DateTime2(),
+                                parameter,
+                            )
+                        } else {
+                            request.input(parameterName, parameter)
+                        }
                     }
                 })
             }


### PR DESCRIPTION
### Description of change
Fixes #10115

### Pull-Request Checklist

- [x] Code is up-to-date with the `master` branch
- [x] `npm run format` to apply prettier formatting
- [ ] `npm run test` passes with this change
- [x] This pull request links relevant issues as `Fixes #0000`
- [ ] There are new or updated unit tests validating the change
- [ ] Documentation has been updated to reflect this change
- [x] The new commits follow conventions explained in [CONTRIBUTING.md](https://github.com/typeorm/typeorm/blob/master/CONTRIBUTING.md)

<!--
  🎉 Thank you for contributing and making TypeORM even better!
-->
