### PR TITLE
docs: update redis cache client options

### DIFF
--- a/docs/caching.md
+++ b/docs/caching.md
@@ -137,8 +137,10 @@ Example:
     cache: {
         type: "redis",
         options: {
-            host: "localhost",
-            port: 6379
+            socket: {
+                host: "localhost",
+                port: 6379
+            }
         }
     }
 }
@@ -240,8 +242,10 @@ Example:
     cache: {
         type: "redis",
         options: {
-            host: "localhost",
-            port: 6379
+            socket: {
+                host: "localhost",
+                port: 6379
+            }
         },
         ignoreErrors: true
     }


### PR DESCRIPTION
### Description of change
Between v3 and v4 in node-redis the client options changed for a collection of socket related paramaters. In the caching documentation the v3 format for used for `host` and `socket`.

When following the documented example the redis client would default to `localhost` even when a different value for `host` was specified.

Fixes #9987

### Pull-Request Checklist

- [x] Code is up-to-date with the `master` branch
- [x] `npm run format` to apply prettier formatting
- [ ] `npm run test` passes with this change N/A
- [x] This pull request links relevant issues as `Fixes #0000`
- [ ] There are new or updated unit tests validating the change N/A
- [x] Documentation has been updated to reflect this change
- [x] The new commits follow conventions explained in [CONTRIBUTING.md] (https://github.com/typeorm/typeorm/blob/master/CONTRIBUTING.md)
