### PR TITLE
fix: postgres defaults to NO ACTION in src/metadata-builder/JunctionEntityMetadataBuilder.ts

### DIFF
--- a/src/metadata-builder/JunctionEntityMetadataBuilder.ts
+++ b/src/metadata-builder/JunctionEntityMetadataBuilder.ts
@@ -224,7 +224,13 @@ export class JunctionEntityMetadataBuilder {
         const unsupporteDeleteCascadeDrivers = ["spanner"]
         const unsupportedUpdateCascadeDrivers = ["oracle", "spanner"]
 
-        const defaultOnDeleteAndUpdateType = "CASCADE"
+        const noActionByDefaultDrivers = ["postgres"]
+
+        const defaultOnDeleteAndUpdateType = noActionByDefaultDrivers.includes(
+            this.connection.driver.options.type,
+        )
+            ? "NO ACTION"
+            : "CASCADE"
 
         entityMetadata.foreignKeys = relation.createForeignKeyConstraints
             ? [


### PR DESCRIPTION
<!--
  😀 Wonderful!  Thank you for opening a pull request for TypeORM.

  Please fill in the information below to expedite the review
  and (hopefully) merge of your change.

  If unsure about something.. just do as best as you're able,
  or reach out through our community support channels!
  https://github.com/typeorm/typeorm/blob/master/docs/support.md
-->

### Description of change

<!--
  Please be clear and concise what the change is intended to do,
  why this change is needed, and how you've verified that it
  corrects what you intended.

  In some cases it may be helpful to include the current behavior
  and the new behavior.

  If the change is related to an open issue, you can link it here.
  If you include `Fixes #0000` (replacing `0000` with the issue number)
  when this is merged it will automatically mark the issue as fixed and
  close it.
-->

PostgreSQL defaults to `NO ACTION` for `ON DELETE` and `ON UPDATE`.  See:
- https://www.postgresql.org/docs/14/sql-createtable.html
- https://www.postgresql.org/docs/14/ddl-constraints.html

See also https://github.com/typeorm/typeorm/issues/10862

### Pull-Request Checklist

<!--
  Please make sure to review and check all of the following.

  If an item is not applicable, you can add "N/A" to the end.
-->

- [x] Code is up-to-date with the `master` branch
- [x] `npm run format` to apply prettier formatting
- [ ] `npm run test` passes with this change
- [ ] This pull request links relevant issues as `Fixes #0000`
- [ ] There are new or updated unit tests validating the change
- [ ] Documentation has been updated to reflect this change
- [ ] The new commits follow conventions explained in [CONTRIBUTING.md](https://github.com/typeorm/typeorm/blob/master/CONTRIBUTING.md)

<!--
  🎉 Thank you for contributing and making TypeORM even better!
-->
