### PR TITLE
feat: user-defined index name for STI discriminator column

### DIFF
--- a/src/metadata-builder/EntityMetadataBuilder.ts
+++ b/src/metadata-builder/EntityMetadataBuilder.ts
@@ -1128,6 +1128,21 @@ export class EntityMetadataBuilder {
      * Creates indices for the table of single table inheritance.
      */
     protected createKeysForTableInheritance(entityMetadata: EntityMetadata) {
+        const isDiscriminatorColumnAlreadyIndexed = entityMetadata.indices.some(
+            ({ givenColumnNames }) =>
+                !!givenColumnNames &&
+                Array.isArray(givenColumnNames) &&
+                givenColumnNames.length === 1 &&
+                givenColumnNames[0] ===
+                    entityMetadata.discriminatorColumn?.databaseName,
+        )
+
+        // If the discriminator column is already indexed, there is no need to
+        // add another index on top of it.
+        if (isDiscriminatorColumnAlreadyIndexed) {
+            return
+        }
+
         entityMetadata.indices.push(
             new IndexMetadata({
                 entityMetadata: entityMetadata,

--- a/test/github-issues/10496/entity/A.ts
+++ b/test/github-issues/10496/entity/A.ts
@@ -1,0 +1,15 @@
+import { ChildEntity, Column } from "../../../../src"
+
+import { Base } from "./Base"
+
+@ChildEntity()
+export class A extends Base {
+    @Column()
+    a!: boolean
+
+    constructor(a: boolean) {
+        super()
+
+        this.a = a
+    }
+}

--- a/test/github-issues/10496/entity/B.ts
+++ b/test/github-issues/10496/entity/B.ts
@@ -1,0 +1,16 @@
+import { ChildEntity, Column, Index } from "../../../../src"
+
+import { Base } from "./Base"
+
+@ChildEntity()
+export class B extends Base {
+    @Column()
+    @Index("IX_Base_b")
+    b!: number
+
+    constructor(b: number) {
+        super()
+
+        this.b = b
+    }
+}

--- a/test/github-issues/10496/entity/Base.ts
+++ b/test/github-issues/10496/entity/Base.ts
@@ -1,0 +1,26 @@
+import {
+    Column,
+    CreateDateColumn,
+    Entity,
+    Index,
+    PrimaryGeneratedColumn,
+    TableInheritance,
+    UpdateDateColumn,
+} from "../../../../src"
+
+@Entity()
+@TableInheritance({ column: { type: String, name: "type" } })
+export abstract class Base {
+    @PrimaryGeneratedColumn()
+    id!: number
+
+    @Column()
+    @Index("IX_Base_type")
+    type!: string
+
+    @CreateDateColumn()
+    createdAt!: Date
+
+    @UpdateDateColumn()
+    updatedAt!: Date
+}

--- a/test/github-issues/10496/entity/C.ts
+++ b/test/github-issues/10496/entity/C.ts
@@ -1,0 +1,15 @@
+import { ChildEntity, Column } from "../../../../src"
+
+import { Base } from "./Base"
+
+@ChildEntity()
+export class C extends Base {
+    @Column()
+    c!: string
+
+    constructor(c: string) {
+        super()
+
+        this.c = c
+    }
+}

--- a/test/github-issues/10496/entity/index.ts
+++ b/test/github-issues/10496/entity/index.ts
@@ -1,0 +1,5 @@
+export * from "./Base"
+
+export * from "./A"
+export * from "./B"
+export * from "./C"

--- a/test/github-issues/10496/issue-10496.ts
+++ b/test/github-issues/10496/issue-10496.ts
@@ -1,0 +1,63 @@
+import "reflect-metadata"
+
+import { expect } from "chai"
+
+import {
+    createTestingConnections,
+    closeTestingConnections,
+    reloadTestingDatabases,
+} from "../../utils/test-utils"
+import { DataSource } from "../../../src/data-source/DataSource"
+
+import { Base, A, B, C } from "./entity"
+
+describe("github issues > #10496 User-defined index name for Single Table Inheritance discriminator columns", () => {
+    let dataSources: DataSource[]
+
+    before(
+        async () =>
+            (dataSources = await createTestingConnections({
+                entities: [Base, A, B, C],
+                schemaCreate: true,
+                dropSchema: true,
+                enabledDrivers: [
+                    "better-sqlite3",
+                    "cockroachdb",
+                    "mariadb",
+                    "mssql",
+                    "mysql",
+                    "oracle",
+                    "postgres",
+                    "spanner",
+                    "sqlite",
+                ],
+            })),
+    )
+
+    beforeEach(() => reloadTestingDatabases(dataSources))
+
+    after(() => closeTestingConnections(dataSources))
+
+    it("should create a single index for the discriminator column, with the specified column name", () =>
+        Promise.all(
+            dataSources.map(async (dataSource) => {
+                const queryRunner = dataSource.createQueryRunner()
+                await queryRunner.connect()
+
+                const table = (await queryRunner.getTable("base"))!
+
+                await queryRunner.release()
+
+                const discriminatorColumnIndices = table.indices.filter(
+                    (index) =>
+                        index.columnNames.length === 1 &&
+                        index.columnNames[0] === "type",
+                )
+
+                expect(discriminatorColumnIndices).to.have.length(1)
+                expect(discriminatorColumnIndices[0].name).to.be.equal(
+                    "IX_Base_type",
+                )
+            }),
+        ))
+})


### PR DESCRIPTION
avoid index duplication on the discriminator column when using STI and explicitly defining an index for it

Closes: #10496

<!--
  😀 Wonderful!  Thank you for opening a pull request for TypeORM.

  Please fill in the information below to expedite the review
  and (hopefully) merge of your change.

  If unsure about something.. just do as best as you're able,
  or reach out through our community support channels!
  https://github.com/typeorm/typeorm/blob/master/docs/support.md
-->

### Description of change

<!--
  Please be clear and concise what the change is intended to do,
  why this change is needed, and how you've verified that it
  corrects what you intended.

  In some cases it may be helpful to include the current behavior
  and the new behavior.

  If the change is related to an open issue, you can link it here.
  If you include `Fixes #0000` (replacing `0000` with the issue number)
  when this is merged it will automatically mark the issue as fixed and
  close it.
-->

Currently, when using Single Table Inheritance, TypeORM will automatically index the discriminator column, with a pre-determined index name, such as "IDX_da86e1027abd881610c93feaee".

Attempting to explicitly specify an index for this column will result in 2 indices being created (the automatically added one, plus the user-defined), which is unnecessary. On Oracle Database, this is actually an error (ORA-01408).

This change adds a check that attempts to validate whether a user-defined index has already been created for the discriminator column, in which case no other indices will be added automatically by TypeORM.

### Pull-Request Checklist

<!--
  Please make sure to review and check all of the following.

  If an item is not applicable, you can add "N/A" to the end.
-->

- [X] Code is up-to-date with the `master` branch
- [X] `npm run format` to apply prettier formatting
- [X] `npm run test` passes with this change
- [X] This pull request links relevant issues as `Fixes #0000`
- [X] There are new or updated unit tests validating the change
- [ ] Documentation has been updated to reflect this change
  - N/A - no new / updated APIs
- [X] The new commits follow conventions explained in [CONTRIBUTING.md](https://github.com/typeorm/typeorm/blob/master/CONTRIBUTING.md)

<!--
  🎉 Thank you for contributing and making TypeORM even better!
-->
