### PR TITLE
chore(deps-dev): bump better-sqlite3 to 12.4.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -46,7 +46,7 @@
         "@types/sinon-chai": "^3.2.12",
         "@types/source-map-support": "^0.5.10",
         "@types/yargs": "^17.0.33",
-        "better-sqlite3": "^8.7.0",
+        "better-sqlite3": "^12.4.1",
         "chai": "^4.5.0",
         "chai-as-promised": "^7.1.2",
         "class-transformer": "^0.5.1",
@@ -3466,15 +3466,18 @@
       "license": "Apache-2.0"
     },
     "node_modules/better-sqlite3": {
-      "version": "8.7.0",
-      "resolved": "https://registry.npmjs.org/better-sqlite3/-/better-sqlite3-8.7.0.tgz",
-      "integrity": "sha512-99jZU4le+f3G6aIl6PmmV0cxUIWqKieHxsiF7G34CVFiE+/UabpYqkU0NJIkY/96mQKikHeBjtR27vFfs5JpEw==",
+      "version": "12.4.1",
+      "resolved": "https://registry.npmjs.org/better-sqlite3/-/better-sqlite3-12.4.1.tgz",
+      "integrity": "sha512-3yVdyZhklTiNrtg+4WqHpJpFDd+WHTg2oM7UcR80GqL05AOV0xEJzc6qNvFYoEtE+hRp1n9MpN6/+4yhlGkDXQ==",
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
         "bindings": "^1.5.0",
         "prebuild-install": "^7.1.1"
+      },
+      "engines": {
+        "node": "20.x || 22.x || 23.x || 24.x"
       }
     },
     "node_modules/bignumber.js": {

--- a/package.json
+++ b/package.json
@@ -127,7 +127,7 @@
     "@types/sinon-chai": "^3.2.12",
     "@types/source-map-support": "^0.5.10",
     "@types/yargs": "^17.0.33",
-    "better-sqlite3": "^8.7.0",
+    "better-sqlite3": "^12.4.1",
     "chai": "^4.5.0",
     "chai-as-promised": "^7.1.2",
     "class-transformer": "^0.5.1",

--- a/src/commands/InitCommand.ts
+++ b/src/commands/InitCommand.ts
@@ -709,7 +709,7 @@ Steps to run this project:
                 packageJson.dependencies["sqlite3"] = "^5.1.7"
                 break
             case "better-sqlite3":
-                packageJson.dependencies["better-sqlite3"] = "^8.7.0"
+                packageJson.dependencies["better-sqlite3"] = "^12.4.1"
                 break
             case "oracle":
                 packageJson.dependencies["oracledb"] = "^6.8.0"


### PR DESCRIPTION
### Description of change

There are no binaries provided for macOS Tahoe and compiling package from source requires extensive setup, which is cumbersome. I propose we move forward with `better-sqlite3` to make it easier for developers to contribute.

### Pull-Request Checklist

-   [x] Code is up-to-date with the `master` branch
-   [ ] This pull request links relevant issues as `Fixes #00000`
-   [ ] There are new or updated unit tests validating the change
-   [ ] Documentation has been updated to reflect this change


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated a development dependency (better-sqlite3) to a newer major version for improved compatibility and maintenance.
  * No impact on features, workflows, or runtime performance for end-users.

* **Documentation**
  * Confirmed there are no changes to exported/public interfaces.

* **General**
  * Maintenance-only update; no user-facing changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->