### PR TITLE
fix: FindOptionsSelect to use correct type when property is an object

### DIFF
--- a/src/find-options/FindOptionsSelect.ts
+++ b/src/find-options/FindOptionsSelect.ts
@@ -24,7 +24,7 @@ export type FindOptionsSelectProperty<Property> = Property extends Promise<
     : Property extends ObjectId
     ? boolean
     : Property extends object
-    ? FindOptionsSelect<Property>
+    ? FindOptionsSelect<Property> | boolean
     : boolean
 
 /**

--- a/test/functional/find-options/select/entity/Category.ts
+++ b/test/functional/find-options/select/entity/Category.ts
@@ -20,7 +20,7 @@ export class Category {
     @VersionColumn()
     version: string
 
-    @Column("json", { nullable: true })
+    @Column("simple-json", { nullable: true })
     meta?: CategoryMeta
 
     @OneToMany(() => Post, (post) => post.category, {

--- a/test/functional/find-options/select/entity/Category.ts
+++ b/test/functional/find-options/select/entity/Category.ts
@@ -1,0 +1,30 @@
+import { Entity } from "../../../../../src/decorator/entity/Entity"
+import { PrimaryGeneratedColumn } from "../../../../../src/decorator/columns/PrimaryGeneratedColumn"
+import { Column } from "../../../../../src/decorator/columns/Column"
+import { VersionColumn } from "../../../../../src/decorator/columns/VersionColumn"
+import { Post } from "./Post"
+import { OneToMany } from "../../../../../src"
+import { CategoryMeta } from "../types"
+
+@Entity()
+export class Category {
+    @PrimaryGeneratedColumn()
+    id: number
+
+    @Column()
+    name: string
+
+    @Column()
+    description: string
+
+    @VersionColumn()
+    version: string
+
+    @Column("json", { nullable: true })
+    meta?: CategoryMeta
+
+    @OneToMany(() => Post, (post) => post.category, {
+        cascade: ["insert", "update", "soft-remove", "recover"],
+    })
+    posts: Post[]
+}

--- a/test/functional/find-options/select/entity/Post.ts
+++ b/test/functional/find-options/select/entity/Post.ts
@@ -1,0 +1,35 @@
+import {
+    Column,
+    Entity,
+    JoinTable,
+    ManyToMany,
+    ManyToOne,
+    PrimaryColumn,
+} from "../../../../../src"
+import { Tag } from "./Tag"
+import { Category } from "./Category"
+import { PostMeta } from "../types"
+
+@Entity()
+export class Post {
+    @PrimaryColumn()
+    id: number
+
+    @Column()
+    title: string
+
+    @Column()
+    description: string
+
+    @ManyToOne((type) => Category)
+    category: Category
+
+    @Column("json", { nullable: true })
+    meta?: PostMeta
+
+    @ManyToMany(() => Tag, (tag) => tag.posts, {
+        cascade: ["insert", "update", "soft-remove", "recover"],
+    })
+    @JoinTable()
+    tags: Tag[]
+}

--- a/test/functional/find-options/select/entity/Post.ts
+++ b/test/functional/find-options/select/entity/Post.ts
@@ -24,7 +24,7 @@ export class Post {
     @ManyToOne((type) => Category)
     category: Category
 
-    @Column("json", { nullable: true })
+    @Column("simple-json", { nullable: true })
     meta?: PostMeta
 
     @ManyToMany(() => Tag, (tag) => tag.posts, {

--- a/test/functional/find-options/select/entity/Tag.ts
+++ b/test/functional/find-options/select/entity/Tag.ts
@@ -1,0 +1,19 @@
+import { Post } from "./Post"
+import {
+    Column,
+    Entity,
+    ManyToMany,
+    PrimaryGeneratedColumn,
+} from "../../../../../src"
+
+@Entity()
+export class Tag {
+    @PrimaryGeneratedColumn()
+    id: number
+
+    @Column()
+    name: string
+
+    @ManyToMany(() => Post, (post) => post.tags)
+    posts: Post[]
+}

--- a/test/functional/find-options/select/find-options-select.ts
+++ b/test/functional/find-options/select/find-options-select.ts
@@ -1,0 +1,187 @@
+import "reflect-metadata"
+import "../../../utils/test-setup"
+import { DataSource } from "../../../../src"
+import {
+    closeTestingConnections,
+    createTestingConnections,
+    reloadTestingDatabases,
+} from "../../../utils/test-utils"
+import { Post } from "./entity/Post"
+import { Category } from "./entity/Category"
+import { Tag } from "./entity/Tag"
+
+describe("find options > select", () => {
+    let dataSources: DataSource[]
+    before(
+        async () =>
+            (dataSources = await createTestingConnections({
+                __dirname,
+            })),
+    )
+    beforeEach(() => reloadTestingDatabases(dataSources))
+    after(() => closeTestingConnections(dataSources))
+
+    async function prepareData(dataSource: DataSource) {
+        const tag = new Tag()
+        tag.id = 1
+        tag.name = "SuperTag"
+
+        const post = new Post()
+        post.id = 1
+        post.title = "Hello"
+        post.description = "This is a post!"
+        post.meta = {
+            likes: 10,
+            dislikes: 1,
+        }
+        post.tags = [tag]
+
+        const category = new Category()
+        category.id = 1
+        category.name = "Action"
+        category.description = "Action movies"
+        category.posts = [post]
+
+        await dataSource.manager.save(category)
+    }
+
+    it("should select all properties of relation post", () =>
+        Promise.all(
+            dataSources.map(async (dataSource) => {
+                await prepareData(dataSource)
+
+                const categories = await dataSource.manager.find(Category, {
+                    select: {
+                        id: true,
+                        posts: true,
+                    },
+                    relations: ["posts"],
+                })
+
+                categories.should.be.eql([
+                    {
+                        id: 1,
+                        posts: [
+                            {
+                                id: 1,
+                                title: "Hello",
+                                description: "This is a post!",
+                                meta: {
+                                    likes: 10,
+                                    dislikes: 1,
+                                },
+                            },
+                        ],
+                    },
+                ])
+            }),
+        ))
+
+    it("should select all properties of relation post and its relation tag", () =>
+        Promise.all(
+            dataSources.map(async (dataSource) => {
+                await prepareData(dataSource)
+
+                const categories = await dataSource.manager.find(Category, {
+                    select: {
+                        id: true,
+                        posts: {
+                            id: true,
+                            title: true,
+                            description: true,
+                            meta: true,
+                            tags: true,
+                        },
+                    },
+                    relations: ["posts", "posts.tags"],
+                })
+
+                categories.should.be.eql([
+                    {
+                        id: 1,
+                        posts: [
+                            {
+                                id: 1,
+                                title: "Hello",
+                                description: "This is a post!",
+                                meta: {
+                                    likes: 10,
+                                    dislikes: 1,
+                                },
+                                tags: [
+                                    {
+                                        id: 1,
+                                        name: "SuperTag",
+                                    },
+                                ],
+                            },
+                        ],
+                    },
+                ])
+            }),
+        ))
+
+    it("should select all from category and meta only from post", () =>
+        Promise.all(
+            dataSources.map(async (dataSource) => {
+                await prepareData(dataSource)
+
+                const categories = await dataSource.manager.find(Category, {
+                    select: {
+                        id: true,
+                        posts: {
+                            meta: true,
+                        },
+                    },
+                    relations: ["posts"],
+                })
+
+                categories.should.be.eql([
+                    {
+                        id: 1,
+                        posts: [
+                            {
+                                meta: {
+                                    likes: 10,
+                                    dislikes: 1,
+                                },
+                            },
+                        ],
+                    },
+                ])
+            }),
+        ))
+
+    it("should select all from category and meta only from post with all meta properties", () =>
+        Promise.all(
+            dataSources.map(async (dataSource) => {
+                await prepareData(dataSource)
+
+                const categories = await dataSource.manager.find(Category, {
+                    select: {
+                        id: true,
+                        posts: {
+                            meta: {
+                                likes: true,
+                            },
+                        },
+                    },
+                    relations: ["posts"],
+                })
+
+                categories.should.be.eql([
+                    {
+                        id: 1,
+                        posts: [
+                            {
+                                meta: {
+                                    likes: 10,
+                                    dislikes: 1,
+                                },
+                            },
+                        ],
+                    },
+                ])
+            }),
+        ))
+})

--- a/test/functional/find-options/select/types.ts
+++ b/test/functional/find-options/select/types.ts
@@ -1,0 +1,8 @@
+export interface PostMeta {
+    likes: number
+    dislikes: number
+}
+
+export interface CategoryMeta {
+    views: number
+}


### PR DESCRIPTION
### Description of change

FindOptionsSelect type now resolves to properties of object OR boolean when property is an object. Fixes #11358

### Current Behaviour
FindOptionsSelect throws a type error when the type of column is an object.
This can happen when ValueTransformer is used in columns, and the expected type might be an object. Or simply in case of json columns having an interface as type.

For example:
<img width="307" alt="Screenshot 2025-03-23 at 3 19 55 AM" src="https://github.com/user-attachments/assets/d987544b-b4d9-4260-82da-3be3ae4ea11c" />

When selecting:
<img width="332" alt="Screenshot 2025-03-23 at 3 22 14 AM" src="https://github.com/user-attachments/assets/9e8a41f3-8f63-47d1-8413-e032600b9e6e" />

The error:
<img width="765" alt="Screenshot 2025-03-23 at 3 23 05 AM" src="https://github.com/user-attachments/assets/ce576b68-6f17-4b8a-9e48-d9da388e13cd" />

### Expected Behavior

Types of object should be selectable 

### Pull-Request Checklist

- [x] Code is up-to-date with the `master` branch
- [x] `npm run format` to apply prettier formatting
- [x] `npm run test` passes with this change
- [x] This pull request links relevant issues as `Fixes #11358` N/A
- [x] There are new or updated unit tests validating the change
- [ ] Documentation has been updated to reflect this change N/A
- [x] The new commits follow conventions explained in [CONTRIBUTING.md](https://github.com/typeorm/typeorm/blob/master/CONTRIBUTING.md)