### PR TITLE
docs: update Soft-Delete, Restore-Soft-Delete examples

### DIFF
--- a/docs/delete-query-builder.md
+++ b/docs/delete-query-builder.md
@@ -33,7 +33,8 @@ Examples:
 
 ```typescript
 await myDataSource
-  .createQueryBuilder('users')
+  .getRepository(User)
+  .createQueryBuilder()
   .softDelete()
   .where("id = :id", { id: 1 })
   .execute();
@@ -51,7 +52,8 @@ Examples:
 
 ```typescript
 await myDataSource
-  .createQueryBuilder('users')
+  .getRepository(User)
+  .createQueryBuilder()
   .restore()
   .where("id = :id", { id: 1 })
   .execute();


### PR DESCRIPTION
### Description of change

The getRepository method is missing from the example. 

Delete the "users" written in the createQueryBuilder method because it is not used in the where method.


### Pull-Request Checklist

- [x] Code is up-to-date with the `master` branch
- [ ] `npm run format` to apply prettier formatting
- [ ] `npm run test` passes with this change
- [ ] This pull request links relevant issues as `Fixes #0000`
- [ ] There are new or updated unit tests validating the change
- [x] Documentation has been updated to reflect this change
- [x] The new commits follow conventions explained in [CONTRIBUTING.md](https://github.com/typeorm/typeorm/blob/master/CONTRIBUTING.md)

