### PR TITLE
feat: add sqlite strict table support

### DIFF
--- a/docs/docs/drivers/sqlite.md
+++ b/docs/docs/drivers/sqlite.md
@@ -113,6 +113,16 @@ When strict mode is enabled, TypeORM will:
     - BLOB → `blob`
     - Other types → `any`
 
+`any` type behavior in strict tables:
+
+- `any` can be used only when entity is marked with `strict: true`.
+- Primitive values are stored using native SQLite storage classes.
+    - `number`, `string`, `bigint`, and `Uint8Array` values are persisted as-is.
+    - `boolean` values are persisted as `0` or `1`.
+- Complex values (`object` and `array`) are persisted as JSON text.
+- On hydration, JSON text representing objects/arrays (and JSON-quoted strings) is parsed back to JavaScript values.
+- Numeric values like `0` and `1` remain numbers for `any` columns.
+
 Benefits of strict tables:
 
 - **Type safety**: Ensures data stored matches the declared column type

--- a/docs/docs/drivers/sqlite.md
+++ b/docs/docs/drivers/sqlite.md
@@ -71,7 +71,7 @@ See [Data Source Options](../data-source/2-data-source-options.md) for the commo
 
 ## Column Types
 
-`int`, `int2`, `int8`, `integer`, `tinyint`, `smallint`, `mediumint`, `bigint`, `decimal`, `numeric`, `float`, `double`, `real`, `double precision`, `datetime`, `varying character`, `character`, `native character`, `varchar`, `nchar`, `nvarchar2`, `unsigned big int`, `boolean`, `blob`, `text`, `clob`, `date`, `json`, `jsonb`
+`int`, `int2`, `int8`, `integer`, `tinyint`, `smallint`, `mediumint`, `bigint`, `decimal`, `numeric`, `float`, `double`, `real`, `double precision`, `datetime`, `varying character`, `character`, `native character`, `varchar`, `nchar`, `nvarchar2`, `unsigned big int`, `boolean`, `blob`, `text`, `clob`, `date`, `json`, `jsonb`, `any`
 
 TypeORM supports both `json` and `jsonb` types in SQLite:
 
@@ -79,3 +79,44 @@ TypeORM supports both `json` and `jsonb` types in SQLite:
 - `jsonb` is stored as SQLite's binary JSON format. TypeORM automatically wraps values with the `jsonb()` function during persistence and with the `json()` function during retrieval for transparent support and better performance.
 
 JSONB support requires SQLite 3.45.0 or newer. When using the `jsonb` column type, TypeORM will use the `jsonb` type in your database schema, which SQLite handles as a binary `BLOB` internally.
+
+## Strict Tables
+
+SQLite supports strict tables (requires SQLite 3.37.0+), which enforce type safety and enhance data integrity. To enable strict mode for an entity, use the `strict` option in the `@Entity` decorator:
+
+```typescript
+import { Entity, PrimaryGeneratedColumn, Column } from "typeorm"
+
+@Entity({ strict: true })
+export class User {
+    @PrimaryGeneratedColumn()
+    id: number
+
+    @Column()
+    name: string
+
+    @Column()
+    email: string
+}
+```
+
+When strict mode is enabled, TypeORM will:
+
+- Create the table with the `STRICT` keyword
+- Automatically convert column types to SQLite strict-compatible types:
+    - Text types (`varchar`, `char`, `nchar`, etc.) → `text`
+    - Integer types (`int`, `tinyint`, `smallint`, `bigint`, etc.) → `integer`
+    - Numeric/decimal types → `real`
+    - Date/time types → `text` (SQLite stores as text)
+    - Boolean → `integer` (SQLite stores as 0/1)
+    - JSON → `text`
+    - BLOB → `blob`
+    - Other types → `any`
+
+Benefits of strict tables:
+
+- **Type safety**: Ensures data stored matches the declared column type
+- **Data integrity**: Prevents type coercion issues
+- **Standards compliance**: Aligns SQLite behavior more closely with other SQL databases
+
+For more information, see the [SQLite strict tables documentation](https://www.sqlite.org/stricttables.html).

--- a/docs/docs/entity/1-entities.md
+++ b/docs/docs/entity/1-entities.md
@@ -80,6 +80,26 @@ When using an entity constructor its arguments **must be optional**. Since ORM c
 
 Learn more about parameters `@Entity` in [Decorators reference](../help/3-decorator-reference.md).
 
+### SQLite Strict Mode
+
+For SQLite databases, you can enable strict mode to enforce type safety on your tables. When enabled, strict mode ensures that columns are always treated with their defined types, preventing type coercion issues. To enable this, set the `strict` option to `true` in the `@Entity` decorator:
+
+```typescript
+@Entity({ strict: true })
+export class User {
+    @PrimaryGeneratedColumn()
+    id: number
+
+    @Column()
+    firstName: string
+
+    @Column()
+    lastName: string
+}
+```
+
+Strict mode requires SQLite 3.37.0 or later. For more information, see [SQLite Strict Tables](../drivers/sqlite.md#strict-tables).
+
 ## Entity columns
 
 Since database tables consist of columns your entities must consist of columns too.

--- a/docs/docs/help/3-decorator-reference.md
+++ b/docs/docs/help/3-decorator-reference.md
@@ -23,6 +23,7 @@ You can also specify some additional entity options:
 - `engine` - database engine to be set during table creation (works only in some databases).
 - `synchronize` - entities marked with `false` are skipped from schema updates.
 - `orderBy` - specifies default ordering for entities when using `find` operations and `QueryBuilder`.
+- `strict` - enables strict mode for SQLite. When set to `true`, columns are enforced to have their defined types. Supported only for SQLite (requires SQLite 3.37.0+). For more information, see [SQLite strict tables](https://www.sqlite.org/stricttables.html).
 
 Example:
 
@@ -41,6 +42,18 @@ Example:
 })
 export class User {}
 ```
+
+For SQLite, you can also enable strict mode:
+
+```typescript
+@Entity({
+    name: "users",
+    strict: true,
+})
+export class User {}
+```
+
+This will create a table with the `STRICT` keyword, ensuring type safety and data integrity in SQLite.
 
 Learn more about [Entities](../entity/1-entities.md).
 

--- a/src/decorator/entity/Entity.ts
+++ b/src/decorator/entity/Entity.ts
@@ -49,6 +49,7 @@ export function Entity(
             schema: options.schema ?? undefined,
             synchronize: options.synchronize,
             withoutRowid: options.withoutRowid,
+            strict: options.strict,
             comment: options.comment ?? undefined,
         } as TableMetadataArgs)
     }

--- a/src/decorator/options/EntityOptions.ts
+++ b/src/decorator/options/EntityOptions.ts
@@ -49,6 +49,15 @@ export interface EntityOptions {
     withoutRowid?: boolean
 
     /**
+     * Enables strict mode. This will make sure that columns are always treated with their defined types.
+     * For example, if a column is defined as an integer, it will always be treated as an integer.
+     * This can help prevent issues with type coercion and ensure data integrity.
+     *
+     * @see https://www.sqlite.org/stricttables.html
+     */
+    strict?: boolean
+
+    /**
      * Table comment. Not supported by all database types.
      */
     comment?: string

--- a/src/driver/sqlite-abstract/AbstractSqliteDriver.ts
+++ b/src/driver/sqlite-abstract/AbstractSqliteDriver.ts
@@ -141,6 +141,7 @@ export abstract class AbstractSqliteDriver implements Driver {
         "nchar",
         "native character",
         "nvarchar",
+        "nvarchar2",
         "text",
         "clob",
         "text",
@@ -158,6 +159,7 @@ export abstract class AbstractSqliteDriver implements Driver {
         "datetime",
         "json",
         "jsonb",
+        "any",
     ]
 
     /**
@@ -175,6 +177,7 @@ export abstract class AbstractSqliteDriver implements Driver {
         "nchar",
         "native character",
         "nvarchar",
+        "nvarchar2",
         "text",
         "blob",
         "clob",
@@ -386,6 +389,8 @@ export abstract class AbstractSqliteDriver implements Driver {
             return DateUtils.simpleArrayToString(value)
         } else if (columnMetadata.type === "simple-enum") {
             return DateUtils.simpleEnumToString(value)
+        } else if (columnMetadata.type === "any") {
+            return DateUtils.simpleJsonToString(value)
         }
 
         return value
@@ -453,7 +458,8 @@ export abstract class AbstractSqliteDriver implements Driver {
         } else if (
             columnMetadata.type === "json" ||
             columnMetadata.type === "jsonb" ||
-            columnMetadata.type === "simple-json"
+            columnMetadata.type === "simple-json" ||
+            columnMetadata.type === "any"
         ) {
             value = DateUtils.stringToSimpleJson(value)
         } else if (columnMetadata.type === "simple-array") {
@@ -1021,6 +1027,55 @@ export abstract class AbstractSqliteDriver implements Driver {
             return jsonb ? `jsonb(${value})` : `json(${value})`
         }
         return value
+    }
+
+    /**
+     * Converts column type to strict-compatible type for SQLite strict mode.
+     * SQLite strict mode only allows: INT, INTEGER, REAL, TEXT, BLOB, ANY
+     *
+     * @param columnType
+     */
+    convertToStrictType(columnType: string): string {
+        const type = columnType.toLowerCase().trim()
+
+        switch (type) {
+            case "int":
+            case "integer":
+            case "tinyint":
+            case "smallint":
+            case "mediumint":
+            case "bigint":
+            case "unsigned big int":
+            case "int2":
+            case "int8":
+            case "boolean":
+                return "integer"
+            case "text":
+            case "character":
+            case "varchar":
+            case "varying character":
+            case "nchar":
+            case "native character":
+            case "nvarchar":
+            case "nvarchar2":
+            case "clob":
+            case "datetime":
+            case "date":
+            case "time":
+            case "json":
+                return "text"
+            case "real":
+            case "double":
+            case "double precision":
+            case "float":
+            case "numeric":
+            case "decimal":
+                return "real"
+            case "blob":
+                return "blob"
+            default:
+                return "any"
+        }
     }
 
     // -------------------------------------------------------------------------

--- a/src/driver/sqlite-abstract/AbstractSqliteDriver.ts
+++ b/src/driver/sqlite-abstract/AbstractSqliteDriver.ts
@@ -14,6 +14,7 @@ import { ApplyValueTransformers } from "../../util/ApplyValueTransformers"
 import { DateUtils } from "../../util/DateUtils"
 import { InstanceChecker } from "../../util/InstanceChecker"
 import { OrmUtils } from "../../util/OrmUtils"
+import { isUint8Array } from "../../util/Uint8ArrayUtils"
 import type { Driver } from "../Driver"
 import { DriverUtils } from "../DriverUtils"
 import type { ColumnType } from "../types/ColumnTypes"
@@ -390,6 +391,19 @@ export abstract class AbstractSqliteDriver implements Driver {
         } else if (columnMetadata.type === "simple-enum") {
             return DateUtils.simpleEnumToString(value)
         } else if (columnMetadata.type === "any") {
+            if (typeof value === "boolean") {
+                return value === true ? 1 : 0
+            }
+
+            if (
+                typeof value === "number" ||
+                typeof value === "string" ||
+                typeof value === "bigint" ||
+                isUint8Array(value)
+            ) {
+                return value
+            }
+
             return DateUtils.simpleJsonToString(value)
         }
 
@@ -458,10 +472,22 @@ export abstract class AbstractSqliteDriver implements Driver {
         } else if (
             columnMetadata.type === "json" ||
             columnMetadata.type === "jsonb" ||
-            columnMetadata.type === "simple-json" ||
-            columnMetadata.type === "any"
+            columnMetadata.type === "simple-json"
         ) {
             value = DateUtils.stringToSimpleJson(value)
+        } else if (columnMetadata.type === "any") {
+            if (
+                typeof value === "string" &&
+                (value.startsWith("{") ||
+                    value.startsWith("[") ||
+                    value.startsWith('"'))
+            ) {
+                try {
+                    value = DateUtils.stringToSimpleJson(value)
+                } catch {
+                    // Keep raw string if not valid JSON.
+                }
+            }
         } else if (columnMetadata.type === "simple-array") {
             value = DateUtils.stringToSimpleArray(value)
         } else if (columnMetadata.type === "simple-enum") {

--- a/src/driver/sqlite-abstract/AbstractSqliteQueryRunner.ts
+++ b/src/driver/sqlite-abstract/AbstractSqliteQueryRunner.ts
@@ -1553,7 +1553,12 @@ export abstract class AbstractSqliteQueryRunner
                 const sql = dbTable["sql"]
 
                 const withoutRowid = sql.includes("WITHOUT ROWID")
-                const table = new Table({ name: tablePath, withoutRowid })
+                const strict = sql.includes("STRICT")
+                const table = new Table({
+                    name: tablePath,
+                    withoutRowid,
+                    strict,
+                })
 
                 // load columns and indices
                 const [dbColumns, dbIndices, dbForeignKeys]: ObjectLiteral[][] =
@@ -1916,7 +1921,9 @@ export abstract class AbstractSqliteQueryRunner
             )
 
         const columnDefinitions = table.columns
-            .map((column) => this.buildCreateColumnSql(column, skipPrimary))
+            .map((column) =>
+                this.buildCreateColumnSql(column, skipPrimary, table.strict),
+            )
             .join(", ")
         const [database] = this.splitTablePath(table.name)
         let sql = `CREATE TABLE ${this.escapePath(
@@ -2037,9 +2044,21 @@ export abstract class AbstractSqliteQueryRunner
 
         sql += `)`
 
+        const otherTableOptions = []
+
         if (table.withoutRowid) {
-            sql += " WITHOUT ROWID"
+            otherTableOptions.push("WITHOUT ROWID")
         }
+        if (table.strict) {
+            otherTableOptions.push("STRICT")
+        }
+
+        const optionsSql =
+            otherTableOptions.length > 0
+                ? ` ${otherTableOptions.join(", ")}`
+                : ""
+
+        sql += optionsSql
 
         return new Query(sql)
     }
@@ -2169,17 +2188,29 @@ export abstract class AbstractSqliteQueryRunner
      *
      * @param column
      * @param skipPrimary
+     * @param isStrictMode
      */
     protected buildCreateColumnSql(
         column: TableColumn,
         skipPrimary?: boolean,
+        isStrictMode?: boolean,
     ): string {
         let c = '"' + column.name + '"'
+        let columnType: string
         if (InstanceChecker.isColumnMetadata(column)) {
-            c += " " + this.driver.normalizeType(column)
+            columnType = this.driver.normalizeType(column)
         } else {
-            c += " " + this.dataSource.driver.createFullType(column)
+            columnType = this.dataSource.driver.createFullType(column)
         }
+
+        if (isStrictMode) {
+            // Convert types to strict-compatible types for SQLite strict mode
+            // Need to extract base type in case of types with length/precision/scale
+            const baseType = columnType.split("(")[0].trim()
+            columnType = this.driver.convertToStrictType(baseType)
+        }
+        c += " " + columnType
+
         if (column.enum && !column.isArray)
             c +=
                 ' CHECK( "' +

--- a/src/driver/types/ColumnTypes.ts
+++ b/src/driver/types/ColumnTypes.ts
@@ -214,6 +214,7 @@ export type SimpleColumnType =
     | "array" // cockroachdb, sap, spanner
     | "cube" // postgres
     | "ltree" // postgres
+    | "any" // sqlite
 
 /**
  * Any column type column can be.

--- a/src/metadata-args/TableMetadataArgs.ts
+++ b/src/metadata-args/TableMetadataArgs.ts
@@ -73,6 +73,16 @@ export interface TableMetadataArgs {
     withoutRowid?: boolean
 
     /**
+     * Enables strict mode. This will make sure that columns are always treated with their defined types.
+     * For example, if a column is defined as an integer, it will always be treated as an integer.
+     * This can help prevent issues with type coercion and ensure data integrity.
+     * Supports only Sqlite.
+     *
+     * @see https://www.sqlite.org/stricttables.html
+     */
+    strict?: boolean
+
+    /**
      * Table comment. Not supported by all database types.
      */
     comment?: string

--- a/src/metadata-builder/EntityMetadataValidator.ts
+++ b/src/metadata-builder/EntityMetadataValidator.ts
@@ -61,6 +61,14 @@ export class EntityMetadataValidator {
         allEntityMetadatas: EntityMetadata[],
         driver: Driver,
     ) {
+        // check if strict mode is supported by the driver
+        if (entityMetadata.strict && !DriverUtils.isSQLiteFamily(driver)) {
+            throw new TypeORMError(
+                `Entity ${entityMetadata.name} is marked as 'strict', ` +
+                    `but 'strict' mode is only supported for SQLite-based drivers.`,
+            )
+        }
+
         // check if table metadata has an id
         if (!entityMetadata.primaryColumns.length && !entityMetadata.isJunction)
             throw new MissingPrimaryColumnError(entityMetadata)

--- a/src/metadata-builder/EntityMetadataValidator.ts
+++ b/src/metadata-builder/EntityMetadataValidator.ts
@@ -69,6 +69,20 @@ export class EntityMetadataValidator {
             )
         }
 
+        // check if sqlite `any` type is used only with strict mode
+        if (DriverUtils.isSQLiteFamily(driver) && !entityMetadata.strict) {
+            const anyColumn = entityMetadata.columns.find(
+                (column) => !column.isVirtualProperty && column.type === "any",
+            )
+
+            if (anyColumn) {
+                throw new TypeORMError(
+                    `Column "${anyColumn.propertyName}" of Entity "${entityMetadata.name}" uses SQLite "any" type, ` +
+                        `but the entity is not marked as strict. Set "strict: true" in @Entity options to use type "any".`,
+                )
+            }
+        }
+
         // check if table metadata has an id
         if (!entityMetadata.primaryColumns.length && !entityMetadata.isJunction)
             throw new MissingPrimaryColumnError(entityMetadata)

--- a/src/metadata/EntityMetadata.ts
+++ b/src/metadata/EntityMetadata.ts
@@ -122,6 +122,16 @@ export class EntityMetadata {
     withoutRowid?: boolean = false
 
     /**
+     * Enables strict mode. This will make sure that columns are always treated with their defined types.
+     * For example, if a column is defined as an integer, it will always be treated as an integer.
+     * This can help prevent issues with type coercion and ensure data integrity.
+     * Supports only Sqlite.
+     *
+     * @see https://www.sqlite.org/stricttables.html
+     */
+    strict?: boolean = false
+
+    /**
      * Original user-given table name (taken from schema or @Entity(tableName) decorator).
      * If user haven't specified a table name this property will be undefined.
      */
@@ -550,6 +560,7 @@ export class EntityMetadata {
         this.tableType = this.tableMetadataArgs.type
         this.expression = this.tableMetadataArgs.expression
         this.withoutRowid = this.tableMetadataArgs.withoutRowid
+        this.strict = this.tableMetadataArgs.strict
         this.dependsOn = this.tableMetadataArgs.dependsOn
     }
 
@@ -1074,6 +1085,8 @@ export class EntityMetadata {
         this.expression = this.tableMetadataArgs.expression
         this.withoutRowid =
             this.tableMetadataArgs.withoutRowid === true ? true : false
+        this.strict = this.tableMetadataArgs.strict === true ? true : false
+
         this.tablePath = this.dataSource.driver.buildTableName(
             this.tableName,
             this.schema,

--- a/src/metadata/EntityMetadata.ts
+++ b/src/metadata/EntityMetadata.ts
@@ -1085,7 +1085,7 @@ export class EntityMetadata {
         this.expression = this.tableMetadataArgs.expression
         this.withoutRowid =
             this.tableMetadataArgs.withoutRowid === true ? true : false
-        this.strict = this.tableMetadataArgs.strict === true ? true : false
+        this.strict = this.tableMetadataArgs.strict === true
 
         this.tablePath = this.dataSource.driver.buildTableName(
             this.tableName,
@@ -1116,7 +1116,7 @@ export class EntityMetadata {
      * @param column
      */
     registerColumn(column: ColumnMetadata) {
-        if (this.ownColumns.indexOf(column) !== -1) return
+        if (this.ownColumns.includes(column)) return
 
         this.ownColumns.push(column)
         this.columns = this.embeddeds.reduce(

--- a/src/schema-builder/options/TableOptions.ts
+++ b/src/schema-builder/options/TableOptions.ts
@@ -71,6 +71,16 @@ export interface TableOptions {
     withoutRowid?: boolean
 
     /**
+     * Enables strict mode. This will make sure that columns are always treated with their defined types.
+     * For example, if a column is defined as an integer, it will always be treated as an integer.
+     * This can help prevent issues with type coercion and ensure data integrity.
+     * Supports only Sqlite.
+     *
+     * @see https://www.sqlite.org/stricttables.html
+     */
+    strict?: boolean
+
+    /**
      * Table engine.
      */
     engine?: string

--- a/src/schema-builder/table/Table.ts
+++ b/src/schema-builder/table/Table.ts
@@ -151,7 +151,7 @@ export class Table {
 
             if (options.withoutRowid) this.withoutRowid = options.withoutRowid
 
-            this.strict = options.strict === true ? true : false
+            this.strict = options.strict === true
 
             this.engine = options.engine
 

--- a/src/schema-builder/table/Table.ts
+++ b/src/schema-builder/table/Table.ts
@@ -79,6 +79,16 @@ export class Table {
     withoutRowid?: boolean = false
 
     /**
+     * Enables strict mode. This will make sure that columns are always treated with their defined types.
+     * For example, if a column is defined as an integer, it will always be treated as an integer.
+     * This can help prevent issues with type coercion and ensure data integrity.
+     * Supports only Sqlite.
+     *
+     * @see https://www.sqlite.org/stricttables.html
+     */
+    strict?: boolean = false
+
+    /**
      * Table engine.
      */
     engine?: string
@@ -141,6 +151,8 @@ export class Table {
 
             if (options.withoutRowid) this.withoutRowid = options.withoutRowid
 
+            this.strict = options.strict === true ? true : false
+
             this.engine = options.engine
 
             this.comment = options.comment
@@ -177,6 +189,7 @@ export class Table {
             exclusions: this.exclusions.map((constraint) => constraint.clone()),
             justCreated: this.justCreated,
             withoutRowid: this.withoutRowid,
+            strict: this.strict,
             engine: this.engine,
             comment: this.comment,
         })
@@ -438,6 +451,7 @@ export class Table {
                 database,
             ),
             withoutRowid: entityMetadata.withoutRowid,
+            strict: entityMetadata.strict,
             engine: entityMetadata.engine,
             columns: entityMetadata.columns
                 .filter((column) => column && !column.isVirtualProperty)

--- a/test/functional/entity-metadata-validator/sqlite-any-type/entity/NonStrictAnyEntity.ts
+++ b/test/functional/entity-metadata-validator/sqlite-any-type/entity/NonStrictAnyEntity.ts
@@ -1,0 +1,10 @@
+import { Entity, PrimaryGeneratedColumn, Column } from "../../../../../src"
+
+@Entity()
+export class NonStrictAnyEntity {
+    @PrimaryGeneratedColumn()
+    id: number
+
+    @Column({ type: "any" })
+    payload: any
+}

--- a/test/functional/entity-metadata-validator/sqlite-any-type/entity/StrictAnyEntity.ts
+++ b/test/functional/entity-metadata-validator/sqlite-any-type/entity/StrictAnyEntity.ts
@@ -1,0 +1,10 @@
+import { Entity, PrimaryGeneratedColumn, Column } from "../../../../../src"
+
+@Entity({ strict: true })
+export class StrictAnyEntity {
+    @PrimaryGeneratedColumn()
+    id: number
+
+    @Column({ type: "any" })
+    payload: any
+}

--- a/test/functional/entity-metadata-validator/sqlite-any-type/validator-sqlite-any-type.test.ts
+++ b/test/functional/entity-metadata-validator/sqlite-any-type/validator-sqlite-any-type.test.ts
@@ -1,0 +1,61 @@
+import { expect } from "chai"
+import { DataSource, TypeORMError } from "../../../../src"
+import { ConnectionMetadataBuilder } from "../../../../src/connection/ConnectionMetadataBuilder"
+import { EntityMetadataValidator } from "../../../../src/metadata-builder/EntityMetadataValidator"
+import { NonStrictAnyEntity } from "./entity/NonStrictAnyEntity"
+import { StrictAnyEntity } from "./entity/StrictAnyEntity"
+
+describe("entity-metadata-validator > sqlite any type", () => {
+    it("should throw error when any type is used without strict mode", async () => {
+        const connection = new DataSource({
+            type: "better-sqlite3",
+            database: ":memory:",
+            entities: [__dirname + "/entity/*{.js,.ts}"],
+        })
+
+        const connectionMetadataBuilder = new ConnectionMetadataBuilder(
+            connection,
+        )
+        const entityMetadatas =
+            await connectionMetadataBuilder.buildEntityMetadatas([
+                NonStrictAnyEntity,
+            ])
+
+        const entityMetadataValidator = new EntityMetadataValidator()
+
+        expect(() =>
+            entityMetadataValidator.validateMany(
+                entityMetadatas,
+                connection.driver,
+            ),
+        ).to.throw(
+            TypeORMError,
+            'Column "payload" of Entity "NonStrictAnyEntity" uses SQLite "any" type, but the entity is not marked as strict. Set "strict: true" in @Entity options to use type "any".',
+        )
+    })
+
+    it("should not throw error when any type is used with strict mode", async () => {
+        const connection = new DataSource({
+            type: "better-sqlite3",
+            database: ":memory:",
+            entities: [__dirname + "/entity/*{.js,.ts}"],
+        })
+
+        const connectionMetadataBuilder = new ConnectionMetadataBuilder(
+            connection,
+        )
+        const entityMetadatas =
+            await connectionMetadataBuilder.buildEntityMetadatas([
+                StrictAnyEntity,
+            ])
+
+        const entityMetadataValidator = new EntityMetadataValidator()
+
+        expect(() =>
+            entityMetadataValidator.validateMany(
+                entityMetadatas,
+                connection.driver,
+            ),
+        ).to.not.throw(TypeORMError)
+    })
+})

--- a/test/functional/sqlite-strict/entity/NonStrictUser.ts
+++ b/test/functional/sqlite-strict/entity/NonStrictUser.ts
@@ -1,0 +1,10 @@
+import { Column, Entity, PrimaryColumn } from "../../../../src"
+
+@Entity({ strict: false })
+export class NonStrictUser {
+    @PrimaryColumn()
+    id: number
+
+    @Column()
+    name: string
+}

--- a/test/functional/sqlite-strict/entity/StrictAny.ts
+++ b/test/functional/sqlite-strict/entity/StrictAny.ts
@@ -1,0 +1,16 @@
+import { Column, Entity, PrimaryGeneratedColumn } from "../../../../src"
+
+@Entity({ strict: true })
+export class StrictAny {
+    @PrimaryGeneratedColumn()
+    id: number
+
+    @Column({ type: "any", nullable: true })
+    anyField: number | string | boolean | object | null
+
+    @Column({ type: "any", nullable: true })
+    anotherAnyField: any
+
+    @Column({ type: "any" })
+    yetAnotherAnyField: any
+}

--- a/test/functional/sqlite-strict/entity/StrictUser.ts
+++ b/test/functional/sqlite-strict/entity/StrictUser.ts
@@ -1,0 +1,50 @@
+import {
+    Column,
+    CreateDateColumn,
+    Entity,
+    PrimaryGeneratedColumn,
+    Unique,
+} from "../../../../src"
+
+@Entity({ strict: true })
+@Unique(["firstName", "email"])
+export class StrictUser {
+    @PrimaryGeneratedColumn()
+    id: number
+
+    @Column()
+    firstName: string
+
+    @Column({ type: "varchar", length: 100, unique: true })
+    email: string
+
+    @Column({ type: "text" })
+    lastName: string
+
+    @Column()
+    age: number
+
+    @Column({ type: "int", nullable: true })
+    class: number
+
+    @Column({ type: "bigint", nullable: true })
+    experience: number
+
+    @Column({ type: "float", nullable: true })
+    score: number
+
+    @Column({ type: "double", nullable: true })
+    weight: number
+
+    @Column({ type: "decimal", precision: 10, scale: 2, nullable: true })
+    height: number
+
+    @CreateDateColumn()
+    createdAt: Date
+
+    @Column({ type: "blob", nullable: true })
+    data: Buffer
+
+    @Column({ type: "any", nullable: true })
+    anyField: any
+}

--- a/test/functional/sqlite-strict/entity/StrictUser.ts
+++ b/test/functional/sqlite-strict/entity/StrictUser.ts
@@ -43,7 +43,7 @@ export class StrictUser {
     createdAt: Date
 
     @Column({ type: "blob", nullable: true })
-    data: Buffer
+    data: Uint8Array
 
     @Column({ type: "any", nullable: true })
     anyField: any

--- a/test/functional/sqlite-strict/sqlite-strict.test.ts
+++ b/test/functional/sqlite-strict/sqlite-strict.test.ts
@@ -1,0 +1,388 @@
+import "reflect-metadata"
+import { DataSource } from "../../../src/data-source/DataSource"
+import {
+    closeTestingConnections,
+    createTestingConnections,
+    reloadTestingDatabases,
+} from "../../utils/test-utils"
+import { expect } from "chai"
+import { StrictUser } from "./entity/StrictUser"
+import { StrictAny } from "./entity/StrictAny"
+
+describe("sqlite strict mode", () => {
+    let dataSources: DataSource[]
+    before(
+        async () =>
+            (dataSources = await createTestingConnections({
+                entities: [__dirname + "/entity/*{.js,.ts}"],
+                enabledDrivers: ["better-sqlite3", "sqlite", "sqljs"],
+                schemaCreate: true,
+                dropSchema: true,
+            })),
+    )
+    beforeEach(() => reloadTestingDatabases(dataSources))
+    after(() => closeTestingConnections(dataSources))
+
+    async function prepareData(dataSource: DataSource, index: number = 1) {
+        const user = new StrictUser()
+        user.firstName = "Alice" + index
+        user.email = "alice" + index + "@example.com"
+        user.lastName = "Smith"
+        user.age = 16
+        user.class = 10
+        user.experience = 5
+        user.score = 88.5
+        user.weight = 55.0
+        user.height = 5.6
+        user.data = Buffer.from("Sample binary data")
+        user.anyField = { key: "value" }
+
+        return await dataSource.manager.save(user)
+    }
+
+    it("should create table with STRICT keyword when strict option is enabled", () =>
+        Promise.all(
+            dataSources.map(async (dataSource) => {
+                const queryRunner = dataSource.createQueryRunner()
+                const table = await queryRunner.getTable("strict_user")
+
+                expect(table).to.not.be.undefined
+                expect(table!.strict).to.be.true
+
+                const sql = await dataSource.query(
+                    `SELECT sql FROM sqlite_master WHERE name = 'strict_user'`,
+                )
+                expect(sql[0].sql).to.include("STRICT")
+                await queryRunner.release()
+            }),
+        ))
+
+    it("should create table without STRICT keyword when strict option is disabled", () =>
+        Promise.all(
+            dataSources.map(async (dataSource) => {
+                const queryRunner = dataSource.createQueryRunner()
+                const table = await queryRunner.getTable("non_strict_user")
+
+                expect(table).to.not.be.undefined
+                expect(table!.strict).to.be.false
+
+                const sql = await dataSource.query(
+                    `SELECT sql FROM sqlite_master WHERE name = 'non_strict_user'`,
+                )
+                expect(sql[0].sql).to.not.include("STRICT")
+                await queryRunner.release()
+            }),
+        ))
+
+    it("should convert common types to strict-compatible types", () =>
+        Promise.all(
+            dataSources.map(async (dataSource) => {
+                const queryRunner = dataSource.createQueryRunner()
+                const table = await queryRunner.getTable("strict_user")
+
+                expect(table).to.not.be.undefined
+
+                const textFields = ["firstName", "email", "lastName"]
+                textFields.forEach((field) => {
+                    const column = table!.findColumnByName(field)
+                    expect(column).to.not.be.undefined
+                    expect(column!.type).to.equal("text")
+                })
+
+                const integerFields = ["age", "class", "experience"]
+                integerFields.forEach((field) => {
+                    const column = table!.findColumnByName(field)
+                    expect(column).to.not.be.undefined
+                    expect(column!.type).to.equal("integer")
+                })
+
+                const floatFields = ["score", "weight", "height"]
+                floatFields.forEach((field) => {
+                    const column = table!.findColumnByName(field)
+                    expect(column).to.not.be.undefined
+                    expect(column!.type).to.equal("real")
+                })
+
+                const createdAtField = table!.findColumnByName("createdAt")
+                expect(createdAtField).to.not.be.undefined
+                expect(createdAtField!.type).to.equal("text")
+
+                const dataField = table!.findColumnByName("data")
+                expect(dataField).to.not.be.undefined
+                expect(dataField!.type).to.equal("blob")
+
+                const anyField = table!.findColumnByName("anyField")
+                expect(anyField).to.not.be.undefined
+                expect(anyField!.type).to.equal("any")
+                await queryRunner.release()
+            }),
+        ))
+
+    it("should handle primary key with strict mode", () =>
+        Promise.all(
+            dataSources.map(async (dataSource) => {
+                const queryRunner = dataSource.createQueryRunner()
+                const table = await queryRunner.getTable("strict_user")
+
+                expect(table).to.not.be.undefined
+                expect(table!.strict).to.be.true
+
+                const idColumn = table!.findColumnByName("id")
+                expect(idColumn).to.not.be.undefined
+                expect(idColumn!.isPrimary).to.be.true
+                expect(idColumn!.type).to.equal("integer")
+
+                await queryRunner.release()
+            }),
+        ))
+    it("should handle unique constraints with strict mode", () =>
+        Promise.all(
+            dataSources.map(async (dataSource) => {
+                const queryRunner = dataSource.createQueryRunner()
+                const table = await queryRunner.getTable("strict_user")
+
+                expect(table).to.not.be.undefined
+                expect(table!.strict).to.be.true
+                const email = table!.findColumnByName("email")
+                expect(email).to.not.be.undefined
+                expect(email!.isUnique).to.be.true
+
+                await queryRunner.release()
+            }),
+        ))
+
+    it("should insert records with all data types in strict mode", () =>
+        Promise.all(
+            dataSources.map(async (dataSource) => {
+                const user = await prepareData(dataSource)
+                const loadResult = await dataSource
+                    .getRepository(StrictUser)
+                    .findOne({ where: { id: user.id } })
+                expect(loadResult).to.deep.equal({
+                    ...user,
+                    id: loadResult!.id,
+                })
+            }),
+        ))
+
+    it("should select records with where conditions in strict mode", () =>
+        Promise.all(
+            dataSources.map(async (dataSource) => {
+                const user = await prepareData(dataSource)
+
+                const loadedUser = await dataSource
+                    .getRepository(StrictUser)
+                    .findOne({
+                        where: { firstName: "Alice1", age: 16 },
+                    })
+                expect(loadedUser).to.deep.equal({
+                    ...user,
+                    id: loadedUser!.id,
+                })
+            }),
+        ))
+
+    it("should update records in strict mode", () =>
+        Promise.all(
+            dataSources.map(async (dataSource) => {
+                const user = await prepareData(dataSource)
+
+                user.data = Buffer.from("Updated binary data")
+                user.score = 82.5
+
+                await dataSource.manager.save(user)
+                const updatedUser = await dataSource
+                    .getRepository(StrictUser)
+                    .findOne({
+                        where: { id: user.id },
+                    })
+
+                expect(updatedUser).to.deep.equal({
+                    ...user,
+                    id: user.id,
+                })
+            }),
+        ))
+
+    it("should delete records in strict mode", () =>
+        Promise.all(
+            dataSources.map(async (dataSource) => {
+                const user = await prepareData(dataSource)
+                await dataSource.manager.remove(user)
+
+                const deletedUser = await dataSource.manager.findOne(
+                    StrictUser,
+                    {
+                        where: { id: user.id },
+                    },
+                )
+
+                expect(deletedUser).to.be.null
+            }),
+        ))
+
+    it("should perform bulk insert operations in strict mode", () =>
+        Promise.all(
+            dataSources.map(async (dataSource) => {
+                const users = []
+                for (let i = 0; i < 10; i++) {
+                    users.push(await prepareData(dataSource, i))
+                }
+
+                await dataSource.manager.save(users)
+
+                const count = await dataSource.manager.count(StrictUser)
+                expect(count).to.equal(10)
+            }),
+        ))
+
+    it("should perform bulk delete operations in strict mode", () =>
+        Promise.all(
+            dataSources.map(async (dataSource) => {
+                const users = []
+                for (let i = 0; i < 5; i++) {
+                    users.push(await prepareData(dataSource, i))
+                }
+
+                await dataSource.manager.save(users)
+
+                await dataSource.manager.delete(StrictUser, { age: 16 })
+
+                const remainingCount =
+                    await dataSource.manager.count(StrictUser)
+                expect(remainingCount).to.equal(0)
+            }),
+        ))
+
+    it("should perform bulk update operations in strict mode", () =>
+        Promise.all(
+            dataSources.map(async (dataSource) => {
+                const users = []
+                for (let i = 0; i < 3; i++) {
+                    users.push(await prepareData(dataSource, i))
+                }
+
+                await dataSource.manager.save(users)
+
+                await dataSource.manager.update(
+                    StrictUser,
+                    { age: 16 },
+                    { data: Buffer.from("Bulk updated") },
+                )
+
+                const updatedUsers = await dataSource.manager.find(StrictUser, {
+                    where: { age: 16 },
+                })
+
+                expect(updatedUsers).to.have.length(3)
+                updatedUsers.forEach((user) => {
+                    expect(user.data).to.deep.equal(Buffer.from("Bulk updated"))
+                })
+            }),
+        ))
+
+    it("should select with query builder in strict mode", () =>
+        Promise.all(
+            dataSources.map(async (dataSource) => {
+                const users = [
+                    {
+                        firstName: "Henry",
+                        email: "henry@example.com",
+                        lastName: "Adams",
+                        age: 45,
+                        score: 95.0,
+                    },
+                    {
+                        firstName: "Iris",
+                        email: "iris@example.com",
+                        lastName: "Johnson",
+                        age: 22,
+                        score: 65.0,
+                    },
+                ]
+
+                await dataSource.getRepository(StrictUser).save(users)
+
+                const highScorers = await dataSource
+                    .getRepository(StrictUser)
+                    .createQueryBuilder("user")
+                    .where("user.score >= :minScore", { minScore: 90 })
+                    .getMany()
+
+                expect(highScorers).to.have.length(1)
+                expect(highScorers[0].firstName).to.equal("Henry")
+            }),
+        ))
+
+    it("should handle transactions in strict mode", () =>
+        Promise.all(
+            dataSources.map(async (dataSource) => {
+                await dataSource.manager.transaction(
+                    async (transactionalEntityManager) => {
+                        const user1 = new StrictUser()
+                        user1.firstName = "Jack"
+                        user1.email = "jack@example.com"
+                        user1.lastName = "Brown"
+                        user1.age = 33
+                        user1.score = 88.0
+                        user1.data = Buffer.from("Transaction data 1")
+
+                        const user2 = new StrictUser()
+                        user2.firstName = "Kelly"
+                        user2.email = "kelly@example.com"
+                        user2.lastName = "Davis"
+                        user2.age = 27
+                        user2.score = 92.5
+                        user2.data = Buffer.from("Transaction data 2")
+
+                        await transactionalEntityManager.save([user1, user2])
+                    },
+                )
+
+                const count = await dataSource.manager.count(StrictUser)
+                expect(count).to.equal(2)
+            }),
+        ))
+
+    it("should handle any type with strict mode", () =>
+        Promise.all(
+            dataSources.map(async (dataSource) => {
+                const anyEntity1 = new StrictAny()
+                anyEntity1.anyField = 39
+                anyEntity1.anotherAnyField = "A string value"
+                anyEntity1.yetAnotherAnyField = {
+                    nested: "object",
+                    arr: [1, 2, 3],
+                }
+
+                const savedEntity = await dataSource
+                    .getRepository(StrictAny)
+                    .save(anyEntity1)
+
+                const loadedEntity = await dataSource
+                    .getRepository(StrictAny)
+                    .findOne({ where: { id: savedEntity.id } })
+                expect(loadedEntity).to.deep.equal({
+                    ...savedEntity,
+                    id: loadedEntity!.id,
+                })
+
+                const anyEntity2 = new StrictAny()
+                anyEntity2.anyField = { foo: "bar", num: 42 }
+                anyEntity2.anotherAnyField = false
+                anyEntity2.yetAnotherAnyField = 93.5
+
+                const savedEntity2 = await dataSource
+                    .getRepository(StrictAny)
+                    .save(anyEntity2)
+
+                const loadedEntity2 = await dataSource
+                    .getRepository(StrictAny)
+                    .findOne({ where: { id: savedEntity2.id } })
+                expect(loadedEntity2).to.deep.equal({
+                    ...savedEntity2,
+                    id: loadedEntity2!.id,
+                })
+            }),
+        ))
+})

--- a/test/functional/sqlite-strict/sqlite-strict.test.ts
+++ b/test/functional/sqlite-strict/sqlite-strict.test.ts
@@ -1,5 +1,5 @@
 import "reflect-metadata"
-import { DataSource } from "../../../src/data-source/DataSource"
+import type { DataSource } from "../../../src/data-source/DataSource"
 import {
     closeTestingConnections,
     createTestingConnections,
@@ -11,15 +11,12 @@ import { StrictAny } from "./entity/StrictAny"
 
 describe("sqlite strict mode", () => {
     let dataSources: DataSource[]
-    before(
-        async () =>
-            (dataSources = await createTestingConnections({
-                entities: [__dirname + "/entity/*{.js,.ts}"],
-                enabledDrivers: ["better-sqlite3", "sqlite", "sqljs"],
-                schemaCreate: true,
-                dropSchema: true,
-            })),
-    )
+    before(async () => {
+        dataSources = await createTestingConnections({
+            entities: [__dirname + "/entity/*{.js,.ts}"],
+            enabledDrivers: ["better-sqlite3", "sqljs"],
+        })
+    })
     beforeEach(() => reloadTestingDatabases(dataSources))
     after(() => closeTestingConnections(dataSources))
 
@@ -32,9 +29,9 @@ describe("sqlite strict mode", () => {
         user.class = 10
         user.experience = 5
         user.score = 88.5
-        user.weight = 55.0
+        user.weight = 55
         user.height = 5.6
-        user.data = Buffer.from("Sample binary data")
+        user.data = Uint8Array.from("Sample binary data")
         user.anyField = { key: "value" }
 
         return await dataSource.manager.save(user)
@@ -47,7 +44,7 @@ describe("sqlite strict mode", () => {
                 const table = await queryRunner.getTable("strict_user")
 
                 expect(table).to.not.be.undefined
-                expect(table!.strict).to.be.true
+                expect(table?.strict).to.be.true
 
                 const sql = await dataSource.query(
                     `SELECT sql FROM sqlite_master WHERE name = 'strict_user'`,
@@ -64,7 +61,7 @@ describe("sqlite strict mode", () => {
                 const table = await queryRunner.getTable("non_strict_user")
 
                 expect(table).to.not.be.undefined
-                expect(table!.strict).to.be.false
+                expect(table?.strict).to.be.false
 
                 const sql = await dataSource.query(
                     `SELECT sql FROM sqlite_master WHERE name = 'non_strict_user'`,
@@ -84,36 +81,36 @@ describe("sqlite strict mode", () => {
 
                 const textFields = ["firstName", "email", "lastName"]
                 textFields.forEach((field) => {
-                    const column = table!.findColumnByName(field)
+                    const column = table?.findColumnByName(field)
                     expect(column).to.not.be.undefined
-                    expect(column!.type).to.equal("text")
+                    expect(column?.type).to.equal("text")
                 })
 
                 const integerFields = ["age", "class", "experience"]
                 integerFields.forEach((field) => {
-                    const column = table!.findColumnByName(field)
+                    const column = table?.findColumnByName(field)
                     expect(column).to.not.be.undefined
-                    expect(column!.type).to.equal("integer")
+                    expect(column?.type).to.equal("integer")
                 })
 
                 const floatFields = ["score", "weight", "height"]
                 floatFields.forEach((field) => {
-                    const column = table!.findColumnByName(field)
+                    const column = table?.findColumnByName(field)
                     expect(column).to.not.be.undefined
-                    expect(column!.type).to.equal("real")
+                    expect(column?.type).to.equal("real")
                 })
 
-                const createdAtField = table!.findColumnByName("createdAt")
+                const createdAtField = table?.findColumnByName("createdAt")
                 expect(createdAtField).to.not.be.undefined
-                expect(createdAtField!.type).to.equal("text")
+                expect(createdAtField?.type).to.equal("text")
 
-                const dataField = table!.findColumnByName("data")
+                const dataField = table?.findColumnByName("data")
                 expect(dataField).to.not.be.undefined
-                expect(dataField!.type).to.equal("blob")
+                expect(dataField?.type).to.equal("blob")
 
-                const anyField = table!.findColumnByName("anyField")
+                const anyField = table?.findColumnByName("anyField")
                 expect(anyField).to.not.be.undefined
-                expect(anyField!.type).to.equal("any")
+                expect(anyField?.type).to.equal("any")
                 await queryRunner.release()
             }),
         ))
@@ -125,12 +122,12 @@ describe("sqlite strict mode", () => {
                 const table = await queryRunner.getTable("strict_user")
 
                 expect(table).to.not.be.undefined
-                expect(table!.strict).to.be.true
+                expect(table?.strict).to.be.true
 
-                const idColumn = table!.findColumnByName("id")
+                const idColumn = table?.findColumnByName("id")
                 expect(idColumn).to.not.be.undefined
-                expect(idColumn!.isPrimary).to.be.true
-                expect(idColumn!.type).to.equal("integer")
+                expect(idColumn?.isPrimary).to.be.true
+                expect(idColumn?.type).to.equal("integer")
 
                 await queryRunner.release()
             }),
@@ -142,10 +139,10 @@ describe("sqlite strict mode", () => {
                 const table = await queryRunner.getTable("strict_user")
 
                 expect(table).to.not.be.undefined
-                expect(table!.strict).to.be.true
-                const email = table!.findColumnByName("email")
+                expect(table?.strict).to.be.true
+                const email = table?.findColumnByName("email")
                 expect(email).to.not.be.undefined
-                expect(email!.isUnique).to.be.true
+                expect(email?.isUnique).to.be.true
 
                 await queryRunner.release()
             }),
@@ -160,7 +157,7 @@ describe("sqlite strict mode", () => {
                     .findOne({ where: { id: user.id } })
                 expect(loadResult).to.deep.equal({
                     ...user,
-                    id: loadResult!.id,
+                    id: loadResult?.id,
                 })
             }),
         ))
@@ -177,7 +174,7 @@ describe("sqlite strict mode", () => {
                     })
                 expect(loadedUser).to.deep.equal({
                     ...user,
-                    id: loadedUser!.id,
+                    id: loadedUser?.id,
                 })
             }),
         ))
@@ -187,7 +184,7 @@ describe("sqlite strict mode", () => {
             dataSources.map(async (dataSource) => {
                 const user = await prepareData(dataSource)
 
-                user.data = Buffer.from("Updated binary data")
+                user.data = Uint8Array.from("Updated binary data")
                 user.score = 82.5
 
                 await dataSource.manager.save(user)
@@ -208,12 +205,13 @@ describe("sqlite strict mode", () => {
         Promise.all(
             dataSources.map(async (dataSource) => {
                 const user = await prepareData(dataSource)
+                const id = user.id
                 await dataSource.manager.remove(user)
 
                 const deletedUser = await dataSource.manager.findOne(
                     StrictUser,
                     {
-                        where: { id: user.id },
+                        where: { id: id },
                     },
                 )
 
@@ -267,7 +265,7 @@ describe("sqlite strict mode", () => {
                 await dataSource.manager.update(
                     StrictUser,
                     { age: 16 },
-                    { data: Buffer.from("Bulk updated") },
+                    { data: Uint8Array.from("Bulk updated") },
                 )
 
                 const updatedUsers = await dataSource.manager.find(StrictUser, {
@@ -276,7 +274,9 @@ describe("sqlite strict mode", () => {
 
                 expect(updatedUsers).to.have.length(3)
                 updatedUsers.forEach((user) => {
-                    expect(user.data).to.deep.equal(Buffer.from("Bulk updated"))
+                    expect(user.data).to.deep.equal(
+                        Uint8Array.from("Bulk updated"),
+                    )
                 })
             }),
         ))
@@ -290,14 +290,14 @@ describe("sqlite strict mode", () => {
                         email: "henry@example.com",
                         lastName: "Adams",
                         age: 45,
-                        score: 95.0,
+                        score: 95,
                     },
                     {
                         firstName: "Iris",
                         email: "iris@example.com",
                         lastName: "Johnson",
                         age: 22,
-                        score: 65.0,
+                        score: 65,
                     },
                 ]
 
@@ -324,8 +324,8 @@ describe("sqlite strict mode", () => {
                         user1.email = "jack@example.com"
                         user1.lastName = "Brown"
                         user1.age = 33
-                        user1.score = 88.0
-                        user1.data = Buffer.from("Transaction data 1")
+                        user1.score = 88
+                        user1.data = Uint8Array.from("Transaction data 1")
 
                         const user2 = new StrictUser()
                         user2.firstName = "Kelly"
@@ -333,7 +333,7 @@ describe("sqlite strict mode", () => {
                         user2.lastName = "Davis"
                         user2.age = 27
                         user2.score = 92.5
-                        user2.data = Buffer.from("Transaction data 2")
+                        user2.data = Uint8Array.from("Transaction data 2")
 
                         await transactionalEntityManager.save([user1, user2])
                     },
@@ -364,8 +364,15 @@ describe("sqlite strict mode", () => {
                     .findOne({ where: { id: savedEntity.id } })
                 expect(loadedEntity).to.deep.equal({
                     ...savedEntity,
-                    id: loadedEntity!.id,
                 })
+
+                const rawStorage1 = await dataSource.query(
+                    `SELECT typeof(anyField) AS anyFieldType, typeof(anotherAnyField) AS anotherAnyFieldType, typeof(yetAnotherAnyField) AS yetAnotherAnyFieldType FROM strict_any WHERE id = ?`,
+                    [savedEntity.id],
+                )
+                expect(rawStorage1[0].anyFieldType).to.equal("integer")
+                expect(rawStorage1[0].anotherAnyFieldType).to.equal("text")
+                expect(rawStorage1[0].yetAnotherAnyFieldType).to.equal("text")
 
                 const anyEntity2 = new StrictAny()
                 anyEntity2.anyField = { foo: "bar", num: 42 }
@@ -381,8 +388,16 @@ describe("sqlite strict mode", () => {
                     .findOne({ where: { id: savedEntity2.id } })
                 expect(loadedEntity2).to.deep.equal({
                     ...savedEntity2,
-                    id: loadedEntity2!.id,
+                    anotherAnyField: 0, // with strict mode returned value will be number
                 })
+
+                const rawStorage2 = await dataSource.query(
+                    `SELECT typeof(anyField) AS anyFieldType, typeof(anotherAnyField) AS anotherAnyFieldType, typeof(yetAnotherAnyField) AS yetAnotherAnyFieldType FROM strict_any WHERE id = ?`,
+                    [savedEntity2.id],
+                )
+                expect(rawStorage2[0].anyFieldType).to.equal("text")
+                expect(rawStorage2[0].anotherAnyFieldType).to.equal("integer")
+                expect(rawStorage2[0].yetAnotherAnyFieldType).to.equal("real")
             }),
         ))
 })


### PR DESCRIPTION
### Description of change

This PR adds support for SQLite strict tables, a feature introduced in SQLite 3.37.0 that enforces strict type checking and enhances data integrity.

#### What this change does:
1. **Entity-level configuration**: Adds support for `@Entity({ strict: true })` decorator to enable strict mode per entity
2. **Type conversion**: Automatically converts common column types (varchar, int, float, datetime, etc.) to strict-compatible types (TEXT, INTEGER, REAL, BLOB, ANY)
3. **Schema operations**: Properly handles STRICT keyword in CREATE TABLE statements

#### Why this change is needed:

SQLite strict tables provide several benefits:
- **Type safety**: Enforces that data stored matches the declared column type
- **Data integrity**: Prevents type coercion issues that can occur in non-strict SQLite tables
- **Performance**: Can improve query performance in some cases
- **Standards compliance**: Aligns SQLite behavior more closely with other SQL databases

#### How this has been verified:

Comprehensive test suite added with 15 tests covering:
- [x] STRICT keyword in CREATE TABLE statements
- [x] Type conversion from common types to strict-compatible types
- [x] Data insertion and retrieval in strict mode
- [x] Bulk insert, update and delete
- [x] Select with QueryBuilder

Test files:
- `test/functional/sqlite-strict/sqlite-strict.test.ts` - Core functionality tests

#### Implementation details:

**Modified files:**
- `src/metadata/EntityMetadata.ts` - Added strict property with precedence logic
- `src/metadata-args/EntityMetadataArgs.ts` - Added strict to entity options
- `src/decorator/entity/Entity.ts` - Updated Entity decorator types
- `src/schema-builder/table/Table.ts` - Added strict property
- `src/driver/sqlite-abstract/AbstractSqliteDriver.ts` - Added convertToStrictType utility
- `src/driver/sqlite-abstract/AbstractSqliteQueryRunner.ts` - Implemented strict mode schema operations

**Type conversion mapping:**
- Text types (varchar, char, nchar, etc.) → `text`
- Integer types (int, tinyint, smallint, bigint, etc.) → `integer`
- Numeric/decimal types → `real`
- Date/time types → `text` (SQLite stores as text)
- Boolean → `integer` (SQLite stores as 0/1)
- JSON → `text` (SQLite stores JSON as text)
- BLOB → `blob`

#### Example usage:

```typescript
@Entity({ strict: true })
export class User {
    @PrimaryGeneratedColumn()
    id: number

    @Column()  // varchar → text in strict mode
    name: string

    @Column()  // int → integer in strict mode
    age: number
}
```

### Pull-Request Checklist

- [x] Code is up-to-date with the `master` branch
- [x] This pull request links relevant issues as `Fixes #11552`
- [x] There are new or updated tests validating the change (`test/functional/sqlite-strict/*.test.ts`)
- [x] Documentation has been updated to reflect this change (`docs/docs/**.md`)

### Fixes: #11552

**Breaking changes:** None. This is a purely additive feature with backward compatibility.