### PR TITLE
chore: fix changelog generation

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -48,8 +48,6 @@
         "chai": "^4.5.0",
         "chai-as-promised": "^7.1.2",
         "class-transformer": "^0.5.1",
-        "conventional-changelog-angular": "^7.0.0",
-        "conventional-changelog-cli": "^5.0.0",
         "eslint": "^9.22.0",
         "globals": "^16.0.0",
         "gulp": "^4.0.2",
@@ -78,6 +76,7 @@
         "source-map-support": "^0.5.21",
         "sql.js": "^1.13.0",
         "sqlite3": "^5.1.7",
+        "standard-changelog": "^6.0.0",
         "ts-node": "^10.9.2",
         "typescript": "^5.8.2",
         "typescript-eslint": "^8.27.0"
@@ -5042,85 +5041,10 @@
       "dev": true,
       "optional": true
     },
-    "node_modules/conventional-changelog": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/conventional-changelog/-/conventional-changelog-6.0.0.tgz",
-      "integrity": "sha512-tuUH8H/19VjtD9Ig7l6TQRh+Z0Yt0NZ6w/cCkkyzUbGQTnUEmKfGtkC9gGfVgCfOL1Rzno5NgNF4KY8vR+Jo3w==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "conventional-changelog-angular": "^8.0.0",
-        "conventional-changelog-atom": "^5.0.0",
-        "conventional-changelog-codemirror": "^5.0.0",
-        "conventional-changelog-conventionalcommits": "^8.0.0",
-        "conventional-changelog-core": "^8.0.0",
-        "conventional-changelog-ember": "^5.0.0",
-        "conventional-changelog-eslint": "^6.0.0",
-        "conventional-changelog-express": "^5.0.0",
-        "conventional-changelog-jquery": "^6.0.0",
-        "conventional-changelog-jshint": "^5.0.0",
-        "conventional-changelog-preset-loader": "^5.0.0"
-      },
-      "engines": {
-        "node": ">=18"
-      }
-    },
     "node_modules/conventional-changelog-angular": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/conventional-changelog-angular/-/conventional-changelog-angular-7.0.0.tgz",
-      "integrity": "sha512-ROjNchA9LgfNMTTFSIWPzebCwOGFdgkEq45EnvvrmSLvCtAw0HSmrCs7/ty+wAeYUZyNay0YMUNYFTRL72PkBQ==",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "compare-func": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=16"
-      }
-    },
-    "node_modules/conventional-changelog-atom": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/conventional-changelog-atom/-/conventional-changelog-atom-5.0.0.tgz",
-      "integrity": "sha512-WfzCaAvSCFPkznnLgLnfacRAzjgqjLUjvf3MftfsJzQdDICqkOOpcMtdJF3wTerxSpv2IAAjX8doM3Vozqle3g==",
-      "dev": true,
-      "license": "ISC",
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/conventional-changelog-cli": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/conventional-changelog-cli/-/conventional-changelog-cli-5.0.0.tgz",
-      "integrity": "sha512-9Y8fucJe18/6ef6ZlyIlT2YQUbczvoQZZuYmDLaGvcSBP+M6h+LAvf7ON7waRxKJemcCII8Yqu5/8HEfskTxJQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "add-stream": "^1.0.0",
-        "conventional-changelog": "^6.0.0",
-        "meow": "^13.0.0",
-        "tempfile": "^5.0.0"
-      },
-      "bin": {
-        "conventional-changelog": "cli.js"
-      },
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/conventional-changelog-codemirror": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/conventional-changelog-codemirror/-/conventional-changelog-codemirror-5.0.0.tgz",
-      "integrity": "sha512-8gsBDI5Y3vrKUCxN6Ue8xr6occZ5nsDEc4C7jO/EovFGozx8uttCAyfhRrvoUAWi2WMm3OmYs+0mPJU7kQdYWQ==",
-      "dev": true,
-      "license": "ISC",
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/conventional-changelog-conventionalcommits": {
       "version": "8.0.0",
-      "resolved": "https://registry.npmjs.org/conventional-changelog-conventionalcommits/-/conventional-changelog-conventionalcommits-8.0.0.tgz",
-      "integrity": "sha512-eOvlTO6OcySPyyyk8pKz2dP4jjElYunj9hn9/s0OB+gapTO8zwS9UQWrZ1pmF2hFs3vw1xhonOLGcGjy/zgsuA==",
+      "resolved": "https://registry.npmjs.org/conventional-changelog-angular/-/conventional-changelog-angular-8.0.0.tgz",
+      "integrity": "sha512-CLf+zr6St0wIxos4bmaKHRXWAcsCXrJU6F4VdNDrGRK3B8LDLKoX3zuMV5GhtbGkVR/LohZ6MT6im43vZLSjmA==",
       "dev": true,
       "license": "ISC",
       "dependencies": {
@@ -5152,69 +5076,6 @@
         "node": ">=18"
       }
     },
-    "node_modules/conventional-changelog-ember": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/conventional-changelog-ember/-/conventional-changelog-ember-5.0.0.tgz",
-      "integrity": "sha512-RPflVfm5s4cSO33GH/Ey26oxhiC67akcxSKL8CLRT3kQX2W3dbE19sSOM56iFqUJYEwv9mD9r6k79weWe1urfg==",
-      "dev": true,
-      "license": "ISC",
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/conventional-changelog-eslint": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/conventional-changelog-eslint/-/conventional-changelog-eslint-6.0.0.tgz",
-      "integrity": "sha512-eiUyULWjzq+ybPjXwU6NNRflApDWlPEQEHvI8UAItYW/h22RKkMnOAtfCZxMmrcMO1OKUWtcf2MxKYMWe9zJuw==",
-      "dev": true,
-      "license": "ISC",
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/conventional-changelog-express": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/conventional-changelog-express/-/conventional-changelog-express-5.0.0.tgz",
-      "integrity": "sha512-D8Q6WctPkQpvr2HNCCmwU5GkX22BVHM0r4EW8vN0230TSyS/d6VQJDAxGb84lbg0dFjpO22MwmsikKL++Oo/oQ==",
-      "dev": true,
-      "license": "ISC",
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/conventional-changelog-jquery": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/conventional-changelog-jquery/-/conventional-changelog-jquery-6.0.0.tgz",
-      "integrity": "sha512-2kxmVakyehgyrho2ZHBi90v4AHswkGzHuTaoH40bmeNqUt20yEkDOSpw8HlPBfvEQBwGtbE+5HpRwzj6ac2UfA==",
-      "dev": true,
-      "license": "ISC",
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/conventional-changelog-jshint": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/conventional-changelog-jshint/-/conventional-changelog-jshint-5.0.0.tgz",
-      "integrity": "sha512-gGNphSb/opc76n2eWaO6ma4/Wqu3tpa2w7i9WYqI6Cs2fncDSI2/ihOfMvXveeTTeld0oFvwMVNV+IYQIk3F3g==",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "compare-func": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/conventional-changelog-preset-loader": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/conventional-changelog-preset-loader/-/conventional-changelog-preset-loader-5.0.0.tgz",
-      "integrity": "sha512-SetDSntXLk8Jh1NOAl1Gu5uLiCNSYenB5tm0YVeZKePRIgDW9lQImromTwLa3c/Gae298tsgOM+/CYT9XAl0NA==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=18"
-      }
-    },
     "node_modules/conventional-changelog-writer": {
       "version": "8.0.1",
       "resolved": "https://registry.npmjs.org/conventional-changelog-writer/-/conventional-changelog-writer-8.0.1.tgz",
@@ -5229,19 +5090,6 @@
       },
       "bin": {
         "conventional-changelog-writer": "dist/cli/index.js"
-      },
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/conventional-changelog/node_modules/conventional-changelog-angular": {
-      "version": "8.0.0",
-      "resolved": "https://registry.npmjs.org/conventional-changelog-angular/-/conventional-changelog-angular-8.0.0.tgz",
-      "integrity": "sha512-CLf+zr6St0wIxos4bmaKHRXWAcsCXrJU6F4VdNDrGRK3B8LDLKoX3zuMV5GhtbGkVR/LohZ6MT6im43vZLSjmA==",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "compare-func": "^2.0.0"
       },
       "engines": {
         "node": ">=18"
@@ -13344,6 +13192,32 @@
         "node": "*"
       }
     },
+    "node_modules/standard-changelog": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/standard-changelog/-/standard-changelog-6.0.0.tgz",
+      "integrity": "sha512-VaoASALkUoStWRFFNZAHPt+9NMZxD7HimU69CvW13ywC2yW8SQzRGdbPGkn8ih1LD3h37fNG3bxOqJlY88K5uA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "conventional-changelog-angular": "^8.0.0",
+        "conventional-changelog-core": "^8.0.0",
+        "meow": "^13.0.0",
+        "picocolors": "^1.0.0"
+      },
+      "bin": {
+        "standard-changelog": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/standard-changelog/node_modules/picocolors": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/static-extend": {
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/static-extend/-/static-extend-0.1.2.tgz",
@@ -13728,32 +13602,6 @@
       "license": "MIT",
       "dependencies": {
         "safe-buffer": "~5.2.0"
-      }
-    },
-    "node_modules/temp-dir": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/temp-dir/-/temp-dir-3.0.0.tgz",
-      "integrity": "sha512-nHc6S/bwIilKHNRgK/3jlhDoIHcp45YgyiwcAk46Tr0LfEqGBVpmiAyuiuxeVE44m3mXnEeVhaipLOEWmH+Njw==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=14.16"
-      }
-    },
-    "node_modules/tempfile": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/tempfile/-/tempfile-5.0.0.tgz",
-      "integrity": "sha512-bX655WZI/F7EoTDw9JvQURqAXiPHi8o8+yFxPF2lWYyz1aHnmMRuXWqL6YB6GmeO0o4DIYWHLgGNi/X64T+X4Q==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "temp-dir": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=14.18"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/test-exclude": {

--- a/package.json
+++ b/package.json
@@ -75,7 +75,7 @@
     "typeorm-ts-node-esm": "./cli-ts-node-esm.js"
   },
   "scripts": {
-    "changelog": "conventional-changelog -p angular -i CHANGELOG.md -s -r 1",
+    "changelog": "standard-changelog",
     "compile": "rimraf ./build && tsc",
     "format": "prettier --cache --write \"./**/*.ts\"",
     "format:ci": "prettier --check \"./**/*.ts\"",
@@ -122,8 +122,6 @@
     "chai": "^4.5.0",
     "chai-as-promised": "^7.1.2",
     "class-transformer": "^0.5.1",
-    "conventional-changelog-angular": "^7.0.0",
-    "conventional-changelog-cli": "^5.0.0",
     "eslint": "^9.22.0",
     "globals": "^16.0.0",
     "gulp": "^4.0.2",
@@ -152,6 +150,7 @@
     "source-map-support": "^0.5.21",
     "sql.js": "^1.13.0",
     "sqlite3": "^5.1.7",
+    "standard-changelog": "^6.0.0",
     "ts-node": "^10.9.2",
     "typescript": "^5.8.2",
     "typescript-eslint": "^8.27.0"


### PR DESCRIPTION
### Description of change

Fixes the generation of changelog for new releases.

`standard-changelog` automatically generates the changelog in the same format until now, without requiring any configuration.

### Pull-Request Checklist

- [x] Code is up-to-date with the `master` branch
- [x] `npm run format` to apply prettier formatting
- [ ] `npm run test` passes with this change
- [ ] This pull request links relevant issues as `Fixes #0000`
- [ ] There are new or updated unit tests validating the change
- [ ] Documentation has been updated to reflect this change
- [x] The new commits follow conventions explained in [CONTRIBUTING.md](https://github.com/typeorm/typeorm/blob/master/CONTRIBUTING.md)
