### PR TITLE
fix: Add package.json exports for react-native

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,6 +19,9 @@
   "exports": {
     ".": {
       "types": "./index.d.ts",
+      "react-native": {
+        "default": "./browser/index.js"
+      },
       "node": {
         "types": "./index.d.ts",
         "import": "./index.mjs",


### PR DESCRIPTION
<!--
  😀 Wonderful!  Thank you for opening a pull request for TypeORM.

  Please fill in the information below to expedite the review
  and (hopefully) merge of your change.

  If unsure about something.. just do as best as you're able,
  or reach out through our community support channels!
  https://github.com/typeorm/typeorm/blob/master/docs/support.md
  https://github.com/typeorm/typeorm/blob/master/CONTRIBUTING.md
-->

### Description of change

<!--
  Please describe:
  - what the change is intended to do
  - why this change is needed
  - how you've verified it
  - any other context that will help reviewers understand the change

  In some cases it may be helpful to include the current behavior
  and the new behavior.
-->

Importing typeorm in a react native app (metro@0.82.4, react-native@0.79.5, expo@53.0.22) generates this warning:

```
WARN  Attempted to import the module "-snip-/node_modules/typeorm" which is listed in the "exports" of "-snip-/node_modules/typeorm", however no match was resolved for this request (platform = ios). Falling back to file-based resolution. Consider updating the call site or asking the package maintainer(s) to expose this API.
```

This is happening because Metro by default [now looks at package.json exports to find which file to use when a module is imported in react native.](https://metrobundler.dev/docs/configuration/#unstable_enablepackageexports-experimental)

Previously, Metro would consider the `browser` property in package.json. However, in the new "Package Exports" feature, it only looks for the `require` or `react-native` conditions inside the exports property, as well as [optional extra conditions on a per-platform basis](https://metrobundler.dev/docs/configuration/#unstable_conditionsbyplatform-experimental). If none of those conditions can be found, it will fall back to the old behaviour, but continue to issue a warning.

An easy fix is to add the `react-native` condition as part of the exports field (Implemented here). In the end, the behaviour is the same (since the fallback behaviour imports the browser code anyway) but suppresses the warning at runtime. This is non-invasive and should have no impact on other platforms.

### Pull-Request Checklist

<!--
  Please make sure to review and check all of the following.

  If an item is not applicable, you can add "N/A" to the end.
-->

-   [x] Code is up-to-date with the `master` branch
-   [ ] This pull request links relevant issues as `Fixes #00000`
-   [ ] There are new or updated unit tests validating the change
-   [ ] Documentation has been updated to reflect this change

<!--
  🎉 Thank you for contributing and making TypeORM even better!
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved React Native compatibility by adding a dedicated React Native export, enabling seamless module resolution in React Native projects.
  * Reduces the need for manual configuration or aliasing when integrating the package in mobile apps.
  * Ensures the correct browser-friendly build is selected for React Native environments for more reliable behavior across platforms.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->