### PR TITLE
fix: stop column transformers from modifying `where`

### DIFF
--- a/src/find-options/FindOperator.ts
+++ b/src/find-options/FindOperator.ts
@@ -138,11 +138,26 @@ export class FindOperator<T> {
         return this._getSql
     }
 
-    transformValue(transformer: ValueTransformer | ValueTransformer[]) {
+    clone() {
+        return new FindOperator(
+            this._type,
+            this._value,
+            this._useParameter,
+            this._multipleParameters,
+            this._getSql,
+            this._objectLiteralParameters,
+        )
+    }
+
+    transformValue(
+        transformer: ValueTransformer | ValueTransformer[],
+    ): T | FindOperator<T> {
+        const cloned = this.clone()
+
         if (this._value instanceof FindOperator) {
-            this._value.transformValue(transformer)
+            cloned._value = this._value.transformValue(transformer)
         } else {
-            this._value =
+            cloned._value =
                 Array.isArray(this._value) && this._multipleParameters
                     ? this._value.map(
                           (v: any) =>
@@ -157,5 +172,7 @@ export class FindOperator<T> {
                           this._value,
                       )
         }
+
+        return cloned
     }
 }

--- a/src/query-builder/SelectQueryBuilder.ts
+++ b/src/query-builder/SelectQueryBuilder.ts
@@ -4271,13 +4271,16 @@ export class SelectQueryBuilder<Entity extends ObjectLiteral>
                         parameterValue = where[key].value
                     }
                     if (column.transformer) {
-                        parameterValue instanceof FindOperator
-                            ? parameterValue.transformValue(column.transformer)
-                            : (parameterValue =
-                                  ApplyValueTransformers.transformTo(
-                                      column.transformer,
-                                      parameterValue,
-                                  ))
+                        if (parameterValue instanceof FindOperator) {
+                            parameterValue = parameterValue.transformValue(
+                                column.transformer,
+                            )
+                        } else {
+                            parameterValue = ApplyValueTransformers.transformTo(
+                                column.transformer,
+                                parameterValue,
+                            )
+                        }
                     }
 
                     // if (parameterValue === null) {


### PR DESCRIPTION
<!--
  😀 Wonderful!  Thank you for opening a pull request for TypeORM.

  Please fill in the information below to expedite the review
  and (hopefully) merge of your change.

  If unsure about something.. just do as best as you're able,
  or reach out through our community support channels!
  https://github.com/typeorm/typeorm/blob/master/docs/support.md
-->

### Description of change

This change stops column transformers from modifying the original `where` criteria. 

```typescript
@Entity()
export class Job {
  @Column({
    type: "varchar",
    transformer: {
      from: (raw: string): Date => new Date(raw),
      to: (date: Date): string => date.toISOString(),
    },
  })
  submittedAt: Date;
}

// ...

const criteria = {
  submittedAt: MoreThanOrEqual(sinceTime),
};

await jobRepo.findBy(criteria);
await jobRepo.findBy(criteria);
```

The `FindOperator` within the `where` was changed during the first `findBy`, causing the second query to fail by trying to transform a transformed value.

This PR tries to fix this problem.

### Pull-Request Checklist

<!--
  Please make sure to review and check all of the following.

  If an item is not applicable, you can add "N/A" to the end.
-->

- [x] Code is up-to-date with the `master` branch
- [x] `npm run format` to apply prettier formatting
- I want to keep files that I didn't touch.
- [x] `npm run test` passes with this change
- They failed but were not related to this change.
- [ ] This pull request links relevant issues as `Fixes #0000`  N/A
- [ ] There are new or updated unit tests validating the change
- [ ] Documentation has been updated to reflect this change
- [x] The new commits follow conventions explained in [CONTRIBUTING.md](https://github.com/typeorm/typeorm/blob/master/CONTRIBUTING.md)

<!--
  🎉 Thank you for contributing and making TypeORM even better!
-->
