### PR TITLE
chore: bump better-sqlite3 devDependency to ^11.0.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -43,7 +43,7 @@
         "@types/source-map-support": "^0.5.6",
         "@types/uuid": "^9.0.0",
         "@types/yargs": "^17.0.22",
-        "better-sqlite3": "^8.1.0",
+        "better-sqlite3": "^11.0.0",
         "chai": "^4.3.7",
         "chai-as-promised": "^7.1.1",
         "class-transformer": "^0.5.1",
@@ -3002,11 +3002,12 @@
       ]
     },
     "node_modules/better-sqlite3": {
-      "version": "8.7.0",
-      "resolved": "https://registry.npmjs.org/better-sqlite3/-/better-sqlite3-8.7.0.tgz",
-      "integrity": "sha512-99jZU4le+f3G6aIl6PmmV0cxUIWqKieHxsiF7G34CVFiE+/UabpYqkU0NJIkY/96mQKikHeBjtR27vFfs5JpEw==",
+      "version": "11.9.0",
+      "resolved": "https://registry.npmjs.org/better-sqlite3/-/better-sqlite3-11.9.0.tgz",
+      "integrity": "sha512-4b9xYnoaskj8eIkke9ZCB42p5bOPabptSku8Rl4Yww70Jf+aHeLvrIjXDJrKQxUEjdppsFb+fdJSjoH4TklROA==",
       "dev": true,
       "hasInstallScript": true,
+      "license": "MIT",
       "dependencies": {
         "bindings": "^1.5.0",
         "prebuild-install": "^7.1.1"

--- a/package.json
+++ b/package.json
@@ -107,7 +107,7 @@
     "@types/source-map-support": "^0.5.6",
     "@types/uuid": "^9.0.0",
     "@types/yargs": "^17.0.22",
-    "better-sqlite3": "^8.1.0",
+    "better-sqlite3": "^11.0.0",
     "chai": "^4.3.7",
     "chai-as-promised": "^7.1.1",
     "class-transformer": "^0.5.1",
@@ -150,7 +150,7 @@
   "peerDependencies": {
     "@google-cloud/spanner": "^5.18.0",
     "@sap/hana-client": "^2.12.25",
-    "better-sqlite3": "^8.0.0 || ^9.0.0 || ^10.0.0 || ^11.0.0" ,
+    "better-sqlite3": "^8.0.0 || ^9.0.0 || ^10.0.0 || ^11.0.0",
     "hdb-pool": "^0.1.6",
     "ioredis": "^5.0.4",
     "mongodb": "^5.8.0",


### PR DESCRIPTION
### Description of change

Bumps the devDependency `better-sqlite3` to `^11.0.0`.

When trying to install devDependencies on Node v22, `better-sqlite3@^8.1.0` fails to install. The peer dependency was updated via #11096 and remains unchanged.

### Pull-Request Checklist

- [x] Code is up-to-date with the `master` branch
- [ ] `npm run format` to apply prettier formatting
- [ ] `npm run test` passes with this change
- [ ] ~~This pull request links relevant issues as `Fixes #0000`~~
- [ ] ~~There are new or updated unit tests validating the change~~
- [ ] ~~Documentation has been updated to reflect this change~~
- [x] The new commits follow conventions explained in [CONTRIBUTING.md](https://github.com/typeorm/typeorm/blob/master/CONTRIBUTING.md)