### PR TITLE
chore: update workflows to ignore changes in docs directory

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -3,8 +3,12 @@ name: "CodeQL"
 on:
   push:
     branches: ["master"]
+    paths-ignore:
+      - "docs/**"
   pull_request:
     branches: ["master"]
+    paths-ignore:
+      - "docs/**"
   schedule:
     - cron: "21 14 * * 2"
 

--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -8,6 +8,8 @@ on:
       - "gulpfile.ts"
       - "package.json"
       - "tsconfig.json"
+    paths-ignore:
+      - "docs/**"
 
 jobs:
   release:

--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -8,8 +8,6 @@ on:
       - "gulpfile.ts"
       - "package.json"
       - "tsconfig.json"
-    paths-ignore:
-      - "docs/**"
 
 jobs:
   release:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,8 +7,12 @@ name: test
 on:
   push:
     branches: ["**"]
+    paths-ignore:
+      - "docs/**"
   pull_request:
     branches: ["master"]
+    paths-ignore:
+      - "docs/**"
 
 jobs:
   formatting:


### PR DESCRIPTION
### Description of change

Excludes all changes to files under `docs/**` in workflows that are running tests. This should prevent our GH runners being blocked by unnecessary runs. 

### Pull-Request Checklist

-   [x] Code is up-to-date with the `master` branch
-   [ ] This pull request links relevant issues as `Fixes #00000`
-   [ ] There are new or updated unit tests validating the change
-   [ ] Documentation has been updated to reflect this change



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated workflows so that changes to documentation files no longer trigger automated analysis, testing, or preview release processes. Only changes outside the "docs" directory will initiate these workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->