### PR TITLE
fix: disable SQLite FK checks in all code paths, and re-enable them even when migration fails

### DIFF
--- a/src/migration/MigrationExecutor.ts
+++ b/src/migration/MigrationExecutor.ts
@@ -336,8 +336,10 @@ export class MigrationExecutor {
                 )
 
                 // commit transaction if we started it
-                if (migration.transaction && transactionStartedByUs)
+                if (migration.transaction && transactionStartedByUs) {
                     await queryRunner.commitTransaction()
+                    await queryRunner.afterMigration()
+                }
 
                 // informative log about migration success
                 successMigrations.push(migration)
@@ -349,10 +351,8 @@ export class MigrationExecutor {
             }
 
             // commit transaction if we started it
-            if (this.transaction === "all" && transactionStartedByUs) {
+            if (this.transaction === "all" && transactionStartedByUs)
                 await queryRunner.commitTransaction()
-                await queryRunner.afterMigration()
-            }
         } catch (err) {
             // rollback transaction if we started it
             if (transactionStartedByUs) {
@@ -441,7 +441,6 @@ export class MigrationExecutor {
             if (!this.fake) {
                 await queryRunner.beforeMigration()
                 await migrationToRevert.instance!.down(queryRunner)
-                await queryRunner.afterMigration()
             }
 
             await this.deleteExecutedMigration(queryRunner, migrationToRevert)
@@ -464,6 +463,7 @@ export class MigrationExecutor {
 
             throw err
         } finally {
+            if (!this.fake) await queryRunner.afterMigration()
             // if query runner was created by us then release it
             if (!this.queryRunner) await queryRunner.release()
         }


### PR DESCRIPTION
https://github.com/typeorm/typeorm/pull/7922 added the code to disable/enable foreign key checks for sqlite when running migrations individually, but is missing the code do so when the migrations are run via `connection.runMigrations()`.
This change ensures a consistent behavior between the code paths. 

- [x] Code is up-to-date with the `master` branch
- [x] `npm run format` to apply prettier formatting
- [x] `npm run test` passes with this change
- [x] This pull request links relevant issues as `Fixes #0000`
- [ ] There are new or updated unit tests validating the change
- [ ] Documentation has been updated to reflect this change
- [ ] The new commits follow conventions explained in [CONTRIBUTING.md](https://github.com/typeorm/typeorm/blob/master/CONTRIBUTING.md)
