### PR TITLE
fix: preserve `useIndex` when cloning a QueryExpressionMap (or a QueryBuilder)

### DIFF
--- a/src/query-builder/QueryExpressionMap.ts
+++ b/src/query-builder/QueryExpressionMap.ts
@@ -517,6 +517,7 @@ export class QueryExpressionMap {
         map.offset = this.offset
         map.skip = this.skip
         map.take = this.take
+        map.useIndex = this.useIndex
         map.lockMode = this.lockMode
         map.onLocked = this.onLocked
         map.lockVersion = this.lockVersion

--- a/test/github-issues/10678/entity/user.ts
+++ b/test/github-issues/10678/entity/user.ts
@@ -1,0 +1,13 @@
+import { Column, Entity, Index, PrimaryGeneratedColumn } from "../../../../src"
+
+@Entity({
+    name: "user",
+})
+export class User {
+    @PrimaryGeneratedColumn()
+    id: number
+
+    @Index("IDX_name")
+    @Column({ nullable: true })
+    name: string
+}

--- a/test/github-issues/10678/issue-10678.ts
+++ b/test/github-issues/10678/issue-10678.ts
@@ -1,0 +1,38 @@
+import "reflect-metadata"
+import {
+    createTestingConnections,
+    closeTestingConnections,
+    reloadTestingDatabases,
+} from "../../utils/test-utils"
+import { DataSource } from "../../../src/data-source/DataSource"
+import { expect } from "chai"
+import { User } from "./entity/user"
+
+describe("github issues > #10678 useIndex is not preserved when cloning a QueryExpressionMap (or a QueryBuilder) instance", () => {
+    let dataSources: DataSource[]
+    before(
+        async () =>
+            (dataSources = await createTestingConnections({
+                entities: [__dirname + "/entity/*{.js,.ts}"],
+                schemaCreate: true,
+                dropSchema: true,
+                enabledDrivers: ["aurora-mysql", "mysql", "mariadb"],
+            })),
+    )
+    beforeEach(() => reloadTestingDatabases(dataSources))
+    after(() => closeTestingConnections(dataSources))
+
+    it("should preserve the useIndex property when a QueryBuilder instance is cloned", () =>
+        Promise.all(
+            dataSources.map(async (dataSource) => {
+                const useIndex = "IDX_name"
+                const qb = dataSource
+                    .getRepository(User)
+                    .createQueryBuilder("u")
+                    .useIndex(useIndex)
+
+                expect(qb.expressionMap.useIndex).to.equal(useIndex)
+                expect(qb.clone().expressionMap.useIndex).to.equal(useIndex)
+            }),
+        ))
+})


### PR DESCRIPTION
### Description of change

Make sure that the `useIndex` property is copied over when calling `QueryExpressionMap#clone`

### Pull-Request Checklist

- [x] Code is up-to-date with the `master` branch
- [x] `npm run format` to apply prettier formatting
- [x] `npm run test` passes with this change
- [x] This pull request links relevant issues as `Fixes #0000`
- [x] There are new or updated unit tests validating the change
- [ ] Documentation has been updated to reflect this change
- [x] The new commits follow conventions explained in [CONTRIBUTING.md](https://github.com/typeorm/typeorm/blob/master/CONTRIBUTING.md)

<!--
  🎉 Thank you for contributing and making TypeORM even better!
-->
