### PR TITLE
fix: add socket path to postgres driver

### DIFF
--- a/src/commands/CommandUtils.ts
+++ b/src/commands/CommandUtils.ts
@@ -14,7 +14,7 @@ export class CommandUtils {
     ): Promise<DataSource> {
         let dataSourceFileExports
         try {
-            [dataSourceFileExports] = await importOrRequireFile(
+            ;[dataSourceFileExports] = await importOrRequireFile(
                 dataSourceFilePath,
             )
         } catch (err) {

--- a/src/data-source/DataSource.ts
+++ b/src/data-source/DataSource.ts
@@ -520,7 +520,7 @@ export class DataSource {
 
     /**
      * Executes raw SQL query and returns raw database results.
-     * 
+     *
      * @see [Official docs](https://typeorm.io/data-source-api) for examples.
      */
     async query<T = any>(

--- a/src/driver/postgres/PostgresConnectionCredentialsOptions.ts
+++ b/src/driver/postgres/PostgresConnectionCredentialsOptions.ts
@@ -44,4 +44,9 @@ export interface PostgresConnectionCredentialsOptions {
      * the service using this connection. Defaults to 'undefined'
      */
     readonly applicationName?: string
+
+    /**
+     * Database socket path
+     */
+    readonly socketPath?: string
 }

--- a/src/driver/postgres/PostgresDriver.ts
+++ b/src/driver/postgres/PostgresDriver.ts
@@ -1482,6 +1482,7 @@ export class PostgresDriver implements Driver {
                 application_name:
                     options.applicationName ?? credentials.applicationName,
                 max: options.poolSize,
+                socketPath: options.socketPath,
             },
             options.extra || {},
         )

--- a/src/entity-manager/EntityManager.ts
+++ b/src/entity-manager/EntityManager.ts
@@ -169,7 +169,7 @@ export class EntityManager {
 
     /**
      * Executes raw SQL query and returns raw database results.
-     * 
+     *
      * @see [Official docs](https://typeorm.io/entity-manager-api) for examples.
      */
     async query<T = any>(query: string, parameters?: any[]): Promise<T> {

--- a/src/query-builder/QueryBuilder.ts
+++ b/src/query-builder/QueryBuilder.ts
@@ -1152,7 +1152,8 @@ export abstract class QueryBuilder<Entity extends ObjectLiteral> {
 
         const cteStrings = this.expressionMap.commonTableExpressions.map(
             (cte) => {
-                let cteBodyExpression = typeof cte.queryBuilder === 'string' ? cte.queryBuilder : '';
+                let cteBodyExpression =
+                    typeof cte.queryBuilder === "string" ? cte.queryBuilder : ""
                 if (typeof cte.queryBuilder !== "string") {
                     if (cte.queryBuilder.hasCommonTableExpressions()) {
                         throw new TypeORMError(

--- a/src/repository/Repository.ts
+++ b/src/repository/Repository.ts
@@ -644,7 +644,7 @@ export class Repository<Entity extends ObjectLiteral> {
     /**
      * Executes a raw SQL query and returns a raw database results.
      * Raw query execution is supported only by relational databases (MongoDB is not supported).
-     * 
+     *
      * @see [Official docs](https://typeorm.io/repository-api) for examples.
      */
     query(query: string, parameters?: any[]): Promise<any> {


### PR DESCRIPTION
### Description of change

Adds socket path to postgres driver to support socket path for slaves

Fixes #11335

### Pull-Request Checklist

- [x] Code is up-to-date with the `master` branch
- [x] `npm run format` to apply prettier formatting
- [ ] `npm run test` passes with this change
- [x] This pull request links relevant issues as `Fixes #11335`
- [ ] There are new or updated unit tests validating the change
- [ ] Documentation has been updated to reflect this change
- [x] The new commits follow conventions explained in [CONTRIBUTING.md](https://github.com/typeorm/typeorm/blob/master/CONTRIBUTING.md)
