### PR TITLE
fix: incorrect check for pagination

### DIFF
--- a/src/query-builder/SelectQueryBuilder.ts
+++ b/src/query-builder/SelectQueryBuilder.ts
@@ -3410,7 +3410,8 @@ export class SelectQueryBuilder<Entity extends ObjectLiteral>
         // first query find ids in skip and take range
         // and second query loads the actual data in given ids range
         if (
-            (this.expressionMap.skip || this.expressionMap.take) &&
+            this.expressionMap.skip &&
+            this.expressionMap.take &&
             this.expressionMap.joinAttributes.length > 0
         ) {
             // we are skipping order by here because its not working in subqueries anyway

--- a/test/github-issues/5694/entity/Post.ts
+++ b/test/github-issues/5694/entity/Post.ts
@@ -1,0 +1,12 @@
+import { PrimaryColumn } from "../../../../src/decorator/columns/PrimaryColumn"
+import { Entity } from "../../../../src/decorator/entity/Entity"
+
+@Entity()
+export class Post {
+    @PrimaryColumn()
+    id: number
+
+    constructor(id: number) {
+        this.id = id
+    }
+}

--- a/test/github-issues/5694/issue-5694.ts
+++ b/test/github-issues/5694/issue-5694.ts
@@ -1,0 +1,53 @@
+import "reflect-metadata"
+import {
+    createTestingConnections,
+    closeTestingConnections,
+    reloadTestingDatabases,
+} from "../../utils/test-utils"
+import { DataSource } from "../../../src/data-source/DataSource"
+import { expect } from "chai"
+import { Post } from "./entity/Post"
+
+describe("github issues > #5694 findOne with relations does two queries", () => {
+    let dataSources: DataSource[]
+    before(
+        async () =>
+            (dataSources = await createTestingConnections({
+                entities: [__dirname + "/entity/*{.js,.ts}"],
+                schemaCreate: true,
+                dropSchema: true,
+            })),
+    )
+    beforeEach(() => reloadTestingDatabases(dataSources))
+    after(() => closeTestingConnections(dataSources))
+
+    it("should not try to paginate when skip is undefined and take is defined", () =>
+        Promise.all(
+            dataSources.map(async (dataSource) => {
+                const builder = dataSource
+                    .getRepository(Post)
+                    .createQueryBuilder()
+                const createOrderByCombinedWithSelectExpression =
+                    builder["createOrderByCombinedWithSelectExpression"]
+
+                let called = true
+
+                builder["createOrderByCombinedWithSelectExpression"] = (
+                    ...args
+                ) => {
+                    called = true
+                    return createOrderByCombinedWithSelectExpression.apply(
+                        builder,
+                        args,
+                    )
+                }
+
+                await builder.setFindOptions({ take: 1 }).getOne()
+
+                expect(called).to.be.false
+
+                builder["createOrderByCombinedWithSelectExpression"] =
+                    createOrderByCombinedWithSelectExpression
+            }),
+        ))
+})


### PR DESCRIPTION
The check for whether or not the user is trying to paginate is incorrect resulting in all findOne queries executing an additional query.

Closes: #5694

### Description of change

The check for whether or not the user is trying to paginated is changed from:
```js
skip || take
```
to
```js
skip && take
```

### Pull-Request Checklist

- [x] Code is up-to-date with the `master` branch
- [x] `npm run format` to apply prettier formatting
- [ ] `npm run test` passes with this change
- [x] This pull request links relevant issues as `Fixes #5694`
- [x] There are new or updated unit tests validating the change
- [x] Documentation has been updated to reflect this change
- [x] The new commits follow conventions explained in [CONTRIBUTING.md](https://github.com/typeorm/typeorm/blob/master/CONTRIBUTING.md)
