### PR TITLE
refactor(columns)!: remove deprecated unsigned from ColumnNumericOptions

### DIFF
--- a/docs/docs/guides/8-migration-v1.md
+++ b/docs/docs/guides/8-migration-v1.md
@@ -269,3 +269,7 @@ authorName: string
 @Column({ update: false })
 authorName: string
 ```
+
+### `ColumnNumericOptions.unsigned`
+
+The deprecated `unsigned` property on `ColumnNumericOptions` (used with decimal/float column type overloads like `@Column("decimal", { unsigned: true })`) has been removed, as MySQL deprecated `UNSIGNED` for non-integer numeric types. The `unsigned` option on `ColumnOptions` for integer types is **not** affected and continues to work.

--- a/src/decorator/options/ColumnNumericOptions.ts
+++ b/src/decorator/options/ColumnNumericOptions.ts
@@ -13,11 +13,4 @@ export interface ColumnNumericOptions {
      * of digits to the right of the decimal point and must not be greater than precision.
      */
     scale?: number
-
-    /**
-     * Puts UNSIGNED attribute on to numeric column. Works only for MySQL.
-     * @deprecated MySQL deprecated the UNSIGNED attribute for non-integer
-     * numeric types. This will also be removed from TypeORM in an upcoming version.
-     */
-    unsigned?: boolean
 }


### PR DESCRIPTION
Removes the deprecated `unsigned` property from `ColumnNumericOptions`, as MySQL deprecated `UNSIGNED` for non-integer numeric types (DECIMAL, FLOAT, DOUBLE).

The `unsigned` option on `ColumnOptions` and `ColumnUnsignedOptions` for integer types is not affected.

Part of #11603.