### PR TITLE
feat(codemod): flag removed FindOneOptions/FindManyOptions `join` property

### DIFF
--- a/packages/codemod/src/transforms/todo.ts
+++ b/packages/codemod/src/transforms/todo.ts
@@ -2,13 +2,27 @@ import type { JSCodeshift, Node } from "jscodeshift"
 
 const formatTodo = (message: string): string => ` TODO(typeorm-v1): ${message}`
 
+// Prettier treats a leading `// prettier-ignore` line-comment as a directive
+// for the statement immediately following it. If we append a TODO *after*
+// that directive, it ends up between `prettier-ignore` and its target, which
+// silently disables the directive. Detect the pattern so we can insert the
+// TODO before any such directives.
+const isPrettierIgnore = (comment: { type: string; value: string }): boolean =>
+    comment.type === "CommentLine" && comment.value.trim() === "prettier-ignore"
+
 export const addTodoComment = (
     node: Node,
     message: string,
     j: JSCodeshift,
 ): void => {
     if (!node.comments) node.comments = []
-    node.comments.push(j.commentLine(formatTodo(message)))
+    const todo = j.commentLine(formatTodo(message))
+    const firstDirectiveIndex = node.comments.findIndex(isPrettierIgnore)
+    if (firstDirectiveIndex === -1) {
+        node.comments.push(todo)
+    } else {
+        node.comments.splice(firstDirectiveIndex, 0, todo)
+    }
 }
 
 /**

--- a/packages/codemod/src/transforms/v1/find-options-join.ts
+++ b/packages/codemod/src/transforms/v1/find-options-join.ts
@@ -1,0 +1,94 @@
+import path from "node:path"
+import type { API, FileInfo, Node, ObjectProperty } from "jscodeshift"
+import { fileImportsFrom, getStringValue } from "../ast-helpers"
+import { addTodoComment } from "../todo"
+import { stats } from "../stats"
+
+export const name = path.basename(__filename, path.extname(__filename))
+export const description =
+    "flag removed `join` find option for manual migration to `relations` or QueryBuilder"
+export const manual = true
+
+const MIGRATION_HINT =
+    "migrate `leftJoinAndSelect` to the `relations` option, or switch to QueryBuilder for `innerJoin`/`innerJoinAndSelect`/`leftJoin` — see the v1 upgrading guide"
+
+// A find-options `join` property has a value like
+// `{ alias: "...", leftJoinAndSelect: { ... }, ... }`. We look for the
+// `alias` sub-property to distinguish it from unrelated `join` keys.
+const isFindOptionsJoinProperty = (prop: ObjectProperty): boolean => {
+    const keyName =
+        prop.key.type === "Identifier"
+            ? prop.key.name
+            : getStringValue(prop.key)
+    if (keyName !== "join") return false
+    if (prop.value.type !== "ObjectExpression") return false
+
+    return prop.value.properties.some((inner) => {
+        if (inner.type !== "ObjectProperty") return false
+        const innerKey =
+            inner.key.type === "Identifier"
+                ? inner.key.name
+                : getStringValue(inner.key)
+        return innerKey === "alias"
+    })
+}
+
+export const findOptionsJoin = (file: FileInfo, api: API) => {
+    const j = api.jscodeshift
+    const root = j(file.source)
+
+    // Only operate on files that import from typeorm
+    if (!fileImportsFrom(root, j, "typeorm")) return undefined
+
+    let hasChanges = false
+    let hasTodos = false
+
+    root.find(j.ObjectExpression).forEach((objPath) => {
+        const obj = objPath.node
+        const hasJoin = obj.properties.some(
+            (prop) =>
+                prop.type === "ObjectProperty" &&
+                isFindOptionsJoinProperty(prop),
+        )
+        if (!hasJoin) return
+
+        // Walk up to the enclosing statement for the TODO
+        let current = objPath.parent
+        while (current) {
+            const node: Node = current.node
+            if (
+                node.type === "ExpressionStatement" ||
+                node.type === "VariableDeclaration" ||
+                node.type === "ReturnStatement" ||
+                node.type === "ExportDefaultDeclaration" ||
+                node.type === "ExportNamedDeclaration"
+            ) {
+                const todoLine = ` TODO(typeorm-v1): \`join\` find option was removed — ${MIGRATION_HINT}`
+                const nodeWithComments = node as Node & {
+                    comments?: { value: string }[]
+                }
+                const alreadyFlagged = nodeWithComments.comments?.some(
+                    (c) => c.value === todoLine,
+                )
+                if (!alreadyFlagged) {
+                    addTodoComment(
+                        node,
+                        `\`join\` find option was removed — ${MIGRATION_HINT}`,
+                        j,
+                    )
+                    hasChanges = true
+                    hasTodos = true
+                }
+                break
+            }
+            current = current.parent
+        }
+    })
+
+    if (hasTodos) stats.count.todo(api, name, file)
+
+    return hasChanges ? root.toSource() : undefined
+}
+
+export const fn = findOptionsJoin
+export default fn

--- a/packages/codemod/src/transforms/v1/find-options-join.ts
+++ b/packages/codemod/src/transforms/v1/find-options-join.ts
@@ -1,7 +1,7 @@
 import path from "node:path"
 import type { API, FileInfo, Node, ObjectExpression } from "jscodeshift"
 import { fileImportsFrom, getStringValue } from "../ast-helpers"
-import { addTodoComment } from "../todo"
+import { addTodoComment, hasTodoComment } from "../todo"
 import { stats } from "../stats"
 
 export const name = path.basename(__filename, path.extname(__filename))
@@ -11,6 +11,19 @@ export const manual = true
 
 const MIGRATION_HINT =
     "migrate `leftJoinAndSelect` to the `relations` option, or switch to QueryBuilder for `innerJoin`/`innerJoinAndSelect`/`leftJoin` — see the v1 upgrading guide"
+
+const MESSAGE = `\`join\` find option was removed — ${MIGRATION_HINT}`
+
+// A TODO attached to one of these nodes will survive jscodeshift/recast's
+// printing. Walking up until we reach one of these produces a visible
+// comment above the enclosing statement or declaration.
+const isTodoHost = (type: string): boolean =>
+    type.endsWith("Statement") ||
+    type === "VariableDeclaration" ||
+    type === "ExportDefaultDeclaration" ||
+    type === "ExportNamedDeclaration" ||
+    type === "ClassProperty" ||
+    type === "PropertyDefinition"
 
 // A find-options `join` property has a value like
 // `{ alias: "...", leftJoinAndSelect: { ... }, ... }`. We look for the
@@ -57,30 +70,14 @@ export const findOptionsJoin = (file: FileInfo, api: API) => {
         const hasJoin = obj.properties.some(isFindOptionsJoinProperty)
         if (!hasJoin) return
 
-        // Walk up to the enclosing statement for the TODO
+        // Walk up to the enclosing statement for the TODO. Idempotent: skip
+        // hosts that already carry the same message.
         let current = objPath.parent
         while (current) {
             const node: Node = current.node
-            if (
-                node.type === "ExpressionStatement" ||
-                node.type === "VariableDeclaration" ||
-                node.type === "ReturnStatement" ||
-                node.type === "ExportDefaultDeclaration" ||
-                node.type === "ExportNamedDeclaration"
-            ) {
-                const todoLine = ` TODO(typeorm-v1): \`join\` find option was removed — ${MIGRATION_HINT}`
-                const nodeWithComments = node as Node & {
-                    comments?: { value: string }[]
-                }
-                const alreadyFlagged = nodeWithComments.comments?.some(
-                    (c) => c.value === todoLine,
-                )
-                if (!alreadyFlagged) {
-                    addTodoComment(
-                        node,
-                        `\`join\` find option was removed — ${MIGRATION_HINT}`,
-                        j,
-                    )
+            if (isTodoHost(node.type)) {
+                if (!hasTodoComment(node, MESSAGE)) {
+                    addTodoComment(node, MESSAGE, j)
                     hasChanges = true
                     hasTodos = true
                 }

--- a/packages/codemod/src/transforms/v1/find-options-join.ts
+++ b/packages/codemod/src/transforms/v1/find-options-join.ts
@@ -1,5 +1,5 @@
 import path from "node:path"
-import type { API, FileInfo, Node, ObjectProperty } from "jscodeshift"
+import type { API, FileInfo, Node, ObjectExpression } from "jscodeshift"
 import { fileImportsFrom, getStringValue } from "../ast-helpers"
 import { addTodoComment } from "../todo"
 import { stats } from "../stats"
@@ -15,7 +15,14 @@ const MIGRATION_HINT =
 // A find-options `join` property has a value like
 // `{ alias: "...", leftJoinAndSelect: { ... }, ... }`. We look for the
 // `alias` sub-property to distinguish it from unrelated `join` keys.
-const isFindOptionsJoinProperty = (prop: ObjectProperty): boolean => {
+// Accept both `ObjectProperty` (Babel) and `Property` (Esprima) node shapes
+// and both identifier (`join:`) and string-literal (`"join":`) keys.
+const isFindOptionsJoinProperty = (
+    prop: ObjectExpression["properties"][number],
+): boolean => {
+    if (prop.type !== "Property" && prop.type !== "ObjectProperty") {
+        return false
+    }
     const keyName =
         prop.key.type === "Identifier"
             ? prop.key.name
@@ -24,7 +31,9 @@ const isFindOptionsJoinProperty = (prop: ObjectProperty): boolean => {
     if (prop.value.type !== "ObjectExpression") return false
 
     return prop.value.properties.some((inner) => {
-        if (inner.type !== "ObjectProperty") return false
+        if (inner.type !== "Property" && inner.type !== "ObjectProperty") {
+            return false
+        }
         const innerKey =
             inner.key.type === "Identifier"
                 ? inner.key.name
@@ -45,11 +54,7 @@ export const findOptionsJoin = (file: FileInfo, api: API) => {
 
     root.find(j.ObjectExpression).forEach((objPath) => {
         const obj = objPath.node
-        const hasJoin = obj.properties.some(
-            (prop) =>
-                prop.type === "ObjectProperty" &&
-                isFindOptionsJoinProperty(prop),
-        )
+        const hasJoin = obj.properties.some(isFindOptionsJoinProperty)
         if (!hasJoin) return
 
         // Walk up to the enclosing statement for the TODO

--- a/packages/codemod/src/transforms/v1/index.ts
+++ b/packages/codemod/src/transforms/v1/index.ts
@@ -9,6 +9,7 @@ import * as datasourceName from "./datasource-name"
 import * as datasourceSap from "./datasource-sap"
 import * as datasourceSqliteOptions from "./datasource-sqlite-options"
 import * as datasourceSqliteType from "./datasource-sqlite-type"
+import * as findOptionsJoin from "./find-options-join"
 import * as findOptionsLockModes from "./find-options-lock-modes"
 import * as findOptionsStringRelations from "./find-options-string-relations"
 import * as findOptionsStringSelect from "./find-options-string-select"
@@ -71,6 +72,7 @@ export const transforms = [
     queryBuilderReplacePropertyNames,
     findOptionsStringSelect,
     findOptionsStringRelations,
+    findOptionsJoin,
 ]
 
 export default transformer(transforms)

--- a/packages/codemod/src/transforms/v1/index.ts
+++ b/packages/codemod/src/transforms/v1/index.ts
@@ -54,6 +54,7 @@ export const transforms = [
     columnReadonly,
     columnWidthZerofill,
     datasourceSqliteType,
+    findOptionsJoin,
     findOptionsLockModes,
     useContainer,
     datasourceMysqlConnector,
@@ -74,7 +75,6 @@ export const transforms = [
     findOptionsStringSelect,
     findOptionsStringRelations,
     connectionManager,
-    findOptionsJoin,
 ]
 
 export default transformer(transforms)

--- a/packages/codemod/test/transforms/v1/fixtures/find-options-join/find-options-join.input.ts
+++ b/packages/codemod/test/transforms/v1/fixtures/find-options-join/find-options-join.input.ts
@@ -28,10 +28,11 @@ const c = processOptions({
     join: { separator: "," },
 })
 
-// Case 4: quoted key — should still be detected
+// Case 4: string-literal key — should still be detected via `getStringValue`
+// prettier-ignore
 const d = await repository.find({
-    join: {
-        alias: "post",
-        leftJoinAndSelect: { categories: "post.categories" },
+    "join": {
+        "alias": "post",
+        "leftJoinAndSelect": { categories: "post.categories" },
     },
 })

--- a/packages/codemod/test/transforms/v1/fixtures/find-options-join/find-options-join.input.ts
+++ b/packages/codemod/test/transforms/v1/fixtures/find-options-join/find-options-join.input.ts
@@ -28,11 +28,13 @@ const c = processOptions({
     join: { separator: "," },
 })
 
-// Case 4: string-literal key — should still be detected via `getStringValue`
+// Case 4: string-literal key — should still be detected via `getStringValue`.
+// The trailing `;` below exists because jscodeshift/recast emits it when the
+// block is reprinted, and `prettier-ignore` stops Prettier from stripping it.
 // prettier-ignore
 const d = await repository.find({
     "join": {
         "alias": "post",
         "leftJoinAndSelect": { categories: "post.categories" },
     },
-})
+});

--- a/packages/codemod/test/transforms/v1/fixtures/find-options-join/find-options-join.input.ts
+++ b/packages/codemod/test/transforms/v1/fixtures/find-options-join/find-options-join.input.ts
@@ -1,0 +1,37 @@
+import { DataSource } from "typeorm"
+
+// Case 1: leftJoinAndSelect → should get TODO (migrates to relations)
+const a = await repository.find({
+    join: {
+        alias: "post",
+        leftJoinAndSelect: {
+            categories: "post.categories",
+            author: "post.author",
+        },
+    },
+})
+
+// Case 2: innerJoinAndSelect with lock → should get TODO (migrates to QueryBuilder)
+const b = await repository.findOne({
+    join: {
+        alias: "post",
+        innerJoinAndSelect: {
+            categories: "post.categories",
+        },
+    },
+    lock: { mode: "pessimistic_write", tables: ["category"] },
+})
+
+// Case 3: unrelated object with a `join` key that is NOT a find-options join
+// (no `alias` sibling property) — should NOT get TODO
+const c = processOptions({
+    join: { separator: "," },
+})
+
+// Case 4: quoted key — should still be detected
+const d = await repository.find({
+    join: {
+        alias: "post",
+        leftJoinAndSelect: { categories: "post.categories" },
+    },
+})

--- a/packages/codemod/test/transforms/v1/fixtures/find-options-join/find-options-join.output.ts
+++ b/packages/codemod/test/transforms/v1/fixtures/find-options-join/find-options-join.output.ts
@@ -30,11 +30,12 @@ const c = processOptions({
     join: { separator: "," },
 })
 
-// Case 4: quoted key — should still be detected
+// Case 4: string-literal key — should still be detected via `getStringValue`
+// prettier-ignore
 // TODO(typeorm-v1): `join` find option was removed — migrate `leftJoinAndSelect` to the `relations` option, or switch to QueryBuilder for `innerJoin`/`innerJoinAndSelect`/`leftJoin` — see the v1 upgrading guide
 const d = await repository.find({
-    join: {
-        alias: "post",
-        leftJoinAndSelect: { categories: "post.categories" },
+    "join": {
+        "alias": "post",
+        "leftJoinAndSelect": { categories: "post.categories" },
     },
-})
+});

--- a/packages/codemod/test/transforms/v1/fixtures/find-options-join/find-options-join.output.ts
+++ b/packages/codemod/test/transforms/v1/fixtures/find-options-join/find-options-join.output.ts
@@ -30,9 +30,11 @@ const c = processOptions({
     join: { separator: "," },
 })
 
-// Case 4: string-literal key — should still be detected via `getStringValue`
-// prettier-ignore
+// Case 4: string-literal key — should still be detected via `getStringValue`.
+// The trailing `;` below exists because jscodeshift/recast emits it when the
+// block is reprinted, and `prettier-ignore` stops Prettier from stripping it.
 // TODO(typeorm-v1): `join` find option was removed — migrate `leftJoinAndSelect` to the `relations` option, or switch to QueryBuilder for `innerJoin`/`innerJoinAndSelect`/`leftJoin` — see the v1 upgrading guide
+// prettier-ignore
 const d = await repository.find({
     "join": {
         "alias": "post",

--- a/packages/codemod/test/transforms/v1/fixtures/find-options-join/find-options-join.output.ts
+++ b/packages/codemod/test/transforms/v1/fixtures/find-options-join/find-options-join.output.ts
@@ -1,0 +1,40 @@
+import { DataSource } from "typeorm"
+
+// Case 1: leftJoinAndSelect → should get TODO (migrates to relations)
+// TODO(typeorm-v1): `join` find option was removed — migrate `leftJoinAndSelect` to the `relations` option, or switch to QueryBuilder for `innerJoin`/`innerJoinAndSelect`/`leftJoin` — see the v1 upgrading guide
+const a = await repository.find({
+    join: {
+        alias: "post",
+        leftJoinAndSelect: {
+            categories: "post.categories",
+            author: "post.author",
+        },
+    },
+})
+
+// Case 2: innerJoinAndSelect with lock → should get TODO (migrates to QueryBuilder)
+// TODO(typeorm-v1): `join` find option was removed — migrate `leftJoinAndSelect` to the `relations` option, or switch to QueryBuilder for `innerJoin`/`innerJoinAndSelect`/`leftJoin` — see the v1 upgrading guide
+const b = await repository.findOne({
+    join: {
+        alias: "post",
+        innerJoinAndSelect: {
+            categories: "post.categories",
+        },
+    },
+    lock: { mode: "pessimistic_write", tables: ["category"] },
+})
+
+// Case 3: unrelated object with a `join` key that is NOT a find-options join
+// (no `alias` sibling property) — should NOT get TODO
+const c = processOptions({
+    join: { separator: "," },
+})
+
+// Case 4: quoted key — should still be detected
+// TODO(typeorm-v1): `join` find option was removed — migrate `leftJoinAndSelect` to the `relations` option, or switch to QueryBuilder for `innerJoin`/`innerJoinAndSelect`/`leftJoin` — see the v1 upgrading guide
+const d = await repository.find({
+    join: {
+        alias: "post",
+        leftJoinAndSelect: { categories: "post.categories" },
+    },
+})


### PR DESCRIPTION
The `join` property on `FindOneOptions` / `FindManyOptions` (and the `JoinOptions` interface) were removed in v1. Migration is context-dependent:

- `leftJoinAndSelect` → `relations: { ... }` option
- `innerJoin`, `innerJoinAndSelect`, `leftJoin` (without select) → QueryBuilder

Because the correct replacement depends on the join type and whether locking or other modifiers are present, this transform doesn't attempt an automatic rewrite — it flags every affected find-options object with a TODO pointing to the upgrading guide.

### Detection

Matches any `ObjectExpression` containing a `join` property whose value is an `ObjectExpression` with an `alias` sub-property — the `alias` anchor is specific to TypeORM's `JoinOptions` and avoids false positives on unrelated config objects that happen to have a `join:` key. Quoted keys (`{ "join": { ... } }`) are matched the same way.

Scoped to files that import from `"typeorm"`, mirroring other v1 transforms.

### Example

Input:
```ts
const posts = await repository.find({
    join: { alias: "post", leftJoinAndSelect: { categories: "post.categories" } },
})
```

Output:
```ts
// TODO(typeorm-v1): `join` find option was removed — migrate `leftJoinAndSelect` to the `relations` option, or switch to QueryBuilder for `innerJoin`/`innerJoinAndSelect`/`leftJoin` — see the v1 upgrading guide
const posts = await repository.find({
    join: { alias: "post", leftJoinAndSelect: { categories: "post.categories" } },
})
```