### PR TITLE
fix(sap): normalize deprecated/removed data types in SAP HANA Cloud

### DIFF
--- a/docs/entities.md
+++ b/docs/entities.md
@@ -13,6 +13,7 @@
     - [Column types for `sqlite` / `cordova` / `react-native` / `expo`](#column-types-for-sqlite--cordova--react-native--expo)
     - [Column types for `mssql`](#column-types-for-mssql)
     - [Column types for `oracle`](#column-types-for-oracle)
+    - [Column types for `sap`](#column-types-for-sap)
     - [Column types for `spanner`](#column-types-for-spanner)
     - [`enum` column type](#enum-column-type)
     - [`set` column type](#set-column-type)
@@ -380,7 +381,6 @@ or
 
 > Note: UUID, INET4, and INET6 are only available for mariadb and for respective versions that made them available.
 
-
 ### Column types for `postgres`
 
 `int`, `int2`, `int4`, `int8`, `smallint`, `integer`, `bigint`, `decimal`, `numeric`, `real`,
@@ -424,6 +424,12 @@ or
 `decimal`, `integer`, `int`, `smallint`, `real`, `double precision`, `date`, `timestamp`, `timestamp with time zone`,
 `timestamp with local time zone`, `interval year to month`, `interval day to second`, `bfile`, `blob`, `clob`,
 `nclob`, `rowid`, `urowid`
+
+### Column types for `sap`
+
+`tinyint`, `smallint`, `integer`, `bigint`, `smalldecimal`, `decimal`, `real`, `double`, `date`, `time`, `seconddate`, `timestamp`, `boolean`, `char`, `nchar`, `varchar`, `nvarchar`, `text`, `alphanum`, `shorttext`, `array`, `varbinary`, `blob`, `clob`, `nclob`, `st_geometry`, `st_point`.
+
+> Note: SAP HANA Cloud deprecated or removed some of these data types. TypeORM will convert them to the closest available alternative when connected to a Cloud version.
 
 ### Column types for `spanner`
 

--- a/src/driver/sap/SapDriver.ts
+++ b/src/driver/sap/SapDriver.ts
@@ -835,7 +835,7 @@ export class SapDriver implements Driver {
      * Returns true if driver supports fulltext indices.
      */
     isFullTextColumnTypeSupported(): boolean {
-        return true
+        return !DriverUtils.isReleaseVersionOrGreater(this, "4.0")
     }
 
     /**

--- a/src/driver/sap/SapDriver.ts
+++ b/src/driver/sap/SapDriver.ts
@@ -774,26 +774,12 @@ export class SapDriver implements Driver {
             const tableColumn = tableColumns.find(
                 (c) => c.name === columnMetadata.databaseName,
             )
-            if (!tableColumn) return false // we don't need new columns, we only need exist and changed
+            if (!tableColumn) {
+                // we don't need new columns, we only need exist and changed
+                return false
+            }
 
-            // console.log("table:", columnMetadata.entityMetadata.tableName);
-            // console.log("name:", tableColumn.name, columnMetadata.databaseName);
-            // console.log("type:", tableColumn.type, _this.normalizeType(columnMetadata));
-            // console.log("length:", tableColumn.length, _this.getColumnLength(columnMetadata));
-            // console.log("width:", tableColumn.width, columnMetadata.width);
-            // console.log("precision:", tableColumn.precision, columnMetadata.precision);
-            // console.log("scale:", tableColumn.scale, columnMetadata.scale);
-            // console.log("default:", tableColumn.default, columnMetadata.default);
-            // console.log("isPrimary:", tableColumn.isPrimary, columnMetadata.isPrimary);
-            // console.log("isNullable:", tableColumn.isNullable, columnMetadata.isNullable);
-            // console.log("isUnique:", tableColumn.isUnique, _this.normalizeIsUnique(columnMetadata));
-            // console.log("isGenerated:", tableColumn.isGenerated, columnMetadata.isGenerated);
-            // console.log((columnMetadata.generationStrategy !== "uuid" && tableColumn.isGenerated !== columnMetadata.isGenerated));
-            // console.log("==========================================");
-
-            const normalizeDefault = this.normalizeDefault(columnMetadata)
-            const hanaNullComapatibleDefault =
-                normalizeDefault == null ? undefined : normalizeDefault
+            const normalizedDefault = this.normalizeDefault(columnMetadata)
 
             return (
                 tableColumn.name !== columnMetadata.databaseName ||
@@ -806,7 +792,7 @@ export class SapDriver implements Driver {
                 tableColumn.comment !==
                     this.escapeComment(columnMetadata.comment) ||
                 (!tableColumn.isGenerated &&
-                    hanaNullComapatibleDefault !== tableColumn.default) || // we included check for generated here, because generated columns already can have default values
+                    normalizedDefault !== tableColumn.default) || // we included check for generated here, because generated columns already can have default values
                 tableColumn.isPrimary !== columnMetadata.isPrimary ||
                 tableColumn.isNullable !== columnMetadata.isNullable ||
                 tableColumn.isUnique !==

--- a/src/driver/sap/SapQueryRunner.ts
+++ b/src/driver/sap/SapQueryRunner.ts
@@ -2788,12 +2788,6 @@ export class SapQueryRunner extends BaseQueryRunner implements QueryRunner {
                             if (dbColumn["COMMENTS"]) {
                                 tableColumn.comment = dbColumn["COMMENTS"]
                             }
-                            if (dbColumn["character_set_name"])
-                                tableColumn.charset =
-                                    dbColumn["character_set_name"]
-                            if (dbColumn["collation_name"])
-                                tableColumn.collation =
-                                    dbColumn["collation_name"]
                             return tableColumn
                         }),
                 )
@@ -3349,8 +3343,6 @@ export class SapQueryRunner extends BaseQueryRunner implements QueryRunner {
     ) {
         let c =
             `"${column.name}" ` + this.connection.driver.createFullType(column)
-        if (column.charset) c += " CHARACTER SET " + column.charset
-        if (column.collation) c += " COLLATE " + column.collation
         if (column.default !== undefined && column.default !== null) {
             c += " DEFAULT " + column.default
         } else if (explicitDefault) {

--- a/src/driver/sap/SapQueryRunner.ts
+++ b/src/driver/sap/SapQueryRunner.ts
@@ -3153,7 +3153,7 @@ export class SapQueryRunner extends BaseQueryRunner implements QueryRunner {
         if (index.isUnique) {
             indexType += "UNIQUE "
         }
-        if (index.isFulltext) {
+        if (index.isFulltext && this.driver.isFullTextColumnTypeSupported()) {
             indexType += "FULLTEXT "
         }
 

--- a/test/functional/database-schema/column-length/sap/column-length-sap.ts
+++ b/test/functional/database-schema/column-length/sap/column-length-sap.ts
@@ -1,12 +1,13 @@
-import "reflect-metadata"
 import { expect } from "chai"
-import { Post } from "./entity/Post"
+import "reflect-metadata"
+
 import { DataSource } from "../../../../../src"
 import {
     closeTestingConnections,
     createTestingConnections,
     reloadTestingDatabases,
 } from "../../../../utils/test-utils"
+import { Post } from "./entity/Post"
 
 describe("database schema > column length > sap", () => {
     let connections: DataSource[]

--- a/test/functional/database-schema/column-types/sap/column-types-sap.ts
+++ b/test/functional/database-schema/column-types/sap/column-types-sap.ts
@@ -1,14 +1,16 @@
 import "reflect-metadata"
-import { Post } from "./entity/Post"
+
 import { DataSource } from "../../../../../src"
+import { DriverUtils } from "../../../../../src/driver/DriverUtils"
+import { DateUtils } from "../../../../../src/util/DateUtils"
 import {
     closeTestingConnections,
     createTestingConnections,
     reloadTestingDatabases,
 } from "../../../../utils/test-utils"
+import { Post } from "./entity/Post"
 import { PostWithOptions } from "./entity/PostWithOptions"
 import { PostWithoutTypes } from "./entity/PostWithoutTypes"
-import { DateUtils } from "../../../../../src/util/DateUtils"
 
 describe("database schema > column types > sap", () => {
     let connections: DataSource[]
@@ -144,21 +146,10 @@ describe("database schema > column types > sap", () => {
                     .findColumnByName("double")!
                     .type.should.be.equal("double")
                 table!.findColumnByName("float")!.type.should.be.equal("double")
-                table!.findColumnByName("char")!.type.should.be.equal("char")
                 table!.findColumnByName("nchar")!.type.should.be.equal("nchar")
-                table!
-                    .findColumnByName("varchar")!
-                    .type.should.be.equal("varchar")
                 table!
                     .findColumnByName("nvarchar")!
                     .type.should.be.equal("nvarchar")
-                table!
-                    .findColumnByName("alphanum")!
-                    .type.should.be.equal("alphanum")
-                table!.findColumnByName("text")!.type.should.be.equal("text")
-                table!
-                    .findColumnByName("shorttext")!
-                    .type.should.be.equal("shorttext")
                 table!.findColumnByName("dateObj")!.type.should.be.equal("date")
                 table!.findColumnByName("date")!.type.should.be.equal("date")
                 table!.findColumnByName("timeObj")!.type.should.be.equal("time")
@@ -170,7 +161,6 @@ describe("database schema > column types > sap", () => {
                     .findColumnByName("seconddate")!
                     .type.should.be.equal("seconddate")
                 table!.findColumnByName("blob")!.type.should.be.equal("blob")
-                table!.findColumnByName("clob")!.type.should.be.equal("clob")
                 table!.findColumnByName("nclob")!.type.should.be.equal("nclob")
                 table!
                     .findColumnByName("boolean")!
@@ -181,6 +171,52 @@ describe("database schema > column types > sap", () => {
                 table!
                     .findColumnByName("simpleArray")!
                     .type.should.be.equal("nclob")
+
+                // Deprecated column types that have a different behavior in SAP HANA Cloud
+                if (
+                    DriverUtils.isReleaseVersionOrGreater(
+                        connection.driver,
+                        "4.0",
+                    )
+                ) {
+                    table!
+                        .findColumnByName("char")!
+                        .type.should.be.equal("nchar")
+                    table!
+                        .findColumnByName("varchar")!
+                        .type.should.be.equal("nvarchar")
+                    table!
+                        .findColumnByName("alphanum")!
+                        .type.should.be.equal("nvarchar")
+                    table!
+                        .findColumnByName("shorttext")!
+                        .type.should.be.equal("nvarchar")
+                    table!
+                        .findColumnByName("text")!
+                        .type.should.be.equal("nclob")
+                    table!
+                        .findColumnByName("clob")!
+                        .type.should.be.equal("nclob")
+                } else {
+                    table!
+                        .findColumnByName("char")!
+                        .type.should.be.equal("char")
+                    table!
+                        .findColumnByName("varchar")!
+                        .type.should.be.equal("varchar")
+                    table!
+                        .findColumnByName("alphanum")!
+                        .type.should.be.equal("alphanum")
+                    table!
+                        .findColumnByName("shorttext")!
+                        .type.should.be.equal("shorttext")
+                    table!
+                        .findColumnByName("text")!
+                        .type.should.be.equal("text")
+                    table!
+                        .findColumnByName("clob")!
+                        .type.should.be.equal("clob")
+                }
             }),
         ))
 
@@ -225,29 +261,57 @@ describe("database schema > column types > sap", () => {
                     .precision!.should.be.equal(10)
                 table!.findColumnByName("decimal")!.scale!.should.be.equal(3)
                 table!
-                    .findColumnByName("varchar")!
-                    .type.should.be.equal("varchar")
-                table!
-                    .findColumnByName("varchar")!
-                    .length!.should.be.equal("50")
-                table!
                     .findColumnByName("nvarchar")!
                     .type.should.be.equal("nvarchar")
                 table!
                     .findColumnByName("nvarchar")!
                     .length!.should.be.equal("50")
-                table!
-                    .findColumnByName("alphanum")!
-                    .type.should.be.equal("alphanum")
-                table!
-                    .findColumnByName("alphanum")!
-                    .length!.should.be.equal("50")
-                table!
-                    .findColumnByName("shorttext")!
-                    .type.should.be.equal("shorttext")
-                table!
-                    .findColumnByName("shorttext")!
-                    .length!.should.be.equal("50")
+
+                // Deprecated column types that have a different behavior in SAP HANA Cloud
+                if (
+                    DriverUtils.isReleaseVersionOrGreater(
+                        connection.driver,
+                        "4.0",
+                    )
+                ) {
+                    table!
+                        .findColumnByName("varchar")!
+                        .type.should.be.equal("nvarchar")
+                    table!
+                        .findColumnByName("varchar")!
+                        .length!.should.be.equal("50")
+                    table!
+                        .findColumnByName("alphanum")!
+                        .type.should.be.equal("nvarchar")
+                    table!
+                        .findColumnByName("alphanum")!
+                        .length!.should.be.equal("50")
+                    table!
+                        .findColumnByName("shorttext")!
+                        .type.should.be.equal("nvarchar")
+                    table!
+                        .findColumnByName("shorttext")!
+                        .length!.should.be.equal("50")
+                } else {
+                    table!
+                        .findColumnByName("varchar")!
+                        .type.should.be.equal("varchar")
+                    table!
+                        .findColumnByName("varchar")!
+                        .length!.should.be.equal("50")
+                    table!
+                        .findColumnByName("alphanum")!
+                        .type.should.be.equal("alphanum")
+                    table!
+                        .findColumnByName("alphanum")!
+                        .length!.should.be.equal("50")
+                    table!
+                        .findColumnByName("shorttext")!
+                        .type.should.be.equal("shorttext")
+                    table!
+                        .findColumnByName("shorttext")!
+                        .length!.should.be.equal("50")
+                }
             }),
         ))
 


### PR DESCRIPTION
### Description of change

Convert [SAP HANA data types](https://help.sap.com/docs/SAP_HANA_PLATFORM/4fe29514fd584807ac9f2a04f6754767/20a1569875191014b507cf392724b7eb.html) that have been deprecated/removed in SAP HANA Cloud to [compatible alternatives](https://help.sap.com/docs/hana-cloud-database/sap-hana-cloud-sap-hana-database-sql-reference-guide/data-types).

Based on the database version (cloud version starts at 4.0), the deprecated ASCII types are converted to their Unicode alternatives, similar to how HANA does it (to avoid incorrect migrations), while the removed types are converted to their best alternative to allow backwards-compatibility.

Fixes #11354.

### Pull-Request Checklist

- [X] Code is up-to-date with the `master` branch
- [X] `npm run format` to apply prettier formatting
- [X] `npm run test` passes with this change
- [X] This pull request links relevant issues as `Fixes #11354`
- [X] There are new or updated unit tests validating the change
- [X] Documentation has been updated to reflect this change
- [X] The new commits follow conventions explained in [CONTRIBUTING.md](https://github.com/typeorm/typeorm/blob/master/CONTRIBUTING.md)
