### PR TITLE
ci(publish): serialize nightly publish jobs to avoid npm 409 conflict

### DIFF
--- a/.github/workflows/publish-package.yml
+++ b/.github/workflows/publish-package.yml
@@ -89,6 +89,7 @@ jobs:
       id-token: write
     strategy:
       fail-fast: false
+      max-parallel: 1
       matrix:
         include: ${{ fromJson(needs.setup.outputs.matrix) }}
     steps:


### PR DESCRIPTION
The scheduled nightly publish workflow runs two matrix jobs in parallel (`master/dev` and `v0.3/nightly`). Both publish to the same `typeorm` npm package, causing an npm registry race condition:

```
npm error code E409
npm error 409 Conflict - PUT https://registry.npmjs.org/typeorm
  - Failed to save packument. A common cause is if you try to publish
    a new package before the previous package has been fully processed.
```

See failed run: https://github.com/typeorm/typeorm/actions/runs/23176436061/job/67339540603

Adding `max-parallel: 1` to the publish matrix strategy serializes the jobs so the second publish waits for the first to complete.