### PR TITLE
fix(codemod): correct relation-count guidance and flag loadRelationCountAndMap

### DIFF
--- a/packages/codemod/src/transforms/v1/relation-count.ts
+++ b/packages/codemod/src/transforms/v1/relation-count.ts
@@ -5,7 +5,7 @@ import {
     getLocalNamesForImport,
     removeImportSpecifiers,
 } from "../ast-helpers"
-import { addTodoComment } from "../todo"
+import { addTodoComment, hasTodoComment } from "../todo"
 import { stats } from "../stats"
 
 export const name = path.basename(__filename, path.extname(__filename))
@@ -15,6 +15,17 @@ export const manual = true
 
 const MIGRATION_HINT =
     "use `@VirtualColumn` with a sub-query instead — see the v1 upgrading guide"
+
+// A TODO attached to one of these nodes will survive jscodeshift/recast's
+// printing. Walking up until we reach one of these produces a visible
+// comment above the enclosing statement or declaration.
+const isTodoHost = (type: string): boolean =>
+    type.endsWith("Statement") ||
+    type === "VariableDeclaration" ||
+    type === "ExportDefaultDeclaration" ||
+    type === "ExportNamedDeclaration" ||
+    type === "ClassProperty" ||
+    type === "PropertyDefinition"
 
 export const relationCount = (file: FileInfo, api: API) => {
     const j = api.jscodeshift
@@ -55,13 +66,17 @@ export const relationCount = (file: FileInfo, api: API) => {
                 )
             })
             if (!matches) return
+            if (hasTodoComment(node, message)) return
             addTodoComment(node, message, j)
             hasChanges = true
             hasTodos = true
         })
     }
 
-    // Find .loadRelationCountAndMap() calls and add TODO above the enclosing statement
+    // Find .loadRelationCountAndMap() calls and add TODO above the enclosing statement.
+    // Multiple chained calls on one statement resolve to the same host, so the
+    // `hasTodoComment` guard keeps the transform idempotent.
+    const callMessage = `\`loadRelationCountAndMap()\` was removed — ${MIGRATION_HINT}`
     root.find(j.CallExpression, {
         callee: {
             type: "MemberExpression",
@@ -71,18 +86,12 @@ export const relationCount = (file: FileInfo, api: API) => {
         let current = callPath.parent
         while (current) {
             const node: Node = current.node
-            if (
-                node.type === "ExpressionStatement" ||
-                node.type === "VariableDeclaration" ||
-                node.type === "ReturnStatement"
-            ) {
-                addTodoComment(
-                    node,
-                    `\`loadRelationCountAndMap()\` was removed — ${MIGRATION_HINT}`,
-                    j,
-                )
-                hasChanges = true
-                hasTodos = true
+            if (isTodoHost(node.type)) {
+                if (!hasTodoComment(node, callMessage)) {
+                    addTodoComment(node, callMessage, j)
+                    hasChanges = true
+                    hasTodos = true
+                }
                 break
             }
             current = current.parent

--- a/packages/codemod/src/transforms/v1/relation-count.ts
+++ b/packages/codemod/src/transforms/v1/relation-count.ts
@@ -1,10 +1,6 @@
 import path from "node:path"
 import type { API, ClassProperty, Decorator, FileInfo, Node } from "jscodeshift"
-import {
-    fileImportsFrom,
-    getLocalNamesForImport,
-    removeImportSpecifiers,
-} from "../ast-helpers"
+import { getLocalNamesForImport, removeImportSpecifiers } from "../ast-helpers"
 import { addTodoComment, hasTodoComment } from "../todo"
 import { stats } from "../stats"
 
@@ -31,7 +27,11 @@ export const relationCount = (file: FileInfo, api: API) => {
     const j = api.jscodeshift
     const root = j(file.source)
 
-    if (!fileImportsFrom(root, j, "typeorm")) return undefined
+    // No `fileImportsFrom` guard at the top: `.loadRelationCountAndMap()` call
+    // sites can appear in files that only receive a `QueryBuilder` via a helper
+    // and never import from "typeorm" directly. The decorator and import-
+    // removal blocks below self-gate via `getLocalNamesForImport` /
+    // `removeImportSpecifiers`, which are no-ops when typeorm is absent.
 
     let hasChanges = false
     let hasTodos = false

--- a/packages/codemod/src/transforms/v1/relation-count.ts
+++ b/packages/codemod/src/transforms/v1/relation-count.ts
@@ -1,13 +1,16 @@
 import path from "node:path"
-import type { API, FileInfo } from "jscodeshift"
+import type { API, FileInfo, Node } from "jscodeshift"
 import { removeImportSpecifiers } from "../ast-helpers"
 import { addTodoComment } from "../todo"
 import { stats } from "../stats"
 
 export const name = path.basename(__filename, path.extname(__filename))
 export const description =
-    "flag removed `@RelationCount` decorator for manual migration"
+    "flag removed `@RelationCount` decorator and `loadRelationCountAndMap()` for manual migration"
 export const manual = true
+
+const MIGRATION_HINT =
+    "use `@VirtualColumn` with a sub-query instead — see the v1 upgrading guide"
 
 export const relationCount = (file: FileInfo, api: API) => {
     const j = api.jscodeshift
@@ -15,20 +18,53 @@ export const relationCount = (file: FileInfo, api: API) => {
     let hasChanges = false
     let hasTodos = false
 
-    // Find @RelationCount decorators and add TODO
+    // Find @RelationCount decorators and add TODO. Note: jscodeshift
+    // currently loses leading comments attached to decorators or their
+    // enclosing class members in the printed output, so this TODO is
+    // largely a signal for future runs when the printer improves.
+    // The removed `RelationCount` import below will surface the break
+    // immediately as a TypeScript error.
     root.find(j.Decorator, {
         expression: {
             type: "CallExpression",
             callee: { type: "Identifier", name: "RelationCount" },
         },
-    }).forEach((path) => {
+    }).forEach((decoratorPath) => {
         addTodoComment(
-            path.node,
-            "`@RelationCount` was removed — use `QueryBuilder` with `loadRelationCountAndMap()` instead",
+            decoratorPath.node,
+            `\`@RelationCount\` was removed — ${MIGRATION_HINT}`,
             j,
         )
         hasChanges = true
         hasTodos = true
+    })
+
+    // Find .loadRelationCountAndMap() calls and add TODO above the enclosing statement
+    root.find(j.CallExpression, {
+        callee: {
+            type: "MemberExpression",
+            property: { type: "Identifier", name: "loadRelationCountAndMap" },
+        },
+    }).forEach((callPath) => {
+        let current = callPath.parent
+        while (current) {
+            const node: Node = current.node
+            if (
+                node.type === "ExpressionStatement" ||
+                node.type === "VariableDeclaration" ||
+                node.type === "ReturnStatement"
+            ) {
+                addTodoComment(
+                    node,
+                    `\`loadRelationCountAndMap()\` was removed — ${MIGRATION_HINT}`,
+                    j,
+                )
+                hasChanges = true
+                hasTodos = true
+                break
+            }
+            current = current.parent
+        }
     })
 
     // Remove RelationCount import from typeorm

--- a/packages/codemod/test/transforms/v1/fixtures/relation-count/relation-count-no-typeorm-import.input.ts
+++ b/packages/codemod/test/transforms/v1/fixtures/relation-count/relation-count-no-typeorm-import.input.ts
@@ -1,0 +1,12 @@
+// File has no direct `typeorm` import but receives a QueryBuilder via a
+// helper. The `.loadRelationCountAndMap()` call still needs to be flagged.
+import type { SelectQueryBuilder } from "./helpers/types"
+import { Post } from "./entity/Post"
+
+export async function listWithCounts(
+    qb: SelectQueryBuilder<Post>,
+): Promise<Post[]> {
+    return qb
+        .loadRelationCountAndMap("post.categoryCount", "post.categories")
+        .getMany()
+}

--- a/packages/codemod/test/transforms/v1/fixtures/relation-count/relation-count-no-typeorm-import.output.ts
+++ b/packages/codemod/test/transforms/v1/fixtures/relation-count/relation-count-no-typeorm-import.output.ts
@@ -1,0 +1,13 @@
+// File has no direct `typeorm` import but receives a QueryBuilder via a
+// helper. The `.loadRelationCountAndMap()` call still needs to be flagged.
+import type { SelectQueryBuilder } from "./helpers/types"
+import { Post } from "./entity/Post"
+
+export async function listWithCounts(
+    qb: SelectQueryBuilder<Post>,
+): Promise<Post[]> {
+    // TODO(typeorm-v1): `loadRelationCountAndMap()` was removed — use `@VirtualColumn` with a sub-query instead — see the v1 upgrading guide
+    return qb
+        .loadRelationCountAndMap("post.categoryCount", "post.categories")
+        .getMany()
+}

--- a/packages/codemod/test/transforms/v1/fixtures/relation-count/relation-count.input.ts
+++ b/packages/codemod/test/transforms/v1/fixtures/relation-count/relation-count.input.ts
@@ -15,3 +15,35 @@ const posts = await dataSource
     .createQueryBuilder(Post, "post")
     .loadRelationCountAndMap("post.categoryCount", "post.categories")
     .getMany()
+
+// Multiple chained `.loadRelationCountAndMap()` calls on a single statement
+// should receive exactly one TODO (idempotency)
+const withBoth = await dataSource
+    .createQueryBuilder(Post, "post")
+    .loadRelationCountAndMap("post.categoryCount", "post.categories")
+    .loadRelationCountAndMap("post.tagCount", "post.tags")
+    .getMany()
+
+// Call inside a return statement
+function listWithCounts() {
+    return dataSource
+        .createQueryBuilder(Post, "post")
+        .loadRelationCountAndMap("post.categoryCount", "post.categories")
+        .getMany()
+}
+
+// Call inside a throw — `ThrowStatement` should still be flagged
+function fail() {
+    throw new Error(
+        dataSource
+            .createQueryBuilder(Post, "post")
+            .loadRelationCountAndMap("post.categoryCount", "post.categories")
+            .getSql(),
+    )
+}
+
+// Call inside a default export — `ExportDefaultDeclaration` should be flagged
+export default dataSource
+    .createQueryBuilder(Post, "post")
+    .loadRelationCountAndMap("post.categoryCount", "post.categories")
+    .getMany()

--- a/packages/codemod/test/transforms/v1/fixtures/relation-count/relation-count.input.ts
+++ b/packages/codemod/test/transforms/v1/fixtures/relation-count/relation-count.input.ts
@@ -5,3 +5,9 @@ class Post {
     @RelationCount((post: Post) => post.categories)
     categoryCount: number
 }
+
+// `.loadRelationCountAndMap()` was removed alongside @RelationCount
+const posts = await dataSource
+    .createQueryBuilder(Post, "post")
+    .loadRelationCountAndMap("post.categoryCount", "post.categories")
+    .getMany()

--- a/packages/codemod/test/transforms/v1/fixtures/relation-count/relation-count.output.ts
+++ b/packages/codemod/test/transforms/v1/fixtures/relation-count/relation-count.output.ts
@@ -17,3 +17,39 @@ const posts = await dataSource
     .createQueryBuilder(Post, "post")
     .loadRelationCountAndMap("post.categoryCount", "post.categories")
     .getMany()
+
+// Multiple chained `.loadRelationCountAndMap()` calls on a single statement
+// should receive exactly one TODO (idempotency)
+// TODO(typeorm-v1): `loadRelationCountAndMap()` was removed — use `@VirtualColumn` with a sub-query instead — see the v1 upgrading guide
+const withBoth = await dataSource
+    .createQueryBuilder(Post, "post")
+    .loadRelationCountAndMap("post.categoryCount", "post.categories")
+    .loadRelationCountAndMap("post.tagCount", "post.tags")
+    .getMany()
+
+// Call inside a return statement
+function listWithCounts() {
+    // TODO(typeorm-v1): `loadRelationCountAndMap()` was removed — use `@VirtualColumn` with a sub-query instead — see the v1 upgrading guide
+    return dataSource
+        .createQueryBuilder(Post, "post")
+        .loadRelationCountAndMap("post.categoryCount", "post.categories")
+        .getMany()
+}
+
+// Call inside a throw — `ThrowStatement` should still be flagged
+function fail() {
+    // TODO(typeorm-v1): `loadRelationCountAndMap()` was removed — use `@VirtualColumn` with a sub-query instead — see the v1 upgrading guide
+    throw new Error(
+        dataSource
+            .createQueryBuilder(Post, "post")
+            .loadRelationCountAndMap("post.categoryCount", "post.categories")
+            .getSql(),
+    )
+}
+
+// Call inside a default export — `ExportDefaultDeclaration` should be flagged
+// TODO(typeorm-v1): `loadRelationCountAndMap()` was removed — use `@VirtualColumn` with a sub-query instead — see the v1 upgrading guide
+export default dataSource
+    .createQueryBuilder(Post, "post")
+    .loadRelationCountAndMap("post.categoryCount", "post.categories")
+    .getMany()

--- a/packages/codemod/test/transforms/v1/fixtures/relation-count/relation-count.output.ts
+++ b/packages/codemod/test/transforms/v1/fixtures/relation-count/relation-count.output.ts
@@ -5,3 +5,10 @@ class Post {
     @RelationCount((post: Post) => post.categories)
     categoryCount: number
 }
+
+// `.loadRelationCountAndMap()` was removed alongside @RelationCount
+// TODO(typeorm-v1): `loadRelationCountAndMap()` was removed — use `@VirtualColumn` with a sub-query instead — see the v1 upgrading guide
+const posts = await dataSource
+    .createQueryBuilder(Post, "post")
+    .loadRelationCountAndMap("post.categoryCount", "post.categories")
+    .getMany()


### PR DESCRIPTION
Two related fixes for the `relation-count` v1 codemod transform.

### Corrected migration guidance

The TODO message recommended `loadRelationCountAndMap()` as the migration target — but that method was also removed in v1 alongside `@RelationCount`. Following the suggestion would just send users to another removed API.

Updated to match the upgrading guide: users are now directed to `@VirtualColumn` with a sub-query.

### `.loadRelationCountAndMap()` call sites now flagged

The transform only looked for `@RelationCount` decorators. Any user calling `.loadRelationCountAndMap()` on a `SelectQueryBuilder` would get no signal from the codemod, even though the method is gone.

Added a `CallExpression` matcher for `.loadRelationCountAndMap(` that walks up to the enclosing statement and attaches a TODO there.

### Note on decorator TODOs

jscodeshift's printer currently loses leading comments attached to `Decorator` nodes and to class members carrying decorators, so the TODO on `@RelationCount` itself isn't visible in the output. The import removal still immediately breaks compilation (`Cannot find name 'RelationCount'`), which is the primary surfacing mechanism. The `.loadRelationCountAndMap()` TODO prints correctly because its enclosing context is a regular statement. A follow-up can add decorator-TODO support once the printer handles it.