### PR TITLE
fix: update RawSqlResultsToEntityTransformer selection matching for * selector

### DIFF
--- a/src/query-builder/transformer/RawSqlResultsToEntityTransformer.ts
+++ b/src/query-builder/transformer/RawSqlResultsToEntityTransformer.ts
@@ -238,7 +238,9 @@ export class RawSqlResultsToEntityTransformer {
                     (select) =>
                         select.selection === alias.name ||
                         select.selection ===
-                            alias.name + "." + column.propertyPath,
+                            alias.name + "." + column.propertyPath ||
+                        select.selection ===
+                            alias.name + ".*",
                 )
             )
                 return


### PR DESCRIPTION
### Description of change

update RawSqlResultsToEntityTransformer selection matching for * selector

This fixes RawSqlResultsToEntityTransformer to populate entities when you're query is SELECT *, and not specific columns


### Pull-Request Checklist

- [x] Code is up-to-date with the `master` branch
- [ ] `npm run format` to apply prettier formatting
- [ ] `npm run test` passes with this change
- [ ] This pull request links relevant issues as `Fixes #0000`
- [ ] There are new or updated unit tests validating the change
- [ ] Documentation has been updated to reflect this change
- [x] The new commits follow conventions explained in [CONTRIBUTING.md](https://github.com/typeorm/typeorm/blob/master/CONTRIBUTING.md)
