### PR TITLE
chore(metadata-args): remove stale todo on ColumnMetadataArgs.mode

### DIFF
--- a/src/metadata-args/ColumnMetadataArgs.ts
+++ b/src/metadata-args/ColumnMetadataArgs.ts
@@ -17,8 +17,6 @@ export interface ColumnMetadataArgs {
 
     /**
      * Column mode in which column will work.
-     *
-     * todo: find name better then "mode".
      */
     readonly mode: ColumnMode
 


### PR DESCRIPTION
## Summary
- Remove the stale `todo: find name better then "mode"` JSDoc comment on `ColumnMetadataArgs.mode`.
- Decision: keep the property named `mode`. There's no clearer name that justifies the churn of a rename across the decorator surface and every consumer that reads from `getMetadataArgsStorage().columns`.

Not a breaking change — no API or behavior change, just a one-hunk comment cleanup.

## Test plan
- [x] `pnpm run typecheck`
- [ ] Visual diff review