### PR TITLE
feat: Adding TS Types for DefaultAzureCredential usage

### DIFF
--- a/src/driver/sqlserver/SqlServerConnectionCredentialsOptions.ts
+++ b/src/driver/sqlserver/SqlServerConnectionCredentialsOptions.ts
@@ -1,5 +1,6 @@
 import { DefaultAuthentication } from "./authentication/DefaultAuthentication"
 import { AzureActiveDirectoryAccessTokenAuthentication } from "./authentication/AzureActiveDirectoryAccessTokenAuthentication"
+import { AzureActiveDirectoryDefaultAuthentication } from "./authentication/AzureActiveDirectoryDefaultAuthentication"
 import { AzureActiveDirectoryMsiAppServiceAuthentication } from "./authentication/AzureActiveDirectoryMsiAppServiceAuthentication"
 import { AzureActiveDirectoryMsiVmAuthentication } from "./authentication/AzureActiveDirectoryMsiVmAuthentication"
 import { AzureActiveDirectoryPasswordAuthentication } from "./authentication/AzureActiveDirectoryPasswordAuthentication"
@@ -10,6 +11,7 @@ export type SqlServerConnectionCredentialsAuthenticationOptions =
     | DefaultAuthentication
     | NtlmAuthentication
     | AzureActiveDirectoryAccessTokenAuthentication
+    | AzureActiveDirectoryDefaultAuthentication
     | AzureActiveDirectoryMsiAppServiceAuthentication
     | AzureActiveDirectoryMsiVmAuthentication
     | AzureActiveDirectoryPasswordAuthentication

--- a/src/driver/sqlserver/authentication/AzureActiveDirectoryDefaultAuthentication.ts
+++ b/src/driver/sqlserver/authentication/AzureActiveDirectoryDefaultAuthentication.ts
@@ -1,0 +1,12 @@
+export interface AzureActiveDirectoryDefaultAuthentication {
+    /**
+     * This uses DefaultAzureCredential from @azure/identity to try multiple methods of authentication
+     */
+    type: "azure-active-directory-default"
+    options: {
+        /**
+         * The clientId of the user you want to log in with, mapped to the managedIdentityClientId in tedious
+         */
+        clientId?: string
+    }
+}


### PR DESCRIPTION
<!--
  😀 Wonderful!  Thank you for opening a pull request for TypeORM.

  Please fill in the information below to expedite the review
  and (hopefully) merge of your change.

  If unsure about something.. just do as best as you're able,
  or reach out through our community support channels!
  https://github.com/typeorm/typeorm/blob/master/docs/support.md
-->

### Description of change

Tedious Supports the DefaultAzureCredential via specifying `azure-active-directory-default` as the auth type and an optional clientId. These types are missing from the TS contract that typeorm accepts

http://tediousjs.github.io/tedious/api-connection.html#function_newConnection

This is an additional option to what was introduced here: https://github.com/typeorm/typeorm/pull/7477

Fixes: https://github.com/typeorm/typeorm/issues/10223


### Pull-Request Checklist

<!--
  Please make sure to review and check all of the following.

  If an item is not applicable, you can add "N/A" to the end.
-->

- [x] Code is up-to-date with the `master` branch
- [x] `npm run format` to apply prettier formatting
- [x] `npm run test` passes with this change (N/A)
- [x] This pull request links relevant issues as `Fixes #0000`
- [x] There are new or updated unit tests validating the change (N/A)
- [x] Documentation has been updated to reflect this change (N/A)
- [x] The new commits follow conventions explained in [CONTRIBUTING.md](https://github.com/typeorm/typeorm/blob/master/CONTRIBUTING.md)

<!--
  🎉 Thank you for contributing and making TypeORM even better!
-->
