### PR TITLE
fix: scrub all comment end markers from comments

### DIFF
--- a/src/query-builder/QueryBuilder.ts
+++ b/src/query-builder/QueryBuilder.ts
@@ -829,7 +829,7 @@ export abstract class QueryBuilder<Entity extends ObjectLiteral> {
         // to scrub "ending" characters from the SQL but otherwise we can leave everything else
         // as-is and it should be valid.
 
-        return `/* ${this.expressionMap.comment.replace("*/", "")} */ `
+        return `/* ${this.expressionMap.comment.replace(/\*\//g, "")} */ `
     }
 
     /**

--- a/test/functional/query-builder/comment/query-builder-comment.ts
+++ b/test/functional/query-builder/comment/query-builder-comment.ts
@@ -24,10 +24,10 @@ describe("query builder > comment", () => {
             connections.map(async (connection) => {
                 const sql = connection.manager
                     .createQueryBuilder(Test, "test")
-                    .comment("Hello World */")
+                    .comment("Hello World */ */")
                     .getSql()
 
-                expect(sql).to.match(/^\/\* Hello World  \*\/ /)
+                expect(sql).to.match(/^\/\* Hello World   \*\/ /)
             }),
         ))
 


### PR DESCRIPTION
<!--
  😀 Wonderful!  Thank you for opening a pull request for TypeORM.

  Please fill in the information below to expedite the review
  and (hopefully) merge of your change.

  If unsure about something.. just do as best as you're able,
  or reach out through our community support channels!
  https://github.com/typeorm/typeorm/blob/master/docs/support.md
-->

### Description of change

This was only removing the first comment end marker, so it was still possible to generate invalid SQL with the comment method.


### Pull-Request Checklist

<!--
  Please make sure to review and check all of the following.

  If an item is not applicable, you can add "N/A" to the end.
-->

- [x] Code is up-to-date with the `master` branch
- [x] `npm run format` to apply prettier formatting
- [x] `npm run test` passes with this change
- [ ] This pull request links relevant issues as `Fixes #0000`
- [x] There are new or updated unit tests validating the change
- [ ] Documentation has been updated to reflect this change
- [x] The new commits follow conventions explained in [CONTRIBUTING.md](https://github.com/typeorm/typeorm/blob/master/CONTRIBUTING.md)

<!--
  🎉 Thank you for contributing and making TypeORM even better!
-->
