### PR TITLE
test: add test for saving lazy many to one relation with existing entities

### DIFF
--- a/test/github-issues/10190/entity/LazyPost.ts
+++ b/test/github-issues/10190/entity/LazyPost.ts
@@ -1,0 +1,24 @@
+import {
+    Entity,
+    Column,
+    ManyToOne,
+    JoinColumn,
+    PrimaryColumn,
+} from "../../../../src"
+import { LazyUser } from "./LazyUser"
+
+@Entity("lazy_post")
+export class LazyPost {
+    @PrimaryColumn({ type: "varchar" })
+    id: string
+
+    @Column()
+    name: string
+
+    @Column({ nullable: true, name: "user_id" })
+    userId: string
+
+    @ManyToOne(() => LazyUser, (u) => u.posts)
+    @JoinColumn({ name: "user_id" })
+    user: Promise<LazyUser>
+}

--- a/test/github-issues/10190/entity/LazyUser.ts
+++ b/test/github-issues/10190/entity/LazyUser.ts
@@ -1,0 +1,14 @@
+import { Entity, Column, OneToMany, PrimaryColumn } from "../../../../src"
+import { LazyPost } from "./LazyPost"
+
+@Entity("lazy_user")
+export class LazyUser {
+    @PrimaryColumn({ type: "varchar" })
+    id: string
+
+    @Column()
+    name: string
+
+    @OneToMany(() => LazyPost, (p) => p.user)
+    posts: Promise<LazyPost[]>
+}

--- a/test/github-issues/10190/entity/Post.ts
+++ b/test/github-issues/10190/entity/Post.ts
@@ -1,0 +1,24 @@
+import {
+    Entity,
+    Column,
+    ManyToOne,
+    JoinColumn,
+    PrimaryColumn,
+} from "../../../../src"
+import { User } from "./User"
+
+@Entity("post")
+export class Post {
+    @PrimaryColumn({ type: "varchar" })
+    id: string
+
+    @Column()
+    name: string
+
+    @Column({ nullable: true, name: "user_id" })
+    userId: string
+
+    @ManyToOne(() => User, (u) => u.posts)
+    @JoinColumn({ name: "user_id" })
+    user: User
+}

--- a/test/github-issues/10190/entity/User.ts
+++ b/test/github-issues/10190/entity/User.ts
@@ -1,0 +1,14 @@
+import { Entity, Column, OneToMany, PrimaryColumn } from "../../../../src"
+import { Post } from "./Post"
+
+@Entity("user")
+export class User {
+    @PrimaryColumn({ type: "varchar" })
+    id: string
+
+    @Column()
+    name: string
+
+    @OneToMany(() => Post, (p) => p.user)
+    posts: Post[]
+}

--- a/test/github-issues/10190/issue-10190.ts
+++ b/test/github-issues/10190/issue-10190.ts
@@ -1,0 +1,97 @@
+import "reflect-metadata"
+import {
+    createTestingConnections,
+    closeTestingConnections,
+    reloadTestingDatabases,
+} from "../../utils/test-utils"
+import { DataSource } from "../../../src/data-source/DataSource"
+import { expect } from "chai"
+import { User } from "./entity/User"
+import { Post } from "./entity/Post"
+import { LazyPost } from "./entity/LazyPost"
+import { LazyUser } from "./entity/LazyUser"
+
+describe.only("github issues > #10190 Cannot save a one-to-many relation", () => {
+    let dataSources: DataSource[]
+    before(
+        async () =>
+            (dataSources = await createTestingConnections({
+                entities: [__dirname + "/entity/*{.js,.ts}"],
+                schemaCreate: true,
+                dropSchema: true,
+                enabledDrivers: ["postgres"],
+            })),
+    )
+    beforeEach(() => reloadTestingDatabases(dataSources))
+    after(() => closeTestingConnections(dataSources))
+
+    it("should update the user id of a post when the the user is saved with a list of posts that already exist in the database", () =>
+        Promise.all(
+            dataSources.map(async (dataSource) => {
+                const entityManager = dataSource.manager
+
+                // Create a post without a user
+                const post = new Post()
+                post.id = "post-id"
+                post.name = "Post"
+                const savedPost = await entityManager.save(post)
+
+                // Create a user
+                const user = new User()
+                user.id = "user-id"
+                user.name = "John"
+                await entityManager.save(user)
+
+                // Add the post to the user
+                const fetchedUser = await entityManager.findOneOrFail(User, {
+                    where: { id: user.id },
+                })
+                fetchedUser.posts = [savedPost]
+                await entityManager.save(fetchedUser)
+
+                // Check that the post has the user id
+                const updatedPost = await entityManager.findOneOrFail(Post, {
+                    where: { name: "Post" },
+                })
+                expect(updatedPost.userId).to.equal(user.id)
+            }),
+        ))
+
+    it("should update the user id of a post when the the user is saved with a list of posts that already exist in the database (with lazy relations)", () =>
+        Promise.all(
+            dataSources.map(async (dataSource) => {
+                const entityManager = dataSource.manager
+
+                // Create a post without a user
+                const post = new LazyPost()
+                post.id = "post-id"
+                post.name = "Lazy Post"
+                const savedPost = await entityManager.save(post)
+
+                // Create a user
+                const user = new LazyUser()
+                user.id = "user-id"
+                user.name = "Lazy John"
+                await entityManager.save(user)
+
+                // Add the post to the user
+                const fetchedUser = await entityManager.findOneOrFail(
+                    LazyUser,
+                    {
+                        where: { id: user.id },
+                    },
+                )
+                fetchedUser.posts = Promise.resolve([savedPost])
+                await entityManager.save(fetchedUser)
+
+                // Check that the post has the user id
+                const updatedPost = await entityManager.findOneOrFail(
+                    LazyPost,
+                    {
+                        where: { name: "Lazy Post" },
+                    },
+                )
+                expect(updatedPost.userId).to.equal(user.id)
+            }),
+        ))
+})


### PR DESCRIPTION
<!--
  😀 Wonderful!  Thank you for opening a pull request for TypeORM.

  Please fill in the information below to expedite the review
  and (hopefully) merge of your change.

  If unsure about something.. just do as best as you're able,
  or reach out through our community support channels!
  https://github.com/typeorm/typeorm/blob/master/docs/support.md
-->

### Description of change

Adds a test for saving a lazy one to many relation. With non-lazy relations the save call binds the relations, with lazy one to many relations it does not.

I sadly don't know how to fix this, but @gioboa requested this PR with a test to demonstrate the problem.

Related to: #10190

Some more insights I gathered which might help to fix this:

Adding the following logs to `src/persistence/SubjectExecutor.ts` in line 618
```
console.log("updateMap", updateMap)
console.log(
    "updateQueryBuilder",
    updateQueryBuilder.getQueryAndParameters(),
)
```
gives the following output for the two tests:
```
// non-lazy version:
updateMap { user: { id: 'user-id' } }
updateQueryBuilder [
  'UPDATE "post" SET "user_id" = $1 WHERE "id" = $2',
  [ 'user-id', 'post-id' ]
]

// lazy version:
updateMap { user: { id: 'user-id' } }
updateQueryBuilder [
  'UPDATE "lazy_post" SET "user_id" = $1 WHERE "id" = $2',
  [ undefined, 'post-id' ]
]
```
So to me it looks like the user id is present in both cases, but with the lazy relation it does not get converted to the parameter properly.

### Pull-Request Checklist

<!--
  Please make sure to review and check all of the following.

  If an item is not applicable, you can add "N/A" to the end.
-->

- [ ] Code is up-to-date with the `master` branch
- [ ] `npm run format` to apply prettier formatting
- [ ] `npm run test` passes with this change
- [ ] This pull request links relevant issues as `Fixes #0000`
- [ ] There are new or updated unit tests validating the change
- [ ] Documentation has been updated to reflect this change
- [ ] The new commits follow conventions explained in [CONTRIBUTING.md](https://github.com/typeorm/typeorm/blob/master/CONTRIBUTING.md)

<!--
  🎉 Thank you for contributing and making TypeORM even better!
-->
