### PR TITLE
fix: Remove dynamic require calls | Vite compatibility fix

### DIFF
--- a/src/data-source/DataSource.ts
+++ b/src/data-source/DataSource.ts
@@ -40,6 +40,9 @@ import { RelationIdLoader } from "../query-builder/RelationIdLoader"
 import { DriverUtils } from "../driver/DriverUtils"
 import { InstanceChecker } from "../util/InstanceChecker"
 import { ObjectLiteral } from "../common/ObjectLiteral"
+import { registerQueryBuilders } from "../query-builder"
+
+registerQueryBuilders()
 
 /**
  * DataSource is a pre-defined connection configuration to a specific database.

--- a/src/platform/BrowserPlatformTools.template
+++ b/src/platform/BrowserPlatformTools.template
@@ -1,3 +1,5 @@
+import { Buffer } from "buffer";
+
 /**
  * Browser's implementation of the platform-specific tools.
  *
@@ -164,8 +166,8 @@ interface Window {
 }
 
 declare var window: Window;
-if (typeof window !== "undefined" && typeof require !== "undefined") {
-    window.Buffer = require("buffer/").Buffer;
+if (typeof window !== "undefined") {
+    window.Buffer = Buffer;
 }
 // NativeScript uses global, not window
 if (typeof global !== "undefined" && typeof require !== "undefined") {

--- a/src/query-builder/QueryBuilder.ts
+++ b/src/query-builder/QueryBuilder.ts
@@ -80,6 +80,11 @@ export abstract class QueryBuilder<Entity extends ObjectLiteral> {
      */
     private parameterIndex = 0
 
+    /**
+     * Contains all registered query builder classes.
+     */
+    private static queryBuilderRegistry: Record<string, any> = {}
+
     // -------------------------------------------------------------------------
     // Constructor
     // -------------------------------------------------------------------------
@@ -179,12 +184,9 @@ export abstract class QueryBuilder<Entity extends ObjectLiteral> {
             ]
         }
 
-        // loading it dynamically because of circular issue
-        const SelectQueryBuilderCls =
-            require("./SelectQueryBuilder").SelectQueryBuilder
         if (InstanceChecker.isSelectQueryBuilder(this)) return this as any
 
-        return new SelectQueryBuilderCls(this)
+        return QueryBuilder.queryBuilderRegistry["SelectQueryBuilder"](this)
     }
 
     /**
@@ -193,12 +195,9 @@ export abstract class QueryBuilder<Entity extends ObjectLiteral> {
     insert(): InsertQueryBuilder<Entity> {
         this.expressionMap.queryType = "insert"
 
-        // loading it dynamically because of circular issue
-        const InsertQueryBuilderCls =
-            require("./InsertQueryBuilder").InsertQueryBuilder
         if (InstanceChecker.isInsertQueryBuilder(this)) return this as any
 
-        return new InsertQueryBuilderCls(this)
+        return QueryBuilder.queryBuilderRegistry["InsertQueryBuilder"](this)
     }
 
     /**
@@ -256,12 +255,9 @@ export abstract class QueryBuilder<Entity extends ObjectLiteral> {
         this.expressionMap.queryType = "update"
         this.expressionMap.valuesSet = updateSet
 
-        // loading it dynamically because of circular issue
-        const UpdateQueryBuilderCls =
-            require("./UpdateQueryBuilder").UpdateQueryBuilder
         if (InstanceChecker.isUpdateQueryBuilder(this)) return this as any
 
-        return new UpdateQueryBuilderCls(this)
+        return QueryBuilder.queryBuilderRegistry["UpdateQueryBuilder"](this)
     }
 
     /**
@@ -270,34 +266,25 @@ export abstract class QueryBuilder<Entity extends ObjectLiteral> {
     delete(): DeleteQueryBuilder<Entity> {
         this.expressionMap.queryType = "delete"
 
-        // loading it dynamically because of circular issue
-        const DeleteQueryBuilderCls =
-            require("./DeleteQueryBuilder").DeleteQueryBuilder
         if (InstanceChecker.isDeleteQueryBuilder(this)) return this as any
 
-        return new DeleteQueryBuilderCls(this)
+        return QueryBuilder.queryBuilderRegistry["DeleteQueryBuilder"](this)
     }
 
     softDelete(): SoftDeleteQueryBuilder<any> {
         this.expressionMap.queryType = "soft-delete"
 
-        // loading it dynamically because of circular issue
-        const SoftDeleteQueryBuilderCls =
-            require("./SoftDeleteQueryBuilder").SoftDeleteQueryBuilder
         if (InstanceChecker.isSoftDeleteQueryBuilder(this)) return this as any
 
-        return new SoftDeleteQueryBuilderCls(this)
+        return QueryBuilder.queryBuilderRegistry["SoftDeleteQueryBuilder"](this)
     }
 
     restore(): SoftDeleteQueryBuilder<any> {
         this.expressionMap.queryType = "restore"
 
-        // loading it dynamically because of circular issue
-        const SoftDeleteQueryBuilderCls =
-            require("./SoftDeleteQueryBuilder").SoftDeleteQueryBuilder
         if (InstanceChecker.isSoftDeleteQueryBuilder(this)) return this as any
 
-        return new SoftDeleteQueryBuilderCls(this)
+        return QueryBuilder.queryBuilderRegistry["SoftDeleteQueryBuilder"](this)
     }
 
     /**
@@ -335,12 +322,9 @@ export abstract class QueryBuilder<Entity extends ObjectLiteral> {
             this.expressionMap.setMainAlias(mainAlias)
         }
 
-        // loading it dynamically because of circular issue
-        const RelationQueryBuilderCls =
-            require("./RelationQueryBuilder").RelationQueryBuilder
         if (InstanceChecker.isRelationQueryBuilder(this)) return this as any
 
-        return new RelationQueryBuilderCls(this)
+        return QueryBuilder.queryBuilderRegistry["RelationQueryBuilder"](this)
     }
 
     /**
@@ -1649,5 +1633,9 @@ export abstract class QueryBuilder<Entity extends ObjectLiteral> {
 
     protected hasCommonTableExpressions(): boolean {
         return this.expressionMap.commonTableExpressions.length > 0
+    }
+
+    static registerQueryBuilderClass(name: string, factory: any) {
+        QueryBuilder.queryBuilderRegistry[name] = factory
     }
 }

--- a/src/query-builder/index.ts
+++ b/src/query-builder/index.ts
@@ -1,0 +1,34 @@
+import { DeleteQueryBuilder } from "./DeleteQueryBuilder"
+import { InsertQueryBuilder } from "./InsertQueryBuilder"
+import { QueryBuilder } from "./QueryBuilder"
+import { RelationQueryBuilder } from "./RelationQueryBuilder"
+import { SelectQueryBuilder } from "./SelectQueryBuilder"
+import { SoftDeleteQueryBuilder } from "./SoftDeleteQueryBuilder"
+import { UpdateQueryBuilder } from "./UpdateQueryBuilder"
+
+export function registerQueryBuilders() {
+    QueryBuilder.registerQueryBuilderClass(
+        "DeleteQueryBuilder",
+        (qb: QueryBuilder<any>) => new DeleteQueryBuilder(qb),
+    )
+    QueryBuilder.registerQueryBuilderClass(
+        "InsertQueryBuilder",
+        (qb: QueryBuilder<any>) => new InsertQueryBuilder(qb),
+    )
+    QueryBuilder.registerQueryBuilderClass(
+        "RelationQueryBuilder",
+        (qb: QueryBuilder<any>) => new RelationQueryBuilder(qb),
+    )
+    QueryBuilder.registerQueryBuilderClass(
+        "SelectQueryBuilder",
+        (qb: QueryBuilder<any>) => new SelectQueryBuilder(qb),
+    )
+    QueryBuilder.registerQueryBuilderClass(
+        "SoftDeleteQueryBuilder",
+        (qb: QueryBuilder<any>) => new SoftDeleteQueryBuilder(qb),
+    )
+    QueryBuilder.registerQueryBuilderClass(
+        "UpdateQueryBuilder",
+        (qb: QueryBuilder<any>) => new UpdateQueryBuilder(qb),
+    )
+}


### PR DESCRIPTION
### Description of change

Removes all dynamic require calls from QueryBuilder class in order to make the library compatible with Vite.

### Pull-Request Checklist

- [x] Code is up-to-date with the `master` branch
- [x] `npm run format` to apply prettier formatting
- [ ] `npm run test` passes with this change
- [x] This pull request links relevant issues as Fixes #8738
- [ ] There are new or updated unit tests validating the change
- [ ] Documentation has been updated to reflect this change
- [x] The new commits follow conventions explained in [CONTRIBUTING.md](https://github.com/typeorm/typeorm/blob/master/CONTRIBUTING.md)

