### PR TITLE
feat(sap): add pool timeout

### DIFF
--- a/docs/docs/drivers/sap.md
+++ b/docs/docs/drivers/sap.md
@@ -25,6 +25,7 @@ See [Data Source Options](../data-source/2-data-source-options.md) for the commo
 -   `pool` — Connection pool configuration object:
     -   `maxConnectedOrPooled` (number) — Max active or idle connections in the pool (default: 10).
     -   `maxPooledIdleTime` (seconds) — Time before an idle connection is closed (default: 30).
+    -   `maxWaitTimeoutIfPoolExhausted` (milliseconds) - Time to wait for a connection to become available (default: 0, no wait). Requires `@sap/hana-client` version `2.27` or later.
     -   `pingCheck` (boolean) — Whether to validate connections before use (default: false).
     -   `poolCapacity` (number) — Maximum number of connections to be kept available (default: no limit).
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -33,7 +33,7 @@
       "devDependencies": {
         "@eslint/js": "^9.39.1",
         "@google-cloud/spanner": "^8.3.1",
-        "@sap/hana-client": "^2.26.26",
+        "@sap/hana-client": "^2.27.19",
         "@tsconfig/node16": "^16.1.8",
         "@types/chai": "^4.3.20",
         "@types/chai-as-promised": "^7.1.8",
@@ -2208,9 +2208,9 @@
       }
     },
     "node_modules/@sap/hana-client": {
-      "version": "2.26.26",
-      "resolved": "https://registry.npmjs.org/@sap/hana-client/-/hana-client-2.26.26.tgz",
-      "integrity": "sha512-r5OSJKDLcuRCA1Ka5O4CMtTmKp9BD9EsrrqSLZ6mwCIxQd7WL+Km7aIKveyJZ0Bt511dZY279DGgvs3fXB20Tw==",
+      "version": "2.27.19",
+      "resolved": "https://registry.npmjs.org/@sap/hana-client/-/hana-client-2.27.19.tgz",
+      "integrity": "sha512-Bqx9isM8uW/ud/jLqUh7BCHnoTor6hwuC4fOtOxPub00oHQ6LNExLnOrofFskom+4V0po1303dJ8geXlStdFuw==",
       "dev": true,
       "hasInstallScript": true,
       "hasShrinkwrap": true,

--- a/package.json
+++ b/package.json
@@ -114,7 +114,7 @@
   "devDependencies": {
     "@eslint/js": "^9.39.1",
     "@google-cloud/spanner": "^8.3.1",
-    "@sap/hana-client": "^2.26.26",
+    "@sap/hana-client": "^2.27.19",
     "@tsconfig/node16": "^16.1.8",
     "@types/chai": "^4.3.20",
     "@types/chai-as-promised": "^7.1.8",

--- a/src/driver/sap/SapConnectionOptions.ts
+++ b/src/driver/sap/SapConnectionOptions.ts
@@ -46,6 +46,14 @@ export interface SapConnectionOptions
         readonly maxPooledIdleTime?: number
 
         /**
+         * Defines the maximum time, in milliseconds, to wait for a connection
+         * to become available once the specified number of `maxConnectedOrPooled`
+         * open connections have been reached (default: 0, no wait).
+         * @remarks Requires `@sap/hana-client` version `2.27` or later.
+         */
+        readonly maxWaitTimeoutIfPoolExhausted?: number
+
+        /**
          * Determines whether or not the pooled connection should be tested for
          * viability before being reused (default: false).
          */
@@ -77,7 +85,7 @@ export interface SapConnectionOptions
 
         /**
          * Max milliseconds a request will wait for a resource before timing out.
-         * @deprecated Obsolete, no alternative exists.
+         * @deprecated Use {@link maxWaitTimeoutIfPoolExhausted} instead.
          */
         readonly requestTimeout?: number
 

--- a/src/driver/sap/SapDriver.ts
+++ b/src/driver/sap/SapDriver.ts
@@ -291,6 +291,10 @@ export class SapDriver implements Driver {
                 (this.options.pool?.idleTimeout
                     ? this.options.pool.idleTimeout / 1000
                     : 30),
+            maxWaitTimeoutIfPoolExhausted:
+                this.options.pool?.maxWaitTimeoutIfPoolExhausted ??
+                this.options.pool?.requestTimeout ??
+                0,
         }
         if (this.options.pool?.pingCheck) {
             poolOptions.pingCheck = this.options.pool.pingCheck


### PR DESCRIPTION
### Description of change

Fixes #11619.

Adds support for the `maxWaitTimeoutIfPoolExhausted` pool option (available in `@sap/hana-client` version `2.27` or later) and maps the deprecated `requestTimeout` from the old `hdb-pool` library to this option.  

### Pull-Request Checklist

<!--
  Please make sure to review and check all of the following.

  If an item is not applicable, you can add "N/A" to the end.
-->

-   [x] Code is up-to-date with the `v0.3` branch
-   [x] This pull request links relevant issues as `Fixes #00000`
-   [ ] There are new or updated tests validating the change (`tests/**.test.ts`)
-   [x] Documentation has been updated to reflect this change (`docs/docs/**.md`)

<!--
  🎉 Thank you for contributing and making TypeORM even better!
-->
