### PR TITLE
docs: add link to QueryRunner API documentation

### DIFF
--- a/docs/docs/query-runner.md
+++ b/docs/docs/query-runner.md
@@ -5,6 +5,8 @@
 Each new `QueryRunner` instance takes a single connection from the connection pool, if the RDBMS supports connection pooling.
 For databases that do not support connection pools, it uses the same connection across the entire data source.
 
+The full QueryRunner API is documented in the [migrations section](./migrations/09-api.md).
+
 ## Creating a new `QueryRunner` instance
 
 Use the `createQueryRunner` method to create a new `QueryRunner`:


### PR DESCRIPTION
## Description

This PR adds a reference link to the full QueryRunner API documentation in the migrations section from the main QueryRunner page. This improves documentation discoverability by making it easier for users to find the complete API reference.

## Changes

- Added a link in `docs/docs/query-runner.md` pointing to the QueryRunner API documentation in the migrations section

## Type of Change

- [x] Documentation update

---

Cherry-picked from commit 23eecadeddaf9308347f833da953c0ba7fb9082d
