### PR TITLE
chore: update node versions into GH actions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -52,7 +52,7 @@ jobs:
       fail-fast: false
       matrix:
         # See supported Node.js release schedule at https://nodejs.org/en/about/releases/
-        node-version: [16, 18, 20] #, 22]
+        node-version: [18.x, 20.x, 22.14.0, 23.x]
     uses: ./.github/workflows/database-tests.yml
     with:
       node-version: ${{matrix.node-version}}
@@ -64,7 +64,7 @@ jobs:
       fail-fast: false
       matrix:
         # See supported Node.js release schedule at https://nodejs.org/en/about/releases/
-        node-version: [18, 20] #, 22]
+        node-version: [18.x, 20.x, 22.14.0, 23.x]
     uses: ./.github/workflows/database-tests-compose.yml
     with:
       node-version: ${{matrix.node-version}}


### PR DESCRIPTION
Update node versions with the actual NodeJS supported versions.
- latest 18
- latest 20
- current LTS 22
- latest 23

> [!WARNING]
> Drop v16 because is not supported anymore.

### Pull-Request Checklist

- [x] Code is up-to-date with the `master` branch
- [x] `npm run format` to apply prettier formatting
- [x] `npm run test` passes with this change
