### PR TITLE
chore: don't use version in docker-compose files

### DIFF
--- a/.github/workflows/test/oracle.docker-compose
+++ b/.github/workflows/test/oracle.docker-compose
@@ -1,4 +1,3 @@
-version: "3"
 services:
   oracle:
     build:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,3 @@
-version: "3"
 services:
   # mysql
   mysql:
@@ -64,9 +63,9 @@ services:
     ports:
       - "1521:1521"
     #volumes:
-     # - oracle-data:/opt/oracle/oradata
+    # - oracle-data:/opt/oracle/oradata
     healthcheck:
-      test: [ "CMD", "/opt/oracle/checkDBStatus.sh" ]
+      test: ["CMD", "/opt/oracle/checkDBStatus.sh"]
       interval: 2s
 
   # google cloud spanner
@@ -117,7 +116,6 @@ services:
   #   container_name: "typeorm-redis"
   #   ports:
   #     - "6379:6379"
-
 #volumes:
 #  volume-hana-xe:
 #  mysql8_volume:

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "typeorm",
-  "version": "0.3.20",
+  "version": "0.3.21",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "typeorm",
-      "version": "0.3.20",
+      "version": "0.3.21",
       "license": "MIT",
       "dependencies": {
         "@sqltools/formatter": "^1.2.5",

--- a/src/commands/InitCommand.ts
+++ b/src/commands/InitCommand.ts
@@ -548,8 +548,7 @@ AppDataSource.initialize().then(async () => {
     protected static getDockerComposeTemplate(database: string): string {
         switch (database) {
             case "mysql":
-                return `version: '3'
-services:
+                return `services:
 
   mysql:
     image: "mysql:8.0.30"
@@ -563,8 +562,7 @@ services:
 
 `
             case "mariadb":
-                return `version: '3'
-services:
+                return `services:
 
   mariadb:
     image: "mariadb:10.8.4"
@@ -578,8 +576,7 @@ services:
 
 `
             case "postgres":
-                return `version: '3'
-services:
+                return `services:
 
   postgres:
     image: "postgres:14.5"
@@ -592,8 +589,7 @@ services:
 
 `
             case "cockroachdb":
-                return `version: '3'
-services:
+                return `services:
 
   cockroachdb:
     image: "cockroachdb/cockroach:v22.1.6"
@@ -604,8 +600,7 @@ services:
 `
             case "sqlite":
             case "better-sqlite3":
-                return `version: '3'
-services:
+                return `services:
 `
             case "oracle":
                 throw new TypeORMError(
@@ -613,8 +608,7 @@ services:
                 ) // todo: implement for oracle as well
 
             case "mssql":
-                return `version: '3'
-services:
+                return `services:
 
   mssql:
     image: "microsoft/mssql-server-linux:rc2"
@@ -626,8 +620,7 @@ services:
 
 `
             case "mongodb":
-                return `version: '3'
-services:
+                return `services:
 
   mongodb:
     image: "mongo:5.0.12"
@@ -637,8 +630,7 @@ services:
 
 `
             case "spanner":
-                return `version: '3'
-services:
+                return `services:
 
   spanner:
     image: gcr.io/cloud-spanner-emulator/emulator:1.4.1


### PR DESCRIPTION

### Description of change

Fixes #11319

when creating a new project with `npx typeorm init ... --docker` as instructed in the [docs](https://github.com/typeorm/typeorm?tab=readme-ov-file#quick-start) it will create a `docker-compose.yml` file with `version: '3'`, which when running 
```shell
docker compose up -d
```
will emit the following warning: 
```shell
WARN[0000] /<redacted path>/docker-compose.yml: the attribute `version` is obsolete, it will be ignored, please remove it to avoid potential confusion 
```

This change will remove these lines from the template and will not emit this warning.
### Pull-Request Checklist

<!--
  Please make sure to review and check all of the following.

  If an item is not applicable, you can add "N/A" to the end.
-->

- [x] Code is up-to-date with the `master` branch
- [ ] `npm run format` to apply prettier formatting - **NOPE - this causes many unrelated changes!"
- [x] `npm run test` passes with this change
- [x] This pull request links relevant issues as `Fixes #0000`
- [ ] There are new or updated unit tests validating the change - not relevant
- [ ] Documentation has been updated to reflect this change
- [x] The new commits follow conventions explained in [CONTRIBUTING.md](https://github.com/typeorm/typeorm/blob/master/CONTRIBUTING.md)

<!--
  🎉 Thank you for contributing and making TypeORM even better!
-->
