### PR TITLE
Many to many er dup entry #5704

### DIFF
--- a/src/persistence/subject-builder/ManyToManySubjectBuilder.ts
+++ b/src/persistence/subject-builder/ManyToManySubjectBuilder.ts
@@ -99,9 +99,14 @@ export class ManyToManySubjectBuilder {
         // if subject don't have database entity it means all related entities in persisted subject are new and must be bind
         // and we don't need to remove something that is not exist
         if (subject.databaseEntity) {
-            const databaseRelatedEntityValue = relation.getEntityValue(subject.databaseEntity);
+            const databaseRelatedEntityValue = relation.getEntityValue(
+                subject.databaseEntity,
+            )
             if (databaseRelatedEntityValue) {
-                databaseRelatedEntityIds = databaseRelatedEntityValue.map((e:any) => relation.inverseEntityMetadata.getEntityIdMap(e));
+                databaseRelatedEntityIds = databaseRelatedEntityValue.map(
+                    (e: any) =>
+                        relation.inverseEntityMetadata.getEntityIdMap(e),
+                )
             }
         }
 

--- a/src/persistence/subject-builder/ManyToManySubjectBuilder.ts
+++ b/src/persistence/subject-builder/ManyToManySubjectBuilder.ts
@@ -98,10 +98,12 @@ export class ManyToManySubjectBuilder {
 
         // if subject don't have database entity it means all related entities in persisted subject are new and must be bind
         // and we don't need to remove something that is not exist
-        if (subject.databaseEntity)
-            databaseRelatedEntityIds = relation.getEntityValue(
-                subject.databaseEntity,
-            )
+        if (subject.databaseEntity) {
+            const databaseRelatedEntityValue = relation.getEntityValue(subject.databaseEntity);
+            if (databaseRelatedEntityValue) {
+                databaseRelatedEntityIds = databaseRelatedEntityValue.map((e:any) => relation.inverseEntityMetadata.getEntityIdMap(e));
+            }
+        }
 
         // extract entity's relation value
         // by example: categories inside our post (subject.entity is post)

--- a/test/github-issues/5704/entity/Category.ts
+++ b/test/github-issues/5704/entity/Category.ts
@@ -1,0 +1,21 @@
+import {
+    Column,
+    ManyToMany,
+    Entity,
+    PrimaryGeneratedColumn,
+} from "../../../../src"
+import { Post } from "./Post"
+
+@Entity()
+export class Category {
+    @PrimaryGeneratedColumn()
+    id: number
+
+    @Column()
+    name: string
+
+    @ManyToMany(() => Post, (o) => o.categories)
+    posts!: Promise<Post[]>
+
+    addedProp: boolean = false
+}

--- a/test/github-issues/5704/entity/Post.ts
+++ b/test/github-issues/5704/entity/Post.ts
@@ -1,0 +1,23 @@
+import {
+    Column,
+    Entity,
+    JoinTable,
+    ManyToMany,
+    PrimaryGeneratedColumn,
+} from "../../../../src"
+import { Category } from "./Category"
+
+@Entity()
+export class Post {
+    @PrimaryGeneratedColumn()
+    id: number
+
+    @Column()
+    title: string
+
+    @ManyToMany(() => Category, (o) => o.posts, {
+        cascade: true,
+    })
+    @JoinTable()
+    categories!: Promise<Category[]>
+}

--- a/test/github-issues/5704/issue-5704.ts
+++ b/test/github-issues/5704/issue-5704.ts
@@ -54,13 +54,13 @@ describe("github issues > #5704 Many-to-many gives error ER_DUP_ENTRY everytime 
                     {
                         where: { name: catName },
                     },
-                );
-                assert.isTrue(categoryTest instanceof Category);
+                )
+                assert.isTrue(categoryTest instanceof Category)
 
-                post1.categories = Promise.resolve([categoryTest as Category]);
-                
+                post1.categories = Promise.resolve([categoryTest as Category])
+
                 // This is the line that causes the error "QueryFailedError: ER_DUP_ENTRY: Duplicate entry '1-1' for key 'PRIMARY'" with previous code
-                await connection.manager.save(post1);
+                await connection.manager.save(post1)
             }),
         ))
 })

--- a/test/github-issues/5704/issue-5704.ts
+++ b/test/github-issues/5704/issue-5704.ts
@@ -44,7 +44,7 @@ describe("github issues > #5704 Many-to-many gives error ER_DUP_ENTRY everytime 
 
                 if (!post1) {
                     post1 = new Post()
-                    post1.title = "post #1"
+                    post1.title = postName
                     post1.categories = Promise.resolve([category1])
                     await connection.manager.save(post1)
                 }

--- a/test/github-issues/5704/issue-5704.ts
+++ b/test/github-issues/5704/issue-5704.ts
@@ -1,0 +1,66 @@
+import "reflect-metadata"
+import {
+    closeTestingConnections,
+    createTestingConnections,
+    reloadTestingDatabases,
+} from "../../utils/test-utils"
+import { DataSource } from "../../../src"
+import { Post } from "./entity/Post"
+import { Category } from "./entity/Category"
+import { assert } from "chai"
+
+describe.only("github issues > #5704 Many-to-many gives error ER_DUP_ENTRY everytime I save. This one also related to inverseJoinColumn.", () => {
+    let connections: DataSource[]
+    before(
+        async () =>
+            (connections = await createTestingConnections({
+                entities: [__dirname + "/entity/*{.js,.ts}"],
+                subscribers: [__dirname + "/subscriber/*{.js,.ts}"],
+                enabledDrivers: ["mysql"],
+            })),
+    )
+    beforeEach(() => reloadTestingDatabases(connections))
+    after(() => closeTestingConnections(connections))
+
+    it("should work as expected", () =>
+        Promise.all(
+            connections.map(async (connection) => {
+                const postName = "post for issue #5704"
+                const catName = "cat for issue #5704"
+
+                let post1 = await connection.manager.findOne(Post, {
+                    where: { title: postName },
+                })
+
+                let category1 = await connection.manager.findOne(Category, {
+                    where: { name: catName },
+                })
+
+                if (!category1) {
+                    category1 = new Category()
+                    category1.name = catName
+                    await connection.manager.save(category1)
+                }
+
+                if (!post1) {
+                    post1 = new Post()
+                    post1.title = "post #1"
+                    post1.categories = Promise.resolve([category1])
+                    await connection.manager.save(post1)
+                }
+
+                const categoryTest = await connection.manager.findOne(
+                    Category,
+                    {
+                        where: { name: catName },
+                    },
+                );
+                assert.isTrue(categoryTest instanceof Category);
+
+                post1.categories = Promise.resolve([categoryTest as Category]);
+                
+                // This is the line that causes the error "QueryFailedError: ER_DUP_ENTRY: Duplicate entry '1-1' for key 'PRIMARY'" with previous code
+                await connection.manager.save(post1);
+            }),
+        ))
+})

--- a/test/github-issues/5704/issue-5704.ts
+++ b/test/github-issues/5704/issue-5704.ts
@@ -9,7 +9,7 @@ import { Post } from "./entity/Post"
 import { Category } from "./entity/Category"
 import { assert } from "chai"
 
-describe.only("github issues > #5704 Many-to-many gives error ER_DUP_ENTRY everytime I save. This one also related to inverseJoinColumn.", () => {
+describe("github issues > #5704 Many-to-many gives error ER_DUP_ENTRY everytime I save. This one also related to inverseJoinColumn.", () => {
     let connections: DataSource[]
     before(
         async () =>

--- a/test/github-issues/5704/subscriber/CategorySubscriber.ts
+++ b/test/github-issues/5704/subscriber/CategorySubscriber.ts
@@ -1,0 +1,16 @@
+import { Category } from "../entity/Category"
+import {
+    EntitySubscriberInterface,
+    EventSubscriber,
+} from "../../../../src"
+
+@EventSubscriber()
+export class CategorySubscriber implements EntitySubscriberInterface<Category> {
+    listenTo() {
+        return Category
+    }
+
+    async afterLoad(entity: Category): Promise<any> {
+        entity.addedProp = true;
+    }
+}

--- a/test/github-issues/5704/subscriber/CategorySubscriber.ts
+++ b/test/github-issues/5704/subscriber/CategorySubscriber.ts
@@ -1,8 +1,5 @@
 import { Category } from "../entity/Category"
-import {
-    EntitySubscriberInterface,
-    EventSubscriber,
-} from "../../../../src"
+import { EntitySubscriberInterface, EventSubscriber } from "../../../../src"
 
 @EventSubscriber()
 export class CategorySubscriber implements EntitySubscriberInterface<Category> {
@@ -11,6 +8,6 @@ export class CategorySubscriber implements EntitySubscriberInterface<Category> {
     }
 
     async afterLoad(entity: Category): Promise<any> {
-        entity.addedProp = true;
+        entity.addedProp = true
     }
 }


### PR DESCRIPTION
### Problem found
In the method `buildForSubjectRelation` of `ManyToManySubjectBuilder`, in order to know if it is needed to insert the relation rows, `databaseRelatedEntityIds` is compared with `relatedEntityRelationIdMap` (line 154). The problem is that `databaseRelatedEntityIds` is not always an "EntityIdMap". If one is overloading the entity in the `afterLoad` event of an EventSubscriber for example then the object compared would contains additionnal field(s) and the ids won't match. This means that the relation is considered has not existing in the DB and the program tries to insert it. And as the relation already exists, a Mysql error is thrown...

### Description of change

 To fix this, in this commit, we ensure that `databaseRelatedEntityIds` is containing an "EntityIdMap" by using `relation.inverseEntityMetadata.getEntityIdMap(overloadedObject)`.


### Pull-Request Checklist

- [x] Code is up-to-date with the `master` branch
- [x] `npm run format` to apply prettier formatting
- [x] `npm run test` passes with this change
- [x] This pull request links relevant issues as `Fixes #0000` -> `Closes #5704` as mentionned in CONTRIBUTING file
- [x] There are new or updated unit tests validating the change
- [ ] Documentation has been updated to reflect this change
- [x] The new commits follow conventions explained in [CONTRIBUTING.md](https://github.com/typeorm/typeorm/blob/master/CONTRIBUTING.md)

<!--
  🎉 Thank you for contributing and making TypeORM even better!
-->
