### PR TITLE
fix: CommandUtils unable to process a regular default export

### DIFF
--- a/src/commands/CommandUtils.ts
+++ b/src/commands/CommandUtils.ts
@@ -33,6 +33,10 @@ export class CommandUtils {
             )
         }
 
+        if (InstanceChecker.isDataSource(dataSourceFileExports)) {
+            return dataSourceFileExports
+        }
+
         const dataSourceExports = []
         for (const fileExportKey in dataSourceFileExports) {
             const fileExport = dataSourceFileExports[fileExportKey]


### PR DESCRIPTION
The solution to `loadDataSource` was probably designed to adapt to various forms of exports coming from ormconfig.js however it failed to adapt to a very regular case where you just do `module.exports = new DataSource({ ... })` resulting in `Error: Given data source file must contain export of a DataSource instance`

Fixes #8810


### Description of change

The loadDataSource did not take into account that the default export might already contain the `DataSource` instance itself. The solution started to iterate over the keys of the `DataSource` in the hope to find a `DataSource` instance under one of those keys. I've adjusted the logic to check if the DataSource is the subject to default export itself then just return it from the function and do not iterate over its keys.



### Pull-Request Checklist

<!--
  Please make sure to review and check all of the following.

  If an item is not applicable, you can add "N/A" to the end.
-->

- [x] Code is up-to-date with the `master` branch
- [x] `npm run format` to apply prettier formatting
- [ ] `npm run test` passes with this change N/A
- [x] This pull request links relevant issues as `Fixes #0000`
- [ ] There are new or updated unit tests validating the change N/A
- [ ] Documentation has been updated to reflect this change N/A
- [x] The new commits follow conventions explained in [CONTRIBUTING.md](https://github.com/typeorm/typeorm/blob/master/CONTRIBUTING.md)

