### PR TITLE
feat: Incorporate wrapping metadata for MongoDB client instances

### DIFF
--- a/src/driver/mongodb/MongoDriver.ts
+++ b/src/driver/mongodb/MongoDriver.ts
@@ -572,6 +572,11 @@ export class MongoDriver implements Driver {
             }
         }
 
+        mongoOptions.driverInfo = {
+            name: "TypeORM",
+            version: "X.Y.Z" // FIXME: import actual library version
+        }
+
         return mongoOptions
     }
 }


### PR DESCRIPTION
The PR incorporates MongoDB's [wrapping client library](https://github.com/mongodb/specifications/blob/master/source/mongodb-handshake/handshake.md#supporting-wrapping-libraries) specification for the connection handshake to allow library details to be included in the metadata written to `mongos` or `mongod` logs.

For example, this change would allow server-side logs such as the following:

```
{"t":{"$date":"2024-12-30T10:45:50.868-05:00"},"s":"I","c":"NETWORK","id":51800,"ctx":"conn5","msg":"client metadata","attr":{"remote":"127.0.0.1:55714","client":"conn5","negotiatedCompressors":[],"doc":{"driver":{"name":"nodejs|TypeORM","version":"5.9.2|X.Y.Z"},"platform":"Node.js v22.12.0, LE","os":{"name":"darwin","architecture":"arm64","version":"23.6.0","type":"Darwin"}}}}
```

### Pull-Request Checklist

- [x] Code is up-to-date with the `master` branch
- [x] `npm run format` to apply prettier formatting
- [x] `npm run test` passes with this change (N/A)
- [x] This pull request links relevant issues as `Fixes #0000` (N/A)
- [x] There are new or updated unit tests validating the change (N/A)
- [x] Documentation has been updated to reflect this change (N/A)
- [x] The new commits follow conventions explained in [CONTRIBUTING.md](https://github.com/typeorm/typeorm/blob/master/CONTRIBUTING.md)