### PR TITLE
fix: resolve nameless TableForeignKey on drop foreign key

### DIFF
--- a/src/driver/aurora-mysql/AuroraMysqlQueryRunner.ts
+++ b/src/driver/aurora-mysql/AuroraMysqlQueryRunner.ts
@@ -1769,6 +1769,13 @@ export class AuroraMysqlQueryRunner
                 `Supplied foreign key was not found in table ${table.name}`,
             )
 
+        if (!foreignKey.name) {
+            foreignKey.name = this.connection.namingStrategy.foreignKeyName(
+                table,
+                foreignKey.columnNames,
+            )
+        }
+
         const up = this.dropForeignKeySql(table, foreignKey)
         const down = this.createForeignKeySql(table, foreignKey)
         await this.executeQueries(up, down)

--- a/src/driver/cockroachdb/CockroachQueryRunner.ts
+++ b/src/driver/cockroachdb/CockroachQueryRunner.ts
@@ -2705,6 +2705,15 @@ export class CockroachQueryRunner
                 `Supplied foreign key was not found in table ${table.name}`,
             )
 
+        if (!foreignKey.name) {
+            foreignKey.name = this.connection.namingStrategy.foreignKeyName(
+                table,
+                foreignKey.columnNames,
+                this.getTablePath(foreignKey),
+                foreignKey.referencedColumnNames,
+            )
+        }
+
         const up = this.dropForeignKeySql(table, foreignKey)
         const down = this.createForeignKeySql(table, foreignKey)
         await this.executeQueries(up, down)

--- a/src/driver/mysql/MysqlQueryRunner.ts
+++ b/src/driver/mysql/MysqlQueryRunner.ts
@@ -2152,6 +2152,15 @@ export class MysqlQueryRunner extends BaseQueryRunner implements QueryRunner {
                 `Supplied foreign key was not found in table ${table.name}`,
             )
 
+        if (!foreignKey.name) {
+            foreignKey.name = this.connection.namingStrategy.foreignKeyName(
+                table,
+                foreignKey.columnNames,
+                this.getTablePath(foreignKey),
+                foreignKey.referencedColumnNames,
+            )
+        }
+
         const up = this.dropForeignKeySql(table, foreignKey)
         const down = this.createForeignKeySql(table, foreignKey)
         await this.executeQueries(up, down)

--- a/src/driver/oracle/OracleQueryRunner.ts
+++ b/src/driver/oracle/OracleQueryRunner.ts
@@ -2115,6 +2115,15 @@ export class OracleQueryRunner extends BaseQueryRunner implements QueryRunner {
                 `Supplied foreign key was not found in table ${table.name}`,
             )
 
+        if (!foreignKey.name) {
+            foreignKey.name = this.connection.namingStrategy.foreignKeyName(
+                table,
+                foreignKey.columnNames,
+                this.getTablePath(foreignKey),
+                foreignKey.referencedColumnNames,
+            )
+        }
+
         const up = this.dropForeignKeySql(table, foreignKey)
         const down = this.createForeignKeySql(table, foreignKey)
         await this.executeQueries(up, down)

--- a/src/driver/postgres/PostgresQueryRunner.ts
+++ b/src/driver/postgres/PostgresQueryRunner.ts
@@ -601,10 +601,22 @@ export class PostgresQueryRunner
                 downQueries.push(this.dropIndexSql(table, index))
             })
         }
-        
+
         if (table.comment) {
-            upQueries.push(new Query("COMMENT ON TABLE " + this.escapePath(table) + " IS '" + table.comment + "'"));
-            downQueries.push(new Query("COMMENT ON TABLE " + this.escapePath(table) + " IS NULL"));
+            upQueries.push(
+                new Query(
+                    "COMMENT ON TABLE " +
+                        this.escapePath(table) +
+                        " IS '" +
+                        table.comment +
+                        "'",
+                ),
+            )
+            downQueries.push(
+                new Query(
+                    "COMMENT ON TABLE " + this.escapePath(table) + " IS NULL",
+                ),
+            )
         }
 
         await this.executeQueries(upQueries, downQueries)
@@ -4744,7 +4756,7 @@ export class PostgresQueryRunner
 
         newComment = this.escapeComment(newComment)
         const comment = this.escapeComment(table.comment)
-        
+
         if (newComment === comment) {
             return
         }

--- a/src/driver/sap/SapQueryRunner.ts
+++ b/src/driver/sap/SapQueryRunner.ts
@@ -2272,6 +2272,15 @@ export class SapQueryRunner extends BaseQueryRunner implements QueryRunner {
                 `Supplied foreign key was not found in table ${table.name}`,
             )
 
+        if (!foreignKey.name) {
+            foreignKey.name = this.connection.namingStrategy.foreignKeyName(
+                table,
+                foreignKey.columnNames,
+                this.getTablePath(foreignKey),
+                foreignKey.referencedColumnNames,
+            )
+        }
+
         const up = this.dropForeignKeySql(table, foreignKey)
         const down = this.createForeignKeySql(table, foreignKey)
         await this.executeQueries(up, down)

--- a/src/driver/spanner/SpannerQueryRunner.ts
+++ b/src/driver/spanner/SpannerQueryRunner.ts
@@ -1332,6 +1332,15 @@ export class SpannerQueryRunner extends BaseQueryRunner implements QueryRunner {
                 `Supplied foreign key was not found in table ${table.name}`,
             )
 
+        if (!foreignKey.name) {
+            foreignKey.name = this.connection.namingStrategy.foreignKeyName(
+                table,
+                foreignKey.columnNames,
+                this.getTablePath(foreignKey),
+                foreignKey.referencedColumnNames,
+            )
+        }
+
         const up = this.dropForeignKeySql(table, foreignKey)
         const down = this.createForeignKeySql(table, foreignKey)
         await this.executeQueries(up, down)

--- a/src/driver/sqlserver/SqlServerQueryRunner.ts
+++ b/src/driver/sqlserver/SqlServerQueryRunner.ts
@@ -2523,6 +2523,15 @@ export class SqlServerQueryRunner
                 `Supplied foreign key was not found in table ${table.name}`,
             )
 
+        if (!foreignKey.name) {
+            foreignKey.name = this.connection.namingStrategy.foreignKeyName(
+                table,
+                foreignKey.columnNames,
+                this.getTablePath(foreignKey),
+                foreignKey.referencedColumnNames,
+            )
+        }
+
         const up = this.dropForeignKeySql(table, foreignKey)
         const down = this.createForeignKeySql(table, foreignKey)
         await this.executeQueries(up, down)

--- a/src/query-builder/InsertQueryBuilder.ts
+++ b/src/query-builder/InsertQueryBuilder.ts
@@ -459,10 +459,8 @@ export class InsertQueryBuilder<
         // add VALUES expression
         if (valuesExpression) {
             if (
-                (
-                    this.connection.driver.options.type === "oracle" ||
-                    this.connection.driver.options.type === "sap"
-                ) &&
+                (this.connection.driver.options.type === "oracle" ||
+                    this.connection.driver.options.type === "sap") &&
                 this.getValueSets().length > 1
             ) {
                 query += ` ${valuesExpression}`

--- a/src/query-builder/QueryBuilder.ts
+++ b/src/query-builder/QueryBuilder.ts
@@ -522,7 +522,10 @@ export abstract class QueryBuilder<Entity extends ObjectLiteral> {
      * Uses same query runner as current QueryBuilder.
      */
     createQueryBuilder(queryRunner?: QueryRunner): this {
-        return new (this.constructor as any)(this.connection, queryRunner ?? this.queryRunner)
+        return new (this.constructor as any)(
+            this.connection,
+            queryRunner ?? this.queryRunner,
+        )
     }
 
     /**

--- a/src/schema-builder/RdbmsSchemaBuilder.ts
+++ b/src/schema-builder/RdbmsSchemaBuilder.ts
@@ -604,7 +604,7 @@ export class RdbmsSchemaBuilder implements SchemaBuilder {
 
             if (
                 DriverUtils.isMySQLFamily(this.connection.driver) ||
-                this.connection.driver.options.type === 'postgres'
+                this.connection.driver.options.type === "postgres"
             ) {
                 const newComment = metadata.comment
                 await this.queryRunner.changeTableComment(table, newComment)

--- a/test/integration/sample2-one-to-one.ts
+++ b/test/integration/sample2-one-to-one.ts
@@ -211,14 +211,15 @@ describe("one-to-one", function () {
             expectedPost.details!.comment = savedPost.details!.comment
             expectedPost.details!.metadata = savedPost.details!.metadata
 
-            const findOne = () => postRepository.findOne({
+            const findOne = () =>
+                postRepository.findOne({
                     where: {
-                        id: savedPost.id
+                        id: savedPost.id,
                     },
                     relations: {
-                        details: true
+                        details: true,
                     },
-                    relationLoadStrategy: "query"
+                    relationLoadStrategy: "query",
                 })
 
             const posts = await Promise.all([
@@ -234,7 +235,7 @@ describe("one-to-one", function () {
                 findOne(),
             ])
 
-            posts.forEach(post => {
+            posts.forEach((post) => {
                 expect(post).not.to.be.null
                 post!.should.eql(expectedPost)
             })

--- a/test/integration/sample3-many-to-one.ts
+++ b/test/integration/sample3-many-to-one.ts
@@ -213,15 +213,16 @@ describe("many-to-one", function () {
             expectedPost.details!.comment = savedPost.details!.comment
             expectedPost.details!.metadata = savedPost.details!.metadata
 
-            const findOne = () => postRepository.findOne({
-                where: {
-                    id: savedPost.id
-                },
-                relations: {
-                    details: true
-                },
-                relationLoadStrategy: "query"
-            })
+            const findOne = () =>
+                postRepository.findOne({
+                    where: {
+                        id: savedPost.id,
+                    },
+                    relations: {
+                        details: true,
+                    },
+                    relationLoadStrategy: "query",
+                })
 
             const posts = await Promise.all([
                 findOne(),
@@ -236,7 +237,7 @@ describe("many-to-one", function () {
                 findOne(),
             ])
 
-            posts.forEach(post => {
+            posts.forEach((post) => {
                 expect(post).not.to.be.null
                 post!.should.eql(expectedPost)
             })


### PR DESCRIPTION
<!--
  😀 Wonderful!  Thank you for opening a pull request for TypeORM.

  Please fill in the information below to expedite the review
  and (hopefully) merge of your change.

  If unsure about something.. just do as best as you're able,
  or reach out through our community support channels!
  https://github.com/typeorm/typeorm/blob/master/docs/support.md
-->

### Description of change

<!--
  Please be clear and concise what the change is intended to do,
  why this change is needed, and how you've verified that it
  corrects what you intended.

  In some cases it may be helpful to include the current behavior
  and the new behavior.

  If the change is related to an open issue, you can link it here.
  If you include `Fixes #0000` (replacing `0000` with the issue number)
  when this is merged it will automatically mark the issue as fixed and
  close it.
-->
Fixes #9432 #9460

If a TableForeignKey is without a name on dropForeignKey so it's create a name like on createForeignKey.

#9460 only fix postgres. This PR fix all query runner.

### Pull-Request Checklist

<!--
  Please make sure to review and check all of the following.

  If an item is not applicable, you can add "N/A" to the end.
-->

- [x] Code is up-to-date with the `master` branch
- [x] `npm run format` to apply prettier formatting
- [ ] `npm run test` passes with this change
- [x] This pull request links relevant issues as `Fixes #0000`
- [ ] There are new or updated unit tests validating the change
- [ ] Documentation has been updated to reflect this change
- [ ] The new commits follow conventions explained in [CONTRIBUTING.md](https://github.com/typeorm/typeorm/blob/master/CONTRIBUTING.md)

<!--
  🎉 Thank you for contributing and making TypeORM even better!
-->
