### PR TITLE
chore(decorator): remove stale todo on JoinColumnOptions.referencedColumnName

### DIFF
--- a/src/decorator/options/JoinColumnOptions.ts
+++ b/src/decorator/options/JoinColumnOptions.ts
@@ -10,7 +10,7 @@ export interface JoinColumnOptions {
     /**
      * Name of the column in the entity to which this column is referenced.
      */
-    referencedColumnName?: string // TODO rename to referencedColumn
+    referencedColumnName?: string
 
     /**
      * Name of the foreign key constraint.


### PR DESCRIPTION
## Summary
- Remove the stale `// TODO rename to referencedColumn` comment on `JoinColumnOptions.referencedColumnName`.
- Decision: keep the property named `referencedColumnName`. The property is referenced ~170 times across 26 files in `src/` alone and is documented in the user-facing decorator surface; the churn of a rename outweighs the modest naming improvement.

Not a breaking change — no API or behavior change, just a one-hunk comment cleanup.

## Test plan
- [x] `pnpm run typecheck`
- [ ] Visual diff review