### PR TITLE
refactor(mongo)!: remove deprecated getMongoRepository and getMongoManager globals

### DIFF
--- a/docs/docs/drivers/mongodb.md
+++ b/docs/docs/drivers/mongodb.md
@@ -190,8 +190,6 @@ export class User {
 If you save this entity:
 
 ```typescript
-import { getMongoManager } from "typeorm"
-
 const user = new User()
 user.firstName = "Timber"
 user.lastName = "Saw"
@@ -204,8 +202,7 @@ user.photos = [
     new Photo("me-and-chakram.jpg", "Me and Chakram", 200),
 ]
 
-const manager = getMongoManager()
-await manager.save(user)
+await myDataSource.manager.save(user)
 ```
 
 The following document will be saved in the database:

--- a/docs/docs/guides/8-migration-v1.md
+++ b/docs/docs/guides/8-migration-v1.md
@@ -143,6 +143,22 @@ const UserRepository = dataSource.getRepository(User).extend({
 
 The following error classes were also removed: `CustomRepositoryDoesNotHaveEntityError`, `CustomRepositoryCannotInheritRepositoryError`, `CustomRepositoryNotFoundError`.
 
+### `getMongoRepository` and `getMongoManager` globals
+
+The deprecated global functions `getMongoRepository()` and `getMongoManager()` have been removed. Use the corresponding instance methods on `DataSource` or `EntityManager` instead:
+
+```typescript
+// Before
+import { getMongoManager, getMongoRepository } from "typeorm"
+
+const manager = getMongoManager()
+const repository = getMongoRepository(User)
+
+// After
+const manager = dataSource.mongoManager
+const repository = dataSource.getMongoRepository(User)
+```
+
 ### Deprecated lock modes
 
 The `pessimistic_partial_write` and `pessimistic_write_or_fail` lock modes have been removed. Use `pessimistic_write` with the `onLocked` option instead:

--- a/src/globals.ts
+++ b/src/globals.ts
@@ -6,12 +6,10 @@ import { ConnectionManager } from "./connection/ConnectionManager"
 import { getFromContainer } from "./container"
 import type { DataSource } from "./data-source/DataSource"
 import type { EntityManager } from "./entity-manager/EntityManager"
-import type { MongoEntityManager } from "./entity-manager/MongoEntityManager"
 import type { SqljsEntityManager } from "./entity-manager/SqljsEntityManager"
 import type { EntityTarget } from "./common/EntityTarget"
 import type { Repository } from "./repository/Repository"
 import type { TreeRepository } from "./repository/TreeRepository"
-import type { MongoRepository } from "./repository/MongoRepository"
 import type { SelectQueryBuilder } from "./query-builder/SelectQueryBuilder"
 import { ObjectUtils } from "./util/ObjectUtils"
 import type { ObjectLiteral } from "./common/ObjectLiteral"
@@ -141,19 +139,6 @@ export function getManager(connectionName: string = "default"): EntityManager {
 }
 
 /**
- * Gets MongoDB entity manager from the connection.
- * If connection name wasn't specified, then "default" connection will be retrieved.
- * @param connectionName
- * @deprecated
- */
-export function getMongoManager(
-    connectionName: string = "default",
-): MongoEntityManager {
-    return getConnectionManager().get(connectionName)
-        .manager as MongoEntityManager
-}
-
-/**
  * Gets Sqljs entity manager from connection name.
  * "default" connection is used, when no name is specified.
  * Only works when Sqljs driver is used.
@@ -195,21 +180,6 @@ export function getTreeRepository<Entity extends ObjectLiteral>(
     return getConnectionManager()
         .get(connectionName)
         .getTreeRepository<Entity>(entityClass)
-}
-
-/**
- * Gets mongodb repository for the given entity class or name.
- * @param entityClass
- * @param connectionName
- * @deprecated
- */
-export function getMongoRepository<Entity extends ObjectLiteral>(
-    entityClass: EntityTarget<Entity>,
-    connectionName: string = "default",
-): MongoRepository<Entity> {
-    return getConnectionManager()
-        .get(connectionName)
-        .getMongoRepository<Entity>(entityClass)
 }
 
 /**


### PR DESCRIPTION
Remove the deprecated global functions `getMongoRepository()` and `getMongoManager()` from `src/globals.ts`, along with their now-unused `MongoRepository` and `MongoEntityManager` imports.

Instance methods on `DataSource` and `EntityManager` are unaffected.

Closes #12078

Part of #11603.