### PR TITLE
fix(query-builder): getManyAndCount returns incorrect count value for out-of-bounds skip [ISSUE-11640]

### DIFF
--- a/src/query-builder/SelectQueryBuilder.ts
+++ b/src/query-builder/SelectQueryBuilder.ts
@@ -1955,6 +1955,12 @@ export class SelectQueryBuilder<Entity extends ObjectLiteral>
             ? this.expressionMap.skip!
             : 0
 
+        // When we have no entities and there's a skip/offset, we can't deduce the total count
+        // because the skip might be out-of-bounds
+        if (entitiesAndRaw.entities.length === 0 && previousResults > 0) {
+            return undefined
+        }
+
         return entitiesAndRaw.entities.length + previousResults
     }
 


### PR DESCRIPTION
### Description of change

Resolves #11640 

`SelectQueryBuilder::getManyAndCount()` returns the incorrect count value for out-of-bounds `skip`

### Pull-Request Checklist

-   [x] Code is up-to-date with the `master` branch
-   [x] This pull request links relevant issues as `Fixes #00000`
-   [x] There are new or updated unit tests validating the change
-   [x] (N/A) Documentation has been updated to reflect this change

<!--
  🎉 Thank you for contributing and making TypeORM even better!
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected total count when paginating beyond available items. In cases where the offset exceeds the dataset, results now return empty with an accurate total computed via a count query, avoiding misleading inferred totals.

* **Tests**
  * Added coverage to verify correct behavior when pagination offset is out of bounds, ensuring a count query is executed and totals remain accurate.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->