### PR TITLE
Fix issue 10176 mssql datasource testonborrow not working

### DIFF
--- a/docs/data-source-options.md
+++ b/docs/data-source-options.md
@@ -239,6 +239,7 @@ Different RDBMS-es have their own specific options.
 -   `database` - Database name
 
 ## `mssql` data source options
+Based on [tedious](https://tediousjs.github.io/node-mssql/) MSSQL implementation. See [SqlServerConnectionOptions.ts](..\src\driver\sqlserver\SqlServerConnectionOptions.ts) for details on exposed attributes.
 
 -   `url` - Connection url where perform connection to. Please note that other data source options will override parameters set from url.
 

--- a/docs/data-source-options.md
+++ b/docs/data-source-options.md
@@ -272,9 +272,6 @@ Different RDBMS-es have their own specific options.
 -   `pool.maxWaitingClients` - maximum number of queued requests allowed, additional acquire calls will be callback with
     an err in a future cycle of the event loop.
 
--   `pool.testOnBorrow` - should the pool validate resources before giving them to clients. Requires that either
-    `factory.validate` or `factory.validateAsync` to be specified.
-
 -   `pool.acquireTimeoutMillis` - max milliseconds an `acquire` call will wait for a resource before timing out.
     (default no limit), if supplied should non-zero positive integer.
 

--- a/src/driver/sqlserver/SqlServerConnectionOptions.ts
+++ b/src/driver/sqlserver/SqlServerConnectionOptions.ts
@@ -63,12 +63,6 @@ export interface SqlServerConnectionOptions
         readonly maxWaitingClients?: number
 
         /**
-         * Should the pool validate resources before giving them to clients. Requires that either factory.validate or
-         * factory.validateAsync to be specified
-         */
-        readonly testOnBorrow?: boolean
-
-        /**
          * Max milliseconds an acquire call will wait for a resource before timing out. (default no limit), if supplied should non-zero positive integer.
          */
         readonly acquireTimeoutMillis?: number


### PR DESCRIPTION
### fix:  #10176  Remove invalid data-source-options 'pool.testonborrow' option 

[data-source-options.md](https://github.com/typeorm/typeorm/blob/master/docs/data-source-options.md) defines connection settings for a variety of data sources, among which is MSSQL.

Specifically the Data Source Option 'pool.testOnBorrow' indicates that factory.validate or factory.validateAsync is required if this field is used.

The Option pool.testOnBorrow appears to be ignored if populated. The documentation states that factory.validate or factory.validateAsync is required.

The options factory.validate or factory.validateAsync are not defined anywhere in [data-source-options.md](https://github.com/typeorm/typeorm/blob/master/docs/data-source-options.md) or imported in code.

Through research, testing, and discussion on discord, it appears this option is deprecated as testing is automatically done with the latest [implementation that typeorm uses](https://github.com/tediousjs/node-mssql/blob/7248e58ff223b2369cb1570005d54e9196c904bf/lib/base/connection-pool.js) and no longer requires pool.testOnBorrow. 


### Pull-Request Checklist

- [x] Code is up-to-date with the `master` branch
- [x] `npm run format` to apply prettier formatting
- [ ] `npm run test` passes with this change
- [x] This pull request links relevant issues as `Fixes #0000`
- [N/A] There are new or updated unit tests validating the change
- [x] Documentation has been updated to reflect this change
- [See Note] The new commits follow conventions explained in [CONTRIBUTING.md](https://github.com/typeorm/typeorm/blob/master/CONTRIBUTING.md)

NOTES:
- No existing unit tests were affected
- Apologies in advance -- The commit structures don't follow the conventions. This was noticed only after all the commits were made.