### PR TITLE
build: setup testing matrix for postgres 14 and 17

### DIFF
--- a/.github/workflows/database-tests.yml
+++ b/.github/workflows/database-tests.yml
@@ -212,10 +212,14 @@ jobs:
 
   postgres:
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        postgis-version: ["14-3.5", "17-3.5"]
 
     services:
       postgres:
-        image: postgis/postgis:14-3.3
+        image: postgis/postgis:${{ matrix.postgis-version }}
         ports:
           - "5432:5432"
         env:


### PR DESCRIPTION
### Description of change

Sets up a testing matrix for PostgreSQL so we run tests on 14 and 17.

This is prompted by https://github.com/typeorm/typeorm/pull/10986 which depends on changes introduced in Postgres 15. Instead of testing all active versions of Postgres in CI on every change, this continues to test version 14, and adds 17 which is the latest version. We can always add more versions later if we need to verify functionality on a specific version.

Versions correspond to postgis docker images https://hub.docker.com/r/postgis/postgis

### Pull-Request Checklist

- [x] Code is up-to-date with the `master` branch
- [x] `npm run format` to apply prettier formatting
- [x] `npm run test` passes with this change
- [ ] This pull request links relevant issues as `Fixes #0000`
- [ ] There are new or updated unit tests validating the change
- [ ] Documentation has been updated to reflect this change
- [ ] The new commits follow conventions explained in [CONTRIBUTING.md](https://github.com/typeorm/typeorm/blob/master/CONTRIBUTING.md)