### PR TITLE
Affixing comments to the end of queries

### DIFF
--- a/src/query-builder/DeleteQueryBuilder.ts
+++ b/src/query-builder/DeleteQueryBuilder.ts
@@ -38,9 +38,9 @@ export class DeleteQueryBuilder<Entity extends ObjectLiteral>
      * Gets generated SQL query without parameters being replaced.
      */
     getQuery(): string {
-        let sql = this.createComment()
-        sql += this.createCteExpression()
+        let sql = this.createCteExpression()
         sql += this.createDeleteExpression()
+        sql += this.createComment()
         return this.replacePropertyNamesForTheWholeQuery(sql.trim())
     }
 

--- a/src/query-builder/InsertQueryBuilder.ts
+++ b/src/query-builder/InsertQueryBuilder.ts
@@ -34,9 +34,9 @@ export class InsertQueryBuilder<
      * Gets generated SQL query without parameters being replaced.
      */
     getQuery(): string {
-        let sql = this.createComment()
-        sql += this.createCteExpression()
+        let sql = this.createCteExpression()
         sql += this.createInsertExpression()
+        sql += this.createComment()
         return this.replacePropertyNamesForTheWholeQuery(sql.trim())
     }
 

--- a/src/query-builder/SelectQueryBuilder.ts
+++ b/src/query-builder/SelectQueryBuilder.ts
@@ -81,8 +81,7 @@ export class SelectQueryBuilder<Entity extends ObjectLiteral>
      * Gets generated SQL query without parameters being replaced.
      */
     getQuery(): string {
-        let sql = this.createComment()
-        sql += this.createCteExpression()
+        let sql = this.createCteExpression()
         sql += this.createSelectExpression()
         sql += this.createJoinExpression()
         sql += this.createWhereExpression()
@@ -91,6 +90,7 @@ export class SelectQueryBuilder<Entity extends ObjectLiteral>
         sql += this.createOrderByExpression()
         sql += this.createLimitOffsetExpression()
         sql += this.createLockExpression()
+        sql += this.createComment()
         sql = sql.trim()
         if (this.expressionMap.subQuery) sql = "(" + sql + ")"
         return this.replacePropertyNamesForTheWholeQuery(sql)

--- a/src/query-builder/UpdateQueryBuilder.ts
+++ b/src/query-builder/UpdateQueryBuilder.ts
@@ -48,11 +48,11 @@ export class UpdateQueryBuilder<Entity extends ObjectLiteral>
      * Gets generated SQL query without parameters being replaced.
      */
     getQuery(): string {
-        let sql = this.createComment()
-        sql += this.createCteExpression()
+        let sql = this.createCteExpression()
         sql += this.createUpdateExpression()
         sql += this.createOrderByExpression()
         sql += this.createLimitExpression()
+        sql += this.createComment()
         return this.replacePropertyNamesForTheWholeQuery(sql.trim())
     }
 


### PR DESCRIPTION
<!--
  😀 Wonderful!  Thank you for opening a pull request for TypeORM.

  Please fill in the information below to expedite the review
  and (hopefully) merge of your change.

  If unsure about something.. just do as best as you're able,
  or reach out through our community support channels!
  https://github.com/typeorm/typeorm/blob/master/docs/support.md
-->

### Description of change

<!--
  Please be clear and concise what the change is intended to do,
  why this change is needed, and how you've verified that it
  corrects what you intended.

  In some cases it may be helpful to include the current behavior
  and the new behavior.

  If the change is related to an open issue, you can link it here.
  If you include `Fixes #0000` (replacing `0000` with the issue number)
  when this is merged it will automatically mark the issue as fixed and
  close it.
-->

Affixing the comments enables support for tooling that reads comments from the end of queries, such as sqlcommenter.

Fixes #10227


### Pull-Request Checklist

<!--
  Please make sure to review and check all of the following.

  If an item is not applicable, you can add "N/A" to the end.
-->

- [x] Code is up-to-date with the `master` branch
- [x] `npm run format` to apply prettier formatting
- [ ] `npm run test` passes with this change
- [x] This pull request links relevant issues as `Fixes #10227`
- [ ] There are new or updated unit tests validating the change
- [ ] Documentation has been updated to reflect this change
- [ ] The new commits follow conventions explained in [CONTRIBUTING.md](https://github.com/typeorm/typeorm/blob/master/CONTRIBUTING.md)

<!--
  🎉 Thank you for contributing and making TypeORM even better!
-->
