### PR TITLE
feat: Add tsvector & tsquery to cockroachdb

### DIFF
--- a/docs/entities.md
+++ b/docs/entities.md
@@ -399,7 +399,7 @@ or
 `float4`, `float8`, `double precision`, `real`, `inet`, `int`, `integer`, `int2`, `int8`, `int64`,
 `smallint`, `bigint`, `interval`, `string`, `character varying`, `character`, `char`, `char varying`,
 `varchar`, `text`, `time`, `time without time zone`, `timestamp`, `timestamptz`, `timestamp without time zone`,
-`timestamp with time zone`, `json`, `jsonb`, `uuid`
+`timestamp with time zone`, `json`, `jsonb`, `uuid`, `tsvector`, `tsquery`
 
 > Note: CockroachDB returns all numeric data types as `string`. However if you omit column type and define your property as
 > `number` ORM will `parseInt` string into number.

--- a/src/driver/cockroachdb/CockroachDriver.ts
+++ b/src/driver/cockroachdb/CockroachDriver.ts
@@ -157,6 +157,8 @@ export class CockroachDriver implements Driver {
         "json",
         "jsonb",
         "uuid",
+        "tsvector",
+        "tsquery",
     ]
 
     /**

--- a/src/driver/types/ColumnTypes.ts
+++ b/src/driver/types/ColumnTypes.ts
@@ -191,8 +191,8 @@ export type SimpleColumnType =
     | "bit" // postgres, mssql
     | "bit varying" // postgres
     | "varbit" // postgres
-    | "tsvector" // postgres
-    | "tsquery" // postgres
+    | "tsvector" // postgres, cockroachdb
+    | "tsquery" // postgres, cockroachdb
     | "uuid" // postgres, cockroachdb, mariadb
     | "xml" // mssql, postgres
     | "json" // mysql, postgres, cockroachdb, spanner


### PR DESCRIPTION
Cockroach added 'tsvector' & 'tsquery' in the v23 Stable Release.

https://www.cockroachlabs.com/docs/stable/data-types


### Pull-Request Checklist

- [x] Code is up-to-date with the `master` branch
- [x] `npm run format` to apply prettier formatting
- [x] `npm run test` passes with this change
- [x] This pull request links relevant issues as `Fixes #0000`
- [x] There are new or updated unit tests validating the change
- [x] Documentation has been updated to reflect this change
- [x] The new commits follow conventions explained in [CONTRIBUTING.md](https://github.com/typeorm/typeorm/blob/master/CONTRIBUTING.md)