### PR TITLE
fix: prevent error when replication is undefined

### DIFF
--- a/src/data-source/DataSource.ts
+++ b/src/data-source/DataSource.ts
@@ -750,7 +750,7 @@ export class DataSource {
      * Get the replication mode SELECT queries should use for this datasource by default
      */
     defaultReplicationModeForReads(): ReplicationMode {
-        if ("replication" in this.driver.options) {
+        if ("replication" in this.driver.options && this.driver.options.replication) {
             const value = (
                 this.driver.options.replication as {
                     defaultMode?: ReplicationMode


### PR DESCRIPTION
<!--
  😀 Wonderful!  Thank you for opening a pull request for TypeORM.

  Please fill in the information below to expedite the review
  and (hopefully) merge of your change.

  If unsure about something.. just do as best as you're able,
  or reach out through our community support channels!
  https://github.com/typeorm/typeorm/blob/master/docs/support.md
-->

### Description of change

Allow dynamic replication config. On my application, I have replication for production, but not for staging or development.

If I set the replication to `undefined` on staging, I get

`Cannot read properties of undefined (reading 'defaultMode')`

````
return {
  type: 'postgres',
  ...,
  replication: this.databaseSlaveUrl
        ? {
            master: {
              url: this.databaseUrl,
            },
            slaves: [
              {
                url: this.databaseSlaveUrl,
              },
            ],
          }
        : undefined,
};
````

My workaround is to create two config objects: one for production and one for the other environments.

<!--
  Please be clear and concise what the change is intended to do,
  why this change is needed, and how you've verified that it
  corrects what you intended.

  In some cases it may be helpful to include the current behavior
  and the new behavior.

  If the change is related to an open issue, you can link it here.
  If you include `Fixes #0000` (replacing `0000` with the issue number)
  when this is merged it will automatically mark the issue as fixed and
  close it.
-->


### Pull-Request Checklist

<!--
  Please make sure to review and check all of the following.

  If an item is not applicable, you can add "N/A" to the end.
-->

- [ ] Code is up-to-date with the `master` branch
- [ ] `npm run format` to apply prettier formatting
- [ ] `npm run test` passes with this change
- [ ] This pull request links relevant issues as `Fixes #0000`
- [ ] There are new or updated unit tests validating the change
- [ ] Documentation has been updated to reflect this change
- [ ] The new commits follow conventions explained in [CONTRIBUTING.md](https://github.com/typeorm/typeorm/blob/master/CONTRIBUTING.md)

<!--
  🎉 Thank you for contributing and making TypeORM even better!
-->
