### PR TITLE
docs: removed dead link about using typeorm with DI from faq.md

### DIFF
--- a/docs/faq.md
+++ b/docs/faq.md
@@ -5,7 +5,6 @@
 -   [How to do validation?](#how-to-do-validation)
 -   [What does "owner side" in relations mean or why we need to put `@JoinColumn` and `@JoinTable` decorators?](#what-does-owner-side-in-a-relations-mean-or-why-we-need-to-use-joincolumn-and-jointable)
 -   [How do I add extra columns into many-to-many (junction) table?](#how-do-i-add-extra-columns-into-many-to-many-junction-table)
--   [How to use TypeORM with dependency injection tool?](#how-to-use-typeorm-with-a-dependency-injection-tool)
 -   [How to handle outDir TypeScript compiler option?](#how-to-handle-outdir-typescript-compiler-option)
 -   [How to use TypeORM with ts-node?](#how-to-use-typeorm-with-ts-node)
 -   [How to use Webpack for the backend](#how-to-use-webpack-for-the-backend)


### PR DESCRIPTION
### Description of change
Removed dead link `how-to-use-typeorm-with-a-dependency-injection-tool` from faq.md.
Content was removed in 3b8a031

### Pull-Request Checklist
- [x] Code is up-to-date with the `master` branch
- [x] Documentation has been updated to reflect this change
- [x] The new commits follow conventions explained in [CONTRIBUTING.md](https://github.com/typeorm/typeorm/blob/master/CONTRIBUTING.md)
