### PR TITLE
MongoDB aggregate typing

### DIFF
--- a/src/repository/MongoRepository.ts
+++ b/src/repository/MongoRepository.ts
@@ -4,7 +4,7 @@ import { MongoFindManyOptions } from "../find-options/mongodb/MongoFindManyOptio
 import { MongoEntityManager } from "../entity-manager/MongoEntityManager"
 import { QueryRunner } from "../query-runner/QueryRunner"
 import { SelectQueryBuilder } from "../query-builder/SelectQueryBuilder"
-import { TypeORMError } from "../error/TypeORMError"
+import { TypeORMError } from '../error'
 import { MongoFindOneOptions } from "../find-options/mongodb/MongoFindOneOptions"
 import { FindOneOptions } from "../find-options/FindOneOptions"
 
@@ -205,7 +205,7 @@ export class MongoRepository<
     aggregate<R = any>(
         pipeline: ObjectLiteral[],
         options?: AggregateOptions,
-    ): AggregationCursor<Entity> {
+    ): AggregationCursor<R> {
         return this.manager.aggregate<R>(
             this.metadata.target,
             pipeline,

--- a/src/repository/MongoRepository.ts
+++ b/src/repository/MongoRepository.ts
@@ -4,7 +4,7 @@ import { MongoFindManyOptions } from "../find-options/mongodb/MongoFindManyOptio
 import { MongoEntityManager } from "../entity-manager/MongoEntityManager"
 import { QueryRunner } from "../query-runner/QueryRunner"
 import { SelectQueryBuilder } from "../query-builder/SelectQueryBuilder"
-import { TypeORMError } from '../error'
+import { TypeORMError } from "../error"
 import { MongoFindOneOptions } from "../find-options/mongodb/MongoFindOneOptions"
 import { FindOneOptions } from "../find-options/FindOneOptions"
 

--- a/src/repository/MongoRepository.ts
+++ b/src/repository/MongoRepository.ts
@@ -4,7 +4,7 @@ import { MongoFindManyOptions } from "../find-options/mongodb/MongoFindManyOptio
 import { MongoEntityManager } from "../entity-manager/MongoEntityManager"
 import { QueryRunner } from "../query-runner/QueryRunner"
 import { SelectQueryBuilder } from "../query-builder/SelectQueryBuilder"
-import { TypeORMError } from "../error"
+import { TypeORMError } from "../error/TypeORMError"
 import { MongoFindOneOptions } from "../find-options/mongodb/MongoFindOneOptions"
 import { FindOneOptions } from "../find-options/FindOneOptions"
 

--- a/test/functional/repository/aggregate-methods/repository-aggregate-methods.ts
+++ b/test/functional/repository/aggregate-methods/repository-aggregate-methods.ts
@@ -3,8 +3,8 @@ import {
     closeTestingConnections,
     createTestingConnections,
 } from "../../../utils/test-utils"
-import { Repository } from "../../../../src/repository/Repository"
-import { DataSource } from "../../../../src/data-source/DataSource"
+import { Repository } from "../../../../src"
+import { DataSource } from "../../../../src"
 import { Post } from "./entity/Post"
 import { LessThan } from "../../../../src"
 import { expect } from "chai"

--- a/test/functional/repository/aggregate-methods/repository-aggregate-methods.ts
+++ b/test/functional/repository/aggregate-methods/repository-aggregate-methods.ts
@@ -3,8 +3,8 @@ import {
     closeTestingConnections,
     createTestingConnections,
 } from "../../../utils/test-utils"
-import { Repository } from "../../../../src"
-import { DataSource } from "../../../../src"
+import { Repository } from "../../../../src/repository/Repository"
+import { DataSource } from "../../../../src/data-source/DataSource"
 import { Post } from "./entity/Post"
 import { LessThan } from "../../../../src"
 import { expect } from "chai"


### PR DESCRIPTION
The MongoDB aggregate function returned AggregationCursor<Entity> instead of AggregationCursor<R>.

- [x] Code is up-to-date with the `master` branch
- [x] `npm run format` to apply prettier formatting
- [x] `npm run test` passes with this change
- [x] This pull request links relevant issues as [`#10303`](https://github.com/typeorm/typeorm/issues/10303)
- [ ] There are new or updated unit tests validating the change
- [ ] Documentation has been updated to reflect this change
- [x] The new commits follow conventions explained in [CONTRIBUTING.md](https://github.com/typeorm/typeorm/blob/master/CONTRIBUTING.md)
