### PR TITLE
refactor!: remove internal nativeParameters plumbing from drivers and query builders

### DIFF
--- a/src/driver/Driver.ts
+++ b/src/driver/Driver.ts
@@ -170,7 +170,6 @@ export interface Driver {
     escapeQueryWithParameters(
         sql: string,
         parameters: ObjectLiteral,
-        nativeParameters: ObjectLiteral,
     ): [string, any[]]
 
     /**

--- a/src/driver/aurora-mysql/AuroraMysqlDriver.ts
+++ b/src/driver/aurora-mysql/AuroraMysqlDriver.ts
@@ -384,16 +384,12 @@ export class AuroraMysqlDriver implements Driver {
      * and an array of parameter names to be passed to a query.
      * @param sql
      * @param parameters
-     * @param nativeParameters
      */
     escapeQueryWithParameters(
         sql: string,
         parameters: ObjectLiteral,
-        nativeParameters: ObjectLiteral,
     ): [string, any[]] {
-        const escapedParameters: any[] = Object.keys(nativeParameters).map(
-            (key) => nativeParameters[key],
-        )
+        const escapedParameters: any[] = []
         if (!parameters || !Object.keys(parameters).length)
             return [sql, escapedParameters]
 

--- a/src/driver/cockroachdb/CockroachDriver.ts
+++ b/src/driver/cockroachdb/CockroachDriver.ts
@@ -511,16 +511,12 @@ export class CockroachDriver implements Driver {
      * and an array of parameter names to be passed to a query.
      * @param sql
      * @param parameters
-     * @param nativeParameters
      */
     escapeQueryWithParameters(
         sql: string,
         parameters: ObjectLiteral,
-        nativeParameters: ObjectLiteral,
     ): [string, any[]] {
-        const escapedParameters: any[] = Object.keys(nativeParameters).map(
-            (key) => nativeParameters[key],
-        )
+        const escapedParameters: any[] = []
         if (!parameters || !Object.keys(parameters).length)
             return [sql, escapedParameters]
 

--- a/src/driver/mongodb/MongoDriver.ts
+++ b/src/driver/mongodb/MongoDriver.ts
@@ -286,12 +286,10 @@ export class MongoDriver implements Driver {
      * and an array of parameter names to be passed to a query.
      * @param sql
      * @param parameters
-     * @param nativeParameters
      */
     escapeQueryWithParameters(
         sql: string,
         parameters: ObjectLiteral,
-        nativeParameters: ObjectLiteral,
     ): [string, any[]] {
         throw new TypeORMError(
             `This operation is not supported by Mongodb driver.`,

--- a/src/driver/mysql/MysqlDriver.ts
+++ b/src/driver/mysql/MysqlDriver.ts
@@ -461,16 +461,12 @@ export class MysqlDriver implements Driver {
      * and an array of parameter names to be passed to a query.
      * @param sql
      * @param parameters
-     * @param nativeParameters
      */
     escapeQueryWithParameters(
         sql: string,
         parameters: ObjectLiteral,
-        nativeParameters: ObjectLiteral,
     ): [string, any[]] {
-        const escapedParameters: any[] = Object.keys(nativeParameters).map(
-            (key) => nativeParameters[key],
-        )
+        const escapedParameters: any[] = []
         if (!parameters || !Object.keys(parameters).length)
             return [sql, escapedParameters]
 

--- a/src/driver/oracle/OracleDriver.ts
+++ b/src/driver/oracle/OracleDriver.ts
@@ -372,20 +372,12 @@ export class OracleDriver implements Driver {
      * and an array of parameter names to be passed to a query.
      * @param sql
      * @param parameters
-     * @param nativeParameters
      */
     escapeQueryWithParameters(
         sql: string,
         parameters: ObjectLiteral,
-        nativeParameters: ObjectLiteral,
     ): [string, any[]] {
-        const escapedParameters: any[] = Object.keys(nativeParameters).map(
-            (key) => {
-                if (typeof nativeParameters[key] === "boolean")
-                    return nativeParameters[key] ? 1 : 0
-                return nativeParameters[key]
-            },
-        )
+        const escapedParameters: any[] = []
         if (!parameters || !Object.keys(parameters).length)
             return [sql, escapedParameters]
 

--- a/src/driver/postgres/PostgresDriver.ts
+++ b/src/driver/postgres/PostgresDriver.ts
@@ -979,16 +979,12 @@ export class PostgresDriver implements Driver {
      * and an array of parameter names to be passed to a query.
      * @param sql
      * @param parameters
-     * @param nativeParameters
      */
     escapeQueryWithParameters(
         sql: string,
         parameters: ObjectLiteral,
-        nativeParameters: ObjectLiteral,
     ): [string, any[]] {
-        const escapedParameters: any[] = Object.keys(nativeParameters).map(
-            (key) => nativeParameters[key],
-        )
+        const escapedParameters: any[] = []
         if (!parameters || !Object.keys(parameters).length)
             return [sql, escapedParameters]
 

--- a/src/driver/react-native/ReactNativeDriver.ts
+++ b/src/driver/react-native/ReactNativeDriver.ts
@@ -443,29 +443,12 @@ export class ReactNativeDriver implements Driver {
      * and an array of parameter names to be passed to a query.
      * @param sql
      * @param parameters
-     * @param nativeParameters
      */
     escapeQueryWithParameters(
         sql: string,
         parameters: ObjectLiteral,
-        nativeParameters: ObjectLiteral,
     ): [string, any[]] {
-        const escapedParameters: any[] = Object.keys(nativeParameters).map(
-            (key) => {
-                // Mapping boolean values to their numeric representation
-                if (typeof nativeParameters[key] === "boolean") {
-                    return nativeParameters[key] === true ? 1 : 0
-                }
-
-                if (nativeParameters[key] instanceof Date) {
-                    return DateUtils.mixedDateToUtcDatetimeString(
-                        nativeParameters[key],
-                    )
-                }
-
-                return nativeParameters[key]
-            },
-        )
+        const escapedParameters: any[] = []
 
         if (!parameters || !Object.keys(parameters).length)
             return [sql, escapedParameters]

--- a/src/driver/sap/SapDriver.ts
+++ b/src/driver/sap/SapDriver.ts
@@ -396,16 +396,12 @@ export class SapDriver implements Driver {
      * and an array of parameter names to be passed to a query.
      * @param sql
      * @param parameters
-     * @param nativeParameters
      */
     escapeQueryWithParameters(
         sql: string,
         parameters: ObjectLiteral,
-        nativeParameters: ObjectLiteral,
     ): [string, any[]] {
-        const escapedParameters: any[] = Object.keys(nativeParameters).map(
-            (key) => nativeParameters[key],
-        )
+        const escapedParameters: any[] = []
 
         if (!parameters || !Object.keys(parameters).length)
             return [sql, escapedParameters]

--- a/src/driver/spanner/SpannerDriver.ts
+++ b/src/driver/spanner/SpannerDriver.ts
@@ -231,16 +231,12 @@ export class SpannerDriver implements Driver {
      * and an array of parameter names to be passed to a query.
      * @param sql
      * @param parameters
-     * @param nativeParameters
      */
     escapeQueryWithParameters(
         sql: string,
         parameters: ObjectLiteral,
-        nativeParameters: ObjectLiteral,
     ): [string, any[]] {
-        const escapedParameters: any[] = Object.keys(nativeParameters).map(
-            (key) => nativeParameters[key],
-        )
+        const escapedParameters: any[] = []
         if (!parameters || !Object.keys(parameters).length)
             return [sql, escapedParameters]
 

--- a/src/driver/sqlite-abstract/AbstractSqliteDriver.ts
+++ b/src/driver/sqlite-abstract/AbstractSqliteDriver.ts
@@ -444,29 +444,12 @@ export abstract class AbstractSqliteDriver implements Driver {
      * and an array of parameter names to be passed to a query.
      * @param sql
      * @param parameters
-     * @param nativeParameters
      */
     escapeQueryWithParameters(
         sql: string,
         parameters: ObjectLiteral,
-        nativeParameters: ObjectLiteral,
     ): [string, any[]] {
-        const escapedParameters: any[] = Object.keys(nativeParameters).map(
-            (key) => {
-                // Mapping boolean values to their numeric representation
-                if (typeof nativeParameters[key] === "boolean") {
-                    return nativeParameters[key] === true ? 1 : 0
-                }
-
-                if (nativeParameters[key] instanceof Date) {
-                    return DateUtils.mixedDateToUtcDatetimeString(
-                        nativeParameters[key],
-                    )
-                }
-
-                return nativeParameters[key]
-            },
-        )
+        const escapedParameters: any[] = []
 
         if (!parameters || !Object.keys(parameters).length)
             return [sql, escapedParameters]

--- a/src/driver/sqlserver/SqlServerDriver.ts
+++ b/src/driver/sqlserver/SqlServerDriver.ts
@@ -371,16 +371,12 @@ export class SqlServerDriver implements Driver {
      * and an array of parameter names to be passed to a query.
      * @param sql
      * @param parameters
-     * @param nativeParameters
      */
     escapeQueryWithParameters(
         sql: string,
         parameters: ObjectLiteral,
-        nativeParameters: ObjectLiteral,
     ): [string, any[]] {
-        const escapedParameters: any[] = Object.keys(nativeParameters).map(
-            (key) => nativeParameters[key],
-        )
+        const escapedParameters: any[] = []
         if (!parameters || !Object.keys(parameters).length)
             return [sql, escapedParameters]
 

--- a/src/query-builder/QueryBuilder.ts
+++ b/src/query-builder/QueryBuilder.ts
@@ -489,13 +489,11 @@ export abstract class QueryBuilder<Entity extends ObjectLiteral> {
      * Gets query to be executed with all parameters used in it.
      */
     getQueryAndParameters(): [string, any[]] {
-        // this execution order is important because getQuery method generates this.expressionMap.nativeParameters values
         const query = this.getQuery()
         const parameters = this.getParameters()
         return this.connection.driver.escapeQueryWithParameters(
             query,
             parameters,
-            this.expressionMap.nativeParameters,
         )
     }
 
@@ -1623,8 +1621,6 @@ export abstract class QueryBuilder<Entity extends ObjectLiteral> {
                 this.expressionMap.aliasNamePrefixingEnabled
             whereQueryBuilder.expressionMap.parameters =
                 this.expressionMap.parameters
-            whereQueryBuilder.expressionMap.nativeParameters =
-                this.expressionMap.nativeParameters
             whereQueryBuilder.expressionMap.joinAttributes =
                 this.expressionMap.joinAttributes
 

--- a/src/query-builder/QueryExpressionMap.ts
+++ b/src/query-builder/QueryExpressionMap.ts
@@ -321,12 +321,6 @@ export class QueryExpressionMap {
     timeTravel?: boolean | string
 
     /**
-     * Extra parameters.
-     * @deprecated Use standard parameters instead
-     */
-    nativeParameters: ObjectLiteral = {}
-
-    /**
      * Query Comment to include extra information for debugging or other purposes.
      */
     comment?: string
@@ -544,7 +538,6 @@ export class QueryExpressionMap {
         map.callListeners = this.callListeners
         map.useTransaction = this.useTransaction
         map.timeTravel = this.timeTravel
-        map.nativeParameters = Object.assign({}, this.nativeParameters)
         map.comment = this.comment
         map.commonTableExpressions = this.commonTableExpressions.map(
             (cteOptions) => ({

--- a/src/query-builder/SelectQueryBuilder.ts
+++ b/src/query-builder/SelectQueryBuilder.ts
@@ -3624,9 +3624,6 @@ export class SelectQueryBuilder<Entity extends ObjectLiteral>
                     this.expressionMap.cacheDuration,
                 )
                 .setParameters(this.getParameters())
-            paginationQueryBuilder.expressionMap.nativeParameters = {
-                ...this.expressionMap.nativeParameters,
-            }
             rawResults = await paginationQueryBuilder.getRawMany()
 
             if (rawResults.length > 0) {
@@ -4373,7 +4370,6 @@ export class SelectQueryBuilder<Entity extends ObjectLiteral>
         embedPrefix?: string,
     ) {
         let condition: string = ""
-        // let parameterIndex = Object.keys(this.expressionMap.nativeParameters).length;
         if (Array.isArray(where)) {
             if (where.length) {
                 condition = where
@@ -4701,7 +4697,6 @@ export class SelectQueryBuilder<Entity extends ObjectLiteral>
                         )
                         if (condition) {
                             andConditions.push(condition)
-                            // parameterIndex = Object.keys(this.expressionMap.nativeParameters).length;
                         }
                     }
                 }

--- a/test/functional/driver/abstract-sqlite/abstract-sqlite-escape-query-parameters.test.ts
+++ b/test/functional/driver/abstract-sqlite/abstract-sqlite-escape-query-parameters.test.ts
@@ -22,7 +22,6 @@ describe("escape sqlite query parameters", () => {
             const [_, parameters] = connection.driver.escapeQueryWithParameters(
                 "SELECT nothing FROM irrelevant WHERE a = :param1",
                 { param1: true },
-                {},
             )
 
             expect(parameters).to.deep.equal([1])
@@ -33,29 +32,6 @@ describe("escape sqlite query parameters", () => {
             const [_, parameters] = connection.driver.escapeQueryWithParameters(
                 "SELECT nothing FROM irrelevant WHERE a = :param1",
                 { param1: false },
-                {},
-            )
-
-            expect(parameters).to.deep.equal([0])
-        }))
-
-    it("should transform boolean nativeParameters with value `true` into `1`", () =>
-        dataSources.map((connection) => {
-            const [_, parameters] = connection.driver.escapeQueryWithParameters(
-                "SELECT nothing FROM irrelevant",
-                {},
-                { nativeParam1: true },
-            )
-
-            expect(parameters).to.deep.equal([1])
-        }))
-
-    it("should transform boolean nativeParameters with value `false` into 0", () =>
-        dataSources.map((connection) => {
-            const [_, parameters] = connection.driver.escapeQueryWithParameters(
-                "SELECT nothing FROM irrelevant",
-                {},
-                { nativeParam1: false },
             )
 
             expect(parameters).to.deep.equal([0])


### PR DESCRIPTION
Follow-up to #12090. Removes the internal `nativeParameters` property and its flow through all drivers, which became dead code after the public API removal (`setNativeParameters()`, `onConflict()`).

- Removed `nativeParameters` property from `QueryExpressionMap` and its cloning in `clone()`
- Removed `nativeParameters` passing in `QueryBuilder.getQueryAndParameters()` and where-clause factory
- Removed `nativeParameters` parameter from `Driver.escapeQueryWithParameters()` interface
- Removed `nativeParameters` parameter and seeded `escapedParameters` array from all 11 driver implementations (Postgres, MySQL, Aurora MySQL, Oracle, CockroachDB, SQL Server, AbstractSqlite, ReactNative, MongoDB, SAP, Spanner)
- Removed `nativeParameters` propagation in `SelectQueryBuilder` pagination logic and commented-out lines
- Updated SQLite test file to remove nativeParameters-specific test cases and drop the third argument
- Added migration doc section about the removal

Part of #11603.