### PR TITLE
fix: .save() method with plain object doesn't return entity instance issue #10849

### DIFF
--- a/src/entity-manager/EntityManager.ts
+++ b/src/entity-manager/EntityManager.ts
@@ -428,12 +428,15 @@ export class EntityManager {
 
         if (target) {
             const metadata = this.connection.getMetadata(target)
-            entity = this.plainObjectToEntityTransformer.transform(
-                metadata.create(this.queryRunner),
-                entity,
-                metadata,
-                true,
-            )
+            const objects = Array.isArray(entity) ? entity : [entity]
+            entity = objects.map((object) =>
+                this.plainObjectToEntityTransformer.transform(
+                    metadata.create(this.queryRunner),
+                    object,
+                    metadata,
+                    true,
+                ),
+            ) as T | T[]
         }
 
         // if user passed empty array of entities then we don't need to do anything

--- a/test/github-issues/10849/entity/user.ts
+++ b/test/github-issues/10849/entity/user.ts
@@ -1,0 +1,12 @@
+import {Column, Entity, PrimaryGeneratedColumn} from "../../../../src";
+
+@Entity({
+    name: "user",
+})
+export class User {
+    @PrimaryGeneratedColumn()
+    id: number
+
+    @Column()
+    name: string
+}

--- a/test/github-issues/10849/entity/user.ts
+++ b/test/github-issues/10849/entity/user.ts
@@ -1,4 +1,4 @@
-import {Column, Entity, PrimaryGeneratedColumn} from "../../../../src";
+import { Column, Entity, PrimaryGeneratedColumn } from "../../../../src"
 
 @Entity({
     name: "user",

--- a/test/github-issues/10849/issue-10849.ts
+++ b/test/github-issues/10849/issue-10849.ts
@@ -43,4 +43,16 @@ describe("github issues > #10839 Entity instance is not correctly initialized in
                 expect(savedUser).to.be.instanceOf(User)
             }),
         ))
+
+    it("should return an array of entity instances when save is called with array of plain objects", () =>
+        Promise.all(
+            dataSources.map(async (dataSource) => {
+                const savedUsers = await dataSource
+                    .getRepository(User)
+                    .save([{ name: "John Doe" }, { name: "Jane Doe" }])
+                expect(savedUsers).to.be.instanceOf(Array)
+                expect(savedUsers[0]).to.be.instanceOf(User)
+                expect(savedUsers[1]).to.be.instanceOf(User)
+            }),
+        ))
 })

--- a/test/github-issues/10849/issue-10849.ts
+++ b/test/github-issues/10849/issue-10849.ts
@@ -1,0 +1,46 @@
+import "reflect-metadata"
+import {
+    createTestingConnections,
+    closeTestingConnections,
+    reloadTestingDatabases,
+} from "../../utils/test-utils"
+import { DataSource } from "../../../src/data-source/DataSource"
+import { expect } from "chai"
+import { User } from "./entity/user"
+
+describe("github issues > #10839 Entity instance is not correctly initialized inside .save() method", () => {
+    let dataSources: DataSource[]
+    before(
+        async () =>
+            (dataSources = await createTestingConnections({
+                entities: [__dirname + "/entity/*{.js,.ts}"],
+                schemaCreate: true,
+                dropSchema: true,
+            })),
+    )
+    beforeEach(() => reloadTestingDatabases(dataSources))
+    after(() => closeTestingConnections(dataSources))
+
+    it("should return a entity instance when save is called before create with entity instance", () =>
+        Promise.all(
+            dataSources.map(async (dataSource) => {
+                const userInstance = new User()
+                userInstance.name = "John Doe"
+                const user = dataSource.getRepository(User).create(userInstance)
+                const savedUser = await dataSource
+                    .getRepository(User)
+                    .save(user)
+                expect(savedUser).to.be.instanceOf(User)
+            }),
+        ))
+
+    it("should return an entity instance when save is called with plain object", () =>
+        Promise.all(
+            dataSources.map(async (dataSource) => {
+                const savedUser = await dataSource
+                    .getRepository(User)
+                    .save({ name: "John Doe" })
+                expect(savedUser).to.be.instanceOf(User)
+            }),
+        ))
+})


### PR DESCRIPTION
<!--
  😀 Wonderful!  Thank you for opening a pull request for TypeORM.

  Please fill in the information below to expedite the review
  and (hopefully) merge of your change.

  If unsure about something.. just do as best as you're able,
  or reach out through our community support channels!
  https://github.com/typeorm/typeorm/blob/master/docs/support.md
-->

### Description of change

<!--
  Please be clear and concise what the change is intended to do,
  why this change is needed, and how you've verified that it
  corrects what you intended.

  In some cases it may be helpful to include the current behavior
  and the new behavior.

  If the change is related to an open issue, you can link it here.
  If you include `Fixes #0000` (replacing `0000` with the issue number)
  when this is merged it will automatically mark the issue as fixed and
  close it.
-->
This change fixes #10849.
With this change, the `save()` method with plain object as an argument, returns an entity instance transformed from the plain object.

### Pull-Request Checklist

<!--
  Please make sure to review and check all of the following.

  If an item is not applicable, you can add "N/A" to the end.
-->

- [X] Code is up-to-date with the `master` branch
- [X] `npm run format` to apply prettier formatting
- [ ] `npm run test` passes with this change
- [X] This pull request links relevant issues as `Fixes #10849`
- [X] There are new or updated unit tests validating the change
- [ ] Documentation has been updated to reflect this change
- [X] The new commits follow conventions explained in [CONTRIBUTING.md](https://github.com/typeorm/typeorm/blob/master/CONTRIBUTING.md)

<!--
  🎉 Thank you for contributing and making TypeORM even better!
-->
