### PR TITLE
fix: resolve issue order subquery column

### DIFF
--- a/src/query-builder/SelectQueryBuilder.ts
+++ b/src/query-builder/SelectQueryBuilder.ts
@@ -2508,7 +2508,7 @@ export class SelectQueryBuilder<Entity extends ObjectLiteral>
                         const alias = this.expressionMap.aliases.find(
                             (alias) => alias.name === aliasName,
                         )
-                        if (alias) {
+                        if (alias && alias.hasMetadata) {
                             const column =
                                 alias.metadata.findColumnWithPropertyPath(
                                     propertyPath,

--- a/test/github-issues/9420/entity/User.ts
+++ b/test/github-issues/9420/entity/User.ts
@@ -1,0 +1,13 @@
+import { Column, Entity, PrimaryGeneratedColumn } from "../../../../src"
+
+@Entity("user")
+export class User {
+    @PrimaryGeneratedColumn({ type: "int" })
+    id: number
+
+    @Column()
+    name: string
+
+    @Column()
+    email: string
+}

--- a/test/github-issues/9420/issue-9420.ts
+++ b/test/github-issues/9420/issue-9420.ts
@@ -1,0 +1,46 @@
+import { expect } from "chai"
+import { DataSource } from "../../../src"
+import {
+    closeTestingConnections,
+    createTestingConnections,
+    reloadTestingDatabases,
+} from "../../utils/test-utils"
+import { User } from "./entity/User"
+
+describe("github issues > #9420 Get error 'Cannot get metadata of given alias' when order column from subquery.", () => {
+    let connections: DataSource[]
+    before(async () => {
+        connections = await createTestingConnections({
+            enabledDrivers: ["postgres"],
+            entities: [User],
+            schemaCreate: true,
+            dropSchema: true,
+        })
+    })
+    beforeEach(() => reloadTestingDatabases(connections))
+    after(() => closeTestingConnections(connections))
+
+    it("should not throw errors", async () =>
+        await Promise.all(
+            connections.map(async (connection) => {
+                const userSubQb = connection
+                    .getRepository(User)
+                    .createQueryBuilder("user")
+                    .select("user.id", "id")
+                    .addSelect("user.name", "name")
+                    .where("user.name = :name", {
+                        name: "ABCxyz",
+                    })
+                    .orderBy("user.name", "ASC")
+
+                const userQuery = connection
+                    .createQueryBuilder()
+                    .select(["sub.id", "sub.name"])
+                    .from("(" + userSubQb.getQuery() + ")", "sub")
+                    .orderBy("sub.name", "ASC")
+                    .setParameters(userSubQb.getParameters())
+
+                expect(await userQuery.getRawMany()).to.deep.eq([])
+            }),
+        ))
+})


### PR DESCRIPTION
Closes: #9420

### Description of change

add condition to check if alias has metadata before access it to avoid the error 'Cannot get metadata for given alias'

### Pull-Request Checklist

- [x] Code is up-to-date with the `master` branch
- [x] `npm run format` to apply prettier formatting
- [x] `npm run test` passes with this change
- [x] This pull request links relevant issues as `Fixes #0000`
- [x] There are new or updated unit tests validating the change
- [ ] Documentation has been updated to reflect this change "N/A"
- [x] The new commits follow conventions explained in [CONTRIBUTING.md] 