### PR TITLE
fix: resolve issue of generating migration for numeric array columns repeatedly

### DIFF
--- a/src/driver/postgres/PostgresQueryRunner.ts
+++ b/src/driver/postgres/PostgresQueryRunner.ts
@@ -3416,47 +3416,60 @@ export class PostgresQueryRunner
 
                             if (
                                 tableColumn.type === "numeric" ||
+                                tableColumn.type === "numeric[]" ||
                                 tableColumn.type === "decimal" ||
                                 tableColumn.type === "float"
                             ) {
+                                let numericPrecision =
+                                    dbColumn["numeric_precision"]
+                                let numericScale = dbColumn["numeric_scale"]
+                                if (dbColumn["data_type"] === "ARRAY") {
+                                    const numericSize = dbColumn[
+                                        "format_type"
+                                    ].match(
+                                        /^numeric\(([0-9]+),([0-9]+)\)\[\]$/,
+                                    )
+                                    if (numericSize) {
+                                        numericPrecision = +numericSize[1]
+                                        numericScale = +numericSize[2]
+                                    }
+                                }
                                 // If one of these properties was set, and another was not, Postgres sets '0' in to unspecified property
                                 // we set 'undefined' in to unspecified property to avoid changing column on sync
                                 if (
-                                    dbColumn["numeric_precision"] !== null &&
+                                    numericPrecision !== null &&
                                     !this.isDefaultColumnPrecision(
                                         table,
                                         tableColumn,
-                                        dbColumn["numeric_precision"],
+                                        numericPrecision,
                                     )
                                 ) {
-                                    tableColumn.precision =
-                                        dbColumn["numeric_precision"]
+                                    tableColumn.precision = numericPrecision
                                 } else if (
-                                    dbColumn["numeric_scale"] !== null &&
+                                    numericScale !== null &&
                                     !this.isDefaultColumnScale(
                                         table,
                                         tableColumn,
-                                        dbColumn["numeric_scale"],
+                                        numericScale,
                                     )
                                 ) {
                                     tableColumn.precision = undefined
                                 }
                                 if (
-                                    dbColumn["numeric_scale"] !== null &&
+                                    numericScale !== null &&
                                     !this.isDefaultColumnScale(
                                         table,
                                         tableColumn,
-                                        dbColumn["numeric_scale"],
+                                        numericScale,
                                     )
                                 ) {
-                                    tableColumn.scale =
-                                        dbColumn["numeric_scale"]
+                                    tableColumn.scale = numericScale
                                 } else if (
-                                    dbColumn["numeric_precision"] !== null &&
+                                    numericPrecision !== null &&
                                     !this.isDefaultColumnPrecision(
                                         table,
                                         tableColumn,
-                                        dbColumn["numeric_precision"],
+                                        numericPrecision,
                                     )
                                 ) {
                                     tableColumn.scale = undefined

--- a/test/github-issues/10043/entity/Foo.ts
+++ b/test/github-issues/10043/entity/Foo.ts
@@ -1,0 +1,14 @@
+import { Column, Entity, PrimaryGeneratedColumn } from "../../../../src"
+
+@Entity()
+export class Foo {
+    @PrimaryGeneratedColumn("uuid", { primaryKeyConstraintName: "PK_foo" })
+    id: string
+
+    @Column("numeric", {
+        precision: 12,
+        scale: 7,
+        array: true,
+    })
+    bar: number[]
+}

--- a/test/github-issues/10043/issue-10043.ts
+++ b/test/github-issues/10043/issue-10043.ts
@@ -1,0 +1,35 @@
+import "reflect-metadata"
+import {
+    createTestingConnections,
+    closeTestingConnections,
+} from "../../utils/test-utils"
+import { DataSource } from "../../../src/data-source/DataSource"
+
+describe("github issues > #10043 Numeric array column type creates migration repeatedly", () => {
+    let dataSources: DataSource[]
+    before(
+        async () =>
+            (dataSources = await createTestingConnections({
+                entities: [__dirname + "/entity/*{.js,.ts}"],
+                migrations: [__dirname + "/migration/*{.js,.ts}"],
+                schemaCreate: false,
+                dropSchema: true,
+                enabledDrivers: ["postgres"],
+            })),
+    )
+    after(() => closeTestingConnections(dataSources))
+
+    it("should not generate migration for synchronized sized-numeric array column", () =>
+        Promise.all(
+            dataSources.map(async (dataSource) => {
+                await dataSource.runMigrations()
+
+                const sqlInMemory = await dataSource.driver
+                    .createSchemaBuilder()
+                    .log()
+
+                sqlInMemory.upQueries.length.should.equal(0)
+                sqlInMemory.downQueries.length.should.equal(0)
+            }),
+        ))
+})

--- a/test/github-issues/10043/migration/1699343893360-create-table.ts
+++ b/test/github-issues/10043/migration/1699343893360-create-table.ts
@@ -1,0 +1,15 @@
+import { MigrationInterface, QueryRunner } from "../../../../src"
+
+export class CreateTable1699343893360 implements MigrationInterface {
+    name = "CreateTable1699343893360"
+
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(
+            `CREATE TABLE "foo" ("id" uuid NOT NULL DEFAULT uuid_generate_v4(), "bar" numeric(12,7) array NOT NULL, CONSTRAINT "PK_foo" PRIMARY KEY ("id"))`,
+        )
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`DROP TABLE "foo"`)
+    }
+}


### PR DESCRIPTION
Fixes: #10043

### Description of change

Added determining precision and scale values of numeric array columns when loading tables by Postgres query runner.

The reason of these changes is described within the issue that is linked above.
The reason of the issue was found by debugging the source code.

### Pull-Request Checklist

- [x] Code is up-to-date with the `master` branch
- [x] `npm run format` to apply prettier formatting
- [x] `npm run test` passes with this change
- [x] This pull request links relevant issues as `Fixes #0000`
- [x] There are new or updated unit tests validating the change
- [ ] Documentation has been updated to reflect this change N/A
- [x] The new commits follow conventions explained in [CONTRIBUTING.md](https://github.com/typeorm/typeorm/blob/master/CONTRIBUTING.md)
