### PR TITLE
chore: Fix publish command

### DIFF
--- a/.github/workflows/publish-package.yml
+++ b/.github/workflows/publish-package.yml
@@ -2,6 +2,7 @@ name: Publish Package to npmjs
 on:
   release:
     types: [published]
+  workflow_dispatch:
 jobs:
   build:
     runs-on: ubuntu-latest
@@ -17,7 +18,8 @@ jobs:
           registry-url: 'https://registry.npmjs.org'
       - run: npm ci
       - run: npm run package
-      - run: cd build/package
-      - run: npm publish --provenance --access public
+      - run: |
+          cd build/package
+          npm publish --provenance --access public
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
- The publish command was being executed as 2 separate `run` steps, which meant that the `cd build/package` didn't have an effect on the subsequent publish command, so it attempted to publish from the root, which doesn't work because the root package.json is private (plus the contents of the package would have been totally wrong.

I also added the `workflow_dispatch` trigger so I can manually trigger this without needing to create a new release.