### PR TITLE
fix: handle view entity relations in query load strategy

### DIFF
--- a/src/query-builder/RelationIdLoader.ts
+++ b/src/query-builder/RelationIdLoader.ts
@@ -149,7 +149,6 @@ export class RelationIdLoader {
             inverseColumns = relation.inverseRelation!.joinColumns.map(
                 (column) => column.referencedColumn!,
             )
-        } else {
         }
 
         return entities.map((entity) => {
@@ -764,12 +763,22 @@ export class RelationIdLoader {
     private getInverseEntityColumnsForQueryStrategyRelationIds(
         inverseEntityMetadata: EntityMetadata,
     ): ColumnMetadata[] {
-        if (inverseEntityMetadata.primaryColumns.length > 0) {
-            return inverseEntityMetadata.primaryColumns
+        const columns =
+            inverseEntityMetadata.primaryColumns.length > 0
+                ? inverseEntityMetadata.primaryColumns
+                : inverseEntityMetadata.columns.filter(
+                      (column) =>
+                          !column.isVirtual && !column.isVirtualProperty,
+                  )
+        if (columns.length === 0) {
+            throw new TypeORMError(
+                `Cannot determine correlation columns for entity "${inverseEntityMetadata.name}" ` +
+                    `when loading relations with strategy "query". ` +
+                    `The entity has no primary columns and no non-virtual columns, ` +
+                    `so relation rows cannot be correlated with parent entities.`,
+            )
         }
-        return inverseEntityMetadata.columns.filter(
-            (column) => !column.isVirtual && !column.isVirtualProperty,
-        )
+        return columns
     }
 
     /**

--- a/src/query-builder/RelationIdLoader.ts
+++ b/src/query-builder/RelationIdLoader.ts
@@ -1,5 +1,6 @@
 import type { RelationMetadata } from "../metadata/RelationMetadata"
 import type { ColumnMetadata } from "../metadata/ColumnMetadata"
+import type { EntityMetadata } from "../metadata/EntityMetadata"
 import type { DataSource } from "../data-source/DataSource"
 import type { ObjectLiteral } from "../common/ObjectLiteral"
 import type { SelectQueryBuilder } from "./SelectQueryBuilder"
@@ -142,7 +143,9 @@ export class RelationIdLoader {
             )
             inverseColumns = relation.entityMetadata.primaryColumns
         } else if (relation.isOneToMany || relation.isOneToOneNotOwner) {
-            columns = relation.inverseRelation!.entityMetadata.primaryColumns
+            columns = this.getInverseEntityColumnsForQueryStrategyRelationIds(
+                relation.inverseRelation!.entityMetadata,
+            )
             inverseColumns = relation.inverseRelation!.joinColumns.map(
                 (column) => column.referencedColumn!,
             )
@@ -650,7 +653,11 @@ export class RelationIdLoader {
 
         // select all columns we need
         const qb = this.dataSource.createQueryBuilder(this.queryRunner)
-        relation.entityMetadata.primaryColumns.forEach((primaryColumn) => {
+        const inverseRelationIdColumns =
+            this.getInverseEntityColumnsForQueryStrategyRelationIds(
+                relation.entityMetadata,
+            )
+        inverseRelationIdColumns.forEach((primaryColumn) => {
             const columnName = DriverUtils.buildAlias(
                 this.dataSource.driver,
                 undefined,
@@ -743,6 +750,25 @@ export class RelationIdLoader {
             mainAlias,
             condition,
             fieldsToMetadata,
+        )
+    }
+
+    /**
+     * Columns used to correlate inverse-side rows when grouping query-strategy
+     * relation loads. View entities (and similar) often have no primary columns
+     * in metadata; without non-empty columns here, `Array.prototype.every`
+     * matches all related entities against every relation-id row.
+     *
+     * @param inverseEntityMetadata
+     */
+    private getInverseEntityColumnsForQueryStrategyRelationIds(
+        inverseEntityMetadata: EntityMetadata,
+    ): ColumnMetadata[] {
+        if (inverseEntityMetadata.primaryColumns.length > 0) {
+            return inverseEntityMetadata.primaryColumns
+        }
+        return inverseEntityMetadata.columns.filter(
+            (column) => !column.isVirtual && !column.isVirtualProperty,
         )
     }
 

--- a/src/query-builder/RelationIdLoader.ts
+++ b/src/query-builder/RelationIdLoader.ts
@@ -151,6 +151,21 @@ export class RelationIdLoader {
             )
         }
 
+        if (inverseColumns.length === 0) {
+            throw new TypeORMError(
+                `Cannot determine inverse correlation columns for relation "${relation.propertyPath}" ` +
+                    `when grouping query-strategy relation results. ` +
+                    `The owning side has no primary columns to match relation identifiers against; ` +
+                    `add @PrimaryColumn, map @ViewColumn to physical columns, or use a relation with explicit join columns.`,
+            )
+        }
+        if (columns.length === 0) {
+            throw new TypeORMError(
+                `Cannot determine relation correlation columns for relation "${relation.propertyPath}" ` +
+                    `when grouping query-strategy relation results.`,
+            )
+        }
+
         return entities.map((entity) => {
             const group: { entity: E1; related?: E2 | E2[] } = {
                 entity: entity,
@@ -158,44 +173,52 @@ export class RelationIdLoader {
             }
 
             const entityRelationIds = relationIds.filter((relationId) => {
-                return inverseColumns.every((column) => {
-                    return column.compareEntityValue(
-                        entity,
-                        relationId[
-                            DriverUtils.buildAlias(
-                                this.dataSource.driver,
-                                undefined,
-                                column.entityMetadata.name +
-                                    "_" +
-                                    column.propertyAliasName,
-                            )
-                        ],
-                    )
-                })
-            })
-            if (!entityRelationIds.length) return group
-
-            relatedEntities.forEach((relatedEntity) => {
-                entityRelationIds.forEach((relationId) => {
-                    const relatedEntityMatched = columns.every((column) => {
+                return (
+                    inverseColumns.length > 0 &&
+                    inverseColumns.every((column) => {
                         return column.compareEntityValue(
-                            relatedEntity,
+                            entity,
                             relationId[
                                 DriverUtils.buildAlias(
                                     this.dataSource.driver,
                                     undefined,
                                     column.entityMetadata.name +
                                         "_" +
-                                        relation.propertyPath.replace(
-                                            ".",
-                                            "_",
-                                        ) +
-                                        "_" +
-                                        column.propertyPath.replace(".", "_"),
+                                        column.propertyAliasName,
                                 )
                             ],
                         )
                     })
+                )
+            })
+            if (!entityRelationIds.length) return group
+
+            relatedEntities.forEach((relatedEntity) => {
+                entityRelationIds.forEach((relationId) => {
+                    const relatedEntityMatched =
+                        columns.length > 0 &&
+                        columns.every((column) => {
+                            return column.compareEntityValue(
+                                relatedEntity,
+                                relationId[
+                                    DriverUtils.buildAlias(
+                                        this.dataSource.driver,
+                                        undefined,
+                                        column.entityMetadata.name +
+                                            "_" +
+                                            relation.propertyPath.replace(
+                                                ".",
+                                                "_",
+                                            ) +
+                                            "_" +
+                                            column.propertyPath.replace(
+                                                ".",
+                                                "_",
+                                            ),
+                                    )
+                                ],
+                            )
+                        })
                     if (relatedEntityMatched) {
                         if (isMany) {
                             ;(group.related as E2[]).push(relatedEntity)

--- a/test/github-issues/12330/entity/ClientRow.ts
+++ b/test/github-issues/12330/entity/ClientRow.ts
@@ -1,0 +1,10 @@
+import { Column, Entity, PrimaryGeneratedColumn } from "../../../../src"
+
+@Entity()
+export class ClientRow {
+    @PrimaryGeneratedColumn()
+    id: number
+
+    @Column()
+    groupId: number
+}

--- a/test/github-issues/12330/entity/ClientView.ts
+++ b/test/github-issues/12330/entity/ClientView.ts
@@ -1,0 +1,25 @@
+import type { DataSource } from "../../../../src"
+import { JoinColumn, ManyToOne, ViewColumn, ViewEntity } from "../../../../src"
+import { ClientRow } from "./ClientRow"
+import { Group } from "./Group"
+
+@ViewEntity({
+    name: "client_view_12330",
+    expression: (dataSource: DataSource) =>
+        dataSource
+            .createQueryBuilder()
+            .select("c.id", "id")
+            .addSelect("c.groupId", "groupId")
+            .from(ClientRow, "c"),
+})
+export class ClientView {
+    @ViewColumn()
+    id: number
+
+    @ViewColumn()
+    groupId: number
+
+    @ManyToOne(() => Group, (group) => group.currentClients)
+    @JoinColumn({ name: "groupId" })
+    group: Group
+}

--- a/test/github-issues/12330/entity/Group.ts
+++ b/test/github-issues/12330/entity/Group.ts
@@ -1,0 +1,11 @@
+import { Entity, OneToMany, PrimaryColumn } from "../../../../src"
+import { ClientView } from "./ClientView"
+
+@Entity()
+export class Group {
+    @PrimaryColumn()
+    id: number
+
+    @OneToMany(() => ClientView, (client) => client.group)
+    currentClients: ClientView[]
+}

--- a/test/github-issues/12330/issue-12330.test.ts
+++ b/test/github-issues/12330/issue-12330.test.ts
@@ -1,0 +1,85 @@
+import "reflect-metadata"
+import { expect } from "chai"
+import type { DataSource } from "../../../src/data-source/DataSource"
+import {
+    closeTestingConnections,
+    createTestingConnections,
+    reloadTestingDatabases,
+} from "../../utils/test-utils"
+import { ClientRow } from "./entity/ClientRow"
+import { ClientView } from "./entity/ClientView"
+import { Group } from "./entity/Group"
+
+describe("github issues > #12330 One-to-many view relation with query load strategy", () => {
+    let dataSources: DataSource[]
+
+    before(async () => {
+        dataSources = await createTestingConnections({
+            entities: [Group, ClientRow, ClientView],
+            enabledDrivers: ["better-sqlite3"],
+            schemaCreate: true,
+            dropSchema: true,
+        })
+    })
+
+    beforeEach(() => reloadTestingDatabases(dataSources))
+    after(() => closeTestingConnections(dataSources))
+
+    it("should not cross-join one-to-many view relations when using relationLoadStrategy query", () =>
+        Promise.all(
+            dataSources.map(async (dataSource) => {
+                const groupRepo = dataSource.getRepository(Group)
+                const rowRepo = dataSource.getRepository(ClientRow)
+
+                await groupRepo.save(groupRepo.create({ id: 1 }))
+                await groupRepo.save(groupRepo.create({ id: 2 }))
+
+                await rowRepo.save(
+                    rowRepo.create([
+                        { groupId: 1 },
+                        { groupId: 1 },
+                        { groupId: 2 },
+                    ]),
+                )
+
+                const joinStrategy = await groupRepo.find({
+                    relations: { currentClients: true },
+                    relationLoadStrategy: "join",
+                    order: { id: "ASC" },
+                })
+
+                const queryStrategy = await groupRepo.find({
+                    relations: { currentClients: true },
+                    relationLoadStrategy: "query",
+                    order: { id: "ASC" },
+                })
+
+                expect(joinStrategy).to.have.length(2)
+                expect(queryStrategy).to.have.length(2)
+
+                expect(
+                    joinStrategy[0].currentClients.map((c) => c.id).sort(),
+                ).to.deep.equal(
+                    queryStrategy[0].currentClients.map((c) => c.id).sort(),
+                )
+                expect(
+                    joinStrategy[1].currentClients.map((c) => c.id).sort(),
+                ).to.deep.equal(
+                    queryStrategy[1].currentClients.map((c) => c.id).sort(),
+                )
+
+                expect(queryStrategy[0].currentClients).to.have.length(2)
+                expect(queryStrategy[1].currentClients).to.have.length(1)
+                expect(
+                    queryStrategy[0].currentClients.every(
+                        (c) => c.groupId === 1,
+                    ),
+                ).to.equal(true)
+                expect(
+                    queryStrategy[1].currentClients.every(
+                        (c) => c.groupId === 2,
+                    ),
+                ).to.equal(true)
+            }),
+        ))
+})


### PR DESCRIPTION
## Summary

Fixes #12330

When using `relationLoadStrategy: 'query'` with one-to-many relations backed by view entities, the query strategy produces incorrect join conditions, loading wrong results (cross-join across parents).

## Root Cause

In `RelationIdLoader`, child identifiers are taken from `inverseEntityMetadata.primaryColumns`. View entities often have no primary columns in metadata, so the list is empty. `[].every(() => ...)` is always `true` in JavaScript, meaning each parent receives the union of all children.

## Fix

- Fall back to non-virtual columns when primaryColumns is empty in view entities
- Use the same column list for SELECT aliases and entity matching
- Added regression test under `test/github-issues/12330/`


Made with [Cursor](https://cursor.com)