### PR TITLE
docs: fix missing DataSource in migrations config

### DIFF
--- a/docs/migrations.md
+++ b/docs/migrations.md
@@ -61,7 +61,9 @@ This place is called "migrations".
 Before creating a new migration you need to setup your data source options properly:
 
 ```ts
-{
+import { DataSource } from "typeorm";
+
+export default new DataSource({
     type: "mysql",
     host: "localhost",
     port: 3306,
@@ -71,7 +73,7 @@ Before creating a new migration you need to setup your data source options prope
     entities: [/*...*/],
     migrations: [/*...*/],
     migrationsTableName: "custom_migration_table",
-}
+})
 ```
 
 Here we setup two options:


### PR DESCRIPTION
### Motivation
Running migrations using current documentation ends with error:
`Error: Given data source file must contain export of a DataSource instance`

### Pull-Request Checklist

<!--
  Please make sure to review and check all of the following.

  If an item is not applicable, you can add "N/A" to the end.
-->

- [x] Code is up-to-date with the `master` branch
- [x] `npm run format` to apply prettier formatting
- `npm run test` passes with this change N/A
- This pull request links relevant issues as `Fixes #0000` N/A
- There are new or updated unit tests validating the change N/A
- Documentation has been updated to reflect this change N/A
- The new commits follow conventions explained in [CONTRIBUTING.md](https://github.com/typeorm/typeorm/blob/master/CONTRIBUTING.md) N/A

<!--
  🎉 Thank you for contributing and making TypeORM even better!
-->
