### PR TITLE
test(lazy-relations): skip re-fetch when relation in find options

### DIFF
--- a/test/functional/relations/lazy-relations/basic-lazy-relation/basic-lazy-relations.test.ts
+++ b/test/functional/relations/lazy-relations/basic-lazy-relation/basic-lazy-relations.test.ts
@@ -11,6 +11,9 @@ import type { EntitySchemaOptions } from "../../../../../src"
 import { EntitySchema } from "../../../../../src"
 import UserSchema from "./schema/user.json"
 import ProfileSchema from "./schema/profile.json"
+import { Parent } from "./entity/Parent"
+import { Child } from "./entity/Child"
+import sinon from "sinon"
 
 describe("relations > lazy relations > basic-lazy-relations", () => {
     let dataSources: DataSource[]
@@ -19,10 +22,11 @@ describe("relations > lazy relations > basic-lazy-relations", () => {
             entities: [
                 Post,
                 Category,
+                Parent,
+                Child,
                 new EntitySchema(UserSchema as EntitySchemaOptions<unknown>),
                 new EntitySchema(ProfileSchema as EntitySchemaOptions<unknown>),
             ],
-            enabledDrivers: ["mysql", "postgres"],
         })
     })
     beforeEach(() => reloadTestingDatabases(dataSources))
@@ -62,15 +66,15 @@ describe("relations > lazy relations > basic-lazy-relations", () => {
                     savedCategory3,
                 ])
 
-                const post = (await postRepository.findOneBy({ id: 1 }))!
-                post.title.should.be.equal("Hello post")
-                post.text.should.be.equal("This is post about post")
+                const post = await postRepository.findOneBy({ id: 1 })
+                post?.title.should.be.equal("Hello post")
+                post?.text.should.be.equal("This is post about post")
 
-                const categories = await post.categories
-                categories.length.should.be.equal(3)
-                categories.should.deep.include({ id: 1, name: "kids" })
-                categories.should.deep.include({ id: 2, name: "people" })
-                categories.should.deep.include({ id: 3, name: "animals" })
+                const categories = await post?.categories
+                categories?.length.should.be.equal(3)
+                categories?.should.deep.include({ id: 1, name: "kids" })
+                categories?.should.deep.include({ id: 2, name: "people" })
+                categories?.should.deep.include({ id: 3, name: "animals" })
             }),
         ))
 
@@ -108,28 +112,28 @@ describe("relations > lazy relations > basic-lazy-relations", () => {
                     savedCategory3,
                 ])
 
-                const post = (await postRepository.findOneBy({ id: 1 }))!
-                post.title.should.be.equal("Hello post")
-                post.text.should.be.equal("This is post about post")
+                const post = await postRepository.findOneBy({ id: 1 })
+                post?.title.should.be.equal("Hello post")
+                post?.text.should.be.equal("This is post about post")
 
-                const categories = await post.twoSideCategories
-                categories.length.should.be.equal(3)
-                categories.should.deep.include({ id: 1, name: "kids" })
-                categories.should.deep.include({ id: 2, name: "people" })
-                categories.should.deep.include({ id: 3, name: "animals" })
+                const categories = await post?.twoSideCategories
+                categories?.length.should.be.equal(3)
+                categories?.should.deep.include({ id: 1, name: "kids" })
+                categories?.should.deep.include({ id: 2, name: "people" })
+                categories?.should.deep.include({ id: 3, name: "animals" })
 
-                const category = (await categoryRepository.findOneBy({
+                const category = await categoryRepository.findOneBy({
                     id: 1,
-                }))!
-                category.name.should.be.equal("kids")
+                })
+                category?.name.should.be.equal("kids")
 
-                const twoSidePosts = await category.twoSidePosts
+                const twoSidePosts = await category?.twoSidePosts
 
                 const likePost = new Post()
                 likePost.id = 1
                 likePost.title = "Hello post"
                 likePost.text = "This is post about post"
-                twoSidePosts.should.deep.include(likePost)
+                twoSidePosts?.should.deep.include(likePost)
             }),
         ))
 
@@ -139,11 +143,11 @@ describe("relations > lazy relations > basic-lazy-relations", () => {
                 const userRepository = dataSource.getRepository("User")
                 const profileRepository = dataSource.getRepository("Profile")
 
-                const profile: any = profileRepository.create()
+                const profile = profileRepository.create()
                 profile.country = "Japan"
                 await profileRepository.save(profile)
 
-                const newUser: any = userRepository.create()
+                const newUser = userRepository.create()
                 newUser.firstName = "Umed"
                 newUser.secondName = "San"
                 newUser.profile = Promise.resolve(profile)
@@ -152,13 +156,13 @@ describe("relations > lazy relations > basic-lazy-relations", () => {
                 await newUser.profile.should.eventually.be.eql(profile)
 
                 // const loadOptions: FindOptions = { alias: "user", innerJoinAndSelect };
-                const loadedUser: any = await userRepository.findOneBy({
+                const loadedUser = await userRepository.findOneBy({
                     id: 1,
                 })
-                loadedUser.firstName.should.be.equal("Umed")
-                loadedUser.secondName.should.be.equal("San")
+                loadedUser?.firstName.should.be.equal("Umed")
+                loadedUser?.secondName.should.be.equal("San")
 
-                const lazyLoadedProfile = await loadedUser.profile
+                const lazyLoadedProfile = await loadedUser?.profile
                 lazyLoadedProfile.country.should.be.equal("Japan")
             }),
         ))
@@ -439,5 +443,46 @@ describe("relations > lazy relations > basic-lazy-relations", () => {
                     const loadedPost = await loadedCategory.onePost
                     loadedPost.title.should.be.equal("post with great category")
                 }),
+        ))
+    it("should not fetch again if relation already selected in the find options", () =>
+        Promise.all(
+            dataSources.map(async (connection) => {
+                const child1 = new Child()
+                const child2 = new Child()
+                await connection.manager.save([child1, child2])
+
+                const parent = new Parent()
+                parent.children = Promise.resolve([child1, child2])
+                await connection.manager.save(parent)
+
+                const loadedParentWithChildren = await connection
+                    .getRepository(Parent)
+                    .findOne({
+                        where: { id: parent.id },
+                        relations: { children: true },
+                    })
+                const loadedParent = await connection
+                    .getRepository(Parent)
+                    .findOneBy({ id: parent.id })
+
+                let queryCount = 0
+                const loggerStub = sinon
+                    .stub(connection.logger, "logQuery")
+                    .callsFake(() => queryCount++)
+
+                try {
+                    const loadedChildren =
+                        await loadedParentWithChildren?.children
+
+                    queryCount.should.be.equal(0)
+                    loadedChildren?.length.should.be.equal(2)
+
+                    const loadedChildren1 = await loadedParent?.children
+                    queryCount.should.be.not.equal(0)
+                    loadedChildren1?.length.should.be.equal(2)
+                } finally {
+                    loggerStub.restore()
+                }
+            }),
         ))
 })

--- a/test/functional/relations/lazy-relations/basic-lazy-relation/entity/Child.ts
+++ b/test/functional/relations/lazy-relations/basic-lazy-relation/entity/Child.ts
@@ -1,0 +1,25 @@
+import {
+    Entity,
+    PrimaryGeneratedColumn,
+    CreateDateColumn,
+    UpdateDateColumn,
+    ManyToOne,
+    JoinColumn,
+} from "../../../../../../src"
+import { Parent } from "./Parent"
+
+@Entity()
+export class Child {
+    @PrimaryGeneratedColumn("uuid")
+    id: string
+
+    @CreateDateColumn()
+    createdAt: Date
+
+    @UpdateDateColumn()
+    updatedAt: Date
+
+    @ManyToOne(() => Parent, (parent) => parent.children)
+    @JoinColumn({ name: "parentId" })
+    parent?: Promise<Parent | null>
+}

--- a/test/functional/relations/lazy-relations/basic-lazy-relation/entity/Parent.ts
+++ b/test/functional/relations/lazy-relations/basic-lazy-relation/entity/Parent.ts
@@ -1,0 +1,23 @@
+import {
+    Entity,
+    PrimaryGeneratedColumn,
+    CreateDateColumn,
+    UpdateDateColumn,
+    OneToMany,
+} from "../../../../../../src"
+import { Child } from "./Child"
+
+@Entity()
+export class Parent {
+    @PrimaryGeneratedColumn("uuid")
+    id: string
+
+    @CreateDateColumn()
+    createdAt: Date
+
+    @UpdateDateColumn()
+    updatedAt: Date
+
+    @OneToMany(() => Child, (child) => child.parent)
+    children?: Promise<Array<Child>>
+}


### PR DESCRIPTION
Close #2428

### Description of change
This PR adds tests for #2428.

I tried to verify the bug by calling `connection.logger.logQuery()` as a stub using `sinon`.

Note: Even if `logging: false` is set in tests, the stub still invokes `logQuery` because of the following implementation in `AbstractLogger`:

```typescript
logQuery(query: string, parameters?: any[], queryRunner?: QueryRunner) {
    if (!this.isLogEnabledFor("query")) {
        return;  // Exits if logging is disabled
    }

    this.writeLog(
        "query",
        {
            type: "query",
            prefix: "query",
            message: query,
            format: "sql",
            parameters,
        },
        queryRunner,
    );
}
```

Utilizing this fact, I used the following in the test:

```typescript
let queryCount = 0;
const loggerStub = sinon
    .stub(connection.logger, "logQuery")
    .callsFake(() => queryCount++);

const loadedChildren = await loadedParent!.children;

queryCount.should.equal(0);
loadedChildren!.length.should.equal(2);

loggerStub.restore();
```

### Pull-Request Checklist
- [x] Code is up-to-date with the `master` branch
- [x] This pull request links relevant issues as `Related #2428`
- [x] There are new or updated tests validating the change (`tests/**.test.ts`)
- [ ] Documentation has been updated to reflect this change (`docs/docs/**.md`) (N/A)