### PR TITLE
fix: handle limit(0) and offset(0) correctly in SelectQueryBuilder

### DIFF
--- a/test/functional/query-builder/select/query-builder-select.ts
+++ b/test/functional/query-builder/select/query-builder-select.ts
@@ -619,4 +619,177 @@ describe("query builder > select", () => {
                 expect(sql).contains("FROM post USE INDEX (my_index)")
             }),
         ))
+
+    describe("limit and offset handling", () => {
+        it("should generate LIMIT 0 when limit is set to 0", () =>
+            Promise.all(
+                connections.map(async (connection) => {
+                    const sql = connection
+                        .createQueryBuilder(Post, "post")
+                        .limit(0)
+                        .disableEscaping()
+                        .getSql()
+
+                    expect(sql).to.equal(
+                        "SELECT post.id AS post_id, " +
+                            "post.title AS post_title, " +
+                            "post.description AS post_description, " +
+                            "post.rating AS post_rating, " +
+                            "post.version AS post_version, " +
+                            "post.heroImageId AS post_heroImageId, " +
+                            "post.categoryId AS post_categoryId " +
+                            "FROM post post LIMIT 0",
+                    )
+                }),
+            ))
+
+        it("should generate LIMIT 0 OFFSET 5 when limit is 0 and offset is 5", () =>
+            Promise.all(
+                connections.map(async (connection) => {
+                    const sql = connection
+                        .createQueryBuilder(Post, "post")
+                        .limit(0)
+                        .offset(5)
+                        .disableEscaping()
+                        .getSql()
+
+                    expect(sql).to.equal(
+                        "SELECT post.id AS post_id, " +
+                            "post.title AS post_title, " +
+                            "post.description AS post_description, " +
+                            "post.rating AS post_rating, " +
+                            "post.version AS post_version, " +
+                            "post.heroImageId AS post_heroImageId, " +
+                            "post.categoryId AS post_categoryId " +
+                            "FROM post post LIMIT 0 OFFSET 5",
+                    )
+                }),
+            ))
+
+        it("should generate OFFSET 0 when offset is set to 0", () =>
+            Promise.all(
+                connections.map(async (connection) => {
+                    const sql = connection
+                        .createQueryBuilder(Post, "post")
+                        .limit(10)
+                        .offset(0)
+                        .disableEscaping()
+                        .getSql()
+
+                    expect(sql).to.equal(
+                        "SELECT post.id AS post_id, " +
+                            "post.title AS post_title, " +
+                            "post.description AS post_description, " +
+                            "post.rating AS post_rating, " +
+                            "post.version AS post_version, " +
+                            "post.heroImageId AS post_heroImageId, " +
+                            "post.categoryId AS post_categoryId " +
+                            "FROM post post LIMIT 10 OFFSET 0",
+                    )
+                }),
+            ))
+
+        it("should generate LIMIT 0 when take is set to 0 without joins", () =>
+            Promise.all(
+                connections.map(async (connection) => {
+                    const sql = connection
+                        .createQueryBuilder(Post, "post")
+                        .take(0)
+                        .disableEscaping()
+                        .getSql()
+
+                    expect(sql).to.equal(
+                        "SELECT post.id AS post_id, " +
+                            "post.title AS post_title, " +
+                            "post.description AS post_description, " +
+                            "post.rating AS post_rating, " +
+                            "post.version AS post_version, " +
+                            "post.heroImageId AS post_heroImageId, " +
+                            "post.categoryId AS post_categoryId " +
+                            "FROM post post LIMIT 0",
+                    )
+                }),
+            ))
+
+        it("should generate OFFSET 0 when skip is set to 0 without joins", () =>
+            Promise.all(
+                connections.map(async (connection) => {
+                    const sql = connection
+                        .createQueryBuilder(Post, "post")
+                        .take(10)
+                        .skip(0)
+                        .disableEscaping()
+                        .getSql()
+
+                    expect(sql).to.equal(
+                        "SELECT post.id AS post_id, " +
+                            "post.title AS post_title, " +
+                            "post.description AS post_description, " +
+                            "post.rating AS post_rating, " +
+                            "post.version AS post_version, " +
+                            "post.heroImageId AS post_heroImageId, " +
+                            "post.categoryId AS post_categoryId " +
+                            "FROM post post LIMIT 10 OFFSET 0",
+                    )
+                }),
+            ))
+
+        it("should return empty array when limit(0) is used in actual query execution", () =>
+            Promise.all(
+                connections.map(async (connection) => {
+                    // Insert some test data
+                    await connection.getRepository(Post).save([
+                        {
+                            id: "1",
+                            title: "Post 1",
+                            description: "Description 1",
+                            rating: 1,
+                        },
+                        {
+                            id: "2",
+                            title: "Post 2",
+                            description: "Description 2",
+                            rating: 2,
+                        },
+                    ])
+
+                    const posts = await connection
+                        .createQueryBuilder(Post, "post")
+                        .limit(0)
+                        .getMany()
+
+                    expect(posts).to.be.an("array")
+                    expect(posts.length).to.equal(0)
+                }),
+            ))
+
+        it("should return empty array when take(0) is used in actual query execution without joins", () =>
+            Promise.all(
+                connections.map(async (connection) => {
+                    // Insert some test data
+                    await connection.getRepository(Post).save([
+                        {
+                            id: "1",
+                            title: "Post 1",
+                            description: "Description 1",
+                            rating: 1,
+                        },
+                        {
+                            id: "2",
+                            title: "Post 2",
+                            description: "Description 2",
+                            rating: 2,
+                        },
+                    ])
+
+                    const posts = await connection
+                        .createQueryBuilder(Post, "post")
+                        .take(0)
+                        .getMany()
+
+                    expect(posts).to.be.an("array")
+                    expect(posts.length).to.equal(0)
+                }),
+            ))
+    })
 })


### PR DESCRIPTION
## 🐛 Bug Fix

### Description of change

**Problem:**
Currently, when `limit(0)` or `offset(0)` is used in SelectQueryBuilder, they are treated as falsy values in JavaScript and completely ignored, causing the query to return all records instead of the expected empty result. This is a potential security issue and goes against SQL standard behavior.

**Root Cause:**
JavaScript falsy value evaluation in conditional statements:
```typescript
if (limit && offset) // limit=0 evaluates to false
if (limit)          // limit=0 evaluates to false
```

**Solution:**
- Replace falsy checks (`!limit`) with explicit undefined/null checks (`limit === undefined`)
- Add helper functions `hasLimit` and `hasOffset` to properly distinguish between unset values and zero values
- Ensure consistent behavior across all database drivers (MySQL, PostgreSQL, SQLite, SQL Server, Oracle)
- Add comprehensive test coverage for zero value scenarios

**Current Behavior:**
```typescript
queryBuilder.limit(0).getMany()
// SQL: SELECT * FROM users (no LIMIT clause)
// Result: ALL records (security risk!)
```

**New Behavior:**
```typescript
queryBuilder.limit(0).getMany()
// SQL: SELECT * FROM users LIMIT 0
// Result: [] (empty array, as expected)
```

**Changes Made:**
1. **SelectQueryBuilder.ts**: 
   - Modified `createLimitOffsetExpression()` to handle zero values correctly
   - Added helper functions to distinguish between undefined and 0
   - Updated all database-specific condition checks

2. **Test Coverage**:
   - Added comprehensive test cases for `limit(0)`, `offset(0)`, `take(0)`, `skip(0)`
   - Verified SQL generation correctness
   - Tested actual query execution behavior

**Verification:**
- ✅ All existing tests pass
- ✅ New test cases added and passing
- ✅ Tested across SQLite (in test suite)
- ✅ Manual verification of SQL generation for all database types

### Pull-Request Checklist

- [x] Code is up-to-date with the `master` branch
- [ ] This pull request links relevant issues as `Fixes #00000` (N/A - no existing issue)
- [x] There are new or updated unit tests validating the change
- [ ] Documentation has been updated to reflect this change (N/A - behavior fix, not new feature)

### Breaking Changes
**None.** This is a bug fix that makes the behavior match developer expectations and SQL standards.

### Database Compatibility
- ✅ MySQL/MariaDB: `LIMIT 0`
- ✅ PostgreSQL: `LIMIT 0`
- ✅ SQLite: `LIMIT 0`
- ✅ SQL Server: `FETCH NEXT 0 ROWS ONLY`
- ✅ Oracle: `FETCH NEXT 0 ROWS ONLY`

### Before vs After Examples

#### Before (Broken Behavior)
```typescript
// Expected: Get 0 results
const users = await userRepository
  .createQueryBuilder("user")
  .limit(0)
  .getMany()

// Actual SQL: SELECT * FROM users (no LIMIT!)
// Actual Result: [user1, user2, user3, ...] (ALL users - security risk!)
```

#### After (Fixed Behavior)
```typescript
// Expected: Get 0 results
const users = await userRepository
  .createQueryBuilder("user")
  .limit(0)
  .getMany()

// Generated SQL: SELECT * FROM users LIMIT 0
// Result: [] (empty array, as expected)
```

### Use Cases This Fixes

1. **Dynamic Pagination**: When page size is conditionally set to 0
2. **Conditional Queries**: When limit is calculated and might be 0
3. **Security**: Prevents accidental data exposure when 0 limit was intended
4. **API Consistency**: Makes behavior match standard SQL and other ORMs

This fix ensures TypeORM behaves predictably and securely when developers explicitly set limit or offset to zero.