### PR TITLE
ci: improve path filters for format and test jobs

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -51,14 +51,6 @@ jobs:
               - .mocharc.json
               - ormconfig.sample.json
 
-            format:
-              - *ci
-              - *docs
-              - *src-or-tests
-              - .editorconfig
-              - .prettierignore
-              - .prettierrc.js
-
             lint:
               - *src-or-tests
               - eslint.config.mjs
@@ -103,8 +95,6 @@ jobs:
           retention-days: 1
 
   format:
-    if: contains(needs.detect-changes.outputs.changes, 'format')
-    needs: detect-changes
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6


### PR DESCRIPTION
- Add dedicated `ci` path filter group for `.github/**/*`, `.pr_agent.toml`, and `pr_compliance_checklist.yaml`
- Include `ci` and `docs` path filters in the `format` job trigger
- Add `docker/**/*` to `src-or-tests` filter and sort entries alphabetically