### PR TITLE
feat: implement query stream for sqlite3 driver

### DIFF
--- a/src/driver/sqlite/SqliteQueryStream.ts
+++ b/src/driver/sqlite/SqliteQueryStream.ts
@@ -1,0 +1,36 @@
+import { Statement } from "sqlite3"
+import { Readable } from "../../platform/PlatformTools"
+
+/**
+ * Provides a readable interface over a SQLite query statement.
+ */
+export class SqliteQueryStream extends Readable {
+    constructor(protected statement: Statement) {
+        super({ objectMode: true })
+        this.finalizeStatementWhenDone()
+    }
+
+    public override _read(): void {
+        // SQLite's statement returns one row at a time, so we
+        // can just call 'get' each time the stream wants more data.
+        this.statement.get((err, row) => {
+            if (err) {
+                this.destroy(err)
+            } else if (row) {
+                this.push(row)
+            } else {
+                this.push(null)
+            }
+        })
+    }
+
+    /**
+     * SQLite locks the database while a statement is being executed.
+     * To unlock, we need to call finalize when we're done.
+     */
+    protected finalizeStatementWhenDone(): void {
+        const finalize = () => this.statement.finalize()
+        this.once("end", finalize)
+        this.once("error", finalize)
+    }
+}

--- a/src/query-runner/QueryRunner.ts
+++ b/src/query-runner/QueryRunner.ts
@@ -132,8 +132,8 @@ export interface QueryRunner {
     stream(
         query: string,
         parameters?: any[],
-        onEnd?: Function,
-        onError?: Function,
+        onEnd?: () => void,
+        onError?: (error: Error) => void,
     ): Promise<ReadStream>
 
     /**

--- a/test/functional/query-runner/stream.ts
+++ b/test/functional/query-runner/stream.ts
@@ -21,6 +21,7 @@ describe("query runner > stream", () => {
                 "postgres",
                 "sap",
                 "spanner",
+                "sqlite",
             ],
         })
     })


### PR DESCRIPTION
Introduces `SqliteQueryStream`, a readable wrapper over a `sqlite3` prepared statement.

Closes: #11243

<!--
  😀 Wonderful!  Thank you for opening a pull request for TypeORM.

  Please fill in the information below to expedite the review
  and (hopefully) merge of your change.

  If unsure about something.. just do as best as you're able,
  or reach out through our community support channels!
  https://github.com/typeorm/typeorm/blob/master/docs/support.md
-->

### Description of change

<!--
  Please be clear and concise what the change is intended to do,
  why this change is needed, and how you've verified that it
  corrects what you intended.

  In some cases it may be helpful to include the current behavior
  and the new behavior.

  If the change is related to an open issue, you can link it here.
  If you include `Fixes #0000` (replacing `0000` with the issue number)
  when this is merged it will automatically mark the issue as fixed and
  close it.
-->

Implements `SqliteQueryRunner#stream` to return a readable stream of query rows from a prepared statement. Uses the new `SqliteQueryStream` class to adapt the sqlite3 `Statement#get` API to `stream.Readable`.

Since a test suite already existed for streaming, the test change was to add the `sqlite3` driver to the tested data sources.

### Pull-Request Checklist

<!--
  Please make sure to review and check all of the following.

  If an item is not applicable, you can add "N/A" to the end.
-->

- [x] Code is up-to-date with the `master` branch
- [x] `npm run format` to apply prettier formatting
- [x] `npm run test` passes with this change
- [x] This pull request links relevant issues as `Fixes #0000`
- [x] There are new or updated unit tests validating the change
- [ ] Documentation has been updated to reflect this change "N/A"
- [x] The new commits follow conventions explained in [CONTRIBUTING.md](https://github.com/typeorm/typeorm/blob/master/CONTRIBUTING.md)

<!--
  🎉 Thank you for contributing and making TypeORM even better!
-->
