### PR TITLE
fix: add collation update detection in PostgresDriver

### DIFF
--- a/src/driver/postgres/PostgresDriver.ts
+++ b/src/driver/postgres/PostgresDriver.ts
@@ -1249,7 +1249,8 @@ export class PostgresDriver implements Driver {
                 tableColumn.srid !== columnMetadata.srid ||
                 tableColumn.generatedType !== columnMetadata.generatedType ||
                 (tableColumn.asExpression || "").trim() !==
-                    (columnMetadata.asExpression || "").trim()
+                    (columnMetadata.asExpression || "").trim() ||
+                tableColumn.collation !== columnMetadata.collation
 
             // DEBUG SECTION
             // if (isColumnChanged) {

--- a/src/driver/postgres/PostgresQueryRunner.ts
+++ b/src/driver/postgres/PostgresQueryRunner.ts
@@ -2183,6 +2183,31 @@ export class PostgresQueryRunner
                 )
             }
 
+            // update column collation
+            if (newColumn.collation !== oldColumn.collation) {
+                upQueries.push(
+                    new Query(
+                        `ALTER TABLE ${this.escapePath(table)} ALTER COLUMN "${
+                            newColumn.name
+                        }" TYPE ${newColumn.type} COLLATE "${
+                            newColumn.collation
+                        }"`,
+                    ),
+                )
+
+                const oldCollation = oldColumn.collation
+                    ? `"${oldColumn.collation}"`
+                    : `pg_catalog."default"` // if there's no old collation, use defualt
+
+                downQueries.push(
+                    new Query(
+                        `ALTER TABLE ${this.escapePath(table)} ALTER COLUMN "${
+                            newColumn.name
+                        }" TYPE ${newColumn.type} COLLATE ${oldCollation}`,
+                    ),
+                )
+            }
+
             if (newColumn.generatedType !== oldColumn.generatedType) {
                 // Convert generated column data to normal column
                 if (

--- a/src/driver/postgres/PostgresQueryRunner.ts
+++ b/src/driver/postgres/PostgresQueryRunner.ts
@@ -2197,7 +2197,7 @@ export class PostgresQueryRunner
 
                 const oldCollation = oldColumn.collation
                     ? `"${oldColumn.collation}"`
-                    : `pg_catalog."default"` // if there's no old collation, use defualt
+                    : `pg_catalog."default"` // if there's no old collation, use default
 
                 downQueries.push(
                     new Query(

--- a/test/github-issues/8647/entity/item.entity.ts
+++ b/test/github-issues/8647/entity/item.entity.ts
@@ -1,7 +1,7 @@
 import { Entity, PrimaryGeneratedColumn, Column } from "../../../../src/index";
 
-export const OLD_COLLATION = "C";
-export const NEW_COLLATION = "C.utf8";
+export const OLD_COLLATION = "POSIX";
+export const NEW_COLLATION = "C";
 
 
 @Entity()

--- a/test/github-issues/8647/entity/item.entity.ts
+++ b/test/github-issues/8647/entity/item.entity.ts
@@ -1,14 +1,13 @@
-import { Entity, PrimaryGeneratedColumn, Column } from "../../../../src/index";
+import { Entity, PrimaryGeneratedColumn, Column } from "../../../../src/index"
 
-export const OLD_COLLATION = "POSIX";
-export const NEW_COLLATION = "C";
-
+export const OLD_COLLATION = "POSIX"
+export const NEW_COLLATION = "C"
 
 @Entity()
 export class Item {
     @PrimaryGeneratedColumn()
-    id: number;
+    id: number
 
     @Column({ type: "varchar", length: 100, collation: OLD_COLLATION })
-    name: string;
+    name: string
 }

--- a/test/github-issues/8647/entity/item.entity.ts
+++ b/test/github-issues/8647/entity/item.entity.ts
@@ -1,0 +1,14 @@
+import { Entity, PrimaryGeneratedColumn, Column } from "../../../../src/index";
+
+export const OLD_COLLATION = "C";
+export const NEW_COLLATION = "C.utf8";
+
+
+@Entity()
+export class Item {
+    @PrimaryGeneratedColumn()
+    id: number;
+
+    @Column({ type: "varchar", length: 100, collation: OLD_COLLATION })
+    name: string;
+}

--- a/test/github-issues/8647/issue-8647.ts
+++ b/test/github-issues/8647/issue-8647.ts
@@ -35,8 +35,8 @@ describe("github issues > #8647 Collation changes are not synced to RDBMS", () =
         // capture generated up queries
         const sqlInMemory = await connection.driver.createSchemaBuilder().log();
         const tableName = meta.tableName;
-        const expectedUp = `ALTER TABLE \"${tableName}\" ALTER COLUMN \"${COLUMN_NAME}\" TYPE character varying COLLATE \"${NEW_COLLATION}\"`;
-        const expectedDown = `ALTER TABLE \"${tableName}\" ALTER COLUMN \"${COLUMN_NAME}\" TYPE character varying COLLATE \"${OLD_COLLATION}\"`;
+        const expectedUp = `ALTER TABLE "${tableName}" ALTER COLUMN "${COLUMN_NAME}" TYPE character varying COLLATE "${NEW_COLLATION}"`;
+        const expectedDown = `ALTER TABLE "${tableName}" ALTER COLUMN "${COLUMN_NAME}" TYPE character varying COLLATE "${OLD_COLLATION}"`;
 
         // assert that the expected queries are in the generated SQL
         const upJoined = sqlInMemory.upQueries

--- a/test/github-issues/8647/issue-8647.ts
+++ b/test/github-issues/8647/issue-8647.ts
@@ -12,7 +12,7 @@ describe("github issues > #8647 Collation changes are not synced to RDBMS", () =
         (connections = await createTestingConnections({
             enabledDrivers: ["postgres"],
             driverSpecific: {
-                applicationName: "syoon test name",
+                applicationName: "collation-detection-test",
             },
             entities: [__dirname + "/entity/*{.js,.ts}"],
             schemaCreate: true,

--- a/test/github-issues/8647/issue-8647.ts
+++ b/test/github-issues/8647/issue-8647.ts
@@ -28,7 +28,7 @@ describe("github issues > #8647 Collation changes are not synced to RDBMS", () =
 
     const COLUMN_NAME = "name"
 
-    it("ALTER ... COLATE query should be created", async () => {
+    it("ALTER ... COLLATE query should be created", async () => {
         await Promise.all(
             connections.map(async (connection) => {
                 // change metadata

--- a/test/github-issues/8647/issue-8647.ts
+++ b/test/github-issues/8647/issue-8647.ts
@@ -1,72 +1,85 @@
-import "reflect-metadata";
-import { createTestingConnections, closeTestingConnections, reloadTestingDatabases } from "../../utils/test-utils";
-import { DataSource } from "../../../src/data-source/DataSource";
-import { expect } from "chai";
-import { Item, NEW_COLLATION } from "./entity/item.entity";
+import "reflect-metadata"
+import {
+    createTestingConnections,
+    closeTestingConnections,
+    reloadTestingDatabases,
+} from "../../utils/test-utils"
+import { DataSource } from "../../../src/data-source/DataSource"
+import { expect } from "chai"
+import { Item, NEW_COLLATION } from "./entity/item.entity"
 
 describe("github issues > #8647 Collation changes are not synced to RDBMS", () => {
-  let connections: DataSource[]
+    let connections: DataSource[]
 
-  before(
-    async () =>
-        (connections = await createTestingConnections({
-            enabledDrivers: ["postgres"],
-            driverSpecific: {
-                applicationName: "collation-detection-test",
-            },
-            entities: [__dirname + "/entity/*{.js,.ts}"],
-            schemaCreate: true,
-            dropSchema: true,
-        })),
-  )
-  beforeEach(() => reloadTestingDatabases(connections));
-  after(() => closeTestingConnections(connections));
+    before(
+        async () =>
+            (connections = await createTestingConnections({
+                enabledDrivers: ["postgres"],
+                driverSpecific: {
+                    applicationName: "collation-detection-test",
+                },
+                entities: [__dirname + "/entity/*{.js,.ts}"],
+                schemaCreate: true,
+                dropSchema: true,
+            })),
+    )
+    beforeEach(() => reloadTestingDatabases(connections))
+    after(() => closeTestingConnections(connections))
 
-  const COLUMN_NAME = "name";
+    const COLUMN_NAME = "name"
 
-  it("ALTER ... COLATE query should be created", async () => {
-    await Promise.all(connections.map(async (connection) => {
-        // change metadata
-        const meta = connection.getMetadata(Item);
-        const col = meta.columns.find(c => c.propertyName === COLUMN_NAME)!;
-        const OLD_COLLATION = col.collation;
-        col.collation = NEW_COLLATION;
+    it("ALTER ... COLATE query should be created", async () => {
+        await Promise.all(
+            connections.map(async (connection) => {
+                // change metadata
+                const meta = connection.getMetadata(Item)
+                const col = meta.columns.find(
+                    (c) => c.propertyName === COLUMN_NAME,
+                )!
+                const OLD_COLLATION = col.collation
+                col.collation = NEW_COLLATION
 
-        // capture generated up queries
-        const sqlInMemory = await connection.driver.createSchemaBuilder().log();
-        const tableName = meta.tableName;
-        const expectedUp = `ALTER TABLE "${tableName}" ALTER COLUMN "${COLUMN_NAME}" TYPE character varying COLLATE "${NEW_COLLATION}"`;
-        const expectedDown = `ALTER TABLE "${tableName}" ALTER COLUMN "${COLUMN_NAME}" TYPE character varying COLLATE "${OLD_COLLATION}"`;
+                // capture generated up queries
+                const sqlInMemory = await connection.driver
+                    .createSchemaBuilder()
+                    .log()
+                const tableName = meta.tableName
+                const expectedUp = `ALTER TABLE "${tableName}" ALTER COLUMN "${COLUMN_NAME}" TYPE character varying COLLATE "${NEW_COLLATION}"`
+                const expectedDown = `ALTER TABLE "${tableName}" ALTER COLUMN "${COLUMN_NAME}" TYPE character varying COLLATE "${OLD_COLLATION}"`
 
-        // assert that the expected queries are in the generated SQL
-        const upJoined = sqlInMemory.upQueries
-          .map(q => q.query.replace(/\s+/g, ' ').trim())
-          .join(' ');
-        expect(upJoined).to.include(expectedUp);
-        const downJoined = sqlInMemory.downQueries
-          .map(q => q.query.replace(/\s+/g, ' ').trim())
-          .join(' ');
-        expect(downJoined).to.include(expectedDown);
+                // assert that the expected queries are in the generated SQL
+                const upJoined = sqlInMemory.upQueries
+                    .map((q) => q.query.replace(/\s+/g, " ").trim())
+                    .join(" ")
+                expect(upJoined).to.include(expectedUp)
+                const downJoined = sqlInMemory.downQueries
+                    .map((q) => q.query.replace(/\s+/g, " ").trim())
+                    .join(" ")
+                expect(downJoined).to.include(expectedDown)
 
-        // assert that collation changes are applied to the database
-        const queryRunner = connection.createQueryRunner();
+                // assert that collation changes are applied to the database
+                const queryRunner = connection.createQueryRunner()
 
-        try {
-          let table = await queryRunner.getTable(meta.tableName);
-          const originColumn = table!.columns.find(c => c.name === COLUMN_NAME)!;
-          // old collation should be appeared
-          expect(originColumn.collation).to.equal(OLD_COLLATION);
+                try {
+                    let table = await queryRunner.getTable(meta.tableName)
+                    const originColumn = table!.columns.find(
+                        (c) => c.name === COLUMN_NAME,
+                    )!
+                    // old collation should be appeared
+                    expect(originColumn.collation).to.equal(OLD_COLLATION)
 
-          await connection.synchronize();
+                    await connection.synchronize()
 
-          table = await queryRunner.getTable(meta.tableName);
-          const appliedColumn = table!.columns.find(c => c.name === COLUMN_NAME)!;
-          // new collation should be appeared
-          expect(appliedColumn.collation).to.equal(NEW_COLLATION);
-        } finally {
-            await queryRunner.release();
-        }
-      })
-    )}
-  );
+                    table = await queryRunner.getTable(meta.tableName)
+                    const appliedColumn = table!.columns.find(
+                        (c) => c.name === COLUMN_NAME,
+                    )!
+                    // new collation should be appeared
+                    expect(appliedColumn.collation).to.equal(NEW_COLLATION)
+                } finally {
+                    await queryRunner.release()
+                }
+            }),
+        )
+    })
 })

--- a/test/github-issues/8647/issue-8647.ts
+++ b/test/github-issues/8647/issue-8647.ts
@@ -1,0 +1,81 @@
+import "reflect-metadata";
+import { createTestingConnections, closeTestingConnections, 
+    // reloadTestingDatabases
+ } from "../../utils/test-utils";
+import { DataSource } from "../../../src/data-source/DataSource";
+import { expect } from "chai";
+import { Item, NEW_COLLATION, OLD_COLLATION } from "./entity/item.entity";
+
+describe("github issues > #8647 Collation changes are not synced to RDBMS", () => {
+
+  let dataSources: DataSource[];
+
+  beforeEach(
+    async () => {
+        dataSources = await createTestingConnections({
+          entities: [Item],
+          schemaCreate: true,
+          dropSchema: true,
+        });
+    }
+  );
+  after(() => closeTestingConnections(dataSources));
+
+  const COLUMN_NAME = "name";
+
+  it("ALTER ... COLATE query should be created", () =>
+    Promise.all(dataSources.map(async (dataSource) => {
+      // Change Entity's collation
+      const meta = dataSource.getMetadata(Item);
+      const col = meta.columns.find(c => c.propertyName === COLUMN_NAME)!;
+      col.collation = NEW_COLLATION;
+
+      // Check Native Query Built by PostgresQueryRunner
+      const sqlInMemory = await dataSource.driver.createSchemaBuilder().log();
+      const tableName = meta.tableName;
+      const expectedUp = `ALTER TABLE "${tableName}" ALTER COLUMN "${
+                            COLUMN_NAME
+                        }" TYPE character varying COLLATE "${NEW_COLLATION}"`; // PostgresDriver's normalizeType method will convert varchar to character varying
+      const expectedDown = `ALTER TABLE "${tableName}" ALTER COLUMN "${
+                            COLUMN_NAME
+                        }" TYPE character varying COLLATE "${OLD_COLLATION}"`;
+
+      // Assert that the generated up quries are correct
+      const upJoined = sqlInMemory.upQueries
+        .map(q => q.query.replace(/\s+/g, ' ').trim())
+        .join(' ');
+        // console.log(`Native Query Result => ${upJoined}`)
+        // console.log(`expected Query => ${expectedUp}`)
+      expect(upJoined).to.include(expectedUp);
+
+      // Assert that the generated down quries are correct
+      const downJoined = sqlInMemory.downQueries
+        .map(q => q.query.replace(/\s+/g, ' ').trim())
+        .join(' ');
+      expect(downJoined).to.include(expectedDown);
+    }))
+  );
+
+  it("collation update should be applied after synchronize", () =>
+    Promise.all(dataSources.map(async (dataSource) => {
+      // Change Entity's collation
+      const meta = dataSource.getMetadata(Item);
+      const col = meta.columns.find(c => c.propertyName === COLUMN_NAME)!;
+      col.collation = NEW_COLLATION;
+      await dataSource.synchronize();
+      
+      // Assert that the collation is applied to the DB
+      const qr = dataSource.createQueryRunner();
+      try {
+        const table = await qr.getTable(meta.tableName);
+        const appliedCol = table!.columns.find(c => c.name === COLUMN_NAME)!;
+        // console.log(`Applied collation => ${appliedCol.collation}`)
+        // console.log(`expected collation => ${NEW_COLLATION}`)
+        expect(appliedCol.collation).to.equal(NEW_COLLATION);
+      } finally {
+        await qr.release();
+      }
+    }))
+  );
+
+});


### PR DESCRIPTION
### Description of change
issue - #8647
This changes enhance the Postgresdriver’s schema synchronization logic to detect when a column’s `collation` property has been modified and include the appropriate `ALTER … COLLATE` statement in both `up` and `down` migration SQL.

So, I made a few changes in `PostgresDriver.ts` and `PostgresQueryRunner.ts`

> **It seems that the same issue is observed not only in `PostgreSQL` but also in several other RDBMS drivers that allow Collation to be configured** _(`SQL Server`, `MySQL`, `Oracle`, etc... as far as I know...)_ 
>
> Please let me know if you'd like this to be applied uniformly across those other DBMS as well. 😄 

### Pull-Request Checklist
- [x] Code is up-to-date with the `master` branch
- [x] `npm run format` to apply prettier formatting
- [x] `npm run test` passes with this change
- [x] This pull request links relevant issues as `Fixes #8647`
- [x] There are new or updated unit tests validating the change
- [ ] Documentation has been updated to reflect this change (N/A)
- [x] The new commits follow conventions explained in [CONTRIBUTING.md](https://github.com/typeorm/typeorm/blob/master/CONTRIBUTING.md)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added support for detecting and synchronizing collation changes on PostgreSQL columns during schema updates.

- **Tests**
  - Introduced tests to verify that collation changes are correctly detected, generate the appropriate migration SQL, and are applied to the database schema.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->