### PR TITLE
docs: add note about using YugabyteDB

### DIFF
--- a/docs/docs/data-source/2-data-source-options.md
+++ b/docs/docs/data-source/2-data-source-options.md
@@ -152,6 +152,10 @@ Different RDBMS-es have their own specific options.
 
 ## `postgres` / `cockroachdb` data source options
 
+PostgreSQL and CockroachDB are supported as TypeORM drivers. Databases that are PostgreSQL-compatible can also be used with TypeORM via the `postgres` data source option.
+
+To use YugabyteDB, refer to [their ORM docs](https://docs.yugabyte.com/stable/drivers-orms/nodejs/typeorm/) to get started. Note that because some postgres features are [not supported](https://docs.yugabyte.com/stable/develop/postgresql-compatibility/#unsupported-postgresql-features) by YugabyteDB, some TypeORM functionality may be limited.
+
 -   `url` - Connection url where the connection is performed. Please note that other data source options will override parameters set from url.
 
 -   `host` - Database host.


### PR DESCRIPTION
### Description of change

Adds a note about using YugabyteDB via the postgres driver to our docs.

### Pull-Request Checklist

-   [x] Code is up-to-date with the `master` branch
-   [x] This pull request links relevant issues as `Fixes #00000`
-   [x] ~There are new or updated unit tests validating the change~
-   [x] Documentation has been updated to reflect this change

closes https://github.com/typeorm/typeorm/issues/11364


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
	- Enhanced documentation for PostgreSQL and CockroachDB data source options with clearer explanations and guidance.
	- Added information about using YugabyteDB, including a link to its ORM documentation and notes on feature compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->