### PR TITLE
test: correct and re-enabled test cases for migration commands

### DIFF
--- a/src/commands/MigrationCreateCommand.ts
+++ b/src/commands/MigrationCreateCommand.ts
@@ -30,6 +30,11 @@ export class MigrationCreateCommand implements yargs.CommandModule {
     }
 
     async handler(args: yargs.Arguments) {
+        const exitCode = await this.handle(args)
+        process.exit(exitCode)
+    }
+
+    async handle(args: yargs.Arguments): Promise<number> {
         try {
             const timestamp = CommandUtils.getTimestamp(args.timestamp)
             const inputPath = (args.path as string).startsWith("/")
@@ -55,9 +60,10 @@ export class MigrationCreateCommand implements yargs.CommandModule {
                     fullPath + (args.outputJs ? ".js" : ".ts"),
                 )} has been generated successfully.`,
             )
+            return 0
         } catch (err) {
             PlatformTools.logCmdErr("Error during migration creation:", err)
-            process.exit(1)
+            return 1
         }
     }
 

--- a/src/commands/MigrationGenerateCommand.ts
+++ b/src/commands/MigrationGenerateCommand.ts
@@ -61,6 +61,10 @@ export class MigrationGenerateCommand implements yargs.CommandModule {
     }
 
     async handler(args: yargs.Arguments) {
+        const exitCode = await this.handle(args)
+        process.exit(exitCode)
+    }
+    async handle(args: yargs.Arguments): Promise<number> {
         const timestamp = CommandUtils.getTimestamp(args.timestamp)
         const extension = args.outputJs ? ".js" : ".ts"
         const fullPath = (args.path as string).startsWith("/")
@@ -137,18 +141,18 @@ export class MigrationGenerateCommand implements yargs.CommandModule {
                     console.log(
                         chalk.green(`No changes in database schema were found`),
                     )
-                    process.exit(0)
+                    return 0
                 } else {
                     console.log(
                         chalk.yellow(
                             `No changes in database schema were found - cannot generate a migration. To create a new empty migration use "typeorm migration:create" command`,
                         ),
                     )
-                    process.exit(1)
+                    return 1
                 }
             } else if (!args.path) {
                 console.log(chalk.yellow("Please specify a migration path"))
-                process.exit(1)
+                return 1
             }
 
             const fileContent = args.outputJs
@@ -173,7 +177,7 @@ export class MigrationGenerateCommand implements yargs.CommandModule {
                         )}`,
                     ),
                 )
-                process.exit(1)
+                return 1
             }
 
             if (args.dryrun) {
@@ -196,11 +200,11 @@ export class MigrationGenerateCommand implements yargs.CommandModule {
                         )} has been generated successfully.`,
                     ),
                 )
-                process.exit(0)
             }
+            return 0
         } catch (err) {
             PlatformTools.logCmdErr("Error during migration generation:", err)
-            process.exit(1)
+            return 1
         }
     }
 

--- a/test/functional/commands/templates/result-templates-create.ts
+++ b/test/functional/commands/templates/result-templates-create.ts
@@ -1,7 +1,7 @@
 export const resultsTemplates: Record<string, any> = {
-    control: `import {MigrationInterface, QueryRunner} from "typeorm";
+    control: `import { MigrationInterface, QueryRunner } from "typeorm"
 
-export class testMigration1610975184784 implements MigrationInterface {
+export class TestMigration1610975184784 implements MigrationInterface {
 
     public async up(queryRunner: QueryRunner): Promise<void> {
     }
@@ -12,17 +12,18 @@ export class testMigration1610975184784 implements MigrationInterface {
 }`,
     javascript: `const { MigrationInterface, QueryRunner } = require("typeorm");
 
-module.exports = class testMigration1610975184784 {
+module.exports = class TestMigration1610975184784 {
 
     async up(queryRunner) {
     }
 
     async down(queryRunner) {
     }
-}`,
-    timestamp: `import {MigrationInterface, QueryRunner} from "typeorm";
 
-export class testMigration1641163894670 implements MigrationInterface {
+}`,
+    timestamp: `import { MigrationInterface, QueryRunner } from "typeorm"
+
+export class TestMigration1641163894670 implements MigrationInterface {
 
     public async up(queryRunner: QueryRunner): Promise<void> {
     }

--- a/test/functional/commands/templates/result-templates-generate.ts
+++ b/test/functional/commands/templates/result-templates-generate.ts
@@ -1,8 +1,8 @@
 export const resultsTemplates: Record<string, any> = {
-    control: `import {MigrationInterface, QueryRunner} from "typeorm";
+    control: `import { MigrationInterface, QueryRunner } from "typeorm";
 
-export class testMigration1610975184784 implements MigrationInterface {
-    name = 'testMigration1610975184784'
+export class TestMigration1610975184784 implements MigrationInterface {
+    name = 'TestMigration1610975184784'
 
     public async up(queryRunner: QueryRunner): Promise<void> {
         await queryRunner.query(\`CREATE TABLE \\\`post\\\` (\\\`id\\\` int NOT NULL AUTO_INCREMENT, \\\`title\\\` varchar(255) NOT NULL, \\\`createdAt\\\` datetime(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6), PRIMARY KEY (\\\`id\\\`)) ENGINE=InnoDB\`);
@@ -15,8 +15,8 @@ export class testMigration1610975184784 implements MigrationInterface {
 }`,
     javascript: `const { MigrationInterface, QueryRunner } = require("typeorm");
 
-module.exports = class testMigration1610975184784 {
-    name = 'testMigration1610975184784'
+module.exports = class TestMigration1610975184784 {
+    name = 'TestMigration1610975184784'
 
     async up(queryRunner) {
         await queryRunner.query(\`CREATE TABLE \\\`post\\\` (\\\`id\\\` int NOT NULL AUTO_INCREMENT, \\\`title\\\` varchar(255) NOT NULL, \\\`createdAt\\\` datetime(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6), PRIMARY KEY (\\\`id\\\`)) ENGINE=InnoDB\`);
@@ -26,10 +26,10 @@ module.exports = class testMigration1610975184784 {
         await queryRunner.query(\`DROP TABLE \\\`post\\\`\`);
     }
 }`,
-    timestamp: `import {MigrationInterface, QueryRunner} from "typeorm";
+    timestamp: `import { MigrationInterface, QueryRunner } from "typeorm";
 
-export class testMigration1641163894670 implements MigrationInterface {
-    name = 'testMigration1641163894670'
+export class TestMigration1641163894670 implements MigrationInterface {
+    name = 'TestMigration1641163894670'
 
     public async up(queryRunner: QueryRunner): Promise<void> {
         await queryRunner.query(\`CREATE TABLE \\\`post\\\` (\\\`id\\\` int NOT NULL AUTO_INCREMENT, \\\`title\\\` varchar(255) NOT NULL, \\\`createdAt\\\` datetime(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6), PRIMARY KEY (\\\`id\\\`)) ENGINE=InnoDB\`);


### PR DESCRIPTION
### Description of change

Correct and re-enabled test cases for `migration:create` and `migration:generate` commands.

### Pull-Request Checklist

<!--
  Please make sure to review and check all of the following.

  If an item is not applicable, you can add "N/A" to the end.
-->

- [x] Code is up-to-date with the `master` branch
- [x] `npm run format` to apply prettier formatting
- [x] `npm run test` passes with this change
- [ ] This pull request links relevant issues as `Fixes #0000`
- [x] There are new or updated unit tests validating the change
- [ ] Documentation has been updated to reflect this change
- [x] The new commits follow conventions explained in [CONTRIBUTING.md](https://github.com/typeorm/typeorm/blob/master/CONTRIBUTING.md)

<!--
  🎉 Thank you for contributing and making TypeORM even better!
-->
