### PR TITLE
fix: fix working with tables with quotes in the names for PostgreSQL …

### DIFF
--- a/src/driver/postgres/PostgresQueryRunner.ts
+++ b/src/driver/postgres/PostgresQueryRunner.ts
@@ -601,10 +601,22 @@ export class PostgresQueryRunner
                 downQueries.push(this.dropIndexSql(table, index))
             })
         }
-        
+
         if (table.comment) {
-            upQueries.push(new Query("COMMENT ON TABLE " + this.escapePath(table) + " IS '" + table.comment + "'"));
-            downQueries.push(new Query("COMMENT ON TABLE " + this.escapePath(table) + " IS NULL"));
+            upQueries.push(
+                new Query(
+                    "COMMENT ON TABLE " +
+                        this.escapePath(table) +
+                        " IS '" +
+                        table.comment +
+                        "'",
+                ),
+            )
+            downQueries.push(
+                new Query(
+                    "COMMENT ON TABLE " + this.escapePath(table) + " IS NULL",
+                ),
+            )
         }
 
         await this.executeQueries(upQueries, downQueries)
@@ -3102,7 +3114,7 @@ export class PostgresQueryRunner
             const version = await this.getVersion()
             // drop views
             const selectViewDropsQuery =
-                `SELECT 'DROP VIEW IF EXISTS "' || schemaname || '"."' || viewname || '" CASCADE;' as "query" ` +
+                `SELECT 'DROP VIEW IF EXISTS ' || quote_ident(schemaname) || '.' || quote_ident(viewname) || ' CASCADE;' as "query" ` +
                 `FROM "pg_views" WHERE "schemaname" IN (${schemaNamesString}) AND "viewname" NOT IN ('geography_columns', 'geometry_columns', 'raster_columns', 'raster_overviews')`
             const dropViewQueries: ObjectLiteral[] = await this.query(
                 selectViewDropsQuery,
@@ -3115,7 +3127,7 @@ export class PostgresQueryRunner
             // Note: materialized views introduced in Postgres 9.3
             if (VersionUtils.isGreaterOrEqual(version, "9.3")) {
                 const selectMatViewDropsQuery =
-                    `SELECT 'DROP MATERIALIZED VIEW IF EXISTS "' || schemaname || '"."' || matviewname || '" CASCADE;' as "query" ` +
+                    `SELECT 'DROP MATERIALIZED VIEW IF EXISTS ' || quote_ident(schemaname) || '.' || quote_ident(matviewname) || ' CASCADE;' as "query" ` +
                     `FROM "pg_matviews" WHERE "schemaname" IN (${schemaNamesString})`
                 const dropMatViewQueries: ObjectLiteral[] = await this.query(
                     selectMatViewDropsQuery,
@@ -3129,7 +3141,7 @@ export class PostgresQueryRunner
             // TODO generalize this as this.driver.ignoreTables
 
             // drop tables
-            const selectTableDropsQuery = `SELECT 'DROP TABLE IF EXISTS "' || schemaname || '"."' || tablename || '" CASCADE;' as "query" FROM "pg_tables" WHERE "schemaname" IN (${schemaNamesString}) AND "tablename" NOT IN ('spatial_ref_sys')`
+            const selectTableDropsQuery = `SELECT 'DROP TABLE IF EXISTS ' || quote_ident(schemaname) || '.' || quote_ident(tablename) || ' CASCADE;' as "query" FROM "pg_tables" WHERE "schemaname" IN (${schemaNamesString}) AND "tablename" NOT IN ('spatial_ref_sys')`
             const dropTableQueries: ObjectLiteral[] = await this.query(
                 selectTableDropsQuery,
             )
@@ -3288,7 +3300,7 @@ export class PostgresQueryRunner
         }[] = []
 
         if (!tableNames) {
-            const tablesSql = `SELECT "table_schema", "table_name", obj_description(('"' || "table_schema" || '"."' || "table_name" || '"')::regclass, 'pg_class') AS table_comment FROM "information_schema"."tables"`
+            const tablesSql = `SELECT "table_schema", "table_name", obj_description((quote_ident("table_schema") || '.' || quote_ident("table_name"))::regclass, 'pg_class') AS table_comment FROM "information_schema"."tables"`
             dbTables.push(...(await this.query(tablesSql)))
         } else {
             const tablesCondition = tableNames
@@ -3301,7 +3313,7 @@ export class PostgresQueryRunner
                 .join(" OR ")
 
             const tablesSql =
-                `SELECT "table_schema", "table_name", obj_description(('"' || "table_schema" || '"."' || "table_name" || '"')::regclass, 'pg_class') AS table_comment FROM "information_schema"."tables" WHERE ` +
+                `SELECT "table_schema", "table_name", obj_description((quote_ident("table_schema") || '.' || quote_ident("table_name"))::regclass, 'pg_class') AS table_comment FROM "information_schema"."tables" WHERE ` +
                 tablesCondition
             dbTables.push(...(await this.query(tablesSql)))
         }
@@ -3322,7 +3334,7 @@ export class PostgresQueryRunner
             })
             .join(" OR ")
         const columnsSql =
-            `SELECT columns.*, pg_catalog.col_description(('"' || table_catalog || '"."' || table_schema || '"."' || table_name || '"')::regclass::oid, ordinal_position) AS description, ` +
+            `SELECT columns.*, pg_catalog.col_description((quote_ident(table_catalog) || '.' || quote_ident(table_schema) || '.' || quote_ident(table_name))::regclass::oid, ordinal_position) AS description, ` +
             `('"' || "udt_schema" || '"."' || "udt_name" || '"')::"regtype" AS "regtype", pg_catalog.format_type("col_attr"."atttypid", "col_attr"."atttypmod") AS "format_type" ` +
             `FROM "information_schema"."columns" ` +
             `LEFT JOIN "pg_catalog"."pg_attribute" AS "col_attr" ON "col_attr"."attname" = "columns"."column_name" ` +
@@ -4744,7 +4756,7 @@ export class PostgresQueryRunner
 
         newComment = this.escapeComment(newComment)
         const comment = this.escapeComment(table.comment)
-        
+
         if (newComment === comment) {
             return
         }

--- a/test/github-issues/10991/issue-10991.ts
+++ b/test/github-issues/10991/issue-10991.ts
@@ -1,0 +1,34 @@
+import { DataSource } from "../../../src"
+import {
+    closeTestingConnections,
+    createTestingConnections,
+    reloadTestingDatabases,
+} from "../../utils/test-utils"
+import { TEST_TABLE_NAME } from "./migrations/init"
+import { expect } from "chai"
+
+describe("github issues > #10991", () => {
+    let dataSources: DataSource[]
+
+    before(async () => {
+        dataSources = await createTestingConnections({
+            migrations: [__dirname + "/migrations/*{.js,.ts}"],
+            enabledDrivers: ["postgres"],
+        })
+    })
+
+    beforeEach(() => reloadTestingDatabases(dataSources))
+    after(() => closeTestingConnections(dataSources))
+
+    it("should be able to load tables with names containing quotes", () =>
+        Promise.all(
+            dataSources.map(async (connection) => {
+                await connection.runMigrations()
+                const queryRunner = connection.createQueryRunner()
+                const tables = await queryRunner.getTables()
+                const tableNames = tables.map((table) => table.name)
+                expect(tableNames).to.include(TEST_TABLE_NAME)
+                await queryRunner.release()
+            }),
+        ))
+})

--- a/test/github-issues/10991/migrations/init.ts
+++ b/test/github-issues/10991/migrations/init.ts
@@ -1,0 +1,15 @@
+import { MigrationInterface, QueryRunner } from "../../../../src"
+
+export const TEST_TABLE_NAME = `This is the "Table Name"`
+
+export class CreateDatabase0000000000001 implements MigrationInterface {
+    name = "CreateDatabase0000000000001"
+
+    async up(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(
+            `CREATE TABLE "${TEST_TABLE_NAME.replace(/"/g, '""')}" ()`,
+        )
+    }
+
+    async down(queryRunner: QueryRunner): Promise<void> {}
+}


### PR DESCRIPTION
…(#10991)

Fix working with tables with quotes in the names for PostgreSQL

Closes: #10991

### Description of change
There were a few changes in PostgresQueryRunner with changing quoting table_schema and table_name from '"' || "table_schema" || '"' to quote_ident("table_schema"), which allows to deal with table names containing quotes.
It's important because tables with these unusual names can exist, while sometimes it's impossible just rename those tables as this is an arbitrary database, the structure of which needs to be obtained.

Case: PostgreSQL DB containg table with the name `This is the "Table Name"`.
Current behaviour: connection.createQueryRunner().getTables() throws an error.
Next behaviour: connection.createQueryRunner().getTables() works

Fixes #10991

### Pull-Request Checklist

<!--
  Please make sure to review and check all of the following.

  If an item is not applicable, you can add "N/A" to the end.
-->

- [x] Code is up-to-date with the `master` branch
- [x] `npm run format` to apply prettier formatting
- [x] `npm run test` passes with this change
- [x] This pull request links relevant issues as `Fixes #0000`
- [x] There are new or updated unit tests validating the change
- [-] Documentation has been updated to reflect this change N/A
- [x] The new commits follow conventions explained in [CONTRIBUTING.md](https://github.com/typeorm/typeorm/blob/master/CONTRIBUTING.md)

<!--
  🎉 Thank you for contributing and making TypeORM even better!
-->
