### PR TITLE
fix: update UpdateDateColumn on upsert

### DIFF
--- a/test/github-issues/9015/entity/Post.ts
+++ b/test/github-issues/9015/entity/Post.ts
@@ -1,0 +1,22 @@
+import {
+    BaseEntity,
+    Entity,
+    Column,
+    UpdateDateColumn,
+    PrimaryGeneratedColumn,
+} from "../../../../src"
+
+@Entity()
+export class Post extends BaseEntity {
+    @PrimaryGeneratedColumn()
+    id: number
+
+    @Column({ type: "varchar", unique: true })
+    title: string
+
+    @Column({ type: "varchar" })
+    description: string
+
+    @UpdateDateColumn()
+    updated_at: Date
+}

--- a/test/github-issues/9015/issue-9015.ts
+++ b/test/github-issues/9015/issue-9015.ts
@@ -1,0 +1,65 @@
+import "reflect-metadata"
+import { expect } from "chai"
+import { DataSource, Repository } from "../../../src"
+import { Post } from "./entity/Post"
+import {
+    reloadTestingDatabases,
+    closeTestingConnections,
+    setupSingleTestingConnection,
+} from "../../utils/test-utils"
+
+describe("github issues > #9015 @UpdateDateColumn not updating on upsert", () => {
+    let dataSource: DataSource
+    let repository: Repository<Post>
+
+    before(async () => {
+        const options = setupSingleTestingConnection("postgres", {
+            entities: [__dirname + "/entity/*{.js,.ts}"],
+            schemaCreate: true,
+            dropSchema: true,
+        })
+
+        if (!options) return
+
+        dataSource = new DataSource(options)
+        await dataSource.initialize()
+    })
+    beforeEach(async () => {
+        if (!dataSource) return
+        await reloadTestingDatabases([dataSource])
+        repository = dataSource.getRepository(Post)
+    })
+    after(() => closeTestingConnections([dataSource]))
+
+    it("should update the @UpdateDateColumn", async () => {
+        if (!dataSource) return
+
+        const oldDate = new Date("1970-01-01")
+        const post = new Post()
+        post.id = 1
+        post.title = "Some post"
+        post.description = "Some description"
+        post.updated_at = oldDate
+
+        await repository.save(post)
+        await repository.upsert(
+            {
+                title: post.title,
+                description: "Some new description",
+            },
+            {
+                conflictPaths: { title: true },
+                skipUpdateIfNoValuesChanged: true,
+            },
+        )
+        const postReloaded = await repository.findOne({
+            where: { id: post.id },
+        })
+
+        expect(postReloaded).to.exist
+        expect(postReloaded!.description).to.be.equal("Some new description")
+        expect(postReloaded!.updated_at.toString()).to.not.equal(
+            oldDate.toString(),
+        )
+    })
+})


### PR DESCRIPTION
Closes: #9015

### Description of change
This PR makes sure to update any `UpdateDateColumn` during an update that is triggered via `upsert`.

There are a couple of corner cases that I made sure to take care of:
- The fix doesn't break `skipUpdateIfNoValuesChanged` like a previous fix attempt
- When a  `UpdateDateColumn` is explicitly updated then I'm excluding it from the new logic

### Pull-Request Checklist

<!--
  Please make sure to review and check all of the following.

  If an item is not applicable, you can add "N/A" to the end.
-->

- [x] Code is up-to-date with the `master` branch
- [x] `npm run format` to apply prettier formatting
- [x] `npm run test` passes with this change
- [x] This pull request links relevant issues as `Fixes #0000`
- [x] There are new or updated unit tests validating the change
- [x] Documentation has been updated to reflect this change
- [x] The new commits follow conventions explained in [CONTRIBUTING.md](https://github.com/typeorm/typeorm/blob/master/CONTRIBUTING.md)

<!--
  🎉 Thank you for contributing and making TypeORM even better!
-->
