### PR TITLE
docs: add comment explaining select version()

### DIFF
--- a/src/driver/postgres/PostgresQueryRunner.ts
+++ b/src/driver/postgres/PostgresQueryRunner.ts
@@ -4157,6 +4157,12 @@ export class PostgresQueryRunner
      * Loads Postgres version.
      */
     async getVersion(): Promise<string> {
+        // we use `SELECT version()` instead of `SHOW server_version` or `SHOW server_version_num`
+        // to maintain compatability with Amazon Redshift.
+        //
+        // see:
+        //  - https://github.com/typeorm/typeorm/pull/9319
+        //  - https://docs.aws.amazon.com/redshift/latest/dg/c_unsupported-postgresql-functions.html
         const result: [{ version: string }] = await this.query(
             `SELECT version()`,
         )


### PR DESCRIPTION
### Description of change

Adds a comment explaining why we use `SELECT version()` for Postgres version detection. (Follow up to https://github.com/typeorm/typeorm/pull/11375).

### Pull-Request Checklist

- [x] Code is up-to-date with the `master` branch
- [x] `npm run format` to apply prettier formatting
- [x] `npm run test` passes with this change
- [x] ~~This pull request links relevant issues as `Fixes #0000`~~
- [x] ~~There are new or updated unit tests validating the change~~
- [x] ~~Documentation has been updated to reflect this change~~
- [x] The new commits follow conventions explained in [CONTRIBUTING.md](https://github.com/typeorm/typeorm/blob/master/CONTRIBUTING.md)