### PR TITLE
A bug for insert json[] or jsonb[] of postgresql

### DIFF
--- a/src/driver/postgres/PostgresDriver.ts
+++ b/src/driver/postgres/PostgresDriver.ts
@@ -640,7 +640,8 @@ export class PostgresDriver implements Driver {
                 columnMetadata.type,
             ) >= 0
         ) {
-            return JSON.stringify(value)
+            return value
+            //return JSON.stringify(value)
         } else if (columnMetadata.type === "hstore") {
             if (typeof value === "string") {
                 return value

--- a/src/driver/postgres/PostgresDriver.ts
+++ b/src/driver/postgres/PostgresDriver.ts
@@ -640,6 +640,7 @@ export class PostgresDriver implements Driver {
                 columnMetadata.type,
             ) >= 0
         ) {
+            //if value is string will be fail where type of field is json[] or jsonb[]
             return value
             //return JSON.stringify(value)
         } else if (columnMetadata.type === "hstore") {


### PR DESCRIPTION
database : postgresql
if the type of field is json[] or jsonb[] when insert into, will be error,
for example：
this.db.device.repository.insert({
    deviceNo : '3333444',
    ports : [{status:true, count : 1},{status:true, count : 0}]
})
error info:
query: INSERT INTO "public"."device"("device_no", "name", "type", "port_count", "ports", "owners", "params", "remark", "create_time", "update_time") VALUES ($1, DEFAULT, DEFAULT, DEFAULT, $2, DEFAULT, DEFAULT, DEFAULT, DEFAULT, DEFAULT) RETURNING "id", "device_no", "name", "type", "port_count", "remark", "create_time", "update_time" -- PARAMETERS: ["3333444","[{\"status\":true,\"count\":1},{\"status\":true,\"count\":0}]"]
query failed: INSERT INTO "public"."device"("device_no", "name", "type", "port_count", "ports", "owners", "params", "remark", "create_time", "update_time") VALUES ($1, DEFAULT, DEFAULT, DEFAULT, $2, DEFAULT, DEFAULT, DEFAULT, DEFAULT, DEFAULT) RETURNING "id", "device_no", "name", "type", "port_count", "remark", "create_time", "update_time" -- PARAMETERS: ["3333444","[{\"status\":true,\"count\":1},{\"status\":true,\"count\":0}]"]
error: error: 有缺陷的数组常量:"[{"status":true,"count":1},{"status":true,"count":0}]",