### PR TITLE
docs(issue-template): add capacitor option to drivers list and remove sqlite-abstract

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yml
@@ -78,6 +78,8 @@ body:
           required: false
         - label: better-sqlite3
           required: false
+        - label: capacitor
+          required: false
         - label: cockroachdb
           required: false
         - label: cordova
@@ -101,8 +103,6 @@ body:
         - label: spanner
           required: false
         - label: sqlite
-          required: false
-        - label: sqlite-abstract
           required: false
         - label: sqljs
           required: false

--- a/.github/ISSUE_TEMPLATE/feature-request.yml
+++ b/.github/ISSUE_TEMPLATE/feature-request.yml
@@ -57,6 +57,8 @@ body:
           required: false
         - label: better-sqlite3
           required: false
+        - label: capacitor
+          required: false
         - label: cockroachdb
           required: false
         - label: cordova
@@ -80,8 +82,6 @@ body:
         - label: spanner
           required: false
         - label: sqlite
-          required: false
-        - label: sqlite-abstract
           required: false
         - label: sqljs
           required: false


### PR DESCRIPTION
Closes #12358

### Description of change
- Add `capacitor` to bug and feature issue templates.
- Remove `sqlite-abstract` as it is not an driver.

### Pull-Request Checklist

- [x] Code is up-to-date with the `master` branch
- [x] This pull request links relevant issues as `Fixes #12358`
- [ ] There are new or updated tests validating the change (`tests/**.test.ts`)
- [ ] Documentation has been updated to reflect this change (`docs/docs/**.md`) (N/A)