### PR TITLE
fix: add async to the method using setFindOptions()

### DIFF
--- a/src/entity-manager/EntityManager.ts
+++ b/src/entity-manager/EntityManager.ts
@@ -957,7 +957,7 @@ export class EntityManager {
     /**
      * Checks whether any entity exists with the given options.
      */
-    exists<Entity extends ObjectLiteral>(
+    async exists<Entity extends ObjectLiteral>(
         entityClass: EntityTarget<Entity>,
         options?: FindManyOptions<Entity>,
     ): Promise<boolean> {
@@ -988,7 +988,7 @@ export class EntityManager {
      * Counts entities that match given options.
      * Useful for pagination.
      */
-    count<Entity extends ObjectLiteral>(
+    async count<Entity extends ObjectLiteral>(
         entityClass: EntityTarget<Entity>,
         options?: FindManyOptions<Entity>,
     ): Promise<number> {
@@ -1006,7 +1006,7 @@ export class EntityManager {
      * Counts entities that match given conditions.
      * Useful for pagination.
      */
-    countBy<Entity extends ObjectLiteral>(
+    async countBy<Entity extends ObjectLiteral>(
         entityClass: EntityTarget<Entity>,
         where: FindOptionsWhere<Entity> | FindOptionsWhere<Entity>[],
     ): Promise<number> {
@@ -1126,7 +1126,7 @@ export class EntityManager {
      * Also counts all entities that match given conditions,
      * but ignores pagination settings (from and take options).
      */
-    findAndCount<Entity extends ObjectLiteral>(
+    async findAndCount<Entity extends ObjectLiteral>(
         entityClass: EntityTarget<Entity>,
         options?: FindManyOptions<Entity>,
     ): Promise<[Entity[], number]> {
@@ -1145,7 +1145,7 @@ export class EntityManager {
      * Also counts all entities that match given conditions,
      * but ignores pagination settings (from and take options).
      */
-    findAndCountBy<Entity extends ObjectLiteral>(
+    async findAndCountBy<Entity extends ObjectLiteral>(
         entityClass: EntityTarget<Entity>,
         where: FindOptionsWhere<Entity> | FindOptionsWhere<Entity>[],
     ): Promise<[Entity[], number]> {


### PR DESCRIPTION
### Description of change

* Although the return type in TypeScript is Promise<>, it is not possible to catch as shown below (not promise return)
* This is because 5 modified methods are set to sync.

```typescript
// definition: Repository<IamOrganization>.exists(options?: FindManyOptions<IamOrganization> | undefined): Promise<boolean>
// expected error: Promise.reject(EntityPropertyNotFoundError)

// AS-IS(not working)
this.repository.exists({ select: 'not_exists' }).catch((error) => console.error);

// AS-IS(working)
try {
  this.repository.exists({ select: 'not_exists' });
} catch (error) {
  console.error(error);
}

// TO-BE(working)
this.repository.exists({ select: 'not_exists' }).catch((error) => console.error);
// or
try {
  await this.repository.exists({ select: 'not_exists' });
} catch (error) {
  console.error(error);
}


```


### Pull-Request Checklist


- [x] Code is up-to-date with the `master` branch
- [x] `npm run format` to apply prettier formatting
- [x] `npm run test` passes with this change
- [ ] This pull request links relevant issues as `Fixes #0000` - N/A
- [ ] There are new or updated unit tests validating the change - N/A
- [ ] Documentation has been updated to reflect this change - N/A
- [x] The new commits follow conventions explained in [CONTRIBUTING.md](https://github.com/typeorm/typeorm/blob/master/CONTRIBUTING.md)
