### PR TITLE
fix: resolve issues sqlite can use timestamp type column

### DIFF
--- a/src/driver/sqlite-abstract/AbstractSqliteDriver.ts
+++ b/src/driver/sqlite-abstract/AbstractSqliteDriver.ts
@@ -375,7 +375,7 @@ export abstract class AbstractSqliteDriver implements Driver {
         } else if (
             columnMetadata.type === "datetime" ||
             columnMetadata.type === Date ||
-            columnMetadata.type === 'timestamp'
+            columnMetadata.type === "timestamp"
         ) {
             /**
              * Fix date conversion issue
@@ -635,8 +635,8 @@ export abstract class AbstractSqliteDriver implements Driver {
             return "text"
         } else if (column.type === "simple-enum") {
             return "varchar"
-        } else if (column.type === 'timestamp') {
-            return 'bigint'
+        } else if (column.type === "timestamp") {
+            return "bigint"
         } else {
             return (column.type as string) || ""
         }

--- a/src/driver/sqlite-abstract/AbstractSqliteDriver.ts
+++ b/src/driver/sqlite-abstract/AbstractSqliteDriver.ts
@@ -374,7 +374,8 @@ export abstract class AbstractSqliteDriver implements Driver {
             value = value ? true : false
         } else if (
             columnMetadata.type === "datetime" ||
-            columnMetadata.type === Date
+            columnMetadata.type === Date ||
+            columnMetadata.type === 'timestamp'
         ) {
             /**
              * Fix date conversion issue
@@ -634,6 +635,8 @@ export abstract class AbstractSqliteDriver implements Driver {
             return "text"
         } else if (column.type === "simple-enum") {
             return "varchar"
+        } else if (column.type === 'timestamp') {
+            return 'bigint'
         } else {
             return (column.type as string) || ""
         }

--- a/test/github-issues/10140/entity/Photo.ts
+++ b/test/github-issues/10140/entity/Photo.ts
@@ -1,0 +1,15 @@
+import { Column, Entity, PrimaryGeneratedColumn } from "../../../../src";
+
+@Entity()
+export class Photo {
+    @PrimaryGeneratedColumn({
+        type: 'int',
+    })
+    id: number
+
+    @Column('varchar')
+    name: string;
+
+    @Column('timestamp')
+    publishedAt: Date
+}

--- a/test/github-issues/10140/entity/Photo.ts
+++ b/test/github-issues/10140/entity/Photo.ts
@@ -1,15 +1,15 @@
-import { Column, Entity, PrimaryGeneratedColumn } from "../../../../src";
+import { Column, Entity, PrimaryGeneratedColumn } from "../../../../src"
 
 @Entity()
 export class Photo {
     @PrimaryGeneratedColumn({
-        type: 'int',
+        type: "int",
     })
     id: number
 
-    @Column('varchar')
-    name: string;
+    @Column("varchar")
+    name: string
 
-    @Column('timestamp')
+    @Column("timestamp")
     publishedAt: Date
 }

--- a/test/github-issues/10140/issue-10140.ts
+++ b/test/github-issues/10140/issue-10140.ts
@@ -1,34 +1,47 @@
-import "reflect-metadata";
-import { createTestingConnections, closeTestingConnections, reloadTestingDatabases } from "../../utils/test-utils";
+import "reflect-metadata"
+import {
+    createTestingConnections,
+    closeTestingConnections,
+    reloadTestingDatabases,
+} from "../../utils/test-utils"
 import { DataSource } from "../../../src"
-import { expect } from "chai";
-import { Photo } from "./entity/Photo";
+import { expect } from "chai"
+import { Photo } from "./entity/Photo"
 
 describe("github issues > #10140 timestamp type column doesn't work when using sqlite", () => {
+    let dataSources: DataSource[]
+    before(
+        async () =>
+            (dataSources = await createTestingConnections({
+                entities: [__dirname + "/entity/*{.js,.ts}"],
+                schemaCreate: true,
+                dropSchema: true,
+            })),
+    )
+    beforeEach(() => reloadTestingDatabases(dataSources))
+    after(() => closeTestingConnections(dataSources))
 
-    let dataSources: DataSource[];
-    before(async () => dataSources = await createTestingConnections({
-        entities: [__dirname + "/entity/*{.js,.ts}"],
-        schemaCreate: true,
-        dropSchema: true,
-    }));
-    beforeEach(() => reloadTestingDatabases(dataSources));
-    after(() => closeTestingConnections(dataSources));
+    it("should return date who has timestamp type column", () =>
+        Promise.all(
+            dataSources.map(async (dataSource) => {
+                const photo = dataSource.manager.create(Photo)
 
-    it("should return date who has timestamp type column", () => Promise.all(dataSources.map(async dataSource => {
-        const photo = dataSource.manager.create(Photo);
+                const publishedAt = new Date("2023-06-16T08:24:53Z")
+                photo.name = "photo"
+                photo.publishedAt = publishedAt
+                await dataSource.manager.save(photo)
 
-        const publishedAt = new Date('2023-06-16T08:24:53Z');
-        photo.name = 'photo';
-        photo.publishedAt = publishedAt;
-        await dataSource.manager.save(photo);
+                const freshPhoto = await dataSource.manager.findOneByOrFail(
+                    Photo,
+                    {
+                        name: "photo",
+                    },
+                )
 
-        const freshPhoto = await dataSource.manager.findOneByOrFail(Photo, {
-            name: 'photo'
-        });
-
-        expect(freshPhoto.publishedAt instanceof Date).equal(true);
-        expect(freshPhoto.publishedAt.toISOString()).equal(publishedAt.toISOString());
-
-    })));
-});
+                expect(freshPhoto.publishedAt instanceof Date).equal(true)
+                expect(freshPhoto.publishedAt.toISOString()).equal(
+                    publishedAt.toISOString(),
+                )
+            }),
+        ))
+})

--- a/test/github-issues/10140/issue-10140.ts
+++ b/test/github-issues/10140/issue-10140.ts
@@ -16,6 +16,7 @@ describe("github issues > #10140 timestamp type column doesn't work when using s
                 entities: [__dirname + "/entity/*{.js,.ts}"],
                 schemaCreate: true,
                 dropSchema: true,
+                enabledDrivers: ["sqlite"],
             })),
     )
     beforeEach(() => reloadTestingDatabases(dataSources))

--- a/test/github-issues/10140/issue-10140.ts
+++ b/test/github-issues/10140/issue-10140.ts
@@ -1,0 +1,34 @@
+import "reflect-metadata";
+import { createTestingConnections, closeTestingConnections, reloadTestingDatabases } from "../../utils/test-utils";
+import { DataSource } from "../../../src"
+import { expect } from "chai";
+import { Photo } from "./entity/Photo";
+
+describe("github issues > #10140 timestamp type column doesn't work when using sqlite", () => {
+
+    let dataSources: DataSource[];
+    before(async () => dataSources = await createTestingConnections({
+        entities: [__dirname + "/entity/*{.js,.ts}"],
+        schemaCreate: true,
+        dropSchema: true,
+    }));
+    beforeEach(() => reloadTestingDatabases(dataSources));
+    after(() => closeTestingConnections(dataSources));
+
+    it("should return date who has timestamp type column", () => Promise.all(dataSources.map(async dataSource => {
+        const photo = dataSource.manager.create(Photo);
+
+        const publishedAt = new Date('2023-06-16T08:24:53Z');
+        photo.name = 'photo';
+        photo.publishedAt = publishedAt;
+        await dataSource.manager.save(photo);
+
+        const freshPhoto = await dataSource.manager.findOneByOrFail(Photo, {
+            name: 'photo'
+        });
+
+        expect(freshPhoto.publishedAt instanceof Date).equal(true);
+        expect(freshPhoto.publishedAt.toISOString()).equal(publishedAt.toISOString());
+
+    })));
+});


### PR DESCRIPTION
Closes: #10140

<!--
  😀 Wonderful!  Thank you for opening a pull request for TypeORM.

  Please fill in the information below to expedite the review
  and (hopefully) merge of your change.

  If unsure about something.. just do as best as you're able,
  or reach out through our community support channels!
  https://github.com/typeorm/typeorm/blob/master/docs/support.md
-->

### Description of change

<!--
  Please be clear and concise what the change is intended to do,
  why this change is needed, and how you've verified that it
  corrects what you intended.

  In some cases it may be helpful to include the current behavior
  and the new behavior.

  If the change is related to an open issue, you can link it here.
  If you include `Fixes #0000` (replacing `0000` with the issue number)
  when this is merged it will automatically mark the issue as fixed and
  close it.
-->
I'm using typeorm with mysql, all of my code works based on typeorm. 
But when I tried to converting my database to sqlite, I found that with sqlite, timestamp column doesn't work.

```
DataTypeNotSupportedError: Data type "timestamp" in "xxxx" is not supported by "sqlite" database.
```

In this situation I have to change all of my code that using timestamp column. that's why I made this PR.
I made timestamp type work using bigint type with sqlite.

If you have any good idea or advice, let me know.
I'll do my best to fix this issue.
thank you.

### Pull-Request Checklist

<!--
  Please make sure to review and check all of the following.

  If an item is not applicable, you can add "N/A" to the end.
-->

- [x] Code is up-to-date with the `master` branch
- [x] `npm run format` to apply prettier formatting
- [x] `npm run test` passes with this change
- [x] This pull request links relevant issues as `Fixes #10140`
- [x] There are new or updated unit tests validating the change
- [x] Documentation has been updated to reflect this change
- [x] The new commits follow conventions explained in [CONTRIBUTING.md](https://github.com/typeorm/typeorm/blob/master/CONTRIBUTING.md)

<!--
  🎉 Thank you for contributing and making TypeORM even better!
-->
