### PR TITLE
fix: do not skip undefined or null properties in where conditions

### DIFF
--- a/src/query-builder/QueryBuilder.ts
+++ b/src/query-builder/QueryBuilder.ts
@@ -1553,13 +1553,11 @@ export abstract class QueryBuilder<Entity extends ObjectLiteral> {
                     parameters: [aliasPath, ...parameters],
                 }
             }
-            // } else if (parameterValue === null) {
-            //     return {
-            //         operator: "isNull",
-            //         parameters: [
-            //             aliasPath,
-            //         ]
-            //     };
+        } else if (parameterValue === null) {
+            return {
+                operator: "isNull",
+                parameters: [aliasPath],
+            }
         } else {
             return {
                 operator: "equal",

--- a/src/query-builder/SelectQueryBuilder.ts
+++ b/src/query-builder/SelectQueryBuilder.ts
@@ -4222,7 +4222,9 @@ export class SelectQueryBuilder<Entity extends ObjectLiteral>
         } else {
             let andConditions: string[] = []
             for (let key in where) {
-                if (where[key] === undefined || where[key] === null) continue
+                // NOTE: preserving typeorm v0.2 behavior for query safety,
+                //  nulls will be treated as IsNull, undefined values should never return results
+                //if (where[key] === undefined || where[key] === null) continue
 
                 const propertyPath = embedPrefix ? embedPrefix + "." + key : key
                 const column =

--- a/test/functional/find-options/empty-properties/entity/Post.ts
+++ b/test/functional/find-options/empty-properties/entity/Post.ts
@@ -8,6 +8,6 @@ export class Post {
     @Column()
     title: string
 
-    @Column()
+    @Column({ nullable: true })
     text: string
 }

--- a/test/functional/find-options/empty-properties/find-options-empty-properties.ts
+++ b/test/functional/find-options/empty-properties/find-options-empty-properties.ts
@@ -27,9 +27,13 @@ describe("find options > where", () => {
         post2.title = "Post #2"
         post2.text = "About post #2"
         await connection.manager.save(post2)
+
+        const post3 = new Post()
+        post3.title = "Post #3"
+        await connection.manager.save(post3)
     }
 
-    it("should skip undefined properties", () =>
+    it("should not skip undefined properties and return no result", () =>
         Promise.all(
             connections.map(async (connection) => {
                 await prepareData(connection)
@@ -47,13 +51,11 @@ describe("find options > where", () => {
                     })
                     .getMany()
 
-                posts.should.be.eql([
-                    { id: 1, title: "Post #1", text: "About post #1" },
-                ])
+                posts.should.be.eql([])
             }),
         ))
 
-    it("should skip null properties", () =>
+    it("should not skip null properties and only return if the field matches IsNull", () =>
         Promise.all(
             connections.map(async (connection) => {
                 await prepareData(connection)
@@ -72,9 +74,7 @@ describe("find options > where", () => {
                     })
                     .getMany()
 
-                posts1.should.be.eql([
-                    { id: 1, title: "Post #1", text: "About post #1" },
-                ])
+                posts1.should.be.eql([])
 
                 const posts2 = await connection
                     .createQueryBuilder(Post, "post")
@@ -89,10 +89,7 @@ describe("find options > where", () => {
                     })
                     .getMany()
 
-                posts2.should.be.eql([
-                    { id: 1, title: "Post #1", text: "About post #1" },
-                    { id: 2, title: "Post #2", text: "About post #2" },
-                ])
+                posts2.should.be.eql([{ id: 3, title: "Post #3", text: null }])
             }),
         ))
 })


### PR DESCRIPTION
<!--
  😀 Wonderful!  Thank you for opening a pull request for TypeORM.

  Please fill in the information below to expedite the review
  and (hopefully) merge of your change.

  If unsure about something.. just do as best as you're able,
  or reach out through our community support channels!
  https://github.com/typeorm/typeorm/blob/master/docs/support.md
-->

### Description of change

Changes behavior of `getWherePredicateCondition` and `buildWhere` methods to match the behavior in typeorm 0.2, which is to apply an IsNull() condition to null values and not ignore undefined values so that when passing undefined queries do not return any data (null or []) rather than excluding that condition which is a vector for security issues.

I would be ok with a behavior where null values return no results as well, just as long as conditions aren't skipped then this is not a vector for security issues / cross-user data leakage, etc...

We are in the process of upgrading from TypeOrm 0.2.x to 0.3.x and discovered this behavior change in 0.3.x that makes it prohibitively difficult to finish the upgrade without risking leaking incorrect data or possibly causing updates to incorrect data. Similar to the PR here: https://github.com/typeorm/typeorm/pull/9487 except doesn't make this behavior configurable for simplicity. This is of course a breaking change for 0.3.x and is perhaps a candidate for 0.4.x, we'll have to use the forked version to finish the upgrade and perhaps that alternative version will help other people upgrade from 0.2.x, if it is decided that this is not how typeorm should behave long term that is understandable yet disappointing for those of us who have built large systems on top of this great ORM.

I'm not sure what documentation changes should be made to reflect that but I'm happy to make the necessary changes as needed.

Fixes: #9316 

<!--
  Please be clear and concise what the change is intended to do,
  why this change is needed, and how you've verified that it
  corrects what you intended.

  In some cases it may be helpful to include the current behavior
  and the new behavior.

  If the change is related to an open issue, you can link it here.
  If you include `Fixes #0000` (replacing `0000` with the issue number)
  when this is merged it will automatically mark the issue as fixed and
  close it.
-->


### Pull-Request Checklist

<!--
  Please make sure to review and check all of the following.

  If an item is not applicable, you can add "N/A" to the end.
-->

- [x] Code is up-to-date with the `master` branch
- [x] `npm run format` to apply prettier formatting
- [x] `npm run test` passes with this change
- [x] This pull request links relevant issues as `Fixes #0000`
- [x] There are new or updated unit tests validating the change
- [ ] Documentation has been updated to reflect this change
- [x] The new commits follow conventions explained in [CONTRIBUTING.md](https://github.com/typeorm/typeorm/blob/master/CONTRIBUTING.md)

<!--
  🎉 Thank you for contributing and making TypeORM even better!
-->
