### PR TITLE
Use node-oracledb 6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## [0.3.17](https://github.com/typeorm/typeorm/compare/0.3.16...0.3.17) (2023-06-20)
+
+### Bug Fixes
+
+* [#10040](https://github.com/typeorm/typeorm/issues/10040) TypeORM synchronize database even if it is up to date ([#10041](https://github.com/typeorm/typeorm/issues/10041)) ([b1a3a39](https://github.com/typeorm/typeorm/commit/b1a3a395049052f3f031e9fd27b99769b03b9011))
+* add missing await ([#10084](https://github.com/typeorm/typeorm/issues/10084)) ([f5d4397](https://github.com/typeorm/typeorm/commit/f5d43975dbbf02d0e40d64d01265105d4018cf7a))
+
 ## [0.3.16](https://github.com/typeorm/typeorm/compare/0.3.15...0.3.16) (2023-05-09)
 
 ### Bug Fixes

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "typeorm",
-  "version": "0.3.16",
+  "version": "0.3.17",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "typeorm",
-      "version": "0.3.16",
+      "version": "0.3.17",
       "license": "MIT",
       "dependencies": {
         "@sqltools/formatter": "^1.2.5",
@@ -95,7 +95,7 @@
         "mongodb": "^5.2.0",
         "mssql": "^9.1.1",
         "mysql2": "^2.2.5 || ^3.0.1",
-        "oracledb": "^5.1.0",
+        "oracledb": "^6.0.3",
         "pg": "^8.5.1",
         "pg-native": "^3.0.0",
         "pg-query-stream": "^4.0.0",
@@ -9826,6 +9826,17 @@
       },
       "engines": {
         "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/oracledb": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/oracledb/-/oracledb-6.0.3.tgz",
+      "integrity": "sha512-szsaTgEcVpmGwi5sCHLXvvpoL5ZJIE69wSOBpclsGO5XX6QMce6KRr+R+t68ihns+8MV4A0J4oeR6efCfxScrg==",
+      "hasInstallScript": true,
+      "optional": true,
+      "peer": true,
+      "engines": {
+        "node": ">=14.6"
       }
     },
     "node_modules/ordered-read-streams": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -95,7 +95,7 @@
         "mongodb": "^5.2.0",
         "mssql": "^9.1.1",
         "mysql2": "^2.2.5 || ^3.0.1",
-        "oracledb": "^6.0.3",
+        "oracledb": "^6.1.0",
         "pg": "^8.5.1",
         "pg-native": "^3.0.0",
         "pg-query-stream": "^4.0.0",
@@ -9829,9 +9829,9 @@
       }
     },
     "node_modules/oracledb": {
-      "version": "6.0.3",
-      "resolved": "https://registry.npmjs.org/oracledb/-/oracledb-6.0.3.tgz",
-      "integrity": "sha512-szsaTgEcVpmGwi5sCHLXvvpoL5ZJIE69wSOBpclsGO5XX6QMce6KRr+R+t68ihns+8MV4A0J4oeR6efCfxScrg==",
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/oracledb/-/oracledb-6.1.0.tgz",
+      "integrity": "sha512-0mQ5d7DTgz18SjHMksPT0DT/jhIbbdtncDd8M+xxU6lrdlePqdS/tMGlphDcGKKtCDXG42aOf/leS007q7s+ew==",
       "hasInstallScript": true,
       "optional": true,
       "peer": true,

--- a/package-lock.json
+++ b/package-lock.json
@@ -95,7 +95,7 @@
         "mongodb": "^5.2.0",
         "mssql": "^9.1.1",
         "mysql2": "^2.2.5 || ^3.0.1",
-        "oracledb": "^6.1.0",
+        "oracledb": "^6.2.0",
         "pg": "^8.5.1",
         "pg-native": "^3.0.0",
         "pg-query-stream": "^4.0.0",
@@ -9829,9 +9829,9 @@
       }
     },
     "node_modules/oracledb": {
-      "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/oracledb/-/oracledb-6.1.0.tgz",
-      "integrity": "sha512-0mQ5d7DTgz18SjHMksPT0DT/jhIbbdtncDd8M+xxU6lrdlePqdS/tMGlphDcGKKtCDXG42aOf/leS007q7s+ew==",
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/oracledb/-/oracledb-6.2.0.tgz",
+      "integrity": "sha512-NP6Q3pukVhmowFszQhDfqaiC4RngcuSQ9Vj79quRw9f9s+R1Awo+I1Oexj+qYGFONRJz+Nl7TpkTUiXICbblGg==",
       "hasInstallScript": true,
       "optional": true,
       "peer": true,

--- a/package.json
+++ b/package.json
@@ -151,7 +151,7 @@
     "mongodb": "^5.2.0",
     "mssql": "^9.1.1",
     "mysql2": "^2.2.5 || ^3.0.1",
-    "oracledb": "^6.0.3",
+    "oracledb": "^6.1.0",
     "pg": "^8.5.1",
     "pg-native": "^3.0.0",
     "pg-query-stream": "^4.0.0",

--- a/package.json
+++ b/package.json
@@ -151,7 +151,7 @@
     "mongodb": "^5.2.0",
     "mssql": "^9.1.1",
     "mysql2": "^2.2.5 || ^3.0.1",
-    "oracledb": "^5.1.0",
+    "oracledb": "^6.0.3",
     "pg": "^8.5.1",
     "pg-native": "^3.0.0",
     "pg-query-stream": "^4.0.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "typeorm",
   "private": true,
-  "version": "0.3.16",
+  "version": "0.3.17",
   "description": "Data-Mapper ORM for TypeScript, ES7, ES6, ES5. Supports MySQL, PostgreSQL, MariaDB, SQLite, MS SQL Server, Oracle, MongoDB databases.",
   "license": "MIT",
   "readmeFilename": "README.md",

--- a/package.json
+++ b/package.json
@@ -151,7 +151,7 @@
     "mongodb": "^5.2.0",
     "mssql": "^9.1.1",
     "mysql2": "^2.2.5 || ^3.0.1",
-    "oracledb": "^6.1.0",
+    "oracledb": "^6.2.0",
     "pg": "^8.5.1",
     "pg-native": "^3.0.0",
     "pg-query-stream": "^4.0.0",

--- a/package.json
+++ b/package.json
@@ -151,7 +151,7 @@
     "mongodb": "^5.2.0",
     "mssql": "^9.1.1",
     "mysql2": "^2.2.5 || ^3.0.1",
-    "oracledb": "^6.2.0",
+    "oracledb": "^6.3.0",
     "pg": "^8.5.1",
     "pg-native": "^3.0.0",
     "pg-query-stream": "^4.0.0",

--- a/src/driver/oracle/OracleConnectionOptions.ts
+++ b/src/driver/oracle/OracleConnectionOptions.ts
@@ -2,6 +2,7 @@ import { BaseDataSourceOptions } from "../../data-source/BaseDataSourceOptions"
 import { OracleConnectionCredentialsOptions } from "./OracleConnectionCredentialsOptions"
 
 export interface OracleThickModeOptions {
+    binaryDir?:string
     configDir?: string
     driverName?: string
     errorUrl?: string

--- a/src/driver/oracle/OracleConnectionOptions.ts
+++ b/src/driver/oracle/OracleConnectionOptions.ts
@@ -24,11 +24,12 @@ export interface OracleConnectionOptions
     readonly driver?: any
 
     /**
-     * Utilize the thick driver. Starting from oracledb version 6, it's necessary to set this to true when opting for the thick client usage.
-     * Another option is to configure the libDir to the Oracle Instant Client. For additional information, refer to the details provided in the following link:
+     * This specifies the directory containing the Oracle Client libraries.
+     * If libDir is not specified, the default library search mechanism is used.
+     * For additional information, refer to the details provided in the following link:
      * (https://node-oracledb.readthedocs.io/en/latest/api_manual/oracledb.html#oracledb.initOracleClient)
      */
-    readonly thickDriver?: boolean | string
+    readonly thickDriverLibDir?: string
 
     /**
      * A boolean determining whether to pass time values in UTC or local time. (default: false).

--- a/src/driver/oracle/OracleConnectionOptions.ts
+++ b/src/driver/oracle/OracleConnectionOptions.ts
@@ -24,6 +24,13 @@ export interface OracleConnectionOptions
     readonly driver?: any
 
     /**
+     * Utilize the thick driver. Starting from oracledb version 6, it's necessary to set this to true when opting for the thick client usage.
+     * Another option is to configure the libDir to the Oracle Instant Client. For additional information, refer to the details provided in the following link:
+     * (https://node-oracledb.readthedocs.io/en/latest/api_manual/oracledb.html#oracledb.initOracleClient)
+     */
+    readonly thickDriver?: boolean | string
+
+    /**
      * A boolean determining whether to pass time values in UTC or local time. (default: false).
      */
     readonly useUTC?: boolean

--- a/src/driver/oracle/OracleConnectionOptions.ts
+++ b/src/driver/oracle/OracleConnectionOptions.ts
@@ -2,7 +2,7 @@ import { BaseDataSourceOptions } from "../../data-source/BaseDataSourceOptions"
 import { OracleConnectionCredentialsOptions } from "./OracleConnectionCredentialsOptions"
 
 export interface OracleThickModeOptions {
-    binaryDir?:string
+    binaryDir?: string
     configDir?: string
     driverName?: string
     errorUrl?: string

--- a/src/driver/oracle/OracleConnectionOptions.ts
+++ b/src/driver/oracle/OracleConnectionOptions.ts
@@ -1,6 +1,13 @@
 import { BaseDataSourceOptions } from "../../data-source/BaseDataSourceOptions"
 import { OracleConnectionCredentialsOptions } from "./OracleConnectionCredentialsOptions"
 
+export interface OracleThickModeOptions {
+    configDir?: string
+    driverName?: string
+    errorUrl?: string
+    libDir?: string
+}
+
 /**
  * Oracle-specific connection options.
  */
@@ -24,12 +31,12 @@ export interface OracleConnectionOptions
     readonly driver?: any
 
     /**
-     * This specifies the directory containing the Oracle Client libraries.
-     * If libDir is not specified, the default library search mechanism is used.
+     * Utilize the thick driver. Starting from oracledb version 6, it's necessary to set this to true when opting for the thick client usage.
+     * Alternatively, an 'OracleThickModeOptions' object can be configured, which is used for the thick mode configuration by passing it to the 'node-oracledb' driver.
      * For additional information, refer to the details provided in the following link:
      * (https://node-oracledb.readthedocs.io/en/latest/api_manual/oracledb.html#oracledb.initOracleClient)
      */
-    readonly thickDriverLibDir?: string
+    readonly thickMode?: boolean | OracleThickModeOptions
 
     /**
      * A boolean determining whether to pass time values in UTC or local time. (default: false).

--- a/src/driver/oracle/OracleDriver.ts
+++ b/src/driver/oracle/OracleDriver.ts
@@ -975,10 +975,12 @@ export class OracleDriver implements Driver {
         } catch (e) {
             throw new DriverPackageNotInstalledError("Oracle", "oracledb")
         }
-        if (this.options.thickDriver) {
-            typeof this.options.thickDriver === "string"
+        const oracleDBDriverMode =
+            process.env.NODE_ORACLEDB_DRIVER_MODE || "thick"
+        if (oracleDBDriverMode === "thick") {
+            typeof this.options.thickDriverLibDir
                 ? this.oracle.initOracleClient({
-                      libDir: this.options.thickDriver,
+                      libDir: this.options.thickDriverLibDir,
                   })
                 : this.oracle.initOracleClient()
         }

--- a/src/driver/oracle/OracleDriver.ts
+++ b/src/driver/oracle/OracleDriver.ts
@@ -975,6 +975,13 @@ export class OracleDriver implements Driver {
         } catch (e) {
             throw new DriverPackageNotInstalledError("Oracle", "oracledb")
         }
+        if (this.options.thickDriver) {
+            typeof this.options.thickDriver === "string"
+                ? this.oracle.initOracleClient({
+                      libDir: this.options.thickDriver,
+                  })
+                : this.oracle.initOracleClient()
+        }
     }
 
     /**

--- a/src/driver/oracle/OracleDriver.ts
+++ b/src/driver/oracle/OracleDriver.ts
@@ -975,13 +975,10 @@ export class OracleDriver implements Driver {
         } catch (e) {
             throw new DriverPackageNotInstalledError("Oracle", "oracledb")
         }
-        const oracleDBDriverMode =
-            process.env.NODE_ORACLEDB_DRIVER_MODE || "thick"
-        if (oracleDBDriverMode === "thick") {
-            typeof this.options.thickDriverLibDir
-                ? this.oracle.initOracleClient({
-                      libDir: this.options.thickDriverLibDir,
-                  })
+        const thickMode = this.options.thickMode
+        if (thickMode) {
+            typeof thickMode === "object"
+                ? this.oracle.initOracleClient(thickMode)
                 : this.oracle.initOracleClient()
         }
     }


### PR DESCRIPTION
<!--
  😀 Wonderful!  Thank you for opening a pull request for TypeORM.

  Please fill in the information below to expedite the review
  and (hopefully) merge of your change.

  If unsure about something.. just do as best as you're able,
  or reach out through our community support channels!
  https://github.com/typeorm/typeorm/blob/master/docs/support.md
-->

### Description of change
Increase node-oracledb version to 6. Since node-oracledb version 6+ the used driver is a Thin Client, no additional Oracle Instant Client Lib is necessary.
Addtional funtionality  for opt in to the  Thick Client was added.


Closes: #10277, #10094

<!--
  Please be clear and concise what the change is intended to do,
  why this change is needed, and how you've verified that it
  corrects what you intended.

  In some cases it may be helpful to include the current behavior
  and the new behavior.

  If the change is related to an open issue, you can link it here.
  If you include `Fixes #0000` (replacing `0000` with the issue number)
  when this is merged it will automatically mark the issue as fixed and
  close it.
-->


### Pull-Request Checklist

<!--
  Please make sure to review and check all of the following.

  If an item is not applicable, you can add "N/A" to the end.
-->

- [x] Code is up-to-date with the `master` branch
- [x] `npm run format` to apply prettier formatting
- [x] `npm run test` passes with this change
- [x] This pull request links relevant issues as `Fixes #0000`
- [N/A] There are new or updated unit tests validating the change 
- [N/A] Documentation has been updated to reflect this change
- [x] The new commits follow conventions explained in [CONTRIBUTING.md](https://github.com/typeorm/typeorm/blob/master/CONTRIBUTING.md)

<!--
  🎉 Thank you for contributing and making TypeORM even better!
-->
