### PR TITLE
Add possibility to generate concurrent indexes for pg

### DIFF
--- a/docs/indices.md
+++ b/docs/indices.md
@@ -137,6 +137,18 @@ export class Thing {
 }
 ```
 
+## Concurrent creation
+
+In order to avoid having to obtain an access exclusive lock when creating and dropping indexes in postgres, you may create them using the CONCURRENTLY modifier.
+
+Typeorm supports generating SQL with this option if when the concurrent option is specified on the index.
+
+```typescript
+@Index(["firstName", "middleName", "lastName"], { concurrent: true })
+```
+
+For more information see the [postgres documentation](https://www.postgresql.org/docs/current/sql-createindex.html).
+
 ## Disabling synchronization
 
 TypeORM does not support some index options and definitions (e.g. `lower`, `pg_trgm`) because of lot of different database specifics and multiple

--- a/src/decorator/Index.ts
+++ b/src/decorator/Index.ts
@@ -139,6 +139,7 @@ export function Index(
             parser: options ? options.parser : undefined,
             sparse: options && options.sparse ? true : false,
             background: options && options.background ? true : false,
+            concurrent: options && options.concurrent ? true : false,
             expireAfterSeconds: options
                 ? options.expireAfterSeconds
                 : undefined,

--- a/src/decorator/options/IndexOptions.ts
+++ b/src/decorator/options/IndexOptions.ts
@@ -53,6 +53,12 @@ export interface IndexOptions {
     background?: boolean
 
     /**
+     * Create the index using the CONCURRENTLY modifier
+     * Works only in postgres.
+     */
+    concurrent?: boolean
+
+    /**
      * Specifies a time to live, in seconds.
      * This option is only supported for mongodb database.
      */

--- a/src/driver/postgres/PostgresQueryRunner.ts
+++ b/src/driver/postgres/PostgresQueryRunner.ts
@@ -4244,9 +4244,9 @@ export class PostgresQueryRunner
             .map((columnName) => `"${columnName}"`)
             .join(", ")
         return new Query(
-            `CREATE ${index.isUnique ? "UNIQUE " : ""}INDEX "${
-                index.name
-            }" ON ${this.escapePath(table)} ${
+            `CREATE ${index.isUnique ? "UNIQUE " : ""}${
+                index.isConcurrent ? "CONCURRENTLY " : ""
+            }INDEX "${index.name}" ON ${this.escapePath(table)} ${
                 index.isSpatial ? "USING GiST " : ""
             }(${columns}) ${index.where ? "WHERE " + index.where : ""}`,
         )
@@ -4278,10 +4278,21 @@ export class PostgresQueryRunner
         let indexName = InstanceChecker.isTableIndex(indexOrName)
             ? indexOrName.name
             : indexOrName
+        const concurrent = InstanceChecker.isTableIndex(indexOrName)
+            ? indexOrName.isConcurrent
+            : false
         const { schema } = this.driver.parseTableName(table)
         return schema
-            ? new Query(`DROP INDEX "${schema}"."${indexName}"`)
-            : new Query(`DROP INDEX "${indexName}"`)
+            ? new Query(
+                  `DROP INDEX ${
+                      concurrent ? "CONCURRENTLY" : ""
+                  }"${schema}"."${indexName}"`,
+              )
+            : new Query(
+                  `DROP INDEX ${
+                      concurrent ? "CONCURRENTLY" : ""
+                  }"${indexName}"`,
+              )
     }
 
     /**

--- a/src/metadata-args/IndexMetadataArgs.ts
+++ b/src/metadata-args/IndexMetadataArgs.ts
@@ -73,6 +73,12 @@ export interface IndexMetadataArgs {
     background?: boolean
 
     /**
+     * Builds the index using the concurrently option.
+     * This option is only supported for postgres database.
+     */
+    concurrent?: boolean
+
+    /**
      * Specifies a time to live, in seconds.
      * This option is only supported for mongodb database.
      */

--- a/src/metadata/IndexMetadata.ts
+++ b/src/metadata/IndexMetadata.ts
@@ -74,6 +74,12 @@ export class IndexMetadata {
     isBackground?: boolean
 
     /**
+     * Builds the index using the concurrently option.
+     * This options is only supported for postgres database.
+     */
+    isConcurrent?: boolean
+
+    /**
      * Specifies a time to live, in seconds.
      * This option is only supported for mongodb database.
      */
@@ -148,6 +154,7 @@ export class IndexMetadata {
             this.where = options.args.where
             this.isSparse = options.args.sparse
             this.isBackground = options.args.background
+            this.isConcurrent = options.args.concurrent
             this.expireAfterSeconds = options.args.expireAfterSeconds
             this.givenName = options.args.name
             this.givenColumnNames = options.args.columns

--- a/src/schema-builder/options/TableIndexOptions.ts
+++ b/src/schema-builder/options/TableIndexOptions.ts
@@ -28,6 +28,12 @@ export interface TableIndexOptions {
     isSpatial?: boolean
 
     /**
+     * Builds the index using the concurrently option.
+     * This options is only supported for postgres database.
+     */
+    isConcurrent?: boolean
+
+    /**
      * The FULLTEXT modifier indexes the entire column and does not allow prefixing.
      * Supported only in MySQL & SAP HANA.
      */

--- a/src/schema-builder/table/TableIndex.ts
+++ b/src/schema-builder/table/TableIndex.ts
@@ -33,6 +33,12 @@ export class TableIndex {
     isSpatial: boolean
 
     /**
+     * Create the index using the CONCURRENTLY modifier
+     * Works only in postgres.
+     */
+    isConcurrent: boolean
+
+    /**
      * The FULLTEXT modifier indexes the entire column and does not allow prefixing.
      * Works only in MySQL.
      */
@@ -67,6 +73,7 @@ export class TableIndex {
         this.columnNames = options.columnNames
         this.isUnique = !!options.isUnique
         this.isSpatial = !!options.isSpatial
+        this.isConcurrent = !!options.isConcurrent
         this.isFulltext = !!options.isFulltext
         this.isNullFiltered = !!options.isNullFiltered
         this.parser = options.parser
@@ -86,6 +93,7 @@ export class TableIndex {
             columnNames: [...this.columnNames],
             isUnique: this.isUnique,
             isSpatial: this.isSpatial,
+            isConcurrent: this.isConcurrent,
             isFulltext: this.isFulltext,
             isNullFiltered: this.isNullFiltered,
             parser: this.parser,
@@ -108,6 +116,7 @@ export class TableIndex {
             ),
             isUnique: indexMetadata.isUnique,
             isSpatial: indexMetadata.isSpatial,
+            isConcurrent: indexMetadata.isConcurrent,
             isFulltext: indexMetadata.isFulltext,
             isNullFiltered: indexMetadata.isNullFiltered,
             parser: indexMetadata.parser,


### PR DESCRIPTION
<!--
  😀 Wonderful!  Thank you for opening a pull request for TypeORM.

  Please fill in the information below to expedite the review
  and (hopefully) merge of your change.

  If unsure about something.. just do as best as you're able,
  or reach out through our community support channels!
  https://github.com/typeorm/typeorm/blob/master/docs/support.md
-->

### Description of change

Add the possibility to generate indexes concurrently for postgres, following a similar pattern to background indexes already implemented for mongo.

<!--
  Please be clear and concise what the change is intended to do,
  why this change is needed, and how you've verified that it
  corrects what you intended.

  In some cases it may be helpful to include the current behavior
  and the new behavior.

  If the change is related to an open issue, you can link it here.
  If you include `Fixes #0000` (replacing `0000` with the issue number)
  when this is merged it will automatically mark the issue as fixed and
  close it.
-->


### Pull-Request Checklist

<!--
  Please make sure to review and check all of the following.

  If an item is not applicable, you can add "N/A" to the end.
-->

- [ x ] Code is up-to-date with the `master` branch
- [ x ] `npm run format` to apply prettier formatting
- [ x ] `npm run test` passes with this change
- [ ] This pull request links relevant issues as `Fixes #0000`
- [ ] There are new or updated unit tests validating the change
- [ x ] Documentation has been updated to reflect this change
- [ x ] The new commits follow conventions explained in [CONTRIBUTING.md](https://github.com/typeorm/typeorm/blob/master/CONTRIBUTING.md)

<!--
  🎉 Thank you for contributing and making TypeORM even better!
-->

Happy to add a test, but struggled to navigate the best place to add it!
Note I have tested manually.
