### PR TITLE
fix: using async datasource to configure typeorm

### DIFF
--- a/src/commands/CommandUtils.ts
+++ b/src/commands/CommandUtils.ts
@@ -38,8 +38,9 @@ export class CommandUtils {
             const fileExport = dataSourceFileExports[fileExportKey]
             // It is necessary to await here in case of the exported async value (Promise<DataSource>).
             // e.g. the DataSource is instantiated with an async factory in the source file
-            const awaitedFileExport =
-                fileExport instanceof Promise ? await fileExport : fileExport
+            // It is safe to await regardless of the export being async or not due to `awaits` definition:
+            // https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/await#return_value
+            const awaitedFileExport = await fileExport
             if (InstanceChecker.isDataSource(awaitedFileExport)) {
                 dataSourceExports.push(awaitedFileExport)
             }


### PR DESCRIPTION
Fixes #10168 

<!--
  😀 Wonderful!  Thank you for opening a pull request for TypeORM.

  Please fill in the information below to expedite the review
  and (hopefully) merge of your change.

  If unsure about something.. just do as best as you're able,
  or reach out through our community support channels!
  https://github.com/typeorm/typeorm/blob/master/docs/support.md
-->

### Description of change

The check in `CommandUtils.ts` for detecting whether the DataSource-source is a promise is broken.

Rather than testing whether it's a promise, simply await the value and use it. The `await` operator is defined in such way that if the thing is not awaitable we simply get the value back

https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/await#return_value

<!--
  Please be clear and concise what the change is intended to do,
  why this change is needed, and how you've verified that it
  corrects what you intended.

  In some cases it may be helpful to include the current behavior
  and the new behavior.

  If the change is related to an open issue, you can link it here.
  If you include `Fixes #0000` (replacing `0000` with the issue number)
  when this is merged it will automatically mark the issue as fixed and
  close it.
-->

### Pull-Request Checklist

<!--
  Please make sure to review and check all of the following.

  If an item is not applicable, you can add "N/A" to the end.
-->

- [x] Code is up-to-date with the `master` branch
- [x] `npm run format` to apply prettier formatting
- [x] `npm run test` passes with this change
- [x] This pull request links relevant issues as `Fixes #0000`
- [ ] There are new or updated unit tests validating the change - no because all relevant unit tests have been disabled by the code-owners
- [x] Documentation has been updated to reflect this change
- [x] The new commits follow conventions explained in [CONTRIBUTING.md](https://github.com/typeorm/typeorm/blob/master/CONTRIBUTING.md)

<!--
  🎉 Thank you for contributing and making TypeORM even better!
-->
