### PR TITLE
chore: remove `--file` from test running

### DIFF
--- a/package.json
+++ b/package.json
@@ -150,7 +150,7 @@
   "peerDependencies": {
     "@google-cloud/spanner": "^5.18.0",
     "@sap/hana-client": "^2.12.25",
-    "better-sqlite3": "^8.0.0 || ^9.0.0 || ^10.0.0 || ^11.0.0" ,
+    "better-sqlite3": "^8.0.0 || ^9.0.0 || ^10.0.0 || ^11.0.0",
     "hdb-pool": "^0.1.6",
     "ioredis": "^5.0.4",
     "mongodb": "^5.8.0",
@@ -236,8 +236,8 @@
     "yargs": "^17.6.2"
   },
   "scripts": {
-    "test": "rimraf ./build && tsc && mocha --file ./build/compiled/test/utils/test-setup.js --bail --recursive --timeout 90000 ./build/compiled/test",
-    "test-fast": "mocha --file ./build/compiled/test/utils/test-setup.js --bail --recursive --timeout 90000 ./build/compiled/test",
+    "test": "rimraf ./build && tsc && mocha --bail --recursive --timeout 90000 ./build/compiled/test",
+    "test-fast": "mocha --bail --recursive --timeout 90000 ./build/compiled/test",
     "compile": "rimraf ./build && tsc",
     "watch": "./node_modules/.bin/tsc -w",
     "package": "gulp package",

--- a/test/utils/xfail.ts
+++ b/test/utils/xfail.ts
@@ -1,3 +1,4 @@
+import "./test-setup"
 import { assert, AssertionError } from "chai"
 import { AsyncFunc, Context, Func, Test, TestFunction } from "mocha"
 
@@ -21,7 +22,7 @@ const wrap = (
 
         return new Promise<void>((ok, fail) => {
             if (fn.length > 1) {
-                ;(fn as Func).call(context as unknown as Context, (err: any) =>
+                (fn as Func).call(context as unknown as Context, (err: any) =>
                     err ? fail(err) : ok(),
                 )
             } else {


### PR DESCRIPTION
<!--
  😀 Wonderful!  Thank you for opening a pull request for TypeORM.

  Please fill in the information below to expedite the review
  and (hopefully) merge of your change.

  If unsure about something.. just do as best as you're able,
  or reach out through our community support channels!
  https://github.com/typeorm/typeorm/blob/master/docs/support.md
-->

### Description of change

Remove `--file ./build/compiled/test/utils/test-setup.js` and move the `test-setup.ts` import into the necessary files. Removing the `--file` flag allows using `--parallel` flag (in the future).

<!--
  Please be clear and concise what the change is intended to do,
  why this change is needed, and how you've verified that it
  corrects what you intended.

  In some cases it may be helpful to include the current behavior
  and the new behavior.

  If the change is related to an open issue, you can link it here.
  If you include `Fixes #0000` (replacing `0000` with the issue number)
  when this is merged it will automatically mark the issue as fixed and
  close it.
-->


### Pull-Request Checklist

<!--
  Please make sure to review and check all of the following.

  If an item is not applicable, you can add "N/A" to the end.
-->

- [x] Code is up-to-date with the `master` branch
- [x] `npm run format` to apply prettier formatting
- [x] `npm run test` passes with this change
- [ ] This pull request links relevant issues as `Fixes #0000`
- [ ] There are new or updated unit tests validating the change
- [ ] Documentation has been updated to reflect this change
- [x] The new commits follow conventions explained in [CONTRIBUTING.md](https://github.com/typeorm/typeorm/blob/master/CONTRIBUTING.md)

<!--
  🎉 Thank you for contributing and making TypeORM even better!
-->
