### PR TITLE
Default replication mode

### DIFF
--- a/src/data-source/DataSource.ts
+++ b/src/data-source/DataSource.ts
@@ -737,4 +737,21 @@ export class DataSource {
             }
         }
     }
+
+    /**
+     * Get the replication mode SELECT queries should use for this datasource by default
+     */
+    defaultReplicationModeForReads(): ReplicationMode {
+        if ("replication" in this.driver.options) {
+            const value = (
+                this.driver.options.replication as {
+                    defaultMode?: ReplicationMode
+                }
+            ).defaultMode
+            if (value) {
+                return value
+            }
+        }
+        return "slave"
+    }
 }

--- a/src/driver/cockroachdb/CockroachConnectionOptions.ts
+++ b/src/driver/cockroachdb/CockroachConnectionOptions.ts
@@ -1,4 +1,5 @@
 import { BaseDataSourceOptions } from "../../data-source/BaseDataSourceOptions"
+import { ReplicationMode } from "../types/ReplicationMode"
 import { CockroachConnectionCredentialsOptions } from "./CockroachConnectionCredentialsOptions"
 
 /**
@@ -48,6 +49,12 @@ export interface CockroachConnectionOptions
          * List of read-from severs (slaves).
          */
         readonly slaves: CockroachConnectionCredentialsOptions[]
+
+        /**
+         * Default connection pool to use for SELECT queries
+         * @default "slave"
+         */
+        readonly defaultMode?: ReplicationMode
     }
 
     /**

--- a/src/driver/mysql/MysqlConnectionOptions.ts
+++ b/src/driver/mysql/MysqlConnectionOptions.ts
@@ -1,4 +1,5 @@
 import { BaseDataSourceOptions } from "../../data-source/BaseDataSourceOptions"
+import { ReplicationMode } from "../types/ReplicationMode"
 import { MysqlConnectionCredentialsOptions } from "./MysqlConnectionCredentialsOptions"
 
 /**
@@ -146,5 +147,11 @@ export interface MysqlConnectionOptions
          * ORDER: Select the first node available unconditionally.
          */
         readonly selector?: "RR" | "RANDOM" | "ORDER"
+
+        /**
+         * Default connection pool to use for SELECT queries
+         * @default "slave"
+         */
+        readonly defaultMode?: ReplicationMode
     }
 }

--- a/src/driver/postgres/PostgresConnectionCredentialsOptions.ts
+++ b/src/driver/postgres/PostgresConnectionCredentialsOptions.ts
@@ -38,4 +38,10 @@ export interface PostgresConnectionCredentialsOptions {
      * Object with ssl parameters
      */
     readonly ssl?: boolean | TlsOptions
+
+    /**
+     * sets the application_name var to help db administrators identify
+     * the service using this connection. Defaults to 'undefined'
+     */
+    readonly applicationName?: string
 }

--- a/src/driver/postgres/PostgresConnectionOptions.ts
+++ b/src/driver/postgres/PostgresConnectionOptions.ts
@@ -6,7 +6,7 @@ import { PostgresConnectionCredentialsOptions } from "./PostgresConnectionCreden
  */
 export interface PostgresConnectionOptions
     extends BaseDataSourceOptions,
-        PostgresConnectionCredentialsOptions {
+    PostgresConnectionCredentialsOptions {
     /**
      * Database type.
      */
@@ -77,12 +77,6 @@ export interface PostgresConnectionOptions
      * Automatically install postgres extensions
      */
     readonly installExtensions?: boolean
-
-    /**
-     * sets the application_name var to help db administrators identify
-     * the service using this connection. Defaults to 'undefined'
-     */
-    readonly applicationName?: string
 
     /**
      * Return 64-bit integers (int8) as JavaScript integers.

--- a/src/driver/postgres/PostgresConnectionOptions.ts
+++ b/src/driver/postgres/PostgresConnectionOptions.ts
@@ -1,4 +1,5 @@
 import { BaseDataSourceOptions } from "../../data-source/BaseDataSourceOptions"
+import { ReplicationMode } from "../types/ReplicationMode"
 import { PostgresConnectionCredentialsOptions } from "./PostgresConnectionCredentialsOptions"
 
 /**
@@ -6,7 +7,7 @@ import { PostgresConnectionCredentialsOptions } from "./PostgresConnectionCreden
  */
 export interface PostgresConnectionOptions
     extends BaseDataSourceOptions,
-    PostgresConnectionCredentialsOptions {
+        PostgresConnectionCredentialsOptions {
     /**
      * Database type.
      */
@@ -47,6 +48,12 @@ export interface PostgresConnectionOptions
          * List of read-from severs (slaves).
          */
         readonly slaves: PostgresConnectionCredentialsOptions[]
+
+        /**
+         * Default connection pool to use for SELECT queries
+         * @default "slave"
+         */
+        readonly defaultMode?: ReplicationMode
     }
 
     /**

--- a/src/driver/postgres/PostgresDriver.ts
+++ b/src/driver/postgres/PostgresDriver.ts
@@ -1466,7 +1466,8 @@ export class PostgresDriver implements Driver {
                 port: credentials.port,
                 ssl: credentials.ssl,
                 connectionTimeoutMillis: options.connectTimeoutMS,
-                application_name: options.applicationName ?? credentials.applicationName,
+                application_name:
+                    options.applicationName ?? credentials.applicationName,
                 max: options.poolSize,
             },
             options.extra || {},

--- a/src/driver/postgres/PostgresDriver.ts
+++ b/src/driver/postgres/PostgresDriver.ts
@@ -1466,7 +1466,7 @@ export class PostgresDriver implements Driver {
                 port: credentials.port,
                 ssl: credentials.ssl,
                 connectionTimeoutMillis: options.connectTimeoutMS,
-                application_name: options.applicationName,
+                application_name: options.applicationName ?? credentials.applicationName,
                 max: options.poolSize,
             },
             options.extra || {},

--- a/src/driver/spanner/SpannerConnectionOptions.ts
+++ b/src/driver/spanner/SpannerConnectionOptions.ts
@@ -1,4 +1,5 @@
 import { BaseConnectionOptions } from "../../connection/BaseConnectionOptions"
+import { ReplicationMode } from "../types/ReplicationMode"
 import { SpannerConnectionCredentialsOptions } from "./SpannerConnectionCredentialsOptions"
 
 /**
@@ -143,6 +144,12 @@ export interface SpannerConnectionOptions
          * ORDER: Select the first node available unconditionally.
          */
         readonly selector?: "RR" | "RANDOM" | "ORDER"
+
+        /**
+         * Default connection pool to use for SELECT queries
+         * @default "slave"
+         */
+        readonly defaultMode?: ReplicationMode
     }
 
     readonly poolSize?: never

--- a/src/driver/sqlserver/SqlServerConnectionOptions.ts
+++ b/src/driver/sqlserver/SqlServerConnectionOptions.ts
@@ -1,4 +1,5 @@
 import { BaseDataSourceOptions } from "../../data-source/BaseDataSourceOptions"
+import { ReplicationMode } from "../types/ReplicationMode"
 import { SqlServerConnectionCredentialsOptions } from "./SqlServerConnectionCredentialsOptions"
 
 /**
@@ -310,6 +311,12 @@ export interface SqlServerConnectionOptions
          * List of read-from severs (slaves).
          */
         readonly slaves: SqlServerConnectionCredentialsOptions[]
+
+        /**
+         * Default connection pool to use for SELECT queries
+         * @default "slave"
+         */
+        readonly defaultMode?: ReplicationMode
     }
 
     readonly poolSize?: never

--- a/src/query-builder/SelectQueryBuilder.ts
+++ b/src/query-builder/SelectQueryBuilder.ts
@@ -3842,7 +3842,12 @@ export class SelectQueryBuilder<Entity extends ObjectLiteral>
      * Creates a query builder used to execute sql queries inside this query builder.
      */
     protected obtainQueryRunner() {
-        return this.queryRunner || this.connection.createQueryRunner("slave")
+        return (
+            this.queryRunner ||
+            this.connection.createQueryRunner(
+                this.connection.defaultReplicationModeForReads(),
+            )
+        )
     }
 
     protected buildSelect(

--- a/test/functional/connection/replication.ts
+++ b/test/functional/connection/replication.ts
@@ -1,0 +1,87 @@
+import "reflect-metadata"
+import "../../utils/test-setup"
+import { expect } from "chai"
+import { Post } from "./entity/Post"
+import { Category } from "./entity/Category"
+import {
+    closeTestingConnections,
+    createTestingConnections,
+    getTypeOrmConfig,
+} from "../../utils/test-utils"
+import { DataSource } from "../../../src/data-source/DataSource"
+import { QueryRunner } from "../../../src"
+
+describe("Connection replication", () => {
+    describe("after connection is established successfully", function () {
+        let connection: DataSource
+        beforeEach(async () => {
+            const ormConfigConnectionOptionsArray = getTypeOrmConfig()
+            const postgres = ormConfigConnectionOptionsArray.find(options => options.type == "postgres");
+            if (!postgres) throw new Error("need a postgres connection in the test connection options to test replication")
+
+            connection = (await createTestingConnections({
+                entities: [Post, Category],
+                enabledDrivers: ["postgres"],
+                schemaCreate: true,
+                dropSchema: true,
+                driverSpecific: {
+                    replication: {
+                        master: { ...postgres, applicationName: "master" },
+                        slaves: [{ ...postgres, applicationName: "slave" }]
+                    }
+                }
+            }))[0]
+
+            const post = new Post()
+            post.title = "TypeORM Intro"
+
+            await connection
+                .createQueryBuilder()
+                .insert()
+                .into(Post)
+                .values(post)
+                .execute()
+        })
+
+        afterEach(() => closeTestingConnections([connection]))
+
+        const expectCurrentApplicationName = async (queryRunner: QueryRunner, name: string) => {
+            const result = await queryRunner.query("SELECT current_setting('application_name') as application_name;")
+            expect(result[0].application_name).to.equal(name)
+        }
+
+        it("connection.isConnected should be true", () =>
+            connection.isInitialized.should.be.true
+        )
+
+        it("query runners should go to the master by default", async () => {
+            const queryRunner = connection.createQueryRunner();
+            expect(queryRunner.getReplicationMode()).to.equal("master");
+
+            await expectCurrentApplicationName(queryRunner, "master")
+        })
+
+        it("query runners can have their replication mode overridden", async () => {
+            let queryRunner = connection.createQueryRunner("master")
+            queryRunner.getReplicationMode().should.equal("master")
+            await expectCurrentApplicationName(queryRunner, "master")
+
+            queryRunner = connection.createQueryRunner("slave")
+            queryRunner.getReplicationMode().should.equal("slave")
+            await expectCurrentApplicationName(queryRunner, "slave")
+        })
+
+        it("read queries should go to the slaves by default", async () => {
+            const result = await connection.manager.createQueryBuilder(Post, "post").select("id").addSelect("current_setting('application_name')", 'current_setting').execute();
+            expect(result[0].current_setting).to.equal("slave")
+        })
+
+        it("write queries should go to the master", async () => {
+            const result = await connection.manager.createQueryBuilder(Post, "post").insert().into(Post).values({
+                title: () => "current_setting('application_name')"
+            }).returning("title").execute();
+
+            expect(result.raw[0].title).to.equal("master")
+        })
+    })
+})

--- a/test/functional/connection/replication.ts
+++ b/test/functional/connection/replication.ts
@@ -11,26 +11,43 @@ import {
 import { DataSource } from "../../../src/data-source/DataSource"
 import { QueryRunner } from "../../../src"
 
+const expectCurrentApplicationName = async (
+    queryRunner: QueryRunner,
+    name: string,
+) => {
+    const result = await queryRunner.query(
+        "SELECT current_setting('application_name') as application_name;",
+    )
+    expect(result[0].application_name).to.equal(name)
+}
+
 describe("Connection replication", () => {
     describe("after connection is established successfully", function () {
         let connection: DataSource
         beforeEach(async () => {
             const ormConfigConnectionOptionsArray = getTypeOrmConfig()
-            const postgres = ormConfigConnectionOptionsArray.find(options => options.type == "postgres");
-            if (!postgres) throw new Error("need a postgres connection in the test connection options to test replication")
+            const postgres = ormConfigConnectionOptionsArray.find(
+                (options) => options.type == "postgres",
+            )
+            if (!postgres)
+                throw new Error(
+                    "need a postgres connection in the test connection options to test replication",
+                )
 
-            connection = (await createTestingConnections({
-                entities: [Post, Category],
-                enabledDrivers: ["postgres"],
-                schemaCreate: true,
-                dropSchema: true,
-                driverSpecific: {
-                    replication: {
-                        master: { ...postgres, applicationName: "master" },
-                        slaves: [{ ...postgres, applicationName: "slave" }]
-                    }
-                }
-            }))[0]
+            connection = (
+                await createTestingConnections({
+                    entities: [Post, Category],
+                    enabledDrivers: ["postgres"],
+                    schemaCreate: true,
+                    dropSchema: true,
+                    driverSpecific: {
+                        replication: {
+                            master: { ...postgres, applicationName: "master" },
+                            slaves: [{ ...postgres, applicationName: "slave" }],
+                        },
+                    },
+                })
+            )[0]
 
             const post = new Post()
             post.title = "TypeORM Intro"
@@ -45,18 +62,12 @@ describe("Connection replication", () => {
 
         afterEach(() => closeTestingConnections([connection]))
 
-        const expectCurrentApplicationName = async (queryRunner: QueryRunner, name: string) => {
-            const result = await queryRunner.query("SELECT current_setting('application_name') as application_name;")
-            expect(result[0].application_name).to.equal(name)
-        }
-
         it("connection.isConnected should be true", () =>
-            connection.isInitialized.should.be.true
-        )
+            connection.isInitialized.should.be.true)
 
         it("query runners should go to the master by default", async () => {
-            const queryRunner = connection.createQueryRunner();
-            expect(queryRunner.getReplicationMode()).to.equal("master");
+            const queryRunner = connection.createQueryRunner()
+            expect(queryRunner.getReplicationMode()).to.equal("master")
 
             await expectCurrentApplicationName(queryRunner, "master")
         })
@@ -72,16 +83,100 @@ describe("Connection replication", () => {
         })
 
         it("read queries should go to the slaves by default", async () => {
-            const result = await connection.manager.createQueryBuilder(Post, "post").select("id").addSelect("current_setting('application_name')", 'current_setting').execute();
+            const result = await connection.manager
+                .createQueryBuilder(Post, "post")
+                .select("id")
+                .addSelect(
+                    "current_setting('application_name')",
+                    "current_setting",
+                )
+                .execute()
             expect(result[0].current_setting).to.equal("slave")
         })
 
         it("write queries should go to the master", async () => {
-            const result = await connection.manager.createQueryBuilder(Post, "post").insert().into(Post).values({
-                title: () => "current_setting('application_name')"
-            }).returning("title").execute();
+            const result = await connection.manager
+                .createQueryBuilder(Post, "post")
+                .insert()
+                .into(Post)
+                .values({
+                    title: () => "current_setting('application_name')",
+                })
+                .returning("title")
+                .execute()
 
             expect(result.raw[0].title).to.equal("master")
+        })
+    })
+
+    describe("with custom replication default mode", function () {
+        let connection: DataSource
+        beforeEach(async () => {
+            const ormConfigConnectionOptionsArray = getTypeOrmConfig()
+            const postgres = ormConfigConnectionOptionsArray.find(
+                (options) => options.type == "postgres",
+            )
+            if (!postgres)
+                throw new Error(
+                    "need a postgres connection in the test connection options to test replication",
+                )
+
+            connection = (
+                await createTestingConnections({
+                    entities: [Post, Category],
+                    enabledDrivers: ["postgres"],
+                    schemaCreate: true,
+                    dropSchema: true,
+                    driverSpecific: {
+                        replication: {
+                            defaultMode: "master",
+                            master: { ...postgres, applicationName: "master" },
+                            slaves: [{ ...postgres, applicationName: "slave" }],
+                        },
+                    },
+                })
+            )[0]
+
+            const post = new Post()
+            post.title = "TypeORM Intro"
+
+            await connection
+                .createQueryBuilder()
+                .insert()
+                .into(Post)
+                .values(post)
+                .execute()
+        })
+
+        afterEach(() => closeTestingConnections([connection]))
+
+        it("query runners should go to the master by default", async () => {
+            const queryRunner = connection.createQueryRunner()
+            expect(queryRunner.getReplicationMode()).to.equal("master")
+
+            await expectCurrentApplicationName(queryRunner, "master")
+        })
+
+        it("query runners can have their replication mode overridden", async () => {
+            let queryRunner = connection.createQueryRunner("master")
+            queryRunner.getReplicationMode().should.equal("master")
+            await expectCurrentApplicationName(queryRunner, "master")
+
+            queryRunner = connection.createQueryRunner("slave")
+            queryRunner.getReplicationMode().should.equal("slave")
+            await expectCurrentApplicationName(queryRunner, "slave")
+        })
+
+        it("read queries should go to the master by default", async () => {
+            const result = await connection.manager
+                .createQueryBuilder(Post, "post")
+                .select("id")
+                .addSelect(
+                    "current_setting('application_name')",
+                    "current_setting",
+                )
+                .execute()
+            expect(result[0].current_setting).to.equal("master")
         })
     })
 })


### PR DESCRIPTION
### Description of change

For many applications that want to use read slaves, data consistency isn't super important, and so all reads can be sent by default to a read slave. For some applications though, it's only select queries that can be sent to read slaves as end-users of the application expect data consistency almost everywhere. This new setting lets apps like those change the default such that query builders need to opt *in* to sending to a read slave, instead of opt out.

For existing replication users, the default for queries is unchanged (send to the slave) but this allows folks who care like me to change the default behaviour. 

### Pull-Request Checklist

- [X] Code is up-to-date with the `master` branch
- [X] `npm run format` to apply prettier formatting
- [X] `npm run test` passes with this change
- [X] This pull request links relevant issues as `Fixes #0000`
- [X] There are new or updated unit tests validating the change
- [X] Documentation has been updated to reflect this change
- [X] The new commits follow conventions explained in [CONTRIBUTING.md](https://github.com/typeorm/typeorm/blob/master/CONTRIBUTING.md)