### PR TITLE
ci(qodo): turn off progress comments and agentic describe

### DIFF
--- a/.pr_agent.toml
+++ b/.pr_agent.toml
@@ -1,7 +1,6 @@
 [github_app]
-pr_commands = ["/agentic_describe", "/agentic_review"]
+pr_commands = ["/agentic_review"]
 feedback_or_draft_pr = false
-
 handle_push_trigger = true
 push_commands = ["/agentic_review"]
 
@@ -13,9 +12,11 @@ utilize_auto_best_practices = true
 enabled = true
 publish_output = true
 comments_location_policy = "summary"
-persistent_comment = true
 final_update_message = false
-publish_output_progress = false
+persistent_comment = true
 
 [checks]
 enable_auto_checks_feedback = false
+
+[config]
+publish_output_progress = false


### PR DESCRIPTION
moved publish_output_progress to config 
removed /agentic_describe - will be triggered manually when needed.

<!--
  😀 Wonderful!  Thank you for opening a pull request for TypeORM.

  Please fill in the information below to expedite the review
  and (hopefully) merge of your change.

  If unsure about something.. just do as best as you're able,
  or reach out through our community support channels!
  https://github.com/typeorm/typeorm/blob/master/docs/support.md
  https://github.com/typeorm/typeorm/blob/master/CONTRIBUTING.md
-->

### Description of change

<!--
  Please describe:
  - what the change is intended to do
  - why this change is needed
  - how you've verified it
  - any other context that will help reviewers understand the change

  In some cases it may be helpful to include the current behavior
  and the new behavior.
-->

### Pull-Request Checklist

<!--
  Please make sure to review and check all of the following.

  If an item is not applicable, you can add "N/A" to the end.
-->

- [ ] Code is up-to-date with the `master` branch
- [ ] This pull request links relevant issues as `Fixes #00000`
- [ ] There are new or updated tests validating the change (`tests/**.test.ts`)
- [ ] Documentation has been updated to reflect this change (`docs/docs/**.md`)

<!--
  🎉 Thank you for contributing and making TypeORM even better!
-->
