### PR TITLE
feat: introduce FindOptionsRelations<T> to FindTreeOptions

### DIFF
--- a/docs/tree-entities.md
+++ b/docs/tree-entities.md
@@ -231,10 +231,14 @@ There are other special methods to work with tree entities through `TreeReposito
 -   `findTrees` - Returns all trees in the database with all their children, children of children, etc.
 
 ```typescript
-const treeCategories = await dataSource.manager.getTreeRepository(Category).findTrees()
+const treeCategories = await dataSource.manager
+    .getTreeRepository(Category)
+    .findTrees()
 // returns root categories with sub categories inside
 
-const treeCategoriesWithLimitedDepth = await dataSource.manager.getTreeRepository(Category).findTrees({ depth: 2 })
+const treeCategoriesWithLimitedDepth = await dataSource.manager
+    .getTreeRepository(Category)
+    .findTrees({ depth: 2 })
 // returns root categories with sub categories inside, up to depth 2
 ```
 
@@ -242,14 +246,18 @@ const treeCategoriesWithLimitedDepth = await dataSource.manager.getTreeRepositor
     Does not load children's leaves.
 
 ```typescript
-const rootCategories = await dataSource.manager.getTreeRepository(Category).findRoots()
+const rootCategories = await dataSource.manager
+    .getTreeRepository(Category)
+    .findRoots()
 // returns root categories without sub categories inside
 ```
 
 -   `findDescendants` - Gets all children (descendants) of the given entity. Returns them all in a flat array.
 
 ```typescript
-const children = await dataSource.manager.getTreeRepository(Category).findDescendants(parentCategory)
+const children = await dataSource.manager
+    .getTreeRepository(Category)
+    .findDescendants(parentCategory)
 // returns all direct subcategories (without its nested categories) of a parentCategory
 ```
 
@@ -281,7 +289,9 @@ const children = await repository
 -   `countDescendants` - Gets the number of descendants of the entity.
 
 ```typescript
-const childrenCount = await dataSource.manager.getTreeRepository(Category).countDescendants(parentCategory)
+const childrenCount = await dataSource.manager
+    .getTreeRepository(Category)
+    .countDescendants(parentCategory)
 ```
 
 -   `findAncestors` - Gets all parents (ancestors) of the given entity. Returns them all in a flat array.
@@ -294,7 +304,9 @@ const parents = await repository.findAncestors(childCategory)
 -   `findAncestorsTree` - Gets all parents (ancestors) of the given entity. Returns them in a tree - nested into each other.
 
 ```typescript
-const parentsTree = await dataSource.manager.getTreeRepository(Category).findAncestorsTree(childCategory)
+const parentsTree = await dataSource.manager
+    .getTreeRepository(Category)
+    .findAncestorsTree(childCategory)
 // returns all direct childCategory's parent categories (with "parent of parents")
 ```
 
@@ -310,7 +322,9 @@ const parents = await repository
 -   `countAncestors` - Gets the number of ancestors of the entity.
 
 ```typescript
-const parentsCount = await dataSource.manager.getTreeRepository(Category).countAncestors(childCategory)
+const parentsCount = await dataSource.manager
+    .getTreeRepository(Category)
+    .countAncestors(childCategory)
 ```
 
 For the following methods, options can be passed:
@@ -329,13 +343,17 @@ The following options are available:
 Examples:
 
 ```typescript
-const treeCategoriesWithRelations = await dataSource.manager.getTreeRepository(Category).findTrees({
-    relations: ["sites"],
-})
+const treeCategoriesWithRelations = await dataSource.manager
+    .getTreeRepository(Category)
+    .findTrees({
+        relations: { sites: true },
+    })
 // automatically joins the sites relation
 
-const parentsWithRelations = await dataSource.manager.getTreeRepository(Category).findAncestors(childCategory, {
-    relations: ["members"],
-})
+const parentsWithRelations = await dataSource.manager
+    .getTreeRepository(Category)
+    .findAncestors(childCategory, {
+        relations: { members: true },
+    })
 // returns all direct childCategory's parent categories (without "parent of parents") and joins the 'members' relation
 ```

--- a/src/find-options/FindTreeOptions.ts
+++ b/src/find-options/FindTreeOptions.ts
@@ -1,11 +1,16 @@
+import {
+    FindOptionsRelationByString,
+    FindOptionsRelations,
+} from "./FindOptionsRelations"
+
 /**
  * Defines a special criteria to find specific entities.
  */
-export interface FindTreeOptions {
+export interface FindTreeOptions<Entity = any> {
     /**
      * Indicates what relations of entity should be loaded (simplified left join form).
      */
-    relations?: string[]
+    relations?: FindOptionsRelations<Entity> | FindOptionsRelationByString
 
     /**
      * When loading a tree from a TreeRepository, limits the depth of the descendents loaded

--- a/src/repository/TreeRepository.ts
+++ b/src/repository/TreeRepository.ts
@@ -239,7 +239,7 @@ export class TreeRepository<
      */
     findAncestors(
         entity: Entity,
-        options?: FindTreeOptions,
+        options?: FindTreeOptions<Entity>,
     ): Promise<Entity[]> {
         const qb = this.createAncestorsQueryBuilder(
             "treeEntity",

--- a/test/functional/tree-tables/materialized-path/entity/Brand.ts
+++ b/test/functional/tree-tables/materialized-path/entity/Brand.ts
@@ -1,0 +1,19 @@
+import {
+    Column,
+    Entity,
+    ManyToOne,
+    PrimaryGeneratedColumn,
+} from "../../../../../src"
+import { Product } from "./Product"
+
+@Entity()
+export class Brand {
+    @PrimaryGeneratedColumn()
+    id: number
+
+    @Column()
+    name: string
+
+    @ManyToOne(() => Product, (product) => product.brand)
+    products: Product[]
+}

--- a/test/functional/tree-tables/materialized-path/entity/Product.ts
+++ b/test/functional/tree-tables/materialized-path/entity/Product.ts
@@ -3,7 +3,8 @@ import { Entity } from "../../../../../src/decorator/entity/Entity"
 import { Category } from "./Category"
 import { OneToMany } from "../../../../../src/decorator/relations/OneToMany"
 import { Column } from "../../../../../src/decorator/columns/Column"
-
+import { JoinColumn, ManyToOne } from "../../../../../src"
+import { Brand } from "./Brand"
 @Entity()
 export class Product {
     @PrimaryGeneratedColumn()
@@ -16,4 +17,8 @@ export class Product {
         cascade: true,
     })
     categories: Category[]
+
+    @ManyToOne(() => Brand, (brand) => brand.products)
+    @JoinColumn()
+    brand: Brand
 }


### PR DESCRIPTION
<!--
  😀 Wonderful!  Thank you for opening a pull request for TypeORM.

  Please fill in the information below to expedite the review
  and (hopefully) merge of your change.

  If unsure about something.. just do as best as you're able,
  or reach out through our community support channels!
  https://github.com/typeorm/typeorm/blob/master/docs/support.md
-->

### Description of change

Introduces `FindOptionsRelations<Entity> | FindOptionsRelationByString` to `FindTreeOptions`
Tree Repositories currently only loads Relations by primitive strings, which is not only going to be deprecated, but also does not use the proper type safety.

The logic under `FindOptionsUtils.applyRelationsRecursively` is very similar to what happens inside the `SelectQueryBuilder.buildRelations` but I could not find a way to deduplicate and abstract logic without making too many changes as they live in different contexts and have some differences that I do not fully understand yet.

<!--
  Please be clear and concise what the change is intended to do,
  why this change is needed, and how you've verified that it
  corrects what you intended.

  In some cases it may be helpful to include the current behavior
  and the new behavior.

  If the change is related to an open issue, you can link it here.
  If you include `Fixes #0000` (replacing `0000` with the issue number)
  when this is merged it will automatically mark the issue as fixed and
  close it.
-->


### Pull-Request Checklist

<!--
  Please make sure to review and check all of the following.

  If an item is not applicable, you can add "N/A" to the end.
-->

- [X] Code is up-to-date with the `master` branch
- [X] `npm run format` to apply prettier formatting
- [X] `npm run test` passes with this change
- [X] There are new or updated unit tests validating the change
- [X] Documentation has been updated to reflect this change
- [X] The new commits follow conventions explained in [CONTRIBUTING.md](https://github.com/typeorm/typeorm/blob/master/CONTRIBUTING.md)

<!--
  🎉 Thank you for contributing and making TypeORM even better!
-->
