### PR TITLE
fix: add multiSubnetFailover option for mssql

### DIFF
--- a/docs/data-source-options.md
+++ b/docs/data-source-options.md
@@ -384,6 +384,8 @@ Based on [tedious](https://tediousjs.github.io/node-mssql/) MSSQL implementation
 
 -   `options.trustServerCertificate` - A boolean, controlling whether encryption occurs if there is no verifiable server certificate. (default: `false`)
 
+-   `options.multiSubnetFailover` - A boolean, controlling whether the driver should connect to all IPs return in DNS in parallel. (default: `false`)
+
 -   `options.debug.packet` - A boolean, controlling whether `debug` events will be emitted with text describing packet
     details (default: `false`).
 

--- a/src/driver/sqlserver/SqlServerConnectionOptions.ts
+++ b/src/driver/sqlserver/SqlServerConnectionOptions.ts
@@ -290,6 +290,12 @@ export interface SqlServerConnectionOptions
          * (default: false)
          */
         readonly trustServerCertificate?: boolean
+
+        /**
+         * A boolean, controlling whether the driver should connect to all IPs return in DNS in parallel.
+         * (default: false)
+         */
+        readonly multiSubnetFailover?: boolean
     }
 
     /**


### PR DESCRIPTION
<!--
  😀 Wonderful!  Thank you for opening a pull request for TypeORM.

  Please fill in the information below to expedite the review
  and (hopefully) merge of your change.

  If unsure about something.. just do as best as you're able,
  or reach out through our community support channels!
  https://github.com/typeorm/typeorm/blob/master/docs/support.md
-->

### Description of change

add multiSubnetFailover option for SqlServerConnectionOptions.

This will support MSSQL alway on avalibility group to be failover faster
![image](https://github.com/typeorm/typeorm/assets/803047/d6f463d1-f4c2-4019-819a-12821a553412)
ref: https://learn.microsoft.com/en-us/sql/sql-server/failover-clusters/windows/sql-server-multi-subnet-clustering-sql-server?view=sql-server-ver16#DNS

in tediousjs this feature was implemented in https://github.com/tediousjs/tedious/pull/362

### Pull-Request Checklist

<!--
  Please make sure to review and check all of the following.

  If an item is not applicable, you can add "N/A" to the end.
-->

- [ ] Code is up-to-date with the `master` branch
- [ ] `npm run format` to apply prettier formatting
- [ ] `npm run test` passes with this change
- [ ] This pull request links relevant issues as `Fixes #0000`
- [ ] There are new or updated unit tests validating the change
- [ ] Documentation has been updated to reflect this change
- [ ] The new commits follow conventions explained in [CONTRIBUTING.md](https://github.com/typeorm/typeorm/blob/master/CONTRIBUTING.md)

<!--
  🎉 Thank you for contributing and making TypeORM even better!
-->
