### PR TITLE
chore: Add package publishing workflow

### DIFF
--- a/.github/workflows/publish-package.yml
+++ b/.github/workflows/publish-package.yml
@@ -1,0 +1,23 @@
+name: Publish Package to npmjs
+on:
+  release:
+    types: [published]
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
+    steps:
+      - uses: actions/checkout@v4
+      # Setup .npmrc file to publish to npm
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20.x'
+          registry-url: 'https://registry.npmjs.org'
+      - run: npm ci
+      - run: npm run package
+      - run: cd build/package
+      - run: npm publish --provenance --access public
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
### Description of change

This PR introduces a new GitHub Actions workflow that will publish a new version of TypeORM to npm.

It is based on the guide from GitHub: https://docs.github.com/en/actions/use-cases-and-examples/publishing-packages/publishing-nodejs-packages#publishing-packages-to-the-npm-registry

I have already generated an automation token and put it in the secrets of this repo as `NPM_TOKEN`, which should allow the publish to take place and not be stopped by 2-factor auth.

The intended workflow would be:

1. The repo is ready for a new release
2. A PR is made which bumps the package version in package.json and updates the changelog by running `npm run changelog`
3. The PR is merged
4. A new Release is created using the GitHub releases feature. In this process a new tag is created, e.g. `v0.3.22`.
5. Once the release is published, this workflow should trigger and build & publish the package to npm.