### PR TITLE
docs(v0.3): add version dropdown (stable/dev)

### DIFF
--- a/docs/docusaurus.config.ts
+++ b/docs/docusaurus.config.ts
@@ -99,6 +99,21 @@ const config: Config = {
                     label: "Docs",
                 },
                 {
+                    type: "dropdown",
+                    label: "Version",
+                    position: "right",
+                    items: [
+                        {
+                            label: "Stable (v0.3)",
+                            href: "https://typeorm.io",
+                        },
+                        {
+                            label: "Dev (master)",
+                            href: "https://dev.typeorm.io",
+                        },
+                    ],
+                },
+                {
                     href: "https://github.com/typeorm/typeorm",
                     label: "GitHub",
                     position: "right",


### PR DESCRIPTION
Adds a navbar "Version" dropdown to the v0.3 docs site so users can switch between:
- Stable (v0.3): https://typeorm.io
- Dev (master): https://dev.typeorm.io

<img width="462" height="380" alt="image" src="https://github.com/user-attachments/assets/d301c2fc-9221-46b2-97d6-ca045f0892ca" />
