### PR TITLE
fix: bind Buffer parameters using the correct Oracle type

### DIFF
--- a/src/driver/oracle/OracleQueryRunner.ts
+++ b/src/driver/oracle/OracleQueryRunner.ts
@@ -211,6 +211,15 @@ export class OracleQueryRunner extends BaseQueryRunner implements QueryRunner {
                 outFormat: this.driver.oracle.OUT_FORMAT_OBJECT,
             }
 
+            if (parameters && parameters.length) {
+                parameters = parameters.map((param) => {
+                    if (Buffer.isBuffer(param)) {
+                        return { val: param, type: this.driver.oracle.BLOB }
+                    }
+                    return param
+                })
+            }
+
             const raw = await databaseConnection.execute(
                 query,
                 parameters || {},

--- a/test/functional/database-schema/column-types/oracle/column-types-oracle.test.ts
+++ b/test/functional/database-schema/column-types/oracle/column-types-oracle.test.ts
@@ -58,7 +58,7 @@ describe("database schema > column types > oracle", () => {
                 post.timestampWithTimeZone.setMilliseconds(0)
                 post.timestampWithLocalTimeZone = new Date()
                 post.timestampWithLocalTimeZone.setMilliseconds(0)
-                post.blob = Buffer.from("This is blob")
+                post.blob = Buffer.alloc(100_000, 1) // 100 KB of binary data
                 post.clob = "This is clob"
                 post.nclob = "This is nclob"
                 post.simpleArray = ["A", "B", "C"]
@@ -299,7 +299,7 @@ describe("database schema > column types > oracle", () => {
                 post.id = 1
                 post.name = "Post"
                 post.boolean = true
-                post.blob = Buffer.from("This is blob")
+                post.blob = Buffer.alloc(100_000, 1) // 100 KB of binary data
                 post.datetime = new Date()
                 await postRepository.save(post)
 


### PR DESCRIPTION
Fixes #11937

<!--
  😀 Wonderful!  Thank you for opening a pull request for TypeORM.

  Please fill in the information below to expedite the review
  and (hopefully) merge of your change.

  If unsure about something.. just do as best as you're able,
  or reach out through our community support channels!
  https://github.com/typeorm/typeorm/blob/master/docs/support.md
  https://github.com/typeorm/typeorm/blob/master/CONTRIBUTING.md
-->

### Description of change

<!--
  Please describe:
  - what the change is intended to do
  - why this change is needed
  - how you've verified it
  - any other context that will help reviewers understand the change

  In some cases it may be helpful to include the current behavior
  and the new behavior.
-->

This change ensures that Buffer values are bound as BLOB,
when inserting data into Oracle. The previous behavior caused large binary
payloads to fail. The fix updates the parameter binding logic
to correctly detect and map Buffer instances to the appropriate Oracle type.

Closes #11937

### Pull-Request Checklist

<!--
  Please make sure to review and check all of the following.

  If an item is not applicable, you can add "N/A" to the end.
-->

-   [x] Code is up-to-date with the `master` branch
-   [x] This pull request links relevant issues as `Fixes #00000`
-   [x] There are new or updated tests validating the change (`tests/**.test.ts`)
-   [~] Documentation has been updated to reflect this change (`docs/docs/**.md`)

<!--
  🎉 Thank you for contributing and making TypeORM even better!
-->
