### PR TITLE
fix: Default value in child table/entity column decorator for multipl…

### DIFF
--- a/src/metadata-builder/EntityMetadataBuilder.ts
+++ b/src/metadata-builder/EntityMetadataBuilder.ts
@@ -542,6 +542,21 @@ export class EntityMetadataBuilder {
                         (column) => column.propertyName === args.propertyName,
                     )!
 
+                // for multiple table inheritance we can override default column values
+                if (
+                    entityMetadata.tableType === "regular" &&
+                    args.target !== entityMetadata.target
+                ) {
+                    const childArgs = this.metadataArgsStorage.columns.find(
+                        (c) =>
+                            c.propertyName === args.propertyName &&
+                            c.target === entityMetadata.target,
+                    )
+                    if (childArgs && childArgs.options.default) {
+                        args.options.default = childArgs.options.default
+                    }
+                }
+
                 const column = new ColumnMetadata({
                     connection: this.connection,
                     entityMetadata,

--- a/test/github-issues/10563/entity/family.ts
+++ b/test/github-issues/10563/entity/family.ts
@@ -1,0 +1,23 @@
+import { Column, Entity, PrimaryColumn } from "../../../../src"
+
+@Entity()
+export class FamilyMember {
+    @PrimaryColumn()
+    name: string
+
+    @Column({
+        default: "PERSON",
+    })
+    type: string
+}
+
+@Entity()
+export class Dog extends FamilyMember {
+    @PrimaryColumn()
+    name: string
+
+    @Column({
+        default: "PET",
+    })
+    type: string
+}

--- a/test/github-issues/10563/issue-10563.ts
+++ b/test/github-issues/10563/issue-10563.ts
@@ -1,0 +1,44 @@
+import "reflect-metadata"
+import {
+    createTestingConnections,
+    closeTestingConnections,
+    reloadTestingDatabases,
+} from "../../utils/test-utils"
+import { DataSource } from "../../../src/data-source/DataSource"
+import { assert } from "chai"
+import { Dog } from "./entity/family"
+
+describe("github issues > #10653 Default value in child table/entity column decorator for multiple table inheritance is ignored for inherited columns", () => {
+    let dataSources: DataSource[]
+    before(
+        async () =>
+            (dataSources = await createTestingConnections({
+                entities: [__dirname + "/entity/*{.js,.ts}"],
+                schemaCreate: true,
+                dropSchema: true,
+            })),
+    )
+    beforeEach(() => reloadTestingDatabases(dataSources))
+    after(() => closeTestingConnections(dataSources))
+
+    it("should honor distinct default value configured on inherited column of child entity", () =>
+        Promise.all(
+            dataSources.map(async (dataSource) => {
+                await Promise.all(
+                    dataSources.map(async (dataSource) => {
+                        const manager = dataSource.manager
+                        let dog: Dog = new Dog()
+                        dog.name = "Fifi"
+                        await manager.save(dog)
+                        let fifi = await manager.findOneBy(Dog, {
+                            name: "Fifi",
+                        })
+                        assert(
+                            fifi instanceof Dog && fifi["type"] == "PET",
+                            `Fifi=${JSON.stringify(fifi)}`,
+                        )
+                    }),
+                )
+            }),
+        ))
+})


### PR DESCRIPTION
…e table inheritance is ignored for inherited columns (#10563)

<!--
  😀 Wonderful!  Thank you for opening a pull request for TypeORM.

  Please fill in the information below to expedite the review
  and (hopefully) merge of your change.

  If unsure about something.. just do as best as you're able,
  or reach out through our community support channels!
  https://github.com/typeorm/typeorm/blob/master/docs/support.md
-->

### Description of change
Allows to override default column values for multiple table inheritance
<!--
  Please be clear and concise what the change is intended to do,
  why this change is needed, and how you've verified that it
  corrects what you intended.

  In some cases it may be helpful to include the current behavior
  and the new behavior.

  If the change is related to an open issue, you can link it here.
  If you include `Fixes #0000` (replacing `0000` with the issue number)
  when this is merged it will automatically mark the issue as fixed and
  close it.
-->


### Pull-Request Checklist

<!--
  Please make sure to review and check all of the following.

  If an item is not applicable, you can add "N/A" to the end.
-->

- [x ] Code is up-to-date with the `master` branch
- [x] `npm run format` to apply prettier formatting
- [x ] `npm run test` passes with this change
- [x ] This pull request links relevant issues as `Fixes #0000`
- [x ] There are new or updated unit tests validating the change
- [x ] Documentation has been updated to reflect this change
- [x ] The new commits follow conventions explained in [CONTRIBUTING.md](https://github.com/typeorm/typeorm/blob/master/CONTRIBUTING.md)

<!--
  🎉 Thank you for contributing and making TypeORM even better!
-->
