### PR TITLE
fix: unique and foreign keys extraction

### DIFF
--- a/src/util/OrmUtils.ts
+++ b/src/util/OrmUtils.ts
@@ -1,5 +1,11 @@
 import { ObjectLiteral } from "../common/ObjectLiteral"
 
+type ConstraintMapping = {
+    name: string
+    columns: string[]
+    referencedTableName?: string // Optional for foreign key constraints
+}
+
 export class OrmUtils {
     // -------------------------------------------------------------------------
     // Public methods
@@ -413,6 +419,34 @@ export class OrmUtils {
             }
         }
         return undefined
+    }
+
+    static extractConstraints(
+        sql: string,
+        regex: RegExp,
+        propertyHandler?: (
+            result: RegExpExecArray,
+        ) => Partial<ConstraintMapping>,
+    ): ConstraintMapping[] {
+        let result
+        const mappings: ConstraintMapping[] = []
+
+        while ((result = regex.exec(sql)) !== null) {
+            const columns = result[2].trim()
+            const additionalProperties = propertyHandler
+                ? propertyHandler(result)
+                : {}
+
+            mappings.push({
+                name: result[1],
+                columns: columns
+                    .substr(1, columns.length - 2)
+                    .split(/"\s*,\s*"/),
+                ...additionalProperties,
+            })
+        }
+
+        return mappings
     }
 
     // -------------------------------------------------------------------------

--- a/test/unit/orm-utils.ts
+++ b/test/unit/orm-utils.ts
@@ -72,4 +72,72 @@ describe(`orm-utils`, () => {
             ])
         })
     })
+
+    describe("extractConstraints", () => {
+        it("should correctly identify unique constraints in the SQL statement regardless of the number of white spaces", () => {
+            const uniqueRegex = /CONSTRAINT "([^"]*)" UNIQUE ?\((.*?)\)/g
+            const result = OrmUtils.extractConstraints(
+                `CREATE TABLE "foo_table_options" (                "rank" integer NOT NULL,                "isDefaultSelected" boolean NOT NULL,                "fooID" varchar NOT NULL,                "fooCol" varchar NOT NULL,                "buzID" varchar NOT NULL,                "buzCol" varchar NOT NULL,                "barCol" varchar,                "barID" varchar,                CONSTRAINT "REL_f549bbcf58127bef87b9003d99" UNIQUE ("barID", "barCol"),       CONSTRAINT "REL_f52871a9129b190a91002" UNIQUE ("buzID", "buzCol"),         CONSTRAINT "FK_764fb473800a7a60dbe148b3b56" FOREIGN KEY (                    "fooID",                    "fooCol"                ) REFERENCES "foo" ("id", "Etag") ON DELETE NO ACTION ON UPDATE NO ACTION,                CONSTRAINT "FK_f549bbcf58127bef87b9003d99e" FOREIGN KEY ("barID", "barCol") REFERENCES "bar" ("id", "Etag") ON DELETE NO ACTION ON UPDATE NO ACTION,                CONSTRAINT "FK_f0a30f25454246f6b91ee5448ed" FOREIGN KEY (                    "buzID",                    "buzCol"                ) REFERENCES "buz" ("id", "Etag") ON DELETE NO ACTION ON UPDATE NO ACTION,                PRIMARY KEY (                    "fooID",                    "fooCol",                    "buzID",                    "buzCol"                )            )`,
+                uniqueRegex,
+            )
+            const expectedResult = [
+                {
+                    columns: ["barID", "barCol"],
+                    name: "REL_f549bbcf58127bef87b9003d99",
+                },
+                {
+                    columns: ["buzID", "buzCol"],
+                    name: "REL_f52871a9129b190a91002",
+                },
+            ]
+
+            expect(result).to.have.lengthOf(2)
+            expectedResult.forEach(({ columns, name }, index) => {
+                expect(result[index].name).to.equal(name)
+                expect(result[index].columns).to.deep.equal(columns)
+                expect(result[index].referencedTableName).to.be.undefined
+            })
+        })
+
+        it("should correctly identify foreign key constraints in the SQL statement regardless of the number of white spaces - should return proper referencedTableName", () => {
+            const fkRegex =
+                /CONSTRAINT "([^"]*)" FOREIGN KEY ?\((.*?)\) REFERENCES "([^"]*)"/g
+            const result = OrmUtils.extractConstraints(
+                `CREATE TABLE "foo_table_options" (               "isDefault" boolean NOT NULL,                "fooID" varchar NOT NULL,                "fooCol" varchar NOT NULL,                "buzID" varchar NOT NULL,                "buzCol" varchar NOT NULL,                "barCol" varchar,                "barID" varchar,                CONSTRAINT "REL_f549bbcf58127bef87b9003d99" UNIQUE ("barID", "barCol"),                CONSTRAINT "FK_764fb473800a7a60dbe148b3b56" FOREIGN KEY (                    "fooID",                    "fooCol"                ) REFERENCES "foo" ("id", "Etag") ON DELETE NO ACTION ON UPDATE NO ACTION,                CONSTRAINT "FK_f549bbcf58127bef87b9003d99e" FOREIGN KEY ("barID", "barCol") REFERENCES "bar" ("id", "Etag") ON DELETE NO ACTION ON UPDATE NO ACTION,                CONSTRAINT "FK_f0a30f25454246f6b91ee5448ed" FOREIGN KEY (                    "buzID",                    "buzCol"                ) REFERENCES "buz" ("id", "Etag") ON DELETE NO ACTION ON UPDATE NO ACTION,                PRIMARY KEY (                    "fooID",                    "fooCol",                    "buzID",                    "buzCol"                )            )`,
+                fkRegex,
+                (result) => ({
+                    referencedTableName: result[3],
+                }),
+            )
+
+            const expectedResult = [
+                {
+                    columns: ["fooID", "fooCol"],
+                    name: "FK_764fb473800a7a60dbe148b3b56",
+                    referencedTableName: "foo",
+                },
+                {
+                    columns: ["barID", "barCol"],
+                    name: "FK_f549bbcf58127bef87b9003d99e",
+                    referencedTableName: "bar",
+                },
+                {
+                    columns: ["buzID", "buzCol"],
+                    name: "FK_f0a30f25454246f6b91ee5448ed",
+                    referencedTableName: "buz",
+                },
+            ]
+
+            expect(result).to.have.lengthOf(3)
+            expectedResult.forEach(
+                ({ columns, name, referencedTableName }, index) => {
+                    expect(result[index].name).to.equal(name)
+                    expect(result[index].columns).to.deep.equal(columns)
+                    expect(result[index].referencedTableName).to.deep.equal(
+                        referencedTableName,
+                    )
+                },
+            )
+        })
+    })
 })


### PR DESCRIPTION

### Description of change

The error causing incorrect unique/foreign key constraints extraction has been fixed. This issue occurred when there were multiple white spaces in the SQL string or when white spaces appeared at the beginning or end of the SQL string.

```sql
CONSTRAINT "FK_764fb473800a7a60dbe148b3b56" FOREIGN KEY (                    "fooID",                    "fooCol"                ) REFERENCES "foo" ("id", "Etag") ON DELETE NO ACTION ON UPDATE NO ACTION
```


To address this issue, a separate method was created, which is reused for extracting unique and foreign key constraints. Within the loop, each string matching a specific regular expression is trimmed of excess white spaces at the beginning and end. Additionally, the method of splitting was modified. The split now uses a regular expression that does not distinguish whether there is exactly one white space between individual columns; there may be more than one whitespace.

### Pull-Request Checklist

- [x] Code is up-to-date with the `master` branch
- [x] `npm run format` to apply prettier formatting
- [x] `npm run test` passes with this change
- [ ] This pull request links relevant issues as `Fixes #0000`
- [x] There are new or updated unit tests validating the change
- [ ] Documentation has been updated to reflect this change
- [x] The new commits follow conventions explained in [CONTRIBUTING.md](https://github.com/typeorm/typeorm/blob/master/CONTRIBUTING.md)
