### PR TITLE
refactor: use pragma method in better-sqlite3

### DIFF
--- a/src/driver/better-sqlite3/BetterSqlite3Driver.ts
+++ b/src/driver/better-sqlite3/BetterSqlite3Driver.ts
@@ -138,7 +138,7 @@ export class BetterSqlite3Driver extends AbstractSqliteDriver {
             nativeBinding = null,
             prepareDatabase,
         } = this.options
-        const databaseConnection = this.sqlite(database, {
+        const databaseConnection = new this.sqlite(database, {
             readonly,
             fileMustExist,
             timeout,
@@ -148,8 +148,8 @@ export class BetterSqlite3Driver extends AbstractSqliteDriver {
         // in the options, if encryption key for SQLCipher is setted.
         // Must invoke key pragma before trying to do any other interaction with the database.
         if (this.options.key) {
-            databaseConnection.exec(
-                `PRAGMA key = ${JSON.stringify(this.options.key)}`,
+            databaseConnection.pragma(
+                `key = ${JSON.stringify(this.options.key)}`,
             )
         }
 
@@ -160,11 +160,11 @@ export class BetterSqlite3Driver extends AbstractSqliteDriver {
 
         // we need to enable foreign keys in sqlite to make sure all foreign key related features
         // working properly. this also makes onDelete to work with sqlite.
-        databaseConnection.exec(`PRAGMA foreign_keys = ON`)
+        databaseConnection.pragma("foreign_keys = ON")
 
         // turn on WAL mode to enhance performance
         if (this.options.enableWAL) {
-            databaseConnection.exec(`PRAGMA journal_mode = WAL`)
+            databaseConnection.pragma("journal_mode = WAL")
         }
 
         return databaseConnection

--- a/src/driver/better-sqlite3/BetterSqlite3QueryRunner.ts
+++ b/src/driver/better-sqlite3/BetterSqlite3QueryRunner.ts
@@ -61,14 +61,16 @@ export class BetterSqlite3QueryRunner extends AbstractSqliteQueryRunner {
      * Called before migrations are run.
      */
     async beforeMigration(): Promise<void> {
-        await this.query(`PRAGMA foreign_keys = OFF`)
+        const databaseConnection = await this.connect()
+        databaseConnection.pragma("foreign_keys = OFF")
     }
 
     /**
      * Called after migrations are run.
      */
     async afterMigration(): Promise<void> {
-        await this.query(`PRAGMA foreign_keys = ON`)
+        const databaseConnection = await this.connect()
+        databaseConnection.pragma("foreign_keys = ON")
     }
 
     /**
@@ -154,10 +156,9 @@ export class BetterSqlite3QueryRunner extends AbstractSqliteQueryRunner {
     }
     protected async loadPragmaRecords(tablePath: string, pragma: string) {
         const [database, tableName] = this.splitTablePath(tablePath)
-        const res = await this.query(
-            `PRAGMA ${
-                database ? `"${database}".` : ""
-            }${pragma}("${tableName}")`,
+        const databaseConnection = await this.connect()
+        const res = databaseConnection.pragma(
+            `${database ? `"${database}".` : ""}${pragma}("${tableName}")`,
         )
         return res
     }


### PR DESCRIPTION
### Description of change

Use the `pragma` method in better-sqlite3. This is the recommended way to run pragmas.


### Pull-Request Checklist

- [x] Code is up-to-date with the `master` branch
- [x] `npm run format` to apply prettier formatting
- [x] `npm run test` passes with this change
- [x] The new commits follow conventions explained in [CONTRIBUTING.md](https://github.com/typeorm/typeorm/blob/master/CONTRIBUTING.md)