### PR TITLE
feat: allow `VirtualColumn`s to be initially non-selectable

### DIFF
--- a/src/decorator/options/VirtualColumnOptions.ts
+++ b/src/decorator/options/VirtualColumnOptions.ts
@@ -11,6 +11,12 @@ export interface VirtualColumnOptions {
     type?: ColumnType
 
     /**
+     * Indicates if column is always selected by QueryBuilder and find operations.
+     * Default value is "true".
+     */
+    select?: boolean
+
+    /**
      * Return type of HSTORE column.
      * Returns value as string or as object.
      */

--- a/src/query-builder/SelectQueryBuilder.ts
+++ b/src/query-builder/SelectQueryBuilder.ts
@@ -2965,17 +2965,15 @@ export class SelectQueryBuilder<Entity extends ObjectLiteral>
         aliasName: string,
         metadata: EntityMetadata,
     ): SelectQuery[] {
-        const mainSelect = this.expressionMap.selects.find(
-            (select) => select.selection === aliasName,
+        return this.expressionMap.selects.filter(
+            (select) =>
+                select.selection === aliasName ||
+                metadata.columns.some(
+                    (column) =>
+                        select.selection ===
+                        aliasName + "." + column.propertyPath,
+                ),
         )
-        if (mainSelect) return [mainSelect]
-
-        return this.expressionMap.selects.filter((select) => {
-            return metadata.columns.some(
-                (column) =>
-                    select.selection === aliasName + "." + column.propertyPath,
-            )
-        })
     }
 
     private computeCountExpression() {

--- a/test/functional/columns/virtual-columns/entity/Company.ts
+++ b/test/functional/columns/virtual-columns/entity/Company.ts
@@ -1,3 +1,4 @@
+import { default as sql } from "dedent"
 import {
     Entity,
     OneToMany,
@@ -8,15 +9,28 @@ import { Employee } from "./Employee"
 
 @Entity({ name: "companies" })
 export class Company {
-    @PrimaryColumn("varchar", { length: 50 })
+    @PrimaryColumn()
     name: string
+
+    @OneToMany(() => Employee, (employee) => employee.company, {
+        cascade: true,
+    })
+    employees: Employee[]
 
     @VirtualColumn({
         query: (alias) =>
-            `SELECT COUNT("name") FROM "employees" WHERE "companyName" = ${alias}."name"`,
+            sql`SELECT COUNT("name") FROM "employees" WHERE "companyName" = ${alias}."name"`,
     })
-    totalEmployeesCount: number
+    totalEmployeesCount?: number
 
-    @OneToMany(() => Employee, (employee) => employee.company)
-    employees: Employee[]
+    @VirtualColumn({
+        select: false,
+        query: (alias) => sql`
+            SELECT SUM("activities"."hours")
+            FROM "activities"
+            INNER JOIN "timesheets" ON "activities"."timesheetId" = "timesheets"."id"
+            INNER JOIN "employees" ON "timesheets"."employeeName" = "employees"."name"
+            WHERE "employees"."companyName" = ${alias}."name"`,
+    })
+    totalReportedHours?: number
 }

--- a/test/functional/columns/virtual-columns/entity/Employee.ts
+++ b/test/functional/columns/virtual-columns/entity/Employee.ts
@@ -4,12 +4,14 @@ import { TimeSheet } from "./TimeSheet"
 
 @Entity({ name: "employees" })
 export class Employee {
-    @PrimaryColumn("varchar", { length: 50 })
+    @PrimaryColumn()
     name: string
 
     @ManyToOne(() => Company, (company) => company.employees)
     company: Company
 
-    @OneToMany(() => TimeSheet, (timesheet) => timesheet.employee)
+    @OneToMany(() => TimeSheet, (timesheet) => timesheet.employee, {
+        cascade: true,
+    })
     timesheets: TimeSheet[]
 }

--- a/test/functional/columns/virtual-columns/entity/TimeSheet.ts
+++ b/test/functional/columns/virtual-columns/entity/TimeSheet.ts
@@ -1,6 +1,8 @@
+import { default as sql } from "dedent"
 import {
     Entity,
     ManyToOne,
+    OneToMany,
     PrimaryGeneratedColumn,
     VirtualColumn,
 } from "../../../../../src"
@@ -12,15 +14,17 @@ export class TimeSheet {
     @PrimaryGeneratedColumn()
     id: number
 
-    @VirtualColumn({
-        query: (alias) =>
-            `SELECT SUM("hours") FROM "activities" WHERE "timesheetId" = ${alias}."id"`,
-    })
-    totalActivityHours: number
-
-    @ManyToOne(() => Activity, (activity) => activity.timesheet)
-    activities: Activity[]
-
     @ManyToOne(() => Employee, (employee) => employee.timesheets)
     employee: Employee
+
+    @OneToMany(() => Activity, (activity) => activity.timesheet, {
+        cascade: true,
+    })
+    activities: Activity[]
+
+    @VirtualColumn({
+        query: (alias) =>
+            sql`SELECT SUM("hours") FROM "activities" WHERE "timesheetId" = ${alias}."id"`,
+    })
+    totalActivityHours?: number
 }


### PR DESCRIPTION
### Description of change

Allows the user to declare `VirtualColumn`s that by default are not selected, similar to regular columns. They can be explicitly selected using `QueryBuilder.addSelect` or `FindOptions.select`.

Fixes #11277

### Pull-Request Checklist

-   [x] Code is up-to-date with the `master` branch
-   [x] This pull request links relevant issues as `Fixes #00000`
-   [x] There are new or updated unit tests validating the change
-   [ ] Documentation has been updated to reflect this change


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for marking virtual columns as non-selectable by default, allowing finer control over which virtual columns are included in query results.
  * Introduced a new virtual column for companies to report total hours from related activities, which is not selected by default.

* **Bug Fixes**
  * Improved handling and selection logic for virtual columns in queries.

* **Tests**
  * Enhanced and expanded tests for virtual columns, including scenarios for non-selectable virtual columns and complex data aggregation.
  * Simplified test data creation for better readability and maintainability.

* **Refactor**
  * Streamlined entity definitions and updated decorators for clarity and consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->