### PR TITLE
Feat where exists in brackets

### DIFF
--- a/src/query-builder/DeleteQueryBuilder.ts
+++ b/src/query-builder/DeleteQueryBuilder.ts
@@ -8,6 +8,7 @@ import { Brackets } from "./Brackets"
 import { DeleteResult } from "./result/DeleteResult"
 import { ReturningStatementNotSupportedError } from "../error/ReturningStatementNotSupportedError"
 import { InstanceChecker } from "../util/InstanceChecker"
+import { SelectQueryBuilder } from "./SelectQueryBuilder"
 
 /**
  * Allows to build complex sql queries in a fashion way and execute those queries.
@@ -193,6 +194,27 @@ export class DeleteQueryBuilder<Entity extends ObjectLiteral>
         })
         if (parameters) this.setParameters(parameters)
         return this
+    }
+
+    /**
+     * Sets a new where EXISTS clause
+     */
+    whereExists(subQuery: SelectQueryBuilder<any>): this {
+        return this.where(...this.getExistsCondition(subQuery))
+    }
+
+    /**
+     * Adds a new AND where EXISTS clause
+     */
+    andWhereExists(subQuery: SelectQueryBuilder<any>): this {
+        return this.andWhere(...this.getExistsCondition(subQuery))
+    }
+
+    /**
+     * Adds a new OR where EXISTS clause
+     */
+    orWhereExists(subQuery: SelectQueryBuilder<any>): this {
+        return this.orWhere(...this.getExistsCondition(subQuery))
     }
 
     /**

--- a/src/query-builder/SoftDeleteQueryBuilder.ts
+++ b/src/query-builder/SoftDeleteQueryBuilder.ts
@@ -15,6 +15,7 @@ import { UpdateValuesMissingError } from "../error/UpdateValuesMissingError"
 import { TypeORMError } from "../error"
 import { DriverUtils } from "../driver/DriverUtils"
 import { InstanceChecker } from "../util/InstanceChecker"
+import { SelectQueryBuilder } from "./SelectQueryBuilder"
 
 /**
  * Allows to build complex sql queries in a fashion way and execute those queries.
@@ -241,6 +242,27 @@ export class SoftDeleteQueryBuilder<Entity extends ObjectLiteral>
         })
         if (parameters) this.setParameters(parameters)
         return this
+    }
+
+    /**
+     * Sets a new where EXISTS clause
+     */
+    whereExists(subQuery: SelectQueryBuilder<any>): this {
+        return this.where(...this.getExistsCondition(subQuery))
+    }
+
+    /**
+     * Adds a new AND where EXISTS clause
+     */
+    andWhereExists(subQuery: SelectQueryBuilder<any>): this {
+        return this.andWhere(...this.getExistsCondition(subQuery))
+    }
+
+    /**
+     * Adds a new OR where EXISTS clause
+     */
+    orWhereExists(subQuery: SelectQueryBuilder<any>): this {
+        return this.orWhere(...this.getExistsCondition(subQuery))
     }
 
     /**

--- a/src/query-builder/UpdateQueryBuilder.ts
+++ b/src/query-builder/UpdateQueryBuilder.ts
@@ -18,6 +18,7 @@ import { TypeORMError } from "../error"
 import { EntityPropertyNotFoundError } from "../error/EntityPropertyNotFoundError"
 import { SqlServerDriver } from "../driver/sqlserver/SqlServerDriver"
 import { DriverUtils } from "../driver/DriverUtils"
+import { SelectQueryBuilder } from "./SelectQueryBuilder"
 
 /**
  * Allows to build complex sql queries in a fashion way and execute those queries.
@@ -270,6 +271,27 @@ export class UpdateQueryBuilder<Entity extends ObjectLiteral>
         })
         if (parameters) this.setParameters(parameters)
         return this
+    }
+
+    /**
+     * Sets a new where EXISTS clause
+     */
+    whereExists(subQuery: SelectQueryBuilder<any>): this {
+        return this.where(...this.getExistsCondition(subQuery))
+    }
+
+    /**
+     * Adds a new AND where EXISTS clause
+     */
+    andWhereExists(subQuery: SelectQueryBuilder<any>): this {
+        return this.andWhere(...this.getExistsCondition(subQuery))
+    }
+
+    /**
+     * Adds a new OR where EXISTS clause
+     */
+    orWhereExists(subQuery: SelectQueryBuilder<any>): this {
+        return this.orWhere(...this.getExistsCondition(subQuery))
     }
 
     /**

--- a/src/query-builder/WhereExpressionBuilder.ts
+++ b/src/query-builder/WhereExpressionBuilder.ts
@@ -1,5 +1,6 @@
 import { ObjectLiteral } from "../common/ObjectLiteral"
 import { Brackets } from "./Brackets"
+import { SelectQueryBuilder } from "./SelectQueryBuilder"
 
 /**
  * Query Builders can implement this interface to support where expression
@@ -104,6 +105,21 @@ export interface WhereExpressionBuilder {
      * Additionally you can add parameters used in where expression.
      */
     orWhere(subQuery: (qb: this) => string, parameters?: ObjectLiteral): this
+
+    /**
+     * Sets a new where EXISTS clause
+     */
+    whereExists(subQuery: SelectQueryBuilder<any>): this;
+
+    /**
+     * Adds a new AND where EXISTS clause
+     */
+    andWhereExists(subQuery: SelectQueryBuilder<any>): this;
+
+    /**
+     * Adds a new OR where EXISTS clause
+     */
+    orWhereExists(subQuery: SelectQueryBuilder<any>): this;
 
     /**
      * Sets WHERE condition in the query builder with a condition for the given ids.

--- a/src/query-builder/WhereExpressionBuilder.ts
+++ b/src/query-builder/WhereExpressionBuilder.ts
@@ -109,17 +109,17 @@ export interface WhereExpressionBuilder {
     /**
      * Sets a new where EXISTS clause
      */
-    whereExists(subQuery: SelectQueryBuilder<any>): this;
+    whereExists(subQuery: SelectQueryBuilder<any>): this
 
     /**
      * Adds a new AND where EXISTS clause
      */
-    andWhereExists(subQuery: SelectQueryBuilder<any>): this;
+    andWhereExists(subQuery: SelectQueryBuilder<any>): this
 
     /**
      * Adds a new OR where EXISTS clause
      */
-    orWhereExists(subQuery: SelectQueryBuilder<any>): this;
+    orWhereExists(subQuery: SelectQueryBuilder<any>): this
 
     /**
      * Sets WHERE condition in the query builder with a condition for the given ids.


### PR DESCRIPTION
This allows for the SoftDelete, Delete and Update QueryBuilders to perform whereExists conditions. This allows for Brackets and NotBrackets to use whereExists statements.

Closes #10066

### Description of change

PR #9303 closed #2815, however the implementation was only available in the SelectQueryBuilder.

By including where exists methods in the `WhereExpressionBuilder` other query builders benefit from this, including the `Brackets` and `NotBrackets` classes.

### Pull-Request Checklist

- [X] Code is up-to-date with the `master` branch
- [X] `npm run format` to apply prettier formatting
- [ ] `npm run test` passes with this change **N/A**
- [X] This pull request links relevant issues as `Fixes #10066`
- [ ] There are new or updated unit tests validating the change **N/A**
- [ ] Documentation has been updated to reflect this change
- [X] The new commits follow conventions explained in [CONTRIBUTING.md](https://github.com/typeorm/typeorm/blob/master/CONTRIBUTING.md)
