### PR TITLE
add conditions to handle joins with different name fields in related entities

### DIFF
--- a/src/util/OrmUtils.ts
+++ b/src/util/OrmUtils.ts
@@ -350,7 +350,7 @@ export class OrmUtils {
         x: any,
         y: any,
     ) {
-        let p
+        let p, subProperty
 
         // remember that NaN === NaN returns false
         // and isNaN(undefined) returns true
@@ -410,7 +410,16 @@ export class OrmUtils {
             if (y.hasOwnProperty(p) !== x.hasOwnProperty(p)) {
                 return false
             } else if (typeof y[p] !== typeof x[p]) {
-                return false
+                // Added condition AND for index y[p][p] and second condition to handle joins with different name field in related table
+                try {
+                    subProperty =
+                        Object.keys(y[p]).length > 0 ? Object.keys(y[p])[0] : p
+                } catch (e) {
+                    subProperty = p
+                }
+                if (typeof y[p][subProperty] !== typeof x[p]) {
+                    return false
+                }
             }
         }
 
@@ -418,7 +427,16 @@ export class OrmUtils {
             if (y.hasOwnProperty(p) !== x.hasOwnProperty(p)) {
                 return false
             } else if (typeof y[p] !== typeof x[p]) {
-                return false
+                // added condition AND for index y[p][p] and second condition to handle joins with different name field in related table >>>
+                try {
+                    subProperty =
+                        Object.keys(y[p]).length > 0 ? Object.keys(y[p])[0] : p
+                } catch (e) {
+                    subProperty = p
+                }
+                if (typeof y[p][subProperty] !== typeof x[p]) {
+                    return false
+                }
             }
 
             switch (typeof x[p]) {
@@ -439,7 +457,18 @@ export class OrmUtils {
 
                 default:
                     if (x[p] !== y[p]) {
-                        return false
+                        // added condition AND for index y[p][p] and second condition to handle joins with different name field in related table
+                        try {
+                            subProperty =
+                                Object.keys(y[p]).length > 0
+                                    ? Object.keys(y[p])[0]
+                                    : p
+                        } catch (e) {
+                            subProperty = p
+                        }
+                        if (y[p][subProperty] !== x[p]) {
+                            return false
+                        }
                     }
                     break
             }


### PR DESCRIPTION
Feature Description
When querying data from an entity and using leftJoin on it, a problem arises: if the relation data from the leftJoin is null and the save method is called on the parent record, the relation keys in the updated record are being removed. This behavior is not desirable in cases where you only intend to update the parent record without affecting the relation keys, even if the relation data is null.

Example:
@ManyToOne(() => Entries)
@JoinColumn([
    {name: "entry_id", referencedColumnName: "entry_id" },
    { name: "customer_id", referencedColumnName: "customer_id" }
])
public Entry: Entries
 
const exc = await this.excRepo.createQueryBuilder('exc')
            .where('exc.entryxclasses_id = :excId', { excId })
            .andWhere('c.customer_id = :customerId', { customerId })
            .leftJoinAndSelect('exc.Entry', 'e')
            .getOne()

exc.is_gone = true
await this.excRepo.save(exc) // makes customer_id & entry_id null when exc.Entry is null.
<!--
  😀 Wonderful!  Thank you for opening a pull request for TypeORM.

  Please fill in the information below to expedite the review
  and (hopefully) merge of your change.

  If unsure about something.. just do as best as you're able,
  or reach out through our community support channels!
  https://github.com/typeorm/typeorm/blob/master/docs/support.md
-->

### Description of change

<!--
  Please be clear and concise what the change is intended to do,
  why this change is needed, and how you've verified that it
  corrects what you intended.

  In some cases it may be helpful to include the current behavior
  and the new behavior.

  If the change is related to an open issue, you can link it here.
  If you include `Fixes #0000` (replacing `0000` with the issue number)
  when this is merged it will automatically mark the issue as fixed and
  close it.
-->


### Pull-Request Checklist

<!--
  Please make sure to review and check all of the following.

  If an item is not applicable, you can add "N/A" to the end.
-->

- [x] Code is up-to-date with the `master` branch
- [x] `npm run format` to apply prettier formatting
- [x] `npm run test` passes with this change
- [ ] This pull request links relevant issues as `Fixes #0000`
- [ ] There are new or updated unit tests validating the change
- [ ] Documentation has been updated to reflect this change
- [ ] The new commits follow conventions explained in [CONTRIBUTING.md](https://github.com/typeorm/typeorm/blob/master/CONTRIBUTING.md)

<!--
  🎉 Thank you for contributing and making TypeORM even better!
-->
