### PR TITLE
fix: improve helper for cli for commands missing positionals

### DIFF
--- a/src/commands/EntityCreateCommand.ts
+++ b/src/commands/EntityCreateCommand.ts
@@ -11,6 +11,14 @@ export class EntityCreateCommand implements yargs.CommandModule {
     command = "entity:create <path>"
     describe = "Generates a new entity."
 
+    builder(args: yargs.Argv) {
+        return args.positional("path", {
+            type: "string",
+            describe: "Path of the entity file",
+            demandOption: true,
+        })
+    }
+
     async handler(args: yargs.Arguments) {
         try {
             const fullPath = (args.path as string).startsWith("/")

--- a/src/commands/MigrationCreateCommand.ts
+++ b/src/commands/MigrationCreateCommand.ts
@@ -14,6 +14,11 @@ export class MigrationCreateCommand implements yargs.CommandModule {
 
     builder(args: yargs.Argv) {
         return args
+            .positional("path", {
+                type: "string",
+                describe: "Path of the migration file",
+                demandOption: true,
+            })
             .option("o", {
                 alias: "outputJs",
                 type: "boolean",

--- a/src/commands/MigrationCreateCommand.ts
+++ b/src/commands/MigrationCreateCommand.ts
@@ -34,12 +34,12 @@ export class MigrationCreateCommand implements yargs.CommandModule {
             })
     }
 
-    async handler(args: yargs.Arguments) {
+    async handler(args: yargs.Arguments<any & { path: string }>) {
         try {
             const timestamp = CommandUtils.getTimestamp(args.timestamp)
-            const inputPath = (args.path as string).startsWith("/")
-                ? (args.path as string)
-                : path.resolve(process.cwd(), args.path as string)
+            const inputPath = args.path.startsWith("/")
+                ? args.path
+                : path.resolve(process.cwd(), args.path)
             const filename = path.basename(inputPath)
             const fullPath =
                 path.dirname(inputPath) + "/" + timestamp + "-" + filename
@@ -74,7 +74,7 @@ export class MigrationCreateCommand implements yargs.CommandModule {
      * Gets contents of the migration file.
      */
     protected static getTemplate(name: string, timestamp: number): string {
-        return `import { MigrationInterface, QueryRunner } from "typeorm"
+        return `import { MigrationInterface, QueryRunner } from "typeorm";
 
 export class ${camelCase(
             name,

--- a/src/commands/MigrationGenerateCommand.ts
+++ b/src/commands/MigrationGenerateCommand.ts
@@ -65,12 +65,12 @@ export class MigrationGenerateCommand implements yargs.CommandModule {
             })
     }
 
-    async handler(args: yargs.Arguments) {
+    async handler(args: yargs.Arguments<any & { path: string }>) {
         const timestamp = CommandUtils.getTimestamp(args.timestamp)
         const extension = args.outputJs ? ".js" : ".ts"
-        const fullPath = (args.path as string).startsWith("/")
-            ? (args.path as string)
-            : path.resolve(process.cwd(), args.path as string)
+        const fullPath = args.path.startsWith("/")
+            ? args.path
+            : path.resolve(process.cwd(), args.path)
         const filename = timestamp + "-" + path.basename(fullPath) + extension
 
         let dataSource: DataSource | undefined = undefined

--- a/src/commands/MigrationGenerateCommand.ts
+++ b/src/commands/MigrationGenerateCommand.ts
@@ -18,6 +18,11 @@ export class MigrationGenerateCommand implements yargs.CommandModule {
 
     builder(args: yargs.Argv) {
         return args
+            .positional("path", {
+                type: "string",
+                describe: "Path of the migration file",
+                demandOption: true,
+            })
             .option("dataSource", {
                 alias: "d",
                 type: "string",

--- a/src/commands/SubscriberCreateCommand.ts
+++ b/src/commands/SubscriberCreateCommand.ts
@@ -11,6 +11,14 @@ export class SubscriberCreateCommand implements yargs.CommandModule {
     command = "subscriber:create <path>"
     describe = "Generates a new subscriber."
 
+    builder(args: yargs.Argv) {
+        return args.positional("path", {
+            type: "string",
+            describe: "Path of the subscriber file",
+            demandOption: true,
+        })
+    }
+
     async handler(args: yargs.Arguments) {
         try {
             const fullPath = (args.path as string).startsWith("/")

--- a/test/functional/commands/migration-create.ts
+++ b/test/functional/commands/migration-create.ts
@@ -16,8 +16,7 @@ import { MigrationCreateCommand } from "../../../src/commands/MigrationCreateCom
 import { Post } from "./entity/Post"
 import { resultsTemplates } from "./templates/result-templates-create"
 
-// TODO: broken after 0.3.0 changes, fix later
-describe.skip("commands - migration create", () => {
+describe("commands - migration create", () => {
     let connectionOptions: DataSourceOptions[]
     let createFileStub: sinon.SinonStub
     let timerStub: sinon.SinonFakeTimers
@@ -41,8 +40,7 @@ describe.skip("commands - migration create", () => {
     const testHandlerArgs = (options: Record<string, any>) => ({
         $0: "test",
         _: ["test"],
-        name: "test-migration",
-        dir: "test-directory",
+        path: "test-directory/test-migration",
         ...options,
     })
 

--- a/test/functional/commands/migration-generate.ts
+++ b/test/functional/commands/migration-generate.ts
@@ -2,6 +2,7 @@ import sinon from "sinon"
 import {
     ConnectionOptionsReader,
     DatabaseType,
+    DataSource,
     DataSourceOptions,
 } from "../../../src"
 import {
@@ -15,24 +16,32 @@ import { MigrationGenerateCommand } from "../../../src/commands/MigrationGenerat
 import { Post } from "./entity/Post"
 import { resultsTemplates } from "./templates/result-templates-generate"
 
-// TODO: broken after 0.3.0 changes, fix later
-describe.skip("commands - migration generate", () => {
+describe("commands - migration generate", () => {
     let connectionOptions: DataSourceOptions[]
     let createFileStub: sinon.SinonStub
+    let loadDataSourceStub: sinon.SinonStub
     let timerStub: sinon.SinonFakeTimers
     let getConnectionOptionsStub: sinon.SinonStub
     let migrationGenerateCommand: MigrationGenerateCommand
     let connectionOptionsReader: ConnectionOptionsReader
     let baseConnectionOptions: DataSourceOptions
 
-    const enabledDrivers = ["mysql"] as DatabaseType[]
+    const enabledDrivers = [
+        "postgres",
+        "mssql",
+        "mysql",
+        "mariadb",
+        "sqlite",
+        "better-sqlite3",
+        "oracle",
+        "cockroachdb",
+    ] as DatabaseType[]
 
     // simulate args: `npm run typeorm migration:run -- -n test-migration -d test-directory`
     const testHandlerArgs = (options: Record<string, any>) => ({
         $0: "test",
         _: ["test"],
-        name: "test-migration",
-        dir: "test-directory",
+        path: "test-directory/test-migration",
         ...options,
     })
 
@@ -52,6 +61,7 @@ describe.skip("commands - migration generate", () => {
         connectionOptionsReader = new ConnectionOptionsReader()
         migrationGenerateCommand = new MigrationGenerateCommand()
         createFileStub = sinon.stub(CommandUtils, "createFile")
+        loadDataSourceStub = sinon.stub(CommandUtils, "loadDataSource")
 
         timerStub = sinon.useFakeTimers(1610975184784)
     })
@@ -59,6 +69,7 @@ describe.skip("commands - migration generate", () => {
     after(async () => {
         timerStub.restore()
         createFileStub.restore()
+        loadDataSourceStub.restore()
     })
 
     it("writes regular migration file when no option is passed", async () => {
@@ -75,9 +86,11 @@ describe.skip("commands - migration generate", () => {
                     entities: [Post],
                 })
 
+            loadDataSourceStub.resolves(new DataSource(connectionOption))
+
             await migrationGenerateCommand.handler(
                 testHandlerArgs({
-                    connection: connectionOption.name,
+                    dataSource: "dummy-path",
                 }),
             )
 
@@ -106,9 +119,11 @@ describe.skip("commands - migration generate", () => {
                     entities: [Post],
                 })
 
+            loadDataSourceStub.resolves(new DataSource(connectionOption))
+
             await migrationGenerateCommand.handler(
                 testHandlerArgs({
-                    connection: connectionOption.name,
+                    dataSource: "dummy-path",
                     outputJs: true,
                 }),
             )
@@ -138,9 +153,11 @@ describe.skip("commands - migration generate", () => {
                     entities: [Post],
                 })
 
+            loadDataSourceStub.resolves(new DataSource(connectionOption))
+
             await migrationGenerateCommand.handler(
                 testHandlerArgs({
-                    connection: connectionOption.name,
+                    dataSource: "dummy-path",
                     timestamp: "1641163894670",
                 }),
             )

--- a/test/functional/commands/templates/result-templates-create.ts
+++ b/test/functional/commands/templates/result-templates-create.ts
@@ -1,7 +1,7 @@
 export const resultsTemplates: Record<string, any> = {
-    control: `import {MigrationInterface, QueryRunner} from "typeorm";
+    control: `import { MigrationInterface, QueryRunner } from "typeorm";
 
-export class testMigration1610975184784 implements MigrationInterface {
+export class TestMigration1610975184784 implements MigrationInterface {
 
     public async up(queryRunner: QueryRunner): Promise<void> {
     }
@@ -9,20 +9,23 @@ export class testMigration1610975184784 implements MigrationInterface {
     public async down(queryRunner: QueryRunner): Promise<void> {
     }
 
-}`,
+}
+`,
     javascript: `const { MigrationInterface, QueryRunner } = require("typeorm");
 
-module.exports = class testMigration1610975184784 {
+module.exports = class TestMigration1610975184784 {
 
     async up(queryRunner) {
     }
 
     async down(queryRunner) {
     }
-}`,
-    timestamp: `import {MigrationInterface, QueryRunner} from "typeorm";
 
-export class testMigration1641163894670 implements MigrationInterface {
+}
+`,
+    timestamp: `import { MigrationInterface, QueryRunner } from "typeorm";
+
+export class TestMigration1641163894670 implements MigrationInterface {
 
     public async up(queryRunner: QueryRunner): Promise<void> {
     }
@@ -30,5 +33,6 @@ export class testMigration1641163894670 implements MigrationInterface {
     public async down(queryRunner: QueryRunner): Promise<void> {
     }
 
-}`,
+}
+`,
 }


### PR DESCRIPTION
<!--
  😀 Wonderful!  Thank you for opening a pull request for TypeORM.

  Please fill in the information below to expedite the review
  and (hopefully) merge of your change.

  If unsure about something.. just do as best as you're able,
  or reach out through our community support channels!
  https://github.com/typeorm/typeorm/blob/master/docs/support.md
-->

### Description of change

Add `positionals` as [other commands](https://github.com/typeorm/typeorm/blob/a100a7a7f1c17432549e5e93fb141d0f52062213/src/commands/QueryCommand.ts#L20-L23) to improve the `--help` output
it adds it to:
 - MigrationCreateCommand
 - MigrationGenerateCommand
 - SubscriberCreateCommand
 - EntityCreateCommand

Also **fixes** and **reactivates** the tests for `migration - create` and `migration - generate`

<!--
  Please be clear and concise what the change is intended to do,
  why this change is needed, and how you've verified that it
  corrects what you intended.

  In some cases it may be helpful to include the current behavior
  and the new behavior.

  If the change is related to an open issue, you can link it here.
  If you include `Fixes #0000` (replacing `0000` with the issue number)
  when this is merged it will automatically mark the issue as fixed and
  close it.
-->
## before
```
cli.js migration:create <path>

Creates a new migration file.

Options:
  -h, --help       Show help                                           [boolean]
  -o, --outputJs   Generate a migration file on Javascript instead of Typescript
                                                      [boolean] [default: false]
  -t, --timestamp  Custom timestamp for the migration name
                                                       [number] [default: false]
  -v, --version    Show version number                                 [boolean]
```

## after
```shell
cli.js migration:create <path>

Creates a new migration file.

Positionals:
  path  Path of the migration file                           [string] [required]

Options:
  -h, --help       Show help                                           [boolean]
  -o, --outputJs   Generate a migration file on Javascript instead of Typescript
                                                      [boolean] [default: false]
  -t, --timestamp  Custom timestamp for the migration name
                                                       [number] [default: false]
  -v, --version    Show version number                                 [boolean]
```


### Pull-Request Checklist

<!--
  Please make sure to review and check all of the following.

  If an item is not applicable, you can add "N/A" to the end.
-->

- [x] Code is up-to-date with the `master` branch
- [x] `npm run format` to apply prettier formatting
- [x] `npm run test` passes with this change
- [x] There are new or updated unit tests validating the change
- [x] Documentation has been updated to reflect this change
- [x] The new commits follow conventions explained in [CONTRIBUTING.md](https://github.com/typeorm/typeorm/blob/master/CONTRIBUTING.md)

<!--
  🎉 Thank you for contributing and making TypeORM even better!
-->
