### PR TITLE
docs: remove contradictory statement in Active Record/Data Mapper guide

### DIFF
--- a/docs/docs/guides/1-active-record-data-mapper.md
+++ b/docs/docs/guides/1-active-record-data-mapper.md
@@ -154,4 +154,3 @@ Both strategies have their own cons and pros.
 One thing we should always keep in mind with software development is how we are going to maintain our applications.
 The `Data Mapper` approach helps with maintainability, which is more effective in larger apps.
 The `Active Record` approach helps keep things simple which works well in smaller apps.
-And simplicity is always a key to better maintainability.


### PR DESCRIPTION
Closes #11715

-   [x] Code is up-to-date with the `master` branch
-   [x] This pull request links relevant issues as `Fixes #00000`
-   [n/a] There are new or updated unit tests validating the change
-   [x] Documentation has been updated to reflect this change


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the “Which one should I choose?” section in the Active Record vs. Data Mapper guide, removing a standalone sentence to streamline the conclusion.
  * Improved readability by tightening phrasing and reducing redundancy in the final paragraph.
  * No functional changes to the product; this update only affects written guidance visible in the documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->