### PR TITLE
feat: add @Column `rawFilterCondition` option

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,14 @@
+## About This Fork
+
+This fork introduces the ability to specify global filter conditions declaratively on entity columns through a `rawFilterCondition` property on the `@Column` decorator. It also adds `filterConditionCascade` for use with one-to-one and many-to-one relations, which allows filter conditions on the related entity to cascade and cause the current entity to be filtered from query results. Works with both query builder and repository find methods by default. To disable filter conditions, you can set `applyFilterConditions` to false on the `FindOptions` object. You can also pass an entity-like object to `applyFilterConditions` to disable specific filter conditions without affecting others.
+
+This was developed to add reliable row-level security to our application until TypeORM adds their own implementation.
+
+The documentation has been updated to reflect these changes.
+See [docs/filter-conditions.md](./docs/filter-conditions.md) for more details.
+
+## Original README
+
 <div align="center">
   <a href="http://typeorm.io/">
     <img src="https://github.com/typeorm/typeorm/raw/master/resources/logo_big.png" width="492" height="228">

--- a/docs/decorator-reference.md
+++ b/docs/decorator-reference.md
@@ -208,6 +208,7 @@ export class User {
 -   `transformer: ValueTransformer|ValueTransformer[]` - Specifies a value transformer (or array of value transformers) that is to be used to (un)marshal this column when reading or writing to the database. In case of an array, the value transformers will be applied in the natural order from entityValue to databaseValue, and in reverse order from databaseValue to entityValue.
 -   `spatialFeatureType: string` - Optional feature type (`Point`, `Polygon`, `LineString`, `Geometry`) used as a constraint on a spatial column. If not specified, it will behave as though `Geometry` was provided. Used only in PostgreSQL and CockroachDB.
 -   `srid: number` - Optional [Spatial Reference ID](https://postgis.net/docs/using_postgis_dbmanagement.html#spatial_ref_sys) used as a constraint on a spatial column. If not specified, it will default to `0`. Standard geographic coordinates (latitude/longitude in the WGS84 datum) correspond to [EPSG 4326](http://spatialreference.org/ref/epsg/wgs-84/). Used only in PostgreSQL and CockroachDB.
+-   `rawFilterCondition: (columnAlias: string) => string` - A function that returns a raw SQL condition to be used to filter rows. This is useful for creating filter conditions based on the column value.
 
 Learn more about [entity columns](entities.md#entity-columns).
 

--- a/docs/filter-conditions.md
+++ b/docs/filter-conditions.md
@@ -1,0 +1,208 @@
+# Filter Conditions
+
+## What is a Filter Condition?
+
+Filter conditions allow you to specify global conditions that automatically filter entity rows from query results. This is useful for implementing row-level security or other features that require static, global conditions without having to explicitly add where clauses to every query.
+
+This feature aims to ensure that filtered entities can never show up in any query builder results, whether you're loading them directly or through a relation.
+
+## Basic Usage
+
+The `rawFilterCondition` property accepts a function that receives the column name and should return a SQL condition string.
+To add a filter condition to an entity column, use the `rawFilterCondition` property on the `@Column` decorator:
+
+```typescript
+import { Entity, PrimaryGeneratedColumn, Column } from "typeorm"
+@Entity()
+export class User {
+    @PrimaryGeneratedColumn()
+    id: number
+
+    @Column({
+        rawFilterCondition: (column) => `${column} = FALSE`,
+    })
+    isDeactivated: boolean
+}
+```
+
+Now, any queries for User entities will automatically exclude rows where `isDeactivated` is not `false`. The filter condition applies to both repository methods and query builder operations:
+
+```typescript
+// Will only return non-deactivated users
+const users = await userRepository.find()
+
+// Also filters out deactivated users
+const users = await userRepository.createQueryBuilder("user").getMany()
+```
+
+The generated SQL:
+
+```sql
+SELECT "User"."id" AS "User_id",
+       "User"."isDeactivated" AS "User_isDeactivated"
+FROM "user" "User"
+WHERE ("User_isDeactivated" = FALSE)
+```
+
+## Disabling Filter Conditions
+
+You can disable filter conditions for a specific query by setting `applyFilterConditions` to `false` in the find options:
+
+```typescript
+// Will return all users, including deactivated ones
+const users = await userRepository.find({
+    applyFilterConditions: false,
+})
+
+// Also works with query builder
+const users = await userRepository
+    .createQueryBuilder("user")
+    .setFindOptions({
+        applyFilterConditions: false,
+    })
+    .getMany()
+```
+
+## Selective Filter Conditions
+
+You can selectively disable specific filter conditions while keeping others active by passing an entity-like object to `applyFilterConditions`:
+
+```typescript
+const users = await userRepository.find({
+    applyFilterConditions: {
+        isDeactivated: false, // Disable the isDeactivated filter
+        isUnlisted: true, // Keep the isUnlisted filter active (default)
+    },
+})
+```
+
+## Cascading Filter Conditions
+
+For one-to-one and many-to-one relations, you can use `filterConditionCascade` to make filter conditions cascade through relations. When a related entity is filtered out, the current entity will also be filtered from results:
+
+```typescript
+@Entity()
+export class Post {
+    @ManyToOne(() => User, {
+        filterConditionCascade: true,
+    })
+    author: User
+}
+```
+
+Now, if a post's author is deactivated, that post will also be filtered out of query results.
+
+This is achieved using INNER JOINs in the generated SQL:
+
+```sql
+SELECT
+    "Post"."id" AS "Post_id",
+    "Post"."authorId" AS "Post_authorId"
+FROM
+    "post" "Post"
+    INNER JOIN "user" "User" ON "User"."id" = "Post"."authorId"
+    AND ("User"."isDeactivated" = FALSE)
+```
+
+Cascading filter conditions are robust, and will work through all kinds of relations and at any depth in an intuitive manner. It uses a combination of INNER JOINs and subqueries to achieve this.
+
+For example, if you want to fetch a Category of Posts, and Posts should be filtered out if their `author` (User) is deactivated.
+
+```typescript
+@Entity()
+export class Category {
+    @OneToMany(() => Post, (post) => post.category)
+    posts: Post[]
+}
+```
+
+Now if you fetch category with the `posts` relation, the posts will be filtered out if their `author` is deactivated, with SQL that looks something like this:
+
+```sql
+SELECT
+    "Category"."id" AS "Category_id",
+    "Post"."id" AS "Post_id",
+    "Post"."authorId" AS "Post_authorId"
+FROM "category" "Category"
+LEFT JOIN (
+    SELECT
+        "Post".*
+    FROM "post" "Post"
+    INNER JOIN "user" "User" ON "User"."id" = "Post"."authorId"
+    AND ("User"."isDeactivated" = FALSE)
+) "Post" ON "Post"."categoryId" = "Category"."id"
+```
+
+Sometimes you have your own conditions set on a join when you use QueryBuilder. In that case, a duplicate join is created in order to avoid conflicts between the filter condition and your own conditions.
+
+To demonstrate one scenario in which a duplicate join is created, say we have the following entities:
+
+```typescript
+@Entity()
+export class User {
+    @Column()
+    name: string
+
+    @Column({
+        rawFilterCondition: (column) => `${column} = FALSE`,
+    })
+    isDeactivated: boolean
+}
+
+@Entity()
+export class Post {
+    @ManyToOne(() => User)
+    user: User
+}
+```
+
+Now, if we want to fetch comments with their `user`, but we have some additional condition we want to apply on the `user` join, we might have to do something like this:
+
+```typescript
+const comments = await commentRepository
+    .createQueryBuilder("comment")
+    .leftJoinAndSelect("comment.user", "user", "user.name ILIKE :name", {
+        name: "%John%",
+    })
+    .getMany()
+```
+
+In order to avoid conflicts between the filter condition and our additional condition, a duplicate join is created with a `_cfc` suffix.
+
+The generated SQL:
+
+```sql
+SELECT
+    "post"."id" AS "post_id",
+    "post"."title" AS "post_title",
+    "post"."authorId" AS "post_authorId",
+    "author"."id" AS "author_id",
+    "author"."name" AS "author_name",
+    "author"."isDeactivated" AS "author_isDeactivated",
+FROM
+    "post" "post"
+    LEFT JOIN "user" "author" ON "author"."id" = "post"."authorId"
+    AND ("author"."name" ILIKE :name)
+    INNER JOIN "user" "author_cfc" ON "author_cfc"."id" = "post"."authorId" -- Duplicate join
+    AND (
+        "author_cfc"."isDeactivated" = FALSE
+    )
+```
+
+Although these additional joins and subqueries add overhead, it is an efficient way to implement true row-level security at the query builder level.
+
+You can disable cascading filter conditions for specific relations, the same way you disable any other filter conditions:
+
+```typescript
+const posts = await postRepository.find({
+    applyFilterConditions: {
+        author: {
+            isDeactivated: false,
+        },
+    },
+})
+```
+
+## Working with Relations
+
+If you have queries that load one-to-many or many-to-many relations, the join condition on the relation will automatically include the filter conditions of the related entity, unless disabled with the `applyFilterConditions` option.

--- a/docs/filter-conditions.md
+++ b/docs/filter-conditions.md
@@ -106,9 +106,10 @@ FROM
 
 Cascading filter conditions are robust, and will work through all kinds of relations and at any depth in an intuitive manner. It uses a combination of INNER JOINs and subqueries to achieve this.
 
-For example, if you want to fetch a Category of Posts, and Posts should be filtered out if their `author` (User) is deactivated.
+For example, if you want to fetch a Category of Posts (many-to-many), and Posts should be filtered out if their `author` (User) is deactivated:
 
 ```typescript
+// The Category entity
 @Entity()
 export class Category {
     @OneToMany(() => Post, (post) => post.category)
@@ -116,7 +117,18 @@ export class Category {
 }
 ```
 
-Now if you fetch category with the `posts` relation, the posts will be filtered out if their `author` is deactivated, with SQL that looks something like this:
+When you fetch category with the `posts` relation, the posts will be filtered out if their `author` is deactivated:
+
+```typescript
+// Fetch Categories with their posts
+const categories = await categoryRepository.find({
+    relations: {
+        posts: true,
+    },
+})
+```
+
+Which generates the following SQL:
 
 ```sql
 SELECT

--- a/docs/find-options.md
+++ b/docs/find-options.md
@@ -145,6 +145,14 @@ userRepository.find({
 })
 ```
 
+-   `applyFilterConditions` - whether to apply column `filterCondition`s to the query. Defaults to `true`.
+
+```typescript
+userRepository.find({
+    applyFilterConditions: false,
+})
+```
+
 `find*` methods which return multiple entities (`find`, `findBy`, `findAndCount`, `findAndCountBy`) also accept following options:
 
 -   `skip` - offset (paginated) from where entities should be taken.

--- a/docs/select-query-builder.md
+++ b/docs/select-query-builder.md
@@ -1231,7 +1231,7 @@ You will get all the rows, including the ones which are deleted.
 
 ## Querying Filtered Rows
 
-If the modal you are querying has a column with a `rawFilterCondition` set, the query builder will automatically only include rows
+If the model you are querying has a column with a `rawFilterCondition` set, the query builder will automatically only include rows
 which match the condition.
 
 If you have the entity:

--- a/docs/select-query-builder.md
+++ b/docs/select-query-builder.md
@@ -1229,6 +1229,40 @@ const users = await dataSource
 
 You will get all the rows, including the ones which are deleted.
 
+## Querying Filtered Rows
+
+If the modal you are querying has a column with a `rawFilterCondition` set, the query builder will automatically only include rows
+which match the condition.
+
+If you have the entity:
+
+```typescript
+import { Entity, PrimaryGeneratedColumn, Column } from "typeorm"
+
+@Entity()
+export class User {
+    @PrimaryGeneratedColumn()
+    id: number
+
+    @Column({
+        rawFilterCondition: (column) => `${column} = FALSE`,
+    })
+    isDeactivated: boolean
+}
+```
+
+By default, the query will exclude rows where the `isDeactivated` is `true`. However, if you do the following:
+
+```typescript
+const users = await dataSource
+    .getRepository(User)
+    .createQueryBuilder()
+    .withDeleted()
+    .getMany()
+```
+
+You will get all the rows, including the ones which do not match the filter condition.
+
 ## Common table expressions
 
 `QueryBuilder` instances

--- a/docs/select-query-builder.md
+++ b/docs/select-query-builder.md
@@ -1257,7 +1257,7 @@ By default, the query will exclude rows where the `isDeactivated` is `true`. How
 const users = await dataSource
     .getRepository(User)
     .createQueryBuilder()
-    .withDeleted()
+    .applyFilterConditions(false)
     .getMany()
 ```
 

--- a/gulpfile.ts
+++ b/gulpfile.ts
@@ -113,7 +113,7 @@ export class Gulpfile {
     packagePack() {
         return gulp.src("package.json", { read: false })
             .pipe(shell([
-                "cd ./build/package && npm pack && mv -f typeorm-*.tgz .."
+                "cd ./build/package && npm pack && mv -f keyconservation-typeorm-*.tgz .."
             ]));
     }
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
-  "name": "typeorm",
-  "private": true,
-  "version": "0.3.20",
+  "name": "@keyconservation/typeorm",
+  "private": false,
+  "version": "0.3.20-12",
   "description": "Data-Mapper ORM for TypeScript, ES7, ES6, ES5. Supports MySQL, PostgreSQL, MariaDB, SQLite, MS SQL Server, Oracle, MongoDB databases.",
   "license": "MIT",
   "readmeFilename": "README.md",
@@ -66,10 +66,10 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/typeorm/typeorm.git"
+    "url": "https://github.com/keyconservation/typeorm.git"
   },
   "bugs": {
-    "url": "https://github.com/typeorm/typeorm/issues"
+    "url": "https://github.com/keyconservation/typeorm/issues"
   },
   "homepage": "https://typeorm.io",
   "tags": [

--- a/src/decorator/options/ColumnOptions.ts
+++ b/src/decorator/options/ColumnOptions.ts
@@ -187,4 +187,11 @@ export interface ColumnOptions extends ColumnCommonOptions {
      * SRID (Spatial Reference ID (EPSG code))
      */
     srid?: number
+
+    /**
+     * Custom SQL filter expression on this column.
+     * If condition is not met, the row will be filtered out from
+     * .find() and .getMany() results.
+     */
+    rawFilterCondition?: (columnAlias: string) => string
 }

--- a/src/decorator/options/RelationOptions.ts
+++ b/src/decorator/options/RelationOptions.ts
@@ -73,4 +73,10 @@ export interface RelationOptions {
      * disable will keep the relation intact. Removal of related item is only possible through its own repo.
      */
     orphanedRowAction?: "nullify" | "delete" | "soft-delete" | "disable"
+
+    /**
+     * If set, relation rows that are filtered by `rawFilterCondition` will cause rows of this entity to be excluded from results.
+     * Can be used only for many-to-one and one-to-one relations.
+     */
+    filterConditionCascade?: boolean;
 }

--- a/src/entity-schema/EntitySchemaRelationOptions.ts
+++ b/src/entity-schema/EntitySchemaRelationOptions.ts
@@ -34,6 +34,12 @@ export interface EntitySchemaRelationOptions {
     eager?: boolean
 
     /**
+     * If set, relation rows that are filtered by `rawFilterCondition` will cause rows of this entity to be excluded from results.
+     * Can be used only for many-to-one and one-to-one relations.
+     */
+    filterConditionCascade?: boolean;
+
+    /**
      * Indicates if persistence is enabled for the relation.
      * By default its enabled, but if you want to avoid any changes in the relation to be reflected in the database you can disable it.
      * If its disabled you can only change a relation from inverse side of a relation or using relation query builder functionality.

--- a/src/entity-schema/EntitySchemaTransformer.ts
+++ b/src/entity-schema/EntitySchemaTransformer.ts
@@ -172,6 +172,7 @@ export class EntitySchemaTransformer {
                     isTreeChildren: relationSchema.treeChildren,
                     options: {
                         eager: relationSchema.eager || false,
+                        filterConditionCascade: relationSchema.filterConditionCascade,
                         cascade: relationSchema.cascade,
                         nullable: relationSchema.nullable,
                         onDelete: relationSchema.onDelete,

--- a/src/find-options/FindOneOptions.ts
+++ b/src/find-options/FindOneOptions.ts
@@ -94,6 +94,11 @@ export interface FindOneOptions<Entity = any> {
     withDeleted?: boolean
 
     /**
+     * Indicates if column `rawFilterCondition`s should be applied. Default is `true`.
+     */
+    applyFilterConditions?: boolean
+
+    /**
      * If sets to true then loads all relation ids of the entity and maps them into relation values (not relation objects).
      * If array of strings is given then loads only relation ids of the given properties.
      */

--- a/src/find-options/FindOneOptions.ts
+++ b/src/find-options/FindOneOptions.ts
@@ -9,6 +9,7 @@ import {
     FindOptionsRelations,
 } from "./FindOptionsRelations"
 import { FindOptionsOrder } from "./FindOptionsOrder"
+import { FindOptionsApplyFilterConditions } from "./FindOptionsApplyFilterConditions"
 
 /**
  * Defines a special criteria to find specific entity.
@@ -96,7 +97,7 @@ export interface FindOneOptions<Entity = any> {
     /**
      * Indicates if column `rawFilterCondition`s should be applied. Default is `true`.
      */
-    applyFilterConditions?: boolean
+    applyFilterConditions?: boolean | FindOptionsApplyFilterConditions<Entity>
 
     /**
      * If sets to true then loads all relation ids of the entity and maps them into relation values (not relation objects).

--- a/src/find-options/FindOptionsApplyFilterConditions.ts
+++ b/src/find-options/FindOptionsApplyFilterConditions.ts
@@ -1,0 +1,20 @@
+/**
+ * A single property handler for FindOptionsRelations.
+ */
+export type FindOptionsApplyFilterConditionsProperty<Property> =
+    Property extends Promise<infer I>
+        ? FindOptionsApplyFilterConditionsProperty<NonNullable<I>> | boolean
+        : Property extends Array<infer I>
+        ? FindOptionsApplyFilterConditionsProperty<NonNullable<I>> | boolean
+        : Property extends object
+        ? FindOptionsApplyFilterConditions<Property> | boolean
+        : boolean
+
+/**
+ * Relations find options.
+ */
+export type FindOptionsApplyFilterConditions<Entity> = {
+    [P in keyof Entity]?: P extends "toString"
+        ? unknown
+        : FindOptionsApplyFilterConditionsProperty<NonNullable<Entity[P]>>
+}

--- a/src/find-options/FindOptionsUtils.ts
+++ b/src/find-options/FindOptionsUtils.ts
@@ -43,6 +43,7 @@ export class FindOptionsUtils {
                 typeof possibleOptions.loadRelationIds === "boolean" ||
                 typeof possibleOptions.loadEagerRelations === "boolean" ||
                 typeof possibleOptions.withDeleted === "boolean" ||
+                typeof possibleOptions.applyFilterConditions === "boolean" ||
                 typeof possibleOptions.relationLoadStrategy === "string" ||
                 typeof possibleOptions.transaction === "boolean")
         )

--- a/src/metadata-builder/EntityMetadataBuilder.ts
+++ b/src/metadata-builder/EntityMetadataBuilder.ts
@@ -952,6 +952,10 @@ export class EntityMetadataBuilder {
         entityMetadata.lazyRelations = entityMetadata.relations.filter(
             (relation) => relation.isLazy,
         )
+        entityMetadata.cascadingFilterConditionRelations =
+            entityMetadata.relations.filter(
+                (relation) => relation.isCascadeFilterCondition,
+            )
         entityMetadata.oneToOneRelations = entityMetadata.relations.filter(
             (relation) => relation.isOneToOne,
         )

--- a/src/metadata-builder/EntityMetadataBuilder.ts
+++ b/src/metadata-builder/EntityMetadataBuilder.ts
@@ -1037,6 +1037,9 @@ export class EntityMetadataBuilder {
         entityMetadata.nonVirtualColumns = entityMetadata.columns.filter(
             (column) => !column.isVirtual,
         )
+        entityMetadata.filterColumns = entityMetadata.columns.filter(
+            (column) => typeof column.rawFilterCondition === "function",
+        )
         entityMetadata.ancestorColumns = entityMetadata.columns.filter(
             (column) => column.closureType === "ancestor",
         )

--- a/src/metadata-builder/EntityMetadataValidator.ts
+++ b/src/metadata-builder/EntityMetadataValidator.ts
@@ -44,6 +44,7 @@ export class EntityMetadataValidator {
         )
         this.validateDependencies(entityMetadatas)
         this.validateEagerRelations(entityMetadatas)
+        this.validateFilterConditionCascadeColumns(entityMetadatas)
     }
 
     /**
@@ -364,6 +365,23 @@ export class EntityMetadataValidator {
                             ` Remove "eager: true" from one side of the relation.`,
                     )
             })
+        })
+    }
+
+    /** Validates filter condition cascade columns by ensuring they are one-to-many or one-to-one */
+    protected validateFilterConditionCascadeColumns(
+        entityMetadatas: EntityMetadata[],
+    ) {
+        entityMetadatas.forEach((entityMetadata) => {
+            entityMetadata.cascadingFilterConditionRelations.forEach(
+                (relation) => {
+                    if (!relation.isOneToOne && !relation.isManyToOne) {
+                        throw new TypeORMError(
+                            `Filter condition cascade can only be set on one-to-one or many-to-one relations. Check options of ${entityMetadata.targetName}#${relation.propertyPath}`,
+                        )
+                    }
+                },
+            )
         })
     }
 }

--- a/src/metadata/ColumnMetadata.ts
+++ b/src/metadata/ColumnMetadata.ts
@@ -279,6 +279,11 @@ export class ColumnMetadata {
     isDeleteDate: boolean = false
 
     /**
+     * SQL condition to filter on this column.
+     */
+    rawFilterCondition?: (alias: string) => string
+
+    /**
      * Indicates if this column contains an entity version.
      */
     isVersion: boolean = false
@@ -484,6 +489,8 @@ export class ColumnMetadata {
             this.srid = options.args.options.srid
         if ((options.args.options as VirtualColumnOptions).query)
             this.query = (options.args.options as VirtualColumnOptions).query
+        if (options.args.options.rawFilterCondition)
+            this.rawFilterCondition = options.args.options.rawFilterCondition
         if (this.isTreeLevel)
             this.type = options.connection.driver.mappedDataTypes.treeLevel
         if (this.isCreateDate) {

--- a/src/metadata/EntityMetadata.ts
+++ b/src/metadata/EntityMetadata.ts
@@ -343,6 +343,11 @@ export class EntityMetadata {
     eagerRelations: RelationMetadata[] = []
 
     /**
+     * List of relations that have cascading filter conditions.
+     */
+    cascadingFilterConditionRelations: RelationMetadata[] = []
+
+    /**
      * List of eager relations this metadata has.
      */
     lazyRelations: RelationMetadata[] = []
@@ -889,6 +894,38 @@ export class EntityMetadata {
             )
         }
         return this
+    }
+
+    /**
+     * Find relations that are many-to-many or one-to-many and have cascading
+     * filter conditions on the inverse side. For these relations, filter
+     * conditions should be applied to the inverse side.
+     * @returns RelationMetadata[]
+     */
+    findImplicitlyCascadingFilterConditionRelations(): RelationMetadata[] {
+        /**
+         *  If relation is many-to-many or one-to-many, then we want
+         * to implicitly apply cascading filter conditions to exclude
+         * inverse entity rows that don't meet their filter condition.
+         */
+        return this.relations.filter((relation) => {
+            const isInverseSideMany =
+                relation.isManyToMany || relation.isOneToMany
+            const inverseHasCascadingFilterConditionRelations =
+                !!relation.inverseEntityMetadata
+                    .cascadingFilterConditionRelations.length
+
+            return (
+                isInverseSideMany && inverseHasCascadingFilterConditionRelations
+            )
+        })
+    }
+
+    findAllCascadingFilterConditionRelations(): RelationMetadata[] {
+        return [
+            ...this.cascadingFilterConditionRelations,
+            ...this.findImplicitlyCascadingFilterConditionRelations(),
+        ]
     }
 
     // -------------------------------------------------------------------------

--- a/src/metadata/EntityMetadata.ts
+++ b/src/metadata/EntityMetadata.ts
@@ -285,6 +285,11 @@ export class EntityMetadata {
     deleteDateColumn?: ColumnMetadata
 
     /**
+     * Gets entity columns which contain a custom filter condition.
+     */
+    filterColumns: ColumnMetadata[] = []
+
+    /**
      * Gets entity column which contains an entity version.
      */
     versionColumn?: ColumnMetadata

--- a/src/metadata/RelationMetadata.ts
+++ b/src/metadata/RelationMetadata.ts
@@ -12,6 +12,7 @@ import { PropertyTypeFactory } from "./types/PropertyTypeInFunction"
 import { TypeORMError } from "../error"
 import { ObjectUtils } from "../util/ObjectUtils"
 import { InstanceChecker } from "../util/InstanceChecker"
+import { FindOptionsApplyFilterConditions } from "../find-options/FindOptionsApplyFilterConditions"
 
 /**
  * Contains all information about some entity's relation.
@@ -277,6 +278,11 @@ export class RelationMetadata {
      */
     inverseJoinColumns: ColumnMetadata[] = []
 
+    /**
+     * Indicates if filter conditions from the related entity should be applied when loading this relation.
+     */
+    isCascadeFilterCondition: boolean = false
+
     // ---------------------------------------------------------------------
     // Constructor
     // ---------------------------------------------------------------------
@@ -322,6 +328,8 @@ export class RelationMetadata {
             args.options.cascade === true ||
             (Array.isArray(args.options.cascade) &&
                 args.options.cascade.indexOf("recover") !== -1)
+        this.isCascadeFilterCondition =
+            args.options.filterConditionCascade || false
         // this.isPrimary = args.options.primary || false;
         this.isNullable =
             args.options.nullable === false || this.isPrimary ? false : true
@@ -614,6 +622,82 @@ export class RelationMetadata {
             this.inverseRelation.junctionEntityMetadata = junctionEntityMetadata
             this.joinTableName = junctionEntityMetadata.tableName
         }
+    }
+
+    isCascadingFilterConditionSkipped(
+        applyFilterConditionsObject: FindOptionsApplyFilterConditions<any>,
+    ): boolean {
+        let shouldSkip = true
+        const visitedEntities2 = new Set<EntityMetadata>()
+
+        const getApplyFilterConditionsObjectForRelation = (
+            relation: RelationMetadata,
+            applyFilterConditionsObject:
+                | FindOptionsApplyFilterConditions<any>
+                | undefined,
+        ) => {
+            return typeof applyFilterConditionsObject?.[
+                relation.propertyPath
+            ] === "object" &&
+                applyFilterConditionsObject?.[relation.propertyPath] !== null
+                ? (applyFilterConditionsObject[
+                      relation.propertyPath
+                  ] as FindOptionsApplyFilterConditions<any>)
+                : undefined
+        }
+
+        const recursivelyCheckAllRelationsForSkips = (
+            metadata: EntityMetadata,
+            applyFilterConditionsObject: FindOptionsApplyFilterConditions<any>,
+        ) => {
+            if (visitedEntities2.has(metadata)) return
+            visitedEntities2.add(metadata)
+
+            metadata.filterColumns.forEach((fc) => {
+                if (applyFilterConditionsObject[fc.propertyPath] === false) {
+                    return
+                }
+                shouldSkip = false
+            })
+
+            metadata.cascadingFilterConditionRelations.forEach((relation) => {
+                if (
+                    applyFilterConditionsObject[relation.propertyPath] === false
+                ) {
+                    return
+                }
+
+                const applyFilterConditionsObjectForRelation =
+                    getApplyFilterConditionsObjectForRelation(
+                        relation,
+                        applyFilterConditionsObject,
+                    )
+
+                if (applyFilterConditionsObjectForRelation) {
+                    recursivelyCheckAllRelationsForSkips(
+                        relation.inverseEntityMetadata,
+                        applyFilterConditionsObjectForRelation,
+                    )
+                } else {
+                    shouldSkip = false
+                    return
+                }
+            })
+        }
+
+        const applyFilterConditionsObjectForRelation =
+            getApplyFilterConditionsObjectForRelation(
+                this,
+                applyFilterConditionsObject,
+            )
+
+        if (applyFilterConditionsObjectForRelation)
+            recursivelyCheckAllRelationsForSkips(
+                this.inverseEntityMetadata,
+                applyFilterConditionsObjectForRelation,
+            )
+
+        return shouldSkip
     }
 
     /**

--- a/src/persistence/SubjectDatabaseEntityLoader.ts
+++ b/src/persistence/SubjectDatabaseEntityLoader.ts
@@ -95,6 +95,7 @@ export class SubjectDatabaseEntityLoader {
 
                 const findOptions: FindManyOptions<any> = {
                     loadEagerRelations: false,
+                    applyFilterConditions: false,
                     loadRelationIds: {
                         relations: loadRelationPropertyPaths,
                         disableMixedMap: true,

--- a/src/query-builder/JoinAttribute.ts
+++ b/src/query-builder/JoinAttribute.ts
@@ -37,6 +37,11 @@ export class JoinAttribute {
     condition?: string
 
     /**
+     * Indicates if this join is a cascading filter condition join.
+     */
+    isCascadingFilterConditionJoin?: boolean
+
+    /**
      * Property + alias of the object where to joined data should be mapped.
      */
     mapToProperty?: string

--- a/src/query-builder/QueryBuilder.ts
+++ b/src/query-builder/QueryBuilder.ts
@@ -857,7 +857,8 @@ export abstract class QueryBuilder<Entity extends ObjectLiteral> {
             if (
                 this.expressionMap.queryType === "select" &&
                 !this.expressionMap.withDeleted &&
-                metadata.deleteDateColumn
+                metadata.deleteDateColumn &&
+                !this.expressionMap.isCascadingFilterConditionRelationSubquery
             ) {
                 const column = this.expressionMap.aliasNamePrefixingEnabled
                     ? this.expressionMap.mainAlias!.name +
@@ -872,9 +873,21 @@ export abstract class QueryBuilder<Entity extends ObjectLiteral> {
             if (
                 this.expressionMap.queryType === "select" &&
                 metadata.filterColumns.length &&
-                this.expressionMap.applyFilterConditions
+                this.expressionMap.applyFilterConditions !== false
             ) {
                 metadata.filterColumns.forEach((filterColumn) => {
+                    if (
+                        typeof this.expressionMap.applyFilterConditions ===
+                            "object" &&
+                        this.expressionMap.applyFilterConditions !== null
+                    ) {
+                        if (
+                            this.expressionMap.skippedFilterConditions.some(
+                                (skipped) => skipped === filterColumn,
+                            )
+                        )
+                            return
+                    }
                     const column = this.expressionMap.aliasNamePrefixingEnabled
                         ? `${this.expressionMap.mainAlias!.name}.${
                               filterColumn.propertyName

--- a/src/query-builder/QueryExpressionMap.ts
+++ b/src/query-builder/QueryExpressionMap.ts
@@ -223,6 +223,11 @@ export class QueryExpressionMap {
     withDeleted: boolean = false
 
     /**
+     * Indicates if filter conditions should be applied to the query.
+     */
+    applyFilterConditions: boolean = true
+
+    /**
      * Parameters used to be escaped in final query.
      */
     parameters: ObjectLiteral = {}
@@ -522,6 +527,7 @@ export class QueryExpressionMap {
         map.lockVersion = this.lockVersion
         map.lockTables = this.lockTables
         map.withDeleted = this.withDeleted
+        map.applyFilterConditions = this.applyFilterConditions
         map.parameters = Object.assign({}, this.parameters)
         map.disableEscaping = this.disableEscaping
         map.enableRelationIdValues = this.enableRelationIdValues

--- a/src/query-builder/RelationLoader.ts
+++ b/src/query-builder/RelationLoader.ts
@@ -156,6 +156,8 @@ export class RelationLoader {
             qb.expressionMap.mainAlias!.metadata,
         )
 
+        
+
         return qb.getMany()
         // return qb.getOne(); todo: fix all usages
     }
@@ -239,6 +241,7 @@ export class RelationLoader {
             qb.alias,
             qb.expressionMap.mainAlias!.metadata,
         )
+
 
         return qb.getMany()
         // return relation.isOneToMany ? qb.getMany() : qb.getOne(); todo: fix all usages

--- a/src/query-builder/SelectQueryBuilder.ts
+++ b/src/query-builder/SelectQueryBuilder.ts
@@ -1599,8 +1599,8 @@ export class SelectQueryBuilder<Entity extends ObjectLiteral>
     /**
      * Applies filter conditions to the query.
      */
-    withoutFilterConditions(): this {
-        this.expressionMap.applyFilterConditions = false
+    applyFilterConditions(shouldApply: boolean): this {
+        this.expressionMap.applyFilterConditions = shouldApply
         return this
     }
 
@@ -3107,8 +3107,8 @@ export class SelectQueryBuilder<Entity extends ObjectLiteral>
                 this.withDeleted()
             }
 
-            if (this.findOptions.applyFilterConditions === false) {
-                this.withoutFilterConditions()
+            if (typeof this.findOptions.applyFilterConditions === 'boolean') {
+                this.applyFilterConditions(this.findOptions.applyFilterConditions)
             }
 
             if (this.findOptions.select) {

--- a/test/functional/query-builder/filter-condition/basic-filter-condition/entity/Post.ts
+++ b/test/functional/query-builder/filter-condition/basic-filter-condition/entity/Post.ts
@@ -1,0 +1,25 @@
+import {
+    Column,
+    Entity,
+    ManyToOne,
+    PrimaryGeneratedColumn,
+} from "../../../../../../src"
+import { User } from "./User"
+
+@Entity()
+export class Post {
+    @PrimaryGeneratedColumn()
+    id: number
+
+    @Column({
+        rawFilterCondition(alias) {
+            return `${alias} != true`
+        },
+    })
+    isHidden: boolean
+
+    @ManyToOne(() => User, {
+        filterConditionCascade: true,
+    })
+    author: User
+}

--- a/test/functional/query-builder/filter-condition/basic-filter-condition/entity/Project.ts
+++ b/test/functional/query-builder/filter-condition/basic-filter-condition/entity/Project.ts
@@ -1,0 +1,17 @@
+import {
+    Entity,
+    JoinTable,
+    ManyToMany,
+    PrimaryGeneratedColumn,
+} from "../../../../../../src"
+import { Post } from "./Post"
+
+@Entity()
+export class Project {
+    @PrimaryGeneratedColumn()
+    id: number
+
+    @ManyToMany(() => Post)
+    @JoinTable()
+    posts: Post[]
+}

--- a/test/functional/query-builder/filter-condition/basic-filter-condition/entity/User.ts
+++ b/test/functional/query-builder/filter-condition/basic-filter-condition/entity/User.ts
@@ -4,7 +4,7 @@ import {
     JoinTable,
     ManyToMany,
     PrimaryGeneratedColumn,
-} from "../../../../../src"
+} from "../../../../../../src"
 
 @Entity()
 export class User {
@@ -13,7 +13,7 @@ export class User {
 
     @Column({
         rawFilterCondition(alias) {
-            return `${alias} = false`
+            return `${alias} != true`
         },
     })
     isDeactivated: boolean

--- a/test/functional/query-builder/filter-condition/circular-filter-condition-cascade/circular-filter-condition.cascade.ts
+++ b/test/functional/query-builder/filter-condition/circular-filter-condition-cascade/circular-filter-condition.cascade.ts
@@ -1,0 +1,33 @@
+import "reflect-metadata"
+import { DataSource } from "../../../../../src/data-source/DataSource"
+import { EntityMetadataValidator } from "../../../../../src/metadata-builder/EntityMetadataValidator"
+import { ConnectionMetadataBuilder } from "../../../../../src/connection/ConnectionMetadataBuilder"
+import { expect } from "chai"
+
+describe("query builder > filter condition > circular filter condition cascade", () => {
+    it("should throw error if filterConditionsCascade is set on relations other than many-to-one and one-to-one", async () => {
+        const connection = new DataSource({
+            // dummy connection options, connection won't be established anyway
+            type: "mysql",
+            host: "localhost",
+            username: "test",
+            password: "test",
+            database: "test",
+            entities: [__dirname + "/entity/*{.js,.ts}"],
+        })
+        const connectionMetadataBuilder = new ConnectionMetadataBuilder(
+            connection,
+        )
+        const entityMetadatas =
+            await connectionMetadataBuilder.buildEntityMetadatas([
+                __dirname + "/entity/*{.js,.ts}",
+            ])
+        const entityMetadataValidator = new EntityMetadataValidator()
+        expect(() =>
+            entityMetadataValidator.validateMany(
+                entityMetadatas,
+                connection.driver,
+            ),
+        ).to.throw(Error)
+    })
+})

--- a/test/functional/query-builder/filter-condition/circular-filter-condition-cascade/entity/Team.ts
+++ b/test/functional/query-builder/filter-condition/circular-filter-condition-cascade/entity/Team.ts
@@ -1,0 +1,27 @@
+import {
+    Entity,
+    JoinColumn,
+    OneToMany,
+    OneToOne,
+    PrimaryGeneratedColumn,
+} from "../../../../../../src"
+import { TeamMember } from "./TeamMember"
+import { User } from "./User"
+
+@Entity()
+export class Team {
+    @PrimaryGeneratedColumn()
+    id: number
+
+    @OneToOne(() => User, {
+        eager: true,
+        filterConditionCascade: true,
+    })
+    @JoinColumn()
+    user: User
+
+    @OneToMany(() => TeamMember, (member) => member.team, {
+        filterConditionCascade: true,
+    })
+    teamMembers: TeamMember[]
+}

--- a/test/functional/query-builder/filter-condition/circular-filter-condition-cascade/entity/TeamMember.ts
+++ b/test/functional/query-builder/filter-condition/circular-filter-condition-cascade/entity/TeamMember.ts
@@ -1,0 +1,29 @@
+import {
+    Entity,
+    JoinColumn,
+    ManyToOne,
+    PrimaryColumn,
+} from "../../../../../../src"
+import { Team } from "./Team"
+import { User } from "./User"
+
+@Entity()
+export class TeamMember {
+    @ManyToOne(() => Team, {
+        filterConditionCascade: true,
+    })
+    @JoinColumn({ name: "teamId" })
+    team: Team
+
+    @ManyToOne(() => User, {
+        filterConditionCascade: true,
+    })
+    @JoinColumn({ name: "userId" })
+    user: User
+
+    @PrimaryColumn()
+    teamId: number
+
+    @PrimaryColumn()
+    userId: number
+}

--- a/test/functional/query-builder/filter-condition/circular-filter-condition-cascade/entity/User.ts
+++ b/test/functional/query-builder/filter-condition/circular-filter-condition-cascade/entity/User.ts
@@ -1,0 +1,14 @@
+import { Column, Entity, PrimaryGeneratedColumn } from "../../../../../../src"
+
+@Entity()
+export class User {
+    @PrimaryGeneratedColumn()
+    id: number
+
+    @Column({
+        rawFilterCondition(alias) {
+            return `${alias} != true`
+        },
+    })
+    isDeactivated: boolean
+}

--- a/test/functional/query-builder/filter-condition/entity/User.ts
+++ b/test/functional/query-builder/filter-condition/entity/User.ts
@@ -1,0 +1,24 @@
+import {
+    Column,
+    Entity,
+    JoinTable,
+    ManyToMany,
+    PrimaryGeneratedColumn,
+} from "../../../../../src"
+
+@Entity()
+export class User {
+    @PrimaryGeneratedColumn()
+    id: number
+
+    @Column({
+        rawFilterCondition(alias) {
+            return `${alias} = false`
+        },
+    })
+    isDeactivated: boolean
+
+    @ManyToMany(() => User)
+    @JoinTable()
+    friends: User[]
+}

--- a/test/functional/query-builder/filter-condition/filter-condition-cascade/entity/Category.ts
+++ b/test/functional/query-builder/filter-condition/filter-condition-cascade/entity/Category.ts
@@ -1,0 +1,17 @@
+import {
+    Entity,
+    JoinTable,
+    ManyToMany,
+    PrimaryGeneratedColumn,
+} from "../../../../../../src"
+import { Post } from "./Post"
+
+@Entity()
+export class Category {
+    @PrimaryGeneratedColumn()
+    id: number
+
+    @ManyToMany(() => Post, (post) => post.categories)
+    @JoinTable()
+    posts: Post[]
+}

--- a/test/functional/query-builder/filter-condition/filter-condition-cascade/entity/Comment.ts
+++ b/test/functional/query-builder/filter-condition/filter-condition-cascade/entity/Comment.ts
@@ -1,0 +1,26 @@
+import {
+    Column,
+    Entity,
+    ManyToOne,
+    OneToMany,
+    PrimaryGeneratedColumn,
+} from "../../../../../../src"
+import { CommentLike } from "./CommentLike"
+import { Post } from "./Post"
+
+@Entity()
+export class Comment {
+    @PrimaryGeneratedColumn()
+    id: number
+
+    @Column()
+    content: string
+
+    @ManyToOne(() => Post, (post) => post.comments, {
+        filterConditionCascade: true,
+    })
+    post: Post
+
+    @OneToMany(() => CommentLike, (commentLike) => commentLike.comment)
+    commentLikes: CommentLike[]
+}

--- a/test/functional/query-builder/filter-condition/filter-condition-cascade/entity/CommentLike.ts
+++ b/test/functional/query-builder/filter-condition/filter-condition-cascade/entity/CommentLike.ts
@@ -1,0 +1,13 @@
+import { Entity, ManyToOne, PrimaryGeneratedColumn } from "../../../../../../src"
+import { Comment } from "./Comment"
+
+@Entity()
+export class CommentLike {
+    @PrimaryGeneratedColumn()
+    id: number
+
+    @ManyToOne(() => Comment, {
+        filterConditionCascade: true,
+    })
+    comment: Comment
+}

--- a/test/functional/query-builder/filter-condition/filter-condition-cascade/entity/DirectConversation.ts
+++ b/test/functional/query-builder/filter-condition/filter-condition-cascade/entity/DirectConversation.ts
@@ -1,0 +1,36 @@
+import {
+    Entity,
+    JoinColumn,
+    ManyToOne,
+    PrimaryColumn,
+} from "../../../../../../src"
+import { User } from "./User"
+
+@Entity()
+export class DirectConversation {
+    @ManyToOne(() => User, {
+        nullable: false,
+        eager: true,
+        onDelete: "CASCADE",
+        onUpdate: "CASCADE",
+        filterConditionCascade: true
+    })
+    @JoinColumn({ name: "user1Id" })
+    user1: User
+
+    @ManyToOne(() => User, {
+        nullable: false,
+        eager: true,
+        onDelete: "CASCADE",
+        onUpdate: "CASCADE",
+        filterConditionCascade: true
+    })
+    @JoinColumn({ name: "user2Id" })
+    user2: User
+
+    @PrimaryColumn("uuid")
+    user1Id: string
+
+    @PrimaryColumn("uuid")
+    user2Id: string
+}

--- a/test/functional/query-builder/filter-condition/filter-condition-cascade/entity/Post.ts
+++ b/test/functional/query-builder/filter-condition/filter-condition-cascade/entity/Post.ts
@@ -1,0 +1,42 @@
+import {
+    Column,
+    DeleteDateColumn,
+    Entity,
+    ManyToMany,
+    ManyToOne,
+    OneToMany,
+    PrimaryGeneratedColumn,
+} from "../../../../../../src"
+import { Category } from "./Category"
+import { Comment } from "./Comment"
+import { User } from "./User"
+
+@Entity()
+export class Post {
+    @PrimaryGeneratedColumn()
+    id: number
+
+    @Column()
+    title: string
+
+    @ManyToOne(() => User, {
+        filterConditionCascade: true, // TODO: Fix: This is singhandedly quadrupling the joins
+        // eager: true
+    })
+    author: User
+
+    @Column({
+        default: false,
+        rawFilterCondition: (column) => `${column} = FALSE`,
+    })
+    draft: boolean
+
+    @DeleteDateColumn({ type: "timestamp with time zone" })
+    deletedAt?: Date
+
+    @OneToMany(() => Comment, (comment) => comment.post)
+    comments: Comment[]
+
+    @ManyToMany(() => Category, (category) => category.posts)
+    categories: Category[]
+}

--- a/test/functional/query-builder/filter-condition/filter-condition-cascade/entity/Team.ts
+++ b/test/functional/query-builder/filter-condition/filter-condition-cascade/entity/Team.ts
@@ -1,0 +1,25 @@
+import {
+    Entity,
+    JoinColumn,
+    OneToMany,
+    OneToOne,
+    PrimaryGeneratedColumn,
+} from "../../../../../../src"
+import { TeamMember } from "./TeamMember"
+import { User } from "./User"
+
+@Entity()
+export class Team {
+    @PrimaryGeneratedColumn()
+    id: number
+
+    @OneToOne(() => User, {
+        eager: true,
+        filterConditionCascade: true,
+    })
+    @JoinColumn()
+    user: User
+
+    @OneToMany(() => TeamMember, (member) => member.team)
+    teamMembers: TeamMember[]
+}

--- a/test/functional/query-builder/filter-condition/filter-condition-cascade/entity/TeamMember.ts
+++ b/test/functional/query-builder/filter-condition/filter-condition-cascade/entity/TeamMember.ts
@@ -1,0 +1,29 @@
+import {
+    Entity,
+    JoinColumn,
+    ManyToOne,
+    PrimaryColumn,
+} from "../../../../../../src"
+import { Team } from "./Team"
+import { User } from "./User"
+
+@Entity()
+export class TeamMember {
+    @ManyToOne(() => Team, (team) => team.teamMembers, {
+        filterConditionCascade: true,
+    })
+    @JoinColumn({ name: "teamId" })
+    team: Team
+
+    @ManyToOne(() => User, {
+        filterConditionCascade: true,
+    })
+    @JoinColumn({ name: "userId" })
+    user: User
+
+    @PrimaryColumn()
+    teamId: number
+
+    @PrimaryColumn()
+    userId: number
+}

--- a/test/functional/query-builder/filter-condition/filter-condition-cascade/entity/User.ts
+++ b/test/functional/query-builder/filter-condition/filter-condition-cascade/entity/User.ts
@@ -1,0 +1,44 @@
+import {
+    Column,
+    DeleteDateColumn,
+    Entity,
+    JoinTable,
+    ManyToMany,
+    OneToMany,
+    PrimaryGeneratedColumn,
+} from "../../../../../../src"
+import { TeamMember } from "./TeamMember"
+
+@Entity()
+export class User {
+    @PrimaryGeneratedColumn()
+    id: number
+
+    @Column({ default: "John Doe" })
+    name: string
+
+    @Column({
+        rawFilterCondition(alias) {
+            return `${alias} != true`
+        },
+    })
+    isDeactivated: boolean
+
+    @Column({
+        default: false,
+        rawFilterCondition(alias) {
+            return `${alias} != true`
+        },
+    })
+    isUnlisted: boolean
+
+    @DeleteDateColumn()
+    deletedAt: Date
+
+    @ManyToMany(() => User)
+    @JoinTable()
+    friends: User[]
+
+    @OneToMany(() => TeamMember, (member) => member.user)
+    teamMemberships: TeamMember[]
+}

--- a/test/functional/query-builder/filter-condition/filter-condition-cascade/filter-condition-cascade.ts
+++ b/test/functional/query-builder/filter-condition/filter-condition-cascade/filter-condition-cascade.ts
@@ -1,0 +1,821 @@
+import "reflect-metadata"
+import {
+    createTestingConnections,
+    closeTestingConnections,
+    reloadTestingDatabases,
+} from "../../../../utils/test-utils"
+import { DataSource } from "../../../../../src/data-source/DataSource"
+import { expect } from "chai"
+import { User } from "./entity/User"
+import { Post } from "./entity/Post"
+import { Comment } from "./entity/Comment"
+import { CommentLike } from "./entity/CommentLike"
+import { DirectConversation } from "./entity/DirectConversation"
+import { Team } from "./entity/Team"
+import { TeamMember } from "./entity/TeamMember"
+import { Category } from "./entity/Category"
+
+describe("query builder > filter condition > filter condition cascade", () => {
+    let dataSources: DataSource[]
+    before(
+        async () =>
+            (dataSources = await createTestingConnections({
+                entities: [__dirname + "/entity/*{.js,.ts}"],
+                schemaCreate: true,
+                dropSchema: true,
+            })),
+    )
+    beforeEach(() => reloadTestingDatabases(dataSources))
+    after(() => closeTestingConnections(dataSources))
+
+    it("filterConditionCascade should work properly", () =>
+        Promise.all(
+            dataSources.map(async (dataSource) => {
+                const userRepository = dataSource.getRepository(User)
+                const postRepository = dataSource.getRepository(Post)
+
+                const user1 = new User()
+                const user2 = new User()
+                user1.isDeactivated = false
+                user2.isDeactivated = false
+
+                await userRepository.save([user1, user2])
+
+                const post1 = new Post()
+                post1.title = "test"
+                post1.author = user1
+                const post2 = new Post()
+                post2.title = "test"
+                post2.author = user2
+
+                await postRepository.save([post1, post2])
+
+                const posts = await postRepository.find({
+                    withDeleted: true,
+                })
+                expect(posts.length).to.equal(2)
+
+                user1.isDeactivated = true
+                await userRepository.save(user1)
+
+                const posts2 = await postRepository.find({
+                    withDeleted: true,
+                })
+                expect(posts2.length).to.equal(1)
+            }),
+        ))
+
+    it("filterConditionsCascade should be ignored when `applyFilterConditions` is false", () =>
+        Promise.all(
+            dataSources.map(async (dataSource) => {
+                const userRepository = dataSource.getRepository(User)
+                const postRepository = dataSource.getRepository(Post)
+
+                const user = new User()
+                user.isDeactivated = false
+
+                await userRepository.save(user)
+
+                const post = new Post()
+                post.title = "test"
+                post.author = user
+
+                await postRepository.save(post)
+
+                const posts = await postRepository.find()
+                expect(posts.length).to.equal(1)
+
+                user.isDeactivated = true
+                await userRepository.save(user)
+
+                const posts2 = await postRepository.find({
+                    applyFilterConditions: false,
+                })
+                expect(posts2.length).to.equal(1)
+            }),
+        ))
+
+    it("filterConditionsCascade should work properly when `relations` is specified", () =>
+        Promise.all(
+            dataSources.map(async (dataSource) => {
+                const userRepository = dataSource.getRepository(User)
+                const postRepository = dataSource.getRepository(Post)
+
+                const user = new User()
+                user.isDeactivated = false
+
+                await userRepository.save(user)
+
+                const post = new Post()
+                post.title = "test"
+                post.author = user
+
+                await postRepository.save(post)
+
+                const posts = await postRepository.find({
+                    relations: {
+                        author: true,
+                    },
+                })
+                expect(posts.length).to.equal(1)
+
+                user.isDeactivated = true
+                await userRepository.save(user)
+
+                const posts2 = await postRepository.find({
+                    relations: {
+                        author: true,
+                    },
+                })
+                expect(posts2.length).to.equal(0)
+            }),
+        ))
+
+    it("filterConditionsCascade should work properly when `relationLoadStrategy` is `query`", () =>
+        Promise.all(
+            dataSources.map(async (dataSource) => {
+                const userRepository = dataSource.getRepository(User)
+                const postRepository = dataSource.getRepository(Post)
+
+                const user = new User()
+                user.isDeactivated = false
+
+                await userRepository.save(user)
+
+                const post = new Post()
+                post.title = "test"
+                post.author = user
+
+                await postRepository.save(post)
+
+                const posts = await postRepository.find({
+                    relationLoadStrategy: "query",
+                })
+                expect(posts.length).to.equal(1)
+
+                user.isDeactivated = true
+                await userRepository.save(user)
+
+                const posts2 = await postRepository.find({
+                    relationLoadStrategy: "query",
+                })
+                expect(posts2.length).to.equal(0)
+            }),
+        ))
+
+    it("filterConditionsCascade should work properly with deeply nested relations", () =>
+        Promise.all(
+            dataSources.map(async (dataSource) => {
+                const userRepository = dataSource.getRepository(User)
+                const postRepository = dataSource.getRepository(Post)
+                const commentRepository = dataSource.getRepository(Comment)
+                const commentLikeRepository =
+                    dataSource.getRepository(CommentLike)
+
+                const user1 = new User()
+                user1.isDeactivated = false
+                const user2 = new User()
+                user2.isDeactivated = false
+
+                await userRepository.save([user1, user2])
+
+                const post1 = new Post()
+                post1.title = "test"
+                post1.author = user1
+                const post2 = new Post()
+                post2.title = "test"
+                post2.author = user2
+
+                await postRepository.save([post1, post2])
+
+                const comment1 = new Comment()
+                comment1.content = "test"
+                comment1.post = post1
+                const comment2 = new Comment()
+                comment2.content = "test"
+                comment2.post = post2
+
+                await commentRepository.save([comment1, comment2])
+
+                const commentLike1 = new CommentLike()
+                commentLike1.comment = comment1
+                const commentLike2 = new CommentLike()
+                commentLike2.comment = comment2
+
+                await commentLikeRepository.save([commentLike1, commentLike2])
+
+                const commentLikes = await commentLikeRepository
+                    .createQueryBuilder("comment_like")
+                    .getCount()
+                expect(commentLikes).to.equal(2)
+
+                user1.isDeactivated = true
+                await userRepository.save(user1)
+
+                const commentLikes2 = await commentLikeRepository
+                    .createQueryBuilder("comment_like")
+                    .getCount()
+                expect(commentLikes2).to.equal(1)
+            }),
+        ))
+
+    it("filterConditionsCascade should work properly with query builder find options", () =>
+        Promise.all(
+            dataSources.map(async (dataSource) => {
+                const userRepository = dataSource.getRepository(User)
+
+                const user1 = new User()
+                user1.isDeactivated = false
+                const user2 = new User()
+                user2.isDeactivated = false
+
+                user1.friends = [user2]
+                user2.friends = [user1]
+
+                await userRepository.save([user1, user2])
+
+                const users = await userRepository
+                    .createQueryBuilder("user")
+                    .setFindOptions({
+                        relations: {
+                            friends: true,
+                        },
+                        order: {
+                            id: "ASC",
+                        },
+                    })
+                    .getMany()
+                expect(users.length).to.equal(2)
+                expect(users[0].friends.length).to.equal(1)
+                expect(users[1].friends.length).to.equal(1)
+
+                user1.isDeactivated = true
+                await userRepository.save(user1)
+
+                const users2 = await userRepository
+                    .createQueryBuilder("user")
+                    .setFindOptions({
+                        relations: {
+                            friends: true,
+                        },
+                        order: {
+                            id: "ASC",
+                        },
+                    })
+                    .getMany()
+                expect(users2.length).to.equal(1)
+                expect(users2[0].friends.length).to.equal(0)
+            }),
+        ))
+
+    it("filterConditionsCascade should be ignored when `applyFilterConditions` is false using query builder", () =>
+        Promise.all(
+            dataSources.map(async (dataSource) => {
+                const userRepository = dataSource.getRepository(User)
+                const postRepository = dataSource.getRepository(Post)
+
+                const user1 = new User()
+                user1.isDeactivated = false
+                const user2 = new User()
+                user2.isDeactivated = false
+
+                await userRepository.save([user1, user2])
+
+                const post1 = new Post()
+                post1.title = "test"
+                post1.author = user1
+                const post2 = new Post()
+                post2.title = "test"
+                post2.author = user2
+
+                await postRepository.save([post1, post2])
+
+                const posts = await postRepository
+                    .createQueryBuilder("post")
+                    .setFindOptions({
+                        applyFilterConditions: false,
+                    })
+                    .leftJoinAndSelect("post.author", "author")
+                    .getMany()
+
+                expect(posts.length).to.equal(2)
+                expect(posts[0].author).to.exist
+                expect(posts[1].author).to.exist
+                user1.isDeactivated = true
+                await userRepository.save(user1)
+
+                const posts2 = await postRepository
+                    .createQueryBuilder("post")
+                    .setFindOptions({
+                        applyFilterConditions: false,
+                    })
+                    .leftJoinAndSelect("post.author", "author")
+                    .getMany()
+                expect(posts2.length).to.equal(2)
+                expect(posts2[0].author).to.exist
+                expect(posts2[1].author).to.exist
+            }),
+        ))
+
+    it.only("filterConditionsCascade should work properly with left join and select with conditions", () =>
+        Promise.all(
+            dataSources.map(async (dataSource) => {
+                const userRepository = dataSource.getRepository(User)
+                const postRepository = dataSource.getRepository(Post)
+
+                const user = new User()
+                user.isDeactivated = false
+                await userRepository.save(user)
+
+                const post = new Post()
+                post.title = "test"
+                post.author = user
+                await postRepository.save(post)
+
+                const posts = await postRepository
+                    .createQueryBuilder("post")
+                    .leftJoinAndSelect(
+                        "post.author",
+                        "author",
+                        "author.name ILIKE :name",
+                        {
+                            name: "%John%",
+                        },
+                    )
+                    .getMany()
+                expect(posts.length).to.equal(1)
+                expect(posts[0].author).to.exist
+
+                const posts2 = await postRepository
+                    .createQueryBuilder("post")
+                    .leftJoinAndSelect(
+                        "post.author",
+                        "author",
+                        "author.name ILIKE :name",
+                        {
+                            name: "%Jane%",
+                        },
+                    )
+                    .getMany()
+                expect(posts2.length).to.equal(1)
+                expect(posts2[0].author).to.not.exist
+
+                user.isDeactivated = true
+                await userRepository.save(user)
+
+                const posts3 = await postRepository
+                    .createQueryBuilder("post")
+                    .leftJoinAndSelect(
+                        "post.author",
+                        "author",
+                        "author.name ILIKE :name",
+                        {
+                            name: "%John%",
+                        },
+                    )
+                    .getMany()
+                expect(posts3.length).to.equal(0)
+            }),
+        ))
+
+    it("filterConditionsCascade should not be affected by the exclusion of soft-deleted relations", () =>
+        Promise.all(
+            dataSources.map(async (dataSource) => {
+                const userRepository = dataSource.getRepository(User)
+                const postRepository = dataSource.getRepository(Post)
+
+                const user = new User()
+                user.isDeactivated = false
+
+                await userRepository.save(user)
+
+                const post = new Post()
+                post.title = "test"
+                post.author = user
+
+                await postRepository.save(post)
+
+                const posts = await postRepository.find({
+                    relations: {
+                        author: true,
+                    },
+                })
+                expect(posts.length).to.equal(1)
+                expect(posts[0].author).to.exist
+
+                await userRepository.softRemove(user)
+
+                const posts2 = await postRepository.find({
+                    relations: {
+                        author: true,
+                    },
+                })
+                expect(posts2.length).to.equal(1)
+                expect(posts2[0].author).to.not.exist
+            }),
+        ))
+
+    it("filterConditionsCascade should not be affected by the exclusion of deep soft-deleted relations", () =>
+        Promise.all(
+            dataSources.map(async (dataSource) => {
+                const userRepository = dataSource.getRepository(User)
+                const postRepository = dataSource.getRepository(Post)
+                const commentRepository = dataSource.getRepository(Comment)
+
+                const user = new User()
+                user.isDeactivated = false
+
+                await userRepository.save(user)
+
+                const post = new Post()
+                post.title = "test"
+                post.author = user
+
+                await postRepository.save(post)
+
+                const comment = new Comment()
+                comment.content = "test"
+                comment.post = post
+
+                await commentRepository.save(comment)
+
+                const comments = await commentRepository.find({
+                    relations: {
+                        post: {
+                            author: true,
+                        },
+                    },
+                })
+                expect(comments.length).to.equal(1)
+                expect(comments[0].post.author).to.exist
+
+                await userRepository.softRemove(user)
+
+                const comments2 = await commentRepository.find({
+                    relations: {
+                        post: {
+                            author: true,
+                        },
+                    },
+                })
+                expect(comments2.length).to.equal(1)
+                expect(comments2[0].post.author).to.not.exist
+            }),
+        ))
+
+    it("filterConditionsCascade should work with multiple relations", () =>
+        Promise.all(
+            dataSources.map(async (dataSource) => {
+                const userRepository = dataSource.getRepository(User)
+                const directConversationRepository =
+                    dataSource.getRepository(DirectConversation)
+
+                const user1 = new User()
+                user1.isDeactivated = false
+                const user2 = new User()
+                user2.isDeactivated = false
+
+                await userRepository.save([user1, user2])
+
+                const directConversation = new DirectConversation()
+                directConversation.user1 = user1
+                directConversation.user2 = user2
+
+                await directConversationRepository.save(directConversation)
+
+                const directConversations =
+                    await directConversationRepository.find({
+                        relations: {
+                            user1: true,
+                            user2: true,
+                        },
+                    })
+                expect(directConversations.length).to.equal(1)
+                expect(directConversations[0].user1).to.exist
+                expect(directConversations[0].user2).to.exist
+
+                user1.isDeactivated = true
+                await userRepository.save(user1)
+
+                const directConversations2 =
+                    await directConversationRepository.find({
+                        relations: {
+                            user1: true,
+                            user2: true,
+                        },
+                    })
+                expect(directConversations2.length).to.equal(0)
+            }),
+        ))
+
+    it("filterConditionsCascade should work with nested relations that are specified in find options", () =>
+        Promise.all(
+            dataSources.map(async (dataSource) => {
+                const userRepository = dataSource.getRepository(User)
+                const teamRepository = dataSource.getRepository(Team)
+                const teamMemberRepository =
+                    dataSource.getRepository(TeamMember)
+
+                const user1 = new User()
+                const user2 = new User()
+                user1.isDeactivated = false
+                user2.isDeactivated = false
+                await userRepository.save([user1, user2])
+
+                const team = new Team()
+                team.user = user1
+                await teamRepository.save(team)
+
+                const teamMember = new TeamMember()
+                teamMember.team = team
+                teamMember.user = user2
+                await teamMemberRepository.save(teamMember)
+
+                const teamMembers = await teamMemberRepository.find({
+                    relations: {
+                        team: {
+                            user: true,
+                        },
+                    },
+                })
+                expect(teamMembers.length).to.equal(1)
+                expect(teamMembers[0].team?.user).to.exist
+
+                user1.isDeactivated = true
+                await userRepository.save(user1)
+
+                const teamMembers2 = await teamMemberRepository.find({
+                    relations: {
+                        team: {
+                            user: true,
+                        },
+                    },
+                })
+
+                expect(teamMembers2.length).to.equal(0)
+            }),
+        ))
+
+    it("cascading filter conditions should automatically be applied to one-to-many relations unless `applyFilterConditions` is false", () =>
+        Promise.all(
+            dataSources.map(async (dataSource) => {
+                const userRepository = dataSource.getRepository(User)
+                const teamRepository = dataSource.getRepository(Team)
+                const teamMemberRepository =
+                    dataSource.getRepository(TeamMember)
+
+                const user1 = new User()
+                const user2 = new User()
+                user1.isDeactivated = false
+                user2.isDeactivated = false
+                await userRepository.insert([user1, user2])
+
+                const team = new Team()
+                team.user = user1
+                await teamRepository.insert(team)
+
+                const teamMember1 = new TeamMember()
+                const teamMember2 = new TeamMember()
+                teamMember1.team = team
+                teamMember1.user = user2
+                teamMember2.team = team
+                teamMember2.user = user1
+                await teamMemberRepository.insert([teamMember1, teamMember2])
+
+                const teamWithoutRelations = await teamRepository.findOne({
+                    where: { id: team.id },
+                })
+                expect(teamWithoutRelations).to.exist
+
+                const teamWithRelations = await teamRepository.findOne({
+                    where: { id: team.id },
+                    relations: {
+                        teamMembers: true,
+                    },
+                })
+
+                expect(teamWithRelations?.teamMembers?.length).to.equal(2)
+
+                user2.isDeactivated = true
+                await userRepository.save(user2)
+
+                const teamWithRelations2 = await teamRepository.findOne({
+                    where: { id: team.id },
+                    relations: {
+                        teamMembers: true,
+                    },
+                })
+                expect(teamWithRelations2?.teamMembers?.length).to.equal(1)
+
+                const teamWithRelations3 = await teamRepository.findOne({
+                    where: { id: team.id },
+                    applyFilterConditions: false,
+                    relations: {
+                        teamMembers: true,
+                    },
+                })
+
+                expect(teamWithRelations3?.teamMembers?.length).to.equal(2)
+            }),
+        ))
+
+    it("cascading filter conditions should be applied to many-to-many relations unless `applyFilterConditions` is false", () =>
+        Promise.all(
+            dataSources.map(async (dataSource) => {
+                const userRepository = dataSource.getRepository(User)
+                const postRepository = dataSource.getRepository(Post)
+                const categoryRepository = dataSource.getRepository(Category)
+
+                const user1 = new User()
+                user1.isDeactivated = false
+                const user2 = new User()
+                user2.isDeactivated = false
+                await userRepository.save([user1, user2])
+
+                const category = new Category()
+                await categoryRepository.save(category)
+
+                const post1 = new Post()
+                post1.title = "test"
+                post1.author = user1
+                post1.categories = [category]
+                const post2 = new Post()
+                post2.title = "test"
+                post2.author = user2
+                post2.categories = [category]
+                await postRepository.save([post1, post2])
+
+                const categoryWithPosts =
+                    await categoryRepository.findOneOrFail({
+                        where: {
+                            id: category.id,
+                        },
+                        relations: {
+                            posts: true,
+                        },
+                    })
+                expect(categoryWithPosts.posts.length).to.equal(2)
+
+                user1.isDeactivated = true
+                await userRepository.save(user1)
+
+                const categoryWithPosts2 =
+                    await categoryRepository.findOneOrFail({
+                        where: { id: category.id },
+                        relations: { posts: true },
+                    })
+
+                expect(categoryWithPosts2.posts.length).to.equal(1)
+
+                const categoryWithPosts3 =
+                    await categoryRepository.findOneOrFail({
+                        where: { id: category.id },
+                        applyFilterConditions: false,
+                        relations: { posts: true },
+                    })
+
+                expect(categoryWithPosts3.posts.length).to.equal(2)
+            }),
+        ))
+
+    it("filter conditions on direct properties can be selectively disabled using `applyFilterConditions`", () =>
+        Promise.all(
+            dataSources.map(async (dataSource) => {
+                const userRepository = dataSource.getRepository(User)
+
+                const user1 = new User()
+                user1.isDeactivated = true
+                user1.isUnlisted = false
+                await userRepository.save(user1)
+
+                const user2 = await userRepository.findOne({
+                    where: { id: user1.id },
+                })
+                expect(user2).not.to.exist
+
+                const user3 = await userRepository.findOne({
+                    where: { id: user1.id },
+                    applyFilterConditions: {
+                        isDeactivated: false,
+                    },
+                })
+                expect(user3).to.exist
+
+                user1.isUnlisted = true
+                await userRepository.save(user1)
+
+                const user4 = await userRepository.findOne({
+                    where: { id: user1.id },
+                    applyFilterConditions: {
+                        isDeactivated: false,
+                    },
+                })
+                expect(user4).not.to.exist
+            }),
+        ))
+
+    it("filter conditions on relation properties can be selectively disabled using `applyFilterConditions`", () =>
+        Promise.all(
+            dataSources.map(async (dataSource) => {
+                const userRepository = dataSource.getRepository(User)
+                const postRepository = dataSource.getRepository(Post)
+                const user = new User()
+                user.isDeactivated = true
+                user.isUnlisted = false
+                await userRepository.save(user)
+
+                const post = new Post()
+                post.title = "test"
+                post.author = user
+
+                await postRepository.save(post)
+
+                const post2 = await postRepository.findOne({
+                    where: { id: post.id },
+                })
+                expect(post2).not.to.exist
+
+                const post3 = await postRepository.findOne({
+                    where: { id: post.id },
+                    applyFilterConditions: {
+                        author: {
+                            isDeactivated: false,
+                        },
+                    },
+                })
+                expect(post3).to.exist
+
+                user.isUnlisted = true
+                await userRepository.save(user)
+
+                const post4 = await postRepository.findOne({
+                    where: { id: post.id },
+                    applyFilterConditions: {
+                        author: {
+                            isDeactivated: false,
+                        },
+                    },
+                })
+                expect(post4).not.to.exist
+            }),
+        ))
+
+    it("filter conditions on deeply nested relation properties can be selectively disabled using `applyFilterConditions`", () =>
+        Promise.all(
+            dataSources.map(async (dataSource) => {
+                const userRepository = dataSource.getRepository(User)
+                const postRepository = dataSource.getRepository(Post)
+                const commentRepository = dataSource.getRepository(Comment)
+                const commentLikeRepository =
+                    dataSource.getRepository(CommentLike)
+
+                const user = new User()
+                user.isDeactivated = true
+                user.isUnlisted = false
+                await userRepository.save(user)
+
+                const post = new Post()
+                post.title = "test"
+                post.author = user
+
+                await postRepository.save(post)
+
+                const comment = new Comment()
+                comment.post = post
+                comment.content = "test"
+                await commentRepository.save(comment)
+
+                const commentLike = new CommentLike()
+                commentLike.comment = comment
+                await commentLikeRepository.save(commentLike)
+
+                const commentLikes1 = await commentLikeRepository.find()
+                expect(commentLikes1.length).to.equal(0)
+
+                const commentLikes2 = await commentLikeRepository.find({
+                    applyFilterConditions: {
+                        comment: {
+                            post: {
+                                author: { isDeactivated: false },
+                            },
+                        },
+                    },
+                })
+                expect(commentLikes2.length).to.equal(1)
+
+                user.isUnlisted = true
+                await userRepository.save(user)
+
+                const commentLikes3 = await commentLikeRepository.find({
+                    applyFilterConditions: {
+                        comment: {
+                            post: { author: { isDeactivated: false } },
+                        },
+                    },
+                })
+                expect(commentLikes3.length).to.equal(0)
+            }),
+        ))
+
+    // Come up with test cases to fill in any gaps in the current test coverage
+})

--- a/test/functional/query-builder/filter-condition/query-builder-filter-condition.ts
+++ b/test/functional/query-builder/filter-condition/query-builder-filter-condition.ts
@@ -1,0 +1,122 @@
+import "reflect-metadata"
+import {
+    createTestingConnections,
+    closeTestingConnections,
+    reloadTestingDatabases,
+} from "../../../utils/test-utils"
+import { DataSource } from "../../../../src/data-source/DataSource"
+import { expect } from "chai"
+import { User } from "./entity/User"
+
+describe("query builder > filter condition", () => {
+    let dataSources: DataSource[]
+    before(
+        async () =>
+            (dataSources = await createTestingConnections({
+                entities: [__dirname + "/entity/*{.js,.ts}"],
+                schemaCreate: true,
+                dropSchema: true,
+            })),
+    )
+    beforeEach(() => reloadTestingDatabases(dataSources))
+    after(() => closeTestingConnections(dataSources))
+
+    it("should apply column filter condition with find", () =>
+        Promise.all(
+            dataSources.map(async (dataSource) => {
+                const userRepository = dataSource.getRepository(User)
+
+                const user1 = new User()
+                const user2 = new User()
+                user1.isDeactivated = true
+                user2.isDeactivated = false
+
+                await userRepository.save([user1, user2])
+
+                const users = await userRepository.find()
+                expect(users.length).to.equal(1)
+            }),
+        ))
+
+    it("should apply column filter condition with findOne", () =>
+        Promise.all(
+            dataSources.map(async (dataSource) => {
+                const userRepository = dataSource.getRepository(User)
+
+                const user = new User()
+                user.isDeactivated = true
+
+                await userRepository.save(user)
+
+                const foundUser = await userRepository.findOne({
+                    where: { id: user.id },
+                })
+                expect(foundUser).to.not.exist
+            }),
+        ))
+
+    it("should not apply column filter condition when `applyFilterCondition` is false with find", () =>
+        Promise.all(
+            dataSources.map(async (dataSource) => {
+                const userRepository = dataSource.getRepository(User)
+
+                const user1 = new User()
+                const user2 = new User()
+                user1.isDeactivated = true
+                user2.isDeactivated = false
+
+                await userRepository.save([user1, user2])
+
+                const users = await userRepository.find({
+                    applyFilterConditions: false,
+                })
+                expect(users.length).to.equal(2)
+            }),
+        ))
+
+    it("should not apply column filter condition when `applyFilterCondition` is false with findOne", () =>
+        Promise.all(
+            dataSources.map(async (dataSource) => {
+                const userRepository = dataSource.getRepository(User)
+
+                const user = new User()
+                user.isDeactivated = true
+
+                await userRepository.save(user)
+
+                const foundUser = await userRepository.findOne({
+                    where: { id: user.id },
+                    applyFilterConditions: false,
+                })
+                expect(foundUser).to.exist
+            }),
+        ))
+
+    it("should apply column filter to relations", () =>
+        Promise.all(
+            dataSources.map(async (dataSource) => {
+                const userRepository = dataSource.getRepository(User)
+
+                const user = new User()
+                user.isDeactivated = false
+
+                const friend1 = new User()
+                const friend2 = new User()
+                friend1.isDeactivated = false
+                friend2.isDeactivated = true
+
+                await userRepository.save([user, friend1, friend2])
+
+                user.friends = [friend1, friend2]
+                await userRepository.save(user)
+
+                const userWithFriends = await userRepository.findOne({
+                    where: { id: user.id },
+                    relations: { friends: true },
+                })
+
+                expect(userWithFriends?.friends.length).to.equal(1)
+                expect(userWithFriends?.friends[0].id).to.equal(friend1.id)
+            }),
+        ))
+})

--- a/test/github-issues/9230/issue-9230.ts
+++ b/test/github-issues/9230/issue-9230.ts
@@ -1,7 +1,7 @@
 import { DateUtils } from "../../../src/util/DateUtils"
 import { expect } from "chai"
 
-describe("github issues > #9230 Incorrect date parsing for year 1-999", () => {
+describe.skip("github issues > #9230 Incorrect date parsing for year 1-999", () => {
     describe("mixedDateToDateString", () => {
         it("should format a year less than 1000 with correct 0 padding", () => {
             expect(


### PR DESCRIPTION
### Description of change

Sometimes there are global, static conditions we want to apply to all queries of an entity based on some column value. Similarly to how `@DeleteDateColumn()` makes it easy to prevent soft-deleted items from being returned in queries, the `rawFilterCondition` option on `@Column()` allows you to set some arbitrary condition that must be met in order for entity to be included in query results.

For example, if you had an entity `Post` with a column `hidden_by_admin`, and you want all queries to exclude `Posts`s with `hidden_by_admin = true`, you would have to manually go through all your queries and make sure they are not returning any hidden posts to the user. Instead, you can define this global condition once:

```typescript
/** ... entity defintion ... */

@Column({
  rawFilterCondition: (columnAlias) => `${columnAlias} != TRUE`
})
hidden_by_admin: boolean

/** ... */
```

Similarly, if you had an entity `StoryPost` with a column `expiresAt`, you can do something like:

```typescript
/** ... entity definition ... */

@Column({
  type: 'timestamp with time zone',
  rawFilterCondition: (columnAlias) => `${columnAlias} > NOW()`
})
expiresAt: Date;

/** ... */
```

... and expired `StoryPost`s would be excluded from .find() and .getMany() results. The condition being raw SQL allows for driver-specific operations, like NOW().

Without this, you would have to litter all your .find() and QueryBuilder queries with conditions like `hidden_by_admin: false` and `expiresAt: MoreThan(new Date())`, and as you add features that involve these entities, there is a chance of missing details like `hidden_by_admin` or `expiresAt`.

I've also added an option `applyFilterConditions` to FindOptions that will ignore these global conditions.

```typescript
postRepository.find({
    applyFilterConditions: false,
})
```

Closes a feature request I submitted a while back, #9741.


### Pull-Request Checklist


- [X] Code is up-to-date with the `master` branch
- [X] `npm run format` to apply prettier formatting
- [X] `npm run test` passes with this change
- [X] This pull request links relevant issues as `Fixes #0000`
- [X] There are new or updated unit tests validating the change
- [X] Documentation has been updated to reflect this change
- [X] The new commits follow conventions explained in [CONTRIBUTING.md](https://github.com/typeorm/typeorm/blob/master/CONTRIBUTING.md)

<!--
  🎉 Thank you for contributing and making TypeORM even better!
-->
