### PR TITLE
refactor: test only required database

### DIFF
--- a/test/github-issues/8975/issue-8975.test.ts
+++ b/test/github-issues/8975/issue-8975.test.ts
@@ -1,10 +1,11 @@
 import { expect } from "chai"
-import { exec } from "child_process"
-import { readFile, rm, unlink, writeFile } from "fs/promises"
+import { exec } from "node:child_process"
+import { readFile, rm, unlink, writeFile } from "node:fs/promises"
+import { getTypeOrmConfig } from "../../utils/test-utils"
 
 describe("cli init command", () => {
     const cliPath = `${__dirname}/../../../src/cli.js`
-    const databaseOptions = [
+    const databasesToTest = [
         "mysql",
         "mariadb",
         "postgres",
@@ -13,7 +14,19 @@ describe("cli init command", () => {
         // "oracle", // as always oracle have issues: dependency installation doesn't work on mac m1 due to missing oracle binaries for m1
         "mssql",
         "mongodb",
-    ]
+    ] as const
+
+    const databaseOptions = (() => {
+        const typeOrmConfig = getTypeOrmConfig()
+        return databasesToTest.filter((databaseType) =>
+            typeOrmConfig.some(
+                (connectionOptions) =>
+                    !connectionOptions.skip &&
+                    connectionOptions.type === databaseType,
+            ),
+        )
+    })()
+
     const testProjectPath = `temp/${Date.now()}TestProject`
     const builtSrcDirectory = "build/compiled/src"
 


### PR DESCRIPTION
### Description of change
Test only the required database.

For postgres job in CI:
```log
// Before
cli init command
    ✔ should work with mysql option (5960ms)
    ✔ should work with mariadb option (1274ms)
    ✔ should work with postgres option (2653ms)
    ✔ should work with cockroachdb option (1301ms)
    ✔ should work with better-sqlite3 option (5829ms)
    ✔ should work with mssql option (7125ms)
    ✔ should work with mongodb option (5529ms)

// After
cli init command
    ✔ should work with postgres option (6167ms)
```


### Pull-Request Checklist

- [x] Code is up-to-date with the `master` branch
- [ ] This pull request links relevant issues as `Fixes #00000`
- [x] There are new or updated tests validating the change (`tests/**.test.ts`)
- [ ] Documentation has been updated to reflect this change (`docs/docs/**.md`) (N/A)