### PR TITLE
fix: prevent eager-loaded entities with DeleteDateColumn from overwriting manual relations

### DIFF
--- a/src/metadata/RelationMetadata.ts
+++ b/src/metadata/RelationMetadata.ts
@@ -520,6 +520,8 @@ export class RelationMetadata {
                 entity,
             )
         } else {
+            if (ObjectUtils.isObject(entity[propertyName]))
+                ObjectUtils.assign(value, entity[propertyName])
             entity[propertyName] = value
         }
     }

--- a/test/github-issues/11265/entity/parent.ts
+++ b/test/github-issues/11265/entity/parent.ts
@@ -1,0 +1,11 @@
+import { Entity, ManyToOne, PrimaryGeneratedColumn } from "../../../../src"
+import { RelationEntity } from "./relationEntity"
+
+@Entity()
+export class ParentEntity {
+    @PrimaryGeneratedColumn()
+    id: number
+
+    @ManyToOne(() => RelationEntity, { eager: true })
+    relationEntity: RelationEntity
+}

--- a/test/github-issues/11265/entity/relationEntity.ts
+++ b/test/github-issues/11265/entity/relationEntity.ts
@@ -1,0 +1,18 @@
+import {
+    DeleteDateColumn,
+    Entity,
+    ManyToOne,
+    PrimaryGeneratedColumn,
+} from "../../../../src"
+import { RelationNestedEntity } from "./relationNestedEntity"
+@Entity()
+export class RelationEntity {
+    @PrimaryGeneratedColumn()
+    id: number
+
+    @DeleteDateColumn()
+    deletedAt?: Date
+
+    @ManyToOne(() => RelationNestedEntity)
+    nested: RelationNestedEntity
+}

--- a/test/github-issues/11265/entity/relationNestedEntity.ts
+++ b/test/github-issues/11265/entity/relationNestedEntity.ts
@@ -1,0 +1,7 @@
+import { Entity, PrimaryGeneratedColumn } from "../../../../src"
+
+@Entity()
+export class RelationNestedEntity {
+    @PrimaryGeneratedColumn()
+    id: number
+}

--- a/test/github-issues/11265/issue-11265.ts
+++ b/test/github-issues/11265/issue-11265.ts
@@ -1,0 +1,65 @@
+import "reflect-metadata"
+import {
+    createTestingConnections,
+    closeTestingConnections,
+    reloadTestingDatabases,
+} from "../../utils/test-utils"
+import { DataSource } from "../../../src/data-source/DataSource"
+import { expect } from "chai"
+import { RelationNestedEntity } from "./entity/relationNestedEntity"
+import { RelationEntity } from "./entity/relationEntity"
+import { ParentEntity } from "./entity/parent"
+
+describe.only("github issues > #11265 Eager Relations with DeleteDateColumn Overwrite Manual Relations During Query Loading", () => {
+    let dataSources: DataSource[]
+
+    before(
+        async () =>
+            (dataSources = await createTestingConnections({
+                entities: [__dirname + "/entity/*{.js,.ts}"],
+                schemaCreate: true,
+                dropSchema: true,
+            })),
+    )
+    beforeEach(() => reloadTestingDatabases(dataSources))
+    after(() => closeTestingConnections(dataSources))
+
+    it("should preserve manually requested nested relations", async () => {
+        return Promise.all(
+            dataSources.map(async (dataSource) => {
+                // Prepare test data
+                const relationNestedRepository =
+                    dataSource.getRepository(RelationNestedEntity)
+                const relationEntityRepository =
+                    dataSource.getRepository(RelationEntity)
+                const parentRepository = dataSource.getRepository(ParentEntity)
+
+                const relationNested = new RelationNestedEntity()
+                await relationNestedRepository.save(relationNested)
+
+                const relationEntity = new RelationEntity()
+                relationEntity.nested = relationNested
+                await relationEntityRepository.save(relationEntity)
+
+                const parent = new ParentEntity()
+                parent.relationEntity = relationEntity
+                await parentRepository.save(parent)
+
+                // Retrieve user with manually specified nested relation
+                const retrievedParent = await parentRepository.findOne({
+                    where: { id: parent.id },
+                    relations: {
+                        relationEntity: {
+                            nested: {},
+                        },
+                    },
+                })
+
+                // Assertions
+                expect(retrievedParent).to.exist
+                expect(retrievedParent!.relationEntity).to.exist
+                expect(retrievedParent!.relationEntity.nested).to.exist
+            }),
+        )
+    })
+})


### PR DESCRIPTION
The issue was caused by the way TypeORM processing queries. For each join, it checks if the join for that table exists. However, if the join has a condition, it will always add the join, even if a previous join for the same table already exists.

In the case of eager loading, TypeORM creates its own join, and since it has a DeleteDateColumn, an additional condition is added to the join (checking for a null DeletedDate). This newly added join does not match the manually specified join, and if the manual relation had additional nested fields that were not part of the eager load, those fields would be overwritten.

This fix addresses the issue by merging the manually requested relations with the eager-loaded data, preserving the complete details of the manual relations.

In issue #10426 , the same case was described, where there are 2 joins to the same table,
which causes performance issues.

The current fix does not change the join process and leaves both joins as they were,
but only fixes the consequences that were created as a result of it in the object creation,
because this is a consequence that is relevant both to this case and to other cases.

Unrelated, it should check how to deal with the problem of having 2 joins, for performance reasons.


Closes: #11265
Closes: #11056
Closes: #10812
Closes: #9774
Closes: #9581

<!--
  😀 Wonderful!  Thank you for opening a pull request for TypeORM.

  Please fill in the information below to expedite the review
  and (hopefully) merge of your change.

  If unsure about something.. just do as best as you're able,
  or reach out through our community support channels!
  https://github.com/typeorm/typeorm/blob/master/docs/support.md
-->

### Description of change

<!--
  Please be clear and concise what the change is intended to do,
  why this change is needed, and how you've verified that it
  corrects what you intended.

  In some cases it may be helpful to include the current behavior
  and the new behavior.

  If the change is related to an open issue, you can link it here.
  If you include `Fixes #0000` (replacing `0000` with the issue number)
  when this is merged it will automatically mark the issue as fixed and
  close it.
-->


### Pull-Request Checklist

<!--
  Please make sure to review and check all of the following.

  If an item is not applicable, you can add "N/A" to the end.
-->

- [X] Code is up-to-date with the `master` branch
- [X] `npm run format` to apply prettier formatting
- [X] `npm run test` passes with this change
- [X] This pull request links relevant issues as `Fixes #0000`
- [X] There are new or updated unit tests validating the change
- [ ] N/A - Documentation has been updated to reflect this change
- [X] The new commits follow conventions explained in [CONTRIBUTING.md](https://github.com/typeorm/typeorm/blob/master/CONTRIBUTING.md)

<!--
  🎉 Thank you for contributing and making TypeORM even better!
-->
