### PR TITLE
Added fail callback

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "typeorm",
-  "private": false,
+  "private": true,
   "version": "0.3.17",
   "description": "Data-Mapper ORM for TypeScript, ES7, ES6, ES5. Supports MySQL, PostgreSQL, MariaDB, SQLite, MS SQL Server, Oracle, MongoDB databases.",
   "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "typeorm",
-  "private": true,
+  "private": false,
   "version": "0.3.17",
   "description": "Data-Mapper ORM for TypeScript, ES7, ES6, ES5. Supports MySQL, PostgreSQL, MariaDB, SQLite, MS SQL Server, Oracle, MongoDB databases.",
   "license": "MIT",

--- a/src/driver/cordova/CordovaDriver.ts
+++ b/src/driver/cordova/CordovaDriver.ts
@@ -1,10 +1,10 @@
-import { AbstractSqliteDriver } from "../sqlite-abstract/AbstractSqliteDriver"
-import { CordovaConnectionOptions } from "./CordovaConnectionOptions"
-import { CordovaQueryRunner } from "./CordovaQueryRunner"
-import { QueryRunner } from "../../query-runner/QueryRunner"
-import { DataSource } from "../../data-source/DataSource"
-import { DriverPackageNotInstalledError } from "../../error/DriverPackageNotInstalledError"
-import { ReplicationMode } from "../types/ReplicationMode"
+import {AbstractSqliteDriver} from "../sqlite-abstract/AbstractSqliteDriver"
+import {CordovaConnectionOptions} from "./CordovaConnectionOptions"
+import {CordovaQueryRunner} from "./CordovaQueryRunner"
+import {QueryRunner} from "../../query-runner/QueryRunner"
+import {DataSource} from "../../data-source/DataSource"
+import {DriverPackageNotInstalledError} from "../../error/DriverPackageNotInstalledError"
+import {ReplicationMode} from "../types/ReplicationMode"
 
 // needed for typescript compiler
 interface Window {
@@ -74,8 +74,9 @@ export class CordovaDriver extends AbstractSqliteDriver {
             this.options.extra || {},
         )
 
-        const connection = await new Promise<any>((resolve) => {
-            this.sqlite.openDatabase(options, (db: any) => resolve(db))
+        const connection = await new Promise<any>((resolve, fail) => {
+            //fix moianra - Added fail callback in order to throw an exception if the database cannot be opened.
+            this.sqlite.openDatabase(options, (db: any) => resolve(db), (err: any) => fail(err))
         })
 
         await new Promise<void>((ok, fail) => {

--- a/src/driver/cordova/CordovaDriver.ts
+++ b/src/driver/cordova/CordovaDriver.ts
@@ -75,7 +75,6 @@ export class CordovaDriver extends AbstractSqliteDriver {
         )
 
         const connection = await new Promise<any>((resolve, fail) => {
-            //fix moianra - Added fail callback in order to throw an exception if the database cannot be opened.
             this.sqlite.openDatabase(
                 options,
                 (db: any) => resolve(db),

--- a/src/driver/cordova/CordovaDriver.ts
+++ b/src/driver/cordova/CordovaDriver.ts
@@ -1,10 +1,10 @@
-import {AbstractSqliteDriver} from "../sqlite-abstract/AbstractSqliteDriver"
-import {CordovaConnectionOptions} from "./CordovaConnectionOptions"
-import {CordovaQueryRunner} from "./CordovaQueryRunner"
-import {QueryRunner} from "../../query-runner/QueryRunner"
-import {DataSource} from "../../data-source/DataSource"
-import {DriverPackageNotInstalledError} from "../../error/DriverPackageNotInstalledError"
-import {ReplicationMode} from "../types/ReplicationMode"
+import { AbstractSqliteDriver } from "../sqlite-abstract/AbstractSqliteDriver"
+import { CordovaConnectionOptions } from "./CordovaConnectionOptions"
+import { CordovaQueryRunner } from "./CordovaQueryRunner"
+import { QueryRunner } from "../../query-runner/QueryRunner"
+import { DataSource } from "../../data-source/DataSource"
+import { DriverPackageNotInstalledError } from "../../error/DriverPackageNotInstalledError"
+import { ReplicationMode } from "../types/ReplicationMode"
 
 // needed for typescript compiler
 interface Window {
@@ -76,7 +76,11 @@ export class CordovaDriver extends AbstractSqliteDriver {
 
         const connection = await new Promise<any>((resolve, fail) => {
             //fix moianra - Added fail callback in order to throw an exception if the database cannot be opened.
-            this.sqlite.openDatabase(options, (db: any) => resolve(db), (err: any) => fail(err))
+            this.sqlite.openDatabase(
+                options,
+                (db: any) => resolve(db),
+                (err: any) => fail(err),
+            )
         })
 
         await new Promise<void>((ok, fail) => {


### PR DESCRIPTION
I have added the fail callback while opening the database. Doing so, If there is an issue with the database, the error is thrown and the logic can be treated.


- [x] Code is up-to-date with the `master` branch
- [x] `npm run format` to apply prettier formatting
- [ ] `npm run test` passes with this change
- [ ] This pull request links relevant issues as `Fixes #0000`
- [ ] There are new or updated unit tests validating the change
- [ ] Documentation has been updated to reflect this change
- [ ] The new commits follow conventions explained in [CONTRIBUTING.md](https://github.com/typeorm/typeorm/blob/master/CONTRIBUTING.md)
