### PR TITLE
fix: migrations on indexed TIMESTAMP WITH TIME ZONE Oracle columns

### DIFF
--- a/test/github-issues/10493/entity/User.ts
+++ b/test/github-issues/10493/entity/User.ts
@@ -1,0 +1,26 @@
+import {
+    Entity,
+    PrimaryGeneratedColumn,
+    Column,
+    CreateDateColumn,
+    Index,
+} from "../../../../src"
+
+@Entity()
+export class User {
+    @PrimaryGeneratedColumn()
+    id: number
+
+    @Column()
+    firstName: string
+
+    @Column()
+    lastName: string
+
+    @Column()
+    age: number
+
+    @CreateDateColumn({ type: "timestamp with time zone" })
+    @Index("IX_User_createdAt")
+    createdAt: Date
+}

--- a/test/github-issues/10493/issue-10493.ts
+++ b/test/github-issues/10493/issue-10493.ts
@@ -1,0 +1,47 @@
+import "reflect-metadata"
+import {
+    createTestingConnections,
+    closeTestingConnections,
+    reloadTestingDatabases,
+} from "../../utils/test-utils"
+import { DataSource } from "../../../src/data-source/DataSource"
+import { expect } from "chai"
+import { User } from "./entity/User"
+
+describe("github issues > #10493 Broken migrations for indices on TIMESTAMP WITH TIMEZONE Oracle Database columns", () => {
+    let dataSources: DataSource[]
+
+    before(
+        async () =>
+            (dataSources = await createTestingConnections({
+                entities: [User],
+                enabledDrivers: ["oracle"],
+                schemaCreate: true,
+                dropSchema: true,
+            })),
+    )
+
+    beforeEach(() => reloadTestingDatabases(dataSources))
+    after(() => closeTestingConnections(dataSources))
+
+    it("should ignore virtual columns when indexing Oracle TIMESTAMP WITH TIME ZONE columns", () =>
+        Promise.all(
+            dataSources.map(async (dataSource) => {
+                // Prior to this fix, TypeORM would attempt to drop the virtual
+                // column and recreate the index.
+                //
+                // Usually, this would fail because it should not have any info
+                // about the virtual column on the "typeorm_metadata" table.
+                //
+                // But even after creating the metadata table manually, it
+                // would still fail because Oracle does not allow dropping
+                // virtual columns that were automatically generated.
+                const sqlInMemory = await dataSource.driver
+                    .createSchemaBuilder()
+                    .log()
+
+                expect(sqlInMemory.upQueries).to.have.length(0)
+                expect(sqlInMemory.downQueries).to.have.length(0)
+            }),
+        ))
+})


### PR DESCRIPTION
ignore auto-generated virtual columns and attempt to map them into their respective reference columns

Closes: #10493

<!--
  😀 Wonderful!  Thank you for opening a pull request for TypeORM.

  Please fill in the information below to expedite the review
  and (hopefully) merge of your change.

  If unsure about something.. just do as best as you're able,
  or reach out through our community support channels!
  https://github.com/typeorm/typeorm/blob/master/docs/support.md
-->

### Description of change

<!--
  Please be clear and concise what the change is intended to do,
  why this change is needed, and how you've verified that it
  corrects what you intended.

  In some cases it may be helpful to include the current behavior
  and the new behavior.

  If the change is related to an open issue, you can link it here.
  If you include `Fixes #0000` (replacing `0000` with the issue number)
  when this is merged it will automatically mark the issue as fixed and
  close it.
-->

Ignore automatically generated virtual columns on the Oracle driver, in order to avoid errors when generating migrations and / or synchronizing the entities / schemas to the database.

This is accomplished by ignoring any virtual columns that have the "USER_GENERATED" column set to "NO".

Also, since this mainly happens when a TIMESTAMP WITH TIME ZONE column is indexed, generating a virtual TIMESTAMP column, it is also necessary to infer that this virtual column actually refers to the original one, during indices discovery. This way, TypeORM won't attempt to recreate it.

A test case has been added to reproduce and fix the aforementioned issue.

### Pull-Request Checklist

<!--
  Please make sure to review and check all of the following.

  If an item is not applicable, you can add "N/A" to the end.
-->

- [X] Code is up-to-date with the `master` branch
- [X] `npm run format` to apply prettier formatting
- [X] `npm run test` passes with this change
  - Ran tests with only the "oracle" driver enabled, since that's the only set of files altered by this PR
- [X] This pull request links relevant issues as `Fixes #0000`
- [X] There are new or updated unit tests validating the change
- [ ] Documentation has been updated to reflect this change
  - N/A
- [X] The new commits follow conventions explained in [CONTRIBUTING.md](https://github.com/typeorm/typeorm/blob/master/CONTRIBUTING.md)

<!--
  🎉 Thank you for contributing and making TypeORM even better!
-->
