### PR TITLE
fix: version detection for Postgres derived variants

### DIFF
--- a/src/driver/postgres/PostgresQueryRunner.ts
+++ b/src/driver/postgres/PostgresQueryRunner.ts
@@ -4160,7 +4160,11 @@ export class PostgresQueryRunner
         const result: [{ version: string }] = await this.query(
             `SELECT version()`,
         )
-        return result[0].version.replace(/^PostgreSQL ([\d.]+) .*$/, "$1")
+
+        // Examples:
+        // Postgres: "PostgreSQL 14.10 on x86_64-pc-linux-gnu, compiled by gcc (GCC) 8.5.0 20210514 (Red Hat 8.5.0-20), 64-bit"
+        // Yugabyte: "PostgreSQL 11.2-YB-2.18.1.0-b0 on x86_64-pc-linux-gnu, compiled by clang version 15.0.3 (https://github.com/yugabyte/llvm-project.git 0b8d1183745fd3998d8beffeec8cbe99c1b20529), 64-bit"
+        return result[0].version.replace(/^PostgreSQL ([\d.]+).*$/, "$1")
     }
 
     /**

--- a/test/functional/cube/postgres/cube-postgres.ts
+++ b/test/functional/cube/postgres/cube-postgres.ts
@@ -1,6 +1,8 @@
-import "reflect-metadata"
 import { expect } from "chai"
+import "reflect-metadata"
+
 import { DataSource } from "../../../../src/data-source/DataSource"
+import { DriverUtils } from "../../../../src/driver/DriverUtils"
 import {
     closeTestingConnections,
     createTestingConnections,
@@ -109,12 +111,12 @@ describe("cube-postgres", () => {
                 // Get Postgres version because zero-length cubes are not legal
                 // on all Postgres versions. Zero-length cubes are only tested
                 // to be working on Postgres version >=10.6.
-                const [{ version }] = await connection.query("SELECT version()")
-                const semverArray = version
-                    .replace(/^PostgreSQL ([\d.]+) .*$/, "$1")
-                    .split(".")
-                    .map(Number)
-                if (!(semverArray[0] >= 10 && semverArray[1] >= 6)) {
+                if (
+                    !DriverUtils.isReleaseVersionOrGreater(
+                        connection.driver,
+                        "10.6",
+                    )
+                ) {
                     return
                 }
 

--- a/test/github-issues/9318/issue-9318.ts
+++ b/test/github-issues/9318/issue-9318.ts
@@ -1,14 +1,14 @@
+import { expect } from "chai"
 import "reflect-metadata"
+
+import { DataSource } from "../../../src"
+import { PostgresDriver } from "../../../src/driver/postgres/PostgresDriver"
 import {
-    createTestingConnections,
     closeTestingConnections,
+    createTestingConnections,
     reloadTestingDatabases,
 } from "../../utils/test-utils"
-import { DataSource } from "../../../src"
-
-import { expect } from "chai"
-import { PostgresDriver } from "../../../src/driver/postgres/PostgresDriver"
-import { VersionUtils } from "../../../src/util/VersionUtils"
+import { DriverUtils } from "../../../src/driver/DriverUtils"
 
 describe("github issues > #9318 Change version query from SHOW server_version to SELECT version", () => {
     let connections: DataSource[]
@@ -29,15 +29,11 @@ describe("github issues > #9318 Change version query from SHOW server_version to
             connections.map(async (connection) => {
                 const { isGeneratedColumnsSupported } =
                     connection.driver as PostgresDriver
-                const result = await connection.query("SELECT VERSION()")
-                const dbVersion = result[0]["version"].replace(
-                    /^PostgreSQL ([\d.]+) .*$/,
-                    "$1",
-                )
-                const versionGreaterOfEqualTo12 = VersionUtils.isGreaterOrEqual(
-                    dbVersion,
-                    "12.0",
-                )
+                const versionGreaterOfEqualTo12 =
+                    DriverUtils.isReleaseVersionOrGreater(
+                        connection.driver,
+                        "12.0",
+                    )
 
                 expect(isGeneratedColumnsSupported).to.eq(
                     versionGreaterOfEqualTo12,


### PR DESCRIPTION
### Description of change

Fixes version detection for PostgreSQL. The version might not always be followed by a space (similar to MySQL/MariaDB).

Example version strings:
```
PostgreSQL 9.3.25 on x86_64-pc-linux-musl, compiled by gcc (Alpine 11.2.1_git20220219) 11.2.1 20220219, 64-bit
PostgreSQL 9.6.24 on x86_64-pc-linux-musl, compiled by gcc (Alpine 11.2.1_git20220219) 11.2.1 20220219, 64-bit
PostgreSQL 10.23 on x86_64-pc-linux-gnu, compiled by gcc (GCC) 8.5.0 20210514 (Red Hat 8.5.0-15), 64-bit
PostgreSQL 14.9 (Debian 14.9-1.pgdg110+1) on x86_64-pc-linux-gnu, compiled by gcc (Debian 10.2.1-6) 10.2.1 20210110, 64-bit
PostgreSQL 14.10 on x86_64-pc-linux-gnu, compiled by gcc (GCC) 8.5.0 20210514 (Red Hat 8.5.0-20), 64-bit
PostgreSQL 17.2 (Debian 17.2-1.pgdg120+1) on x86_64-pc-linux-gnu, compiled by gcc (Debian 12.2.0-14) 12.2.0, 64-bit
PostgreSQL 11.2-YB-2.6.18.0-b0 on x86_64-pc-linux-gnu, compiled by gcc (Homebrew gcc 5.5.0_4) 5.5.0, 64-bit
PostgreSQL 11.2-YB-2.18.1.0-b0 on x86_64-pc-linux-gnu, compiled by clang version 15.0.3 (https://github.com/yugabyte/llvm-project.git 0b8d1183745fd3998d8beffeec8cbe99c1b20529), 64-bit
PostgreSQL 15.2-YB-2.25.1.0-b0 on x86_64-pc-linux-gnu, compiled by clang version 17.0.6 (https://github.com/yugabyte/llvm-project.git 9b881774e40024e901fc6f3d313607b071c08631), 64-bit
```

### Pull-Request Checklist

- [x] Code is up-to-date with the `master` branch
- [x] `npm run format` to apply prettier formatting
- [x] `npm run test` passes with this change
- [ ] This pull request links relevant issues as `Fixes #0000`
- [x] There are new or updated unit tests validating the change
- [ ] Documentation has been updated to reflect this change
- [x] The new commits follow conventions explained in [CONTRIBUTING.md](https://github.com/typeorm/typeorm/blob/master/CONTRIBUTING.md)
