### PR TITLE
docs: update repository additional chunk option usage example

### DIFF
--- a/docs/repository-api.md
+++ b/docs/repository-api.md
@@ -451,7 +451,6 @@ Optional `SaveOptions` can be passed as parameter for `save`.
 Example:
 
 ```typescript
-// users contains array of User Entities
 userRepository.save(users, { chunk: 1000 })
 ```
 

--- a/docs/repository-api.md
+++ b/docs/repository-api.md
@@ -465,7 +465,6 @@ Optional `RemoveOptions` can be passed as parameter for `remove` and `delete`.
 Example:
 
 ```typescript
-// users contains array of User Entities
 userRepository.remove(users, { chunk: 1000 })
 ```
 

--- a/docs/repository-api.md
+++ b/docs/repository-api.md
@@ -452,7 +452,7 @@ Example:
 
 ```typescript
 // users contains array of User Entities
-userRepository.save(users, { chunk: users.length / 1000 })
+userRepository.save(users, { chunk: 1000 })
 ```
 
 Optional `RemoveOptions` can be passed as parameter for `remove` and `delete`.
@@ -466,7 +466,7 @@ Example:
 
 ```typescript
 // users contains array of User Entities
-userRepository.remove(users, { chunk: entities.length / 1000 })
+userRepository.remove(users, { chunk: 1000 })
 ```
 
 ## `TreeRepository` API


### PR DESCRIPTION
### Description of change
This pull request adds on to discussion #5050 regarding https://github.com/typeorm/typeorm/issues/5050#issuecomment-2649287909

I've updated part of official documentation regarding the usage of `chunk` property in advanced options of repository. 
I strongly believe that current examples given in the official documentation gets blindly copied and lead to unexpected bugs due to inappropriate usage 

Instead of 
![image](https://github.com/user-attachments/assets/e2afd300-f5dc-4021-ba75-0581afa1bbb8)

There should be 
```
// users contains array of User Entities
userRepository.save(users, { chunk: 1000 })
```

### Pull-Request Checklist

- [x] Code is up-to-date with the `master` branch
- [x] `npm run format` to apply prettier formatting
- [x] `npm run test` passes with this change
- [x] This pull request links relevant issues as `Fixes #5050`
- [ ] There are new or updated unit tests validating the change
- [x] Documentation has been updated to reflect this change
- [x] The new commits follow conventions explained in [CONTRIBUTING.md](https://github.com/typeorm/typeorm/blob/master/CONTRIBUTING.md)
