### PR TITLE
Split SQLite tests and fix better-sqlite3

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -124,7 +124,7 @@ jobs:
     - run: npm test
 
 
-  sqlite_better-sqlite3_sqljs:
+  better-sqlite3:
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
@@ -137,7 +137,41 @@ jobs:
     steps:
     - uses: actions/checkout@v4
     - run: npm i
-    - run: cp .github/workflows/test/sqlite-better-sqlite3-sqljs.ormconfig.json ormconfig.json
+    - run: cp .github/workflows/test/better-sqlite3.ormconfig.json ormconfig.json
+    - run: npm test
+  
+
+  sqlite:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        node-container: ["node:18"] #["node:16", "node:18", "node:20", "node:22"]
+        # See supported Node.js release schedule at https://nodejs.org/en/about/releases/
+
+    container: ${{ matrix.node-container }}
+
+    steps:
+    - uses: actions/checkout@v4
+    - run: npm i
+    - run: cp .github/workflows/test/sqlite.ormconfig.json ormconfig.json
+    - run: npm test
+
+
+  sqljs:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        node-container: ["node:18"] #["node:16", "node:18", "node:20", "node:22"]
+        # See supported Node.js release schedule at https://nodejs.org/en/about/releases/
+
+    container: ${{ matrix.node-container }}
+
+    steps:
+    - uses: actions/checkout@v4
+    - run: npm i
+    - run: cp .github/workflows/test/sqljs.ormconfig.json ormconfig.json
     - run: npm test
 
 

--- a/.github/workflows/test/better-sqlite3.ormconfig.json
+++ b/.github/workflows/test/better-sqlite3.ormconfig.json
@@ -1,0 +1,21 @@
+[
+  {
+    "skip": false,
+    "name": "better-sqlite3",
+    "type": "better-sqlite3",
+    "database": "temp/better-sqlite3db.db",
+    "logging": false
+  },
+
+  {
+    "skip": true,
+    "name": "postgres",
+    "type": "postgres",
+    "host": "postgres",
+    "port": 5432,
+    "username": "postgres",
+    "password": "postgres",
+    "database": "postgres",
+    "logging": false
+  }
+]

--- a/.github/workflows/test/sqlite.ormconfig.json
+++ b/.github/workflows/test/sqlite.ormconfig.json
@@ -1,24 +1,11 @@
 [
   {
     "skip": false,
-    "name": "sqljs",
-    "type": "sqljs",
-    "logging": false
-  },
-  {
-    "skip": false,
     "name": "sqlite",
     "type": "sqlite",
     "database": "./temp/sqlitedb-1.db",
     "logging": false,
     "relationLoadStrategy": "join"
-  },
-  {
-    "skip": false,
-    "name": "better-sqlite3",
-    "type": "better-sqlite3",
-    "database": "temp/better-sqlite3db.db",
-    "logging": false
   },
 
   {

--- a/.github/workflows/test/sqljs.ormconfig.json
+++ b/.github/workflows/test/sqljs.ormconfig.json
@@ -1,0 +1,20 @@
+[
+  {
+    "skip": false,
+    "name": "sqljs",
+    "type": "sqljs",
+    "logging": false
+  },
+
+  {
+    "skip": true,
+    "name": "postgres",
+    "type": "postgres",
+    "host": "postgres",
+    "port": 5432,
+    "username": "postgres",
+    "password": "postgres",
+    "database": "postgres",
+    "logging": false
+  }
+]


### PR DESCRIPTION
<!--
  😀 Wonderful!  Thank you for opening a pull request for TypeORM.

  Please fill in the information below to expedite the review
  and (hopefully) merge of your change.

  If unsure about something.. just do as best as you're able,
  or reach out through our community support channels!
  https://github.com/typeorm/typeorm/blob/master/docs/support.md
-->

### Description of change

This change splits SQLite (sqljs, sqlite and better-sqlite3) tests into their own workflows.

This change also adds `broadcastBeforeQueryEvent` and `broadcastAfterQueryEvent` that were missing in the better-sqlite3 driver implementation (caught after tests split). Fixes #3302 for better-sqlite3.

<!--
  Please be clear and concise what the change is intended to do,
  why this change is needed, and how you've verified that it
  corrects what you intended.

  In some cases it may be helpful to include the current behavior
  and the new behavior.

  If the change is related to an open issue, you can link it here.
  If you include `Fixes #0000` (replacing `0000` with the issue number)
  when this is merged it will automatically mark the issue as fixed and
  close it.
-->


### Pull-Request Checklist

<!--
  Please make sure to review and check all of the following.

  If an item is not applicable, you can add "N/A" to the end.
-->

- [x] Code is up-to-date with the `master` branch
- [x] `npm run format` to apply prettier formatting
- [x] `npm run test` passes with this change
- [x] This pull request links relevant issues as `Fixes #0000`
- [x] There are new or updated unit tests validating the change
- [ ] Documentation has been updated to reflect this change
- [x] The new commits follow conventions explained in [CONTRIBUTING.md](https://github.com/typeorm/typeorm/blob/master/CONTRIBUTING.md)

<!--
  🎉 Thank you for contributing and making TypeORM even better!
-->
