### PR TITLE
docs: correct "it's" -> "its"

### DIFF
--- a/docs/custom-repository.md
+++ b/docs/custom-repository.md
@@ -55,7 +55,7 @@ export class UserController {
 Transactions have their own scope of execution: they have their own query runner, entity manager and repository instances.
 That's why using global (data source's) entity manager and repositories won't work in transactions.
 In order to execute queries properly in scope of transaction you **must** use provided entity manager
-and it's `getRepository` method. In order to use custom repositories within transaction,
+and its `getRepository` method. In order to use custom repositories within transaction,
 you must use `withRepository` method of the provided entity manager instance:
 
 ```typescript

--- a/docs/view-entities.md
+++ b/docs/view-entities.md
@@ -16,7 +16,7 @@ You can create a view entity by defining a new class and mark it with `@ViewEnti
 -   `database` - database name in selected DB server.
 -   `schema` - schema name.
 -   `expression` - view definition. **Required parameter**.
--   `dependsOn` - List of other views on which the current views depends. If your view uses another view in it's definition, you can add it here so that migrations are generated in the correct order.
+-   `dependsOn` - List of other views on which the current views depends. If your view uses another view in its definition, you can add it here so that migrations are generated in the correct order.
 
 `expression` can be string with properly escaped columns and tables, depend on database used (postgres in example):
 


### PR DESCRIPTION
"It's" is a contraction for "it is". "its" is the possessive form of "it".

<!--
  😀 Wonderful!  Thank you for opening a pull request for TypeORM.

  Please fill in the information below to expedite the review
  and (hopefully) merge of your change.

  If unsure about something.. just do as best as you're able,
  or reach out through our community support channels!
  https://github.com/typeorm/typeorm/blob/master/docs/support.md
-->

### Description of change

<!--
  Please be clear and concise what the change is intended to do,
  why this change is needed, and how you've verified that it
  corrects what you intended.

  In some cases it may be helpful to include the current behavior
  and the new behavior.

  If the change is related to an open issue, you can link it here.
  If you include `Fixes #0000` (replacing `0000` with the issue number)
  when this is merged it will automatically mark the issue as fixed and
  close it.
-->


### Pull-Request Checklist

<!--
  Please make sure to review and check all of the following.

  If an item is not applicable, you can add "N/A" to the end.
-->

- [x] Code is up-to-date with the `master` branch
- [ ] `npm run format` to apply prettier formatting (n/a)
- [ ] `npm run test` passes with this change (n/a)
- [ ] This pull request links relevant issues as `Fixes #0000` (n/a)
- [ ] There are new or updated unit tests validating the change (n/a)
- [x] Documentation has been updated to reflect this change
- [x] The new commits follow conventions explained in [CONTRIBUTING.md](https://github.com/typeorm/typeorm/blob/master/CONTRIBUTING.md)

<!--
  🎉 Thank you for contributing and making TypeORM even better!
-->
