### PR TITLE
fix(ci): resolve duplicate action runs

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,7 +6,7 @@ name: test
 
 on:
   push:
-    branches: ["**"]
+    branches: ["master"]
   pull_request:
     branches: ["master"]
 


### PR DESCRIPTION
# Description

Currently, our actions are running twice because the `push` trigger is set to `branches: ["**"]`, even though we already have a `pull_request` trigger.  

This PR updates the `push` trigger to run only on `master`, which should prevent the duplication.
