### PR TITLE
fix: enable preload to retrieve entities added within a transaction

### DIFF
--- a/src/entity-manager/EntityManager.ts
+++ b/src/entity-manager/EntityManager.ts
@@ -330,7 +330,7 @@ export class EntityManager {
     ): Promise<Entity | undefined> {
         const metadata = this.connection.getMetadata(entityClass)
         const plainObjectToDatabaseEntityTransformer =
-            new PlainObjectToDatabaseEntityTransformer(this.connection.manager)
+            new PlainObjectToDatabaseEntityTransformer(this)
         const transformedEntity =
             await plainObjectToDatabaseEntityTransformer.transform(
                 entityLike,

--- a/test/functional/repository/basic-methods/repository-basic-methods.ts
+++ b/test/functional/repository/basic-methods/repository-basic-methods.ts
@@ -270,26 +270,24 @@ describe("repository > basic methods", () => {
             ))
 
         it("should preload entity from the given object with only id within a transaction", () =>
-        Promise.all(
-            connections.map(async (connection) => {
-                await connection.manager.transaction(
-                    async (em) => {
+            Promise.all(
+                connections.map(async (connection) => {
+                    await connection.manager.transaction(async (em) => {
                         const blogRepository = em.getRepository(Blog)
-                        const categoryRepository =
-                        em.getRepository(Category)
-        
+                        const categoryRepository = em.getRepository(Category)
+
                         // save the category
                         const category = new Category()
                         category.name = "people"
                         await categoryRepository.save(category)
-        
+
                         // save the blog
                         const blog = new Blog()
                         blog.title = "About people"
                         blog.text = "Blog about good people"
                         blog.categories = [category]
                         await blogRepository.save(blog)
-        
+
                         // and preload it
                         const plainBlogWithId = { id: 1 }
                         const preloadedBlog = await blogRepository.preload(
@@ -301,11 +299,10 @@ describe("repository > basic methods", () => {
                         preloadedBlog!.title.should.be.equal("About people")
                         preloadedBlog!.text.should.be.equal(
                             "Blog about good people",
-                        )   
-                    }
-                )
-            }),
-        ))
+                        )
+                    })
+                }),
+            ))
 
         it("should preload entity and all relations given in the object", () =>
             Promise.all(
@@ -343,28 +340,29 @@ describe("repository > basic methods", () => {
             ))
 
         it("should preload entity and all relations given in the object within a transaction", () =>
-        Promise.all(
-            connections.map(async (connection) => {
-                connection.manager.transaction(
-                    async (em) => {
+            Promise.all(
+                connections.map(async (connection) => {
+                    connection.manager.transaction(async (em) => {
                         const blogRepository = em.getRepository(Blog)
-                        const categoryRepository =
-                        em.getRepository(Category)
-        
+                        const categoryRepository = em.getRepository(Category)
+
                         // save the category
                         const category = new Category()
                         category.name = "people"
                         await categoryRepository.save(category)
-        
+
                         // save the blog
                         const blog = new Blog()
                         blog.title = "About people"
                         blog.text = "Blog about good people"
                         blog.categories = [category]
                         await blogRepository.save(blog)
-        
+
                         // and preload it
-                        const plainBlogWithId = { id: 1, categories: [{ id: 1 }] }
+                        const plainBlogWithId = {
+                            id: 1,
+                            categories: [{ id: 1 }],
+                        }
                         const preloadedBlog = await blogRepository.preload(
                             plainBlogWithId,
                         )
@@ -375,11 +373,12 @@ describe("repository > basic methods", () => {
                             "Blog about good people",
                         )
                         preloadedBlog!.categories[0].id.should.be.equal(1)
-                        preloadedBlog!.categories[0].name.should.be.equal("people")
-                            }
-                )
-            }),
-        ))
+                        preloadedBlog!.categories[0].name.should.be.equal(
+                            "people",
+                        )
+                    })
+                }),
+            ))
     })
 
     describe("merge", function () {


### PR DESCRIPTION
This fixes an issue whereby if you used an running transactional entity manager to save a new entity to the db if you then called preload the entity would not be retrieved as the underlying PlainObjectToDatabaseEntityTransformer was called with this.connection.manager rather than using just this.

### Description of change

This PR makes EntityManager `preload` work within a transaction.

**Issue:**
1. Use a data source to create a new transaction
2. Within the transaction save a new entity to the database using the transactions EntityManager
3. Call `preload` on the transactions EntityManager
4. You received `undefined`

**Why is this a problem?**
We are running our API tests within a single transaction. We start the transaction in a `beforeEach` and roll it bakc with the `afterEach` to give us total isolation between tests. However, whilst testing an update scenario (that uses pre load) our test set up first creates a new entity before calling an end point that updates it. When the end point called `preload` on the shared EntityManager is returned `undefined`. We further experimented by simply creating an enrity within a transaction and the calling `preload` - still we got `undefined`. The only way to make the entity visible within was to create a totally separate transaction that committed the entity to the DB. However, this then breaks the isolation of the tests as all tests would then see this entity which could potentially cause nasty side affects.

I traced the issue to the EntityManager creating a PlainObjectToDatabaseEntityTransformer and passing in `this.connection.manager` which was used within PlainObjectToDatabaseEntityTransformer to find all entities with matching id's - but as this was executed on the root connection and the data hadn't been committed it failed to load them.

### Pull-Request Checklist

- [x] Code is up-to-date with the `master` branch
- [x] `npm run format` to apply prettier formatting
- [x] `npm run test` passes with this change
- [ ] This pull request links relevant issues as `Fixes #0000` N/A
- [x] There are new or updated unit tests validating the change
- [ ] Documentation has been updated to reflect this change N/A
- [x] The new commits follow conventions explained in [CONTRIBUTING.md](https://github.com/typeorm/typeorm/blob/master/CONTRIBUTING.md)

