### PR TITLE
chore(ci): avoid duplicate CI runs for pushes to non-fork PRs

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,11 +6,11 @@ name: test
 
 on:
   push:
-    branches: ["**"]
+    branches: ["master"]
     paths-ignore:
       - "docs/**"
   pull_request:
-    branches: ["master"]
+    branches: ["**"]
     paths-ignore:
       - "docs/**"
 


### PR DESCRIPTION
### Description of change

Previously, pushes to branches in this repository with pull requests would trigger duplicate CI runs:

<img width="812" alt="image" src="https://github.com/user-attachments/assets/373747a7-2704-4e6e-852c-41703b91c8c3" />
<img width="1284" alt="image" src="https://github.com/user-attachments/assets/4bafa940-1ed5-4991-b7fc-b3311f9ed1a0" />
<img width="1286" alt="image" src="https://github.com/user-attachments/assets/05532b05-89f8-4ba0-ac0b-c4e0920710b2" />

This is because our workflow uses both the `push` and `pull_request` events, and GitHub Actions doesn't do any de-duplication. So a push to a `typeorm/typeorm` branch with a PR would trigger both events (producing 86 test jobs instead of 43).

This didn't happen very often because most PRs are from outside contributors on branches in their own forks, which would only trigger the `pull_request` event. However it would occur when maintainers with write access created PRs using non-fork branches in `typeorm/typeorm`.

We can fix this by changing the trigger branch criteria:

- Filter the `push` event so it only triggers for pushes to the `master` branch. We have (I believe?) branch protection rules to ensure that commits can't be made directly to `master`, but this ensures we re-validate `master` after a PR is merged. Since all changes require a PR, CI doesn't need to run on other branches unless a PR is opened.

- I've also widened the filter on the `pull_request` event so it triggers for PRs based on all branches. I don't see any need to restrict this, and it ensures that tests can run in chained PRs.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated workflow triggers so tests now run on pushes to the master branch and on pull requests targeting any branch.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->