### PR TITLE
feat: Pass identifier into InsertEvent

### DIFF
--- a/src/persistence/SubjectExecutor.ts
+++ b/src/persistence/SubjectExecutor.ts
@@ -300,6 +300,7 @@ export class SubjectExecutor {
                     result,
                     subject.metadata,
                     subject.entity!,
+                    subject.identifier,
                 ),
             )
         if (this.updateSubjects.length)

--- a/src/subscriber/Broadcaster.ts
+++ b/src/subscriber/Broadcaster.ts
@@ -366,6 +366,7 @@ export class Broadcaster {
         result: BroadcasterResult,
         metadata: EntityMetadata,
         entity?: ObjectLiteral,
+        identifier?: ObjectLiteral,
     ): void {
         if (entity && metadata.afterInsertListeners.length) {
             metadata.afterInsertListeners.forEach((listener) => {
@@ -390,6 +391,7 @@ export class Broadcaster {
                         manager: this.queryRunner.manager,
                         entity: entity,
                         metadata: metadata,
+                        entityId: metadata.getEntityIdMixedMap(identifier),
                     })
                     if (executionResult instanceof Promise)
                         result.promises.push(executionResult)

--- a/src/subscriber/event/InsertEvent.ts
+++ b/src/subscriber/event/InsertEvent.ts
@@ -2,6 +2,7 @@ import { EntityManager } from "../../entity-manager/EntityManager"
 import { DataSource } from "../../data-source/DataSource"
 import { QueryRunner } from "../../query-runner/QueryRunner"
 import { EntityMetadata } from "../../metadata/EntityMetadata"
+import { ObjectLiteral } from "../../common/ObjectLiteral"
 
 /**
  * InsertEvent is an object that broadcaster sends to the entity subscriber when entity is inserted to the database.
@@ -28,6 +29,11 @@ export interface InsertEvent<Entity> {
      * Inserting event.
      */
     entity: Entity
+
+    /**
+     * Id or ids of the entity being inserted.
+     */
+    entityId?: ObjectLiteral
 
     /**
      * Metadata of the entity.

--- a/test/github-issues/8221/entity/SettingSubscriber.ts
+++ b/test/github-issues/8221/entity/SettingSubscriber.ts
@@ -1,6 +1,7 @@
 import {
     EntitySubscriberInterface,
     EventSubscriber,
+    InsertEvent,
     LoadEvent,
     UpdateEvent,
 } from "../../../../src"
@@ -27,7 +28,7 @@ export class SettingSubscriber implements EntitySubscriberInterface {
         this.counter.updates++
     }
 
-    beforeInsert(event: UpdateEvent<any>): void {
+    beforeInsert(event: InsertEvent<any>): void {
         this.counter.inserts++
     }
 

--- a/test/github-issues/9965/entity/Book.ts
+++ b/test/github-issues/9965/entity/Book.ts
@@ -1,0 +1,10 @@
+import { Column, Entity, PrimaryGeneratedColumn } from "../../../../src"
+
+@Entity()
+export class Book {
+    @PrimaryGeneratedColumn("uuid")
+    id: string
+
+    @Column()
+    name: string
+}

--- a/test/github-issues/9965/entity/User.ts
+++ b/test/github-issues/9965/entity/User.ts
@@ -1,0 +1,23 @@
+import {
+    Column,
+    Entity,
+    JoinTable,
+    ManyToMany,
+    PrimaryGeneratedColumn,
+} from "../../../../src"
+import { Book } from "./Book"
+
+export const BORROWED = "borrowed"
+
+@Entity()
+export class User {
+    @PrimaryGeneratedColumn("uuid")
+    id: string
+
+    @Column()
+    name: string
+
+    @ManyToMany((_type) => Book, {})
+    @JoinTable({ name: BORROWED })
+    public borrowed: Book[]
+}

--- a/test/github-issues/9965/issue-9965.ts
+++ b/test/github-issues/9965/issue-9965.ts
@@ -1,0 +1,57 @@
+import Sinon, { spy } from "sinon"
+import { DataSource } from "../../../src"
+import {
+    closeTestingConnections,
+    createTestingConnections,
+    reloadTestingDatabases,
+} from "../../utils/test-utils"
+import { Book } from "./entity/Book"
+import { User } from "./entity/User"
+import { BorrowedSubscriber } from "./subscriber/BorrrowedSubscriber"
+import { expect } from "chai"
+
+describe("github issues > #9965", () => {
+    let dataSources: DataSource[]
+
+    before(async () => {
+        dataSources = await createTestingConnections({
+            entities: [Book, User],
+            subscribers: [BorrowedSubscriber],
+            enabledDrivers: ["postgres"],
+            schemaCreate: true,
+            dropSchema: true,
+        })
+    })
+
+    beforeEach(() => reloadTestingDatabases(dataSources))
+    after(() => closeTestingConnections(dataSources))
+
+    it("should pass entityId to afterInsert method", async () => {
+        const [dataSource] = dataSources
+
+        const testBook = dataSource.manager.create(Book, { name: "TestPost" })
+        await dataSource.manager.save(testBook)
+
+        const testUser = dataSource.manager.create(User, { name: "TestUser" })
+        await dataSource.manager.save(testUser)
+
+        testUser.borrowed = [testBook]
+
+        const [subscriber] = dataSource.subscribers
+        const beforeInsert = spy(subscriber, "afterInsert")
+
+        await dataSource.manager.save(testUser)
+
+        expect(beforeInsert.called).to.be.true
+        expect(
+            beforeInsert.calledWith(
+                Sinon.match((event) => {
+                    return (
+                        typeof event.entityId?.userId === "string" &&
+                        typeof event.entityId?.bookId === "string"
+                    )
+                }),
+            ),
+        ).to.be.ok
+    })
+})

--- a/test/github-issues/9965/subscriber/BorrrowedSubscriber.ts
+++ b/test/github-issues/9965/subscriber/BorrrowedSubscriber.ts
@@ -1,0 +1,11 @@
+import { EntitySubscriberInterface, EventSubscriber } from "../../../../src"
+import { BORROWED } from "../entity/User"
+
+@EventSubscriber()
+export class BorrowedSubscriber implements EntitySubscriberInterface {
+    listenTo(): string | Function {
+        return BORROWED
+    }
+
+    afterInsert(): void | Promise<any> {}
+}


### PR DESCRIPTION
<!--
  😀 Wonderful!  Thank you for opening a pull request for TypeORM.

  Please fill in the information below to expedite the review
  and (hopefully) merge of your change.

  If unsure about something.. just do as best as you're able,
  or reach out through our community support channels!
  https://github.com/typeorm/typeorm/blob/master/docs/support.md
-->

### Description of change

Set entityId on InsertEvent as identifier.  Fixes #9965.

Allows subscribers to have information about join records when they're inserted.

### Pull-Request Checklist

<!--
  Please make sure to review and check all of the following.

  If an item is not applicable, you can add "N/A" to the end.
-->

- [x] Code is up-to-date with the `master` branch
- [x] `npm run format` to apply prettier formatting
- [x] `npm run test` passes with this change
- [x] This pull request links relevant issues as `Fixes #0000`
- [x] There are new or updated unit tests validating the change
- [x] Documentation has been updated to reflect this change: N/A
- [x] The new commits follow conventions explained in [CONTRIBUTING.md](https://github.com/typeorm/typeorm/blob/master/CONTRIBUTING.md)

<!--
  🎉 Thank you for contributing and making TypeORM even better!
-->
