### PR TITLE
docs: fix typos in SelectQueryBuilder.ts

### DIFF
--- a/src/query-builder/SelectQueryBuilder.ts
+++ b/src/query-builder/SelectQueryBuilder.ts
@@ -1445,10 +1445,10 @@ export class SelectQueryBuilder<Entity extends ObjectLiteral>
     }
 
     /**
-     * Set's LIMIT - maximum number of rows to be selected.
+     * Sets LIMIT - maximum number of rows to be selected.
      * NOTE that it may not work as you expect if you are using joins.
      * If you want to implement pagination, and you are having join in your query,
-     * then use instead take method instead.
+     * then use the take method instead.
      */
     limit(limit?: number): this {
         this.expressionMap.limit = this.normalizeNumber(limit)
@@ -1464,10 +1464,10 @@ export class SelectQueryBuilder<Entity extends ObjectLiteral>
     }
 
     /**
-     * Set's OFFSET - selection offset.
+     * Sets OFFSET - selection offset.
      * NOTE that it may not work as you expect if you are using joins.
      * If you want to implement pagination, and you are having join in your query,
-     * then use instead skip method instead.
+     * then use the skip method instead.
      */
     offset(offset?: number): this {
         this.expressionMap.offset = this.normalizeNumber(offset)


### PR DESCRIPTION
### Description of change

I was working with the `.limit()` and `.skip()` methods and noticed some minor typos. Fixed them to improve the development experience.