### PR TITLE
bug fix: property `where` creates incorrect sql query

### DIFF
--- a/src/query-builder/SelectQueryBuilder.ts
+++ b/src/query-builder/SelectQueryBuilder.ts
@@ -4489,6 +4489,11 @@ export class SelectQueryBuilder<Entity extends ObjectLiteral>
             }
             condition = andConditions.join(" AND ")
         }
+
+        if (condition === '()') {
+            condition = '(1=1)'
+        }
+
         return condition
     }
 }


### PR DESCRIPTION
bug fix: when parameters are undefined with operator OR throws exception instead data from table

<!--
  😀 Wonderful!  Thank you for opening a pull request for TypeORM.

  Please fill in the information below to expedite the review
  and (hopefully) merge of your change.

  If unsure about something.. just do as best as you're able,
  or reach out through our community support channels!
  https://github.com/typeorm/typeorm/blob/master/docs/support.md
-->

### Description of issue
![telegram-cloud-photo-size-2-5293996961751487555-y](https://github.com/typeorm/typeorm/assets/66509035/1e619262-a491-44e3-b690-098fd52b88b6)
if all parameters are undefined it creates sql query like: `select * from table where ()`. `()` - tadaaam )
<!--
  Please be clear and concise what the change is intended to do,
  why this change is needed, and how you've verified that it
  corrects what you intended.

  In some cases it may be helpful to include the current behavior
  and the new behavior.

  If the change is related to an open issue, you can link it here.
  If you include `Fixes #0000` (replacing `0000` with the issue number)
  when this is merged it will automatically mark the issue as fixed and
  close it.
-->

<!--
  🎉 Thank you for contributing and making TypeORM even better!
-->
