### PR TITLE
chore: clarify commit practices

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -12,19 +12,15 @@
 ### Description of change
 
 <!--
-  Please be clear and concise what the change is intended to do,
-  why this change is needed, and how you've verified that it
-  corrects what you intended.
+  Please describe:
+  - what the change is intended to do
+  - why this change is needed
+  - how you've verified it
+  - any other context that will help reviewers understand the change
 
   In some cases it may be helpful to include the current behavior
   and the new behavior.
-
-  If the change is related to an open issue, you can link it here.
-  If you include `Fixes #0000` (replacing `0000` with the issue number)
-  when this is merged it will automatically mark the issue as fixed and
-  close it.
 -->
-
 
 ### Pull-Request Checklist
 
@@ -34,13 +30,10 @@
   If an item is not applicable, you can add "N/A" to the end.
 -->
 
-- [ ] Code is up-to-date with the `master` branch
-- [ ] `npm run format` to apply prettier formatting
-- [ ] `npm run test` passes with this change
-- [ ] This pull request links relevant issues as `Fixes #0000`
-- [ ] There are new or updated unit tests validating the change
-- [ ] Documentation has been updated to reflect this change
-- [ ] The new commits follow conventions explained in [CONTRIBUTING.md](https://github.com/typeorm/typeorm/blob/master/CONTRIBUTING.md)
+-   [ ] Code is up-to-date with the `master` branch
+-   [ ] This pull request links relevant issues as `Fixes #00000`
+-   [ ] There are new or updated unit tests validating the change
+-   [ ] Documentation has been updated to reflect this change
 
 <!--
   🎉 Thank you for contributing and making TypeORM even better!

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -7,6 +7,7 @@
   If unsure about something.. just do as best as you're able,
   or reach out through our community support channels!
   https://github.com/typeorm/typeorm/blob/master/docs/support.md
+  https://github.com/typeorm/typeorm/blob/master/CONTRIBUTING.md
 -->
 
 ### Description of change

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -119,9 +119,20 @@ We will squash and merge commits into a single commit when merging a PR to follo
 
 If you're contributing to the project, we recommend following the same guidelines.
 
+```
+<type>: <subject>
+<BLANK LINE>
+<body>
+<BLANK LINE>
+<footer>
+```
+
+Any line of the commit message should not be longer than 100 characters. This allows the message
+to be easier to read on GitHub as well as in various git tools.
+
 ### Type
 
-Must be one of the following:
+One of the following:
 
 * **feat**: A new feature
 * **fix**: A bug fix
@@ -133,6 +144,26 @@ Must be one of the following:
 * **build**: Changes that affect the build system, CI configuration or external dependencies
 * **chore**: Other changes that don't modify `src` or `test` files
 * **revert**: Reverts a previous commit. Include the hash of the commit being reverted.
+
+### Subject
+
+The subject contains succinct description of the change:
+
+* use the imperative, present tense: "change" not "changed" nor "changes"
+* don't capitalize first letter
+* no dot (.) at the end
+
+### Body
+
+Just as in the **subject**, use the imperative, present tense: "change" not "changed" nor "changes".
+The body should include the motivation for the change and contrast this with previous behavior.
+
+### Footer
+
+The footer should contain any information about **Breaking Changes** and is also the place to
+reference GitHub issues that this commit **Closes**.
+**Breaking Changes** should start with the word `BREAKING CHANGE:` with a space or two newlines.
+The rest of the commit message is then used for this.
 
 ## Financial contributions
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -64,7 +64,7 @@ Before you submit your Pull Request (PR) consider the following guidelines:
 
 * Create your patch, **including appropriate test cases**. Without tests your PR will not be accepted.
 * Run the full TypeORM test suite, as described in the [developer documentation](DEVELOPER.md), and ensure that all tests pass.
-* Commit your changes using a descriptive commit message that follows our [commit message conventions](#commit). Adherence to these conventions is necessary because release notes are automatically generated from these messages.
+* Commit your changes using descriptive commit messages. See our [commit message conventions](#commit)
 
      ```shell
      git commit -a
@@ -77,16 +77,8 @@ Before you submit your Pull Request (PR) consider the following guidelines:
     git push origin my-fix-branch
     ```
 
-* In GitHub, send a pull request to `typeorm:master`.
-* If we suggest changes then:
-  * Make the required updates.
-  * Re-run the TypeORM test suites to ensure tests are still passing.
-  * Rebase your branch and force push to your GitHub repository (this will update your Pull Request):
-
-    ```shell
-    git rebase master -i
-    git push -f
-    ```
+* In GitHub, send a pull request to `typeorm:master` and include a description following the template.
+* Changes can be added as new commits to the same branch, which will update your pull request.
 
 That's it! Thank you for your contribution!
 
@@ -122,31 +114,13 @@ from the main (upstream) repository:
 
 ## <a name="commit"></a> Commit Message Guidelines
 
-We have very precise rules over how our git commit messages can be formatted.  This leads to **more
-readable messages** that are easy to follow when looking through the **project history**.  But also,
-we use the git commit messages to **generate changelog**.
+We follow the format below to help generate changelogs and keep commit history readable.
+We will squash and merge commits into a single commit when merging a PR to follow this convention.
 
-### Commit Message Format
-Each commit message consists of a **header**, a **body** and a **footer**.  The header has a special
-format that includes a **type** and a **subject**:
-
-```
-<type>: <subject>
-<BLANK LINE>
-<body>
-<BLANK LINE>
-<footer>
-```
-
-Any line of the commit message cannot be longer 100 characters! This allows the message to be easier
-to read on GitHub as well as in various git tools.
-
-### Revert
-If the commit reverts a previous commit, it should begin with `revert: `, followed by the header of
-the reverted commit. In the body it should say: `This reverts commit <hash>.`, where the hash is
-the SHA of the commit being reverted.
+If you're contributing to the project, we recommend following the same guidelines.
 
 ### Type
+
 Must be one of the following:
 
 * **feat**: A new feature
@@ -158,50 +132,7 @@ Must be one of the following:
 * **test**: Adding missing tests or correcting existing tests
 * **build**: Changes that affect the build system, CI configuration or external dependencies
 * **chore**: Other changes that don't modify `src` or `test` files
-
-### Subject
-The subject contains succinct description of the change:
-
-* use the imperative, present tense: "change" not "changed" nor "changes"
-* don't capitalize first letter
-* no dot (.) at the end
-
-### Body
-Just as in the **subject**, use the imperative, present tense: "change" not "changed" nor "changes".
-The body should include the motivation for the change and contrast this with previous behavior.
-
-### Footer
-The footer should contain any information about **Breaking Changes** and is also the place to
-reference GitHub issues that this commit **Closes**.
-
-**Breaking Changes** should start with the word `BREAKING CHANGE:` with a space or two newlines.
-The rest of the commit message is then used for this.
-
-### Examples
-Fix and close issue:
-```
-fix: resolve issues uppercase column names
-
-Closes: #123456
-```
-Implement new feature:
-```
-feat: implement new magic decorator
-
-This new feature change bahviour of typeorm to allow use new magic decorator...
-
-Closes: #22222
-```
-Docs update:
-```
-docs: update supported mssql column types
-```
-Breaking change:
-```
-refactor: refactor driver API
-
-BREAKING CHANGE: description of breaking change in driver API
-```
+* **revert**: Reverts a previous commit. Include the hash of the commit being reverted.
 
 ## Financial contributions
 


### PR DESCRIPTION
Clarifies our documentation for commit messages and pull request descriptions.

The intention is to make it easier for people to contribute and for maintainers to review changes. Since we squash and merge all PRs when merging to master, we can revise some of our existing guidelines.

Specifically this reduces our commit message convention to a recommendation instead of a requirement. Maintainers should still follow the conventions when squashing and merging PRs. It also removes the ask to rebase and force push new changes. It's often easier for us to review changes when revisions are added as new commits.