### PR TITLE
chore: Remove manual trigger on publish workflow

### DIFF
--- a/.github/workflows/publish-package.yml
+++ b/.github/workflows/publish-package.yml
@@ -3,7 +3,6 @@ on:
   release:
     types:
       - published
-  workflow_dispatch:
 
 jobs:
   publish:


### PR DESCRIPTION
Removes the possibility for anyone with `write` access to the repo to manually trigger the "publish to npm" workflow. This is to prevent possible abuse/mistakes/security issues.