### PR TITLE
Rename SubjectTopoligicalSorter as SubjectTopologicalSorter

### DIFF
--- a/src/driver/postgres/PostgresQueryRunner.ts
+++ b/src/driver/postgres/PostgresQueryRunner.ts
@@ -601,10 +601,22 @@ export class PostgresQueryRunner
                 downQueries.push(this.dropIndexSql(table, index))
             })
         }
-        
+
         if (table.comment) {
-            upQueries.push(new Query("COMMENT ON TABLE " + this.escapePath(table) + " IS '" + table.comment + "'"));
-            downQueries.push(new Query("COMMENT ON TABLE " + this.escapePath(table) + " IS NULL"));
+            upQueries.push(
+                new Query(
+                    "COMMENT ON TABLE " +
+                        this.escapePath(table) +
+                        " IS '" +
+                        table.comment +
+                        "'",
+                ),
+            )
+            downQueries.push(
+                new Query(
+                    "COMMENT ON TABLE " + this.escapePath(table) + " IS NULL",
+                ),
+            )
         }
 
         await this.executeQueries(upQueries, downQueries)
@@ -4744,7 +4756,7 @@ export class PostgresQueryRunner
 
         newComment = this.escapeComment(newComment)
         const comment = this.escapeComment(table.comment)
-        
+
         if (newComment === comment) {
             return
         }

--- a/src/persistence/SubjectExecutor.ts
+++ b/src/persistence/SubjectExecutor.ts
@@ -1,6 +1,6 @@
 import { QueryRunner } from "../query-runner/QueryRunner"
 import { Subject } from "./Subject"
-import { SubjectTopoligicalSorter } from "./SubjectTopoligicalSorter"
+import { SubjectTopologicalSorter } from "./SubjectTopologicalSorter"
 import { SubjectChangedColumnsComputer } from "./SubjectChangedColumnsComputer"
 import { SubjectWithoutIdentifierError } from "../error/SubjectWithoutIdentifierError"
 import { SubjectRemovedAndUpdatedError } from "../error/SubjectRemovedAndUpdatedError"
@@ -131,7 +131,7 @@ export class SubjectExecutor {
 
         // execute all insert operations
         // console.time(".insertion");
-        this.insertSubjects = new SubjectTopoligicalSorter(
+        this.insertSubjects = new SubjectTopologicalSorter(
             this.insertSubjects,
         ).sort("insert")
         await this.executeInsertOperations()
@@ -150,7 +150,7 @@ export class SubjectExecutor {
 
         // make sure our remove subjects are sorted (using topological sorting) when multiple entities are passed for the removal
         // console.time(".removal");
-        this.removeSubjects = new SubjectTopoligicalSorter(
+        this.removeSubjects = new SubjectTopologicalSorter(
             this.removeSubjects,
         ).sort("delete")
         await this.executeRemoveOperations()

--- a/src/persistence/SubjectTopologicalSorter.ts
+++ b/src/persistence/SubjectTopologicalSorter.ts
@@ -6,7 +6,7 @@ import { TypeORMError } from "../error"
  * Orders insert or remove subjects in proper order (using topological sorting)
  * to make sure insert or remove operations are executed in a proper order.
  */
-export class SubjectTopoligicalSorter {
+export class SubjectTopologicalSorter {
     // -------------------------------------------------------------------------
     // Public Properties
     // -------------------------------------------------------------------------

--- a/src/query-builder/InsertQueryBuilder.ts
+++ b/src/query-builder/InsertQueryBuilder.ts
@@ -459,10 +459,8 @@ export class InsertQueryBuilder<
         // add VALUES expression
         if (valuesExpression) {
             if (
-                (
-                    this.connection.driver.options.type === "oracle" ||
-                    this.connection.driver.options.type === "sap"
-                ) &&
+                (this.connection.driver.options.type === "oracle" ||
+                    this.connection.driver.options.type === "sap") &&
                 this.getValueSets().length > 1
             ) {
                 query += ` ${valuesExpression}`

--- a/src/query-builder/QueryBuilder.ts
+++ b/src/query-builder/QueryBuilder.ts
@@ -522,7 +522,10 @@ export abstract class QueryBuilder<Entity extends ObjectLiteral> {
      * Uses same query runner as current QueryBuilder.
      */
     createQueryBuilder(queryRunner?: QueryRunner): this {
-        return new (this.constructor as any)(this.connection, queryRunner ?? this.queryRunner)
+        return new (this.constructor as any)(
+            this.connection,
+            queryRunner ?? this.queryRunner,
+        )
     }
 
     /**

--- a/src/schema-builder/RdbmsSchemaBuilder.ts
+++ b/src/schema-builder/RdbmsSchemaBuilder.ts
@@ -604,7 +604,7 @@ export class RdbmsSchemaBuilder implements SchemaBuilder {
 
             if (
                 DriverUtils.isMySQLFamily(this.connection.driver) ||
-                this.connection.driver.options.type === 'postgres'
+                this.connection.driver.options.type === "postgres"
             ) {
                 const newComment = metadata.comment
                 await this.queryRunner.changeTableComment(table, newComment)

--- a/test/integration/sample2-one-to-one.ts
+++ b/test/integration/sample2-one-to-one.ts
@@ -211,14 +211,15 @@ describe("one-to-one", function () {
             expectedPost.details!.comment = savedPost.details!.comment
             expectedPost.details!.metadata = savedPost.details!.metadata
 
-            const findOne = () => postRepository.findOne({
+            const findOne = () =>
+                postRepository.findOne({
                     where: {
-                        id: savedPost.id
+                        id: savedPost.id,
                     },
                     relations: {
-                        details: true
+                        details: true,
                     },
-                    relationLoadStrategy: "query"
+                    relationLoadStrategy: "query",
                 })
 
             const posts = await Promise.all([
@@ -234,7 +235,7 @@ describe("one-to-one", function () {
                 findOne(),
             ])
 
-            posts.forEach(post => {
+            posts.forEach((post) => {
                 expect(post).not.to.be.null
                 post!.should.eql(expectedPost)
             })

--- a/test/integration/sample3-many-to-one.ts
+++ b/test/integration/sample3-many-to-one.ts
@@ -213,15 +213,16 @@ describe("many-to-one", function () {
             expectedPost.details!.comment = savedPost.details!.comment
             expectedPost.details!.metadata = savedPost.details!.metadata
 
-            const findOne = () => postRepository.findOne({
-                where: {
-                    id: savedPost.id
-                },
-                relations: {
-                    details: true
-                },
-                relationLoadStrategy: "query"
-            })
+            const findOne = () =>
+                postRepository.findOne({
+                    where: {
+                        id: savedPost.id,
+                    },
+                    relations: {
+                        details: true,
+                    },
+                    relationLoadStrategy: "query",
+                })
 
             const posts = await Promise.all([
                 findOne(),
@@ -236,7 +237,7 @@ describe("many-to-one", function () {
                 findOne(),
             ])
 
-            posts.forEach(post => {
+            posts.forEach((post) => {
                 expect(post).not.to.be.null
                 post!.should.eql(expectedPost)
             })


### PR DESCRIPTION
### Description of change 

Fixing the small typo in SubjectTopoligicalSorter and renaming it as SubjectTopologicalSorter.
The actual change is in 2 files
- `src/persistence/SubjectExecutor.ts`
- `src/persistence/SubjectTopologicalSorter.ts`

Other changes are the result of `npm run format`

### Pull-Request Checklist

- [x] Code is up-to-date with the `master` branch
- [x] `npm run format` to apply prettier formatting
- [x] `npm run test` passes with this change
- [x] This pull request links relevant issues as `Fixes #0000` (N/A)
- [x] There are new or updated unit tests validating the change (N/A)
- [x] Documentation has been updated to reflect this change (N/A)
- [x] The new commits follow conventions explained in [CONTRIBUTING.md] (https://github.com/typeorm/typeorm/blob/master/CONTRIBUTING.md) (N/A)
