### PR TITLE
fix(mysql): set `stringifyObjects` implicitly

### DIFF
--- a/src/driver/mysql/MysqlDriver.ts
+++ b/src/driver/mysql/MysqlDriver.ts
@@ -1233,6 +1233,7 @@ export class MysqlDriver implements Driver {
                 trace: options.trace,
                 multipleStatements: options.multipleStatements,
                 flags: options.flags,
+                stringifyObjects: true,
             },
             {
                 host: credentials.host,
@@ -1242,11 +1243,11 @@ export class MysqlDriver implements Driver {
                 port: credentials.port,
                 ssl: options.ssl,
                 socketPath: credentials.socketPath,
+                connectionLimit: options.poolSize,
             },
             options.acquireTimeout === undefined
                 ? {}
                 : { acquireTimeout: options.acquireTimeout },
-            { connectionLimit: options.poolSize },
             options.extra || {},
         )
     }


### PR DESCRIPTION
### Description of change

Pass `stringifyObjects: true` to the `mysql2` client to avoid any unexpected behavior.

It should not really affect the users though, as they should send valid data to TypeORM in most scenarios, but it can be disabled by passing `stringifyObjects: false` in the `extra` connection options if needed.

### Pull-Request Checklist

-   [X] Code is up-to-date with the `master` branch
-   [ ] This pull request links relevant issues as `Fixes #00000`
-   [ ] There are new or updated unit tests validating the change
-   [ ] Documentation has been updated to reflect this change

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated MySQL connection configuration to improve connection pooling and object handling. No changes to user-facing features.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->