### PR TITLE
Add support for vector types in postgres for pgvector support

### DIFF
--- a/src/driver/postgres/PostgresDriver.ts
+++ b/src/driver/postgres/PostgresDriver.ts
@@ -184,6 +184,7 @@ export class PostgresDriver implements Driver {
         "geography",
         "cube",
         "ltree",
+        "vector",
     ]
 
     /**

--- a/src/driver/types/ColumnTypes.ts
+++ b/src/driver/types/ColumnTypes.ts
@@ -199,6 +199,7 @@ export type SimpleColumnType =
     | "array" // cockroachdb, sap, spanner
     | "cube" // postgres
     | "ltree" // postgres
+    | "vector" // postgres via pgvector extension
 
 /**
  * Any column type column can be.


### PR DESCRIPTION


### Description of change

Add support for the vector type produced by `pgvector` when using Postgres

### Pull-Request Checklist

- [X] Code is up-to-date with the `master` branch
- [X] `npm run format` to apply prettier formatting
- [X] `npm run test` passes with this change
- [X] This pull request links relevant issues as `Fixes #0000`
- [X] There are new or updated unit tests validating the change
- [X] Documentation has been updated to reflect this change
- [X] The new commits follow conventions explained in [CONTRIBUTING.md](https://github.com/typeorm/typeorm/blob/master/CONTRIBUTING.md)
