### PR TITLE
perf(query-runner): use Date.now() intead of +new Date()

### DIFF
--- a/src/driver/better-sqlite3/BetterSqlite3QueryRunner.ts
+++ b/src/driver/better-sqlite3/BetterSqlite3QueryRunner.ts
@@ -84,7 +84,7 @@ export class BetterSqlite3QueryRunner extends AbstractSqliteQueryRunner {
         const connection = this.driver.connection
 
         this.driver.connection.logger.logQuery(query, parameters, this)
-        const queryStartTime = +new Date()
+        const queryStartTime = Date.now()
 
         const stmt = await this.getStmt(query)
 
@@ -108,7 +108,7 @@ export class BetterSqlite3QueryRunner extends AbstractSqliteQueryRunner {
             // log slow queries if maxQueryExecution time is set
             const maxQueryExecutionTime =
                 this.driver.options.maxQueryExecutionTime
-            const queryEndTime = +new Date()
+            const queryEndTime = Date.now()
             const queryExecutionTime = queryEndTime - queryStartTime
             if (
                 maxQueryExecutionTime &&

--- a/src/driver/cockroachdb/CockroachQueryRunner.ts
+++ b/src/driver/cockroachdb/CockroachQueryRunner.ts
@@ -281,7 +281,7 @@ export class CockroachQueryRunner
             parameters,
         )
 
-        const queryStartTime = +new Date()
+        const queryStartTime = Date.now()
 
         if (this.isTransactionActive && this.storeQueries) {
             this.queries.push({ query, parameters })
@@ -299,7 +299,7 @@ export class CockroachQueryRunner
             // log slow queries if maxQueryExecution time is set
             const maxQueryExecutionTime =
                 this.driver.options.maxQueryExecutionTime
-            const queryEndTime = +new Date()
+            const queryEndTime = Date.now()
             const queryExecutionTime = queryEndTime - queryStartTime
             if (
                 maxQueryExecutionTime &&

--- a/src/driver/cordova/CordovaQueryRunner.ts
+++ b/src/driver/cordova/CordovaQueryRunner.ts
@@ -62,7 +62,7 @@ export class CordovaQueryRunner extends AbstractSqliteQueryRunner {
             parameters,
         )
 
-        const queryStartTime = +new Date()
+        const queryStartTime = Date.now()
 
         try {
             const raw = await new Promise<any>(async (ok, fail) => {
@@ -77,7 +77,7 @@ export class CordovaQueryRunner extends AbstractSqliteQueryRunner {
             // log slow queries if maxQueryExecution time is set
             const maxQueryExecutionTime =
                 this.driver.options.maxQueryExecutionTime
-            const queryEndTime = +new Date()
+            const queryEndTime = Date.now()
             const queryExecutionTime = queryEndTime - queryStartTime
 
             this.broadcaster.broadcastAfterQueryEvent(

--- a/src/driver/expo/ExpoQueryRunner.ts
+++ b/src/driver/expo/ExpoQueryRunner.ts
@@ -174,7 +174,7 @@ export class ExpoQueryRunner extends AbstractSqliteQueryRunner {
                 parameters,
             )
 
-            const queryStartTime = +new Date()
+            const queryStartTime = Date.now()
             // All Expo SQL queries are executed in a transaction context
             databaseConnection.transaction(
                 async (transaction: ITransaction) => {
@@ -189,7 +189,7 @@ export class ExpoQueryRunner extends AbstractSqliteQueryRunner {
                             // log slow queries if maxQueryExecution time is set
                             const maxQueryExecutionTime =
                                 this.driver.options.maxQueryExecutionTime
-                            const queryEndTime = +new Date()
+                            const queryEndTime = Date.now()
                             const queryExecutionTime =
                                 queryEndTime - queryStartTime
 

--- a/src/driver/mysql/MysqlQueryRunner.ts
+++ b/src/driver/mysql/MysqlQueryRunner.ts
@@ -203,7 +203,7 @@ export class MysqlQueryRunner extends BaseQueryRunner implements QueryRunner {
                     parameters,
                 )
 
-                const queryStartTime = +new Date()
+                const queryStartTime = Date.now()
                 databaseConnection.query(
                     query,
                     parameters,
@@ -211,7 +211,7 @@ export class MysqlQueryRunner extends BaseQueryRunner implements QueryRunner {
                         // log slow queries if maxQueryExecution time is set
                         const maxQueryExecutionTime =
                             this.driver.options.maxQueryExecutionTime
-                        const queryEndTime = +new Date()
+                        const queryEndTime = Date.now()
                         const queryExecutionTime = queryEndTime - queryStartTime
 
                         if (

--- a/src/driver/nativescript/NativescriptQueryRunner.ts
+++ b/src/driver/nativescript/NativescriptQueryRunner.ts
@@ -63,7 +63,7 @@ export class NativescriptQueryRunner extends AbstractSqliteQueryRunner {
                 // log slow queries if maxQueryExecution time is set
                 const maxQueryExecutionTime =
                     this.driver.options.maxQueryExecutionTime
-                const queryEndTime = +new Date()
+                const queryEndTime = Date.now()
                 const queryExecutionTime = queryEndTime - queryStartTime
 
                 if (
@@ -101,7 +101,7 @@ export class NativescriptQueryRunner extends AbstractSqliteQueryRunner {
                     ok(result.raw)
                 }
             }
-            const queryStartTime = +new Date()
+            const queryStartTime = Date.now()
 
             if (isInsertQuery) {
                 databaseConnection.execSQL(query, parameters, handler)

--- a/src/driver/oracle/OracleQueryRunner.ts
+++ b/src/driver/oracle/OracleQueryRunner.ts
@@ -209,7 +209,7 @@ export class OracleQueryRunner extends BaseQueryRunner implements QueryRunner {
             parameters,
         )
 
-        const queryStartTime = +new Date()
+        const queryStartTime = Date.now()
 
         try {
             const executionOptions = {
@@ -226,7 +226,7 @@ export class OracleQueryRunner extends BaseQueryRunner implements QueryRunner {
             // log slow queries if maxQueryExecution time is set
             const maxQueryExecutionTime =
                 this.driver.options.maxQueryExecutionTime
-            const queryEndTime = +new Date()
+            const queryEndTime = Date.now()
             const queryExecutionTime = queryEndTime - queryStartTime
 
             this.broadcaster.broadcastAfterQueryEvent(

--- a/src/driver/postgres/PostgresQueryRunner.ts
+++ b/src/driver/postgres/PostgresQueryRunner.ts
@@ -256,12 +256,12 @@ export class PostgresQueryRunner
         )
 
         try {
-            const queryStartTime = +new Date()
+            const queryStartTime = Date.now()
             const raw = await databaseConnection.query(query, parameters)
             // log slow queries if maxQueryExecution time is set
             const maxQueryExecutionTime =
                 this.driver.options.maxQueryExecutionTime
-            const queryEndTime = +new Date()
+            const queryEndTime = Date.now()
             const queryExecutionTime = queryEndTime - queryStartTime
 
             this.broadcaster.broadcastAfterQueryEvent(
@@ -601,7 +601,7 @@ export class PostgresQueryRunner
                 downQueries.push(this.dropIndexSql(table, index))
             })
         }
-        
+
         if (table.comment) {
             upQueries.push(new Query("COMMENT ON TABLE " + this.escapePath(table) + " IS '" + table.comment + "'"));
             downQueries.push(new Query("COMMENT ON TABLE " + this.escapePath(table) + " IS NULL"));
@@ -4744,7 +4744,7 @@ export class PostgresQueryRunner
 
         newComment = this.escapeComment(newComment)
         const comment = this.escapeComment(table.comment)
-        
+
         if (newComment === comment) {
             return
         }

--- a/src/driver/react-native/ReactNativeQueryRunner.ts
+++ b/src/driver/react-native/ReactNativeQueryRunner.ts
@@ -63,7 +63,7 @@ export class ReactNativeQueryRunner extends AbstractSqliteQueryRunner {
                 parameters,
             )
 
-            const queryStartTime = +new Date()
+            const queryStartTime = Date.now()
             databaseConnection.executeSql(
                 query,
                 parameters,
@@ -71,7 +71,7 @@ export class ReactNativeQueryRunner extends AbstractSqliteQueryRunner {
                     // log slow queries if maxQueryExecution time is set
                     const maxQueryExecutionTime =
                         this.driver.options.maxQueryExecutionTime
-                    const queryEndTime = +new Date()
+                    const queryEndTime = Date.now()
                     const queryExecutionTime = queryEndTime - queryStartTime
 
                     this.broadcaster.broadcastAfterQueryEvent(

--- a/src/driver/sap/SapQueryRunner.ts
+++ b/src/driver/sap/SapQueryRunner.ts
@@ -207,7 +207,7 @@ export class SapQueryRunner extends BaseQueryRunner implements QueryRunner {
                 parameters,
             )
 
-            const queryStartTime = +new Date()
+            const queryStartTime = Date.now()
             const isInsertQuery = query.substr(0, 11) === "INSERT INTO"
 
             if (parameters?.some(Array.isArray)) {
@@ -232,7 +232,7 @@ export class SapQueryRunner extends BaseQueryRunner implements QueryRunner {
             // log slow queries if maxQueryExecution time is set
             const maxQueryExecutionTime =
                 this.driver.connection.options.maxQueryExecutionTime
-            const queryEndTime = +new Date()
+            const queryEndTime = Date.now()
             const queryExecutionTime = queryEndTime - queryStartTime
 
             this.broadcaster.broadcastAfterQueryEvent(

--- a/src/driver/spanner/SpannerQueryRunner.ts
+++ b/src/driver/spanner/SpannerQueryRunner.ts
@@ -159,7 +159,7 @@ export class SpannerQueryRunner extends BaseQueryRunner implements QueryRunner {
         const broadcasterResult = new BroadcasterResult()
 
         try {
-            const queryStartTime = +new Date()
+            const queryStartTime = Date.now()
             await this.connect()
             let rawResult:
                 | [
@@ -216,7 +216,7 @@ export class SpannerQueryRunner extends BaseQueryRunner implements QueryRunner {
             // log slow queries if maxQueryExecution time is set
             const maxQueryExecutionTime =
                 this.driver.options.maxQueryExecutionTime
-            const queryEndTime = +new Date()
+            const queryEndTime = Date.now()
             const queryExecutionTime = queryEndTime - queryStartTime
 
             this.broadcaster.broadcastAfterQueryEvent(
@@ -286,7 +286,7 @@ export class SpannerQueryRunner extends BaseQueryRunner implements QueryRunner {
 
         this.driver.connection.logger.logQuery(query, parameters, this)
         try {
-            const queryStartTime = +new Date()
+            const queryStartTime = Date.now()
             const [operation] = await this.driver.instanceDatabase.updateSchema(
                 query,
             )
@@ -294,7 +294,7 @@ export class SpannerQueryRunner extends BaseQueryRunner implements QueryRunner {
             // log slow queries if maxQueryExecution time is set
             const maxQueryExecutionTime =
                 this.driver.options.maxQueryExecutionTime
-            const queryEndTime = +new Date()
+            const queryEndTime = Date.now()
             const queryExecutionTime = queryEndTime - queryStartTime
             if (
                 maxQueryExecutionTime &&

--- a/src/driver/sqlite/SqliteQueryRunner.ts
+++ b/src/driver/sqlite/SqliteQueryRunner.ts
@@ -75,7 +75,7 @@ export class SqliteQueryRunner extends AbstractSqliteQueryRunner {
             try {
                 const databaseConnection = await this.connect()
                 this.driver.connection.logger.logQuery(query, parameters, this)
-                const queryStartTime = +new Date()
+                const queryStartTime = Date.now()
                 const isInsertQuery = query.startsWith("INSERT ")
                 const isDeleteQuery = query.startsWith("DELETE ")
                 const isUpdateQuery = query.startsWith("UPDATE ")
@@ -101,7 +101,7 @@ export class SqliteQueryRunner extends AbstractSqliteQueryRunner {
                     }
 
                     // log slow queries if maxQueryExecution time is set
-                    const queryEndTime = +new Date()
+                    const queryEndTime = Date.now()
                     const queryExecutionTime = queryEndTime - queryStartTime
                     if (
                         maxQueryExecutionTime &&

--- a/src/driver/sqljs/SqljsQueryRunner.ts
+++ b/src/driver/sqljs/SqljsQueryRunner.ts
@@ -94,7 +94,7 @@ export class SqljsQueryRunner extends AbstractSqliteQueryRunner {
             parameters,
         )
 
-        const queryStartTime = +new Date()
+        const queryStartTime = Date.now()
         let statement: any
         try {
             statement = databaseConnection.prepare(query)
@@ -109,7 +109,7 @@ export class SqljsQueryRunner extends AbstractSqliteQueryRunner {
             // log slow queries if maxQueryExecution time is set
             const maxQueryExecutionTime =
                 this.driver.options.maxQueryExecutionTime
-            const queryEndTime = +new Date()
+            const queryEndTime = Date.now()
             const queryExecutionTime = queryEndTime - queryStartTime
 
             if (

--- a/src/driver/sqlserver/SqlServerQueryRunner.ts
+++ b/src/driver/sqlserver/SqlServerQueryRunner.ts
@@ -246,14 +246,14 @@ export class SqlServerQueryRunner
                     }
                 })
             }
-            const queryStartTime = +new Date()
+            const queryStartTime = Date.now()
 
             const raw = await new Promise<any>((ok, fail) => {
                 request.query(query, (err: any, raw: any) => {
                     // log slow queries if maxQueryExecution time is set
                     const maxQueryExecutionTime =
                         this.driver.options.maxQueryExecutionTime
-                    const queryEndTime = +new Date()
+                    const queryEndTime = Date.now()
                     const queryExecutionTime = queryEndTime - queryStartTime
 
                     this.broadcaster.broadcastAfterQueryEvent(


### PR DESCRIPTION
### Description of change

Replaced `+new Date()` with `Date.now()` in query runners to avoid two Date objects allocations per query.


### Pull-Request Checklist

<!--
  Please make sure to review and check all of the following.

  If an item is not applicable, you can add "N/A" to the end.
-->

- [ ] Code is up-to-date with the `master` branch
- [ ] `npm run format` to apply prettier formatting
- [ ] `npm run test` passes with this change
- [ ] This pull request links relevant issues as `Fixes #0000`
- [ ] There are new or updated unit tests validating the change
- [ ] Documentation has been updated to reflect this change
- [ ] The new commits follow conventions explained in [CONTRIBUTING.md](https://github.com/typeorm/typeorm/blob/master/CONTRIBUTING.md)

<!--
  🎉 Thank you for contributing and making TypeORM even better!
-->
