### PR TITLE
docs: fix typo 'spass' to 'pass'

### DIFF
--- a/docs/docs/getting-started.md
+++ b/docs/docs/getting-started.md
@@ -798,7 +798,7 @@ export class Photo {
 
 `photo => photo.metadata` is a function that returns the name of the inverse side of the relation.
 Here we show that the metadata property of the Photo class is where we store PhotoMetadata in the Photo class.
-Instead of passing a function that returns a property of the photo, you could alternatively spass a string to `@OneToOne` decorator, like `"metadata"`.
+Instead of passing a function that returns a property of the photo, you could alternatively pass a string to `@OneToOne` decorator, like `"metadata"`.
 But we used this function-typed approach to make our refactoring easier.
 
 Note that we should use the `@JoinColumn` decorator only on one side of a relation.


### PR DESCRIPTION
### Description of change

This pull request fixes a typo in the Getting Started documentation.

In the "Inverse side of the relationship" section:
https://typeorm.io/docs/getting-started/#inverse-side-of-the-relationship

"spass" → "pass".
No functional changes.

### Pull-Request Checklist

-   [ x ] Code is up-to-date with the `master` branch
-   [ ] This pull request links relevant issues as `Fixes #00000`
-   [ ] There are new or updated tests validating the change (`tests/**.test.ts`)
-   [ x ] Documentation has been updated to reflect this change (`docs/docs/**.md`)
