### PR TITLE
refactor: database server version fetching & comparison

### DIFF
--- a/src/driver/DriverUtils.ts
+++ b/src/driver/DriverUtils.ts
@@ -34,10 +34,7 @@ export class DriverUtils {
     }
 
     static isReleaseVersionOrGreater(driver: Driver, version: string): boolean {
-        return (
-            driver.version != null &&
-            VersionUtils.isGreaterOrEqual(driver.version, version)
-        )
+        return VersionUtils.isGreaterOrEqual(driver.version, version)
     }
 
     static isPostgresFamily(driver: Driver): boolean {

--- a/src/driver/aurora-mysql/AuroraMysqlDriver.ts
+++ b/src/driver/aurora-mysql/AuroraMysqlDriver.ts
@@ -361,7 +361,7 @@ export class AuroraMysqlDriver implements Driver {
      */
     async connect(): Promise<void> {
         if (!this.database) {
-            const queryRunner = await this.createQueryRunner("master")
+            const queryRunner = this.createQueryRunner("master")
 
             this.database = await queryRunner.getCurrentDatabase()
 

--- a/src/driver/cockroachdb/CockroachDriver.ts
+++ b/src/driver/cockroachdb/CockroachDriver.ts
@@ -305,7 +305,7 @@ export class CockroachDriver implements Driver {
         }
 
         if (!this.database || !this.searchSchema) {
-            const queryRunner = await this.createQueryRunner("master")
+            const queryRunner = this.createQueryRunner("master")
 
             if (!this.database) {
                 this.database = await queryRunner.getCurrentDatabase()

--- a/src/driver/mysql/MysqlQueryRunner.ts
+++ b/src/driver/mysql/MysqlQueryRunner.ts
@@ -2555,7 +2555,7 @@ export class MysqlQueryRunner extends BaseQueryRunner implements QueryRunner {
         ])
 
         const isMariaDb = this.driver.options.type === "mariadb"
-        const dbVersion = await this.getVersion()
+        const dbVersion = this.driver.version
 
         // create tables for loaded tables
         return Promise.all(
@@ -3366,9 +3366,13 @@ export class MysqlQueryRunner extends BaseQueryRunner implements QueryRunner {
         return c
     }
 
-    protected async getVersion(): Promise<string> {
+    async getVersion(): Promise<string> {
         const result = await this.query(`SELECT VERSION() AS \`version\``)
-        return result[0]["version"]
+        const dbVersion = result[0]["version"]
+
+        return this.driver.options.type === "mariadb"
+            ? dbVersion.replace(/^([\d.]+).*$/, "$1")
+            : dbVersion
     }
 
     /**

--- a/src/driver/oracle/OracleDriver.ts
+++ b/src/driver/oracle/OracleDriver.ts
@@ -318,7 +318,7 @@ export class OracleDriver implements Driver {
         }
 
         if (!this.database || !this.schema) {
-            const queryRunner = await this.createQueryRunner("master")
+            const queryRunner = this.createQueryRunner("master")
 
             if (!this.database) {
                 this.database = await queryRunner.getCurrentDatabase()

--- a/src/driver/postgres/PostgresQueryRunner.ts
+++ b/src/driver/postgres/PostgresQueryRunner.ts
@@ -4155,9 +4155,11 @@ export class PostgresQueryRunner
     /**
      * Loads Postgres version.
      */
-    protected async getVersion(): Promise<string> {
-        const result = await this.query(`SELECT version()`)
-        return result[0]["version"].replace(/^PostgreSQL ([\d.]+) .*$/, "$1")
+    async getVersion(): Promise<string> {
+        const result: [{ version: string }] = await this.query(
+            `SELECT version()`,
+        )
+        return result[0].version.replace(/^PostgreSQL ([\d.]+) .*$/, "$1")
     }
 
     /**

--- a/src/driver/sap/SapDriver.ts
+++ b/src/driver/sap/SapDriver.ts
@@ -72,6 +72,11 @@ export class SapDriver implements Driver {
     options: SapConnectionOptions
 
     /**
+     * Version of SAP HANA. Requires a SQL query to the DB, so it is not always set
+     */
+    version?: string
+
+    /**
      * Database name used to perform all write queries.
      */
     database?: string
@@ -295,19 +300,19 @@ export class SapDriver implements Driver {
         // create the pool
         this.master = this.client.createPool(dbParams, options)
 
-        if (!this.database || !this.schema) {
-            const queryRunner = await this.createQueryRunner("master")
+        const queryRunner = this.createQueryRunner("master")
 
-            if (!this.database) {
-                this.database = await queryRunner.getCurrentDatabase()
-            }
+        this.version = await queryRunner.getVersion()
 
-            if (!this.schema) {
-                this.schema = await queryRunner.getCurrentSchema()
-            }
-
-            await queryRunner.release()
+        if (!this.database) {
+            this.database = await queryRunner.getCurrentDatabase()
         }
+
+        if (!this.schema) {
+            this.schema = await queryRunner.getCurrentSchema()
+        }
+
+        await queryRunner.release()
     }
 
     /**

--- a/src/driver/sap/SapQueryRunner.ts
+++ b/src/driver/sap/SapQueryRunner.ts
@@ -387,9 +387,19 @@ export class SapQueryRunner extends BaseQueryRunner implements QueryRunner {
      */
     async getCurrentDatabase(): Promise<string> {
         const currentDBQuery = await this.query(
-            `SELECT "VALUE" AS "db_name" FROM "SYS"."M_SYSTEM_OVERVIEW" WHERE "SECTION" = 'System' and "NAME" = 'Instance ID'`,
+            `SELECT "DATABASE_NAME" AS "db_name" FROM "SYS"."M_DATABASE"`,
         )
         return currentDBQuery[0]["db_name"]
+    }
+
+    /**
+     * Returns the database server version.
+     */
+    async getVersion(): Promise<string> {
+        const currentDBQuery = await this.query(
+            `SELECT "VERSION" AS "version" FROM "SYS"."M_DATABASE"`,
+        )
+        return currentDBQuery[0]["version"]
     }
 
     /**

--- a/src/driver/sqlserver/SqlServerDriver.ts
+++ b/src/driver/sqlserver/SqlServerDriver.ts
@@ -300,7 +300,7 @@ export class SqlServerDriver implements Driver {
         }
 
         if (!this.database || !this.searchSchema) {
-            const queryRunner = await this.createQueryRunner("master")
+            const queryRunner = this.createQueryRunner("master")
 
             if (!this.database) {
                 this.database = await queryRunner.getCurrentDatabase()

--- a/src/util/VersionUtils.ts
+++ b/src/util/VersionUtils.ts
@@ -1,22 +1,27 @@
-export type Version = [number, number, number]
-
 export class VersionUtils {
-    static isGreaterOrEqual(version: string, targetVersion: string): boolean {
+    static isGreaterOrEqual(
+        version: string | undefined,
+        targetVersion: string,
+    ): boolean {
+        if (!version) {
+            return false
+        }
+
         const v1 = parseVersion(version)
         const v2 = parseVersion(targetVersion)
 
-        return (
-            v1[0] > v2[0] ||
-            (v1[0] === v2[0] && v1[1] > v2[1]) ||
-            (v1[0] === v2[0] && v1[1] === v2[1] && v1[2] >= v2[2])
-        )
+        for (let i = 0; i < v1.length && i < v2.length; i++) {
+            if (v1[i] > v2[i]) {
+                return true
+            } else if (v1[i] < v2[i]) {
+                return false
+            }
+        }
+
+        return true
     }
 }
 
-function parseVersion(version: string = ""): Version {
-    const v: Version = [0, 0, 0]
-
-    version.split(".").forEach((value, i) => (v[i] = parseInt(value, 10)))
-
-    return v
+function parseVersion(version: string): number[] {
+    return version.split(".").map((value) => parseInt(value, 10))
 }

--- a/test/github-issues/4782/issue-4782.ts
+++ b/test/github-issues/4782/issue-4782.ts
@@ -1,12 +1,12 @@
+import { expect } from "chai"
 import "reflect-metadata"
+
+import { DataSource } from "../../../src/data-source/DataSource"
 import {
     closeTestingConnections,
     createTestingConnections,
     reloadTestingDatabases,
 } from "../../utils/test-utils"
-import { DataSource } from "../../../src/data-source/DataSource"
-import { expect } from "chai"
-import { VersionUtils } from "../../../src/util/VersionUtils"
 
 describe("github issues > #4782 mariadb driver wants to recreate create/update date columns CURRENT_TIMESTAMP(6) === current_timestamp(6)", () => {
     let connections: DataSource[]
@@ -28,63 +28,4 @@ describe("github issues > #4782 mariadb driver wants to recreate create/update d
                 expect(sql1.upQueries).to.eql([])
             }),
         ))
-
-    describe("VersionUtils", () => {
-        describe("isGreaterOrEqual", () => {
-            it("should return false when comparing invalid versions", () => {
-                expect(VersionUtils.isGreaterOrEqual("", "")).to.equal(false)
-            })
-
-            it("should return false when targetVersion is larger", () => {
-                expect(
-                    VersionUtils.isGreaterOrEqual("1.2.3", "1.2.4"),
-                ).to.equal(false)
-                expect(
-                    VersionUtils.isGreaterOrEqual("1.2.3", "1.4.3"),
-                ).to.equal(false)
-                expect(
-                    VersionUtils.isGreaterOrEqual("1.2.3", "2.2.3"),
-                ).to.equal(false)
-                expect(VersionUtils.isGreaterOrEqual("1.2", "1.3")).to.equal(
-                    false,
-                )
-                expect(VersionUtils.isGreaterOrEqual("1", "2")).to.equal(false)
-                expect(
-                    VersionUtils.isGreaterOrEqual(
-                        undefined as unknown as string,
-                        "0.0.1",
-                    ),
-                ).to.equal(false)
-            })
-
-            it("should return true when targetVersion is smaller", () => {
-                expect(
-                    VersionUtils.isGreaterOrEqual("1.2.3", "1.2.2"),
-                ).to.equal(true)
-                expect(
-                    VersionUtils.isGreaterOrEqual("1.2.3", "1.1.3"),
-                ).to.equal(true)
-                expect(
-                    VersionUtils.isGreaterOrEqual("1.2.3", "0.2.3"),
-                ).to.equal(true)
-                expect(VersionUtils.isGreaterOrEqual("1.2", "1.2")).to.equal(
-                    true,
-                )
-                expect(VersionUtils.isGreaterOrEqual("1", "1")).to.equal(true)
-            })
-
-            it("should work with mariadb-style versions", () => {
-                const dbVersion = "10.4.8-MariaDB-1:10.4.8+maria~bionic"
-                expect(
-                    VersionUtils.isGreaterOrEqual("10.4.9", dbVersion),
-                ).to.equal(true)
-                expect(
-                    VersionUtils.isGreaterOrEqual("10.4.8", dbVersion),
-                ).to.equal(true)
-                expect(
-                    VersionUtils.isGreaterOrEqual("10.4.7", dbVersion),
-                ).to.equal(false)
-            })
-        })
-    })
 })

--- a/test/github-issues/7235/issue-7235.ts
+++ b/test/github-issues/7235/issue-7235.ts
@@ -10,18 +10,20 @@ import { expect } from "chai"
 import { VersionUtils } from "../../../src/util/VersionUtils"
 
 describe('github issues > #7235 Use "INSERT...RETURNING" in MariaDB.', () => {
-    const runOnSpecificVersion = (version: string, fn: Function) => async () =>
-        Promise.all(
-            connections.map(async (connection) => {
-                const result = await connection.query(
-                    `SELECT VERSION() AS \`version\``,
-                )
-                const dbVersion = result[0]["version"]
-                if (VersionUtils.isGreaterOrEqual(dbVersion, version)) {
-                    await fn(connection)
-                }
-            }),
-        )
+    const runOnSpecificVersion =
+        (version: string, fn: (dataSource: DataSource) => Promise<void>) =>
+        async () =>
+            Promise.all(
+                connections.map(async (connection) => {
+                    const result = await connection.query(
+                        `SELECT VERSION() AS \`version\``,
+                    )
+                    const dbVersion = result[0]["version"]
+                    if (VersionUtils.isGreaterOrEqual(dbVersion, version)) {
+                        await fn(connection)
+                    }
+                }),
+            )
 
     let connections: DataSource[]
 

--- a/test/unit/version-utils.ts
+++ b/test/unit/version-utils.ts
@@ -1,0 +1,77 @@
+import { expect } from "chai"
+
+import { VersionUtils } from "../../src/util/VersionUtils"
+
+describe("VersionUtils", () => {
+    describe("isGreaterOrEqual", () => {
+        it("should return false when comparing invalid versions", () => {
+            expect(VersionUtils.isGreaterOrEqual("", "")).to.equal(false)
+            expect(VersionUtils.isGreaterOrEqual(undefined, "0.0.1")).to.equal(
+                false,
+            )
+        })
+
+        it("should return false when targetVersion is larger", () => {
+            expect(VersionUtils.isGreaterOrEqual("1.2.3", "1.2.4")).to.equal(
+                false,
+            )
+            expect(VersionUtils.isGreaterOrEqual("1.2.3", "1.4.3")).to.equal(
+                false,
+            )
+            expect(VersionUtils.isGreaterOrEqual("1.2.3", "2.2.3")).to.equal(
+                false,
+            )
+            expect(VersionUtils.isGreaterOrEqual("1.2", "1.3")).to.equal(false)
+            expect(VersionUtils.isGreaterOrEqual("1.2", "1.3.1")).to.equal(
+                false,
+            )
+            expect(VersionUtils.isGreaterOrEqual("1.2.3", "1.3")).to.equal(
+                false,
+            )
+            expect(VersionUtils.isGreaterOrEqual("1", "2")).to.equal(false)
+            expect(
+                VersionUtils.isGreaterOrEqual(
+                    "2.00.040.00.20190729.1",
+                    "2.00.076.00.1705400033",
+                ),
+            ).to.equal(false)
+            expect(
+                VersionUtils.isGreaterOrEqual(
+                    "4.00.000.00.1732616693",
+                    "4.00.000.00.1739875052",
+                ),
+            ).to.equal(false)
+        })
+
+        it("should return true when targetVersion is smaller", () => {
+            expect(VersionUtils.isGreaterOrEqual("1.2.3", "1.2.2")).to.equal(
+                true,
+            )
+            expect(VersionUtils.isGreaterOrEqual("1.2.3", "1.1.3")).to.equal(
+                true,
+            )
+            expect(VersionUtils.isGreaterOrEqual("1.2.3", "1.1.5")).to.equal(
+                true,
+            )
+            expect(VersionUtils.isGreaterOrEqual("1.2.3", "0.2.3")).to.equal(
+                true,
+            )
+            expect(VersionUtils.isGreaterOrEqual("1.2", "1.2")).to.equal(true)
+            expect(VersionUtils.isGreaterOrEqual("1.3", "1.2.3")).to.equal(true)
+            expect(VersionUtils.isGreaterOrEqual("1.2.3", "1.2")).to.equal(true)
+            expect(VersionUtils.isGreaterOrEqual("1", "1")).to.equal(true)
+            expect(
+                VersionUtils.isGreaterOrEqual(
+                    "2.00.076.00.1705400033",
+                    "2.00.040.00.20190729.1",
+                ),
+            ).to.equal(true)
+            expect(
+                VersionUtils.isGreaterOrEqual(
+                    "4.00.000.00.1739875052",
+                    "4.00.000.00.1732616693",
+                ),
+            ).to.equal(true)
+        })
+    })
+})


### PR DESCRIPTION
### Description of change

Refactor the way the database server version is being fetched as well as the version comparison utils:
* improve code reuse for MySQL/MariaDB and Postgres drivers
* fetch the version correctly for MariaDB servers 
* implement version fetching upon connect the SAP driver
* refactor `VersionUtils.isGreaterOrEqual` to support versions with any number of components
* extract the unit tests for `VersionUtils`
* avoid awaiting for result of sync function call of `Driver.createQueryRunner`

### Pull-Request Checklist

- [x] Code is up-to-date with the `master` branch
- [x] `npm run format` to apply prettier formatting
- [x] `npm run test` passes with this change
- [ ] This pull request links relevant issues as `Fixes #0000`
- [x] There are new or updated unit tests validating the change
- [ ] Documentation has been updated to reflect this change
- [x] The new commits follow conventions explained in [CONTRIBUTING.md](https://github.com/typeorm/typeorm/blob/master/CONTRIBUTING.md)