### PR TITLE
RFC: query-builder: when .where() is called twice, throw an error

### DIFF
--- a/src/query-builder/DeleteQueryBuilder.ts
+++ b/src/query-builder/DeleteQueryBuilder.ts
@@ -1,3 +1,4 @@
+import { TypeORMError } from "../error"
 import { QueryBuilder } from "./QueryBuilder"
 import { ObjectLiteral } from "../common/ObjectLiteral"
 import { EntityTarget } from "../common/EntityTarget"
@@ -131,7 +132,7 @@ export class DeleteQueryBuilder<Entity extends ObjectLiteral>
     /**
      * Sets WHERE condition in the query builder.
      * If you had previously WHERE expression defined,
-     * calling this function will override previously set WHERE conditions.
+     * calling this function will throw an error.
      * Additionally you can add parameters used in where expression.
      */
     where(
@@ -143,7 +144,9 @@ export class DeleteQueryBuilder<Entity extends ObjectLiteral>
             | ObjectLiteral[],
         parameters?: ObjectLiteral,
     ): this {
-        this.expressionMap.wheres = [] // don't move this block below since computeWhereParameter can add where expressions
+        if (this.expressionMap.wheres.length !== 0) {
+            throw new TypeORMError("WHERE condition is already set")
+        }
         const condition = this.getWhereCondition(where)
         if (condition)
             this.expressionMap.wheres = [

--- a/src/query-builder/SelectQueryBuilder.ts
+++ b/src/query-builder/SelectQueryBuilder.ts
@@ -1142,7 +1142,7 @@ export class SelectQueryBuilder<Entity extends ObjectLiteral>
     /**
      * Sets WHERE condition in the query builder.
      * If you had previously WHERE expression defined,
-     * calling this function will override previously set WHERE conditions.
+     * calling this function will throw an error.
      * Additionally you can add parameters used in where expression.
      */
     where(
@@ -1154,7 +1154,9 @@ export class SelectQueryBuilder<Entity extends ObjectLiteral>
             | ObjectLiteral[],
         parameters?: ObjectLiteral,
     ): this {
-        this.expressionMap.wheres = [] // don't move this block below since computeWhereParameter can add where expressions
+        if (this.expressionMap.wheres.length !== 0) {
+            throw new TypeORMError("WHERE condition is already set")
+        }
         const condition = this.getWhereCondition(where)
         if (condition) {
             this.expressionMap.wheres = [

--- a/src/query-builder/SoftDeleteQueryBuilder.ts
+++ b/src/query-builder/SoftDeleteQueryBuilder.ts
@@ -179,7 +179,7 @@ export class SoftDeleteQueryBuilder<Entity extends ObjectLiteral>
     /**
      * Sets WHERE condition in the query builder.
      * If you had previously WHERE expression defined,
-     * calling this function will override previously set WHERE conditions.
+     * calling this function will throw an error.
      * Additionally you can add parameters used in where expression.
      */
     where(
@@ -191,7 +191,9 @@ export class SoftDeleteQueryBuilder<Entity extends ObjectLiteral>
             | ObjectLiteral[],
         parameters?: ObjectLiteral,
     ): this {
-        this.expressionMap.wheres = [] // don't move this block below since computeWhereParameter can add where expressions
+        if (this.expressionMap.wheres.length !== 0) {
+            throw new TypeORMError("WHERE condition is already set")
+        }
         const condition = this.getWhereCondition(where)
         if (condition)
             this.expressionMap.wheres = [

--- a/src/query-builder/UpdateQueryBuilder.ts
+++ b/src/query-builder/UpdateQueryBuilder.ts
@@ -208,7 +208,7 @@ export class UpdateQueryBuilder<Entity extends ObjectLiteral>
     /**
      * Sets WHERE condition in the query builder.
      * If you had previously WHERE expression defined,
-     * calling this function will override previously set WHERE conditions.
+     * calling this function will throw an error.
      * Additionally you can add parameters used in where expression.
      */
     where(
@@ -220,7 +220,9 @@ export class UpdateQueryBuilder<Entity extends ObjectLiteral>
             | ObjectLiteral[],
         parameters?: ObjectLiteral,
     ): this {
-        this.expressionMap.wheres = [] // don't move this block below since computeWhereParameter can add where expressions
+        if (this.expressionMap.wheres.length !== 0) {
+            throw new TypeORMError("WHERE condition is already set")
+        }
         const condition = this.getWhereCondition(where)
         if (condition)
             this.expressionMap.wheres = [


### PR DESCRIPTION
<!--
  😀 Wonderful!  Thank you for opening a pull request for TypeORM.

  Please fill in the information below to expedite the review
  and (hopefully) merge of your change.

  If unsure about something.. just do as best as you're able,
  or reach out through our community support channels!
  https://github.com/typeorm/typeorm/blob/master/docs/support.md
-->

### Description of change

I find it rather dangerous that `builder.where(oldCondition).where(condition)` silently discards oldCondition. If one accidentally uses `.where` instead of `.andWhere`, they might leak __confidential data__, or even __wipe their table entirely__.

This PR prevents such problem by throwing an error when the builder already contains a condition.

<!--
  Please be clear and concise what the change is intended to do,
  why this change is needed, and how you've verified that it
  corrects what you intended.

  In some cases it may be helpful to include the current behavior
  and the new behavior.

  If the change is related to an open issue, you can link it here.
  If you include `Fixes #0000` (replacing `0000` with the issue number)
  when this is merged it will automatically mark the issue as fixed and
  close it.
-->


### Pull-Request Checklist

<!--
  Please make sure to review and check all of the following.

  If an item is not applicable, you can add "N/A" to the end.
-->

- [x] Code is up-to-date with the `master` branch
- [x] `npm run format` to apply prettier formatting
- [x] `npm run test` passes with this change
- [ ] This pull request links relevant issues as `Fixes #0000`
- [ ] There are new or updated unit tests validating the change
- [x] Documentation has been updated to reflect this change
- [ ] The new commits follow conventions explained in [CONTRIBUTING.md](https://github.com/typeorm/typeorm/blob/master/CONTRIBUTING.md)

<!--
  🎉 Thank you for contributing and making TypeORM even better!
-->
