### PR TITLE
fix: oracle bulk insert does work with @PrimaryGeneratedColumn

### DIFF
--- a/src/query-builder/InsertQueryBuilder.ts
+++ b/src/query-builder/InsertQueryBuilder.ts
@@ -459,10 +459,8 @@ export class InsertQueryBuilder<
         // add VALUES expression
         if (valuesExpression) {
             if (
-                (
-                    this.connection.driver.options.type === "oracle" ||
-                    this.connection.driver.options.type === "sap"
-                ) &&
+                (this.connection.driver.options.type === "oracle" ||
+                    this.connection.driver.options.type === "sap") &&
                 this.getValueSets().length > 1
             ) {
                 query += ` ${valuesExpression}`
@@ -698,12 +696,10 @@ export class InsertQueryBuilder<
                 }
 
                 // if user did not specified such list then return all columns except auto-increment one
-                // for Oracle we return auto-increment column as well because Oracle does not support DEFAULT VALUES expression
                 if (
                     column.isGenerated &&
                     column.generationStrategy === "increment" &&
                     !(this.connection.driver.options.type === "spanner") &&
-                    !(this.connection.driver.options.type === "oracle") &&
                     !DriverUtils.isSQLiteFamily(this.connection.driver) &&
                     !DriverUtils.isMySQLFamily(this.connection.driver) &&
                     !(this.connection.driver.options.type === "aurora-mysql") &&

--- a/test/functional/query-builder/insert/query-builder-insert.ts
+++ b/test/functional/query-builder/insert/query-builder-insert.ts
@@ -67,12 +67,8 @@ describe("query builder > insert", () => {
     it("should perform bulk insertion correctly", () =>
         Promise.all(
             connections.map(async (connection) => {
-                // it is skipped for Oracle and SAP because it does not support bulk insertion
-                if (
-                    connection.driver.options.type === "oracle" ||
-                    connection.driver.options.type === "sap"
-                )
-                    return
+                // it is skipped for SAP because it does not support bulk insertion
+                if (connection.driver.options.type === "sap") return
 
                 await connection
                     .createQueryBuilder()
@@ -128,7 +124,6 @@ describe("query builder > insert", () => {
                 // also it is skipped for Oracle and SAP because it does not support bulk insertion
                 if (
                     DriverUtils.isSQLiteFamily(connection.driver) ||
-                    connection.driver.options.type === "oracle" ||
                     connection.driver.options.type === "sap"
                 )
                     return
@@ -156,6 +151,7 @@ describe("query builder > insert", () => {
                     .getRepository(Photo)
                     .findOneBy({ url: "1.jpg" })
                 expect(loadedPhoto1).to.exist
+
                 loadedPhoto1!.should.be.eql({
                     id: 1,
                     url: "1.jpg",


### PR DESCRIPTION
closes: #10936

<!--
  😀 Wonderful!  Thank you for opening a pull request for TypeORM.

  Please fill in the information below to expedite the review
  and (hopefully) merge of your change.

  If unsure about something.. just do as best as you're able,
  or reach out through our community support channels!
  https://github.com/typeorm/typeorm/blob/master/docs/support.md
-->

### Description of change

fix oracle bulk insert, when no columns are defined and entity has primary key
<!--
  Please be clear and concise what the change is intended to do,
  why this change is needed, and how you've verified that it
  corrects what you intended.

  In some cases it may be helpful to include the current behavior
  and the new behavior.

  If the change is related to an open issue, you can link it here.
  If you include `Fixes #0000` (replacing `0000` with the issue number)
  when this is merged it will automatically mark the issue as fixed and
  close it.
-->


### Pull-Request Checklist

<!--
  Please make sure to review and check all of the following.

  If an item is not applicable, you can add "N/A" to the end.
-->

- [x] Code is up-to-date with the `master` branch
- [x] `npm run format` to apply prettier formatting
- [ ] `npm run test` passes with this change
- [x] This pull request links relevant issues as `Fixes #0000`
- [x] There are new or updated unit tests validating the change
- [~] Documentation has been updated to reflect this change
- [x] The new commits follow conventions explained in [CONTRIBUTING.md](https://github.com/typeorm/typeorm/blob/master/CONTRIBUTING.md)

<!--
  🎉 Thank you for contributing and making TypeORM even better!
-->
