### PR TITLE
feat: postgres start transaction and set isolation level in 1 call

### DIFF
--- a/src/driver/postgres/PostgresQueryRunner.ts
+++ b/src/driver/postgres/PostgresQueryRunner.ts
@@ -175,12 +175,14 @@ export class PostgresQueryRunner
 
         if (this.transactionDepth === 0) {
             this.transactionDepth += 1
-            await this.query("START TRANSACTION")
-            if (isolationLevel) {
+            if (!isolationLevel) {
+                await this.query("START TRANSACTION")
+            } else {
                 await this.query(
-                    "SET TRANSACTION ISOLATION LEVEL " + isolationLevel,
+                    "START TRANSACTION ISOLATION LEVEL " + isolationLevel,
                 )
             }
+
         } else {
             this.transactionDepth += 1
             await this.query(`SAVEPOINT typeorm_${this.transactionDepth - 1}`)


### PR DESCRIPTION
### Description of change

I noticed when looking at some of our traces that there is a call to start the transaction and then right after often a call to set the isolation level. Postgres supports doing this in 1 call. Shaving off some precious ms on a lot of our requests.

### Pull-Request Checklist


- [ ] Code is up-to-date with the `master` branch
- [ ] `npm run format` to apply prettier formatting
- [ ] `npm run test` passes with this change
- [ ] This pull request links relevant issues as `Fixes #0000`
- [ ] There are new or updated unit tests validating the change
- [ ] Documentation has been updated to reflect this change
- [ ] The new commits follow conventions explained in [CONTRIBUTING.md](https://github.com/typeorm/typeorm/blob/master/CONTRIBUTING.md)
