### PR TITLE
ci(spanner): add spanner job to the linux test matrix

### DIFF
--- a/.github/workflows/tests-linux.yml
+++ b/.github/workflows/tests-linux.yml
@@ -295,3 +295,30 @@ jobs:
         with:
           flag-name: sap-node:${{ inputs.node-version }}
           parallel: true
+
+  spanner:
+    runs-on: ubuntu-latest
+    services:
+      spanner:
+        image: roryq/spanner-emulator:latest
+        ports:
+          - "9010:9010"
+          - "9020:9020"
+        env:
+          SPANNER_PROJECT_ID: typeorm
+          SPANNER_INSTANCE_ID: typeorm
+          SPANNER_DATABASE_ID: typeorm
+    steps:
+      - uses: actions/checkout@v6
+      - uses: ./.github/actions/setup-node
+        with:
+          node-version: ${{ inputs.node-version }}
+          download-build: true
+
+      - run: jq 'map(select(.type == "spanner"))' ormconfig.sample.json > ormconfig.json
+      - run: pnpm exec c8 pnpm run test:ci
+
+      - uses: coverallsapp/github-action@v2
+        with:
+          flag-name: spanner-node:${{ inputs.node-version }}
+          parallel: true

--- a/.github/workflows/tests-linux.yml
+++ b/.github/workflows/tests-linux.yml
@@ -316,6 +316,11 @@ jobs:
           download-build: true
 
       - run: jq 'map(select(.type == "spanner"))' ormconfig.sample.json > ormconfig.json
+
+      - name: healthcheck
+        run: |
+          timeout 30 bash -c 'until curl -sf http://localhost:9020/v1/projects/typeorm/instances/typeorm/databases/typeorm > /dev/null; do sleep 1; done'
+
       - run: pnpm exec c8 pnpm run test:ci
 
       - uses: coverallsapp/github-action@v2

--- a/.gitignore
+++ b/.gitignore
@@ -21,6 +21,7 @@ node_modules/
 *.iml
 
 ### TypeORM ###
+temp/
 ormconfig.json
 ormlogs.log
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -110,13 +110,17 @@ services:
       # - oracle-data:/opt/oracle/oradata
       - ./docker/oracle/startup:/opt/oracle/scripts/startup:ro
 
-  # google cloud spanner
+  # spanner
   spanner:
-    image: alexmesser/spanner-emulator
+    image: roryq/spanner-emulator:latest
     container_name: "typeorm-spanner"
     ports:
       - "9010:9010"
       - "9020:9020"
+    environment:
+      SPANNER_PROJECT_ID: "typeorm"
+      SPANNER_INSTANCE_ID: "typeorm"
+      SPANNER_DATABASE_ID: "typeorm"
 
   # sap hana
   # works only on linux, minimum 10GB RAM for docker required

--- a/ormconfig.sample.json
+++ b/ormconfig.sample.json
@@ -1,97 +1,5 @@
 [
   {
-    "skip": false,
-    "type": "mysql",
-    "host": "localhost",
-    "port": 3306,
-    "username": "root",
-    "password": "admin",
-    "database": "typeorm",
-    "logging": false
-  },
-  {
-    "skip": false,
-    "type": "mariadb",
-    "host": "localhost",
-    "port": 3307,
-    "username": "root",
-    "password": "admin",
-    "database": "typeorm",
-    "logging": false
-  },
-  {
-    "skip": false,
-    "type": "better-sqlite3",
-    "database": "temp/better-sqlite3.db",
-    "logging": false
-  },
-  {
-    "skip": false,
-    "type": "sqljs",
-    "logging": false
-  },
-  {
-    "skip": false,
-    "type": "postgres",
-    "host": "localhost",
-    "port": 5432,
-    "username": "username",
-    "password": "password",
-    "database": "typeorm",
-    "logging": false
-  },
-  {
-    "skip": false,
-    "type": "mssql",
-    "host": "localhost",
-    "port": 1433,
-    "username": "sa",
-    "password": "Admin12345",
-    "database": "tempdb",
-    "logging": false,
-    "extra": {
-      "trustServerCertificate": true
-    }
-  },
-  {
-    "skip": false,
-    "type": "oracle",
-    "host": "localhost",
-    "port": 1521,
-    "username": "typeorm",
-    "password": "oracle",
-    "serviceName": "FREEPDB1",
-    "logging": false
-  },
-  {
-    "skip": false,
-    "type": "cockroachdb",
-    "host": "localhost",
-    "port": 26257,
-    "username": "root",
-    "password": "",
-    "database": "defaultdb",
-    "logging": false
-  },
-  {
-    "skip": false,
-    "type": "sap",
-    "host": "localhost",
-    "port": 39041,
-    "username": "SYSTEM",
-    "password": "HXEHana1",
-    "logging": false
-  },
-  {
-    "skip": false,
-    "disabledIfNotEnabledImplicitly": true,
-    "type": "mongodb",
-    "host": "localhost",
-    "port": 27017,
-    "database": "test",
-    "logging": false
-  },
-  {
     "skip": true,
     "type": "aurora-mysql",
     "region": "us-east-1",
@@ -117,12 +25,104 @@
   },
   {
     "skip": false,
+    "type": "better-sqlite3",
+    "database": "temp/better-sqlite3.db",
+    "logging": false
+  },
+  {
+    "skip": false,
+    "type": "cockroachdb",
+    "host": "localhost",
+    "port": 26257,
+    "username": "root",
+    "password": "",
+    "database": "defaultdb",
+    "logging": false
+  },
+  {
+    "skip": false,
+    "type": "mariadb",
+    "host": "localhost",
+    "port": 3307,
+    "username": "root",
+    "password": "admin",
+    "database": "typeorm",
+    "logging": false
+  },
+  {
+    "skip": false,
+    "disabledIfNotEnabledImplicitly": true,
+    "type": "mongodb",
+    "host": "localhost",
+    "port": 27017,
+    "database": "test",
+    "logging": false
+  },
+  {
+    "skip": false,
+    "type": "mssql",
+    "host": "localhost",
+    "port": 1433,
+    "username": "sa",
+    "password": "Admin12345",
+    "database": "tempdb",
+    "logging": false,
+    "extra": {
+      "trustServerCertificate": true
+    }
+  },
+  {
+    "skip": false,
+    "type": "mysql",
+    "host": "localhost",
+    "port": 3306,
+    "username": "root",
+    "password": "admin",
+    "database": "typeorm",
+    "logging": false
+  },
+  {
+    "skip": false,
+    "type": "oracle",
+    "host": "localhost",
+    "port": 1521,
+    "username": "typeorm",
+    "password": "oracle",
+    "serviceName": "FREEPDB1",
+    "logging": false
+  },
+  {
+    "skip": false,
+    "type": "postgres",
+    "host": "localhost",
+    "port": 5432,
+    "username": "username",
+    "password": "password",
+    "database": "typeorm",
+    "logging": false
+  },
+  {
+    "skip": false,
+    "type": "sap",
+    "host": "localhost",
+    "port": 39041,
+    "username": "SYSTEM",
+    "password": "HXEHana1",
+    "logging": false
+  },
+  {
+    "skip": false,
     "type": "spanner",
     "host": "localhost",
     "port": 9010,
     "projectId": "typeorm",
     "instanceId": "typeorm",
     "databaseId": "typeorm",
+    "logging": false
+  },
+  {
+    "skip": false,
+    "type": "sqljs",
     "logging": false
   }
 ]

--- a/ormconfig.sample.json
+++ b/ormconfig.sample.json
@@ -120,9 +120,9 @@
     "type": "spanner",
     "host": "localhost",
     "port": 9010,
-    "projectId": "test-project",
-    "instanceId": "test-instance",
-    "databaseId": "test-db",
+    "projectId": "typeorm",
+    "instanceId": "typeorm",
+    "databaseId": "typeorm",
     "logging": false
   }
 ]

--- a/test/functional/cache/custom-cache-provider.test.ts
+++ b/test/functional/cache/custom-cache-provider.test.ts
@@ -15,6 +15,7 @@ describe("custom cache provider", () => {
     let dataSources: DataSource[]
     before(async () => {
         dataSources = await createTestingConnections({
+            disabledDrivers: ["spanner"],
             entities: [__dirname + "/entity/*{.js,.ts}"],
             cache: {
                 provider(dataSource) {

--- a/test/functional/cascades/cascade-insert-composite-pk/cascade-insert-composite-pk.test.ts
+++ b/test/functional/cascades/cascade-insert-composite-pk/cascade-insert-composite-pk.test.ts
@@ -15,6 +15,7 @@ describe("cascades > insert with composite primary keys", () => {
     let dataSources: DataSource[]
     before(async () => {
         dataSources = await createTestingConnections({
+            disabledDrivers: ["spanner"],
             __dirname,
         })
     })

--- a/test/functional/cascades/cascade-insert-inheritance/cascade-insert-inheritance.test.ts
+++ b/test/functional/cascades/cascade-insert-inheritance/cascade-insert-inheritance.test.ts
@@ -14,6 +14,7 @@ describe("cascades > insert with table inheritance", () => {
     let dataSources: DataSource[]
     before(async () => {
         dataSources = await createTestingConnections({
+            disabledDrivers: ["spanner"],
             entities: [__dirname + "/entity/*{.js,.ts}"],
             schemaCreate: true,
             dropSchema: true,

--- a/test/functional/cascades/cascade-insert-one-to-one-inverse-sti/cascade-insert-one-to-one-inverse-sti.test.ts
+++ b/test/functional/cascades/cascade-insert-one-to-one-inverse-sti/cascade-insert-one-to-one-inverse-sti.test.ts
@@ -13,6 +13,7 @@ describe("cascades > insert one-to-one inverse with single table inheritance", (
     let dataSources: DataSource[] = []
     before(async () => {
         dataSources = await createTestingConnections({
+            disabledDrivers: ["spanner"],
             entities: [__dirname + "/entity/*{.js,.ts}"],
         })
     })

--- a/test/functional/cascades/cascade-remove/cascade-remove.test.ts
+++ b/test/functional/cascades/cascade-remove/cascade-remove.test.ts
@@ -13,6 +13,7 @@ describe("cascades > remove", () => {
     let dataSources: DataSource[]
     before(async () => {
         dataSources = await createTestingConnections({
+            disabledDrivers: ["spanner"],
             __dirname,
         })
     })

--- a/test/functional/cascades/cascade-soft-remove/cascade-soft-remove.test.ts
+++ b/test/functional/cascades/cascade-soft-remove/cascade-soft-remove.test.ts
@@ -15,6 +15,7 @@ describe("cascades > soft-remove", () => {
     let dataSources: DataSource[]
     before(async () => {
         dataSources = await createTestingConnections({
+            disabledDrivers: ["spanner"],
             __dirname,
         })
     })

--- a/test/functional/cascades/cascade-traversal-scope/cascade-traversal-scope.test.ts
+++ b/test/functional/cascades/cascade-traversal-scope/cascade-traversal-scope.test.ts
@@ -14,6 +14,7 @@ describe("cascades > traversal scope", () => {
     let dataSources: DataSource[]
     before(async () => {
         dataSources = await createTestingConnections({
+            disabledDrivers: ["spanner"],
             __dirname,
         })
     })

--- a/test/functional/columns/virtual-columns/virtual-columns.test.ts
+++ b/test/functional/columns/virtual-columns/virtual-columns.test.ts
@@ -21,6 +21,7 @@ describe("column > virtual columns", () => {
     let dataSources: DataSource[]
     before(async () => {
         dataSources = await createTestingConnections({
+            disabledDrivers: ["spanner"],
             schemaCreate: true,
             dropSchema: true,
             entities: [Company, Employee, TimeSheet, Activity],

--- a/test/functional/database-schema/custom-constraint-names/foreign-key/foreign-key.test.ts
+++ b/test/functional/database-schema/custom-constraint-names/foreign-key/foreign-key.test.ts
@@ -13,6 +13,7 @@ describe("database schema > custom constraint names > foreign key", () => {
 
     before(async () => {
         dataSources = await createTestingConnections({
+            disabledDrivers: ["spanner"],
             entities: [__dirname + "/entity/*{.js,.ts}"],
         })
     })

--- a/test/functional/database-schema/custom-constraint-names/index/index.test.ts
+++ b/test/functional/database-schema/custom-constraint-names/index/index.test.ts
@@ -13,6 +13,7 @@ describe("database schema > custom constraint names > index", () => {
 
     before(async () => {
         dataSources = await createTestingConnections({
+            disabledDrivers: ["spanner"],
             entities: [__dirname + "/entity/*{.js,.ts}"],
         })
     })

--- a/test/functional/database-schema/custom-constraint-names/unique/unique.test.ts
+++ b/test/functional/database-schema/custom-constraint-names/unique/unique.test.ts
@@ -14,6 +14,7 @@ describe("database schema > custom constraint names > unique", () => {
 
     before(async () => {
         dataSources = await createTestingConnections({
+            disabledDrivers: ["spanner"],
             entities: [__dirname + "/entity/*{.js,.ts}"],
         })
     })

--- a/test/functional/decorators/foreign-key/foreign-key-decorator.test.ts
+++ b/test/functional/decorators/foreign-key/foreign-key-decorator.test.ts
@@ -17,6 +17,7 @@ describe("decorators > foreign-key", () => {
 
     before(async () => {
         dataSources = await createTestingConnections({
+            disabledDrivers: ["spanner"],
             entities: [__dirname + "/entity/*{.js,.ts}"],
         })
     })

--- a/test/functional/embedded/embedded-many-to-one-case1/embedded-many-to-one-case1.test.ts
+++ b/test/functional/embedded/embedded-many-to-one-case1/embedded-many-to-one-case1.test.ts
@@ -15,6 +15,7 @@ describe("embedded > embedded-many-to-one-case1", () => {
     let dataSources: DataSource[]
     before(async () => {
         dataSources = await createTestingConnections({
+            disabledDrivers: ["spanner"],
             entities: [__dirname + "/entity/*{.js,.ts}"],
         })
     })

--- a/test/functional/embedded/embedded-many-to-one-case2/embedded-many-to-one-case2.test.ts
+++ b/test/functional/embedded/embedded-many-to-one-case2/embedded-many-to-one-case2.test.ts
@@ -15,6 +15,7 @@ describe("embedded > embedded-many-to-one-case2", () => {
     let dataSources: DataSource[]
     before(async () => {
         dataSources = await createTestingConnections({
+            disabledDrivers: ["spanner"],
             entities: [__dirname + "/entity/*{.js,.ts}"],
         })
     })

--- a/test/functional/embedded/embedded-many-to-one-case3/embedded-many-to-one-case3.test.ts
+++ b/test/functional/embedded/embedded-many-to-one-case3/embedded-many-to-one-case3.test.ts
@@ -15,6 +15,7 @@ describe("embedded > embedded-many-to-one-case3", () => {
     let dataSources: DataSource[]
     before(async () => {
         dataSources = await createTestingConnections({
+            disabledDrivers: ["spanner"],
             entities: [__dirname + "/entity/*{.js,.ts}"],
         })
     })

--- a/test/functional/embedded/embedded-many-to-one-case4/embedded-many-to-one-case4.test.ts
+++ b/test/functional/embedded/embedded-many-to-one-case4/embedded-many-to-one-case4.test.ts
@@ -15,6 +15,7 @@ describe("embedded > embedded-many-to-one-case4", () => {
     let dataSources: DataSource[]
     before(async () => {
         dataSources = await createTestingConnections({
+            disabledDrivers: ["spanner"],
             entities: [__dirname + "/entity/*{.js,.ts}"],
         })
     })

--- a/test/functional/embedded/embedded-many-to-one-case5/embedded-many-to-one-case5.test.ts
+++ b/test/functional/embedded/embedded-many-to-one-case5/embedded-many-to-one-case5.test.ts
@@ -15,6 +15,7 @@ describe("embedded > embedded-many-to-one-case5", () => {
     let dataSources: DataSource[]
     before(async () => {
         dataSources = await createTestingConnections({
+            disabledDrivers: ["spanner"],
             entities: [__dirname + "/entity/*{.js,.ts}"],
         })
     })

--- a/test/functional/entity-listeners/entity-listeners.test.ts
+++ b/test/functional/entity-listeners/entity-listeners.test.ts
@@ -13,6 +13,7 @@ describe("entity-listeners", () => {
     let dataSources: DataSource[]
     before(async () => {
         dataSources = await createTestingConnections({
+            disabledDrivers: ["spanner"],
             entities: [__dirname + "/entity/*{.js,.ts}"],
             dropSchema: true,
             schemaCreate: true,

--- a/test/functional/entity-schema/custom-constraint-names/foreign-key/foreign-key.test.ts
+++ b/test/functional/entity-schema/custom-constraint-names/foreign-key/foreign-key.test.ts
@@ -13,6 +13,7 @@ describe("entity schema > custom constraint names > foreign key", () => {
 
     before(async () => {
         dataSources = await createTestingConnections({
+            disabledDrivers: ["spanner"],
             entities: [__dirname + "/entity/*{.js,.ts}"],
         })
     })

--- a/test/functional/entity-schema/custom-constraint-names/index/index.test.ts
+++ b/test/functional/entity-schema/custom-constraint-names/index/index.test.ts
@@ -13,6 +13,7 @@ describe("entity schema > custom constraint names > index", () => {
 
     before(async () => {
         dataSources = await createTestingConnections({
+            disabledDrivers: ["spanner"],
             entities: [__dirname + "/entity/*{.js,.ts}"],
         })
     })

--- a/test/functional/entity-schema/custom-constraint-names/unique/unique.test.ts
+++ b/test/functional/entity-schema/custom-constraint-names/unique/unique.test.ts
@@ -14,6 +14,7 @@ describe("database schema > custom constraint names > unique", () => {
 
     before(async () => {
         dataSources = await createTestingConnections({
+            disabledDrivers: ["spanner"],
             entities: [__dirname + "/entity/*{.js,.ts}"],
         })
     })

--- a/test/functional/entity-schema/foreign-keys/foreign-keys-basic.test.ts
+++ b/test/functional/entity-schema/foreign-keys/foreign-keys-basic.test.ts
@@ -14,6 +14,7 @@ describe("entity-schema > foreign-keys", () => {
 
     before(async () => {
         dataSources = await createTestingConnections({
+            disabledDrivers: ["spanner"],
             entities: [__dirname + "/entity/*{.js,.ts}"],
         })
     })

--- a/test/functional/entity-subscriber/query-data/query-data.test.ts
+++ b/test/functional/entity-subscriber/query-data/query-data.test.ts
@@ -11,6 +11,7 @@ describe("entity subscriber > query data", () => {
     let dataSources: DataSource[]
     before(async () => {
         dataSources = await createTestingConnections({
+            disabledDrivers: ["spanner"],
             entities: [Example],
             subscribers: [MockSubscriber],
             dropSchema: true,

--- a/test/functional/find-options/basic-usage/find-options-order.test.ts
+++ b/test/functional/find-options/basic-usage/find-options-order.test.ts
@@ -16,6 +16,7 @@ describe("find options > order", () => {
     before(async () => {
         dataSources = await createTestingConnections({
             __dirname,
+            disabledDrivers: ["spanner"],
         })
     })
     beforeEach(() => reloadTestingDatabases(dataSources))

--- a/test/functional/find-options/basic-usage/find-options-relations.test.ts
+++ b/test/functional/find-options/basic-usage/find-options-relations.test.ts
@@ -14,6 +14,7 @@ describe("find options > relations", () => {
     let dataSources: DataSource[]
     before(async () => {
         dataSources = await createTestingConnections({
+            disabledDrivers: ["spanner"],
             __dirname,
         })
     })

--- a/test/functional/find-options/basic-usage/find-options-select.test.ts
+++ b/test/functional/find-options/basic-usage/find-options-select.test.ts
@@ -12,7 +12,10 @@ import { prepareData } from "./find-options-test-utils"
 describe("find options > select", () => {
     let dataSources: DataSource[]
     before(async () => {
-        dataSources = await createTestingConnections({ __dirname })
+        dataSources = await createTestingConnections({
+            __dirname,
+            disabledDrivers: ["spanner"],
+        })
     })
     beforeEach(() => reloadTestingDatabases(dataSources))
     after(() => closeTestingConnections(dataSources))

--- a/test/functional/find-options/basic-usage/find-options-where.test.ts
+++ b/test/functional/find-options/basic-usage/find-options-where.test.ts
@@ -27,6 +27,7 @@ describe("find options > where", () => {
     let dataSources: DataSource[]
     before(async () => {
         dataSources = await createTestingConnections({
+            disabledDrivers: ["spanner"],
             __dirname,
         })
     })

--- a/test/functional/find-options/select/find-options-select.test.ts
+++ b/test/functional/find-options/select/find-options-select.test.ts
@@ -14,6 +14,7 @@ describe("find options > select", () => {
     let dataSources: DataSource[]
     before(async () => {
         dataSources = await createTestingConnections({
+            disabledDrivers: ["spanner"],
             __dirname,
         })
     })

--- a/test/functional/metadata-builder/relation-join-column-builder/relation-join-column-builder.test.ts
+++ b/test/functional/metadata-builder/relation-join-column-builder/relation-join-column-builder.test.ts
@@ -19,6 +19,7 @@ describe("metadata builder > RelationJoinColumnBuilder", () => {
 
     before(async () => {
         dataSources = await createTestingConnections({
+            disabledDrivers: ["spanner"],
             entities: [__dirname + "/entity/*{.js,.ts}"],
         })
     })

--- a/test/functional/null-undefined-handling/find-options.test.ts
+++ b/test/functional/null-undefined-handling/find-options.test.ts
@@ -17,6 +17,7 @@ describe("find options > null and undefined handling", () => {
     describe("with default behavior (throw)", () => {
         before(async () => {
             dataSources = await createTestingConnections({
+                disabledDrivers: ["spanner"],
                 entities: [Post, Category],
                 schemaCreate: true,
                 dropSchema: true,
@@ -261,6 +262,7 @@ describe("find options > null and undefined handling", () => {
     describe("with invalidWhereValuesBehavior.null set to 'sql-null'", () => {
         before(async () => {
             dataSources = await createTestingConnections({
+                disabledDrivers: ["spanner"],
                 entities: [Post, Category],
                 schemaCreate: true,
                 dropSchema: true,
@@ -398,6 +400,7 @@ describe("find options > null and undefined handling", () => {
     describe("with invalidWhereValuesBehavior.undefined set to 'throw'", () => {
         before(async () => {
             dataSources = await createTestingConnections({
+                disabledDrivers: ["spanner"],
                 entities: [Post, Category],
                 schemaCreate: true,
                 dropSchema: true,
@@ -583,6 +586,7 @@ describe("find options > null and undefined handling", () => {
     describe("with both invalidWhereValuesBehavior options enabled", () => {
         before(async () => {
             dataSources = await createTestingConnections({
+                disabledDrivers: ["spanner"],
                 entities: [Post, Category],
                 schemaCreate: true,
                 dropSchema: true,
@@ -708,6 +712,7 @@ describe("find options > null and undefined handling", () => {
     describe("with ignore behavior", () => {
         before(async () => {
             dataSources = await createTestingConnections({
+                disabledDrivers: ["spanner"],
                 entities: [Post, Category],
                 schemaCreate: true,
                 dropSchema: true,
@@ -902,6 +907,7 @@ describe("find options > null and undefined handling", () => {
     describe("with invalidWhereValuesBehavior.null set to 'throw'", () => {
         before(async () => {
             dataSources = await createTestingConnections({
+                disabledDrivers: ["spanner"],
                 entities: [Post, Category],
                 schemaCreate: true,
                 dropSchema: true,

--- a/test/functional/null-undefined-handling/query-builders.test.ts
+++ b/test/functional/null-undefined-handling/query-builders.test.ts
@@ -16,6 +16,7 @@ describe("entity manager > invalidWhereValuesBehavior with throw", () => {
 
     before(async () => {
         dataSources = await createTestingConnections({
+            disabledDrivers: ["spanner"],
             entities: [Post, Category],
             schemaCreate: true,
             dropSchema: true,
@@ -244,6 +245,7 @@ describe("entity manager > invalidWhereValuesBehavior with sql-null", () => {
 
     before(async () => {
         dataSources = await createTestingConnections({
+            disabledDrivers: ["spanner"],
             entities: [Post, Category],
             schemaCreate: true,
             dropSchema: true,
@@ -312,6 +314,7 @@ describe("entity manager > invalidWhereValuesBehavior with ignore", () => {
 
     before(async () => {
         dataSources = await createTestingConnections({
+            disabledDrivers: ["spanner"],
             entities: [Post, Category],
             schemaCreate: true,
             dropSchema: true,
@@ -419,6 +422,7 @@ describe("entity manager > invalidWhereValuesBehavior does NOT affect QB .where(
 
     before(async () => {
         dataSources = await createTestingConnections({
+            disabledDrivers: ["spanner"],
             entities: [Post, Category],
             schemaCreate: true,
             dropSchema: true,

--- a/test/functional/persistence/custom-column-names/persistence-custom-column-names.test.ts
+++ b/test/functional/persistence/custom-column-names/persistence-custom-column-names.test.ts
@@ -14,6 +14,7 @@ describe("persistence > custom-column-names", () => {
     let dataSources: DataSource[]
     before(async () => {
         dataSources = await createTestingConnections({
+            disabledDrivers: ["spanner"],
             entities: [Post, Category, CategoryMetadata],
         })
     })

--- a/test/functional/persistence/entity-updation/persistence-entity-updation.test.ts
+++ b/test/functional/persistence/entity-updation/persistence-entity-updation.test.ts
@@ -17,7 +17,10 @@ import { PostEmbedded } from "./entity/PostEmbedded"
 describe("persistence > entity updation", () => {
     let dataSources: DataSource[]
     before(async () => {
-        dataSources = await createTestingConnections({ __dirname })
+        dataSources = await createTestingConnections({
+            __dirname,
+            disabledDrivers: ["spanner"],
+        })
     })
     beforeEach(() => reloadTestingDatabases(dataSources))
     after(() => closeTestingConnections(dataSources))

--- a/test/functional/persistence/many-to-many/persistence-many-to-many.test.ts
+++ b/test/functional/persistence/many-to-many/persistence-many-to-many.test.ts
@@ -17,7 +17,10 @@ describe("persistence > many-to-many", function () {
 
     let dataSources: DataSource[]
     before(async () => {
-        dataSources = await createTestingConnections({ __dirname })
+        dataSources = await createTestingConnections({
+            __dirname,
+            disabledDrivers: ["spanner"],
+        })
     })
     beforeEach(() => reloadTestingDatabases(dataSources))
     after(() => closeTestingConnections(dataSources))

--- a/test/functional/persistence/one-to-many/persistence-one-to-many.test.ts
+++ b/test/functional/persistence/one-to-many/persistence-one-to-many.test.ts
@@ -17,6 +17,7 @@ describe("persistence > one-to-many", function () {
     let dataSources: DataSource[]
     before(async () => {
         dataSources = await createTestingConnections({
+            disabledDrivers: ["spanner"],
             entities: [Post, Category],
         })
     })

--- a/test/functional/persistence/persistence-options/listeners/persistence-options-listeners.test.ts
+++ b/test/functional/persistence/persistence-options/listeners/persistence-options-listeners.test.ts
@@ -15,7 +15,10 @@ describe("persistence > persistence options > listeners", () => {
 
     let dataSources: DataSource[]
     before(async () => {
-        dataSources = await createTestingConnections({ __dirname })
+        dataSources = await createTestingConnections({
+            __dirname,
+            disabledDrivers: ["spanner"],
+        })
     })
     beforeEach(() => reloadTestingDatabases(dataSources))
     after(() => closeTestingConnections(dataSources))

--- a/test/functional/persistence/persistence-options/transaction/persistence-options-transaction.test.ts
+++ b/test/functional/persistence/persistence-options/transaction/persistence-options-transaction.test.ts
@@ -16,7 +16,10 @@ describe("persistence > persistence options > transaction", () => {
 
     let dataSources: DataSource[]
     before(async () => {
-        dataSources = await createTestingConnections({ __dirname })
+        dataSources = await createTestingConnections({
+            __dirname,
+            disabledDrivers: ["spanner"],
+        })
     })
     beforeEach(() => reloadTestingDatabases(dataSources))
     after(() => closeTestingConnections(dataSources))

--- a/test/functional/persistence/remove-topological-order/remove-topolotical-order.test.ts
+++ b/test/functional/persistence/remove-topological-order/remove-topolotical-order.test.ts
@@ -16,7 +16,10 @@ describe("persistence > remove-topological-order", function () {
 
     let dataSources: DataSource[]
     before(async () => {
-        dataSources = await createTestingConnections({ __dirname })
+        dataSources = await createTestingConnections({
+            __dirname,
+            disabledDrivers: ["spanner"],
+        })
     })
     beforeEach(() => reloadTestingDatabases(dataSources))
     after(() => closeTestingConnections(dataSources))

--- a/test/functional/query-builder/cache/query-builder-cache.test.ts
+++ b/test/functional/query-builder/cache/query-builder-cache.test.ts
@@ -13,6 +13,7 @@ describe("query builder > cache", () => {
     let dataSources: DataSource[]
     before(async () => {
         dataSources = await createTestingConnections({
+            disabledDrivers: ["spanner"],
             entities: [__dirname + "/entity/*{.js,.ts}"],
             cache: true,
             // cache: {

--- a/test/functional/query-builder/cte/simple-cte.test.ts
+++ b/test/functional/query-builder/cte/simple-cte.test.ts
@@ -14,6 +14,7 @@ describe("query builder > cte > simple", () => {
     let dataSources: DataSource[]
     before(async () => {
         dataSources = await createTestingConnections({
+            disabledDrivers: ["spanner"],
             entities: [__dirname + "/entity/*{.js,.ts}"],
             schemaCreate: true,
             dropSchema: true,

--- a/test/functional/query-builder/enabling-transaction/enabling-transaction.test.ts
+++ b/test/functional/query-builder/enabling-transaction/enabling-transaction.test.ts
@@ -10,7 +10,10 @@ import { Post } from "./entity/Post"
 describe("query builder > enabling transaction", () => {
     let dataSources: DataSource[]
     before(async () => {
-        dataSources = await createTestingConnections({ __dirname })
+        dataSources = await createTestingConnections({
+            __dirname,
+            disabledDrivers: ["spanner"],
+        })
     })
     beforeEach(() => reloadTestingDatabases(dataSources))
     after(() => closeTestingConnections(dataSources))

--- a/test/functional/query-builder/entity-updation/entity-updation.test.ts
+++ b/test/functional/query-builder/entity-updation/entity-updation.test.ts
@@ -11,7 +11,10 @@ import { expect } from "chai"
 describe("query builder > entity updation", () => {
     let dataSources: DataSource[]
     before(async () => {
-        dataSources = await createTestingConnections({ __dirname })
+        dataSources = await createTestingConnections({
+            __dirname,
+            disabledDrivers: ["spanner"],
+        })
     })
     beforeEach(() => reloadTestingDatabases(dataSources))
     after(() => closeTestingConnections(dataSources))

--- a/test/functional/query-builder/insert-from-select/insert-from-select.test.ts
+++ b/test/functional/query-builder/insert-from-select/insert-from-select.test.ts
@@ -15,6 +15,7 @@ describe("query builder > insert from select", () => {
     let dataSources: DataSource[]
     before(async () => {
         dataSources = await createTestingConnections({
+            disabledDrivers: ["spanner"],
             entities: [__dirname + "/entity/*{.js,.ts}"],
         })
     })

--- a/test/functional/query-builder/order-by/query-builder-order-by.test.ts
+++ b/test/functional/query-builder/order-by/query-builder-order-by.test.ts
@@ -14,6 +14,7 @@ describe("query builder > order-by", () => {
     let dataSources: DataSource[]
     before(async () => {
         dataSources = await createTestingConnections({
+            disabledDrivers: ["spanner"],
             entities: [__dirname + "/entity/*{.js,.ts}"],
         })
     })

--- a/test/functional/query-builder/parameters/date-parameters.test.ts
+++ b/test/functional/query-builder/parameters/date-parameters.test.ts
@@ -12,6 +12,7 @@ describe("query builder > parameters > date parameters", () => {
     let dataSources: DataSource[]
     before(async () => {
         dataSources = await createTestingConnections({
+            disabledDrivers: ["spanner"],
             entities: [Product],
             schemaCreate: true,
             dropSchema: true,

--- a/test/functional/query-builder/parameters/reused-parameters.test.ts
+++ b/test/functional/query-builder/parameters/reused-parameters.test.ts
@@ -13,6 +13,7 @@ describe("query builder > parameters > reused parameters", () => {
     let dataSources: DataSource[]
     before(async () => {
         dataSources = await createTestingConnections({
+            disabledDrivers: ["spanner"],
             entities: [Person],
             schemaCreate: true,
             dropSchema: true,

--- a/test/functional/query-builder/relation-id/one-to-many/basic-functionality/basic-functionality.test.ts
+++ b/test/functional/query-builder/relation-id/one-to-many/basic-functionality/basic-functionality.test.ts
@@ -14,6 +14,7 @@ describe("query builder > relation-id > one-to-many > basic-functionality", () =
     let dataSources: DataSource[]
     before(async () => {
         dataSources = await createTestingConnections({
+            disabledDrivers: ["spanner"],
             entities: [__dirname + "/entity/*{.js,.ts}"],
         })
     })

--- a/test/functional/query-builder/relation-id/one-to-many/embedded-with-multiple-pk/embedded-with-multiple-pk.test.ts
+++ b/test/functional/query-builder/relation-id/one-to-many/embedded-with-multiple-pk/embedded-with-multiple-pk.test.ts
@@ -16,6 +16,7 @@ describe("query builder > relation-id > one-to-many > embedded-with-multiple-pk"
     let dataSources: DataSource[]
     before(async () => {
         dataSources = await createTestingConnections({
+            disabledDrivers: ["spanner"],
             entities: [__dirname + "/entity/*{.js,.ts}"],
         })
     })

--- a/test/functional/query-builder/relation-id/one-to-many/embedded/embedded.test.ts
+++ b/test/functional/query-builder/relation-id/one-to-many/embedded/embedded.test.ts
@@ -16,6 +16,7 @@ describe("query builder > relation-id > one-to-many > embedded", () => {
     let dataSources: DataSource[]
     before(async () => {
         dataSources = await createTestingConnections({
+            disabledDrivers: ["spanner"],
             entities: [__dirname + "/entity/*{.js,.ts}"],
         })
     })

--- a/test/functional/query-builder/relation-id/one-to-many/multiple-pk/multiple-pk.test.ts
+++ b/test/functional/query-builder/relation-id/one-to-many/multiple-pk/multiple-pk.test.ts
@@ -14,6 +14,7 @@ describe("query builder > relation-id > one-to-many > multiple-pk", () => {
     let dataSources: DataSource[]
     before(async () => {
         dataSources = await createTestingConnections({
+            disabledDrivers: ["spanner"],
             entities: [__dirname + "/entity/*{.js,.ts}"],
         })
     })

--- a/test/functional/query-builder/soft-delete/global-condition-non-deleted/query-builder-global-condition-non-deleted-with-eager-relation.test.ts
+++ b/test/functional/query-builder/soft-delete/global-condition-non-deleted/query-builder-global-condition-non-deleted-with-eager-relation.test.ts
@@ -12,6 +12,7 @@ describe(`query builder > find with the global condition of "non-deleted" and ea
     let dataSources: DataSource[]
     before(async () => {
         dataSources = await createTestingConnections({
+            disabledDrivers: ["spanner"],
             entities: [__dirname + "/entity/*{.js,.ts}"],
         })
     })

--- a/test/functional/query-builder/soft-delete/global-condition-non-deleted/query-builder-global-condition-non-deleted.test.ts
+++ b/test/functional/query-builder/soft-delete/global-condition-non-deleted/query-builder-global-condition-non-deleted.test.ts
@@ -11,6 +11,7 @@ describe(`query builder > find with the global condition of "non-deleted"`, () =
     let dataSources: DataSource[]
     before(async () => {
         dataSources = await createTestingConnections({
+            disabledDrivers: ["spanner"],
             entities: [__dirname + "/entity/*{.js,.ts}"],
         })
     })

--- a/test/functional/query-builder/sql-injection/sql-injection.test.ts
+++ b/test/functional/query-builder/sql-injection/sql-injection.test.ts
@@ -12,6 +12,7 @@ describe("query builder > sql injection", () => {
     let dataSources: DataSource[]
     before(async () => {
         dataSources = await createTestingConnections({
+            disabledDrivers: ["spanner"],
             entities: [__dirname + "/entity/*{.js,.ts}"],
             schemaCreate: true,
             dropSchema: true,

--- a/test/functional/query-runner/add-column.test.ts
+++ b/test/functional/query-runner/add-column.test.ts
@@ -14,6 +14,7 @@ describe("query runner > add column", () => {
     let dataSources: DataSource[]
     before(async () => {
         dataSources = await createTestingConnections({
+            disabledDrivers: ["spanner"],
             entities: [__dirname + "/entity/*{.js,.ts}"],
             schemaCreate: true,
             dropSchema: true,

--- a/test/functional/query-runner/change-column.test.ts
+++ b/test/functional/query-runner/change-column.test.ts
@@ -14,6 +14,7 @@ describe("query runner > change column", () => {
     let dataSources: DataSource[]
     before(async () => {
         dataSources = await createTestingConnections({
+            disabledDrivers: ["spanner"],
             entities: [__dirname + "/entity/*{.js,.ts}"],
             schemaCreate: true,
             dropSchema: true,

--- a/test/functional/query-runner/create-check-constraint.test.ts
+++ b/test/functional/query-runner/create-check-constraint.test.ts
@@ -13,6 +13,7 @@ describe("query runner > create check constraint", () => {
     let dataSources: DataSource[]
     before(async () => {
         dataSources = await createTestingConnections({
+            disabledDrivers: ["spanner"],
             entities: [__dirname + "/entity/*{.js,.ts}"],
             schemaCreate: true,
             dropSchema: true,

--- a/test/functional/query-runner/create-foreign-key.test.ts
+++ b/test/functional/query-runner/create-foreign-key.test.ts
@@ -13,6 +13,7 @@ describe("query runner > create foreign key", () => {
     let dataSources: DataSource[]
     before(async () => {
         dataSources = await createTestingConnections({
+            disabledDrivers: ["spanner"],
             entities: [__dirname + "/entity/*{.js,.ts}"],
             schemaCreate: true,
             dropSchema: true,

--- a/test/functional/query-runner/create-index.test.ts
+++ b/test/functional/query-runner/create-index.test.ts
@@ -13,6 +13,7 @@ describe("query runner > create index", () => {
     let dataSources: DataSource[]
     before(async () => {
         dataSources = await createTestingConnections({
+            disabledDrivers: ["spanner"],
             entities: [__dirname + "/entity/*{.js,.ts}"],
             schemaCreate: true,
             dropSchema: true,

--- a/test/functional/query-runner/create-primary-key.test.ts
+++ b/test/functional/query-runner/create-primary-key.test.ts
@@ -11,6 +11,7 @@ describe("query runner > create primary key", () => {
     let dataSources: DataSource[]
     before(async () => {
         dataSources = await createTestingConnections({
+            disabledDrivers: ["spanner"],
             entities: [__dirname + "/entity/*{.js,.ts}"],
             schemaCreate: true,
             dropSchema: true,

--- a/test/functional/query-runner/create-table.test.ts
+++ b/test/functional/query-runner/create-table.test.ts
@@ -16,6 +16,7 @@ describe("query runner > create table", () => {
     let dataSources: DataSource[]
     before(async () => {
         dataSources = await createTestingConnections({
+            disabledDrivers: ["spanner"],
             entities: [__dirname + "/entity/*{.js,.ts}"],
             dropSchema: true,
         })

--- a/test/functional/query-runner/drop-check-constraint.test.ts
+++ b/test/functional/query-runner/drop-check-constraint.test.ts
@@ -11,6 +11,7 @@ describe("query runner > drop check constraint", () => {
     let dataSources: DataSource[]
     before(async () => {
         dataSources = await createTestingConnections({
+            disabledDrivers: ["spanner"],
             entities: [__dirname + "/entity/*{.js,.ts}"],
             schemaCreate: true,
             dropSchema: true,

--- a/test/functional/query-runner/drop-column.test.ts
+++ b/test/functional/query-runner/drop-column.test.ts
@@ -12,6 +12,7 @@ describe("query runner > drop column", () => {
     let dataSources: DataSource[]
     before(async () => {
         dataSources = await createTestingConnections({
+            disabledDrivers: ["spanner"],
             entities: [__dirname + "/entity/*{.js,.ts}"],
             schemaCreate: true,
             dropSchema: true,

--- a/test/functional/query-runner/drop-foreign-key.test.ts
+++ b/test/functional/query-runner/drop-foreign-key.test.ts
@@ -13,6 +13,7 @@ describe("query runner > drop foreign key", () => {
     let dataSources: DataSource[]
     before(async () => {
         dataSources = await createTestingConnections({
+            disabledDrivers: ["spanner"],
             entities: [__dirname + "/entity/*{.js,.ts}"],
             schemaCreate: true,
             dropSchema: true,

--- a/test/functional/query-runner/drop-index.test.ts
+++ b/test/functional/query-runner/drop-index.test.ts
@@ -13,6 +13,7 @@ describe("query runner > drop index", () => {
     let dataSources: DataSource[]
     before(async () => {
         dataSources = await createTestingConnections({
+            disabledDrivers: ["spanner"],
             entities: [__dirname + "/entity/*{.js,.ts}"],
             schemaCreate: true,
             dropSchema: true,

--- a/test/functional/query-runner/drop-primary-key.test.ts
+++ b/test/functional/query-runner/drop-primary-key.test.ts
@@ -10,6 +10,7 @@ describe("query runner > drop primary key", () => {
     let dataSources: DataSource[]
     before(async () => {
         dataSources = await createTestingConnections({
+            disabledDrivers: ["spanner"],
             entities: [__dirname + "/entity/*{.js,.ts}"],
             schemaCreate: true,
             dropSchema: true,

--- a/test/functional/query-runner/drop-table.test.ts
+++ b/test/functional/query-runner/drop-table.test.ts
@@ -11,6 +11,7 @@ describe("query runner > drop table", () => {
     let dataSources: DataSource[]
     before(async () => {
         dataSources = await createTestingConnections({
+            disabledDrivers: ["spanner"],
             entities: [__dirname + "/entity/*{.js,.ts}"],
             schemaCreate: true,
         })

--- a/test/functional/query-runner/has-column.test.ts
+++ b/test/functional/query-runner/has-column.test.ts
@@ -9,6 +9,7 @@ describe("query runner > has column", () => {
     let dataSources: DataSource[]
     before(async () => {
         dataSources = await createTestingConnections({
+            disabledDrivers: ["spanner"],
             entities: [__dirname + "/entity/*{.js,.ts}"],
             schemaCreate: true,
             dropSchema: true,

--- a/test/functional/query-runner/has-table.test.ts
+++ b/test/functional/query-runner/has-table.test.ts
@@ -9,6 +9,7 @@ describe("query runner > has table", () => {
     let dataSources: DataSource[]
     before(async () => {
         dataSources = await createTestingConnections({
+            disabledDrivers: ["spanner"],
             entities: [__dirname + "/entity/*{.js,.ts}"],
             schemaCreate: true,
             dropSchema: true,

--- a/test/functional/query-runner/rename-column.test.ts
+++ b/test/functional/query-runner/rename-column.test.ts
@@ -12,6 +12,7 @@ describe("query runner > rename column", () => {
     let dataSources: DataSource[]
     before(async () => {
         dataSources = await createTestingConnections({
+            disabledDrivers: ["spanner"],
             entities: [__dirname + "/entity/*{.js,.ts}"],
             schemaCreate: true,
             dropSchema: true,

--- a/test/functional/query-runner/rename-table.test.ts
+++ b/test/functional/query-runner/rename-table.test.ts
@@ -14,6 +14,7 @@ describe("query runner > rename table", () => {
     let dataSources: DataSource[]
     before(async () => {
         dataSources = await createTestingConnections({
+            disabledDrivers: ["spanner"],
             entities: [__dirname + "/entity/*{.js,.ts}"],
             schemaCreate: true,
             dropSchema: true,

--- a/test/functional/relations/load-strategy/query/relation-load-strategy-query.test.ts
+++ b/test/functional/relations/load-strategy/query/relation-load-strategy-query.test.ts
@@ -17,6 +17,7 @@ describe("relations > load-strategy > query", () => {
     let dataSources: DataSource[]
     before(async () => {
         dataSources = await createTestingConnections({
+            disabledDrivers: ["spanner"],
             entities: [__dirname + "/entity/*{.js,.ts}"],
             schemaCreate: true,
             dropSchema: true,
@@ -336,6 +337,7 @@ describe("relations > load-strategy > query", () => {
         let dsLevelDataSources: DataSource[]
         before(async () => {
             dsLevelDataSources = await createTestingConnections({
+                disabledDrivers: ["spanner"],
                 entities: [__dirname + "/entity/*{.js,.ts}"],
                 schemaCreate: true,
                 dropSchema: true,

--- a/test/functional/relations/multiple-primary-keys/multiple-primary-keys-many-to-one/multiple-primary-keys-many-to-one.test.ts
+++ b/test/functional/relations/multiple-primary-keys/multiple-primary-keys-many-to-one/multiple-primary-keys-many-to-one.test.ts
@@ -13,6 +13,7 @@ describe("relations > multiple-primary-keys > many-to-one", () => {
     let dataSources: DataSource[]
     before(async () => {
         dataSources = await createTestingConnections({
+            disabledDrivers: ["spanner"],
             entities: [__dirname + "/entity/*{.js,.ts}"],
         })
     })

--- a/test/functional/relations/multiple-primary-keys/multiple-primary-keys-one-to-many/multiple-primary-keys-one-to-many.test.ts
+++ b/test/functional/relations/multiple-primary-keys/multiple-primary-keys-one-to-many/multiple-primary-keys-one-to-many.test.ts
@@ -16,6 +16,7 @@ describe("relations > multiple-primary-keys > one-to-many", () => {
 
     before(async () => {
         dataSources = await createTestingConnections({
+            disabledDrivers: ["spanner"],
             entities: [User, Setting],
             schemaCreate: true,
             dropSchema: true,

--- a/test/functional/repository/basic-methods/repository-basic-methods.test.ts
+++ b/test/functional/repository/basic-methods/repository-basic-methods.test.ts
@@ -32,6 +32,7 @@ describe("repository > basic methods", () => {
     let dataSources: DataSource[]
     before(async () => {
         dataSources = await createTestingConnections({
+            disabledDrivers: ["spanner"],
             entities: [
                 Post,
                 Blog,

--- a/test/functional/repository/delete-by-criteria/repository-delete-by-criteria.test.ts
+++ b/test/functional/repository/delete-by-criteria/repository-delete-by-criteria.test.ts
@@ -16,6 +16,7 @@ describe("repository > delete methods", function () {
     let dataSources: DataSource[]
     before(async () => {
         dataSources = await createTestingConnections({
+            disabledDrivers: ["spanner"],
             entities: [__dirname + "/entity/*{.js,.ts}"],
         })
     })

--- a/test/functional/repository/find-options-relations/repository-find-options-relations.test.ts
+++ b/test/functional/repository/find-options-relations/repository-find-options-relations.test.ts
@@ -21,6 +21,7 @@ describe("repository > find options > relations", () => {
     let dataSources: DataSource[]
     before(async () => {
         dataSources = await createTestingConnections({
+            disabledDrivers: ["spanner"],
             entities: [__dirname + "/entity/*{.js,.ts}"],
         })
     })

--- a/test/functional/repository/find-options/repository-find-options.test.ts
+++ b/test/functional/repository/find-options/repository-find-options.test.ts
@@ -19,6 +19,7 @@ describe("repository > find options", () => {
     let dataSources: DataSource[]
     before(async () => {
         dataSources = await createTestingConnections({
+            disabledDrivers: ["spanner"],
             entities: [__dirname + "/entity/*{.js,.ts}"],
         })
     })
@@ -246,6 +247,7 @@ describe("repository > find options > comment", () => {
         // test logger that buffers messages.
         const logger = new FileLogger(["query"], { logPath })
         dataSources = await createTestingConnections({
+            disabledDrivers: ["spanner"],
             entities: [__dirname + "/entity/*{.js,.ts}"],
             createLogger: () => logger,
         })
@@ -279,6 +281,7 @@ describe("repository > find options > cache", () => {
     let dataSources: DataSource[]
     before(async () => {
         dataSources = await createTestingConnections({
+            disabledDrivers: ["spanner"],
             entities: [__dirname + "/entity/*{.js,.ts}"],
             cache: true,
         })

--- a/test/functional/repository/returning/repository-returning.test.ts
+++ b/test/functional/repository/returning/repository-returning.test.ts
@@ -51,6 +51,8 @@ describe("repository > returning", () => {
                 if (!dataSource.driver.isReturningSqlSupported("insert")) {
                     return
                 }
+                // Spanner's Data API has no ON CONFLICT DO UPDATE equivalent.
+                if (dataSource.driver.options.type === "spanner") return
 
                 const repo = dataSource.getRepository(User)
                 const created = await repo.save({ name: "seed" })
@@ -77,6 +79,8 @@ describe("repository > returning", () => {
                 if (!dataSource.driver.isReturningSqlSupported("update")) {
                     return
                 }
+                // Spanner rejects UPDATE without a WHERE clause.
+                if (dataSource.driver.options.type === "spanner") return
 
                 const repo = dataSource.getRepository(User)
                 const user1 = await repo.save({ name: "user1" })

--- a/test/functional/repository/soft-delete/entity-soft-remove.test.ts
+++ b/test/functional/repository/soft-delete/entity-soft-remove.test.ts
@@ -14,6 +14,7 @@ describe("entity > soft-remove", () => {
     let dataSources: DataSource[]
     before(async () => {
         dataSources = await createTestingConnections({
+            disabledDrivers: ["spanner"],
             entities: [__dirname + "/entity/*{.js,.ts}"],
         })
     })

--- a/test/functional/repository/soft-delete/global-condition-non-deleted/repository-global-condition-non-deleted-with-eager-relation.test.ts
+++ b/test/functional/repository/soft-delete/global-condition-non-deleted/repository-global-condition-non-deleted-with-eager-relation.test.ts
@@ -13,6 +13,7 @@ describe(`repository > the global condtion of "non-deleted" with eager relation`
     let dataSources: DataSource[]
     before(async () => {
         dataSources = await createTestingConnections({
+            disabledDrivers: ["spanner"],
             entities: [__dirname + "/entity/*{.js,.ts}"],
         })
     })

--- a/test/functional/repository/soft-delete/global-condition-non-deleted/repository-global-condition-non-deleted.test.ts
+++ b/test/functional/repository/soft-delete/global-condition-non-deleted/repository-global-condition-non-deleted.test.ts
@@ -12,6 +12,7 @@ describe(`repository > the global condtion of "non-deleted"`, () => {
     let dataSources: DataSource[]
     before(async () => {
         dataSources = await createTestingConnections({
+            disabledDrivers: ["spanner"],
             entities: [__dirname + "/entity/*{.js,.ts}"],
         })
     })

--- a/test/functional/repository/soft-delete/repository-soft-remove.test.ts
+++ b/test/functional/repository/soft-delete/repository-soft-remove.test.ts
@@ -14,6 +14,7 @@ describe("repository > soft-remove", () => {
     let dataSources: DataSource[]
     before(async () => {
         dataSources = await createTestingConnections({
+            disabledDrivers: ["spanner"],
             entities: [__dirname + "/entity/*{.js,.ts}"],
         })
     })

--- a/test/functional/repository/update-by-criteria/repository-update-by-criteria.test.ts
+++ b/test/functional/repository/update-by-criteria/repository-update-by-criteria.test.ts
@@ -18,6 +18,7 @@ describe("repository > update methods", function () {
     let dataSources: DataSource[]
     before(async () => {
         dataSources = await createTestingConnections({
+            disabledDrivers: ["spanner"],
             entities: [__dirname + "/entity/*{.js,.ts}"],
         })
     })

--- a/test/functional/schema-builder/column/add/add-column/add-column.test.ts
+++ b/test/functional/schema-builder/column/add/add-column/add-column.test.ts
@@ -13,6 +13,7 @@ describe("schema builder > add column", () => {
     let dataSources: DataSource[]
     before(async () => {
         dataSources = await createTestingConnections({
+            disabledDrivers: ["spanner"],
             entities: [__dirname + "/entity/*{.js,.ts}"],
             schemaCreate: true,
             dropSchema: true,

--- a/test/functional/schema-builder/column/change/change-column/change-column.test.ts
+++ b/test/functional/schema-builder/column/change/change-column/change-column.test.ts
@@ -14,6 +14,7 @@ describe("schema builder > change column", () => {
     let dataSources: DataSource[]
     before(async () => {
         dataSources = await createTestingConnections({
+            disabledDrivers: ["spanner"],
             entities: [__dirname + "/entity/*{.js,.ts}"],
             schemaCreate: true,
             dropSchema: true,

--- a/test/functional/schema-builder/constraint/check/change-check-constraint/change-check-constraint.test.ts
+++ b/test/functional/schema-builder/constraint/check/change-check-constraint/change-check-constraint.test.ts
@@ -14,6 +14,7 @@ describe("schema builder > change check constraint", () => {
     let dataSources: DataSource[]
     before(async () => {
         dataSources = await createTestingConnections({
+            disabledDrivers: ["spanner"],
             entities: [__dirname + "/entity/*{.js,.ts}"],
             schemaCreate: true,
             dropSchema: true,

--- a/test/functional/schema-builder/constraint/unique/change-unique-constraint/change-unique-constraint.test.ts
+++ b/test/functional/schema-builder/constraint/unique/change-unique-constraint/change-unique-constraint.test.ts
@@ -15,6 +15,7 @@ describe("schema builder > change unique constraint", () => {
     let dataSources: DataSource[]
     before(async () => {
         dataSources = await createTestingConnections({
+            disabledDrivers: ["spanner"],
             entities: [__dirname + "/entity/*{.js,.ts}"],
             schemaCreate: true,
             dropSchema: true,

--- a/test/functional/schema-builder/foreign-key/create-foreign-key/create-foreign-key.test.ts
+++ b/test/functional/schema-builder/foreign-key/create-foreign-key/create-foreign-key.test.ts
@@ -12,6 +12,7 @@ describe("schema builder > create foreign key", () => {
     let dataSources: DataSource[]
     before(async () => {
         dataSources = await createTestingConnections({
+            disabledDrivers: ["spanner"],
             entities: [__dirname + "/entity/*{.js,.ts}"],
             schemaCreate: true,
             dropSchema: true,

--- a/test/functional/schema-builder/table/create-table/create-table.test.ts
+++ b/test/functional/schema-builder/table/create-table/create-table.test.ts
@@ -11,6 +11,7 @@ describe("schema builder > create table", () => {
     let dataSources: DataSource[]
     before(async () => {
         dataSources = await createTestingConnections({
+            disabledDrivers: ["spanner"],
             entities: [__dirname + "/entity/*{.js,.ts}"],
             dropSchema: true,
         })

--- a/test/functional/table-inheritance/single-table/basic-functionality/basic-functionality.test.ts
+++ b/test/functional/table-inheritance/single-table/basic-functionality/basic-functionality.test.ts
@@ -18,6 +18,7 @@ describe("table-inheritance > single-table > basic-functionality", () => {
     let dataSources: DataSource[]
     before(async () => {
         dataSources = await createTestingConnections({
+            disabledDrivers: ["spanner"],
             entities: [__dirname + "/entity/*{.js,.ts}"],
         })
     })
@@ -515,6 +516,7 @@ describe("table-inheritance > single-table > basic-functionality", () => {
         let dataSources: DataSource[]
         before(async () => {
             dataSources = await createTestingConnections({
+                disabledDrivers: ["spanner"],
                 entities: [Human, Male],
                 enabledDrivers: ["postgres", "cockroachdb", "mssql"],
                 schema: "my_schema",

--- a/test/functional/table-inheritance/single-table/relations/one-to-many/one-to-many.test.ts
+++ b/test/functional/table-inheritance/single-table/relations/one-to-many/one-to-many.test.ts
@@ -18,6 +18,7 @@ describe("table-inheritance > single-table > relations > one-to-many", () => {
     let dataSources: DataSource[]
     before(async () => {
         dataSources = await createTestingConnections({
+            disabledDrivers: ["spanner"],
             entities: [__dirname + "/entity/*{.js,.ts}"],
         })
     })

--- a/test/functional/tree-tables/materialized-path/custom-join-column/non-pk-parent-column.test.ts
+++ b/test/functional/tree-tables/materialized-path/custom-join-column/non-pk-parent-column.test.ts
@@ -11,6 +11,7 @@ describe("tree-tables > materialized-path > non-pk parent column", () => {
     let dataSources: DataSource[]
     before(async () => {
         dataSources = await createTestingConnections({
+            disabledDrivers: ["spanner"],
             entities: [Category],
         })
     })

--- a/test/functional/view-entity/general/view-entity-general.test.ts
+++ b/test/functional/view-entity/general/view-entity-general.test.ts
@@ -18,6 +18,7 @@ describe("view entity > general", () => {
     let dataSources: DataSource[]
     before(async () => {
         dataSources = await createTestingConnections({
+            disabledDrivers: ["spanner"],
             entities: [__dirname + "/entity/*{.js,.ts}"],
         })
     })

--- a/test/github-issues/1014/issue-1014.test.ts
+++ b/test/github-issues/1014/issue-1014.test.ts
@@ -12,6 +12,7 @@ describe("github issues > #1014 Transaction doesn't rollback", () => {
     let dataSources: DataSource[]
     before(async () => {
         dataSources = await createTestingConnections({
+            disabledDrivers: ["spanner"],
             entities: [__dirname + "/entity/*{.js,.ts}"],
         })
     })

--- a/test/github-issues/10322/issue-10322.test.ts
+++ b/test/github-issues/10322/issue-10322.test.ts
@@ -34,6 +34,7 @@ describe("github issues > #10322 logMigration of AbstractLogger has wrong loggin
 
     before(async () => {
         dataSources = await createTestingConnections({
+            disabledDrivers: ["spanner"],
             entities: [__dirname + "/entity/*{.js,.ts}"],
             migrations: [__dirname + "/migration/*{.js,.ts}"],
             schemaCreate: true,

--- a/test/github-issues/10389/issue-10389.test.ts
+++ b/test/github-issues/10389/issue-10389.test.ts
@@ -13,6 +13,7 @@ describe("github issues > #10389 softDelete should not update already deleted ro
     let dataSources: DataSource[]
     before(async () => {
         dataSources = await createTestingConnections({
+            disabledDrivers: ["spanner"],
             entities: [__dirname + "/entity/*{.js,.ts}"],
             schemaCreate: true,
             dropSchema: true,

--- a/test/github-issues/10431/issue-10431.test.ts
+++ b/test/github-issues/10431/issue-10431.test.ts
@@ -14,6 +14,7 @@ describe("github issues > #10431 When requesting nested relations on foreign key
 
     before(async () => {
         dataSources = await createTestingConnections({
+            disabledDrivers: ["spanner"],
             entities: [Category, Product],
             schemaCreate: true,
             dropSchema: true,

--- a/test/github-issues/10494/issue-10494.test.ts
+++ b/test/github-issues/10494/issue-10494.test.ts
@@ -18,6 +18,7 @@ describe("github issues > #10494 Custom discriminator values when using Single T
 
     before(async () => {
         dataSources = await createTestingConnections({
+            disabledDrivers: ["spanner"],
             entities: [BaseSchema, ASchema, BSchema, CSchema],
             schemaCreate: true,
             dropSchema: true,

--- a/test/github-issues/10496/issue-10496.test.ts
+++ b/test/github-issues/10496/issue-10496.test.ts
@@ -16,6 +16,7 @@ describe("github issues > #10496 User-defined index name for Single Table Inheri
 
     before(async () => {
         dataSources = await createTestingConnections({
+            disabledDrivers: ["spanner"],
             entities: [Base, A, B, C],
             schemaCreate: true,
             dropSchema: true,

--- a/test/github-issues/10517/issue-10517.test.ts
+++ b/test/github-issues/10517/issue-10517.test.ts
@@ -16,6 +16,7 @@ describe("github issues > #10517 EntityManager update/delete/softDelete don't wo
     let dataSources: DataSource[]
     before(async () => {
         dataSources = await createTestingConnections({
+            disabledDrivers: ["spanner"],
             entities: [Post],
         })
     })

--- a/test/github-issues/10563/issue-10563.test.ts
+++ b/test/github-issues/10563/issue-10563.test.ts
@@ -12,6 +12,7 @@ describe("github issues > #10653 Default value in child table/entity column deco
     let dataSources: DataSource[]
     before(async () => {
         dataSources = await createTestingConnections({
+            disabledDrivers: ["spanner"],
             entities: [__dirname + "/entity/*{.js,.ts}"],
             schemaCreate: true,
             dropSchema: true,

--- a/test/github-issues/10569/issue-10569.test.ts
+++ b/test/github-issues/10569/issue-10569.test.ts
@@ -16,6 +16,7 @@ describe("github issues > #10569 Fix type inferencing of EntityManager#create", 
     let dataSources: DataSource[]
     before(async () => {
         dataSources = await createTestingConnections({
+            disabledDrivers: ["spanner"],
             entities: [__dirname + "/entity/*{.js,.ts}"],
             schemaCreate: true,
             dropSchema: true,

--- a/test/github-issues/1099/issue-1099.test.ts
+++ b/test/github-issues/1099/issue-1099.test.ts
@@ -13,6 +13,7 @@ describe("github issues > #1099 BUG - QueryBuilder MySQL skip sql is wrong", () 
     let dataSources: DataSource[]
     before(async () => {
         dataSources = await createTestingConnections({
+            disabledDrivers: ["spanner"],
             entities: [__dirname + "/entity/*{.js,.ts}"],
         })
     })

--- a/test/github-issues/1123/issue-1123.test.ts
+++ b/test/github-issues/1123/issue-1123.test.ts
@@ -12,6 +12,7 @@ describe("github issues > #1123 load relation eagerly by setting isEager propert
     let dataSources: DataSource[]
     before(async () => {
         dataSources = await createTestingConnections({
+            disabledDrivers: ["spanner"],
             entities: [
                 new EntitySchema<Author>(AuthorSchema),
                 new EntitySchema<Post>(PostSchema),

--- a/test/github-issues/1140/issue-1140.test.ts
+++ b/test/github-issues/1140/issue-1140.test.ts
@@ -12,6 +12,7 @@ describe("github issues > #1140 timestamp column and value transformer causes Ty
     let dataSources: DataSource[]
     before(async () => {
         dataSources = await createTestingConnections({
+            disabledDrivers: ["spanner"],
             entities: [__dirname + "/entity/*{.js,.ts}"],
             schemaCreate: true,
             dropSchema: true,

--- a/test/github-issues/1200/issue-1200.test.ts
+++ b/test/github-issues/1200/issue-1200.test.ts
@@ -12,6 +12,7 @@ describe("github issues > #1200 Update multiple nested embeddeds", () => {
     let dataSources: DataSource[]
     before(async () => {
         dataSources = await createTestingConnections({
+            disabledDrivers: ["spanner"],
             entities: [__dirname + "/entity/*{.js,.ts}"],
         })
     })

--- a/test/github-issues/1245/issue-1245.test.ts
+++ b/test/github-issues/1245/issue-1245.test.ts
@@ -13,6 +13,7 @@ describe("github issues > #1245 `findBy` with `In` ignores `FindManyOptions`", (
     let dataSources: DataSource[]
     before(async () => {
         dataSources = await createTestingConnections({
+            disabledDrivers: ["spanner"],
             entities: [__dirname + "/entity/*{.js,.ts}"],
             schemaCreate: true,
             dropSchema: true,

--- a/test/github-issues/1282/issue-1282.test.ts
+++ b/test/github-issues/1282/issue-1282.test.ts
@@ -16,6 +16,7 @@ describe("github issue > #1282 FEATURE REQUEST - Naming strategy joinTableColumn
 
     before(async () => {
         dataSources = await createTestingConnections({
+            disabledDrivers: ["spanner"],
             entities: [__dirname + "/entity/*{.js,.ts}"],
             namingStrategy,
         })

--- a/test/github-issues/1355/issue-1355.test.ts
+++ b/test/github-issues/1355/issue-1355.test.ts
@@ -13,6 +13,7 @@ describe("github issues > #1355 Allow explicitly named primary keys, foreign key
 
     before(async () => {
         dataSources = await createTestingConnections({
+            disabledDrivers: ["spanner"],
             entities: [__dirname + "/entity/*{.js,.ts}"],
         })
     })

--- a/test/github-issues/1369/issue-1369.test.ts
+++ b/test/github-issues/1369/issue-1369.test.ts
@@ -12,6 +12,7 @@ describe("github issues > #1369 EntitySubscriber not firing events on abstract c
     let dataSources: DataSource[]
     before(async () => {
         dataSources = await createTestingConnections({
+            disabledDrivers: ["spanner"],
             entities: [__dirname + "/entity/*{.js,.ts}"],
             subscribers: [__dirname + "/subscriber/*{.js,.ts}"],
             schemaCreate: true,

--- a/test/github-issues/151/issue-151.test.ts
+++ b/test/github-issues/151/issue-151.test.ts
@@ -13,6 +13,7 @@ describe("github issues > #151 joinAndSelect can't find entity from inverse side
     let dataSources: DataSource[]
     before(async () => {
         dataSources = await createTestingConnections({
+            disabledDrivers: ["spanner"],
             entities: [__dirname + "/entity/*{.js,.ts}"],
         })
     })

--- a/test/github-issues/161/issue-161.test.ts
+++ b/test/github-issues/161/issue-161.test.ts
@@ -13,6 +13,7 @@ describe("github issues > #161 joinAndSelect can't find entity from inverse side
     let dataSources: DataSource[]
     before(async () => {
         dataSources = await createTestingConnections({
+            disabledDrivers: ["spanner"],
             entities: [__dirname + "/entity/*{.js,.ts}"],
         })
     })

--- a/test/github-issues/1623/issue-1623.test.ts
+++ b/test/github-issues/1623/issue-1623.test.ts
@@ -12,6 +12,7 @@ describe("github issues > #1623 NOT NULL constraint failed after a new column is
     let dataSources: DataSource[]
     before(async () => {
         dataSources = await createTestingConnections({
+            disabledDrivers: ["spanner"],
             entities: [__dirname + "/entity/*{.js,.ts}"],
             schemaCreate: true,
             dropSchema: true,

--- a/test/github-issues/1680/issue-1680.test.ts
+++ b/test/github-issues/1680/issue-1680.test.ts
@@ -11,6 +11,7 @@ describe("github issues > #1680 Delete & Update applies to all entities in table
     let dataSources: DataSource[]
     before(async () => {
         dataSources = await createTestingConnections({
+            disabledDrivers: ["spanner"],
             entities: [__dirname + "/entity/*{.js,.ts}"],
             schemaCreate: true,
             dropSchema: true,

--- a/test/github-issues/1748/issue-1748.test.ts
+++ b/test/github-issues/1748/issue-1748.test.ts
@@ -13,6 +13,7 @@ describe("github issues > #1748 PrimaryColumn combined with transformer leads to
     let dataSources: DataSource[]
     before(async () => {
         dataSources = await createTestingConnections({
+            disabledDrivers: ["spanner"],
             entities: [Post],
             dropSchema: true,
         })

--- a/test/github-issues/2065/issue-2065.test.ts
+++ b/test/github-issues/2065/issue-2065.test.ts
@@ -11,6 +11,7 @@ describe("github issues > #2065 TypeError: Cannot convert object to primitive va
     let dataSources: DataSource[]
     before(async () => {
         dataSources = await createTestingConnections({
+            disabledDrivers: ["spanner"],
             entities: [__dirname + "/entity/*{.js,.ts}"],
             schemaCreate: true,
             dropSchema: true,

--- a/test/github-issues/2103/issue-2103.test.ts
+++ b/test/github-issues/2103/issue-2103.test.ts
@@ -12,6 +12,7 @@ describe("github issues > #2103 query builder regression", () => {
     let dataSources: DataSource[]
     before(async () => {
         dataSources = await createTestingConnections({
+            disabledDrivers: ["spanner"],
             entities: [__dirname + "/entity/*{.js,.ts}"],
             schemaCreate: true,
             dropSchema: true,

--- a/test/github-issues/215/issue-215.test.ts
+++ b/test/github-issues/215/issue-215.test.ts
@@ -13,6 +13,7 @@ describe("github issues > #215 invalid replacements of join conditions", () => {
     let dataSources: DataSource[]
     before(async () => {
         dataSources = await createTestingConnections({
+            disabledDrivers: ["spanner"],
             entities: [__dirname + "/entity/*{.js,.ts}"],
         })
     })

--- a/test/github-issues/219/issue-219.test.ts
+++ b/test/github-issues/219/issue-219.test.ts
@@ -12,6 +12,7 @@ describe("github issues > #219 FindOptions should be able to resolve null values
     let dataSources: DataSource[]
     before(async () => {
         dataSources = await createTestingConnections({
+            disabledDrivers: ["spanner"],
             entities: [__dirname + "/entity/*{.js,.ts}"],
         })
     })

--- a/test/github-issues/2200/issue-2200.test.ts
+++ b/test/github-issues/2200/issue-2200.test.ts
@@ -14,6 +14,7 @@ describe("github issue > #2200 Bug - Issue with snake_case naming strategy", () 
 
     before(async () => {
         dataSources = await createTestingConnections({
+            disabledDrivers: ["spanner"],
             entities: [__dirname + "/entity/*{.js,.ts}"],
             namingStrategy,
         })

--- a/test/github-issues/2201/issue-2201.test.ts
+++ b/test/github-issues/2201/issue-2201.test.ts
@@ -10,6 +10,7 @@ import { User } from "./entity/ver2/user"
 describe("github issues > #2201 - Create a select query when using a (custom) junction table", () => {
     it("Should create only two PM columns ('order_id' and 'user_id')", async () => {
         const connections = await createTestingConnections({
+            disabledDrivers: ["spanner"],
             entities: [__dirname + "/entity/ver1/*{.js,.ts}"],
             schemaCreate: true,
             dropSchema: true,
@@ -32,6 +33,7 @@ describe("github issues > #2201 - Create a select query when using a (custom) ju
 
     it("Should not try to update the junction table when not needed", async () => {
         const connections = await createTestingConnections({
+            disabledDrivers: ["spanner"],
             entities: [__dirname + "/entity/ver2/*{.js,.ts}"],
             enabledDrivers: ["postgres"],
             schemaCreate: true,

--- a/test/github-issues/2251/issue-2251.test.ts
+++ b/test/github-issues/2251/issue-2251.test.ts
@@ -15,6 +15,7 @@ describe("github issues > #2251 - Unexpected behavior when passing duplicate ent
     let dataSources: DataSource[]
     before(async () => {
         dataSources = await createTestingConnections({
+            disabledDrivers: ["spanner"],
             entities: [__dirname + "/entity/*{.js,.ts}"],
             schemaCreate: true,
             dropSchema: true,

--- a/test/github-issues/2253/issue-2253.test.ts
+++ b/test/github-issues/2253/issue-2253.test.ts
@@ -12,6 +12,7 @@ describe("github issues > #2253 - inserting multiple child entities fails", () =
 
     before(async () => {
         dataSources = await createTestingConnections({
+            disabledDrivers: ["spanner"],
             entities: [__dirname + "/entity/*{.js,.ts}"],
             schemaCreate: true,
             dropSchema: true,

--- a/test/github-issues/2298/issue-2298.test.ts
+++ b/test/github-issues/2298/issue-2298.test.ts
@@ -14,6 +14,7 @@ describe("github issues > #2298 - Repository filtering not considering related c
     let dataSources: DataSource[]
     before(async () => {
         dataSources = await createTestingConnections({
+            disabledDrivers: ["spanner"],
             entities: [__dirname + "/entity/*{.js,.ts}"],
         })
     })

--- a/test/github-issues/2313/issue-2313.test.ts
+++ b/test/github-issues/2313/issue-2313.test.ts
@@ -13,6 +13,7 @@ describe("github issues > #2313 - BaseEntity has no findOneOrFail() method", () 
     let dataSources: DataSource[]
     before(async () => {
         dataSources = await createTestingConnections({
+            disabledDrivers: ["spanner"],
             entities: [__dirname + "/entity/*{.js,.ts}"],
         })
     })

--- a/test/github-issues/2364/issue-2364.test.ts
+++ b/test/github-issues/2364/issue-2364.test.ts
@@ -14,6 +14,7 @@ describe("github issues > #2364 should generate id value if @Column generated:tr
 
     it("should generate id value", async () => {
         dataSources = await createTestingConnections({
+            disabledDrivers: ["spanner"],
             entities: [__dirname + "/entity/*{.js,.ts}"],
             schemaCreate: true,
             dropSchema: true,

--- a/test/github-issues/2376/issue-2376.test.ts
+++ b/test/github-issues/2376/issue-2376.test.ts
@@ -12,6 +12,7 @@ describe("github issues > #2376 Naming single column unique constraint with deco
     let dataSources: DataSource[]
     before(async () => {
         dataSources = await createTestingConnections({
+            disabledDrivers: ["spanner"],
             schemaCreate: true,
             dropSchema: true,
             entities: [User],

--- a/test/github-issues/2464/issue-2464.test.ts
+++ b/test/github-issues/2464/issue-2464.test.ts
@@ -15,6 +15,7 @@ describe("github issues > #2464 - ManyToMany onDelete option not working", () =>
     let dataSources: DataSource[]
     before(async () => {
         dataSources = await createTestingConnections({
+            disabledDrivers: ["spanner"],
             entities: [__dirname + "/entity/*{.js,.ts}"],
         })
     })

--- a/test/github-issues/2557/issue-2557.test.ts
+++ b/test/github-issues/2557/issue-2557.test.ts
@@ -13,6 +13,7 @@ describe("github issues > #2557 object looses its prototype before transformer.t
     let dataSources: DataSource[]
     before(async () => {
         dataSources = await createTestingConnections({
+            disabledDrivers: ["spanner"],
             entities: [__dirname + "/entity/*{.js,.ts}"],
             schemaCreate: true,
             dropSchema: true,

--- a/test/github-issues/2588/issue-2588.test.ts
+++ b/test/github-issues/2588/issue-2588.test.ts
@@ -15,6 +15,7 @@ describe("github issues > #2588 - createQueryBuilder always does left joins on r
     let dataSources: DataSource[]
     before(async () => {
         dataSources = await createTestingConnections({
+            disabledDrivers: ["spanner"],
             entities: [__dirname + "/entity/*{.js,.ts}"],
         })
     })

--- a/test/github-issues/2632/issue-2632.test.ts
+++ b/test/github-issues/2632/issue-2632.test.ts
@@ -13,6 +13,7 @@ describe("github issues > #2632 createQueryBuilder relation remove works only if
     let dataSources: DataSource[]
     before(async () => {
         dataSources = await createTestingConnections({
+            disabledDrivers: ["spanner"],
             entities: [__dirname + "/entity/*{.js,.ts}"],
             schemaCreate: true,
             dropSchema: true,

--- a/test/github-issues/2703/issue-2703.test.ts
+++ b/test/github-issues/2703/issue-2703.test.ts
@@ -14,6 +14,7 @@ describe("github issues > #2703 Column with transformer is not normalized for up
 
     before(async () => {
         dataSources = await createTestingConnections({
+            disabledDrivers: ["spanner"],
             entities: [`${__dirname}/entity/*{.js,.ts}`],
             schemaCreate: true,
             dropSchema: true,

--- a/test/github-issues/2800/issue-2800.test.ts
+++ b/test/github-issues/2800/issue-2800.test.ts
@@ -12,6 +12,7 @@ describe("github issues > #2800 - Can't override embedded entities in STI implem
 
     before(async () => {
         dataSources = await createTestingConnections({
+            disabledDrivers: ["spanner"],
             entities: [__dirname + "/entity/*{.js,.ts}"],
             schemaCreate: true,
             dropSchema: true,

--- a/test/github-issues/2809/issue-2809.test.ts
+++ b/test/github-issues/2809/issue-2809.test.ts
@@ -12,6 +12,7 @@ describe("github issues > #2809 afterUpdate subscriber entity argument is undefi
     let dataSources: DataSource[]
     before(async () => {
         dataSources = await createTestingConnections({
+            disabledDrivers: ["spanner"],
             entities: [__dirname + "/entity/*{.js,.ts}"],
             subscribers: [__dirname + "/subscriber/*{.js,.ts}"],
         })

--- a/test/github-issues/2965/index.test.ts
+++ b/test/github-issues/2965/index.test.ts
@@ -13,6 +13,7 @@ describe("github issues > #2965 Reuse preloaded lazy relations", () => {
     let dataSources: DataSource[]
     before(async () => {
         dataSources = await createTestingConnections({
+            disabledDrivers: ["spanner"],
             entities: [__dirname + "/entity/*{.js,.ts}"],
         })
     })

--- a/test/github-issues/2984/issue-2984.test.ts
+++ b/test/github-issues/2984/issue-2984.test.ts
@@ -11,6 +11,7 @@ describe("github issues > #2984 Discriminator conflict reported even for non-inh
     let dataSources: DataSource[]
     before(async () => {
         dataSources = await createTestingConnections({
+            disabledDrivers: ["spanner"],
             entities: [__dirname + "/entity/**/*{.js,.ts}"],
         })
     })

--- a/test/github-issues/300/issue-300.test.ts
+++ b/test/github-issues/300/issue-300.test.ts
@@ -12,6 +12,7 @@ describe("github issues > #300 support of embeddeds that are not set", () => {
     let dataSources: DataSource[]
     before(async () => {
         dataSources = await createTestingConnections({
+            disabledDrivers: ["spanner"],
             entities: [__dirname + "/entity/*{.js,.ts}"],
         })
     })

--- a/test/github-issues/3047/issue-3047.test.ts
+++ b/test/github-issues/3047/issue-3047.test.ts
@@ -14,6 +14,7 @@ describe("github issues > #3047 Mysqsl on duplicate key update use current value
 
     before(async () => {
         dataSources = await createTestingConnections({
+            disabledDrivers: ["spanner"],
             entities: [User],
             schemaCreate: true,
             dropSchema: true,

--- a/test/github-issues/306/issue-306.test.ts
+++ b/test/github-issues/306/issue-306.test.ts
@@ -13,6 +13,7 @@ describe("github issues > #306 embeddeds with custom column name don't work", ()
     let dataSources: DataSource[]
     before(async () => {
         dataSources = await createTestingConnections({
+            disabledDrivers: ["spanner"],
             entities: [__dirname + "/entity/*{.js,.ts}"],
         })
     })

--- a/test/github-issues/3111/issue-3111.test.ts
+++ b/test/github-issues/3111/issue-3111.test.ts
@@ -13,6 +13,7 @@ describe("github issues > #3111 Inserting with query builder attempts to insert 
     let dataSources: DataSource[]
     before(async () => {
         dataSources = await createTestingConnections({
+            disabledDrivers: ["spanner"],
             entities: [__dirname + "/entity/*{.js,.ts}"],
             schemaCreate: true,
             dropSchema: true,

--- a/test/github-issues/3112/issue-3112.test.ts
+++ b/test/github-issues/3112/issue-3112.test.ts
@@ -12,6 +12,7 @@ describe("github issues > #3112 default:null should inserts nulls to database", 
 
     before(async () => {
         dataSources = await createTestingConnections({
+            disabledDrivers: ["spanner"],
             entities: [User],
             schemaCreate: true,
             dropSchema: true,

--- a/test/github-issues/3302/issue-3302.test.ts
+++ b/test/github-issues/3302/issue-3302.test.ts
@@ -18,6 +18,7 @@ describe("github issues > #3302 Tracking query time for slow queries and statsd 
 
     before(async () => {
         dataSources = await createTestingConnections({
+            disabledDrivers: ["spanner"],
             entities: [__dirname + "/entity/*{.js,.ts}"],
             subscribers: [__dirname + "/subscriber/*{.js,.ts}"],
         })

--- a/test/github-issues/3349/issue-3349.test.ts
+++ b/test/github-issues/3349/issue-3349.test.ts
@@ -13,6 +13,7 @@ describe("github issues > #3349 Multiple where conditions with parameters", () =
     let dataSources: DataSource[]
     before(async () => {
         dataSources = await createTestingConnections({
+            disabledDrivers: ["spanner"],
             entities: [__dirname + "/entity/*{.js,.ts}"],
         })
     })

--- a/test/github-issues/3363/issue-3363.test.ts
+++ b/test/github-issues/3363/issue-3363.test.ts
@@ -13,6 +13,7 @@ describe("github issues > #3363 Isolation Level in transaction() from Connection
     let dataSources: DataSource[]
     before(async () => {
         dataSources = await createTestingConnections({
+            disabledDrivers: ["spanner"],
             entities: [__dirname + "/entity/*{.js,.ts}"],
             subscribers: [__dirname + "/subscriber/*{.js,.ts}"],
         })

--- a/test/github-issues/341/issue-341.test.ts
+++ b/test/github-issues/341/issue-341.test.ts
@@ -13,6 +13,7 @@ describe("github issues > #341 OneToOne relation with referencedColumnName does 
     let dataSources: DataSource[]
     before(async () => {
         dataSources = await createTestingConnections({
+            disabledDrivers: ["spanner"],
             entities: [__dirname + "/entity/*{.js,.ts}"],
         })
     })

--- a/test/github-issues/3416/issue-3416.test.ts
+++ b/test/github-issues/3416/issue-3416.test.ts
@@ -13,6 +13,7 @@ describe("github issues > #3416 Unknown fields are stripped from WHERE clause", 
     let dataSources: DataSource[]
     before(async () => {
         dataSources = await createTestingConnections({
+            disabledDrivers: ["spanner"],
             entities: [User],
         })
     })

--- a/test/github-issues/345/issue-345.test.ts
+++ b/test/github-issues/345/issue-345.test.ts
@@ -13,6 +13,7 @@ describe("github issues > #345 Join query on ManyToMany relations not working", 
     let dataSources: DataSource[]
     before(async () => {
         dataSources = await createTestingConnections({
+            disabledDrivers: ["spanner"],
             entities: [__dirname + "/entity/*{.js,.ts}"],
         })
     })

--- a/test/github-issues/3534/issue-3534.test.ts
+++ b/test/github-issues/3534/issue-3534.test.ts
@@ -12,6 +12,7 @@ describe("github issues > #3534: store regexp", () => {
     let dataSources: DataSource[]
     before(async () => {
         dataSources = await createTestingConnections({
+            disabledDrivers: ["spanner"],
             entities: [__dirname + "/entity/*{.js,.ts}"],
         })
     })

--- a/test/github-issues/363/issue-363.test.ts
+++ b/test/github-issues/363/issue-363.test.ts
@@ -13,6 +13,7 @@ describe("github issues > #363 Can't save 2 unrelated entity types in a single p
     let dataSources: DataSource[]
     before(async () => {
         dataSources = await createTestingConnections({
+            disabledDrivers: ["spanner"],
             entities: [__dirname + "/entity/*{.js,.ts}"],
         })
     })

--- a/test/github-issues/3685/issue-3685.test.ts
+++ b/test/github-issues/3685/issue-3685.test.ts
@@ -12,6 +12,7 @@ describe("github issues > #3685 Brackets syntax failed when use where with objec
     let dataSources: DataSource[]
     before(async () => {
         dataSources = await createTestingConnections({
+            disabledDrivers: ["spanner"],
             entities: [__dirname + "/entity/*{.js,.ts}"],
             dropSchema: true,
             schemaCreate: true,

--- a/test/github-issues/3803/issue-3803.test.ts
+++ b/test/github-issues/3803/issue-3803.test.ts
@@ -14,6 +14,7 @@ describe("github issues > #3803 column option unique sqlite error", () => {
     let dataSources: DataSource[]
     before(async () => {
         dataSources = await createTestingConnections({
+            disabledDrivers: ["spanner"],
             entities: [new EntitySchema<Post>(PostSchema)],
         })
     })

--- a/test/github-issues/3847/issue-3847.test.ts
+++ b/test/github-issues/3847/issue-3847.test.ts
@@ -15,6 +15,7 @@ describe("github issues > #3847 FEATURE REQUEST - Naming strategy foreign key ov
 
     before(async () => {
         dataSources = await createTestingConnections({
+            disabledDrivers: ["spanner"],
             entities: [__dirname + "/entity/*{.js,.ts}"],
             namingStrategy,
         })

--- a/test/github-issues/388/issue-388.test.ts
+++ b/test/github-issues/388/issue-388.test.ts
@@ -12,6 +12,7 @@ describe("github issues > #388 skip and take with string ID don't work", () => {
     let dataSources: DataSource[]
     before(async () => {
         dataSources = await createTestingConnections({
+            disabledDrivers: ["spanner"],
             entities: [__dirname + "/entity/*{.js,.ts}"],
         })
     })

--- a/test/github-issues/401/issue-401.test.ts
+++ b/test/github-issues/401/issue-401.test.ts
@@ -13,6 +13,7 @@ describe("github issues > #401 special keywords should be escaped in join querie
     let dataSources: DataSource[]
     before(async () => {
         dataSources = await createTestingConnections({
+            disabledDrivers: ["spanner"],
             entities: [__dirname + "/entity/*{.js,.ts}"],
         })
     })

--- a/test/github-issues/4185/issue-4185.test.ts
+++ b/test/github-issues/4185/issue-4185.test.ts
@@ -11,6 +11,7 @@ describe("github issues > #4185 afterLoad() subscriber interface missing additio
     let dataSources: DataSource[]
     before(async () => {
         dataSources = await createTestingConnections({
+            disabledDrivers: ["spanner"],
             entities: [__dirname + "/entity/*{.js,.ts}"],
             subscribers: [__dirname + "/subscriber/*{.js,.ts}"],
             schemaCreate: true,

--- a/test/github-issues/4190/issue-4190.test.ts
+++ b/test/github-issues/4190/issue-4190.test.ts
@@ -16,6 +16,7 @@ describe("github issues > #4190 Relation decorators: allow to pass string instea
     let dataSources: DataSource[]
     before(async () => {
         dataSources = await createTestingConnections({
+            disabledDrivers: ["spanner"],
             entities: [__dirname + "/entity/*{.js,.ts}"],
             schemaCreate: true,
             dropSchema: true,

--- a/test/github-issues/423/issue-423.test.ts
+++ b/test/github-issues/423/issue-423.test.ts
@@ -9,6 +9,7 @@ describe("github issues > #423 Cannot use Group as Table name && cannot autoSche
     let dataSources: DataSource[]
     before(async () => {
         dataSources = await createTestingConnections({
+            disabledDrivers: ["spanner"],
             entities: [__dirname + "/entity/*{.js,.ts}"],
             schemaCreate: false,
             dropSchema: true,

--- a/test/github-issues/4277/issue-4277.test.ts
+++ b/test/github-issues/4277/issue-4277.test.ts
@@ -12,6 +12,7 @@ describe("github issues > #4277 Using cache in findAndCount and getManyAndCount 
     let dataSources: DataSource[]
     before(async () => {
         dataSources = await createTestingConnections({
+            disabledDrivers: ["spanner"],
             entities: [__dirname + "/entity/*{.js,.ts}"],
             schemaCreate: true,
             dropSchema: true,

--- a/test/github-issues/4410/issue-4410.test.ts
+++ b/test/github-issues/4410/issue-4410.test.ts
@@ -36,6 +36,7 @@ describe("github issues > #4410 allow custom filepath for FileLogger", () => {
     describe("when no option is passed", () => {
         before(async () => {
             dataSources = await createTestingConnections({
+                disabledDrivers: ["spanner"],
                 ...testingOptions,
                 createLogger: () => new FileLogger("all"),
             })
@@ -60,6 +61,7 @@ describe("github issues > #4410 allow custom filepath for FileLogger", () => {
     describe("when logPath option is passed as a file", () => {
         before(async () => {
             dataSources = await createTestingConnections({
+                disabledDrivers: ["spanner"],
                 ...testingOptions,
                 createLogger: () =>
                     new FileLogger("all", {
@@ -87,6 +89,7 @@ describe("github issues > #4410 allow custom filepath for FileLogger", () => {
     describe("when logPath option is passed as a nested path", () => {
         before(async () => {
             dataSources = await createTestingConnections({
+                disabledDrivers: ["spanner"],
                 ...testingOptions,
                 createLogger: () =>
                     new FileLogger("all", {

--- a/test/github-issues/4452/issue-4452.test.ts
+++ b/test/github-issues/4452/issue-4452.test.ts
@@ -12,6 +12,7 @@ describe("github issues > #4452 InsertQueryBuilder fails on some SQL Expressions
     let dataSources: DataSource[]
     before(async () => {
         dataSources = await createTestingConnections({
+            disabledDrivers: ["spanner"],
             // enabledDrivers: ["postgres"],
             entities: [User],
             dropSchema: true,

--- a/test/github-issues/479/issue-479.test.ts
+++ b/test/github-issues/479/issue-479.test.ts
@@ -12,6 +12,7 @@ describe("github issues > #479 orWhere breaks skip / take", () => {
     let dataSources: DataSource[]
     before(async () => {
         dataSources = await createTestingConnections({
+            disabledDrivers: ["spanner"],
             entities: [__dirname + "/entity/*{.js,.ts}"],
         })
     })

--- a/test/github-issues/4842/issue-4842.test.ts
+++ b/test/github-issues/4842/issue-4842.test.ts
@@ -12,6 +12,7 @@ describe("github issues > #4842 QueryExpressionMap doesn't clone distinct proper
     let dataSources: DataSource[]
     before(async () => {
         dataSources = await createTestingConnections({
+            disabledDrivers: ["spanner"],
             entities: [__dirname + "/entity/*{.js,.ts}"],
         })
     })

--- a/test/github-issues/493/issue-493.test.ts
+++ b/test/github-issues/493/issue-493.test.ts
@@ -11,6 +11,7 @@ describe("github issues > #493 pagination should work with string primary keys",
     let dataSources: DataSource[]
     before(async () => {
         dataSources = await createTestingConnections({
+            disabledDrivers: ["spanner"],
             entities: [__dirname + "/entity/*{.js,.ts}"],
         })
     })

--- a/test/github-issues/4947/issue-4947.test.ts
+++ b/test/github-issues/4947/issue-4947.test.ts
@@ -12,6 +12,7 @@ describe("github issues > #4947 beforeUpdate subscriber entity argument is undef
     let dataSources: DataSource[]
     before(async () => {
         dataSources = await createTestingConnections({
+            disabledDrivers: ["spanner"],
             entities: [__dirname + "/entity/*{.js,.ts}"],
             subscribers: [__dirname + "/subscriber/*{.js,.ts}"],
         })

--- a/test/github-issues/495/issue-495.test.ts
+++ b/test/github-issues/495/issue-495.test.ts
@@ -12,6 +12,7 @@ describe("github issues > #495 Unable to set multi-column indices", () => {
     let dataSources: DataSource[]
     before(async () => {
         dataSources = await createTestingConnections({
+            disabledDrivers: ["spanner"],
             entities: [__dirname + "/entity/*{.js,.ts}"],
         })
     })

--- a/test/github-issues/499/issue-499.test.ts
+++ b/test/github-issues/499/issue-499.test.ts
@@ -12,6 +12,7 @@ describe("github issues > #499 postgres DATE hydrated as DATETIME object", () =>
     let dataSources: DataSource[]
     before(async () => {
         dataSources = await createTestingConnections({
+            disabledDrivers: ["spanner"],
             entities: [__dirname + "/entity/*{.js,.ts}"],
         })
     })

--- a/test/github-issues/512/issue-512.test.ts
+++ b/test/github-issues/512/issue-512.test.ts
@@ -12,6 +12,7 @@ describe("github issues > #512 Table name escaping in UPDATE in QueryBuilder", (
     let dataSources: DataSource[]
     before(async () => {
         dataSources = await createTestingConnections({
+            disabledDrivers: ["spanner"],
             entities: [__dirname + "/entity/*{.js,.ts}"],
         })
     })

--- a/test/github-issues/5160/issue-5160.test.ts
+++ b/test/github-issues/5160/issue-5160.test.ts
@@ -13,6 +13,7 @@ describe("github issues > #5160 (MSSQL) DML statement cannot have any enabled tr
 
     before(async () => {
         dataSources = await createTestingConnections({
+            disabledDrivers: ["spanner"],
             entities: [Post],
             schemaCreate: true,
             dropSchema: true,

--- a/test/github-issues/5174/issue-5174.test.ts
+++ b/test/github-issues/5174/issue-5174.test.ts
@@ -14,6 +14,7 @@ describe("github issues > #5174 `selectQueryBuilder.take` messes up the query wh
 
     before(async () => {
         dataSources = await createTestingConnections({
+            disabledDrivers: ["spanner"],
             entities: [User, Role],
             schemaCreate: true,
             dropSchema: true,

--- a/test/github-issues/521/issue-521.test.ts
+++ b/test/github-issues/521/issue-521.test.ts
@@ -11,6 +11,7 @@ describe("github issues > #521 Attributes in UPDATE in QB arent getting replaced
     let dataSources: DataSource[]
     before(async () => {
         dataSources = await createTestingConnections({
+            disabledDrivers: ["spanner"],
             entities: [__dirname + "/entity/*{.js,.ts}"],
         })
     })

--- a/test/github-issues/5520/issue-5520.test.ts
+++ b/test/github-issues/5520/issue-5520.test.ts
@@ -15,6 +15,7 @@ describe("github issues > #5520 save does not return generated id if object to s
     let dataSources: DataSource[]
     before(async () => {
         dataSources = await createTestingConnections({
+            disabledDrivers: ["spanner"],
             entities: [__dirname + "/entity/*{.js,.ts}"],
             schemaCreate: true,
             dropSchema: true,

--- a/test/github-issues/5684/issue-5684.test.ts
+++ b/test/github-issues/5684/issue-5684.test.ts
@@ -14,6 +14,7 @@ describe("github issues > #5684 eager relation skips children relations", () => 
     let dataSources: DataSource[]
     before(async () => {
         dataSources = await createTestingConnections({
+            disabledDrivers: ["spanner"],
             entities: [User, Company],
             schemaCreate: true,
             dropSchema: true,

--- a/test/github-issues/5691/issue-5691.test.ts
+++ b/test/github-issues/5691/issue-5691.test.ts
@@ -60,6 +60,7 @@ describe("github issues > #5691 RelationId is too slow", () => {
     let dataSources: DataSource[]
     before(async () => {
         dataSources = await createTestingConnections({
+            disabledDrivers: ["spanner"],
             entities: [Root, Child1, Child2, Shared],
             schemaCreate: true,
             dropSchema: true,

--- a/test/github-issues/5734/issue-5734.test.ts
+++ b/test/github-issues/5734/issue-5734.test.ts
@@ -11,6 +11,7 @@ describe("github issues > #5734 insert([]) should not crash", () => {
     let dataSources: DataSource[]
     before(async () => {
         dataSources = await createTestingConnections({
+            disabledDrivers: ["spanner"],
             entities: [__dirname + "/entity/*{.js,.ts}"],
             subscribers: [__dirname + "/subscriber/*{.js,.ts}"],
             schemaCreate: true,

--- a/test/github-issues/5762/issue-5762.test.ts
+++ b/test/github-issues/5762/issue-5762.test.ts
@@ -14,6 +14,7 @@ describe("github issues > #5762 `Using URL as a rich column type breaks", () => 
 
     before(async () => {
         dataSources = await createTestingConnections({
+            disabledDrivers: ["spanner"],
             entities: [User],
             schemaCreate: true,
             dropSchema: true,

--- a/test/github-issues/594/issue-594.test.ts
+++ b/test/github-issues/594/issue-594.test.ts
@@ -11,6 +11,7 @@ describe("github issues > #594 WhereInIds no longer works in the latest version.
     let dataSources: DataSource[]
     before(async () => {
         dataSources = await createTestingConnections({
+            disabledDrivers: ["spanner"],
             entities: [__dirname + "/entity/*{.js,.ts}"],
         })
     })

--- a/test/github-issues/6195/issue-6195.test.ts
+++ b/test/github-issues/6195/issue-6195.test.ts
@@ -34,6 +34,7 @@ describe("github issues > #6195 feature: fake migrations for existing tables", (
 
     before(async () => {
         dataSources = await createTestingConnections({
+            disabledDrivers: ["spanner"],
             entities: [__dirname + "/entity/*{.js,.ts}"],
             schemaCreate: false,
             dropSchema: false,

--- a/test/github-issues/620/issue-620.test.ts
+++ b/test/github-issues/620/issue-620.test.ts
@@ -12,6 +12,7 @@ describe("github issues > #620 Feature Request: Flexibility in Foreign Key names
     let dataSources: DataSource[]
     before(async () => {
         dataSources = await createTestingConnections({
+            disabledDrivers: ["spanner"],
             entities: [__dirname + "/entity/*{.js,.ts}"],
         })
     })

--- a/test/github-issues/6265/issue-6265.test.ts
+++ b/test/github-issues/6265/issue-6265.test.ts
@@ -14,6 +14,7 @@ describe("github issues > #6265 `fix: resolve issue with find with relations ret
 
     before(async () => {
         dataSources = await createTestingConnections({
+            disabledDrivers: ["spanner"],
             entities: [User, Role],
             schemaCreate: true,
             dropSchema: true,

--- a/test/github-issues/6327/issue-6327.test.ts
+++ b/test/github-issues/6327/issue-6327.test.ts
@@ -11,6 +11,7 @@ describe("github issues > #6327 softRemove DeleteDateColumn is null at Susbscrib
     let dataSources: DataSource[]
     before(async () => {
         dataSources = await createTestingConnections({
+            disabledDrivers: ["spanner"],
             entities: [__dirname + "/entity/*{.js,.ts}"],
             subscribers: [__dirname + "/subscriber/*{.js,.ts}"],
             schemaCreate: true,

--- a/test/github-issues/6977/issue-6977.test.ts
+++ b/test/github-issues/6977/issue-6977.test.ts
@@ -13,6 +13,7 @@ describe("github issues > #6977 Relation columns in embedded entities are not pr
     let dataSources: DataSource[]
     before(async () => {
         dataSources = await createTestingConnections({
+            disabledDrivers: ["spanner"],
             entities: [User, Embedded],
         })
     })

--- a/test/github-issues/703/issue-703.test.ts
+++ b/test/github-issues/703/issue-703.test.ts
@@ -12,6 +12,7 @@ describe("github issues > #703.findOne does not return an empty array on OneToMa
     let dataSources: DataSource[]
     before(async () => {
         dataSources = await createTestingConnections({
+            disabledDrivers: ["spanner"],
             entities: [__dirname + "/entity/*{.js,.ts}"],
         })
     })

--- a/test/github-issues/704/issue-704.test.ts
+++ b/test/github-issues/704/issue-704.test.ts
@@ -11,6 +11,7 @@ describe("github issues > #704 Table alias in WHERE clause is not quoted in Post
     let dataSources: DataSource[]
     before(async () => {
         dataSources = await createTestingConnections({
+            disabledDrivers: ["spanner"],
             entities: [__dirname + "/entity/*{.js,.ts}"],
         })
     })

--- a/test/github-issues/7041/issue-7041.test.ts
+++ b/test/github-issues/7041/issue-7041.test.ts
@@ -12,6 +12,7 @@ describe("github issues > #7041 When requesting nested relations on foreign key 
     let dataSources: DataSource[]
     before(async () => {
         dataSources = await createTestingConnections({
+            disabledDrivers: ["spanner"],
             entities: [Organization, Admin, User, OrganizationMembership],
             schemaCreate: true,
             dropSchema: true,

--- a/test/github-issues/7065/issue-7065.test.ts
+++ b/test/github-issues/7065/issue-7065.test.ts
@@ -19,6 +19,7 @@ describe("github issues > #7065 ChildEntity type relationship produces unexpecte
     let dataSources: DataSource[]
     before(async () => {
         dataSources = await createTestingConnections({
+            disabledDrivers: ["spanner"],
             entities: [Contact, Email, Phone, User],
             schemaCreate: true,
             dropSchema: true,

--- a/test/github-issues/7079/issue-7079.test.ts
+++ b/test/github-issues/7079/issue-7079.test.ts
@@ -12,6 +12,7 @@ describe("github issues > #7079 Error when sorting by an embedded entity while u
     let dataSources: DataSource[]
     before(async () => {
         dataSources = await createTestingConnections({
+            disabledDrivers: ["spanner"],
             entities: [Post, User],
             schemaCreate: true,
             dropSchema: true,

--- a/test/github-issues/7109/issue-7109.test.ts
+++ b/test/github-issues/7109/issue-7109.test.ts
@@ -22,6 +22,7 @@ describe("github issues > #7109 stream() bug from 0.2.25 to 0.2.26 with postgres
     let dataSources: DataSource[]
     before(async () => {
         dataSources = await createTestingConnections({
+            disabledDrivers: ["spanner"],
             entities: [__dirname + "/entity/*{.js,.ts}"],
             schemaCreate: true,
             dropSchema: true,

--- a/test/github-issues/7146/issue-7146.test.ts
+++ b/test/github-issues/7146/issue-7146.test.ts
@@ -12,6 +12,7 @@ describe("github issues > #7146 Lazy relations resolve to 'undefined' instead of
     let dataSources: DataSource[]
     before(async () => {
         dataSources = await createTestingConnections({
+            disabledDrivers: ["spanner"],
             entities: [__dirname + "/entity/*{.js,.ts}"],
             schemaCreate: true,
             dropSchema: true,

--- a/test/github-issues/736/issue-736.test.ts
+++ b/test/github-issues/736/issue-736.test.ts
@@ -9,6 +9,7 @@ describe("github issues > #736 ClosureEntity should set (composite) primary/uniq
     let dataSources: DataSource[]
     before(async () => {
         dataSources = await createTestingConnections({
+            disabledDrivers: ["spanner"],
             entities: [__dirname + "/entity/*{.js,.ts}"],
             schemaCreate: true,
             dropSchema: true,

--- a/test/github-issues/752/issue-752.test.ts
+++ b/test/github-issues/752/issue-752.test.ts
@@ -11,6 +11,7 @@ describe("github issues > #752 postgres - count query fails for empty table", ()
     let dataSources: DataSource[]
     before(async () => {
         dataSources = await createTestingConnections({
+            disabledDrivers: ["spanner"],
             entities: [__dirname + "/entity/*{.js,.ts}"],
         })
     })

--- a/test/github-issues/7558/issue-7758.test.ts
+++ b/test/github-issues/7558/issue-7758.test.ts
@@ -20,6 +20,7 @@ describe("github issues > #7558 Child entities' wrong discriminator value when e
     let dataSources: DataSource[]
     before(async () => {
         dataSources = await createTestingConnections({
+            disabledDrivers: ["spanner"],
             entities: [__dirname + "/entity/*{.js,.ts}"],
             schemaCreate: true,
             dropSchema: true,

--- a/test/github-issues/762/issue-762.test.ts
+++ b/test/github-issues/762/issue-762.test.ts
@@ -13,6 +13,7 @@ describe("github issues > #762 Nullable @Embedded inside @Embedded", () => {
     let dataSources: DataSource[]
     before(async () => {
         dataSources = await createTestingConnections({
+            disabledDrivers: ["spanner"],
             entities: [__dirname + "/entity/*{.js,.ts}"],
         })
     })

--- a/test/github-issues/8018/issue-8018.test.ts
+++ b/test/github-issues/8018/issue-8018.test.ts
@@ -14,6 +14,7 @@ describe("github issues > #8018 Non-unique relation property names causes entity
     let dataSources: DataSource[]
     before(async () => {
         dataSources = await createTestingConnections({
+            disabledDrivers: ["spanner"],
             entities: [Parent, Child, Grandchild],
             schemaCreate: true,
             dropSchema: true,

--- a/test/github-issues/8026/issue-8026.test.ts
+++ b/test/github-issues/8026/issue-8026.test.ts
@@ -13,6 +13,7 @@ describe("github issues > #8026 Inserting a value for a column that has a relati
 
     before(async () => {
         dataSources = await createTestingConnections({
+            disabledDrivers: ["spanner"],
             entities: [Sailing, ScheduledSailing],
             schemaCreate: true,
             dropSchema: true,

--- a/test/github-issues/807/issue-807.test.ts
+++ b/test/github-issues/807/issue-807.test.ts
@@ -11,6 +11,7 @@ describe("github issues > #807 Error in persisting dates", () => {
     let dataSources: DataSource[]
     before(async () => {
         dataSources = await createTestingConnections({
+            disabledDrivers: ["spanner"],
             entities: [__dirname + "/entity/*{.js,.ts}"],
         })
     })

--- a/test/github-issues/813/issue-813.test.ts
+++ b/test/github-issues/813/issue-813.test.ts
@@ -13,6 +13,7 @@ describe("github issues > #813 order by must support functions", () => {
     let dataSources: DataSource[]
     before(async () => {
         dataSources = await createTestingConnections({
+            disabledDrivers: ["spanner"],
             entities: [__dirname + "/entity/*{.js,.ts}"],
         })
     })

--- a/test/github-issues/815/issue-815.test.ts
+++ b/test/github-issues/815/issue-815.test.ts
@@ -13,6 +13,7 @@ describe("github issues > #815 @RelationId properties are not updated after enti
     let dataSources: DataSource[]
     before(async () => {
         dataSources = await createTestingConnections({
+            disabledDrivers: ["spanner"],
             entities: [__dirname + "/entity/*{.js,.ts}"],
         })
     })

--- a/test/github-issues/8221/issue-8221.test.ts
+++ b/test/github-issues/8221/issue-8221.test.ts
@@ -17,6 +17,7 @@ describe("github issues > #8221", () => {
 
     before(async () => {
         dataSources = await createTestingConnections({
+            disabledDrivers: ["spanner"],
             entities: [User, Setting],
             subscribers: [SettingSubscriber],
             schemaCreate: true,

--- a/test/github-issues/8346/issue-8346.test.ts
+++ b/test/github-issues/8346/issue-8346.test.ts
@@ -13,6 +13,7 @@ describe("github issues > #8346 MySQL: Regression when using take, orderBy, and 
     let dataSources: DataSource[]
     before(async () => {
         dataSources = await createTestingConnections({
+            disabledDrivers: ["spanner"],
             entities: [__dirname + "/entity/*{.js,.ts}"],
             schemaCreate: true,
             dropSchema: true,

--- a/test/github-issues/8393/issue-8393.test.ts
+++ b/test/github-issues/8393/issue-8393.test.ts
@@ -13,6 +13,7 @@ describe("github issues > #8393 When trying to update `update: false` column wit
     let dataSources: DataSource[]
     before(async () => {
         dataSources = await createTestingConnections({
+            disabledDrivers: ["spanner"],
             entities: [__dirname + "/entity/*{.js,.ts}"],
             schemaCreate: true,
             dropSchema: true,

--- a/test/github-issues/8398/issue-8398.test.ts
+++ b/test/github-issues/8398/issue-8398.test.ts
@@ -12,6 +12,7 @@ describe("github issues > #8398 Separate update event into the update, soft remo
     let dataSources: DataSource[]
     before(async () => {
         dataSources = await createTestingConnections({
+            disabledDrivers: ["spanner"],
             entities: [__dirname + "/entity/*{.js,.ts}"],
             subscribers: [__dirname + "/subscriber/*{.js,.ts}"],
             schemaCreate: true,

--- a/test/github-issues/8444/issue-8444.test.ts
+++ b/test/github-issues/8444/issue-8444.test.ts
@@ -14,6 +14,7 @@ describe("github issues > #8444 entitySkipConstructor not working", () => {
                 DataSource[]
             > {
                 return await createTestingConnections({
+                    disabledDrivers: ["spanner"],
                     driverSpecific: {
                         entitySkipConstructor: false,
                     },
@@ -43,6 +44,7 @@ describe("github issues > #8444 entitySkipConstructor not working", () => {
 
         it("createTestingConnections should succeed", async () => {
             dataSources = await createTestingConnections({
+                disabledDrivers: ["spanner"],
                 driverSpecific: {
                     entitySkipConstructor: true,
                 },

--- a/test/github-issues/8522/issue-8522.test.ts
+++ b/test/github-issues/8522/issue-8522.test.ts
@@ -21,6 +21,7 @@ describe("github issues > #8522 Single table inheritance returns the same discri
     describe("Unrelated tables", () => {
         before(async () => {
             dataSources = await createTestingConnections({
+                disabledDrivers: ["spanner"],
                 entities: [BaseEntity, InternalUser, InternalRole, Role, User],
                 schemaCreate: true,
                 dropSchema: true,
@@ -85,6 +86,7 @@ describe("github issues > #8522 Single table inheritance returns the same discri
         it("Should throw error when related tables have the same discriminator", async () => {
             try {
                 const dataSources = await createTestingConnections({
+                    disabledDrivers: ["spanner"],
                     entities: [
                         BaseEntity,
                         ClientRole,

--- a/test/github-issues/8627/issue-8627.test.ts
+++ b/test/github-issues/8627/issue-8627.test.ts
@@ -12,6 +12,7 @@ describe("github issues > #8627 junction aliases are not unique", () => {
     let dataSources: DataSource[]
     before(async () => {
         dataSources = await createTestingConnections({
+            disabledDrivers: ["spanner"],
             entities: [__dirname + "/entity/*{.js,.ts}"],
             dropSchema: true,
             schemaCreate: true,

--- a/test/github-issues/863/issue-863.test.ts
+++ b/test/github-issues/863/issue-863.test.ts
@@ -13,6 +13,7 @@ describe("github issues > #863 indices > create schema", () => {
     let dataSources: DataSource[]
     before(async () => {
         dataSources = await createTestingConnections({
+            disabledDrivers: ["spanner"],
             entities: [Master, Detail],
         })
     })

--- a/test/github-issues/867/issue-867.test.ts
+++ b/test/github-issues/867/issue-867.test.ts
@@ -12,6 +12,7 @@ describe("github issues > #867 result of `findAndCount` is wrong when apply `ski
     let dataSources: DataSource[]
     before(async () => {
         dataSources = await createTestingConnections({
+            disabledDrivers: ["spanner"],
             entities: [__dirname + "/entity/*{.js,.ts}"],
         })
     })

--- a/test/github-issues/8681/issue-8681.test.ts
+++ b/test/github-issues/8681/issue-8681.test.ts
@@ -15,6 +15,7 @@ describe("github issues > #8681 DeepPartial simplification breaks the .create() 
 
     before(async () => {
         dataSources = await createTestingConnections({
+            disabledDrivers: ["spanner"],
             entities: [__dirname + "/entity/*{.js,.ts}"],
             schemaCreate: true,
             dropSchema: true,

--- a/test/github-issues/8690/issue-8690.test.ts
+++ b/test/github-issues/8690/issue-8690.test.ts
@@ -12,6 +12,7 @@ describe("github issues > #8690 Relations do not render primary key column value
     let dataSources: DataSource[]
     before(async () => {
         dataSources = await createTestingConnections({
+            disabledDrivers: ["spanner"],
             entities: [__dirname + "/entity/*{.js,.ts}"],
             schemaCreate: true,
             dropSchema: true,

--- a/test/github-issues/8723/issue-8723.test.ts
+++ b/test/github-issues/8723/issue-8723.test.ts
@@ -11,6 +11,7 @@ describe("github issues > #8723 Fail on Update when reference exists together wi
     let dataSources: DataSource[]
     before(async () => {
         dataSources = await createTestingConnections({
+            disabledDrivers: ["spanner"],
             entities: [__dirname + "/entity/*{.js,.ts}"],
             schemaCreate: true,
             dropSchema: true,

--- a/test/github-issues/8796/issue-8796.test.ts
+++ b/test/github-issues/8796/issue-8796.test.ts
@@ -25,6 +25,7 @@ describe("github issues > #8796 New find select object api should support false 
 
     before(async () => {
         dataSources = await createTestingConnections({
+            disabledDrivers: ["spanner"],
             entities: [__dirname + "/entity/*{.js,.ts}"],
             schemaCreate: true,
             dropSchema: true,

--- a/test/github-issues/8890/issue-8890.test.ts
+++ b/test/github-issues/8890/issue-8890.test.ts
@@ -15,6 +15,7 @@ describe("github issues > #8890 it should be possible to query IS NULL on ManyTo
     let dataSources: DataSource[]
     before(async () => {
         dataSources = await createTestingConnections({
+            disabledDrivers: ["spanner"],
             __dirname,
         })
     })
@@ -131,6 +132,7 @@ describe("github issues > #8890 it should be possible to query IS NULL on OneToO
     let dataSources: DataSource[]
     before(async () => {
         dataSources = await createTestingConnections({
+            disabledDrivers: ["spanner"],
             __dirname,
         })
     })

--- a/test/github-issues/8892/issue-8892.test.ts
+++ b/test/github-issues/8892/issue-8892.test.ts
@@ -15,6 +15,7 @@ describe('github issues > #8892 ManyToMany relations save throws "Violation of P
 
     before(async () => {
         dataSources = await createTestingConnections({
+            disabledDrivers: ["spanner"],
             entities: [__dirname + "/entity/*{.js,.ts}"],
             schemaCreate: true,
             dropSchema: true,

--- a/test/github-issues/9033/issue-9033.test.ts
+++ b/test/github-issues/9033/issue-9033.test.ts
@@ -15,6 +15,7 @@ using single table inheritance when creating instance of parent entity", () => {
     let dataSources: DataSource[]
     before(async () => {
         dataSources = await createTestingConnections({
+            disabledDrivers: ["spanner"],
             entities: [__dirname + "/entity/*{.js,.ts}"],
             schemaCreate: true,
             dropSchema: true,

--- a/test/github-issues/9152/issue-9152.test.ts
+++ b/test/github-issues/9152/issue-9152.test.ts
@@ -14,6 +14,7 @@ describe("github issues > #9152 Can't use LessThan for Union field", () => {
     let dataSources: DataSource[]
     before(async () => {
         dataSources = await createTestingConnections({
+            disabledDrivers: ["spanner"],
             entities: [Test],
         })
     })

--- a/test/github-issues/9272/issue-9272.test.ts
+++ b/test/github-issues/9272/issue-9272.test.ts
@@ -13,6 +13,7 @@ describe("github issues > #9272 Fix select on deeply nested embedded entities, u
     let dataSources: DataSource[]
     before(async () => {
         dataSources = await createTestingConnections({
+            disabledDrivers: ["spanner"],
             entities: [__dirname + "/entity/*{.js,.ts}"],
             schemaCreate: true,
             dropSchema: true,

--- a/test/github-issues/929/issue-929.test.ts
+++ b/test/github-issues/929/issue-929.test.ts
@@ -12,6 +12,7 @@ describe("github issues > #929 sub-queries should set their own parameters on ex
     let dataSources: DataSource[]
     before(async () => {
         dataSources = await createTestingConnections({
+            disabledDrivers: ["spanner"],
             entities: [__dirname + "/entity/*{.js,.ts}"],
         })
     })

--- a/test/github-issues/9381/issue-9381.test.ts
+++ b/test/github-issues/9381/issue-9381.test.ts
@@ -11,6 +11,7 @@ import { JsonExampleEntity } from "./entity/JsonExampleEntity"
 describe("github issues > #9381 The column option 《transformer》 affects the result of the query condition generation", () => {
     it("transform and find values", async () => {
         const dataSources = await createTestingConnections({
+            disabledDrivers: ["spanner"],
             entities: [__dirname + "/entity/ExampleEntity{.js,.ts}"],
             schemaCreate: true,
             dropSchema: true,
@@ -52,6 +53,7 @@ describe("github issues > #9381 The column option 《transformer》 affects the 
 
     it("transform json values and find values", async () => {
         const dataSources = await createTestingConnections({
+            disabledDrivers: ["spanner"],
             entities: [__dirname + "/entity/JsonExampleEntity{.js,.ts}"],
             schemaCreate: true,
             dropSchema: true,

--- a/test/github-issues/966/issue-966.test.ts
+++ b/test/github-issues/966/issue-966.test.ts
@@ -12,6 +12,7 @@ describe("github issues > #966 Inheritance in embeddables", () => {
     let dataSources: DataSource[]
     before(async () => {
         dataSources = await createTestingConnections({
+            disabledDrivers: ["spanner"],
             entities: [__dirname + "/entity/*{.js,.ts}"],
         })
     })

--- a/test/github-issues/9833/issue-9833.test.ts
+++ b/test/github-issues/9833/issue-9833.test.ts
@@ -18,6 +18,7 @@ describe("github issues > #9833 Add support for Single Table Inheritance when us
 
     before(async () => {
         dataSources = await createTestingConnections({
+            disabledDrivers: ["spanner"],
             entities: [BaseSchema, ASchema, BSchema, CSchema],
             schemaCreate: true,
             dropSchema: true,

--- a/test/github-issues/9910/issue-9910.test.ts
+++ b/test/github-issues/9910/issue-9910.test.ts
@@ -12,6 +12,7 @@ describe("github issues > #9910 Incorrect behaivor of 'alwaysEnabled: true' afte
     let dataSources: DataSource[]
     before(async () => {
         dataSources = await createTestingConnections({
+            disabledDrivers: ["spanner"],
             entities: [__dirname + "/entity/*{.js,.ts}"],
             cache: {
                 alwaysEnabled: true,

--- a/test/github-issues/9948/issue-9948.test.ts
+++ b/test/github-issues/9948/issue-9948.test.ts
@@ -12,6 +12,7 @@ describe("github issues > #9948 Subscribers with both 'beforeUpdate' and 'afterU
     let dataSources: DataSource[]
     before(async () => {
         dataSources = await createTestingConnections({
+            disabledDrivers: ["spanner"],
             entities: [__dirname + "/entity/*{.js,.ts}"],
             subscribers: [__dirname + "/subscriber/*{.js,.ts}"],
             schemaCreate: true,

--- a/test/github-issues/9977/issue-9977.test.ts
+++ b/test/github-issues/9977/issue-9977.test.ts
@@ -16,6 +16,7 @@ describe("github issues > #9977", () => {
     let dataSources: DataSource[]
     before(async () => {
         dataSources = await createTestingConnections({
+            disabledDrivers: ["spanner"],
             __dirname,
         })
     })

--- a/test/other-issues/auto-increment-id-as-string/auto-increment-id-as-string.test.ts
+++ b/test/other-issues/auto-increment-id-as-string/auto-increment-id-as-string.test.ts
@@ -12,6 +12,7 @@ describe("other issues > auto-increment id as string", () => {
     let dataSources: DataSource[]
     before(async () => {
         dataSources = await createTestingConnections({
+            disabledDrivers: ["spanner"],
             entities: [__dirname + "/entity/*{.js,.ts}"],
         })
     })

--- a/test/other-issues/column-getters/column-getters.test.ts
+++ b/test/other-issues/column-getters/column-getters.test.ts
@@ -12,6 +12,7 @@ describe("other issues > column with getter / setter should work", () => {
     let dataSources: DataSource[]
     before(async () => {
         dataSources = await createTestingConnections({
+            disabledDrivers: ["spanner"],
             entities: [__dirname + "/entity/*{.js,.ts}"],
         })
     })

--- a/test/other-issues/composite-keys/composite-keys.test.ts
+++ b/test/other-issues/composite-keys/composite-keys.test.ts
@@ -13,6 +13,7 @@ describe("other issues > composite keys doesn't work as expected in 0.3 compared
     let dataSources: DataSource[]
     before(async () => {
         dataSources = await createTestingConnections({
+            disabledDrivers: ["spanner"],
             entities: [__dirname + "/entity/*{.js,.ts}"],
         })
     })

--- a/test/other-issues/entity-change-in-listeners/entity-change-in-listeners.test.ts
+++ b/test/other-issues/entity-change-in-listeners/entity-change-in-listeners.test.ts
@@ -12,6 +12,7 @@ describe("other issues > entity change in listeners should affect persistence", 
     let dataSources: DataSource[]
     before(async () => {
         dataSources = await createTestingConnections({
+            disabledDrivers: ["spanner"],
             entities: [__dirname + "/entity/*{.js,.ts}"],
         })
     })

--- a/test/other-issues/entity-change-in-subscribers/entity-change-in-subscribers.test.ts
+++ b/test/other-issues/entity-change-in-subscribers/entity-change-in-subscribers.test.ts
@@ -13,6 +13,7 @@ describe("other issues > entity change in subscribers should affect persistence"
     let dataSources: DataSource[]
     before(async () => {
         dataSources = await createTestingConnections({
+            disabledDrivers: ["spanner"],
             entities: [__dirname + "/entity/*{.js,.ts}"],
             subscribers: [__dirname + "/subscriber/*{.js,.ts}"],
         })

--- a/test/other-issues/escaping-function-parameter/escaping-function-parameter.test.ts
+++ b/test/other-issues/escaping-function-parameter/escaping-function-parameter.test.ts
@@ -12,6 +12,7 @@ describe("other issues > escaping function parameter", () => {
     let dataSources: DataSource[]
     before(async () => {
         dataSources = await createTestingConnections({
+            disabledDrivers: ["spanner"],
             entities: [__dirname + "/entity/*{.js,.ts}"],
         })
     })

--- a/test/other-issues/get-id-for-composite-primary-key/get-id-for-composite-primary-key.test.ts
+++ b/test/other-issues/get-id-for-composite-primary-key/get-id-for-composite-primary-key.test.ts
@@ -14,6 +14,7 @@ describe("other issues > getId should not return undefined for composite primary
     let dataSources: DataSource[]
     before(async () => {
         dataSources = await createTestingConnections({
+            disabledDrivers: ["spanner"],
             entities: [__dirname + "/entity/*{.js,.ts}"],
         })
     })

--- a/test/other-issues/inheritance-duplicate-columns/inheritance-duplicate-columns.test.ts
+++ b/test/other-issues/inheritance-duplicate-columns/inheritance-duplicate-columns.test.ts
@@ -12,6 +12,7 @@ describe("other issues > double inheritance produces multiple duplicated columns
     let dataSources: DataSource[]
     before(async () => {
         dataSources = await createTestingConnections({
+            disabledDrivers: ["spanner"],
             entities: [__dirname + "/entity/*{.js,.ts}"],
         })
     })

--- a/test/other-issues/join-empty-relations/join-empty-relations.test.ts
+++ b/test/other-issues/join-empty-relations/join-empty-relations.test.ts
@@ -12,6 +12,7 @@ describe("other issues > joining empty relations", () => {
     let dataSources: DataSource[]
     before(async () => {
         dataSources = await createTestingConnections({
+            disabledDrivers: ["spanner"],
             entities: [__dirname + "/entity/*{.js,.ts}"],
         })
     })

--- a/test/other-issues/lazy-count/lazy-count.test.ts
+++ b/test/other-issues/lazy-count/lazy-count.test.ts
@@ -14,6 +14,7 @@ describe("other issues > lazy count", () => {
     let dataSources: DataSource[]
     before(async () => {
         dataSources = await createTestingConnections({
+            disabledDrivers: ["spanner"],
             entities: [__dirname + "/entity/*{.js,.ts}"],
             subscribers: [AfterQuerySubscriber],
             dropSchema: true,

--- a/test/other-issues/limit-with-order-by/limit-with-order-by.test.ts
+++ b/test/other-issues/limit-with-order-by/limit-with-order-by.test.ts
@@ -13,6 +13,7 @@ describe("other issues > using limit in conjunction with order by", () => {
     let dataSources: DataSource[]
     before(async () => {
         dataSources = await createTestingConnections({
+            disabledDrivers: ["spanner"],
             entities: [__dirname + "/entity/*{.js,.ts}"],
         })
     })

--- a/test/other-issues/merge-entity-with-null/merge-entity-with-null.test.ts
+++ b/test/other-issues/merge-entity-with-null/merge-entity-with-null.test.ts
@@ -12,6 +12,7 @@ describe("other issues > using limit in conjunction with order by", () => {
     let dataSources: DataSource[]
     before(async () => {
         dataSources = await createTestingConnections({
+            disabledDrivers: ["spanner"],
             entities: [__dirname + "/entity/*{.js,.ts}"],
         })
     })

--- a/test/other-issues/preventing-injection/preventing-injection.test.ts
+++ b/test/other-issues/preventing-injection/preventing-injection.test.ts
@@ -13,6 +13,7 @@ describe("other issues > preventing-injection", () => {
     let dataSources: DataSource[]
     before(async () => {
         dataSources = await createTestingConnections({
+            disabledDrivers: ["spanner"],
             entities: [__dirname + "/entity/*{.js,.ts}"],
         })
     })

--- a/test/other-issues/table-name-relation/table-name-relation.test.ts
+++ b/test/other-issues/table-name-relation/table-name-relation.test.ts
@@ -16,6 +16,7 @@ describe("other issues > Relation decorators: allow to pass given table name str
     let dataSources: DataSource[]
     before(async () => {
         dataSources = await createTestingConnections({
+            disabledDrivers: ["spanner"],
             entities: [__dirname + "/entity/*{.js,.ts}"],
             schemaCreate: true,
             dropSchema: true,

--- a/test/other-issues/take-multiple-pk/take-multiple-pk.test.ts
+++ b/test/other-issues/take-multiple-pk/take-multiple-pk.test.ts
@@ -15,6 +15,7 @@ describe("other issues > using take with multiple primary keys", () => {
     let dataSources: DataSource[]
     before(async () => {
         dataSources = await createTestingConnections({
+            disabledDrivers: ["spanner"],
             entities: [__dirname + "/entity/*{.js,.ts}"],
         })
     })

--- a/test/other-issues/update-relational-column-on-relation-change/update-relational-column-on-relation-change.test.ts
+++ b/test/other-issues/update-relational-column-on-relation-change/update-relational-column-on-relation-change.test.ts
@@ -12,6 +12,7 @@ describe("other issues > update relational column on relation change", () => {
     let dataSources: DataSource[]
     before(async () => {
         dataSources = await createTestingConnections({
+            disabledDrivers: ["spanner"],
             entities: [__dirname + "/entity/*{.js,.ts}"],
         })
     })

--- a/test/utils/test-utils.ts
+++ b/test/utils/test-utils.ts
@@ -46,6 +46,14 @@ export interface TestingOptions {
     enabledDrivers?: DatabaseType[]
 
     /**
+     * List of drivers that should be excluded from this test suite. Applied
+     * after enabledDrivers — use this to opt a specific driver out of a test
+     * without enumerating every other driver. Typical use: marking a test as
+     * incompatible with a particular driver until the driver side is fixed.
+     */
+    disabledDrivers?: DatabaseType[]
+
+    /**
      * Entities needs to be included in the connection for the given test suite.
      */
     entities?: (string | Function | EntitySchema<any>)[]
@@ -225,6 +233,9 @@ export function setupTestingConnections(
     return ormConfigConnectionOptionsArray
         .filter((connectionOptions) => {
             if (connectionOptions.skip === true) return false
+
+            if (options?.disabledDrivers?.includes(connectionOptions.type!))
+                return false
 
             if (options?.enabledDrivers?.length)
                 return (

--- a/test/utils/test-utils.ts
+++ b/test/utils/test-utils.ts
@@ -331,9 +331,14 @@ getMetadataArgsStorage().entitySubscribers.push({
 
 export function createDataSource(options: DataSourceOptions): DataSource {
     if (options.type === "spanner") {
-        process.env.SPANNER_EMULATOR_HOST = "localhost:9010"
-        // process.env.GOOGLE_APPLICATION_CREDENTIALS =
-        //     "/Users/messer/Documents/google/typeorm-spanner-3b57e071cbf0.json"
+        const spannerOptions = options as DataSourceOptions & {
+            host?: string
+            port?: number
+        }
+
+        process.env.SPANNER_EMULATOR_HOST = `${spannerOptions.host ?? "localhost"}:${spannerOptions.port ?? 9010}`
+        process.env.METADATA_SERVER_DETECTION = "none"
+
         if (Array.isArray(options.subscribers)) {
             options.subscribers.push(
                 GeneratedColumnReplacerSubscriber as Function,


### PR DESCRIPTION
Adds a Spanner job to the Linux test matrix using [`roryq/spanner-emulator`](https://github.com/RoryQ/spanner-emulator), a thin wrapper around the official `gcr.io/cloud-spanner-emulator/emulator` image that auto-provisions the configured project, instance, and database on startup via env vars.

- `docker-compose.yml`: switch from the stale, unmaintained `alexmesser/spanner-emulator` to `roryq/spanner-emulator:latest` and declare `SPANNER_PROJECT_ID`/`SPANNER_INSTANCE_ID`/`SPANNER_DATABASE_ID` so the emulator comes up with `typeorm`/`typeorm`/`typeorm` preconfigured.
- `ormconfig.sample.json`: align spanner `projectId`/`instanceId`/`databaseId` with the docker-compose defaults.
- `test/utils/test-utils.ts`: derive `SPANNER_EMULATOR_HOST` from the ormconfig `host`/`port` instead of hardcoding `localhost:9010`, drop the stale commented-out `GOOGLE_APPLICATION_CREDENTIALS` line, silence google-auth-library's `MetadataLookupWarning` via `METADATA_SERVER_DETECTION`.
- `.github/workflows/tests-linux.yml`: add a `spanner` job.

## Spanner test coverage

After this PR, of 930 total test files:

```
Total test files:                       930
─────────────────────────────────────────
Excluded from spanner:                  701  (75.3%)
  via disabledDrivers tag:              237  (25.4%)
  via enabledDrivers without spanner:   464  (49.8%)

Run on spanner:                         229  (24.6%)
  enabledDrivers includes spanner:       17  (1.8%)
  no driver restriction:                212  (22.7%)
```
