### PR TITLE
fix: remove unnecessary spaces in message when running non-fake migrations

### DIFF
--- a/src/migration/MigrationExecutor.ts
+++ b/src/migration/MigrationExecutor.ts
@@ -359,8 +359,8 @@ export class MigrationExecutor {
                         successMigrations.push(migration)
                         this.connection.logger.logSchemaBuild(
                             `Migration ${migration.name} has been ${
-                                this.fake ? "(fake)" : ""
-                            } executed successfully.`,
+                                this.fake ? "(fake) " : ""
+                            }executed successfully.`,
                         )
                     })
             }
@@ -464,8 +464,8 @@ export class MigrationExecutor {
             await this.deleteExecutedMigration(queryRunner, migrationToRevert)
             this.connection.logger.logSchemaBuild(
                 `Migration ${migrationToRevert.name} has been ${
-                    this.fake ? "(fake)" : ""
-                } reverted successfully.`,
+                    this.fake ? "(fake) " : ""
+                }reverted successfully.`,
             )
 
             // commit transaction if we started it


### PR DESCRIPTION
<!--
  😀 Wonderful!  Thank you for opening a pull request for TypeORM.

  Please fill in the information below to expedite the review
  and (hopefully) merge of your change.

  If unsure about something.. just do as best as you're able,
  or reach out through our community support channels!
  https://github.com/typeorm/typeorm/blob/master/docs/support.md
-->

### Description of change

<!--
  Please be clear and concise what the change is intended to do,
  why this change is needed, and how you've verified that it
  corrects what you intended.

  In some cases it may be helpful to include the current behavior
  and the new behavior.

  If the change is related to an open issue, you can link it here.
  If you include `Fixes #0000` (replacing `0000` with the issue number)
  when this is merged it will automatically mark the issue as fixed and
  close it.
-->

In the log of a successful non-fake migration, there is an unnecessary space as shown in the screenshot. This PR remove this.

<img width="257" alt="Screenshot of output message" src="https://github.com/typeorm/typeorm/assets/107108195/6e2206c3-5ba2-418f-bd9a-710515b7eb6a">


### Pull-Request Checklist

<!--
  Please make sure to review and check all of the following.

  If an item is not applicable, you can add "N/A" to the end.
-->

- [x] Code is up-to-date with the `master` branch
- [ ] `npm run format` to apply prettier formatting
- [ ] `npm run test` passes with this change
- [ ] This pull request links relevant issues as `Fixes #0000`
- [ ] There are new or updated unit tests validating the change
- [ ] Documentation has been updated to reflect this change
- [ ] The new commits follow conventions explained in [CONTRIBUTING.md](https://github.com/typeorm/typeorm/blob/master/CONTRIBUTING.md)

<!--
  🎉 Thank you for contributing and making TypeORM even better!
-->
