### PR TITLE
fix: include asExpression columns in returning clause

### DIFF
--- a/src/metadata/EntityMetadata.ts
+++ b/src/metadata/EntityMetadata.ts
@@ -1127,6 +1127,7 @@ export class EntityMetadata {
         return this.columns.filter((column) => {
             return (
                 column.default !== undefined ||
+                column.asExpression !== undefined ||
                 column.isGenerated ||
                 column.isCreateDate ||
                 column.isUpdateDate ||

--- a/src/query-builder/ReturningResultsEntityUpdator.ts
+++ b/src/query-builder/ReturningResultsEntityUpdator.ts
@@ -274,7 +274,11 @@ export class ReturningResultsEntityUpdator {
     getUpdationReturningColumns(): ColumnMetadata[] {
         return this.expressionMap.mainAlias!.metadata.columns.filter(
             (column) => {
-                return column.isUpdateDate || column.isVersion
+                return (
+                    column.asExpression !== undefined ||
+                    column.isUpdateDate ||
+                    column.isVersion
+                )
             },
         )
     }
@@ -286,6 +290,7 @@ export class ReturningResultsEntityUpdator {
         return this.expressionMap.mainAlias!.metadata.columns.filter(
             (column) => {
                 return (
+                    column.asExpression !== undefined ||
                     column.isUpdateDate ||
                     column.isVersion ||
                     column.isDeleteDate

--- a/test/github-issues/8450/entity/UserEntity.ts
+++ b/test/github-issues/8450/entity/UserEntity.ts
@@ -1,0 +1,16 @@
+import { Entity } from "../../../../src/decorator/entity/Entity"
+import { PrimaryColumn } from "../../../../src/decorator/columns/PrimaryColumn"
+import { Column } from "../../../../src/decorator/columns/Column"
+
+@Entity("user")
+export class UserEntity {
+    @PrimaryColumn("int")
+    id: number
+
+    @Column({
+        type: "int",
+        generatedType: "STORED",
+        asExpression: "id * 2",
+    })
+    generated: number
+}

--- a/test/github-issues/8450/issue-8450.ts
+++ b/test/github-issues/8450/issue-8450.ts
@@ -1,0 +1,38 @@
+import "reflect-metadata"
+import {
+    closeTestingConnections,
+    createTestingConnections,
+    reloadTestingDatabases,
+} from "../../utils/test-utils"
+import { UserEntity } from "./entity/UserEntity"
+import { expect } from "chai"
+import { DataSource } from "../../../src"
+
+describe("github issues > #8450 Generated column not in RETURNING clause on save", () => {
+    let connections: DataSource[]
+
+    before(
+        async () =>
+            (connections = await createTestingConnections({
+                entities: [__dirname + "/entity/*{.js,.ts}"],
+                enabledDrivers: ["postgres", "mysql"],
+            })),
+    )
+    beforeEach(() => reloadTestingDatabases(connections))
+    after(() => closeTestingConnections(connections))
+
+    it("should populate an object with generated column values after saving", () =>
+        Promise.all(
+            connections.map(async (connection) => {
+                const user = new UserEntity()
+                user.id = 100
+
+                expect(user.generated).to.be.undefined
+
+                await connection.manager.save(user)
+
+                expect(user.generated).to.be.a("number")
+                expect(user.generated).to.be.equal(user.id * 2)
+            }),
+        ))
+})


### PR DESCRIPTION
<!--
  😀 Wonderful!  Thank you for opening a pull request for TypeORM.

  Please fill in the information below to expedite the review
  and (hopefully) merge of your change.

  If unsure about something.. just do as best as you're able,
  or reach out through our community support channels!
  https://github.com/typeorm/typeorm/blob/master/docs/support.md
-->

### Description of change

Fixes https://github.com/typeorm/typeorm/issues/8450

This is a rework of PR https://github.com/typeorm/typeorm/pull/8472, which was closed due to being outdated.

The values of a column generated by an expression should be returned when inserting or updating a record.


### Pull-Request Checklist

<!--
  Please make sure to review and check all of the following.

  If an item is not applicable, you can add "N/A" to the end.
-->

- [x] Code is up-to-date with the `master` branch
- [x] `npm run format` to apply prettier formatting
- [x] `npm run test` passes with this change
- [x] This pull request links relevant issues as `Fixes #0000`
- [x] There are new or updated unit tests validating the change
- [x] Documentation has been updated to reflect this change N/A
- [x] The new commits follow conventions explained in [CONTRIBUTING.md](https://github.com/typeorm/typeorm/blob/master/CONTRIBUTING.md)

<!--
  🎉 Thank you for contributing and making TypeORM even better!
-->
