### PR TITLE
docs: Include info about using soft delete in Repository API

### DIFF
--- a/docs/repository-api.md
+++ b/docs/repository-api.md
@@ -224,14 +224,18 @@ await repository.delete([1, 2, 3])
 await repository.delete({ firstName: "Timber" })
 ```
 
--   `softDelete` and `restore` - Soft deleting and restoring a row by id
+-   `softDelete` and `restore` - Soft deleting and restoring a row by id, ids, or given conditions:
 
 ```typescript
 const repository = dataSource.getRepository(Entity)
-// Delete a entity
+// Soft delete an entity
 await repository.softDelete(1)
-// And You can restore it using restore;
+// And you can restore it using restore;
 await repository.restore(1)
+// Soft delete multiple entities
+await repository.softDelete([1, 2, 3])
+// Or soft delete by other attribute
+await repository.softDelete({ firstName: "Jake" })
 ```
 
 -   `softRemove` and `recover` - This is alternative to `softDelete` and `restore`.


### PR DESCRIPTION
### Description of change

The docs have been updated to contain the important information that using `repository.softDelete()` allows the user to specify multiple id's, or other row attributes as it happens with the `delete()` operation, for instance.


### Pull-Request Checklist

- [x] Code is up-to-date with the `master` branch
- [x] `npm run format` to apply prettier formatting
- [x] `npm run test` passes with this change
- [x] This pull request links relevant issues as `Fixes #0000`
- [x] There are new or updated unit tests validating the change
- [x] Documentation has been updated to reflect this change
- [x] The new commits follow conventions explained in [CONTRIBUTING.md](https://github.com/typeorm/typeorm/blob/master/CONTRIBUTING.md)