### PR TITLE
fix: allow `FindOptionsWhere` to accept `LessThan` with `Union`

### DIFF
--- a/src/find-options/FindOptionsWhere.ts
+++ b/src/find-options/FindOptionsWhere.ts
@@ -4,33 +4,28 @@ import { EqualOperator } from "./EqualOperator"
 
 /**
  * A single property handler for FindOptionsWhere.
- *
- * The reason why we have both "PropertyToBeNarrowed" and "Property" is that Union is narrowed down when extends is used.
- * It means the result of FindOptionsWhereProperty<1 | 2> doesn't include FindOperator<1 | 2> but FindOperator<1> | FindOperator<2>.
- * So we keep the original Union as Original and pass it to the FindOperator too. Original remains Union as extends is not used for it.
  */
 export type FindOptionsWhereProperty<
-    PropertyToBeNarrowed,
-    Property = PropertyToBeNarrowed,
-> = PropertyToBeNarrowed extends Promise<infer I>
+    Property,
+> = [Property] extends [Promise<infer I>]
     ? FindOptionsWhereProperty<NonNullable<I>>
-    : PropertyToBeNarrowed extends Array<infer I>
+    : [Property] extends [Array<infer I>]
     ? FindOptionsWhereProperty<NonNullable<I>>
-    : PropertyToBeNarrowed extends Function
+    : [Property] extends [Function]
     ? never
-    : PropertyToBeNarrowed extends Buffer
+    : [Property] extends [Buffer]
     ? Property | FindOperator<Property>
-    : PropertyToBeNarrowed extends Date
+    : [Property] extends [Date]
     ? Property | FindOperator<Property>
-    : PropertyToBeNarrowed extends ObjectId
+    : [Property] extends [ObjectId]
     ? Property | FindOperator<Property>
-    : PropertyToBeNarrowed extends string
+    : [Property] extends [string]
     ? Property | FindOperator<Property>
-    : PropertyToBeNarrowed extends number
+    : [Property] extends [number]
     ? Property | FindOperator<Property>
-    : PropertyToBeNarrowed extends boolean
+    : [Property] extends [boolean]
     ? Property | FindOperator<Property>
-    : PropertyToBeNarrowed extends object
+    : [Property] extends [object]
     ?
           | FindOptionsWhere<Property>
           | FindOptionsWhere<Property>[]


### PR DESCRIPTION
### Description of change

A better fix for #9152 (replaces #9607)

The existing fix for #9152 in #9607 relies on a somewhat implicit behaviour of TypeScript where having multiple generic parameters causes the generic parameters to _not_ be distributive (default is that union types become distributive).

Per [TypeScript docs](https://www.typescriptlang.org/docs/handbook/2/conditional-types.html#distributive-conditional-types), the suggested way to do it is to enclose both sides of the extends in square brackets:

> Typically, distributivity is the desired behavior. To avoid that behavior, you can surround each side of the extends keyword with square brackets.
> ```
> type ToArrayNonDist<Type> = [Type] extends [any] ? Type[] : never;
> ```

This PR applies the suggested way from the TypeScript handbook

### Pull-Request Checklist

- [#] Code is up-to-date with the `master` branch
- [ ] `npm run format` to apply prettier formatting
- [ ] `npm run test` passes with this change
- [#] This pull request links relevant issues as `Fixes #0000`
- [ ] There are new or updated unit tests validating the change -- N/A (old ones do)
- [ ] Documentation has been updated to reflect this change -- N/A
- [#] The new commits follow conventions explained in [CONTRIBUTING.md](https://github.com/typeorm/typeorm/blob/master/CONTRIBUTING.md)
