### PR TITLE
fix: disable SQLite FK checks in all code paths

### DIFF
--- a/src/migration/MigrationExecutor.ts
+++ b/src/migration/MigrationExecutor.ts
@@ -334,6 +334,7 @@ export class MigrationExecutor {
                     transactionStartedByUs = true
                 }
 
+                await queryRunner.beforeMigration()
                 try {
                     await migration.instance!.up(queryRunner)
                 } catch (error) {
@@ -342,6 +343,8 @@ export class MigrationExecutor {
                         `Migration "${migration.name}" failed, error: ${error?.message}`,
                     )
                     throw error
+                } finally {
+                    await queryRunner.afterMigration()
                 }
 
                 // now when migration is executed we need to insert record about it into the database

--- a/src/migration/MigrationExecutor.ts
+++ b/src/migration/MigrationExecutor.ts
@@ -334,34 +334,30 @@ export class MigrationExecutor {
                     transactionStartedByUs = true
                 }
 
-                await migration
-                    .instance!.up(queryRunner)
-                    .catch((error) => {
-                        // informative log about migration failure
-                        this.connection.logger.logMigration(
-                            `Migration "${migration.name}" failed, error: ${error?.message}`,
-                        )
-                        throw error
-                    })
-                    .then(async () => {
-                        // now when migration is executed we need to insert record about it into the database
-                        await this.insertExecutedMigration(
-                            queryRunner,
-                            migration,
-                        )
-                        // commit transaction if we started it
-                        if (migration.transaction && transactionStartedByUs)
-                            await queryRunner.commitTransaction()
-                    })
-                    .then(() => {
-                        // informative log about migration success
-                        successMigrations.push(migration)
-                        this.connection.logger.logSchemaBuild(
-                            `Migration ${migration.name} has been ${
-                                this.fake ? "(fake)" : ""
-                            } executed successfully.`,
-                        )
-                    })
+                try {
+                    await migration.instance!.up(queryRunner)
+                } catch (error) {
+                    // informative log about migration failure
+                    this.connection.logger.logMigration(
+                        `Migration "${migration.name}" failed, error: ${error?.message}`,
+                    )
+                    throw error
+                }
+
+                // now when migration is executed we need to insert record about it into the database
+                await this.insertExecutedMigration(queryRunner, migration)
+
+                // commit transaction if we started it
+                if (migration.transaction && transactionStartedByUs)
+                    await queryRunner.commitTransaction()
+
+                // informative log about migration success
+                successMigrations.push(migration)
+                this.connection.logger.logSchemaBuild(
+                    `Migration ${migration.name} has been ${
+                        this.fake ? "(fake)" : ""
+                    } executed successfully.`,
+                )
             }
 
             // commit transaction if we started it

--- a/src/migration/MigrationExecutor.ts
+++ b/src/migration/MigrationExecutor.ts
@@ -81,8 +81,11 @@ export class MigrationExecutor {
             }
 
             await queryRunner.beforeMigration()
-            await (migration.instance as any).up(queryRunner)
-            await queryRunner.afterMigration()
+            try {
+                await (migration.instance as any).up(queryRunner)
+            } finally {
+                await queryRunner.afterMigration()
+            }
             await this.insertExecutedMigration(queryRunner, migration)
 
             return migration
@@ -451,8 +454,11 @@ export class MigrationExecutor {
         try {
             if (!this.fake) {
                 await queryRunner.beforeMigration()
-                await migrationToRevert.instance!.down(queryRunner)
-                await queryRunner.afterMigration()
+                try {
+                    await migrationToRevert.instance!.down(queryRunner)
+                } finally {
+                    await queryRunner.afterMigration()
+                }
             }
 
             await this.deleteExecutedMigration(queryRunner, migrationToRevert)


### PR DESCRIPTION
https://github.com/typeorm/typeorm/pull/7922 added the code to disable/enable foreign key checks for sqlite when running migrations individually, but is missing the code do so when the migrations are run via `connection.runMigrations()`.
This change ensures a consistent behavior between the code paths. 

- [x] Code is up-to-date with the `master` branch
- [x] `npm run format` to apply prettier formatting
- [x] `npm run test` passes with this change
- [x] This pull request links relevant issues as `Fixes #0000`
- [ ] There are new or updated unit tests validating the change
- [ ] Documentation has been updated to reflect this change
- [ ] The new commits follow conventions explained in [CONTRIBUTING.md](https://github.com/typeorm/typeorm/blob/master/CONTRIBUTING.md)
