### PR TITLE
fix(sap): incorrect handling of simple array/json data type

### DIFF
--- a/src/driver/sap/SapDriver.ts
+++ b/src/driver/sap/SapDriver.ts
@@ -99,17 +99,18 @@ export class SapDriver implements Driver {
     /**
      * Gets list of supported column data types by a driver.
      *
-     * @see https://help.sap.com/viewer/4fe29514fd584807ac9f2a04f6754767/2.0.03/en-US/20a1569875191014b507cf392724b7eb.html
+     * @see https://help.sap.com/docs/SAP_HANA_PLATFORM/4fe29514fd584807ac9f2a04f6754767/20a1569875191014b507cf392724b7eb.html
+     * @see https://help.sap.com/docs/hana-cloud-database/sap-hana-cloud-sap-hana-database-sql-reference-guide/data-types
      */
     supportedDataTypes: ColumnType[] = [
         "tinyint",
         "smallint",
-        "int",
+        "int", // alias for "integer"
         "integer",
         "bigint",
         "smalldecimal",
         "decimal",
-        "dec",
+        "dec", // alias for "decimal"
         "real",
         "double",
         "float",
@@ -118,17 +119,17 @@ export class SapDriver implements Driver {
         "seconddate",
         "timestamp",
         "boolean",
-        "char",
-        "nchar",
-        "varchar",
+        "char", // not officially supported
+        "nchar", // not officially supported
+        "varchar", // deprecated
         "nvarchar",
-        "text",
-        "alphanum",
-        "shorttext",
+        "text", // deprecated
+        "alphanum", // deprecated
+        "shorttext", // deprecated
         "array",
         "varbinary",
         "blob",
-        "clob",
+        "clob", // deprecated
         "nclob",
         "st_geometry",
         "st_point",
@@ -564,6 +565,8 @@ export class SapDriver implements Driver {
     }): string {
         if (column.type === Number || column.type === "int") {
             return "integer"
+        } else if (column.type === "dec") {
+            return "decimal"
         } else if (column.type === String) {
             return "nvarchar"
         } else if (column.type === Date) {
@@ -578,7 +581,7 @@ export class SapDriver implements Driver {
             column.type === "simple-array" ||
             column.type === "simple-json"
         ) {
-            return "text"
+            return "nclob"
         } else if (column.type === "simple-enum") {
             return "nvarchar"
         } else {

--- a/test/functional/database-schema/column-types/sap/column-types-sap.ts
+++ b/test/functional/database-schema/column-types/sap/column-types-sap.ts
@@ -24,6 +24,7 @@ describe("database schema > column types > sap", () => {
     it("all types should work correctly - persist and hydrate", () =>
         Promise.all(
             connections.map(async (connection) => {
+                // this test contains data types that are available only in SAP HANA 2.0 and that have been removed in SAP HANA Cloud
                 const postRepository = connection.getRepository(Post)
                 const queryRunner = connection.createQueryRunner()
                 const table = await queryRunner.getTable("post")
@@ -179,7 +180,7 @@ describe("database schema > column types > sap", () => {
                     .type.should.be.equal("varbinary")
                 table!
                     .findColumnByName("simpleArray")!
-                    .type.should.be.equal("text")
+                    .type.should.be.equal("nclob")
             }),
         ))
 


### PR DESCRIPTION
### Description of change

Columns defined as `simple-array` or `simple-json` should now be stored as `NCLOB` instead of `TEXT` (which used to be an alias of `NCLOB`). The `TEXT` data type has been removed from newer SAP HANA versions.

Fixes #6985.

### Pull-Request Checklist

- [X] Code is up-to-date with the `master` branch
- [X] `npm run format` to apply prettier formatting
- [X] `npm run test` passes with this change
- [X] This pull request links relevant issues as `Fixes #6985`
- [X] There are new or updated unit tests validating the change
- [ ] Documentation has been updated to reflect this change
- [X] The new commits follow conventions explained in [CONTRIBUTING.md](https://github.com/typeorm/typeorm/blob/master/CONTRIBUTING.md)
