### PR TITLE
chore(tests): send only mutation score to the Stryker dashboard

### DIFF
--- a/stryker.config.json
+++ b/stryker.config.json
@@ -4,6 +4,9 @@
   "buildCommand": "pnpm run compile",
   "concurrency": 6,
   "coverageAnalysis": "perTest",
+  "dashboard": {
+    "reportType": "mutationScore"
+  },
   "dryRunTimeoutMinutes": 10,
   "inPlace": true,
   "plugins": ["@stryker-mutator/mocha-runner"],


### PR DESCRIPTION
<!--
  😀 Wonderful!  Thank you for opening a pull request for TypeORM.

  Please fill in the information below to expedite the review
  and (hopefully) merge of your change.

  If unsure about something.. just do as best as you're able,
  or reach out through our community support channels!
  https://github.com/typeorm/typeorm/blob/master/docs/support.md
  https://github.com/typeorm/typeorm/blob/master/CONTRIBUTING.md
-->

### Description of change

So, the mutation report turned out to be too big for the Dashboard to properly handle even once (~86 MB). I'm suggesting to currently send only the mutation score so the badge will show the score. We will still be able to download the mutation report via the GHA's artifacts from the "mutation-testing" workflow.

Related issue: https://github.com/stryker-mutator/stryker-dashboard/issues/1183

<!--
  Please describe:
  - what the change is intended to do
  - why this change is needed
  - how you've verified it
  - any other context that will help reviewers understand the change

  In some cases it may be helpful to include the current behavior
  and the new behavior.
-->

### Pull-Request Checklist

<!--
  Please make sure to review and check all of the following.

  If an item is not applicable, you can add "N/A" to the end.
-->

-   [x] Code is up-to-date with the `master` branch
-   [ ] This pull request links relevant issues as `Fixes #00000`
-   [ ] There are new or updated tests validating the change (`tests/**.test.ts`)
-   [ ] Documentation has been updated to reflect this change (`docs/docs/**.md`)

<!--
  🎉 Thank you for contributing and making TypeORM even better!
-->
