### PR TITLE
docs: update QueryResultCache method descriptions

### DIFF
--- a/src/cache/QueryResultCache.ts
+++ b/src/cache/QueryResultCache.ts
@@ -16,12 +16,14 @@ export interface QueryResultCache {
     disconnect(): Promise<void>
 
     /**
-     * Performs operations needs to be created during schema synchronization.
+     * Perform operations during schema synchronization.
      */
     synchronize(queryRunner?: QueryRunner): Promise<void>
 
     /**
-     * Caches given query result.
+     * Get data from cache.
+     * Returns cache result if found.
+     * Returns undefined if result is not cached.
      */
     getFromCache(
         options: QueryResultCacheOptions,


### PR DESCRIPTION
### Description of change

Correct the description for getFromCache, matching the descriptions found on the [redis](https://github.com/typeorm/typeorm/blob/master/src/cache/RedisQueryResultCache.ts#L125-L130) and [db](https://github.com/typeorm/typeorm/blob/master/src/cache/DbQueryResultCache.ts#L133-L138) cache implementations.

Also correct grammar on the description of the synchronize method.

### Pull-Request Checklist

- [x] Code is up-to-date with the `master` branch
- [x] `npm run format` to apply prettier formatting
- [x] `npm run test` passes with this change
- [x] ~This pull request links relevant issues as `Fixes #0000`~ N/A
- [x] ~There are new or updated unit tests validating the change~ N/A
- [x] ~Documentation has been updated to reflect this change~ N/A
- [x] The new commits follow conventions explained in [CONTRIBUTING.md](https://github.com/typeorm/typeorm/blob/master/CONTRIBUTING.md)