### PR TITLE
fix: export QueryEvent before/after types

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -134,6 +134,7 @@ export * from "./driver/types/DatabaseType"
 export * from "./driver/types/GeoJsonTypes"
 export * from "./driver/types/ReplicationMode"
 export * from "./driver/sqlserver/MssqlParameter"
+export * from "./subscriber/event/QueryEvent"
 
 // export * from "./data-source";
 

--- a/src/subscriber/event/QueryEvent.ts
+++ b/src/subscriber/event/QueryEvent.ts
@@ -43,7 +43,7 @@ export interface AfterQueryEvent<Entity> extends QueryEvent<Entity> {
     success: boolean
 
     /**
-     * The duration of the query execution.
+     * The duration of the query execution, in milliseconds.
      */
     executionTime?: number
 


### PR DESCRIPTION
<!--
  😀 Wonderful!  Thank you for opening a pull request for TypeORM.

  Please fill in the information below to expedite the review
  and (hopefully) merge of your change.

  If unsure about something.. just do as best as you're able,
  or reach out through our community support channels!
  https://github.com/typeorm/typeorm/blob/master/docs/support.md
-->

### Description of change

This PR exports the types added in PR #10234 - `QueryEvent` (`AfterQueryEvent`, `BeforeQueryEvent`) so that one can build subscribers that use the `before..` and `afterQuery` listeners.

Also the JS doc for the `AfterQueryEvent` is updated to clarify that execution time is in milliseconds to remove guess-work.

<!--
  Please be clear and concise what the change is intended to do,
  why this change is needed, and how you've verified that it
  corrects what you intended.

  In some cases it may be helpful to include the current behavior
  and the new behavior.

  If the change is related to an open issue, you can link it here.
  If you include `Fixes #0000` (replacing `0000` with the issue number)
  when this is merged it will automatically mark the issue as fixed and
  close it.
-->


### Pull-Request Checklist

<!--
  Please make sure to review and check all of the following.

  If an item is not applicable, you can add "N/A" to the end.
-->

- [x] Code is up-to-date with the `master` branch
- [x] `npm run format` to apply prettier formatting (this changed other unrelated files which have not been committed)
- [x] `npm run test` passes with this change
- [ ] This pull request links relevant issues as `Fixes #0000`
- [ ] There are new or updated unit tests validating the change
- [x] Documentation has been updated to reflect this change
- [x] The new commits follow conventions explained in [CONTRIBUTING.md](https://github.com/typeorm/typeorm/blob/master/CONTRIBUTING.md)

<!--
  🎉 Thank you for contributing and making TypeORM even better!
-->
