### PR TITLE
feat: lazy load all drivers to reduce typeorm's memory footprint

### DIFF
--- a/gulpfile.ts
+++ b/gulpfile.ts
@@ -77,7 +77,7 @@ export class Gulpfile {
     @MergedTask()
     browserCompile() {
         const tsProject = ts.createProject("tsconfig.json", {
-            module: "es2015",
+            module: "es2020",
             "lib": ["es5", "es6", "dom"],
             typescript: require("typescript")
         });

--- a/src/data-source/DataSource.ts
+++ b/src/data-source/DataSource.ts
@@ -142,14 +142,10 @@ export class DataSource {
             this.options.logger,
             this.options.logging,
         )
-        this.driver = new DriverFactory().create(this)
         this.manager = this.createEntityManager()
         this.namingStrategy =
             options.namingStrategy || new DefaultNamingStrategy()
         this.metadataTableName = options.metadataTableName || "typeorm_metadata"
-        this.queryResultCache = options.cache
-            ? new QueryResultCacheFactory(this).create()
-            : undefined
         this.relationLoader = new RelationLoader(this)
         this.relationIdLoader = new RelationIdLoader(this)
         this.isInitialized = false
@@ -244,6 +240,11 @@ export class DataSource {
     async initialize(): Promise<this> {
         if (this.isInitialized)
             throw new CannotConnectAlreadyConnectedError(this.name)
+
+        this.driver = await DriverFactory.create(this)
+        this.queryResultCache = this.options.cache
+            ? new QueryResultCacheFactory(this).create()
+            : undefined
 
         // connect to the database via its driver
         await this.driver.connect()

--- a/src/driver/Driver.ts
+++ b/src/driver/Driver.ts
@@ -1,21 +1,22 @@
-import { QueryRunner } from "../query-runner/QueryRunner"
-import { ColumnMetadata } from "../metadata/ColumnMetadata"
-import { ObjectLiteral } from "../common/ObjectLiteral"
-import { ColumnType } from "./types/ColumnTypes"
-import { CteCapabilities } from "./types/CteCapabilities"
-import { MappedColumnTypes } from "./types/MappedColumnTypes"
-import { SchemaBuilder } from "../schema-builder/SchemaBuilder"
-import { DataTypeDefaults } from "./types/DataTypeDefaults"
-import { BaseDataSourceOptions } from "../data-source/BaseDataSourceOptions"
-import { TableColumn } from "../schema-builder/table/TableColumn"
-import { EntityMetadata } from "../metadata/EntityMetadata"
-import { ReplicationMode } from "./types/ReplicationMode"
-import { Table } from "../schema-builder/table/Table"
-import { View } from "../schema-builder/view/View"
-import { TableForeignKey } from "../schema-builder/table/TableForeignKey"
-import { UpsertType } from "./types/UpsertType"
-import { OnDeleteType } from "../metadata/types/OnDeleteType"
-import { OnUpdateType } from "../metadata/types/OnUpdateType"
+import type { QueryRunner } from "../query-runner/QueryRunner"
+import type { ColumnMetadata } from "../metadata/ColumnMetadata"
+import type { ObjectLiteral } from "../common/ObjectLiteral"
+import type { ColumnType } from "./types/ColumnTypes"
+import type { CteCapabilities } from "./types/CteCapabilities"
+import type { MappedColumnTypes } from "./types/MappedColumnTypes"
+import type { SchemaBuilder } from "../schema-builder/SchemaBuilder"
+import type { DataTypeDefaults } from "./types/DataTypeDefaults"
+import type { BaseDataSourceOptions } from "../data-source/BaseDataSourceOptions"
+import type { TableColumn } from "../schema-builder/table/TableColumn"
+import type { EntityMetadata } from "../metadata/EntityMetadata"
+import type { ReplicationMode } from "./types/ReplicationMode"
+import type { Table } from "../schema-builder/table/Table"
+import type { View } from "../schema-builder/view/View"
+import type { TableForeignKey } from "../schema-builder/table/TableForeignKey"
+import type { UpsertType } from "./types/UpsertType"
+import type { OnDeleteType } from "../metadata/types/OnDeleteType"
+import type { OnUpdateType } from "../metadata/types/OnUpdateType"
+import type { DataSource } from "../data-source"
 
 export type ReturningType = "insert" | "update" | "delete"
 
@@ -277,4 +278,8 @@ export interface Driver {
      * Creates an escaped parameter.
      */
     createParameter(parameterName: string, index: number): string
+}
+
+export interface DriverConstructor {
+    new (connection: DataSource): Driver
 }

--- a/src/driver/DriverFactory.ts
+++ b/src/driver/DriverFactory.ts
@@ -1,24 +1,5 @@
-import { MissingDriverError } from "../error/MissingDriverError"
-import { CockroachDriver } from "./cockroachdb/CockroachDriver"
-import { MongoDriver } from "./mongodb/MongoDriver"
-import { SqlServerDriver } from "./sqlserver/SqlServerDriver"
-import { OracleDriver } from "./oracle/OracleDriver"
-import { SqliteDriver } from "./sqlite/SqliteDriver"
-import { CordovaDriver } from "./cordova/CordovaDriver"
-import { ReactNativeDriver } from "./react-native/ReactNativeDriver"
-import { NativescriptDriver } from "./nativescript/NativescriptDriver"
-import { SqljsDriver } from "./sqljs/SqljsDriver"
-import { MysqlDriver } from "./mysql/MysqlDriver"
-import { PostgresDriver } from "./postgres/PostgresDriver"
-import { ExpoDriver } from "./expo/ExpoDriver"
-import { AuroraMysqlDriver } from "./aurora-mysql/AuroraMysqlDriver"
-import { AuroraPostgresDriver } from "./aurora-postgres/AuroraPostgresDriver"
-import { Driver } from "./Driver"
-import { DataSource } from "../data-source/DataSource"
-import { SapDriver } from "./sap/SapDriver"
-import { BetterSqlite3Driver } from "./better-sqlite3/BetterSqlite3Driver"
-import { CapacitorDriver } from "./capacitor/CapacitorDriver"
-import { SpannerDriver } from "./spanner/SpannerDriver"
+import type { Driver, DriverConstructor } from "./Driver"
+import type { DataSource } from "../data-source/DataSource"
 
 /**
  * Helps to create drivers.
@@ -29,46 +10,57 @@ export class DriverFactory {
      */
     create(connection: DataSource): Driver {
         const { type } = connection.options
+        return new (this.getDriver(type))(connection)
+    }
+
+    private getDriver(type: DataSource["options"]["type"]): DriverConstructor {
         switch (type) {
             case "mysql":
-                return new MysqlDriver(connection)
-            case "postgres":
-                return new PostgresDriver(connection)
-            case "cockroachdb":
-                return new CockroachDriver(connection)
-            case "sap":
-                return new SapDriver(connection)
             case "mariadb":
-                return new MysqlDriver(connection)
+                return require("./mysql/MysqlDriver").MysqlDriver
+            case "postgres":
+                return require("./postgres/PostgresDriver").PostgresDriver
+            case "cockroachdb":
+                return require("./cockroachdb/CockroachDriver").CockroachDriver
+            case "sap":
+                return require("./sap/SapDriver").SapDriver
             case "sqlite":
-                return new SqliteDriver(connection)
+                return require("./sqlite/SqliteDriver").SqliteDriver
             case "better-sqlite3":
-                return new BetterSqlite3Driver(connection)
+                return require("./better-sqlite3/BetterSqlite3Driver")
+                    .BetterSqlite3Driver
             case "cordova":
-                return new CordovaDriver(connection)
+                return require("./cordova/CordovaDriver").CordovaDriver
             case "nativescript":
-                return new NativescriptDriver(connection)
+                return require("./nativescript/NativescriptDriver")
+                    .NativescriptDriver
             case "react-native":
-                return new ReactNativeDriver(connection)
+                return require("./react-native/ReactNativeDriver")
+                    .ReactNativeDriver
             case "sqljs":
-                return new SqljsDriver(connection)
+                return require("./sqljs/SqljsDriver").SqljsDriver
             case "oracle":
-                return new OracleDriver(connection)
+                return require("./oracle/OracleDriver").OracleDriver
             case "mssql":
-                return new SqlServerDriver(connection)
+                return require("./sqlserver/SqlServerDriver").SqlServerDriver
             case "mongodb":
-                return new MongoDriver(connection)
+                return require("./mongodb/MongoDriver").MongoDriver
             case "expo":
-                return new ExpoDriver(connection)
+                return require("./expo/ExpoDriver").ExpoDriver
             case "aurora-mysql":
-                return new AuroraMysqlDriver(connection)
+                return require("./aurora-mysql/AuroraMysqlDriver")
+                    .AuroraMysqlDriver
             case "aurora-postgres":
-                return new AuroraPostgresDriver(connection)
+                return require("./aurora-postgres/AuroraPostgresDriver")
+                    .AuroraPostgresDriver
             case "capacitor":
-                return new CapacitorDriver(connection)
+                return require("./capacitor/CapacitorDriver").CapacitorDriver
             case "spanner":
-                return new SpannerDriver(connection)
+                return require("./spanner/SpannerDriver").SpannerDriver
             default:
+                const {
+                    MissingDriverError,
+                } = require("../error/MissingDriverError")
                 throw new MissingDriverError(type, [
                     "aurora-mysql",
                     "aurora-postgres",

--- a/src/driver/DriverFactory.ts
+++ b/src/driver/DriverFactory.ts
@@ -1,6 +1,81 @@
 import type { Driver, DriverConstructor } from "./Driver"
 import type { DataSource } from "../data-source/DataSource"
 
+const getDriver = async (
+    type: DataSource["options"]["type"],
+): Promise<DriverConstructor> => {
+    switch (type) {
+        case "mysql":
+        case "mariadb":
+            return (await import("./mysql/MysqlDriver")).MysqlDriver
+        case "postgres":
+            return (await import("./postgres/PostgresDriver")).PostgresDriver
+        case "cockroachdb":
+            return (await import("./cockroachdb/CockroachDriver"))
+                .CockroachDriver
+        case "sap":
+            return (await import("./sap/SapDriver")).SapDriver
+        case "sqlite":
+            return (await import("./sqlite/SqliteDriver")).SqliteDriver
+        case "better-sqlite3":
+            return (await import("./better-sqlite3/BetterSqlite3Driver"))
+                .BetterSqlite3Driver
+        case "cordova":
+            return (await import("./cordova/CordovaDriver")).CordovaDriver
+        case "nativescript":
+            return (await import("./nativescript/NativescriptDriver"))
+                .NativescriptDriver
+        case "react-native":
+            return (await import("./react-native/ReactNativeDriver"))
+                .ReactNativeDriver
+        case "sqljs":
+            return (await import("./sqljs/SqljsDriver")).SqljsDriver
+        case "oracle":
+            return (await import("./oracle/OracleDriver")).OracleDriver
+        case "mssql":
+            return (await import("./sqlserver/SqlServerDriver")).SqlServerDriver
+        case "mongodb":
+            return (await import("./mongodb/MongoDriver")).MongoDriver
+        case "expo":
+            return (await import("./expo/ExpoDriver")).ExpoDriver
+        case "aurora-mysql":
+            return (await import("./aurora-mysql/AuroraMysqlDriver"))
+                .AuroraMysqlDriver
+        case "aurora-postgres":
+            return (await import("./aurora-postgres/AuroraPostgresDriver"))
+                .AuroraPostgresDriver
+        case "capacitor":
+            return (await import("./capacitor/CapacitorDriver")).CapacitorDriver
+        case "spanner":
+            return (await import("./spanner/SpannerDriver")).SpannerDriver
+        default:
+            const { MissingDriverError } = await import(
+                "../error/MissingDriverError"
+            )
+            throw new MissingDriverError(type, [
+                "aurora-mysql",
+                "aurora-postgres",
+                "better-sqlite3",
+                "capacitor",
+                "cockroachdb",
+                "cordova",
+                "expo",
+                "mariadb",
+                "mongodb",
+                "mssql",
+                "mysql",
+                "nativescript",
+                "oracle",
+                "postgres",
+                "react-native",
+                "sap",
+                "sqlite",
+                "sqljs",
+                "spanner",
+            ])
+    }
+}
+
 /**
  * Helps to create drivers.
  */
@@ -8,80 +83,8 @@ export class DriverFactory {
     /**
      * Creates a new driver depend on a given connection's driver type.
      */
-    create(connection: DataSource): Driver {
+    static async create(connection: DataSource): Promise<Driver> {
         const { type } = connection.options
-        return new (this.getDriver(type))(connection)
-    }
-
-    private getDriver(type: DataSource["options"]["type"]): DriverConstructor {
-        switch (type) {
-            case "mysql":
-            case "mariadb":
-                return require("./mysql/MysqlDriver").MysqlDriver
-            case "postgres":
-                return require("./postgres/PostgresDriver").PostgresDriver
-            case "cockroachdb":
-                return require("./cockroachdb/CockroachDriver").CockroachDriver
-            case "sap":
-                return require("./sap/SapDriver").SapDriver
-            case "sqlite":
-                return require("./sqlite/SqliteDriver").SqliteDriver
-            case "better-sqlite3":
-                return require("./better-sqlite3/BetterSqlite3Driver")
-                    .BetterSqlite3Driver
-            case "cordova":
-                return require("./cordova/CordovaDriver").CordovaDriver
-            case "nativescript":
-                return require("./nativescript/NativescriptDriver")
-                    .NativescriptDriver
-            case "react-native":
-                return require("./react-native/ReactNativeDriver")
-                    .ReactNativeDriver
-            case "sqljs":
-                return require("./sqljs/SqljsDriver").SqljsDriver
-            case "oracle":
-                return require("./oracle/OracleDriver").OracleDriver
-            case "mssql":
-                return require("./sqlserver/SqlServerDriver").SqlServerDriver
-            case "mongodb":
-                return require("./mongodb/MongoDriver").MongoDriver
-            case "expo":
-                return require("./expo/ExpoDriver").ExpoDriver
-            case "aurora-mysql":
-                return require("./aurora-mysql/AuroraMysqlDriver")
-                    .AuroraMysqlDriver
-            case "aurora-postgres":
-                return require("./aurora-postgres/AuroraPostgresDriver")
-                    .AuroraPostgresDriver
-            case "capacitor":
-                return require("./capacitor/CapacitorDriver").CapacitorDriver
-            case "spanner":
-                return require("./spanner/SpannerDriver").SpannerDriver
-            default:
-                const {
-                    MissingDriverError,
-                } = require("../error/MissingDriverError")
-                throw new MissingDriverError(type, [
-                    "aurora-mysql",
-                    "aurora-postgres",
-                    "better-sqlite3",
-                    "capacitor",
-                    "cockroachdb",
-                    "cordova",
-                    "expo",
-                    "mariadb",
-                    "mongodb",
-                    "mssql",
-                    "mysql",
-                    "nativescript",
-                    "oracle",
-                    "postgres",
-                    "react-native",
-                    "sap",
-                    "sqlite",
-                    "sqljs",
-                    "spanner",
-                ])
-        }
+        return new (await getDriver(type))(connection)
     }
 }

--- a/src/entity-manager/EntityManagerFactory.ts
+++ b/src/entity-manager/EntityManagerFactory.ts
@@ -12,10 +12,10 @@ export class EntityManagerFactory {
      * Creates a new entity manager depend on a given connection's driver.
      */
     create(connection: DataSource, queryRunner?: QueryRunner): EntityManager {
-        if (connection.driver.options.type === "mongodb")
+        if (connection.options.type === "mongodb")
             return new MongoEntityManager(connection)
 
-        if (connection.driver.options.type === "sqljs")
+        if (connection.options.type === "sqljs")
             return new SqljsEntityManager(connection, queryRunner)
 
         return new EntityManager(connection, queryRunner)


### PR DESCRIPTION
### Description of change

Typeorm [already lazy-loads external node_modules](https://github.com/typeorm/typeorm/blob/master/src/platform/PlatformTools.ts#L36) that the driver classes are built around, but the Driver classes themselves are all immediately loaded into memory when someone imports typeorm into their code.

This PR changes that behavior to lazy-load the drivers only when they are actually used. This cuts down on typeorm's baseline memory footprint.
This change also reduces the memory that the garbage collector has to collect after typeorm is loaded.

Combined with #10221, the initial memory usage of typeorm reduces from about **50MB to 24MB**, and after the first GC, the retained memory is reduced from **20MB to 10MB**.


### Pull-Request Checklist
- [x] Code is up-to-date with the `master` branch
- [x] `npm run format` to apply prettier formatting
- [x] `npm run test` passes with this change
- [ ] Documentation has been updated to reflect this change
- [x] The new commits follow conventions explained in [CONTRIBUTING.md](https://github.com/typeorm/typeorm/blob/master/CONTRIBUTING.md)

---

PS: [This comment](https://github.com/typeorm/typeorm/pull/10221#issuecomment-1650709288) from #10221 applies to this PR as well. 
If these changes don't seem relevant enough to the project maintainers, please let us know, so that we can try other ways to patch typeorm. 
Currently typeorm takes up about **40%** of our baseline memory usage, and bringing this number down is important to us.
