### PR TITLE
chore(lint/jsdoc): enable jsdoc/valid-types rule and fix offenses

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -84,7 +84,12 @@ export default tseslint.config([
     },
 
     jsdoc({
-        config: 'flat/recommended-typescript', // change to 'flat/recommended-typescript-error' once warnings are fixed
+        config: "flat/recommended-typescript",
         files: ["src/**/*.ts"],
+        // Temporarily enable individual rules when they are fixed, until all current warnings are gone,
+        // and then remove manual config in favor of `config: "flat/recommended-typescript-error"`
+        rules: {
+            "jsdoc/valid-types": "error"
+        }
     }),
 ])

--- a/src/driver/mongodb/typings.ts
+++ b/src/driver/mongodb/typings.ts
@@ -1,3 +1,9 @@
+/**
+ * Content of this file below the imports is a copy of mongodb.d.ts from the version of mongodb package
+ * listed in package.json:devDependencies. We disabled eslint for this file, since it does not come from us
+ * and does not necessary have to adhere to our rules.
+ */
+/* eslint-disable */
 import type { SrvRecord } from "dns"
 import type { Socket, TcpNetConnectOpts } from "net"
 import type {


### PR DESCRIPTION
### Description of change

Enable `jsdoc/valid-types` rule and fix offenses

### Pull-Request Checklist

-   [x] Code is up-to-date with the `master` branch
-   [ ] This pull request links relevant issues as `Fixes #00000`
-   [ ] There are new or updated unit tests validating the change
-   [ ] Documentation has been updated to reflect this change


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated linting configuration to temporarily enforce stricter JSDoc type validation, improving code quality without affecting functionality.
* **Documentation**
  * Added explanatory comments and clarified linting exemptions in type definition files to improve maintainability and readability.
* **Style**
  * Minor formatting adjustments to configuration for consistency.

No user-facing changes or behavioral impacts in this release.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->