### PR TITLE
Print out a warning if no entities are passed

### DIFF
--- a/src/commands/MigrationGenerateCommand.ts
+++ b/src/commands/MigrationGenerateCommand.ts
@@ -7,6 +7,7 @@ import { PlatformTools } from "../platform/PlatformTools"
 import { DataSource } from "../data-source"
 import * as path from "path"
 import process from "process"
+import { isEmpty } from "../common/MixedList"
 
 /**
  * Generates a new migration file with sql needs to be executed to update schema.
@@ -78,6 +79,18 @@ export class MigrationGenerateCommand implements yargs.CommandModule {
             dataSource = await CommandUtils.loadDataSource(
                 path.resolve(process.cwd(), args.dataSource as string),
             )
+
+            if (
+                dataSource.options.entities !== undefined &&
+                isEmpty(dataSource.options.entities)
+            ) {
+                console.log(
+                    chalk.yellow(
+                        "No entity classes or directories passed to Typeorm",
+                    ),
+                )
+            }
+
             dataSource.setOptions({
                 synchronize: false,
                 migrationsRun: false,

--- a/src/common/MixedList.ts
+++ b/src/common/MixedList.ts
@@ -4,3 +4,13 @@
  * Example usage: entities as an array of imported using import * as syntax.
  */
 export type MixedList<T> = T[] | { [key: string]: T }
+
+export function isEmpty<T>(list: MixedList<T>): boolean {
+    if (Array.isArray(list)) {
+        // Check if it's an empty array
+        return list.length === 0
+    } else {
+        // Check if it's an empty object
+        return Object.keys(list).length === 0
+    }
+}


### PR DESCRIPTION
### Description of change

This is a very common problem for people getting started with Typeorm: They have it configured wrong and no entities are actually being passed into the system. The migration runner will then print out that nothing is to be done and you as a beginner don't really have an easy way to figure out what is going wrong here.

This is a simply check and warning in the migration create CLI to catch this case and print out a message that could help the person debug this situation.


### Pull-Request Checklist

- [x] Code is up-to-date with the `master` branch
- [x] `npm run format` to apply prettier formatting
- [x] `npm run test` passes with this change
- [x] This pull request links relevant issues as: #2961 and #10558
- [ ] ~~There are new or updated unit tests validating the change~~
- [ ] ~~Documentation has been updated to reflect this change~~
- [x] The new commits follow conventions explained in [CONTRIBUTING.md](https://github.com/typeorm/typeorm/blob/master/CONTRIBUTING.md)
