### PR TITLE
fix(codemod): handle aliases, quoted keys, and ObjectProperty variants

### DIFF
--- a/packages/codemod/src/transforms/ast-helpers.ts
+++ b/packages/codemod/src/transforms/ast-helpers.ts
@@ -56,6 +56,40 @@ export const fileImportsFrom = (
 }
 
 /**
+ * Returns the set of local identifiers bound to a given named export.
+ * Handles direct imports and aliased imports:
+ *
+ *   import { RelationCount } from "typeorm"         → { "RelationCount" }
+ *   import { RelationCount as RC } from "typeorm"   → { "RC" }
+ */
+export const getLocalNamesForImport = (
+    root: Collection,
+    j: JSCodeshift,
+    moduleName: string,
+    importedName: string,
+): Set<string> => {
+    const localNames = new Set<string>()
+    root.find(j.ImportDeclaration, {
+        source: { value: moduleName },
+    }).forEach((importPath) => {
+        for (const spec of importPath.node.specifiers ?? []) {
+            if (
+                spec.type !== "ImportSpecifier" ||
+                spec.imported.type !== "Identifier" ||
+                spec.imported.name !== importedName
+            ) {
+                continue
+            }
+            const local = spec.local ?? spec.imported
+            if (local.type === "Identifier") {
+                localNames.add(local.name)
+            }
+        }
+    })
+    return localNames
+}
+
+/**
  * Calls `callback` for each Identifier parameter found in function-like
  * nodes (functions, methods, arrows) and TSParameterProperty nodes.
  */
@@ -113,6 +147,7 @@ export const forEachDecoratorObjectArg = (
 
 /**
  * Removes properties matching the given key names from an ObjectExpression.
+ * Matches both identifier keys (`name`) and string-literal keys (`"name"`).
  * Returns true if any properties were removed.
  */
 export const removeObjectProperties = (
@@ -122,14 +157,14 @@ export const removeObjectProperties = (
     const original = obj.properties.length
 
     obj.properties = obj.properties.filter((prop) => {
-        if (
-            (prop.type === "Property" || prop.type === "ObjectProperty") &&
-            prop.key.type === "Identifier" &&
-            propertyNames.has(prop.key.name)
-        ) {
-            return false
+        if (prop.type !== "Property" && prop.type !== "ObjectProperty") {
+            return true
         }
-        return true
+        const keyName =
+            prop.key.type === "Identifier"
+                ? prop.key.name
+                : getStringValue(prop.key)
+        return keyName === null ? true : !propertyNames.has(keyName)
     })
 
     return obj.properties.length !== original

--- a/packages/codemod/src/transforms/v1/column-readonly.ts
+++ b/packages/codemod/src/transforms/v1/column-readonly.ts
@@ -1,6 +1,6 @@
 import path from "node:path"
 import type { API, FileInfo } from "jscodeshift"
-import { forEachDecoratorObjectArg } from "../ast-helpers"
+import { forEachDecoratorObjectArg, getStringValue } from "../ast-helpers"
 
 export const name = path.basename(__filename, path.extname(__filename))
 export const description = "replace `readonly` column option with `update`"
@@ -12,23 +12,25 @@ export const columnReadonly = (file: FileInfo, api: API) => {
 
     forEachDecoratorObjectArg(root, j, (obj) => {
         for (const prop of obj.properties) {
+            if (prop.type !== "ObjectProperty") continue
+
+            const keyName =
+                prop.key.type === "Identifier"
+                    ? prop.key.name
+                    : getStringValue(prop.key)
+            if (keyName !== "readonly") continue
+
+            // readonly: true → update: false
+            // readonly: false → update: true
+            prop.key = j.identifier("update")
             if (
-                prop.type === "ObjectProperty" &&
-                prop.key.type === "Identifier" &&
-                prop.key.name === "readonly"
+                prop.value.type === "BooleanLiteral" ||
+                (prop.value.type === "Literal" &&
+                    typeof prop.value.value === "boolean")
             ) {
-                // readonly: true → update: false
-                // readonly: false → update: true
-                prop.key.name = "update"
-                if (
-                    prop.value.type === "BooleanLiteral" ||
-                    (prop.value.type === "Literal" &&
-                        typeof prop.value.value === "boolean")
-                ) {
-                    prop.value.value = !prop.value.value
-                }
-                hasChanges = true
+                prop.value.value = !prop.value.value
             }
+            hasChanges = true
         }
     })
 

--- a/packages/codemod/src/transforms/v1/column-readonly.ts
+++ b/packages/codemod/src/transforms/v1/column-readonly.ts
@@ -1,5 +1,5 @@
 import path from "node:path"
-import type { API, FileInfo } from "jscodeshift"
+import type { API, FileInfo, UnaryExpression } from "jscodeshift"
 import { forEachDecoratorObjectArg, getStringValue } from "../ast-helpers"
 
 export const name = path.basename(__filename, path.extname(__filename))
@@ -20,8 +20,9 @@ export const columnReadonly = (file: FileInfo, api: API) => {
                     : getStringValue(prop.key)
             if (keyName !== "readonly") continue
 
-            // readonly: true → update: false
-            // readonly: false → update: true
+            // readonly: true   → update: false
+            // readonly: false  → update: true
+            // readonly: <expr> → update: !<expr>
             prop.key = j.identifier("update")
             if (
                 prop.value.type === "BooleanLiteral" ||
@@ -29,6 +30,20 @@ export const columnReadonly = (file: FileInfo, api: API) => {
                     typeof prop.value.value === "boolean")
             ) {
                 prop.value.value = !prop.value.value
+            } else if (
+                prop.value.type === "UnaryExpression" &&
+                prop.value.operator === "!"
+            ) {
+                // `readonly: !flag` → `update: flag` (strip the existing NOT
+                // rather than double-negating).
+                prop.value = prop.value.argument
+            } else {
+                // `readonly: someVar` / `readonly: obj.flag` → `update: !(…)`
+                prop.value = j.unaryExpression(
+                    "!",
+                    prop.value as UnaryExpression["argument"],
+                    true,
+                )
             }
             hasChanges = true
         }

--- a/packages/codemod/src/transforms/v1/column-unsigned-numeric.ts
+++ b/packages/codemod/src/transforms/v1/column-unsigned-numeric.ts
@@ -47,12 +47,12 @@ export const columnUnsignedNumeric = (file: FileInfo, api: API) => {
         if (arg.type !== "ObjectExpression") return
 
         // Check if type is a numeric type
-        const typeProp = arg.properties.find(
-            (p) =>
-                p.type === "ObjectProperty" &&
-                p.key.type === "Identifier" &&
-                p.key.name === "type",
-        )
+        const typeProp = arg.properties.find((p) => {
+            if (p.type !== "ObjectProperty") return false
+            const keyName =
+                p.key.type === "Identifier" ? p.key.name : getStringValue(p.key)
+            return keyName === "type"
+        })
 
         if (typeProp?.type !== "ObjectProperty") return
 

--- a/packages/codemod/src/transforms/v1/datasource-sap.ts
+++ b/packages/codemod/src/transforms/v1/datasource-sap.ts
@@ -1,6 +1,6 @@
 import path from "node:path"
-import type { API, FileInfo } from "jscodeshift"
-import { fileImportsFrom } from "../ast-helpers"
+import type { API, ASTNode, FileInfo, ObjectProperty } from "jscodeshift"
+import { fileImportsFrom, getStringValue, setStringValue } from "../ast-helpers"
 
 export const name = path.basename(__filename, path.extname(__filename))
 export const description =
@@ -26,15 +26,27 @@ export const datasourceSap = (file: FileInfo, api: API) => {
 
     const poolRemoves = new Set(["min", "maxWaitingRequests", "checkInterval"])
 
+    const getKeyName = (key: ASTNode): string | null => {
+        if (key.type === "Identifier") return key.name
+        return getStringValue(key)
+    }
+
+    const renameKey = (key: ASTNode, newName: string): void => {
+        if (key.type === "Identifier") {
+            key.name = newName
+        } else {
+            setStringValue(key, newName)
+        }
+    }
+
     // Rename top-level options
     root.find(j.ObjectProperty).forEach((path) => {
-        if (path.node.key.type !== "Identifier") return
-
-        const name = path.node.key.name
+        const name = getKeyName(path.node.key)
+        if (name === null) return
 
         // Top-level renames
         if (topLevelRenames[name]) {
-            path.node.key.name = topLevelRenames[name]
+            renameKey(path.node.key, topLevelRenames[name])
             hasChanges = true
             return
         }
@@ -45,19 +57,15 @@ export const datasourceSap = (file: FileInfo, api: API) => {
             if (parent.node.type !== "ObjectExpression") return
 
             const grandparent = parent.parent
-            if (
-                grandparent.node.type !== "ObjectProperty" ||
-                grandparent.node.key.type !== "Identifier" ||
-                grandparent.node.key.name !== "pool"
-            ) {
-                return
-            }
+            if (grandparent.node.type !== "ObjectProperty") return
+            const gpNode = grandparent.node as ObjectProperty
+            if (getKeyName(gpNode.key) !== "pool") return
 
             if (poolRemoves.has(name)) {
                 j(path).remove()
                 hasChanges = true
             } else if (poolRenames[name]) {
-                path.node.key.name = poolRenames[name]
+                renameKey(path.node.key, poolRenames[name])
                 hasChanges = true
             }
         }

--- a/packages/codemod/src/transforms/v1/find-options-lock-modes.ts
+++ b/packages/codemod/src/transforms/v1/find-options-lock-modes.ts
@@ -96,9 +96,12 @@ export const findOptionsLockModes = (file: FileInfo, api: API) => {
         )
 
         if (!hasOnLocked) {
+            // Use `objectProperty` (Babel builder) rather than `property` so
+            // the injected node matches the sibling nodes produced by the
+            // `tsx` parser — avoids mixing `Property` and `ObjectProperty`
+            // inside the same `ObjectExpression.properties` array.
             lockObj.properties.push(
-                j.property(
-                    "init",
+                j.objectProperty(
                     j.identifier("onLocked"),
                     j.stringLiteral(replacement.onLocked),
                 ),

--- a/packages/codemod/src/transforms/v1/find-options-lock-modes.ts
+++ b/packages/codemod/src/transforms/v1/find-options-lock-modes.ts
@@ -1,6 +1,14 @@
 import path from "node:path"
-import type { API, FileInfo, ObjectExpression } from "jscodeshift"
-import { getStringValue, setStringValue } from "../ast-helpers"
+import type {
+    API,
+    ASTNode,
+    ASTPath,
+    FileInfo,
+    ObjectExpression,
+    ObjectProperty,
+    Property,
+} from "jscodeshift"
+import { fileImportsFrom, getStringValue, setStringValue } from "../ast-helpers"
 
 export const name = path.basename(__filename, path.extname(__filename))
 export const description = "replace deprecated pessimistic lock modes"
@@ -8,6 +16,9 @@ export const description = "replace deprecated pessimistic lock modes"
 export const findOptionsLockModes = (file: FileInfo, api: API) => {
     const j = api.jscodeshift
     const root = j(file.source)
+
+    if (!fileImportsFrom(root, j, "typeorm")) return undefined
+
     let hasChanges = false
 
     const lockModeMap: Record<string, { mode: string; onLocked: string }> = {
@@ -51,36 +62,37 @@ export const findOptionsLockModes = (file: FileInfo, api: API) => {
 
     // Handle find options: { lock: { mode: "pessimistic_partial_write" } }
     // → { lock: { mode: "pessimistic_write", onLocked: "skip_locked" } }
-    root.find(j.ObjectProperty, {
-        key: { name: "mode" },
-    }).forEach((path) => {
-        const value = getStringValue(path.node.value)
+    // Match both Property (Esprima) and ObjectProperty (Babel) node shapes.
+    const keyNameOf = (key: ASTNode): string | null =>
+        key.type === "Identifier" ? key.name : getStringValue(key)
+
+    const visitModeProperty = (astPath: ASTPath<Property | ObjectProperty>) => {
+        if (keyNameOf(astPath.node.key) !== "mode") return
+
+        const value = getStringValue(astPath.node.value)
         if (!value || !lockModeMap[value]) return
 
-        // Check parent is a lock options object
-        if (path.parent.node.type !== "ObjectExpression") return
-        const lockObj: ObjectExpression = path.parent.node
+        if (astPath.parent.node.type !== "ObjectExpression") return
+        const lockObj: ObjectExpression = astPath.parent.node
 
-        const grandparent = path.parent.parent
+        const grandparent = astPath.parent.parent.node
         if (
-            grandparent.node.type !== "Property" ||
-            grandparent.node.key.type !== "Identifier" ||
-            grandparent.node.key.name !== "lock"
+            grandparent.type !== "Property" &&
+            grandparent.type !== "ObjectProperty"
         ) {
             return
         }
+        const gpKey = (grandparent as Property | ObjectProperty).key
+        if (keyNameOf(gpKey) !== "lock") return
 
         const replacement = lockModeMap[value]
 
-        // Update mode value
-        setStringValue(path.node.value, replacement.mode)
+        setStringValue(astPath.node.value, replacement.mode)
 
-        // Add onLocked property to the lock object
         const hasOnLocked = lockObj.properties.some(
-            (p: ObjectExpression["properties"][number]) =>
-                p.type === "Property" &&
-                p.key.type === "Identifier" &&
-                p.key.name === "onLocked",
+            (p) =>
+                (p.type === "Property" || p.type === "ObjectProperty") &&
+                keyNameOf(p.key) === "onLocked",
         )
 
         if (!hasOnLocked) {
@@ -94,7 +106,10 @@ export const findOptionsLockModes = (file: FileInfo, api: API) => {
         }
 
         hasChanges = true
-    })
+    }
+
+    root.find(j.Property).forEach(visitModeProperty)
+    root.find(j.ObjectProperty).forEach(visitModeProperty)
 
     return hasChanges ? root.toSource() : undefined
 }

--- a/packages/codemod/src/transforms/v1/global-functions.ts
+++ b/packages/codemod/src/transforms/v1/global-functions.ts
@@ -1,6 +1,6 @@
 import path from "node:path"
 import type { API, FileInfo, Node } from "jscodeshift"
-import { removeImportSpecifiers } from "../ast-helpers"
+import { getLocalNamesForImport, removeImportSpecifiers } from "../ast-helpers"
 import { addTodoComment } from "../todo"
 import { stats } from "../stats"
 
@@ -39,11 +39,17 @@ export const globalFunctions = (file: FileInfo, api: API) => {
         getMongoRepository: "dataSource.getMongoRepository",
     }
 
-    // Replace function calls
+    // Replace function calls. For each imported canonical name, resolve its
+    // set of local names (including aliases like `import { getManager as gm }`)
+    // and match call expressions against those.
     for (const [funcName, replacement] of Object.entries(simpleReplacements)) {
-        root.find(j.CallExpression, {
-            callee: { type: "Identifier", name: funcName },
-        }).forEach((path) => {
+        const localNames = getLocalNamesForImport(root, j, "typeorm", funcName)
+        if (localNames.size === 0) continue
+        root.find(j.CallExpression).forEach((path) => {
+            const callee = path.node.callee
+            if (callee.type !== "Identifier" || !localNames.has(callee.name)) {
+                return
+            }
             const parts = replacement.split(".")
             if (parts.length === 2 && !replacement.includes("(")) {
                 // Property access like dataSource.manager — check if it's called with no args
@@ -76,14 +82,26 @@ export const globalFunctions = (file: FileInfo, api: API) => {
     }
 
     // getConnection() → dataSource (just a reference)
-    root.find(j.CallExpression, {
-        callee: { type: "Identifier", name: "getConnection" },
-    }).forEach((path) => {
-        if (path.node.arguments.length === 0) {
+    const getConnectionLocals = getLocalNamesForImport(
+        root,
+        j,
+        "typeorm",
+        "getConnection",
+    )
+    if (getConnectionLocals.size > 0) {
+        root.find(j.CallExpression).forEach((path) => {
+            const callee = path.node.callee
+            if (
+                callee.type !== "Identifier" ||
+                !getConnectionLocals.has(callee.name) ||
+                path.node.arguments.length !== 0
+            ) {
+                return
+            }
             j(path).replaceWith(j.identifier("dataSource"))
             hasChanges = true
-        }
-    })
+        })
+    }
 
     // Remove imports of deprecated globals from "typeorm"
     if (removeImportSpecifiers(root, j, "typeorm", removedGlobals)) {

--- a/packages/codemod/src/transforms/v1/global-functions.ts
+++ b/packages/codemod/src/transforms/v1/global-functions.ts
@@ -39,66 +39,72 @@ export const globalFunctions = (file: FileInfo, api: API) => {
         getMongoRepository: "dataSource.getMongoRepository",
     }
 
-    // Replace function calls. For each imported canonical name, resolve its
-    // set of local names (including aliases like `import { getManager as gm }`)
-    // and match call expressions against those.
+    // Resolve the local names (including aliases such as
+    // `import { getManager as gm } from "typeorm"`) for every function we
+    // know how to rewrite, then replace all matching call-sites in a single
+    // pass over `CallExpression` nodes.
+    const callReplacements = new Map<string, string>()
     for (const [funcName, replacement] of Object.entries(simpleReplacements)) {
-        const localNames = getLocalNamesForImport(root, j, "typeorm", funcName)
-        if (localNames.size === 0) continue
-        root.find(j.CallExpression).forEach((path) => {
-            const callee = path.node.callee
-            if (callee.type !== "Identifier" || !localNames.has(callee.name)) {
-                return
-            }
-            const parts = replacement.split(".")
-            if (parts.length === 2 && !replacement.includes("(")) {
-                // Property access like dataSource.manager — check if it's called with no args
-                if (
-                    path.node.arguments.length === 0 &&
-                    !replacement.includes("get")
-                ) {
-                    // Replace with property access
-                    j(path).replaceWith(
-                        j.memberExpression(
-                            j.identifier(parts[0]),
-                            j.identifier(parts[1]),
-                        ),
-                    )
-                } else {
-                    // Replace with method call
-                    j(path).replaceWith(
-                        j.callExpression(
-                            j.memberExpression(
-                                j.identifier(parts[0]),
-                                j.identifier(parts[1]),
-                            ),
-                            path.node.arguments,
-                        ),
-                    )
-                }
-                hasChanges = true
-            }
-        })
+        for (const localName of getLocalNamesForImport(
+            root,
+            j,
+            "typeorm",
+            funcName,
+        )) {
+            callReplacements.set(localName, replacement)
+        }
     }
-
-    // getConnection() → dataSource (just a reference)
     const getConnectionLocals = getLocalNamesForImport(
         root,
         j,
         "typeorm",
         "getConnection",
     )
-    if (getConnectionLocals.size > 0) {
+
+    if (callReplacements.size > 0 || getConnectionLocals.size > 0) {
         root.find(j.CallExpression).forEach((path) => {
             const callee = path.node.callee
+            if (callee.type !== "Identifier") return
+
+            // getConnection() → dataSource (just a reference)
             if (
-                callee.type !== "Identifier" ||
-                !getConnectionLocals.has(callee.name) ||
-                path.node.arguments.length !== 0
+                getConnectionLocals.has(callee.name) &&
+                path.node.arguments.length === 0
             ) {
+                j(path).replaceWith(j.identifier("dataSource"))
+                hasChanges = true
                 return
             }
-            j(path).replaceWith(j.identifier("dataSource"))
+
+            const replacement = callReplacements.get(callee.name)
+            if (!replacement) return
+
+            const parts = replacement.split(".")
+            if (parts.length !== 2 || replacement.includes("(")) return
+
+            if (
+                path.node.arguments.length === 0 &&
+                !replacement.includes("get")
+            ) {
+                // Property access like `dataSource.manager`
+                j(path).replaceWith(
+                    j.memberExpression(
+                        j.identifier(parts[0]),
+                        j.identifier(parts[1]),
+                    ),
+                )
+            } else {
+                // Method call like `dataSource.getRepository(User)`
+                j(path).replaceWith(
+                    j.callExpression(
+                        j.memberExpression(
+                            j.identifier(parts[0]),
+                            j.identifier(parts[1]),
+                        ),
+                        path.node.arguments,
+                    ),
+                )
+            }
             hasChanges = true
         })
     }

--- a/packages/codemod/src/transforms/v1/query-builder-or-update.ts
+++ b/packages/codemod/src/transforms/v1/query-builder-or-update.ts
@@ -1,5 +1,6 @@
 import path from "node:path"
 import type { API, FileInfo, ObjectProperty } from "jscodeshift"
+import { getStringValue } from "../ast-helpers"
 
 export const name = path.basename(__filename, path.extname(__filename))
 export const description =
@@ -28,11 +29,15 @@ export const queryBuilderOrUpdate = (file: FileInfo, api: API) => {
 
         for (const prop of arg.properties) {
             if (prop.type !== "ObjectProperty") continue
-            if (prop.key.type !== "Identifier") continue
 
-            if (prop.key.name === "conflict_target") {
+            const keyName =
+                prop.key.type === "Identifier"
+                    ? prop.key.name
+                    : getStringValue(prop.key)
+
+            if (keyName === "conflict_target") {
                 conflictTarget = prop.value
-            } else if (prop.key.name === "overwrite") {
+            } else if (keyName === "overwrite") {
                 overwrite = prop.value
             }
         }

--- a/packages/codemod/src/transforms/v1/relation-count.ts
+++ b/packages/codemod/src/transforms/v1/relation-count.ts
@@ -1,5 +1,5 @@
 import path from "node:path"
-import type { API, FileInfo, Node } from "jscodeshift"
+import type { API, ClassProperty, Decorator, FileInfo } from "jscodeshift"
 import { getLocalNamesForImport, removeImportSpecifiers } from "../ast-helpers"
 import { addTodoComment } from "../todo"
 import { stats } from "../stats"
@@ -26,25 +26,27 @@ export const relationCount = (file: FileInfo, api: API) => {
     )
 
     if (localNames.size > 0) {
-        // Find @<localName>(...) decorators and add TODO to the enclosing
-        // class property (decorator-attached comments get dropped by recast).
+        // Decorators live on `ClassProperty.decorators` but jscodeshift's
+        // default visitor does not descend into that array, so
+        // `root.find(j.Decorator)` is a no-op with the `tsx` parser. Walk the
+        // class properties explicitly instead and attach the TODO to the
+        // property itself (decorator-attached comments are dropped by recast).
         const message =
             "`@RelationCount` was removed — use `QueryBuilder` with `loadRelationCountAndMap()` instead"
-        root.find(j.Decorator).forEach((decoratorPath) => {
-            const expr = decoratorPath.node.expression
-            if (
-                expr.type !== "CallExpression" ||
-                expr.callee.type !== "Identifier" ||
-                !localNames.has(expr.callee.name)
-            ) {
-                return
+        root.find(j.ClassProperty).forEach((propertyPath) => {
+            const node = propertyPath.node as ClassProperty & {
+                decorators?: Decorator[]
             }
-            const parentNode: Node = decoratorPath.parent.node
-            const target: Node =
-                parentNode.type === "ClassProperty"
-                    ? parentNode
-                    : decoratorPath.node
-            addTodoComment(target, message, j)
+            const matches = node.decorators?.some((decorator) => {
+                const expr = decorator.expression
+                return (
+                    expr.type === "CallExpression" &&
+                    expr.callee.type === "Identifier" &&
+                    localNames.has(expr.callee.name)
+                )
+            })
+            if (!matches) return
+            addTodoComment(node, message, j)
             hasChanges = true
             hasTodos = true
         })

--- a/packages/codemod/src/transforms/v1/relation-count.ts
+++ b/packages/codemod/src/transforms/v1/relation-count.ts
@@ -1,6 +1,6 @@
 import path from "node:path"
-import type { API, FileInfo } from "jscodeshift"
-import { removeImportSpecifiers } from "../ast-helpers"
+import type { API, FileInfo, Node } from "jscodeshift"
+import { getLocalNamesForImport, removeImportSpecifiers } from "../ast-helpers"
 import { addTodoComment } from "../todo"
 import { stats } from "../stats"
 
@@ -15,21 +15,40 @@ export const relationCount = (file: FileInfo, api: API) => {
     let hasChanges = false
     let hasTodos = false
 
-    // Find @RelationCount decorators and add TODO
-    root.find(j.Decorator, {
-        expression: {
-            type: "CallExpression",
-            callee: { type: "Identifier", name: "RelationCount" },
-        },
-    }).forEach((path) => {
-        addTodoComment(
-            path.node,
-            "`@RelationCount` was removed — use `QueryBuilder` with `loadRelationCountAndMap()` instead",
-            j,
-        )
-        hasChanges = true
-        hasTodos = true
-    })
+    // Collect local names bound to `RelationCount` from typeorm — including aliases:
+    //   import { RelationCount } from "typeorm"          → "RelationCount"
+    //   import { RelationCount as RC } from "typeorm"    → "RC"
+    const localNames = getLocalNamesForImport(
+        root,
+        j,
+        "typeorm",
+        "RelationCount",
+    )
+
+    if (localNames.size > 0) {
+        // Find @<localName>(...) decorators and add TODO to the enclosing
+        // class property (decorator-attached comments get dropped by recast).
+        const message =
+            "`@RelationCount` was removed — use `QueryBuilder` with `loadRelationCountAndMap()` instead"
+        root.find(j.Decorator).forEach((decoratorPath) => {
+            const expr = decoratorPath.node.expression
+            if (
+                expr.type !== "CallExpression" ||
+                expr.callee.type !== "Identifier" ||
+                !localNames.has(expr.callee.name)
+            ) {
+                return
+            }
+            const parentNode: Node = decoratorPath.parent.node
+            const target: Node =
+                parentNode.type === "ClassProperty"
+                    ? parentNode
+                    : decoratorPath.node
+            addTodoComment(target, message, j)
+            hasChanges = true
+            hasTodos = true
+        })
+    }
 
     // Remove RelationCount import from typeorm
     if (

--- a/packages/codemod/test/transforms/v1/fixtures/column-readonly/column-readonly.input.ts
+++ b/packages/codemod/test/transforms/v1/fixtures/column-readonly/column-readonly.input.ts
@@ -1,11 +1,22 @@
 import { Column } from "typeorm"
 
+declare const isReadonly: boolean
+declare const flag: boolean
+
 class Post {
     @Column({ readonly: true })
     authorName: string
 
     @Column({ readonly: false })
     updatedAt: Date
+
+    // Non-literal value — must be negated, not just renamed
+    @Column({ readonly: isReadonly })
+    title: string
+
+    // Existing `!<expr>` — the NOT should be stripped rather than doubled
+    @Column({ readonly: !flag })
+    body: string
 }
 
 // Should NOT be transformed — not a @Column decorator

--- a/packages/codemod/test/transforms/v1/fixtures/column-readonly/column-readonly.input.ts
+++ b/packages/codemod/test/transforms/v1/fixtures/column-readonly/column-readonly.input.ts
@@ -3,6 +3,9 @@ import { Column } from "typeorm"
 class Post {
     @Column({ readonly: true })
     authorName: string
+
+    @Column({ readonly: false })
+    updatedAt: Date
 }
 
 // Should NOT be transformed — not a @Column decorator

--- a/packages/codemod/test/transforms/v1/fixtures/column-readonly/column-readonly.output.ts
+++ b/packages/codemod/test/transforms/v1/fixtures/column-readonly/column-readonly.output.ts
@@ -1,11 +1,22 @@
 import { Column } from "typeorm"
 
+declare const isReadonly: boolean
+declare const flag: boolean
+
 class Post {
     @Column({ update: false })
     authorName: string
 
     @Column({ update: true })
     updatedAt: Date
+
+    // Non-literal value — must be negated, not just renamed
+    @Column({ update: !isReadonly })
+    title: string
+
+    // Existing `!<expr>` — the NOT should be stripped rather than doubled
+    @Column({ update: flag })
+    body: string
 }
 
 // Should NOT be transformed — not a @Column decorator

--- a/packages/codemod/test/transforms/v1/fixtures/column-readonly/column-readonly.output.ts
+++ b/packages/codemod/test/transforms/v1/fixtures/column-readonly/column-readonly.output.ts
@@ -3,6 +3,9 @@ import { Column } from "typeorm"
 class Post {
     @Column({ update: false })
     authorName: string
+
+    @Column({ update: true })
+    updatedAt: Date
 }
 
 // Should NOT be transformed — not a @Column decorator

--- a/packages/codemod/test/transforms/v1/fixtures/column-width-zerofill/column-width-zerofill.input.ts
+++ b/packages/codemod/test/transforms/v1/fixtures/column-width-zerofill/column-width-zerofill.input.ts
@@ -3,6 +3,9 @@ import { Column } from "typeorm"
 class Post {
     @Column({ type: "int", width: 9, zerofill: true })
     postCode: number
+
+    @Column({ type: "int", width: 4, zerofill: false })
+    areaCode: number
 }
 
 // Should NOT be transformed — not a @Column decorator

--- a/packages/codemod/test/transforms/v1/fixtures/column-width-zerofill/column-width-zerofill.output.ts
+++ b/packages/codemod/test/transforms/v1/fixtures/column-width-zerofill/column-width-zerofill.output.ts
@@ -5,6 +5,11 @@ class Post {
         type: "int",
     })
     postCode: number
+
+    @Column({
+        type: "int",
+    })
+    areaCode: number
 }
 
 // Should NOT be transformed — not a @Column decorator

--- a/packages/codemod/test/transforms/v1/fixtures/find-options-lock-modes/find-options-lock-modes.input.ts
+++ b/packages/codemod/test/transforms/v1/fixtures/find-options-lock-modes/find-options-lock-modes.input.ts
@@ -3,8 +3,14 @@ import "typeorm"
 await queryBuilder.setLock("pessimistic_partial_write").getMany()
 await queryBuilder.setLock("pessimistic_write_or_fail").getMany()
 
-// Find options form
-const users = await repository.find({
+// Find options form — skip_locked variant
+const skipLockedUsers = await repository.find({
     where: { id: 1 },
     lock: { mode: "pessimistic_partial_write" },
+})
+
+// Find options form — nowait variant
+const nowaitUsers = await repository.find({
+    where: { id: 2 },
+    lock: { mode: "pessimistic_write_or_fail" },
 })

--- a/packages/codemod/test/transforms/v1/fixtures/find-options-lock-modes/find-options-lock-modes.input.ts
+++ b/packages/codemod/test/transforms/v1/fixtures/find-options-lock-modes/find-options-lock-modes.input.ts
@@ -1,2 +1,10 @@
+import "typeorm"
+
 await queryBuilder.setLock("pessimistic_partial_write").getMany()
 await queryBuilder.setLock("pessimistic_write_or_fail").getMany()
+
+// Find options form
+const users = await repository.find({
+    where: { id: 1 },
+    lock: { mode: "pessimistic_partial_write" },
+})

--- a/packages/codemod/test/transforms/v1/fixtures/find-options-lock-modes/find-options-lock-modes.output.ts
+++ b/packages/codemod/test/transforms/v1/fixtures/find-options-lock-modes/find-options-lock-modes.output.ts
@@ -6,11 +6,20 @@ await queryBuilder
     .getMany()
 await queryBuilder.setLock("pessimistic_write").setOnLocked("nowait").getMany()
 
-// Find options form
-const users = await repository.find({
+// Find options form — skip_locked variant
+const skipLockedUsers = await repository.find({
     where: { id: 1 },
     lock: {
         mode: "pessimistic_write",
         onLocked: "skip_locked",
+    },
+})
+
+// Find options form — nowait variant
+const nowaitUsers = await repository.find({
+    where: { id: 2 },
+    lock: {
+        mode: "pessimistic_write",
+        onLocked: "nowait",
     },
 })

--- a/packages/codemod/test/transforms/v1/fixtures/find-options-lock-modes/find-options-lock-modes.output.ts
+++ b/packages/codemod/test/transforms/v1/fixtures/find-options-lock-modes/find-options-lock-modes.output.ts
@@ -1,5 +1,16 @@
+import "typeorm"
+
 await queryBuilder
     .setLock("pessimistic_write")
     .setOnLocked("skip_locked")
     .getMany()
 await queryBuilder.setLock("pessimistic_write").setOnLocked("nowait").getMany()
+
+// Find options form
+const users = await repository.find({
+    where: { id: 1 },
+    lock: {
+        mode: "pessimistic_write",
+        onLocked: "skip_locked",
+    },
+})

--- a/packages/codemod/test/transforms/v1/fixtures/global-functions/global-functions.input.ts
+++ b/packages/codemod/test/transforms/v1/fixtures/global-functions/global-functions.input.ts
@@ -1,5 +1,7 @@
 import { getRepository, getManager, createQueryBuilder } from "typeorm"
+import { getRepository as gr } from "typeorm"
 
 const repo = getRepository(User)
 const manager = getManager()
 const qb = createQueryBuilder("user")
+const postRepo = gr(Post)

--- a/packages/codemod/test/transforms/v1/fixtures/global-functions/global-functions.output.ts
+++ b/packages/codemod/test/transforms/v1/fixtures/global-functions/global-functions.output.ts
@@ -2,3 +2,4 @@
 const repo = dataSource.getRepository(User)
 const manager = dataSource.manager
 const qb = dataSource.createQueryBuilder("user")
+const postRepo = dataSource.getRepository(Post)

--- a/packages/codemod/test/transforms/v1/fixtures/relation-count/relation-count.input.ts
+++ b/packages/codemod/test/transforms/v1/fixtures/relation-count/relation-count.input.ts
@@ -1,7 +1,11 @@
 import { Entity, RelationCount } from "typeorm"
+import { RelationCount as RC } from "typeorm"
 
 @Entity()
 class Post {
     @RelationCount((post: Post) => post.categories)
     categoryCount: number
+
+    @RC((post: Post) => post.tags)
+    tagCount: number
 }

--- a/packages/codemod/test/transforms/v1/fixtures/relation-count/relation-count.output.ts
+++ b/packages/codemod/test/transforms/v1/fixtures/relation-count/relation-count.output.ts
@@ -4,4 +4,7 @@ import { Entity } from "typeorm"
 class Post {
     @RelationCount((post: Post) => post.categories)
     categoryCount: number
+
+    @RC((post: Post) => post.tags)
+    tagCount: number
 }

--- a/packages/codemod/test/transforms/v1/fixtures/relation-count/relation-count.output.ts
+++ b/packages/codemod/test/transforms/v1/fixtures/relation-count/relation-count.output.ts
@@ -2,9 +2,11 @@ import { Entity } from "typeorm"
 
 @Entity()
 class Post {
+    // TODO(typeorm-v1): `@RelationCount` was removed — use `QueryBuilder` with `loadRelationCountAndMap()` instead
     @RelationCount((post: Post) => post.categories)
     categoryCount: number
 
+    // TODO(typeorm-v1): `@RelationCount` was removed — use `QueryBuilder` with `loadRelationCountAndMap()` instead
     @RC((post: Post) => post.tags)
     tagCount: number
 }


### PR DESCRIPTION
Four partial-coverage fixes for v1 transforms uncovered during a full audit. Each addresses a case where a transform silently skipped user code it should have handled.

### Alias blindness

`@RelationCount` and the global-function transforms matched decorators and calls by the canonical name only. `import { RelationCount as RC } from "typeorm"` → `@RC(...)` was silently skipped while the `RelationCount` import was still removed — leaving code that no longer compiled.

A new `getLocalNamesForImport(root, j, moduleName, importedName)` helper in `ast-helpers.ts` returns the set of local identifiers bound to a named export, including aliases. `relation-count` and `global-functions` now resolve this set and match against it.

### `find-options-lock-modes` — `Property` / `ObjectProperty` mismatch

The `{ lock: { mode: "pessimistic_partial_write" } }` find-options migration looked up `j.ObjectProperty` but walked the grandparent checking for `"Property"`. On Babel-parsed files (what the CLI uses via the `tsx` parser) the grandparent is `ObjectProperty`, so the entire lock-object migration silently no-op'd. Fixed by accepting both node shapes and visiting both property types. Also adds the missing `fileImportsFrom` scope guard.

### Quoted-key handling

`removeObjectProperties` matched identifier keys only, so `{ "width": 9 }` wasn't matched even though it's valid JS. The helper now matches both `name:` and `"name":` keys. Targeted fixes applied to `column-readonly`, `column-unsigned-numeric` (for the `type` key lookup), `datasource-sap`, and `query-builder-or-update` — all of which had their own hardcoded `Identifier` key checks.

### Fixtures

Extended fixtures with alias cases (`relation-count`, `global-functions`), a lock-object case (`find-options-lock-modes`), and a second decorator (`column-readonly`, `column-width-zerofill`).
