### PR TITLE
feat(codemod): flag removed ConnectionManager class constructions

### DIFF
--- a/packages/codemod/src/transforms/ast-helpers.ts
+++ b/packages/codemod/src/transforms/ast-helpers.ts
@@ -92,10 +92,12 @@ export const fileImportsFrom = (
 
 /**
  * Returns the set of local identifiers bound to a given named export.
- * Handles direct imports and aliased imports:
+ * Handles ESM direct/aliased imports and CommonJS destructured requires:
  *
  *   import { RelationCount } from "typeorm"         → { "RelationCount" }
  *   import { RelationCount as RC } from "typeorm"   → { "RC" }
+ *   const { RelationCount } = require("typeorm")    → { "RelationCount" }
+ *   const { RelationCount: RC } = require("typeorm")→ { "RC" }
  */
 export const getLocalNamesForImport = (
     root: Collection,
@@ -104,6 +106,8 @@ export const getLocalNamesForImport = (
     importedName: string,
 ): Set<string> => {
     const localNames = new Set<string>()
+
+    // ESM: `import { X [as Y] } from "moduleName"`
     root.find(j.ImportDeclaration, {
         source: { value: moduleName },
     }).forEach((importPath) => {
@@ -121,6 +125,37 @@ export const getLocalNamesForImport = (
             }
         }
     })
+
+    // CommonJS: `const { X [: Y] } = require("moduleName")`
+    root.find(j.CallExpression, {
+        callee: { type: "Identifier", name: "require" },
+    }).forEach((callPath) => {
+        const [arg] = callPath.node.arguments
+        if (!arg || getStringValue(arg) !== moduleName) return
+
+        const parent = callPath.parent.node
+        if (parent.type !== "VariableDeclarator") return
+        const id = parent.id
+        if (id.type !== "ObjectPattern") return
+
+        for (const prop of id.properties) {
+            if (prop.type !== "Property" && prop.type !== "ObjectProperty") {
+                continue
+            }
+            if (
+                prop.key.type !== "Identifier" ||
+                prop.key.name !== importedName
+            ) {
+                continue
+            }
+            const localName: string =
+                prop.value.type === "Identifier"
+                    ? prop.value.name
+                    : prop.key.name
+            localNames.add(localName)
+        }
+    })
+
     return localNames
 }
 

--- a/packages/codemod/src/transforms/todo.ts
+++ b/packages/codemod/src/transforms/todo.ts
@@ -1,10 +1,22 @@
 import type { JSCodeshift, Node } from "jscodeshift"
 
+const formatTodo = (message: string): string => ` TODO(typeorm-v1): ${message}`
+
 export const addTodoComment = (
     node: Node,
     message: string,
     j: JSCodeshift,
 ): void => {
     if (!node.comments) node.comments = []
-    node.comments.push(j.commentLine(` TODO(typeorm-v1): ${message}`))
+    node.comments.push(j.commentLine(formatTodo(message)))
+}
+
+/**
+ * Returns true when `node` already carries a line-comment whose value
+ * matches the formatted TODO for `message`. Used to keep transforms
+ * idempotent — running the codemod twice must not stack duplicate TODOs.
+ */
+export const hasTodoComment = (node: Node, message: string): boolean => {
+    const expected = formatTodo(message)
+    return (node.comments ?? []).some((c) => c.value === expected)
 }

--- a/packages/codemod/src/transforms/v1/connection-manager.ts
+++ b/packages/codemod/src/transforms/v1/connection-manager.ts
@@ -1,7 +1,7 @@
 import path from "node:path"
-import type { API, FileInfo, Node } from "jscodeshift"
+import type { API, ASTPath, FileInfo, Node } from "jscodeshift"
 import { removeImportSpecifiers } from "../ast-helpers"
-import { addTodoComment } from "../todo"
+import { addTodoComment, hasTodoComment } from "../todo"
 import { stats } from "../stats"
 
 export const name = path.basename(__filename, path.extname(__filename))
@@ -9,8 +9,18 @@ export const description =
     "flag removed `ConnectionManager` class for manual migration to direct `DataSource` instantiation"
 export const manual = true
 
-const MIGRATION_HINT =
-    "create and manage `DataSource` instances directly instead — there is no replacement class"
+const MESSAGE = `\`ConnectionManager\` was removed — create and manage \`DataSource\` instances directly instead — there is no replacement class`
+
+// A TODO attached to one of these nodes will survive jscodeshift/recast's
+// printing. Walking up until we reach one of these produces a visible
+// comment above the enclosing statement or declaration.
+const isTodoHost = (type: string): boolean =>
+    type.endsWith("Statement") ||
+    type === "VariableDeclaration" ||
+    type === "ExportDefaultDeclaration" ||
+    type === "ExportNamedDeclaration" ||
+    type === "ClassProperty" ||
+    type === "PropertyDefinition"
 
 export const connectionManager = (file: FileInfo, api: API) => {
     const j = api.jscodeshift
@@ -44,7 +54,23 @@ export const connectionManager = (file: FileInfo, api: API) => {
         return undefined
     }
 
-    // Flag `new ConnectionManager(...)` (or aliased) constructions
+    const flagEnclosingStatement = (startPath: ASTPath): void => {
+        let current = startPath.parent
+        while (current) {
+            const node: Node = current.node
+            if (isTodoHost(node.type)) {
+                if (!hasTodoComment(node, MESSAGE)) {
+                    addTodoComment(node, MESSAGE, j)
+                    hasChanges = true
+                    hasTodos = true
+                }
+                return
+            }
+            current = current.parent
+        }
+    }
+
+    // Flag `new ConnectionManager(...)` constructions wherever they appear
     root.find(j.NewExpression)
         .filter((p) => {
             const callee = p.node.callee
@@ -53,56 +79,37 @@ export const connectionManager = (file: FileInfo, api: API) => {
                 localNames.has((callee as { name: string }).name)
             )
         })
-        .forEach((newPath) => {
-            let current = newPath.parent
-            while (current) {
-                const node: Node = current.node
-                if (
-                    node.type === "ExpressionStatement" ||
-                    node.type === "VariableDeclaration" ||
-                    node.type === "ReturnStatement" ||
-                    node.type === "ExportDefaultDeclaration" ||
-                    node.type === "ExportNamedDeclaration" ||
-                    node.type === "ClassProperty" ||
-                    node.type === "PropertyDefinition"
-                ) {
-                    const todoLine = ` TODO(typeorm-v1): \`ConnectionManager\` was removed — ${MIGRATION_HINT}`
-                    const nodeWithComments = node as Node & {
-                        comments?: { value: string }[]
-                    }
-                    const alreadyFlagged = nodeWithComments.comments?.some(
-                        (c) => c.value === todoLine,
-                    )
-                    if (!alreadyFlagged) {
-                        addTodoComment(
-                            node,
-                            `\`ConnectionManager\` was removed — ${MIGRATION_HINT}`,
-                            j,
-                        )
-                        hasChanges = true
-                        hasTodos = true
-                    }
-                    break
-                }
-                current = current.parent
-            }
+        .forEach(flagEnclosingStatement)
+
+    // Flag `: ConnectionManager` type annotations too; otherwise a file
+    // that only uses the class as a type would have its import silently
+    // removed and be left with a broken reference.
+    root.find(j.TSTypeReference)
+        .filter((p) => {
+            const typeName = p.node.typeName
+            return (
+                typeName.type === "Identifier" &&
+                localNames.has((typeName as { name: string }).name)
+            )
         })
+        .forEach(flagEnclosingStatement)
 
-    // Remove `ConnectionManager` from imports. The class is gone, so
-    // leaving the specifier would produce a TypeScript error that adds
-    // noise on top of the TODO.
-    if (
-        removeImportSpecifiers(
-            root,
-            j,
-            "typeorm",
-            new Set(["ConnectionManager"]),
-        )
-    ) {
-        hasChanges = true
+    // Only drop the import when at least one usage was successfully
+    // flagged — leaving a dangling `ConnectionManager` reference without a
+    // TODO would be worse than leaving the deprecated import in place.
+    if (hasTodos) {
+        if (
+            removeImportSpecifiers(
+                root,
+                j,
+                "typeorm",
+                new Set(["ConnectionManager"]),
+            )
+        ) {
+            hasChanges = true
+        }
+        stats.count.todo(api, name, file)
     }
-
-    if (hasTodos) stats.count.todo(api, name, file)
 
     return hasChanges ? root.toSource() : undefined
 }

--- a/packages/codemod/src/transforms/v1/connection-manager.ts
+++ b/packages/codemod/src/transforms/v1/connection-manager.ts
@@ -1,0 +1,111 @@
+import path from "node:path"
+import type { API, FileInfo, Node } from "jscodeshift"
+import { removeImportSpecifiers } from "../ast-helpers"
+import { addTodoComment } from "../todo"
+import { stats } from "../stats"
+
+export const name = path.basename(__filename, path.extname(__filename))
+export const description =
+    "flag removed `ConnectionManager` class for manual migration to direct `DataSource` instantiation"
+export const manual = true
+
+const MIGRATION_HINT =
+    "create and manage `DataSource` instances directly instead — there is no replacement class"
+
+export const connectionManager = (file: FileInfo, api: API) => {
+    const j = api.jscodeshift
+    const root = j(file.source)
+    let hasChanges = false
+    let hasTodos = false
+
+    // Collect local aliases bound to the typeorm `ConnectionManager` class
+    // so aliased imports like `import { ConnectionManager as CM }` are
+    // correctly matched.
+    const localNames = new Set<string>()
+    root.find(j.ImportDeclaration, {
+        source: { value: "typeorm" },
+    }).forEach((p) => {
+        for (const s of p.node.specifiers ?? []) {
+            if (
+                s.type === "ImportSpecifier" &&
+                s.imported.type === "Identifier" &&
+                s.imported.name === "ConnectionManager"
+            ) {
+                const local = s.local?.name
+                localNames.add(
+                    typeof local === "string" ? local : s.imported.name,
+                )
+            }
+        }
+    })
+
+    if (localNames.size === 0) {
+        // Not imported from typeorm; nothing to flag.
+        return undefined
+    }
+
+    // Flag `new ConnectionManager(...)` (or aliased) constructions
+    root.find(j.NewExpression)
+        .filter((p) => {
+            const callee = p.node.callee
+            return (
+                callee.type === "Identifier" &&
+                localNames.has((callee as { name: string }).name)
+            )
+        })
+        .forEach((newPath) => {
+            let current = newPath.parent
+            while (current) {
+                const node: Node = current.node
+                if (
+                    node.type === "ExpressionStatement" ||
+                    node.type === "VariableDeclaration" ||
+                    node.type === "ReturnStatement" ||
+                    node.type === "ExportDefaultDeclaration" ||
+                    node.type === "ExportNamedDeclaration" ||
+                    node.type === "ClassProperty" ||
+                    node.type === "PropertyDefinition"
+                ) {
+                    const todoLine = ` TODO(typeorm-v1): \`ConnectionManager\` was removed — ${MIGRATION_HINT}`
+                    const nodeWithComments = node as Node & {
+                        comments?: { value: string }[]
+                    }
+                    const alreadyFlagged = nodeWithComments.comments?.some(
+                        (c) => c.value === todoLine,
+                    )
+                    if (!alreadyFlagged) {
+                        addTodoComment(
+                            node,
+                            `\`ConnectionManager\` was removed — ${MIGRATION_HINT}`,
+                            j,
+                        )
+                        hasChanges = true
+                        hasTodos = true
+                    }
+                    break
+                }
+                current = current.parent
+            }
+        })
+
+    // Remove `ConnectionManager` from imports. The class is gone, so
+    // leaving the specifier would produce a TypeScript error that adds
+    // noise on top of the TODO.
+    if (
+        removeImportSpecifiers(
+            root,
+            j,
+            "typeorm",
+            new Set(["ConnectionManager"]),
+        )
+    ) {
+        hasChanges = true
+    }
+
+    if (hasTodos) stats.count.todo(api, name, file)
+
+    return hasChanges ? root.toSource() : undefined
+}
+
+export const fn = connectionManager
+export default fn

--- a/packages/codemod/src/transforms/v1/connection-to-datasource.ts
+++ b/packages/codemod/src/transforms/v1/connection-to-datasource.ts
@@ -1,5 +1,11 @@
 import path from "node:path"
-import type { API, ASTNode, FileInfo, Identifier } from "jscodeshift"
+import type {
+    API,
+    ASTNode,
+    FileInfo,
+    Identifier,
+    ObjectPattern,
+} from "jscodeshift"
 import {
     forEachIdentifierParam,
     getStringValue,
@@ -162,10 +168,33 @@ export const connectionToDataSource = (file: FileInfo, api: API) => {
         }
     })
 
+    // Rewrite a single `{ X [: Y] }` property in a destructured require of
+    // typeorm. Records the local binding in `localRenames` so the shared
+    // NewExpression/TSTypeReference rewrite loop below picks it up.
+    const rewriteRequireDestructuredProperty = (
+        prop: ObjectPattern["properties"][number],
+    ): boolean => {
+        if (prop.type !== "Property" && prop.type !== "ObjectProperty") {
+            return false
+        }
+        if (prop.key.type !== "Identifier") return false
+        const oldImported: string = prop.key.name
+        const newName: string | undefined = typeRenames[oldImported]
+        if (!newName) return false
+
+        const localName: string =
+            prop.value.type === "Identifier" ? prop.value.name : oldImported
+        localRenames.set(localName, newName)
+
+        prop.key.name = newName
+        if (prop.value.type === "Identifier" && prop.shorthand) {
+            prop.value.name = newName
+        }
+        return true
+    }
+
     // CommonJS `require("typeorm[/...]")` — rewrite both the module path and
     // any destructured identifiers (`const { Connection } = require(...)`).
-    // Identifiers collected here are added to `localRenames` so the shared
-    // NewExpression/TSTypeReference rewrite loop below picks them up.
     root.find(j.CallExpression, {
         callee: { type: "Identifier", name: "require" },
     }).forEach((callPath) => {
@@ -179,39 +208,20 @@ export const connectionToDataSource = (file: FileInfo, api: API) => {
             return
         }
 
-        // Rewrite the require() path
         const rewrittenSource = rewriteTypeormPath(source)
         if (rewrittenSource !== source) {
             setStringValue(arg, rewrittenSource)
             hasChanges = true
         }
 
-        // Rewrite destructured identifiers on `const { X } = require(...)`
         const parent = callPath.parent.node
         if (parent.type !== "VariableDeclarator") return
         const id = parent.id
         if (id.type !== "ObjectPattern") return
 
-        for (const prop of id.properties) {
-            if (prop.type !== "Property" && prop.type !== "ObjectProperty") {
-                continue
-            }
-            if (prop.key.type !== "Identifier") continue
-            const oldImported: string = prop.key.name
-            const newName: string | undefined = typeRenames[oldImported]
-            if (!newName) continue
-
-            const localName: string =
-                prop.value.type === "Identifier" ? prop.value.name : oldImported
-            localRenames.set(localName, newName)
-
-            // Rename the source-side key
-            prop.key.name = newName
-            // When un-aliased (shorthand), rename the binding too
-            if (prop.value.type === "Identifier" && prop.shorthand) {
-                prop.value.name = newName
-            }
-            hasChanges = true
+        const pattern: ObjectPattern = id
+        for (const prop of pattern.properties) {
+            if (rewriteRequireDestructuredProperty(prop)) hasChanges = true
         }
     })
 
@@ -350,41 +360,40 @@ export const connectionToDataSource = (file: FileInfo, api: API) => {
         createQueryBuilder: "SelectQueryBuilder",
     }
 
-    root.find(j.VariableDeclarator).forEach((path) => {
-        if (path.node.id.type !== "Identifier") return
-        const init = path.node.init
-        if (!init) return
-
-        // `const X = dataSourceVar.manager`
+    // Returns the TypeORM type that a DataSource accessor chain resolves to
+    // (`ds.manager` → "EntityManager", `ds.getRepository(X)` → "Repository"),
+    // or null when the initializer isn't a recognized accessor-chain pattern.
+    const resolveAccessorChainType = (init: ASTNode): string | null => {
         if (init.type === "MemberExpression") {
             const baseName = unwrapIdentifierName(init.object)
             if (
-                baseName &&
-                connectionVarNames.has(baseName) &&
-                init.property.type === "Identifier"
+                !baseName ||
+                !connectionVarNames.has(baseName) ||
+                init.property.type !== "Identifier"
             ) {
-                const typeName = dataSourceMemberAccessors[init.property.name]
-                if (typeName && typesWithConnectionProp.has(typeName)) {
-                    connectionPropVarNames.add(path.node.id.name)
-                }
+                return null
             }
-            return
+            return dataSourceMemberAccessors[init.property.name] ?? null
         }
-
-        // `const X = dataSourceVar.getRepository(Y)`
         if (
             init.type === "CallExpression" &&
             init.callee.type === "MemberExpression" &&
             init.callee.property.type === "Identifier"
         ) {
             const baseName = unwrapIdentifierName(init.callee.object)
-            if (baseName && connectionVarNames.has(baseName)) {
-                const typeName =
-                    dataSourceCallAccessors[init.callee.property.name]
-                if (typeName && typesWithConnectionProp.has(typeName)) {
-                    connectionPropVarNames.add(path.node.id.name)
-                }
-            }
+            if (!baseName || !connectionVarNames.has(baseName)) return null
+            return dataSourceCallAccessors[init.callee.property.name] ?? null
+        }
+        return null
+    }
+
+    root.find(j.VariableDeclarator).forEach((path) => {
+        if (path.node.id.type !== "Identifier") return
+        if (!path.node.init) return
+
+        const typeName = resolveAccessorChainType(path.node.init)
+        if (typeName && typesWithConnectionProp.has(typeName)) {
+            connectionPropVarNames.add(path.node.id.name)
         }
     })
 

--- a/packages/codemod/src/transforms/v1/connection-to-datasource.ts
+++ b/packages/codemod/src/transforms/v1/connection-to-datasource.ts
@@ -75,8 +75,8 @@ export const connectionToDataSource = (file: FileInfo, api: API) => {
         close: "destroy",
     }
 
-    // TypeORM types whose instances have a `.connection` property
-    // that was renamed to `.dataSource` in v1
+    // TypeORM types whose instances had their `.connection` property renamed
+    // to `.dataSource` directly.
     const typesWithConnectionProp = new Set([
         "QueryRunner",
         "EntityManager",
@@ -89,8 +89,14 @@ export const connectionToDataSource = (file: FileInfo, api: API) => {
         "DeleteQueryBuilder",
         "SoftDeleteQueryBuilder",
         "RelationQueryBuilder",
-        // Metadata classes (renamed in #12249)
         "EntityMetadata",
+    ])
+
+    // Metadata types whose v0.3 `.connection` getter was removed entirely in
+    // v1 (renamed in #12249). Access now goes through `.entityMetadata.dataSource`
+    // — a naive `.dataSource` rewrite would produce invalid code because these
+    // classes never exposed a top-level `.dataSource` field.
+    const typesWithIndirectDataSource = new Set([
         "ColumnMetadata",
         "IndexMetadata",
     ])
@@ -318,6 +324,7 @@ export const connectionToDataSource = (file: FileInfo, api: API) => {
 
     // Collect variable/param names typed as TypeORM types with .connection
     const connectionPropVarNames = new Set<string>()
+    const indirectDataSourceVarNames = new Set<string>()
 
     const collectTypedIdentifier = (id: Identifier) => {
         if (!id.name || !id.typeAnnotation) return
@@ -327,11 +334,12 @@ export const connectionToDataSource = (file: FileInfo, api: API) => {
         if (ann.typeAnnotation.type !== "TSTypeReference") return
 
         const ref = ann.typeAnnotation
-        if (
-            ref.typeName.type === "Identifier" &&
-            typesWithConnectionProp.has(ref.typeName.name)
-        ) {
+        if (ref.typeName.type !== "Identifier") return
+
+        if (typesWithConnectionProp.has(ref.typeName.name)) {
             connectionPropVarNames.add(id.name)
+        } else if (typesWithIndirectDataSource.has(ref.typeName.name)) {
+            indirectDataSourceVarNames.add(id.name)
         }
     }
 
@@ -410,16 +418,30 @@ export const connectionToDataSource = (file: FileInfo, api: API) => {
         }
     })
 
-    // Rename .connection → .dataSource on known TypeORM instances
+    // Rename .connection → .dataSource on known TypeORM instances.
+    // For types without a direct `.dataSource` field (ColumnMetadata /
+    // IndexMetadata) the rename goes through `.entityMetadata.dataSource`.
     root.find(j.MemberExpression, {
         property: { name: "connection" },
     }).forEach((path) => {
-        if (path.node.property.type === "Identifier") {
-            const objName = unwrapIdentifierName(path.node.object)
-            if (objName && connectionPropVarNames.has(objName)) {
-                path.node.property.name = "dataSource"
-                hasChanges = true
-            }
+        if (path.node.property.type !== "Identifier") return
+        const objName = unwrapIdentifierName(path.node.object)
+        if (!objName) return
+
+        if (connectionPropVarNames.has(objName)) {
+            path.node.property.name = "dataSource"
+            hasChanges = true
+            return
+        }
+
+        if (indirectDataSourceVarNames.has(objName)) {
+            // `col.connection` → `col.entityMetadata.dataSource`
+            path.node.object = j.memberExpression(
+                path.node.object,
+                j.identifier("entityMetadata"),
+            )
+            path.node.property.name = "dataSource"
+            hasChanges = true
         }
     })
 

--- a/packages/codemod/src/transforms/v1/datasource-sqlite-options.ts
+++ b/packages/codemod/src/transforms/v1/datasource-sqlite-options.ts
@@ -23,14 +23,16 @@ const sqliteFamilyTypes = new Set([
 
 const isSqliteOptions = (obj: ObjectExpression): boolean => {
     for (const prop of obj.properties) {
-        if (
-            (prop.type === "Property" || prop.type === "ObjectProperty") &&
-            prop.key.type === "Identifier" &&
-            prop.key.name === "type"
-        ) {
-            const value = getStringValue(prop.value)
-            return value !== null && sqliteFamilyTypes.has(value)
+        if (prop.type !== "Property" && prop.type !== "ObjectProperty") {
+            continue
         }
+        const keyName =
+            prop.key.type === "Identifier"
+                ? prop.key.name
+                : getStringValue(prop.key)
+        if (keyName !== "type") continue
+        const value = getStringValue(prop.value)
+        return value !== null && sqliteFamilyTypes.has(value)
     }
     return false
 }
@@ -45,14 +47,18 @@ export const datasourceSqliteOptions = (file: FileInfo, api: API) => {
         if (!isSqliteOptions(objPath.node)) return
 
         for (const prop of objPath.node.properties) {
-            if (
-                (prop.type === "Property" || prop.type === "ObjectProperty") &&
-                prop.key.type === "Identifier" &&
-                prop.key.name === "busyTimeout"
-            ) {
-                prop.key.name = "timeout"
-                hasChanges = true
+            if (prop.type !== "Property" && prop.type !== "ObjectProperty") {
+                continue
             }
+            const keyName =
+                prop.key.type === "Identifier"
+                    ? prop.key.name
+                    : getStringValue(prop.key)
+            if (keyName !== "busyTimeout") continue
+            // Replace the key with an identifier — `"timeout"` doesn't need
+            // quoting and prettier would strip the quotes anyway.
+            prop.key = j.identifier("timeout")
+            hasChanges = true
         }
 
         if (removeObjectProperties(objPath.node, new Set(["flags"]))) {

--- a/packages/codemod/src/transforms/v1/global-functions.ts
+++ b/packages/codemod/src/transforms/v1/global-functions.ts
@@ -1,6 +1,13 @@
 import path from "node:path"
-import type { API, ASTPath, CallExpression, FileInfo, Node } from "jscodeshift"
-import type { Collection, JSCodeshift } from "jscodeshift"
+import type {
+    API,
+    ASTPath,
+    CallExpression,
+    Collection,
+    FileInfo,
+    JSCodeshift,
+    Node,
+} from "jscodeshift"
 import { getLocalNamesForImport, removeImportSpecifiers } from "../ast-helpers"
 import { addTodoComment } from "../todo"
 import { stats } from "../stats"

--- a/packages/codemod/src/transforms/v1/global-functions.ts
+++ b/packages/codemod/src/transforms/v1/global-functions.ts
@@ -74,6 +74,7 @@ const rewriteSimpleCall = (
 const annotateFirstDataSourceUsage = (
     root: Collection,
     j: JSCodeshift,
+    hadNamedConnection: boolean,
 ): void => {
     const [firstUsage] = root.find(j.Identifier, { name: "dataSource" }).paths()
     if (!firstUsage) return
@@ -82,11 +83,15 @@ const annotateFirstDataSourceUsage = (
     while (current.parent) {
         const node: Node = current.parent.node
         if (todoHostTypes.has(node.type)) {
-            addTodoComment(
-                node,
+            const messages = [
                 "`dataSource` is not defined — inject or import your DataSource instance",
-                j,
-            )
+            ]
+            if (hadNamedConnection) {
+                messages.push(
+                    'named connections were removed in v1 — if you relied on `getConnection("name")`, wire up a second DataSource and reference it here',
+                )
+            }
+            for (const message of messages) addTodoComment(node, message, j)
             return
         }
         current = current.parent
@@ -120,18 +125,22 @@ export const globalFunctions = (file: FileInfo, api: API) => {
         "getConnection",
     )
 
+    let hasNamedConnection = false
+
     if (callReplacements.size > 0 || getConnectionLocals.size > 0) {
         root.find(j.CallExpression).forEach((astPath) => {
             const callee = astPath.node.callee
             if (callee.type !== "Identifier") return
 
-            // getConnection() → dataSource (just a reference)
-            if (
-                getConnectionLocals.has(callee.name) &&
-                astPath.node.arguments.length === 0
-            ) {
+            // `getConnection()` → `dataSource`. Named connections are gone
+            // in v1 — rewrite `getConnection("name")` to `dataSource` too
+            // (the argument is dropped) and flag so the user knows to
+            // reconfigure for multi-DataSource setups.
+            if (getConnectionLocals.has(callee.name)) {
+                const hadArg = astPath.node.arguments.length > 0
                 j(astPath).replaceWith(j.identifier("dataSource"))
                 hasChanges = true
+                if (hadArg) hasNamedConnection = true
                 return
             }
 
@@ -148,7 +157,7 @@ export const globalFunctions = (file: FileInfo, api: API) => {
     }
 
     if (hasChanges) {
-        annotateFirstDataSourceUsage(root, j)
+        annotateFirstDataSourceUsage(root, j, hasNamedConnection)
         stats.count.todo(api, name, file)
     }
 

--- a/packages/codemod/src/transforms/v1/index.ts
+++ b/packages/codemod/src/transforms/v1/index.ts
@@ -1,6 +1,7 @@
 import * as columnReadonly from "./column-readonly"
 import * as columnUnsignedNumeric from "./column-unsigned-numeric"
 import * as columnWidthZerofill from "./column-width-zerofill"
+import * as connectionManager from "./connection-manager"
 import * as connectionToDataSource from "./connection-to-datasource"
 import * as datasourceMongodb from "./datasource-mongodb"
 import * as datasourceMssql from "./datasource-mssql"
@@ -71,6 +72,7 @@ export const transforms = [
     queryBuilderReplacePropertyNames,
     findOptionsStringSelect,
     findOptionsStringRelations,
+    connectionManager,
 ]
 
 export default transformer(transforms)

--- a/packages/codemod/test/cli/run-transforms.test.ts
+++ b/packages/codemod/test/cli/run-transforms.test.ts
@@ -1,4 +1,8 @@
 import { expect } from "chai"
+import fs from "node:fs/promises"
+import os from "node:os"
+import path from "node:path"
+import { run as jscodeshift } from "jscodeshift/src/Runner"
 import {
     DEFAULT_IGNORE_PATTERNS,
     buildIgnorePatterns,
@@ -35,6 +39,57 @@ describe("run-transforms", () => {
             const before = [...DEFAULT_IGNORE_PATTERNS]
             buildIgnorePatterns(["**/foo"])
             expect(DEFAULT_IGNORE_PATTERNS).to.deep.equal(before)
+        })
+    })
+
+    describe("jscodeshift integration with DEFAULT_IGNORE_PATTERNS", () => {
+        // Exercises the end-to-end guard: jscodeshift must honor the default
+        // ignore and leave ambient declaration files untouched even when the
+        // transform would otherwise rewrite them.
+        it("does not visit .d.ts files during a run", async () => {
+            const tmpDir = await fs.mkdtemp(
+                path.join(os.tmpdir(), "codemod-dts-"),
+            )
+            try {
+                const original = 'export type Foo = "bar"\n'
+                const dtsPath = path.join(tmpDir, "types.d.ts")
+                const tsPath = path.join(tmpDir, "code.ts")
+                await fs.writeFile(dtsPath, original)
+                await fs.writeFile(tsPath, original)
+
+                // A minimal transform that appends a marker to every file
+                // jscodeshift hands it.
+                const transformPath = path.join(tmpDir, "transform.cjs")
+                await fs.writeFile(
+                    transformPath,
+                    "module.exports = (file) => file.source + '// MARKER\\n'\n",
+                )
+
+                // Silence jscodeshift's progress output for the duration of
+                // the run — mocha's reporter doesn't need it.
+                const originalWrite = process.stdout.write.bind(process.stdout)
+                process.stdout.write = (() =>
+                    true) as typeof process.stdout.write
+                try {
+                    await jscodeshift(transformPath, [tmpDir], {
+                        dry: false,
+                        verbose: 0,
+                        extensions: "ts,tsx,js,jsx",
+                        parser: "tsx",
+                        ignorePattern: buildIgnorePatterns(),
+                    })
+                } finally {
+                    process.stdout.write = originalWrite
+                }
+
+                const dtsAfter = await fs.readFile(dtsPath, "utf8")
+                expect(dtsAfter).to.equal(original)
+
+                const tsAfter = await fs.readFile(tsPath, "utf8")
+                expect(tsAfter).to.include("// MARKER")
+            } finally {
+                await fs.rm(tmpDir, { recursive: true, force: true })
+            }
         })
     })
 })

--- a/packages/codemod/test/transforms/ast-helpers.test.ts
+++ b/packages/codemod/test/transforms/ast-helpers.test.ts
@@ -2,6 +2,7 @@ import { expect } from "chai"
 import jscodeshift, { type ASTNode } from "jscodeshift"
 import {
     fileImportsFrom,
+    getLocalNamesForImport,
     getStringValue,
     setStringValue,
 } from "../../src/transforms/ast-helpers"
@@ -94,6 +95,49 @@ describe("ast-helpers", () => {
         it("does not match require calls for other modules", () => {
             const root = j('const fs = require("node:fs")')
             expect(fileImportsFrom(root, j, "typeorm")).to.be.false
+        })
+    })
+
+    describe("getLocalNamesForImport", () => {
+        const localNames = (src: string) =>
+            [
+                ...getLocalNamesForImport(j(src), j, "typeorm", "getManager"),
+            ].sort()
+
+        it("finds ESM direct-import binding", () => {
+            expect(
+                localNames('import { getManager } from "typeorm"'),
+            ).to.deep.equal(["getManager"])
+        })
+
+        it("finds ESM aliased-import binding", () => {
+            expect(
+                localNames('import { getManager as gm } from "typeorm"'),
+            ).to.deep.equal(["gm"])
+        })
+
+        it("finds CommonJS destructured binding", () => {
+            expect(
+                localNames('const { getManager } = require("typeorm")'),
+            ).to.deep.equal(["getManager"])
+        })
+
+        it("finds CommonJS aliased-destructured binding", () => {
+            expect(
+                localNames('const { getManager: gm } = require("typeorm")'),
+            ).to.deep.equal(["gm"])
+        })
+
+        it("returns empty set for a name that is not imported", () => {
+            expect(localNames('import { other } from "typeorm"')).to.deep.equal(
+                [],
+            )
+        })
+
+        it("returns empty set for imports from a different module", () => {
+            expect(
+                localNames('import { getManager } from "other-lib"'),
+            ).to.deep.equal([])
         })
     })
 })

--- a/packages/codemod/test/transforms/v1/fixtures/connection-manager/connection-manager.input.ts
+++ b/packages/codemod/test/transforms/v1/fixtures/connection-manager/connection-manager.input.ts
@@ -6,3 +6,19 @@ const manager = new ConnectionManager()
 
 // Case 2: aliased instantiation
 const manager2 = new CM()
+
+// Case 3: instantiation inside a `throw` — previous allowlist missed this
+function mustFail() {
+    throw new ConnectionManager()
+}
+
+// Case 4: instantiation inside an `if` condition — previously missed
+if (new ConnectionManager()) {
+    console.log("never")
+}
+
+// Case 5: the class is only used as a type annotation — previously the
+// import was silently stripped leaving a broken reference.
+function create(): ConnectionManager {
+    return null as any
+}

--- a/packages/codemod/test/transforms/v1/fixtures/connection-manager/connection-manager.input.ts
+++ b/packages/codemod/test/transforms/v1/fixtures/connection-manager/connection-manager.input.ts
@@ -1,0 +1,8 @@
+import { ConnectionManager } from "typeorm"
+import { ConnectionManager as CM } from "typeorm"
+
+// Case 1: direct instantiation
+const manager = new ConnectionManager()
+
+// Case 2: aliased instantiation
+const manager2 = new CM()

--- a/packages/codemod/test/transforms/v1/fixtures/connection-manager/connection-manager.output.ts
+++ b/packages/codemod/test/transforms/v1/fixtures/connection-manager/connection-manager.output.ts
@@ -5,3 +5,21 @@ const manager = new ConnectionManager()
 // Case 2: aliased instantiation
 // TODO(typeorm-v1): `ConnectionManager` was removed — create and manage `DataSource` instances directly instead — there is no replacement class
 const manager2 = new CM()
+
+// Case 3: instantiation inside a `throw` — previous allowlist missed this
+function mustFail() {
+    // TODO(typeorm-v1): `ConnectionManager` was removed — create and manage `DataSource` instances directly instead — there is no replacement class
+    throw new ConnectionManager()
+}
+
+// Case 4: instantiation inside an `if` condition — previously missed
+// TODO(typeorm-v1): `ConnectionManager` was removed — create and manage `DataSource` instances directly instead — there is no replacement class
+if (new ConnectionManager()) {
+    console.log("never")
+}
+
+// Case 5: the class is only used as a type annotation — previously the
+// import was silently stripped leaving a broken reference.
+function create(): ConnectionManager {
+    return null as any
+}

--- a/packages/codemod/test/transforms/v1/fixtures/connection-manager/connection-manager.output.ts
+++ b/packages/codemod/test/transforms/v1/fixtures/connection-manager/connection-manager.output.ts
@@ -1,0 +1,7 @@
+// Case 1: direct instantiation
+// TODO(typeorm-v1): `ConnectionManager` was removed — create and manage `DataSource` instances directly instead — there is no replacement class
+const manager = new ConnectionManager()
+
+// Case 2: aliased instantiation
+// TODO(typeorm-v1): `ConnectionManager` was removed — create and manage `DataSource` instances directly instead — there is no replacement class
+const manager2 = new CM()

--- a/packages/codemod/test/transforms/v1/fixtures/connection-to-datasource/connection-to-datasource.input.ts
+++ b/packages/codemod/test/transforms/v1/fixtures/connection-to-datasource/connection-to-datasource.input.ts
@@ -45,13 +45,19 @@ const repoDs = repo.connection
 const qr = connection.createQueryRunner()
 const qrDs = qr.connection
 
-// Metadata types also had `.connection` renamed to `.dataSource` (#12249)
+// `EntityMetadata` exposes `.dataSource` directly in v1 — simple rename
 function useEntityMetadata(meta: EntityMetadata) {
     return meta.connection.getRepository(meta.target)
 }
 
+// `ColumnMetadata` / `IndexMetadata` never had `.dataSource` — access now
+// goes through `.entityMetadata.dataSource`
 function useColumnMetadata(col: ColumnMetadata) {
     return col.connection.driver
+}
+
+function useIndexMetadata(idx: IndexMetadata) {
+    return idx.connection.driver.options.type
 }
 
 // DataSource-typed parameter should also be tracked as a DataSource instance

--- a/packages/codemod/test/transforms/v1/fixtures/connection-to-datasource/connection-to-datasource.output.ts
+++ b/packages/codemod/test/transforms/v1/fixtures/connection-to-datasource/connection-to-datasource.output.ts
@@ -45,13 +45,19 @@ const repoDs = repo.dataSource
 const qr = connection.createQueryRunner()
 const qrDs = qr.dataSource
 
-// Metadata types also had `.connection` renamed to `.dataSource` (#12249)
+// `EntityMetadata` exposes `.dataSource` directly in v1 — simple rename
 function useEntityMetadata(meta: EntityMetadata) {
     return meta.dataSource.getRepository(meta.target)
 }
 
+// `ColumnMetadata` / `IndexMetadata` never had `.dataSource` — access now
+// goes through `.entityMetadata.dataSource`
 function useColumnMetadata(col: ColumnMetadata) {
-    return col.dataSource.driver
+    return col.entityMetadata.dataSource.driver
+}
+
+function useIndexMetadata(idx: IndexMetadata) {
+    return idx.entityMetadata.dataSource.driver.options.type
 }
 
 // DataSource-typed parameter should also be tracked as a DataSource instance

--- a/packages/codemod/test/transforms/v1/fixtures/datasource-sqlite-options/datasource-sqlite-options.input.ts
+++ b/packages/codemod/test/transforms/v1/fixtures/datasource-sqlite-options/datasource-sqlite-options.input.ts
@@ -21,3 +21,12 @@ const commanderOptions = {
     busyTimeout: 1000,
     flags: ["--verbose"],
 }
+
+// String-literal keys (e.g. JSON-style quoted `"busyTimeout"`) must also be rewritten
+// prettier-ignore
+const quoted = {
+    "type": "sqlite",
+    "database": "db.sqlite",
+    "busyTimeout": 3000,
+    "flags": ["OPEN_URI"],
+}

--- a/packages/codemod/test/transforms/v1/fixtures/datasource-sqlite-options/datasource-sqlite-options.output.ts
+++ b/packages/codemod/test/transforms/v1/fixtures/datasource-sqlite-options/datasource-sqlite-options.output.ts
@@ -19,3 +19,11 @@ const commanderOptions = {
     busyTimeout: 1000,
     flags: ["--verbose"],
 }
+
+// String-literal keys (e.g. JSON-style quoted `"busyTimeout"`) must also be rewritten
+// prettier-ignore
+const quoted = {
+    "type": "sqlite",
+    "database": "db.sqlite",
+    timeout: 3000
+}

--- a/packages/codemod/test/transforms/v1/fixtures/global-functions/global-functions.input.ts
+++ b/packages/codemod/test/transforms/v1/fixtures/global-functions/global-functions.input.ts
@@ -1,7 +1,18 @@
-import { getRepository, getManager, createQueryBuilder } from "typeorm"
+import {
+    getConnection,
+    getRepository,
+    getManager,
+    createQueryBuilder,
+} from "typeorm"
 import { getRepository as gr } from "typeorm"
 
 const repo = getRepository(User)
 const manager = getManager()
 const qb = createQueryBuilder("user")
 const postRepo = gr(Post)
+
+// getConnection() with no args → dataSource
+const ds = getConnection()
+
+// Named connections removed in v1 — argument is dropped, TODO flags manual reconfiguration
+const secondary = getConnection("secondary")

--- a/packages/codemod/test/transforms/v1/fixtures/global-functions/global-functions.output.ts
+++ b/packages/codemod/test/transforms/v1/fixtures/global-functions/global-functions.output.ts
@@ -1,5 +1,12 @@
 // TODO(typeorm-v1): `dataSource` is not defined — inject or import your DataSource instance
+// TODO(typeorm-v1): named connections were removed in v1 — if you relied on `getConnection("name")`, wire up a second DataSource and reference it here
 const repo = dataSource.getRepository(User)
 const manager = dataSource.manager
 const qb = dataSource.createQueryBuilder("user")
 const postRepo = dataSource.getRepository(Post)
+
+// getConnection() with no args → dataSource
+const ds = dataSource
+
+// Named connections removed in v1 — argument is dropped, TODO flags manual reconfiguration
+const secondary = dataSource


### PR DESCRIPTION
The `ConnectionManager` class was removed in v1 with no direct replacement — users must create and manage `DataSource` instances directly. The existing `global-functions` transform already handled the `getConnectionManager()` function, but `new ConnectionManager()` constructions were silently left in place.

### What this transform does

- Collects local names bound to TypeORM's `ConnectionManager` (including aliased imports like `import { ConnectionManager as CM } from "typeorm"`)
- Flags every `new ConnectionManager(...)` / `new CM(...)` with a TODO comment on the enclosing statement (variable declaration, return, export default / named declaration, class property, expression statement)
- Removes `ConnectionManager` from the `typeorm` import so the TypeScript error from the removed class doesn't stack on top of the TODO
- Scoped: only runs when the file imports `ConnectionManager` from `"typeorm"`

### Example

Input:
```ts
import { ConnectionManager } from "typeorm"
const manager = new ConnectionManager()
```

Output:
```ts
// TODO(typeorm-v1): `ConnectionManager` was removed — create and manage `DataSource` instances directly instead — there is no replacement class
const manager = new ConnectionManager()
```

### Follow-up

Re-export handling (`export { ConnectionManager } from "typeorm"`) is intentionally not included here — it will be covered once the re-export helpers from #12373 land on master.