### PR TITLE
fix(query-builder): handle empty result set when offset exceeds total

### DIFF
--- a/src/query-builder/SelectQueryBuilder.ts
+++ b/src/query-builder/SelectQueryBuilder.ts
@@ -1939,6 +1939,10 @@ export class SelectQueryBuilder<Entity extends ObjectLiteral>
             return undefined
         }
 
+        if (entitiesAndRaw.entities.length === 0) {
+            return undefined;
+        }
+
         const hasSkip =
             this.expressionMap.skip !== undefined &&
             this.expressionMap.skip !== null &&

--- a/src/query-builder/SelectQueryBuilder.ts
+++ b/src/query-builder/SelectQueryBuilder.ts
@@ -1939,10 +1939,6 @@ export class SelectQueryBuilder<Entity extends ObjectLiteral>
             return undefined
         }
 
-        if (entitiesAndRaw.entities.length === 0) {
-            return undefined;
-        }
-
         const hasSkip =
             this.expressionMap.skip !== undefined &&
             this.expressionMap.skip !== null &&
@@ -1951,6 +1947,12 @@ export class SelectQueryBuilder<Entity extends ObjectLiteral>
             this.expressionMap.offset !== undefined &&
             this.expressionMap.offset !== null &&
             this.expressionMap.offset > 0
+
+        if (entitiesAndRaw.entities.length === 0 && (hasSkip || hasOffset)) {
+            // when skip or offset were used and no results found, we need to execute a full count
+            // (the given offset may have exceeded the actual number of rows)
+            return undefined
+        }
 
         // offset overrides skip when no join is defined
         const previousResults: number = hasOffset

--- a/test/other-issues/lazy-count/lazy-count.ts
+++ b/test/other-issues/lazy-count/lazy-count.ts
@@ -266,6 +266,34 @@ describe("other issues > lazy count", () => {
             }),
         ))
 
+    it("run count query when joining a relation with skip is greater than total entities", () =>
+        Promise.all(
+            connections.map(async function (connection) {
+                await savePostEntities(connection, 5)
+
+                const afterQuery = connection
+                    .subscribers[0] as AfterQuerySubscriber
+                afterQuery.clear()
+
+                const [entities, count] = await connection.manager
+                    .createQueryBuilder(Post, "post")
+                    .innerJoin("post.comments", "comments")
+                    .take(10)
+                    .skip(20)
+                    .orderBy("post.id")
+                    .getManyAndCount()
+
+                expect(count).to.be.equal(5)
+                expect(entities.length).to.be.equal(0)
+
+                expect(
+                    afterQuery
+                        .getCalledQueries()
+                        .filter((query) => query.match(/(count|cnt)/i)),
+                ).not.to.be.empty
+            }),
+        ))
+
     it("run count query when offset is greater than total entities", () =>
         Promise.all(
             connections.map(async function (connection) {


### PR DESCRIPTION
Fixes #11640

### Description of change
This PR fixes a bug in lazy count optimization of geManyAndCount. (Introduced in #11524)

Currently, when using limit/offset, the count query can be skipped if the total can be deduced from the number of returned rows. However, there was an incorrect behavior when the offset value was greater than the total number of entities.

Before: lazyCount returned an incorrect total (equal to offset + 0).
Now: lazyCount correctly returns undefined in this case, forcing a proper COUNT(*) query to be executed.

### Pull-Request Checklist

-   [x] Code is up-to-date with the `master` branch
-   [x] This pull request links relevant issues as `Fixes #00000`
-   [x] There are new or updated unit tests validating the change
-   [ ] Documentation has been updated to reflect this change



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Ensures total counts are correctly reported for paginated queries when offset/skip exceeds available items, avoiding missing or undefined totals for empty result sets.
* **Tests**
  * Added tests to confirm a separate count query runs in offset/skip scenarios, validating accurate totals even when no records are returned.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->