### PR TITLE
docs(entity-subscribers): document primary key availability in UpdateEvent

### DIFF
--- a/docs/listeners-and-subscribers.md
+++ b/docs/listeners-and-subscribers.md
@@ -396,7 +396,7 @@ Excluding `listenTo`, all `EntitySubscriberInterface` methods are passed an even
 
 See each [Event's interface](https://github.com/typeorm/typeorm/tree/master/src/subscriber/event) for additional properties.
 
-Note that `event.entity` may not necessarily contain primary key(s) when `.update` is used. Only the values provided as the entity partial will be available. In order to make primary keys available in the subscribers, you can explicitly pass primary key value(s) in the partial entity object literal or use `.save()`, which performs re-fetching.
+Note that `event.entity` may not necessarily contain primary key(s) when `Repository.update()` is used. Only the values provided as the entity partial will be available. In order to make primary keys available in the subscribers, you can explicitly pass primary key value(s) in the partial entity object literal or use `Repository.save()`, which performs re-fetching.
 
 ```typescript
 await postRepository.update(post.id, { description: "Bacon ipsum dolor amet cow" })

--- a/docs/listeners-and-subscribers.md
+++ b/docs/listeners-and-subscribers.md
@@ -396,4 +396,15 @@ Excluding `listenTo`, all `EntitySubscriberInterface` methods are passed an even
 
 See each [Event's interface](https://github.com/typeorm/typeorm/tree/master/src/subscriber/event) for additional properties.
 
+Note that `event.entity` may not necessarily contain primary key(s) when `.update` is used. Only the values provided as the entity partial will be available. In order to make primary keys available in the subscribers, you can explicitly pass primary key value(s) in the partial entity object literal or use `.save()`, which performs re-fetching.
+
+```typescript
+await postRepository.update(post.id, { description: "Bacon ipsum dolor amet cow" })
+
+// post.subscriber.ts
+afterUpdate(event: UpdateEvent<Post>) {
+  console.log(event.entity) // outputs { description: 'Bacon ipsum dolor amet cow' }
+}
+```
+
 **Note:** All database operations in the subscribed event listeners should be performed using the event object's `queryRunner` or `manager` instance.

--- a/src/subscriber/event/UpdateEvent.ts
+++ b/src/subscriber/event/UpdateEvent.ts
@@ -29,6 +29,8 @@ export interface UpdateEvent<Entity> {
 
     /**
      * Updating entity.
+     *
+     * Contains the same data that was passed to the updating method, be it the instance of an entity or the partial entity.
      */
     entity: ObjectLiteral | undefined
 
@@ -39,6 +41,8 @@ export interface UpdateEvent<Entity> {
 
     /**
      * Updating entity in the database.
+     *
+     * Is set only when one of the following methods are used: .save(), .remove(), .softRemove(), and .recover()
      */
     databaseEntity: Entity
 


### PR DESCRIPTION
<!--
  😀 Wonderful!  Thank you for opening a pull request for TypeORM.

  Please fill in the information below to expedite the review
  and (hopefully) merge of your change.

  If unsure about something.. just do as best as you're able,
  or reach out through our community support channels!
  https://github.com/typeorm/typeorm/blob/master/docs/support.md
-->

### Description of change

<!--
  Please be clear and concise what the change is intended to do,
  why this change is needed, and how you've verified that it
  corrects what you intended.

  In some cases it may be helpful to include the current behavior
  and the new behavior.

  If the change is related to an open issue, you can link it here.
  If you include `Fixes #0000` (replacing `0000` with the issue number)
  when this is merged it will automatically mark the issue as fixed and
  close it.
-->
Documents the availability of the primary keys in the entity subscribers when update operations are performed. The issue is explained [in this repo](https://github.com/jovanadjuric/typeorm-onupdate-subscriber-issue).


 - [Discord discussion](https://discord.com/channels/1124626013360488529/1298590310447841300/1341594239120838757)

### Pull-Request Checklist

<!--
  Please make sure to review and check all of the following.

  If an item is not applicable, you can add "N/A" to the end.
-->

- [x] Code is up-to-date with the `master` branch
- [x] `npm run format` to apply prettier formatting
- [ ] `npm run test` passes with this change - N/A
- [ ] This pull request links relevant issues as `Fixes #0000` - N/A
- [ ] There are new or updated unit tests validating the change - N/A
- [ ] Documentation has been updated to reflect this change - N/A
- [x] The new commits follow conventions explained in [CONTRIBUTING.md](https://github.com/typeorm/typeorm/blob/master/CONTRIBUTING.md)

<!--
  🎉 Thank you for contributing and making TypeORM even better!
-->
