### PR TITLE
This PR addresses an issue in the `save` function

### DIFF
--- a/src/persistence/SubjectChangedColumnsComputer.ts
+++ b/src/persistence/SubjectChangedColumnsComputer.ts
@@ -115,6 +115,8 @@ export class SubjectChangedColumnsComputer {
                                 )
                             break
 
+                        case "geography":
+                        case "geometry":
                         case "json":
                         case "jsonb":
                             // JSON.stringify doesn't work because postgresql sorts jsonb before save.


### PR DESCRIPTION
### Description of change
Fixes #10377
https://github.com/typeorm/typeorm/issues/10377

"geography" and "geometry" values are always updated, even if they haven't changed. 
The issue arose due to the omission of comparing values as JSON format 
(TypeORM uses GeoJSON for values of geography and geometry types)

With this fix, updates are only made when there are real changes to the data.

Two cases are added in the existing switch statement within  the `SubjectChangedColumnsComputer.computeDiffColumns` function to handle the values as a JSON for comparison.

Without this fix, any save operation involving geoJson fields would result in unnecessary updates,


In issue 10377, I proposed adding all following spatial types mentioned.
  1. geometry
  2. geography
  3. st_geometry
  4. st_point

However, for my project, only the following two types are used
So I added following two cases that can be tested in my project.
  1. geometry
  2. geography

If you are sure that the types(st_geometry, st_point) also always use geoJson, 
 I would suggest to add the missing type in the "swith~case"

### Pull-Request Checklist
- [O] Code is up-to-date with the `master` branch
- [O] `npm run format` to apply prettier formatting
- [O] `npm run test` passes with this change
- [O] This pull request links relevant issues as `Fixes #10377`
- [X] There are new or updated unit tests validating the change
- [N/A] Documentation has been updated to reflect this change
- [O] The new commits follow conventions explained in [CONTRIBUTING.md](https://github.com/typeorm/typeorm/blob/master/CONTRIBUTING.md)

<!--
  🎉 Thank you for contributing and making TypeORM even better!
-->
