### PR TITLE
fix: preserve bigint string type in single JoinColumn value extraction

### DIFF
--- a/src/metadata/ColumnMetadata.ts
+++ b/src/metadata/ColumnMetadata.ts
@@ -720,11 +720,20 @@ export class ColumnMetadata {
                     if (Object.keys(map).length > 0)
                         return { [this.propertyName]: map }
                 } else {
-                    const value =
+                    let value =
                         this.relationMetadata.joinColumns[0].referencedColumn!.getEntityValue(
                             entity[this.relationMetadata!.propertyName],
                         )
                     if (value) {
+                        // Ensure bigint values are preserved as strings to prevent
+                        // JS Number precision loss for values > Number.MAX_SAFE_INTEGER.
+                        // See: https://github.com/typeorm/typeorm/issues/12337
+                        if (
+                            this.type === "bigint" &&
+                            typeof value === "number"
+                        ) {
+                            value = String(value)
+                        }
                         return { [this.propertyName]: value }
                     }
                 }


### PR DESCRIPTION
## Summary

Fixes #12337

Since PR #10672 (0.3.21), `getEntityValueMap()` in `ColumnMetadata.ts` uses `getEntityValue()` for single `@JoinColumn` columns as a performance optimization. However, `getEntityValue()` lacks the `String(value)` conversion that `getEntityValueMap()`/`createValueMap()` applies for bigint columns. This causes **silent precision loss** when the value exceeds `Number.MAX_SAFE_INTEGER` (`2^53 - 1`).

### The Problem

```typescript
// Single JoinColumn path (0.3.21+) — missing bigint protection:
const value = this.relationMetadata.joinColumns[0]
    .referencedColumn!.getEntityValue(entity[...])
// value can be coerced to Number downstream, losing precision

// Composite key path & createValueMap() — has protection:
if (this.type === "bigint" && value !== null)
    value = String(value)  // ← this protection is missing in the single JoinColumn path
```

### The Fix

Added `String(value)` conversion for bigint types in the single `@JoinColumn` code path, matching the existing protection in `createValueMap()`.

### Impact

In our production environment, this bug silently corrupted ~1,457 records across ~575 users. The corrupted FK values caused `INNER JOIN` failures, making affected records invisible to users with no error logged.

### Affected Versions

- **0.3.21 ~ 0.3.28** (all affected)
- **0.3.19, 0.3.20** (safe — before PR #10672)