### PR TITLE
 Fixes #10687 - regression caused by #10273. Changing PRAGMA queries back to use query() instead of run()

### DIFF
--- a/src/driver/capacitor/CapacitorDriver.ts
+++ b/src/driver/capacitor/CapacitorDriver.ts
@@ -80,7 +80,7 @@ export class CapacitorDriver extends AbstractSqliteDriver {
 
         // we need to enable foreign keys in sqlite to make sure all foreign key related features
         // working properly. this also makes onDelete to work with sqlite.
-        await connection.run(`PRAGMA foreign_keys = ON`)
+        await connection.query(`PRAGMA foreign_keys = ON`)
 
         if (
             this.options.journalMode &&
@@ -88,7 +88,7 @@ export class CapacitorDriver extends AbstractSqliteDriver {
                 this.options.journalMode,
             ) !== -1
         ) {
-            await connection.run(
+            await connection.query(
                 `PRAGMA journal_mode = ${this.options.journalMode}`,
             )
         }

--- a/src/driver/capacitor/CapacitorQueryRunner.ts
+++ b/src/driver/capacitor/CapacitorQueryRunner.ts
@@ -82,7 +82,7 @@ export class CapacitorQueryRunner extends AbstractSqliteQueryRunner {
             ) {
                 raw = await databaseConnection.execute(query, false)
             } else if (
-                ["INSERT", "UPDATE", "DELETE", "PRAGMA"].indexOf(command) !== -1
+                ["INSERT", "UPDATE", "DELETE"].indexOf(command) !== -1
             ) {
                 raw = await databaseConnection.run(query, parameters, false)
             } else {


### PR DESCRIPTION
A recent MR #10273 included some unnecessary changes that made SQLite PRAGMA queries be executed using `connection.run` instead of `connection.query`.

This causes the bug reported in #10687

This MR simply reverts a small part of #10273 to go back to the previous working behavior.