### PR TITLE
test: remove unused type parameter from decorators

### DIFF
--- a/sample/sample10-mixed/entity/Category.ts
+++ b/sample/sample10-mixed/entity/Category.ts
@@ -16,9 +16,9 @@ export class Category {
     @Column()
     description: string
 
-    @ManyToMany((type) => Post, (post) => post.categories)
+    @ManyToMany(() => Post, (post) => post.categories)
     posts: Post[]
 
-    @ManyToOne((type) => PostDetails, (postDetails) => postDetails.categories)
+    @ManyToOne(() => PostDetails, (postDetails) => postDetails.categories)
     details: PostDetails
 }

--- a/sample/sample10-mixed/entity/Chapter.ts
+++ b/sample/sample10-mixed/entity/Chapter.ts
@@ -14,6 +14,6 @@ export class Chapter {
     @Column()
     about: string
 
-    @OneToMany((type) => PostDetails, (postDetails) => postDetails.chapter)
+    @OneToMany(() => PostDetails, (postDetails) => postDetails.chapter)
     postDetails: PostDetails[]
 }

--- a/sample/sample10-mixed/entity/Cover.ts
+++ b/sample/sample10-mixed/entity/Cover.ts
@@ -14,6 +14,6 @@ export class Cover {
     @Column()
     url: string
 
-    @OneToMany((type) => Post, (post) => post.cover)
+    @OneToMany(() => Post, (post) => post.cover)
     posts: Post[]
 }

--- a/sample/sample10-mixed/entity/Image.ts
+++ b/sample/sample10-mixed/entity/Image.ts
@@ -17,15 +17,15 @@ export class Image {
     @Column()
     name: string
 
-    @ManyToOne((type) => Post, (post) => post.images)
+    @ManyToOne(() => Post, (post) => post.images)
     post: Post
 
-    @ManyToOne((type) => Post, (post) => post.secondaryImages, {
+    @ManyToOne(() => Post, (post) => post.secondaryImages, {
         cascade: ["insert"],
     })
     secondaryPost: Post
 
-    @OneToOne((type) => ImageDetails, (details) => details.image, {
+    @OneToOne(() => ImageDetails, (details) => details.image, {
         cascade: true,
     })
     @JoinColumn()

--- a/sample/sample10-mixed/entity/ImageDetails.ts
+++ b/sample/sample10-mixed/entity/ImageDetails.ts
@@ -17,6 +17,6 @@ export class ImageDetails {
     @Column()
     comment: string
 
-    @OneToOne((type) => Image, (image) => image.details)
+    @OneToOne(() => Image, (image) => image.details)
     image: Image
 }

--- a/sample/sample10-mixed/entity/Post.ts
+++ b/sample/sample10-mixed/entity/Post.ts
@@ -29,21 +29,21 @@ export class Post {
     })
     text: string
 
-    @OneToOne((type) => PostDetails, (details) => details.post, {
+    @OneToOne(() => PostDetails, (details) => details.post, {
         cascade: true,
     })
     @JoinColumn()
     details: PostDetails
 
-    @OneToMany((type) => Image, (image) => image.post, {
+    @OneToMany(() => Image, (image) => image.post, {
         cascade: true,
     })
     images: Image[] = []
 
-    @OneToMany((type) => Image, (image) => image.secondaryPost)
+    @OneToMany(() => Image, (image) => image.secondaryPost)
     secondaryImages: Image[]
 
-    @ManyToOne((type) => Cover, (cover) => cover.posts, {
+    @ManyToOne(() => Cover, (cover) => cover.posts, {
         cascade: ["insert"],
     })
     @JoinColumn({ name: "coverId" })
@@ -54,7 +54,7 @@ export class Post {
     })
     coverId: number
 
-    @ManyToMany((type) => Category, (category) => category.posts, {
+    @ManyToMany(() => Category, (category) => category.posts, {
         cascade: true,
     })
     @JoinTable()

--- a/sample/sample10-mixed/entity/PostDetails.ts
+++ b/sample/sample10-mixed/entity/PostDetails.ts
@@ -21,15 +21,15 @@ export class PostDetails {
     @Column()
     comment: string
 
-    @OneToOne((type) => Post, (post) => post.details)
+    @OneToOne(() => Post, (post) => post.details)
     post: Post
 
-    @OneToMany((type) => Category, (category) => category.details, {
+    @OneToMany(() => Category, (category) => category.details, {
         cascade: ["insert"],
     })
     categories: Category[]
 
-    @ManyToOne((type) => Chapter, (chapter) => chapter.postDetails, {
+    @ManyToOne(() => Chapter, (chapter) => chapter.postDetails, {
         cascade: ["insert"],
     })
     chapter: Chapter

--- a/sample/sample13-everywhere-abstraction/entity/BaseObject.ts
+++ b/sample/sample13-everywhere-abstraction/entity/BaseObject.ts
@@ -13,7 +13,7 @@ export class BaseObject extends BasePost {
     @Column()
     title: string
 
-    @ManyToOne((type) => PostAuthor, (post) => post.posts, {
+    @ManyToOne(() => PostAuthor, (post) => post.posts, {
         cascade: true,
     })
     author: PostAuthor

--- a/sample/sample13-everywhere-abstraction/entity/PostAuthor.ts
+++ b/sample/sample13-everywhere-abstraction/entity/PostAuthor.ts
@@ -11,6 +11,6 @@ export class PostAuthor extends PostUser {
     @Column()
     name: string
 
-    @OneToMany((type) => Post, (post) => post.author)
+    @OneToMany(() => Post, (post) => post.author)
     posts: Post[]
 }

--- a/sample/sample14-errors-in-wrong-metdata/entity/Post.ts
+++ b/sample/sample14-errors-in-wrong-metdata/entity/Post.ts
@@ -21,14 +21,14 @@ export class Post {
     @Column()
     text: string
 
-    @OneToOne((type) => PostAuthor, (author) => author.post, {
+    @OneToOne(() => PostAuthor, (author) => author.post, {
         cascade: true,
     })
     @JoinColumn() // comment this and you'll get an error because JoinColumn must be at least on one side of the one-to-one relationship
     // @JoinTable() // uncomment this and you'll get an error because JoinTable is not allowed here (only many-to-many)
     author: PostAuthor
 
-    @OneToMany((type) => PostAuthor, (author) => author.editedPost, {
+    @OneToMany(() => PostAuthor, (author) => author.editedPost, {
         cascade: true,
     })
     // @JoinColumn() // uncomment this and you'll get an error, because JoinColumn is not allowed here (only many-to-one/one-to-one)

--- a/sample/sample14-errors-in-wrong-metdata/entity/PostAuthor.ts
+++ b/sample/sample14-errors-in-wrong-metdata/entity/PostAuthor.ts
@@ -16,15 +16,15 @@ export class PostAuthor {
     @Column()
     name: string
 
-    @OneToOne((type) => Post, (post) => post.author)
+    @OneToOne(() => Post, (post) => post.author)
     // @JoinColumn() // uncomment this and it will case an error, because JoinColumn is allowed only on one side
     post: Post
 
-    @ManyToOne((type) => Post, (post) => post.editors)
+    @ManyToOne(() => Post, (post) => post.editors)
     // @JoinColumn() // JoinColumn is optional here, so if it present or not you should not get an error
     editedPost: Post
 
-    @ManyToMany((type) => Post, (post) => post.manyAuthors)
+    @ManyToMany(() => Post, (post) => post.manyAuthors)
     // @JoinTable() // uncomment this and it will case an error, because only one side of the ManyToMany relation can have a JoinTable decorator.
     manyPosts: Post[]
 }

--- a/sample/sample18-lazy-relations/entity/Author.ts
+++ b/sample/sample18-lazy-relations/entity/Author.ts
@@ -10,7 +10,7 @@ export class Author {
     @Column()
     name: string
 
-    @OneToMany((type) => Post, (post) => post.author, {
+    @OneToMany(() => Post, (post) => post.author, {
         cascade: true,
     })
     posts: Promise<Post[]>

--- a/sample/sample18-lazy-relations/entity/Post.ts
+++ b/sample/sample18-lazy-relations/entity/Post.ts
@@ -16,13 +16,13 @@ export class Post {
     @Column()
     text: string
 
-    @ManyToOne((type) => Author, (author) => author.posts, {
+    @ManyToOne(() => Author, (author) => author.posts, {
         cascade: ["insert"],
         onDelete: "SET NULL",
     })
     author: Promise<Author | null>
 
-    @ManyToMany((type) => Category, (category) => category.posts, {
+    @ManyToMany(() => Category, (category) => category.posts, {
         cascade: true,
     })
     @JoinTable()

--- a/sample/sample19-one-side-relations/entity/Post.ts
+++ b/sample/sample19-one-side-relations/entity/Post.ts
@@ -19,14 +19,14 @@ export class Post {
     @Column()
     text: string
 
-    @ManyToOne((type) => Author, { cascade: true })
+    @ManyToOne(() => Author, { cascade: true })
     author: Author
 
-    @ManyToMany((type) => Category, { cascade: true })
+    @ManyToMany(() => Category, { cascade: true })
     @JoinTable()
     categories: Category[]
 
-    @OneToOne((type) => PostMetadata, { cascade: true })
+    @OneToOne(() => PostMetadata, { cascade: true })
     @JoinColumn()
     metadata: PostMetadata
 }

--- a/sample/sample2-one-to-one/entity/Post.ts
+++ b/sample/sample2-one-to-one/entity/Post.ts
@@ -24,7 +24,7 @@ export class Post {
     text: string
 
     // post has relation with category, however inverse relation is not set (category does not have relation with post set)
-    @OneToOne((type) => PostCategory, {
+    @OneToOne(() => PostCategory, {
         cascade: true,
     })
     @JoinColumn()
@@ -32,7 +32,7 @@ export class Post {
 
     // post has relation with details. cascade inserts here means if new PostDetails instance will be set to this
     // relation it will be inserted automatically to the db when you save this Post entity
-    @OneToOne((type) => PostDetails, (details) => details.post, {
+    @OneToOne(() => PostDetails, (details) => details.post, {
         cascade: ["insert"],
     })
     @JoinColumn()
@@ -40,7 +40,7 @@ export class Post {
 
     // post has relation with details. cascade update here means if new PostDetail instance will be set to this relation
     // it will be inserted automatically to the db when you save this Post entity
-    @OneToOne((type) => PostImage, (image) => image.post, {
+    @OneToOne(() => PostImage, (image) => image.post, {
         cascade: ["update"],
     })
     @JoinColumn()
@@ -48,19 +48,19 @@ export class Post {
 
     // post has relation with details. cascade update here means if new PostDetail instance will be set to this relation
     // it will be inserted automatically to the db when you save this Post entity
-    @OneToOne((type) => PostMetadata, (metadata) => metadata.post)
+    @OneToOne(() => PostMetadata, (metadata) => metadata.post)
     @JoinColumn()
     metadata: PostMetadata | null
 
     // post has relation with details. full cascades here
-    @OneToOne((type) => PostInformation, (information) => information.post, {
+    @OneToOne(() => PostInformation, (information) => information.post, {
         cascade: true,
     })
     @JoinColumn()
     information: PostInformation
 
     // post has relation with details. not cascades here. means cannot be persisted, updated or removed
-    @OneToOne((type) => PostAuthor, (author) => author.post)
+    @OneToOne(() => PostAuthor, (author) => author.post)
     @JoinColumn()
     author: PostAuthor
 }

--- a/sample/sample2-one-to-one/entity/PostAuthor.ts
+++ b/sample/sample2-one-to-one/entity/PostAuthor.ts
@@ -14,6 +14,6 @@ export class PostAuthor {
     @Column()
     name: string
 
-    @OneToOne((type) => Post, (post) => post.author)
+    @OneToOne(() => Post, (post) => post.author)
     post: Post
 }

--- a/sample/sample2-one-to-one/entity/PostDetails.ts
+++ b/sample/sample2-one-to-one/entity/PostDetails.ts
@@ -20,7 +20,7 @@ export class PostDetails {
     @Column()
     metadata: string
 
-    @OneToOne((type) => Post, (post) => post.details, {
+    @OneToOne(() => Post, (post) => post.details, {
         cascade: true,
     })
     post: Post

--- a/sample/sample2-one-to-one/entity/PostImage.ts
+++ b/sample/sample2-one-to-one/entity/PostImage.ts
@@ -14,6 +14,6 @@ export class PostImage {
     @Column()
     url: string
 
-    @OneToOne((type) => Post, (post) => post.image)
+    @OneToOne(() => Post, (post) => post.image)
     post: Post
 }

--- a/sample/sample2-one-to-one/entity/PostInformation.ts
+++ b/sample/sample2-one-to-one/entity/PostInformation.ts
@@ -14,7 +14,7 @@ export class PostInformation {
     @Column()
     text: string
 
-    @OneToOne((type) => Post, (post) => post.information, {
+    @OneToOne(() => Post, (post) => post.information, {
         cascade: ["update"],
     })
     post: Post

--- a/sample/sample2-one-to-one/entity/PostMetadata.ts
+++ b/sample/sample2-one-to-one/entity/PostMetadata.ts
@@ -14,6 +14,6 @@ export class PostMetadata {
     @Column()
     description: string
 
-    @OneToOne((type) => Post, (post) => post.metadata)
+    @OneToOne(() => Post, (post) => post.metadata)
     post: Post
 }

--- a/sample/sample21-custom-join-table-column/entity/Author.ts
+++ b/sample/sample21-custom-join-table-column/entity/Author.ts
@@ -10,7 +10,7 @@ export class Author {
     @Column()
     name: string
 
-    @OneToMany((type) => Post, (post) => post.author, {
+    @OneToMany(() => Post, (post) => post.author, {
         cascade: true,
     })
     posts: Post[]

--- a/sample/sample21-custom-join-table-column/entity/Post.ts
+++ b/sample/sample21-custom-join-table-column/entity/Post.ts
@@ -17,7 +17,7 @@ export class Post {
     @Column()
     text: string
 
-    @ManyToOne((type) => Author, (author) => author.posts, {
+    @ManyToOne(() => Author, (author) => author.posts, {
         cascade: true,
     })
     @JoinColumn({
@@ -26,7 +26,7 @@ export class Post {
     })
     author: Author
 
-    @ManyToMany((type) => Category, (category) => category.posts, {
+    @ManyToMany(() => Category, (category) => category.posts, {
         cascade: true,
     })
     @JoinTable({

--- a/sample/sample23-nested-joins/entity/Post.ts
+++ b/sample/sample23-nested-joins/entity/Post.ts
@@ -16,12 +16,12 @@ export class Post {
     @Column()
     text: string
 
-    @ManyToMany((type) => Category, {
+    @ManyToMany(() => Category, {
         cascade: true,
     })
     @JoinTable()
     categories: Category[]
 
-    @ManyToOne((type) => Author, { cascade: ["insert"] })
+    @ManyToOne(() => Author, { cascade: ["insert"] })
     author: Author | null
 }

--- a/sample/sample25-insert-from-inverse-side/entity/Author.ts
+++ b/sample/sample25-insert-from-inverse-side/entity/Author.ts
@@ -10,6 +10,6 @@ export class Author {
     @Column()
     name: string
 
-    @OneToMany((type) => Post, (author) => author.author)
+    @OneToMany(() => Post, (author) => author.author)
     posts: Post[]
 }

--- a/sample/sample25-insert-from-inverse-side/entity/Post.ts
+++ b/sample/sample25-insert-from-inverse-side/entity/Post.ts
@@ -13,6 +13,6 @@ export class Post {
     @Column()
     text: string
 
-    @ManyToOne((type) => Author, (author) => author.posts)
+    @ManyToOne(() => Author, (author) => author.posts)
     author: Author
 }

--- a/sample/sample3-many-to-one/entity/Post.ts
+++ b/sample/sample3-many-to-one/entity/Post.ts
@@ -23,37 +23,37 @@ export class Post {
     text: string
 
     // post has relation with category, however inverse relation is not set (category does not have relation with post set)
-    @ManyToOne((type) => PostCategory, {
+    @ManyToOne(() => PostCategory, {
         cascade: true,
     })
     category: PostCategory
 
     // post has relation with details. cascade inserts here means if new PostDetails instance will be set to this
     // relation it will be inserted automatically to the db when you save this Post entity
-    @ManyToOne((type) => PostDetails, (details) => details.posts, {
+    @ManyToOne(() => PostDetails, (details) => details.posts, {
         cascade: ["insert"],
     })
     details?: PostDetails
 
     // post has relation with details. cascade update here means if new PostDetail instance will be set to this relation
     // it will be inserted automatically to the db when you save this Post entity
-    @ManyToOne((type) => PostImage, (image) => image.posts, {
+    @ManyToOne(() => PostImage, (image) => image.posts, {
         cascade: ["update"],
     })
     image: PostImage
 
     // post has relation with details. cascade update here means if new PostDetail instance will be set to this relation
     // it will be inserted automatically to the db when you save this Post entity
-    @ManyToOne((type) => PostMetadata, (metadata) => metadata.posts)
+    @ManyToOne(() => PostMetadata, (metadata) => metadata.posts)
     metadata: PostMetadata | null
 
     // post has relation with details. full cascades here
-    @ManyToOne((type) => PostInformation, (information) => information.posts, {
+    @ManyToOne(() => PostInformation, (information) => information.posts, {
         cascade: true,
     })
     information: PostInformation
 
     // post has relation with details. not cascades here. means cannot be persisted, updated or removed
-    @ManyToOne((type) => PostAuthor, (author) => author.posts)
+    @ManyToOne(() => PostAuthor, (author) => author.posts)
     author: PostAuthor
 }

--- a/sample/sample3-many-to-one/entity/PostAuthor.ts
+++ b/sample/sample3-many-to-one/entity/PostAuthor.ts
@@ -14,6 +14,6 @@ export class PostAuthor {
     @Column()
     name: string
 
-    @OneToMany((type) => Post, (post) => post.author)
+    @OneToMany(() => Post, (post) => post.author)
     posts: Post[]
 }

--- a/sample/sample3-many-to-one/entity/PostDetails.ts
+++ b/sample/sample3-many-to-one/entity/PostDetails.ts
@@ -29,7 +29,7 @@ export class PostDetails {
     })
     metadata: string | null
 
-    @OneToMany((type) => Post, (post) => post.details, {
+    @OneToMany(() => Post, (post) => post.details, {
         cascade: true,
     })
     posts: Post[]

--- a/sample/sample3-many-to-one/entity/PostImage.ts
+++ b/sample/sample3-many-to-one/entity/PostImage.ts
@@ -14,6 +14,6 @@ export class PostImage {
     @Column()
     url: string
 
-    @OneToMany((type) => Post, (post) => post.image)
+    @OneToMany(() => Post, (post) => post.image)
     posts: Post[]
 }

--- a/sample/sample3-many-to-one/entity/PostInformation.ts
+++ b/sample/sample3-many-to-one/entity/PostInformation.ts
@@ -14,7 +14,7 @@ export class PostInformation {
     @Column()
     text: string
 
-    @OneToMany((type) => Post, (post) => post.information, {
+    @OneToMany(() => Post, (post) => post.information, {
         cascade: ["update"],
     })
     posts: Post[]

--- a/sample/sample3-many-to-one/entity/PostMetadata.ts
+++ b/sample/sample3-many-to-one/entity/PostMetadata.ts
@@ -14,6 +14,6 @@ export class PostMetadata {
     @Column()
     description: string
 
-    @OneToMany((type) => Post, (post) => post.metadata)
+    @OneToMany(() => Post, (post) => post.metadata)
     posts: Post[]
 }

--- a/sample/sample31-table-prefix/entity/Post.ts
+++ b/sample/sample31-table-prefix/entity/Post.ts
@@ -20,12 +20,12 @@ export class Post {
     @Column()
     text: string
 
-    @ManyToOne((type) => Author, {
+    @ManyToOne(() => Author, {
         cascade: ["insert"],
     })
     author: Author
 
-    @ManyToMany((type) => Category, {
+    @ManyToMany(() => Category, {
         cascade: ["insert"],
     })
     @JoinTable()

--- a/sample/sample32-migrations/entity/Post.ts
+++ b/sample/sample32-migrations/entity/Post.ts
@@ -14,7 +14,7 @@ export class Post {
     @Column()
     title: string
 
-    @ManyToOne((type) => Author, {
+    @ManyToOne(() => Author, {
         cascade: ["insert"],
     })
     author: Author

--- a/sample/sample33-custom-repository/entity/Post.ts
+++ b/sample/sample33-custom-repository/entity/Post.ts
@@ -14,7 +14,7 @@ export class Post {
     @Column()
     title: string
 
-    @ManyToOne((type) => Author, {
+    @ManyToOne(() => Author, {
         cascade: ["insert"],
     })
     author: Author

--- a/sample/sample5-subscribers/entity/Post.ts
+++ b/sample/sample5-subscribers/entity/Post.ts
@@ -20,12 +20,12 @@ export class Post {
     @Column()
     text: string
 
-    @ManyToOne((type) => PostAuthor, (post) => post.posts, {
+    @ManyToOne(() => PostAuthor, (post) => post.posts, {
         cascade: true,
     })
     author: PostAuthor
 
-    @ManyToMany((type) => PostCategory, (category) => category.posts, {
+    @ManyToMany(() => PostCategory, (category) => category.posts, {
         cascade: true,
     })
     @JoinTable()

--- a/sample/sample5-subscribers/entity/PostAuthor.ts
+++ b/sample/sample5-subscribers/entity/PostAuthor.ts
@@ -10,6 +10,6 @@ export class PostAuthor {
     @Column()
     name: string
 
-    @OneToMany((type) => Post, (post) => post.author)
+    @OneToMany(() => Post, (post) => post.author)
     posts: Post[]
 }

--- a/sample/sample6-abstract-table/entity/Blog.ts
+++ b/sample/sample6-abstract-table/entity/Blog.ts
@@ -11,12 +11,12 @@ export class Blog extends BasePost {
     @Column()
     text: string
 
-    @ManyToOne((type) => PostAuthor, (post) => post.posts, {
+    @ManyToOne(() => PostAuthor, (post) => post.posts, {
         cascade: true,
     })
     author: PostAuthor
 
-    @ManyToMany((type) => PostCategory, (category) => category.posts, {
+    @ManyToMany(() => PostCategory, (category) => category.posts, {
         cascade: true,
     })
     @JoinTable()

--- a/sample/sample6-abstract-table/entity/Post.ts
+++ b/sample/sample6-abstract-table/entity/Post.ts
@@ -11,12 +11,12 @@ export class Post extends BasePost {
     @Column()
     text: string
 
-    @ManyToOne((type) => PostAuthor, (post) => post.posts, {
+    @ManyToOne(() => PostAuthor, (post) => post.posts, {
         cascade: true,
     })
     author: PostAuthor
 
-    @ManyToMany((type) => PostCategory, (category) => category.posts, {
+    @ManyToMany(() => PostCategory, (category) => category.posts, {
         cascade: true,
     })
     @JoinTable()

--- a/sample/sample6-abstract-table/entity/PostAuthor.ts
+++ b/sample/sample6-abstract-table/entity/PostAuthor.ts
@@ -10,6 +10,6 @@ export class PostAuthor {
     @Column()
     name: string
 
-    @OneToMany((type) => Post, (post) => post.author)
+    @OneToMany(() => Post, (post) => post.author)
     posts: Post[]
 }

--- a/sample/sample7-pagination/entity/Post.ts
+++ b/sample/sample7-pagination/entity/Post.ts
@@ -20,12 +20,12 @@ export class Post {
     @Column()
     text: string
 
-    @ManyToOne((type) => PostAuthor, (post) => post.posts, {
+    @ManyToOne(() => PostAuthor, (post) => post.posts, {
         cascade: true,
     })
     author: PostAuthor
 
-    @ManyToMany((type) => PostCategory, (category) => category.posts, {
+    @ManyToMany(() => PostCategory, (category) => category.posts, {
         cascade: true,
     })
     @JoinTable()

--- a/sample/sample7-pagination/entity/PostAuthor.ts
+++ b/sample/sample7-pagination/entity/PostAuthor.ts
@@ -10,6 +10,6 @@ export class PostAuthor {
     @Column()
     name: string
 
-    @OneToMany((type) => Post, (post) => post.author)
+    @OneToMany(() => Post, (post) => post.author)
     posts: Post[]
 }

--- a/sample/sample8-self-referencing/entity/Category.ts
+++ b/sample/sample8-self-referencing/entity/Category.ts
@@ -18,38 +18,34 @@ export class Category {
     @Column()
     name: string
 
-    @OneToOne((type) => Category, (category) => category.oneInverseCategory, {
+    @OneToOne(() => Category, (category) => category.oneInverseCategory, {
         cascade: true,
     })
     @JoinColumn()
     oneCategory: Category
 
-    @OneToOne((type) => Category, (category) => category.oneCategory, {
+    @OneToOne(() => Category, (category) => category.oneCategory, {
         cascade: true,
     })
     oneInverseCategory: Category
 
-    @ManyToOne((type) => Category, (category) => category.oneManyCategories, {
+    @ManyToOne(() => Category, (category) => category.oneManyCategories, {
         cascade: true,
     })
     oneManyCategory: Category
 
-    @OneToMany((type) => Category, (category) => category.oneManyCategory, {
+    @OneToMany(() => Category, (category) => category.oneManyCategory, {
         cascade: true,
     })
     oneManyCategories: Category[]
 
-    @ManyToMany(
-        (type) => Category,
-        (category) => category.manyInverseCategories,
-        {
-            cascade: true,
-        },
-    )
+    @ManyToMany(() => Category, (category) => category.manyInverseCategories, {
+        cascade: true,
+    })
     @JoinTable()
     manyCategories: Category[]
 
-    @ManyToMany((type) => Category, (category) => category.manyCategories, {
+    @ManyToMany(() => Category, (category) => category.manyCategories, {
         cascade: true,
     })
     manyInverseCategories: Category[]

--- a/sample/sample9-entity-listeners/entity/PostAuthor.ts
+++ b/sample/sample9-entity-listeners/entity/PostAuthor.ts
@@ -20,7 +20,7 @@ export class PostAuthor {
     @Column()
     name: string
 
-    @OneToMany((type) => Post, (post) => post.author)
+    @OneToMany(() => Post, (post) => post.author)
     posts: Post[]
 
     @BeforeInsert()

--- a/test/benchmark/multiple-joins-querybuilder/entity/Eight.ts
+++ b/test/benchmark/multiple-joins-querybuilder/entity/Eight.ts
@@ -9,7 +9,7 @@ export class Eight {
     @PrimaryGeneratedColumn()
     id: number
 
-    @ManyToOne((type) => One)
+    @ManyToOne(() => One)
     one: One
 
     @Column({ type: "text" })

--- a/test/benchmark/multiple-joins-querybuilder/entity/Five.ts
+++ b/test/benchmark/multiple-joins-querybuilder/entity/Five.ts
@@ -9,7 +9,7 @@ export class Five {
     @PrimaryGeneratedColumn()
     id: number
 
-    @ManyToOne((type) => One)
+    @ManyToOne(() => One)
     one: One
 
     @Column({ type: "text" })

--- a/test/benchmark/multiple-joins-querybuilder/entity/Four.ts
+++ b/test/benchmark/multiple-joins-querybuilder/entity/Four.ts
@@ -9,7 +9,7 @@ export class Four {
     @PrimaryGeneratedColumn()
     id: number
 
-    @ManyToOne((type) => One)
+    @ManyToOne(() => One)
     one: One
 
     @Column({ type: "text" })

--- a/test/benchmark/multiple-joins-querybuilder/entity/Nine.ts
+++ b/test/benchmark/multiple-joins-querybuilder/entity/Nine.ts
@@ -9,7 +9,7 @@ export class Nine {
     @PrimaryGeneratedColumn()
     id: number
 
-    @ManyToOne((type) => One)
+    @ManyToOne(() => One)
     one: One
 
     @Column({ type: "text" })

--- a/test/benchmark/multiple-joins-querybuilder/entity/One.ts
+++ b/test/benchmark/multiple-joins-querybuilder/entity/One.ts
@@ -17,31 +17,31 @@ export class One {
     @PrimaryGeneratedColumn()
     id: number
 
-    @OneToOne((type) => Two, (two) => two.one)
+    @OneToOne(() => Two, (two) => two.one)
     two: Two
 
-    @OneToOne((type) => Three, (three) => three.one)
+    @OneToOne(() => Three, (three) => three.one)
     three: Three
 
-    @OneToOne((type) => Four, (four) => four.one)
+    @OneToOne(() => Four, (four) => four.one)
     four: Four
 
-    @OneToOne((type) => Five, (five) => five.one)
+    @OneToOne(() => Five, (five) => five.one)
     five: Five
 
-    @OneToOne((type) => Six, (six) => six.one)
+    @OneToOne(() => Six, (six) => six.one)
     six: Six
 
-    @OneToOne((type) => Seven, (seven) => seven.one)
+    @OneToOne(() => Seven, (seven) => seven.one)
     seven: Seven
 
-    @OneToOne((type) => Eight, (eight) => eight.one)
+    @OneToOne(() => Eight, (eight) => eight.one)
     eight: Eight
 
-    @OneToOne((type) => Nine, (nine) => nine.one)
+    @OneToOne(() => Nine, (nine) => nine.one)
     nine: Nine
 
-    @OneToOne((type) => Ten, (ten) => ten.one)
+    @OneToOne(() => Ten, (ten) => ten.one)
     ten: Ten
 
     @Column({ type: "text" })

--- a/test/benchmark/multiple-joins-querybuilder/entity/Seven.ts
+++ b/test/benchmark/multiple-joins-querybuilder/entity/Seven.ts
@@ -9,7 +9,7 @@ export class Seven {
     @PrimaryGeneratedColumn()
     id: number
 
-    @ManyToOne((type) => One)
+    @ManyToOne(() => One)
     one: One
 
     @Column({ type: "text" })

--- a/test/benchmark/multiple-joins-querybuilder/entity/Six.ts
+++ b/test/benchmark/multiple-joins-querybuilder/entity/Six.ts
@@ -9,7 +9,7 @@ export class Six {
     @PrimaryGeneratedColumn()
     id: number
 
-    @ManyToOne((type) => One)
+    @ManyToOne(() => One)
     one: One
 
     @Column({ type: "text" })

--- a/test/benchmark/multiple-joins-querybuilder/entity/Ten.ts
+++ b/test/benchmark/multiple-joins-querybuilder/entity/Ten.ts
@@ -9,7 +9,7 @@ export class Ten {
     @PrimaryGeneratedColumn()
     id: number
 
-    @ManyToOne((type) => One)
+    @ManyToOne(() => One)
     one: One
 
     @Column({ type: "text" })

--- a/test/benchmark/multiple-joins-querybuilder/entity/Three.ts
+++ b/test/benchmark/multiple-joins-querybuilder/entity/Three.ts
@@ -9,7 +9,7 @@ export class Three {
     @PrimaryGeneratedColumn()
     id: number
 
-    @ManyToOne((type) => One)
+    @ManyToOne(() => One)
     one: One
 
     @Column({ type: "text" })

--- a/test/benchmark/multiple-joins-querybuilder/entity/Two.ts
+++ b/test/benchmark/multiple-joins-querybuilder/entity/Two.ts
@@ -9,7 +9,7 @@ export class Two {
     @PrimaryGeneratedColumn()
     id: number
 
-    @ManyToOne((type) => One)
+    @ManyToOne(() => One)
     one: One
 
     @Column({ type: "text" })

--- a/test/functional/cascades/cascade-insert-from-both-sides/entity/Post.ts
+++ b/test/functional/cascades/cascade-insert-from-both-sides/entity/Post.ts
@@ -10,7 +10,7 @@ export class Post {
     @PrimaryGeneratedColumn()
     key: number
 
-    @OneToOne((type) => PostDetails, (details) => details.post, {
+    @OneToOne(() => PostDetails, (details) => details.post, {
         cascade: ["insert"],
     })
     @JoinColumn()

--- a/test/functional/cascades/cascade-insert-from-both-sides/entity/PostDetails.ts
+++ b/test/functional/cascades/cascade-insert-from-both-sides/entity/PostDetails.ts
@@ -8,7 +8,7 @@ export class PostDetails {
     @PrimaryColumn()
     keyword: string
 
-    @OneToOne((type) => Post, (post) => post.details, {
+    @OneToOne(() => Post, (post) => post.details, {
         cascade: ["insert"],
     })
     post: Post

--- a/test/functional/connection/entity/v1/Comment.ts
+++ b/test/functional/connection/entity/v1/Comment.ts
@@ -19,12 +19,12 @@ export class Comment {
     @Column()
     context: string
 
-    @OneToMany((type) => Comment, (comment) => comment.relay)
+    @OneToMany(() => Comment, (comment) => comment.relay)
     reference?: Comment
 
-    @ManyToOne((type) => Comment, (comment) => comment.reference)
+    @ManyToOne(() => Comment, (comment) => comment.reference)
     relay?: Comment
 
-    @ManyToOne((type) => Guest, (guest) => guest.comments)
+    @ManyToOne(() => Guest, (guest) => guest.comments)
     author: Guest
 }

--- a/test/functional/connection/entity/v1/Guest.ts
+++ b/test/functional/connection/entity/v1/Guest.ts
@@ -12,6 +12,6 @@ export class Guest {
     @Column()
     username: string
 
-    @OneToMany((type) => Comment, (comment) => comment.author)
+    @OneToMany(() => Comment, (comment) => comment.author)
     comments: Comment[]
 }

--- a/test/functional/connection/entity/v2/Comment.ts
+++ b/test/functional/connection/entity/v2/Comment.ts
@@ -20,6 +20,6 @@ export class Comment {
     @Column()
     context: string
 
-    @ManyToOne((type) => Guest, (guest) => guest.comments)
+    @ManyToOne(() => Guest, (guest) => guest.comments)
     author: Guest
 }

--- a/test/functional/connection/entity/v2/Guest.ts
+++ b/test/functional/connection/entity/v2/Guest.ts
@@ -12,6 +12,6 @@ export class Guest {
     @Column()
     username: string
 
-    @OneToMany((type) => Comment, (comment) => comment.author)
+    @OneToMany(() => Comment, (comment) => comment.author)
     comments: Comment[]
 }

--- a/test/functional/decorators/relation-count/relation-count-one-to-many/entity/Category.ts
+++ b/test/functional/decorators/relation-count/relation-count-one-to-many/entity/Category.ts
@@ -18,10 +18,10 @@ export class Category {
     @Column()
     isRemoved: boolean = false
 
-    @ManyToOne((type) => Post, (post) => post.categories)
+    @ManyToOne(() => Post, (post) => post.categories)
     post: Post
 
-    @OneToMany((type) => Image, (image) => image.category)
+    @OneToMany(() => Image, (image) => image.category)
     images: Image[]
 
     @RelationCount((category: Category) => category.images)

--- a/test/functional/decorators/relation-count/relation-count-one-to-many/entity/Image.ts
+++ b/test/functional/decorators/relation-count/relation-count-one-to-many/entity/Image.ts
@@ -15,6 +15,6 @@ export class Image {
     @Column()
     isRemoved: boolean = false
 
-    @ManyToOne((type) => Category, (category) => category.images)
+    @ManyToOne(() => Category, (category) => category.images)
     category: Category
 }

--- a/test/functional/decorators/relation-count/relation-count-one-to-many/entity/Post.ts
+++ b/test/functional/decorators/relation-count/relation-count-one-to-many/entity/Post.ts
@@ -13,7 +13,7 @@ export class Post {
     @Column()
     title: string
 
-    @OneToMany((type) => Category, (category) => category.post)
+    @OneToMany(() => Category, (category) => category.post)
     categories: Category[]
 
     @RelationCount((post: Post) => post.categories)

--- a/test/functional/decorators/relation-id/relation-id-many-to-one/entity/Post.ts
+++ b/test/functional/decorators/relation-id/relation-id-many-to-one/entity/Post.ts
@@ -14,11 +14,11 @@ export class Post {
     @Column()
     title: string
 
-    @ManyToOne((type) => Category)
+    @ManyToOne(() => Category)
     @JoinColumn()
     category: Category
 
-    @ManyToOne((type) => Category)
+    @ManyToOne(() => Category)
     @JoinColumn({ referencedColumnName: "name" })
     categoryByName: Category
 

--- a/test/functional/decorators/relation-id/relation-id-one-to-many/entity/Category.ts
+++ b/test/functional/decorators/relation-id/relation-id-one-to-many/entity/Category.ts
@@ -13,7 +13,7 @@ export class Category {
     @Column()
     name: string
 
-    @OneToMany((type) => Post, (post) => post.category)
+    @OneToMany(() => Post, (post) => post.category)
     posts: Post[]
 
     @RelationId((category: Category) => category.posts)

--- a/test/functional/decorators/relation-id/relation-id-one-to-many/entity/Post.ts
+++ b/test/functional/decorators/relation-id/relation-id-one-to-many/entity/Post.ts
@@ -15,7 +15,7 @@ export class Post {
     @Column()
     isRemoved: boolean = false
 
-    @ManyToOne((type) => Category)
+    @ManyToOne(() => Category)
     category: Category
 
     categoryId: number

--- a/test/functional/decorators/relation-id/relation-id-one-to-one/entity/Category.ts
+++ b/test/functional/decorators/relation-id/relation-id-one-to-one/entity/Category.ts
@@ -13,7 +13,7 @@ export class Category {
     @Column({ unique: true })
     name: string
 
-    @OneToOne((type) => Post, (post) => post.category2)
+    @OneToOne(() => Post, (post) => post.category2)
     post: Post
 
     @RelationId((category: Category) => category.post)

--- a/test/functional/decorators/relation-id/relation-id-one-to-one/entity/Post.ts
+++ b/test/functional/decorators/relation-id/relation-id-one-to-one/entity/Post.ts
@@ -14,15 +14,15 @@ export class Post {
     @Column()
     title: string
 
-    @OneToOne((type) => Category)
+    @OneToOne(() => Category)
     @JoinColumn()
     category: Category
 
-    @OneToOne((type) => Category)
+    @OneToOne(() => Category)
     @JoinColumn({ referencedColumnName: "name" })
     categoryByName: Category
 
-    @OneToOne((type) => Category, (category) => category.post)
+    @OneToOne(() => Category, (category) => category.post)
     @JoinColumn()
     category2: Category
 

--- a/test/functional/embedded/embedded-many-to-one-case1/entity/Counters.ts
+++ b/test/functional/embedded/embedded-many-to-one-case1/entity/Counters.ts
@@ -20,7 +20,7 @@ export class Counters {
     @Column(() => Subcounters, { prefix: "subcnt" })
     subcounters: Subcounters
 
-    @ManyToOne((type) => User)
+    @ManyToOne(() => User)
     @JoinColumn()
     likedUser: User
 }

--- a/test/functional/embedded/embedded-many-to-one-case1/entity/User.ts
+++ b/test/functional/embedded/embedded-many-to-one-case1/entity/User.ts
@@ -12,6 +12,6 @@ export class User {
     @Column()
     name: string
 
-    @OneToMany((type) => Post, (post) => post.counters.likedUser)
+    @OneToMany(() => Post, (post) => post.counters.likedUser)
     likedPosts: Post[]
 }

--- a/test/functional/embedded/embedded-many-to-one-case2/entity/Counters.ts
+++ b/test/functional/embedded/embedded-many-to-one-case2/entity/Counters.ts
@@ -19,6 +19,6 @@ export class Counters {
     @Column(() => Subcounters, { prefix: "subcnt" })
     subcounters: Subcounters
 
-    @OneToMany((type) => User, (user) => user.likedPost)
+    @OneToMany(() => User, (user) => user.likedPost)
     likedUsers: User[]
 }

--- a/test/functional/embedded/embedded-many-to-one-case2/entity/User.ts
+++ b/test/functional/embedded/embedded-many-to-one-case2/entity/User.ts
@@ -13,7 +13,7 @@ export class User {
     @Column()
     name: string
 
-    @ManyToOne((type) => Post)
+    @ManyToOne(() => Post)
     @JoinColumn()
     likedPost: Post
 }

--- a/test/functional/embedded/embedded-many-to-one-case3/entity/Counters.ts
+++ b/test/functional/embedded/embedded-many-to-one-case3/entity/Counters.ts
@@ -21,7 +21,7 @@ export class Counters {
     @Column(() => Subcounters, { prefix: "subcnt" })
     subcounters: Subcounters
 
-    @ManyToOne((type) => User)
+    @ManyToOne(() => User)
     @JoinColumn()
     likedUser: User
 }

--- a/test/functional/embedded/embedded-many-to-one-case3/entity/User.ts
+++ b/test/functional/embedded/embedded-many-to-one-case3/entity/User.ts
@@ -12,6 +12,6 @@ export class User {
     @Column()
     name: string
 
-    @OneToMany((type) => Post, (post) => post.counters.likedUser)
+    @OneToMany(() => Post, (post) => post.counters.likedUser)
     likedPosts: Post[]
 }

--- a/test/functional/embedded/embedded-many-to-one-case4/entity/Counters.ts
+++ b/test/functional/embedded/embedded-many-to-one-case4/entity/Counters.ts
@@ -20,7 +20,7 @@ export class Counters {
     @Column(() => Subcounters, { prefix: "subcnt" })
     subcounters: Subcounters
 
-    @ManyToOne((type) => User)
+    @ManyToOne(() => User)
     @JoinColumn()
     likedUser: User
 }

--- a/test/functional/embedded/embedded-many-to-one-case4/entity/User.ts
+++ b/test/functional/embedded/embedded-many-to-one-case4/entity/User.ts
@@ -15,6 +15,6 @@ export class User {
     @Column()
     name: string
 
-    @OneToMany((type) => Post, (post) => post.counters.likedUser)
+    @OneToMany(() => Post, (post) => post.counters.likedUser)
     likedPosts: Post[]
 }

--- a/test/functional/embedded/embedded-many-to-one-case5/entity/Counters.ts
+++ b/test/functional/embedded/embedded-many-to-one-case5/entity/Counters.ts
@@ -21,7 +21,7 @@ export class Counters {
     @Column(() => Subcounters, { prefix: "subcnt" })
     subcounters: Subcounters
 
-    @ManyToOne((type) => User)
+    @ManyToOne(() => User)
     @JoinColumn()
     likedUser: User
 }

--- a/test/functional/embedded/embedded-many-to-one-case5/entity/User.ts
+++ b/test/functional/embedded/embedded-many-to-one-case5/entity/User.ts
@@ -15,6 +15,6 @@ export class User {
     @Column()
     name: string
 
-    @OneToMany((type) => Post, (post) => post.counters.likedUser)
+    @OneToMany(() => Post, (post) => post.counters.likedUser)
     likedPosts: Post[]
 }

--- a/test/functional/entity-metadata-validator/basic/entity/Post.ts
+++ b/test/functional/entity-metadata-validator/basic/entity/Post.ts
@@ -14,7 +14,7 @@ export class Post {
     @Column()
     title: string
 
-    @OneToOne((type) => Category)
+    @OneToOne(() => Category)
     category: Category
 
     @ManyToMany((type) => Category)

--- a/test/functional/entity-metadata-validator/initialized-relations/entity/Image.ts
+++ b/test/functional/entity-metadata-validator/initialized-relations/entity/Image.ts
@@ -12,6 +12,6 @@ export class Image {
     @Column()
     title: string
 
-    @OneToMany((type) => ImageInfo, (imageInfo) => imageInfo.image)
+    @OneToMany(() => ImageInfo, (imageInfo) => imageInfo.image)
     informations: ImageInfo[] = []
 }

--- a/test/functional/entity-metadata-validator/initialized-relations/entity/ImageInfo.ts
+++ b/test/functional/entity-metadata-validator/initialized-relations/entity/ImageInfo.ts
@@ -12,6 +12,6 @@ export class ImageInfo {
     @Column()
     name: string
 
-    @ManyToOne((type) => Image, (image) => image.informations)
+    @ManyToOne(() => Image, (image) => image.informations)
     image: Image
 }

--- a/test/functional/entity-metadata-validator/initialized-relations/entity/Post.ts
+++ b/test/functional/entity-metadata-validator/initialized-relations/entity/Post.ts
@@ -15,7 +15,7 @@ export class Post {
     @Column()
     title: string
 
-    @OneToOne((type) => Category)
+    @OneToOne(() => Category)
     @JoinColumn()
     category: Category
 

--- a/test/functional/find-options/select/entity/Post.ts
+++ b/test/functional/find-options/select/entity/Post.ts
@@ -21,7 +21,7 @@ export class Post {
     @Column()
     description: string
 
-    @ManyToOne((type) => Category)
+    @ManyToOne(() => Category)
     category: Category
 
     @Column("simple-json", { nullable: true })

--- a/test/functional/multi-database/multi-database-basic-functionality/entity/Category.ts
+++ b/test/functional/multi-database/multi-database-basic-functionality/entity/Category.ts
@@ -12,6 +12,6 @@ export class Category {
     @Column()
     name: string
 
-    @ManyToOne((type) => Post)
+    @ManyToOne(() => Post)
     post: Post
 }

--- a/test/functional/multi-schema-and-database/multi-schema-and-database-basic-functionality/entity/Category.ts
+++ b/test/functional/multi-schema-and-database/multi-schema-and-database-basic-functionality/entity/Category.ts
@@ -12,6 +12,6 @@ export class Category {
     @Column()
     name: string
 
-    @ManyToOne((type) => Post)
+    @ManyToOne(() => Post)
     post: Post
 }

--- a/test/functional/persistence/cascades/cascades-example1/entity/Profile.ts
+++ b/test/functional/persistence/cascades/cascades-example1/entity/Profile.ts
@@ -10,13 +10,13 @@ export class Profile {
     @PrimaryColumn()
     id: number
 
-    @OneToOne((type) => User, (user) => user.profile, {
+    @OneToOne(() => User, (user) => user.profile, {
         nullable: false,
     })
     @JoinColumn()
     user: User
 
-    @OneToOne((type) => Photo, {
+    @OneToOne(() => Photo, {
         nullable: false,
         cascade: ["insert"],
     })

--- a/test/functional/persistence/cascades/cascades-example1/entity/User.ts
+++ b/test/functional/persistence/cascades/cascades-example1/entity/User.ts
@@ -12,7 +12,7 @@ export class User {
     @Column()
     name: string
 
-    @OneToOne((type) => Profile, (profile) => profile.user, {
+    @OneToOne(() => Profile, (profile) => profile.user, {
         cascade: ["insert"],
     })
     profile: Profile

--- a/test/functional/persistence/cascades/cascades-example2/entity/Answer.ts
+++ b/test/functional/persistence/cascades/cascades-example2/entity/Answer.ts
@@ -10,19 +10,19 @@ export class Answer {
     @PrimaryGeneratedColumn()
     id: number
 
-    @ManyToOne((type) => Question, (question) => question.answers, {
+    @ManyToOne(() => Question, (question) => question.answers, {
         cascade: ["insert"],
         nullable: false,
     })
     question: Question
 
-    @ManyToOne((type) => Photo, {
+    @ManyToOne(() => Photo, {
         cascade: ["insert"],
         nullable: false,
     })
     photo: Photo
 
-    @ManyToOne((type) => User, {
+    @ManyToOne(() => User, {
         cascade: ["insert"],
         nullable: false,
     })

--- a/test/functional/persistence/cascades/cascades-example2/entity/Question.ts
+++ b/test/functional/persistence/cascades/cascades-example2/entity/Question.ts
@@ -12,7 +12,7 @@ export class Question {
     @Column({ default: "My question" })
     name: string
 
-    @OneToMany((type) => Answer, (answer) => answer.question, {
+    @OneToMany(() => Answer, (answer) => answer.question, {
         cascade: ["insert"],
     })
     answers: Answer[]

--- a/test/functional/persistence/cascades/cascades-example2/entity/User.ts
+++ b/test/functional/persistence/cascades/cascades-example2/entity/User.ts
@@ -8,7 +8,7 @@ export class User {
     @PrimaryGeneratedColumn()
     id: number
 
-    @ManyToOne((type) => Question, {
+    @ManyToOne(() => Question, {
         cascade: ["insert"],
         nullable: true,
     })

--- a/test/functional/persistence/cascades/cascades-remove/entity/Photo.ts
+++ b/test/functional/persistence/cascades/cascades-remove/entity/Photo.ts
@@ -12,7 +12,7 @@ export class Photo {
     @Column()
     name: string
 
-    @ManyToOne((type) => User, (user) => user.manyPhotos)
+    @ManyToOne(() => User, (user) => user.manyPhotos)
     user: User
 
     constructor(name: string) {

--- a/test/functional/persistence/cascades/cascades-remove/entity/User.ts
+++ b/test/functional/persistence/cascades/cascades-remove/entity/User.ts
@@ -16,7 +16,7 @@ export class User {
     @Column()
     name: string
 
-    @OneToMany((type) => Photo, (photo) => photo.user, { cascade: true })
+    @OneToMany(() => Photo, (photo) => photo.user, { cascade: true })
     manyPhotos: Photo[]
 
     @ManyToMany((type) => Photo, { cascade: true })

--- a/test/functional/persistence/cascades/cascades-soft-remove/entity/Photo.ts
+++ b/test/functional/persistence/cascades/cascades-soft-remove/entity/Photo.ts
@@ -16,7 +16,7 @@ export class Photo {
     @DeleteDateColumn()
     deletedAt: Date
 
-    @ManyToOne((type) => User, (user) => user.manyPhotos)
+    @ManyToOne(() => User, (user) => user.manyPhotos)
     user: User
 
     constructor(name: string) {

--- a/test/functional/persistence/cascades/cascades-soft-remove/entity/User.ts
+++ b/test/functional/persistence/cascades/cascades-soft-remove/entity/User.ts
@@ -20,7 +20,7 @@ export class User {
     @DeleteDateColumn()
     deletedAt: Date
 
-    @OneToMany((type) => Photo, (photo) => photo.user, { cascade: true })
+    @OneToMany(() => Photo, (photo) => photo.user, { cascade: true })
     manyPhotos: Photo[]
 
     @ManyToMany((type) => Photo, { cascade: true })

--- a/test/functional/persistence/custom-column-name-pk/entity/Category.ts
+++ b/test/functional/persistence/custom-column-name-pk/entity/Category.ts
@@ -14,7 +14,7 @@ export class Category {
     @Column()
     name: string
 
-    @OneToMany((type) => Post, (post) => post.category, {
+    @OneToMany(() => Post, (post) => post.category, {
         cascade: ["insert"],
     })
     posts: Post[]

--- a/test/functional/persistence/custom-column-name-pk/entity/Post.ts
+++ b/test/functional/persistence/custom-column-name-pk/entity/Post.ts
@@ -14,7 +14,7 @@ export class Post {
     @Column()
     title: string
 
-    @ManyToOne((type) => Category, (category) => category.posts, {
+    @ManyToOne(() => Category, (category) => category.posts, {
         cascade: ["insert"],
     })
     category: Category

--- a/test/functional/persistence/custom-column-names/entity/Category.ts
+++ b/test/functional/persistence/custom-column-names/entity/Category.ts
@@ -12,13 +12,13 @@ export class Category {
     @PrimaryGeneratedColumn()
     id: number
 
-    @OneToMany((type) => Post, (post) => post.category)
+    @OneToMany(() => Post, (post) => post.category)
     posts: Post[]
 
     @Column({ type: "int", nullable: true })
     metadataId: number
 
-    @OneToOne((type) => CategoryMetadata, (metadata) => metadata.category, {
+    @OneToOne(() => CategoryMetadata, (metadata) => metadata.category, {
         cascade: ["insert"],
     })
     @JoinColumn({ name: "metadataId" })

--- a/test/functional/persistence/custom-column-names/entity/CategoryMetadata.ts
+++ b/test/functional/persistence/custom-column-names/entity/CategoryMetadata.ts
@@ -12,6 +12,6 @@ export class CategoryMetadata {
     @Column()
     keyword: string
 
-    @OneToOne((type) => Category, (category) => category.metadata)
+    @OneToOne(() => Category, (category) => category.metadata)
     category: Category
 }

--- a/test/functional/persistence/custom-column-names/entity/Post.ts
+++ b/test/functional/persistence/custom-column-names/entity/Post.ts
@@ -16,7 +16,7 @@ export class Post {
     @Column("int", { nullable: true })
     categoryId: number
 
-    @ManyToOne((type) => Category, (category) => category.posts, {
+    @ManyToOne(() => Category, (category) => category.posts, {
         cascade: true,
     })
     @JoinColumn({ name: "categoryId" })

--- a/test/functional/persistence/insert/update-relation-columns-after-insertion/entity/Category.ts
+++ b/test/functional/persistence/insert/update-relation-columns-after-insertion/entity/Category.ts
@@ -12,6 +12,6 @@ export class Category {
     @Column()
     name: string
 
-    @OneToMany((type) => Post, (post) => post.category)
+    @OneToMany(() => Post, (post) => post.category)
     posts: Post[]
 }

--- a/test/functional/persistence/insert/update-relation-columns-after-insertion/entity/Post.ts
+++ b/test/functional/persistence/insert/update-relation-columns-after-insertion/entity/Post.ts
@@ -12,6 +12,6 @@ export class Post {
     @Column()
     title: string
 
-    @ManyToOne((type) => Category, (category) => category.posts)
+    @ManyToOne(() => Category, (category) => category.posts)
     category: Category
 }

--- a/test/functional/persistence/many-to-many/entity/User.ts
+++ b/test/functional/persistence/many-to-many/entity/User.ts
@@ -12,6 +12,6 @@ export class User {
     @Column()
     name: string
 
-    @ManyToOne((type) => Post, { cascade: ["update"] })
+    @ManyToOne(() => Post, { cascade: ["update"] })
     post: Post
 }

--- a/test/functional/persistence/many-to-one-bi-directional/entity/Category.ts
+++ b/test/functional/persistence/many-to-one-bi-directional/entity/Category.ts
@@ -12,7 +12,7 @@ export class Category {
     @Column()
     name: string
 
-    @ManyToOne((type) => Post, (post) => post.categories, {
+    @ManyToOne(() => Post, (post) => post.categories, {
         cascade: true,
         onDelete: "SET NULL",
     })

--- a/test/functional/persistence/many-to-one-bi-directional/entity/Post.ts
+++ b/test/functional/persistence/many-to-one-bi-directional/entity/Post.ts
@@ -12,7 +12,7 @@ export class Post {
     @Column()
     title: string
 
-    @OneToMany((type) => Category, (category) => category.post)
+    @OneToMany(() => Category, (category) => category.post)
     categories: Category[]
 
     constructor(id: number, title: string) {

--- a/test/functional/persistence/many-to-one-uni-directional/entity/Category.ts
+++ b/test/functional/persistence/many-to-one-uni-directional/entity/Category.ts
@@ -12,7 +12,7 @@ export class Category {
     @Column()
     name: string
 
-    @ManyToOne((type) => Post, {
+    @ManyToOne(() => Post, {
         cascade: true,
         onDelete: "SET NULL",
     })

--- a/test/functional/persistence/multi-primary-key-on-both-sides/entity/Category.ts
+++ b/test/functional/persistence/multi-primary-key-on-both-sides/entity/Category.ts
@@ -12,6 +12,6 @@ export class Category {
     @Column()
     name: string
 
-    @OneToMany((type) => Post, (post) => post.category)
+    @OneToMany(() => Post, (post) => post.category)
     posts: Post[]
 }

--- a/test/functional/persistence/multi-primary-key-on-both-sides/entity/Post.ts
+++ b/test/functional/persistence/multi-primary-key-on-both-sides/entity/Post.ts
@@ -15,6 +15,6 @@ export class Post {
     @Column()
     title: string
 
-    @ManyToOne((type) => Category, (category) => category.posts)
+    @ManyToOne(() => Category, (category) => category.posts)
     category: Category
 }

--- a/test/functional/persistence/multi-primary-key/entity/Category.ts
+++ b/test/functional/persistence/multi-primary-key/entity/Category.ts
@@ -12,6 +12,6 @@ export class Category {
     @Column()
     name: string
 
-    @OneToMany((type) => Post, (post) => post.category)
+    @OneToMany(() => Post, (post) => post.category)
     posts: Post[]
 }

--- a/test/functional/persistence/multi-primary-key/entity/Post.ts
+++ b/test/functional/persistence/multi-primary-key/entity/Post.ts
@@ -15,6 +15,6 @@ export class Post {
     @Column()
     title: string
 
-    @ManyToOne((type) => Category, (category) => category.posts)
+    @ManyToOne(() => Category, (category) => category.posts)
     category: Category
 }

--- a/test/functional/persistence/one-to-many/entity/Category.ts
+++ b/test/functional/persistence/one-to-many/entity/Category.ts
@@ -9,7 +9,7 @@ export class Category {
     @PrimaryColumn()
     id: number
 
-    @ManyToOne((type) => Post, (post) => post.categories)
+    @ManyToOne(() => Post, (post) => post.categories)
     post: Post
 
     @Column()

--- a/test/functional/persistence/one-to-many/entity/Post.ts
+++ b/test/functional/persistence/one-to-many/entity/Post.ts
@@ -9,7 +9,7 @@ export class Post {
     @PrimaryColumn()
     id: number
 
-    @OneToMany((type) => Category, (category) => category.post)
+    @OneToMany(() => Category, (category) => category.post)
     categories: Category[] | null
 
     @Column()

--- a/test/functional/persistence/one-to-one/entity/AccessToken.ts
+++ b/test/functional/persistence/one-to-one/entity/AccessToken.ts
@@ -11,7 +11,7 @@ export class AccessToken {
     @Generated()
     primaryKey: number
 
-    @OneToOne((type) => User, (user) => user.access_token)
+    @OneToOne(() => User, (user) => user.access_token)
     @JoinColumn()
     user: User
 }

--- a/test/functional/persistence/one-to-one/entity/User.ts
+++ b/test/functional/persistence/one-to-one/entity/User.ts
@@ -14,6 +14,6 @@ export class User {
     @Column()
     email: string
 
-    @OneToOne((type) => AccessToken, (token) => token.user)
+    @OneToOne(() => AccessToken, (token) => token.user)
     access_token: AccessToken
 }

--- a/test/functional/persistence/persistence-order/entity/Category.ts
+++ b/test/functional/persistence/persistence-order/entity/Category.ts
@@ -12,6 +12,6 @@ export class Category {
     @Column()
     name: string
 
-    @OneToOne((type) => Post, (post) => post.category)
+    @OneToOne(() => Post, (post) => post.category)
     post: Post
 }

--- a/test/functional/persistence/persistence-order/entity/Details.ts
+++ b/test/functional/persistence/persistence-order/entity/Details.ts
@@ -14,10 +14,10 @@ export class Details {
     @Column()
     title: string
 
-    @OneToOne((type) => Post, (post) => post.details)
+    @OneToOne(() => Post, (post) => post.details)
     post: Post
 
-    @OneToOne((type) => Photo, (photo) => photo.details, {
+    @OneToOne(() => Photo, (photo) => photo.details, {
         nullable: false,
     })
     @JoinColumn()

--- a/test/functional/persistence/persistence-order/entity/Photo.ts
+++ b/test/functional/persistence/persistence-order/entity/Photo.ts
@@ -15,16 +15,16 @@ export class Photo {
     @Column()
     name: string
 
-    @OneToOne((type) => Details, (details) => details.photo)
+    @OneToOne(() => Details, (details) => details.photo)
     details: Details
 
-    @OneToOne((type) => Post, (post) => post.photo, {
+    @OneToOne(() => Post, (post) => post.photo, {
         nullable: false,
     })
     @JoinColumn()
     post: Post
 
-    @OneToOne((type) => Category, {
+    @OneToOne(() => Category, {
         nullable: false,
     })
     @JoinColumn()

--- a/test/functional/persistence/persistence-order/entity/Post.ts
+++ b/test/functional/persistence/persistence-order/entity/Post.ts
@@ -15,18 +15,18 @@ export class Post {
     @Column()
     title: string
 
-    @OneToOne((type) => Category, (category) => category.post, {
+    @OneToOne(() => Category, (category) => category.post, {
         nullable: true,
     })
     @JoinColumn()
     category: Category
 
-    @OneToOne((type) => Details, (details) => details.post, {
+    @OneToOne(() => Details, (details) => details.post, {
         nullable: false,
     })
     @JoinColumn()
     details: Details
 
-    @OneToOne((type) => Photo, (photo) => photo.post)
+    @OneToOne(() => Photo, (photo) => photo.post)
     photo: Photo
 }

--- a/test/functional/persistence/remove-topological-order/entity/Category.ts
+++ b/test/functional/persistence/remove-topological-order/entity/Category.ts
@@ -12,6 +12,6 @@ export class Category {
     @Column()
     name: string
 
-    @ManyToOne((type) => Post, (post) => post.categories)
+    @ManyToOne(() => Post, (post) => post.categories)
     post: Post
 }

--- a/test/functional/persistence/remove-topological-order/entity/Post.ts
+++ b/test/functional/persistence/remove-topological-order/entity/Post.ts
@@ -12,7 +12,7 @@ export class Post {
     @Column()
     title: string
 
-    @OneToMany((type) => Category, (category) => category.post, {
+    @OneToMany(() => Category, (category) => category.post, {
         cascade: ["insert"],
     })
     categories: Category[]

--- a/test/functional/query-builder/composite-primary/entity/Bar.ts
+++ b/test/functional/query-builder/composite-primary/entity/Bar.ts
@@ -7,6 +7,6 @@ export class Bar {
     @PrimaryColumn()
     id: number
 
-    @ManyToOne((type) => Foo)
+    @ManyToOne(() => Foo)
     foo: Foo
 }

--- a/test/functional/query-builder/join/entity/Post.ts
+++ b/test/functional/query-builder/join/entity/Post.ts
@@ -19,10 +19,10 @@ export class Post {
     @Column()
     title: string
 
-    @ManyToOne((type) => Tag)
+    @ManyToOne(() => Tag)
     tag: Tag
 
-    @OneToOne((type) => User)
+    @OneToOne(() => User)
     @JoinColumn()
     author: User
 

--- a/test/functional/query-builder/locking/entity/Post.ts
+++ b/test/functional/query-builder/locking/entity/Post.ts
@@ -19,10 +19,10 @@ export class Post {
     @Column()
     title: string
 
-    @ManyToOne((type) => Tag)
+    @ManyToOne(() => Tag)
     tag: Tag
 
-    @OneToOne((type) => User)
+    @OneToOne(() => User)
     @JoinColumn()
     author: User
 

--- a/test/functional/query-builder/relation-count/relation-count-one-to-many/entity/Category.ts
+++ b/test/functional/query-builder/relation-count/relation-count-one-to-many/entity/Category.ts
@@ -17,10 +17,10 @@ export class Category {
     @Column()
     isRemoved: boolean = false
 
-    @ManyToOne((type) => Post, (post) => post.categories)
+    @ManyToOne(() => Post, (post) => post.categories)
     post: Post
 
-    @OneToMany((type) => Image, (image) => image.category)
+    @OneToMany(() => Image, (image) => image.category)
     images: Image[]
 
     imageCount: number

--- a/test/functional/query-builder/relation-count/relation-count-one-to-many/entity/Image.ts
+++ b/test/functional/query-builder/relation-count/relation-count-one-to-many/entity/Image.ts
@@ -15,6 +15,6 @@ export class Image {
     @Column()
     isRemoved: boolean = false
 
-    @ManyToOne((type) => Category, (category) => category.images)
+    @ManyToOne(() => Category, (category) => category.images)
     category: Category[]
 }

--- a/test/functional/query-builder/relation-count/relation-count-one-to-many/entity/Post.ts
+++ b/test/functional/query-builder/relation-count/relation-count-one-to-many/entity/Post.ts
@@ -12,7 +12,7 @@ export class Post {
     @Column()
     title: string
 
-    @OneToMany((type) => Category, (category) => category.post)
+    @OneToMany(() => Category, (category) => category.post)
     categories: Category[]
 
     categoryCount: number

--- a/test/functional/query-builder/relation-id/many-to-many/basic-functionality/entity/Post.ts
+++ b/test/functional/query-builder/relation-id/many-to-many/basic-functionality/entity/Post.ts
@@ -15,7 +15,7 @@ export class Post {
     @Column()
     title: string
 
-    @ManyToOne((type) => Tag)
+    @ManyToOne(() => Tag)
     tag: Tag
 
     tagId: number

--- a/test/functional/query-builder/relation-id/many-to-one/basic-functionality/entity/Category.ts
+++ b/test/functional/query-builder/relation-id/many-to-one/basic-functionality/entity/Category.ts
@@ -12,6 +12,6 @@ export class Category {
     @Column({ unique: true })
     name: string
 
-    @OneToMany((type) => PostCategory, (postCategory) => postCategory.category)
+    @OneToMany(() => PostCategory, (postCategory) => postCategory.category)
     posts: PostCategory[]
 }

--- a/test/functional/query-builder/relation-id/many-to-one/basic-functionality/entity/Post.ts
+++ b/test/functional/query-builder/relation-id/many-to-one/basic-functionality/entity/Post.ts
@@ -15,16 +15,16 @@ export class Post {
     @Column()
     title: string
 
-    @ManyToOne((type) => Category)
+    @ManyToOne(() => Category)
     @JoinColumn({ referencedColumnName: "name" })
     categoryByName: Category
 
-    @ManyToOne((type) => Category)
+    @ManyToOne(() => Category)
     @JoinColumn()
     category: Category
 
     @OneToMany(
-        (type) => PostCategory,
+        () => PostCategory,
         (postCategoryRelation) => postCategoryRelation.post,
     )
     categories: PostCategory[]

--- a/test/functional/query-builder/relation-id/many-to-one/basic-functionality/entity/PostCategory.ts
+++ b/test/functional/query-builder/relation-id/many-to-one/basic-functionality/entity/PostCategory.ts
@@ -13,13 +13,13 @@ export class PostCategory {
     @PrimaryColumn()
     categoryId: number
 
-    @ManyToOne((type) => Post, (post) => post.categories)
+    @ManyToOne(() => Post, (post) => post.categories)
     post: Post
 
-    @ManyToOne((type) => Category, (category) => category.posts)
+    @ManyToOne(() => Category, (category) => category.posts)
     category: Category
 
-    @ManyToOne((type) => Image)
+    @ManyToOne(() => Image)
     image: Image
 
     imageId: number

--- a/test/functional/query-builder/relation-id/many-to-one/embedded-with-multiple-pk/entity/Counters.ts
+++ b/test/functional/query-builder/relation-id/many-to-one/embedded-with-multiple-pk/entity/Counters.ts
@@ -17,7 +17,7 @@ export class Counters {
     @Column()
     favorites: number
 
-    @ManyToOne((type) => Category)
+    @ManyToOne(() => Category)
     category: Category
 
     @Column(() => Subcounters, { prefix: "sub" })

--- a/test/functional/query-builder/relation-id/many-to-one/embedded-with-multiple-pk/entity/Subcounters.ts
+++ b/test/functional/query-builder/relation-id/many-to-one/embedded-with-multiple-pk/entity/Subcounters.ts
@@ -10,7 +10,7 @@ export class Subcounters {
     @Column()
     watches: number
 
-    @ManyToOne((type) => User)
+    @ManyToOne(() => User)
     watchedUser: User
 
     watchedUserId: number

--- a/test/functional/query-builder/relation-id/many-to-one/embedded/entity/Category.ts
+++ b/test/functional/query-builder/relation-id/many-to-one/embedded/entity/Category.ts
@@ -12,7 +12,7 @@ export class Category {
     @Column()
     name: string
 
-    @OneToMany((type) => Post, (post) => post.counters.category)
+    @OneToMany(() => Post, (post) => post.counters.category)
     posts: Post[]
 
     postIds: number[]

--- a/test/functional/query-builder/relation-id/many-to-one/embedded/entity/Counters.ts
+++ b/test/functional/query-builder/relation-id/many-to-one/embedded/entity/Counters.ts
@@ -13,7 +13,7 @@ export class Counters {
     @Column()
     favorites: number
 
-    @ManyToOne((type) => Category, (category) => category.posts)
+    @ManyToOne(() => Category, (category) => category.posts)
     category: Category
 
     @Column(() => Subcounters, { prefix: "sub" })

--- a/test/functional/query-builder/relation-id/many-to-one/embedded/entity/Subcounters.ts
+++ b/test/functional/query-builder/relation-id/many-to-one/embedded/entity/Subcounters.ts
@@ -13,7 +13,7 @@ export class Subcounters {
     @Column()
     watches: number
 
-    @ManyToOne((type) => User)
+    @ManyToOne(() => User)
     watchedUser: User
 
     watchedUserId: number

--- a/test/functional/query-builder/relation-id/many-to-one/multiple-pk/entity/Category.ts
+++ b/test/functional/query-builder/relation-id/many-to-one/multiple-pk/entity/Category.ts
@@ -21,10 +21,10 @@ export class Category {
     @Column()
     isRemoved: boolean = false
 
-    @OneToMany((type) => Post, (post) => post.category)
+    @OneToMany(() => Post, (post) => post.category)
     posts: Post[]
 
-    @ManyToOne((type) => Image, (image) => image.categories)
+    @ManyToOne(() => Image, (image) => image.categories)
     @JoinTable()
     image: Image
 

--- a/test/functional/query-builder/relation-id/many-to-one/multiple-pk/entity/Image.ts
+++ b/test/functional/query-builder/relation-id/many-to-one/multiple-pk/entity/Image.ts
@@ -12,7 +12,7 @@ export class Image {
     @Column()
     name: string
 
-    @OneToMany((type) => Category, (category) => category.image)
+    @OneToMany(() => Category, (category) => category.image)
     categories: Category[]
 
     categoryIds: number[]

--- a/test/functional/query-builder/relation-id/many-to-one/multiple-pk/entity/Post.ts
+++ b/test/functional/query-builder/relation-id/many-to-one/multiple-pk/entity/Post.ts
@@ -18,10 +18,10 @@ export class Post {
     @Column()
     isRemoved: boolean = false
 
-    @ManyToOne((type) => Category, (category) => category.posts)
+    @ManyToOne(() => Category, (category) => category.posts)
     category: Category
 
-    @ManyToOne((type) => Category)
+    @ManyToOne(() => Category)
     subcategory: Category
 
     categoryId: number

--- a/test/functional/query-builder/relation-id/one-to-many/basic-functionality/entity/Category.ts
+++ b/test/functional/query-builder/relation-id/one-to-many/basic-functionality/entity/Category.ts
@@ -17,12 +17,12 @@ export class Category {
     @Column()
     isRemoved: boolean = false
 
-    @OneToMany((type) => Image, (image) => image.category)
+    @OneToMany(() => Image, (image) => image.category)
     images: Image[]
 
     imageIds: number[]
 
-    @ManyToOne((type) => Post, (post) => post.categories)
+    @ManyToOne(() => Post, (post) => post.categories)
     post: Post
 
     postId: number

--- a/test/functional/query-builder/relation-id/one-to-many/basic-functionality/entity/Image.ts
+++ b/test/functional/query-builder/relation-id/one-to-many/basic-functionality/entity/Image.ts
@@ -12,7 +12,7 @@ export class Image {
     @Column()
     name: string
 
-    @ManyToOne((type) => Category, (category) => category.images)
+    @ManyToOne(() => Category, (category) => category.images)
     category: Category
 
     categoryId: number

--- a/test/functional/query-builder/relation-id/one-to-many/basic-functionality/entity/Post.ts
+++ b/test/functional/query-builder/relation-id/one-to-many/basic-functionality/entity/Post.ts
@@ -12,7 +12,7 @@ export class Post {
     @Column()
     title: string
 
-    @OneToMany((type) => Category, (category) => category.post)
+    @OneToMany(() => Category, (category) => category.post)
     categories: Category[]
 
     categoryIds: number[]

--- a/test/functional/query-builder/relation-id/one-to-many/embedded-with-multiple-pk/entity/Category.ts
+++ b/test/functional/query-builder/relation-id/one-to-many/embedded-with-multiple-pk/entity/Category.ts
@@ -11,6 +11,6 @@ export class Category {
     @PrimaryColumn()
     name: string
 
-    @ManyToOne((type) => Post, (post) => post.counters.categories)
+    @ManyToOne(() => Post, (post) => post.counters.categories)
     post: Post
 }

--- a/test/functional/query-builder/relation-id/one-to-many/embedded-with-multiple-pk/entity/Counters.ts
+++ b/test/functional/query-builder/relation-id/one-to-many/embedded-with-multiple-pk/entity/Counters.ts
@@ -17,7 +17,7 @@ export class Counters {
     @Column()
     favorites: number
 
-    @OneToMany((type) => Category, (category) => category.post)
+    @OneToMany(() => Category, (category) => category.post)
     categories: Category[]
 
     @Column(() => Subcounters, { prefix: "sub" })

--- a/test/functional/query-builder/relation-id/one-to-many/embedded-with-multiple-pk/entity/Subcounters.ts
+++ b/test/functional/query-builder/relation-id/one-to-many/embedded-with-multiple-pk/entity/Subcounters.ts
@@ -10,7 +10,7 @@ export class Subcounters {
     @Column()
     watches: number
 
-    @OneToMany((type) => User, (user) => user.post)
+    @OneToMany(() => User, (user) => user.post)
     watchedUsers: User[]
 
     watchedUserIds: number[]

--- a/test/functional/query-builder/relation-id/one-to-many/embedded-with-multiple-pk/entity/User.ts
+++ b/test/functional/query-builder/relation-id/one-to-many/embedded-with-multiple-pk/entity/User.ts
@@ -11,6 +11,6 @@ export class User {
     @PrimaryColumn()
     name: string
 
-    @ManyToOne((type) => Post, (post) => post.counters.subcounters.watchedUsers)
+    @ManyToOne(() => Post, (post) => post.counters.subcounters.watchedUsers)
     post: Post
 }

--- a/test/functional/query-builder/relation-id/one-to-many/embedded/entity/Category.ts
+++ b/test/functional/query-builder/relation-id/one-to-many/embedded/entity/Category.ts
@@ -13,7 +13,7 @@ export class Category {
     @Column()
     name: string
 
-    @ManyToOne((type) => Post, (post) => post.counters.categories)
+    @ManyToOne(() => Post, (post) => post.counters.categories)
     @JoinColumn()
     posts: Post[]
 

--- a/test/functional/query-builder/relation-id/one-to-many/embedded/entity/Counters.ts
+++ b/test/functional/query-builder/relation-id/one-to-many/embedded/entity/Counters.ts
@@ -13,7 +13,7 @@ export class Counters {
     @Column()
     favorites: number
 
-    @OneToMany((type) => Category, (category) => category.posts)
+    @OneToMany(() => Category, (category) => category.posts)
     categories: Category[]
 
     @Column(() => Subcounters, { prefix: "sub" })

--- a/test/functional/query-builder/relation-id/one-to-many/embedded/entity/Subcounters.ts
+++ b/test/functional/query-builder/relation-id/one-to-many/embedded/entity/Subcounters.ts
@@ -13,7 +13,7 @@ export class Subcounters {
     @Column()
     watches: number
 
-    @OneToMany((type) => User, (user) => user.posts)
+    @OneToMany(() => User, (user) => user.posts)
     watchedUsers: User[]
 
     watchedUserIds: number[]

--- a/test/functional/query-builder/relation-id/one-to-many/embedded/entity/User.ts
+++ b/test/functional/query-builder/relation-id/one-to-many/embedded/entity/User.ts
@@ -13,7 +13,7 @@ export class User {
     @Column()
     name: string
 
-    @ManyToOne((type) => Post, (post) => post.counters.subcounters.watchedUsers)
+    @ManyToOne(() => Post, (post) => post.counters.subcounters.watchedUsers)
     @JoinColumn()
     posts: Post[]
 }

--- a/test/functional/query-builder/relation-id/one-to-many/multiple-pk/entity/Category.ts
+++ b/test/functional/query-builder/relation-id/one-to-many/multiple-pk/entity/Category.ts
@@ -20,10 +20,10 @@ export class Category {
     @Column()
     isRemoved: boolean = false
 
-    @ManyToOne((type) => Post, (post) => post.categories)
+    @ManyToOne(() => Post, (post) => post.categories)
     post: Post
 
-    @OneToMany((type) => Image, (image) => image.category)
+    @OneToMany(() => Image, (image) => image.category)
     images: Image[]
 
     postId: number

--- a/test/functional/query-builder/relation-id/one-to-many/multiple-pk/entity/Image.ts
+++ b/test/functional/query-builder/relation-id/one-to-many/multiple-pk/entity/Image.ts
@@ -12,7 +12,7 @@ export class Image {
     @Column()
     name: string
 
-    @ManyToOne((type) => Category, (category) => category.images)
+    @ManyToOne(() => Category, (category) => category.images)
     category: Category
 
     categoryId: number

--- a/test/functional/query-builder/relation-id/one-to-many/multiple-pk/entity/Post.ts
+++ b/test/functional/query-builder/relation-id/one-to-many/multiple-pk/entity/Post.ts
@@ -15,7 +15,7 @@ export class Post {
     @Column()
     title: string
 
-    @OneToMany((type) => Category, (category) => category.post)
+    @OneToMany(() => Category, (category) => category.post)
     categories: Category[]
 
     categoryIds: any[]

--- a/test/functional/query-builder/relation-id/one-to-one/basic-functionality/entity/Category.ts
+++ b/test/functional/query-builder/relation-id/one-to-one/basic-functionality/entity/Category.ts
@@ -12,7 +12,7 @@ export class Category {
     @Column()
     name: string
 
-    @OneToOne((type) => Post, (post) => post.category2)
+    @OneToOne(() => Post, (post) => post.category2)
     post: Post
 
     postId: number

--- a/test/functional/query-builder/relation-id/one-to-one/basic-functionality/entity/Post.ts
+++ b/test/functional/query-builder/relation-id/one-to-one/basic-functionality/entity/Post.ts
@@ -13,11 +13,11 @@ export class Post {
     @Column()
     title: string
 
-    @OneToOne((type) => Category)
+    @OneToOne(() => Category)
     @JoinColumn()
     category: Category
 
-    @OneToOne((type) => Category, (category) => category.post)
+    @OneToOne(() => Category, (category) => category.post)
     @JoinColumn()
     category2: Category
 

--- a/test/functional/query-builder/relation-id/one-to-one/embedded-with-multiple-pk/entity/Counters.ts
+++ b/test/functional/query-builder/relation-id/one-to-one/embedded-with-multiple-pk/entity/Counters.ts
@@ -18,7 +18,7 @@ export class Counters {
     @Column()
     favorites: number
 
-    @OneToOne((type) => Category)
+    @OneToOne(() => Category)
     @JoinColumn()
     category: Category
 

--- a/test/functional/query-builder/relation-id/one-to-one/embedded-with-multiple-pk/entity/Subcounters.ts
+++ b/test/functional/query-builder/relation-id/one-to-one/embedded-with-multiple-pk/entity/Subcounters.ts
@@ -11,7 +11,7 @@ export class Subcounters {
     @Column()
     watches: number
 
-    @OneToOne((type) => User)
+    @OneToOne(() => User)
     @JoinColumn()
     watchedUser: User
 

--- a/test/functional/query-builder/relation-id/one-to-one/embedded/entity/Category.ts
+++ b/test/functional/query-builder/relation-id/one-to-one/embedded/entity/Category.ts
@@ -12,7 +12,7 @@ export class Category {
     @Column()
     name: string
 
-    @OneToOne((type) => Post, (post) => post.counters.category)
+    @OneToOne(() => Post, (post) => post.counters.category)
     post: Post
 
     postId: number

--- a/test/functional/query-builder/relation-id/one-to-one/embedded/entity/Counters.ts
+++ b/test/functional/query-builder/relation-id/one-to-one/embedded/entity/Counters.ts
@@ -14,7 +14,7 @@ export class Counters {
     @Column()
     favorites: number
 
-    @OneToOne((type) => Category, (category) => category.post)
+    @OneToOne(() => Category, (category) => category.post)
     @JoinColumn()
     category: Category
 

--- a/test/functional/query-builder/relation-id/one-to-one/embedded/entity/Subcounters.ts
+++ b/test/functional/query-builder/relation-id/one-to-one/embedded/entity/Subcounters.ts
@@ -14,7 +14,7 @@ export class Subcounters {
     @Column()
     watches: number
 
-    @OneToOne((type) => User)
+    @OneToOne(() => User)
     @JoinColumn()
     watchedUser: User
 

--- a/test/functional/query-builder/relation-id/one-to-one/multiple-pk/entity/Category.ts
+++ b/test/functional/query-builder/relation-id/one-to-one/multiple-pk/entity/Category.ts
@@ -20,10 +20,10 @@ export class Category {
     @Column()
     isRemoved: boolean = false
 
-    @OneToOne((type) => Post, (post) => post.category)
+    @OneToOne(() => Post, (post) => post.category)
     post: Post
 
-    @OneToOne((type) => Image, (image) => image.category)
+    @OneToOne(() => Image, (image) => image.category)
     @JoinColumn()
     image: Image
 

--- a/test/functional/query-builder/relation-id/one-to-one/multiple-pk/entity/Image.ts
+++ b/test/functional/query-builder/relation-id/one-to-one/multiple-pk/entity/Image.ts
@@ -12,7 +12,7 @@ export class Image {
     @Column()
     name: string
 
-    @OneToOne((type) => Category, (category) => category.image)
+    @OneToOne(() => Category, (category) => category.image)
     category: Category
 
     categoryId: number

--- a/test/functional/query-builder/relation-id/one-to-one/multiple-pk/entity/Post.ts
+++ b/test/functional/query-builder/relation-id/one-to-one/multiple-pk/entity/Post.ts
@@ -19,11 +19,11 @@ export class Post {
     @Column()
     isRemoved: boolean = false
 
-    @OneToOne((type) => Category, (category) => category.post)
+    @OneToOne(() => Category, (category) => category.post)
     @JoinColumn()
     category: Category
 
-    @OneToOne((type) => Category)
+    @OneToOne(() => Category)
     @JoinColumn()
     subcategory: Category
 

--- a/test/functional/query-builder/relational/with-many/entity/Category.ts
+++ b/test/functional/query-builder/relational/with-many/entity/Category.ts
@@ -12,6 +12,6 @@ export class Category {
     @Column()
     name: string
 
-    @OneToMany((type) => Post, (post) => post.category)
+    @OneToMany(() => Post, (post) => post.category)
     posts: Post[]
 }

--- a/test/functional/query-builder/relational/with-many/entity/Post.ts
+++ b/test/functional/query-builder/relational/with-many/entity/Post.ts
@@ -15,7 +15,7 @@ export class Post {
     @Column()
     title: string
 
-    @ManyToOne((type) => Category, (category) => category.posts)
+    @ManyToOne(() => Category, (category) => category.posts)
     category: Category
 
     @ManyToMany((type) => Image, (image) => image.posts)

--- a/test/functional/query-builder/relational/with-one/entity/Image.ts
+++ b/test/functional/query-builder/relational/with-one/entity/Image.ts
@@ -12,6 +12,6 @@ export class Image {
     @Column()
     url: string
 
-    @OneToOne((type) => Post, (post) => post.image)
+    @OneToOne(() => Post, (post) => post.image)
     post: Post
 }

--- a/test/functional/query-builder/relational/with-one/entity/Post.ts
+++ b/test/functional/query-builder/relational/with-one/entity/Post.ts
@@ -15,10 +15,10 @@ export class Post {
     @Column()
     title: string
 
-    @ManyToOne((type) => Category)
+    @ManyToOne(() => Category)
     category: Category
 
-    @OneToOne((type) => Image, (image) => image.post)
+    @OneToOne(() => Image, (image) => image.post)
     @JoinColumn()
     image: Image
 }

--- a/test/functional/query-builder/select/entity/Post.ts
+++ b/test/functional/query-builder/select/entity/Post.ts
@@ -34,7 +34,7 @@ export class Post {
     @JoinColumn()
     heroImage: HeroImage
 
-    @ManyToOne((type) => Category)
+    @ManyToOne(() => Category)
     category: Category
 
     @ManyToMany(() => Tag, (tag) => tag.posts)

--- a/test/functional/query-builder/soft-delete/global-condition-non-deleted/entity/CategoryWithRelation.ts
+++ b/test/functional/query-builder/soft-delete/global-condition-non-deleted/entity/CategoryWithRelation.ts
@@ -12,6 +12,6 @@ export class CategoryWithRelation {
     @Column({ unique: true })
     name: string
 
-    @OneToOne((type) => PostWithRelation, (post) => post.category)
+    @OneToOne(() => PostWithRelation, (post) => post.category)
     post: PostWithRelation
 }

--- a/test/functional/query-builder/soft-delete/global-condition-non-deleted/entity/PostWithRelation.ts
+++ b/test/functional/query-builder/soft-delete/global-condition-non-deleted/entity/PostWithRelation.ts
@@ -14,7 +14,7 @@ export class PostWithRelation {
     @Column()
     title: string
 
-    @OneToOne((type) => CategoryWithRelation, (category) => category.post, {
+    @OneToOne(() => CategoryWithRelation, (category) => category.post, {
         eager: true,
     })
     @JoinColumn()

--- a/test/functional/query-runner/entity/Student.ts
+++ b/test/functional/query-runner/entity/Student.ts
@@ -17,9 +17,9 @@ export class Student {
     @Column()
     name: string
 
-    @ManyToOne((type) => Faculty)
+    @ManyToOne(() => Faculty)
     faculty: Faculty
 
-    @ManyToOne((type) => Teacher)
+    @ManyToOne(() => Teacher)
     teacher: Teacher
 }

--- a/test/functional/query-runner/entity/Teacher.ts
+++ b/test/functional/query-runner/entity/Teacher.ts
@@ -14,6 +14,6 @@ export class Teacher {
     @Column()
     name: string
 
-    @OneToMany((type) => Student, (student) => student.teacher)
+    @OneToMany(() => Student, (student) => student.teacher)
     students: Student[]
 }

--- a/test/functional/relations/custom-referenced-column-name/entity/Post.ts
+++ b/test/functional/relations/custom-referenced-column-name/entity/Post.ts
@@ -27,43 +27,43 @@ export class Post {
     @Column({ type: "int", nullable: true })
     tagId: number
 
-    @ManyToOne((type) => Category)
+    @ManyToOne(() => Category)
     @JoinColumn()
     categoryWithEmptyJoinCol: Category
 
-    @ManyToOne((type) => Category)
+    @ManyToOne(() => Category)
     @JoinColumn({ name: "categoryId" })
     categoryWithoutRefColName: Category
 
-    @ManyToOne((type) => Category)
+    @ManyToOne(() => Category)
     @JoinColumn({ referencedColumnName: "name" })
     categoryWithoutColName: Category
 
-    @ManyToOne((type) => Category)
+    @ManyToOne(() => Category)
     @JoinColumn({ name: "categoryIdentifier" })
     categoryWithoutRefColName2: Category
 
-    @ManyToOne((type) => Category)
+    @ManyToOne(() => Category)
     @JoinColumn({ name: "categoryName", referencedColumnName: "name" })
     category: Category
 
-    @OneToOne((type) => Tag)
+    @OneToOne(() => Tag)
     @JoinColumn()
     tagWithEmptyJoinCol: Tag
 
-    @OneToOne((type) => Tag)
+    @OneToOne(() => Tag)
     @JoinColumn({ name: "tagId" })
     tagWithoutRefColName: Tag
 
-    @OneToOne((type) => Tag)
+    @OneToOne(() => Tag)
     @JoinColumn({ referencedColumnName: "name" })
     tagWithoutColName: Tag
 
-    @OneToOne((type) => Tag)
+    @OneToOne(() => Tag)
     @JoinColumn({ name: "tagIdentifier" })
     tagWithoutRefColName2: Tag
 
-    @OneToOne((type) => Tag)
+    @OneToOne(() => Tag)
     @JoinColumn({ name: "tagName", referencedColumnName: "name" })
     tag: Tag
 }

--- a/test/functional/relations/eager-relations/basic-eager-relations/entity/Editor.ts
+++ b/test/functional/relations/eager-relations/basic-eager-relations/entity/Editor.ts
@@ -14,10 +14,10 @@ export class Editor {
     @PrimaryColumn()
     postId: number
 
-    @OneToOne((type) => User, { eager: true })
+    @OneToOne(() => User, { eager: true })
     @JoinColumn()
     user: User
 
-    @ManyToOne((type) => Post)
+    @ManyToOne(() => Post)
     post: Post
 }

--- a/test/functional/relations/eager-relations/basic-eager-relations/entity/Post.ts
+++ b/test/functional/relations/eager-relations/basic-eager-relations/entity/Post.ts
@@ -26,9 +26,9 @@ export class Post {
     })
     categories2: Category[]
 
-    @ManyToOne((type) => User, { eager: true })
+    @ManyToOne(() => User, { eager: true })
     author: User
 
-    @OneToMany((type) => Editor, (editor) => editor.post, { eager: true })
+    @OneToMany(() => Editor, (editor) => editor.post, { eager: true })
     editors: Editor[]
 }

--- a/test/functional/relations/eager-relations/basic-eager-relations/entity/User.ts
+++ b/test/functional/relations/eager-relations/basic-eager-relations/entity/User.ts
@@ -16,7 +16,7 @@ export class User {
     @Column()
     lastName: string
 
-    @OneToOne((type) => Profile, { eager: true })
+    @OneToOne(() => Profile, { eager: true })
     @JoinColumn()
     profile: Profile
 }

--- a/test/functional/relations/eager-relations/circular-eager-relations/entity/Post.ts
+++ b/test/functional/relations/eager-relations/circular-eager-relations/entity/Post.ts
@@ -12,6 +12,6 @@ export class Post {
     @Column()
     title: string
 
-    @ManyToOne((type) => User, { eager: true })
+    @ManyToOne(() => User, { eager: true })
     author: User
 }

--- a/test/functional/relations/eager-relations/circular-eager-relations/entity/Profile.ts
+++ b/test/functional/relations/eager-relations/circular-eager-relations/entity/Profile.ts
@@ -12,6 +12,6 @@ export class Profile {
     @Column()
     about: string
 
-    @OneToOne((type) => User, (user) => user.profile, { eager: true })
+    @OneToOne(() => User, (user) => user.profile, { eager: true })
     user: User
 }

--- a/test/functional/relations/eager-relations/circular-eager-relations/entity/User.ts
+++ b/test/functional/relations/eager-relations/circular-eager-relations/entity/User.ts
@@ -16,7 +16,7 @@ export class User {
     @Column()
     lastName: string
 
-    @OneToOne((type) => Profile, (profile) => profile.user, { eager: true })
+    @OneToOne(() => Profile, (profile) => profile.user, { eager: true })
     @JoinColumn()
     profile: Profile
 }

--- a/test/functional/relations/eager-relations/lazy-nested-eager-relations/entity/Editor.ts
+++ b/test/functional/relations/eager-relations/lazy-nested-eager-relations/entity/Editor.ts
@@ -13,10 +13,10 @@ export class Editor {
     @PrimaryGeneratedColumn()
     id: number
 
-    @OneToOne((type) => User, { eager: true })
+    @OneToOne(() => User, { eager: true })
     @JoinColumn()
     user: User
 
-    @ManyToOne((type) => Post, { lazy: true })
+    @ManyToOne(() => Post, { lazy: true })
     post: Promise<Post>
 }

--- a/test/functional/relations/eager-relations/lazy-nested-eager-relations/entity/Post.ts
+++ b/test/functional/relations/eager-relations/lazy-nested-eager-relations/entity/Post.ts
@@ -26,9 +26,9 @@ export class Post {
     })
     categories2: Category[]
 
-    @ManyToOne((type) => User, { eager: true })
+    @ManyToOne(() => User, { eager: true })
     author: User
 
-    @OneToMany((type) => Editor, (editor) => editor.post, { eager: true })
+    @OneToMany(() => Editor, (editor) => editor.post, { eager: true })
     editors: Editor[]
 }

--- a/test/functional/relations/eager-relations/lazy-nested-eager-relations/entity/User.ts
+++ b/test/functional/relations/eager-relations/lazy-nested-eager-relations/entity/User.ts
@@ -16,7 +16,7 @@ export class User {
     @Column()
     lastName: string
 
-    @OneToOne((type) => Profile, { eager: true })
+    @OneToOne(() => Profile, { eager: true })
     @JoinColumn()
     profile: Profile
 }

--- a/test/functional/relations/lazy-relations/basic-lazy-relation/entity/Category.ts
+++ b/test/functional/relations/lazy-relations/basic-lazy-relation/entity/Category.ts
@@ -14,12 +14,12 @@ export class Category {
     @Column()
     name: string
 
-    @OneToOne((type) => Post, (post) => post.oneCategory)
+    @OneToOne(() => Post, (post) => post.oneCategory)
     onePost: Promise<Post>
 
     @ManyToMany((type) => Post, (post) => post.twoSideCategories)
     twoSidePosts: Promise<Post[]>
 
-    @OneToMany((type) => Post, (post) => post.twoSideCategory)
+    @OneToMany(() => Post, (post) => post.twoSideCategory)
     twoSidePosts2: Promise<Post[]>
 }

--- a/test/functional/relations/lazy-relations/basic-lazy-relation/entity/Post.ts
+++ b/test/functional/relations/lazy-relations/basic-lazy-relation/entity/Post.ts
@@ -30,13 +30,13 @@ export class Post {
     @Column()
     viewCount: number = 0
 
-    @ManyToOne((type) => Category)
+    @ManyToOne(() => Category)
     category: Promise<Category>
 
-    @OneToOne((type) => Category, (category) => category.onePost)
+    @OneToOne(() => Category, (category) => category.onePost)
     @JoinColumn()
     oneCategory: Promise<Category>
 
-    @ManyToOne((type) => Category, (category) => category.twoSidePosts2)
+    @ManyToOne(() => Category, (category) => category.twoSidePosts2)
     twoSideCategory: Promise<Category>
 }

--- a/test/functional/relations/lazy-relations/named-columns/entity/Category.ts
+++ b/test/functional/relations/lazy-relations/named-columns/entity/Category.ts
@@ -16,13 +16,13 @@ export class Category {
     @Column()
     name: string
 
-    @OneToOne((type) => Post, (post) => post.oneCategory)
+    @OneToOne(() => Post, (post) => post.oneCategory)
     onePost: Promise<Post>
 
     @ManyToMany((type) => Post, (post) => post.twoSideCategories)
     twoSidePosts: Promise<Post[]>
 
-    @OneToMany((type) => Post, (post) => post.twoSideCategory)
+    @OneToMany(() => Post, (post) => post.twoSideCategory)
     twoSidePosts2: Promise<Post[]>
 
     // ManyToMany with named properties
@@ -30,10 +30,10 @@ export class Category {
     postsNamedColumn: Promise<Post[]>
 
     // OneToMany with named properties
-    @OneToMany((type) => Post, (post) => post.categoryNamedColumn)
+    @OneToMany(() => Post, (post) => post.categoryNamedColumn)
     onePostsNamedColumn: Promise<Post[]>
 
     // OneToOne with named properties
-    @OneToOne((type) => Post, (post) => post.oneCategoryNamedColumn)
+    @OneToOne(() => Post, (post) => post.oneCategoryNamedColumn)
     onePostNamedColumn: Promise<Post>
 }

--- a/test/functional/relations/lazy-relations/named-columns/entity/Post.ts
+++ b/test/functional/relations/lazy-relations/named-columns/entity/Post.ts
@@ -32,14 +32,14 @@ export class Post {
     @Column()
     viewCount: number = 0
 
-    @ManyToOne((type) => Category)
+    @ManyToOne(() => Category)
     category: Promise<Category>
 
-    @OneToOne((type) => Category, (category) => category.onePost)
+    @OneToOne(() => Category, (category) => category.onePost)
     @JoinColumn()
     oneCategory: Promise<Category>
 
-    @ManyToOne((type) => Category, (category) => category.twoSidePosts2)
+    @ManyToOne(() => Category, (category) => category.twoSidePosts2)
     twoSideCategory: Promise<Category>
 
     // ManyToMany with named properties
@@ -48,14 +48,14 @@ export class Post {
     categoriesNamedColumn: Promise<Category[]>
 
     // ManyToOne with named properties
-    @ManyToOne((type) => Category, (category) => category.onePostsNamedColumn)
+    @ManyToOne(() => Category, (category) => category.onePostsNamedColumn)
     @JoinColumn({
         name: "s_category_named_column_id",
     })
     categoryNamedColumn: Promise<Category>
 
     // OneToOne with named properties
-    @OneToOne((type) => Category, (category) => category.onePostNamedColumn)
+    @OneToOne(() => Category, (category) => category.onePostNamedColumn)
     @JoinColumn({
         name: "s_one_category_named_column_id",
     })

--- a/test/functional/relations/lazy-relations/named-tables-and-columns/entity/Category.ts
+++ b/test/functional/relations/lazy-relations/named-tables-and-columns/entity/Category.ts
@@ -20,13 +20,13 @@ export class Category {
     @Column()
     name: string
 
-    @OneToOne((type) => Post, (post) => post.oneCategory)
+    @OneToOne(() => Post, (post) => post.oneCategory)
     onePost: Promise<Post>
 
     @ManyToMany((type) => Post, (post) => post.twoSideCategories)
     twoSidePosts: Promise<Post[]>
 
-    @OneToMany((type) => Post, (post) => post.twoSideCategory)
+    @OneToMany(() => Post, (post) => post.twoSideCategory)
     twoSidePosts2: Promise<Post[]>
 
     // ManyToMany with named properties
@@ -34,10 +34,10 @@ export class Category {
     postsNamedAll: Promise<Post[]>
 
     // OneToMany with named properties
-    @OneToMany((type) => Post, (post) => post.categoryNamedAll)
+    @OneToMany(() => Post, (post) => post.categoryNamedAll)
     onePostsNamedAll: Promise<Post[]>
 
     // OneToOne with named properties
-    @OneToOne((type) => Post, (post) => post.oneCategoryNamedAll)
+    @OneToOne(() => Post, (post) => post.oneCategoryNamedAll)
     onePostNamedAll: Promise<Post>
 }

--- a/test/functional/relations/lazy-relations/named-tables-and-columns/entity/Post.ts
+++ b/test/functional/relations/lazy-relations/named-tables-and-columns/entity/Post.ts
@@ -37,14 +37,14 @@ export class Post {
     @Column()
     viewCount: number = 0
 
-    @ManyToOne((type) => Category)
+    @ManyToOne(() => Category)
     category: Promise<Category>
 
-    @OneToOne((type) => Category, (category) => category.onePost)
+    @OneToOne(() => Category, (category) => category.onePost)
     @JoinColumn()
     oneCategory: Promise<Category>
 
-    @ManyToOne((type) => Category, (category) => category.twoSidePosts2)
+    @ManyToOne(() => Category, (category) => category.twoSidePosts2)
     twoSideCategory: Promise<Category>
 
     // ManyToMany with named properties
@@ -53,14 +53,14 @@ export class Post {
     categoriesNamedAll: Promise<Category[]>
 
     // ManyToOne with named properties
-    @ManyToOne((type) => Category, (category) => category.onePostsNamedAll)
+    @ManyToOne(() => Category, (category) => category.onePostsNamedAll)
     @JoinColumn({
         name: "s_category_named_all_id",
     })
     categoryNamedAll: Promise<Category>
 
     // OneToOne with named properties
-    @OneToOne((type) => Category, (category) => category.onePostNamedAll)
+    @OneToOne(() => Category, (category) => category.onePostNamedAll)
     @JoinColumn({
         name: "s_one_category_named_all_id",
     })

--- a/test/functional/relations/lazy-relations/named-tables/entity/Category.ts
+++ b/test/functional/relations/lazy-relations/named-tables/entity/Category.ts
@@ -18,13 +18,13 @@ export class Category {
     @Column()
     name: string
 
-    @OneToOne((type) => Post, (post) => post.oneCategory)
+    @OneToOne(() => Post, (post) => post.oneCategory)
     onePost: Promise<Post>
 
     @ManyToMany((type) => Post, (post) => post.twoSideCategories)
     twoSidePosts: Promise<Post[]>
 
-    @OneToMany((type) => Post, (post) => post.twoSideCategory)
+    @OneToMany(() => Post, (post) => post.twoSideCategory)
     twoSidePosts2: Promise<Post[]>
 
     // ManyToMany with named properties
@@ -32,10 +32,10 @@ export class Category {
     postsNamedTable: Promise<Post[]>
 
     // OneToMany with named properties
-    @OneToMany((type) => Post, (post) => post.categoryNamedTable)
+    @OneToMany(() => Post, (post) => post.categoryNamedTable)
     onePostsNamedTable: Promise<Post[]>
 
     // OneToOne with named properties
-    @OneToOne((type) => Post, (post) => post.oneCategoryNamedTable)
+    @OneToOne(() => Post, (post) => post.oneCategoryNamedTable)
     onePostNamedTable: Promise<Post>
 }

--- a/test/functional/relations/lazy-relations/named-tables/entity/Post.ts
+++ b/test/functional/relations/lazy-relations/named-tables/entity/Post.ts
@@ -35,14 +35,14 @@ export class Post {
     @Column()
     viewCount: number = 0
 
-    @ManyToOne((type) => Category)
+    @ManyToOne(() => Category)
     category: Promise<Category>
 
-    @OneToOne((type) => Category, (category) => category.onePost)
+    @OneToOne(() => Category, (category) => category.onePost)
     @JoinColumn()
     oneCategory: Promise<Category>
 
-    @ManyToOne((type) => Category, (category) => category.twoSidePosts2)
+    @ManyToOne(() => Category, (category) => category.twoSidePosts2)
     twoSideCategory: Promise<Category>
 
     // ManyToMany with named properties
@@ -51,12 +51,12 @@ export class Post {
     categoriesNamedTable: Promise<Category[]>
 
     // ManyToOne with named properties
-    @ManyToOne((type) => Category, (category) => category.onePostsNamedTable)
+    @ManyToOne(() => Category, (category) => category.onePostsNamedTable)
     @JoinColumn()
     categoryNamedTable: Promise<Category>
 
     // OneToOne with named properties
-    @OneToOne((type) => Category, (category) => category.onePostNamedTable)
+    @OneToOne(() => Category, (category) => category.onePostNamedTable)
     @JoinColumn()
     oneCategoryNamedTable: Promise<Category>
 }

--- a/test/functional/relations/multiple-primary-keys/multiple-primary-keys-many-to-one/entity/Category.ts
+++ b/test/functional/relations/multiple-primary-keys/multiple-primary-keys-many-to-one/entity/Category.ts
@@ -23,15 +23,15 @@ export class Category {
     @Column({ nullable: true })
     description: string
 
-    @OneToMany((type) => Post, (post) => post.category)
+    @OneToMany(() => Post, (post) => post.category)
     posts: Post[]
 
-    @OneToMany((type) => Post, (post) => post.categoryWithJoinColumn)
+    @OneToMany(() => Post, (post) => post.categoryWithJoinColumn)
     postsWithJoinColumn: Post[]
 
-    @OneToMany((type) => Post, (post) => post.categoryWithOptions)
+    @OneToMany(() => Post, (post) => post.categoryWithOptions)
     postsWithOptions: Post[]
 
-    @OneToMany((type) => Post, (post) => post.categoryWithNonPKColumns)
+    @OneToMany(() => Post, (post) => post.categoryWithNonPKColumns)
     postsWithNonPKColumns: Post[]
 }

--- a/test/functional/relations/multiple-primary-keys/multiple-primary-keys-many-to-one/entity/Post.ts
+++ b/test/functional/relations/multiple-primary-keys/multiple-primary-keys-many-to-one/entity/Post.ts
@@ -13,21 +13,21 @@ export class Post {
     @Column()
     title: string
 
-    @ManyToOne((type) => Category)
+    @ManyToOne(() => Category)
     category: Category
 
-    @ManyToOne((type) => Category)
+    @ManyToOne(() => Category)
     @JoinColumn()
     categoryWithJoinColumn: Category
 
-    @ManyToOne((type) => Category)
+    @ManyToOne(() => Category)
     @JoinColumn([
         { name: "category_name", referencedColumnName: "name" },
         { name: "category_type", referencedColumnName: "type" },
     ])
     categoryWithOptions: Category
 
-    @ManyToOne((type) => Category)
+    @ManyToOne(() => Category)
     @JoinColumn([
         { name: "category_code", referencedColumnName: "code" },
         { name: "category_version", referencedColumnName: "version" },

--- a/test/functional/relations/multiple-primary-keys/multiple-primary-keys-one-to-one/entity/Category.ts
+++ b/test/functional/relations/multiple-primary-keys/multiple-primary-keys-one-to-one/entity/Category.ts
@@ -24,21 +24,21 @@ export class Category {
     @Column({ nullable: true })
     description: string
 
-    @OneToOne((type) => Post, (post) => post.category)
+    @OneToOne(() => Post, (post) => post.category)
     post: Post
 
-    @OneToOne((type) => Post, (post) => post.categoryWithOptions)
+    @OneToOne(() => Post, (post) => post.categoryWithOptions)
     postWithOptions: Post
 
-    @OneToOne((type) => Post, (post) => post.categoryWithNonPKColumns)
+    @OneToOne(() => Post, (post) => post.categoryWithNonPKColumns)
     postWithNonPKColumns: Post
 
-    @OneToOne((type) => Tag, (tag) => tag.category)
+    @OneToOne(() => Tag, (tag) => tag.category)
     tag: Tag
 
-    @OneToOne((type) => Tag, (tag) => tag.categoryWithOptions)
+    @OneToOne(() => Tag, (tag) => tag.categoryWithOptions)
     tagWithOptions: Tag
 
-    @OneToOne((type) => Tag, (tag) => tag.categoryWithNonPKColumns)
+    @OneToOne(() => Tag, (tag) => tag.categoryWithNonPKColumns)
     tagWithNonPKColumns: Tag
 }

--- a/test/functional/relations/multiple-primary-keys/multiple-primary-keys-one-to-one/entity/Post.ts
+++ b/test/functional/relations/multiple-primary-keys/multiple-primary-keys-one-to-one/entity/Post.ts
@@ -13,18 +13,18 @@ export class Post {
     @Column()
     title: string
 
-    @OneToOne((type) => Category, (category) => category.post)
+    @OneToOne(() => Category, (category) => category.post)
     @JoinColumn()
     category: Category
 
-    @OneToOne((type) => Category, (category) => category.postWithOptions)
+    @OneToOne(() => Category, (category) => category.postWithOptions)
     @JoinColumn([
         { name: "category_name", referencedColumnName: "name" },
         { name: "category_type", referencedColumnName: "type" },
     ])
     categoryWithOptions: Category
 
-    @OneToOne((type) => Category, (category) => category.postWithNonPKColumns)
+    @OneToOne(() => Category, (category) => category.postWithNonPKColumns)
     @JoinColumn([
         { name: "category_code", referencedColumnName: "code" },
         { name: "category_version", referencedColumnName: "version" },

--- a/test/functional/relations/multiple-primary-keys/multiple-primary-keys-one-to-one/entity/Tag.ts
+++ b/test/functional/relations/multiple-primary-keys/multiple-primary-keys-one-to-one/entity/Tag.ts
@@ -16,18 +16,18 @@ export class Tag {
     @PrimaryColumn()
     description: string
 
-    @OneToOne((type) => Category, (category) => category.tag)
+    @OneToOne(() => Category, (category) => category.tag)
     @JoinColumn()
     category: Category
 
-    @OneToOne((type) => Category, (category) => category.tagWithOptions)
+    @OneToOne(() => Category, (category) => category.tagWithOptions)
     @JoinColumn([
         { name: "category_name", referencedColumnName: "name" },
         { name: "category_type", referencedColumnName: "type" },
     ])
     categoryWithOptions: Category
 
-    @OneToOne((type) => Category, (category) => category.tagWithNonPKColumns)
+    @OneToOne(() => Category, (category) => category.tagWithNonPKColumns)
     @JoinColumn([
         { name: "category_code", referencedColumnName: "code" },
         { name: "category_version", referencedColumnName: "version" },

--- a/test/functional/relations/multiple-primary-keys/multiple-primary-keys-other-cases/entity/Event.ts
+++ b/test/functional/relations/multiple-primary-keys/multiple-primary-keys-other-cases/entity/Event.ts
@@ -14,9 +14,9 @@ export class Event {
     @Column()
     name: string
 
-    @ManyToOne((type) => Person)
+    @ManyToOne(() => Person)
     author: Person
 
-    @OneToMany((type) => EventMember, (member) => member.event)
+    @OneToMany(() => EventMember, (member) => member.event)
     members: EventMember[]
 }

--- a/test/functional/relations/multiple-primary-keys/multiple-primary-keys-other-cases/entity/EventMember.ts
+++ b/test/functional/relations/multiple-primary-keys/multiple-primary-keys-other-cases/entity/EventMember.ts
@@ -12,9 +12,9 @@ export class EventMember {
     @PrimaryColumn()
     eventId: number
 
-    @ManyToOne((type) => Event, (event) => event.members)
+    @ManyToOne(() => Event, (event) => event.members)
     event: Event
 
-    @ManyToOne((type) => User, (user) => user.members)
+    @ManyToOne(() => User, (user) => user.members)
     user: User
 }

--- a/test/functional/relations/multiple-primary-keys/multiple-primary-keys-other-cases/entity/Person.ts
+++ b/test/functional/relations/multiple-primary-keys/multiple-primary-keys-other-cases/entity/Person.ts
@@ -13,7 +13,7 @@ export class Person {
     @Column()
     fullName: string
 
-    @OneToOne((type) => User)
+    @OneToOne(() => User)
     @JoinColumn()
     user: User
 }

--- a/test/functional/relations/multiple-primary-keys/multiple-primary-keys-other-cases/entity/User.ts
+++ b/test/functional/relations/multiple-primary-keys/multiple-primary-keys-other-cases/entity/User.ts
@@ -12,6 +12,6 @@ export class User {
     @Column()
     name: string
 
-    @OneToMany((type) => EventMember, (member) => member.user)
+    @OneToMany(() => EventMember, (member) => member.user)
     members: EventMember[]
 }

--- a/test/functional/relations/relation-mapped-to-different-name-column/entity/Post.ts
+++ b/test/functional/relations/relation-mapped-to-different-name-column/entity/Post.ts
@@ -10,7 +10,7 @@ export class Post {
     @PrimaryGeneratedColumn()
     id: number
 
-    @OneToOne((type) => PostDetails)
+    @OneToOne(() => PostDetails)
     @JoinColumn()
     details: PostDetails
 

--- a/test/functional/relations/relation-with-primary-key/entity/Category.ts
+++ b/test/functional/relations/relation-with-primary-key/entity/Category.ts
@@ -12,7 +12,7 @@ export class Category {
     @Column()
     name: string
 
-    @OneToMany((type) => Post, (post) => post.category, {
+    @OneToMany(() => Post, (post) => post.category, {
         cascade: ["insert"],
     })
     posts: Post[]

--- a/test/functional/relations/relation-with-primary-key/entity/Post.ts
+++ b/test/functional/relations/relation-with-primary-key/entity/Post.ts
@@ -9,7 +9,7 @@ export class Post {
     @PrimaryColumn()
     categoryId: number
 
-    @ManyToOne((type) => Category, (category) => category.posts, {
+    @ManyToOne(() => Category, (category) => category.posts, {
         cascade: ["insert"],
     })
     category: Category

--- a/test/functional/repository/find-options-locking/entity/Post.ts
+++ b/test/functional/repository/find-options-locking/entity/Post.ts
@@ -19,10 +19,10 @@ export class Post {
     @Column()
     title: string
 
-    @ManyToOne((type) => Tag)
+    @ManyToOne(() => Tag)
     tag: Tag
 
-    @OneToOne((type) => User)
+    @OneToOne(() => User)
     @JoinColumn()
     author: User
 

--- a/test/functional/repository/find-options-relations/entity/Counters.ts
+++ b/test/functional/repository/find-options-relations/entity/Counters.ts
@@ -9,6 +9,6 @@ export class Counters {
     @Column()
     commentCount: number
 
-    @ManyToOne((type) => User)
+    @ManyToOne(() => User)
     author: User
 }

--- a/test/functional/repository/find-options-relations/entity/Photo.ts
+++ b/test/functional/repository/find-options-relations/entity/Photo.ts
@@ -14,10 +14,10 @@ export class Photo {
     @Column()
     filename: string
 
-    @ManyToOne((type) => User)
+    @ManyToOne(() => User)
     user: User
 
-    @ManyToOne((type) => Post, (post) => post.photos)
+    @ManyToOne(() => Post, (post) => post.photos)
     post: Post
 
     @Column((type) => Counters)

--- a/test/functional/repository/find-options-relations/entity/Post.ts
+++ b/test/functional/repository/find-options-relations/entity/Post.ts
@@ -18,10 +18,10 @@ export class Post {
     @Column()
     title: string
 
-    @OneToMany((type) => Photo, (photo) => photo.post)
+    @OneToMany(() => Photo, (photo) => photo.post)
     photos: Photo[]
 
-    @ManyToOne((type) => User)
+    @ManyToOne(() => User)
     user: User
 
     @ManyToMany((type) => Category)

--- a/test/functional/repository/find-options/entity/Post.ts
+++ b/test/functional/repository/find-options/entity/Post.ts
@@ -15,7 +15,7 @@ export class Post {
     @Column()
     title: string
 
-    @ManyToOne((type) => User)
+    @ManyToOne(() => User)
     author: User
 
     @ManyToMany((type) => Category)

--- a/test/functional/repository/set-add-remove-relations/entity/Category.ts
+++ b/test/functional/repository/set-add-remove-relations/entity/Category.ts
@@ -13,7 +13,7 @@ export class Category {
     @Column()
     name: string
 
-    @ManyToOne((type) => Post, (post) => post.categories)
+    @ManyToOne(() => Post, (post) => post.categories)
     post: Post
 
     @ManyToMany((type) => Post, (post) => post.manyCategories)

--- a/test/functional/repository/set-add-remove-relations/entity/Post.ts
+++ b/test/functional/repository/set-add-remove-relations/entity/Post.ts
@@ -14,7 +14,7 @@ export class Post {
     @Column()
     title: string
 
-    @OneToMany((type) => Category, (category) => category.post)
+    @OneToMany(() => Category, (category) => category.post)
     categories: Category[] | null
 
     @ManyToMany((type) => Category, (category) => category.manyPosts)

--- a/test/functional/repository/soft-delete/global-condition-non-deleted/entity/CategoryWithRelation.ts
+++ b/test/functional/repository/soft-delete/global-condition-non-deleted/entity/CategoryWithRelation.ts
@@ -12,6 +12,6 @@ export class CategoryWithRelation {
     @Column({ unique: true })
     name: string
 
-    @OneToOne((type) => PostWithRelation, (post) => post.category)
+    @OneToOne(() => PostWithRelation, (post) => post.category)
     post: PostWithRelation
 }

--- a/test/functional/repository/soft-delete/global-condition-non-deleted/entity/PostWithRelation.ts
+++ b/test/functional/repository/soft-delete/global-condition-non-deleted/entity/PostWithRelation.ts
@@ -14,7 +14,7 @@ export class PostWithRelation {
     @Column()
     title: string
 
-    @OneToOne((type) => CategoryWithRelation, (category) => category.post, {
+    @OneToOne(() => CategoryWithRelation, (category) => category.post, {
         eager: true,
     })
     @JoinColumn()

--- a/test/functional/schema-builder/entity/PostVersion.ts
+++ b/test/functional/schema-builder/entity/PostVersion.ts
@@ -10,7 +10,7 @@ export class PostVersion {
     @PrimaryColumn()
     id: number
 
-    @ManyToOne((type) => Post)
+    @ManyToOne(() => Post)
     @JoinColumn({ referencedColumnName: "version" })
     post: Post
 

--- a/test/functional/schema-builder/entity/Student.ts
+++ b/test/functional/schema-builder/entity/Student.ts
@@ -15,9 +15,9 @@ export class Student {
     @Column()
     name: string
 
-    @ManyToOne((type) => Faculty)
+    @ManyToOne(() => Faculty)
     faculty: Faculty
 
-    @ManyToOne((type) => Teacher)
+    @ManyToOne(() => Teacher)
     teacher: Teacher
 }

--- a/test/functional/schema-builder/entity/Teacher.ts
+++ b/test/functional/schema-builder/entity/Teacher.ts
@@ -14,6 +14,6 @@ export class Teacher {
     @Column()
     name: string
 
-    @OneToMany((type) => Student, (student) => student.teacher)
+    @OneToMany(() => Student, (student) => student.teacher)
     students: Student[]
 }

--- a/test/functional/table-inheritance/single-table/relations/one-to-many-casecade-save/entity/Faculty.ts
+++ b/test/functional/table-inheritance/single-table/relations/one-to-many-casecade-save/entity/Faculty.ts
@@ -12,7 +12,7 @@ export class Faculty {
     @Column()
     name: string
 
-    @OneToMany((type) => Staff, (staff) => staff.faculty, {
+    @OneToMany(() => Staff, (staff) => staff.faculty, {
         cascade: true,
         eager: true,
     })

--- a/test/functional/table-inheritance/single-table/relations/one-to-many-casecade-save/entity/Staff.ts
+++ b/test/functional/table-inheritance/single-table/relations/one-to-many-casecade-save/entity/Staff.ts
@@ -13,7 +13,7 @@ export class Staff {
     @PrimaryGeneratedColumn()
     id: number
 
-    @ManyToOne((type) => Faculty, (faculty) => faculty.staff)
+    @ManyToOne(() => Faculty, (faculty) => faculty.staff)
     faculty: Faculty
 
     @Column()

--- a/test/functional/table-inheritance/single-table/relations/one-to-many/entity/Accountant.ts
+++ b/test/functional/table-inheritance/single-table/relations/one-to-many/entity/Accountant.ts
@@ -5,6 +5,6 @@ import { Department } from "./Department"
 
 @ChildEntity()
 export class Accountant extends Employee {
-    @OneToMany((type) => Department, (department) => department.accountant)
+    @OneToMany(() => Department, (department) => department.accountant)
     departments: Department[]
 }

--- a/test/functional/table-inheritance/single-table/relations/one-to-many/entity/Department.ts
+++ b/test/functional/table-inheritance/single-table/relations/one-to-many/entity/Department.ts
@@ -12,6 +12,6 @@ export class Department {
     @Column()
     name: string
 
-    @ManyToOne((type) => Accountant, (accountant) => accountant.departments)
+    @ManyToOne(() => Accountant, (accountant) => accountant.departments)
     accountant: Accountant
 }

--- a/test/functional/table-inheritance/single-table/relations/one-to-many/entity/Faculty.ts
+++ b/test/functional/table-inheritance/single-table/relations/one-to-many/entity/Faculty.ts
@@ -12,6 +12,6 @@ export class Faculty {
     @Column()
     name: string
 
-    @ManyToOne((type) => Student, (student) => student.faculties)
+    @ManyToOne(() => Student, (student) => student.faculties)
     student: Student
 }

--- a/test/functional/table-inheritance/single-table/relations/one-to-many/entity/Specialization.ts
+++ b/test/functional/table-inheritance/single-table/relations/one-to-many/entity/Specialization.ts
@@ -12,6 +12,6 @@ export class Specialization {
     @Column()
     name: string
 
-    @ManyToOne((type) => Teacher, (teacher) => teacher.specializations)
+    @ManyToOne(() => Teacher, (teacher) => teacher.specializations)
     teacher: Teacher
 }

--- a/test/functional/table-inheritance/single-table/relations/one-to-many/entity/Student.ts
+++ b/test/functional/table-inheritance/single-table/relations/one-to-many/entity/Student.ts
@@ -5,6 +5,6 @@ import { Faculty } from "./Faculty"
 
 @ChildEntity()
 export class Student extends Person {
-    @OneToMany((type) => Faculty, (faculty) => faculty.student)
+    @OneToMany(() => Faculty, (faculty) => faculty.student)
     faculties: Faculty[]
 }

--- a/test/github-issues/1178/entity/Post.ts
+++ b/test/github-issues/1178/entity/Post.ts
@@ -10,6 +10,6 @@ export class Post {
     @Column()
     name: string
 
-    @ManyToOne((type) => User)
+    @ManyToOne(() => User)
     user: User
 }

--- a/test/github-issues/1261/entity/Bar.ts
+++ b/test/github-issues/1261/entity/Bar.ts
@@ -10,7 +10,7 @@ export class Bar extends BaseEntity {
     @PrimaryGeneratedColumn()
     id: number
 
-    @OneToOne((type) => Foo, {
+    @OneToOne(() => Foo, {
         onDelete: "SET NULL",
     })
     @JoinColumn()

--- a/test/github-issues/1416/entity/Author.ts
+++ b/test/github-issues/1416/entity/Author.ts
@@ -14,6 +14,6 @@ export class Author {
     @Column()
     name: string
 
-    @OneToMany((type) => Photo, (photo) => photo.author)
+    @OneToMany(() => Photo, (photo) => photo.author)
     photos: Photo[]
 }

--- a/test/github-issues/1416/entity/Photo.ts
+++ b/test/github-issues/1416/entity/Photo.ts
@@ -28,10 +28,10 @@ export class Photo {
     @Column()
     isPublished: boolean
 
-    @ManyToOne((type) => Author, (author) => author.photos)
+    @ManyToOne(() => Author, (author) => author.photos)
     author: Author
 
-    @OneToOne((type) => PhotoMetadata, (photoMetadata) => photoMetadata.photo, {
+    @OneToOne(() => PhotoMetadata, (photoMetadata) => photoMetadata.photo, {
         eager: true,
     })
     @JoinColumn()

--- a/test/github-issues/1416/entity/PhotoMetadata.ts
+++ b/test/github-issues/1416/entity/PhotoMetadata.ts
@@ -26,6 +26,6 @@ export class PhotoMetadata {
     @Column()
     comment: string
 
-    @OneToOne((type) => Photo, (photo) => photo.metadata)
+    @OneToOne(() => Photo, (photo) => photo.metadata)
     photo: Photo
 }

--- a/test/github-issues/1465/entity/Account.ts
+++ b/test/github-issues/1465/entity/Account.ts
@@ -8,7 +8,7 @@ import { OneToOne } from "../../../../src/index"
 export class Account {
     @PrimaryGeneratedColumn() id: number
 
-    @OneToOne((type) => AccountActivationToken, "account", {
+    @OneToOne(() => AccountActivationToken, "account", {
         cascade: ["insert", "remove"],
     })
     accountActivationToken: AccountActivationToken

--- a/test/github-issues/1465/entity/AccountActivationToken.ts
+++ b/test/github-issues/1465/entity/AccountActivationToken.ts
@@ -7,7 +7,7 @@ import { Account } from "./Account"
 @Entity()
 @TableInheritance({ column: { type: "varchar", name: "type" } })
 export class AccountActivationToken extends Token {
-    @OneToOne((type) => Account, "accountActivationToken", {
+    @OneToOne(() => Account, "accountActivationToken", {
         cascade: ["insert", "update"],
     })
     @JoinColumn()

--- a/test/github-issues/151/entity/Post.ts
+++ b/test/github-issues/151/entity/Post.ts
@@ -14,11 +14,11 @@ export class Post {
     @Column()
     title: string
 
-    @OneToOne((type) => Category, { cascade: true })
+    @OneToOne(() => Category, { cascade: true })
     @JoinColumn()
     category: Category | null
 
-    @OneToOne((type) => PostMetadata, (metadata) => metadata.post, {
+    @OneToOne(() => PostMetadata, (metadata) => metadata.post, {
         cascade: true,
     })
     @JoinColumn()

--- a/test/github-issues/151/entity/PostMetadata.ts
+++ b/test/github-issues/151/entity/PostMetadata.ts
@@ -12,6 +12,6 @@ export class PostMetadata {
     @Column()
     name: string
 
-    @OneToOne((type) => Post, (post) => post.metadata)
+    @OneToOne(() => Post, (post) => post.metadata)
     post: Post | null
 }

--- a/test/github-issues/1545/entity/DataModel.ts
+++ b/test/github-issues/1545/entity/DataModel.ts
@@ -27,7 +27,7 @@ export class DataModel {
     })
     validations: ValidationModel
 
-    @ManyToOne((type) => MainModel, (main) => main.dataModel)
+    @ManyToOne(() => MainModel, (main) => main.dataModel)
     @JoinColumn({
         name: "mainId",
         referencedColumnName: "id",

--- a/test/github-issues/1545/entity/MainModel.ts
+++ b/test/github-issues/1545/entity/MainModel.ts
@@ -10,7 +10,7 @@ export class MainModel {
     @PrimaryGeneratedColumn()
     id: number
 
-    @OneToMany((type) => DataModel, (dataModel) => dataModel.main, {
+    @OneToMany(() => DataModel, (dataModel) => dataModel.main, {
         cascade: true,
         eager: true,
     })

--- a/test/github-issues/1545/entity/ValidationModel.ts
+++ b/test/github-issues/1545/entity/ValidationModel.ts
@@ -9,6 +9,6 @@ export class ValidationModel {
     })
     validation: number
 
-    @OneToMany((type) => DataModel, (dataModel) => dataModel.validations)
+    @OneToMany(() => DataModel, (dataModel) => dataModel.validations)
     dataModel: DataModel[]
 }

--- a/test/github-issues/1551/entity/Message.ts
+++ b/test/github-issues/1551/entity/Message.ts
@@ -62,7 +62,7 @@ export class Message {
     @PrimaryGeneratedColumn()
     id: number
 
-    @ManyToOne((type) => User, (user) => user.senderMessages, { eager: true })
+    @ManyToOne(() => User, (user) => user.senderMessages, { eager: true })
     sender: User
 
     @Column()
@@ -74,7 +74,7 @@ export class Message {
     @Column({ nullable: true })
     type: MessageType
 
-    @OneToMany((type) => Recipient, (recipient) => recipient.message, {
+    @OneToMany(() => Recipient, (recipient) => recipient.message, {
         cascade: true,
         eager: true,
     })
@@ -84,6 +84,6 @@ export class Message {
     @JoinTable()
     holders: User[]
 
-    @ManyToOne((type) => Chat, (chat) => chat.messages)
+    @ManyToOne(() => Chat, (chat) => chat.messages)
     chat: Chat
 }

--- a/test/github-issues/1551/entity/Recipient.ts
+++ b/test/github-issues/1551/entity/Recipient.ts
@@ -42,10 +42,10 @@ export class Recipient {
     @PrimaryColumn()
     messageId: number
 
-    @ManyToOne((type) => User, (user) => user.recipients)
+    @ManyToOne(() => User, (user) => user.recipients)
     user: User
 
-    @ManyToOne((type) => Message, (message) => message.recipients)
+    @ManyToOne(() => Message, (message) => message.recipients)
     message: Message
 
     @CreateDateColumn()

--- a/test/github-issues/1551/entity/User.ts
+++ b/test/github-issues/1551/entity/User.ts
@@ -76,12 +76,12 @@ export class User {
     @ManyToMany((type) => Message, (message) => message.holders)
     holderMessages: Message[]
 
-    @OneToMany((type) => Chat, (chat) => chat.owner)
+    @OneToMany(() => Chat, (chat) => chat.owner)
     ownerChats: Chat[]
 
-    @OneToMany((type) => Message, (message) => message.sender)
+    @OneToMany(() => Message, (message) => message.sender)
     senderMessages: Message[]
 
-    @OneToMany((type) => Recipient, (recipient) => recipient.user)
+    @OneToMany(() => Recipient, (recipient) => recipient.user)
     recipients: Recipient[]
 }

--- a/test/github-issues/1581/entity/Order.ts
+++ b/test/github-issues/1581/entity/Order.ts
@@ -17,15 +17,15 @@ export class Order {
     @PrimaryColumn()
     userId: number
 
-    @ManyToOne((type) => DeliverySlot)
+    @ManyToOne(() => DeliverySlot)
     deliverySlot: DeliverySlot
 
-    @ManyToOne((type) => User, (user) => user.recurringOrders)
+    @ManyToOne(() => User, (user) => user.recurringOrders)
     user: User
 
     @Column()
     enabled: boolean
 
-    @OneToMany((type) => OrderItem, (item) => item.order)
+    @OneToMany(() => OrderItem, (item) => item.order)
     items: OrderItem[]
 }

--- a/test/github-issues/1581/entity/OrderItem.ts
+++ b/test/github-issues/1581/entity/OrderItem.ts
@@ -10,10 +10,10 @@ export class OrderItem {
     @PrimaryColumn()
     productId: number
 
-    @ManyToOne((type) => Order, (recurringOrder) => recurringOrder.items)
+    @ManyToOne(() => Order, (recurringOrder) => recurringOrder.items)
     order: Order
 
-    @ManyToOne((type) => Product)
+    @ManyToOne(() => Product)
     product: Product
 
     @Column()

--- a/test/github-issues/1581/entity/User.ts
+++ b/test/github-issues/1581/entity/User.ts
@@ -14,6 +14,6 @@ export class User {
     @Column({ unique: true })
     email: string
 
-    @OneToMany((type) => Order, (recurringOrder) => recurringOrder.user)
+    @OneToMany(() => Order, (recurringOrder) => recurringOrder.user)
     recurringOrders: Order[]
 }

--- a/test/github-issues/161/entity/Request.ts
+++ b/test/github-issues/161/entity/Request.ts
@@ -18,6 +18,6 @@ export class Request {
     @Column()
     success: boolean
 
-    @OneToOne((type) => Ticket, (ticket) => ticket.request)
+    @OneToOne(() => Ticket, (ticket) => ticket.request)
     ticket: Ticket
 }

--- a/test/github-issues/161/entity/Ticket.ts
+++ b/test/github-issues/161/entity/Ticket.ts
@@ -13,7 +13,7 @@ export class Ticket {
     @Column()
     name: string
 
-    @OneToOne((type) => Request, {
+    @OneToOne(() => Request, {
         cascade: true,
     })
     @JoinColumn()

--- a/test/github-issues/1685/entity/month.ts
+++ b/test/github-issues/1685/entity/month.ts
@@ -16,10 +16,10 @@ export class Month {
     @PrimaryColumn()
     public monthNo: number
 
-    @ManyToOne((type) => Year, (year) => year.month)
+    @ManyToOne(() => Year, (year) => year.month)
     @JoinColumn({ name: "yearNo", referencedColumnName: "yearNo" })
     public year: Year
 
-    @OneToMany((type) => UserMonth, (userMonth) => userMonth.month)
+    @OneToMany(() => UserMonth, (userMonth) => userMonth.month)
     public userMonth: UserMonth[]
 }

--- a/test/github-issues/1685/entity/user-month.ts
+++ b/test/github-issues/1685/entity/user-month.ts
@@ -19,14 +19,14 @@ export class UserMonth {
     @PrimaryColumn()
     public username: string
 
-    @ManyToOne((type) => Month, (month) => month.userMonth)
+    @ManyToOne(() => Month, (month) => month.userMonth)
     @JoinColumn([
         { name: "yearNo", referencedColumnName: "yearNo" },
         { name: "monthNo", referencedColumnName: "monthNo" },
     ])
     public month: Month
 
-    @ManyToOne((type) => User, (user) => user.username)
+    @ManyToOne(() => User, (user) => user.username)
     @JoinColumn({ name: "username", referencedColumnName: "username" })
     public user: User
 

--- a/test/github-issues/1685/entity/user.ts
+++ b/test/github-issues/1685/entity/user.ts
@@ -6,6 +6,6 @@ export class User {
     @PrimaryColumn()
     public username: string
 
-    @OneToMany((type) => UserMonth, (userMonth) => userMonth.user)
+    @OneToMany(() => UserMonth, (userMonth) => userMonth.user)
     public userMonths: UserMonth[]
 }

--- a/test/github-issues/1685/entity/year.ts
+++ b/test/github-issues/1685/entity/year.ts
@@ -6,6 +6,6 @@ export class Year {
     @PrimaryColumn()
     public yearNo: number
 
-    @OneToMany((type) => Month, (month) => month.yearNo)
+    @OneToMany(() => Month, (month) => month.yearNo)
     public month: Month[]
 }

--- a/test/github-issues/1703/entity/UserToOrganizationEntity.ts
+++ b/test/github-issues/1703/entity/UserToOrganizationEntity.ts
@@ -18,7 +18,7 @@ export class UserToOrganizationEntity {
     })
     role: "owner" | "editor" | "viewer"
 
-    @ManyToOne((type) => UserEntity, (user) => user.organizations)
+    @ManyToOne(() => UserEntity, (user) => user.organizations)
     user: UserEntity
 
     @ManyToOne(

--- a/test/github-issues/175/entity/Category.ts
+++ b/test/github-issues/175/entity/Category.ts
@@ -12,6 +12,6 @@ export class Category {
     @Column()
     name: string
 
-    @ManyToOne((type) => Post, (post) => post.secondaryCategories)
+    @ManyToOne(() => Post, (post) => post.secondaryCategories)
     post: Post
 }

--- a/test/github-issues/175/entity/Post.ts
+++ b/test/github-issues/175/entity/Post.ts
@@ -18,6 +18,6 @@ export class Post {
     @JoinTable()
     categories: Category[]
 
-    @OneToMany((type) => Category, (category) => category.post)
+    @OneToMany(() => Category, (category) => category.post)
     secondaryCategories: Category[]
 }

--- a/test/github-issues/1926/entity/Event.ts
+++ b/test/github-issues/1926/entity/Event.ts
@@ -14,7 +14,7 @@ export class Event {
     @Column()
     title: string
 
-    @OneToMany((type) => EventRole, (role) => role.event, {
+    @OneToMany(() => EventRole, (role) => role.event, {
         // eager: true,
         // persistence: true,
         cascade: true,

--- a/test/github-issues/1926/entity/EventRole.ts
+++ b/test/github-issues/1926/entity/EventRole.ts
@@ -16,12 +16,12 @@ export class EventRole {
     @Column()
     compensation: string
 
-    @ManyToOne((type) => Role, (role) => role.roles, {
+    @ManyToOne(() => Role, (role) => role.roles, {
         onDelete: "CASCADE",
     })
     role: Role
 
-    @ManyToOne((type) => Event, (event) => event.roles, {
+    @ManyToOne(() => Event, (event) => event.roles, {
         onDelete: "CASCADE",
     })
     event: Event

--- a/test/github-issues/1926/entity/Role.ts
+++ b/test/github-issues/1926/entity/Role.ts
@@ -10,6 +10,6 @@ export class Role {
     @Column()
     title: string
 
-    @OneToMany((type) => EventRole, (role) => role.role)
+    @OneToMany(() => EventRole, (role) => role.role)
     roles: EventRole[]
 }

--- a/test/github-issues/1972/entity/TournamentSquadParticipant.ts
+++ b/test/github-issues/1972/entity/TournamentSquadParticipant.ts
@@ -11,7 +11,7 @@ import { User } from "./User"
 
 @ChildEntity()
 export class TournamentSquadParticipant extends TournamentParticipant {
-    @OneToOne((type) => User, {
+    @OneToOne(() => User, {
         eager: true,
     })
     @JoinColumn()

--- a/test/github-issues/1972/entity/TournamentUserParticipant.ts
+++ b/test/github-issues/1972/entity/TournamentUserParticipant.ts
@@ -4,7 +4,7 @@ import { User } from "./User"
 
 @ChildEntity()
 export class TournamentUserParticipant extends TournamentParticipant {
-    @OneToOne((type) => User, {
+    @OneToOne(() => User, {
         eager: true,
     })
     @JoinColumn()

--- a/test/github-issues/2031/entity/Photo.ts
+++ b/test/github-issues/2031/entity/Photo.ts
@@ -20,6 +20,6 @@ export class Photo {
     @Column()
     userId: number
 
-    @ManyToOne((type) => User, (user) => user.photos)
+    @ManyToOne(() => User, (user) => user.photos)
     user: User
 }

--- a/test/github-issues/2031/entity/User.ts
+++ b/test/github-issues/2031/entity/User.ts
@@ -20,6 +20,6 @@ export class User {
     @Column()
     age: number
 
-    @OneToMany((type) => Photo, (photo) => photo.user)
+    @OneToMany(() => Photo, (photo) => photo.user)
     photos: Photo[]
 }

--- a/test/github-issues/2044/entity/Photo.ts
+++ b/test/github-issues/2044/entity/Photo.ts
@@ -21,6 +21,6 @@ export class Photo {
     @Column()
     description: string
 
-    @ManyToOne((type) => User, (user) => user.photos)
+    @ManyToOne(() => User, (user) => user.photos)
     user: User
 }

--- a/test/github-issues/2044/entity/User.ts
+++ b/test/github-issues/2044/entity/User.ts
@@ -21,6 +21,6 @@ export class User {
     @Column()
     age: number
 
-    @OneToMany((type) => Photo, (photo) => photo.user)
+    @OneToMany(() => Photo, (photo) => photo.user)
     photos: Photo[]
 }

--- a/test/github-issues/2147/entity/User.ts
+++ b/test/github-issues/2147/entity/User.ts
@@ -25,7 +25,7 @@ export class User {
     @Column({ name: "updated_by" })
     public updatedById: number
 
-    @ManyToOne((type) => User)
+    @ManyToOne(() => User)
     @JoinColumn([
         { name: "client_id", referencedColumnName: "clientId" },
         { name: "updated_by", referencedColumnName: "key" },

--- a/test/github-issues/215/entity/Post.ts
+++ b/test/github-issues/215/entity/Post.ts
@@ -10,11 +10,11 @@ export class Post {
     @PrimaryGeneratedColumn()
     id: number
 
-    @OneToOne((type) => Author)
+    @OneToOne(() => Author)
     @JoinColumn({ name: "author_id" })
     author: Author
 
-    @OneToOne((type) => Abbreviation)
+    @OneToOne(() => Abbreviation)
     @JoinColumn({ name: "abbreviation_id" })
     abbreviation: Abbreviation
 }

--- a/test/github-issues/2200/entity/Booking.ts
+++ b/test/github-issues/2200/entity/Booking.ts
@@ -11,7 +11,7 @@ export class Booking {
     @PrimaryGeneratedColumn()
     id: number
 
-    @ManyToOne((type) => Contact, (contact) => contact.bookings, {
+    @ManyToOne(() => Contact, (contact) => contact.bookings, {
         eager: true,
     })
     @JoinColumn({

--- a/test/github-issues/2200/entity/Contact.ts
+++ b/test/github-issues/2200/entity/Contact.ts
@@ -10,6 +10,6 @@ export class Contact {
     @PrimaryGeneratedColumn()
     id: number
 
-    @OneToMany((type) => Booking, (booking) => booking.contact)
+    @OneToMany(() => Booking, (booking) => booking.contact)
     bookings: Booking[]
 }

--- a/test/github-issues/2201/entity/ver1/context.ts
+++ b/test/github-issues/2201/entity/ver1/context.ts
@@ -14,11 +14,11 @@ export class RecordContext extends BaseEntity {
     @PrimaryColumn({ name: "user_id" })
     userId: string
 
-    @ManyToOne((type) => Record, (record) => record.contexts)
+    @ManyToOne(() => Record, (record) => record.contexts)
     @JoinColumn({ name: "record_id" })
     public readonly record: Record
 
-    @ManyToOne((type) => User, (user) => user.contexts)
+    @ManyToOne(() => User, (user) => user.contexts)
     @JoinColumn({ name: "user_id" })
     public readonly user: User
 

--- a/test/github-issues/2201/entity/ver1/record.ts
+++ b/test/github-issues/2201/entity/ver1/record.ts
@@ -9,6 +9,6 @@ export class Record extends BaseEntity {
     @PrimaryColumn()
     public id: string
 
-    @OneToMany((type) => RecordContext, (context) => context.record)
+    @OneToMany(() => RecordContext, (context) => context.record)
     public contexts: RecordContext[]
 }

--- a/test/github-issues/2201/entity/ver1/user.ts
+++ b/test/github-issues/2201/entity/ver1/user.ts
@@ -9,6 +9,6 @@ export class User extends BaseEntity {
     @PrimaryColumn()
     public id: string
 
-    @OneToMany((type) => RecordContext, (context) => context.user)
+    @OneToMany(() => RecordContext, (context) => context.user)
     public contexts: RecordContext[]
 }

--- a/test/github-issues/2201/entity/ver2/context.ts
+++ b/test/github-issues/2201/entity/ver2/context.ts
@@ -13,10 +13,10 @@ export class RecordContext extends BaseEntity {
     @PrimaryColumn()
     userId: string
 
-    @ManyToOne((type) => Record, (record) => record.contexts)
+    @ManyToOne(() => Record, (record) => record.contexts)
     public readonly record: Record
 
-    @ManyToOne((type) => User, (user) => user.contexts)
+    @ManyToOne(() => User, (user) => user.contexts)
     public readonly user: User
 
     @Column()

--- a/test/github-issues/2201/entity/ver2/record.ts
+++ b/test/github-issues/2201/entity/ver2/record.ts
@@ -9,7 +9,7 @@ export class Record extends BaseEntity {
     @PrimaryColumn()
     public id: string
 
-    @OneToMany((type) => RecordContext, (context) => context.record)
+    @OneToMany(() => RecordContext, (context) => context.record)
     public contexts: RecordContext[]
 
     @Column()

--- a/test/github-issues/2201/entity/ver2/user.ts
+++ b/test/github-issues/2201/entity/ver2/user.ts
@@ -9,6 +9,6 @@ export class User extends BaseEntity {
     @PrimaryColumn()
     public id: string
 
-    @OneToMany((type) => RecordContext, (context) => context.user)
+    @OneToMany(() => RecordContext, (context) => context.user)
     public contexts: RecordContext[]
 }

--- a/test/github-issues/2251/entity/Bar.ts
+++ b/test/github-issues/2251/entity/Bar.ts
@@ -8,6 +8,6 @@ export class Bar {
 
     @Column() description: string
 
-    @ManyToOne((type) => Foo, (foo) => foo.bars)
+    @ManyToOne(() => Foo, (foo) => foo.bars)
     foo?: Foo
 }

--- a/test/github-issues/2298/entity/Product.ts
+++ b/test/github-issues/2298/entity/Product.ts
@@ -14,7 +14,7 @@ export class Product {
     @Column()
     name: string
 
-    @OneToMany((type) => TicketProduct, (ticketp) => ticketp.product)
+    @OneToMany(() => TicketProduct, (ticketp) => ticketp.product)
     ticketProduct: TicketProduct[]
 
     constructor(name: string) {

--- a/test/github-issues/2298/entity/TicketProduct.ts
+++ b/test/github-issues/2298/entity/TicketProduct.ts
@@ -7,9 +7,9 @@ export class TicketProduct {
     @PrimaryGeneratedColumn()
     id: number
 
-    @ManyToOne((type) => Product, (product) => product.ticketProduct)
+    @ManyToOne(() => Product, (product) => product.ticketProduct)
     product: Product
 
-    @ManyToOne((type) => Ticket, (ticket) => ticket.ticketItems)
+    @ManyToOne(() => Ticket, (ticket) => ticket.ticketItems)
     ticket: Ticket
 }

--- a/test/github-issues/2588/entity/Post.ts
+++ b/test/github-issues/2588/entity/Post.ts
@@ -14,7 +14,7 @@ export class Post {
     @Column()
     title: string
 
-    @OneToMany((type) => PostReview, (postReview) => postReview.post, {
+    @OneToMany(() => PostReview, (postReview) => postReview.post, {
         eager: true,
     })
     reviews: PostReview[]

--- a/test/github-issues/2588/entity/PostReview.ts
+++ b/test/github-issues/2588/entity/PostReview.ts
@@ -17,6 +17,6 @@ export class PostReview {
     @Column()
     comment: string
 
-    @ManyToOne((type) => Post)
+    @ManyToOne(() => Post)
     post: Post
 }

--- a/test/github-issues/2965/entity/note.ts
+++ b/test/github-issues/2965/entity/note.ts
@@ -14,6 +14,6 @@ export class Note {
     @Column()
     public label: string
 
-    @ManyToOne((type) => Person, (person) => person.notes, { lazy: true })
+    @ManyToOne(() => Person, (person) => person.notes, { lazy: true })
     public owner: Promise<Person> | Person
 }

--- a/test/github-issues/2965/entity/person.ts
+++ b/test/github-issues/2965/entity/person.ts
@@ -14,6 +14,6 @@ export class Person {
     @Column()
     public name: string
 
-    @OneToMany((type) => Note, (note) => note.owner, { lazy: true })
+    @OneToMany(() => Note, (note) => note.owner, { lazy: true })
     public notes: Promise<Note[]> | Note[]
 }

--- a/test/github-issues/3105/entity/Child.ts
+++ b/test/github-issues/3105/entity/Child.ts
@@ -21,7 +21,7 @@ export class Child {
     })
     public parentId: number
 
-    @ManyToOne((type) => Parent, (parent) => parent.children)
+    @ManyToOne(() => Parent, (parent) => parent.children)
     @JoinColumn({
         name: "parent_id",
         referencedColumnName: "id",

--- a/test/github-issues/3105/entity/Parent.ts
+++ b/test/github-issues/3105/entity/Parent.ts
@@ -9,7 +9,7 @@ export class Parent {
     })
     public id: number
 
-    @OneToMany((type) => Child, (child) => child.parent, {
+    @OneToMany(() => Child, (child) => child.parent, {
         eager: true,
         cascade: true,
         onDelete: "CASCADE",

--- a/test/github-issues/3120/entity/ActionLog.ts
+++ b/test/github-issues/3120/entity/ActionLog.ts
@@ -21,7 +21,7 @@ export class ActionLog {
     @Column()
     action: string
 
-    @ManyToOne((type) => Person, {
+    @ManyToOne(() => Person, {
         createForeignKeyConstraints: false,
     })
     person: Person
@@ -32,7 +32,7 @@ export class ActionLog {
     @JoinTable()
     addresses: Address[]
 
-    @OneToOne((type) => ActionDetails, {
+    @OneToOne(() => ActionDetails, {
         createForeignKeyConstraints: false,
     })
     @JoinColumn()

--- a/test/github-issues/3120/entity/Passport.ts
+++ b/test/github-issues/3120/entity/Passport.ts
@@ -12,6 +12,6 @@ export class Passport {
     @Column()
     passportNumber: string
 
-    @OneToOne((type) => Person, (person) => person.passport)
+    @OneToOne(() => Person, (person) => person.passport)
     owner: Person
 }

--- a/test/github-issues/3120/entity/Person.ts
+++ b/test/github-issues/3120/entity/Person.ts
@@ -18,14 +18,14 @@ export class Person {
     @Column()
     name: string
 
-    @ManyToOne((type) => Company)
+    @ManyToOne(() => Company)
     company: Company
 
     @ManyToMany((type) => Address, (address) => address.people)
     @JoinTable()
     addresses: Address[]
 
-    @OneToOne((type) => Passport, (passport) => passport.owner)
+    @OneToOne(() => Passport, (passport) => passport.owner)
     @JoinColumn()
     passport: Passport
 }

--- a/test/github-issues/3158/entity/SessionSettings.ts
+++ b/test/github-issues/3158/entity/SessionSettings.ts
@@ -8,7 +8,7 @@ export class SessionSettings {
     @PrimaryColumn()
     sessionId: number
 
-    @OneToOne((type) => Session, (session) => session.id)
+    @OneToOne(() => Session, (session) => session.id)
     @JoinColumn({ name: "sessionId", referencedColumnName: "id" })
     session?: Session
 }

--- a/test/github-issues/3246/entity/Broker.ts
+++ b/test/github-issues/3246/entity/Broker.ts
@@ -16,7 +16,7 @@ export class Broker {
     @Column({ type: "varchar", nullable: true })
     name: string
 
-    @OneToMany((type) => Order, (order) => order.company, {
+    @OneToMany(() => Order, (order) => order.company, {
         cascade: ["insert", "update"],
         onDelete: "CASCADE",
         nullable: true,

--- a/test/github-issues/3246/entity/OrderCustomer.ts
+++ b/test/github-issues/3246/entity/OrderCustomer.ts
@@ -16,7 +16,7 @@ export class OrderCustomer {
     @Column({ type: "varchar", nullable: false })
     name: string
 
-    @OneToOne((type) => Order, (order) => order.orderCustomer, {
+    @OneToOne(() => Order, (order) => order.orderCustomer, {
         cascade: ["insert", "update"],
         nullable: true,
     })

--- a/test/github-issues/341/entity/Category.ts
+++ b/test/github-issues/341/entity/Category.ts
@@ -12,6 +12,6 @@ export class Category {
     @Column({ unique: true })
     name: string
 
-    @OneToOne((type) => Post, (post) => post.category)
+    @OneToOne(() => Post, (post) => post.category)
     post: Post
 }

--- a/test/github-issues/341/entity/Post.ts
+++ b/test/github-issues/341/entity/Post.ts
@@ -16,7 +16,7 @@ export class Post {
     @Column({ nullable: true })
     categoryName: string
 
-    @OneToOne((type) => Category, (category) => category.post)
+    @OneToOne(() => Category, (category) => category.post)
     @JoinColumn({ name: "categoryName", referencedColumnName: "name" })
     category: Category
 }

--- a/test/github-issues/3604/entity/Post.ts
+++ b/test/github-issues/3604/entity/Post.ts
@@ -9,7 +9,7 @@ export class Post {
     @PrimaryGeneratedColumn("uuid")
     id: string
 
-    @ManyToOne((type) => Author)
+    @ManyToOne(() => Author)
     @JoinColumn()
     author: Author
 }

--- a/test/github-issues/401/entity/Player.ts
+++ b/test/github-issues/401/entity/Player.ts
@@ -8,6 +8,6 @@ export class Player {
     @PrimaryColumn()
     email: string
 
-    @ManyToOne((type) => Group)
+    @ManyToOne(() => Group)
     group: Group
 }

--- a/test/github-issues/4764/entity/Cart.ts
+++ b/test/github-issues/4764/entity/Cart.ts
@@ -32,10 +32,10 @@ export class Cart {
     @Column()
     ModifiedDate!: Date
 
-    @OneToMany((type) => CartItems, (t) => t.Cart)
+    @OneToMany(() => CartItems, (t) => t.Cart)
     CartItems?: CartItems[]
 
-    @OneToOne((type) => User, (t) => t.Cart)
+    @OneToOne(() => User, (t) => t.Cart)
     @JoinColumn({ name: "UNID" })
     User?: User
 }

--- a/test/github-issues/4764/entity/CartItems.ts
+++ b/test/github-issues/4764/entity/CartItems.ts
@@ -30,7 +30,7 @@ export class CartItems {
     @Column()
     ModifiedDate!: Date
 
-    @ManyToOne((type) => Cart, (t) => t.CartItems)
+    @ManyToOne(() => Cart, (t) => t.CartItems)
     @JoinColumn({ name: "CartID" })
     Cart?: Cart
 }

--- a/test/github-issues/4764/entity/User.ts
+++ b/test/github-issues/4764/entity/User.ts
@@ -20,6 +20,6 @@ export class User {
     @Column()
     ModifiedDate!: Date
 
-    @OneToOne((type) => Cart, (t) => t.User)
+    @OneToOne(() => Cart, (t) => t.User)
     Cart?: Cart
 }

--- a/test/github-issues/495/entity/Item.ts
+++ b/test/github-issues/495/entity/Item.ts
@@ -12,7 +12,7 @@ export class Item {
     @PrimaryGeneratedColumn()
     postId: number
 
-    @OneToOne((type) => User, (users) => users.userId)
+    @OneToOne(() => User, (users) => users.userId)
     @JoinColumn({ name: "userId" })
     userData: User
 

--- a/test/github-issues/5119/entity/v1/Post.ts
+++ b/test/github-issues/5119/entity/v1/Post.ts
@@ -17,6 +17,6 @@ export class Post {
     @Column()
     text: string
 
-    @ManyToOne((type) => User)
+    @ManyToOne(() => User)
     owner: User
 }

--- a/test/github-issues/5119/entity/v2/Account.ts
+++ b/test/github-issues/5119/entity/v2/Account.ts
@@ -10,6 +10,6 @@ export class Account {
     @PrimaryGeneratedColumn()
     id: number
 
-    @ManyToOne((type) => User)
+    @ManyToOne(() => User)
     user: User
 }

--- a/test/github-issues/5119/entity/v2/Post.ts
+++ b/test/github-issues/5119/entity/v2/Post.ts
@@ -17,6 +17,6 @@ export class Post {
     @Column()
     text: string
 
-    @ManyToOne((type) => Account)
+    @ManyToOne(() => Account)
     owner: Account
 }

--- a/test/github-issues/56/entity/User.ts
+++ b/test/github-issues/56/entity/User.ts
@@ -15,7 +15,7 @@ export class User {
     @Column()
     email: string
 
-    @OneToOne((type) => AccessToken)
+    @OneToOne(() => AccessToken)
     @JoinColumn()
     access_token: AccessToken
 }

--- a/test/github-issues/57/entity/AccessToken.ts
+++ b/test/github-issues/57/entity/AccessToken.ts
@@ -14,7 +14,7 @@ export class AccessToken {
     @Column()
     expireTime: number
 
-    @OneToOne((type) => User, (user) => user.access_token, {
+    @OneToOne(() => User, (user) => user.access_token, {
         cascade: true,
     })
     user: User

--- a/test/github-issues/57/entity/User.ts
+++ b/test/github-issues/57/entity/User.ts
@@ -15,7 +15,7 @@ export class User {
     @Column()
     email: string
 
-    @OneToOne((type) => AccessToken, (token) => token.user)
+    @OneToOne(() => AccessToken, (token) => token.user)
     @JoinColumn()
     access_token: AccessToken
 }

--- a/test/github-issues/58/entity/Category.ts
+++ b/test/github-issues/58/entity/Category.ts
@@ -12,6 +12,6 @@ export class Category {
     @Column()
     name: string
 
-    @OneToMany((type) => PostCategory, (postCategory) => postCategory.category)
+    @OneToMany(() => PostCategory, (postCategory) => postCategory.category)
     posts: PostCategory[]
 }

--- a/test/github-issues/58/entity/PostCategory.ts
+++ b/test/github-issues/58/entity/PostCategory.ts
@@ -13,12 +13,12 @@ export class PostCategory {
     @PrimaryColumn()
     categoryId: number
 
-    @ManyToOne((type) => Post, (post) => post.categories, {
+    @ManyToOne(() => Post, (post) => post.categories, {
         cascade: ["insert"],
     })
     post: Post
 
-    @ManyToOne((type) => Category, (category) => category.posts, {
+    @ManyToOne(() => Category, (category) => category.posts, {
         cascade: ["insert"],
     })
     category: Category

--- a/test/github-issues/620/entity/Cat.ts
+++ b/test/github-issues/620/entity/Cat.ts
@@ -11,6 +11,6 @@ export class Cat {
     // @Column()
     // dogDogID: string; // Need to do this to allow the Foreign Key to work
 
-    @ManyToOne((type) => Dog, (dog) => dog.cats)
+    @ManyToOne(() => Dog, (dog) => dog.cats)
     dog: Dog
 }

--- a/test/github-issues/620/entity/Dog.ts
+++ b/test/github-issues/620/entity/Dog.ts
@@ -8,6 +8,6 @@ export class Dog {
     @PrimaryColumn()
     DogID: string
 
-    @OneToMany((type) => Cat, (cat) => cat.dog)
+    @OneToMany(() => Cat, (cat) => cat.dog)
     cats: Cat[]
 }

--- a/test/github-issues/6752/entity/PlanOfRecord.ts
+++ b/test/github-issues/6752/entity/PlanOfRecord.ts
@@ -46,6 +46,6 @@ export class PlanOfRecord {
     @Column({ nullable: true })
     public comment: string
 
-    @ManyToOne((type) => Block, (block) => block.plan_of_records)
+    @ManyToOne(() => Block, (block) => block.plan_of_records)
     public block: Block
 }

--- a/test/github-issues/695/entity/DeviceInstance.ts
+++ b/test/github-issues/695/entity/DeviceInstance.ts
@@ -10,7 +10,7 @@ export class DeviceInstance {
     @PrimaryColumn({ name: "id", type: "char", length: "36" })
     id: string
 
-    @ManyToOne((type) => Device, { nullable: false })
+    @ManyToOne(() => Device, { nullable: false })
     @JoinColumn({ name: "device_id", referencedColumnName: "id" })
     device: Device
 

--- a/test/github-issues/703/entity/Category.ts
+++ b/test/github-issues/703/entity/Category.ts
@@ -16,7 +16,7 @@ export class Category {
     @Column()
     name: string
 
-    @ManyToOne((type) => Post, (post) => post.categories)
+    @ManyToOne(() => Post, (post) => post.categories)
     post: Post
 
     @RelationId((category: Category) => category.post)

--- a/test/github-issues/703/entity/Post.ts
+++ b/test/github-issues/703/entity/Post.ts
@@ -12,6 +12,6 @@ export class Post {
     @Column()
     title: string
 
-    @OneToMany((type) => Category, (category) => category.post)
+    @OneToMany(() => Category, (category) => category.post)
     categories: Category[]
 }

--- a/test/github-issues/71/entity/Artikel.ts
+++ b/test/github-issues/71/entity/Artikel.ts
@@ -24,7 +24,7 @@ export class Artikel {
     @Column({ name: "artikel_saison" })
     saison: string
 
-    @ManyToOne((type) => Kollektion, { cascade: true })
+    @ManyToOne(() => Kollektion, { cascade: true })
     @JoinColumn({ name: "id_kollektion" })
     kollektion: Kollektion
 }

--- a/test/github-issues/7146/entity/Category.ts
+++ b/test/github-issues/7146/entity/Category.ts
@@ -11,14 +11,14 @@ export class Category {
     @PrimaryGeneratedColumn()
     id: number
 
-    @OneToOne((type) => Post, (post) => post.lazyOneToOne, {
+    @OneToOne(() => Post, (post) => post.lazyOneToOne, {
         nullable: true,
         eager: false,
     })
     @JoinColumn()
     backRef1: Post
 
-    @OneToOne((type) => Post, (post) => post.eagerOneToOne, {
+    @OneToOne(() => Post, (post) => post.eagerOneToOne, {
         nullable: true,
         eager: false,
     })

--- a/test/github-issues/7146/entity/Post.ts
+++ b/test/github-issues/7146/entity/Post.ts
@@ -12,28 +12,28 @@ export class Post {
     @PrimaryGeneratedColumn()
     id: number
 
-    @ManyToOne((type) => Category, { nullable: true, eager: false })
+    @ManyToOne(() => Category, { nullable: true, eager: false })
     lazyManyToOne: Promise<Category | null>
 
-    @ManyToOne((type) => Category, { nullable: true, eager: true })
+    @ManyToOne(() => Category, { nullable: true, eager: true })
     eagerManyToOne: Category | null
 
-    @OneToOne((type) => Category, { nullable: true, eager: false })
+    @OneToOne(() => Category, { nullable: true, eager: false })
     @JoinColumn()
     lazyOneToOneOwner: Promise<Category | null>
 
-    @OneToOne((type) => Category, { nullable: true, eager: true })
+    @OneToOne(() => Category, { nullable: true, eager: true })
     @JoinColumn()
     eagerOneToOneOwner: Category | null
 
     // Not a column; actual value is stored on the other side of this relation
-    @OneToOne((type) => Category, (category) => category.backRef1, {
+    @OneToOne(() => Category, (category) => category.backRef1, {
         eager: false,
     })
     lazyOneToOne: Promise<Category | null>
 
     // Not a column; actual value is stored on the other side of this relation
-    @OneToOne((type) => Category, (category) => category.backRef2, {
+    @OneToOne(() => Category, (category) => category.backRef2, {
         eager: true,
     })
     eagerOneToOne: Category | null

--- a/test/github-issues/815/entity/Category.ts
+++ b/test/github-issues/815/entity/Category.ts
@@ -17,7 +17,7 @@ export class Category {
     @Column()
     name: string
 
-    @ManyToOne((type) => Post, (post) => post.categories)
+    @ManyToOne(() => Post, (post) => post.categories)
     post: Post | null
 
     @RelationId((category: Category) => category.post)

--- a/test/github-issues/815/entity/Post.ts
+++ b/test/github-issues/815/entity/Post.ts
@@ -15,7 +15,7 @@ export class Post {
     @Column()
     title: string
 
-    @OneToMany((type) => Category, (category) => category.post)
+    @OneToMany(() => Category, (category) => category.post)
     categories: Category[]
 
     @RelationId((post: Post) => post.categories)

--- a/test/github-issues/863/entities/detail.ts
+++ b/test/github-issues/863/entities/detail.ts
@@ -21,7 +21,7 @@ export class Detail {
     })
     masterId: string
 
-    @ManyToOne((type) => Master, (master) => master.details, {
+    @ManyToOne(() => Master, (master) => master.details, {
         nullable: false,
         onDelete: "CASCADE",
     })

--- a/test/github-issues/863/entities/master.ts
+++ b/test/github-issues/863/entities/master.ts
@@ -18,6 +18,6 @@ export class Master {
     })
     description: string
 
-    @OneToMany((type) => Detail, (detail) => detail.master)
+    @OneToMany(() => Detail, (detail) => detail.master)
     details: Detail[]
 }

--- a/test/github-issues/9176/entity/Post.ts
+++ b/test/github-issues/9176/entity/Post.ts
@@ -17,6 +17,6 @@ export class Post {
     @Column()
     text: string
 
-    @ManyToOne((type) => Author, { cascade: true, nullable: false })
+    @ManyToOne(() => Author, { cascade: true, nullable: false })
     author: Author
 }

--- a/test/github-issues/996/entity/Category.ts
+++ b/test/github-issues/996/entity/Category.ts
@@ -12,6 +12,6 @@ export class Category {
     @Column()
     name: string
 
-    @ManyToOne((type) => Post, (post) => post.categories)
+    @ManyToOne(() => Post, (post) => post.categories)
     post: Promise<Post>
 }

--- a/test/github-issues/996/entity/Post.ts
+++ b/test/github-issues/996/entity/Post.ts
@@ -12,6 +12,6 @@ export class Post {
     @Column()
     title: string
 
-    @OneToMany((type) => Category, (category) => category.post)
+    @OneToMany(() => Category, (category) => category.post)
     categories: Promise<Category[]>
 }

--- a/test/other-issues/entity-change-in-subscribers/entity/Post.ts
+++ b/test/other-issues/entity-change-in-subscribers/entity/Post.ts
@@ -20,7 +20,7 @@ export class Post {
     @UpdateDateColumn()
     updateDate: Date
 
-    @OneToOne((type) => PostCategory)
+    @OneToOne(() => PostCategory)
     @JoinColumn()
     category: PostCategory
 

--- a/test/other-issues/nested-child-entities/entity/Tournament.ts
+++ b/test/other-issues/nested-child-entities/entity/Tournament.ts
@@ -24,7 +24,7 @@ export abstract class Tournament {
     @Column()
     public name: string
 
-    @OneToOne((type) => TournamentGraph, (graph) => graph.tournament)
+    @OneToOne(() => TournamentGraph, (graph) => graph.tournament)
     @JoinColumn()
     public graph: TournamentGraph
 

--- a/test/other-issues/nested-child-entities/entity/TournamentGraph.ts
+++ b/test/other-issues/nested-child-entities/entity/TournamentGraph.ts
@@ -7,6 +7,6 @@ export class TournamentGraph {
     @PrimaryGeneratedColumn()
     public id: number
 
-    @OneToOne((type) => Tournament, (tournament) => tournament.graph)
+    @OneToOne(() => Tournament, (tournament) => tournament.graph)
     public tournament: Tournament
 }

--- a/test/other-issues/update-relational-column-on-relation-change/entity/Category.ts
+++ b/test/other-issues/update-relational-column-on-relation-change/entity/Category.ts
@@ -12,7 +12,7 @@ export class Category {
     @Column()
     name: string
 
-    @ManyToOne((type) => Post, (post) => post.categories)
+    @ManyToOne(() => Post, (post) => post.categories)
     post: Post
 
     @Column()

--- a/test/other-issues/update-relational-column-on-relation-change/entity/Post.ts
+++ b/test/other-issues/update-relational-column-on-relation-change/entity/Post.ts
@@ -12,7 +12,7 @@ export class Post {
     @Column()
     title: string
 
-    @OneToMany((type) => Category, (category) => category.post, {
+    @OneToMany(() => Category, (category) => category.post, {
         cascade: true,
     })
     categories: Category[]


### PR DESCRIPTION
### Description of change

Remove unused `type` parameter from functions supplied to decorators in tests and sample code. This resolves 477 eslint unused var warnings.

All changes are modifying functions in test or sample code of the following style:

1. `@OneToMany((type) => Entity, ...)` to `@OneToMany(() => Entity)`
2. `@ManyToOne((type) => Entity, ...)`
3. `@ManyToMany((type) => Entity, ...)`
4. `@OneToOne((type) => Entity, ...) `

Note that we don't actually ever call this function with an argument (see [here](https://github.com/typeorm/typeorm/blob/de15df14ede16f11da176a499282a79a2aa9e324/src/metadata/RelationMetadata.ts#L343) and [here](https://github.com/typeorm/typeorm/blob/6ebae3b7956cc6da4258358ba590cd8bb821c54f/src/metadata-builder/EntityMetadataBuilder.ts#L725)). A future PR could probably remove the type parameter [here](https://github.com/typeorm/typeorm/blob/3b8a031ece508820651a3a8f99f9cbf87319812c/src/metadata/types/RelationTypeInFunction.ts#L7).

### Pull-Request Checklist

- [x] Code is up-to-date with the `master` branch
- [x] `npm run format` to apply prettier formatting
- [x] `npm run test` passes with this change
- [ ] This pull request links relevant issues as `Fixes #0000`
- [ ] There are new or updated unit tests validating the change
- [ ] Documentation has been updated to reflect this change
- [x] The new commits follow conventions explained in [CONTRIBUTING.md](https://github.com/typeorm/typeorm/blob/master/CONTRIBUTING.md)