### PR TITLE
Resolves a Memory Leak from an Unclosed Cloned Cursor

### DIFF
--- a/src/entity-manager/MongoEntityManager.ts
+++ b/src/entity-manager/MongoEntityManager.ts
@@ -1008,11 +1008,11 @@ export class MongoEntityManager extends EntityManager {
         cursor: FindCursor<Entity> | AggregationCursor<Entity>,
     ) {
         const queryRunner = this.mongoQueryRunner
-        cursor.toArray = () =>
-            cursor
-                .clone()
-                .toArray()
-                .then(async (results: Entity[]) => {
+
+        ;(cursor as any)["__to_array_func"] = cursor.toArray
+        cursor.toArray = async () =>
+            ((cursor as any)["__to_array_func"] as CallableFunction)().then(
+                async (results: Entity[]) => {
                     const transformer = new DocumentToEntityTransformer()
                     const entities = transformer.transformAll(results, metadata)
                     // broadcast "load" events
@@ -1022,13 +1022,12 @@ export class MongoEntityManager extends EntityManager {
                         entities,
                     )
                     return entities
-                })
-
-        cursor.next = () =>
-            cursor
-                .clone()
-                .next()
-                .then(async (result: Entity) => {
+                },
+            )
+        ;(cursor as any)["__next_func"] = cursor.next
+        cursor.next = async () =>
+            ((cursor as any)["__next_func"] as CallableFunction)().then(
+                async (result: Entity) => {
                     if (!result) {
                         return result
                     }
@@ -1039,7 +1038,8 @@ export class MongoEntityManager extends EntityManager {
                         entity,
                     ])
                     return entity
-                })
+                },
+            )
     }
 
     protected filterSoftDeleted<Entity>(


### PR DESCRIPTION
### Description of change

Removes an underlying `clone` which causes a hanging cursor leading to a memory leak on simple functions like `find`.

fixes: #10315 

### Pull-Request Checklist

- [X] Code is up-to-date with the `master` branch
- [X] `npm run format` to apply prettier formatting
- [ ] `npm run test` passes with this change -- Unfinished local setup
- [X] This pull request links relevant issues as `Fixes #0000`
- [ ] There are new or updated unit tests validating the change -- N/A, unsure of how should I test a memory leak
- [ ] Documentation has been updated to reflect this change -- N/A
- [X] The new commits follow conventions explained in [CONTRIBUTING.md](https://github.com/typeorm/typeorm/blob/master/CONTRIBUTING.md)
