### PR TITLE
perf(cockroachdb): batch DROP statements in clearDatabase()

### DIFF
--- a/src/driver/cockroachdb/CockroachQueryRunner.ts
+++ b/src/driver/cockroachdb/CockroachQueryRunner.ts
@@ -3025,7 +3025,7 @@ export class CockroachQueryRunner
             // drop tables
             const tables: ObjectLiteral[] = await this.query(
                 `SELECT quote_ident(table_schema) || '.' || quote_ident(table_name) as "name" ` +
-                    `FROM "information_schema"."tables" WHERE "table_schema" IN (${schemaNamesString})`,
+                    `FROM "information_schema"."tables" WHERE "table_schema" IN (${schemaNamesString}) AND "table_type" = 'BASE TABLE'`,
             )
 
             if (tables.length > 0) {
@@ -3042,7 +3042,7 @@ export class CockroachQueryRunner
 
             if (sequences.length > 0) {
                 await this.query(
-                    `DROP SEQUENCE ${sequences.map(({ name }) => name).join(", ")}`,
+                    `DROP SEQUENCE IF EXISTS ${sequences.map(({ name }) => name).join(", ")}`,
                 )
             }
 
@@ -4005,7 +4005,7 @@ export class CockroachQueryRunner
      */
     protected async dropEnumTypes(schemaNames: string): Promise<void> {
         const enums: ObjectLiteral[] = await this.query(
-            `SELECT '"' || n.nspname || '"."' || t.typname || '"' as "name" FROM "pg_type" "t" ` +
+            `SELECT quote_ident(n.nspname) || '.' || quote_ident(t.typname) as "name" FROM "pg_type" "t" ` +
                 `INNER JOIN "pg_enum" "e" ON "e"."enumtypid" = "t"."oid" ` +
                 `INNER JOIN "pg_namespace" "n" ON "n"."oid" = "t"."typnamespace" ` +
                 `WHERE "n"."nspname" IN (${schemaNames}) GROUP BY "n"."nspname", "t"."typname"`,


### PR DESCRIPTION
CockroachDB tests take 20+ minutes while other databases complete in 2–3 minutes. A major contributor is `clearDatabase()`, which is called via `synchronize(true)` in every test's `beforeEach`. Previously, it executed each DROP as a separate query — for N tables, that meant N+1 round-trips (1 SELECT + N individual DROPs), repeated for views, tables, sequences, and enum types.

This batches all DROP operations into single statements:

```sql
-- Before: N individual queries
DROP TABLE IF EXISTS "public"."users" CASCADE;
DROP TABLE IF EXISTS "public"."posts" CASCADE;
DROP TABLE IF EXISTS "public"."comments" CASCADE;

-- After: 1 batched query
DROP TABLE IF EXISTS "public"."users", "public"."posts", "public"."comments" CASCADE
```

Applied to all four object types (views, tables, sequences, enums), reducing the total from 4×(N+1) queries down to 4×2 queries per `clearDatabase()` call.

Additionally hardens the DROP statements:
- Use `quote_ident()` for enum type names instead of manual double-quote concatenation
- Add `IF EXISTS` to `DROP SEQUENCE` for resilience to concurrent cleanup
- Filter `information_schema.tables` by `table_type = 'BASE TABLE'` to avoid dropping views as tables