### PR TITLE
fix(mssql): avoid mutating input parameter array values

### DIFF
--- a/src/driver/sqlserver/SqlServerDriver.ts
+++ b/src/driver/sqlserver/SqlServerDriver.ts
@@ -987,24 +987,17 @@ export class SqlServerDriver implements Driver {
      */
     parametrizeValues(column: ColumnMetadata, value: any) {
         if (value instanceof FindOperator) {
-            if (Array.isArray(value.value)) {
-                for (let i = 0; i < value.value.length; i++) {
-                    value.value[i] = this.parametrizeValues(
-                        column,
-                        value.value[i],
-                    )
-                }
-            } else if (value.type !== "raw") {
+            if (value.type !== "raw") {
                 value.transformValue({
-                    to: (v) => this.parametrizeValue(column, v),
+                    to: (v) => this.parametrizeValues(column, v),
                     from: (v) => v,
                 })
             }
-        } else {
-            value = this.parametrizeValue(column, value)
+
+            return value
         }
 
-        return value
+        return this.parametrizeValue(column, value)
     }
 
     /**

--- a/test/github-issues/11285/issue-11285.ts
+++ b/test/github-issues/11285/issue-11285.ts
@@ -167,14 +167,18 @@ describe("github issues > #11285 Missing MSSQL input type", () => {
                         "query",
                     )
 
+                    const excludedUserIds = [user2.memberId]
+
                     const users = await dataSource.getRepository(User).find({
                         where: {
-                            memberId: And(Not(In([user2.memberId]))),
+                            memberId: And(Not(In(excludedUserIds))),
                         },
                     })
 
                     expect(users).to.have.length(1)
                     expect(users[0].memberId).to.be.equal(user.memberId)
+
+                    expect(excludedUserIds).to.eql([user2.memberId])
 
                     expect(selectSpy.calledOnce).to.be.true
 

--- a/test/github-issues/11285/issue-11285.ts
+++ b/test/github-issues/11285/issue-11285.ts
@@ -178,6 +178,8 @@ describe("github issues > #11285 Missing MSSQL input type", () => {
                     expect(users).to.have.length(1)
                     expect(users[0].memberId).to.be.equal(user.memberId)
 
+                    // Ensure that the input array was not mutated into MssqlParameter instances
+                    // https://github.com/typeorm/typeorm/issues/11474
                     expect(excludedUserIds).to.eql([user2.memberId])
 
                     expect(selectSpy.calledOnce).to.be.true


### PR DESCRIPTION
<!--
  😀 Wonderful!  Thank you for opening a pull request for TypeORM.

  Please fill in the information below to expedite the review
  and (hopefully) merge of your change.

  If unsure about something.. just do as best as you're able,
  or reach out through our community support channels!
  https://github.com/typeorm/typeorm/blob/master/docs/support.md
-->

### Description of change

Fixes #11474 (bug introduced in #11468)

Arrays of parameters provided as arguments to FindOperators should not be mutated in place when transforming them into typed MssqlParameter objects. A new array should be produced.

### Pull-Request Checklist

<!--
  Please make sure to review and check all of the following.

  If an item is not applicable, you can add "N/A" to the end.
-->

- [x] Code is up-to-date with the `master` branch
- [x] `npm run format` to apply prettier formatting
- [x] `npm run test` passes with this change
- [x] This pull request links relevant issues as `Fixes #0000`
- [x] There are new or updated unit tests validating the change
- Documentation has been updated to reflect this change (N/A)
- [x] The new commits follow conventions explained in [CONTRIBUTING.md](https://github.com/typeorm/typeorm/blob/master/CONTRIBUTING.md)

<!--
  🎉 Thank you for contributing and making TypeORM even better!
-->
