### PR TITLE
fix: serialize bigint when building a query id #10336

### DIFF
--- a/src/query-builder/SelectQueryBuilder.ts
+++ b/src/query-builder/SelectQueryBuilder.ts
@@ -3743,10 +3743,12 @@ export class SelectQueryBuilder<Entity extends ObjectLiteral>
      */
     protected async loadRawResults(queryRunner: QueryRunner) {
         const [sql, parameters] = this.getQueryAndParameters()
-        const queryId = sql + " -- PARAMETERS: " + JSON.stringify(
-            parameters,
-            (_, value) => typeof value === "bigint" ? value.toString() : value
-        )
+        const queryId =
+            sql +
+            " -- PARAMETERS: " +
+            JSON.stringify(parameters, (_, value) =>
+                typeof value === "bigint" ? value.toString() : value,
+            )
         const cacheOptions =
             typeof this.connection.options.cache === "object"
                 ? this.connection.options.cache

--- a/src/query-builder/SelectQueryBuilder.ts
+++ b/src/query-builder/SelectQueryBuilder.ts
@@ -3743,7 +3743,10 @@ export class SelectQueryBuilder<Entity extends ObjectLiteral>
      */
     protected async loadRawResults(queryRunner: QueryRunner) {
         const [sql, parameters] = this.getQueryAndParameters()
-        const queryId = sql + " -- PARAMETERS: " + JSON.stringify(parameters)
+        const queryId = sql + " -- PARAMETERS: " + JSON.stringify(
+            parameters,
+            (_, value) => typeof value === "bigint" ? value.toString() : value
+        )
         const cacheOptions =
             typeof this.connection.options.cache === "object"
                 ? this.connection.options.cache


### PR DESCRIPTION
### Description of change

Allow to serialize `bigint` parameter as string when building query id for caching purposes.

A fix for this issue:

https://github.com/typeorm/typeorm/issues/10336

```ts
@Entity('my_entity')
class MyEntity {
  @Column('bigint')
  public id: bigint;
}
...
entityRepository.findOne({ id: 1n })
```


### Pull-Request Checklist

- [A] Code is up-to-date with the `master` branch
- [A] `npm run format` to apply prettier formatting
- [N] `npm run test` passes with this change
- [A] This pull request links relevant issues as `Fixes #10336`
- [N] There are new or updated unit tests validating the change
- [N] Documentation has been updated to reflect this change
- [N] The new commits follow conventions explained in [CONTRIBUTING.md](https://github.com/typeorm/typeorm/blob/master/CONTRIBUTING.md)

