### PR TITLE
expose countDocuments in mongodb

### DIFF
--- a/docs/mongodb.md
+++ b/docs/mongodb.md
@@ -284,6 +284,10 @@ Perform a bulkWrite operation without a fluent API.
 
 Count number of matching documents in the db to a query.
 
+### `countDocuments`
+
+Count number of matching documents in the db to a query.
+
 #### `createCollectionIndex`
 
 Creates an index on the db and collection.

--- a/src/entity-manager/MongoEntityManager.ts
+++ b/src/entity-manager/MongoEntityManager.ts
@@ -54,6 +54,7 @@ import {
     IndexInformationOptions,
     ObjectId,
     FilterOperators,
+    CountDocumentsOptions,
 } from "../driver/mongodb/typings"
 import { DataSource } from "../data-source/DataSource"
 import { MongoFindManyOptions } from "../find-options/mongodb/MongoFindManyOptions"
@@ -497,6 +498,22 @@ export class MongoEntityManager extends EntityManager {
     ): Promise<number> {
         const metadata = this.connection.getMetadata(entityClassOrName)
         return this.mongoQueryRunner.count(metadata.tableName, query, options)
+    }
+
+    /**
+     * Count number of matching documents in the db to a query.
+     */
+    countDocuments<Entity>(
+        entityClassOrName: EntityTarget<Entity>,
+        query: Filter<Document> = {},
+        options: CountDocumentsOptions = {},
+    ): Promise<number> {
+        const metadata = this.connection.getMetadata(entityClassOrName)
+        return this.mongoQueryRunner.countDocuments(
+            metadata.tableName,
+            query,
+            options,
+        )
     }
 
     /**

--- a/src/repository/MongoRepository.ts
+++ b/src/repository/MongoRepository.ts
@@ -43,6 +43,7 @@ import {
     UpdateFilter,
     UpdateOptions,
     UpdateResult,
+    CountDocumentsOptions,
 } from "../driver/mongodb/typings"
 import { FindManyOptions } from "../find-options/FindManyOptions"
 
@@ -242,6 +243,20 @@ export class MongoRepository<
      */
     count(query?: ObjectLiteral, options?: CountOptions): Promise<number> {
         return this.manager.count(this.metadata.target, query || {}, options)
+    }
+
+    /**
+     * Count number of matching documents in the db to a query.
+     */
+    countDocuments(
+        query?: ObjectLiteral,
+        options?: CountDocumentsOptions,
+    ): Promise<number> {
+        return this.manager.countDocuments(
+            this.metadata.target,
+            query || {},
+            options,
+        )
     }
 
     /**


### PR DESCRIPTION
### Description of change

This change exposes countDocuments at the `MongoRepository` layer assisting nestjs applications wanting to move to the non-deprecated version.

Additionally this could be used within `executeFindAndCount` in the MongoEntityManager to follow what's recommended at the driver level.

It seems like there was an optimization in the driver to use `countDocuments` reverted 4 months ago to split them into their own functions but wasn't moved up to the respective manager and repositories.

Ideally MongoRepository should be using countDocuments internally for the `count` overload from `Repository` but I think this is a good start for simply exposing it.

### Pull-Request Checklist

I'm not quite sure how to write good tests expressing this change. Some help on this front would be appreciated.

- [X] Code is up-to-date with the `master` branch
- [X] `npm run format` to apply prettier formatting
- [ ] `npm run test` passes with this change -- will update when I get all the configs setup
- [ ] This pull request links relevant issues as `Fixes #0000` -- N/A
- [ ] There are new or updated unit tests validating the change -- unsure where to put tests for something like this
- [X] Documentation has been updated to reflect this change
- [X] The new commits follow conventions explained in [CONTRIBUTING.md](https://github.com/typeorm/typeorm/blob/master/CONTRIBUTING.md)
