### PR TITLE
fix: null relation data removes relation keys on save

### DIFF
--- a/src/persistence/SubjectChangedColumnsComputer.ts
+++ b/src/persistence/SubjectChangedColumnsComputer.ts
@@ -61,6 +61,10 @@ export class SubjectChangedColumnsComputer {
             // we don't perform operation over undefined properties (but we DO need null properties!)
             if (entityValue === undefined) return
 
+            // Ignore marking relation as null
+            if (relatedEntity === null && relation.orphanedRowAction === 'disable')
+                return;
+
             // if there is no database entity then all columns are treated as new, e.g. changed
             if (subject.databaseEntity) {
                 // skip transform database value for json / jsonb for comparison later on

--- a/src/persistence/SubjectChangedColumnsComputer.ts
+++ b/src/persistence/SubjectChangedColumnsComputer.ts
@@ -57,14 +57,9 @@ export class SubjectChangedColumnsComputer {
 
             // get user provided value - column value from the user provided persisted entity
             const entityValue = column.getEntityValue(subject.entity!)
-
             // we don't perform operation over undefined properties (but we DO need null properties!)
             if (entityValue === undefined) return
-
-            // Ignore marking relation as null
-            if (relatedEntity === null && relation.orphanedRowAction === 'disable')
-                return;
-
+            
             // if there is no database entity then all columns are treated as new, e.g. changed
             if (subject.databaseEntity) {
                 // skip transform database value for json / jsonb for comparison later on
@@ -198,6 +193,10 @@ export class SubjectChangedColumnsComputer {
             // we don't perform operation over undefined properties (but we DO need null properties!)
             if (relatedEntity === undefined) return
 
+            // Ignore marking relation as null
+            if (relatedEntity === null && relation.orphanedRowAction === 'disable')
+                return;
+            
             // if there is no database entity then all relational columns are treated as new, e.g. changed
             if (subject.databaseEntity) {
                 // here we cover two scenarios:
@@ -214,6 +213,10 @@ export class SubjectChangedColumnsComputer {
                         relatedEntityRelationIdMap,
                     )!
 
+                // If all the join columns are not selected then save query nullifies the relation columns in primary table.
+                if (relatedEntityRelationIdMap === undefined)
+                    return;
+                
                 // get database related entity. Since loadRelationIds are used on databaseEntity
                 // related entity will contain only its relation ids
                 const databaseRelatedEntityRelationIdMap =


### PR DESCRIPTION
Fix issue with leftJoin and null relation data causing removal of relation keys on parent record update

<!--
  😀 Wonderful!  Thank you for opening a pull request for TypeORM.

  Please fill in the information below to expedite the review
  and (hopefully) merge of your change.

  If unsure about something.. just do as best as you're able,
  or reach out through our community support channels!
  https://github.com/typeorm/typeorm/blob/master/docs/support.md
-->

### Description of change

<!--
  Please be clear and concise what the change is intended to do,
  why this change is needed, and how you've verified that it
  corrects what you intended.

  In some cases it may be helpful to include the current behavior
  and the new behavior.

  If the change is related to an open issue, you can link it here.
  If you include `Fixes #0000` (replacing `0000` with the issue number)
  when this is merged it will automatically mark the issue as fixed and
  close it.
-->


### Pull-Request Checklist

<!--
  Please make sure to review and check all of the following.

  If an item is not applicable, you can add "N/A" to the end.
-->

- [x] Code is up-to-date with the `master` branch
- [ ] `npm run format` to apply prettier formatting
- [ ] `npm run test` passes with this change
- [ ] This pull request links relevant issues as `Fixes #0000`
- [ ] There are new or updated unit tests validating the change
- [ ] Documentation has been updated to reflect this change
- [ ] The new commits follow conventions explained in [CONTRIBUTING.md](https://github.com/typeorm/typeorm/blob/master/CONTRIBUTING.md)

<!--
  🎉 Thank you for contributing and making TypeORM even better!
-->
