### PR TITLE
fix(sap): pass the configured schema to the db client

### DIFF
--- a/src/driver/sap/SapDriver.ts
+++ b/src/driver/sap/SapDriver.ts
@@ -254,6 +254,7 @@ export class SapDriver implements Driver {
         }
 
         if (this.options.database) dbParams.databaseName = this.options.database
+        if (this.options.schema) dbParams.currentSchema = this.options.schema
         if (this.options.encrypt) dbParams.encrypt = this.options.encrypt
         if (this.options.sslValidateCertificate)
             dbParams.validateCertificate = this.options.sslValidateCertificate


### PR DESCRIPTION
### Description of change

Passes the schema configured in TypeORM DataSource options to the client library, similar to other drivers.

Fixes #10622 properly.

Allows us to find a solution for #10099 as well.

### Pull-Request Checklist

<!--
  Please make sure to review and check all of the following.

  If an item is not applicable, you can add "N/A" to the end.
-->

- [X] Code is up-to-date with the `master` branch
- [X] `npm run format` to apply prettier formatting
- [X] `npm run test` passes with this change
- [X] This pull request links relevant issues as `Fixes #10622`
- [ ] There are new or updated unit tests validating the change
- [ ] Documentation has been updated to reflect this change
- [X] The new commits follow conventions explained in [CONTRIBUTING.md](https://github.com/typeorm/typeorm/blob/master/CONTRIBUTING.md)

<!--
  🎉 Thank you for contributing and making TypeORM even better!
-->
