### PR TITLE
refactor(data-source)!: rename dropDatabase to dropAllEntityTables

### DIFF
--- a/docs/docs/data-source/4-data-source-api.md
+++ b/docs/docs/data-source/4-data-source-api.md
@@ -57,12 +57,13 @@ await dataSource.destroy()
 await dataSource.synchronize()
 ```
 
-- `dropDatabase` - Drops the database and all its data.
+- `dropAllEntityTables` - Drops every table managed by this DataSource along with its data.
+  Despite the previous name (`dropDatabase`), this does not drop the database itself on most drivers — it clears all entity tables.
   Be careful with this method on production since this method will erase all your database tables and their data.
   Can be used only after connection to the database is established.
 
 ```typescript
-await dataSource.dropDatabase()
+await dataSource.dropAllEntityTables()
 ```
 
 - `runMigrations` - Runs all pending migrations.

--- a/packages/codemod/src/transforms/v1/datasource-drop-database.ts
+++ b/packages/codemod/src/transforms/v1/datasource-drop-database.ts
@@ -1,0 +1,36 @@
+import path from "node:path"
+import type { API, FileInfo } from "jscodeshift"
+
+export const name = path.basename(__filename, path.extname(__filename))
+export const description =
+    "rename DataSource#dropDatabase() to DataSource#dropAllEntityTables()"
+
+export const datasourceDropDatabase = (file: FileInfo, api: API) => {
+    const j = api.jscodeshift
+    const root = j(file.source)
+    let hasChanges = false
+
+    // DataSource#dropDatabase() takes no arguments.
+    // QueryRunner#dropDatabase(name, ifExists?) always takes at least one argument.
+    // Match only the zero-argument form so QueryRunner calls are left alone.
+    root.find(j.CallExpression, {
+        callee: {
+            type: "MemberExpression",
+            property: { name: "dropDatabase" },
+        },
+    }).forEach((path) => {
+        if (path.node.arguments.length !== 0) return
+        if (
+            path.node.callee.type === "MemberExpression" &&
+            path.node.callee.property.type === "Identifier"
+        ) {
+            path.node.callee.property.name = "dropAllEntityTables"
+            hasChanges = true
+        }
+    })
+
+    return hasChanges ? root.toSource() : undefined
+}
+
+export const fn = datasourceDropDatabase
+export default fn

--- a/packages/codemod/src/transforms/v1/index.ts
+++ b/packages/codemod/src/transforms/v1/index.ts
@@ -2,6 +2,7 @@ import * as columnReadonly from "./column-readonly"
 import * as columnUnsignedNumeric from "./column-unsigned-numeric"
 import * as columnWidthZerofill from "./column-width-zerofill"
 import * as connectionToDataSource from "./connection-to-datasource"
+import * as datasourceDropDatabase from "./datasource-drop-database"
 import * as datasourceMongodb from "./datasource-mongodb"
 import * as datasourceMssql from "./datasource-mssql"
 import * as datasourceMysqlConnector from "./datasource-mysql-connector"
@@ -71,6 +72,7 @@ export const transforms = [
     queryBuilderReplacePropertyNames,
     findOptionsStringSelect,
     findOptionsStringRelations,
+    datasourceDropDatabase,
 ]
 
 export default transformer(transforms)

--- a/packages/codemod/test/transforms/v1/fixtures/datasource-drop-database/datasource-drop-database.input.ts
+++ b/packages/codemod/test/transforms/v1/fixtures/datasource-drop-database/datasource-drop-database.input.ts
@@ -1,0 +1,17 @@
+import { DataSource } from "typeorm"
+
+const dataSource = new DataSource({
+    type: "postgres",
+    database: "test",
+})
+
+async function resetSchema() {
+    await dataSource.dropDatabase()
+}
+
+async function withRunner() {
+    const queryRunner = dataSource.createQueryRunner()
+    // QueryRunner#dropDatabase(name, ifExists?) should NOT be renamed
+    await queryRunner.dropDatabase("myTestDatabase")
+    await queryRunner.dropDatabase("non_existent_database", true)
+}

--- a/packages/codemod/test/transforms/v1/fixtures/datasource-drop-database/datasource-drop-database.output.ts
+++ b/packages/codemod/test/transforms/v1/fixtures/datasource-drop-database/datasource-drop-database.output.ts
@@ -1,0 +1,17 @@
+import { DataSource } from "typeorm"
+
+const dataSource = new DataSource({
+    type: "postgres",
+    database: "test",
+})
+
+async function resetSchema() {
+    await dataSource.dropAllEntityTables()
+}
+
+async function withRunner() {
+    const queryRunner = dataSource.createQueryRunner()
+    // QueryRunner#dropDatabase(name, ifExists?) should NOT be renamed
+    await queryRunner.dropDatabase("myTestDatabase")
+    await queryRunner.dropDatabase("non_existent_database", true)
+}

--- a/src/commands/SchemaDropCommand.ts
+++ b/src/commands/SchemaDropCommand.ts
@@ -37,7 +37,7 @@ export class SchemaDropCommand implements yargs.CommandModule {
                 logging: ["query", "schema"],
             })
             await dataSource.initialize()
-            await dataSource.dropDatabase()
+            await dataSource.dropAllEntityTables()
             await dataSource.destroy()
 
             console.log(

--- a/src/data-source/DataSource.ts
+++ b/src/data-source/DataSource.ts
@@ -260,7 +260,7 @@ export class DataSource {
             await this.driver.afterConnect()
 
             // if option is set - drop schema once connection is done
-            if (this.options.dropSchema) await this.dropDatabase()
+            if (this.options.dropSchema) await this.dropAllEntityTables()
 
             // if option is set - automatically synchronize a schema
             if (this.options.migrationsRun)
@@ -304,19 +304,21 @@ export class DataSource {
     async synchronize(dropBeforeSync: boolean = false): Promise<void> {
         if (!this.isInitialized) throw new CannotExecuteNotConnectedError()
 
-        if (dropBeforeSync) await this.dropDatabase()
+        if (dropBeforeSync) await this.dropAllEntityTables()
 
         const schemaBuilder = this.driver.createSchemaBuilder()
         await schemaBuilder.build()
     }
 
     /**
-     * Drops the database and all its data.
-     * Be careful with this method on production since this method will erase all your database tables and their data.
+     * Drops every table managed by this DataSource along with its data.
+     * Despite the previous name (`dropDatabase`), this does not drop the database
+     * itself on most drivers — it clears all entity tables.
+     * Be careful with this method on production since this method will erase
+     * all your database tables and their data.
      * Can be used only after connection to the database is established.
      */
-    // TODO rename
-    async dropDatabase(): Promise<void> {
+    async dropAllEntityTables(): Promise<void> {
         const queryRunner = this.createQueryRunner()
         try {
             if (

--- a/test/functional/data-source/data-source.test.ts
+++ b/test/functional/data-source/data-source.test.ts
@@ -203,7 +203,7 @@ describe("DataSource", () => {
         })
         after(() => closeTestingConnections(dataSources))
 
-        it("database should be empty after schema is synced with dropDatabase flag", () =>
+        it("database should be empty after schema is synced with dropBeforeSync flag", () =>
             Promise.all(
                 dataSources.map(async (dataSource) => {
                     const postRepository = dataSource.getRepository(Post)


### PR DESCRIPTION
## Summary
- Rename `DataSource#dropDatabase()` to `DataSource#dropAllEntityTables()`. The method never actually dropped the database on most drivers — it calls `queryRunner.clearDatabase()` to clear all entity tables — so the new name describes what it actually does.
- Update internal callers (`DataSource#synchronize`, `dropSchema` init path) and the `schema:drop` CLI command.
- Update the DataSource API docs and a related test description.

## Breaking Change
`DataSource#dropDatabase()` has been removed. Consumers must use `DataSource#dropAllEntityTables()` instead. Behaviour is unchanged.

## Context
Resolves the long-standing `// TODO rename` on `src/data-source/DataSource.ts`. TypeORM is still `1.0.0-pre` and has not released v1, so the deprecation-shim stage is being skipped in favour of a clean rename.

## Test plan
- [ ] `pnpm run typecheck` (passes locally)
- [ ] `pnpm run test:fast` with the default SQLite ormconfig
- [ ] Spot-check `pnpm exec typeorm schema:drop -d <path>` against a SQLite db