### PR TITLE
ci: test if docs build and run task depending on the changes from PR

### DIFF
--- a/.github/workflows/commit-validation.yml
+++ b/.github/workflows/commit-validation.yml
@@ -30,8 +30,8 @@ jobs:
 
             src-or-tests: &src-or-tests
               - *src
-              - ./github/workflows/test/**/*
-              - ./github/workflows/**/*
+              - .github/workflows/test/**/*
+              - .github/workflows/**/*
               - .mocharc.json
               - .nycrc.json
 


### PR DESCRIPTION
### Description of change

1. Tests if `docs` builds
2. Detect changes in the PR
3. Runs certain jobs depending on the changes in the PR

### Pull-Request Checklist

-   [x] Code is up-to-date with the `master` branch
-   [ ] This pull request links relevant issues as `Fixes #00000`
-   [ ] There are new or updated unit tests validating the change
-   [ ] Documentation has been updated to reflect this change


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * CI now detects which areas changed and runs only the relevant jobs.
  * Formatting runs only for lint-related changes.
  * Docs, build, tests, and coverage jobs trigger conditionally based on detected changes.
  * Jobs are gated by a centralized change-detection step, removing unconditional push-triggered runs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->