### PR TITLE
fix: add missing `findBy` method to MongoEntityManager

### DIFF
--- a/src/entity-manager/MongoEntityManager.ts
+++ b/src/entity-manager/MongoEntityManager.ts
@@ -15,46 +15,46 @@ import { DeleteResult } from "../query-builder/result/DeleteResult"
 import { EntityMetadata } from "../metadata/EntityMetadata"
 
 import {
-    BulkWriteResult,
-    AggregationCursor,
-    Collection,
-    FindCursor,
-    Document,
     AggregateOptions,
+    AggregationCursor,
     AnyBulkWriteOperation,
     BulkWriteOptions,
-    Filter,
-    CountOptions,
-    IndexSpecification,
-    CreateIndexesOptions,
-    IndexDescription,
-    DeleteResult as DeleteResultMongoDb,
-    DeleteOptions,
-    CommandOperationOptions,
-    FindOneAndDeleteOptions,
-    FindOneAndReplaceOptions,
-    UpdateFilter,
-    FindOneAndUpdateOptions,
-    RenameOptions,
-    ReplaceOptions,
-    UpdateResult as UpdateResultMongoDb,
+    BulkWriteResult,
+    ChangeStream,
+    ChangeStreamOptions,
+    Collection,
     CollStats,
     CollStatsOptions,
-    ChangeStreamOptions,
-    ChangeStream,
-    UpdateOptions,
-    ListIndexesOptions,
-    ListIndexesCursor,
-    OptionalId,
+    CommandOperationOptions,
+    CountDocumentsOptions,
+    CountOptions,
+    CreateIndexesOptions,
+    DeleteOptions,
+    DeleteResult as DeleteResultMongoDb,
+    Document,
+    Filter,
+    FilterOperators,
+    FindCursor,
+    FindOneAndDeleteOptions,
+    FindOneAndReplaceOptions,
+    FindOneAndUpdateOptions,
+    IndexDescription,
+    IndexInformationOptions,
+    IndexSpecification,
+    InsertManyResult,
     InsertOneOptions,
     InsertOneResult,
-    InsertManyResult,
-    UnorderedBulkOperation,
-    OrderedBulkOperation,
-    IndexInformationOptions,
+    ListIndexesCursor,
+    ListIndexesOptions,
     ObjectId,
-    FilterOperators,
-    CountDocumentsOptions,
+    OptionalId,
+    OrderedBulkOperation,
+    RenameOptions,
+    ReplaceOptions,
+    UnorderedBulkOperation,
+    UpdateFilter,
+    UpdateOptions,
+    UpdateResult as UpdateResultMongoDb,
 } from "../driver/mongodb/typings"
 import { DataSource } from "../data-source/DataSource"
 import { MongoFindManyOptions } from "../find-options/mongodb/MongoFindManyOptions"
@@ -159,6 +159,16 @@ export class MongoEntityManager extends EntityManager {
         where: any,
     ): Promise<[Entity[], number]> {
         return this.executeFindAndCount(entityClassOrName, where)
+    }
+
+    /**
+     * Finds entities that match given WHERE conditions.
+     */
+    async findBy<Entity>(
+        entityClassOrName: EntityTarget<Entity>,
+        where: any,
+    ): Promise<Entity[]> {
+        return this.executeFind(entityClassOrName, where)
     }
 
     /**

--- a/test/functional/mongodb/basic/mongo-repository/mongo-repository.test.ts
+++ b/test/functional/mongodb/basic/mongo-repository/mongo-repository.test.ts
@@ -265,6 +265,39 @@ describe("mongodb > MongoRepository", () => {
                 ))
         })
     })
+
+    it("should be able to use findBy method", () =>
+        Promise.all(
+            connections.map(async (connection) => {
+                const postRepository = connection.getMongoRepository(Post)
+
+                // save few posts
+                const firstPost = new Post()
+                firstPost.title = "Post #1"
+                firstPost.text = "Everything about post #1"
+                await postRepository.save(firstPost)
+
+                const secondPost = new Post()
+                secondPost.title = "Post #1"
+                secondPost.text = "Everything about post #2"
+                await postRepository.save(secondPost)
+
+                const thirdPost = new Post()
+                thirdPost.title = "Post #2"
+                thirdPost.text = "Everything about post #3"
+                await postRepository.save(thirdPost)
+
+                const loadedPosts = await postRepository.findBy({
+                    title: "Post #1",
+                })
+
+                expect(loadedPosts).to.have.length(2)
+                expect(loadedPosts[0]).to.be.instanceOf(Post)
+                expect(loadedPosts[1]).to.be.instanceOf(Post)
+                expect(loadedPosts[0].title).to.eql("Post #1")
+                expect(loadedPosts[1].title).to.eql("Post #1")
+            }),
+        ))
 })
 
 async function seedPosts(postRepository: MongoRepository<PostWithDeleted>) {


### PR DESCRIPTION
## Description of change

Fixes #10264

The `findBy()` method was missing in `MongoEntityManager`, causing it to inherit the SQL-based implementation from `EntityManager`
which uses QueryBuilder. Since MongoDB does not support QueryBuilder, this resulted in a "Query Builder is not supported by MongoDB" error.

### The Problem

When calling `repository.findBy()` on a MongoDB repository:

```typescript
const users = await mongoRepository.findBy({ firstName: "John" });
// ❌ TypeORMError: Query Builder is not supported by MongoDB.

Call chain:
MongoRepository.findBy()
  → EntityManager.findBy()  // No override in MongoEntityManager
    → createQueryBuilder()  // SQL-based, not supported in MongoDB
      → ❌ Error thrown
```

### The Solution

Override findBy() in MongoEntityManager to use MongoDB's native cursor API instead of QueryBuilder:

```typescript
  async findBy<Entity>(
      entityClassOrName: EntityTarget<Entity>,
      where: any,
  ): Promise<Entity[]> {
      return this.executeFind(entityClassOrName, where)
  }
```
This follows the same pattern as existing methods like findAndCountBy() and findOneBy(), which already work correctly.

### Changes:
  - ✅ Added findBy() method to MongoEntityManager (uses MongoDB cursor API)
  - ✅ Added comprehensive test case in mongo-repository.test.ts

### Testing

All MongoDB tests pass successfully:

```bash
npm run test:fast -- --grep "mongodb"
# 47 passing
```

Specific test for this fix:
```bash
npm run test:fast -- --grep "should be able to use findBy method"
# ✔ should be able to use findBy method
```

### Backward Compatibility

✅ No breaking changes
- Existing code continues to work
- Only adds missing functionality that was throwing errors
- Follows existing patterns in MongoEntityManager

### Related Methods

Note: These methods already work correctly and did not need changes:
- findOneBy() - Already implemented in MongoEntityManager
- findAndCountBy() - Already implemented in MongoEntityManager
- findOneByOrFail() - Works via inheritance (calls findOneBy())

## Pull-Request Checklist
-   [x] Code is up-to-date with the `master` branch
-   [x] This pull request links relevant issues as `Fixes #00000`
-   [x] There are new or updated tests validating the change (`tests/**.test.ts`)
-   [ ] Documentation has been updated to reflect this change (`docs/docs/**.md`)

### Additional Notes

The fix is minimal and follows the established patterns in the codebase. Please let me know if any adjustments are needed!
