### PR TITLE
Removed hardcoded database for generated column metadata

### DIFF
--- a/src/driver/postgres/PostgresQueryRunner.ts
+++ b/src/driver/postgres/PostgresQueryRunner.ts
@@ -524,7 +524,6 @@ export class PostgresQueryRunner
             const schema = tableNameWithSchema[0]
 
             const insertQuery = this.insertTypeormMetadataSql({
-                database: this.driver.database,
                 schema,
                 table: tableName,
                 type: MetadataTableType.GENERATED_COLUMN,
@@ -533,7 +532,6 @@ export class PostgresQueryRunner
             })
 
             const deleteQuery = this.deleteTypeormMetadataSql({
-                database: this.driver.database,
                 schema,
                 table: tableName,
                 type: MetadataTableType.GENERATED_COLUMN,
@@ -621,7 +619,6 @@ export class PostgresQueryRunner
             const schema = tableNameWithSchema[0]
 
             const deleteQuery = this.deleteTypeormMetadataSql({
-                database: this.driver.database,
                 schema,
                 table: tableName,
                 type: MetadataTableType.GENERATED_COLUMN,
@@ -629,7 +626,6 @@ export class PostgresQueryRunner
             })
 
             const insertQuery = this.insertTypeormMetadataSql({
-                database: this.driver.database,
                 schema,
                 table: tableName,
                 type: MetadataTableType.GENERATED_COLUMN,
@@ -1074,7 +1070,6 @@ export class PostgresQueryRunner
             const schema = tableNameWithSchema[0]
 
             const insertQuery = this.insertTypeormMetadataSql({
-                database: this.driver.database,
                 schema,
                 table: tableName,
                 type: MetadataTableType.GENERATED_COLUMN,
@@ -1083,7 +1078,6 @@ export class PostgresQueryRunner
             })
 
             const deleteQuery = this.deleteTypeormMetadataSql({
-                database: this.driver.database,
                 schema,
                 table: tableName,
                 type: MetadataTableType.GENERATED_COLUMN,
@@ -2186,7 +2180,6 @@ export class PostgresQueryRunner
                     )
                     upQueries.push(
                         this.deleteTypeormMetadataSql({
-                            database: this.driver.database,
                             schema,
                             table: tableName,
                             type: MetadataTableType.GENERATED_COLUMN,
@@ -2196,7 +2189,6 @@ export class PostgresQueryRunner
                     // However, we can't copy it back on downgrade. It needs to regenerate.
                     downQueries.push(
                         this.insertTypeormMetadataSql({
-                            database: this.driver.database,
                             schema,
                             table: tableName,
                             type: MetadataTableType.GENERATED_COLUMN,
@@ -2221,15 +2213,6 @@ export class PostgresQueryRunner
                             )} DROP COLUMN "${newColumn.name}"`,
                         ),
                     )
-                    // downQueries.push(
-                    //     this.deleteTypeormMetadataSql({
-                    //         database: this.driver.database,
-                    //         schema,
-                    //         table: tableName,
-                    //         type: MetadataTableType.GENERATED_COLUMN,
-                    //         name: newColumn.name,
-                    //     }),
-                    // )
                 }
             }
         }
@@ -2425,14 +2408,12 @@ export class PostgresQueryRunner
             const tableName = tableNameWithSchema[1]
             const schema = tableNameWithSchema[0]
             const deleteQuery = this.deleteTypeormMetadataSql({
-                database: this.driver.database,
                 schema,
                 table: tableName,
                 type: MetadataTableType.GENERATED_COLUMN,
                 name: column.name,
             })
             const insertQuery = this.insertTypeormMetadataSql({
-                database: this.driver.database,
                 schema,
                 table: tableName,
                 type: MetadataTableType.GENERATED_COLUMN,


### PR DESCRIPTION

<!--
  😀 Wonderful!  Thank you for opening a pull request for TypeORM.

  Please fill in the information below to expedite the review
  and (hopefully) merge of your change.

  If unsure about something.. just do as best as you're able,
  or reach out through our community support channels!
  https://github.com/typeorm/typeorm/blob/master/docs/support.md
-->

### Description of change

<!--
  Please be clear and concise what the change is intended to do,
  why this change is needed, and how you've verified that it
  corrects what you intended.

  In some cases it may be helpful to include the current behavior
  and the new behavior.

  If the change is related to an open issue, you can link it here.
  If you include `Fixes #0000` (replacing `0000` with the issue number)
  when this is merged it will automatically mark the issue as fixed and
  close it.
-->
Setting a database on the inserts/deletes to typeorm_metadata can result in unnecessary migration regeneration for generated columns if the database name changes. This can occur if a dump of database `production`, for example, is restored to a database named `local`, and one attempts to generate migrations (typically for a different schema change) against `local`.

The "hardcoded" database name, `production`, will result in the generated column being dropped and recreated, potentially causing an incident if the change is not caught in development.

Fixes #9776


### Pull-Request Checklist

<!--
  Please make sure to review and check all of the following.

  If an item is not applicable, you can add "N/A" to the end.
-->

- [ ] Code is up-to-date with the `master` branch
- [ ] `npm run format` to apply prettier formatting
- [ ] `npm run test` passes with this change
- [x] This pull request links relevant issues as `Fixes #0000`
- [ ] There are new or updated unit tests validating the change
- [ ] Documentation has been updated to reflect this change
- [ ] The new commits follow conventions explained in [CONTRIBUTING.md](https://github.com/typeorm/typeorm/blob/master/CONTRIBUTING.md)

<!--
  🎉 Thank you for contributing and making TypeORM even better!
-->
