### PR TITLE
build: include db version in coveralls flag-name

### DIFF
--- a/.github/workflows/database-tests.yml
+++ b/.github/workflows/database-tests.yml
@@ -99,7 +99,7 @@ jobs:
       - name: Coveralls Parallel
         uses: coverallsapp/github-action@v2
         with:
-          flag-name: mssql-node:${{ inputs.node-version }}
+          flag-name: mssql-node:${{ inputs.node-version }}:${{ matrix.mssql-version }}
           parallel: true
 
   mysql_mariadb:
@@ -248,5 +248,5 @@ jobs:
       - name: Coveralls Parallel
         uses: coverallsapp/github-action@v2
         with:
-          flag-name: postgres-node:${{ inputs.node-version }}
+          flag-name: postgres-node:${{ inputs.node-version }}:${{ matrix.postgis-version }}
           parallel: true

--- a/.github/workflows/database-tests.yml
+++ b/.github/workflows/database-tests.yml
@@ -99,7 +99,7 @@ jobs:
       - name: Coveralls Parallel
         uses: coverallsapp/github-action@v2
         with:
-          flag-name: mssql-node:${{ inputs.node-version }}:${{ matrix.mssql-version }}
+          flag-name: mssql-client:${{ matrix.mssql-version }}-node:${{ inputs.node-version }}
           parallel: true
 
   mysql_mariadb:
@@ -248,5 +248,5 @@ jobs:
       - name: Coveralls Parallel
         uses: coverallsapp/github-action@v2
         with:
-          flag-name: postgres-node:${{ inputs.node-version }}:${{ matrix.postgis-version }}
+          flag-name: postgres-postgis:${{ matrix.postgis-version }}-node:${{ inputs.node-version }}
           parallel: true


### PR DESCRIPTION
### Description of change

Adds the database version for mssql and postgres to Coverall's flag-name.

This fixes an issue where Coveralls was combining the coverage report for mssql and postgres because we have a matrix setup to test multiple versions of the respective databases. The flag name was setup to be unique by node version, but would combine coverage reports for different database versions.

### Pull-Request Checklist

- [x] Code is up-to-date with the `master` branch
- [x] `npm run format` to apply prettier formatting
- [x] `npm run test` passes with this change
- [ ] This pull request links relevant issues as `Fixes #0000`
- [ ] There are new or updated unit tests validating the change
- [ ] Documentation has been updated to reflect this change
- [x] The new commits follow conventions explained in [CONTRIBUTING.md](https://github.com/typeorm/typeorm/blob/master/CONTRIBUTING.md)