### PR TITLE
feat: Add `queryAndParameters` to `EntitySubscriberInterface` `afterUpdate` and `afterSoftRemove`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -19,7 +19,6 @@
         "dotenv": "^16.0.3",
         "glob": "^10.3.10",
         "mkdirp": "^2.1.3",
-        "reflect-metadata": "^0.2.1",
         "sha.js": "^2.4.11",
         "tslib": "^2.5.0",
         "uuid": "^9.0.0",
@@ -105,6 +104,7 @@
         "pg-native": "^3.0.0",
         "pg-query-stream": "^4.0.0",
         "redis": "^3.1.1 || ^4.0.0",
+        "reflect-metadata": "^0.1.14 || ^0.2.0",
         "sql.js": "^1.4.0",
         "sqlite3": "^5.0.3",
         "ts-node": "^10.7.0",
@@ -11751,7 +11751,8 @@
     "node_modules/reflect-metadata": {
       "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/reflect-metadata/-/reflect-metadata-0.2.1.tgz",
-      "integrity": "sha512-i5lLI6iw9AU3Uu4szRNPPEkomnkjRTaVt9hy/bn5g/oSzekBSMeLZblcjP74AW0vBabqERLLIrz+gR8QYR54Tw=="
+      "integrity": "sha512-i5lLI6iw9AU3Uu4szRNPPEkomnkjRTaVt9hy/bn5g/oSzekBSMeLZblcjP74AW0vBabqERLLIrz+gR8QYR54Tw==",
+      "peer": true
     },
     "node_modules/regex-not": {
       "version": "1.0.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@felipecsl/typeorm",
-  "version": "0.3.22",
+  "version": "0.3.23",
   "description": "Data-Mapper ORM for TypeScript, ES7, ES6, ES5. Supports MySQL, PostgreSQL, MariaDB, SQLite, MS SQL Server, Oracle, MongoDB databases.",
   "license": "MIT",
   "readmeFilename": "README.md",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,6 @@
 {
-  "name": "typeorm",
-  "private": true,
-  "version": "0.3.20",
+  "name": "@felipecsl/typeorm",
+  "version": "0.3.22",
   "description": "Data-Mapper ORM for TypeScript, ES7, ES6, ES5. Supports MySQL, PostgreSQL, MariaDB, SQLite, MS SQL Server, Oracle, MongoDB databases.",
   "license": "MIT",
   "readmeFilename": "README.md",

--- a/src/driver/postgres/PostgresQueryRunner.ts
+++ b/src/driver/postgres/PostgresQueryRunner.ts
@@ -601,10 +601,22 @@ export class PostgresQueryRunner
                 downQueries.push(this.dropIndexSql(table, index))
             })
         }
-        
+
         if (table.comment) {
-            upQueries.push(new Query("COMMENT ON TABLE " + this.escapePath(table) + " IS '" + table.comment + "'"));
-            downQueries.push(new Query("COMMENT ON TABLE " + this.escapePath(table) + " IS NULL"));
+            upQueries.push(
+                new Query(
+                    "COMMENT ON TABLE " +
+                        this.escapePath(table) +
+                        " IS '" +
+                        table.comment +
+                        "'",
+                ),
+            )
+            downQueries.push(
+                new Query(
+                    "COMMENT ON TABLE " + this.escapePath(table) + " IS NULL",
+                ),
+            )
         }
 
         await this.executeQueries(upQueries, downQueries)
@@ -4744,7 +4756,7 @@ export class PostgresQueryRunner
 
         newComment = this.escapeComment(newComment)
         const comment = this.escapeComment(table.comment)
-        
+
         if (newComment === comment) {
             return
         }

--- a/src/query-builder/InsertQueryBuilder.ts
+++ b/src/query-builder/InsertQueryBuilder.ts
@@ -459,10 +459,8 @@ export class InsertQueryBuilder<
         // add VALUES expression
         if (valuesExpression) {
             if (
-                (
-                    this.connection.driver.options.type === "oracle" ||
-                    this.connection.driver.options.type === "sap"
-                ) &&
+                (this.connection.driver.options.type === "oracle" ||
+                    this.connection.driver.options.type === "sap") &&
                 this.getValueSets().length > 1
             ) {
                 query += ` ${valuesExpression}`

--- a/src/query-builder/QueryBuilder.ts
+++ b/src/query-builder/QueryBuilder.ts
@@ -522,7 +522,10 @@ export abstract class QueryBuilder<Entity extends ObjectLiteral> {
      * Uses same query runner as current QueryBuilder.
      */
     createQueryBuilder(queryRunner?: QueryRunner): this {
-        return new (this.constructor as any)(this.connection, queryRunner ?? this.queryRunner)
+        return new (this.constructor as any)(
+            this.connection,
+            queryRunner ?? this.queryRunner,
+        )
     }
 
     /**

--- a/src/query-builder/SoftDeleteQueryBuilder.ts
+++ b/src/query-builder/SoftDeleteQueryBuilder.ts
@@ -128,6 +128,10 @@ export class SoftDeleteQueryBuilder<Entity extends ObjectLiteral>
                     await queryRunner.broadcaster.broadcast(
                         "AfterSoftRemove",
                         this.expressionMap.mainAlias!.metadata,
+                        undefined, // entity
+                        undefined, // databaseEntity
+                        undefined, // identifier,
+                        [sql, parameters], // queryAndParameters
                     )
                 else if (this.expressionMap.queryType === "restore")
                     await queryRunner.broadcaster.broadcast(

--- a/src/query-builder/UpdateQueryBuilder.ts
+++ b/src/query-builder/UpdateQueryBuilder.ts
@@ -169,7 +169,11 @@ export class UpdateQueryBuilder<Entity extends ObjectLiteral>
                 await queryRunner.broadcaster.broadcast(
                     "AfterUpdate",
                     this.expressionMap.mainAlias!.metadata,
-                    this.expressionMap.valuesSet,
+                    this.expressionMap.valuesSet, // entity
+                    undefined, // databaseEntity
+                    undefined, // updatedColumns
+                    undefined, // updatedRelations,
+                    [updateSql, parameters], // queryAndParameters
                 )
             }
 

--- a/src/schema-builder/RdbmsSchemaBuilder.ts
+++ b/src/schema-builder/RdbmsSchemaBuilder.ts
@@ -604,7 +604,7 @@ export class RdbmsSchemaBuilder implements SchemaBuilder {
 
             if (
                 DriverUtils.isMySQLFamily(this.connection.driver) ||
-                this.connection.driver.options.type === 'postgres'
+                this.connection.driver.options.type === "postgres"
             ) {
                 const newComment = metadata.comment
                 await this.queryRunner.changeTableComment(table, newComment)

--- a/src/subscriber/Broadcaster.ts
+++ b/src/subscriber/Broadcaster.ts
@@ -31,6 +31,7 @@ interface BroadcasterEvents {
         databaseEntity?: ObjectLiteral,
         updatedColumns?: ColumnMetadata[],
         updatedRelations?: RelationMetadata[],
+        queryAndParameters?: [string, any[]],
     ) => void
 
     BeforeInsert: (
@@ -141,8 +142,8 @@ export class Broadcaster {
                         connection: this.queryRunner.connection,
                         queryRunner: this.queryRunner,
                         manager: this.queryRunner.manager,
-                        entity: entity,
-                        metadata: metadata,
+                        entity,
+                        metadata,
                     })
                     if (executionResult instanceof Promise)
                         result.promises.push(executionResult)
@@ -602,6 +603,7 @@ export class Broadcaster {
         databaseEntity?: ObjectLiteral,
         updatedColumns?: ColumnMetadata[],
         updatedRelations?: RelationMetadata[],
+        queryAndParameters?: [string, any[]],
     ): void {
         if (entity && metadata.afterUpdateListeners.length) {
             metadata.afterUpdateListeners.forEach((listener) => {
@@ -624,11 +626,12 @@ export class Broadcaster {
                         connection: this.queryRunner.connection,
                         queryRunner: this.queryRunner,
                         manager: this.queryRunner.manager,
-                        entity: entity,
-                        metadata: metadata,
-                        databaseEntity: databaseEntity,
+                        entity,
+                        metadata,
+                        databaseEntity,
                         updatedColumns: updatedColumns || [],
                         updatedRelations: updatedRelations || [],
+                        queryAndParameters,
                     })
                     if (executionResult instanceof Promise)
                         result.promises.push(executionResult)

--- a/src/subscriber/Broadcaster.ts
+++ b/src/subscriber/Broadcaster.ts
@@ -63,6 +63,8 @@ interface BroadcasterEvents {
         metadata: EntityMetadata,
         entity?: ObjectLiteral,
         databaseEntity?: ObjectLiteral,
+        identifier?: ObjectLiteral,
+        queryAndParameters?: [string, any[]],
     ) => void
 
     BeforeRecover: (
@@ -706,6 +708,7 @@ export class Broadcaster {
         entity?: ObjectLiteral,
         databaseEntity?: ObjectLiteral,
         identifier?: ObjectLiteral,
+        queryAndParameters?: [string, any[]],
     ): void {
         if (entity && metadata.afterSoftRemoveListeners.length) {
             metadata.afterSoftRemoveListeners.forEach((listener) => {
@@ -728,12 +731,13 @@ export class Broadcaster {
                         connection: this.queryRunner.connection,
                         queryRunner: this.queryRunner,
                         manager: this.queryRunner.manager,
-                        entity: entity,
-                        metadata: metadata,
-                        databaseEntity: databaseEntity,
+                        entity,
+                        metadata,
+                        databaseEntity,
                         entityId: metadata.getEntityIdMixedMap(
                             databaseEntity ?? identifier,
                         ),
+                        queryAndParameters,
                     })
                     if (executionResult instanceof Promise)
                         result.promises.push(executionResult)

--- a/src/subscriber/event/SoftRemoveEvent.ts
+++ b/src/subscriber/event/SoftRemoveEvent.ts
@@ -3,4 +3,7 @@ import { RemoveEvent } from "./RemoveEvent"
 /**
  * SoftRemoveEvent is an object that broadcaster sends to the entity subscriber when entity is being soft removed to the database.
  */
-export interface SoftRemoveEvent<Entity> extends RemoveEvent<Entity> {}
+export interface SoftRemoveEvent<Entity> extends RemoveEvent<Entity> {
+    /** The query that was executed and any parameters bound to it */
+    queryAndParameters?: [string, any[]]
+}

--- a/src/subscriber/event/UpdateEvent.ts
+++ b/src/subscriber/event/UpdateEvent.ts
@@ -51,4 +51,7 @@ export interface UpdateEvent<Entity> {
      * List of updated relations. In query builder has no affected
      */
     updatedRelations: RelationMetadata[]
+
+    /** The query that was executed and any parameters bound to it */
+    queryAndParameters?: [string, any[]]
 }

--- a/test/functional/entity-subscriber/parameters/entity/Post.ts
+++ b/test/functional/entity-subscriber/parameters/entity/Post.ts
@@ -1,6 +1,7 @@
 import { Entity } from "../../../../../src/decorator/entity/Entity"
 import { PrimaryGeneratedColumn } from "../../../../../src/decorator/columns/PrimaryGeneratedColumn"
 import { Column } from "../../../../../src/decorator/columns/Column"
+import { DeleteDateColumn } from "../../../../../src/decorator/columns/DeleteDateColumn"
 
 @Entity()
 export class Post {
@@ -12,4 +13,7 @@ export class Post {
 
     @Column()
     colToUpdate: number = 0
+
+    @DeleteDateColumn()
+    deleteAt?: Date
 }

--- a/test/functional/entity-subscriber/parameters/entity/Post.ts
+++ b/test/functional/entity-subscriber/parameters/entity/Post.ts
@@ -1,0 +1,15 @@
+import { Entity } from "../../../../../src/decorator/entity/Entity"
+import { PrimaryGeneratedColumn } from "../../../../../src/decorator/columns/PrimaryGeneratedColumn"
+import { Column } from "../../../../../src/decorator/columns/Column"
+
+@Entity()
+export class Post {
+    @PrimaryGeneratedColumn()
+    id: number
+
+    @Column({ nullable: true })
+    title?: string
+
+    @Column()
+    colToUpdate: number = 0
+}

--- a/test/functional/entity-subscriber/parameters/query-and-parameters.ts
+++ b/test/functional/entity-subscriber/parameters/query-and-parameters.ts
@@ -1,0 +1,44 @@
+import "reflect-metadata"
+import { expect } from "chai"
+import {
+    closeTestingConnections,
+    createTestingConnections,
+    reloadTestingDatabases,
+} from "../../../../test/utils/test-utils"
+import { DataSource } from "../../../../src/data-source/DataSource"
+import { Post } from "./entity/Post"
+import { PostSubscriber } from "./subscriber/PostSubscriber"
+
+describe("afterUpdate queryAndParameters", () => {
+    let connections: DataSource[]
+    before(
+        async () =>
+            (connections = await createTestingConnections({
+                entities: [__dirname + "/entity/*{.js,.ts}"],
+                subscribers: [__dirname + "/subscriber/*{.js,.ts}"],
+            })),
+    )
+    beforeEach(() => reloadTestingDatabases(connections))
+    after(() => closeTestingConnections(connections))
+
+    it("if entity has been updated via QueryBuilder, subscriber afterUpdate should receive queryAndParameters", () =>
+        Promise.all(
+            connections.map(async function (connection) {
+                const repo = connection.getRepository(Post)
+                const insertPost = new Post()
+                await repo.save(insertPost)
+                const createdPost = await repo.findOneBy({ id: insertPost.id })
+                expect(createdPost).not.to.be.null
+                const { id } = createdPost!
+                await repo.manager
+                    .createQueryBuilder()
+                    .update(Post)
+                    .set({ colToUpdate: 1 })
+                    .where("id = :id", { id })
+                    .execute()
+                const queryAndParameters = PostSubscriber.receivedEvents[0].queryAndParameters
+                expect(queryAndParameters![0]).to.equal('UPDATE "post" SET "colToUpdate" = $1 WHERE "id" = $2')
+                expect(queryAndParameters![1]).to.deep.equal([1, id])
+            }),
+        ))
+})

--- a/test/functional/entity-subscriber/parameters/query-and-parameters.ts
+++ b/test/functional/entity-subscriber/parameters/query-and-parameters.ts
@@ -36,8 +36,12 @@ describe("afterUpdate queryAndParameters", () => {
                     .set({ colToUpdate: 1 })
                     .where("id = :id", { id })
                     .execute()
-                const queryAndParameters = PostSubscriber.receivedAfterUpdateEvents[0].queryAndParameters
-                expect(queryAndParameters![0]).to.equal('UPDATE "post" SET "colToUpdate" = $1 WHERE "id" = $2')
+                const queryAndParameters =
+                    PostSubscriber.receivedAfterUpdateEvents[0]
+                        .queryAndParameters
+                expect(queryAndParameters![0]).to.equal(
+                    'UPDATE "post" SET "colToUpdate" = $1 WHERE "id" = $2',
+                )
                 expect(queryAndParameters![1]).to.deep.equal([1, id])
             }),
         ))
@@ -57,8 +61,12 @@ describe("afterUpdate queryAndParameters", () => {
                     .from(Post)
                     .where("id = :id", { id })
                     .execute()
-                const queryAndParameters = PostSubscriber.receivedAfterSoftRemoveEvents[0].queryAndParameters
-                expect(queryAndParameters![0]).to.equal('UPDATE "post" SET "deleteAt" = CURRENT_TIMESTAMP WHERE "id" = $1')
+                const queryAndParameters =
+                    PostSubscriber.receivedAfterSoftRemoveEvents[0]
+                        .queryAndParameters
+                expect(queryAndParameters![0]).to.equal(
+                    'UPDATE "post" SET "deleteAt" = CURRENT_TIMESTAMP WHERE "id" = $1',
+                )
                 expect(queryAndParameters![1]).to.deep.equal([1])
             }),
         ))

--- a/test/functional/entity-subscriber/parameters/query-and-parameters.ts
+++ b/test/functional/entity-subscriber/parameters/query-and-parameters.ts
@@ -36,9 +36,30 @@ describe("afterUpdate queryAndParameters", () => {
                     .set({ colToUpdate: 1 })
                     .where("id = :id", { id })
                     .execute()
-                const queryAndParameters = PostSubscriber.receivedEvents[0].queryAndParameters
+                const queryAndParameters = PostSubscriber.receivedAfterUpdateEvents[0].queryAndParameters
                 expect(queryAndParameters![0]).to.equal('UPDATE "post" SET "colToUpdate" = $1 WHERE "id" = $2')
                 expect(queryAndParameters![1]).to.deep.equal([1, id])
+            }),
+        ))
+
+    it("if entity has been soft deleted via QueryBuilder, subscriber afterSoftRemove should receive queryAndParameters", () =>
+        Promise.all(
+            connections.map(async function (connection) {
+                const repo = connection.getRepository(Post)
+                const insertPost = new Post()
+                await repo.save(insertPost)
+                const createdPost = await repo.findOneBy({ id: insertPost.id })
+                expect(createdPost).not.to.be.null
+                const { id } = createdPost!
+                await repo.manager
+                    .createQueryBuilder()
+                    .softDelete()
+                    .from(Post)
+                    .where("id = :id", { id })
+                    .execute()
+                const queryAndParameters = PostSubscriber.receivedAfterSoftRemoveEvents[0].queryAndParameters
+                expect(queryAndParameters![0]).to.equal('UPDATE "post" SET "deleteAt" = CURRENT_TIMESTAMP WHERE "id" = $1')
+                expect(queryAndParameters![1]).to.deep.equal([1])
             }),
         ))
 })

--- a/test/functional/entity-subscriber/parameters/subscriber/PostSubscriber.ts
+++ b/test/functional/entity-subscriber/parameters/subscriber/PostSubscriber.ts
@@ -1,7 +1,8 @@
 import { Post } from "../entity/Post"
 import {
     EntitySubscriberInterface,
-    EventSubscriber, SoftRemoveEvent,
+    EventSubscriber,
+    SoftRemoveEvent,
     UpdateEvent,
 } from "../../../../../src"
 

--- a/test/functional/entity-subscriber/parameters/subscriber/PostSubscriber.ts
+++ b/test/functional/entity-subscriber/parameters/subscriber/PostSubscriber.ts
@@ -1,0 +1,19 @@
+import { Post } from "../entity/Post"
+import {
+    EntitySubscriberInterface,
+    EventSubscriber,
+    UpdateEvent,
+} from "../../../../../src"
+
+@EventSubscriber()
+export class PostSubscriber implements EntitySubscriberInterface<Post> {
+    static receivedEvents: UpdateEvent<Post>[] = []
+
+    listenTo() {
+        return Post
+    }
+
+    afterUpdate(event: UpdateEvent<Post>) {
+        PostSubscriber.receivedEvents.push(event)
+    }
+}

--- a/test/functional/entity-subscriber/parameters/subscriber/PostSubscriber.ts
+++ b/test/functional/entity-subscriber/parameters/subscriber/PostSubscriber.ts
@@ -1,19 +1,24 @@
 import { Post } from "../entity/Post"
 import {
     EntitySubscriberInterface,
-    EventSubscriber,
+    EventSubscriber, SoftRemoveEvent,
     UpdateEvent,
 } from "../../../../../src"
 
 @EventSubscriber()
 export class PostSubscriber implements EntitySubscriberInterface<Post> {
-    static receivedEvents: UpdateEvent<Post>[] = []
+    static receivedAfterUpdateEvents: UpdateEvent<Post>[] = []
+    static receivedAfterSoftRemoveEvents: SoftRemoveEvent<Post>[] = []
 
     listenTo() {
         return Post
     }
 
     afterUpdate(event: UpdateEvent<Post>) {
-        PostSubscriber.receivedEvents.push(event)
+        PostSubscriber.receivedAfterUpdateEvents.push(event)
+    }
+
+    afterSoftRemove(event: SoftRemoveEvent<Post>): Promise<any> | void {
+        PostSubscriber.receivedAfterSoftRemoveEvents.push(event)
     }
 }

--- a/test/integration/sample2-one-to-one.ts
+++ b/test/integration/sample2-one-to-one.ts
@@ -211,14 +211,15 @@ describe("one-to-one", function () {
             expectedPost.details!.comment = savedPost.details!.comment
             expectedPost.details!.metadata = savedPost.details!.metadata
 
-            const findOne = () => postRepository.findOne({
+            const findOne = () =>
+                postRepository.findOne({
                     where: {
-                        id: savedPost.id
+                        id: savedPost.id,
                     },
                     relations: {
-                        details: true
+                        details: true,
                     },
-                    relationLoadStrategy: "query"
+                    relationLoadStrategy: "query",
                 })
 
             const posts = await Promise.all([
@@ -234,7 +235,7 @@ describe("one-to-one", function () {
                 findOne(),
             ])
 
-            posts.forEach(post => {
+            posts.forEach((post) => {
                 expect(post).not.to.be.null
                 post!.should.eql(expectedPost)
             })

--- a/test/integration/sample3-many-to-one.ts
+++ b/test/integration/sample3-many-to-one.ts
@@ -213,15 +213,16 @@ describe("many-to-one", function () {
             expectedPost.details!.comment = savedPost.details!.comment
             expectedPost.details!.metadata = savedPost.details!.metadata
 
-            const findOne = () => postRepository.findOne({
-                where: {
-                    id: savedPost.id
-                },
-                relations: {
-                    details: true
-                },
-                relationLoadStrategy: "query"
-            })
+            const findOne = () =>
+                postRepository.findOne({
+                    where: {
+                        id: savedPost.id,
+                    },
+                    relations: {
+                        details: true,
+                    },
+                    relationLoadStrategy: "query",
+                })
 
             const posts = await Promise.all([
                 findOne(),
@@ -236,7 +237,7 @@ describe("many-to-one", function () {
                 findOne(),
             ])
 
-            posts.forEach(post => {
+            posts.forEach((post) => {
                 expect(post).not.to.be.null
                 post!.should.eql(expectedPost)
             })


### PR DESCRIPTION
<!--
  😀 Wonderful!  Thank you for opening a pull request for TypeORM.

  Please fill in the information below to expedite the review
  and (hopefully) merge of your change.

  If unsure about something.. just do as best as you're able,
  or reach out through our community support channels!
  https://github.com/typeorm/typeorm/blob/master/docs/support.md
-->

### Description of change

Right now `EntitySubscriberInterface` are largely useless when queries are executed via `QueryBuilder` since no useful information is passed to the event handlers.
I thought it would be useful to at the very least provide the original query and the parameters bound to it, so people could at least parse the query and do something with it.

We found this as a way to unblock ourselves. Could add it to other hooks as well if people are happy with the approach.


### Pull-Request Checklist

Partially fixes #2246

- [x] Code is up-to-date with the `master` branch
- [x] `npm run format` to apply prettier formatting
- [x] `npm run test` passes with this change
- [x] This pull request links relevant issues as `Fixes #0000`
- [x] There are new or updated unit tests validating the change
- [ ] Documentation has been updated to reflect this change
- [ ] The new commits follow conventions explained in [CONTRIBUTING.md](https://github.com/typeorm/typeorm/blob/master/CONTRIBUTING.md)

<!--
  🎉 Thank you for contributing and making TypeORM even better!
-->
