### PR TITLE
feat: Add an option to disable `cli-highlight` usage

### DIFF
--- a/src/commands/SchemaLogCommand.ts
+++ b/src/commands/SchemaLogCommand.ts
@@ -1,5 +1,4 @@
 import { DataSource } from "../data-source/DataSource"
-import { highlight } from "cli-highlight"
 import * as yargs from "yargs"
 import chalk from "chalk"
 import { PlatformTools } from "../platform/PlatformTools"
@@ -81,7 +80,7 @@ export class SchemaLogCommand implements yargs.CommandModule {
                         sqlString.substr(-1) === ";"
                             ? sqlString
                             : sqlString + ";"
-                    console.log(highlight(sqlString))
+                    console.log(PlatformTools.highlightSql(sqlString))
                 })
             }
             await dataSource.destroy()

--- a/src/platform/PlatformTools.ts
+++ b/src/platform/PlatformTools.ts
@@ -2,11 +2,16 @@ import * as path from "path"
 import * as fs from "fs"
 import dotenv from "dotenv"
 import chalk from "chalk"
-import { highlight, Theme } from "cli-highlight"
+import { type Theme } from "cli-highlight"
 
 export { ReadStream } from "fs"
 export { EventEmitter } from "events"
 export { Readable, Writable } from "stream"
+
+const highlight =
+    process.env.DISABLE_CLI_HIGHLIGHT === "true"
+        ? (str: string) => str
+        : require("cli-highlight").highlight
 
 /**
  * Platform-specific tools.


### PR DESCRIPTION
### Description of change

While cli highlighting can be a very useful tool, the package `cli-highlight` has a handful of issues for us:
1. The library seems abandoned, and a potential security issue waiting to happen.
2. When loading typeorm, over 30% of the code loaded into memory is coming from `cli-highlight` and its dependencies.

Just as how typeorm lazy-loads all drivers, It makes sense to do so for `cli-highlight` as well, optionally giving users the choice to not load this library at all.

### Pull-Request Checklist

- [x] Code is up-to-date with the `master` branch
- [x] `npm run format` to apply prettier formatting
- [x] `npm run test` passes with this change
- [ ] Documentation has been updated to reflect this change
- [x] The new commits follow conventions explained in [CONTRIBUTING.md](https://github.com/typeorm/typeorm/blob/master/CONTRIBUTING.md)
