### PR TITLE
fix: fix null pointer exception on date array column comparison

### DIFF
--- a/src/persistence/SubjectChangedColumnsComputer.ts
+++ b/src/persistence/SubjectChangedColumnsComputer.ts
@@ -1,9 +1,9 @@
-import { Subject } from "./Subject"
-import { DateUtils } from "../util/DateUtils"
 import { ObjectLiteral } from "../common/ObjectLiteral"
-import { OrmUtils } from "../util/OrmUtils"
 import { ApplyValueTransformers } from "../util/ApplyValueTransformers"
+import { DateUtils } from "../util/DateUtils"
 import { ObjectUtils } from "../util/ObjectUtils"
+import { OrmUtils } from "../util/OrmUtils"
+import { Subject } from "./Subject"
 
 /**
  * Finds what columns are changed in the subject entities.
@@ -81,8 +81,8 @@ export class SubjectChangedColumnsComputer {
                     if (value !== null && value !== undefined) return
                 }
                 let normalizedValue = entityValue
-                // normalize special values to make proper comparision
-                if (entityValue !== null) {
+                // if both values are not null, normalize special values to make proper comparision
+                if (entityValue !== null && databaseValue !== null) {
                     switch (column.type) {
                         case "date":
                             normalizedValue = column.isArray

--- a/test/github-issues/5967/entity/User.ts
+++ b/test/github-issues/5967/entity/User.ts
@@ -17,4 +17,10 @@ export class User {
         default: "{}",
     })
     dates: Date[]
+
+    @Column("time without time zone", {
+        nullable: true,
+        array: true,
+    })
+    nullable_times: [string, string] | null
 }

--- a/test/github-issues/5967/issue-5967.ts
+++ b/test/github-issues/5967/issue-5967.ts
@@ -197,4 +197,70 @@ describe("github issues > #5967 @afterUpdate always says array/json field update
                 expect(updateQueries).to.have.length(1)
             }),
         ))
+
+    it("should update a time array column when it goes from null to a value", () =>
+        Promise.all(
+            dataSources.map(async (dataSource) => {
+                const valueBefore = null
+                const valueAfter = ["12:00"]
+
+                const repository = dataSource.getRepository(User)
+
+                const logger = dataSource.logger as MemoryLogger
+                logger.clear()
+
+                const user = await repository.save({
+                    nullable_times: valueBefore,
+                })
+
+                const insertQueries = logger.queries.filter((q) =>
+                    q.startsWith("INSERT"),
+                )
+                expect(insertQueries).to.have.length(1)
+                logger.clear()
+
+                await repository.save({
+                    id: user.id,
+                    nullable_times: valueAfter,
+                })
+
+                const updateQueries = logger.queries.filter((q) =>
+                    q.startsWith("UPDATE"),
+                )
+                expect(updateQueries).to.have.length(1)
+            }),
+        ))
+
+    it("should update a time array column when it goes from a value to null", () =>
+        Promise.all(
+            dataSources.map(async (dataSource) => {
+                const valueBefore = ["12:00"]
+                const valueAfter = null
+
+                const repository = dataSource.getRepository(User)
+
+                const logger = dataSource.logger as MemoryLogger
+                logger.clear()
+
+                const user = await repository.save({
+                    nullable_times: valueBefore,
+                })
+
+                const insertQueries = logger.queries.filter((q) =>
+                    q.startsWith("INSERT"),
+                )
+                expect(insertQueries).to.have.length(1)
+                logger.clear()
+
+                await repository.save({
+                    id: user.id,
+                    nullable_times: valueAfter,
+                })
+
+                const updateQueries = logger.queries.filter((q) =>
+                    q.startsWith("UPDATE"),
+                )
+                expect(updateQueries).to.have.length(1)
+            }),
+        ))
 })


### PR DESCRIPTION
Closes: https://github.com/typeorm/typeorm/issues/11514

<!--
  😀 Wonderful!  Thank you for opening a pull request for TypeORM.

  Please fill in the information below to expedite the review
  and (hopefully) merge of your change.

  If unsure about something.. just do as best as you're able,
  or reach out through our community support channels!
  https://github.com/typeorm/typeorm/blob/master/docs/support.md
  https://github.com/typeorm/typeorm/blob/master/CONTRIBUTING.md
-->

### Description of change

<!--
  Please describe:
  - what the change is intended to do
  - why this change is needed
  - how you've verified it
  - any other context that will help reviewers understand the change

  In some cases it may be helpful to include the current behavior
  and the new behavior.
-->

Follow up to https://github.com/typeorm/typeorm/pull/11269 which was calling Array.map without validating if the array was null. Now only normalize if both values (entity and database) are not null. There is not point in normalizing the values if either is null, because the later comparison will just compare with null anyway. Added a test to the original test suite. The null -> value one failed before my change and succeeded after.

### Pull-Request Checklist

<!--
  Please make sure to review and check all of the following.

  If an item is not applicable, you can add "N/A" to the end.
-->

-   [ ] Code is up-to-date with the `master` branch
-   [ ] This pull request links relevant issues as `Fixes #00000`
-   [ ] There are new or updated unit tests validating the change
-   [ ] Documentation has been updated to reflect this change

<!--
  🎉 Thank you for contributing and making TypeORM even better!
-->
