### PR TITLE
Allow to use custom type witch extends object type for find where argument

### DIFF
--- a/src/find-options/FindOptionsWhere.ts
+++ b/src/find-options/FindOptionsWhere.ts
@@ -36,6 +36,7 @@ export type FindOptionsWhereProperty<
           | FindOptionsWhere<Property>[]
           | EqualOperator<Property>
           | FindOperator<any>
+          | boolean
           | Property
     : Property | FindOperator<Property>
 

--- a/src/find-options/FindOptionsWhere.ts
+++ b/src/find-options/FindOptionsWhere.ts
@@ -36,7 +36,7 @@ export type FindOptionsWhereProperty<
           | FindOptionsWhere<Property>[]
           | EqualOperator<Property>
           | FindOperator<any>
-          | boolean
+          | Property
     : Property | FindOperator<Property>
 
 /**


### PR DESCRIPTION
<!--
  😀 Wonderful!  Thank you for opening a pull request for TypeORM.

  Please fill in the information below to expedite the review
  and (hopefully) merge of your change.

  If unsure about something.. just do as best as you're able,
  or reach out through our community support channels!
  https://github.com/typeorm/typeorm/blob/master/docs/support.md
-->

### Description of change

This PR fixes problem, when I want to use custom type witch extends object type for find where argument.

```typescript
await repository.find({
  where: {
    date: Datestamp.fromYMD(2022, 1, 1),
  },
});
```

Error says:

`
Type 'Datestamp' is not assignable to type 'boolean | FindOperator<any> | FindOptionsWhere<Datestamp> | FindOptionsWhere<Datestamp>[] | EqualOperator<Datestamp> | undefined'.
      Type 'Datestamp' is not assignable to type 'FindOptionsWhere<Datestamp>'.
        Types of property 'getDay' are incompatible.
          Type '() => number' is not assignable to type 'undefined'.ts(2322)
`

Datestamp class:

```typescript
class Datestamp {
  private readonly ['@instanceof'] = Symbol.for(Datestamp.name);
  private readonly year: number;
  private readonly month: number;
  private readonly day: number;
  private readonly timestamp: number;
  private get datestamp() {
    return Datestamp.convertYMDToISOString(this.year, this.month, this.day);
  }

 ...
  
  [Symbol.toPrimitive](hint: 'string' | 'number' | 'default') {
    switch (hint) {
      case 'string':
        return this.datestamp;
      case 'number':
        return this.timestamp;
      case 'default':
        return this.datestamp;
    }
  }

  toString() {
    return this.datestamp;
  }

  toJSON() {
    return this.datestamp;
  }

  getDay() {
    return this.day;
  }

  getMonth() {
    return this.month;
  }

  getYear() {
    return this.year;
  }
...
}
```

I know that my class can be converted to primitives so that typeorm can work with it good. But I have no way to extend the typeorm type, because it is not an interface.

### Pull-Request Checklist

<!--
  Please make sure to review and check all of the following.

  If an item is not applicable, you can add "N/A" to the end.
-->

- [x] Code is up-to-date with the `master` branch
- [x] `npm run format` to apply prettier formatting
- [x] `npm run test` passes with this change
- [ ] This pull request links relevant issues as `Fixes #0000`
- [x] There are new or updated unit tests validating the change
- [x] Documentation has been updated to reflect this change
- [x] The new commits follow conventions explained in [CONTRIBUTING.md](https://github.com/typeorm/typeorm/blob/master/CONTRIBUTING.md)

<!--
  🎉 Thank you for contributing and making TypeORM even better!
-->
