### PR TITLE
fix(sqlite): retrieve collation info from db

### DIFF
--- a/src/driver/sqlite-abstract/AbstractSqliteDriver.ts
+++ b/src/driver/sqlite-abstract/AbstractSqliteDriver.ts
@@ -950,6 +950,7 @@ export abstract class AbstractSqliteDriver implements Driver {
                 tableColumn.isNullable !== columnMetadata.isNullable ||
                 tableColumn.generatedType !== columnMetadata.generatedType ||
                 tableColumn.asExpression !== columnMetadata.asExpression ||
+                tableColumn.collation !== columnMetadata.collation ||
                 tableColumn.isUnique !==
                     this.normalizeIsUnique(columnMetadata) ||
                 !!(

--- a/src/driver/sqlite-abstract/AbstractSqliteQueryRunner.ts
+++ b/src/driver/sqlite-abstract/AbstractSqliteQueryRunner.ts
@@ -48,6 +48,43 @@ export abstract class AbstractSqliteQueryRunner
     }
 
     // -------------------------------------------------------------------------
+    // Private Methods
+    // -------------------------------------------------------------------------
+
+    /**
+     * Extracts column collation from the given sql.
+     *
+     * @param sql
+     * @param columnName
+     * @returns
+     */
+
+    private getColumnCollation(
+        sql: string,
+        columnName: string,
+    ): string | undefined {
+        const escapedColumnName = this.driver.escape(columnName)
+        const columnDefStart = sql.indexOf(`${escapedColumnName}`)
+        if (columnDefStart === -1) return undefined
+
+        sql = sql.slice(columnDefStart + escapedColumnName.length)
+        sql = sql.replaceAll(/CHECK\s*\(\s*(.*)\s+\)\s*/g, "")
+        sql = sql.replaceAll(/DEFAULT\s+\(.*\)\s*/g, "")
+
+        const collateStart = sql.indexOf("COLLATE")
+        if (collateStart === -1) return undefined
+
+        const stripped = sql.slice(0, collateStart)
+
+        if (stripped.indexOf(",") !== -1) return undefined
+
+        const collateRegex = /\bCOLLATE\s+"(\w+)"\s*/i
+        const matches = collateRegex.exec(sql)
+        if (!matches) return undefined
+        return matches[1]
+    }
+
+    // -------------------------------------------------------------------------
     // Public Methods
     // -------------------------------------------------------------------------
 
@@ -1549,6 +1586,10 @@ export abstract class AbstractSqliteQueryRunner
                         : dbTable["name"]
 
                 const sql = dbTable["sql"]
+                const tableDefinition = sql.slice(
+                    sql.indexOf("(") + 1,
+                    sql.lastIndexOf(")"),
+                )
 
                 const withoutRowid = sql.includes("WITHOUT ROWID")
                 const table = new Table({ name: tablePath, withoutRowid })
@@ -1649,6 +1690,14 @@ export abstract class AbstractSqliteQueryRunner
                                 sql,
                                 tableColumn.name,
                             )
+                        }
+
+                        const collation = this.getColumnCollation(
+                            tableDefinition,
+                            tableColumn.name,
+                        )
+                        if (collation) {
+                            tableColumn.collation = collation
                         }
 
                         // parse datatype and attempt to retrieve length, precision and scale
@@ -2192,7 +2241,7 @@ export abstract class AbstractSqliteQueryRunner
         )
             // don't use skipPrimary here since updates can update already exist primary without auto inc.
             c += " AUTOINCREMENT"
-        if (column.collation) c += " COLLATE " + column.collation
+        if (column.collation) c += " COLLATE " + `"${column.collation}"`
         if (column.isNullable !== true) c += " NOT NULL"
 
         if (column.asExpression) {

--- a/test/functional/database-schema/column-collation/sqlite/column-collation-sqlite.test.ts
+++ b/test/functional/database-schema/column-collation/sqlite/column-collation-sqlite.test.ts
@@ -6,9 +6,9 @@ import {
     createTestingConnections,
     reloadTestingDatabases,
 } from "../../../../utils/test-utils"
+import { expect } from "chai"
 
-// skipped because there is no way to get column collation from SQLite table schema
-describe.skip("database schema > column collation > sqlite", () => {
+describe("database schema > column collation > sqlite", () => {
     let dataSources: DataSource[]
     before(async () => {
         dataSources = await createTestingConnections({
@@ -22,19 +22,75 @@ describe.skip("database schema > column collation > sqlite", () => {
     it("should correctly create column with collation option", () =>
         Promise.all(
             dataSources.map(async (dataSource) => {
-                const postRepository = dataSource.getRepository(Post)
                 const queryRunner = dataSource.createQueryRunner()
-                const table = await queryRunner.getTable("post")
-                await queryRunner.release()
+                try {
+                    const postRepository = dataSource.getRepository(Post)
+                    const table = await queryRunner.getTable("post")
 
-                const post = new Post()
-                post.id = 1
-                post.name = "Post"
-                await postRepository.save(post)
+                    const post = new Post()
+                    post.id = 1
+                    post.name = "Post"
+                    post.description = "description"
+                    post.text = "text"
+                    post.nonCollated = "nonCollated"
+                    post.defaultContainsCollateKeyword =
+                        "defaultContainsCollateKeyword"
+                    post.enumCollated = "COLLATE BINARY"
+                    post.nameAsTableName = "nameAsTableName"
+                    post.nameWithComma = "nameWithComma"
+                    post.nameWithDot = "nameWithDot"
+                    await postRepository.save(post)
 
-                table!
-                    .findColumnByName("name")!
-                    .collation!.should.be.equal("RTRIM")
+                    expect(table?.findColumnByName("name")?.collation).to.equal(
+                        "RTRIM",
+                    )
+
+                    expect(
+                        table?.findColumnByName("description")?.collation,
+                    ).to.equal("NOCASE")
+
+                    expect(table?.findColumnByName("text")?.collation).to.equal(
+                        "BINARY",
+                    )
+
+                    expect(
+                        table?.findColumnByName("enumCollated")?.collation,
+                    ).to.equal("NOCASE")
+
+                    expect(table?.findColumnByName("post")?.collation).to.equal(
+                        "NOCASE",
+                    )
+
+                    expect(
+                        table?.findColumnByName("name,with,comma")?.collation,
+                    ).to.equal("RTRIM")
+
+                    expect(
+                        table?.findColumnByName("name.with.dot")?.collation,
+                    ).to.equal("NOCASE")
+
+                    expect(
+                        table?.findColumnByName("defaultContainsCollateKeyword")
+                            ?.collation,
+                    ).to.be.undefined
+
+                    expect(table?.findColumnByName("nonCollated")?.collation).to
+                        .be.undefined
+                } finally {
+                    await queryRunner.release()
+                }
+            }),
+        ))
+
+    it("should not generate schema changes for collation formatting differences", () =>
+        Promise.all(
+            dataSources.map(async (dataSource) => {
+                const sqlInMemory = await dataSource.driver
+                    .createSchemaBuilder()
+                    .log()
+
+                expect(sqlInMemory.upQueries).to.eql([])
+                expect(sqlInMemory.downQueries).to.eql([])
             }),
         ))
 })

--- a/test/functional/database-schema/column-collation/sqlite/entity/Post.ts
+++ b/test/functional/database-schema/column-collation/sqlite/entity/Post.ts
@@ -9,4 +9,33 @@ export class Post {
 
     @Column({ collation: "RTRIM" })
     name: string
+
+    @Column({ collation: "NOCASE" })
+    description: string
+
+    @Column({ collation: "BINARY" })
+    text: string
+
+    @Column()
+    nonCollated: string
+
+    @Column({ default: "COLLATE NOCASE" })
+    defaultContainsCollateKeyword: string
+
+    @Column({
+        type: "varchar",
+        enum: ["COLLATE BINARY", "B", "C,D"],
+        collation: "NOCASE",
+        default: "COLLATE RTRIM",
+    })
+    enumCollated: string
+
+    @Column({ name: "post", collation: "NOCASE" })
+    nameAsTableName: string
+
+    @Column({ name: "name,with,comma", collation: "RTRIM" })
+    nameWithComma: string
+
+    @Column({ name: "name.with.dot", collation: "NOCASE" })
+    nameWithDot: string
 }


### PR DESCRIPTION
Closes #11907

### Description of change
Loads table columns' collation type from the database during `loadTables` for SQLite.

**Before:** schema sync ignored column `collation` changes.
**After:** schema sync takes into account `collation` changes.

### Pull-Request Checklist
- [x] Code is up-to-date with the `master` branch
- [x] This pull request links relevant issues as `Issue #246`
- [x] There are new or updated tests validating the change (`tests/**.test.ts`)
- [ ] Documentation has been updated to reflect this change (`docs/docs/**.md`) (N/A)

**Related**
- #246