### PR TITLE
feat(codemod): rename ConnectionOptionsReader.all() to get() and flag path semantics change

### DIFF
--- a/packages/codemod/src/cli/print-summary.ts
+++ b/packages/codemod/src/cli/print-summary.ts
@@ -62,8 +62,9 @@ const printGrouped = (
     formatter: (line: string) => string = highlight,
 ): void => {
     for (const [line, count] of groupLines(lines)) {
-        const suffix = count > 1 ? ` ${colors.dim(`(${count} times)`)}` : ""
-        console.log(`${indent}${formatter(line)}${suffix}`)
+        const timesLabel = `(${count} times)`
+        const countSuffix = count > 1 ? ` ${colors.dim(timesLabel)}` : ""
+        console.log(`${indent}${formatter(line)}${countSuffix}`)
     }
 }
 

--- a/packages/codemod/src/transforms/ast-helpers.ts
+++ b/packages/codemod/src/transforms/ast-helpers.ts
@@ -148,10 +148,20 @@ export const getLocalNamesForImport = (
             ) {
                 continue
             }
-            const localName: string =
-                prop.value.type === "Identifier"
-                    ? prop.value.name
-                    : prop.key.name
+            // Extract the binding name from each destructuring variant:
+            //   { X }              → "X"            (Identifier)
+            //   { X: Y }           → "Y"            (Identifier alias)
+            //   { X = fallback }   → "X"            (AssignmentPattern, shorthand)
+            //   { X: Y = fallback }→ "Y"            (AssignmentPattern, aliased)
+            let localName: string = prop.key.name
+            if (prop.value.type === "Identifier") {
+                localName = prop.value.name
+            } else if (
+                prop.value.type === "AssignmentPattern" &&
+                prop.value.left.type === "Identifier"
+            ) {
+                localName = prop.value.left.name
+            }
             localNames.add(localName)
         }
     })

--- a/packages/codemod/src/transforms/ast-helpers.ts
+++ b/packages/codemod/src/transforms/ast-helpers.ts
@@ -217,11 +217,13 @@ export const forEachDecoratorObjectArg = (
     callback: (objectExpression: ObjectExpression, path: ASTPath) => void,
     decoratorNames?: ReadonlySet<string>,
 ): void => {
+    // ast-types omits `decorators` from ClassProperty — widen the type so
+    // downstream traversal can inspect the decorators array safely.
+    interface ClassPropertyWithDecorators extends ClassProperty {
+        decorators?: Decorator[]
+    }
     root.find(j.ClassProperty).forEach((path) => {
-        // ast-types omits `decorators` from ClassProperty — extend it
-        const node = path.node as ClassProperty & {
-            decorators?: Decorator[]
-        }
+        const node: ClassPropertyWithDecorators = path.node
         if (!node.decorators) return
 
         for (const decorator of node.decorators) {

--- a/packages/codemod/src/transforms/ast-helpers.ts
+++ b/packages/codemod/src/transforms/ast-helpers.ts
@@ -214,6 +214,27 @@ export const TYPEORM_COLUMN_DECORATORS: ReadonlySet<string> = new Set([
 ])
 
 /**
+ * Expands a set of exported names into the local bindings each one has in
+ * the file — covers ESM aliases (`import { Column as C }`) and CJS aliases
+ * (`const { Column: C } = require(...)`). Returns a union set suitable for
+ * alias-aware identifier matching.
+ */
+export const expandLocalNamesForImports = (
+    root: Collection,
+    j: JSCodeshift,
+    moduleName: string,
+    importedNames: ReadonlySet<string>,
+): Set<string> => {
+    const expanded = new Set<string>()
+    for (const name of importedNames) {
+        for (const local of getLocalNamesForImport(root, j, moduleName, name)) {
+            expanded.add(local)
+        }
+    }
+    return expanded
+}
+
+/**
  * Traverses ClassProperty decorators and calls `callback` for each
  * ObjectExpression argument found in decorator call expressions.
  *

--- a/packages/codemod/src/transforms/todo.ts
+++ b/packages/codemod/src/transforms/todo.ts
@@ -3,10 +3,9 @@ import type { JSCodeshift, Node } from "jscodeshift"
 const formatTodo = (message: string): string => ` TODO(typeorm-v1): ${message}`
 
 // Prettier treats a leading `// prettier-ignore` line-comment as a directive
-// for the statement immediately following it. If we append a TODO *after*
-// that directive, it ends up between `prettier-ignore` and its target, which
-// silently disables the directive. Detect the pattern so we can insert the
-// TODO before any such directives.
+// for the statement immediately following it. Appending our reminder *after*
+// that directive places it between `prettier-ignore` and its target and
+// silently disables the directive, so detect the pattern and insert above.
 const isPrettierIgnore = (comment: { type: string; value: string }): boolean =>
     comment.type === "CommentLine" && comment.value.trim() === "prettier-ignore"
 
@@ -27,8 +26,8 @@ export const addTodoComment = (
 
 /**
  * Returns true when `node` already carries a line-comment whose value
- * matches the formatted TODO for `message`. Used to keep transforms
- * idempotent — running the codemod twice must not stack duplicate TODOs.
+ * matches the formatted reminder for `message`. Used to keep transforms
+ * idempotent — running the codemod twice must not stack duplicate markers.
  */
 export const hasTodoComment = (node: Node, message: string): boolean => {
     const expected = formatTodo(message)

--- a/packages/codemod/src/transforms/todo.ts
+++ b/packages/codemod/src/transforms/todo.ts
@@ -3,7 +3,7 @@ import type { JSCodeshift, Node } from "jscodeshift"
 const formatTodo = (message: string): string => ` TODO(typeorm-v1): ${message}`
 
 // Prettier treats a leading `// prettier-ignore` line-comment as a directive
-// for the statement immediately following it. Appending our reminder *after*
+// for the statement immediately following it. Appending our comment *after*
 // that directive places it between `prettier-ignore` and its target and
 // silently disables the directive, so detect the pattern and insert above.
 const isPrettierIgnore = (comment: { type: string; value: string }): boolean =>
@@ -25,9 +25,9 @@ export const addTodoComment = (
 }
 
 /**
- * Returns true when `node` already carries a line-comment whose value
- * matches the formatted reminder for `message`. Used to keep transforms
- * idempotent — running the codemod twice must not stack duplicate markers.
+ * Returns true when `node` already carries the `message` as a line-comment.
+ * Used to keep transforms idempotent — running the codemod twice must not
+ * stack duplicates.
  */
 export const hasTodoComment = (node: Node, message: string): boolean => {
     const expected = formatTodo(message)

--- a/packages/codemod/src/transforms/v1/column-readonly.ts
+++ b/packages/codemod/src/transforms/v1/column-readonly.ts
@@ -2,6 +2,7 @@ import path from "node:path"
 import type { API, FileInfo, UnaryExpression } from "jscodeshift"
 import {
     TYPEORM_COLUMN_DECORATORS,
+    expandLocalNamesForImports,
     forEachDecoratorObjectArg,
     getStringValue,
 } from "../ast-helpers"
@@ -14,6 +15,12 @@ export const columnReadonly = (file: FileInfo, api: API) => {
     const root = j(file.source)
     let hasChanges = false
 
+    const decoratorLocalNames = expandLocalNamesForImports(
+        root,
+        j,
+        "typeorm",
+        TYPEORM_COLUMN_DECORATORS,
+    )
     forEachDecoratorObjectArg(
         root,
         j,
@@ -55,7 +62,7 @@ export const columnReadonly = (file: FileInfo, api: API) => {
                 hasChanges = true
             }
         },
-        TYPEORM_COLUMN_DECORATORS,
+        decoratorLocalNames,
     )
 
     return hasChanges ? root.toSource() : undefined

--- a/packages/codemod/src/transforms/v1/column-unsigned-numeric.ts
+++ b/packages/codemod/src/transforms/v1/column-unsigned-numeric.ts
@@ -14,20 +14,17 @@ export const columnUnsignedNumeric = (file: FileInfo, api: API) => {
     const root = j(file.source)
     let hasChanges = false
 
-    // Find @Column("decimal", { unsigned: true }) style calls
     root.find(j.CallExpression, {
         callee: { type: "Identifier", name: "Column" },
     }).forEach((path) => {
         const args = path.node.arguments
         if (args.length < 2) return
 
-        // First arg must be a string literal with a numeric type
         const firstArg = args[0]
         const typeName = getStringValue(firstArg)
 
         if (!typeName || !numericTypes.has(typeName)) return
 
-        // Second arg should be an object with unsigned property
         const secondArg = args[1]
         if (secondArg.type !== "ObjectExpression") return
 
@@ -36,7 +33,6 @@ export const columnUnsignedNumeric = (file: FileInfo, api: API) => {
         }
     })
 
-    // Also find decorator calls via @Column({ type: "decimal", unsigned: true })
     root.find(j.CallExpression, {
         callee: { type: "Identifier", name: "Column" },
     }).forEach((path) => {
@@ -46,7 +42,6 @@ export const columnUnsignedNumeric = (file: FileInfo, api: API) => {
         const arg = args[0]
         if (arg.type !== "ObjectExpression") return
 
-        // Check if type is a numeric type
         const typeProp = arg.properties.find((p) => {
             if (p.type !== "ObjectProperty") return false
             const keyName =

--- a/packages/codemod/src/transforms/v1/column-width-zerofill.ts
+++ b/packages/codemod/src/transforms/v1/column-width-zerofill.ts
@@ -2,6 +2,7 @@ import path from "node:path"
 import type { API, FileInfo } from "jscodeshift"
 import {
     TYPEORM_COLUMN_DECORATORS,
+    expandLocalNamesForImports,
     forEachDecoratorObjectArg,
     removeObjectProperties,
 } from "../ast-helpers"
@@ -17,6 +18,12 @@ export const columnWidthZerofill = (file: FileInfo, api: API) => {
     const root = j(file.source)
     let hasChanges = false
 
+    const decoratorLocalNames = expandLocalNamesForImports(
+        root,
+        j,
+        "typeorm",
+        TYPEORM_COLUMN_DECORATORS,
+    )
     forEachDecoratorObjectArg(
         root,
         j,
@@ -25,7 +32,7 @@ export const columnWidthZerofill = (file: FileInfo, api: API) => {
                 hasChanges = true
             }
         },
-        TYPEORM_COLUMN_DECORATORS,
+        decoratorLocalNames,
     )
 
     return hasChanges ? root.toSource() : undefined

--- a/packages/codemod/src/transforms/v1/connection-manager.ts
+++ b/packages/codemod/src/transforms/v1/connection-manager.ts
@@ -11,7 +11,7 @@ export const manual = true
 
 const MESSAGE = `\`ConnectionManager\` was removed — create and manage \`DataSource\` instances directly instead — there is no replacement class`
 
-// A reminder comment attached to one of these nodes survives jscodeshift/recast's
+// A comment attached to one of these nodes survives jscodeshift/recast's
 // jscodeshift/recast printing. Walking up to one of these produces a
 // visible comment above the enclosing statement or declaration.
 const isTodoHost = (type: string): boolean =>
@@ -96,7 +96,7 @@ export const connectionManager = (file: FileInfo, api: API) => {
 
     // Only drop the import when at least one usage was successfully
     // flagged — leaving a dangling `ConnectionManager` reference without a
-    // reminder would be worse than leaving the deprecated import in place.
+    // comment would be worse than leaving the deprecated import in place.
     if (hasTodos) {
         if (
             removeImportSpecifiers(

--- a/packages/codemod/src/transforms/v1/connection-manager.ts
+++ b/packages/codemod/src/transforms/v1/connection-manager.ts
@@ -1,6 +1,6 @@
 import path from "node:path"
 import type { API, ASTPath, FileInfo, Node } from "jscodeshift"
-import { removeImportSpecifiers } from "../ast-helpers"
+import { getLocalNamesForImport, removeImportSpecifiers } from "../ast-helpers"
 import { addTodoComment, hasTodoComment } from "../todo"
 import { stats } from "../stats"
 
@@ -29,25 +29,14 @@ export const connectionManager = (file: FileInfo, api: API) => {
     let hasTodos = false
 
     // Collect local aliases bound to the typeorm `ConnectionManager` class
-    // so aliased imports like `import { ConnectionManager as CM }` are
-    // correctly matched.
-    const localNames = new Set<string>()
-    root.find(j.ImportDeclaration, {
-        source: { value: "typeorm" },
-    }).forEach((p) => {
-        for (const s of p.node.specifiers ?? []) {
-            if (
-                s.type === "ImportSpecifier" &&
-                s.imported.type === "Identifier" &&
-                s.imported.name === "ConnectionManager"
-            ) {
-                const local = s.local?.name
-                localNames.add(
-                    typeof local === "string" ? local : s.imported.name,
-                )
-            }
-        }
-    })
+    // via ESM `import { ConnectionManager [as CM] }` and CJS
+    // `const { ConnectionManager [: CM] } = require("typeorm")`.
+    const localNames = getLocalNamesForImport(
+        root,
+        j,
+        "typeorm",
+        "ConnectionManager",
+    )
 
     if (localNames.size === 0) {
         return undefined

--- a/packages/codemod/src/transforms/v1/connection-manager.ts
+++ b/packages/codemod/src/transforms/v1/connection-manager.ts
@@ -11,9 +11,9 @@ export const manual = true
 
 const MESSAGE = `\`ConnectionManager\` was removed — create and manage \`DataSource\` instances directly instead — there is no replacement class`
 
-// A TODO attached to one of these nodes will survive jscodeshift/recast's
-// printing. Walking up until we reach one of these produces a visible
-// comment above the enclosing statement or declaration.
+// A reminder comment attached to one of these nodes survives jscodeshift/recast's
+// jscodeshift/recast printing. Walking up to one of these produces a
+// visible comment above the enclosing statement or declaration.
 const isTodoHost = (type: string): boolean =>
     type.endsWith("Statement") ||
     type === "VariableDeclaration" ||
@@ -96,7 +96,7 @@ export const connectionManager = (file: FileInfo, api: API) => {
 
     // Only drop the import when at least one usage was successfully
     // flagged — leaving a dangling `ConnectionManager` reference without a
-    // TODO would be worse than leaving the deprecated import in place.
+    // reminder would be worse than leaving the deprecated import in place.
     if (hasTodos) {
         if (
             removeImportSpecifiers(

--- a/packages/codemod/src/transforms/v1/connection-manager.ts
+++ b/packages/codemod/src/transforms/v1/connection-manager.ts
@@ -11,9 +11,9 @@ export const manual = true
 
 const MESSAGE = `\`ConnectionManager\` was removed — create and manage \`DataSource\` instances directly instead — there is no replacement class`
 
-// A comment attached to one of these nodes survives jscodeshift/recast's
-// jscodeshift/recast printing. Walking up to one of these produces a
-// visible comment above the enclosing statement or declaration.
+// Node types on which a leading line-comment survives jscodeshift/recast
+// printing — walking up to one of these keeps the comment visible above
+// the enclosing statement or declaration.
 const isTodoHost = (type: string): boolean =>
     type.endsWith("Statement") ||
     type === "VariableDeclaration" ||
@@ -50,7 +50,6 @@ export const connectionManager = (file: FileInfo, api: API) => {
     })
 
     if (localNames.size === 0) {
-        // Not imported from typeorm; nothing to flag.
         return undefined
     }
 
@@ -70,7 +69,6 @@ export const connectionManager = (file: FileInfo, api: API) => {
         }
     }
 
-    // Flag `new ConnectionManager(...)` constructions wherever they appear
     root.find(j.NewExpression)
         .filter((p) => {
             const callee = p.node.callee

--- a/packages/codemod/src/transforms/v1/connection-options-reader.ts
+++ b/packages/codemod/src/transforms/v1/connection-options-reader.ts
@@ -27,7 +27,7 @@ const CONSTRUCTOR_MESSAGE =
 
 // Statement-like ancestors that survive jscodeshift/recast's printing when
 // used as a comment host. Walking up to one of these produces a visible
-// reminder comment above the enclosing statement or declaration.
+// comment above the enclosing statement or declaration.
 const isTodoHost = (type: string): boolean =>
     type.endsWith("Statement") ||
     type === "VariableDeclaration" ||

--- a/packages/codemod/src/transforms/v1/connection-options-reader.ts
+++ b/packages/codemod/src/transforms/v1/connection-options-reader.ts
@@ -1,7 +1,11 @@
 import path from "node:path"
-import type { API, FileInfo, Node, VariableDeclarator } from "jscodeshift"
-import { fileImportsFrom } from "../ast-helpers"
-import { addTodoComment } from "../todo"
+import type { API, ASTPath, FileInfo, NewExpression, Node } from "jscodeshift"
+import {
+    fileImportsFrom,
+    getLocalNamesForImport,
+    getStringValue,
+} from "../ast-helpers"
+import { addTodoComment, hasTodoComment } from "../todo"
 import { stats } from "../stats"
 
 export const name = path.basename(__filename, path.extname(__filename))
@@ -9,73 +13,145 @@ export const description =
     "rename `ConnectionOptionsReader.all()` to `get()` and flag constructor usage for path semantics change"
 export const manual = true
 
+const CONSTRUCTOR_MESSAGE =
+    '`ConnectionOptionsReader` now searches `process.cwd()` instead of the app root — pass `{ root: "/custom/path" }` to override. `get(name)` and `has(name)` were also removed; use `get()` (previously `all()`) and filter the returned array.'
+
+// Statement-like ancestors that survive jscodeshift/recast's printing when
+// used as a comment host. Walking up to one of these produces a visible
+// TODO above the enclosing statement or declaration.
+const isTodoHost = (type: string): boolean =>
+    type.endsWith("Statement") ||
+    type === "VariableDeclaration" ||
+    type === "ExportDefaultDeclaration" ||
+    type === "ExportNamedDeclaration" ||
+    type === "ClassProperty" ||
+    type === "PropertyDefinition"
+
 export const connectionOptionsReader = (file: FileInfo, api: API) => {
     const j = api.jscodeshift
     const root = j(file.source)
     let hasChanges = false
     let hasTodos = false
 
-    // Only operate on files that import ConnectionOptionsReader from typeorm
+    // Quick scope guard — skip files that never touch typeorm.
     if (!fileImportsFrom(root, j, "typeorm")) {
         return undefined
     }
 
-    const importsReader =
-        root
-            .find(j.ImportDeclaration, {
-                source: { value: "typeorm" },
-            })
-            .filter((p) =>
-                (p.node.specifiers ?? []).some(
-                    (s) =>
-                        s.type === "ImportSpecifier" &&
-                        s.imported.type === "Identifier" &&
-                        s.imported.name === "ConnectionOptionsReader",
-                ),
-            )
-            .size() > 0
+    // Local identifiers bound to `ConnectionOptionsReader` via an ESM
+    // import or a CommonJS destructured require (handles aliases).
+    const readerLocalNames = getLocalNamesForImport(
+        root,
+        j,
+        "typeorm",
+        "ConnectionOptionsReader",
+    )
 
-    if (!importsReader) return undefined
-
-    // Track identifiers bound to `new ConnectionOptionsReader()` so we can
-    // rename `.all()` only on those bindings.
-    const readerIdentifiers = new Set<string>()
-
-    const constructorMessage =
-        '`ConnectionOptionsReader` now searches `process.cwd()` instead of the app root — pass `{ root: "/custom/path" }` to override. `get(name)` and `has(name)` were also removed; use `get()` (previously `all()`) and filter the returned array.'
-
-    root.find(j.NewExpression, {
-        callee: { type: "Identifier", name: "ConnectionOptionsReader" },
+    // Namespace bindings: `import * as typeorm from "typeorm"` or
+    // `const typeorm = require("typeorm")`. Used to recognize
+    // `new typeorm.ConnectionOptionsReader()` constructions.
+    const namespaceNames = new Set<string>()
+    root.find(j.ImportDeclaration, {
+        source: { value: "typeorm" },
     }).forEach((p) => {
-        // Track the identifier for the renaming step below
-        const parentPath = p.parent as { node?: Node } | undefined
-        const parentNode = parentPath?.node
-        if (parentNode?.type === "VariableDeclarator") {
-            const decl = parentNode as VariableDeclarator
-            if (decl.id.type === "Identifier") {
-                readerIdentifiers.add(decl.id.name)
+        for (const s of p.node.specifiers ?? []) {
+            if (
+                s.type === "ImportNamespaceSpecifier" &&
+                s.local?.type === "Identifier"
+            ) {
+                namespaceNames.add(s.local.name)
             }
         }
+    })
+    root.find(j.VariableDeclarator, {
+        init: {
+            type: "CallExpression",
+            callee: { type: "Identifier", name: "require" },
+        },
+    }).forEach((p) => {
+        const init = p.node.init
+        if (!init || init.type !== "CallExpression") return
+        const [arg] = init.arguments
+        if (!arg || getStringValue(arg) !== "typeorm") return
+        if (p.node.id.type === "Identifier") {
+            namespaceNames.add(p.node.id.name)
+        }
+    })
 
-        // Walk up to find the enclosing statement for the TODO comment
-        let current = p.parent
+    if (readerLocalNames.size === 0 && namespaceNames.size === 0) {
+        return undefined
+    }
+
+    // Returns true when `callee` is one of the recognized constructor forms:
+    // a bare identifier from `readerLocalNames` or `namespace.ConnectionOptionsReader`.
+    const isReaderConstruction = (astPath: ASTPath<NewExpression>): boolean => {
+        const callee = astPath.node.callee
+        if (callee.type === "Identifier") {
+            return readerLocalNames.has(callee.name)
+        }
+        if (
+            callee.type === "MemberExpression" &&
+            callee.object.type === "Identifier" &&
+            namespaceNames.has(callee.object.name) &&
+            callee.property.type === "Identifier" &&
+            callee.property.name === "ConnectionOptionsReader"
+        ) {
+            return true
+        }
+        return false
+    }
+
+    // Identifiers that are assigned a reader instance via
+    //   const r = new ConnectionOptionsReader()
+    //   let r; r = new ConnectionOptionsReader()
+    // We rename `.all()` only on these bindings so unrelated `.all()` calls
+    // on other types stay untouched.
+    const readerInstanceBindings = new Set<string>()
+    const flaggedHosts = new WeakSet<Node>()
+
+    root.find(j.NewExpression).forEach((astPath) => {
+        if (!isReaderConstruction(astPath)) return
+
+        // Track instance bindings from both declaration and assignment forms
+        const parent = astPath.parent.node
+        if (
+            parent.type === "VariableDeclarator" &&
+            parent.id.type === "Identifier"
+        ) {
+            readerInstanceBindings.add(parent.id.name as string)
+        } else if (
+            parent.type === "AssignmentExpression" &&
+            parent.left.type === "Identifier"
+        ) {
+            readerInstanceBindings.add(parent.left.name as string)
+        }
+
+        // Walk up to the enclosing statement for the TODO comment, skipping
+        // hosts we have already flagged in this run (dedup) and any host
+        // that already carries the same TODO (idempotent on re-runs).
+        let current = astPath.parent
         while (current) {
             const node: Node = current.node
-            if (
-                node.type === "VariableDeclaration" ||
-                node.type === "ExpressionStatement" ||
-                node.type === "ReturnStatement"
-            ) {
-                addTodoComment(node, constructorMessage, j)
-                hasChanges = true
-                hasTodos = true
+            if (isTodoHost(node.type)) {
+                if (
+                    !flaggedHosts.has(node) &&
+                    !hasTodoComment(node, CONSTRUCTOR_MESSAGE)
+                ) {
+                    addTodoComment(node, CONSTRUCTOR_MESSAGE, j)
+                    flaggedHosts.add(node)
+                    hasChanges = true
+                    hasTodos = true
+                }
                 break
             }
             current = current.parent
         }
     })
 
-    // Rename `.all()` → `.get()` on tracked reader identifiers.
+    // Rename `.all()` → `.get()`:
+    //   * on tracked reader-instance bindings (`r.all()` where `r = new ...`)
+    //   * on inline constructor receivers (`new X().all()` — safe because
+    //     the receiver type is statically known)
     root.find(j.CallExpression, {
         callee: {
             type: "MemberExpression",
@@ -84,10 +160,20 @@ export const connectionOptionsReader = (file: FileInfo, api: API) => {
     }).forEach((p) => {
         const callee = p.node.callee
         if (callee.type !== "MemberExpression") return
-        const obj = callee.object
-        if (obj.type !== "Identifier") return
-        if (!readerIdentifiers.has(obj.name)) return
         if (callee.property.type !== "Identifier") return
+
+        const obj = callee.object
+        const isReaderReceiver =
+            (obj.type === "Identifier" &&
+                readerInstanceBindings.has(obj.name)) ||
+            (obj.type === "NewExpression" &&
+                // Need the typed path for `isReaderConstruction`; jscodeshift
+                // hands us a NewExpression node here directly, so synthesize
+                // a minimal ASTPath wrapper.
+                isReaderConstruction({
+                    node: obj,
+                } as ASTPath<NewExpression>))
+        if (!isReaderReceiver) return
 
         callee.property.name = "get"
         hasChanges = true

--- a/packages/codemod/src/transforms/v1/connection-options-reader.ts
+++ b/packages/codemod/src/transforms/v1/connection-options-reader.ts
@@ -4,8 +4,10 @@ import type {
     ASTPath,
     CallExpression,
     FileInfo,
+    Identifier,
     NewExpression,
     Node,
+    OptionalCallExpression,
 } from "jscodeshift"
 import {
     fileImportsFrom,
@@ -25,7 +27,7 @@ const CONSTRUCTOR_MESSAGE =
 
 // Statement-like ancestors that survive jscodeshift/recast's printing when
 // used as a comment host. Walking up to one of these produces a visible
-// TODO above the enclosing statement or declaration.
+// reminder comment above the enclosing statement or declaration.
 const isTodoHost = (type: string): boolean =>
     type.endsWith("Statement") ||
     type === "VariableDeclaration" ||
@@ -48,7 +50,7 @@ export const connectionOptionsReader = (file: FileInfo, api: API) => {
 
     // Returns true when `node` is `require("typeorm")`.
     const isTypeormRequire = (node: Node | null | undefined): boolean => {
-        if (!node || node.type !== "CallExpression") return false
+        if (node?.type !== "CallExpression") return false
         const call = node as CallExpression
         if (
             call.callee.type !== "Identifier" ||
@@ -155,9 +157,6 @@ export const connectionOptionsReader = (file: FileInfo, api: API) => {
             readerInstanceBindings.add(parent.left.name as string)
         }
 
-        // Walk up to the enclosing statement for the TODO comment, skipping
-        // hosts we have already flagged in this run (dedup) and any host
-        // that already carries the same TODO (idempotent on re-runs).
         let current = astPath.parent
         while (current) {
             const node: Node = current.node
@@ -181,32 +180,46 @@ export const connectionOptionsReader = (file: FileInfo, api: API) => {
     //   * on tracked reader-instance bindings (`r.all()` where `r = new ...`)
     //   * on inline constructor receivers (`new X().all()` — safe because
     //     the receiver type is statically known)
-    root.find(j.CallExpression, {
-        callee: {
-            type: "MemberExpression",
-            property: { type: "Identifier", name: "all" },
-        },
-    }).forEach((p) => {
-        const callee = p.node.callee
-        if (callee.type !== "MemberExpression") return
-        if (callee.property.type !== "Identifier") return
+    //   * on the optional-chain variants `r?.all()`, `r.all?.()`, `r?.all?.()`
+    //
+    // Only rename zero-argument calls: the v0 `all()` never took arguments, so
+    // anything passing an arg is unrelated code that happens to share the name.
+    const isReaderReceiver = (obj: Node): boolean => {
+        if (obj.type === "Identifier") {
+            return readerInstanceBindings.has((obj as Identifier).name)
+        }
+        if (obj.type === "NewExpression") {
+            // jscodeshift hands us a NewExpression node here directly; synthesize
+            // a minimal ASTPath wrapper so we can reuse `isReaderConstruction`.
+            return isReaderConstruction({
+                node: obj as NewExpression,
+            } as ASTPath<NewExpression>)
+        }
+        return false
+    }
 
-        const obj = callee.object
-        const isReaderReceiver =
-            (obj.type === "Identifier" &&
-                readerInstanceBindings.has(obj.name)) ||
-            (obj.type === "NewExpression" &&
-                // Need the typed path for `isReaderConstruction`; jscodeshift
-                // hands us a NewExpression node here directly, so synthesize
-                // a minimal ASTPath wrapper.
-                isReaderConstruction({
-                    node: obj,
-                } as ASTPath<NewExpression>))
-        if (!isReaderReceiver) return
-
-        callee.property.name = "get"
+    const tryRename = (node: CallExpression | OptionalCallExpression): void => {
+        if (node.arguments.length !== 0) return
+        const callee = node.callee
+        if (
+            callee.type !== "MemberExpression" &&
+            callee.type !== "OptionalMemberExpression"
+        ) {
+            return
+        }
+        const member = callee
+        if (
+            member.property.type !== "Identifier" ||
+            member.property.name !== "all"
+        ) {
+            return
+        }
+        if (!isReaderReceiver(member.object)) return
+        member.property.name = "get"
         hasChanges = true
-    })
+    }
+    root.find(j.CallExpression).forEach((p) => tryRename(p.node))
+    root.find(j.OptionalCallExpression).forEach((p) => tryRename(p.node))
 
     if (hasTodos) stats.count.todo(api, name, file)
 

--- a/packages/codemod/src/transforms/v1/connection-options-reader.ts
+++ b/packages/codemod/src/transforms/v1/connection-options-reader.ts
@@ -1,5 +1,12 @@
 import path from "node:path"
-import type { API, ASTPath, FileInfo, NewExpression, Node } from "jscodeshift"
+import type {
+    API,
+    ASTPath,
+    CallExpression,
+    FileInfo,
+    NewExpression,
+    Node,
+} from "jscodeshift"
 import {
     fileImportsFrom,
     getLocalNamesForImport,
@@ -22,6 +29,7 @@ const CONSTRUCTOR_MESSAGE =
 const isTodoHost = (type: string): boolean =>
     type.endsWith("Statement") ||
     type === "VariableDeclaration" ||
+    type === "FunctionDeclaration" ||
     type === "ExportDefaultDeclaration" ||
     type === "ExportNamedDeclaration" ||
     type === "ClassProperty" ||
@@ -38,6 +46,20 @@ export const connectionOptionsReader = (file: FileInfo, api: API) => {
         return undefined
     }
 
+    // Returns true when `node` is `require("typeorm")`.
+    const isTypeormRequire = (node: Node | null | undefined): boolean => {
+        if (!node || node.type !== "CallExpression") return false
+        const call = node as CallExpression
+        if (
+            call.callee.type !== "Identifier" ||
+            call.callee.name !== "require"
+        ) {
+            return false
+        }
+        const [arg] = call.arguments
+        return !!arg && getStringValue(arg) === "typeorm"
+    }
+
     // Local identifiers bound to `ConnectionOptionsReader` via an ESM
     // import or a CommonJS destructured require (handles aliases).
     const readerLocalNames = getLocalNamesForImport(
@@ -47,37 +69,10 @@ export const connectionOptionsReader = (file: FileInfo, api: API) => {
         "ConnectionOptionsReader",
     )
 
-    // CommonJS member-require pattern:
-    //   const Reader = require("typeorm").ConnectionOptionsReader
-    // Not covered by `getLocalNamesForImport` (which only destructures), so
-    // recognize it here and add the local name to the same set.
-    root.find(j.VariableDeclarator, {
-        init: {
-            type: "MemberExpression",
-            object: {
-                type: "CallExpression",
-                callee: { type: "Identifier", name: "require" },
-            },
-            property: {
-                type: "Identifier",
-                name: "ConnectionOptionsReader",
-            },
-        },
-    }).forEach((p) => {
-        const init = p.node.init
-        if (!init || init.type !== "MemberExpression") return
-        const callExpr = init.object
-        if (callExpr.type !== "CallExpression") return
-        const [arg] = callExpr.arguments
-        if (!arg || getStringValue(arg) !== "typeorm") return
-        if (p.node.id.type === "Identifier") {
-            readerLocalNames.add(p.node.id.name)
-        }
-    })
-
-    // Namespace bindings: `import * as typeorm from "typeorm"` or
-    // `const typeorm = require("typeorm")`. Used to recognize
-    // `new typeorm.ConnectionOptionsReader()` constructions.
+    // Namespace and member-require bindings — both anchor on a
+    // `const <id> = require("typeorm")[ .X ]` VariableDeclarator shape so we
+    // iterate once and classify by whether the init is the require call
+    // itself (namespace) or a member access (`.ConnectionOptionsReader`).
     const namespaceNames = new Set<string>()
     root.find(j.ImportDeclaration, {
         source: { value: "typeorm" },
@@ -91,18 +86,19 @@ export const connectionOptionsReader = (file: FileInfo, api: API) => {
             }
         }
     })
-    root.find(j.VariableDeclarator, {
-        init: {
-            type: "CallExpression",
-            callee: { type: "Identifier", name: "require" },
-        },
-    }).forEach((p) => {
+    root.find(j.VariableDeclarator).forEach((p) => {
         const init = p.node.init
-        if (!init || init.type !== "CallExpression") return
-        const [arg] = init.arguments
-        if (!arg || getStringValue(arg) !== "typeorm") return
-        if (p.node.id.type === "Identifier") {
-            namespaceNames.add(p.node.id.name)
+        if (!init || p.node.id.type !== "Identifier") return
+        const localName = p.node.id.name
+        if (isTypeormRequire(init)) {
+            namespaceNames.add(localName)
+        } else if (
+            init.type === "MemberExpression" &&
+            isTypeormRequire(init.object) &&
+            init.property.type === "Identifier" &&
+            init.property.name === "ConnectionOptionsReader"
+        ) {
+            readerLocalNames.add(localName)
         }
     })
 
@@ -130,8 +126,9 @@ export const connectionOptionsReader = (file: FileInfo, api: API) => {
     }
 
     // Identifiers that are assigned a reader instance via
-    //   const r = new ConnectionOptionsReader()
-    //   let r; r = new ConnectionOptionsReader()
+    //   const r = new ConnectionOptionsReader()            // VariableDeclarator
+    //   let r; r = new ConnectionOptionsReader()           // AssignmentExpression
+    //   function f(r = new ConnectionOptionsReader()) {}   // AssignmentPattern (default-param)
     // We rename `.all()` only on these bindings so unrelated `.all()` calls
     // on other types stay untouched.
     const readerInstanceBindings = new Set<string>()
@@ -140,7 +137,6 @@ export const connectionOptionsReader = (file: FileInfo, api: API) => {
     root.find(j.NewExpression).forEach((astPath) => {
         if (!isReaderConstruction(astPath)) return
 
-        // Track instance bindings from both declaration and assignment forms
         const parent = astPath.parent.node
         if (
             parent.type === "VariableDeclarator" &&
@@ -149,6 +145,11 @@ export const connectionOptionsReader = (file: FileInfo, api: API) => {
             readerInstanceBindings.add(parent.id.name as string)
         } else if (
             parent.type === "AssignmentExpression" &&
+            parent.left.type === "Identifier"
+        ) {
+            readerInstanceBindings.add(parent.left.name as string)
+        } else if (
+            parent.type === "AssignmentPattern" &&
             parent.left.type === "Identifier"
         ) {
             readerInstanceBindings.add(parent.left.name as string)

--- a/packages/codemod/src/transforms/v1/connection-options-reader.ts
+++ b/packages/codemod/src/transforms/v1/connection-options-reader.ts
@@ -1,0 +1,102 @@
+import path from "node:path"
+import type { API, FileInfo, Node, VariableDeclarator } from "jscodeshift"
+import { fileImportsFrom } from "../ast-helpers"
+import { addTodoComment } from "../todo"
+import { stats } from "../stats"
+
+export const name = path.basename(__filename, path.extname(__filename))
+export const description =
+    "rename `ConnectionOptionsReader.all()` to `get()` and flag constructor usage for path semantics change"
+export const manual = true
+
+export const connectionOptionsReader = (file: FileInfo, api: API) => {
+    const j = api.jscodeshift
+    const root = j(file.source)
+    let hasChanges = false
+    let hasTodos = false
+
+    // Only operate on files that import ConnectionOptionsReader from typeorm
+    if (!fileImportsFrom(root, j, "typeorm")) {
+        return undefined
+    }
+
+    const importsReader =
+        root
+            .find(j.ImportDeclaration, {
+                source: { value: "typeorm" },
+            })
+            .filter((p) =>
+                (p.node.specifiers ?? []).some(
+                    (s) =>
+                        s.type === "ImportSpecifier" &&
+                        s.imported.type === "Identifier" &&
+                        s.imported.name === "ConnectionOptionsReader",
+                ),
+            )
+            .size() > 0
+
+    if (!importsReader) return undefined
+
+    // Track identifiers bound to `new ConnectionOptionsReader()` so we can
+    // rename `.all()` only on those bindings.
+    const readerIdentifiers = new Set<string>()
+
+    const constructorMessage =
+        '`ConnectionOptionsReader` now searches `process.cwd()` instead of the app root — pass `{ root: "/custom/path" }` to override. `get(name)` and `has(name)` were also removed; use `get()` (previously `all()`) and filter the returned array.'
+
+    root.find(j.NewExpression, {
+        callee: { type: "Identifier", name: "ConnectionOptionsReader" },
+    }).forEach((p) => {
+        // Track the identifier for the renaming step below
+        const parentPath = p.parent as { node?: Node } | undefined
+        const parentNode = parentPath?.node
+        if (parentNode?.type === "VariableDeclarator") {
+            const decl = parentNode as VariableDeclarator
+            if (decl.id.type === "Identifier") {
+                readerIdentifiers.add(decl.id.name)
+            }
+        }
+
+        // Walk up to find the enclosing statement for the TODO comment
+        let current = p.parent
+        while (current) {
+            const node: Node = current.node
+            if (
+                node.type === "VariableDeclaration" ||
+                node.type === "ExpressionStatement" ||
+                node.type === "ReturnStatement"
+            ) {
+                addTodoComment(node, constructorMessage, j)
+                hasChanges = true
+                hasTodos = true
+                break
+            }
+            current = current.parent
+        }
+    })
+
+    // Rename `.all()` → `.get()` on tracked reader identifiers.
+    root.find(j.CallExpression, {
+        callee: {
+            type: "MemberExpression",
+            property: { type: "Identifier", name: "all" },
+        },
+    }).forEach((p) => {
+        const callee = p.node.callee
+        if (callee.type !== "MemberExpression") return
+        const obj = callee.object
+        if (obj.type !== "Identifier") return
+        if (!readerIdentifiers.has(obj.name)) return
+        if (callee.property.type !== "Identifier") return
+
+        callee.property.name = "get"
+        hasChanges = true
+    })
+
+    if (hasTodos) stats.count.todo(api, name, file)
+
+    return hasChanges ? root.toSource() : undefined
+}
+
+export const fn = connectionOptionsReader
+export default fn

--- a/packages/codemod/src/transforms/v1/connection-options-reader.ts
+++ b/packages/codemod/src/transforms/v1/connection-options-reader.ts
@@ -4,7 +4,6 @@ import type {
     ASTPath,
     CallExpression,
     FileInfo,
-    Identifier,
     NewExpression,
     Node,
     OptionalCallExpression,
@@ -131,30 +130,46 @@ export const connectionOptionsReader = (file: FileInfo, api: API) => {
     //   const r = new ConnectionOptionsReader()            // VariableDeclarator
     //   let r; r = new ConnectionOptionsReader()           // AssignmentExpression
     //   function f(r = new ConnectionOptionsReader()) {}   // AssignmentPattern (default-param)
-    // We rename `.all()` only on these bindings so unrelated `.all()` calls
-    // on other types stay untouched.
-    const readerInstanceBindings = new Set<string>()
+    // Tracked as (scope, name) pairs so a shadowed `r` in a nested scope can
+    // hold an unrelated value without its `.all()` calls being renamed.
+    interface ScopeLike {
+        lookup(name: string): ScopeLike | null
+    }
+    interface ScopedPath {
+        scope: ScopeLike
+    }
+    const readerBindings = new Map<ScopeLike, Set<string>>()
     const flaggedHosts = new WeakSet<Node>()
+
+    const recordBinding = (scope: ScopeLike, name: string): void => {
+        let bucket = readerBindings.get(scope)
+        if (!bucket) {
+            bucket = new Set()
+            readerBindings.set(scope, bucket)
+        }
+        bucket.add(name)
+    }
 
     root.find(j.NewExpression).forEach((astPath) => {
         if (!isReaderConstruction(astPath)) return
 
         const parent = astPath.parent.node
+        const parentScope = (astPath.parent as unknown as ScopedPath).scope
         if (
             parent.type === "VariableDeclarator" &&
             parent.id.type === "Identifier"
         ) {
-            readerInstanceBindings.add(parent.id.name as string)
+            recordBinding(parentScope, parent.id.name as string)
         } else if (
             parent.type === "AssignmentExpression" &&
             parent.left.type === "Identifier"
         ) {
-            readerInstanceBindings.add(parent.left.name as string)
+            recordBinding(parentScope, parent.left.name as string)
         } else if (
             parent.type === "AssignmentPattern" &&
             parent.left.type === "Identifier"
         ) {
-            readerInstanceBindings.add(parent.left.name as string)
+            recordBinding(parentScope, parent.left.name as string)
         }
 
         let current = astPath.parent
@@ -176,6 +191,19 @@ export const connectionOptionsReader = (file: FileInfo, api: API) => {
         }
     })
 
+    // Resolves an identifier receiver's scope-declared binding and returns
+    // true if it was recorded as a reader instance. Returning false for
+    // shadowed/reassigned names keeps unrelated `.all()` calls untouched.
+    const isTrackedIdentifier = (
+        name: string,
+        useScope: ScopeLike | undefined,
+    ): boolean => {
+        if (!useScope) return false
+        const declaringScope = useScope.lookup(name)
+        if (!declaringScope) return false
+        return readerBindings.get(declaringScope)?.has(name) ?? false
+    }
+
     // Rename `.all()` → `.get()`:
     //   * on tracked reader-instance bindings (`r.all()` where `r = new ...`)
     //   * on inline constructor receivers (`new X().all()` — safe because
@@ -184,21 +212,10 @@ export const connectionOptionsReader = (file: FileInfo, api: API) => {
     //
     // Only rename zero-argument calls: the v0 `all()` never took arguments, so
     // anything passing an arg is unrelated code that happens to share the name.
-    const isReaderReceiver = (obj: Node): boolean => {
-        if (obj.type === "Identifier") {
-            return readerInstanceBindings.has((obj as Identifier).name)
-        }
-        if (obj.type === "NewExpression") {
-            // jscodeshift hands us a NewExpression node here directly; synthesize
-            // a minimal ASTPath wrapper so we can reuse `isReaderConstruction`.
-            return isReaderConstruction({
-                node: obj as NewExpression,
-            } as ASTPath<NewExpression>)
-        }
-        return false
-    }
-
-    const tryRename = (node: CallExpression | OptionalCallExpression): void => {
+    const tryRename = (
+        callPath: ASTPath<CallExpression | OptionalCallExpression>,
+    ): void => {
+        const node = callPath.node
         if (node.arguments.length !== 0) return
         const callee = node.callee
         if (
@@ -214,12 +231,24 @@ export const connectionOptionsReader = (file: FileInfo, api: API) => {
         ) {
             return
         }
-        if (!isReaderReceiver(member.object)) return
+        const receiver = member.object
+        let matches = false
+        if (receiver.type === "Identifier") {
+            matches = isTrackedIdentifier(
+                receiver.name,
+                (callPath as unknown as ScopedPath).scope,
+            )
+        } else if (receiver.type === "NewExpression") {
+            matches = isReaderConstruction({
+                node: receiver,
+            } as ASTPath<NewExpression>)
+        }
+        if (!matches) return
         member.property.name = "get"
         hasChanges = true
     }
-    root.find(j.CallExpression).forEach((p) => tryRename(p.node))
-    root.find(j.OptionalCallExpression).forEach((p) => tryRename(p.node))
+    root.find(j.CallExpression).forEach(tryRename)
+    root.find(j.OptionalCallExpression).forEach(tryRename)
 
     if (hasTodos) stats.count.todo(api, name, file)
 

--- a/packages/codemod/src/transforms/v1/connection-options-reader.ts
+++ b/packages/codemod/src/transforms/v1/connection-options-reader.ts
@@ -47,6 +47,34 @@ export const connectionOptionsReader = (file: FileInfo, api: API) => {
         "ConnectionOptionsReader",
     )
 
+    // CommonJS member-require pattern:
+    //   const Reader = require("typeorm").ConnectionOptionsReader
+    // Not covered by `getLocalNamesForImport` (which only destructures), so
+    // recognize it here and add the local name to the same set.
+    root.find(j.VariableDeclarator, {
+        init: {
+            type: "MemberExpression",
+            object: {
+                type: "CallExpression",
+                callee: { type: "Identifier", name: "require" },
+            },
+            property: {
+                type: "Identifier",
+                name: "ConnectionOptionsReader",
+            },
+        },
+    }).forEach((p) => {
+        const init = p.node.init
+        if (!init || init.type !== "MemberExpression") return
+        const callExpr = init.object
+        if (callExpr.type !== "CallExpression") return
+        const [arg] = callExpr.arguments
+        if (!arg || getStringValue(arg) !== "typeorm") return
+        if (p.node.id.type === "Identifier") {
+            readerLocalNames.add(p.node.id.name)
+        }
+    })
+
     // Namespace bindings: `import * as typeorm from "typeorm"` or
     // `const typeorm = require("typeorm")`. Used to recognize
     // `new typeorm.ConnectionOptionsReader()` constructions.

--- a/packages/codemod/src/transforms/v1/connection-to-datasource.ts
+++ b/packages/codemod/src/transforms/v1/connection-to-datasource.ts
@@ -256,8 +256,13 @@ export const connectionToDataSource = (file: FileInfo, api: API) => {
         })
     }
 
-    const connectionTypeNames = new Set(Object.keys(typeRenames))
-    connectionTypeNames.add("DataSource")
+    // DataSource-instance class names — used to recognize `new Connection()`
+    // / `const x: DataSource = ...` bindings. Must NOT include *Options types
+    // (e.g. `MysqlConnectionOptions`) because those are plain value-object
+    // shapes whose instances never carry `.connect()` / `.close()` methods,
+    // and treating them as DataSource-typed would incorrectly rename methods
+    // on parameters typed with those options.
+    const connectionTypeNames = new Set(["Connection", "DataSource"])
     const connectionVarNames = new Set<string>()
 
     root.find(j.VariableDeclarator).forEach((path) => {

--- a/packages/codemod/src/transforms/v1/connection-to-datasource.ts
+++ b/packages/codemod/src/transforms/v1/connection-to-datasource.ts
@@ -140,28 +140,60 @@ export const connectionToDataSource = (file: FileInfo, api: API) => {
 
         path.node.specifiers?.forEach((spec) => {
             if (
-                spec.type === "ImportSpecifier" &&
-                spec.imported.type === "Identifier"
+                spec.type !== "ImportSpecifier" ||
+                spec.imported.type !== "Identifier"
             ) {
-                const oldImported = spec.imported.name
-                if (typeRenames[oldImported]) {
-                    const localName =
-                        spec.local?.type === "Identifier"
-                            ? spec.local.name
-                            : oldImported
-                    localRenames.set(localName, typeRenames[oldImported])
+                return
+            }
+            const oldImported = spec.imported.name
+            const newImported = typeRenames[oldImported]
+            if (!newImported) return
 
-                    spec.imported.name = typeRenames[oldImported]
-                    if (
-                        spec.local?.type === "Identifier" &&
-                        spec.local.name === localName
-                    ) {
-                        spec.local.name = typeRenames[oldImported]
-                    }
-                    hasChanges = true
+            const hasAlias =
+                spec.local?.type === "Identifier" &&
+                spec.local.name !== oldImported
+
+            spec.imported.name = newImported
+            if (hasAlias) {
+                // Alias stays; user chose it deliberately. The alias already
+                // refers to the renamed import so usages don't need rewriting.
+            } else {
+                // No alias — propagate the rename to the local binding and
+                // record it for the NewExpression / TSTypeReference loop.
+                const localName =
+                    spec.local?.type === "Identifier"
+                        ? spec.local.name
+                        : oldImported
+                localRenames.set(localName, newImported)
+                if (spec.local?.type === "Identifier") {
+                    spec.local.name = newImported
                 }
             }
+            hasChanges = true
         })
+
+        // Dedupe specifiers that now share the same imported name after the
+        // rename — e.g. `import { Connection, DataSource }` would otherwise
+        // emit `import { DataSource, DataSource }`. Keep the first occurrence
+        // of each imported name and drop subsequent duplicates.
+        if (path.node.specifiers) {
+            const seen = new Set<string>()
+            path.node.specifiers = path.node.specifiers.filter((spec) => {
+                if (
+                    spec.type !== "ImportSpecifier" ||
+                    spec.imported.type !== "Identifier"
+                ) {
+                    return true
+                }
+                const key = `${spec.imported.name}::${spec.local?.type === "Identifier" ? spec.local.name : ""}`
+                if (seen.has(key)) {
+                    hasChanges = true
+                    return false
+                }
+                seen.add(key)
+                return true
+            })
+        }
 
         const rewritten = rewriteTypeormPath(source)
         if (rewritten !== source) {
@@ -263,7 +295,19 @@ export const connectionToDataSource = (file: FileInfo, api: API) => {
     // shapes whose instances never carry `.connect()` / `.close()` methods,
     // and treating them as DataSource-typed would incorrectly rename methods
     // on parameters typed with those options.
-    const connectionTypeNames = new Set(["Connection", "DataSource"])
+    //
+    // Expand to the set of LOCAL bindings — covers aliased ESM imports
+    // (`import { Connection as LegacyConn }`) and aliased CJS destructures
+    // (`const { Connection: LegacyConn } = require("typeorm")`) so code
+    // using the alias still gets `.connect()` → `.initialize()`.
+    const connectionTypeNames = expandLocalNamesForImports(
+        root,
+        j,
+        "typeorm",
+        new Set(["Connection", "DataSource"]),
+    )
+    connectionTypeNames.add("Connection")
+    connectionTypeNames.add("DataSource")
     const connectionVarNames = new Set<string>()
 
     root.find(j.VariableDeclarator).forEach((path) => {

--- a/packages/codemod/src/transforms/v1/connection-to-datasource.ts
+++ b/packages/codemod/src/transforms/v1/connection-to-datasource.ts
@@ -45,7 +45,6 @@ export const connectionToDataSource = (file: FileInfo, api: API) => {
     const root = j(file.source)
     let hasChanges = false
 
-    // Type/class renames
     const typeRenames: Record<string, string> = {
         Connection: "DataSource",
         ConnectionOptions: "DataSourceOptions",
@@ -69,7 +68,6 @@ export const connectionToDataSource = (file: FileInfo, api: API) => {
         SpannerConnectionOptions: "SpannerDataSourceOptions",
     }
 
-    // Method renames on DataSource/Connection instances
     const methodRenames: Record<string, string> = {
         connect: "initialize",
         close: "destroy",
@@ -110,8 +108,6 @@ export const connectionToDataSource = (file: FileInfo, api: API) => {
             "typeorm/driver/better-sqlite3/BetterSqlite3DataSourceOptions",
     }
 
-    // Collect local names imported from "typeorm" (including deep sub-paths
-    // like `typeorm/driver/sap/SapConnectionOptions`) that need renaming.
     const localRenames = new Map<string, string>()
     const typeormPathPrefix = "typeorm/"
 
@@ -154,7 +150,6 @@ export const connectionToDataSource = (file: FileInfo, api: API) => {
                             : oldImported
                     localRenames.set(localName, typeRenames[oldImported])
 
-                    // Rename the import specifier itself
                     spec.imported.name = typeRenames[oldImported]
                     if (
                         spec.local?.type === "Identifier" &&
@@ -199,8 +194,6 @@ export const connectionToDataSource = (file: FileInfo, api: API) => {
         return true
     }
 
-    // CommonJS `require("typeorm[/...]")` — rewrite both the module path and
-    // any destructured identifiers (`const { Connection } = require(...)`).
     root.find(j.CallExpression, {
         callee: { type: "Identifier", name: "require" },
     }).forEach((callPath) => {
@@ -231,7 +224,6 @@ export const connectionToDataSource = (file: FileInfo, api: API) => {
         }
     })
 
-    // Rename only identifiers that were imported from "typeorm"
     for (const [oldName, newName] of localRenames) {
         // TSTypeReference (e.g. const x: Connection = ...)
         root.find(j.TSTypeReference, {
@@ -264,12 +256,10 @@ export const connectionToDataSource = (file: FileInfo, api: API) => {
         })
     }
 
-    // Collect variable names known to be Connection/DataSource instances
     const connectionTypeNames = new Set(Object.keys(typeRenames))
     connectionTypeNames.add("DataSource")
     const connectionVarNames = new Set<string>()
 
-    // Variables assigned from new Connection(...) / new DataSource(...)
     root.find(j.VariableDeclarator).forEach((path) => {
         const init = path.node.init
         if (
@@ -283,7 +273,6 @@ export const connectionToDataSource = (file: FileInfo, api: API) => {
         }
     })
 
-    // Variables and parameters with Connection/DataSource type annotations
     const collectDataSourceTyped = (id: Identifier) => {
         if (!id.name || id.typeAnnotation?.type !== "TSTypeAnnotation") return
         const ann = id.typeAnnotation.typeAnnotation
@@ -322,7 +311,6 @@ export const connectionToDataSource = (file: FileInfo, api: API) => {
         })
     }
 
-    // Collect variable/param names typed as TypeORM types with .connection
     const connectionPropVarNames = new Set<string>()
     const indirectDataSourceVarNames = new Set<string>()
 
@@ -343,12 +331,10 @@ export const connectionToDataSource = (file: FileInfo, api: API) => {
         }
     }
 
-    // Variable declarations with type annotations
     root.find(j.VariableDeclarator).forEach((path) => {
         if (isIdentifier(path.node.id)) collectTypedIdentifier(path.node.id)
     })
 
-    // Function/method/arrow parameters and constructor parameter properties
     forEachIdentifierParam(root, j, collectTypedIdentifier)
 
     // Track variables assigned from DataSource accessors, so code like

--- a/packages/codemod/src/transforms/v1/connection-to-datasource.ts
+++ b/packages/codemod/src/transforms/v1/connection-to-datasource.ts
@@ -7,6 +7,7 @@ import type {
     ObjectPattern,
 } from "jscodeshift"
 import {
+    expandLocalNamesForImports,
     forEachIdentifierParam,
     getStringValue,
     isIdentifier,
@@ -316,6 +317,23 @@ export const connectionToDataSource = (file: FileInfo, api: API) => {
         })
     }
 
+    // Gate metadata type matches on the actual local bindings imported from
+    // typeorm — users sometimes have their own classes named `EntityMetadata`
+    // or `ColumnMetadata` and their `.connection` property access must not
+    // be rewritten.
+    const connectionPropLocalNames = expandLocalNamesForImports(
+        root,
+        j,
+        "typeorm",
+        typesWithConnectionProp,
+    )
+    const indirectDataSourceLocalNames = expandLocalNamesForImports(
+        root,
+        j,
+        "typeorm",
+        typesWithIndirectDataSource,
+    )
+
     const connectionPropVarNames = new Set<string>()
     const indirectDataSourceVarNames = new Set<string>()
 
@@ -329,9 +347,9 @@ export const connectionToDataSource = (file: FileInfo, api: API) => {
         const ref = ann.typeAnnotation
         if (ref.typeName.type !== "Identifier") return
 
-        if (typesWithConnectionProp.has(ref.typeName.name)) {
+        if (connectionPropLocalNames.has(ref.typeName.name)) {
             connectionPropVarNames.add(id.name)
-        } else if (typesWithIndirectDataSource.has(ref.typeName.name)) {
+        } else if (indirectDataSourceLocalNames.has(ref.typeName.name)) {
             indirectDataSourceVarNames.add(id.name)
         }
     }

--- a/packages/codemod/src/transforms/v1/datasource-mongodb.ts
+++ b/packages/codemod/src/transforms/v1/datasource-mongodb.ts
@@ -19,8 +19,8 @@ const renamePropertyKey = (prop: ObjectProperty, newName: string): void => {
 }
 
 // Handles the sslValidate → tlsAllowInvalidCertificates rename, inverting the
-// value when it's a boolean literal and emitting a reminder otherwise.
-// Returns true if a reminder was emitted.
+// value when it's a boolean literal and emitting a comment otherwise.
+// Returns true if a comment was emitted.
 const migrateSslValidate = (prop: ObjectProperty, j: JSCodeshift): boolean => {
     renamePropertyKey(prop, "tlsAllowInvalidCertificates")
     const valueNode = prop.value

--- a/packages/codemod/src/transforms/v1/datasource-mongodb.ts
+++ b/packages/codemod/src/transforms/v1/datasource-mongodb.ts
@@ -1,8 +1,45 @@
 import path from "node:path"
-import type { API, FileInfo } from "jscodeshift"
+import type { API, FileInfo, JSCodeshift, ObjectProperty } from "jscodeshift"
 import { fileImportsFrom } from "../ast-helpers"
 import { addTodoComment } from "../todo"
 import { stats } from "../stats"
+
+// Returns the key name for a property keyed by Identifier or StringLiteral;
+// null for computed / numeric / other key shapes.
+const getPropertyKeyName = (prop: ObjectProperty): string | null => {
+    if (prop.key.type === "Identifier") return prop.key.name
+    if (prop.key.type === "StringLiteral") return prop.key.value
+    return null
+}
+
+// Renames a property's key in-place (handles both Identifier and StringLiteral).
+const renamePropertyKey = (prop: ObjectProperty, newName: string): void => {
+    if (prop.key.type === "Identifier") prop.key.name = newName
+    else if (prop.key.type === "StringLiteral") prop.key.value = newName
+}
+
+// Handles the sslValidate → tlsAllowInvalidCertificates rename, inverting the
+// value when it's a boolean literal and emitting a reminder otherwise.
+// Returns true if a reminder was emitted.
+const migrateSslValidate = (prop: ObjectProperty, j: JSCodeshift): boolean => {
+    renamePropertyKey(prop, "tlsAllowInvalidCertificates")
+    const valueNode = prop.value
+    const isBooleanLiteral =
+        valueNode.type === "BooleanLiteral" ||
+        (valueNode.type === "Literal" && typeof valueNode.value === "boolean")
+    if (isBooleanLiteral) {
+        ;(valueNode as { value: boolean }).value = !(
+            valueNode as { value: boolean }
+        ).value
+        return false
+    }
+    addTodoComment(
+        prop,
+        "`sslValidate` was renamed to `tlsAllowInvalidCertificates` with inverted boolean logic. Review and invert the value.",
+        j,
+    )
+    return true
+}
 
 export const name = path.basename(__filename, path.extname(__filename))
 export const description =
@@ -44,69 +81,28 @@ export const datasourceMongodb = (file: FileInfo, api: API) => {
     ])
 
     // Remove deprecated options
-    root.find(j.ObjectProperty).forEach((path) => {
-        if (
-            path.node.key.type !== "Identifier" &&
-            path.node.key.type !== "StringLiteral"
-        ) {
-            return
-        }
-
-        const name =
-            path.node.key.type === "Identifier"
-                ? path.node.key.name
-                : path.node.key.value
+    root.find(j.ObjectProperty).forEach((astPath) => {
+        const name = getPropertyKeyName(astPath.node)
+        if (name === null) return
 
         if (removeProps.has(name)) {
-            j(path).remove()
+            j(astPath).remove()
             hasChanges = true
             return
         }
-
-        // Simple renames
         if (simpleRenames[name]) {
-            if (path.node.key.type === "Identifier") {
-                path.node.key.name = simpleRenames[name]
-            } else if (path.node.key.type === "StringLiteral") {
-                path.node.key.value = simpleRenames[name]
-            }
+            renamePropertyKey(astPath.node, simpleRenames[name])
             hasChanges = true
             return
         }
-
-        // sslValidate → tlsAllowInvalidCertificates. Semantics are inverted:
-        // when the original value is a boolean literal we can safely flip it;
-        // otherwise we leave the expression alone and emit a TODO so the user
-        // inverts it manually.
         if (name === "sslValidate") {
-            if (path.node.key.type === "Identifier") {
-                path.node.key.name = "tlsAllowInvalidCertificates"
-            } else if (path.node.key.type === "StringLiteral") {
-                path.node.key.value = "tlsAllowInvalidCertificates"
-            }
-            const valueNode = path.node.value
-            if (
-                valueNode.type === "BooleanLiteral" ||
-                (valueNode.type === "Literal" &&
-                    typeof valueNode.value === "boolean")
-            ) {
-                valueNode.value = !valueNode.value
-            } else {
-                addTodoComment(
-                    path.node,
-                    "`sslValidate` was renamed to `tlsAllowInvalidCertificates` with inverted boolean logic. Review and invert the value.",
-                    j,
-                )
-                hasTodos = true
-            }
+            if (migrateSslValidate(astPath.node, j)) hasTodos = true
             hasChanges = true
             return
         }
-
-        // writeConcern-related props → add TODO
         if (writeConcernProps.has(name)) {
             addTodoComment(
-                path.node,
+                astPath.node,
                 `\`${name}\` was removed — migrate to \`writeConcern: { ... }\``,
                 j,
             )

--- a/packages/codemod/src/transforms/v1/datasource-mongodb.ts
+++ b/packages/codemod/src/transforms/v1/datasource-mongodb.ts
@@ -80,7 +80,6 @@ export const datasourceMongodb = (file: FileInfo, api: API) => {
         "wtimeoutMS",
     ])
 
-    // Remove deprecated options
     root.find(j.ObjectProperty).forEach((astPath) => {
         const name = getPropertyKeyName(astPath.node)
         if (name === null) return

--- a/packages/codemod/src/transforms/v1/datasource-mssql.ts
+++ b/packages/codemod/src/transforms/v1/datasource-mssql.ts
@@ -37,7 +37,6 @@ export const datasourceMssql = (file: FileInfo, api: API) => {
         )
         if (!isMssql) return
 
-        // Flag removed `domain` option with TODO
         for (const prop of props) {
             if (
                 prop.type === "ObjectProperty" &&
@@ -63,8 +62,7 @@ export const datasourceMssql = (file: FileInfo, api: API) => {
                 p.value.type === "ObjectExpression",
         )
         if (
-            !optionsProp ||
-            optionsProp.type !== "ObjectProperty" ||
+            optionsProp?.type !== "ObjectProperty" ||
             optionsProp.value.type !== "ObjectExpression"
         )
             return

--- a/packages/codemod/src/transforms/v1/file-logger.ts
+++ b/packages/codemod/src/transforms/v1/file-logger.ts
@@ -55,8 +55,12 @@ const findLogPathProperty = (
 
 // Peels TypeScript expression wrappers so `{ logPath: "x" } as Opts` still
 // inspects the underlying ObjectExpression.
+interface NodeWithExpression extends Node {
+    expression?: Node
+}
+
 const unwrapTsExpression = (node: Node): Node => {
-    let current = node as Node & { expression?: Node }
+    let current: NodeWithExpression = node
     while (
         current.type === "TSAsExpression" ||
         current.type === "TSNonNullExpression" ||
@@ -64,7 +68,7 @@ const unwrapTsExpression = (node: Node): Node => {
         current.type === "TSTypeAssertion"
     ) {
         if (!current.expression) break
-        current = current.expression as Node & { expression?: Node }
+        current = current.expression
     }
     return current
 }

--- a/packages/codemod/src/transforms/v1/file-logger.ts
+++ b/packages/codemod/src/transforms/v1/file-logger.ts
@@ -1,6 +1,6 @@
 import path from "node:path"
 import type { API, FileInfo, Node, ObjectExpression } from "jscodeshift"
-import { addTodoComment } from "../todo"
+import { addTodoComment, hasTodoComment } from "../todo"
 import { stats } from "../stats"
 import { getLocalNamesForImport, getStringValue } from "../ast-helpers"
 
@@ -12,91 +12,77 @@ export const manual = true
 const isAbsolutePath = (literal: string): boolean =>
     path.posix.isAbsolute(literal) || path.win32.isAbsolute(literal)
 
-const inspectOptionsArg = (
-    argNode: Node | undefined,
-): { hasOption: boolean; isAbsolute: boolean } => {
-    // No options argument — flag it (user is using the default logPath)
-    if (argNode === undefined) {
-        return { hasOption: false, isAbsolute: false }
-    }
-
-    // Explicit `undefined` / `null` — same as omitting options, flag
-    const typedArg = argNode as unknown as {
+// Treats `undefined`, `null`, and their literal variants as "no value".
+const isNullishLiteral = (node: Node | undefined): boolean => {
+    if (node === undefined) return true
+    const n = node as {
         type: string
         name?: string
         value?: unknown
     }
-    const isExplicitUndefined =
-        typedArg.type === "Identifier" && typedArg.name === "undefined"
-    const isNullLiteral =
-        typedArg.type === "NullLiteral" ||
-        (typedArg.type === "Literal" && typedArg.value === null)
-    if (isExplicitUndefined || isNullLiteral) {
-        return { hasOption: false, isAbsolute: false }
-    }
+    if (n.type === "Identifier" && n.name === "undefined") return true
+    if (n.type === "NullLiteral") return true
+    return n.type === "Literal" && n.value === null
+}
 
-    // Dynamic options (variable, function call, etc.) — assume the user knows
-    // what they're doing and don't flag it
-    if (argNode.type !== "ObjectExpression") {
-        return { hasOption: true, isAbsolute: true }
-    }
+// Extracts a string from `StringLiteral` or string-valued `Literal`; else null.
+const asStringLiteral = (node: Node): string | null => {
+    const n = node as { type: string; value?: unknown }
+    if (n.type !== "StringLiteral" && n.type !== "Literal") return null
+    return typeof n.value === "string" ? n.value : null
+}
 
+// Locates the `logPath` property in an options object expression, alongside
+// whether the object also contains a spread (which could contribute the key).
+const findLogPathProperty = (
+    obj: ObjectExpression,
+): { value: Node | undefined; hasSpread: boolean } => {
     let hasSpread = false
-
-    for (const prop of (argNode as ObjectExpression).properties) {
+    for (const prop of obj.properties) {
         if (prop.type === "SpreadElement") {
             hasSpread = true
             continue
         }
         if (prop.type !== "ObjectProperty") continue
-
         const keyName =
             prop.key.type === "Identifier"
                 ? prop.key.name
                 : getStringValue(prop.key)
-        if (keyName !== "logPath") continue
+        if (keyName === "logPath") return { value: prop.value, hasSpread }
+    }
+    return { value: undefined, hasSpread }
+}
 
-        const value = prop.value
-        if (value.type === "StringLiteral") {
-            return { hasOption: true, isAbsolute: isAbsolutePath(value.value) }
-        }
-
-        if (
-            value.type === "Literal" &&
-            typeof (value as { value: unknown }).value === "string"
-        ) {
-            return {
-                hasOption: true,
-                isAbsolute: isAbsolutePath((value as { value: string }).value),
-            }
-        }
-
-        // `logPath: undefined` / `logPath: null` behave the same as omitting
-        // the option — flag just like the missing-argument case.
-        if (
-            value.type === "Identifier" &&
-            (value as { name: string }).name === "undefined"
-        ) {
-            return { hasOption: false, isAbsolute: false }
-        }
-        if (
-            value.type === "NullLiteral" ||
-            (value.type === "Literal" &&
-                (value as { value: unknown }).value === null)
-        ) {
-            return { hasOption: false, isAbsolute: false }
-        }
-
-        // Non-literal value (template literal, function call like path.resolve, etc.) —
-        // assume the user knows what they're doing and don't flag it
+const inspectOptionsArg = (
+    argNode: Node | undefined,
+): { hasOption: boolean; isAbsolute: boolean } => {
+    // Missing / explicit nullish → same as omitting options, flag.
+    if (isNullishLiteral(argNode)) {
+        return { hasOption: false, isAbsolute: false }
+    }
+    // Dynamic options (variable, function call, etc.) — trust the user.
+    if (argNode!.type !== "ObjectExpression") {
         return { hasOption: true, isAbsolute: true }
     }
-
-    // No explicit logPath property found — if the object spreads another
-    // value we cannot know what it contributes, so leave it alone
-    if (hasSpread) return { hasOption: true, isAbsolute: true }
-
-    return { hasOption: false, isAbsolute: false }
+    const { value, hasSpread } = findLogPathProperty(
+        argNode as ObjectExpression,
+    )
+    // No explicit logPath — a spread could contribute one, so leave alone.
+    if (value === undefined) {
+        return hasSpread
+            ? { hasOption: true, isAbsolute: true }
+            : { hasOption: false, isAbsolute: false }
+    }
+    // `logPath: undefined` / `logPath: null` behaves as if omitted.
+    if (isNullishLiteral(value)) {
+        return { hasOption: false, isAbsolute: false }
+    }
+    const str = asStringLiteral(value)
+    if (str !== null) {
+        return { hasOption: true, isAbsolute: isAbsolutePath(str) }
+    }
+    // Non-literal (template, path.resolve(), etc.) — trust the user.
+    return { hasOption: true, isAbsolute: true }
 }
 
 export const fileLogger = (file: FileInfo, api: API) => {
@@ -135,7 +121,7 @@ export const fileLogger = (file: FileInfo, api: API) => {
         },
     }).forEach((p) => {
         const init = p.node.init
-        if (!init || init.type !== "CallExpression") return
+        if (init?.type !== "CallExpression") return
         const [arg] = init.arguments
         if (!arg || getStringValue(arg) !== "typeorm") return
 
@@ -179,7 +165,6 @@ export const fileLogger = (file: FileInfo, api: API) => {
             // Skip if user explicitly provided an absolute logPath
             if (hasOption && isAbsolute) return
 
-            // Walk up to find the enclosing statement for the TODO comment
             let current = astPath.parent
             while (current) {
                 const node: Node = current.node
@@ -192,15 +177,7 @@ export const fileLogger = (file: FileInfo, api: API) => {
                     node.type === "ClassProperty" ||
                     node.type === "PropertyDefinition"
                 ) {
-                    // Avoid duplicate TODOs when multiple FileLoggers share a statement
-                    const todoLine = ` TODO(typeorm-v1): ${message}`
-                    const nodeWithComments = node as Node & {
-                        comments?: { value: string }[]
-                    }
-                    const hasSameComment = nodeWithComments.comments?.some(
-                        (c) => c.value === todoLine,
-                    )
-                    if (!hasSameComment) {
+                    if (!hasTodoComment(node, message)) {
                         addTodoComment(node, message, j)
                         hasChanges = true
                         hasTodos = true

--- a/packages/codemod/src/transforms/v1/file-logger.ts
+++ b/packages/codemod/src/transforms/v1/file-logger.ts
@@ -53,6 +53,22 @@ const findLogPathProperty = (
     return { value: undefined, hasSpread }
 }
 
+// Peels TypeScript expression wrappers so `{ logPath: "x" } as Opts` still
+// inspects the underlying ObjectExpression.
+const unwrapTsExpression = (node: Node): Node => {
+    let current = node as Node & { expression?: Node }
+    while (
+        current.type === "TSAsExpression" ||
+        current.type === "TSNonNullExpression" ||
+        current.type === "TSSatisfiesExpression" ||
+        current.type === "TSTypeAssertion"
+    ) {
+        if (!current.expression) break
+        current = current.expression as Node & { expression?: Node }
+    }
+    return current
+}
+
 const inspectOptionsArg = (
     argNode: Node | undefined,
 ): { hasOption: boolean; isAbsolute: boolean } => {
@@ -60,12 +76,13 @@ const inspectOptionsArg = (
     if (isNullishLiteral(argNode)) {
         return { hasOption: false, isAbsolute: false }
     }
+    const unwrapped = unwrapTsExpression(argNode!)
     // Dynamic options (variable, function call, etc.) — trust the user.
-    if (argNode!.type !== "ObjectExpression") {
+    if (unwrapped.type !== "ObjectExpression") {
         return { hasOption: true, isAbsolute: true }
     }
     const { value, hasSpread } = findLogPathProperty(
-        argNode as ObjectExpression,
+        unwrapped as ObjectExpression,
     )
     // No explicit logPath — a spread could contribute one, so leave alone.
     if (value === undefined) {

--- a/packages/codemod/src/transforms/v1/file-logger.ts
+++ b/packages/codemod/src/transforms/v1/file-logger.ts
@@ -125,7 +125,6 @@ export const fileLogger = (file: FileInfo, api: API) => {
         const [arg] = init.arguments
         if (!arg || getStringValue(arg) !== "typeorm") return
 
-        // Whole-module CJS bind: `const typeorm = require("typeorm")`
         if (p.node.id.type === "Identifier") {
             namespaceNames.add(p.node.id.name)
         }
@@ -162,7 +161,6 @@ export const fileLogger = (file: FileInfo, api: API) => {
                 optionsArg as Node | undefined,
             )
 
-            // Skip if user explicitly provided an absolute logPath
             if (hasOption && isAbsolute) return
 
             let current = astPath.parent

--- a/packages/codemod/src/transforms/v1/find-options-join.ts
+++ b/packages/codemod/src/transforms/v1/find-options-join.ts
@@ -10,7 +10,7 @@ export const description =
 export const manual = true
 
 const MIGRATION_HINT =
-    "migrate `leftJoinAndSelect` to the `relations` option, or switch to QueryBuilder for `innerJoin`/`innerJoinAndSelect`/`leftJoin` — see the v1 upgrading guide"
+    "migrate `leftJoinAndSelect` to the `relations` option, or switch to QueryBuilder for `innerJoin`/`innerJoinAndSelect`/`leftJoin`"
 
 const MESSAGE = `\`join\` find option was removed — ${MIGRATION_HINT}`
 

--- a/packages/codemod/src/transforms/v1/find-options-join.ts
+++ b/packages/codemod/src/transforms/v1/find-options-join.ts
@@ -14,9 +14,9 @@ const MIGRATION_HINT =
 
 const MESSAGE = `\`join\` find option was removed — ${MIGRATION_HINT}`
 
-// A comment attached to one of these nodes survives jscodeshift/recast's
-// jscodeshift/recast printing. Walking up to one of these produces a
-// visible comment above the enclosing statement or declaration.
+// Node types on which a leading line-comment survives jscodeshift/recast
+// printing — walking up to one of these keeps the comment visible above
+// the enclosing statement or declaration.
 const isTodoHost = (type: string): boolean =>
     type.endsWith("Statement") ||
     type === "VariableDeclaration" ||
@@ -59,7 +59,6 @@ export const findOptionsJoin = (file: FileInfo, api: API) => {
     const j = api.jscodeshift
     const root = j(file.source)
 
-    // Only operate on files that import from typeorm
     if (!fileImportsFrom(root, j, "typeorm")) return undefined
 
     let hasChanges = false
@@ -70,8 +69,6 @@ export const findOptionsJoin = (file: FileInfo, api: API) => {
         const hasJoin = obj.properties.some(isFindOptionsJoinProperty)
         if (!hasJoin) return
 
-        // Walk up to the enclosing statement. Idempotent: skip
-        // hosts that already carry the same message.
         let current = objPath.parent
         while (current) {
             const node: Node = current.node

--- a/packages/codemod/src/transforms/v1/find-options-join.ts
+++ b/packages/codemod/src/transforms/v1/find-options-join.ts
@@ -14,7 +14,7 @@ const MIGRATION_HINT =
 
 const MESSAGE = `\`join\` find option was removed — ${MIGRATION_HINT}`
 
-// A reminder comment attached to one of these nodes survives jscodeshift/recast's
+// A comment attached to one of these nodes survives jscodeshift/recast's
 // jscodeshift/recast printing. Walking up to one of these produces a
 // visible comment above the enclosing statement or declaration.
 const isTodoHost = (type: string): boolean =>

--- a/packages/codemod/src/transforms/v1/find-options-join.ts
+++ b/packages/codemod/src/transforms/v1/find-options-join.ts
@@ -14,9 +14,9 @@ const MIGRATION_HINT =
 
 const MESSAGE = `\`join\` find option was removed — ${MIGRATION_HINT}`
 
-// A TODO attached to one of these nodes will survive jscodeshift/recast's
-// printing. Walking up until we reach one of these produces a visible
-// comment above the enclosing statement or declaration.
+// A reminder comment attached to one of these nodes survives jscodeshift/recast's
+// jscodeshift/recast printing. Walking up to one of these produces a
+// visible comment above the enclosing statement or declaration.
 const isTodoHost = (type: string): boolean =>
     type.endsWith("Statement") ||
     type === "VariableDeclaration" ||
@@ -70,7 +70,7 @@ export const findOptionsJoin = (file: FileInfo, api: API) => {
         const hasJoin = obj.properties.some(isFindOptionsJoinProperty)
         if (!hasJoin) return
 
-        // Walk up to the enclosing statement for the TODO. Idempotent: skip
+        // Walk up to the enclosing statement. Idempotent: skip
         // hosts that already carry the same message.
         let current = objPath.parent
         while (current) {

--- a/packages/codemod/src/transforms/v1/find-options-lock-modes.ts
+++ b/packages/codemod/src/transforms/v1/find-options-lock-modes.ts
@@ -47,10 +47,8 @@ export const findOptionsLockModes = (file: FileInfo, api: API) => {
 
         const replacement = lockModeMap[value]
 
-        // Change the lock mode argument
         setStringValue(arg, replacement.mode)
 
-        // Wrap in .setOnLocked() call
         const setOnLocked = j.callExpression(
             j.memberExpression(path.node, j.identifier("setOnLocked")),
             [j.stringLiteral(replacement.onLocked)],

--- a/packages/codemod/src/transforms/v1/global-functions.ts
+++ b/packages/codemod/src/transforms/v1/global-functions.ts
@@ -151,7 +151,6 @@ export const globalFunctions = (file: FileInfo, api: API) => {
         })
     }
 
-    // Remove imports of deprecated globals from "typeorm"
     if (removeImportSpecifiers(root, j, "typeorm", removedGlobals)) {
         hasChanges = true
     }

--- a/packages/codemod/src/transforms/v1/index.ts
+++ b/packages/codemod/src/transforms/v1/index.ts
@@ -1,6 +1,7 @@
 import * as columnReadonly from "./column-readonly"
 import * as columnUnsignedNumeric from "./column-unsigned-numeric"
 import * as columnWidthZerofill from "./column-width-zerofill"
+import * as connectionOptionsReader from "./connection-options-reader"
 import * as connectionToDataSource from "./connection-to-datasource"
 import * as datasourceMongodb from "./datasource-mongodb"
 import * as datasourceMssql from "./datasource-mssql"
@@ -71,6 +72,7 @@ export const transforms = [
     queryBuilderReplacePropertyNames,
     findOptionsStringSelect,
     findOptionsStringRelations,
+    connectionOptionsReader,
 ]
 
 export default transformer(transforms)

--- a/packages/codemod/src/transforms/v1/migrations-get-all.ts
+++ b/packages/codemod/src/transforms/v1/migrations-get-all.ts
@@ -11,9 +11,9 @@ export const manual = true
 const MESSAGE =
     "`getAllMigrations()` was removed — use `getPendingMigrations()`, `getExecutedMigrations()`, or `dataSource.migrations` instead"
 
-// A TODO attached to one of these nodes will survive jscodeshift/recast's
-// printing. Walking up until we reach one of these produces a visible
-// comment above the enclosing statement or declaration.
+// A reminder comment attached to one of these nodes survives jscodeshift/recast's
+// jscodeshift/recast printing. Walking up to one of these produces a
+// visible comment above the enclosing statement or declaration.
 const isTodoHost = (type: string): boolean =>
     type.endsWith("Statement") ||
     type === "VariableDeclaration" ||

--- a/packages/codemod/src/transforms/v1/migrations-get-all.ts
+++ b/packages/codemod/src/transforms/v1/migrations-get-all.ts
@@ -11,7 +11,7 @@ export const manual = true
 const MESSAGE =
     "`getAllMigrations()` was removed — use `getPendingMigrations()`, `getExecutedMigrations()`, or `dataSource.migrations` instead"
 
-// A reminder comment attached to one of these nodes survives jscodeshift/recast's
+// A comment attached to one of these nodes survives jscodeshift/recast's
 // jscodeshift/recast printing. Walking up to one of these produces a
 // visible comment above the enclosing statement or declaration.
 const isTodoHost = (type: string): boolean =>

--- a/packages/codemod/src/transforms/v1/migrations-get-all.ts
+++ b/packages/codemod/src/transforms/v1/migrations-get-all.ts
@@ -11,9 +11,9 @@ export const manual = true
 const MESSAGE =
     "`getAllMigrations()` was removed — use `getPendingMigrations()`, `getExecutedMigrations()`, or `dataSource.migrations` instead"
 
-// A comment attached to one of these nodes survives jscodeshift/recast's
-// jscodeshift/recast printing. Walking up to one of these produces a
-// visible comment above the enclosing statement or declaration.
+// Node types on which a leading line-comment survives jscodeshift/recast
+// printing — walking up to one of these keeps the comment visible above
+// the enclosing statement or declaration.
 const isTodoHost = (type: string): boolean =>
     type.endsWith("Statement") ||
     type === "VariableDeclaration" ||

--- a/packages/codemod/src/transforms/v1/query-builder-on-conflict.ts
+++ b/packages/codemod/src/transforms/v1/query-builder-on-conflict.ts
@@ -35,7 +35,6 @@ export const queryBuilderOnConflict = (file: FileInfo, api: API) => {
                 hasChanges = true
             }
         } else {
-            // Add a TODO comment
             const message =
                 "`onConflict()` was removed — use `orIgnore()` or `orUpdate()` instead"
             const parentNode: Node = path.parent.node

--- a/packages/codemod/src/transforms/v1/query-runner-loaded-tables-views.ts
+++ b/packages/codemod/src/transforms/v1/query-runner-loaded-tables-views.ts
@@ -1,6 +1,6 @@
 import path from "node:path"
 import type { ASTNode, API, FileInfo } from "jscodeshift"
-import { addTodoComment } from "../todo"
+import { addTodoComment, hasTodoComment } from "../todo"
 import { stats } from "../stats"
 
 export const name = path.basename(__filename, path.extname(__filename))
@@ -41,14 +41,7 @@ export const queryRunnerLoadedTablesViews = (file: FileInfo, api: API) => {
             ) {
                 const stmt = current.parent.node
                 const message = `\`${propName}\` was removed — use \`getTables()\` / \`getViews()\` instead`
-
-                // Avoid duplicate comments
-                const commentValue = ` TODO(typeorm-v1): ${message}`
-                const comments = (stmt.comments = stmt.comments || [])
-                const hasSameComment = comments.some(
-                    (c) => c.value === commentValue,
-                )
-                if (!hasSameComment) {
+                if (!hasTodoComment(stmt, message)) {
                     addTodoComment(stmt, message, j)
                     hasTodos = true
                 }

--- a/packages/codemod/src/transforms/v1/relation-count.ts
+++ b/packages/codemod/src/transforms/v1/relation-count.ts
@@ -12,7 +12,7 @@ export const manual = true
 const MIGRATION_HINT =
     "use `@VirtualColumn` with a sub-query instead — see the v1 upgrading guide"
 
-// A reminder comment attached to one of these nodes survives jscodeshift/recast's
+// A comment attached to one of these nodes survives jscodeshift/recast's
 // jscodeshift/recast printing. Walking up to one of these produces a
 // visible comment above the enclosing statement or declaration.
 const isTodoHost = (type: string): boolean =>
@@ -50,7 +50,7 @@ export const relationCount = (file: FileInfo, api: API) => {
         // Decorators live on `ClassProperty.decorators` but jscodeshift's
         // default visitor does not descend into that array, so
         // `root.find(j.Decorator)` is a no-op with the `tsx` parser. Walk the
-        // class properties explicitly instead and attach the reminder to the
+        // class properties explicitly instead and attach the comment to the
         // property itself (decorator-attached comments are dropped by recast).
         const message = `\`@RelationCount\` was removed — ${MIGRATION_HINT}`
         root.find(j.ClassProperty).forEach((propertyPath) => {
@@ -73,7 +73,7 @@ export const relationCount = (file: FileInfo, api: API) => {
         })
     }
 
-    // Find .loadRelationCountAndMap() call sites — attach the reminder above the enclosing statement.
+    // Find .loadRelationCountAndMap() call sites — attach the comment above the enclosing statement.
     // Multiple chained calls on one statement resolve to the same host, so the
     // `hasTodoComment` guard keeps the transform idempotent.
     const callMessage = `\`loadRelationCountAndMap()\` was removed — ${MIGRATION_HINT}`

--- a/packages/codemod/src/transforms/v1/relation-count.ts
+++ b/packages/codemod/src/transforms/v1/relation-count.ts
@@ -12,9 +12,9 @@ export const manual = true
 const MIGRATION_HINT =
     "use `@VirtualColumn` with a sub-query instead — see the v1 upgrading guide"
 
-// A TODO attached to one of these nodes will survive jscodeshift/recast's
-// printing. Walking up until we reach one of these produces a visible
-// comment above the enclosing statement or declaration.
+// A reminder comment attached to one of these nodes survives jscodeshift/recast's
+// jscodeshift/recast printing. Walking up to one of these produces a
+// visible comment above the enclosing statement or declaration.
 const isTodoHost = (type: string): boolean =>
     type.endsWith("Statement") ||
     type === "VariableDeclaration" ||
@@ -50,7 +50,7 @@ export const relationCount = (file: FileInfo, api: API) => {
         // Decorators live on `ClassProperty.decorators` but jscodeshift's
         // default visitor does not descend into that array, so
         // `root.find(j.Decorator)` is a no-op with the `tsx` parser. Walk the
-        // class properties explicitly instead and attach the TODO to the
+        // class properties explicitly instead and attach the reminder to the
         // property itself (decorator-attached comments are dropped by recast).
         const message = `\`@RelationCount\` was removed — ${MIGRATION_HINT}`
         root.find(j.ClassProperty).forEach((propertyPath) => {
@@ -73,7 +73,7 @@ export const relationCount = (file: FileInfo, api: API) => {
         })
     }
 
-    // Find .loadRelationCountAndMap() calls and add TODO above the enclosing statement.
+    // Find .loadRelationCountAndMap() call sites — attach the reminder above the enclosing statement.
     // Multiple chained calls on one statement resolve to the same host, so the
     // `hasTodoComment` guard keeps the transform idempotent.
     const callMessage = `\`loadRelationCountAndMap()\` was removed — ${MIGRATION_HINT}`

--- a/packages/codemod/src/transforms/v1/relation-count.ts
+++ b/packages/codemod/src/transforms/v1/relation-count.ts
@@ -12,9 +12,9 @@ export const manual = true
 const MIGRATION_HINT =
     "use `@VirtualColumn` with a sub-query instead — see the v1 upgrading guide"
 
-// A comment attached to one of these nodes survives jscodeshift/recast's
-// jscodeshift/recast printing. Walking up to one of these produces a
-// visible comment above the enclosing statement or declaration.
+// Node types on which a leading line-comment survives jscodeshift/recast
+// printing — walking up to one of these keeps the comment visible above
+// the enclosing statement or declaration.
 const isTodoHost = (type: string): boolean =>
     type.endsWith("Statement") ||
     type === "VariableDeclaration" ||
@@ -98,7 +98,6 @@ export const relationCount = (file: FileInfo, api: API) => {
         }
     })
 
-    // Remove RelationCount import from typeorm
     if (
         removeImportSpecifiers(root, j, "typeorm", new Set(["RelationCount"]))
     ) {

--- a/packages/codemod/src/transforms/v1/relation-count.ts
+++ b/packages/codemod/src/transforms/v1/relation-count.ts
@@ -1,6 +1,10 @@
 import path from "node:path"
 import type { API, ClassProperty, Decorator, FileInfo, Node } from "jscodeshift"
-import { getLocalNamesForImport, removeImportSpecifiers } from "../ast-helpers"
+import {
+    getLocalNamesForImport,
+    getStringValue,
+    removeImportSpecifiers,
+} from "../ast-helpers"
 import { addTodoComment, hasTodoComment } from "../todo"
 import { stats } from "../stats"
 
@@ -9,8 +13,7 @@ export const description =
     "flag removed `@RelationCount` decorator and `loadRelationCountAndMap()` for manual migration"
 export const manual = true
 
-const MIGRATION_HINT =
-    "use `@VirtualColumn` with a sub-query instead — see the v1 upgrading guide"
+const MIGRATION_HINT = "use `@VirtualColumn` with a sub-query instead"
 
 // Node types on which a leading line-comment survives jscodeshift/recast
 // printing — walking up to one of these keeps the comment visible above
@@ -77,12 +80,20 @@ export const relationCount = (file: FileInfo, api: API) => {
     // Multiple chained calls on one statement resolve to the same host, so the
     // `hasTodoComment` guard keeps the transform idempotent.
     const callMessage = `\`loadRelationCountAndMap()\` was removed — ${MIGRATION_HINT}`
-    root.find(j.CallExpression, {
-        callee: {
-            type: "MemberExpression",
-            property: { type: "Identifier", name: "loadRelationCountAndMap" },
-        },
-    }).forEach((callPath) => {
+    // Match both dot access (`qb.loadRelationCountAndMap()`) and computed
+    // access (`qb["loadRelationCountAndMap"]()`). Use a post-filter rather
+    // than a find-pattern so the computed-key branch is visited too.
+    root.find(j.CallExpression).forEach((callPath) => {
+        const callee = callPath.node.callee
+        if (callee.type !== "MemberExpression") return
+        const prop = callee.property
+        const matches =
+            (prop.type === "Identifier" &&
+                prop.name === "loadRelationCountAndMap") ||
+            (callee.computed &&
+                getStringValue(prop) === "loadRelationCountAndMap")
+        if (!matches) return
+
         let current = callPath.parent
         while (current) {
             const node: Node = current.node

--- a/packages/codemod/src/transforms/v1/repository-abstract.ts
+++ b/packages/codemod/src/transforms/v1/repository-abstract.ts
@@ -78,12 +78,10 @@ export const repositoryAbstract = (file: FileInfo, api: API) => {
         },
     }).forEach(addGetCustomRepoTodo)
 
-    // Also find standalone getCustomRepository() calls
     root.find(j.CallExpression, {
         callee: { type: "Identifier", name: "getCustomRepository" },
     }).forEach(addGetCustomRepoTodo)
 
-    // Remove imports
     if (
         removeImportSpecifiers(
             root,

--- a/packages/codemod/src/transforms/v1/repository-abstract.ts
+++ b/packages/codemod/src/transforms/v1/repository-abstract.ts
@@ -18,7 +18,6 @@ export const repositoryAbstract = (file: FileInfo, api: API) => {
     let hasChanges = false
     let hasTodos = false
 
-    // Find @EntityRepository decorators and add TODO
     root.find(j.Decorator, {
         expression: {
             type: "CallExpression",
@@ -34,7 +33,6 @@ export const repositoryAbstract = (file: FileInfo, api: API) => {
         hasTodos = true
     })
 
-    // Find classes extending AbstractRepository and add TODO
     root.find(j.ClassDeclaration).forEach((path) => {
         const superClass = path.node.superClass
         if (!superClass) return
@@ -60,7 +58,6 @@ export const repositoryAbstract = (file: FileInfo, api: API) => {
         hasTodos = true
     })
 
-    // Find getCustomRepository() calls and add TODO
     const addGetCustomRepoTodo = (path: ASTPath) => {
         const message =
             "`getCustomRepository()` was removed — use a custom service class with `dataSource.getRepository()`"

--- a/packages/codemod/src/transforms/v1/repository-find-by-ids.ts
+++ b/packages/codemod/src/transforms/v1/repository-find-by-ids.ts
@@ -47,7 +47,6 @@ export const repositoryFindByIds = (file: FileInfo, api: API) => {
         needsInImport = true
     })
 
-    // Add In import if needed
     if (needsInImport) {
         const typeormImports = root.find(j.ImportDeclaration, {
             source: { value: "typeorm" },
@@ -68,14 +67,12 @@ export const repositoryFindByIds = (file: FileInfo, api: API) => {
 
         if (!hasInImport) {
             if (typeormImports.length > 0) {
-                // Add to existing typeorm import
                 typeormImports.at(0).forEach((path) => {
                     path.node.specifiers?.push(
                         j.importSpecifier(j.identifier("In")),
                     )
                 })
             } else {
-                // Create new import
                 const newImport = j.importDeclaration(
                     [j.importSpecifier(j.identifier("In"))],
                     j.literal("typeorm"),

--- a/packages/codemod/src/transforms/v1/use-container.ts
+++ b/packages/codemod/src/transforms/v1/use-container.ts
@@ -30,7 +30,6 @@ export const useContainer = (file: FileInfo, api: API) => {
                 callee: { type: "Identifier", name: funcName },
             },
         }).forEach((path) => {
-            // Replace with a comment
             const replacement = j.emptyStatement()
             addTodoComment(
                 replacement,
@@ -43,7 +42,6 @@ export const useContainer = (file: FileInfo, api: API) => {
         })
     }
 
-    // Remove imports from typeorm
     const removedImports = new Set([
         "useContainer",
         "getFromContainer",

--- a/packages/codemod/src/transforms/v1/use-container.ts
+++ b/packages/codemod/src/transforms/v1/use-container.ts
@@ -23,7 +23,6 @@ export const useContainer = (file: FileInfo, api: API) => {
 
     const removedFunctions = new Set(["useContainer", "getFromContainer"])
 
-    // Replace calls with a TODO comment
     for (const funcName of removedFunctions) {
         root.find(j.ExpressionStatement, {
             expression: {

--- a/packages/codemod/test/transforms/v1/fixtures/column-readonly/column-readonly.input.ts
+++ b/packages/codemod/test/transforms/v1/fixtures/column-readonly/column-readonly.input.ts
@@ -1,4 +1,5 @@
 import { Column } from "typeorm"
+import { Column as ORMColumn } from "typeorm"
 
 declare const isReadonly: boolean
 declare const flag: boolean
@@ -17,6 +18,10 @@ class Post {
     // Existing `!<expr>` — the NOT should be stripped rather than doubled
     @Column({ readonly: !flag })
     body: string
+
+    // Aliased import — `@ORMColumn` must also be rewritten
+    @ORMColumn({ readonly: true })
+    slug: string
 }
 
 // Should NOT be transformed — not a @Column decorator

--- a/packages/codemod/test/transforms/v1/fixtures/column-readonly/column-readonly.output.ts
+++ b/packages/codemod/test/transforms/v1/fixtures/column-readonly/column-readonly.output.ts
@@ -1,4 +1,5 @@
 import { Column } from "typeorm"
+import { Column as ORMColumn } from "typeorm"
 
 declare const isReadonly: boolean
 declare const flag: boolean
@@ -17,6 +18,10 @@ class Post {
     // Existing `!<expr>` — the NOT should be stripped rather than doubled
     @Column({ update: flag })
     body: string
+
+    // Aliased import — `@ORMColumn` must also be rewritten
+    @ORMColumn({ update: false })
+    slug: string
 }
 
 // Should NOT be transformed — not a @Column decorator

--- a/packages/codemod/test/transforms/v1/fixtures/connection-manager/connection-manager.input.ts
+++ b/packages/codemod/test/transforms/v1/fixtures/connection-manager/connection-manager.input.ts
@@ -22,3 +22,7 @@ if (new ConnectionManager()) {
 function create(): ConnectionManager {
     return null as any
 }
+
+// Case 6: CommonJS destructured require — previously unmigrated
+const { ConnectionManager: CjsManager } = require("typeorm")
+const cjsInstance = new CjsManager()

--- a/packages/codemod/test/transforms/v1/fixtures/connection-manager/connection-manager.output.ts
+++ b/packages/codemod/test/transforms/v1/fixtures/connection-manager/connection-manager.output.ts
@@ -23,3 +23,8 @@ if (new ConnectionManager()) {
 function create(): ConnectionManager {
     return null as any
 }
+
+// Case 6: CommonJS destructured require — previously unmigrated
+const { ConnectionManager: CjsManager } = require("typeorm")
+// TODO(typeorm-v1): `ConnectionManager` was removed — create and manage `DataSource` instances directly instead — there is no replacement class
+const cjsInstance = new CjsManager()

--- a/packages/codemod/test/transforms/v1/fixtures/connection-options-reader/connection-options-reader.input.ts
+++ b/packages/codemod/test/transforms/v1/fixtures/connection-options-reader/connection-options-reader.input.ts
@@ -51,3 +51,13 @@ const fromMemberOptions = await fromMember.all()
 async function loadDefaults(r = new ConnectionOptionsReader()) {
     return r.all()
 }
+
+// Case 12: optional-chain call variants on a tracked reader binding — still
+// rename `.all()` → `.get()`
+const opt1 = await reader?.all()
+const opt2 = await reader.all?.()
+const opt3 = await reader?.all?.()
+
+// Case 13: `.all(arg)` — must NOT be renamed (v0 `all()` was zero-arg; an
+// argument means unrelated user code that happens to share the method name)
+const extraneous = reader.all("extra")

--- a/packages/codemod/test/transforms/v1/fixtures/connection-options-reader/connection-options-reader.input.ts
+++ b/packages/codemod/test/transforms/v1/fixtures/connection-options-reader/connection-options-reader.input.ts
@@ -27,7 +27,7 @@ const cjs = new CjsReader()
 const cjsOptions = await cjs.all()
 
 // Case 7: AssignmentExpression binding — `let r; r = new Reader()`
-let deferred: any
+let deferred: ConnectionOptionsReader | undefined
 deferred = new ConnectionOptionsReader()
 const deferredOptions = await deferred.all()
 
@@ -46,3 +46,8 @@ function mustFail() {
 const MemberReader = require("typeorm").ConnectionOptionsReader
 const fromMember = new MemberReader()
 const fromMemberOptions = await fromMember.all()
+
+// Case 11: default-parameter binding — constructor in a function default
+async function loadDefaults(r = new ConnectionOptionsReader()) {
+    return r.all()
+}

--- a/packages/codemod/test/transforms/v1/fixtures/connection-options-reader/connection-options-reader.input.ts
+++ b/packages/codemod/test/transforms/v1/fixtures/connection-options-reader/connection-options-reader.input.ts
@@ -1,4 +1,6 @@
 import { ConnectionOptionsReader } from "typeorm"
+import { ConnectionOptionsReader as Reader } from "typeorm"
+import * as typeorm from "typeorm"
 
 // Case 1: simple constructor + all() → rename to get()
 const reader = new ConnectionOptionsReader()
@@ -8,6 +10,34 @@ const allOptions = await reader.all()
 const customReader = new ConnectionOptionsReader({ root: "/custom/path" })
 const custom = await customReader.all()
 
-// Case 3: inlined usage — constructor gets a TODO, .all() is not renamed
-// (our transform only tracks bound identifiers)
+// Case 3: inlined usage — constructor gets a TODO AND .all() is renamed to .get()
 const inline = await new ConnectionOptionsReader().all()
+
+// Case 4: aliased ESM import — constructor flagged, .all() renamed
+const aliased = new Reader()
+const aliasedOptions = await aliased.all()
+
+// Case 5: namespace import — `new typeorm.ConnectionOptionsReader()`
+const ns = new typeorm.ConnectionOptionsReader()
+const nsOptions = await ns.all()
+
+// Case 6: CommonJS destructured (aliased) binding
+const { ConnectionOptionsReader: CjsReader } = require("typeorm")
+const cjs = new CjsReader()
+const cjsOptions = await cjs.all()
+
+// Case 7: AssignmentExpression binding — `let r; r = new Reader()`
+let deferred: any
+deferred = new ConnectionOptionsReader()
+const deferredOptions = await deferred.all()
+
+// Case 8: two constructors on the same statement — only one TODO
+const [a, b] = [
+    new ConnectionOptionsReader(),
+    new ConnectionOptionsReader({ root: "/other" }),
+]
+
+// Case 9: constructor inside `throw` — should still be flagged
+function mustFail() {
+    throw new ConnectionOptionsReader()
+}

--- a/packages/codemod/test/transforms/v1/fixtures/connection-options-reader/connection-options-reader.input.ts
+++ b/packages/codemod/test/transforms/v1/fixtures/connection-options-reader/connection-options-reader.input.ts
@@ -41,3 +41,8 @@ const [a, b] = [
 function mustFail() {
     throw new ConnectionOptionsReader()
 }
+
+// Case 10: CommonJS member require — `const R = require("typeorm").ConnectionOptionsReader`
+const MemberReader = require("typeorm").ConnectionOptionsReader
+const fromMember = new MemberReader()
+const fromMemberOptions = await fromMember.all()

--- a/packages/codemod/test/transforms/v1/fixtures/connection-options-reader/connection-options-reader.input.ts
+++ b/packages/codemod/test/transforms/v1/fixtures/connection-options-reader/connection-options-reader.input.ts
@@ -61,3 +61,13 @@ const opt3 = await reader?.all?.()
 // Case 13: `.all(arg)` — must NOT be renamed (v0 `all()` was zero-arg; an
 // argument means unrelated user code that happens to share the method name)
 const extraneous = reader.all("extra")
+
+// Case 14: shadowing — a nested `reader` bound to an unrelated type must NOT
+// have its `.all()` renamed even though the outer `reader` is a tracked
+// ConnectionOptionsReader instance
+function shadowed() {
+    const reader = {
+        all: (): string[] => ["not", "a", "typeorm", "reader"],
+    }
+    return reader.all()
+}

--- a/packages/codemod/test/transforms/v1/fixtures/connection-options-reader/connection-options-reader.input.ts
+++ b/packages/codemod/test/transforms/v1/fixtures/connection-options-reader/connection-options-reader.input.ts
@@ -1,0 +1,13 @@
+import { ConnectionOptionsReader } from "typeorm"
+
+// Case 1: simple constructor + all() → rename to get()
+const reader = new ConnectionOptionsReader()
+const allOptions = await reader.all()
+
+// Case 2: constructor with options
+const customReader = new ConnectionOptionsReader({ root: "/custom/path" })
+const custom = await customReader.all()
+
+// Case 3: inlined usage — constructor gets a TODO, .all() is not renamed
+// (our transform only tracks bound identifiers)
+const inline = await new ConnectionOptionsReader().all()

--- a/packages/codemod/test/transforms/v1/fixtures/connection-options-reader/connection-options-reader.output.ts
+++ b/packages/codemod/test/transforms/v1/fixtures/connection-options-reader/connection-options-reader.output.ts
@@ -33,7 +33,7 @@ const cjs = new CjsReader()
 const cjsOptions = await cjs.get()
 
 // Case 7: AssignmentExpression binding — `let r; r = new Reader()`
-let deferred: any
+let deferred: ConnectionOptionsReader | undefined
 // TODO(typeorm-v1): `ConnectionOptionsReader` now searches `process.cwd()` instead of the app root — pass `{ root: "/custom/path" }` to override. `get(name)` and `has(name)` were also removed; use `get()` (previously `all()`) and filter the returned array.
 deferred = new ConnectionOptionsReader()
 const deferredOptions = await deferred.get()
@@ -56,3 +56,9 @@ const MemberReader = require("typeorm").ConnectionOptionsReader
 // TODO(typeorm-v1): `ConnectionOptionsReader` now searches `process.cwd()` instead of the app root — pass `{ root: "/custom/path" }` to override. `get(name)` and `has(name)` were also removed; use `get()` (previously `all()`) and filter the returned array.
 const fromMember = new MemberReader()
 const fromMemberOptions = await fromMember.get()
+
+// Case 11: default-parameter binding — constructor in a function default
+// TODO(typeorm-v1): `ConnectionOptionsReader` now searches `process.cwd()` instead of the app root — pass `{ root: "/custom/path" }` to override. `get(name)` and `has(name)` were also removed; use `get()` (previously `all()`) and filter the returned array.
+async function loadDefaults(r = new ConnectionOptionsReader()) {
+    return r.get()
+}

--- a/packages/codemod/test/transforms/v1/fixtures/connection-options-reader/connection-options-reader.output.ts
+++ b/packages/codemod/test/transforms/v1/fixtures/connection-options-reader/connection-options-reader.output.ts
@@ -1,0 +1,16 @@
+import { ConnectionOptionsReader } from "typeorm"
+
+// Case 1: simple constructor + all() → rename to get()
+// TODO(typeorm-v1): `ConnectionOptionsReader` now searches `process.cwd()` instead of the app root — pass `{ root: "/custom/path" }` to override. `get(name)` and `has(name)` were also removed; use `get()` (previously `all()`) and filter the returned array.
+const reader = new ConnectionOptionsReader()
+const allOptions = await reader.get()
+
+// Case 2: constructor with options
+// TODO(typeorm-v1): `ConnectionOptionsReader` now searches `process.cwd()` instead of the app root — pass `{ root: "/custom/path" }` to override. `get(name)` and `has(name)` were also removed; use `get()` (previously `all()`) and filter the returned array.
+const customReader = new ConnectionOptionsReader({ root: "/custom/path" })
+const custom = await customReader.get()
+
+// Case 3: inlined usage — constructor gets a TODO, .all() is not renamed
+// (our transform only tracks bound identifiers)
+// TODO(typeorm-v1): `ConnectionOptionsReader` now searches `process.cwd()` instead of the app root — pass `{ root: "/custom/path" }` to override. `get(name)` and `has(name)` were also removed; use `get()` (previously `all()`) and filter the returned array.
+const inline = await new ConnectionOptionsReader().all()

--- a/packages/codemod/test/transforms/v1/fixtures/connection-options-reader/connection-options-reader.output.ts
+++ b/packages/codemod/test/transforms/v1/fixtures/connection-options-reader/connection-options-reader.output.ts
@@ -50,3 +50,9 @@ function mustFail() {
     // TODO(typeorm-v1): `ConnectionOptionsReader` now searches `process.cwd()` instead of the app root — pass `{ root: "/custom/path" }` to override. `get(name)` and `has(name)` were also removed; use `get()` (previously `all()`) and filter the returned array.
     throw new ConnectionOptionsReader()
 }
+
+// Case 10: CommonJS member require — `const R = require("typeorm").ConnectionOptionsReader`
+const MemberReader = require("typeorm").ConnectionOptionsReader
+// TODO(typeorm-v1): `ConnectionOptionsReader` now searches `process.cwd()` instead of the app root — pass `{ root: "/custom/path" }` to override. `get(name)` and `has(name)` were also removed; use `get()` (previously `all()`) and filter the returned array.
+const fromMember = new MemberReader()
+const fromMemberOptions = await fromMember.get()

--- a/packages/codemod/test/transforms/v1/fixtures/connection-options-reader/connection-options-reader.output.ts
+++ b/packages/codemod/test/transforms/v1/fixtures/connection-options-reader/connection-options-reader.output.ts
@@ -62,3 +62,13 @@ const fromMemberOptions = await fromMember.get()
 async function loadDefaults(r = new ConnectionOptionsReader()) {
     return r.get()
 }
+
+// Case 12: optional-chain call variants on a tracked reader binding — still
+// rename `.all()` → `.get()`
+const opt1 = await reader?.get()
+const opt2 = await reader.get?.()
+const opt3 = await reader?.get?.()
+
+// Case 13: `.all(arg)` — must NOT be renamed (v0 `all()` was zero-arg; an
+// argument means unrelated user code that happens to share the method name)
+const extraneous = reader.all("extra")

--- a/packages/codemod/test/transforms/v1/fixtures/connection-options-reader/connection-options-reader.output.ts
+++ b/packages/codemod/test/transforms/v1/fixtures/connection-options-reader/connection-options-reader.output.ts
@@ -72,3 +72,13 @@ const opt3 = await reader?.get?.()
 // Case 13: `.all(arg)` — must NOT be renamed (v0 `all()` was zero-arg; an
 // argument means unrelated user code that happens to share the method name)
 const extraneous = reader.all("extra")
+
+// Case 14: shadowing — a nested `reader` bound to an unrelated type must NOT
+// have its `.all()` renamed even though the outer `reader` is a tracked
+// ConnectionOptionsReader instance
+function shadowed() {
+    const reader = {
+        all: (): string[] => ["not", "a", "typeorm", "reader"],
+    }
+    return reader.all()
+}

--- a/packages/codemod/test/transforms/v1/fixtures/connection-options-reader/connection-options-reader.output.ts
+++ b/packages/codemod/test/transforms/v1/fixtures/connection-options-reader/connection-options-reader.output.ts
@@ -1,4 +1,6 @@
 import { ConnectionOptionsReader } from "typeorm"
+import { ConnectionOptionsReader as Reader } from "typeorm"
+import * as typeorm from "typeorm"
 
 // Case 1: simple constructor + all() → rename to get()
 // TODO(typeorm-v1): `ConnectionOptionsReader` now searches `process.cwd()` instead of the app root — pass `{ root: "/custom/path" }` to override. `get(name)` and `has(name)` were also removed; use `get()` (previously `all()`) and filter the returned array.
@@ -10,7 +12,41 @@ const allOptions = await reader.get()
 const customReader = new ConnectionOptionsReader({ root: "/custom/path" })
 const custom = await customReader.get()
 
-// Case 3: inlined usage — constructor gets a TODO, .all() is not renamed
-// (our transform only tracks bound identifiers)
+// Case 3: inlined usage — constructor gets a TODO AND .all() is renamed to .get()
 // TODO(typeorm-v1): `ConnectionOptionsReader` now searches `process.cwd()` instead of the app root — pass `{ root: "/custom/path" }` to override. `get(name)` and `has(name)` were also removed; use `get()` (previously `all()`) and filter the returned array.
-const inline = await new ConnectionOptionsReader().all()
+const inline = await new ConnectionOptionsReader().get()
+
+// Case 4: aliased ESM import — constructor flagged, .all() renamed
+// TODO(typeorm-v1): `ConnectionOptionsReader` now searches `process.cwd()` instead of the app root — pass `{ root: "/custom/path" }` to override. `get(name)` and `has(name)` were also removed; use `get()` (previously `all()`) and filter the returned array.
+const aliased = new Reader()
+const aliasedOptions = await aliased.get()
+
+// Case 5: namespace import — `new typeorm.ConnectionOptionsReader()`
+// TODO(typeorm-v1): `ConnectionOptionsReader` now searches `process.cwd()` instead of the app root — pass `{ root: "/custom/path" }` to override. `get(name)` and `has(name)` were also removed; use `get()` (previously `all()`) and filter the returned array.
+const ns = new typeorm.ConnectionOptionsReader()
+const nsOptions = await ns.get()
+
+// Case 6: CommonJS destructured (aliased) binding
+const { ConnectionOptionsReader: CjsReader } = require("typeorm")
+// TODO(typeorm-v1): `ConnectionOptionsReader` now searches `process.cwd()` instead of the app root — pass `{ root: "/custom/path" }` to override. `get(name)` and `has(name)` were also removed; use `get()` (previously `all()`) and filter the returned array.
+const cjs = new CjsReader()
+const cjsOptions = await cjs.get()
+
+// Case 7: AssignmentExpression binding — `let r; r = new Reader()`
+let deferred: any
+// TODO(typeorm-v1): `ConnectionOptionsReader` now searches `process.cwd()` instead of the app root — pass `{ root: "/custom/path" }` to override. `get(name)` and `has(name)` were also removed; use `get()` (previously `all()`) and filter the returned array.
+deferred = new ConnectionOptionsReader()
+const deferredOptions = await deferred.get()
+
+// Case 8: two constructors on the same statement — only one TODO
+// TODO(typeorm-v1): `ConnectionOptionsReader` now searches `process.cwd()` instead of the app root — pass `{ root: "/custom/path" }` to override. `get(name)` and `has(name)` were also removed; use `get()` (previously `all()`) and filter the returned array.
+const [a, b] = [
+    new ConnectionOptionsReader(),
+    new ConnectionOptionsReader({ root: "/other" }),
+]
+
+// Case 9: constructor inside `throw` — should still be flagged
+function mustFail() {
+    // TODO(typeorm-v1): `ConnectionOptionsReader` now searches `process.cwd()` instead of the app root — pass `{ root: "/custom/path" }` to override. `get(name)` and `has(name)` were also removed; use `get()` (previously `all()`) and filter the returned array.
+    throw new ConnectionOptionsReader()
+}

--- a/packages/codemod/test/transforms/v1/fixtures/connection-to-datasource/connection-to-datasource.input.ts
+++ b/packages/codemod/test/transforms/v1/fixtures/connection-to-datasource/connection-to-datasource.input.ts
@@ -89,6 +89,16 @@ const {
 
 const cjs = new LegacyConn(options)
 
+// Aliased CJS bindings should still get method renames applied
+await cjs.connect()
+await cjs.close()
+
+// Duplicate-rename: user imports both Connection AND DataSource from typeorm.
+// The rename of Connection → DataSource must not produce `{ DataSource, DataSource }`.
+import { Connection as Conn2, DataSource as DS2 } from "typeorm"
+const both = new Conn2(options)
+const another = new DS2(options)
+
 // Should NOT be transformed — not TypeORM typed
 const ds3 = event.connection
 const ds4 = this.connection

--- a/packages/codemod/test/transforms/v1/fixtures/connection-to-datasource/connection-to-datasource.input.ts
+++ b/packages/codemod/test/transforms/v1/fixtures/connection-to-datasource/connection-to-datasource.input.ts
@@ -1,4 +1,11 @@
-import { Connection, ConnectionOptions, QueryRunner } from "typeorm"
+import {
+    Connection,
+    ConnectionOptions,
+    QueryRunner,
+    EntityMetadata,
+    ColumnMetadata,
+    IndexMetadata,
+} from "typeorm"
 import type { SapConnectionOptions } from "typeorm/driver/sap/SapConnectionOptions"
 import type { BetterSqlite3ConnectionOptions } from "typeorm/driver/better-sqlite3/BetterSqlite3ConnectionOptions"
 

--- a/packages/codemod/test/transforms/v1/fixtures/connection-to-datasource/connection-to-datasource.input.ts
+++ b/packages/codemod/test/transforms/v1/fixtures/connection-to-datasource/connection-to-datasource.input.ts
@@ -99,3 +99,13 @@ class ProductService {
 // Should NOT be transformed — not TypeORM
 await app.close()
 await server.close()
+
+// Options-typed parameters must NOT be classified as DataSource instances.
+// `opts` is a plain value-object whose `.connect` / `.close` methods are
+// unrelated to DataSource's; they must NOT be renamed to initialize/destroy.
+import type { MysqlConnectionOptions } from "typeorm"
+function inspectOpts(opts: MysqlConnectionOptions) {
+    opts.connect()
+    opts.close()
+    return opts
+}

--- a/packages/codemod/test/transforms/v1/fixtures/connection-to-datasource/connection-to-datasource.output.ts
+++ b/packages/codemod/test/transforms/v1/fixtures/connection-to-datasource/connection-to-datasource.output.ts
@@ -99,3 +99,13 @@ class ProductService {
 // Should NOT be transformed — not TypeORM
 await app.close()
 await server.close()
+
+// Options-typed parameters must NOT be classified as DataSource instances.
+// `opts` is a plain value-object whose `.connect` / `.close` methods are
+// unrelated to DataSource's; they must NOT be renamed to initialize/destroy.
+import type { MysqlDataSourceOptions } from "typeorm"
+function inspectOpts(opts: MysqlDataSourceOptions) {
+    opts.connect()
+    opts.close()
+    return opts
+}

--- a/packages/codemod/test/transforms/v1/fixtures/connection-to-datasource/connection-to-datasource.output.ts
+++ b/packages/codemod/test/transforms/v1/fixtures/connection-to-datasource/connection-to-datasource.output.ts
@@ -1,4 +1,11 @@
-import { DataSource, DataSourceOptions, QueryRunner } from "typeorm"
+import {
+    DataSource,
+    DataSourceOptions,
+    QueryRunner,
+    EntityMetadata,
+    ColumnMetadata,
+    IndexMetadata,
+} from "typeorm"
 import type { SapDataSourceOptions } from "typeorm/driver/sap/SapDataSourceOptions"
 import type { BetterSqlite3DataSourceOptions } from "typeorm/driver/better-sqlite3/BetterSqlite3DataSourceOptions"
 

--- a/packages/codemod/test/transforms/v1/fixtures/connection-to-datasource/connection-to-datasource.output.ts
+++ b/packages/codemod/test/transforms/v1/fixtures/connection-to-datasource/connection-to-datasource.output.ts
@@ -89,6 +89,16 @@ const {
 
 const cjs = new DataSource(options)
 
+// Aliased CJS bindings should still get method renames applied
+await cjs.initialize()
+await cjs.destroy()
+
+// Duplicate-rename: user imports both Connection AND DataSource from typeorm.
+// The rename of Connection → DataSource must not produce `{ DataSource, DataSource }`.
+import { DataSource as Conn2, DataSource as DS2 } from "typeorm"
+const both = new Conn2(options)
+const another = new DS2(options)
+
 // Should NOT be transformed — not TypeORM typed
 const ds3 = event.connection
 const ds4 = this.connection

--- a/packages/codemod/test/transforms/v1/fixtures/file-logger/file-logger-ts-wrapped-options.input.ts
+++ b/packages/codemod/test/transforms/v1/fixtures/file-logger/file-logger-ts-wrapped-options.input.ts
@@ -1,0 +1,12 @@
+import { FileLogger, LoggerOptions } from "typeorm"
+
+// Options wrapped in `as LoggerOptions` — the codemod must unwrap the
+// TSAsExpression before inspecting the object, otherwise it treats options
+// as dynamic and silently skips the non-absolute logPath case.
+const logger = new FileLogger("all", {
+    logPath: "relative/path.log",
+} as LoggerOptions)
+
+const logger2 = new FileLogger("all", {
+    logPath: "/absolute/path.log",
+} as LoggerOptions)

--- a/packages/codemod/test/transforms/v1/fixtures/file-logger/file-logger-ts-wrapped-options.output.ts
+++ b/packages/codemod/test/transforms/v1/fixtures/file-logger/file-logger-ts-wrapped-options.output.ts
@@ -1,0 +1,13 @@
+import { FileLogger, LoggerOptions } from "typeorm"
+
+// Options wrapped in `as LoggerOptions` — the codemod must unwrap the
+// TSAsExpression before inspecting the object, otherwise it treats options
+// as dynamic and silently skips the non-absolute logPath case.
+// TODO(typeorm-v1): `FileLogger` now resolves `logPath` from `process.cwd()` instead of the app root — use an absolute path if the app is not started from its root folder
+const logger = new FileLogger("all", {
+    logPath: "relative/path.log",
+} as LoggerOptions)
+
+const logger2 = new FileLogger("all", {
+    logPath: "/absolute/path.log",
+} as LoggerOptions)

--- a/packages/codemod/test/transforms/v1/fixtures/find-options-join/find-options-join.output.ts
+++ b/packages/codemod/test/transforms/v1/fixtures/find-options-join/find-options-join.output.ts
@@ -1,7 +1,7 @@
 import { DataSource } from "typeorm"
 
 // Case 1: leftJoinAndSelect → should get TODO (migrates to relations)
-// TODO(typeorm-v1): `join` find option was removed — migrate `leftJoinAndSelect` to the `relations` option, or switch to QueryBuilder for `innerJoin`/`innerJoinAndSelect`/`leftJoin` — see the v1 upgrading guide
+// TODO(typeorm-v1): `join` find option was removed — migrate `leftJoinAndSelect` to the `relations` option, or switch to QueryBuilder for `innerJoin`/`innerJoinAndSelect`/`leftJoin`
 const a = await repository.find({
     join: {
         alias: "post",
@@ -13,7 +13,7 @@ const a = await repository.find({
 })
 
 // Case 2: innerJoinAndSelect with lock → should get TODO (migrates to QueryBuilder)
-// TODO(typeorm-v1): `join` find option was removed — migrate `leftJoinAndSelect` to the `relations` option, or switch to QueryBuilder for `innerJoin`/`innerJoinAndSelect`/`leftJoin` — see the v1 upgrading guide
+// TODO(typeorm-v1): `join` find option was removed — migrate `leftJoinAndSelect` to the `relations` option, or switch to QueryBuilder for `innerJoin`/`innerJoinAndSelect`/`leftJoin`
 const b = await repository.findOne({
     join: {
         alias: "post",
@@ -33,7 +33,7 @@ const c = processOptions({
 // Case 4: string-literal key — should still be detected via `getStringValue`.
 // The trailing `;` below exists because jscodeshift/recast emits it when the
 // block is reprinted, and `prettier-ignore` stops Prettier from stripping it.
-// TODO(typeorm-v1): `join` find option was removed — migrate `leftJoinAndSelect` to the `relations` option, or switch to QueryBuilder for `innerJoin`/`innerJoinAndSelect`/`leftJoin` — see the v1 upgrading guide
+// TODO(typeorm-v1): `join` find option was removed — migrate `leftJoinAndSelect` to the `relations` option, or switch to QueryBuilder for `innerJoin`/`innerJoinAndSelect`/`leftJoin`
 // prettier-ignore
 const d = await repository.find({
     "join": {

--- a/packages/codemod/test/transforms/v1/fixtures/relation-count/relation-count-no-typeorm-import.output.ts
+++ b/packages/codemod/test/transforms/v1/fixtures/relation-count/relation-count-no-typeorm-import.output.ts
@@ -6,7 +6,7 @@ import { Post } from "./entity/Post"
 export async function listWithCounts(
     qb: SelectQueryBuilder<Post>,
 ): Promise<Post[]> {
-    // TODO(typeorm-v1): `loadRelationCountAndMap()` was removed — use `@VirtualColumn` with a sub-query instead — see the v1 upgrading guide
+    // TODO(typeorm-v1): `loadRelationCountAndMap()` was removed — use `@VirtualColumn` with a sub-query instead
     return qb
         .loadRelationCountAndMap("post.categoryCount", "post.categories")
         .getMany()

--- a/packages/codemod/test/transforms/v1/fixtures/relation-count/relation-count.input.ts
+++ b/packages/codemod/test/transforms/v1/fixtures/relation-count/relation-count.input.ts
@@ -47,3 +47,9 @@ export default dataSource
     .createQueryBuilder(Post, "post")
     .loadRelationCountAndMap("post.categoryCount", "post.categories")
     .getMany()
+
+// Computed member access — should also be flagged
+const computedCall = await dataSource
+    .createQueryBuilder(Post, "post")
+    ["loadRelationCountAndMap"]("post.categoryCount", "post.categories")
+    .getMany()

--- a/packages/codemod/test/transforms/v1/fixtures/relation-count/relation-count.output.ts
+++ b/packages/codemod/test/transforms/v1/fixtures/relation-count/relation-count.output.ts
@@ -2,17 +2,17 @@ import { Entity } from "typeorm"
 
 @Entity()
 class Post {
-    // TODO(typeorm-v1): `@RelationCount` was removed — use `@VirtualColumn` with a sub-query instead — see the v1 upgrading guide
+    // TODO(typeorm-v1): `@RelationCount` was removed — use `@VirtualColumn` with a sub-query instead
     @RelationCount((post: Post) => post.categories)
     categoryCount: number
 
-    // TODO(typeorm-v1): `@RelationCount` was removed — use `@VirtualColumn` with a sub-query instead — see the v1 upgrading guide
+    // TODO(typeorm-v1): `@RelationCount` was removed — use `@VirtualColumn` with a sub-query instead
     @RC((post: Post) => post.tags)
     tagCount: number
 }
 
 // `.loadRelationCountAndMap()` was removed alongside @RelationCount
-// TODO(typeorm-v1): `loadRelationCountAndMap()` was removed — use `@VirtualColumn` with a sub-query instead — see the v1 upgrading guide
+// TODO(typeorm-v1): `loadRelationCountAndMap()` was removed — use `@VirtualColumn` with a sub-query instead
 const posts = await dataSource
     .createQueryBuilder(Post, "post")
     .loadRelationCountAndMap("post.categoryCount", "post.categories")
@@ -20,7 +20,7 @@ const posts = await dataSource
 
 // Multiple chained `.loadRelationCountAndMap()` calls on a single statement
 // should receive exactly one TODO (idempotency)
-// TODO(typeorm-v1): `loadRelationCountAndMap()` was removed — use `@VirtualColumn` with a sub-query instead — see the v1 upgrading guide
+// TODO(typeorm-v1): `loadRelationCountAndMap()` was removed — use `@VirtualColumn` with a sub-query instead
 const withBoth = await dataSource
     .createQueryBuilder(Post, "post")
     .loadRelationCountAndMap("post.categoryCount", "post.categories")
@@ -29,7 +29,7 @@ const withBoth = await dataSource
 
 // Call inside a return statement
 function listWithCounts() {
-    // TODO(typeorm-v1): `loadRelationCountAndMap()` was removed — use `@VirtualColumn` with a sub-query instead — see the v1 upgrading guide
+    // TODO(typeorm-v1): `loadRelationCountAndMap()` was removed — use `@VirtualColumn` with a sub-query instead
     return dataSource
         .createQueryBuilder(Post, "post")
         .loadRelationCountAndMap("post.categoryCount", "post.categories")
@@ -38,7 +38,7 @@ function listWithCounts() {
 
 // Call inside a throw — `ThrowStatement` should still be flagged
 function fail() {
-    // TODO(typeorm-v1): `loadRelationCountAndMap()` was removed — use `@VirtualColumn` with a sub-query instead — see the v1 upgrading guide
+    // TODO(typeorm-v1): `loadRelationCountAndMap()` was removed — use `@VirtualColumn` with a sub-query instead
     throw new Error(
         dataSource
             .createQueryBuilder(Post, "post")
@@ -48,8 +48,15 @@ function fail() {
 }
 
 // Call inside a default export — `ExportDefaultDeclaration` should be flagged
-// TODO(typeorm-v1): `loadRelationCountAndMap()` was removed — use `@VirtualColumn` with a sub-query instead — see the v1 upgrading guide
+// TODO(typeorm-v1): `loadRelationCountAndMap()` was removed — use `@VirtualColumn` with a sub-query instead
 export default dataSource
     .createQueryBuilder(Post, "post")
     .loadRelationCountAndMap("post.categoryCount", "post.categories")
+    .getMany()
+
+// Computed member access — should also be flagged
+// TODO(typeorm-v1): `loadRelationCountAndMap()` was removed — use `@VirtualColumn` with a sub-query instead
+const computedCall = await dataSource
+    .createQueryBuilder(Post, "post")
+    ["loadRelationCountAndMap"]("post.categoryCount", "post.categories")
     .getMany()


### PR DESCRIPTION
PR #12257 renamed `ConnectionOptionsReader.all()` to `get()` and changed the `ormconfig` lookup to resolve from `process.cwd()` instead of the app root.

This codemod transform:

- Renames `reader.all()` calls to `reader.get()` on identifiers bound to `new ConnectionOptionsReader()`
- Adds a `// TODO(typeorm-v1):` comment above every `new ConnectionOptionsReader(...)` constructor to flag the path semantics change — users may need to pass `{ root: "/custom/path" }` if the app is not started from its project root

Operates only on files that import from `"typeorm"`. `get(name)` and `has(name)` were also removed in v1; users hitting the TODO will see the guidance in the comment body.