### PR TITLE
feat: Exposed entity and criteria properties on EntityNotFoundError

### DIFF
--- a/src/error/EntityNotFoundError.ts
+++ b/src/error/EntityNotFoundError.ts
@@ -7,8 +7,14 @@ import { InstanceChecker } from "../util/InstanceChecker"
  * Thrown when no result could be found in methods which are not allowed to return undefined or an empty set.
  */
 export class EntityNotFoundError extends TypeORMError {
+    public readonly entityClass: EntityTarget<any>
+    public readonly criteria: any
+
     constructor(entityClass: EntityTarget<any>, criteria: any) {
         super()
+
+        this.entityClass = entityClass
+        this.criteria = criteria
 
         this.message =
             `Could not find any entity of type "${this.stringifyTarget(

--- a/test/functional/repository/find-methods/repostiory-find-methods.ts
+++ b/test/functional/repository/find-methods/repostiory-find-methods.ts
@@ -1,5 +1,5 @@
 import "reflect-metadata"
-import { expect } from "chai"
+import { assert, expect } from "chai"
 import {
     closeTestingConnections,
     createTestingConnections,
@@ -751,14 +751,20 @@ describe("repository > find methods", () => {
                     loadedUser!.firstName.should.be.equal("name #0")
                     loadedUser!.secondName.should.be.equal("Doe")
 
-                    await userRepository
-                        .findOneOrFail({
-                            where: {
-                                id: 1,
-                                secondName: "Dorian",
-                            },
-                        })
-                        .should.eventually.be.rejectedWith(EntityNotFoundError)
+                    const options = {
+                        where: {
+                            id: 1,
+                            secondName: "Dorian",
+                        },
+                    }
+                    try {
+                        await userRepository.findOneOrFail(options)
+                        assert.fail("Should have thrown an error.")
+                    } catch (err) {
+                        expect(err).to.be.an.instanceOf(EntityNotFoundError)
+                        expect(err).to.have.property("entityClass", "User")
+                        expect(err).to.have.property("criteria", options)
+                    }
                 }),
             ))
 


### PR DESCRIPTION


<!--
  😀 Wonderful!  Thank you for opening a pull request for TypeORM.

  Please fill in the information below to expedite the review
  and (hopefully) merge of your change.

  If unsure about something.. just do as best as you're able,
  or reach out through our community support channels!
  https://github.com/typeorm/typeorm/blob/master/docs/support.md
-->

### Description of change
These properties can be used by consumers to aid in rendering human-readable error messages.

Fixes #10179 

<!--
  Please be clear and concise what the change is intended to do,
  why this change is needed, and how you've verified that it
  corrects what you intended.

  In some cases it may be helpful to include the current behavior
  and the new behavior.

  If the change is related to an open issue, you can link it here.
  If you include `Fixes #0000` (replacing `0000` with the issue number)
  when this is merged it will automatically mark the issue as fixed and
  close it.
-->


### Pull-Request Checklist

<!--
  Please make sure to review and check all of the following.

  If an item is not applicable, you can add "N/A" to the end.
-->

- [x] Code is up-to-date with the `master` branch
- [x] `npm run format` to apply prettier formatting
- [x] `npm run test` passes with this change
- [x] This pull request links relevant issues as `Fixes #10179`
- [x] There are new or updated unit tests validating the change
- [ ] Documentation has been updated to reflect this change
- [x] The new commits follow conventions explained in [CONTRIBUTING.md](https://github.com/typeorm/typeorm/blob/master/CONTRIBUTING.md)

<!--
  🎉 Thank you for contributing and making TypeORM even better!
-->
