### PR TITLE
fix: set undefined in place of null primary columns

### DIFF
--- a/src/persistence/Subject.ts
+++ b/src/persistence/Subject.ts
@@ -309,6 +309,17 @@ export class Subject {
     recompute(): void {
         if (this.entity) {
             this.entityWithFulfilledIds = Object.assign({}, this.entity)
+            
+            this.metadata.primaryColumns.forEach((primaryColumn) => {
+                if (primaryColumn.getEntityValue(this.entity!) === null) {
+                    // You can't have a null in a privary column, maybe user wants to insert the default value from DB
+                    primaryColumn.setEntityValue(
+                        this.entityWithFulfilledIds!,
+                        undefined,
+                    )
+                }
+            })
+
             if (this.parentSubject) {
                 this.metadata.primaryColumns.forEach((primaryColumn) => {
                     if (

--- a/src/query-builder/InsertQueryBuilder.ts
+++ b/src/query-builder/InsertQueryBuilder.ts
@@ -846,7 +846,9 @@ export class InsertQueryBuilder<
                         )
 
                         // if value for this column was not provided then insert default value
-                    } else if (value === undefined) {
+                    } else if (value === undefined
+                        || (value === null && column.isPrimary)
+                    ) {
                         if (
                             (this.connection.driver.options.type === "oracle" &&
                                 valueSets.length > 1) ||

--- a/test/github-issues/10487/entity/Post.ts
+++ b/test/github-issues/10487/entity/Post.ts
@@ -1,0 +1,25 @@
+import { BaseEntity, Column, Entity, ManyToOne, PrimaryGeneratedColumn } from "../../../../src";
+import { User } from "./User";
+
+@Entity()
+export class Post extends BaseEntity {
+    @PrimaryGeneratedColumn({
+        type: "int",
+    })
+    id: any
+
+    @Column({
+        type: "varchar",
+        length: 100,
+    })
+    title: string
+
+    @Column({
+        type: "varchar",
+        length: 100,
+    })
+    content: string
+
+    @ManyToOne(() => User, user => user.posts)
+    user: User;
+}

--- a/test/github-issues/10487/entity/User.ts
+++ b/test/github-issues/10487/entity/User.ts
@@ -1,0 +1,31 @@
+import { BaseEntity, Column, Entity, OneToMany, PrimaryGeneratedColumn } from "../../../../src";
+import { Post } from "./Post";
+
+@Entity()
+export class User extends BaseEntity {
+    @PrimaryGeneratedColumn()
+    id: number
+
+    @Column({
+        type: "varchar",
+        length: 100,
+    })
+    firstName: string
+
+    @Column({
+        type: "varchar",
+        length: 100,
+    })
+    lastName: string
+
+    @Column({
+        type: "int",
+    })
+    age: number
+
+    @OneToMany(() => Post, post => post.user, {
+        cascade: true,
+        eager: true
+    })
+    posts: Post[];
+}

--- a/test/github-issues/10487/issue-10487.ts
+++ b/test/github-issues/10487/issue-10487.ts
@@ -1,0 +1,55 @@
+import "reflect-metadata"
+import {
+    createTestingConnections,
+    closeTestingConnections,
+    reloadTestingDatabases,
+} from "../../utils/test-utils"
+import { DataSource } from "../../../src/data-source/DataSource"
+import { expect } from "chai"
+import { User } from "./entity/User"
+import { Post } from "./entity/Post"
+
+describe.only("github issues > #10487 null in place of primary column", () => {
+    let dataSources: DataSource[]
+
+    before(
+        async () =>
+            (dataSources = await createTestingConnections({
+                entities: [User, Post],
+            })),
+    )
+
+    beforeEach(() => reloadTestingDatabases(dataSources))
+    after(() => closeTestingConnections(dataSources))
+
+    it("should set undefined in place of null primary columns", () =>
+        Promise.all(
+            dataSources.map(async (dataSource) => {
+                await dataSource.getRepository(User).save({
+                    firstName: "Timber",
+                    lastName: "Saw",
+                    age: 25,
+                    posts: [{
+                        id: null,
+                        title: "First post",
+                        content: "Timber is a cat"
+                    }, {
+                        id: null,
+                        title: "Second Post",
+                        content: "Timber is a cat"
+                    }, {
+                        id: null,
+                        title: "Third Post",
+                        content: "Timber is a cat"
+                    }]
+                });
+
+                const users = await dataSource.getRepository(User).find({
+                    relations: ["posts"]
+                });
+
+                expect(users).to.have.length(1)
+                expect(users[0].posts).to.have.length(3)
+            }),
+        ))
+})

--- a/test/github-issues/10487/issue-10487.ts
+++ b/test/github-issues/10487/issue-10487.ts
@@ -9,7 +9,7 @@ import { expect } from "chai"
 import { User } from "./entity/User"
 import { Post } from "./entity/Post"
 
-describe.only("github issues > #10487 null in place of primary column", () => {
+describe("github issues > #10487 null in place of primary column", () => {
     let dataSources: DataSource[]
 
     before(


### PR DESCRIPTION
Fixes #10487

<!--
  😀 Wonderful!  Thank you for opening a pull request for TypeORM.

  Please fill in the information below to expedite the review
  and (hopefully) merge of your change.

  If unsure about something.. just do as best as you're able,
  or reach out through our community support channels!
  https://github.com/typeorm/typeorm/blob/master/docs/support.md
-->

### Description of change

Added a place where primary columns will turn into undefined if user passes null to them. We should consider the use case if this is actually appliable.

<!--
  Please be clear and concise what the change is intended to do,
  why this change is needed, and how you've verified that it
  corrects what you intended.

  In some cases it may be helpful to include the current behavior
  and the new behavior.

  If the change is related to an open issue, you can link it here.
  If you include `Fixes #0000` (replacing `0000` with the issue number)
  when this is merged it will automatically mark the issue as fixed and
  close it.
-->


### Pull-Request Checklist

<!--
  Please make sure to review and check all of the following.

  If an item is not applicable, you can add "N/A" to the end.
-->

- [x] Code is up-to-date with the `master` branch
- [x] `npm run format` to apply prettier formatting
- [x] `npm run test` passes with this change
- [x] This pull request links relevant issues as `Fixes #0000`
- [x] There are new or updated unit tests validating the change
- [ ] Documentation has been updated to reflect this change
- [x] The new commits follow conventions explained in [CONTRIBUTING.md](https://github.com/typeorm/typeorm/blob/master/CONTRIBUTING.md)

<!--
  🎉 Thank you for contributing and making TypeORM even better!
-->
