### PR TITLE
Fix #7308:  QueryBuilder makes different parameter identifiers for same parameter

### DIFF
--- a/src/driver/Driver.ts
+++ b/src/driver/Driver.ts
@@ -113,6 +113,11 @@ export interface Driver {
     mappedDataTypes: MappedColumnTypes
 
     /**
+     * The prefix used for the parameters
+     */
+    parametersPrefix?: string
+
+    /**
      * Max length allowed by the DBMS for aliases (execution of queries).
      */
     maxAliasLength?: number

--- a/src/driver/cockroachdb/CockroachDriver.ts
+++ b/src/driver/cockroachdb/CockroachDriver.ts
@@ -225,6 +225,11 @@ export class CockroachDriver implements Driver {
     }
 
     /**
+     * The prefix used for the parameters
+     */
+    parametersPrefix: string = "$"
+
+    /**
      * Default values of length, precision and scale depends on column data type.
      * Used in the cases when length/precision/scale is not specified by user.
      */
@@ -509,11 +514,16 @@ export class CockroachDriver implements Driver {
         if (!parameters || !Object.keys(parameters).length)
             return [sql, escapedParameters]
 
+        const parameterIndexMap = new Map<string, number>()
         sql = sql.replace(
             /:(\.\.\.)?([A-Za-z0-9_.]+)/g,
             (full, isArray: string, key: string): string => {
                 if (!parameters.hasOwnProperty(key)) {
                     return full
+                }
+
+                if (parameterIndexMap.has(key)) {
+                    return this.parametersPrefix + parameterIndexMap.get(key)
                 }
 
                 let value: any = parameters[key]
@@ -535,6 +545,7 @@ export class CockroachDriver implements Driver {
                 }
 
                 escapedParameters.push(value)
+                parameterIndexMap.set(key, escapedParameters.length)
                 return this.createParameter(key, escapedParameters.length - 1)
             },
         ) // todo: make replace only in value statements, otherwise problems
@@ -961,7 +972,7 @@ export class CockroachDriver implements Driver {
      * Creates an escaped parameter.
      */
     createParameter(parameterName: string, index: number): string {
-        return "$" + (index + 1)
+        return this.parametersPrefix + (index + 1)
     }
 
     // -------------------------------------------------------------------------

--- a/src/driver/oracle/OracleDriver.ts
+++ b/src/driver/oracle/OracleDriver.ts
@@ -216,6 +216,11 @@ export class OracleDriver implements Driver {
     }
 
     /**
+     * The prefix used for the parameters
+     */
+    parametersPrefix: string = ":"
+
+    /**
      * Default values of length, precision and scale depends on column data type.
      * Used in the cases when length/precision/scale is not specified by user.
      */
@@ -378,11 +383,16 @@ export class OracleDriver implements Driver {
         if (!parameters || !Object.keys(parameters).length)
             return [sql, escapedParameters]
 
+        const parameterIndexMap = new Map<string, number>()
         sql = sql.replace(
             /:(\.\.\.)?([A-Za-z0-9_.]+)/g,
             (full, isArray: string, key: string): string => {
                 if (!parameters.hasOwnProperty(key)) {
                     return full
+                }
+
+                if (parameterIndexMap.has(key)) {
+                    return this.parametersPrefix + parameterIndexMap.get(key)
                 }
 
                 let value: any = parameters[key]
@@ -408,6 +418,7 @@ export class OracleDriver implements Driver {
                 }
 
                 escapedParameters.push(value)
+                parameterIndexMap.set(key, escapedParameters.length)
                 return this.createParameter(key, escapedParameters.length - 1)
             },
         ) // todo: make replace only in value statements, otherwise problems
@@ -928,7 +939,7 @@ export class OracleDriver implements Driver {
      * Creates an escaped parameter.
      */
     createParameter(parameterName: string, index: number): string {
-        return ":" + (index + 1)
+        return this.parametersPrefix + (index + 1)
     }
 
     /**

--- a/src/driver/postgres/PostgresDriver.ts
+++ b/src/driver/postgres/PostgresDriver.ts
@@ -258,6 +258,11 @@ export class PostgresDriver implements Driver {
     }
 
     /**
+     * The prefix used for the parameters
+     */
+    parametersPrefix: string = "$"
+
+    /**
      * Default values of length, precision and scale depends on column data type.
      * Used in the cases when length/precision/scale is not specified by user.
      */
@@ -830,11 +835,16 @@ export class PostgresDriver implements Driver {
         if (!parameters || !Object.keys(parameters).length)
             return [sql, escapedParameters]
 
+        const parameterIndexMap = new Map<string, number>()
         sql = sql.replace(
             /:(\.\.\.)?([A-Za-z0-9_.]+)/g,
             (full, isArray: string, key: string): string => {
                 if (!parameters.hasOwnProperty(key)) {
                     return full
+                }
+
+                if (parameterIndexMap.has(key)) {
+                    return this.parametersPrefix + parameterIndexMap.get(key)
                 }
 
                 let value: any = parameters[key]
@@ -856,6 +866,7 @@ export class PostgresDriver implements Driver {
                 }
 
                 escapedParameters.push(value)
+                parameterIndexMap.set(key, escapedParameters.length)
                 return this.createParameter(key, escapedParameters.length - 1)
             },
         ) // todo: make replace only in value statements, otherwise problems
@@ -1399,7 +1410,7 @@ export class PostgresDriver implements Driver {
      * Creates an escaped parameter.
      */
     createParameter(parameterName: string, index: number): string {
-        return "$" + (index + 1)
+        return this.parametersPrefix + (index + 1)
     }
 
     // -------------------------------------------------------------------------

--- a/src/driver/spanner/SpannerDriver.ts
+++ b/src/driver/spanner/SpannerDriver.ts
@@ -158,6 +158,11 @@ export class SpannerDriver implements Driver {
     }
 
     /**
+     * The prefix used for the parameters
+     */
+    parametersPrefix: string = "@param"
+
+    /**
      * Default values of length, precision and scale depends on column data type.
      * Used in the cases when length/precision/scale is not specified by user.
      */
@@ -251,11 +256,16 @@ export class SpannerDriver implements Driver {
         if (!parameters || !Object.keys(parameters).length)
             return [sql, escapedParameters]
 
+        const parameterIndexMap = new Map<string, number>()
         sql = sql.replace(
             /:(\.\.\.)?([A-Za-z0-9_.]+)/g,
             (full, isArray: string, key: string): string => {
                 if (!parameters.hasOwnProperty(key)) {
                     return full
+                }
+
+                if (parameterIndexMap.has(key)) {
+                    return this.parametersPrefix + parameterIndexMap.get(key)
                 }
 
                 let value: any = parameters[key]
@@ -279,7 +289,9 @@ export class SpannerDriver implements Driver {
                 if (value instanceof Function) {
                     return value()
                 }
+
                 escapedParameters.push(value)
+                parameterIndexMap.set(key, escapedParameters.length - 1)
                 return this.createParameter(key, escapedParameters.length - 1)
             },
         ) // todo: make replace only in value statements, otherwise problems
@@ -717,7 +729,7 @@ export class SpannerDriver implements Driver {
      * Creates an escaped parameter.
      */
     createParameter(parameterName: string, index: number): string {
-        return "@param" + index
+        return this.parametersPrefix + index
     }
 
     // -------------------------------------------------------------------------

--- a/src/driver/sqlserver/SqlServerDriver.ts
+++ b/src/driver/sqlserver/SqlServerDriver.ts
@@ -212,6 +212,11 @@ export class SqlServerDriver implements Driver {
     }
 
     /**
+     * The prefix used for the parameters
+     */
+    parametersPrefix: string = "@"
+
+    /**
      * Default values of length, precision and scale depends on column data type.
      * Used in the cases when length/precision/scale is not specified by user.
      */
@@ -371,11 +376,16 @@ export class SqlServerDriver implements Driver {
         if (!parameters || !Object.keys(parameters).length)
             return [sql, escapedParameters]
 
+        const parameterIndexMap = new Map<string, number>()
         sql = sql.replace(
             /:(\.\.\.)?([A-Za-z0-9_.]+)/g,
             (full, isArray: string, key: string): string => {
                 if (!parameters.hasOwnProperty(key)) {
                     return full
+                }
+
+                if (parameterIndexMap.has(key)) {
+                    return this.parametersPrefix + parameterIndexMap.get(key)
                 }
 
                 let value: any = parameters[key]
@@ -397,6 +407,7 @@ export class SqlServerDriver implements Driver {
                 }
 
                 escapedParameters.push(value)
+                parameterIndexMap.set(key, escapedParameters.length - 1)
                 return this.createParameter(key, escapedParameters.length - 1)
             },
         ) // todo: make replace only in value statements, otherwise problems
@@ -908,7 +919,7 @@ export class SqlServerDriver implements Driver {
      * Creates an escaped parameter.
      */
     createParameter(parameterName: string, index: number): string {
-        return "@" + index
+        return this.parametersPrefix + index
     }
 
     // -------------------------------------------------------------------------

--- a/test/functional/repository/aggregate-methods/repository-aggregate-methods.ts
+++ b/test/functional/repository/aggregate-methods/repository-aggregate-methods.ts
@@ -10,7 +10,6 @@ import { LessThan } from "../../../../src"
 import { expect } from "chai"
 
 describe("repository > aggregate methods", () => {
-    debugger
     let connections: DataSource[]
     let repository: Repository<Post>
 

--- a/test/github-issues/7308/entity/weather.ts
+++ b/test/github-issues/7308/entity/weather.ts
@@ -1,0 +1,10 @@
+import { Column, Entity, PrimaryColumn } from "../../../../src"
+
+@Entity()
+export class Weather {
+    @PrimaryColumn()
+    id: string
+
+    @Column({ type: "float" })
+    temperature: number
+}

--- a/test/github-issues/7308/issue-7308.ts
+++ b/test/github-issues/7308/issue-7308.ts
@@ -1,0 +1,70 @@
+import "reflect-metadata"
+import {
+    createTestingConnections,
+    closeTestingConnections,
+    reloadTestingDatabases,
+} from "../../utils/test-utils"
+import { DataSource } from "../../../src/data-source/DataSource"
+import { Weather } from "./entity/weather"
+import { expect } from "chai"
+
+describe("github issues > #7308 queryBuilder makes different parameter identifiers for same parameter, causing problems with groupby", () => {
+    describe("Postgres & cockroachdb", () => {
+        let dataSources: DataSource[]
+        before(
+            async () =>
+                (dataSources = await createTestingConnections({
+                    entities: [Weather],
+                    enabledDrivers: [
+                        "postgres",
+                        "cockroachdb",
+                        "spanner",
+                        "mssql",
+                        "oracle",
+                    ],
+                    schemaCreate: true,
+                    dropSchema: true,
+                })),
+        )
+
+        beforeEach(() => reloadTestingDatabases(dataSources))
+        after(() => closeTestingConnections(dataSources))
+
+        it("should not create different parameters identifiers for the same parameter", () =>
+            Promise.all(
+                dataSources.map(async (dataSource) => {
+                    const [query, parameters] = dataSource
+                        .getRepository(Weather)
+                        .createQueryBuilder()
+                        .select("round(temperature, :floatNumber)")
+                        .addSelect("count(*)", "count")
+                        .groupBy("round(temperature, :floatNumber)")
+                        .setParameters({ floatNumber: 2.4 })
+                        .getQueryAndParameters()
+                    query.should.not.be.undefined
+
+                    if (
+                        dataSource.driver.options.type === "postgres" ||
+                        dataSource.driver.options.type === "cockroachdb"
+                    ) {
+                        expect(query).to.equal(
+                            'SELECT round(temperature, $1), count(*) AS "count" FROM "weather" "Weather" GROUP BY round(temperature, $1)',
+                        )
+                    } else if (dataSource.driver.options.type === "spanner") {
+                        expect(query).to.equal(
+                            'SELECT round(temperature, @param0), count(*) AS "count" FROM "weather" "Weather" GROUP BY round(temperature, @param0)',
+                        )
+                    } else if (dataSource.driver.options.type === "oracle") {
+                        expect(query).to.equal(
+                            'SELECT round(temperature, :1), count(*) AS "count" FROM "weather" "Weather" GROUP BY round(temperature, :1)',
+                        )
+                    } else if (dataSource.driver.options.type === "mssql") {
+                        expect(query).to.equal(
+                            'SELECT round(temperature, @0), count(*) AS "count" FROM "weather" "Weather" GROUP BY round(temperature, @0)',
+                        )
+                    }
+                    return parameters.length.should.eql(1)
+                }),
+            ))
+    })
+})


### PR DESCRIPTION
Hi, this PR is fixing #7308

The query builder will now use the same identifiers for the same parameters, I've made the change to Postgres, SQL Server, Oracle, Spanner, and CockroachDB. 

Closes #7308

<!--
  😀 Wonderful!  Thank you for opening a pull request for TypeORM.

  Please fill in the information below to expedite the review
  and (hopefully) merge of your change.

  If unsure about something.. just do as best as you're able,
  or reach out through our community support channels!
  https://github.com/typeorm/typeorm/blob/master/docs/support.md
-->

### Description of change

<!--
  Please be clear and concise what the change is intended to do,
  why this change is needed, and how you've verified that it
  corrects what you intended.

  In some cases it may be helpful to include the current behavior
  and the new behavior.

  If the change is related to an open issue, you can link it here.
  If you include `Fixes #0000` (replacing `0000` with the issue number)
  when this is merged it will automatically mark the issue as fixed and
  close it.
-->


### Pull-Request Checklist

<!--
  Please make sure to review and check all of the following.

  If an item is not applicable, you can add "N/A" to the end.
-->

- [x] Code is up-to-date with the `master` branch
- [x] `npm run format` to apply prettier formatting
- [x] `npm run test` passes with this change
- [x] This pull request links relevant issues as `Fixes #0000`
- [x] There are new or updated unit tests validating the change
- [ ] Documentation has been updated to reflect this change
- [x] The new commits follow conventions explained in [CONTRIBUTING.md](https://github.com/typeorm/typeorm/blob/master/CONTRIBUTING.md)

<!--
  🎉 Thank you for contributing and making TypeORM even better!
-->
