### PR TITLE
feat: Add query timeout support for MySql

### DIFF
--- a/docs/data-source-options.md
+++ b/docs/data-source-options.md
@@ -162,6 +162,11 @@ Different RDBMS-es have their own specific options.
 -   `ssl` - object with ssl parameters or a string containing the name of ssl profile.
     See [SSL options](https://github.com/mysqljs/mysql#ssl-options).
 
+-   `enableQueryTimeout` - If a value is specified for maxQueryExecutionTime, in addition to generating a warning log when a
+    query exceeds this time limit,
+    the specified maxQueryExecutionTime value is also used as the timeout for the query.
+    For more information, check https://github.com/mysqljs/mysql?tab=readme-ov-file#timeouts
+
 ## `postgres` / `cockroachdb` data source options
 
 -   `url` - Connection url where perform connection to. Please note that other data source options will override parameters set from url.
@@ -242,6 +247,7 @@ Different RDBMS-es have their own specific options.
 -   `database` - Database name
 
 ## `mssql` data source options
+
 Based on [tedious](https://tediousjs.github.io/node-mssql/) MSSQL implementation. See [SqlServerConnectionOptions.ts](..\src\driver\sqlserver\SqlServerConnectionOptions.ts) for details on exposed attributes.
 
 -   `url` - Connection url where perform connection to. Please note that other data source options will override parameters set from url.
@@ -547,9 +553,9 @@ The following TNS connection string will be used in the next explanations:
      (SERVER=shared)))
 )
 ```
+
 -   `sid` - The System Identifier (SID) identifies a specific database instance. For example, "sales".
 -   `serviceName` - The Service Name is an identifier of a database service. For example, `sales.us.example.com`.
-
 
 ## Data Source Options example
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -19,7 +19,6 @@
         "dotenv": "^16.0.3",
         "glob": "^10.3.10",
         "mkdirp": "^2.1.3",
-        "reflect-metadata": "^0.2.1",
         "sha.js": "^2.4.11",
         "tslib": "^2.5.0",
         "uuid": "^9.0.0",
@@ -105,6 +104,7 @@
         "pg-native": "^3.0.0",
         "pg-query-stream": "^4.0.0",
         "redis": "^3.1.1 || ^4.0.0",
+        "reflect-metadata": "^0.1.14 || ^0.2.0",
         "sql.js": "^1.4.0",
         "sqlite3": "^5.0.3",
         "ts-node": "^10.7.0",
@@ -11751,7 +11751,8 @@
     "node_modules/reflect-metadata": {
       "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/reflect-metadata/-/reflect-metadata-0.2.1.tgz",
-      "integrity": "sha512-i5lLI6iw9AU3Uu4szRNPPEkomnkjRTaVt9hy/bn5g/oSzekBSMeLZblcjP74AW0vBabqERLLIrz+gR8QYR54Tw=="
+      "integrity": "sha512-i5lLI6iw9AU3Uu4szRNPPEkomnkjRTaVt9hy/bn5g/oSzekBSMeLZblcjP74AW0vBabqERLLIrz+gR8QYR54Tw==",
+      "peer": true
     },
     "node_modules/regex-not": {
       "version": "1.0.2",

--- a/src/driver/mysql/MysqlConnectionOptions.ts
+++ b/src/driver/mysql/MysqlConnectionOptions.ts
@@ -110,6 +110,13 @@ export interface MysqlConnectionOptions
     readonly connectorPackage?: "mysql" | "mysql2"
 
     /**
+     * If a value is specified for maxQueryExecutionTime, in addition to generating a warning log when a query exceeds this time limit,
+     * the specified maxQueryExecutionTime value is also used as the timeout for the query.
+     * For more information, check https://github.com/mysqljs/mysql?tab=readme-ov-file#timeouts
+     */
+    readonly enableQueryTimeout?: boolean
+
+    /**
      * Replication setup.
      */
     readonly replication?: {

--- a/src/driver/mysql/MysqlQueryRunner.ts
+++ b/src/driver/mysql/MysqlQueryRunner.ts
@@ -202,10 +202,17 @@ export class MysqlQueryRunner extends BaseQueryRunner implements QueryRunner {
                     query,
                     parameters,
                 )
-
+                const enableQueryTimeout =
+                    this.driver.options.enableQueryTimeout
+                const maxQueryExecutionTime =
+                    this.driver.options.maxQueryExecutionTime
+                const queryPayload =
+                    enableQueryTimeout && maxQueryExecutionTime
+                        ? { sql: query, timeout: maxQueryExecutionTime }
+                        : query
                 const queryStartTime = +new Date()
                 databaseConnection.query(
-                    query,
+                    queryPayload,
                     parameters,
                     async (err: any, raw: any) => {
                         // log slow queries if maxQueryExecution time is set


### PR DESCRIPTION
### Description of change

This feature adds the "enableQueryTimeout" option to MysqlConnectionOptions. When enabled, the value of "maxQueryExecutionTime" will be passed to the MySQL driver as the query timeout. (There is support for it by the MySQL driver: https://github.com/mysqljs/mysql?tab=readme-ov-file#timeouts)

Now, passing a value to "maxQueryExecutionTime" logs queries that took more than the specified amount of time.

We use TypeORM with MySQL in multiple projects. Some of these projects involve direct interaction with users, and having a query timeout for the entire project connection is crucial to prevent server blocking due to long queries. On the other hand, some projects run in the background, and we don't mind queries taking a bit more time.

Since multiple drivers support query timeout configuration per datasource/connection (e.g., 'postgres'/'sqlserver'), and MySQL doesn't, I have decided to add this feature for MySQL as well.

### Pull-Request Checklist

- [x] Code is up-to-date with the `master` branch
- [x] `npm run format` to apply prettier formatting
- [x] `npm run test` passes with this change
- [  ] This pull request links relevant issues as `Fixes #0000`
- [  ] There are new or updated unit tests validating the change
- [x] Documentation has been updated to reflect this change
- [x] The new commits follow conventions explained in [CONTRIBUTING.md]
