### PR TITLE
fix(sap): `QueryBuilder` parameter of type JS `Date` not escaped correctly

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -116,14 +116,14 @@ services:
   # sap hana
   # works only on linux, minimum 10GB RAM for docker required
   hanaexpress:
-    image: "saplabs/hanaexpress:2.00.076.00.20240701.1"
+    image: "saplabs/hanaexpress:2.00.088.00.20251110.1"
     container_name: "typeorm-hanaexpress"
     hostname: hxe
     command:
       [
+        "--agree-to-sap-license",
         "--passwords-url",
         "file:////hana/hxe-config.json",
-        "--agree-to-sap-license",
       ]
     ulimits:
       nofile: 1048576

--- a/src/driver/sap/SapDriver.ts
+++ b/src/driver/sap/SapDriver.ts
@@ -406,15 +406,7 @@ export class SapDriver implements Driver {
         nativeParameters: ObjectLiteral,
     ): [string, any[]] {
         const escapedParameters: any[] = Object.keys(nativeParameters).map(
-            (key) => {
-                if (nativeParameters[key] instanceof Date)
-                    return DateUtils.mixedDateToDatetimeString(
-                        nativeParameters[key],
-                        true,
-                    )
-
-                return nativeParameters[key]
-            },
+            (key) => nativeParameters[key],
         )
 
         if (!parameters || !Object.keys(parameters).length)
@@ -443,10 +435,6 @@ export class SapDriver implements Driver {
 
                 if (typeof value === "function") {
                     return value()
-                }
-
-                if (value instanceof Date) {
-                    return DateUtils.mixedDateToDatetimeString(value, true)
                 }
 
                 escapedParameters.push(value)

--- a/test/functional/query-builder/parameters/date-parameters.test.ts
+++ b/test/functional/query-builder/parameters/date-parameters.test.ts
@@ -1,0 +1,58 @@
+import { expect } from "chai"
+import "reflect-metadata"
+import { DataSource } from "../../../../src/data-source/DataSource"
+import {
+    closeTestingConnections,
+    createTestingConnections,
+    reloadTestingDatabases,
+} from "../../../utils/test-utils"
+import { Product } from "./entity/Product"
+
+describe("query builder > parameters > date parameters", () => {
+    let dataSources: DataSource[]
+    before(
+        async () =>
+            (dataSources = await createTestingConnections({
+                entities: [Product],
+                schemaCreate: true,
+                dropSchema: true,
+            })),
+    )
+
+    beforeEach(() => reloadTestingDatabases(dataSources))
+    after(() => closeTestingConnections(dataSources))
+
+    it("should be escaped correctly", () =>
+        Promise.all(
+            dataSources.map(async (dataSource) => {
+                const productRepository = dataSource.getRepository(Product)
+                await productRepository.save([
+                    {
+                        name: "Product A",
+                        createdAt: new Date("2025-12-22T00:00:00Z"),
+                    },
+                    {
+                        name: "Product B",
+                        createdAt: new Date("2025-12-23T00:00:00Z"),
+                    },
+                    {
+                        name: "Product C",
+                        createdAt: new Date("2025-12-24T00:00:00Z"),
+                    },
+                ])
+
+                const newProducts = await productRepository
+                    .createQueryBuilder("product")
+                    .select("product.name")
+                    .where("product.createdAt >= :afterDate", {
+                        afterDate: new Date("2025-12-22T12:00:00Z"),
+                    })
+                    .getMany()
+
+                expect(newProducts).to.deep.equal([
+                    { name: "Product B" },
+                    { name: "Product C" },
+                ])
+            }),
+        ))
+})

--- a/test/functional/query-builder/parameters/entity/Product.ts
+++ b/test/functional/query-builder/parameters/entity/Product.ts
@@ -1,0 +1,13 @@
+import { Column, Entity, PrimaryGeneratedColumn } from "../../../../../src"
+
+@Entity()
+export class Product {
+    @PrimaryGeneratedColumn()
+    id: number
+
+    @Column()
+    name: string
+
+    @Column()
+    createdAt: Date
+}


### PR DESCRIPTION
### Description of change

Before, JS `Date` parameters were embedded in SQL. Now, they will be passed to the client as parameters.

Fixes #11414. 

### Pull-Request Checklist

-   [x] Code is up-to-date with the `v0.3` branch
-   [x] This pull request links relevant issues as `Fixes #00000`
-   [x] There are new or updated tests validating the change (`tests/**.test.ts`)
-   [ ] Documentation has been updated to reflect this change (`docs/docs/**.md`)

<!--
  🎉 Thank you for contributing and making TypeORM even better!
-->
