### PR TITLE
docs: fix naming consistency

### DIFF
--- a/docs/insert-query-builder.md
+++ b/docs/insert-query-builder.md
@@ -41,7 +41,7 @@ This syntax doesn't escape your values, you need to handle escape on your own.
 If the values you are trying to insert conflict due to existing data the `orUpdate` function can be used to update specific values on the conflicted target.
 
 ```typescript
-await datasource
+await dataSource
     .createQueryBuilder()
     .insert()
     .into(User)
@@ -60,7 +60,7 @@ await datasource
 ### Skip data update if values have not changed (Postgres)
 
 ```typescript
-await datasource
+await dataSource
     .createQueryBuilder()
     .insert()
     .into(User)
@@ -82,7 +82,7 @@ await datasource
 ### Use partial index (Postgres)
 
 ```typescript
-await datasource
+await dataSource
     .createQueryBuilder()
     .insert()
     .into(User)


### PR DESCRIPTION
<!--
  😀 Wonderful!  Thank you for opening a pull request for TypeORM.

  Please fill in the information below to expedite the review
  and (hopefully) merge of your change.

  If unsure about something.. just do as best as you're able,
  or reach out through our community support channels!
  https://github.com/typeorm/typeorm/blob/master/docs/support.md
-->

### Description of change

Changed `datasource` to `dataSource` three times to match the first two references to `dataSource` in this document.

<!--
  Please be clear and concise what the change is intended to do,
  why this change is needed, and how you've verified that it
  corrects what you intended.

  In some cases it may be helpful to include the current behavior
  and the new behavior.

  If the change is related to an open issue, you can link it here.
  If you include `Fixes #0000` (replacing `0000` with the issue number)
  when this is merged it will automatically mark the issue as fixed and
  close it.
-->


### Pull-Request Checklist

<!--
  Please make sure to review and check all of the following.

  If an item is not applicable, you can add "N/A" to the end.
-->

- [✓] Code is up-to-date with the `master` branch
- [N/A] `npm run format` to apply prettier formatting
- [N/A] `npm run test` passes with this change
- [N/A] This pull request links relevant issues as `Fixes #0000`
- [N/A] There are new or updated unit tests validating the change
- [N/A] Documentation has been updated to reflect this change
- [✓] The new commits follow conventions explained in [CONTRIBUTING.md](https://github.com/typeorm/typeorm/blob/master/CONTRIBUTING.md)

<!--
  🎉 Thank you for contributing and making TypeORM even better!
-->
