### PR TITLE
refactor: define Position type for GeoJSON objects

### DIFF
--- a/src/driver/types/GeoJsonTypes.ts
+++ b/src/driver/types/GeoJsonTypes.ts
@@ -1,60 +1,66 @@
 /**
+ * Position object.
+ * https://datatracker.ietf.org/doc/html/rfc7946#section-3.1.1
+ */
+export type Position = number[]
+
+/**
  * Point geometry object.
- * https://tools.ietf.org/html/rfc7946#section-3.1.2
+ * https://datatracker.ietf.org/doc/html/rfc7946#section-3.1.2
  */
 export type Point = {
     type: "Point"
-    coordinates: number[]
+    coordinates: Position
 }
 
 /**
  * LineString geometry object.
- * https://tools.ietf.org/html/rfc7946#section-3.1.4
+ * https://datatracker.ietf.org/doc/html/rfc7946#section-3.1.4
  */
 export type LineString = {
     type: "LineString"
-    coordinates: number[][]
+    coordinates: Position[]
 }
 
 /**
  * Polygon geometry object.
- * https://tools.ietf.org/html/rfc7946#section-3.1.6
+ * https://datatracker.ietf.org/doc/html/rfc7946#section-3.1.6
  */
 export type Polygon = {
     type: "Polygon"
-    coordinates: number[][][]
+    coordinates: Position[][]
 }
 
 /**
  * MultiPoint geometry object.
- *  https://tools.ietf.org/html/rfc7946#section-3.1.3
+ *  https://datatracker.ietf.org/doc/html/rfc7946#section-3.1.3
  */
 export type MultiPoint = {
     type: "MultiPoint"
-    coordinates: number[][]
+    coordinates: Position[]
 }
 
 /**
  * MultiLineString geometry object.
- * https://tools.ietf.org/html/rfc7946#section-3.1.5
+ * https://datatracker.ietf.org/doc/html/rfc7946#section-3.1.5
  */
 export type MultiLineString = {
     type: "MultiLineString"
-    coordinates: number[][][]
+    coordinates: Position[][]
 }
 
 /**
  * MultiPolygon geometry object.
- * https://tools.ietf.org/html/rfc7946#section-3.1.7
+ * https://datatracker.ietf.org/doc/html/rfc7946#section-3.1.7
  */
 export type MultiPolygon = {
     type: "MultiPolygon"
-    coordinates: number[][][][]
+    coordinates: Position[][][]
 }
 
 /**
  * Geometry Collection
- * https://tools.ietf.org/html/rfc7946#section-3.1.8
+ * https://datatracker.ietf.org/doc/html/rfc7946#section-3.1.8
  */
 export type GeometryCollection = {
     type: "GeometryCollection"
@@ -83,7 +89,7 @@ export type Geography = Geometry
 
 /**
  * A feature object which contains a geometry and associated properties.
- * https://tools.ietf.org/html/rfc7946#section-3.2
+ * https://datatracker.ietf.org/doc/html/rfc7946#section-3.2
  */
 export type Feature = {
     type: "Feature"
@@ -95,7 +101,7 @@ export type Feature = {
 
 /**
  * A collection of feature objects.
- *  https://tools.ietf.org/html/rfc7946#section-3.3
+ *  https://datatracker.ietf.org/doc/html/rfc7946#section-3.3
  */
 export type FeatureCollection = {
     type: "FeatureCollection"


### PR DESCRIPTION
<!--
  😀 Wonderful!  Thank you for opening a pull request for TypeORM.

  Please fill in the information below to expedite the review
  and (hopefully) merge of your change.

  If unsure about something.. just do as best as you're able,
  or reach out through our community support channels!
  https://github.com/typeorm/typeorm/blob/master/docs/support.md
-->

### Description of change

<!--
  Please be clear and concise what the change is intended to do,
  why this change is needed, and how you've verified that it
  corrects what you intended.

  In some cases it may be helpful to include the current behavior
  and the new behavior.

  If the change is related to an open issue, you can link it here.
  If you include `Fixes #0000` (replacing `0000` with the issue number)
  when this is merged it will automatically mark the issue as fixed and
  close it.
-->
This change requires all Point objects to match the defined structure specified in [RFC 7946](https://datatracker.ietf.org/doc/html/rfc7946#section-3.1.1). I also updated all the links to the specification.

> There MUST be two or more elements. [...] Altitude or elevation MAY be included as an optional third element.

### Pull-Request Checklist

<!--
  Please make sure to review and check all of the following.

  If an item is not applicable, you can add "N/A" to the end.
-->

- [x] Code is up-to-date with the `master` branch
- [x] `npm run format` to apply prettier formatting
- [ ] `npm run test` passes with this change
- [x] This pull request links relevant issues as `Fixes #0000`
- [x] There are new or updated unit tests validating the change
- [ ] Documentation has been updated to reflect this change
- [x] The new commits follow conventions explained in [CONTRIBUTING.md](https://github.com/typeorm/typeorm/blob/master/CONTRIBUTING.md)

<!--
  🎉 Thank you for contributing and making TypeORM even better!
-->
