### PR TITLE
feat: support nullable embedded entities

### DIFF
--- a/docs/embedded-entities.md
+++ b/docs/embedded-entities.md
@@ -165,3 +165,40 @@ All columns defined in the `Name` entity will be merged into `user`, `employee` 
 This way code duplication in the entity classes is reduced.
 You can use as many columns (or relations) in embedded classes as you need.
 You even can have nested embedded columns inside embedded classes.
+
+## Nullable embedded entities
+
+When an embedded entity is stored as `null`, and the column is `nullable`, it will be returned as `null` when read from the database.
+
+```typescript
+import { Entity, PrimaryGeneratedColumn, Column } from "typeorm"
+import { Name } from "./Name"
+
+export class Name {
+    @Column()
+    first: string
+
+    @Column()
+    last: string
+}
+
+@Entity()
+export class Student {
+    @PrimaryGeneratedColumn()
+    id: string
+
+    @Column(() => Name, { nullable: true })
+    name: Name | null
+
+    @Column()
+    faculty: string
+}
+
+const student = new Student()
+student.faculty = 'Faculty'
+student.name = null
+await dataSource.manager.save(student)
+
+// this will return the student name as `null`
+await dataSource.getRepository(Student).findOne()
+```

--- a/src/decorator/columns/Column.ts
+++ b/src/decorator/columns/Column.ts
@@ -182,6 +182,8 @@ export function Column(
                     reflectMetadataType === Array || options.array === true,
                 prefix:
                     options.prefix !== undefined ? options.prefix : undefined,
+                nullable:
+                    options.nullable !== undefined ? options.nullable : undefined,
                 type: typeOrOptions as (type?: any) => Function,
             } as EmbeddedMetadataArgs)
         } else {

--- a/src/decorator/columns/Column.ts
+++ b/src/decorator/columns/Column.ts
@@ -183,7 +183,9 @@ export function Column(
                 prefix:
                     options.prefix !== undefined ? options.prefix : undefined,
                 nullable:
-                    options.nullable !== undefined ? options.nullable : undefined,
+                    options.nullable !== undefined
+                        ? options.nullable
+                        : undefined,
                 type: typeOrOptions as (type?: any) => Function,
             } as EmbeddedMetadataArgs)
         } else {

--- a/src/decorator/options/ColumnEmbeddedOptions.ts
+++ b/src/decorator/options/ColumnEmbeddedOptions.ts
@@ -14,4 +14,9 @@ export interface ColumnEmbeddedOptions {
      * This option works only in mongodb.
      */
     array?: boolean
+
+    /**
+     * Indicates if this embedded is nullable.
+     */
+    nullable?: boolean
 }

--- a/src/entity-schema/EntitySchemaEmbeddedColumnOptions.ts
+++ b/src/entity-schema/EntitySchemaEmbeddedColumnOptions.ts
@@ -18,4 +18,9 @@ export class EntitySchemaEmbeddedColumnOptions {
      * This option works only in mongodb.
      */
     array?: boolean
+
+    /**
+     * Indicates if this embedded is nullable.
+     */
+    nullable?: boolean
 }

--- a/src/entity-schema/EntitySchemaTransformer.ts
+++ b/src/entity-schema/EntitySchemaTransformer.ts
@@ -348,6 +348,7 @@ export class EntitySchemaTransformer {
                     target: options.target || options.name,
                     propertyName: columnName,
                     isArray: embeddedOptions.array === true,
+                    nullable: embeddedOptions.nullable === true,
                     prefix:
                         embeddedOptions.prefix !== undefined
                             ? embeddedOptions.prefix

--- a/src/metadata-args/EmbeddedMetadataArgs.ts
+++ b/src/metadata-args/EmbeddedMetadataArgs.ts
@@ -24,6 +24,11 @@ export interface EmbeddedMetadataArgs {
     prefix?: string | boolean
 
     /**
+     * Indicates if this embedded is nullable.
+     */
+    nullable: boolean
+
+    /**
      * Type of the class to be embedded.
      */
     type: (type?: any) => Function | string

--- a/src/metadata/EmbeddedMetadata.ts
+++ b/src/metadata/EmbeddedMetadata.ts
@@ -99,6 +99,11 @@ export class EmbeddedMetadata {
     isArray: boolean = false
 
     /**
+     * Indicates if this embedded is nullable.
+     */
+    nullable: boolean = false
+
+    /**
      * Prefix of the embedded, used instead of propertyName.
      * If set to empty string or false, then prefix is not set at all.
      */
@@ -185,6 +190,7 @@ export class EmbeddedMetadata {
         this.propertyName = options.args.propertyName
         this.customPrefix = options.args.prefix
         this.isArray = options.args.isArray
+        this.nullable = options.args.nullable
     }
 
     // ---------------------------------------------------------------------

--- a/src/query-builder/transformer/DocumentToEntityTransformer.ts
+++ b/src/query-builder/transformer/DocumentToEntityTransformer.ts
@@ -107,9 +107,14 @@ export class DocumentToEntityTransformer {
             embeddeds: EmbeddedMetadata[],
         ) => {
             embeddeds.forEach((embedded) => {
-                if (!document[embedded.prefix]) return
+                if (document[embedded.prefix] === undefined) return
+                if (document[embedded.prefix] === null && !embedded.nullable) return
 
-                if (embedded.isArray) {
+                if (embedded.nullable && document[embedded.prefix] === null) {
+                    // We allow this to be set to null in the case it's null in the database response
+                    // It's processed first to ensure other embedded options can still remain nullable, like a nullable array
+                    entity[embedded.prefix] = document[embedded.prefix]
+                } else if (embedded.isArray) {
                     entity[embedded.propertyName] = (
                         document[embedded.prefix] as any[]
                     ).map((subValue: any, index: number) => {

--- a/src/query-builder/transformer/DocumentToEntityTransformer.ts
+++ b/src/query-builder/transformer/DocumentToEntityTransformer.ts
@@ -108,7 +108,8 @@ export class DocumentToEntityTransformer {
         ) => {
             embeddeds.forEach((embedded) => {
                 if (document[embedded.prefix] === undefined) return
-                if (document[embedded.prefix] === null && !embedded.nullable) return
+                if (document[embedded.prefix] === null && !embedded.nullable)
+                    return
 
                 if (embedded.nullable && document[embedded.prefix] === null) {
                     // We allow this to be set to null in the case it's null in the database response

--- a/test/github-issues/3913/entity/TestMongo.ts
+++ b/test/github-issues/3913/entity/TestMongo.ts
@@ -1,10 +1,5 @@
 import { ObjectId } from "mongodb"
-import {
-    BaseEntity,
-    Column,
-    Entity,
-    ObjectIdColumn
-} from "../../../../src"
+import { BaseEntity, Column, Entity, ObjectIdColumn } from "../../../../src"
 
 export class Embedded {
     a: string

--- a/test/github-issues/3913/entity/TestMongo.ts
+++ b/test/github-issues/3913/entity/TestMongo.ts
@@ -1,0 +1,20 @@
+import { ObjectId } from "mongodb"
+import {
+    BaseEntity,
+    Column,
+    Entity,
+    ObjectIdColumn
+} from "../../../../src"
+
+export class Embedded {
+    a: string
+}
+
+@Entity()
+export class TestMongo extends BaseEntity {
+    @ObjectIdColumn()
+    _id: ObjectId
+
+    @Column(() => Embedded, { nullable: true })
+    embedded: Embedded | null
+}

--- a/test/github-issues/3913/entity/TestSQL.ts
+++ b/test/github-issues/3913/entity/TestSQL.ts
@@ -2,7 +2,7 @@ import {
     BaseEntity,
     Column,
     Entity,
-    PrimaryGeneratedColumn
+    PrimaryGeneratedColumn,
 } from "../../../../src"
 
 export class Embedded {

--- a/test/github-issues/3913/entity/TestSQL.ts
+++ b/test/github-issues/3913/entity/TestSQL.ts
@@ -1,0 +1,19 @@
+import {
+    BaseEntity,
+    Column,
+    Entity,
+    PrimaryGeneratedColumn
+} from "../../../../src"
+
+export class Embedded {
+    a: string
+}
+
+@Entity()
+export class TestSQL extends BaseEntity {
+    @PrimaryGeneratedColumn()
+    id: number
+
+    @Column(() => Embedded, { nullable: true })
+    embedded: Embedded | null
+}

--- a/test/github-issues/3913/issue-3913.ts
+++ b/test/github-issues/3913/issue-3913.ts
@@ -1,0 +1,64 @@
+import "reflect-metadata"
+import { expect } from "chai"
+import {
+    closeTestingConnections,
+    createTestingConnections,
+    reloadTestingDatabases,
+} from "../../utils/test-utils"
+import { DataSource } from "../../../src/data-source/DataSource"
+import { TestMongo } from "./entity/TestMongo"
+import { TestSQL } from "./entity/TestSQL"
+import { MongoDriver } from "../../../src/driver/mongodb/MongoDriver"
+
+describe("github issues > #3913 Cannnot set embedded entity to null", () => {
+    let connections: DataSource[]
+    before(
+        async () =>
+            (connections = await createTestingConnections({
+                entities: [__dirname + "/entity/*{.js,.ts}"],
+                cache: {
+                    alwaysEnabled: true,
+                },
+            })),
+    )
+    beforeEach(() => reloadTestingDatabases(connections))
+    after(() => closeTestingConnections(connections))
+
+    it("should set the embedded entity to null in the database for mongodb", () =>
+        Promise.all(
+            connections.map(async (connection) => {
+                if (!(connection.driver instanceof MongoDriver)) return // Only run this test for mongodb
+                const test = new TestMongo()
+                test.embedded = null
+
+                await connection.manager.save(test)
+
+                const loadedTest = await connection.manager.findOne(TestMongo, {
+                    where: { _id: test._id },
+                })
+                expect(loadedTest).to.be.eql({
+                    _id: test._id,
+                    embedded: null,
+                })
+            }),
+        ))
+      
+        it("should set the embedded entity to null in the database for non mongodb", () =>
+          Promise.all(
+              connections.map(async (connection) => {
+                  if (connection.driver instanceof MongoDriver) return // Don't run this test for mongodb
+                  const test = new TestSQL()
+                  test.embedded = null
+  
+                  await connection.manager.save(test)
+  
+                  const loadedTest = await connection.manager.findOne(TestSQL, {
+                      where: { id: test.id },
+                  })
+                  expect(loadedTest).to.be.eql({
+                      id: 1,
+                      embedded: null,
+                  })
+              }),
+          ))
+})

--- a/test/github-issues/3913/issue-3913.ts
+++ b/test/github-issues/3913/issue-3913.ts
@@ -42,23 +42,23 @@ describe("github issues > #3913 Cannnot set embedded entity to null", () => {
                 })
             }),
         ))
-      
-        it("should set the embedded entity to null in the database for non mongodb", () =>
-          Promise.all(
-              connections.map(async (connection) => {
-                  if (connection.driver instanceof MongoDriver) return // Don't run this test for mongodb
-                  const test = new TestSQL()
-                  test.embedded = null
-  
-                  await connection.manager.save(test)
-  
-                  const loadedTest = await connection.manager.findOne(TestSQL, {
-                      where: { id: test.id },
-                  })
-                  expect(loadedTest).to.be.eql({
-                      id: 1,
-                      embedded: null,
-                  })
-              }),
-          ))
+
+    it("should set the embedded entity to null in the database for non mongodb", () =>
+        Promise.all(
+            connections.map(async (connection) => {
+                if (connection.driver instanceof MongoDriver) return // Don't run this test for mongodb
+                const test = new TestSQL()
+                test.embedded = null
+
+                await connection.manager.save(test)
+
+                const loadedTest = await connection.manager.findOne(TestSQL, {
+                    where: { id: test.id },
+                })
+                expect(loadedTest).to.be.eql({
+                    id: 1,
+                    embedded: null,
+                })
+            }),
+        ))
 })


### PR DESCRIPTION
Support nullable embedded fields such that embedded documents in MongoDB can correctly be returned as null for a subdocument that is explicitly nullable.

Closes: #3913

### Description of change

This change adds to the `ColumnEmbeddedOptions` the `nullable` field, thus allowing subdocuments in MongoDB to be `null` explicitly. This ensures they're returned correctly from the database in the case a null is set. This is useful when a developer has a required key that can be set to null - currently the key is not returned at all.

I saw this in #3913 though this was reverted as it previously changed all nested fields to null, which caused some problems I imagine for people. This method of implementing this change should not cause problems or any breaking changes and is entirely optional.

I have locally tested this with MongoDB, but not a SQL provider.


### Pull-Request Checklist

<!--
  Please make sure to review and check all of the following.

  If an item is not applicable, you can add "N/A" to the end.
-->

- [x] Code is up-to-date with the `master` branch
- [x] `npm run format` to apply prettier formatting
- [x] `npm run test` passes with this change
- [x] This pull request links relevant issues as `Fixes #0000`
- [x] There are new or updated unit tests validating the change
- [x] Documentation has been updated to reflect this change
- [x] The new commits follow conventions explained in [CONTRIBUTING.md](https://github.com/typeorm/typeorm/blob/master/CONTRIBUTING.md)

<!--
  🎉 Thank you for contributing and making TypeORM even better!
-->
