### PR TITLE
remove github issues as a suggested place for questions

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -11,13 +11,10 @@ As a contributor, here are the guidelines we would like you to follow:
 
 ## <a name="question"></a> Got a Question or Problem?
 
-There are several ways how you can ask your question:
+If you have a question or want community support:
 
 * You can create a question on [StackOverflow](https://stackoverflow.com/questions/tagged/typeorm) where the questions should be tagged with tag `typeorm`.
 * You can ask on [Discord](https://discord.gg/cC9hkmUgNa)
-* You can create issue on [github](https://github.com/typeorm/typeorm/issues)
-
-Preferred way if you create your question on StackOverflow, or create a github issue.
 
 ## <a name="issue"></a> Found a security vulnerability?
 


### PR DESCRIPTION
### Description of change

Remove the suggestion of github issues as a place for questions about using TypeORM. Instead point people towards stack overflow and discord for questions about using TypeORM, to match our suggestions in the [support doc](https://github.com/typeorm/typeorm/blob/master/docs/support.md) and the [new issue form](https://github.com/typeorm/typeorm/issues/new/choose).

### Pull-Request Checklist

<!--
  Please make sure to review and check all of the following.

  If an item is not applicable, you can add "N/A" to the end.
-->

- [x] Code is up-to-date with the `master` branch
- [x] `npm run format` to apply prettier formatting
- [ ] `npm run test` passes with this change
- [ ] This pull request links relevant issues as `Fixes #0000`
- [ ] There are new or updated unit tests validating the change
- [ ] Documentation has been updated to reflect this change
- [x] The new commits follow conventions explained in [CONTRIBUTING.md](https://github.com/typeorm/typeorm/blob/master/CONTRIBUTING.md)
