### PR TITLE
fixed parameter casing inconsistency in QueryBuilder's onUpdate() and values()

### DIFF
--- a/src/query-builder/InsertQueryBuilder.ts
+++ b/src/query-builder/InsertQueryBuilder.ts
@@ -531,18 +531,26 @@ export class InsertQueryBuilder<
 
                     if (Array.isArray(overwrite)) {
                         updatePart.push(
-                            ...overwrite.map(
+                            ...this.expressionMap.mainAlias!.metadata.columns.filter(
+                                (column) => 
+                                    overwrite.includes(column.propertyName)
+                            )
+                            .map(
                                 (column) =>
                                     `${this.escape(
-                                        column,
-                                    )} = EXCLUDED.${this.escape(column)}`,
+                                        column.databaseName,
+                                    )} = EXCLUDED.${this.escape(column.databaseName)}`,
                             ),
                         )
                     } else if (columns) {
                         updatePart.push(
-                            ...columns.map(
+                            ...this.expressionMap.mainAlias!.metadata.columns.filter(
+                                (column) => 
+                                    columns.includes(column.propertyName)
+                            )
+                            .map(
                                 (column) =>
-                                    `${this.escape(column)} = :${column}`,
+                                    `${this.escape(column.databaseName)} = :${column.databaseName}`,
                             ),
                         )
                     }


### PR DESCRIPTION
allowed onUpdate() to accept entity field/property names

<!--
  😀 Wonderful!  Thank you for opening a pull request for TypeORM.

  Please fill in the information below to expedite the review
  and (hopefully) merge of your change.

  If unsure about something.. just do as best as you're able,
  or reach out through our community support channels!
  https://github.com/typeorm/typeorm/blob/master/docs/support.md
-->

### Description of change

<!--
  Please be clear and concise what the change is intended to do,
  why this change is needed, and how you've verified that it
  corrects what you intended.

  In some cases it may be helpful to include the current behavior
  and the new behavior.

  If the change is related to an open issue, you can link it here.
  If you include `Fixes #0000` (replacing `0000` with the issue number)
  when this is merged it will automatically mark the issue as fixed and
  close it.
-->


### Pull-Request Checklist

<!--
  Please make sure to review and check all of the following.

  If an item is not applicable, you can add "N/A" to the end.
-->

- [x] Code is up-to-date with the `master` branch
- [ ] `npm run format` to apply prettier formatting
- [ ] `npm run test` passes with this change
- [x] This pull request links relevant issues as `Fixes #0000`
- [ ] There are new or updated unit tests validating the change
- [ ] Documentation has been updated to reflect this change
- [x] The new commits follow conventions explained in [CONTRIBUTING.md](https://github.com/typeorm/typeorm/blob/master/CONTRIBUTING.md)

<!--
  🎉 Thank you for contributing and making TypeORM even better!
-->
