### PR TITLE
docs: fix typo in many-to-many example

### DIFF
--- a/docs/many-to-many-relations.md
+++ b/docs/many-to-many-relations.md
@@ -293,7 +293,7 @@ Additionally you will have to add a relationship like the following to `Question
 ```typescript
 // category.ts
 ...
-@OneToMany(() => questionToCategory, questionToCategory => questionToCategory.category)
+@OneToMany(() => QuestionToCategory, questionToCategory => questionToCategory.category)
 public questionToCategories: QuestionToCategory[];
 
 // question.ts


### PR DESCRIPTION
### Description of change

This fixes a typo in the many-to-many relations docs. The class should be referenced but the capitalization is off. This can lead to confusion (it did for me).

https://typeorm.io/many-to-many-relations#many-to-many-relations-with-custom-properties


### Pull-Request Checklist

- [x] Code is up-to-date with the `master` branch
- [ ] `npm run format` to apply prettier formatting N/A
- [ ] `npm run test` passes with this change N/A
- [ ] This pull request links relevant issues as `Fixes #0000` N/A
- [ ] There are new or updated unit tests validating the change N/A
- [ ] Documentation has been updated to reflect this change N/A
- [x] The new commits follow conventions explained in [CONTRIBUTING.md](https://github.com/typeorm/typeorm/blob/master/CONTRIBUTING.md)