### PR TITLE
fix(postgres): handle arrays in default values a bit more properly

### DIFF
--- a/src/driver/postgres/PostgresDriver.ts
+++ b/src/driver/postgres/PostgresDriver.ts
@@ -1097,7 +1097,7 @@ export class PostgresDriver implements Driver {
                     "array[]::".length,
                     oldColumnDefault.length - "[]".length,
                 )
-                // Postgres changes stored array of type "ARRAY::varchar[]" to "ARRAY::character varying[]", so here's the comparison
+                // Postgres changes stored array's default value "ARRAY::varchar[]" to "ARRAY::character varying[]", so here's the comparison
                 if (
                     oldColumnDefaultBaseType === "character varying" &&
                     columnDefaultBaseType === "varchar"

--- a/src/driver/postgres/PostgresDriver.ts
+++ b/src/driver/postgres/PostgresDriver.ts
@@ -1078,17 +1078,31 @@ export class PostgresDriver implements Driver {
 
         const columnDefault = this.lowerDefaultValueIfNecessary(
             this.normalizeDefault(columnMetadata),
-        );
-        const oldColumnDefault = this.lowerDefaultValueIfNecessary(tableColumn.default)
+        )
+        const oldColumnDefault = this.lowerDefaultValueIfNecessary(
+            tableColumn.default,
+        )
         if (columnMetadata.isArray && columnDefault && oldColumnDefault) {
-            if (columnDefault.startsWith("array[]::") 
-                && columnDefault.endsWith("[]") 
-                && oldColumnDefault.startsWith("array[]::")
-                && oldColumnDefault.endsWith("[]"))
-            {
-                const columnDefaultBaseType = columnDefault.substring("array[]::".length, columnDefault.length - "[]".length);
-                const oldColumnDefaultBaseType = oldColumnDefault.substring("array[]::".length, oldColumnDefault.length - "[]".length);
-                if (oldColumnDefaultBaseType === "character varying" && columnDefaultBaseType === "varchar") return true;
+            if (
+                columnDefault.startsWith("array[]::") &&
+                columnDefault.endsWith("[]") &&
+                oldColumnDefault.startsWith("array[]::") &&
+                oldColumnDefault.endsWith("[]")
+            ) {
+                const columnDefaultBaseType = columnDefault.substring(
+                    "array[]::".length,
+                    columnDefault.length - "[]".length,
+                )
+                const oldColumnDefaultBaseType = oldColumnDefault.substring(
+                    "array[]::".length,
+                    oldColumnDefault.length - "[]".length,
+                )
+                // Postgres changes stored array of type "ARRAY::varchar[]" to "ARRAY::character varying[]", so here's the comparison
+                if (
+                    oldColumnDefaultBaseType === "character varying" &&
+                    columnDefaultBaseType === "varchar"
+                )
+                    return true
             }
         }
         return columnDefault === tableColumn.default

--- a/src/driver/postgres/PostgresDriver.ts
+++ b/src/driver/postgres/PostgresDriver.ts
@@ -1078,7 +1078,19 @@ export class PostgresDriver implements Driver {
 
         const columnDefault = this.lowerDefaultValueIfNecessary(
             this.normalizeDefault(columnMetadata),
-        )
+        );
+        const oldColumnDefault = this.lowerDefaultValueIfNecessary(tableColumn.default)
+        if (columnMetadata.isArray && columnDefault && oldColumnDefault) {
+            if (columnDefault.startsWith("array[]::") 
+                && columnDefault.endsWith("[]") 
+                && oldColumnDefault.startsWith("array[]::")
+                && oldColumnDefault.endsWith("[]"))
+            {
+                const columnDefaultBaseType = columnDefault.substring("array[]::".length, columnDefault.length - "[]".length);
+                const oldColumnDefaultBaseType = oldColumnDefault.substring("array[]::".length, oldColumnDefault.length - "[]".length);
+                if (oldColumnDefaultBaseType === "character varying" && columnDefaultBaseType === "varchar") return true;
+            }
+        }
         return columnDefault === tableColumn.default
     }
 

--- a/src/driver/postgres/PostgresQueryRunner.ts
+++ b/src/driver/postgres/PostgresQueryRunner.ts
@@ -3784,6 +3784,10 @@ export class PostgresQueryRunner
                                 ) {
                                     tableColumn.default =
                                         dbColumn["column_default"]
+                                } else if (dbColumn["column_default"].startsWith("ARRAY[]::")) {
+                                    // Leave arrays as is???
+                                    tableColumn.default =
+                                        dbColumn["column_default"];
                                 } else {
                                     tableColumn.default = dbColumn[
                                         "column_default"

--- a/src/driver/postgres/PostgresQueryRunner.ts
+++ b/src/driver/postgres/PostgresQueryRunner.ts
@@ -3784,10 +3784,14 @@ export class PostgresQueryRunner
                                 ) {
                                     tableColumn.default =
                                         dbColumn["column_default"]
-                                } else if (dbColumn["column_default"].startsWith("ARRAY[]::")) {
+                                } else if (
+                                    dbColumn["column_default"].startsWith(
+                                        "ARRAY[]::",
+                                    )
+                                ) {
                                     // Leave arrays as is???
                                     tableColumn.default =
-                                        dbColumn["column_default"];
+                                        dbColumn["column_default"]
                                 } else {
                                     tableColumn.default = dbColumn[
                                         "column_default"


### PR DESCRIPTION
Fixes #10375

<!--
  😀 Wonderful!  Thank you for opening a pull request for TypeORM.

  Please fill in the information below to expedite the review
  and (hopefully) merge of your change.

  If unsure about something.. just do as best as you're able,
  or reach out through our community support channels!
  https://github.com/typeorm/typeorm/blob/master/docs/support.md
-->

### Description of change

For Postgres it handles arrays in default value a bit more properly. Needs a complex testing.

<!--
  Please be clear and concise what the change is intended to do,
  why this change is needed, and how you've verified that it
  corrects what you intended.

  In some cases it may be helpful to include the current behavior
  and the new behavior.

  If the change is related to an open issue, you can link it here.
  If you include `Fixes #0000` (replacing `0000` with the issue number)
  when this is merged it will automatically mark the issue as fixed and
  close it.
-->


### Pull-Request Checklist

<!--
  Please make sure to review and check all of the following.

  If an item is not applicable, you can add "N/A" to the end.
-->

- [x] Code is up-to-date with the `master` branch
- [x] `npm run format` to apply prettier formatting
- [x] `npm run test` passes with this change
- [x] This pull request links relevant issues as `Fixes #0000`
- [ ] There are new or updated unit tests validating the change
- [ ] Documentation has been updated to reflect this change
- [ ] The new commits follow conventions explained in [CONTRIBUTING.md](https://github.com/typeorm/typeorm/blob/master/CONTRIBUTING.md)

<!--
  🎉 Thank you for contributing and making TypeORM even better!
-->
