### PR TITLE
Fix maximum call stack error

### DIFF
--- a/src/query-builder/QueryBuilder.ts
+++ b/src/query-builder/QueryBuilder.ts
@@ -1149,10 +1149,6 @@ export abstract class QueryBuilder<Entity extends ObjectLiteral> {
 
         const cteStrings = this.expressionMap.commonTableExpressions.map(
             (cte) => {
-                const cteBodyExpression =
-                    typeof cte.queryBuilder === "string"
-                        ? cte.queryBuilder
-                        : cte.queryBuilder.getQuery()
                 if (typeof cte.queryBuilder !== "string") {
                     if (cte.queryBuilder.hasCommonTableExpressions()) {
                         throw new TypeORMError(
@@ -1169,6 +1165,10 @@ export abstract class QueryBuilder<Entity extends ObjectLiteral> {
                     }
                     this.setParameters(cte.queryBuilder.getParameters())
                 }
+                const cteBodyExpression =
+                    typeof cte.queryBuilder === "string"
+                        ? cte.queryBuilder
+                        : cte.queryBuilder.getQuery()
                 let cteHeader = this.escape(cte.alias)
                 if (cte.options.columnNames) {
                     const escapedColumnNames = cte.options.columnNames.map(


### PR DESCRIPTION
### Description of change
To reproduce:
```
const qb = ds.createQueryBuilder();
qb.addCommonTableExpression(qb, `root`);
console.log(qb.getSql());
```

Old behaviour:
```
RangeError: Maximum call stack size exceeded
    at SelectQueryBuilder.getQuery (/***/src/query-builder/SelectQueryBuilder.ts:82:24)
    at /***/src/query-builder/QueryBuilder.ts:1080:32
    at Array.map (<anonymous>)
    at SelectQueryBuilder.createCteExpression (/***/src/query-builder/QueryBuilder.ts:1077:49)
    at SelectQueryBuilder.getQuery (/***/src/query-builder/SelectQueryBuilder.ts:83:21)
    at /***/src/query-builder/QueryBuilder.ts:1080:32
    at Array.map (<anonymous>)
    at SelectQueryBuilder.createCteExpression (/***/src/query-builder/QueryBuilder.ts:1077:49)
    at SelectQueryBuilder.getQuery (/***src/query-builder/SelectQueryBuilder.ts:83:21)
    at /***src/query-builder/QueryBuilder.ts:1080:32
```

New behaviour:
```
TypeORMError: Nested CTEs aren't supported (CTE: root)
    at /***/src/query-builder/QueryBuilder.ts:1080:31
    at Array.map (<anonymous>)
    at SelectQueryBuilder.createCteExpression (/***/src/query-builder/QueryBuilder.ts:1077:49)
    at SelectQueryBuilder.getQuery (/***/src/query-builder/SelectQueryBuilder.ts:83:21)
    at SelectQueryBuilder.getQueryAndParameters (/***/src/query-builder/QueryBuilder.ts:507:28)
    at SelectQueryBuilder.getSql (/***src/query-builder/QueryBuilder.ts:499:21)
    at Function.canCart (/***/src/modules/v2/access-control/service.ts:46:24)
    at MenuCartRepository.hasReadAccessToEnt (/***/src/modules/v2/db/menu-cart/menu-cart.repository.ts:48:33)
    at /***/src/utils/helper-classes/base-entity-service.ts:125:31
    at MenuCartRepository.req (/***/src/utils/helper-classes/base-entity-service.ts:104:23)

```

<!--
  Please be clear and concise what the change is intended to do,
  why this change is needed, and how you've verified that it
  corrects what you intended.

  In some cases it may be helpful to include the current behavior
  and the new behavior.

  If the change is related to an open issue, you can link it here.
  If you include `Fixes #0000` (replacing `0000` with the issue number)
  when this is merged it will automatically mark the issue as fixed and
  close it.
-->


### Pull-Request Checklist

<!--
  Please make sure to review and check all of the following.

  If an item is not applicable, you can add "N/A" to the end.
-->

- [x] Code is up-to-date with the `master` branch
- [x] `npm run format` to apply prettier formatting
- [ ] `npm run test` passes with this change
- [ ] There are new or updated unit tests validating the change
- [ ] Documentation has been updated to reflect this change
- [x] The new commits follow conventions explained in [CONTRIBUTING.md](https://github.com/typeorm/typeorm/blob/master/CONTRIBUTING.md)

<!--
  🎉 Thank you for contributing and making TypeORM even better!
-->
