### PR TITLE
fix: add graceful shutdown option to Postgres Driver

### DIFF
--- a/src/driver/postgres/PostgresConnectionOptions.ts
+++ b/src/driver/postgres/PostgresConnectionOptions.ts
@@ -76,6 +76,21 @@ export interface PostgresConnectionOptions
     readonly poolErrorHandler?: (err: any) => any
 
     /**
+     * Specifies the duration, in milliseconds, for graceful termination of pool connections during pool closure.
+     *
+     * This property is utilized when invoking the {@link DataSource#destroy|DataSource.destroy()} method.
+     * It facilitates the graceful closure of pool connections and allows for the completion of ongoing queries.
+     *
+     * @remarks
+     * If this property is undefined or set to 0, no timeout will be applied,
+     * resulting in immediate, forceful termination of connections.
+     *
+     * @type {number|undefined}
+     * @readonly
+     */
+    readonly poolGracefulShutdownTimeoutMS?: number
+
+    /**
      * Include notification messages from Postgres server in client logs
      */
     readonly logNotifications?: boolean

--- a/src/driver/postgres/PostgresDriver.ts
+++ b/src/driver/postgres/PostgresDriver.ts
@@ -1554,18 +1554,24 @@ export class PostgresDriver implements Driver {
                 pool.end((err: any) => (err ? fail(err) : ok()))
             })
         } else {
-            const timeout = (promise: Promise<any>, timeMs: number): Promise<void> => {
+            const timeout = (
+                promise: Promise<any>,
+                timeMs: number,
+            ): Promise<void> => {
                 return Promise.race([
                     promise,
                     new Promise((resolve) => setTimeout(resolve, timeMs)),
-                ]);
+                ])
             }
             const poolEndPromise = new Promise<void>((ok, fail) => {
                 pool.end((err: any) => (err ? fail(err) : ok()))
-            });
+            })
 
             try {
-                await timeout(poolEndPromise, this.options.poolGracefulShutdownTimeoutMS);
+                await timeout(
+                    poolEndPromise,
+                    this.options.poolGracefulShutdownTimeoutMS,
+                )
             } finally {
                 while (this.connectedQueryRunners.length) {
                     await this.connectedQueryRunners[0].release()

--- a/src/driver/postgres/PostgresQueryRunner.ts
+++ b/src/driver/postgres/PostgresQueryRunner.ts
@@ -601,10 +601,22 @@ export class PostgresQueryRunner
                 downQueries.push(this.dropIndexSql(table, index))
             })
         }
-        
+
         if (table.comment) {
-            upQueries.push(new Query("COMMENT ON TABLE " + this.escapePath(table) + " IS '" + table.comment + "'"));
-            downQueries.push(new Query("COMMENT ON TABLE " + this.escapePath(table) + " IS NULL"));
+            upQueries.push(
+                new Query(
+                    "COMMENT ON TABLE " +
+                        this.escapePath(table) +
+                        " IS '" +
+                        table.comment +
+                        "'",
+                ),
+            )
+            downQueries.push(
+                new Query(
+                    "COMMENT ON TABLE " + this.escapePath(table) + " IS NULL",
+                ),
+            )
         }
 
         await this.executeQueries(upQueries, downQueries)
@@ -4744,7 +4756,7 @@ export class PostgresQueryRunner
 
         newComment = this.escapeComment(newComment)
         const comment = this.escapeComment(table.comment)
-        
+
         if (newComment === comment) {
             return
         }

--- a/test/github-issues/7394/issue-7394.ts
+++ b/test/github-issues/7394/issue-7394.ts
@@ -1,0 +1,95 @@
+import "reflect-metadata"
+import {
+    createTestingConnections,
+} from "../../utils/test-utils"
+import { DataSource } from "../../../src/data-source/DataSource"
+import { assert, expect } from "chai"
+
+describe("github issues > #7394 Graceful termination for database connection", () => {
+    const gracefulShutdownSeconds = 1
+
+    let dataSources: DataSource[]
+    before(
+        async () =>
+            (dataSources = await createTestingConnections({
+                entities: [__dirname + "/entity/*{.js,.ts}"],
+                schemaCreate: true,
+                dropSchema: true,
+                enabledDrivers: ["postgres"],
+                driverSpecific: {
+                    poolGracefulShutdownTimeoutMS:
+                        gracefulShutdownSeconds * 1000,
+                },
+            })),
+    )
+
+    it("Test graceful termination - DataSource.destroy() waits until queries are complete before terminating the connections", () =>
+        Promise.all(
+            dataSources.map(async (dataSource) => {
+                const sleepSeconds = 0.3
+                const sleepPromise = dataSource.query(
+                    `SELECT pg_sleep(${sleepSeconds})`,
+                )
+
+                // Timeout for 100ms to wait for the query to start
+                await new Promise((resolve) => setTimeout(resolve, 100))
+
+                // Close the connection
+                const closePromise = dataSource.destroy()
+
+                try {
+                    // Wait for both promises to resolve
+                    const [sleepResult, closeResult] = await Promise.all([
+                        sleepPromise,
+                        closePromise,
+                    ])
+                    expect(sleepResult).to.be.an("array")
+                    expect(sleepResult).to.have.length(1)
+                    expect(sleepResult[0].pg_sleep).to.equal("") // pg_sleep returns empty string
+                    expect(closeResult).to.be.undefined
+                } catch (e) {
+                    if (
+                        e.toString() ===
+                        "QueryFailedError: Connection terminated"
+                    ) {
+                        assert.fail(
+                            "Query failed with Connection Terminated error, while expected to be closed gracefully",
+                        )
+                    }
+                    throw e
+                }
+            }),
+        ))
+
+    it("Test graceful termination - DataSource.destroy() aborts if graceful shutdown takes too long ", () =>
+        Promise.all(
+            dataSources.map(async (dataSource) => {
+                const sleepSeconds = 15
+                const sleepPromise = dataSource.query(
+                    `SELECT pg_sleep(${sleepSeconds})`,
+                )
+
+                // Timeout for 100ms to wait for the query to start
+                await new Promise((resolve) => setTimeout(resolve, 100))
+
+                // Close the connection
+                const closePromise = dataSource.destroy()
+
+                const nowMs = Date.now()
+                try {
+                    await Promise.all([sleepPromise, closePromise])
+                    assert.fail(
+                        "Expected the query to be terminated due to timeout",
+                    )
+                } catch (e) {
+                    expect(e?.toString()).to.equal(
+                        "QueryFailedError: Connection terminated",
+                    )
+                    const elapsedMs = Date.now() - nowMs
+                    expect(elapsedMs).to.be.lessThan(
+                        gracefulShutdownSeconds * 1000 + 100,
+                    )
+                }
+            }),
+        ))
+})

--- a/test/github-issues/7394/issue-7394.ts
+++ b/test/github-issues/7394/issue-7394.ts
@@ -1,7 +1,5 @@
 import "reflect-metadata"
-import {
-    createTestingConnections,
-} from "../../utils/test-utils"
+import { createTestingConnections } from "../../utils/test-utils"
 import { DataSource } from "../../../src/data-source/DataSource"
 import { assert, expect } from "chai"
 
@@ -82,9 +80,18 @@ describe("github issues > #7394 Graceful termination for database connection", (
                         "Expected the query to be terminated due to timeout",
                     )
                 } catch (e) {
-                    expect(e?.toString()).to.equal(
-                        "QueryFailedError: Connection terminated",
-                    )
+                    const errMessage = e?.toString()
+                    if (errMessage.includes("TypeORMError:")) {
+                        expect(errMessage).to.include(
+                            "TypeORMError: Driver not Connected",
+                        )
+                    } else if (errMessage.includes("QueryFailedError")) {
+                        expect(errMessage).to.equal(
+                            "QueryFailedError: Connection terminated",
+                        )
+                    } else {
+                        throw e
+                    }
                     const elapsedMs = Date.now() - nowMs
                     expect(elapsedMs).to.be.lessThan(
                         gracefulShutdownSeconds * 1000 + 100,


### PR DESCRIPTION
Fixes #7394 

<!--
  😀 Wonderful!  Thank you for opening a pull request for TypeORM.

  Please fill in the information below to expedite the review
  and (hopefully) merge of your change.

  If unsure about something.. just do as best as you're able,
  or reach out through our community support channels!
  https://github.com/typeorm/typeorm/blob/master/docs/support.md
-->

### Description of change

As described in the https://github.com/typeorm/typeorm/issues/7394 there is currently not a lot of options to complete a graceful termination of the connections in the pool. The reason we (https://later.com/) would like to have an option to do so:

We run a series of NestJS apps in k8s cluster. Upon pod reallocation k8s cluster sends SIGTERMs to the pods and sequentially to the NestJS apps. The apps use TypeORM and to make sure the data is consistent upon shutdown would want to:
1. Block all the incoming web requests to the app on receiving SIGTERM.
2. Wait until all the in-progress web requests are complete.

Since web requests invoke calls to the database, we would like to wait until those are properly complete. Hence, we want to close the connection pool only after we ensure that all the inflight database queries are complete. 

Fortunately, this seems to be the exact behavior of pg-pool .end() function by default. That is, pg-pool changes the state of the pool to the `ending` and waits until the queries are complete, and then changes the state of the pool to `ended` and then calls the callback. This is exactly what we would like to have. 
Unfortunately, the code:
```typescript
            while (this.connectedQueryRunners.length) {
                await this.connectedQueryRunners[0].release()
            }
```
seems to be terminating connections (aborting) rather than waiting until they are complete. 

This PR adds an option to gracefully wait for the given timeout before releasing the query runners. The previous behavior is kept and to my knowledge the changes in the PR are backward compatible.  

The proposed solution:
- adds `readonly poolGracefulShutdownTimeoutMS?: number` to `PostgresConnectionOptions` to allow consumers to specify the shutdown timeout. If it is specified then graceful shutdown is attempted within the provided timeout. 
- modifies `closePool` for `PostgresDriver` to include the logic of reading `poolGracefulShutdownTimeoutMS` and attempting the graceful shutdown by invoking pool.end() prior to releasing the connections. _I used the Promise.race() + setTimeout() to honor the timeout, please let me know if there is a better way of doing it ._
- adds a couple of tests to verify the behavior.

<!--
  Please be clear and concise what the change is intended to do,
  why this change is needed, and how you've verified that it
  corrects what you intended.

  In some cases it may be helpful to include the current behavior
  and the new behavior.

  If the change is related to an open issue, you can link it here.
  If you include `Fixes #0000` (replacing `0000` with the issue number)
  when this is merged it will automatically mark the issue as fixed and
  close it.
-->


### Pull-Request Checklist

<!--
  Please make sure to review and check all of the following.

  If an item is not applicable, you can add "N/A" to the end.
-->

- [x] Code is up-to-date with the `master` branch
- [x] `npm run format` to apply prettier formatting
- [x] `npm run test` passes with this change
- [x] This pull request links relevant issues as `Fixes #0000`
- [x] There are new or updated unit tests validating the change
- [x] Documentation has been updated to reflect this change
- [x] The new commits follow conventions explained in [CONTRIBUTING.md](https://github.com/typeorm/typeorm/blob/master/CONTRIBUTING.md)

<!--
  🎉 Thank you for contributing and making TypeORM even better!
-->
