### PR TITLE
fix: Make `shorten` method to properly work with camelCase_aliases

### DIFF
--- a/src/util/StringUtils.ts
+++ b/src/util/StringUtils.ts
@@ -92,6 +92,7 @@ export function shorten(input: string, options: IShortenOptions = {}): string {
         // split the given segment into many terms based on an eventual camel cased name
         const segmentTerms = val
             .replace(/([a-z\xE0-\xFF])([A-Z\xC0-\xDF])/g, "$1 $2")
+            .replace(/(_)([a-z])/g, " $2")
             .split(" ")
         // "OrderItemList" becomes "OrItLi", while "company" becomes "comp"
         const length = segmentTerms.length > 1 ? termLength : segmentLength

--- a/test/github-issues/9544/issue-9544.ts
+++ b/test/github-issues/9544/issue-9544.ts
@@ -1,0 +1,35 @@
+import { expect } from "chai";
+import { shorten } from "../../../src/util/StringUtils"
+
+describe("github issues > #9544 shorten long camel case alias correctly", () => {
+    const testCases = 
+    [
+        {
+            input: "SupplierStockInTransit__supplierStock__productVariant_customFields_tryonFrameAsset",
+            expected: "SuStInTr__suSt__prVacuFitrFrAs",
+        },
+        {
+            input: "SupplierStockInTransit__supplierStock__productVariant_customFields_visualFrameAsset",
+            expected: "SuStInTr__suSt__prVacuFiviFrAs",
+        },
+        {
+            input: "camelCase_alias",
+            expected: "caCaal",
+        }
+    ];
+    
+    testCases.map((testCase, i) => {
+        it(`should produce correct results for camel case aliases, case #${i+1}`, () => {
+            const {input, expected} = testCase;
+            expect(shorten(input)).to.equal(expected);
+        })
+    })
+
+    it("should produce unique results for different inputs", () => {
+        const uniqueInputs = new Set(testCases.map(x => x.input));
+        const uniqueExpects = new Set(testCases.map(x => x.expected));
+
+        expect(uniqueInputs.size).to.equal(testCases.length);
+        expect(uniqueExpects.size).to.equal(testCases.length);
+    })
+})


### PR DESCRIPTION
Fixes #9544

<!--
  😀 Wonderful!  Thank you for opening a pull request for TypeORM.

  Please fill in the information below to expedite the review
  and (hopefully) merge of your change.

  If unsure about something.. just do as best as you're able,
  or reach out through our community support channels!
  https://github.com/typeorm/typeorm/blob/master/docs/support.md
-->

### Description of change

<!--
  Please be clear and concise what the change is intended to do,
  why this change is needed, and how you've verified that it
  corrects what you intended.

  In some cases it may be helpful to include the current behavior
  and the new behavior.

  If the change is related to an open issue, you can link it here.
  If you include `Fixes #0000` (replacing `0000` with the issue number)
  when this is merged it will automatically mark the issue as fixed and
  close it.
-->


### Pull-Request Checklist

<!--
  Please make sure to review and check all of the following.

  If an item is not applicable, you can add "N/A" to the end.
-->

- [x] Code is up-to-date with the `master` branch
- [x] `npm run format` to apply prettier formatting
- [x] `npm run test` passes with this change
- [x] This pull request links relevant issues as `Fixes #0000`
- [x] There are new or updated unit tests validating the change
- [ ] Documentation has been updated to reflect this change
- [x] The new commits follow conventions explained in [CONTRIBUTING.md](https://github.com/typeorm/typeorm/blob/master/CONTRIBUTING.md)

<!--
  🎉 Thank you for contributing and making TypeORM even better!
-->
