### PR TITLE
fix: Hangup when load relations with relationLoadStrategy: query

### DIFF
--- a/src/query-builder/QueryBuilder.ts
+++ b/src/query-builder/QueryBuilder.ts
@@ -521,8 +521,8 @@ export abstract class QueryBuilder<Entity extends ObjectLiteral> {
      * Creates a completely new query builder.
      * Uses same query runner as current QueryBuilder.
      */
-    createQueryBuilder(): this {
-        return new (this.constructor as any)(this.connection, this.queryRunner)
+    createQueryBuilder(queryRunner?: QueryRunner): this {
+        return new (this.constructor as any)(this.connection, queryRunner ?? this.queryRunner)
     }
 
     /**

--- a/src/query-builder/SelectQueryBuilder.ts
+++ b/src/query-builder/SelectQueryBuilder.ts
@@ -3603,7 +3603,7 @@ export class SelectQueryBuilder<Entity extends ObjectLiteral>
                           )
                         : this.findOptions.relations
 
-                    const queryBuilder = this.createQueryBuilder()
+                    const queryBuilder = this.createQueryBuilder(queryRunner)
                         .select(relationAlias)
                         .from(relationTarget, relationAlias)
                         .setFindOptions({

--- a/test/integration/sample2-one-to-one.ts
+++ b/test/integration/sample2-one-to-one.ts
@@ -198,6 +198,47 @@ describe("one-to-one", function () {
                 .getOne()
                 .should.eventually.eql(expectedDetails)
         })
+
+        it("should load post and its details with no hangup if query used", async function () {
+            if (!dataSource) return
+            const expectedPost = new Post()
+            expectedPost.id = savedPost.id
+            expectedPost.text = savedPost.text
+            expectedPost.title = savedPost.title
+            expectedPost.details = new PostDetails()
+            expectedPost.details!.id = savedPost.details!.id
+            expectedPost.details!.authorName = savedPost.details!.authorName
+            expectedPost.details!.comment = savedPost.details!.comment
+            expectedPost.details!.metadata = savedPost.details!.metadata
+
+            const findOne = () => postRepository.findOne({
+                    where: {
+                        id: savedPost.id
+                    },
+                    relations: {
+                        details: true
+                    },
+                    relationLoadStrategy: "query"
+                })
+
+            const posts = await Promise.all([
+                findOne(),
+                findOne(),
+                findOne(),
+                findOne(),
+                findOne(),
+                findOne(),
+                findOne(),
+                findOne(),
+                findOne(),
+                findOne(),
+            ])
+
+            posts.forEach(post => {
+                expect(post).not.to.be.null
+                post!.should.eql(expectedPost)
+            })
+        })
     })
 
     describe("insert post and category (one-side relation)", function () {

--- a/test/integration/sample3-many-to-one.ts
+++ b/test/integration/sample3-many-to-one.ts
@@ -200,6 +200,47 @@ describe("many-to-one", function () {
                 .getOne()
                 .should.eventually.eql(expectedDetails)
         })
+
+        it("should load post and its details with no hangup if query used", async function () {
+            if (!dataSource) return
+            const expectedPost = new Post()
+            expectedPost.id = savedPost.id
+            expectedPost.text = savedPost.text
+            expectedPost.title = savedPost.title
+            expectedPost.details = new PostDetails()
+            expectedPost.details!.id = savedPost.details!.id
+            expectedPost.details!.authorName = savedPost.details!.authorName
+            expectedPost.details!.comment = savedPost.details!.comment
+            expectedPost.details!.metadata = savedPost.details!.metadata
+
+            const findOne = () => postRepository.findOne({
+                where: {
+                    id: savedPost.id
+                },
+                relations: {
+                    details: true
+                },
+                relationLoadStrategy: "query"
+            })
+
+            const posts = await Promise.all([
+                findOne(),
+                findOne(),
+                findOne(),
+                findOne(),
+                findOne(),
+                findOne(),
+                findOne(),
+                findOne(),
+                findOne(),
+                findOne(),
+            ])
+
+            posts.forEach(post => {
+                expect(post).not.to.be.null
+                post!.should.eql(expectedPost)
+            })
+        })
     })
 
     describe("insert post and category (one-side relation)", function () {


### PR DESCRIPTION
### Description of change
<!--
  Please be clear and concise what the change is intended to do,
  why this change is needed, and how you've verified that it
  corrects what you intended.

  In some cases it may be helpful to include the current behavior
  and the new behavior.

  If the change is related to an open issue, you can link it here.
  If you include `Fixes #0000` (replacing `0000` with the issue number)
  when this is merged it will automatically mark the issue as fixed and
  close it.
-->

#### Overview
Fixes #4738
Fixes #9298 
Fixes #10481  

Modified to use `queryRunner` when `QueryStrategyRelationIdLoader.loadManyToManyRelationIdsAndGroup` is called.

#### Detail
In the current implementation, if a query is executed with `relationLoadStrategy: query`, a new QueryRunner is created when resolving a relation.

The creation of a new QueryRunner means that a connection is allocated from the connection pool, but when the connection pool is exhausted, it waits for the connection to be released.

Because connections to query the parent table are released after the relation is resolved, if such queries are executed in parallel up to the maximum number of connection pools, a deadlock will occur because no connections will be allocated for queries on the `relation`.

#### Summary
So, this probrem can be solved by using the same QueryRunner is created when query parent table.

#### Side note
At first glance, it appears that the query runner is use in line 3587 of `src/query-builder/SelectQueryBuilder.ts`, but in fact, when resolving a relation inside "queryStrategyRelationIdLoader.loadManyToManyRelationIdsAndGroup", the QueryBuilder at line 3606 is used.

### Pull-Request Checklist

- [x] Code is up-to-date with the `master` branch
- [x] `npm run format` to apply prettier formatting
- [x] `npm run test` passes with this change
- [x] This pull request links relevant issues as `Fixes #0000`
- [x] There are new or updated unit tests validating the change
- [x] Documentation has been updated to reflect this change
- [x] The new commits follow conventions explained in [CONTRIBUTING.md](https://github.com/typeorm/typeorm/blob/master/CONTRIBUTING.md)

<!--
  🎉 Thank you for contributing and making TypeORM even better!
-->
