### PR TITLE
perf: avoid unnecessary count on getManyAndCount

### DIFF
--- a/test/other-issues/lazy-count/entity/Post.ts
+++ b/test/other-issues/lazy-count/entity/Post.ts
@@ -1,0 +1,10 @@
+import { Column, Entity, PrimaryGeneratedColumn } from "../../../../src"
+
+@Entity()
+export class Post {
+    @PrimaryGeneratedColumn("increment")
+    id!: number
+
+    @Column()
+    content!: string
+}

--- a/test/other-issues/lazy-count/lazy-count.ts
+++ b/test/other-issues/lazy-count/lazy-count.ts
@@ -1,0 +1,142 @@
+import "reflect-metadata"
+import {
+    closeTestingConnections,
+    createTestingConnections,
+    reloadTestingDatabases,
+} from "../../utils/test-utils"
+import { DataSource } from "../../../src/data-source/DataSource"
+import { Post } from "./entity/Post"
+import { expect } from "chai"
+import { AfterQuerySubscriber } from "./subscribers/AfterQuerySubscriber"
+
+describe("other issues > lazy count", () => {
+    let connections: DataSource[]
+    before(
+        async () =>
+            (connections = await createTestingConnections({
+                entities: [__dirname + "/entity/*{.js,.ts}"],
+                subscribers: [AfterQuerySubscriber],
+                dropSchema: true,
+                schemaCreate: true,
+            })),
+    )
+    beforeEach(() => reloadTestingDatabases(connections))
+    after(() => closeTestingConnections(connections))
+
+    it("skip count query when less entities are returned than the limit", () =>
+        Promise.all(
+            connections.map(async function (connection) {
+                for (let i = 1; i <= 5; i++) {
+                    const post = new Post()
+                    post.content = "Hello Post #" + i
+
+                    await connection.manager.save(post)
+                }
+
+                const afterQuery = connection
+                    .subscribers[0] as AfterQuerySubscriber
+                afterQuery.clear()
+
+                const [entities, count] = await connection.manager
+                    .createQueryBuilder(Post, "post")
+                    .limit(10)
+                    .orderBy("post.id")
+                    .getManyAndCount()
+
+                count.should.be.equal(5)
+                expect(entities).not.to.be.undefined
+                entities.length.should.be.equal(5)
+
+                expect(afterQuery.calls()).to.be.equal(1)
+                expect(afterQuery.lastCalledQuery()).to.not.match(/count/i)
+            }),
+        ))
+
+    it("skip count query when less entities are returned than the take", () =>
+        Promise.all(
+            connections.map(async function (connection) {
+                for (let i = 1; i <= 5; i++) {
+                    const post = new Post()
+                    post.content = "Hello Post #" + i
+
+                    await connection.manager.save(post)
+                }
+
+                const afterQuery = connection
+                    .subscribers[0] as AfterQuerySubscriber
+                afterQuery.clear()
+
+                const [entities, count] = await connection.manager
+                    .createQueryBuilder(Post, "post")
+                    .take(10)
+                    .orderBy("post.id")
+                    .getManyAndCount()
+
+                count.should.be.equal(5)
+                expect(entities).not.to.be.undefined
+                entities.length.should.be.equal(5)
+
+                expect(afterQuery.calls()).to.be.equal(1)
+                expect(afterQuery.lastCalledQuery()).to.not.match(/count/i)
+            }),
+        ))
+
+    it("run count query when returned entities reach the take", () =>
+        Promise.all(
+            connections.map(async function (connection) {
+                for (let i = 1; i <= 2; i++) {
+                    const post = new Post()
+                    post.content = "Hello Post #" + i
+
+                    await connection.manager.save(post)
+                }
+
+                const afterQuery = connection
+                    .subscribers[0] as AfterQuerySubscriber
+                afterQuery.clear()
+
+                const [entities, count] = await connection.manager
+                    .createQueryBuilder(Post, "post")
+                    .take(2)
+                    .orderBy("post.id")
+                    .getManyAndCount()
+
+                count.should.be.equal(2)
+                expect(entities).not.to.be.undefined
+                entities.length.should.be.equal(2)
+
+                expect(afterQuery.calls()).to.be.equal(2)
+                expect(afterQuery.lastCalledQuery()).to.match(/count/i)
+            }),
+        ))
+
+    it("run count query when an offset is defined", () =>
+        Promise.all(
+            connections.map(async function (connection) {
+                for (let i = 1; i <= 5; i++) {
+                    const post = new Post()
+                    post.content = "Hello Post #" + i
+
+                    await connection.manager.save(post)
+                }
+
+                const afterQuery = connection
+                    .subscribers[0] as AfterQuerySubscriber
+                afterQuery.clear()
+
+                const [entities, count] = await connection.manager
+                    .createQueryBuilder(Post, "post")
+                    .take(10)
+                    .offset(3)
+                    .orderBy("post.id")
+                    .getManyAndCount()
+
+                count.should.be.equal(5)
+                expect(entities).not.to.be.undefined
+                entities.length.should.be.equal(2)
+
+                expect(afterQuery.calls()).to.be.equal(2)
+                expect(afterQuery.lastCalledQuery()).to.match(/count/i)
+            }),
+        ))
+})

--- a/test/other-issues/lazy-count/subscribers/AfterQuerySubscriber.ts
+++ b/test/other-issues/lazy-count/subscribers/AfterQuerySubscriber.ts
@@ -1,0 +1,29 @@
+import {
+    AfterQueryEvent,
+    EntitySubscriberInterface,
+    EventSubscriber,
+} from "../../../../src"
+
+@EventSubscriber()
+export class AfterQuerySubscriber implements EntitySubscriberInterface {
+    calledQueries: any[] = []
+
+    afterQuery(event: AfterQueryEvent<any>): void {
+        this.calledQueries.push(event.query)
+    }
+
+    lastCalledQuery(): any | undefined {
+        let calledQueryLength = this.calledQueries.length
+        return calledQueryLength > 0
+            ? this.calledQueries[calledQueryLength - 1]
+            : undefined
+    }
+
+    calls(): number {
+        return this.calledQueries.length
+    }
+
+    clear(): void {
+        this.calledQueries = []
+    }
+}


### PR DESCRIPTION


<!--
  😀 Wonderful!  Thank you for opening a pull request for TypeORM.

  Please fill in the information below to expedite the review
  and (hopefully) merge of your change.

  If unsure about something.. just do as best as you're able,
  or reach out through our community support channels!
  https://github.com/typeorm/typeorm/blob/master/docs/support.md
  https://github.com/typeorm/typeorm/blob/master/CONTRIBUTING.md
-->

### Description of change

When `getManyAndCount` is called, stop execute the `count` query if it can be deduced from the
number of returned rows. This will **increase performance** by avoiding one round trip. It would be especially useful when using pagination libraries such as https://github.com/ppetzold/nestjs-paginate

#### Example

```js
const [entities, count] = await connection.manager
    .createQueryBuilder(Post, "post")
    .limit(10)
    .orderBy("post.id")
    .getManyAndCount()
```

Before this change, it triggers two queries:

```sql
SELECT * FROM post ORDER BY post.id LIMIT 10;
SELECT count(*) FROM post;
```
But if the first query returns only 5 results, we know that the count will also be 5.


After this change, it triggers only the first query:

```sql
SELECT * FROM post ORDER BY post.id LIMIT 10;
```

<!--
  Please describe:
  - what the change is intended to do
  - why this change is needed
  - how you've verified it
  - any other context that will help reviewers understand the change

  In some cases it may be helpful to include the current behavior
  and the new behavior.
-->

### Pull-Request Checklist

<!--
  Please make sure to review and check all of the following.

  If an item is not applicable, you can add "N/A" to the end.
-->

-   [x] Code is up-to-date with the `master` branch
-   [ ] This pull request links relevant issues as `Fixes #00000`
-   [x] There are new or updated unit tests validating the change
-   [ ] Documentation has been updated to reflect this change

<!--
  🎉 Thank you for contributing and making TypeORM even better!
-->
