### PR TITLE
ci: commit prefix should follow `standard-changelog`

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -21,19 +21,20 @@ jobs:
       - uses: amannn/action-semantic-pull-request@v6
         with:
           types: |
-            chore
+            build
             ci
             docs
             feat
             fix
-            lint
+            perf
             refactor
             revert
+            style
             test
           subjectPattern: ^[a-z][a-zA-Z0-9 \-\/()*.@,_`']+$
           subjectPatternError: |
             Our pull requests titles should follow Conventional Commits spec:
-            https://www.conventionalcommits.org 
+            https://www.conventionalcommits.org
 
             The description "{subject}" found in this pull request title "{title}"
             didn't match the configured pattern. Please ensure that it doesn't

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -134,16 +134,16 @@ to be easier to read on GitHub as well as in various git tools.
 
 One of the following:
 
+- **build**: Changes that affect the build system or external dependencies
+- **ci**: Changes to our CI configuration files and scripts
+- **docs**: Documentation only changes
 - **feat**: A new feature
 - **fix**: A bug fix
-- **docs**: Documentation only changes
-- **style**: Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
-- **refactor**: A code change that neither fixes a bug nor adds a feature
 - **perf**: A code change that improves performance
-- **test**: Adding missing tests or correcting existing tests
-- **build**: Changes that affect the build system, CI configuration or external dependencies
-- **chore**: Other changes that don't modify `src` or `test` files
+- **refactor**: A code change that neither fixes a bug nor adds a feature
 - **revert**: Reverts a previous commit. Include the hash of the commit being reverted.
+- **style**: Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
+- **test**: Adding missing tests or correcting existing tests
 
 ### Subject
 


### PR DESCRIPTION
### Description of change

Update contribution guidelines and workflow definition with the prefixes `standard-changelog` **requires** from us.

The only update in the contribution guidelines is replacing `chore:` with `build:` + `ci:`. Seems this is what changed in the angular contribution guidelines since we started following them.

The workflow has been updated to follow the guidelines instead of having its own rules. There shouldn't be any confusions anymore about why this workflow is failing.

We will **not** accept `lint:` as a valid prefix since applying ESLint rules may change the functionality of the code, which would need to be reflected in the generated changelog (`lint:` is excluded from the changelog). If the ESLint rules change the logic, the commit should be a `fix:`. If the ESLint rules change the formatting (less often), it should be `style:`.

### Pull-Request Checklist
- [x] Code is up-to-date with the `master` branch
- [ ] This pull request links relevant issues as `Fixes #00000`
- [ ] There are new or updated tests validating the change (`tests/**.test.ts`)
- [x] Documentation has been updated to reflect this change (`docs/docs/**.md`)

<!--
  🎉 Thank you for contributing and making TypeORM even better!
-->
