### PR TITLE
ci: restore npm upgrade and bump Node to 24 for trusted publishing

### DIFF
--- a/.github/workflows/publish-package.yml
+++ b/.github/workflows/publish-package.yml
@@ -141,8 +141,11 @@ jobs:
       - uses: actions/setup-node@v6
         if: steps.publishable.outputs.should_publish == 'true'
         with:
-          node-version: 22
+          node-version: 24
           cache: "pnpm"
+
+      - run: npm install -g npm@latest
+        if: steps.publishable.outputs.should_publish == 'true'
 
       - run: pnpm install --frozen-lockfile
         if: steps.publishable.outputs.should_publish == 'true'


### PR DESCRIPTION
The nightly publish was failing with ENEEDAUTH because the bundled npm
on Node 22 doesn't complete the OIDC token exchange for Trusted Publishing.

- Bump Node from 22 to 24 (ships with newer npm)
- Restore `npm install -g npm@latest` step before publish as safety net