### PR TITLE
docs: link to queryrunner api docs from top level queryrunner page

### DIFF
--- a/docs/docs/query-runner.md
+++ b/docs/docs/query-runner.md
@@ -5,6 +5,8 @@
 Each new `QueryRunner` instance takes a single connection from the connection pool, if the RDBMS supports connection pooling.
 For databases that do not support connection pools, it uses the same connection across the entire data source.
 
+The full QueryRunner API is documented in the [migrations section](./migrations/09-api.md).
+
 ## Creating a new `QueryRunner` instance
 
 Use the `createQueryRunner` method to create a new `QueryRunner`:


### PR DESCRIPTION
<!--
  😀 Wonderful!  Thank you for opening a pull request for TypeORM.

  Please fill in the information below to expedite the review
  and (hopefully) merge of your change.

  If unsure about something.. just do as best as you're able,
  or reach out through our community support channels!
  https://github.com/typeorm/typeorm/blob/master/docs/support.md
  https://github.com/typeorm/typeorm/blob/master/CONTRIBUTING.md
-->

### Description of change

<!--
  Please describe:
  - what the change is intended to do
  - why this change is needed
  - how you've verified it
  - any other context that will help reviewers understand the change

  In some cases it may be helpful to include the current behavior
  and the new behavior.
-->

I found it unclear that the QueryRunner reference docs weren't referenced from the top level reference docs page, so I am proposing to add a link. Ideally these pages would be consolidated somehow, but I'm not familiar enough with the domain to do that.

### Pull-Request Checklist

<!--
  Please make sure to review and check all of the following.

  If an item is not applicable, you can add "N/A" to the end.
-->

-   [x] Code is up-to-date with the `master` branch
-   [ ] This pull request links relevant issues as `Fixes #00000`
-   [ ] There are new or updated tests validating the change (`tests/**.test.ts`)
-   [x] Documentation has been updated to reflect this change (`docs/docs/**.md`)

<!--
  🎉 Thank you for contributing and making TypeORM even better!
-->
