### PR TITLE
feat(mssql): support column type bool & boolean

### DIFF
--- a/src/driver/sqlserver/SqlServerDriver.ts
+++ b/src/driver/sqlserver/SqlServerDriver.ts
@@ -141,6 +141,8 @@ export class SqlServerDriver implements Driver {
         "geometry",
         "geography",
         "rowversion",
+        "bool", // synonym for bit
+        "boolean", // synonym for bit
     ]
 
     /**
@@ -525,7 +527,10 @@ export class SqlServerDriver implements Driver {
 
         if (value === null || value === undefined) return value
 
-        if (columnMetadata.type === Boolean) {
+        if (columnMetadata.type === Boolean ||
+            columnMetadata.type === "bool" ||
+            columnMetadata.type === "boolean"
+        ) {
             return value === true ? 1 : 0
         } else if (columnMetadata.type === "date") {
             return DateUtils.mixedDateToDate(value)
@@ -565,7 +570,10 @@ export class SqlServerDriver implements Driver {
                   )
                 : value
 
-        if (columnMetadata.type === Boolean) {
+        if (columnMetadata.type === Boolean ||
+            columnMetadata.type === 'bool' ||
+            columnMetadata.type === 'boolean'
+        ) {
             value = value ? true : false
         } else if (
             columnMetadata.type === "datetime" ||
@@ -614,7 +622,10 @@ export class SqlServerDriver implements Driver {
             return "nvarchar"
         } else if (column.type === Date) {
             return "datetime"
-        } else if (column.type === Boolean) {
+        } else if (column.type === Boolean ||
+            column.type === "bool" ||
+            column.type === "boolean"
+        ) {
             return "bit"
         } else if ((column.type as any) === Buffer) {
             return "binary"


### PR DESCRIPTION

### Description of change
a feature, the sql server dialect support column type bool & boolean like Boolean , the database column type is bit. 


### Pull-Request Checklist

<!--
  Please make sure to review and check all of the following.

  If an item is not applicable, you can add "N/A" to the end.
-->

- [ ] Code is up-to-date with the `master` branch
- [ ] `npm run format` to apply prettier formatting
- [ ] `npm run test` passes with this change
- [ ] This pull request links relevant issues as `Fixes #0000`
- [ ] There are new or updated unit tests validating the change
- [ ] Documentation has been updated to reflect this change
- [ ] The new commits follow conventions explained in [CONTRIBUTING.md](https://github.com/typeorm/typeorm/blob/master/CONTRIBUTING.md)

<!--
  🎉 Thank you for contributing and making TypeORM even better!
-->
