### PR TITLE
fix: change relationAlias name from targetName to unique relation alias name

### DIFF
--- a/src/query-builder/SelectQueryBuilder.ts
+++ b/src/query-builder/SelectQueryBuilder.ts
@@ -3589,12 +3589,13 @@ export class SelectQueryBuilder<Entity extends ObjectLiteral>
             await Promise.all(
                 this.relationMetadatas.map(async (relation) => {
                     const relationTarget = relation.inverseEntityMetadata.target
-                    const relationAlias = this.connection.namingStrategy.joinTableName(
-                        relation.propertyName,
-                        relation.inverseEntityMetadata.name,
-                        relation.propertyName,
-                        relation.inverseSidePropertyPath
-                    );
+                    const relationAlias =
+                        this.connection.namingStrategy.joinTableName(
+                            relation.propertyName,
+                            relation.inverseEntityMetadata.name,
+                            relation.propertyName,
+                            relation.inverseSidePropertyPath,
+                        )
 
                     const select = Array.isArray(this.findOptions.select)
                         ? OrmUtils.propertyPathsToTruthyObject(

--- a/src/query-builder/SelectQueryBuilder.ts
+++ b/src/query-builder/SelectQueryBuilder.ts
@@ -3589,8 +3589,12 @@ export class SelectQueryBuilder<Entity extends ObjectLiteral>
             await Promise.all(
                 this.relationMetadatas.map(async (relation) => {
                     const relationTarget = relation.inverseEntityMetadata.target
-                    const relationAlias =
-                        relation.inverseEntityMetadata.targetName
+                    const relationAlias = this.connection.namingStrategy.joinTableName(
+                        relation.propertyName,
+                        relation.inverseEntityMetadata.name,
+                        relation.propertyName,
+                        relation.inverseSidePropertyPath
+                    );
 
                     const select = Array.isArray(this.findOptions.select)
                         ? OrmUtils.propertyPathsToTruthyObject(


### PR DESCRIPTION
<!--
  😀 Wonderful!  Thank you for opening a pull request for TypeORM.

  Please fill in the information below to expedite the review
  and (hopefully) merge of your change.

  If unsure about something.. just do as best as you're able,
  or reach out through our community support channels!
  https://github.com/typeorm/typeorm/blob/master/docs/support.md
-->

### Description of change

<!--
  Please be clear and concise what the change is intended to do,
  why this change is needed, and how you've verified that it
  corrects what you intended.

  In some cases it may be helpful to include the current behavior
  and the new behavior.

  If the change is related to an open issue, you can link it here.
  If you include `Fixes #0000` (replacing `0000` with the issue number)
  when this is merged it will automatically mark the issue as fixed and
  close it.
-->

Fixes #9936 #4286
This change creates a unique alias for queries to prevent duplicate aliases if there are self-referenced relationships in the Entity

### Pull-Request Checklist

<!--
  Please make sure to review and check all of the following.

  If an item is not applicable, you can add "N/A" to the end.
-->

- [x] Code is up-to-date with the `master` branch
- [x] `npm run format` to apply prettier formatting
- [ ] `npm run test` passes with this change
- [x] This pull request links relevant issues as `Fixes #0000`
- [ ] There are new or updated unit tests validating the change
- [ ] Documentation has been updated to reflect this change
- [x] The new commits follow conventions explained in [CONTRIBUTING.md](https://github.com/typeorm/typeorm/blob/master/CONTRIBUTING.md)

<!--
  🎉 Thank you for contributing and making TypeORM even better!
-->
