### PR TITLE
docs(release-notes): restore RdbmsSchemaBuilder.renameTables() entry

### DIFF
--- a/docs/docs/releases/1.0/01-release-notes.md
+++ b/docs/docs/releases/1.0/01-release-notes.md
@@ -60,6 +60,7 @@ TypeORM 1.0 is a major release that removes long-deprecated APIs, modernizes pla
 - **Internal `nativeParameters` plumbing removed** from drivers and query builders ([#12104](https://github.com/typeorm/typeorm/pull/12104) by [@pkuczynski](https://github.com/pkuczynski))
 - **Internal `broadcastLoadEventsForAll()` removed** from Broadcaster ([#12137](https://github.com/typeorm/typeorm/pull/12137) by [@pkuczynski](https://github.com/pkuczynski))
 - **Internal `DriverUtils.buildColumnAlias()` removed** — use `buildAlias()` instead ([#12138](https://github.com/typeorm/typeorm/pull/12138) by [@pkuczynski](https://github.com/pkuczynski))
+- **`RdbmsSchemaBuilder.renameTables()` removed** — empty no-op method that was never called ([#12284](https://github.com/typeorm/typeorm/pull/12284) by [@naorpeled](https://github.com/naorpeled))
 - **`EntityMetadata.getValueMap()` `options` parameter removed** — the `skipNulls` option was never functional; remove the third argument ([#12303](https://github.com/typeorm/typeorm/pull/12303) by [@naorpeled](https://github.com/naorpeled))
 
 ### Behavioral changes

--- a/docs/docs/releases/1.0/02-upgrading-from-0.3.md
+++ b/docs/docs/releases/1.0/02-upgrading-from-0.3.md
@@ -1059,3 +1059,4 @@ The following internal APIs have been removed. These only affect you if you were
 | `DriverUtils.buildColumnAlias()`               | Use `DriverUtils.buildAlias()`                      |
 | `Broadcaster.broadcastLoadEventsForAll()`      | No replacement — use individual event subscribers   |
 | `QueryExpressionMap.nativeParameters`          | Use `QueryExpressionMap.parameters`                 |
+| `RdbmsSchemaBuilder.renameTables()`            | Removed                                             |


### PR DESCRIPTION
## Summary

#12303 inadvertently replaced the `RdbmsSchemaBuilder.renameTables()` entry (added in #12284) instead of appending the new `EntityMetadata.getValueMap()` entry alongside it. This restores the missing entry in both the 1.0 release notes and the upgrade guide so both removals are documented.

## Changes

- `docs/docs/releases/1.0/01-release-notes.md` — re-add the `RdbmsSchemaBuilder.renameTables()` bullet in the API removals list.
- `docs/docs/releases/1.0/02-upgrading-from-0.3.md` — re-add the `RdbmsSchemaBuilder.renameTables()` row in the internal removals table.

## Test plan

- [x] Diff review against #12303 and #12284 confirms both entries are present.