### PR TITLE
typo fixed in the manager.findAndCountBy documentation

### DIFF
--- a/docs/entity-manager-api.md
+++ b/docs/entity-manager-api.md
@@ -234,7 +234,7 @@ const [timbers, timbersCount] = await manager.findAndCount(User, {
     but ignores pagination settings (from and take options).
 
 ```typescript
-const [timbers, timbersCount] = await manager.findAndCount(User, {
+const [timbers, timbersCount] = await manager.findAndCountBy(User, {
     firstName: "Timber",
 })
 ```


### PR DESCRIPTION
There was a mistake I found while surfing through the documentation. The manager.findAndCountBy functions name misspelled and wrote as findAndCountBy, the mistake was fixed.