### PR TITLE
mssql should use NEWID() instead of NEWSEQUENTIALID() for uuid generation strategy

### DIFF
--- a/src/driver/sqlserver/SqlServerQueryRunner.ts
+++ b/src/driver/sqlserver/SqlServerQueryRunner.ts
@@ -3296,7 +3296,7 @@ export class SqlServerQueryRunner
                             tableColumn.isGenerated = isGenerated
                             if (isGenerated)
                                 tableColumn.generationStrategy = "increment"
-                            if (tableColumn.default === "newid()") {
+                            if (tableColumn.default === "newid()" || tableColumn.default === "newsequentialid()") {
                                 tableColumn.isGenerated = true
                                 tableColumn.generationStrategy = "uuid"
                                 tableColumn.default = undefined

--- a/src/driver/sqlserver/SqlServerQueryRunner.ts
+++ b/src/driver/sqlserver/SqlServerQueryRunner.ts
@@ -3296,7 +3296,7 @@ export class SqlServerQueryRunner
                             tableColumn.isGenerated = isGenerated
                             if (isGenerated)
                                 tableColumn.generationStrategy = "increment"
-                            if (tableColumn.default === "newsequentialid()") {
+                            if (tableColumn.default === "newid()") {
                                 tableColumn.isGenerated = true
                                 tableColumn.generationStrategy = "uuid"
                                 tableColumn.default = undefined
@@ -4028,7 +4028,7 @@ export class SqlServerQueryRunner
                     table,
                     column.name,
                 )
-            c += ` CONSTRAINT "${defaultName}" DEFAULT NEWSEQUENTIALID()`
+            c += ` CONSTRAINT "${defaultName}" DEFAULT NEWID()`
         }
         return c
     }


### PR DESCRIPTION
The currently used NEWSEQUENTIALID() actually generates a GUID and not a UUID, but in typeorm it is used for the UUID generation strategy. Instead for a proper UUID generation strategy NEWID() is used in MSSQL:
  [https://learn.microsoft.com/en-us/sql/t-sql/functions/newid-transact-sql?view=sql-server-ver16]
  [https://learn.microsoft.com/en-us/sql/t-sql/functions/newsequentialid-transact-sql?view=sql-server-ver16]

### Description of change
I have changed the SqlServerQueryRunner.ts to use NEWID() in all newly generated migrations. This should be backwards compatible, but the databases will have two different format of IDs - old table will have GUIDs (as they are today), but new tables will actually have proper UUIDs


### Pull-Request Checklist
- [x] Code is up-to-date with the `master` branch
- [x] `npm run format` to apply prettier formatting
- [x] `npm run test` passes with this change
- [n/a] This pull request links relevant issues as `Fixes #0000`
- [n/a] There are new or updated unit tests validating the change
- [n/a] Documentation has been updated to reflect this change
- [x] The new commits follow conventions explained in [CONTRIBUTING.md](https://github.com/typeorm/typeorm/blob/master/CONTRIBUTING.md)
