### PR TITLE
fix: ensure correct MSSQL parameter conversion in where conditions

### DIFF
--- a/src/query-builder/SelectQueryBuilder.ts
+++ b/src/query-builder/SelectQueryBuilder.ts
@@ -45,6 +45,7 @@ import { AuroraMysqlDriver } from "../driver/aurora-mysql/AuroraMysqlDriver"
 import { InstanceChecker } from "../util/InstanceChecker"
 import { FindOperator } from "../find-options/FindOperator"
 import { ApplyValueTransformers } from "../util/ApplyValueTransformers"
+import { SqlServerDriver } from "../driver/sqlserver/SqlServerDriver"
 
 /**
  * Allows to build complex sql queries in a fashion way and execute those queries.
@@ -4270,6 +4271,7 @@ export class SelectQueryBuilder<Entity extends ObjectLiteral>
                     if (InstanceChecker.isEqualOperator(where[key])) {
                         parameterValue = where[key].value
                     }
+
                     if (column.transformer) {
                         parameterValue instanceof FindOperator
                             ? parameterValue.transformValue(column.transformer)
@@ -4278,6 +4280,25 @@ export class SelectQueryBuilder<Entity extends ObjectLiteral>
                                       column.transformer,
                                       parameterValue,
                                   ))
+                    }
+
+                    // MSSQL requires parameters to carry extra type information
+                    if (this.connection.driver.options.type === "mssql") {
+                        const driver = this.connection.driver as SqlServerDriver
+                        if (parameterValue instanceof FindOperator) {
+                            if (parameterValue.type !== "raw") {
+                                parameterValue.transformValue({
+                                    to: (v) =>
+                                        driver.parametrizeValue(column, v),
+                                    from: (v) => v,
+                                })
+                            }
+                        } else {
+                            parameterValue = driver.parametrizeValue(
+                                column,
+                                parameterValue,
+                            )
+                        }
                     }
 
                     // if (parameterValue === null) {

--- a/test/github-issues/11285/entity/user.ts
+++ b/test/github-issues/11285/entity/user.ts
@@ -1,0 +1,13 @@
+import { Column, Entity, Index, PrimaryGeneratedColumn } from "../../../../src"
+
+@Entity({
+    name: "user",
+})
+export class User {
+    @PrimaryGeneratedColumn()
+    id: number
+
+    @Index()
+    @Column({ type: "varchar", nullable: true })
+    memberId: string
+}

--- a/test/github-issues/11285/issue-11285.ts
+++ b/test/github-issues/11285/issue-11285.ts
@@ -1,0 +1,197 @@
+import "reflect-metadata"
+import { expect } from "chai"
+import sinon from "sinon"
+
+import {
+    createTestingConnections,
+    closeTestingConnections,
+    reloadTestingDatabases,
+} from "../../utils/test-utils"
+import { DataSource, MssqlParameter, Not, Raw } from "../../../src/index.js"
+import { SqlServerQueryRunner } from "../../../src/driver/sqlserver/SqlServerQueryRunner"
+import { User } from "./entity/user"
+import { PostgresQueryRunner } from "../../../src/driver/postgres/PostgresQueryRunner"
+
+describe("github issues > #11285 Missing MSSQL input type", () => {
+    describe("mssql connection", () => {
+        let dataSources: DataSource[]
+        before(
+            async () =>
+                (dataSources = await createTestingConnections({
+                    entities: [User],
+                    enabledDrivers: ["mssql"],
+                    schemaCreate: true,
+                    dropSchema: true,
+                })),
+        )
+
+        beforeEach(() => reloadTestingDatabases(dataSources))
+        after(() => closeTestingConnections(dataSources))
+        afterEach(() => sinon.restore())
+
+        it("should convert input parameter to MssqlParameter", () =>
+            Promise.all(
+                dataSources.map(async (dataSource) => {
+                    const user = new User()
+                    user.memberId = "test-member-id"
+
+                    await dataSource.manager.save([user])
+
+                    const selectSpy = sinon.spy(
+                        SqlServerQueryRunner.prototype,
+                        "query",
+                    )
+
+                    const users = await dataSource.getRepository(User).find({
+                        where: {
+                            memberId: user.memberId,
+                        },
+                    })
+
+                    expect(users).to.have.length(1)
+                    expect(users[0].memberId).to.be.equal(user.memberId)
+                    expect(selectSpy.calledOnce).to.be.true
+
+                    sinon.assert.calledWithMatch(
+                        selectSpy,
+                        sinon.match.any,
+                        sinon.match((value) => {
+                            return (
+                                Array.isArray(value) &&
+                                value.length === 1 &&
+                                value[0] instanceof MssqlParameter &&
+                                value[0].value === user.memberId &&
+                                value[0].type === "varchar"
+                            )
+                        }),
+                    )
+                }),
+            ))
+
+        it("should convert input parameter with FindOperator to MssqlParameter", () =>
+            Promise.all(
+                dataSources.map(async (dataSource) => {
+                    const user = new User()
+                    user.memberId = "test-member-id"
+
+                    const user2 = new User()
+                    user2.memberId = "test-member-id-2"
+
+                    await dataSource.manager.save([user, user2])
+
+                    const selectSpy = sinon.spy(
+                        SqlServerQueryRunner.prototype,
+                        "query",
+                    )
+
+                    const users = await dataSource.getRepository(User).find({
+                        where: {
+                            memberId: Not(user2.memberId),
+                        },
+                    })
+
+                    expect(users).to.have.length(1)
+                    expect(users[0].memberId).to.be.equal(user.memberId)
+
+                    expect(selectSpy.calledOnce).to.be.true
+
+                    sinon.assert.calledWithMatch(
+                        selectSpy,
+                        sinon.match.any,
+                        sinon.match((value) => {
+                            return (
+                                Array.isArray(value) &&
+                                value.length === 1 &&
+                                value[0] instanceof MssqlParameter &&
+                                value[0].value === user2.memberId &&
+                                value[0].type === "varchar"
+                            )
+                        }),
+                    )
+                }),
+            ))
+
+        it("should not convert input parameter with raw FindOperator", () =>
+            Promise.all(
+                dataSources.map(async (dataSource) => {
+                    const user = new User()
+                    user.memberId = "test-member-id"
+
+                    await dataSource.manager.save([user])
+
+                    const selectSpy = sinon.spy(
+                        SqlServerQueryRunner.prototype,
+                        "query",
+                    )
+
+                    const users = await dataSource.getRepository(User).find({
+                        where: {
+                            memberId: Raw(`'${user.memberId}'`),
+                        },
+                    })
+
+                    expect(users).to.have.length(1)
+                    expect(users[0].memberId).to.be.equal(user.memberId)
+                    expect(selectSpy.calledOnce).to.be.true
+
+                    sinon.assert.calledWithMatch(
+                        selectSpy,
+                        sinon.match.any,
+                        sinon.match((value) => {
+                            return Array.isArray(value) && value.length === 0
+                        }),
+                    )
+                }),
+            ))
+    })
+
+    describe("other connections", () => {
+        let dataSources: DataSource[]
+        before(
+            async () =>
+                (dataSources = await createTestingConnections({
+                    entities: [User],
+                    enabledDrivers: ["postgres"],
+                    schemaCreate: true,
+                    dropSchema: true,
+                })),
+        )
+
+        beforeEach(() => reloadTestingDatabases(dataSources))
+        after(() => closeTestingConnections(dataSources))
+        afterEach(() => sinon.restore())
+
+        it("should used the input parameter as it is", () =>
+            Promise.all(
+                dataSources.map(async (dataSource) => {
+                    const user = new User()
+                    user.memberId = "test-member-id"
+
+                    await dataSource.manager.save([user])
+
+                    const selectSpy = sinon.spy(
+                        PostgresQueryRunner.prototype,
+                        "query",
+                    )
+
+                    const users = await dataSource.getRepository(User).find({
+                        where: {
+                            memberId: user.memberId,
+                        },
+                    })
+
+                    expect(users).to.have.length(1)
+                    expect(users[0].memberId).to.be.equal(user.memberId)
+                    expect(selectSpy.calledOnce).to.be.true
+
+                    sinon.assert.calledWithMatch(
+                        selectSpy,
+                        sinon.match.any,
+                        sinon.match((value) => {
+                            return value[0] === user.memberId
+                        }),
+                    )
+                }),
+            ))
+    })
+})


### PR DESCRIPTION
Fixes input parameter conversion in SelectQueryBuilder when using an MSSQL connection.

Closes #11285

### Description of change

Instead of passing raw input paramters as it is this change uses the available driver.parametrizeValue method to convert parameters into MSSQL format. 

This implementation was referred from existing usage in [UpdateQueryBuilder](https://github.com/typeorm/typeorm/blob/master/src/query-builder/UpdateQueryBuilder.ts#L553) and [InsertQueryBuilder](https://github.com/typeorm/typeorm/blob/master/src/query-builder/InsertQueryBuilder.ts#L887)

Please note that this issue currently only fixes where condition when used under `.find` method. On testing it was not working for `.createQueryBuilder(..).where()` usage. Could use some insights on a proper approach to implement this parameter transformation.

### Pull-Request Checklist
- [x] Code is up-to-date with the `master` branch
- [x] `npm run format` to apply prettier formatting
- [x] `npm run test` passes with this change
- [x] This pull request links relevant issues as `Fixes #11285`
- [x] There are new or updated unit tests validating the change
- [x] Documentation has been updated to reflect this change (N/A)
- [x] The new commits follow conventions explained in [CONTRIBUTING.md](https://github.com/typeorm/typeorm/blob/master/CONTRIBUTING.md)
