### PR TITLE
fix: capacitor driver PRAGMA bug

### DIFF
--- a/src/driver/capacitor/CapacitorDriver.ts
+++ b/src/driver/capacitor/CapacitorDriver.ts
@@ -80,7 +80,7 @@ export class CapacitorDriver extends AbstractSqliteDriver {
 
         // we need to enable foreign keys in sqlite to make sure all foreign key related features
         // working properly. this also makes onDelete to work with sqlite.
-        await connection.run(`PRAGMA foreign_keys = ON`)
+        await connection.execute(`PRAGMA foreign_keys = ON`)
 
         if (
             this.options.journalMode &&
@@ -88,7 +88,7 @@ export class CapacitorDriver extends AbstractSqliteDriver {
                 this.options.journalMode,
             ) !== -1
         ) {
-            await connection.run(
+            await connection.execute(
                 `PRAGMA journal_mode = ${this.options.journalMode}`,
             )
         }

--- a/src/driver/capacitor/CapacitorQueryRunner.ts
+++ b/src/driver/capacitor/CapacitorQueryRunner.ts
@@ -81,9 +81,7 @@ export class CapacitorQueryRunner extends AbstractSqliteQueryRunner {
                 ].indexOf(command) !== -1
             ) {
                 raw = await databaseConnection.execute(query, false)
-            } else if (
-                ["INSERT", "UPDATE", "DELETE"].indexOf(command) !== -1
-            ) {
+            } else if (["INSERT", "UPDATE", "DELETE"].indexOf(command) !== -1) {
                 raw = await databaseConnection.run(query, parameters, false)
             } else {
                 raw = await databaseConnection.query(query, parameters || [])

--- a/src/driver/capacitor/CapacitorQueryRunner.ts
+++ b/src/driver/capacitor/CapacitorQueryRunner.ts
@@ -82,7 +82,7 @@ export class CapacitorQueryRunner extends AbstractSqliteQueryRunner {
             ) {
                 raw = await databaseConnection.execute(query, false)
             } else if (
-                ["INSERT", "UPDATE", "DELETE", "PRAGMA"].indexOf(command) !== -1
+                ["INSERT", "UPDATE", "DELETE"].indexOf(command) !== -1
             ) {
                 raw = await databaseConnection.run(query, parameters, false)
             } else {


### PR DESCRIPTION
# Fix CapacitorDriver PRAGMA Statement Execution for Schema Synchronization

This PR addresses a critical issue in Capacitor driver that prevents proper schema synchronization and migration functionality. The root cause lies in how PRAGMA statements are executed in the SQLite driver.

## Issue Summary
Related issue: #10687

The current implementation incorrectly routes PRAGMA statements through `run` method in `CapacitorQueryRunnner.ts`, which return `0` instead of the expected metadata results. This causes schema synchronization to fail with errors like:

```
const pos = tableColumn.type.indexOf is not a function. (In 'dbColumns.map(async (dbColumn) => {
```

When TypeORM attempts to retrieve table metadata using PRAGMA statements in `AbstractSqliteQueryRunner`, it receives empty results:

```javascript
// This returns empty results (dbColumns=0, dbIndices=0, dbForeignKeys=0)
const [dbColumns, dbIndices, dbForeignKeys] = await Promise.all([
    this.loadPragmaRecords(tablePath, `table_xinfo`),
    this.loadPragmaRecords(tablePath, `index_list`),
    this.loadPragmaRecords(tablePath, `foreign_key_list`),
]);
```
Another error appears because in `CapacitorDriver.ts` PRAGMA queries executes with `run` method, which leads to this error:
```
prepareSQL step failed rc: 100 message: another row available
```
## Solution

The fix ensures that all PRAGMA statements are executed with the `query` method instead of `execute` or `run` in `CapacitorQueryRunnner.ts`, allowing them to properly return metadata results. This is crucial for:

1. Schema synchronization (`synchronize: true`)
2. Migration functionality
3. Proper entity-to-database mapping

In CapacitorDriver.ts PRAGMA queries executed with `execute` method.
## Implementation Details

1. Modified `CapacitorQueryRunner` to properly route PRAGMA statements to query method
2. Modified `CapacitorDriver` to use `execute` method for PRAGMA statements there.

### Pull-Request Checklist

<!--
  Please make sure to review and check all of the following.

  If an item is not applicable, you can add "N/A" to the end.
-->

- [x] Code is up-to-date with the `master` branch
- [x] `npm run format` to apply prettier formatting
- [x] `npm run test` passes with this change
- [x] Fixes #10687
- [n/a] There are new or updated unit tests validating the change
- [n/a] Documentation has been updated to reflect this change
- [x] The new commits follow conventions explained in [CONTRIBUTING.md](https://github.com/typeorm/typeorm/blob/master/CONTRIBUTING.md)

<!--
  🎉 Thank you for contributing and making TypeORM even better!
-->
