### PR TITLE
build: run format in ci

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -20,10 +20,17 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version: "18.x"
+
       - uses: actions/checkout@v4
+
       - run: npm i
       - run: npm run lint
 
+      # run formatting and fail if any changes are detected
+      - run: npm run format
+      - run: git add --all
+      - run: git status --porcelain
+      - run: git diff --cached --exit-code || (echo "::error::Formatting changes are required. Please run 'npm run format' and commit the changes." && exit 1)
 
   # These tests run in standard node containers with their db attached as a service
   database-tests:
@@ -35,7 +42,6 @@ jobs:
     uses: ./.github/workflows/database-tests.yml
     with:
       node-container: ${{matrix.node-container}}
-
 
   # These tests run with custom docker image attributes that can't be specified in a GHA service
   database-compose-tests:

--- a/src/commands/CommandUtils.ts
+++ b/src/commands/CommandUtils.ts
@@ -14,7 +14,7 @@ export class CommandUtils {
     ): Promise<DataSource> {
         let dataSourceFileExports
         try {
-            [dataSourceFileExports] = await importOrRequireFile(
+            ;[dataSourceFileExports] = await importOrRequireFile(
                 dataSourceFilePath,
             )
         } catch (err) {

--- a/src/data-source/DataSource.ts
+++ b/src/data-source/DataSource.ts
@@ -520,7 +520,7 @@ export class DataSource {
 
     /**
      * Executes raw SQL query and returns raw database results.
-     * 
+     *
      * @see [Official docs](https://typeorm.io/data-source-api) for examples.
      */
     async query<T = any>(

--- a/src/entity-manager/EntityManager.ts
+++ b/src/entity-manager/EntityManager.ts
@@ -169,7 +169,7 @@ export class EntityManager {
 
     /**
      * Executes raw SQL query and returns raw database results.
-     * 
+     *
      * @see [Official docs](https://typeorm.io/entity-manager-api) for examples.
      */
     async query<T = any>(query: string, parameters?: any[]): Promise<T> {

--- a/src/query-builder/QueryBuilder.ts
+++ b/src/query-builder/QueryBuilder.ts
@@ -1152,7 +1152,8 @@ export abstract class QueryBuilder<Entity extends ObjectLiteral> {
 
         const cteStrings = this.expressionMap.commonTableExpressions.map(
             (cte) => {
-                let cteBodyExpression = typeof cte.queryBuilder === 'string' ? cte.queryBuilder : '';
+                let cteBodyExpression =
+                    typeof cte.queryBuilder === "string" ? cte.queryBuilder : ""
                 if (typeof cte.queryBuilder !== "string") {
                     if (cte.queryBuilder.hasCommonTableExpressions()) {
                         throw new TypeORMError(

--- a/src/repository/Repository.ts
+++ b/src/repository/Repository.ts
@@ -644,7 +644,7 @@ export class Repository<Entity extends ObjectLiteral> {
     /**
      * Executes a raw SQL query and returns a raw database results.
      * Raw query execution is supported only by relational databases (MongoDB is not supported).
-     * 
+     *
      * @see [Official docs](https://typeorm.io/repository-api) for examples.
      */
     query(query: string, parameters?: any[]): Promise<any> {

--- a/test/functional/columns/virtual-columns/entity/Employee.ts
+++ b/test/functional/columns/virtual-columns/entity/Employee.ts
@@ -1,9 +1,4 @@
-import {
-    Entity,
-    ManyToOne,
-    OneToMany,
-    PrimaryColumn
-} from "../../../../../src"
+import { Entity, ManyToOne, OneToMany, PrimaryColumn } from "../../../../../src"
 import { Company } from "./Company"
 import { TimeSheet } from "./TimeSheet"
 

--- a/test/functional/multi-database/multi-database-basic-functionality/multi-database-basic-functionality.ts
+++ b/test/functional/multi-database/multi-database-basic-functionality/multi-database-basic-functionality.ts
@@ -25,11 +25,21 @@ describe("multi-database > basic-functionality", () => {
             it(`[${platform}] produces deterministic, unique, and valid table names for relative paths; leaves absolute paths unchanged`, () => {
                 const testMap = [
                     ["FILENAME.db", "filename.db"],
-                    ["..\\FILENAME.db", platform === 'win32' ? "../filename.db" : "..\\filename.db"],
-                    [".\\FILENAME.db", platform === 'win32' ? "./filename.db" : ".\\filename.db"],
+                    [
+                        "..\\FILENAME.db",
+                        platform === "win32"
+                            ? "../filename.db"
+                            : "..\\filename.db",
+                    ],
+                    [
+                        ".\\FILENAME.db",
+                        platform === "win32"
+                            ? "./filename.db"
+                            : ".\\filename.db",
+                    ],
                     [
                         "..\\longpathdir\\longpathdir\\longpathdir\\longpathdir\\longpathdir\\longpathdir\\longpathdir\\FILENAME.db",
-                        platform === 'win32'
+                        platform === "win32"
                             ? "../longpathdir/longpathdir/longpathdir/longpathdir/longpathdir/longpathdir/longpathdir/filename.db"
                             : "..\\longpathdir\\longpathdir\\longpathdir\\longpathdir\\longpathdir\\longpathdir\\longpathdir\\filename.db",
                     ],


### PR DESCRIPTION
### Description of change

Runs `npm run format` in CI. If any files are changed by the format command, CI will fail with an error message.

This PR also formats all existing files via `npm run format` to ensure we pass formatting checks going forward.

### Pull-Request Checklist

- [x] Code is up-to-date with the `master` branch
- [x] `npm run format` to apply prettier formatting
- [x] `npm run test` passes with this change
- [x] This pull request links relevant issues as `Fixes #0000`
- [ ] ~~There are new or updated unit tests validating the change~~
- [ ] ~~Documentation has been updated to reflect this change~~
- [x] The new commits follow conventions explained in [CONTRIBUTING.md](https://github.com/typeorm/typeorm/blob/master/CONTRIBUTING.md)

Fixes #10866 