### PR TITLE
fix: Update child's mpath even if parentId was soft-deleted in TreeRepository

### DIFF
--- a/src/persistence/tree/MaterializedPathSubjectExecutor.ts
+++ b/src/persistence/tree/MaterializedPathSubjectExecutor.ts
@@ -172,6 +172,7 @@ export class MaterializedPathSubjectExecutor {
                     }
                 }),
             )
+            .withDeleted()
             .getRawOne()
             .then((result) => (result ? result["path"] : ""))
     }

--- a/test/github-issues/10843/entity/node.ts
+++ b/test/github-issues/10843/entity/node.ts
@@ -1,0 +1,36 @@
+import {
+    TreeChildren,
+    TreeParent,
+    Entity,
+    PrimaryGeneratedColumn,
+    DeleteDateColumn,
+    Column,
+    Tree,
+    JoinColumn,
+} from "../../../../src"
+
+@Entity("node")
+@Tree("materialized-path")
+export class Node {
+    @PrimaryGeneratedColumn({ type: "int" })
+    id?: number
+
+    @DeleteDateColumn()
+    deletedAt?: Date
+
+    @Column("varchar")
+    name!: string
+
+    @TreeChildren({ cascade: true })
+    children?: Node[]
+
+    @Column({ type: "int", nullable: true, name: "parentId" })
+    parentId?: number
+
+    @TreeParent()
+    @JoinColumn({
+        name: "parentId",
+        referencedColumnName: "id",
+    })
+    parent?: Node
+}

--- a/test/github-issues/10843/issue-10843.ts
+++ b/test/github-issues/10843/issue-10843.ts
@@ -1,0 +1,58 @@
+import "reflect-metadata"
+import {
+    createTestingConnections,
+    closeTestingConnections,
+    reloadTestingDatabases,
+} from "../../utils/test-utils"
+import { DataSource } from "../../../src"
+import {Node} from "./entity/node";
+import {expect} from "chai";
+
+describe("github issues > #10843 TreeRepository does not update mpath if parentId was soft-deleted", () => {
+    let dataSources: DataSource[]
+    before(
+        async () =>
+            (dataSources = await createTestingConnections({
+                entities: [__dirname + "/entity/*{.js,.ts}"],
+                schemaCreate: true,
+                dropSchema: true,
+                relationLoadStrategy: "query",
+                enabledDrivers: ["mysql"],
+            })),
+    )
+    beforeEach(() => reloadTestingDatabases(dataSources))
+    after(() => closeTestingConnections(dataSources))
+
+    it("Should update mpath even if parent was soft deleted", () =>
+        Promise.all(
+            dataSources.map(async (dataSource) => {
+                const nodeRepository = dataSource.getTreeRepository(Node)
+
+                // Entity instances setup
+                const parent = await nodeRepository.save(
+                    nodeRepository.create({ name: "root node" }),
+                );
+                const child = await nodeRepository.save(
+                    nodeRepository.create({ name: "child node", parent }),
+                );
+
+                // Validate mpath
+                let [mpath] = await dataSource.query("SELECT mpath FROM node WHERE id = ?", [child.id]);
+                expect(mpath?.mpath).to.be.equal(`${parent.id}.${child.id}.`)
+                // Soft delete parent
+                await nodeRepository.softDelete(parent);
+
+                // Assign new parent
+                const newParent = await nodeRepository.save(
+                    nodeRepository.create({ name: "root node 2" }),
+                );
+                child.parent = newParent;
+                await nodeRepository.save(child);
+
+                [mpath] = await dataSource.query("SELECT mpath FROM node WHERE id = ?", [child.id]);
+
+                expect(mpath?.mpath).to.be.equal(`${newParent.id}.${child.id}.`)
+
+            }),
+        ))
+})


### PR DESCRIPTION

Include soft-deleted entities in queryBuilder to fetch required parent's path even if parent is soft deleted. This path is required to perforn the corresponding update of the childs' mpath

fix #10843

<!--
  😀 Wonderful!  Thank you for opening a pull request for TypeORM.

  Please fill in the information below to expedite the review
  and (hopefully) merge of your change.

  If unsure about something.. just do as best as you're able,
  or reach out through our community support channels!
  https://github.com/typeorm/typeorm/blob/master/docs/support.md
-->

### Description of change

<!--
  Please be clear and concise what the change is intended to do,
  why this change is needed, and how you've verified that it
  corrects what you intended.

  In some cases it may be helpful to include the current behavior
  and the new behavior.

  If the change is related to an open issue, you can link it here.
  If you include `Fixes #0000` (replacing `0000` with the issue number)
  when this is merged it will automatically mark the issue as fixed and
  close it.
-->


### Pull-Request Checklist

<!--
  Please make sure to review and check all of the following.

  If an item is not applicable, you can add "N/A" to the end.
-->

- [ ] Code is up-to-date with the `master` branch
- [ ] `npm run format` to apply prettier formatting
- [ ] `npm run test` passes with this change
- [ ] This pull request links relevant issues as `Fixes #0000`
- [ ] There are new or updated unit tests validating the change
- [ ] Documentation has been updated to reflect this change
- [ ] The new commits follow conventions explained in [CONTRIBUTING.md](https://github.com/typeorm/typeorm/blob/master/CONTRIBUTING.md)

<!--
  🎉 Thank you for contributing and making TypeORM even better!
-->
