### PR TITLE
fix: ignore changes for columns with `update: false` in persistence

### DIFF
--- a/src/persistence/Subject.ts
+++ b/src/persistence/Subject.ts
@@ -195,7 +195,10 @@ export class Subject {
             (this.databaseEntityLoaded === false ||
                 (this.databaseEntityLoaded && this.databaseEntity)) &&
             // ((this.entity && this.databaseEntity) || (!this.entity && !this.databaseEntity)) &&
-            this.changeMaps.length > 0
+            // ensure there are one or more changes for updatable columns
+            this.changeMaps.some(
+                (change) => !change.column || change.column.isUpdate,
+            )
         )
     }
 

--- a/test/github-issues/10249/entity/example.ts
+++ b/test/github-issues/10249/entity/example.ts
@@ -1,0 +1,13 @@
+import { Column, Entity, PrimaryColumn } from "../../../../src"
+
+@Entity()
+export class Example {
+    @PrimaryColumn()
+    id: string
+
+    @Column({ update: false })
+    notUpdatable: string
+
+    @Column()
+    updatable: string
+}

--- a/test/github-issues/10249/issue-10249.ts
+++ b/test/github-issues/10249/issue-10249.ts
@@ -1,0 +1,64 @@
+import "reflect-metadata"
+import {
+    createTestingConnections,
+    closeTestingConnections,
+    reloadTestingDatabases,
+} from "../../utils/test-utils"
+import { DataSource } from "../../../src/data-source/DataSource"
+import { expect } from "chai"
+import { Example } from "./entity/example"
+
+describe("github issues > #10249 Saving an entity is not possible if only columns with update: false are changed", () => {
+    let dataSources: DataSource[]
+    before(
+        async () =>
+            (dataSources = await createTestingConnections({
+                entities: [Example],
+                enabledDrivers: ["postgres"],
+                schemaCreate: true,
+                dropSchema: true,
+            })),
+    )
+
+    beforeEach(() => reloadTestingDatabases(dataSources))
+    after(() => closeTestingConnections(dataSources))
+
+    it("should ignore changes for columns with `update: false` on saving entity", () =>
+        Promise.all(
+            dataSources.map(async (dataSource) => {
+                await Promise.all(
+                    dataSources.map(async (dataSource) => {
+                        const manager = dataSource.manager
+
+                        // create entity
+                        let exampleEntity = new Example()
+                        exampleEntity.id = "1"
+                        exampleEntity.notUpdatable = "value1"
+                        exampleEntity.updatable = "value1"
+                        await manager.save(exampleEntity)
+
+                        // updates only updatable value
+                        exampleEntity.notUpdatable = "value2"
+                        exampleEntity.updatable = "value2"
+                        await manager.save(exampleEntity)
+
+                        exampleEntity = (await manager.findOneBy(Example, {
+                            id: "1",
+                        }))!
+                        expect(exampleEntity.notUpdatable).to.be.eql("value1")
+                        expect(exampleEntity.updatable).to.be.eql("value2")
+
+                        // if `update: false` column only specified, do nothing
+                        exampleEntity.notUpdatable = "value3"
+                        await manager.save(exampleEntity)
+
+                        exampleEntity = (await manager.findOneBy(Example, {
+                            id: "1",
+                        }))!
+                        expect(exampleEntity.notUpdatable).to.be.eql("value1")
+                        expect(exampleEntity.updatable).to.be.eql("value2")
+                    }),
+                )
+            }),
+        ))
+})


### PR DESCRIPTION
Closes: #10249

<!--
  😀 Wonderful!  Thank you for opening a pull request for TypeORM.

  Please fill in the information below to expedite the review
  and (hopefully) merge of your change.

  If unsure about something.. just do as best as you're able,
  or reach out through our community support channels!
  https://github.com/typeorm/typeorm/blob/master/docs/support.md
-->

### Description of change

<!--
  Please be clear and concise what the change is intended to do,
  why this change is needed, and how you've verified that it
  corrects what you intended.

  In some cases it may be helpful to include the current behavior
  and the new behavior.

  If the change is related to an open issue, you can link it here.
  If you include `Fixes #0000` (replacing `0000` with the issue number)
  when this is merged it will automatically mark the issue as fixed and
  close it.
-->

With this change, EntityManager.save won't throw an error when all changes of a subject are for columns with `update: false`.

Fixes #10249 


### Pull-Request Checklist

<!--
  Please make sure to review and check all of the following.

  If an item is not applicable, you can add "N/A" to the end.
-->

- [x] Code is up-to-date with the `master` branch
- [x] `npm run format` to apply prettier formatting
- [x] `npm run test` passes with this change
- [x] This pull request links relevant issues as `Fixes #0000`
- [x] There are new or updated unit tests validating the change
- [ ] Documentation has been updated to reflect this change (N/A)
- [x] The new commits follow conventions explained in [CONTRIBUTING.md](https://github.com/typeorm/typeorm/blob/master/CONTRIBUTING.md)

<!--
  🎉 Thank you for contributing and making TypeORM even better!
-->
