### PR TITLE
feat(mysql): add pool size options for each connection

### DIFF
--- a/src/driver/mysql/MysqlConnectionCredentialsOptions.ts
+++ b/src/driver/mysql/MysqlConnectionCredentialsOptions.ts
@@ -43,4 +43,10 @@ export interface MysqlConnectionCredentialsOptions {
      * Database socket path
      */
     readonly socketPath?: string
+
+    /**
+     * Maximum number of clients the pool should contain.
+     * for each connection
+     */
+    readonly poolSize?: number
 }

--- a/src/driver/mysql/MysqlDriver.ts
+++ b/src/driver/mysql/MysqlDriver.ts
@@ -1243,7 +1243,7 @@ export class MysqlDriver implements Driver {
                 port: credentials.port,
                 ssl: options.ssl,
                 socketPath: credentials.socketPath,
-                connectionLimit: options.poolSize,
+                connectionLimit: credentials.poolSize ?? options.poolSize,
             },
             options.acquireTimeout === undefined
                 ? {}


### PR DESCRIPTION

### Description of change

I'm not very good at English, so I used a translator. Thank you for your understanding.

Currently, the `MysqlConnectionOptions` poolSize option specifies the connection limit for all replica connections.

In this case, you cannot specify a connection limit for each master or slave.

For example, if you only want to create one master connection and up to 10 slave connections, Typeorm has no solution.

I added the `MysqlConnectionCredentialsOptions` poolSize option, allowing you to specify a poolSize for each replica.

#### Verification Method
If the master's poolSize is 1 and the `slaves[0] poolSize is 2, 
then the master connection should be open at most 1, and the slaves[0] connection should be open at most 2.


### Pull-Request Checklist

-   [o ] Code is up-to-date with the `master` branch
-   [ ] This pull request links relevant issues as `Fixes #00000`
-   [ ] There are new or updated unit tests validating the change
-   [ ] Documentation has been updated to reflect this change


### Related Issues

https://github.com/typeorm/typeorm/issues/8799