### PR TITLE
Use naming strategy for `JoinColumn` provided name

### DIFF
--- a/src/metadata-builder/JunctionEntityMetadataBuilder.ts
+++ b/src/metadata-builder/JunctionEntityMetadataBuilder.ts
@@ -76,14 +76,17 @@ export class JunctionEntityMetadataBuilder {
                       )
                   })
                 : undefined
-            const columnName =
+
+            let columnName =
                 joinColumn && joinColumn.name
                     ? joinColumn.name
-                    : this.connection.namingStrategy.joinTableColumnName(
-                          relation.entityMetadata.tableNameWithoutPrefix,
-                          referencedColumn.propertyName,
-                          referencedColumn.databaseName,
-                      )
+                    : referencedColumn.propertyName
+
+            columnName = this.connection.namingStrategy.joinTableColumnName(
+                relation.entityMetadata.tableNameWithoutPrefix,
+                columnName,
+                referencedColumn.databaseName,
+            )
 
             return new ColumnMetadata({
                 connection: this.connection,

--- a/src/metadata-builder/JunctionEntityMetadataBuilder.ts
+++ b/src/metadata-builder/JunctionEntityMetadataBuilder.ts
@@ -77,14 +77,11 @@ export class JunctionEntityMetadataBuilder {
                   })
                 : undefined
 
-            let columnName =
+            let columnName = this.connection.namingStrategy.joinTableColumnName(
+                relation.entityMetadata.tableNameWithoutPrefix,
                 joinColumn && joinColumn.name
                     ? joinColumn.name
-                    : referencedColumn.propertyName
-
-            columnName = this.connection.namingStrategy.joinTableColumnName(
-                relation.entityMetadata.tableNameWithoutPrefix,
-                columnName,
+                    : referencedColumn.propertyName,
                 referencedColumn.databaseName,
             )
 

--- a/src/metadata-builder/RelationJoinColumnBuilder.ts
+++ b/src/metadata-builder/RelationJoinColumnBuilder.ts
@@ -175,12 +175,14 @@ export class RelationJoinColumnBuilder {
                     !!joinColumn.name
                 )
             })
-            const joinColumnName = joinColumnMetadataArg
-                ? joinColumnMetadataArg.name
-                : this.connection.namingStrategy.joinColumnName(
-                      relation.propertyName,
-                      referencedColumn.propertyName,
-                  )
+
+            const joinColumnName =
+                this.connection.namingStrategy.joinTableColumnName(
+                    joinColumnMetadataArg && joinColumnMetadataArg.name
+                        ? joinColumnMetadataArg.name
+                        : relation.propertyName,
+                    referencedColumn.propertyName,
+                )
 
             const relationalColumns = relation.embeddedMetadata
                 ? relation.embeddedMetadata.columns


### PR DESCRIPTION
### Description of change

Using `@JoinColumn({name: '...'})` ingores custom naming strategies.
This change applies the custom naming strategies to the name provided in `JoinColumn`.


### Pull-Request Checklist

- [X] Code is up-to-date with the `master` branch
- [X] `npm run format` to apply prettier formatting
- [X] `npm run test` passes with this change
- [X] This pull request links relevant issues as `Fixes #0000`
- [ ] There are new or updated unit tests validating the change
- [X] Documentation has been updated to reflect this change
- [X] The new commits follow conventions explained in [CONTRIBUTING.md](https://github.com/typeorm/typeorm/blob/master/CONTRIBUTING.md)

