### PR TITLE
feat: implement autoIncrementStartFrom parameter

### DIFF
--- a/src/decorator/entity/Entity.ts
+++ b/src/decorator/entity/Entity.ts
@@ -42,6 +42,9 @@ export function Entity(
             synchronize: options.synchronize,
             withoutRowid: options.withoutRowid,
             comment: options.comment ? options.comment : undefined,
+            autoIncrementStartFrom: options.autoIncrementStartFrom
+                ? options.autoIncrementStartFrom
+                : undefined,
         } as TableMetadataArgs)
     }
 }

--- a/src/decorator/options/EntityOptions.ts
+++ b/src/decorator/options/EntityOptions.ts
@@ -51,4 +51,9 @@ export interface EntityOptions {
      * Table comment. Not supported by all database types.
      */
     comment?: string
+
+    /**
+     * Set initial value for auto increment. Supported by MySQL family DBs.
+     */
+    autoIncrementStartFrom?: number
 }

--- a/src/driver/aurora-mysql/AuroraMysqlQueryRunner.ts
+++ b/src/driver/aurora-mysql/AuroraMysqlQueryRunner.ts
@@ -2834,4 +2834,16 @@ export class AuroraMysqlQueryRunner
             `aurora-mysql driver does not support change table comment.`,
         )
     }
+
+    /**
+     * Change table auto increment initial value.
+     */
+    changeTableAutoIncrementStartFrom(
+        tableOrName: Table | string,
+        autoIncrementStartFrom?: number,
+    ): Promise<void> {
+        throw new TypeORMError(
+            `aurora-mysql driver does not support change auto increment initial value.`,
+        )
+    }
 }

--- a/src/driver/aurora-postgres/AuroraPostgresQueryRunner.ts
+++ b/src/driver/aurora-postgres/AuroraPostgresQueryRunner.ts
@@ -208,4 +208,16 @@ export class AuroraPostgresQueryRunner
             `aurora-postgres driver does not support change comment.`,
         )
     }
+
+    /**
+     * Change table auto increment initial value.
+     */
+    changeTableAutoIncrementStartFrom(
+        tableOrName: Table | string,
+        autoIncrementStartFrom?: number,
+    ): Promise<void> {
+        throw new TypeORMError(
+            `aurora-postgres driver does not support change auto increment initial value.`,
+        )
+    }
 }

--- a/src/driver/cockroachdb/CockroachQueryRunner.ts
+++ b/src/driver/cockroachdb/CockroachQueryRunner.ts
@@ -4222,4 +4222,16 @@ export class CockroachQueryRunner
             `cockroachdb driver does not support change table comment.`,
         )
     }
+
+    /**
+     * Change table auto increment initial value.
+     */
+    changeTableAutoIncrementStartFrom(
+        tableOrName: Table | string,
+        autoIncrementStartFrom?: number,
+    ): Promise<void> {
+        throw new TypeORMError(
+            `cockroachdb driver does not support change auto increment initial value.`,
+        )
+    }
 }

--- a/src/driver/mongodb/MongoQueryRunner.ts
+++ b/src/driver/mongodb/MongoQueryRunner.ts
@@ -1275,4 +1275,16 @@ export class MongoQueryRunner implements QueryRunner {
             `mongodb driver does not support change table comment.`,
         )
     }
+
+    /**
+     * Change table auto increment initial value.
+     */
+    changeTableAutoIncrementStartFrom(
+        tableOrName: Table | string,
+        autoIncrementStartFrom?: number,
+    ): Promise<void> {
+        throw new TypeORMError(
+            `mongodb driver does not support change auto increment initial value.`,
+        )
+    }
 }

--- a/src/driver/oracle/OracleQueryRunner.ts
+++ b/src/driver/oracle/OracleQueryRunner.ts
@@ -3193,4 +3193,16 @@ export class OracleQueryRunner extends BaseQueryRunner implements QueryRunner {
             `oracle driver does not support change table comment.`,
         )
     }
+
+    /**
+     * Change table auto increment initial value.
+     */
+    changeTableAutoIncrementStartFrom(
+        tableOrName: Table | string,
+        autoIncrementStartFrom?: number,
+    ): Promise<void> {
+        throw new TypeORMError(
+            `oracle driver does not support change auto increment initial value.`,
+        )
+    }
 }

--- a/src/driver/postgres/PostgresQueryRunner.ts
+++ b/src/driver/postgres/PostgresQueryRunner.ts
@@ -4729,4 +4729,16 @@ export class PostgresQueryRunner
             `postgres driver does not support change table comment.`,
         )
     }
+
+    /**
+     * Change table auto increment initial value.
+     */
+    changeTableAutoIncrementStartFrom(
+        tableOrName: Table | string,
+        autoIncrementStartFrom?: number,
+    ): Promise<void> {
+        throw new TypeORMError(
+            `postgres driver does not support change auto increment initial value.`,
+        )
+    }
 }

--- a/src/driver/sap/SapQueryRunner.ts
+++ b/src/driver/sap/SapQueryRunner.ts
@@ -3366,4 +3366,16 @@ export class SapQueryRunner extends BaseQueryRunner implements QueryRunner {
             `spa driver does not support change table comment.`,
         )
     }
+
+    /**
+     * Change table auto increment initial value.
+     */
+    changeTableAutoIncrementStartFrom(
+        tableOrName: Table | string,
+        autoIncrementStartFrom?: number,
+    ): Promise<void> {
+        throw new TypeORMError(
+            `spa driver does not support change auto increment initial value.`,
+        )
+    }
 }

--- a/src/driver/spanner/SpannerQueryRunner.ts
+++ b/src/driver/spanner/SpannerQueryRunner.ts
@@ -2239,4 +2239,16 @@ export class SpannerQueryRunner extends BaseQueryRunner implements QueryRunner {
             `spanner driver does not support change table comment.`,
         )
     }
+
+    /**
+     * Change table auto increment initial value.
+     */
+    changeTableAutoIncrementStartFrom(
+        tableOrName: Table | string,
+        autoIncrementStartFrom?: number,
+    ): Promise<void> {
+        throw new TypeORMError(
+            `spanner driver does not support change auto increment initial value.`,
+        )
+    }
 }

--- a/src/driver/sqlite-abstract/AbstractSqliteQueryRunner.ts
+++ b/src/driver/sqlite-abstract/AbstractSqliteQueryRunner.ts
@@ -2252,4 +2252,16 @@ export abstract class AbstractSqliteQueryRunner
     ): Promise<void> {
         throw new TypeORMError(`sqlit driver does not support change comment.`)
     }
+
+    /**
+     * Change table auto increment initial value.
+     */
+    changeTableAutoIncrementStartFrom(
+        tableOrName: Table | string,
+        autoIncrementStartFrom?: number,
+    ): Promise<void> {
+        throw new TypeORMError(
+            `sqlite driver does not support change auto increment initial value.`,
+        )
+    }
 }

--- a/src/driver/sqlite/SqliteQueryRunner.ts
+++ b/src/driver/sqlite/SqliteQueryRunner.ts
@@ -88,7 +88,7 @@ export class SqliteQueryRunner extends AbstractSqliteQueryRunner {
                     }
                 }
 
-                const self = this;
+                const self = this
                 const handler = function (this: any, err: any, rows: any) {
                     if (err && err.toString().indexOf("SQLITE_BUSY:") !== -1) {
                         if (

--- a/src/driver/sqlserver/SqlServerQueryRunner.ts
+++ b/src/driver/sqlserver/SqlServerQueryRunner.ts
@@ -4173,4 +4173,16 @@ export class SqlServerQueryRunner
             `sqlserver driver does not support change table comment.`,
         )
     }
+
+    /**
+     * Change table auto increment initial value.
+     */
+    changeTableAutoIncrementStartFrom(
+        tableOrName: Table | string,
+        autoIncrementStartFrom?: number,
+    ): Promise<void> {
+        throw new TypeORMError(
+            `sqlserver driver does not support change auto increment initial value.`,
+        )
+    }
 }

--- a/src/metadata-args/TableMetadataArgs.ts
+++ b/src/metadata-args/TableMetadataArgs.ts
@@ -75,4 +75,9 @@ export interface TableMetadataArgs {
      * Table comment. Not supported by all database types.
      */
     comment?: string
+
+    /**
+     * Set initial value for auto increment. Supported by MySQL family DBs.
+     */
+    autoIncrementStartFrom?: number
 }

--- a/src/metadata/EntityMetadata.ts
+++ b/src/metadata/EntityMetadata.ts
@@ -521,6 +521,11 @@ export class EntityMetadata {
      */
     comment?: string
 
+    /**
+     * Set initial value for auto increment. Supported by MySQL family DBs.
+     */
+    autoIncrementStartFrom?: number
+
     // ---------------------------------------------------------------------
     // Constructor
     // ---------------------------------------------------------------------
@@ -1072,6 +1077,8 @@ export class EntityMetadata {
             this.tableMetadataArgs.type === "closure-junction"
 
         this.comment = this.tableMetadataArgs.comment
+        this.autoIncrementStartFrom =
+            this.tableMetadataArgs.autoIncrementStartFrom
     }
 
     /**

--- a/src/query-runner/BaseQueryRunner.ts
+++ b/src/query-runner/BaseQueryRunner.ts
@@ -321,6 +321,8 @@ export abstract class BaseQueryRunner {
             foundTable.justCreated = changedTable.justCreated
             foundTable.engine = changedTable.engine
             foundTable.comment = changedTable.comment
+            foundTable.autoIncrementStartFrom =
+                changedTable.autoIncrementStartFrom
         }
     }
 

--- a/src/query-runner/QueryRunner.ts
+++ b/src/query-runner/QueryRunner.ts
@@ -280,6 +280,14 @@ export interface QueryRunner {
     ): Promise<void>
 
     /**
+     * Change table auto increment initial value. Only supports MySQL and MariaDB
+     */
+    changeTableAutoIncrementStartFrom(
+        tableOrName: Table | string,
+        autoIncrementStartFrom?: number,
+    ): Promise<void>
+
+    /**
      * Adds a new column.
      */
     addColumn(table: Table | string, column: TableColumn): Promise<void>

--- a/src/schema-builder/RdbmsSchemaBuilder.ts
+++ b/src/schema-builder/RdbmsSchemaBuilder.ts
@@ -222,6 +222,7 @@ export class RdbmsSchemaBuilder implements SchemaBuilder {
         // await this.renameTables();
         await this.renameColumns()
         await this.changeTableComment()
+        await this.changeTableAutoIncrementStartFrom()
         await this.createNewTables()
         await this.dropRemovedColumns()
         await this.addNewColumns()
@@ -605,6 +606,28 @@ export class RdbmsSchemaBuilder implements SchemaBuilder {
             if (DriverUtils.isMySQLFamily(this.connection.driver)) {
                 const newComment = metadata.comment
                 await this.queryRunner.changeTableComment(table, newComment)
+            }
+        }
+    }
+
+    /**
+     * Change table auto increment initial value
+     */
+    protected async changeTableAutoIncrementStartFrom(): Promise<void> {
+        for (const metadata of this.entityToSyncMetadatas) {
+            const table = this.queryRunner.loadedTables.find(
+                (table) =>
+                    this.getTablePath(table) === this.getTablePath(metadata),
+            )
+            if (!table) continue
+
+            if (DriverUtils.isMySQLFamily(this.connection.driver)) {
+                const newAutoIncrementStartFrom =
+                    metadata.autoIncrementStartFrom
+                await this.queryRunner.changeTableAutoIncrementStartFrom(
+                    table,
+                    newAutoIncrementStartFrom,
+                )
             }
         }
     }

--- a/src/schema-builder/options/TableOptions.ts
+++ b/src/schema-builder/options/TableOptions.ts
@@ -79,4 +79,9 @@ export interface TableOptions {
      * Table comment. Not supported by all database types.
      */
     comment?: string
+
+    /**
+     * Set initial value for auto increment. Supported by MySQL family DBs.
+     */
+    autoIncrementStartFrom?: number
 }

--- a/src/schema-builder/table/Table.ts
+++ b/src/schema-builder/table/Table.ts
@@ -88,6 +88,11 @@ export class Table {
      */
     comment?: string
 
+    /**
+     * Set initial value for auto increment. Supported by MySQL family DBs.
+     */
+    autoIncrementStartFrom?: number
+
     // -------------------------------------------------------------------------
     // Constructor
     // -------------------------------------------------------------------------
@@ -144,6 +149,8 @@ export class Table {
             this.engine = options.engine
 
             this.comment = options.comment
+
+            this.autoIncrementStartFrom = options.autoIncrementStartFrom
         }
     }
 
@@ -179,6 +186,7 @@ export class Table {
             withoutRowid: this.withoutRowid,
             engine: this.engine,
             comment: this.comment,
+            autoIncrementStartFrom: this.autoIncrementStartFrom,
         })
     }
 
@@ -420,6 +428,7 @@ export class Table {
                 TableExclusion.create(exclusion),
             ),
             comment: entityMetadata.comment,
+            autoIncrementStartFrom: entityMetadata.autoIncrementStartFrom,
         }
 
         return new Table(options)

--- a/test/github-issues/10616/entity/exampleEntity.ts
+++ b/test/github-issues/10616/entity/exampleEntity.ts
@@ -1,0 +1,8 @@
+import { Entity } from "../../../../src/decorator/entity/Entity"
+import { PrimaryGeneratedColumn } from "../../../../src/decorator/columns/PrimaryGeneratedColumn"
+
+@Entity({ autoIncrementStartFrom: 50 })
+export class ExampleEntity {
+    @PrimaryGeneratedColumn()
+    id: number
+}

--- a/test/github-issues/10616/issue-10616.ts
+++ b/test/github-issues/10616/issue-10616.ts
@@ -1,0 +1,56 @@
+import { DataSource } from "../../../src"
+import {
+    closeTestingConnections,
+    createTestingConnections,
+    reloadTestingDatabases,
+} from "../../utils/test-utils"
+import { expect } from "chai"
+import { ExampleEntity } from "./entity/exampleEntity"
+
+describe("github issues > #10616 How to set AUTO_INCREMENT=10000", () => {
+    let dataSources: DataSource[]
+
+    before(async () => {
+        dataSources = await createTestingConnections({
+            entities: [ExampleEntity],
+            enabledDrivers: ["mysql", "mariadb"],
+            schemaCreate: true,
+            dropSchema: true,
+        })
+    })
+
+    beforeEach(() => reloadTestingDatabases(dataSources))
+    after(() => closeTestingConnections(dataSources))
+
+    it("has the first inserted value with id 50", async () => {
+        await Promise.all(
+            dataSources.map(async (dataSource) => {
+                const inserted = await dataSource
+                    .getRepository(ExampleEntity)
+                    .save({})
+                expect(inserted.id).to.be.eql(50)
+            }),
+        )
+    })
+
+    it("has the first inserted value with id 120 if change autoIncrementStartFrom to 10000", async () => {
+        await Promise.all(
+            dataSources.map(async (dataSource) => {
+                const queryRunner = dataSource.createQueryRunner()
+
+                const exampleMetadata = dataSource.getMetadata(ExampleEntity)
+                exampleMetadata.autoIncrementStartFrom = 10000
+
+                await dataSource.synchronize()
+
+                const inserted = await dataSource
+                    .getRepository(ExampleEntity)
+                    .save({})
+                console.log(inserted.id)
+                expect(inserted.id).to.be.eql(10000)
+
+                await queryRunner.release()
+            }),
+        )
+    })
+})


### PR DESCRIPTION
This new feature implements autoIncrementStartFrom parameter in EntityOptions that sets inital value for AUTO_INCREMENT, only for MySQL family DBs

Closes: #10616

<!--
  😀 Wonderful!  Thank you for opening a pull request for TypeORM.

  Please fill in the information below to expedite the review
  and (hopefully) merge of your change.

  If unsure about something.. just do as best as you're able,
  or reach out through our community support channels!
  https://github.com/typeorm/typeorm/blob/master/docs/support.md
-->

### Description of change

<!--
  Please be clear and concise what the change is intended to do,
  why this change is needed, and how you've verified that it
  corrects what you intended.

  In some cases it may be helpful to include the current behavior
  and the new behavior.

  If the change is related to an open issue, you can link it here.
  If you include `Fixes #0000` (replacing `0000` with the issue number)
  when this is merged it will automatically mark the issue as fixed and
  close it.
-->


### Pull-Request Checklist

<!--
  Please make sure to review and check all of the following.

  If an item is not applicable, you can add "N/A" to the end.
-->

- [x] Code is up-to-date with the `master` branch
- [x] `npm run format` to apply prettier formatting
- [ ] `npm run test` passes with this change
- [x] This pull request links relevant issues as `Fixes #0000`
- [x] There are new or updated unit tests validating the change
- [ ] Documentation has been updated to reflect this change
- [x] The new commits follow conventions explained in [CONTRIBUTING.md](https://github.com/typeorm/typeorm/blob/master/CONTRIBUTING.md)

<!--
  🎉 Thank you for contributing and making TypeORM even better!
-->
