### PR TITLE
fix: throw error if where is called multiple times

### DIFF
--- a/src/query-builder/DeleteQueryBuilder.ts
+++ b/src/query-builder/DeleteQueryBuilder.ts
@@ -8,6 +8,7 @@ import { Brackets } from "./Brackets"
 import { DeleteResult } from "./result/DeleteResult"
 import { ReturningStatementNotSupportedError } from "../error/ReturningStatementNotSupportedError"
 import { InstanceChecker } from "../util/InstanceChecker"
+import { TypeORMError } from "../error"
 
 /**
  * Allows to build complex sql queries in a fashion way and execute those queries.
@@ -143,6 +144,10 @@ export class DeleteQueryBuilder<Entity extends ObjectLiteral>
             | ObjectLiteral[],
         parameters?: ObjectLiteral,
     ): this {
+        if (this.expressionMap.wheres.length > 0)
+            throw new TypeORMError(
+                `.where method cannot be called two times or more.`,
+            )
         this.expressionMap.wheres = [] // don't move this block below since computeWhereParameter can add where expressions
         const condition = this.getWhereCondition(where)
         if (condition)

--- a/src/query-builder/SelectQueryBuilder.ts
+++ b/src/query-builder/SelectQueryBuilder.ts
@@ -1154,6 +1154,10 @@ export class SelectQueryBuilder<Entity extends ObjectLiteral>
             | ObjectLiteral[],
         parameters?: ObjectLiteral,
     ): this {
+        if (this.expressionMap.wheres.length > 0)
+            throw new TypeORMError(
+                `.where method cannot be called two times or more.`,
+            )
         this.expressionMap.wheres = [] // don't move this block below since computeWhereParameter can add where expressions
         const condition = this.getWhereCondition(where)
         if (condition) {

--- a/src/query-builder/SoftDeleteQueryBuilder.ts
+++ b/src/query-builder/SoftDeleteQueryBuilder.ts
@@ -191,6 +191,10 @@ export class SoftDeleteQueryBuilder<Entity extends ObjectLiteral>
             | ObjectLiteral[],
         parameters?: ObjectLiteral,
     ): this {
+        if (this.expressionMap.wheres.length > 0)
+            throw new TypeORMError(
+                `.where method cannot be called two times or more, or after .whereEntity method.`,
+            )
         this.expressionMap.wheres = [] // don't move this block below since computeWhereParameter can add where expressions
         const condition = this.getWhereCondition(where)
         if (condition)
@@ -405,6 +409,10 @@ export class SoftDeleteQueryBuilder<Entity extends ObjectLiteral>
         if (!this.expressionMap.mainAlias!.hasMetadata)
             throw new TypeORMError(
                 `.whereEntity method can only be used on queries which update real entity table.`,
+            )
+        if (this.expressionMap.wheres.length > 0)
+            throw new TypeORMError(
+                `.whereEntity method cannot be called two times or more, or after .where method.`,
             )
 
         this.expressionMap.wheres = []

--- a/src/query-builder/UpdateQueryBuilder.ts
+++ b/src/query-builder/UpdateQueryBuilder.ts
@@ -220,6 +220,10 @@ export class UpdateQueryBuilder<Entity extends ObjectLiteral>
             | ObjectLiteral[],
         parameters?: ObjectLiteral,
     ): this {
+        if (this.expressionMap.wheres.length > 0)
+            throw new TypeORMError(
+                `.where method cannot be called two times or more, or after .whereEntity method.`,
+            )
         this.expressionMap.wheres = [] // don't move this block below since computeWhereParameter can add where expressions
         const condition = this.getWhereCondition(where)
         if (condition)
@@ -436,6 +440,10 @@ export class UpdateQueryBuilder<Entity extends ObjectLiteral>
         if (!this.expressionMap.mainAlias!.hasMetadata)
             throw new TypeORMError(
                 `.whereEntity method can only be used on queries which update real entity table.`,
+            )
+        if (this.expressionMap.wheres.length > 0)
+            throw new TypeORMError(
+                `.whereEntity method cannot be called two times or more, or after .where method.`,
             )
 
         this.expressionMap.wheres = []

--- a/test/github-issues/10596/entity/user.ts
+++ b/test/github-issues/10596/entity/user.ts
@@ -1,0 +1,10 @@
+import { Column, Entity, PrimaryGeneratedColumn } from "../../../../src"
+
+@Entity()
+export class User {
+    @PrimaryGeneratedColumn()
+    id: number
+
+    @Column()
+    name: string
+}

--- a/test/github-issues/10596/issue-10596.ts
+++ b/test/github-issues/10596/issue-10596.ts
@@ -1,0 +1,364 @@
+import "reflect-metadata"
+import {
+    createTestingConnections,
+    closeTestingConnections,
+    reloadTestingDatabases,
+} from "../../utils/test-utils"
+import { DataSource } from "../../../src/index.js"
+import { User } from "./entity/user"
+import { expect } from "chai"
+
+describe.only("github issues > #10596 QueryBuilder allowing multiple where calls is dangerous", () => {
+    let dataSources: DataSource[]
+
+    before(
+        async () =>
+            (dataSources = await createTestingConnections({
+                entities: [__dirname + "/entity/*{.js,.ts}"],
+                schemaCreate: true,
+                dropSchema: true,
+            })),
+    )
+    beforeEach(() => reloadTestingDatabases(dataSources))
+    after(() => closeTestingConnections(dataSources))
+
+    it("has to throw an exception if .where is called two times in a select", () =>
+        Promise.all(
+            dataSources.map(async (dataSource) => {
+                await dataSource
+                    .getRepository(User)
+                    .save([
+                        { name: "Al" },
+                        { name: "John" },
+                        { name: "johnny" },
+                        { name: "Jack" },
+                    ])
+                expect(() => {
+                    dataSource.manager
+                        .createQueryBuilder(User, "user")
+                        .where("user.id > :id", { id: 1 })
+                        .where("user.name = :name", { name: "Jack" })
+                }).to.throw(".where method cannot be called two times or more.")
+            }),
+        ))
+
+    it("has to throw an exception if .where is called two times in a update", () =>
+        Promise.all(
+            dataSources.map(async (dataSource) => {
+                await dataSource
+                    .getRepository(User)
+                    .save([
+                        { name: "Al" },
+                        { name: "John" },
+                        { name: "johnny" },
+                        { name: "Jack" },
+                    ])
+                expect(() => {
+                    dataSource.manager
+                        .createQueryBuilder(User, "user")
+                        .update()
+                        .where("user.id > :id", { id: 1 })
+                        .where("user.name = :name", { name: "Jack" })
+                }).to.throw(
+                    ".where method cannot be called two times or more, or after .whereEntity method.",
+                )
+            }),
+        ))
+
+    it("has to throw an exception if .where is called two times in a delete", () =>
+        Promise.all(
+            dataSources.map(async (dataSource) => {
+                await dataSource
+                    .getRepository(User)
+                    .save([
+                        { name: "Al" },
+                        { name: "John" },
+                        { name: "johnny" },
+                        { name: "Jack" },
+                    ])
+                expect(() => {
+                    dataSource.manager
+                        .createQueryBuilder(User, "user")
+                        .delete()
+                        .where("user.id > :id", { id: 1 })
+                        .where("user.name = :name", { name: "Jack" })
+                }).to.throw(".where method cannot be called two times or more.")
+            }),
+        ))
+
+    it("has to throw an exception if .where is called two times in a softDelete", () =>
+        Promise.all(
+            dataSources.map(async (dataSource) => {
+                await dataSource
+                    .getRepository(User)
+                    .save([
+                        { name: "Al" },
+                        { name: "John" },
+                        { name: "johnny" },
+                        { name: "Jack" },
+                    ])
+                expect(() => {
+                    dataSource.manager
+                        .createQueryBuilder(User, "user")
+                        .softDelete()
+                        .where("user.id > :id", { id: 1 })
+                        .where("user.name = :name", { name: "Jack" })
+                }).to.throw(
+                    ".where method cannot be called two times or more, or after .whereEntity method.",
+                )
+            }),
+        ))
+
+    it("has to throw an exception if .where is called after .whereEntity in a softDelete", () =>
+        Promise.all(
+            dataSources.map(async (dataSource) => {
+                await dataSource
+                    .getRepository(User)
+                    .save([
+                        { name: "Al" },
+                        { name: "John" },
+                        { name: "johnny" },
+                        { name: "Jack" },
+                    ])
+
+                const userToDelete = new User()
+                userToDelete.id = 4
+                userToDelete.name = "Jack"
+                expect(() => {
+                    dataSource.manager
+                        .createQueryBuilder(User, "user")
+                        .softDelete()
+                        .whereEntity(userToDelete)
+                        .where("user.id > :id", { id: 1 })
+                }).to.throw(
+                    ".where method cannot be called two times or more, or after .whereEntity method.",
+                )
+            }),
+        ))
+
+    it("has to throw an exception if .whereEntity is called after .where in a softDelete", () =>
+        Promise.all(
+            dataSources.map(async (dataSource) => {
+                await dataSource
+                    .getRepository(User)
+                    .save([
+                        { name: "Al" },
+                        { name: "John" },
+                        { name: "johnny" },
+                        { name: "Jack" },
+                    ])
+
+                const userToDelete = new User()
+                userToDelete.id = 4
+                userToDelete.name = "Jack"
+                expect(() => {
+                    dataSource.manager
+                        .createQueryBuilder(User, "user")
+                        .softDelete()
+                        .where("user.id > :id", { id: 1 })
+                        .whereEntity(userToDelete)
+                }).to.throw(
+                    ".whereEntity method cannot be called two times or more, or after .where method.",
+                )
+            }),
+        ))
+
+    it("has to throw an exception if .where is called after .whereEntity in a update", () =>
+        Promise.all(
+            dataSources.map(async (dataSource) => {
+                await dataSource
+                    .getRepository(User)
+                    .save([
+                        { name: "Al" },
+                        { name: "John" },
+                        { name: "johnny" },
+                        { name: "Jack" },
+                    ])
+
+                const userToUpdate = new User()
+                userToUpdate.id = 4
+                userToUpdate.name = "Jack"
+                expect(() => {
+                    dataSource.manager
+                        .createQueryBuilder(User, "user")
+                        .update()
+                        .whereEntity(userToUpdate)
+                        .where("user.id > :id", { id: 1 })
+                }).to.throw(
+                    ".where method cannot be called two times or more, or after .whereEntity method.",
+                )
+            }),
+        ))
+
+    it("has to throw an exception if .whereEntity is called after .where in a update", () =>
+        Promise.all(
+            dataSources.map(async (dataSource) => {
+                await dataSource
+                    .getRepository(User)
+                    .save([
+                        { name: "Al" },
+                        { name: "John" },
+                        { name: "johnny" },
+                        { name: "Jack" },
+                    ])
+
+                const userToUpdate = new User()
+                userToUpdate.id = 4
+                userToUpdate.name = "Jack"
+                expect(() => {
+                    dataSource.manager
+                        .createQueryBuilder(User, "user")
+                        .update()
+                        .where("user.id > :id", { id: 1 })
+                        .whereEntity(userToUpdate)
+                }).to.throw(
+                    ".whereEntity method cannot be called two times or more, or after .where method.",
+                )
+            }),
+        ))
+
+    it("hasn't to throw an exception if .whereEntity is called once in a update", () =>
+        Promise.all(
+            dataSources.map(async (dataSource) => {
+                await dataSource
+                    .getRepository(User)
+                    .save([
+                        { name: "Al" },
+                        { name: "John" },
+                        { name: "johnny" },
+                        { name: "Jack" },
+                    ])
+
+                const userToUpdate = new User()
+                userToUpdate.id = 4
+                userToUpdate.name = "Jack"
+                expect(() => {
+                    dataSource.manager
+                        .createQueryBuilder(User, "user")
+                        .update()
+                        .whereEntity(userToUpdate)
+                }).not.to.throw(
+                    ".whereEntity method cannot be called two times or more, or after .where method.",
+                )
+            }),
+        ))
+
+    it("hasn't to throw an exception if .whereEntity is called once in a softDelete", () =>
+        Promise.all(
+            dataSources.map(async (dataSource) => {
+                await dataSource
+                    .getRepository(User)
+                    .save([
+                        { name: "Al" },
+                        { name: "John" },
+                        { name: "johnny" },
+                        { name: "Jack" },
+                    ])
+
+                const userToDelete = new User()
+                userToDelete.id = 4
+                userToDelete.name = "Jack"
+                expect(() => {
+                    dataSource.manager
+                        .createQueryBuilder(User, "user")
+                        .softDelete()
+                        .whereEntity(userToDelete)
+                }).not.to.throw(
+                    ".whereEntity method cannot be called two times or more, or after .where method.",
+                )
+            }),
+        ))
+
+    it("hasn't to throw an exception if .where is called once in a select", () =>
+        Promise.all(
+            dataSources.map(async (dataSource) => {
+                await dataSource
+                    .getRepository(User)
+                    .save([
+                        { name: "Al" },
+                        { name: "John" },
+                        { name: "johnny" },
+                        { name: "Jack" },
+                    ])
+
+                const users = await dataSource.manager
+                    .createQueryBuilder(User, "user")
+                    .where("user.id > :id", { id: 1 })
+                    .getMany()
+                expect(users).to.have.length(3)
+            }),
+        ))
+
+    it("hasn't to throw an exception if .where is called once in an update", () =>
+        Promise.all(
+            dataSources.map(async (dataSource) => {
+                await dataSource
+                    .getRepository(User)
+                    .save([
+                        { name: "Al" },
+                        { name: "John" },
+                        { name: "johnny" },
+                        { name: "Jack" },
+                    ])
+
+                expect(async () => {
+                    await dataSource.manager
+                        .createQueryBuilder(User, "user")
+                        .update()
+                        .where("user.id = :id", { id: 1 })
+                        .set({ name: "update" })
+                        .execute()
+                }).not.to.throw(
+                    ".where method cannot be called two times or more.",
+                )
+            }),
+        ))
+
+    it("hasn't to throw an exception if .where is called once in a delete", () =>
+        Promise.all(
+            dataSources.map(async (dataSource) => {
+                await dataSource
+                    .getRepository(User)
+                    .save([
+                        { name: "Al" },
+                        { name: "John" },
+                        { name: "johnny" },
+                        { name: "Jack" },
+                    ])
+
+                expect(async () => {
+                    await dataSource.manager
+                        .createQueryBuilder(User, "user")
+                        .delete()
+                        .where("user.id = :id", { id: 1 })
+                        .execute()
+                }).not.to.throw(
+                    ".where method cannot be called two times or more.",
+                )
+            }),
+        ))
+
+    it("hasn't to throw an exception if .where is called once in a softDelete", () =>
+        Promise.all(
+            dataSources.map(async (dataSource) => {
+                await dataSource
+                    .getRepository(User)
+                    .save([
+                        { name: "Al" },
+                        { name: "John" },
+                        { name: "johnny" },
+                        { name: "Jack" },
+                    ])
+
+                expect(async () => {
+                    await dataSource.manager
+                        .createQueryBuilder(User, "user")
+                        .softDelete()
+                        .where("user.id = :id", { id: 1 })
+                        .execute()
+                }).not.to.throw(
+                    ".where method cannot be called two times or more.",
+                )
+            }),
+        ))
+})


### PR DESCRIPTION
Closes: #10596

<!--
  😀 Wonderful!  Thank you for opening a pull request for TypeORM.

  Please fill in the information below to expedite the review
  and (hopefully) merge of your change.

  If unsure about something.. just do as best as you're able,
  or reach out through our community support channels!
  https://github.com/typeorm/typeorm/blob/master/docs/support.md
-->

### Description of change
Throw an error if .where or .whereEntity is called multiple times (it discards all previous .where/.whereEntity)
<!--
  Please be clear and concise what the change is intended to do,
  why this change is needed, and how you've verified that it
  corrects what you intended.

  In some cases it may be helpful to include the current behavior
  and the new behavior.

  If the change is related to an open issue, you can link it here.
  If you include `Fixes #0000` (replacing `0000` with the issue number)
  when this is merged it will automatically mark the issue as fixed and
  close it.
-->


### Pull-Request Checklist

<!--
  Please make sure to review and check all of the following.

  If an item is not applicable, you can add "N/A" to the end.
-->

- [ ] Code is up-to-date with the `master` branch
- [ ] `npm run format` to apply prettier formatting
- [ ] `npm run test` passes with this change
- [ ] This pull request links relevant issues as `Fixes #0000`
- [ ] There are new or updated unit tests validating the change
- [ ] Documentation has been updated to reflect this change
- [ ] The new commits follow conventions explained in [CONTRIBUTING.md](https://github.com/typeorm/typeorm/blob/master/CONTRIBUTING.md)

<!--
  🎉 Thank you for contributing and making TypeORM even better!
-->
