### PR TITLE
Fix repeated positional arguments in OracleSQL being invalid queries. 

### DIFF
--- a/src/driver/oracle/OracleDriver.ts
+++ b/src/driver/oracle/OracleDriver.ts
@@ -385,7 +385,7 @@ export class OracleDriver implements Driver {
         if (!parameters || !Object.keys(parameters).length)
             return [sql, escapedParameters]
 
-        const parameterIndexMap = new Map<string, number>()
+        // const parameterIndexMap = new Map<string, number>()
         sql = sql.replace(
             /:(\.\.\.)?([A-Za-z0-9_.]+)/g,
             (full, isArray: string, key: string): string => {
@@ -393,37 +393,31 @@ export class OracleDriver implements Driver {
                     return full
                 }
 
-                if (parameterIndexMap.has(key)) {
-                    return this.parametersPrefix + parameterIndexMap.get(key)
-                }
-
                 let value: any = parameters[key]
 
+                // Directly handle the value without checking parameterIndexMap
                 if (isArray) {
-                    return value
+                    // Assume value is an array; process each element
+                    const placeholders = value
                         .map((v: any) => {
-                            escapedParameters.push(v)
+                            escapedParameters.push(v) // Push each value to the array
+                            // Generate placeholder for each value
                             return this.createParameter(
                                 key,
                                 escapedParameters.length - 1,
                             )
                         })
                         .join(", ")
+                    return placeholders
                 }
 
-                if (typeof value === "function") {
-                    return value()
-                }
-
-                if (typeof value === "boolean") {
-                    return value ? "1" : "0"
-                }
-
+                // For non-array values
                 escapedParameters.push(value)
-                parameterIndexMap.set(key, escapedParameters.length)
+                // Generate a unique placeholder based on the current length of escapedParameters
                 return this.createParameter(key, escapedParameters.length - 1)
             },
-        ) // todo: make replace only in value statements, otherwise problems
+        )
+        // todo: make replace only in value statements, otherwise problems
         return [sql, escapedParameters]
     }
 

--- a/src/driver/oracle/OracleDriver.ts
+++ b/src/driver/oracle/OracleDriver.ts
@@ -411,6 +411,14 @@ export class OracleDriver implements Driver {
                     return placeholders
                 }
 
+                if (typeof value === "function") {
+                    return value()
+                }
+                
+                if (typeof value === "boolean") {
+                    return value ? "1" : "0"
+                }
+
                 // For non-array values
                 escapedParameters.push(value)
                 // Generate a unique placeholder based on the current length of escapedParameters

--- a/src/driver/postgres/PostgresQueryRunner.ts
+++ b/src/driver/postgres/PostgresQueryRunner.ts
@@ -601,10 +601,22 @@ export class PostgresQueryRunner
                 downQueries.push(this.dropIndexSql(table, index))
             })
         }
-        
+
         if (table.comment) {
-            upQueries.push(new Query("COMMENT ON TABLE " + this.escapePath(table) + " IS '" + table.comment + "'"));
-            downQueries.push(new Query("COMMENT ON TABLE " + this.escapePath(table) + " IS NULL"));
+            upQueries.push(
+                new Query(
+                    "COMMENT ON TABLE " +
+                        this.escapePath(table) +
+                        " IS '" +
+                        table.comment +
+                        "'",
+                ),
+            )
+            downQueries.push(
+                new Query(
+                    "COMMENT ON TABLE " + this.escapePath(table) + " IS NULL",
+                ),
+            )
         }
 
         await this.executeQueries(upQueries, downQueries)
@@ -4744,7 +4756,7 @@ export class PostgresQueryRunner
 
         newComment = this.escapeComment(newComment)
         const comment = this.escapeComment(table.comment)
-        
+
         if (newComment === comment) {
             return
         }

--- a/src/query-builder/InsertQueryBuilder.ts
+++ b/src/query-builder/InsertQueryBuilder.ts
@@ -459,10 +459,8 @@ export class InsertQueryBuilder<
         // add VALUES expression
         if (valuesExpression) {
             if (
-                (
-                    this.connection.driver.options.type === "oracle" ||
-                    this.connection.driver.options.type === "sap"
-                ) &&
+                (this.connection.driver.options.type === "oracle" ||
+                    this.connection.driver.options.type === "sap") &&
                 this.getValueSets().length > 1
             ) {
                 query += ` ${valuesExpression}`

--- a/src/query-builder/QueryBuilder.ts
+++ b/src/query-builder/QueryBuilder.ts
@@ -522,7 +522,10 @@ export abstract class QueryBuilder<Entity extends ObjectLiteral> {
      * Uses same query runner as current QueryBuilder.
      */
     createQueryBuilder(queryRunner?: QueryRunner): this {
-        return new (this.constructor as any)(this.connection, queryRunner ?? this.queryRunner)
+        return new (this.constructor as any)(
+            this.connection,
+            queryRunner ?? this.queryRunner,
+        )
     }
 
     /**

--- a/src/schema-builder/RdbmsSchemaBuilder.ts
+++ b/src/schema-builder/RdbmsSchemaBuilder.ts
@@ -604,7 +604,7 @@ export class RdbmsSchemaBuilder implements SchemaBuilder {
 
             if (
                 DriverUtils.isMySQLFamily(this.connection.driver) ||
-                this.connection.driver.options.type === 'postgres'
+                this.connection.driver.options.type === "postgres"
             ) {
                 const newComment = metadata.comment
                 await this.queryRunner.changeTableComment(table, newComment)

--- a/test/integration/sample2-one-to-one.ts
+++ b/test/integration/sample2-one-to-one.ts
@@ -211,14 +211,15 @@ describe("one-to-one", function () {
             expectedPost.details!.comment = savedPost.details!.comment
             expectedPost.details!.metadata = savedPost.details!.metadata
 
-            const findOne = () => postRepository.findOne({
+            const findOne = () =>
+                postRepository.findOne({
                     where: {
-                        id: savedPost.id
+                        id: savedPost.id,
                     },
                     relations: {
-                        details: true
+                        details: true,
                     },
-                    relationLoadStrategy: "query"
+                    relationLoadStrategy: "query",
                 })
 
             const posts = await Promise.all([
@@ -234,7 +235,7 @@ describe("one-to-one", function () {
                 findOne(),
             ])
 
-            posts.forEach(post => {
+            posts.forEach((post) => {
                 expect(post).not.to.be.null
                 post!.should.eql(expectedPost)
             })

--- a/test/integration/sample3-many-to-one.ts
+++ b/test/integration/sample3-many-to-one.ts
@@ -213,15 +213,16 @@ describe("many-to-one", function () {
             expectedPost.details!.comment = savedPost.details!.comment
             expectedPost.details!.metadata = savedPost.details!.metadata
 
-            const findOne = () => postRepository.findOne({
-                where: {
-                    id: savedPost.id
-                },
-                relations: {
-                    details: true
-                },
-                relationLoadStrategy: "query"
-            })
+            const findOne = () =>
+                postRepository.findOne({
+                    where: {
+                        id: savedPost.id,
+                    },
+                    relations: {
+                        details: true,
+                    },
+                    relationLoadStrategy: "query",
+                })
 
             const posts = await Promise.all([
                 findOne(),
@@ -236,7 +237,7 @@ describe("many-to-one", function () {
                 findOne(),
             ])
 
-            posts.forEach(post => {
+            posts.forEach((post) => {
                 expect(post).not.to.be.null
                 post!.should.eql(expectedPost)
             })


### PR DESCRIPTION
<!--
  😀 Wonderful!  Thank you for opening a pull request for TypeORM.

  Please fill in the information below to expedite the review
  and (hopefully) merge of your change.

  If unsure about something.. just do as best as you're able,
  or reach out through our community support channels!
  https://github.com/typeorm/typeorm/blob/master/docs/support.md
-->

Positional paramters in oraclesql database don't seem to work properly.
So, if you have params that are being reused, it seems TypeORM will generate a query using the parameterIndexMap where it will reuse paramter names. So :1, :1, :2 in a SQL query doesn't work, even if the argument is exactly the same. It has to be :1, :2, :3 even if the query is reusing arguments. 

<!--
  Please be clear and concise what the change is intended to do,
  why this change is needed, and how you've verified that it
  corrects what you intended.

  In some cases it may be helpful to include the current behavior
  and the new behavior.

  If the change is related to an open issue, you can link it here.
  If you include `Fixes #0000` (replacing `0000` with the issue number)
  when this is merged it will automatically mark the issue as fixed and
  close it.
-->


### Pull-Request Checklist

<!--
  Please make sure to review and check all of the following.

  If an item is not applicable, you can add "N/A" to the end.
-->

- [X] Code is up-to-date with the `master` branch
- [X] `npm run format` to apply prettier formatting
- [X] `npm run test` passes with this change
- [ ] This pull request links relevant issues as `Fixes #0000`
- [ ] There are new or updated unit tests validating the change
- [ ] Documentation has been updated to reflect this change
- [X] The new commits follow conventions explained in [CONTRIBUTING.md](https://github.com/typeorm/typeorm/blob/master/CONTRIBUTING.md)

<!--
  🎉 Thank you for contributing and making TypeORM even better!
-->
