### PR TITLE
fix: sqlite simple-enum column parsing

### DIFF
--- a/src/driver/sqlite-abstract/AbstractSqliteQueryRunner.ts
+++ b/src/driver/sqlite-abstract/AbstractSqliteQueryRunner.ts
@@ -1453,20 +1453,10 @@ export abstract class AbstractSqliteQueryRunner
                         }
 
                         if (tableColumn.type === "varchar") {
-                            // Check if this is an enum
-                            const enumMatch = sql.match(
-                                new RegExp(
-                                    '"(' +
-                                        tableColumn.name +
-                                        ")\" varchar CHECK\\s*\\(\\s*\"\\1\"\\s+IN\\s*\\(('[^']+'(?:\\s*,\\s*'[^']+')+)\\s*\\)\\s*\\)",
-                                ),
+                            tableColumn.enum = OrmUtils.parseSqlCheckExpression(
+                                sql,
+                                tableColumn.name,
                             )
-                            if (enumMatch) {
-                                // This is an enum
-                                tableColumn.enum = enumMatch[2]
-                                    .substr(1, enumMatch[2].length - 2)
-                                    .split("','")
-                            }
                         }
 
                         // parse datatype and attempt to retrieve length, precision and scale

--- a/src/util/OrmUtils.ts
+++ b/src/util/OrmUtils.ts
@@ -340,6 +340,81 @@ export class OrmUtils {
         return !haveSharedObjects
     }
 
+    /**
+     * Parses the CHECK constraint on the specified column and returns
+     * all values allowed by the constraint or undefined if the constraint
+     * is not present.
+     */
+    static parseSqlCheckExpression(
+        sql: string,
+        columnName: string,
+    ): string[] | undefined {
+        const enumMatch = sql.match(
+            new RegExp(
+                `"${columnName}" varchar CHECK\\s*\\(\\s*"${columnName}"\\s+IN\\s*`,
+            ),
+        )
+
+        if (enumMatch && enumMatch.index) {
+            const afterMatch = sql.substring(
+                enumMatch.index + enumMatch[0].length,
+            )
+
+            // This is an enum
+            // all enum values stored as a comma separated list
+            const chars = afterMatch
+
+            /**
+             * * When outside quotes: empty string
+             * * When inside single quotes: `'`
+             */
+            let currentQuotes = ""
+            let nextValue = ""
+            const enumValues: string[] = []
+            for (let idx = 0; idx < chars.length; idx++) {
+                const char = chars[idx]
+                switch (char) {
+                    case ",":
+                        if (currentQuotes == "") {
+                            enumValues.push(nextValue)
+                            nextValue = ""
+                        } else {
+                            nextValue += char
+                        }
+                        break
+                    case "'":
+                        if (currentQuotes == char) {
+                            const isNextCharQuote = chars[idx + 1] === char
+                            if (isNextCharQuote) {
+                                // double quote in sql should be treated as a
+                                // single quote that's part of the quoted string
+                                nextValue += char
+                                idx += 1 // skip that next quote
+                            } else {
+                                currentQuotes = ""
+                            }
+                        } else {
+                            currentQuotes = char
+                        }
+                        break
+                    case ")":
+                        if (currentQuotes == "") {
+                            enumValues.push(nextValue)
+                            return enumValues
+                        } else {
+                            nextValue += char
+                        }
+                        break
+                    default:
+                        if (currentQuotes != "") {
+                            nextValue += char
+                        }
+                }
+            }
+        }
+        return undefined
+    }
+
     // -------------------------------------------------------------------------
     // Private methods
     // -------------------------------------------------------------------------

--- a/test/unit/orm-utils.ts
+++ b/test/unit/orm-utils.ts
@@ -1,0 +1,75 @@
+import { OrmUtils } from "../../src/util/OrmUtils"
+import { expect } from "chai"
+
+describe(`orm-utils`, () => {
+    describe("parseSqlCheckExpression", () => {
+        it("parses a simple CHECK constraint", () => {
+            // Spaces between CHECK values
+            expect(
+                OrmUtils.parseSqlCheckExpression(
+                    `CREATE TABLE "foo_table" (
+                        "id" integer PRIMARY KEY AUTOINCREMENT NOT NULL,
+                        "col" varchar CHECK("col" IN ('FOO', 'BAR', 'BAZ')) NOT NULL,
+                        "some_other_col" integer NOT NULL
+                        );`,
+                    "col",
+                ),
+            ).to.have.same.members(["FOO", "BAR", "BAZ"])
+
+            // No spaces between CHECK values
+            expect(
+                OrmUtils.parseSqlCheckExpression(
+                    `CREATE TABLE "foo_table" (
+                        "id" integer PRIMARY KEY AUTOINCREMENT NOT NULL,
+                        "col" varchar CHECK("col" IN ('FOO','BAR','BAZ')) NOT NULL,
+                        "some_other_col" integer NOT NULL
+                        );`,
+                    "col",
+                ),
+            ).to.have.same.members(["FOO", "BAR", "BAZ"])
+        })
+
+        it("returns undefined when the column doesn't have a CHECK", () => {
+            expect(
+                OrmUtils.parseSqlCheckExpression(
+                    `CREATE TABLE "foo_table" (
+                        "id" integer PRIMARY KEY AUTOINCREMENT NOT NULL,
+                        "col" varchar NOT NULL,
+                        "some_other_col" integer NOT NULL
+                        );`,
+                    "col",
+                ),
+            ).to.equal(undefined)
+        })
+
+        it("parses a CHECK constraint with values containing special characters", () => {
+            expect(
+                OrmUtils.parseSqlCheckExpression(
+                    `CREATE TABLE "foo_table" (
+                        "id" integer PRIMARY KEY AUTOINCREMENT NOT NULL,
+                        "col" varchar CHECK("col" IN (
+                                    'a,b', 
+                                    ',c,', 
+                                    'd''d', 
+                                    '''e''', 
+                                    'f'',''f', 
+                                    ''')', 
+                                    ')'''
+                                )
+                            ) NOT NULL,
+                        "some_other_col" integer NOT NULL
+                        );`,
+                    "col",
+                ),
+            ).to.have.same.members([
+                "a,b",
+                ",c,",
+                "d'd",
+                "'e'",
+                "f','f",
+                "')",
+                ")'",
+            ])
+        })
+    })
+})


### PR DESCRIPTION
### Description of change

Fixed a bug that was causing new migration to be generated even when no changes to the Model was made. Generating migration for a table with a column type `simple-enum` (in sqlite) would produce SQL CREATE TABLE query with a column like this:
```sql
  "col_name" varchar CHECK("col_name" IN ('FOO', 'BAR', 'BAZ')) NOT NULL,
```
When a TableColumn for this column is created, that CHECK statements was being incorrectly parsed (`','` was used as separator, but the statement included whitespaces not present in that separator.) Given the above column in db, instead of parsing it into `["FOO", "BAR", "BAZ"]` it was parsed into `["FOO', 'BAR', 'BAZ"]`, because of this syncing would attempt to update that table and create a new migration every single time.

To fix the issue I've changed how that CHECK statement is parsed, instead of splitting the string using some kind of separator you iterate over characters and evaluate each differently based on whether it is placed inside a quote or not, only commas outside quotes are treated as separators of values, and the whitespaces outside quotes are ignored, so it doesn't matter if there is any number of spaces before or after the comma.

### Pull-Request Checklist

- [x] Code is up-to-date with the `master` branch
- [x] `npm run format` to apply prettier formatting
- [X] `npm run test` passes with this change
- [ ] This pull request links relevant issues as `Fixes #0000`
- [x] There are new or updated unit tests validating the change
- [ ] Documentation has been updated to reflect this change
- [x] The new commits follow conventions explained in [CONTRIBUTING.md](https://github.com/typeorm/typeorm/blob/master/CONTRIBUTING.md)
