### PR TITLE
fix: Multiple relations with same columns cause invalid SQL to be generated

### DIFF
--- a/src/metadata-builder/RelationJoinColumnBuilder.ts
+++ b/src/metadata-builder/RelationJoinColumnBuilder.ts
@@ -233,6 +233,13 @@ export class RelationJoinColumnBuilder {
                     },
                 })
                 relation.entityMetadata.registerColumn(relationalColumn)
+            } else {
+                relationalColumn = Object.assign(
+                    Object.create(
+                        Object.getPrototypeOf(relationalColumn),
+                    ) as ColumnMetadata,
+                    relationalColumn,
+                )
             }
             relationalColumn.referencedColumn = referencedColumn // its important to set it here because we need to set referenced column for user defined join column
             relationalColumn.type = referencedColumn.type // also since types of relational column and join column must be equal we override user defined column type


### PR DESCRIPTION
Closes: #10121, #10148, #11109, #11132, #11180

### Description of change

In `RelationJoinColumnBuilder.collectColumns,` `relationalColumn` is used by reference and `referencedColumn` is overwritten.
Solution: Create a copy of the found `relationalColumn`.

### Pull-Request Checklist

- [ ] Code is up-to-date with the `master` branch
- [ ] `npm run format` to apply prettier formatting
- [ ] `npm run test` passes with this change
- [ ] This pull request links relevant issues as `Fixes #0000`
- [ ] There are new or updated unit tests validating the change
- [ ] Documentation has been updated to reflect this change
- [ ] The new commits follow conventions explained in [CONTRIBUTING.md](https://github.com/typeorm/typeorm/blob/master/CONTRIBUTING.md)