### PR TITLE
fix: allow readonly array in FindManyOptions.where

### DIFF
--- a/src/find-options/FindOneOptions.ts
+++ b/src/find-options/FindOneOptions.ts
@@ -29,7 +29,7 @@ export interface FindOneOptions<Entity = any> {
     /**
      * Simple condition that should be applied to match entities.
      */
-    where?: FindOptionsWhere<Entity>[] | FindOptionsWhere<Entity>
+    where?: readonly FindOptionsWhere<Entity>[] | FindOptionsWhere<Entity>
 
     /**
      * Indicates what relations of entity should be loaded (simplified left join form).

--- a/test/functional/repository/find-options/repository-find-options.ts
+++ b/test/functional/repository/find-options/repository-find-options.ts
@@ -210,17 +210,19 @@ describe("repository > find options", () => {
                     },
                 ])
 
+                const readonlyWhere = [
+                    {
+                        name: "Bears",
+                    },
+                    {
+                        name: "Cats",
+                    },
+                ] as const
+
                 const loadedCategories2 = await connection
                     .getRepository(Category)
                     .find({
-                        where: [
-                            {
-                                name: "Bears",
-                            },
-                            {
-                                name: "Cats",
-                            },
-                        ],
+                        where: readonlyWhere,
                         order: { id: "ASC" },
                     })
 


### PR DESCRIPTION
<!--
  😀 Wonderful!  Thank you for opening a pull request for TypeORM.

  Please fill in the information below to expedite the review
  and (hopefully) merge of your change.

  If unsure about something.. just do as best as you're able,
  or reach out through our community support channels!
  https://github.com/typeorm/typeorm/blob/master/docs/support.md
-->

### Description of change

<!--
  Please be clear and concise what the change is intended to do,
  why this change is needed, and how you've verified that it
  corrects what you intended.

  In some cases it may be helpful to include the current behavior
  and the new behavior.

  If the change is related to an open issue, you can link it here.
  If you include `Fixes #0000` (replacing `0000` with the issue number)
  when this is merged it will automatically mark the issue as fixed and
  close it.
-->

Currently, the `where` option does not accept readonly arrays, even though readonly arrays are commonly used in strict TypeScript codebases.
This change updates the type definition to allow `readonly FindOptionsWhere<Entity>[]` as a valid input for `where`.

This update improves TypeScript compatibility and removes the need to cast readonly arrays to mutable arrays manually.

There is no impact on runtime behavior — it is a purely type-level improvement.

Without this change, attempting to pass a readonly array results in a TypeScript error like the following:

```.ts
test/functional/repository/find-options/repository-find-options.ts:225:25 - error TS2322: Type 'readonly [{ readonly name: "Bears"; }, { readonly name: "Cats"; }]' is not assignable to type 'FindOptionsWhere<Category> | FindOptionsWhere<Category>[] | undefined'.
  The type 'readonly [{ readonly name: "Bears"; }, { readonly name: "Cats"; }]' is 'readonly' and cannot be assigned to the mutable type 'FindOptionsWhere<Category>[]'.

225                         where: readonlyWhere,
                            ~~~~~


Found 1 error in test/functional/repository/find-options/repository-find-options.ts:225
```

- https://github.com/ryoheikudo/typeorm/blob/c4848c91ba01207424c613b83da5440ea27385c5/test/functional/repository/find-options/repository-find-options.ts#L213-L225

### Pull-Request Checklist

<!--
  Please make sure to review and check all of the following.

  If an item is not applicable, you can add "N/A" to the end.
-->

- [ ] Code is up-to-date with the `master` branch
- [ ] `npm run format` to apply prettier formatting
- [ ] `npm run test` passes with this change
- [ ] This pull request links relevant issues as `Fixes #0000`
- [ ] There are new or updated unit tests validating the change
- [ ] Documentation has been updated to reflect this change
- [ ] The new commits follow conventions explained in [CONTRIBUTING.md](https://github.com/typeorm/typeorm/blob/master/CONTRIBUTING.md)

<!--
  🎉 Thank you for contributing and making TypeORM even better!
-->
