### PR TITLE
chore(test): set timezone to UTC

### DIFF
--- a/test/utils/test-setup.ts
+++ b/test/utils/test-setup.ts
@@ -2,6 +2,9 @@ import "source-map-support/register"
 import "reflect-metadata"
 import * as chai from "chai"
 
+// Tests assume UTC time zone when formatting/parsing dates.
+process.env.TZ = "UTC"
+
 chai.should()
 chai.use(require("sinon-chai"))
 chai.use(require("chai-as-promised"))


### PR DESCRIPTION
Fixes: #11246

<!--
  😀 Wonderful!  Thank you for opening a pull request for TypeORM.

  Please fill in the information below to expedite the review
  and (hopefully) merge of your change.

  If unsure about something.. just do as best as you're able,
  or reach out through our community support channels!
  https://github.com/typeorm/typeorm/blob/master/docs/support.md
-->

### Description of change

<!--
  Please be clear and concise what the change is intended to do,
  why this change is needed, and how you've verified that it
  corrects what you intended.

  In some cases it may be helpful to include the current behavior
  and the new behavior.

  If the change is related to an open issue, you can link it here.
  If you include `Fixes #0000` (replacing `0000` with the issue number)
  when this is merged it will automatically mark the issue as fixed and
  close it.
-->

Updates the `test-setup.ts` to set `process.env.TZ = 'UTC'`. Tests that parse/format dates rely on the runtime timezone, and if assertions are hard coded then it can be easy for the formatted results to be off by an hour(s) or day(s). To mitigate, we set an environment variable to instruct node and other code what time zone to operate under.

### Pull-Request Checklist

<!--
  Please make sure to review and check all of the following.

  If an item is not applicable, you can add "N/A" to the end.
-->

- [x] Code is up-to-date with the `master` branch
- [x] `npm run format` to apply prettier formatting
- [x] `npm run test` passes with this change
- [x] This pull request links relevant issues as `Fixes #0000`
- [ ] There are new or updated unit tests validating the change "N/A"
- [x] Documentation has been updated to reflect this change
- [x] The new commits follow conventions explained in [CONTRIBUTING.md](https://github.com/typeorm/typeorm/blob/master/CONTRIBUTING.md)

<!--
  🎉 Thank you for contributing and making TypeORM even better!
-->
