### PR TITLE
fix: add mssql disableAsciiToUnicodeParamConversion option and tests

### DIFF
--- a/src/driver/sqlserver/SqlServerConnectionOptions.ts
+++ b/src/driver/sqlserver/SqlServerConnectionOptions.ts
@@ -186,6 +186,12 @@ export interface SqlServerConnectionOptions
         readonly disableOutputReturning?: boolean
 
         /**
+         * A boolean, controlling whether MssqlParameter types char, varchar, and text are converted to their unicode equivalents, nchar, nvarchar, and ntext.
+         * (default: false, meaning that char/varchar/text parameters will be converted to nchar/nvarchar/ntext)
+         */
+        readonly disableAsciiToUnicodeParamConversion?: boolean
+
+        /**
          * Debug options
          */
         readonly debug?: {

--- a/src/driver/sqlserver/SqlServerQueryRunner.ts
+++ b/src/driver/sqlserver/SqlServerQueryRunner.ts
@@ -4049,12 +4049,33 @@ export class SqlServerQueryRunner
             case "tinyint":
                 return this.driver.mssql.TinyInt
             case "char":
+                if (
+                    this.driver.options.options
+                        ?.disableAsciiToUnicodeParamConversion
+                ) {
+                    return this.driver.mssql.Char(...parameter.params)
+                }
+                return this.driver.mssql.NChar(...parameter.params)
             case "nchar":
                 return this.driver.mssql.NChar(...parameter.params)
             case "text":
+                if (
+                    this.driver.options.options
+                        ?.disableAsciiToUnicodeParamConversion
+                ) {
+                    return this.driver.mssql.Text
+                }
+                return this.driver.mssql.Ntext
             case "ntext":
                 return this.driver.mssql.Ntext
             case "varchar":
+                if (
+                    this.driver.options.options
+                        ?.disableAsciiToUnicodeParamConversion
+                ) {
+                    return this.driver.mssql.VarChar(...parameter.params)
+                }
+                return this.driver.mssql.NVarChar(...parameter.params)
             case "nvarchar":
                 return this.driver.mssql.NVarChar(...parameter.params)
             case "xml":

--- a/test/github-issues/10131/entity/Example.ts
+++ b/test/github-issues/10131/entity/Example.ts
@@ -1,0 +1,13 @@
+import { Entity, PrimaryGeneratedColumn, Column } from "../../../../src"
+
+@Entity()
+export class Example {
+    @PrimaryGeneratedColumn("uuid")
+    id?: string
+
+    @Column("varchar", { length: 10 })
+    varCharField: string = ""
+
+    @Column("char", { length: 10 })
+    charField: string = ""
+}

--- a/test/github-issues/10131/issue-10131.ts
+++ b/test/github-issues/10131/issue-10131.ts
@@ -1,0 +1,109 @@
+import "reflect-metadata"
+import { DataSource } from "../../../src"
+import {
+    closeTestingConnections,
+    createTestingConnections,
+    reloadTestingDatabases,
+} from "../../utils/test-utils"
+import { Example } from "./entity/Example"
+import { SqlServerDriver } from "../../../src/driver/sqlserver/SqlServerDriver"
+import sinon from "sinon"
+
+describe("github issues > #10131 optional to disable ascii to unicode parameter conversion", () => {
+    let connections: DataSource[]
+
+    beforeEach(() => reloadTestingDatabases(connections))
+    afterEach(() => sinon.restore())
+
+    describe("when disableAsciiToUnicodeParamConversion is true", () => {
+        let driver: SqlServerDriver
+
+        before(async () => {
+            connections = await createTestingConnections({
+                entities: [Example],
+                enabledDrivers: ["mssql"],
+                schemaCreate: false,
+                dropSchema: true,
+                driverSpecific: {
+                    options: {
+                        disableAsciiToUnicodeParamConversion: true,
+                    },
+                },
+            })
+        })
+        after(() => closeTestingConnections(connections))
+
+        it("should disable ascii to unicode parameter conversion", () =>
+            Promise.all(
+                connections.map(async (connection) => {
+                    driver = new SqlServerDriver(connection)
+
+                    const driverNCharSpy = sinon.spy(driver.mssql, "NChar")
+                    const driverNVarCharSpy = sinon.spy(
+                        driver.mssql,
+                        "NVarChar",
+                    )
+                    const driverCharSpy = sinon.spy(driver.mssql, "Char")
+                    const driverVarCharSpy = sinon.spy(driver.mssql, "VarChar")
+
+                    const entity = new Example()
+                    entity.varCharField = "test"
+                    entity.charField = "test"
+
+                    const repo = connection.getRepository(Example)
+                    await repo.save(entity)
+
+                    sinon.assert.called(driverCharSpy)
+                    sinon.assert.called(driverVarCharSpy)
+                    sinon.assert.notCalled(driverNCharSpy)
+                    sinon.assert.notCalled(driverNVarCharSpy)
+                }),
+            ))
+    })
+
+    describe("when disableAsciiToUnicodeParamConversion is false", () => {
+        let driver: SqlServerDriver
+
+        before(async () => {
+            connections = await createTestingConnections({
+                entities: [Example],
+                enabledDrivers: ["mssql"],
+                schemaCreate: false,
+                dropSchema: true,
+                driverSpecific: {
+                    options: {
+                        disableAsciiToUnicodeParamConversion: false,
+                    },
+                },
+            })
+        })
+        after(() => closeTestingConnections(connections))
+
+        it("should not disable ascii to unicode parameter conversion", () =>
+            Promise.all(
+                connections.map(async (connection) => {
+                    driver = new SqlServerDriver(connection)
+
+                    const driverNCharSpy = sinon.spy(driver.mssql, "NChar")
+                    const driverNVarCharSpy = sinon.spy(
+                        driver.mssql,
+                        "NVarChar",
+                    )
+                    const driverCharSpy = sinon.spy(driver.mssql, "Char")
+                    const driverVarCharSpy = sinon.spy(driver.mssql, "VarChar")
+
+                    const entity = new Example()
+                    entity.varCharField = "test"
+                    entity.charField = "test"
+
+                    const repo = connection.getRepository(Example)
+                    await repo.save(entity)
+
+                    sinon.assert.notCalled(driverCharSpy)
+                    sinon.assert.notCalled(driverVarCharSpy)
+                    sinon.assert.called(driverNCharSpy)
+                    sinon.assert.called(driverNVarCharSpy)
+                }),
+            ))
+    })
+})


### PR DESCRIPTION
This adds a new property `disableAsciiToUnicodeParamConversion` to `SqlServerConnectionOptions` to control whether the `MssqlParameter` types `char`, `varchar`, and `text` are converted to their unicode equivalents `nchar`, `nvarchar`, and `ntext`. This defaults to `false`, maintaining the current behavior.

Example:
```
andWhere('"name" = :firstName', {
   firstName: new MssqlParameter('Bill', 'varchar', 100)
})
```
- The current behavior: `firstName` is treated as an `nvarchar`
- This PR introduces configuring this behavior: setting `disableAsciiToUnicodeParamConversion` to `true` treats `firstName` as `varchar`. If `disableAsciiToUnicodeParamConversion` is set to `false` or omitted from the ORM configuration values, `firstName` remains `nvarchar`

See full description of the issue, including the motivation, in https://github.com/typeorm/typeorm/issues/10131

Fixes #10131


<!--
  😀 Wonderful!  Thank you for opening a pull request for TypeORM.

  Please fill in the information below to expedite the review
  and (hopefully) merge of your change.

  If unsure about something.. just do as best as you're able,
  or reach out through our community support channels!
  https://github.com/typeorm/typeorm/blob/master/docs/support.md
-->

### Description of change

<!--
  Please be clear and concise what the change is intended to do,
  why this change is needed, and how you've verified that it
  corrects what you intended.

  In some cases it may be helpful to include the current behavior
  and the new behavior.

  If the change is related to an open issue, you can link it here.
  If you include `Fixes #0000` (replacing `0000` with the issue number)
  when this is merged it will automatically mark the issue as fixed and
  close it.
-->


### Pull-Request Checklist

<!--
  Please make sure to review and check all of the following.

  If an item is not applicable, you can add "N/A" to the end.
-->

- [x] Code is up-to-date with the `master` branch
- [x] `npm run format` to apply prettier formatting
- [x] `npm run test` passes with this change
- [x] This pull request links relevant issues as `Fixes #0000`
- [x] There are new or updated unit tests validating the change
- [ ] Documentation has been updated to reflect this change
- [x] The new commits follow conventions explained in [CONTRIBUTING.md](https://github.com/typeorm/typeorm/blob/master/CONTRIBUTING.md)

<!--
  🎉 Thank you for contributing and making TypeORM even better!
-->
