### PR TITLE
refactor(SqlServer)!: remove deprecated domain connection option

### DIFF
--- a/docs/docs/guides/8-migration-v1.md
+++ b/docs/docs/guides/8-migration-v1.md
@@ -126,6 +126,37 @@ const repository = dataSource.getMongoRepository(User)
 
 The internal MongoDB types are no longer exported. You can import `ObjectId` from `mongodb` instead of `typeorm`.
 
+## MS SQL Server
+
+### `domain` connection option removed
+
+The deprecated `domain` option on `SqlServerConnectionCredentialsOptions` has been removed. Use the `authentication` option with NTLM type instead:
+
+```typescript
+// Before
+new DataSource({
+    type: "mssql",
+    domain: "MYDOMAIN",
+    username: "user",
+    password: "pass",
+    // ...
+})
+
+// After
+new DataSource({
+    type: "mssql",
+    authentication: {
+        type: "ntlm",
+        options: {
+            domain: "MYDOMAIN",
+            userName: "user",
+            password: "pass",
+        },
+    },
+    // ...
+})
+```
+
 ## Expo
 
 Support for the legacy Expo SQLite driver has been removed. The legacy API was removed by Expo in SDK v52, so you'll need to use Expo SDK v52 or later with the modern async SQLite API.

--- a/src/driver/sqlserver/SqlServerConnectionCredentialsOptions.ts
+++ b/src/driver/sqlserver/SqlServerConnectionCredentialsOptions.ts
@@ -56,12 +56,4 @@ export interface SqlServerConnectionCredentialsOptions {
      * It overrides username and password, when passed.
      */
     readonly authentication?: SqlServerConnectionCredentialsAuthenticationOptions
-
-    /**
-     * Once you set domain, driver will connect to SQL Server using domain login.
-     * @see SqlServerConnectionCredentialsOptions.authentication
-     * @see NtlmAuthentication
-     * @deprecated
-     */
-    readonly domain?: string
 }

--- a/src/driver/sqlserver/SqlServerDriver.ts
+++ b/src/driver/sqlserver/SqlServerDriver.ts
@@ -1168,17 +1168,6 @@ export class SqlServerDriver implements Driver {
             DriverUtils.buildDriverOptions(credentials),
         ) // todo: do it better way
 
-        // todo: credentials.domain is deprecation. remove it in future
-        const authentication = !credentials.domain
-            ? credentials.authentication
-            : {
-                  type: "ntlm",
-                  options: {
-                      domain: credentials.domain,
-                      userName: credentials.username,
-                      password: credentials.password,
-                  },
-              }
         // build connection options for the driver
         const connectionOptions = Object.assign(
             {},
@@ -1195,7 +1184,7 @@ export class SqlServerDriver implements Driver {
                 port: credentials.port,
                 user: credentials.username,
                 password: credentials.password,
-                authentication: authentication,
+                authentication: credentials.authentication,
             },
             options.extra || {},
         )


### PR DESCRIPTION
- Remove deprecated `domain` property from `SqlServerConnectionCredentialsOptions`
- Remove fallback logic in `SqlServerDriver.createPool()` that converted `domain` to NTLM authentication
- Use `credentials.authentication` directly instead
- Update migration guide with instructions to use `authentication` option with NTLM type

Part of #11603.