### PR TITLE
Fixes for build and tests

### DIFF
--- a/gulpfile.ts
+++ b/gulpfile.ts
@@ -21,7 +21,7 @@ export class Gulpfile {
      */
     @Task()
     async clean() {
-        return rimraf(["./build/**"]);
+        return rimraf(["./build/**"], {glob: true});
     }
 
     /**
@@ -88,7 +88,7 @@ export class Gulpfile {
     async browserClearPackageDirectory() {
         return rimraf([
             "./build/browser/**"
-        ]);
+        ], {glob: true});
     }
 
     // -------------------------------------------------------------------------
@@ -195,7 +195,7 @@ export class Gulpfile {
     async packageClearPackageDirectory() {
         return rimraf([
             "build/package/src/**"
-        ]);
+        ], {glob: true});
     }
 
     /**

--- a/test/functional/multi-database/multi-database-basic-functionality/multi-database-basic-functionality.ts
+++ b/test/functional/multi-database/multi-database-basic-functionality/multi-database-basic-functionality.ts
@@ -19,8 +19,8 @@ import appRoot from "app-root-path"
 const VALID_NAME_REGEX = /^(?!sqlite_).{1,63}$/
 
 describe("multi-database > basic-functionality", () => {
-    describe("filepathToName()", () => {
-        for (const platform of [`darwin`, `win32`]) {
+    for (const platform of [`darwin`, `win32`]) {
+        describe(`filepathToName() (${platform})`, () => {
             let realPlatform: string
 
             beforeEach(() => {
@@ -38,7 +38,7 @@ describe("multi-database > basic-functionality", () => {
                 })
             })
 
-            it(`produces deterministic, unique, and valid table names for relative paths; leaves absolute paths unchanged (${platform})`, () => {
+            it("produces deterministic, unique, and valid table names for relative paths; leaves absolute paths unchanged", () => {
                 const testMap = [
                     ["FILENAME.db", "filename.db"],
                     ["..\\FILENAME.db", "../filename.db"],
@@ -51,16 +51,18 @@ describe("multi-database > basic-functionality", () => {
                 ]
                 for (const [winOs, otherOs] of testMap) {
                     const winOsRes = filepathToName(winOs)
-                    const otherOsRes = filepathToName(otherOs)
-                    expect(winOsRes).to.equal(otherOsRes)
+                    if (process.platform == "win32") {
+                        const otherOsRes = filepathToName(otherOs)
+                        expect(winOsRes).to.equal(otherOsRes)
+                    }
                     expect(winOsRes).to.match(
                         VALID_NAME_REGEX,
                         `'${winOs}' is invalid table name`,
                     )
                 }
             })
-        }
-    })
+        })
+    }
 
     describe("multiple databases", () => {
         let connections: DataSource[]
@@ -91,7 +93,7 @@ describe("multi-database > basic-functionality", () => {
         beforeEach(() => reloadTestingDatabases(connections))
         after(async () => {
             await closeTestingConnections(connections)
-            await rimraf(`${tempPath}/**/*.attach.db`)
+            await rimraf(`${tempPath}/**/*.attach.db`, { glob: true })
         })
 
         it("should correctly attach and create database files", () =>

--- a/test/github-issues/4753/issue-4753.ts
+++ b/test/github-issues/4753/issue-4753.ts
@@ -33,6 +33,7 @@ describe("github issues > #4753 MySQL Replication Config broken", () => {
                     username: connectionOptions.username,
                     password: connectionOptions.password,
                     database: connectionOptions.database,
+                    port: connectionOptions.port,
                 },
                 slaves: [
                     {
@@ -40,6 +41,7 @@ describe("github issues > #4753 MySQL Replication Config broken", () => {
                         username: connectionOptions.username,
                         password: connectionOptions.password,
                         database: connectionOptions.database,
+                        port: connectionOptions.port,
                     },
                 ],
             },

--- a/test/github-issues/8975/issue-8975.ts
+++ b/test/github-issues/8975/issue-8975.ts
@@ -1,10 +1,11 @@
 import { expect } from "chai"
 import { exec } from "child_process"
-import { readFile, writeFile, chmod, unlink, rmdir } from "fs/promises"
+import { readFile, writeFile, unlink, rm } from "fs/promises"
 import { dirname } from "path"
 
 describe("cli init command", () => {
-    const cliPath = `${dirname(dirname(dirname(__dirname)))}/src/cli.js`
+    let cliPath = `node ${dirname(dirname(dirname(__dirname)))}/src/cli.js`
+
     const databaseOptions = [
         "mysql",
         "mariadb",
@@ -20,10 +21,6 @@ describe("cli init command", () => {
     const builtSrcDirectory = "build/compiled/src"
 
     before(async () => {
-        const chmodCli = async () => {
-            await expect(chmod(cliPath, 0o755)).to.not.be.rejected
-        }
-
         const copyPackageJson = async () => {
             // load package.json from the root of the project
             const packageJson = JSON.parse(
@@ -38,7 +35,7 @@ describe("cli init command", () => {
             )
         }
 
-        await Promise.all([chmodCli(), copyPackageJson()])
+        await Promise.all([copyPackageJson()])
     })
 
     after(async () => {
@@ -46,7 +43,7 @@ describe("cli init command", () => {
     })
 
     afterEach(async () => {
-        await rmdir(`./${testProjectName}`, { recursive: true })
+        await rm(`./${testProjectName}`, { recursive: true })
     })
 
     for (const databaseOption of databaseOptions) {

--- a/test/github-issues/9230/issue-9230.ts
+++ b/test/github-issues/9230/issue-9230.ts
@@ -4,9 +4,17 @@ import { expect } from "chai"
 describe("github issues > #9230 Incorrect date parsing for year 1-999", () => {
     describe("mixedDateToDateString", () => {
         it("should format a year less than 1000 with correct 0 padding", () => {
-            expect(
-                DateUtils.mixedDateToDateString(new Date("0202-01-01")),
-            ).to.eq("0202-01-01")
+            // Set this date to 0202-01-01 at 01:00 local time. 01:00 may help to avoid
+            // rounding errors given that before 1883 we had some very weird timezone
+            // offsets like -5:50 for Chicago.
+            //
+            // e.g., if we are 1 millisecond before 01:00 due to rounding, it won't affect
+            // the year/month/day value.
+            const date = new Date("0202-01-01")
+            const timezoneHours = date.getTimezoneOffset() / 60
+            date.setHours(date.getHours() + timezoneHours + 1)
+
+            expect(DateUtils.mixedDateToDateString(date)).to.eq("0202-01-01")
         })
     })
 })


### PR DESCRIPTION
<!--
  😀 Wonderful!  Thank you for opening a pull request for TypeORM.

  Please fill in the information below to expedite the review
  and (hopefully) merge of your change.

  If unsure about something.. just do as best as you're able,
  or reach out through our community support channels!
  https://github.com/typeorm/typeorm/blob/master/docs/support.md
-->

### Description of change

While trying to build and test #11271, I ran into a handful of issues. This PR contains a list of commits to get the build process working on Windows, as well as some other fixes in the tests.

See the commit details for each one for additional info. Brief summary:

- **fix multi-database-basic-functionality**: This test was corrupting the `process.platform` setting for later tests. Also incorrect test logic. #11272
- **fix rimraf usage:** The current rimraf package has some breaking changes and requires an option to be specified to work with globs. Otherwise the build fails.
- **port number missing for issues test 4753**: This test was missing the port number in the configuration block, causing a fail if using nonstandard ports for mysql.
- **windows support for issue 8975 test**: This test was failing on Windows as it relied on a Unix shebang/executing JS scripts directly.
- **fix issue 9230 test for western timezones**: This test was not working if you have a western timezone (which would subtract 1 from the day).

Only one of these fixes has a corresponding issue opened.

Fixes #11272

### Pull-Request Checklist

<!--
  Please make sure to review and check all of the following.

  If an item is not applicable, you can add "N/A" to the end.
-->

- [x] Code is up-to-date with the `master` branch
- [x] `npm run format` to apply prettier formatting
- [x] `npm run test` passes with this change
- [x] This pull request links relevant issues as `Fixes #0000`
- [x] There are new or updated unit tests validating the change
- [x] Documentation has been updated to reflect this change N/A - no functionality changes
- [x] The new commits follow conventions explained in [CONTRIBUTING.md](https://github.com/typeorm/typeorm/blob/master/CONTRIBUTING.md)

<!--
  🎉 Thank you for contributing and making TypeORM even better!
-->
