### PR TITLE
feat: add support for TypedArray in FindOptionsSelect

### DIFF
--- a/src/find-options/FindOptionsSelect.ts
+++ b/src/find-options/FindOptionsSelect.ts
@@ -17,9 +17,7 @@ export type FindOptionsSelectProperty<Property> = Property extends Promise<
     ? boolean
     : Property extends Function
     ? never
-    : Property extends ArrayBufferLike
-    ? boolean
-    : Property extends Buffer
+    : Property extends ArrayBufferView
     ? boolean
     : Property extends Date
     ? boolean

--- a/src/find-options/FindOptionsSelect.ts
+++ b/src/find-options/FindOptionsSelect.ts
@@ -17,6 +17,8 @@ export type FindOptionsSelectProperty<Property> = Property extends Promise<
     ? boolean
     : Property extends Function
     ? never
+    : Property extends ArrayBufferLike
+    ? boolean
     : Property extends Buffer
     ? boolean
     : Property extends Date

--- a/test/github-issues/11425/entity/bufferSet.ts
+++ b/test/github-issues/11425/entity/bufferSet.ts
@@ -1,0 +1,13 @@
+import { Column, Entity, PrimaryGeneratedColumn } from "../../../../src"
+
+@Entity()
+export class bufferSet {
+    @PrimaryGeneratedColumn()
+    id: number
+
+    @Column({ type: "bytea", select: false })
+    BufferData: Buffer
+
+    @Column({ type: "bytea", select: false })
+    Uint8ArrayData: Uint8Array
+}

--- a/test/github-issues/11425/issue-11425.ts
+++ b/test/github-issues/11425/issue-11425.ts
@@ -47,6 +47,10 @@ describe("github issues > #11425 Add support for TypedArray in FindOptionsSelect
                 expect(loadedWithSelect).to.exist
                 expect(loadedWithSelect!.BufferData).to.exist
                 expect(loadedWithSelect!.Uint8ArrayData).to.exist
+                expect(loadedWithSelect!.BufferData).to.be.instanceOf(Buffer)
+                expect(loadedWithSelect!.Uint8ArrayData).to.be.instanceOf(
+                    Uint8Array,
+                )
 
                 const loadedUint8Buffer = Buffer.from(
                     loadedWithSelect!.Uint8ArrayData.buffer,

--- a/test/github-issues/11425/issue-11425.ts
+++ b/test/github-issues/11425/issue-11425.ts
@@ -1,0 +1,70 @@
+import "reflect-metadata"
+import {
+    closeTestingConnections,
+    createTestingConnections,
+    reloadTestingDatabases,
+} from "../../utils/test-utils"
+import { bufferSet } from "./entity/bufferSet"
+import { expect } from "chai"
+import { DataSource } from "../../../src"
+
+describe("github issues > #11425 Add support for TypedArray in FindOptionsSelect", () => {
+    let connections: DataSource[]
+    before(async () => {
+        connections = await createTestingConnections({
+            entities: [__dirname + "/entity/*{.js,.ts}"],
+            enabledDrivers: ["postgres"],
+            schemaCreate: true,
+            dropSchema: true,
+        })
+    })
+    beforeEach(() => reloadTestingDatabases(connections))
+    after(() => closeTestingConnections(connections))
+
+    it("should load TypedArray fields when selected with FindOptionsSelect", async () => {
+        await Promise.all(
+            connections.map(async (connection) => {
+                const bufferSetRepository = connection.getRepository(bufferSet)
+
+                const testBuffer = Buffer.from("test buffer data")
+                const testUint8Array = new Uint8Array([1, 2, 3, 4, 5])
+
+                const entity = new bufferSet()
+                entity.BufferData = testBuffer
+                entity.Uint8ArrayData = testUint8Array
+
+                await bufferSetRepository.save(entity)
+
+                const loadedWithSelect = await bufferSetRepository.findOne({
+                    where: { id: entity.id },
+                    select: {
+                        id: true,
+                        BufferData: true,
+                        Uint8ArrayData: true,
+                    },
+                })
+
+                expect(loadedWithSelect).to.exist
+                expect(loadedWithSelect!.BufferData).to.exist
+                expect(loadedWithSelect!.Uint8ArrayData).to.exist
+
+                const loadedUint8Buffer = Buffer.from(
+                    loadedWithSelect!.Uint8ArrayData.buffer,
+                    loadedWithSelect!.Uint8ArrayData.byteOffset,
+                    loadedWithSelect!.Uint8ArrayData.byteLength,
+                )
+                const originalUint8Buffer = Buffer.from(
+                    testUint8Array.buffer,
+                    testUint8Array.byteOffset,
+                    testUint8Array.byteLength,
+                )
+                expect(
+                    Buffer.compare(loadedUint8Buffer, originalUint8Buffer),
+                ).to.equal(0)
+                expect(
+                    Buffer.compare(loadedWithSelect!.BufferData, testBuffer),
+                ).to.equal(0)
+            }),
+        )
+    })
+})


### PR DESCRIPTION
Closes: #11425

<!--
  😀 Wonderful!  Thank you for opening a pull request for TypeORM.

  Please fill in the information below to expedite the review
  and (hopefully) merge of your change.

  If unsure about something.. just do as best as you're able,
  or reach out through our community support channels!
  https://github.com/typeorm/typeorm/blob/master/docs/support.md
-->

### Description of change

<!--
  Please be clear and concise what the change is intended to do,
  why this change is needed, and how you've verified that it
  corrects what you intended.

  In some cases it may be helpful to include the current behavior
  and the new behavior.

  If the change is related to an open issue, you can link it here.
  If you include `Fixes #0000` (replacing `0000` with the issue number)
  when this is merged it will automatically mark the issue as fixed and
  close it.
-->


### Pull-Request Checklist
@mguida22 This implementation resolves issue #11425.  
It adds the condition [ArrayBufferView](https://github.com/microsoft/TypeScript/blob/62b172b515452b3fe19f4f2da81d4869caedc904/src/lib/es5.d.ts#L1704) , a common interface for TypedArrays, to allow fields related to TypedArrays to be directly selectable as boolean values when using `FindOptionsSelect`. 


<!--
  Please make sure to review and check all of the following.

  If an item is not applicable, you can add "N/A" to the end.
-->

- [x] Code is up-to-date with the `master` branch
- [x] `npm run format` to apply prettier formatting
- [x] `npm run test` passes with this change
- [x] This pull request links relevant issues as `Fixes #0000`
- [x] There are new or updated unit tests validating the change
- [ ] Documentation has been updated to reflect this change
- [ ] The new commits follow conventions explained in [CONTRIBUTING.md](https://github.com/typeorm/typeorm/blob/master/CONTRIBUTING.md)

<!--
  🎉 Thank you for contributing and making TypeORM even better!
-->
