### PR TITLE
ci: introduce jsdoc eslint plugin (warnings only)

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -1,4 +1,5 @@
 import eslint from "@eslint/js"
+import { jsdoc } from "eslint-plugin-jsdoc"
 import tseslint from "typescript-eslint"
 import globals from "globals"
 
@@ -12,6 +13,7 @@ export default tseslint.config([
             "temp/**",
         ],
     },
+
     {
         files: ["**/*.ts"],
         languageOptions: {
@@ -26,7 +28,7 @@ export default tseslint.config([
         },
         extends: [
             eslint.configs.recommended,
-            ...tseslint.configs.recommendedTypeChecked,
+            ...tseslint.configs.recommendedTypeChecked
         ],
         rules: {
             // exceptions from typescript-eslint/recommended
@@ -80,4 +82,9 @@ export default tseslint.config([
             "no-regex-spaces": "warn",
         },
     },
+
+    jsdoc({
+        config: 'flat/recommended-typescript', // change to 'flat/recommended-typescript-error' once warnings are fixed
+        files: ["src/**/*.ts"]
+    })
 ])

--- a/package.json
+++ b/package.json
@@ -132,6 +132,7 @@
     "chai-as-promised": "^7.1.2",
     "class-transformer": "^0.5.1",
     "eslint": "^9.36.0",
+    "eslint-plugin-jsdoc": "^60.3.0",
     "globals": "^16.4.0",
     "gulp": "^4.0.2",
     "gulp-rename": "^2.1.0",


### PR DESCRIPTION
### Description of change

There is quite a lot of inconsistency and missing jsdoc entries. I think it's worth to add eslint plugin now, so they will surface in the PRs and get fixed when new changes are introduced.

Longer run we could also generate docosaurus documentation out of it, like for example [@faker/faker-js](https://github.com/faker-js/faker/blob/next/scripts/apidocs/generate.ts) is doing...

Here is some documentation on the available rules: https://github.com/gajus/eslint-plugin-jsdoc#rules

### Pull-Request Checklist

-   [x] Code is up-to-date with the `master` branch
-   [ ] This pull request links relevant issues as `Fixes #00000`
-   [ ] There are new or updated unit tests validating the change
-   [ ] Documentation has been updated to reflect this change
