### PR TITLE
docs(maintainers): add Prakhar and Shaun as maintainers

### DIFF
--- a/docs/src/pages/index.tsx
+++ b/docs/src/pages/index.tsx
@@ -336,6 +336,7 @@ const teamHighlights = [
     { name: "Simon Garner", github: "sgarner" },
     { name: "Pieter Wigboldus", github: "w3nl" },
     { name: "Mike Guida", github: "mguida22" },
+    { name: "Prakhar Chhalotre", github: "cprakhar" },
 ]
 
 function MaintainersSection() {

--- a/docs/src/pages/index.tsx
+++ b/docs/src/pages/index.tsx
@@ -21,6 +21,7 @@ import {
 
 import { databases } from "@site/src/constants/databases"
 
+import maintainers from "./maintainers.json"
 import styles from "./index.module.css"
 
 // Feature section data
@@ -324,22 +325,6 @@ function PlatformsSection() {
     )
 }
 
-const teamHighlights = [
-    { name: "Michael Bromley", github: "michaelbromley" },
-    { name: "David Höck", github: "dlhck" },
-    { name: "Lucian Mocanu", github: "alumni" },
-    { name: "Naor Peled", github: "naorpeled" },
-    { name: "Giorgio Boa", github: "gioboa" },
-    { name: "Piotr Kuczynski", github: "pkuczynski" },
-    { name: "Mohammed Gomaa", github: "G0maa" },
-    { name: "Julian Pufler", github: "pujux" },
-    { name: "Simon Garner", github: "sgarner" },
-    { name: "Pieter Wigboldus", github: "w3nl" },
-    { name: "Mike Guida", github: "mguida22" },
-    { name: "Shaun Smith", github: "smith-xyz" },
-    { name: "Prakhar Chhalotre", github: "Cprakhar" },
-]
-
 function MaintainersSection() {
     return (
         <section className={styles.maintainersSection}>
@@ -348,7 +333,7 @@ function MaintainersSection() {
                     Maintained By
                 </Heading>
                 <div className={styles.maintainersAvatars}>
-                    {teamHighlights.map((m) => (
+                    {maintainers.map((m) => (
                         <img
                             key={m.github}
                             src={`https://avatars.githubusercontent.com/${m.github}?s=100`}

--- a/docs/src/pages/index.tsx
+++ b/docs/src/pages/index.tsx
@@ -336,7 +336,8 @@ const teamHighlights = [
     { name: "Simon Garner", github: "sgarner" },
     { name: "Pieter Wigboldus", github: "w3nl" },
     { name: "Mike Guida", github: "mguida22" },
-    { name: "Prakhar Chhalotre", github: "cprakhar" },
+    { name: "Shaun Smith", github: "smith-xyz" },
+    { name: "Prakhar Chhalotre", github: "Cprakhar" },
 ]
 
 function MaintainersSection() {

--- a/docs/src/pages/maintainers.json
+++ b/docs/src/pages/maintainers.json
@@ -54,5 +54,10 @@
     "name": "Mike Guida",
     "github": "mguida22",
     "role": "Maintainer"
+  },
+  {
+    "name": "Prakhar Chhalotre",
+    "github": "Cprakhar",
+    "role": "Maintainer"
   }
 ]

--- a/docs/src/pages/maintainers.json
+++ b/docs/src/pages/maintainers.json
@@ -56,6 +56,11 @@
     "role": "Maintainer"
   },
   {
+    "name": "Shaun Smith",
+    "github": "smith-xyz",
+    "role": "Maintainer"
+  },
+  {
     "name": "Prakhar Chhalotre",
     "github": "Cprakhar",
     "role": "Maintainer"


### PR DESCRIPTION
## Summary
- Adds Prakhar Chhalotre ([@Cprakhar](https://github.com/Cprakhar)) to the maintainers list on the docs site.

## Test plan
- [ ] Visit the maintainers page and confirm the new entry renders as expected.