### PR TITLE
Static relational where

### DIFF
--- a/src/decorator/options/RelationOptions.ts
+++ b/src/decorator/options/RelationOptions.ts
@@ -1,11 +1,12 @@
 import { DeferrableType } from "../../metadata/types/DeferrableType"
 import { OnDeleteType } from "../../metadata/types/OnDeleteType"
 import { OnUpdateType } from "../../metadata/types/OnUpdateType"
+import {FindOptionsWhere} from "../../find-options/FindOptionsWhere";
 
 /**
  * Describes all relation's options.
  */
-export interface RelationOptions {
+export interface RelationOptions<T> {
     /**
      * Sets cascades options for the given relation.
      * If set to true then it means that related object can be allowed to be inserted or updated in the database.
@@ -73,4 +74,9 @@ export interface RelationOptions {
      * disable will keep the relation intact. Removal of related item is only possible through its own repo.
      */
     orphanedRowAction?: "nullify" | "delete" | "soft-delete" | "disable"
+
+    /**
+     * Indicates if it has some static where in relationship, like if deletedAt is null, it will be added in left join condition automatically.
+     */
+    where: FindOptionsWhere<T>,
 }

--- a/src/decorator/options/RelationOptions.ts
+++ b/src/decorator/options/RelationOptions.ts
@@ -1,7 +1,7 @@
 import { DeferrableType } from "../../metadata/types/DeferrableType"
 import { OnDeleteType } from "../../metadata/types/OnDeleteType"
 import { OnUpdateType } from "../../metadata/types/OnUpdateType"
-import {FindOptionsWhere} from "../../find-options/FindOptionsWhere";
+import { FindOptionsWhere } from "../../find-options/FindOptionsWhere"
 
 /**
  * Describes all relation's options.
@@ -78,5 +78,5 @@ export interface RelationOptions<T> {
     /**
      * Indicates if it has some static where in relationship, like if deletedAt is null, it will be added in left join condition automatically.
      */
-    where: FindOptionsWhere<T>,
+    where?: FindOptionsWhere<T>
 }

--- a/src/decorator/relations/ManyToMany.ts
+++ b/src/decorator/relations/ManyToMany.ts
@@ -11,7 +11,7 @@ import { ObjectUtils } from "../../util/ObjectUtils"
  */
 export function ManyToMany<T>(
     typeFunctionOrTarget: string | ((type?: any) => ObjectType<T>),
-    options?: RelationOptions,
+    options?: RelationOptions<T>,
 ): PropertyDecorator
 
 /**
@@ -22,7 +22,7 @@ export function ManyToMany<T>(
 export function ManyToMany<T>(
     typeFunctionOrTarget: string | ((type?: any) => ObjectType<T>),
     inverseSide?: string | ((object: T) => any),
-    options?: RelationOptions,
+    options?: RelationOptions<T>,
 ): PropertyDecorator
 
 /**
@@ -32,19 +32,19 @@ export function ManyToMany<T>(
  */
 export function ManyToMany<T>(
     typeFunctionOrTarget: string | ((type?: any) => ObjectType<T>),
-    inverseSideOrOptions?: string | ((object: T) => any) | RelationOptions,
-    options?: RelationOptions,
+    inverseSideOrOptions?: string | ((object: T) => any) | RelationOptions<T>,
+    options?: RelationOptions<T>,
 ): PropertyDecorator {
     // normalize parameters
     let inverseSideProperty: string | ((object: T) => any)
     if (ObjectUtils.isObject(inverseSideOrOptions)) {
-        options = <RelationOptions>inverseSideOrOptions
+        options = <RelationOptions<T>>inverseSideOrOptions
     } else {
         inverseSideProperty = inverseSideOrOptions as any
     }
 
     return function (object: Object, propertyName: string) {
-        if (!options) options = {} as RelationOptions
+        if (!options) options = {} as RelationOptions<T>
 
         // now try to determine it its lazy relation
         let isLazy = options.lazy === true

--- a/src/decorator/relations/ManyToOne.ts
+++ b/src/decorator/relations/ManyToOne.ts
@@ -11,7 +11,7 @@ import { ObjectUtils } from "../../util/ObjectUtils"
  */
 export function ManyToOne<T>(
     typeFunctionOrTarget: string | ((type?: any) => ObjectType<T>),
-    options?: RelationOptions,
+    options?: RelationOptions<T>,
 ): PropertyDecorator
 
 /**
@@ -22,7 +22,7 @@ export function ManyToOne<T>(
 export function ManyToOne<T>(
     typeFunctionOrTarget: string | ((type?: any) => ObjectType<T>),
     inverseSide?: string | ((object: T) => any),
-    options?: RelationOptions,
+    options?: RelationOptions<T>,
 ): PropertyDecorator
 
 /**
@@ -32,19 +32,19 @@ export function ManyToOne<T>(
  */
 export function ManyToOne<T>(
     typeFunctionOrTarget: string | ((type?: any) => ObjectType<T>),
-    inverseSideOrOptions?: string | ((object: T) => any) | RelationOptions,
-    options?: RelationOptions,
+    inverseSideOrOptions?: string | ((object: T) => any) | RelationOptions<T>,
+    options?: RelationOptions<T>,
 ): PropertyDecorator {
     // Normalize parameters.
     let inverseSideProperty: string | ((object: T) => any)
     if (ObjectUtils.isObject(inverseSideOrOptions)) {
-        options = <RelationOptions>inverseSideOrOptions
+        options = <RelationOptions<T>>inverseSideOrOptions
     } else {
         inverseSideProperty = inverseSideOrOptions as any
     }
 
     return function (object: Object, propertyName: string) {
-        if (!options) options = {} as RelationOptions
+        if (!options) options = {} as RelationOptions<T>
 
         // Now try to determine if it is a lazy relation.
         let isLazy = options && options.lazy === true

--- a/src/decorator/relations/OneToMany.ts
+++ b/src/decorator/relations/OneToMany.ts
@@ -11,10 +11,10 @@ import { RelationOptions } from "../options/RelationOptions"
 export function OneToMany<T>(
     typeFunctionOrTarget: string | ((type?: any) => ObjectType<T>),
     inverseSide: string | ((object: T) => any),
-    options?: RelationOptions,
+    options?: RelationOptions<T>,
 ): PropertyDecorator {
     return function (object: Object, propertyName: string) {
-        if (!options) options = {} as RelationOptions
+        if (!options) options = {} as RelationOptions<T>
 
         // Now try to determine if it is a lazy relation.
         let isLazy = options && options.lazy === true

--- a/src/decorator/relations/OneToOne.ts
+++ b/src/decorator/relations/OneToOne.ts
@@ -10,7 +10,7 @@ import { ObjectUtils } from "../../util/ObjectUtils"
  */
 export function OneToOne<T>(
     typeFunctionOrTarget: string | ((type?: any) => ObjectType<T>),
-    options?: RelationOptions,
+    options?: RelationOptions<T>,
 ): PropertyDecorator
 
 /**
@@ -20,7 +20,7 @@ export function OneToOne<T>(
 export function OneToOne<T>(
     typeFunctionOrTarget: string | ((type?: any) => ObjectType<T>),
     inverseSide?: string | ((object: T) => any),
-    options?: RelationOptions,
+    options?: RelationOptions<T>,
 ): PropertyDecorator
 
 /**
@@ -29,19 +29,19 @@ export function OneToOne<T>(
  */
 export function OneToOne<T>(
     typeFunctionOrTarget: string | ((type?: any) => ObjectType<T>),
-    inverseSideOrOptions?: string | ((object: T) => any) | RelationOptions,
-    options?: RelationOptions,
+    inverseSideOrOptions?: string | ((object: T) => any) | RelationOptions<T>,
+    options?: RelationOptions<T>,
 ): PropertyDecorator {
     // normalize parameters
     let inverseSideProperty: string | ((object: T) => any)
     if (ObjectUtils.isObject(inverseSideOrOptions)) {
-        options = <RelationOptions>inverseSideOrOptions
+        options = <RelationOptions<T>>inverseSideOrOptions
     } else {
         inverseSideProperty = inverseSideOrOptions as any
     }
 
     return function (object: Object, propertyName: string) {
-        if (!options) options = {} as RelationOptions
+        if (!options) options = {} as RelationOptions<T>
 
         // now try to determine it its lazy relation
         let isLazy = options && options.lazy === true ? true : false

--- a/src/decorator/tree/TreeChildren.ts
+++ b/src/decorator/tree/TreeChildren.ts
@@ -12,7 +12,7 @@ export function TreeChildren(options?: {
         | ("insert" | "update" | "remove" | "soft-remove" | "recover")[]
 }): PropertyDecorator {
     return function (object: Object, propertyName: string) {
-        if (!options) options = {} as RelationOptions
+        if (!options) options = {} as RelationOptions<any>
 
         // now try to determine it its lazy relation
         const reflectedType =

--- a/src/decorator/tree/TreeParent.ts
+++ b/src/decorator/tree/TreeParent.ts
@@ -11,7 +11,7 @@ export function TreeParent(options?: {
     onDelete?: OnDeleteType
 }): PropertyDecorator {
     return function (object: Object, propertyName: string) {
-        if (!options) options = {} as RelationOptions
+        if (!options) options = {} as RelationOptions<any>
 
         // now try to determine it its lazy relation
         const reflectedType =

--- a/src/metadata-args/RelationMetadataArgs.ts
+++ b/src/metadata-args/RelationMetadataArgs.ts
@@ -54,7 +54,7 @@ export interface RelationMetadataArgs {
     /**
      * Additional relation options.
      */
-    readonly options: RelationOptions
+    readonly options: RelationOptions<any>
 
     /**
      * Indicates if this is a parent (can be only many-to-one relation) relation in the tree tables.

--- a/src/metadata/RelationMetadata.ts
+++ b/src/metadata/RelationMetadata.ts
@@ -12,7 +12,7 @@ import { PropertyTypeFactory } from "./types/PropertyTypeInFunction"
 import { TypeORMError } from "../error"
 import { ObjectUtils } from "../util/ObjectUtils"
 import { InstanceChecker } from "../util/InstanceChecker"
-import {FindOptionsWhere} from "../find-options/FindOptionsWhere";
+import { FindOptionsWhere } from "../find-options/FindOptionsWhere"
 
 /**
  * Contains all information about some entity's relation.
@@ -281,7 +281,7 @@ export class RelationMetadata {
     /**
      * Indicates if it has some static where in relationship, like if deletedAt is null, it will be added in left join condition automatically.
      */
-    where: FindOptionsWhere<any> = {};
+    where: FindOptionsWhere<any> = {}
 
     // ---------------------------------------------------------------------
     // Constructor
@@ -365,7 +365,7 @@ export class RelationMetadata {
         this.isManyToMany = this.relationType === "many-to-many"
         this.isOneToOneNotOwner = this.isOneToOne ? true : false
         this.isManyToManyNotOwner = this.isManyToMany ? true : false
-        this.where = args.options.where
+        this.where = args.options.where || {}
     }
 
     // ---------------------------------------------------------------------

--- a/src/metadata/RelationMetadata.ts
+++ b/src/metadata/RelationMetadata.ts
@@ -12,6 +12,7 @@ import { PropertyTypeFactory } from "./types/PropertyTypeInFunction"
 import { TypeORMError } from "../error"
 import { ObjectUtils } from "../util/ObjectUtils"
 import { InstanceChecker } from "../util/InstanceChecker"
+import {FindOptionsWhere} from "../find-options/FindOptionsWhere";
 
 /**
  * Contains all information about some entity's relation.
@@ -277,6 +278,11 @@ export class RelationMetadata {
      */
     inverseJoinColumns: ColumnMetadata[] = []
 
+    /**
+     * Indicates if it has some static where in relationship, like if deletedAt is null, it will be added in left join condition automatically.
+     */
+    where: FindOptionsWhere<any> = {};
+
     // ---------------------------------------------------------------------
     // Constructor
     // ---------------------------------------------------------------------
@@ -359,6 +365,7 @@ export class RelationMetadata {
         this.isManyToMany = this.relationType === "many-to-many"
         this.isOneToOneNotOwner = this.isOneToOne ? true : false
         this.isManyToManyNotOwner = this.isManyToMany ? true : false
+        this.where = args.options.where
     }
 
     // ---------------------------------------------------------------------

--- a/src/query-builder/SelectQueryBuilder.ts
+++ b/src/query-builder/SelectQueryBuilder.ts
@@ -2367,7 +2367,11 @@ export class SelectQueryBuilder<Entity extends ObjectLiteral>
                 const junctionAlias = joinAttr.junctionAlias
                 let junctionCondition = "",
                     destinationCondition = ""
-                const relationWhere = this.buildWhere(relation.where, relation.inverseEntityMetadata, joinAttr.alias.name);
+                const relationWhere = this.buildWhere(
+                    relation.where,
+                    relation.inverseEntityMetadata,
+                    joinAttr.alias.name,
+                )
                 if (relation.isOwning) {
                     junctionCondition = relation.joinColumns
                         .map((joinColumn) => {
@@ -2398,7 +2402,9 @@ export class SelectQueryBuilder<Entity extends ObjectLiteral>
                             )
                         })
                         .join(" AND ")
-                    destinationCondition += relationWhere ? ` AND ${relationWhere}` : ''
+                    destinationCondition += relationWhere
+                        ? ` AND ${relationWhere}`
+                        : ""
                 } else {
                     junctionCondition = relation
                         .inverseRelation!.inverseJoinColumns.map(
@@ -2431,7 +2437,9 @@ export class SelectQueryBuilder<Entity extends ObjectLiteral>
                             )
                         })
                         .join(" AND ")
-                    destinationCondition += relationWhere ? ` AND ${relationWhere}` : ''
+                    destinationCondition += relationWhere
+                        ? ` AND ${relationWhere}`
+                        : ""
                 }
 
                 return (

--- a/src/query-builder/SelectQueryBuilder.ts
+++ b/src/query-builder/SelectQueryBuilder.ts
@@ -2367,7 +2367,7 @@ export class SelectQueryBuilder<Entity extends ObjectLiteral>
                 const junctionAlias = joinAttr.junctionAlias
                 let junctionCondition = "",
                     destinationCondition = ""
-
+                const relationWhere = this.buildWhere(relation.where, relation.inverseEntityMetadata, joinAttr.alias.name);
                 if (relation.isOwning) {
                     junctionCondition = relation.joinColumns
                         .map((joinColumn) => {
@@ -2398,6 +2398,7 @@ export class SelectQueryBuilder<Entity extends ObjectLiteral>
                             )
                         })
                         .join(" AND ")
+                    destinationCondition += relationWhere ? ` AND ${relationWhere}` : ''
                 } else {
                     junctionCondition = relation
                         .inverseRelation!.inverseJoinColumns.map(
@@ -2430,6 +2431,7 @@ export class SelectQueryBuilder<Entity extends ObjectLiteral>
                             )
                         })
                         .join(" AND ")
+                    destinationCondition += relationWhere ? ` AND ${relationWhere}` : ''
                 }
 
                 return (

--- a/test/functional/find-options/static-where-relationship/entity/Category.ts
+++ b/test/functional/find-options/static-where-relationship/entity/Category.ts
@@ -1,0 +1,13 @@
+import { BaseEntity, Column, Entity, PrimaryColumn } from "../../../../../src"
+
+@Entity()
+export class Category extends BaseEntity {
+    @PrimaryColumn()
+    id: number
+
+    @Column()
+    name: string
+
+    @Column({type: 'date', nullable: true})
+    deletedAt: Date | null
+}

--- a/test/functional/find-options/static-where-relationship/entity/Category.ts
+++ b/test/functional/find-options/static-where-relationship/entity/Category.ts
@@ -8,6 +8,6 @@ export class Category extends BaseEntity {
     @Column()
     name: string
 
-    @Column({type: 'date', nullable: true})
+    @Column({ type: "date", nullable: true })
     deletedAt: Date | null
 }

--- a/test/functional/find-options/static-where-relationship/entity/Post.ts
+++ b/test/functional/find-options/static-where-relationship/entity/Post.ts
@@ -1,0 +1,33 @@
+import {
+    BaseEntity,
+    Column,
+    Entity, IsNull,
+    JoinTable,
+    ManyToMany,
+    PrimaryColumn,
+} from "../../../../../src"
+import { Category } from "./Category"
+
+@Entity()
+export class Post extends BaseEntity {
+    @PrimaryColumn()
+    id: number
+
+    @Column({
+        nullable: true,
+        unique: true,
+    })
+    externalId?: string
+
+    @Column()
+    title: string
+
+    @Column({
+        default: "This is default text.",
+    })
+    text: string
+
+    @ManyToMany((type) => Category, {where: {deletedAt: IsNull()}})
+    @JoinTable()
+    categories: Category[]
+}

--- a/test/functional/find-options/static-where-relationship/entity/Post.ts
+++ b/test/functional/find-options/static-where-relationship/entity/Post.ts
@@ -1,7 +1,8 @@
 import {
     BaseEntity,
     Column,
-    Entity, IsNull,
+    Entity,
+    IsNull,
     JoinTable,
     ManyToMany,
     PrimaryColumn,
@@ -27,7 +28,7 @@ export class Post extends BaseEntity {
     })
     text: string
 
-    @ManyToMany((type) => Category, {where: {deletedAt: IsNull()}})
+    @ManyToMany((type) => Category, { where: { deletedAt: IsNull() } })
     @JoinTable()
     categories: Category[]
 }

--- a/test/functional/find-options/static-where-relationship/static-where-relationship.ts
+++ b/test/functional/find-options/static-where-relationship/static-where-relationship.ts
@@ -1,0 +1,44 @@
+import "../../../utils/test-setup"
+import {DataSource} from "../../../../src";
+import {closeTestingConnections, createTestingConnections, reloadTestingDatabases} from "../../../utils/test-utils";
+import {Post} from "./entity/Post";
+import {Category} from "./entity/Category";
+
+describe("entity-model", () => {
+    let connections: DataSource[]
+    before(
+        async () =>
+            (connections = await createTestingConnections({
+                entities: [__dirname + "/entity/*{.js,.ts}"],
+            })),
+    )
+    beforeEach(() => reloadTestingDatabases(connections))
+    after(() => closeTestingConnections(connections))
+
+    it("Should not return deleted Category", async () => {
+        // These must run sequentially as we have the global context of the `Post` ActiveRecord class
+        for (let connection of connections) {
+            connection = connections[0];
+            Post.useDataSource(connection) // change connection each time because of AR specifics
+            Category.useDataSource(connection)
+
+            const category1 = await Category.save({id: 1, name: 'Category 1', deletedAt: null,})
+            const category2 = await Category.save({id: 2, name: 'Category 2', deletedAt: new Date(),})
+            const category3 = await Category.save({id: 3, name: 'Category 3', deletedAt: null,})
+            const category4 = await Category.save({id: 4, name: 'Category 4', deletedAt: new Date(),})
+
+            await Post.save({id: 1, title: 'Title 1', text: 'Post message', categories: [category1, category2, category3, category4]})
+
+            const posts = await Post.find({relations: {categories: true}});
+
+            posts.length.should.be.eql(1);
+            posts[0].should.be.instanceOf(Post);
+            posts[0].id.should.be.eql(1);
+            posts[0].title.should.be.eql('Title 1');
+            posts[0].text.should.be.eql('Post message');
+            posts[0].categories.length.should.be.eql(2);
+            posts[0].categories[0].should.be.eql({id: 1, name: 'Category 1', deletedAt: null,});
+            posts[0].categories[1].should.be.eql({id: 3, name: 'Category 3', deletedAt: null,});
+        }
+    })
+})

--- a/test/functional/find-options/static-where-relationship/static-where-relationship.ts
+++ b/test/functional/find-options/static-where-relationship/static-where-relationship.ts
@@ -1,8 +1,12 @@
 import "../../../utils/test-setup"
-import {DataSource} from "../../../../src";
-import {closeTestingConnections, createTestingConnections, reloadTestingDatabases} from "../../../utils/test-utils";
-import {Post} from "./entity/Post";
-import {Category} from "./entity/Category";
+import { DataSource } from "../../../../src"
+import {
+    closeTestingConnections,
+    createTestingConnections,
+    reloadTestingDatabases,
+} from "../../../utils/test-utils"
+import { Post } from "./entity/Post"
+import { Category } from "./entity/Category"
 
 describe("entity-model", () => {
     let connections: DataSource[]
@@ -18,27 +22,56 @@ describe("entity-model", () => {
     it("Should not return deleted Category", async () => {
         // These must run sequentially as we have the global context of the `Post` ActiveRecord class
         for (let connection of connections) {
-            connection = connections[0];
+            connection = connections[0]
             Post.useDataSource(connection) // change connection each time because of AR specifics
             Category.useDataSource(connection)
 
-            const category1 = await Category.save({id: 1, name: 'Category 1', deletedAt: null,})
-            const category2 = await Category.save({id: 2, name: 'Category 2', deletedAt: new Date(),})
-            const category3 = await Category.save({id: 3, name: 'Category 3', deletedAt: null,})
-            const category4 = await Category.save({id: 4, name: 'Category 4', deletedAt: new Date(),})
+            const category1 = await Category.save({
+                id: 1,
+                name: "Category 1",
+                deletedAt: null,
+            })
+            const category2 = await Category.save({
+                id: 2,
+                name: "Category 2",
+                deletedAt: new Date(),
+            })
+            const category3 = await Category.save({
+                id: 3,
+                name: "Category 3",
+                deletedAt: null,
+            })
+            const category4 = await Category.save({
+                id: 4,
+                name: "Category 4",
+                deletedAt: new Date(),
+            })
 
-            await Post.save({id: 1, title: 'Title 1', text: 'Post message', categories: [category1, category2, category3, category4]})
+            await Post.save({
+                id: 1,
+                title: "Title 1",
+                text: "Post message",
+                categories: [category1, category2, category3, category4],
+            })
 
-            const posts = await Post.find({relations: {categories: true}});
+            const posts = await Post.find({ relations: { categories: true } })
 
-            posts.length.should.be.eql(1);
-            posts[0].should.be.instanceOf(Post);
-            posts[0].id.should.be.eql(1);
-            posts[0].title.should.be.eql('Title 1');
-            posts[0].text.should.be.eql('Post message');
-            posts[0].categories.length.should.be.eql(2);
-            posts[0].categories[0].should.be.eql({id: 1, name: 'Category 1', deletedAt: null,});
-            posts[0].categories[1].should.be.eql({id: 3, name: 'Category 3', deletedAt: null,});
+            posts.length.should.be.eql(1)
+            posts[0].should.be.instanceOf(Post)
+            posts[0].id.should.be.eql(1)
+            posts[0].title.should.be.eql("Title 1")
+            posts[0].text.should.be.eql("Post message")
+            posts[0].categories.length.should.be.eql(2)
+            posts[0].categories[0].should.be.eql({
+                id: 1,
+                name: "Category 1",
+                deletedAt: null,
+            })
+            posts[0].categories[1].should.be.eql({
+                id: 3,
+                name: "Category 3",
+                deletedAt: null,
+            })
         }
     })
 })


### PR DESCRIPTION

### Description of change

Today its not possbile create a relational filter in typeorm, the only possible its adding where to main search based in relation, for example: `Accounting.find({where: {admin: {isAdmin: true}}})`, but this filter olny be effect in main search, and not in relation, in this PR i added this feature to add relational where in model (can be added in find method later too). 

Issues related
[#1368](https://github.com/typeorm/typeorm/issues/1368)

Example:
```
class Account {
  @PrimaryGeneratedColumn()
  id: number;

  @OneToMany(() => AccountUser, (user) => user.account)
  users: Promise<AccountUser[]>

  @OneToOne(() => AccountUser, (admin) => admin.account, {
    where: { isAdmin: true },   // --> Would be great to be able to specify such a condition somehow
  })
  admin: AccountUser
}

class AccountUser {
  @PrimaryGeneratedColumn()
  id: number;

  @Column()
  isAdmin: boolean;

  @ManyToOne(() => Account, (account) => account.users)
  account: Account;
}
```


### Pull-Request Checklist

<!--
  Please make sure to review and check all of the following.

  If an item is not applicable, you can add "N/A" to the end.
-->

- [ ] Code is up-to-date with the `master` branch
- [ ] `npm run format` to apply prettier formatting
- [ ] `npm run test` passes with this change
- [ ] This pull request links relevant issues as `Fixes #0000`
- [ ] There are new or updated unit tests validating the change
- [ ] Documentation has been updated to reflect this change
- [ ] The new commits follow conventions explained in [CONTRIBUTING.md](https://github.com/typeorm/typeorm/blob/master/CONTRIBUTING.md)

<!--
  🎉 Thank you for contributing and making TypeORM even better!
-->
