### PR TITLE
build: test derived databases

### DIFF
--- a/.github/workflows/database-tests-manual.yml
+++ b/.github/workflows/database-tests-manual.yml
@@ -1,0 +1,26 @@
+name: database-tests-manual
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: "0 0 2 * *"
+
+jobs:
+  yugabyte:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - run: docker compose up yugabyte --detach
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: "npm"
+
+      - run: npm ci
+      - run: cat ormconfig.sample.json | jq -c 'map(select(.name == "yugabyte"))' > ormconfig.json
+      - run: npm run compile
+      - run: docker compose up yugabyte --no-recreate --wait
+      - run: npm run test:fast

--- a/.github/workflows/database-tests-manual.yml
+++ b/.github/workflows/database-tests-manual.yml
@@ -6,6 +6,29 @@ on:
     - cron: "0 0 2 * *"
 
 jobs:
+  crate:
+    runs-on: ubuntu-latest
+
+    services:
+      crate:
+        image: crate:latest
+        ports:
+          - "5434:5432"
+        env:
+          CRATE_HEAP_SIZE: "1G"
+
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: "npm"
+
+      - run: npm ci
+      - run: cat ormconfig.sample.json | jq -c 'map(select(.name == "crate"))' > ormconfig.json
+      - run: npm run compile
+      - run: npm run test:fast
+
   yugabyte:
     runs-on: ubuntu-latest
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -113,6 +113,14 @@ services:
     ports:
       - "27017:27017"
 
+  crate:
+    image: "crate:latest"
+    container_name: "typeorm-crate"
+    ports:
+      - "5434:5432"
+    environment:
+      CRATE_HEAP_SIZE: "1G"
+
   # yugabyte
   yugabyte:
     image: "yugabytedb/yugabyte:latest"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -113,6 +113,14 @@ services:
     ports:
       - "27017:27017"
 
+  # yugabyte
+  yugabyte:
+    image: "yugabytedb/yugabyte:latest"
+    container_name: "typeorm-yugabyte"
+    ports:
+      - "5433:5433"
+    entrypoint: ["yugabyted", "start", "--background=false"]
+
   # redis
   # redis:
   #   image: "redis:3.0.3"

--- a/ormconfig.sample.json
+++ b/ormconfig.sample.json
@@ -137,6 +137,17 @@
   },
   {
     "skip": false,
+    "name": "crate",
+    "type": "postgres",
+    "host": "localhost",
+    "port": 5434,
+    "username": "crate",
+    "password": "",
+    "database": "crate",
+    "logging": false
+  },
+  {
+    "skip": false,
     "name": "yugabyte",
     "type": "postgres",
     "host": "localhost",

--- a/ormconfig.sample.json
+++ b/ormconfig.sample.json
@@ -134,5 +134,16 @@
       "maxRetries": 3
     },
     "logging": false
+  },
+  {
+    "skip": false,
+    "name": "yugabyte",
+    "type": "postgres",
+    "host": "localhost",
+    "port": 5433,
+    "username": "yugabyte",
+    "password": "yugabyte",
+    "database": "yugabyte",
+    "logging": false
   }
 ]

--- a/src/driver/postgres/PostgresQueryRunner.ts
+++ b/src/driver/postgres/PostgresQueryRunner.ts
@@ -4158,7 +4158,7 @@ export class PostgresQueryRunner
      */
     async getVersion(): Promise<string> {
         const result: [{ version: string }] = await this.query(
-            `SELECT version()`,
+            `SELECT version() as "version"`,
         )
 
         // Examples:


### PR DESCRIPTION
### Description of change

Add manual/scheduled tests for derived databases.

Initially just for Yugabyte.

Example workflow: https://github.com/alumni/typeorm/actions/runs/14118685376/job/39554656721

### Pull-Request Checklist

- [x] Code is up-to-date with the `master` branch
- [x] `npm run format` to apply prettier formatting
- [x] `npm run test` passes with this change
- [ ] This pull request links relevant issues as `Fixes #0000`
- [ ] There are new or updated unit tests validating the change
- [ ] Documentation has been updated to reflect this change
- [x] The new commits follow conventions explained in [CONTRIBUTING.md](https://github.com/typeorm/typeorm/blob/master/CONTRIBUTING.md)