### PR TITLE
Add failing test for issue 11733

### DIFF
--- a/test/github-issues/11285/issue-11285.ts
+++ b/test/github-issues/11285/issue-11285.ts
@@ -10,6 +10,7 @@ import {
 import {
     And,
     DataSource,
+    FindOptionsWhere,
     In,
     MssqlParameter,
     Not,
@@ -168,11 +169,12 @@ describe("github issues > #11285 Missing MSSQL input type", () => {
                     )
 
                     const excludedUserIds = [user2.memberId]
+                    const where: FindOptionsWhere<User> = {
+                        memberId: And(Not(In(excludedUserIds))),
+                    }
 
                     const users = await dataSource.getRepository(User).find({
-                        where: {
-                            memberId: And(Not(In(excludedUserIds))),
-                        },
+                        where: where,
                     })
 
                     expect(users).to.have.length(1)
@@ -181,6 +183,11 @@ describe("github issues > #11285 Missing MSSQL input type", () => {
                     // Ensure that the input array was not mutated into MssqlParameter instances
                     // https://github.com/typeorm/typeorm/issues/11474
                     expect(excludedUserIds).to.eql([user2.memberId])
+
+                    // Ensure that the FindOptionsWhere instance is not mutated
+                    expect(where).to.eql({
+                        memberId: And(Not(In(excludedUserIds))),
+                    })
 
                     expect(selectSpy.calledOnce).to.be.true
 


### PR DESCRIPTION
<!--
  😀 Wonderful!  Thank you for opening a pull request for TypeORM.

  Please fill in the information below to expedite the review
  and (hopefully) merge of your change.

  If unsure about something.. just do as best as you're able,
  or reach out through our community support channels!
  https://github.com/typeorm/typeorm/blob/master/docs/support.md
  https://github.com/typeorm/typeorm/blob/master/CONTRIBUTING.md
-->

### Description of change

This updates a test to show the failure as described in #11733.

Running this test on my local produces the following output:

```
  github issues > #11285 Missing MSSQL input type
    mssql connection
      1) should convert input parameter with FindOperator with array to MssqlParameter


  0 passing (349ms)
  1 failing

  1) github issues > #11285 Missing MSSQL input type
       mssql connection
         should convert input parameter with FindOperator with array to MssqlParameter:

      AssertionError: expected { memberId: FindOperator{ …(7) } } to deeply equal { memberId: FindOperator{ …(7) } }
      + expected - actual

                 "_objectLiteralParameters": [undefined]
                 "_type": "in"
                 "_useParameter": true
                 "_value": [
      -            {
      -              "@instanceof": Symbol(MssqlParameter)
      -              "params": []
      -              "type": "varchar"
      -              "value": "test-member-id-2"
      -            }
      +            "test-member-id-2"
                 ]
               }
             }
           ]

      at C:\Users\me\dev\typeorm\test\github-issues\11285\issue-11285.ts:185:38
      at processTicksAndRejections (node:internal/process/task_queues:105:5)
      at async Promise.all (index 0)
```

### Pull-Request Checklist

<!--
  Please make sure to review and check all of the following.

  If an item is not applicable, you can add "N/A" to the end.
-->

-   [X] Code is up-to-date with the `master` branch
-   [ ] This pull request links relevant issues as `Fixes #00000`
-   [ ] There are new or updated unit tests validating the change
-   [ ] Documentation has been updated to reflect this change

<!--
  🎉 Thank you for contributing and making TypeORM even better!
-->
