### PR TITLE
ci: harmonize MongoDB version used in CI, local development environment and `init` command and bump to v8

### DIFF
--- a/.github/workflows/tests-linux.yml
+++ b/.github/workflows/tests-linux.yml
@@ -44,7 +44,7 @@ jobs:
 
     services:
       mongodb:
-        image: mongo:5.0.31
+        image: mongo:8
         ports:
           - "27017:27017"
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -142,7 +142,7 @@ services:
 
   # mongodb
   mongodb:
-    image: "mongo:5.0.31"
+    image: "mongo:8"
     container_name: "typeorm-mongodb"
     ports:
       - "27017:27017"

--- a/src/commands/InitCommand.ts
+++ b/src/commands/InitCommand.ts
@@ -623,7 +623,7 @@ AppDataSource.initialize().then(async () => {
                 return `services:
 
   mongodb:
-    image: "mongo:8.0.5"
+    image: "mongo:8"
     container_name: "typeorm-mongodb"
     ports:
       - "27017:27017"


### PR DESCRIPTION
### Description of change

MongoDB 5.0 reached its End of Life (EOL) on October 1, 2024.

### Pull-Request Checklist

-   [x] Code is up-to-date with the `master` branch
-   [x] This pull request links relevant issues as `Fixes #00000`
-   [ ] There are new or updated unit tests validating the change
-   [ ] Documentation has been updated to reflect this change


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- Chores
  - Standardized the local development and generated Docker Compose environment to use MongoDB 8 for consistent behavior across setups.

- Tests
  - Updated CI test workflow to run against MongoDB 8, aligning tests with the standardized environment and reducing environment-related discrepancies.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->