### PR TITLE
fix: type for aggregation functions

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -19,7 +19,6 @@
         "dotenv": "^16.0.3",
         "glob": "^10.3.10",
         "mkdirp": "^2.1.3",
-        "reflect-metadata": "^0.2.1",
         "sha.js": "^2.4.11",
         "tslib": "^2.5.0",
         "uuid": "^9.0.0",
@@ -105,6 +104,7 @@
         "pg-native": "^3.0.0",
         "pg-query-stream": "^4.0.0",
         "redis": "^3.1.1 || ^4.0.0",
+        "reflect-metadata": "^0.1.14 || ^0.2.0",
         "sql.js": "^1.4.0",
         "sqlite3": "^5.0.3",
         "ts-node": "^10.7.0",
@@ -11751,7 +11751,8 @@
     "node_modules/reflect-metadata": {
       "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/reflect-metadata/-/reflect-metadata-0.2.1.tgz",
-      "integrity": "sha512-i5lLI6iw9AU3Uu4szRNPPEkomnkjRTaVt9hy/bn5g/oSzekBSMeLZblcjP74AW0vBabqERLLIrz+gR8QYR54Tw=="
+      "integrity": "sha512-i5lLI6iw9AU3Uu4szRNPPEkomnkjRTaVt9hy/bn5g/oSzekBSMeLZblcjP74AW0vBabqERLLIrz+gR8QYR54Tw==",
+      "peer": true
     },
     "node_modules/regex-not": {
       "version": "1.0.2",

--- a/src/common/EntityProperty.ts
+++ b/src/common/EntityProperty.ts
@@ -1,0 +1,4 @@
+/**
+ * Expand entity properties.
+ */
+export type EntityProperty<Entity> = Exclude<keyof Entity, symbol | number>;

--- a/src/common/EntityProperty.ts
+++ b/src/common/EntityProperty.ts
@@ -1,4 +1,4 @@
 /**
  * Expand entity properties.
  */
-export type EntityProperty<Entity> = Exclude<keyof Entity, symbol | number>;
+export type EntityProperty<Entity> = Exclude<keyof Entity, symbol | number>

--- a/src/common/PickKeysByType.ts
+++ b/src/common/PickKeysByType.ts
@@ -1,7 +1,0 @@
-/**
- * Pick only the keys that match the Type `U`
- */
-export type PickKeysByType<T, U> = string &
-    keyof {
-        [P in keyof T as T[P] extends U ? P : never]: T[P]
-    }

--- a/src/driver/postgres/PostgresQueryRunner.ts
+++ b/src/driver/postgres/PostgresQueryRunner.ts
@@ -601,10 +601,22 @@ export class PostgresQueryRunner
                 downQueries.push(this.dropIndexSql(table, index))
             })
         }
-        
+
         if (table.comment) {
-            upQueries.push(new Query("COMMENT ON TABLE " + this.escapePath(table) + " IS '" + table.comment + "'"));
-            downQueries.push(new Query("COMMENT ON TABLE " + this.escapePath(table) + " IS NULL"));
+            upQueries.push(
+                new Query(
+                    "COMMENT ON TABLE " +
+                        this.escapePath(table) +
+                        " IS '" +
+                        table.comment +
+                        "'",
+                ),
+            )
+            downQueries.push(
+                new Query(
+                    "COMMENT ON TABLE " + this.escapePath(table) + " IS NULL",
+                ),
+            )
         }
 
         await this.executeQueries(upQueries, downQueries)
@@ -4744,7 +4756,7 @@ export class PostgresQueryRunner
 
         newComment = this.escapeComment(newComment)
         const comment = this.escapeComment(table.comment)
-        
+
         if (newComment === comment) {
             return
         }

--- a/src/entity-manager/EntityManager.ts
+++ b/src/entity-manager/EntityManager.ts
@@ -37,7 +37,7 @@ import { getMetadataArgsStorage } from "../globals"
 import { UpsertOptions } from "../repository/UpsertOptions"
 import { InstanceChecker } from "../util/InstanceChecker"
 import { ObjectLiteral } from "../common/ObjectLiteral"
-import {EntityProperty} from "../common/EntityProperty";
+import { EntityProperty } from "../common/EntityProperty"
 
 /**
  * Entity manager supposed to work with any entity, automatically find its repository and call its methods,
@@ -1077,7 +1077,10 @@ export class EntityManager {
             )
         }
 
-        const result = await this.createQueryBuilder(entityClass, entityMetadata.name)
+        const result = await this.createQueryBuilder(
+            entityClass,
+            entityMetadata.name,
+        )
             .setFindOptions({ where })
             .select(
                 `${fnName}(${this.connection.driver.escape(
@@ -1114,10 +1117,7 @@ export class EntityManager {
         where: FindOptionsWhere<Entity> | FindOptionsWhere<Entity>[],
     ): Promise<Entity[]> {
         const metadata = this.connection.getMetadata(entityClass)
-        return this.createQueryBuilder<Entity>(
-            entityClass,
-            metadata.name,
-        )
+        return this.createQueryBuilder<Entity>(entityClass, metadata.name)
             .setFindOptions({ where: where })
             .getMany()
     }
@@ -1151,10 +1151,7 @@ export class EntityManager {
         where: FindOptionsWhere<Entity> | FindOptionsWhere<Entity>[],
     ): Promise<[Entity[], number]> {
         const metadata = this.connection.getMetadata(entityClass)
-        return this.createQueryBuilder<Entity>(
-            entityClass,
-            metadata.name,
-        )
+        return this.createQueryBuilder<Entity>(entityClass, metadata.name)
             .setFindOptions({ where })
             .getManyAndCount()
     }
@@ -1177,10 +1174,7 @@ export class EntityManager {
         if (!ids.length) return Promise.resolve([])
 
         const metadata = this.connection.getMetadata(entityClass)
-        return this.createQueryBuilder<Entity>(
-            entityClass,
-            metadata.name,
-        )
+        return this.createQueryBuilder<Entity>(entityClass, metadata.name)
             .andWhereInIds(ids)
             .getMany()
     }
@@ -1268,16 +1262,14 @@ export class EntityManager {
         entityClass: EntityTarget<Entity>,
         options: FindOneOptions<Entity>,
     ): Promise<Entity> {
-        return this.findOne<Entity>(entityClass, options).then(
-            (value) => {
-                if (value === null) {
-                    return Promise.reject(
-                        new EntityNotFoundError(entityClass, options),
-                    )
-                }
-                return Promise.resolve(value)
-            },
-        )
+        return this.findOne<Entity>(entityClass, options).then((value) => {
+            if (value === null) {
+                return Promise.reject(
+                    new EntityNotFoundError(entityClass, options),
+                )
+            }
+            return Promise.resolve(value)
+        })
     }
 
     /**
@@ -1288,16 +1280,14 @@ export class EntityManager {
         entityClass: EntityTarget<Entity>,
         where: FindOptionsWhere<Entity> | FindOptionsWhere<Entity>[],
     ): Promise<Entity> {
-        return this.findOneBy<Entity>(entityClass, where).then(
-            (value) => {
-                if (value === null) {
-                    return Promise.reject(
-                        new EntityNotFoundError(entityClass, where),
-                    )
-                }
-                return Promise.resolve(value)
-            },
-        )
+        return this.findOneBy<Entity>(entityClass, where).then((value) => {
+            if (value === null) {
+                return Promise.reject(
+                    new EntityNotFoundError(entityClass, where),
+                )
+            }
+            return Promise.resolve(value)
+        })
     }
 
     /**

--- a/src/query-builder/InsertQueryBuilder.ts
+++ b/src/query-builder/InsertQueryBuilder.ts
@@ -459,10 +459,8 @@ export class InsertQueryBuilder<
         // add VALUES expression
         if (valuesExpression) {
             if (
-                (
-                    this.connection.driver.options.type === "oracle" ||
-                    this.connection.driver.options.type === "sap"
-                ) &&
+                (this.connection.driver.options.type === "oracle" ||
+                    this.connection.driver.options.type === "sap") &&
                 this.getValueSets().length > 1
             ) {
                 query += ` ${valuesExpression}`

--- a/src/query-builder/QueryBuilder.ts
+++ b/src/query-builder/QueryBuilder.ts
@@ -522,7 +522,10 @@ export abstract class QueryBuilder<Entity extends ObjectLiteral> {
      * Uses same query runner as current QueryBuilder.
      */
     createQueryBuilder(queryRunner?: QueryRunner): this {
-        return new (this.constructor as any)(this.connection, queryRunner ?? this.queryRunner)
+        return new (this.constructor as any)(
+            this.connection,
+            queryRunner ?? this.queryRunner,
+        )
     }
 
     /**

--- a/src/repository/BaseEntity.ts
+++ b/src/repository/BaseEntity.ts
@@ -15,7 +15,7 @@ import { ObjectUtils } from "../util/ObjectUtils"
 import { QueryDeepPartialEntity } from "../query-builder/QueryPartialEntity"
 import { UpsertOptions } from "./UpsertOptions"
 import { EntityTarget } from "../common/EntityTarget"
-import { PickKeysByType } from "../common/PickKeysByType"
+import { EntityProperty } from "../common/EntityProperty"
 
 /**
  * Base abstract entity for all entities, used in ActiveRecord patterns.
@@ -434,10 +434,10 @@ export class BaseEntity {
      */
     static sum<T extends BaseEntity>(
         this: { new (): T } & typeof BaseEntity,
-        columnName: PickKeysByType<T, number>,
+        property: EntityProperty<T>,
         where: FindOptionsWhere<T>,
     ): Promise<number | null> {
-        return this.getRepository<T>().sum(columnName, where)
+        return this.getRepository<T>().sum(property, where)
     }
 
     /**
@@ -445,10 +445,10 @@ export class BaseEntity {
      */
     static average<T extends BaseEntity>(
         this: { new (): T } & typeof BaseEntity,
-        columnName: PickKeysByType<T, number>,
+        property: EntityProperty<T>,
         where: FindOptionsWhere<T>,
     ): Promise<number | null> {
-        return this.getRepository<T>().average(columnName, where)
+        return this.getRepository<T>().average(property, where)
     }
 
     /**
@@ -456,10 +456,10 @@ export class BaseEntity {
      */
     static minimum<T extends BaseEntity>(
         this: { new (): T } & typeof BaseEntity,
-        columnName: PickKeysByType<T, number>,
+        property: EntityProperty<T>,
         where: FindOptionsWhere<T>,
     ): Promise<number | null> {
-        return this.getRepository<T>().minimum(columnName, where)
+        return this.getRepository<T>().minimum(property, where)
     }
 
     /**
@@ -467,10 +467,10 @@ export class BaseEntity {
      */
     static maximum<T extends BaseEntity>(
         this: { new (): T } & typeof BaseEntity,
-        columnName: PickKeysByType<T, number>,
+        property: EntityProperty<T>,
         where: FindOptionsWhere<T>,
     ): Promise<number | null> {
-        return this.getRepository<T>().maximum(columnName, where)
+        return this.getRepository<T>().maximum(property, where)
     }
 
     /**

--- a/src/repository/Repository.ts
+++ b/src/repository/Repository.ts
@@ -15,7 +15,7 @@ import { ObjectId } from "../driver/mongodb/typings"
 import { FindOptionsWhere } from "../find-options/FindOptionsWhere"
 import { UpsertOptions } from "./UpsertOptions"
 import { EntityTarget } from "../common/EntityTarget"
-import { PickKeysByType } from "../common/PickKeysByType"
+import { EntityProperty } from "../common/EntityProperty"
 
 /**
  * Repository is supposed to work with your entity objects. Find entities, insert, update, delete, etc.
@@ -79,7 +79,7 @@ export class Repository<Entity extends ObjectLiteral> {
         queryRunner?: QueryRunner,
     ): SelectQueryBuilder<Entity> {
         return this.manager.createQueryBuilder<Entity>(
-            this.metadata.target as any,
+            this.metadata.target,
             alias || this.metadata.targetName,
             queryRunner || this.queryRunner,
         )
@@ -127,8 +127,8 @@ export class Repository<Entity extends ObjectLiteral> {
             | DeepPartial<Entity>[],
     ): Entity | Entity[] {
         return this.manager.create(
-            this.metadata.target as any,
-            plainEntityLikeOrPlainEntityLikes as any,
+            this.metadata.target,
+            plainEntityLikeOrPlainEntityLikes,
         )
     }
 
@@ -140,7 +140,7 @@ export class Repository<Entity extends ObjectLiteral> {
         ...entityLikes: DeepPartial<Entity>[]
     ): Entity {
         return this.manager.merge(
-            this.metadata.target as any,
+            this.metadata.target,
             mergeIntoEntity,
             ...entityLikes,
         )
@@ -156,7 +156,7 @@ export class Repository<Entity extends ObjectLiteral> {
      * Returns undefined if entity with given id was not found.
      */
     preload(entityLike: DeepPartial<Entity>): Promise<Entity | undefined> {
-        return this.manager.preload(this.metadata.target as any, entityLike)
+        return this.manager.preload(this.metadata.target, entityLike)
     }
 
     /**
@@ -203,7 +203,7 @@ export class Repository<Entity extends ObjectLiteral> {
         options?: SaveOptions,
     ): Promise<T | T[]> {
         return this.manager.save<Entity, T>(
-            this.metadata.target as any,
+            this.metadata.target,
             entityOrEntities as any,
             options,
         )
@@ -227,8 +227,8 @@ export class Repository<Entity extends ObjectLiteral> {
         options?: RemoveOptions,
     ): Promise<Entity | Entity[]> {
         return this.manager.remove(
-            this.metadata.target as any,
-            entityOrEntities as any,
+            this.metadata.target,
+            entityOrEntities,
             options,
         )
     }
@@ -273,7 +273,7 @@ export class Repository<Entity extends ObjectLiteral> {
         options?: SaveOptions,
     ): Promise<T | T[]> {
         return this.manager.softRemove<Entity, T>(
-            this.metadata.target as any,
+            this.metadata.target,
             entityOrEntities as any,
             options,
         )
@@ -319,7 +319,7 @@ export class Repository<Entity extends ObjectLiteral> {
         options?: SaveOptions,
     ): Promise<T | T[]> {
         return this.manager.recover<Entity, T>(
-            this.metadata.target as any,
+            this.metadata.target,
             entityOrEntities as any,
             options,
         )
@@ -336,7 +336,7 @@ export class Repository<Entity extends ObjectLiteral> {
             | QueryDeepPartialEntity<Entity>
             | QueryDeepPartialEntity<Entity>[],
     ): Promise<InsertResult> {
-        return this.manager.insert(this.metadata.target as any, entity)
+        return this.manager.insert(this.metadata.target, entity)
     }
 
     /**
@@ -359,8 +359,8 @@ export class Repository<Entity extends ObjectLiteral> {
         partialEntity: QueryDeepPartialEntity<Entity>,
     ): Promise<UpdateResult> {
         return this.manager.update(
-            this.metadata.target as any,
-            criteria as any,
+            this.metadata.target,
+            criteria,
             partialEntity,
         )
     }
@@ -377,7 +377,7 @@ export class Repository<Entity extends ObjectLiteral> {
         conflictPathsOrOptions: string[] | UpsertOptions<Entity>,
     ): Promise<InsertResult> {
         return this.manager.upsert(
-            this.metadata.target as any,
+            this.metadata.target,
             entityOrEntities,
             conflictPathsOrOptions,
         )
@@ -401,7 +401,7 @@ export class Repository<Entity extends ObjectLiteral> {
             | ObjectId[]
             | FindOptionsWhere<Entity>,
     ): Promise<DeleteResult> {
-        return this.manager.delete(this.metadata.target as any, criteria as any)
+        return this.manager.delete(this.metadata.target, criteria)
     }
 
     /**
@@ -423,8 +423,8 @@ export class Repository<Entity extends ObjectLiteral> {
             | FindOptionsWhere<Entity>,
     ): Promise<UpdateResult> {
         return this.manager.softDelete(
-            this.metadata.target as any,
-            criteria as any,
+            this.metadata.target,
+            criteria,
         )
     }
 
@@ -447,8 +447,8 @@ export class Repository<Entity extends ObjectLiteral> {
             | FindOptionsWhere<Entity>,
     ): Promise<UpdateResult> {
         return this.manager.restore(
-            this.metadata.target as any,
-            criteria as any,
+            this.metadata.target,
+            criteria,
         )
     }
 
@@ -501,40 +501,40 @@ export class Repository<Entity extends ObjectLiteral> {
      * Return the SUM of a column
      */
     sum(
-        columnName: PickKeysByType<Entity, number>,
+        property: EntityProperty<Entity>,
         where?: FindOptionsWhere<Entity> | FindOptionsWhere<Entity>[],
     ): Promise<number | null> {
-        return this.manager.sum(this.metadata.target, columnName, where)
+        return this.manager.sum(this.metadata.target, property, where)
     }
 
     /**
      * Return the AVG of a column
      */
     average(
-        columnName: PickKeysByType<Entity, number>,
+        property: EntityProperty<Entity>,
         where?: FindOptionsWhere<Entity> | FindOptionsWhere<Entity>[],
     ): Promise<number | null> {
-        return this.manager.average(this.metadata.target, columnName, where)
+        return this.manager.average(this.metadata.target, property, where)
     }
 
     /**
      * Return the MIN of a column
      */
     minimum(
-        columnName: PickKeysByType<Entity, number>,
+        property: EntityProperty<Entity>,
         where?: FindOptionsWhere<Entity> | FindOptionsWhere<Entity>[],
     ): Promise<number | null> {
-        return this.manager.minimum(this.metadata.target, columnName, where)
+        return this.manager.minimum(this.metadata.target, property, where)
     }
 
     /**
      * Return the MAX of a column
      */
     maximum(
-        columnName: PickKeysByType<Entity, number>,
+        property: EntityProperty<Entity>,
         where?: FindOptionsWhere<Entity> | FindOptionsWhere<Entity>[],
     ): Promise<number | null> {
-        return this.manager.maximum(this.metadata.target, columnName, where)
+        return this.manager.maximum(this.metadata.target, property, where)
     }
 
     /**

--- a/src/repository/Repository.ts
+++ b/src/repository/Repository.ts
@@ -422,10 +422,7 @@ export class Repository<Entity extends ObjectLiteral> {
             | ObjectId[]
             | FindOptionsWhere<Entity>,
     ): Promise<UpdateResult> {
-        return this.manager.softDelete(
-            this.metadata.target,
-            criteria,
-        )
+        return this.manager.softDelete(this.metadata.target, criteria)
     }
 
     /**
@@ -446,10 +443,7 @@ export class Repository<Entity extends ObjectLiteral> {
             | ObjectId[]
             | FindOptionsWhere<Entity>,
     ): Promise<UpdateResult> {
-        return this.manager.restore(
-            this.metadata.target,
-            criteria,
-        )
+        return this.manager.restore(this.metadata.target, criteria)
     }
 
     /**

--- a/src/schema-builder/RdbmsSchemaBuilder.ts
+++ b/src/schema-builder/RdbmsSchemaBuilder.ts
@@ -604,7 +604,7 @@ export class RdbmsSchemaBuilder implements SchemaBuilder {
 
             if (
                 DriverUtils.isMySQLFamily(this.connection.driver) ||
-                this.connection.driver.options.type === 'postgres'
+                this.connection.driver.options.type === "postgres"
             ) {
                 const newComment = metadata.comment
                 await this.queryRunner.changeTableComment(table, newComment)

--- a/test/integration/sample2-one-to-one.ts
+++ b/test/integration/sample2-one-to-one.ts
@@ -211,14 +211,15 @@ describe("one-to-one", function () {
             expectedPost.details!.comment = savedPost.details!.comment
             expectedPost.details!.metadata = savedPost.details!.metadata
 
-            const findOne = () => postRepository.findOne({
+            const findOne = () =>
+                postRepository.findOne({
                     where: {
-                        id: savedPost.id
+                        id: savedPost.id,
                     },
                     relations: {
-                        details: true
+                        details: true,
                     },
-                    relationLoadStrategy: "query"
+                    relationLoadStrategy: "query",
                 })
 
             const posts = await Promise.all([
@@ -234,7 +235,7 @@ describe("one-to-one", function () {
                 findOne(),
             ])
 
-            posts.forEach(post => {
+            posts.forEach((post) => {
                 expect(post).not.to.be.null
                 post!.should.eql(expectedPost)
             })

--- a/test/integration/sample3-many-to-one.ts
+++ b/test/integration/sample3-many-to-one.ts
@@ -213,15 +213,16 @@ describe("many-to-one", function () {
             expectedPost.details!.comment = savedPost.details!.comment
             expectedPost.details!.metadata = savedPost.details!.metadata
 
-            const findOne = () => postRepository.findOne({
-                where: {
-                    id: savedPost.id
-                },
-                relations: {
-                    details: true
-                },
-                relationLoadStrategy: "query"
-            })
+            const findOne = () =>
+                postRepository.findOne({
+                    where: {
+                        id: savedPost.id,
+                    },
+                    relations: {
+                        details: true,
+                    },
+                    relationLoadStrategy: "query",
+                })
 
             const posts = await Promise.all([
                 findOne(),
@@ -236,7 +237,7 @@ describe("many-to-one", function () {
                 findOne(),
             ])
 
-            posts.forEach(post => {
+            posts.forEach((post) => {
                 expect(post).not.to.be.null
                 post!.should.eql(expectedPost)
             })


### PR DESCRIPTION
<!--
  😀 Wonderful!  Thank you for opening a pull request for TypeORM.

  Please fill in the information below to expedite the review
  and (hopefully) merge of your change.

  If unsure about something.. just do as best as you're able,
  or reach out through our community support channels!
  https://github.com/typeorm/typeorm/blob/master/docs/support.md
-->

### Description of change
This PR has no logic changes, just fix type issue and refactors

1. Fix aggregation function property type. 
`PickKeysByType` is a wrong type to describe the entity property, because we may define a property with custom type using custom transformer, so the `number` type is not enough, besides, if we define the entity property as optional with `?` operator, the `PickKeysByType` will always return `never`, that cause type issue. So I create a new type `EntityProperty` to replace it, that type just pick the entity key with `string` type.

2. Rename `columnName` to `property`.
`columnName` means raw table column name, but actually it is just a entity property.

3. Remove uncecessay any
I found many `as any` in source code, some are unnecessary (can remove), some are force used due to function overload declaration (I think this is a bad idea because we will always meet type inconsistent when using these overloaded functions with generics)

<!--
  Please be clear and concise what the change is intended to do,
  why this change is needed, and how you've verified that it
  corrects what you intended.

  In some cases it may be helpful to include the current behavior
  and the new behavior.

  If the change is related to an open issue, you can link it here.
  If you include `Fixes #0000` (replacing `0000` with the issue number)
  when this is merged it will automatically mark the issue as fixed and
  close it.
-->


### Pull-Request Checklist

<!--
  Please make sure to review and check all of the following.

  If an item is not applicable, you can add "N/A" to the end.
-->

- [x] Code is up-to-date with the `master` branch
- [x] `npm run format` to apply prettier formatting
- [ ] `npm run test` passes with this change
- [ ] This pull request links relevant issues as `Fixes #0000`
- [ ] There are new or updated unit tests validating the change
- [ ] Documentation has been updated to reflect this change
- [x] The new commits follow conventions explained in [CONTRIBUTING.md](https://github.com/typeorm/typeorm/blob/master/CONTRIBUTING.md)

<!--
  🎉 Thank you for contributing and making TypeORM even better!
-->
