### PR TITLE
fix(codemod): make TODOs idempotent, extend attachment, surface errors

### DIFF
--- a/packages/codemod/README.md
+++ b/packages/codemod/README.md
@@ -52,6 +52,19 @@ npx prettier --write src/        # or: npx eslint --fix src/
 
 Transforms that rename properties or methods (e.g. `.connection` to `.dataSource`) rely on type annotations to identify TypeORM instances. Code that uses TypeORM APIs without type annotations may not be transformed automatically — review `git diff` after running.
 
+### Known limitations
+
+The codemod uses jscodeshift's bundled TypeScript parser, which doesn't accept every valid modern TypeScript construct. In particular, a legacy decorator combined with a computed class-field name — e.g.:
+
+```ts
+class Dto {
+    @ApiExpose({ enum: { DateFormat } })
+    [UserPreference.DateFormat]?: DateFormat
+}
+```
+
+— fails to parse. The file is skipped (with its parse error surfaced in the final summary) and no transforms apply to it. Workaround: either inline the key (`dateFormat?: DateFormat`) temporarily, or add the file to `--ignore` and migrate it by hand. Parse errors list the exact line — review them after every run.
+
 ## Documentation
 
 See the full upgrading guide for details on all breaking changes:

--- a/packages/codemod/src/cli/print-summary.ts
+++ b/packages/codemod/src/cli/print-summary.ts
@@ -3,13 +3,19 @@ import { formatTime } from "../lib/format-time"
 import { highlight } from "../lib/highlight"
 import { printTodos } from "./print-todos"
 
+export interface SummaryError {
+    file: string
+    message: string
+    stack?: string
+}
+
 export interface SummaryData {
     ok: number
     error: number
     skip: number
     nochange: number
     timeElapsed: number
-    parseErrors: { file: string; message: string }[]
+    parseErrors: SummaryError[]
     todos: Map<string, string[]>
     applied: Map<string, number>
     depChanges: string[]
@@ -38,13 +44,16 @@ const printApplied = (applied: Map<string, number>): void => {
     }
 }
 
-const printParseErrors = (
-    parseErrors: { file: string; message: string }[],
-): void => {
+const printParseErrors = (parseErrors: SummaryError[]): void => {
     console.log(`\n  ${colors.red("Parse errors:")}`)
     const sorted = [...parseErrors].sort((a, b) => a.file.localeCompare(b.file))
-    for (const { file, message } of sorted) {
+    for (const { file, message, stack } of sorted) {
         console.log(`    ${colors.dim(file)} ${message}`)
+        if (stack) {
+            for (const line of stack.split("\n")) {
+                console.log(`      ${colors.dim(line)}`)
+            }
+        }
     }
 }
 

--- a/packages/codemod/src/cli/run-transforms.ts
+++ b/packages/codemod/src/cli/run-transforms.ts
@@ -4,13 +4,20 @@ import { createSpinner } from "../lib/spinner"
 import { formatTime } from "../lib/format-time"
 import { stats } from "../transforms/stats"
 
+export interface TransformError {
+    file: string
+    message: string
+    /** Full stack trace captured from jscodeshift output, if any. */
+    stack?: string
+}
+
 export interface TransformResult {
     ok: number
     error: number
     skip: number
     nochange: number
     timeElapsed: number
-    parseErrors: { file: string; message: string }[]
+    parseErrors: TransformError[]
     todos: Map<string, string[]>
     applied: Map<string, number>
 }
@@ -34,7 +41,7 @@ export const runTransforms = async (
     const { transforms, paths, dry, workers, ignore } = options
     const allTodos = new Map<string, string[]>()
     const allApplied = new Map<string, number>()
-    const allParseErrors: { file: string; message: string }[] = []
+    const allParseErrors: TransformError[] = []
     let totalOk = 0
     let totalError = 0
     let totalSkip = 0
@@ -58,8 +65,20 @@ export const runTransforms = async (
             return text
         }
 
-        // Intercept stdout to capture jscodeshift progress
-        const parseErrors: { file: string; message: string }[] = []
+        // Intercept stdout to capture jscodeshift progress and transform
+        // errors. Stack-trace lines follow each ERR line and don't match the
+        // status pattern; attach them to the most recent error so users see
+        // why a transform threw instead of just a one-line summary.
+        const parseErrors: TransformError[] = []
+        let activeError: TransformError | undefined
+        const stackBuffer: string[] = []
+        const flushStack = () => {
+            if (activeError && stackBuffer.length > 0) {
+                activeError.stack = stackBuffer.join("").trimEnd()
+            }
+            activeError = undefined
+            stackBuffer.length = 0
+        }
         const originalWrite = process.stdout.write.bind(process.stdout)
         process.stdout.write = ((chunk: string | Uint8Array) => {
             const str = typeof chunk === "string" ? chunk : chunk.toString()
@@ -75,23 +94,28 @@ export const runTransforms = async (
 
             // Track per-file completion and collect errors
             if (str.includes(" ERR ")) {
+                flushStack()
                 processed++
                 const errMatch =
                     / ERR (.+?) Transformation error \((.+)\)/.exec(str)
                 if (errMatch) {
-                    parseErrors.push({
+                    activeError = {
                         file: errMatch[1],
                         message: errMatch[2],
-                    })
+                    }
+                    parseErrors.push(activeError)
                 }
             } else if (
                 str.includes(" OKK ") ||
                 str.includes(" NOC ") ||
                 str.includes(" SKIP ")
             ) {
+                flushStack()
                 processed++
             } else {
-                // Suppress other jscodeshift output (including stack traces)
+                // Suppress other jscodeshift output, but keep stack-trace
+                // lines that follow an ERR so we can surface them later.
+                if (activeError) stackBuffer.push(str)
                 return false
             }
 
@@ -118,6 +142,7 @@ export const runTransforms = async (
             )
             throw err
         } finally {
+            flushStack()
             process.stdout.write = originalWrite
         }
 

--- a/packages/codemod/src/transforms/todo.ts
+++ b/packages/codemod/src/transforms/todo.ts
@@ -1,10 +1,49 @@
 import type { JSCodeshift, Node } from "jscodeshift"
 
+/**
+ * Prefix tag attached to every TODO comment left by the codemod.
+ * Kept as a single source of truth so rename/dedup logic cannot drift from
+ * the string `addTodoComment` writes.
+ */
+export const TODO_PREFIX = "TODO(typeorm-v1):"
+
+/**
+ * Builds the line-comment text that `addTodoComment` attaches to a node for
+ * the given `message`. Shared with `hasTodoComment` so dedup checks match
+ * the exact string that will be written.
+ */
+export const formatTodoLine = (
+    message: string,
+    prefix: string = TODO_PREFIX,
+): string => ` ${prefix} ${message}`
+
+/**
+ * Returns true when `node` already carries the exact TODO comment produced
+ * by `addTodoComment(node, message, j, prefix)`. Used to keep repeated
+ * transform runs idempotent.
+ */
+export const hasTodoComment = (
+    node: Node,
+    message: string,
+    prefix: string = TODO_PREFIX,
+): boolean => {
+    const line = formatTodoLine(message, prefix)
+    const comments = (node as Node & { comments?: { value: string }[] | null })
+        .comments
+    return comments?.some((c) => c.value === line) ?? false
+}
+
+/**
+ * Attaches a TODO line comment to `node`. The prefix is configurable so
+ * future codemods (e.g. v2) can reuse this helper without hardcoding the
+ * current version tag.
+ */
 export const addTodoComment = (
     node: Node,
     message: string,
     j: JSCodeshift,
+    prefix: string = TODO_PREFIX,
 ): void => {
     if (!node.comments) node.comments = []
-    node.comments.push(j.commentLine(` TODO(typeorm-v1): ${message}`))
+    node.comments.push(j.commentLine(formatTodoLine(message, prefix)))
 }

--- a/packages/codemod/src/transforms/v1/datasource-mongodb.ts
+++ b/packages/codemod/src/transforms/v1/datasource-mongodb.ts
@@ -1,7 +1,7 @@
 import path from "node:path"
 import type { API, FileInfo } from "jscodeshift"
 import { fileImportsFrom } from "../ast-helpers"
-import { addTodoComment } from "../todo"
+import { addTodoComment, hasTodoComment } from "../todo"
 import { stats } from "../stats"
 
 export const name = path.basename(__filename, path.extname(__filename))
@@ -82,25 +82,24 @@ export const datasourceMongodb = (file: FileInfo, api: API) => {
                 path.node.key.value = "tlsAllowInvalidCertificates"
             }
             // Add TODO comment about inverted boolean
-            addTodoComment(
-                path.node,
-                "`sslValidate` was renamed to `tlsAllowInvalidCertificates` with inverted boolean logic. Review and invert the value.",
-                j,
-            )
+            const message =
+                "`sslValidate` was renamed to `tlsAllowInvalidCertificates` with inverted boolean logic. Review and invert the value."
+            if (!hasTodoComment(path.node, message)) {
+                addTodoComment(path.node, message, j)
+                hasTodos = true
+            }
             hasChanges = true
-            hasTodos = true
             return
         }
 
         // writeConcern-related props → add TODO
         if (writeConcernProps.has(name)) {
-            addTodoComment(
-                path.node,
-                `\`${name}\` was removed — migrate to \`writeConcern: { ... }\``,
-                j,
-            )
+            const message = `\`${name}\` was removed — migrate to \`writeConcern: { ... }\``
+            if (!hasTodoComment(path.node, message)) {
+                addTodoComment(path.node, message, j)
+                hasTodos = true
+            }
             hasChanges = true
-            hasTodos = true
         }
     })
 

--- a/packages/codemod/src/transforms/v1/datasource-mssql.ts
+++ b/packages/codemod/src/transforms/v1/datasource-mssql.ts
@@ -1,7 +1,7 @@
 import path from "node:path"
 import type { API, FileInfo } from "jscodeshift"
 import { fileImportsFrom } from "../ast-helpers"
-import { addTodoComment } from "../todo"
+import { addTodoComment, hasTodoComment } from "../todo"
 import { stats } from "../stats"
 
 export const name = path.basename(__filename, path.extname(__filename))
@@ -38,19 +38,19 @@ export const datasourceMssql = (file: FileInfo, api: API) => {
         if (!isMssql) return
 
         // Flag removed `domain` option with TODO
+        const domainMessage =
+            '`domain` was removed — restructure to `authentication: { type: "ntlm", options: { domain: "..." } }`'
         for (const prop of props) {
             if (
                 prop.type === "ObjectProperty" &&
                 prop.key.type === "Identifier" &&
                 prop.key.name === "domain"
             ) {
-                addTodoComment(
-                    prop,
-                    '`domain` was removed — restructure to `authentication: { type: "ntlm", options: { domain: "..." } }`',
-                    j,
-                )
+                if (!hasTodoComment(prop, domainMessage)) {
+                    addTodoComment(prop, domainMessage, j)
+                    hasTodos = true
+                }
                 hasChanges = true
-                hasTodos = true
             }
         }
 

--- a/packages/codemod/src/transforms/v1/global-functions.ts
+++ b/packages/codemod/src/transforms/v1/global-functions.ts
@@ -1,8 +1,16 @@
 import path from "node:path"
 import type { API, FileInfo, Node } from "jscodeshift"
 import { removeImportSpecifiers } from "../ast-helpers"
-import { addTodoComment } from "../todo"
+import { addTodoComment, hasTodoComment } from "../todo"
 import { stats } from "../stats"
+
+const todoAttachmentTypes = new Set([
+    "ExpressionStatement",
+    "VariableDeclaration",
+    "ReturnStatement",
+    "ClassProperty",
+    "ExportDefaultDeclaration",
+])
 
 export const name = path.basename(__filename, path.extname(__filename))
 export const description =
@@ -92,21 +100,17 @@ export const globalFunctions = (file: FileInfo, api: API) => {
 
     // Add a TODO comment on the first dataSource usage
     if (hasChanges) {
+        const message =
+            "`dataSource` is not defined — inject or import your DataSource instance"
         const firstUsage = root.find(j.Identifier, { name: "dataSource" })
         if (firstUsage.length > 0) {
             let current = firstUsage.paths()[0]
             while (current.parent) {
                 const node: Node = current.parent.node
-                if (
-                    node.type === "ExpressionStatement" ||
-                    node.type === "VariableDeclaration" ||
-                    node.type === "ReturnStatement"
-                ) {
-                    addTodoComment(
-                        node,
-                        "`dataSource` is not defined — inject or import your DataSource instance",
-                        j,
-                    )
+                if (todoAttachmentTypes.has(node.type)) {
+                    if (!hasTodoComment(node, message)) {
+                        addTodoComment(node, message, j)
+                    }
                     break
                 }
                 current = current.parent

--- a/packages/codemod/src/transforms/v1/migrations-get-all.ts
+++ b/packages/codemod/src/transforms/v1/migrations-get-all.ts
@@ -1,6 +1,7 @@
 import path from "node:path"
-import type { API, FileInfo } from "jscodeshift"
-import { addTodoComment } from "../todo"
+import type { API, FileInfo, Node } from "jscodeshift"
+import { fileImportsFrom } from "../ast-helpers"
+import { addTodoComment, hasTodoComment } from "../todo"
 import { stats } from "../stats"
 
 export const name = path.basename(__filename, path.extname(__filename))
@@ -8,10 +9,25 @@ export const description =
     "flag removed `getAllMigrations()` for manual migration"
 export const manual = true
 
+const todoAttachmentTypes = new Set([
+    "ExpressionStatement",
+    "VariableDeclaration",
+    "ReturnStatement",
+    "ClassProperty",
+    "ExportDefaultDeclaration",
+])
+
 export const migrationsGetAll = (file: FileInfo, api: API) => {
     const j = api.jscodeshift
     const root = j(file.source)
+
+    if (!fileImportsFrom(root, j, "typeorm")) return undefined
+
     let hasChanges = false
+    let hasTodos = false
+
+    const message =
+        "`getAllMigrations()` was removed — use `getPendingMigrations()`, `getExecutedMigrations()`, or `dataSource.migrations` instead"
 
     root.find(j.CallExpression, {
         callee: {
@@ -19,21 +35,25 @@ export const migrationsGetAll = (file: FileInfo, api: API) => {
             property: { name: "getAllMigrations" },
         },
     }).forEach((path) => {
-        // Add a TODO comment before the statement
-        const statement = j(path).closest(j.ExpressionStatement)
-        if (statement.length > 0) {
-            statement.forEach((stmtPath) => {
-                addTodoComment(
-                    stmtPath.node,
-                    "`getAllMigrations()` was removed — use `getPendingMigrations()`, `getExecutedMigrations()`, or `dataSource.migrations` instead",
-                    j,
-                )
-            })
+        // Walk up to find a statement-like ancestor to attach the TODO to.
+        let target: Node = path.node
+        let current = path.parent
+        while (current) {
+            const node: Node = current.node
+            if (todoAttachmentTypes.has(node.type)) {
+                target = node
+                break
+            }
+            current = current.parent
+        }
+        if (!hasTodoComment(target, message)) {
+            addTodoComment(target, message, j)
+            hasTodos = true
         }
         hasChanges = true
     })
 
-    if (hasChanges) stats.count.todo(api, name, file)
+    if (hasTodos) stats.count.todo(api, name, file)
 
     return hasChanges ? root.toSource() : undefined
 }

--- a/packages/codemod/src/transforms/v1/mongodb-stats.ts
+++ b/packages/codemod/src/transforms/v1/mongodb-stats.ts
@@ -1,7 +1,7 @@
 import path from "node:path"
 import type { API, FileInfo, Node } from "jscodeshift"
 import { fileImportsFrom } from "../ast-helpers"
-import { addTodoComment } from "../todo"
+import { addTodoComment, hasTodoComment } from "../todo"
 import { stats } from "../stats"
 
 export const name = path.basename(__filename, path.extname(__filename))
@@ -27,20 +27,20 @@ export const mongodbStats = (file: FileInfo, api: API) => {
         },
     }).forEach((path) => {
         const parentNode: Node = path.parent.node
+        let target: Node = path.node
         if (parentNode.type === "ExpressionStatement") {
-            addTodoComment(parentNode, message, j)
+            target = parentNode
         } else if (parentNode.type === "AwaitExpression") {
             const grandparentNode: Node = path.parent.parent.node
             if (grandparentNode.type === "ExpressionStatement") {
-                addTodoComment(grandparentNode, message, j)
-            } else {
-                addTodoComment(path.node, message, j)
+                target = grandparentNode
             }
-        } else {
-            addTodoComment(path.node, message, j)
+        }
+        if (!hasTodoComment(target, message)) {
+            addTodoComment(target, message, j)
+            hasTodos = true
         }
         hasChanges = true
-        hasTodos = true
     })
 
     if (hasTodos) stats.count.todo(api, name, file)

--- a/packages/codemod/src/transforms/v1/query-builder-on-conflict.ts
+++ b/packages/codemod/src/transforms/v1/query-builder-on-conflict.ts
@@ -1,7 +1,7 @@
 import path from "node:path"
 import type { API, FileInfo, Node } from "jscodeshift"
 import { fileImportsFrom, getStringValue } from "../ast-helpers"
-import { addTodoComment } from "../todo"
+import { addTodoComment, hasTodoComment } from "../todo"
 import { stats } from "../stats"
 
 export const name = path.basename(__filename, path.extname(__filename))
@@ -39,13 +39,15 @@ export const queryBuilderOnConflict = (file: FileInfo, api: API) => {
             const message =
                 "`onConflict()` was removed — use `orIgnore()` or `orUpdate()` instead"
             const parentNode: Node = path.parent.node
-            if (parentNode.type === "ExpressionStatement") {
-                addTodoComment(parentNode, message, j)
-            } else {
-                addTodoComment(path.node, message, j)
+            const target =
+                parentNode.type === "ExpressionStatement"
+                    ? parentNode
+                    : path.node
+            if (!hasTodoComment(target, message)) {
+                addTodoComment(target, message, j)
+                hasTodos = true
             }
             hasChanges = true
-            hasTodos = true
         }
     })
 

--- a/packages/codemod/src/transforms/v1/query-builder-print-sql.ts
+++ b/packages/codemod/src/transforms/v1/query-builder-print-sql.ts
@@ -1,13 +1,21 @@
 import path from "node:path"
 import type { API, FileInfo, Node } from "jscodeshift"
 import { fileImportsFrom } from "../ast-helpers"
-import { addTodoComment } from "../todo"
+import { addTodoComment, hasTodoComment } from "../todo"
 import { stats } from "../stats"
 
 export const name = path.basename(__filename, path.extname(__filename))
 export const description =
     "flag removed `printSql()` for manual migration to `getSql()` / `getQueryAndParameters()`"
 export const manual = true
+
+const todoAttachmentTypes = new Set([
+    "ExpressionStatement",
+    "VariableDeclaration",
+    "ReturnStatement",
+    "ClassProperty",
+    "ExportDefaultDeclaration",
+])
 
 export const queryBuilderPrintSql = (file: FileInfo, api: API) => {
     const j = api.jscodeshift
@@ -27,22 +35,22 @@ export const queryBuilderPrintSql = (file: FileInfo, api: API) => {
             property: { name: "printSql" },
         },
     }).forEach((path) => {
-        // Walk up to find the enclosing ExpressionStatement
+        // Walk up to find the enclosing statement-like ancestor.
+        let target: Node = path.node
         let current = path.parent
         while (current) {
             const node: Node = current.node
-            if (node.type === "ExpressionStatement") {
-                addTodoComment(node, message, j)
-                break
-            }
-            if (node.type === "VariableDeclaration") {
-                addTodoComment(node, message, j)
+            if (todoAttachmentTypes.has(node.type)) {
+                target = node
                 break
             }
             current = current.parent
         }
+        if (!hasTodoComment(target, message)) {
+            addTodoComment(target, message, j)
+            hasTodos = true
+        }
         hasChanges = true
-        hasTodos = true
     })
 
     if (hasTodos) stats.count.todo(api, name, file)

--- a/packages/codemod/src/transforms/v1/query-builder-replace-property-names.ts
+++ b/packages/codemod/src/transforms/v1/query-builder-replace-property-names.ts
@@ -1,7 +1,7 @@
 import path from "node:path"
 import type { API, FileInfo } from "jscodeshift"
 import { fileImportsFrom } from "../ast-helpers"
-import { addTodoComment } from "../todo"
+import { addTodoComment, hasTodoComment } from "../todo"
 import { stats } from "../stats"
 
 export const name = path.basename(__filename, path.extname(__filename))
@@ -18,25 +18,29 @@ export const queryBuilderReplacePropertyNames = (file: FileInfo, api: API) => {
     let hasChanges = false
     let hasTodos = false
 
-    // Find method declarations named replacePropertyNames in classes
     const message =
         "`replacePropertyNames` was removed — property name replacement is now handled internally"
 
+    const annotate = (node: Parameters<typeof addTodoComment>[0]) => {
+        if (hasTodoComment(node, message)) return
+        addTodoComment(node, message, j)
+        hasTodos = true
+    }
+
+    // Find method declarations named replacePropertyNames in classes
     root.find(j.ClassMethod, {
         key: { type: "Identifier", name: "replacePropertyNames" },
     }).forEach((path) => {
-        addTodoComment(path.node, message, j)
+        annotate(path.node)
         hasChanges = true
-        hasTodos = true
     })
 
     // Also check for MethodDefinition (alternative AST representation)
     root.find(j.MethodDefinition, {
         key: { type: "Identifier", name: "replacePropertyNames" },
     }).forEach((path) => {
-        addTodoComment(path.node, message, j)
+        annotate(path.node)
         hasChanges = true
-        hasTodos = true
     })
 
     if (hasTodos) stats.count.todo(api, name, file)

--- a/packages/codemod/src/transforms/v1/query-runner-loaded-tables-views.ts
+++ b/packages/codemod/src/transforms/v1/query-runner-loaded-tables-views.ts
@@ -1,6 +1,7 @@
 import path from "node:path"
 import type { ASTNode, API, FileInfo } from "jscodeshift"
-import { addTodoComment } from "../todo"
+import { fileImportsFrom } from "../ast-helpers"
+import { addTodoComment, hasTodoComment } from "../todo"
 import { stats } from "../stats"
 
 export const name = path.basename(__filename, path.extname(__filename))
@@ -8,18 +9,26 @@ export const description =
     "flag removed `loadedTables` and `loadedViews` for manual migration to `getTables()` / `getViews()`"
 export const manual = true
 
+const todoAttachmentTypes = new Set([
+    "ExpressionStatement",
+    "VariableDeclaration",
+    "ReturnStatement",
+    "ClassProperty",
+    "ExportDefaultDeclaration",
+])
+
 interface TraversalNode {
     parent?: TraversalNode & {
-        node: ASTNode & {
-            type: string
-            comments?: { value: string }[]
-        }
+        node: ASTNode & { type: string }
     }
 }
 
 export const queryRunnerLoadedTablesViews = (file: FileInfo, api: API) => {
     const j = api.jscodeshift
     const root = j(file.source)
+
+    if (!fileImportsFrom(root, j, "typeorm")) return undefined
+
     let hasChanges = false
     let hasTodos = false
 
@@ -30,25 +39,14 @@ export const queryRunnerLoadedTablesViews = (file: FileInfo, api: API) => {
         if (!removedProps.has(path.node.property.name)) return
 
         const propName = path.node.property.name
+        const message = `\`${propName}\` was removed — use \`getTables()\` / \`getViews()\` instead`
 
         // Find the containing statement to add a comment
         let current: TraversalNode = path
         while (current.parent && current.parent.node.type !== "Program") {
-            if (
-                current.parent.node.type === "ExpressionStatement" ||
-                current.parent.node.type === "VariableDeclaration" ||
-                current.parent.node.type === "ReturnStatement"
-            ) {
+            if (todoAttachmentTypes.has(current.parent.node.type)) {
                 const stmt = current.parent.node
-                const message = `\`${propName}\` was removed — use \`getTables()\` / \`getViews()\` instead`
-
-                // Avoid duplicate comments
-                const commentValue = ` TODO(typeorm-v1): ${message}`
-                const comments = (stmt.comments = stmt.comments || [])
-                const hasSameComment = comments.some(
-                    (c) => c.value === commentValue,
-                )
-                if (!hasSameComment) {
+                if (!hasTodoComment(stmt, message)) {
                     addTodoComment(stmt, message, j)
                     hasTodos = true
                 }

--- a/packages/codemod/src/transforms/v1/relation-count.ts
+++ b/packages/codemod/src/transforms/v1/relation-count.ts
@@ -1,7 +1,7 @@
 import path from "node:path"
 import type { API, FileInfo } from "jscodeshift"
 import { removeImportSpecifiers } from "../ast-helpers"
-import { addTodoComment } from "../todo"
+import { addTodoComment, hasTodoComment } from "../todo"
 import { stats } from "../stats"
 
 export const name = path.basename(__filename, path.extname(__filename))
@@ -15,6 +15,9 @@ export const relationCount = (file: FileInfo, api: API) => {
     let hasChanges = false
     let hasTodos = false
 
+    const message =
+        "`@RelationCount` was removed — use `QueryBuilder` with `loadRelationCountAndMap()` instead"
+
     // Find @RelationCount decorators and add TODO
     root.find(j.Decorator, {
         expression: {
@@ -22,13 +25,11 @@ export const relationCount = (file: FileInfo, api: API) => {
             callee: { type: "Identifier", name: "RelationCount" },
         },
     }).forEach((path) => {
-        addTodoComment(
-            path.node,
-            "`@RelationCount` was removed — use `QueryBuilder` with `loadRelationCountAndMap()` instead",
-            j,
-        )
+        if (!hasTodoComment(path.node, message)) {
+            addTodoComment(path.node, message, j)
+            hasTodos = true
+        }
         hasChanges = true
-        hasTodos = true
     })
 
     // Remove RelationCount import from typeorm

--- a/packages/codemod/src/transforms/v1/repository-abstract.ts
+++ b/packages/codemod/src/transforms/v1/repository-abstract.ts
@@ -1,7 +1,7 @@
 import path from "node:path"
 import type { API, ASTPath, FileInfo, Node } from "jscodeshift"
 import { removeImportSpecifiers } from "../ast-helpers"
-import { addTodoComment } from "../todo"
+import { addTodoComment, hasTodoComment } from "../todo"
 import { stats } from "../stats"
 
 export const name = path.basename(__filename, path.extname(__filename))
@@ -9,11 +9,27 @@ export const description =
     "flag removed `@EntityRepository` and `AbstractRepository` for manual migration"
 export const manual = true
 
+const entityRepositoryMessage =
+    "`@EntityRepository` was removed — use a custom service class with `dataSource.getRepository()`"
+const abstractRepositoryMessage =
+    "`AbstractRepository` was removed — use a custom service class with `dataSource.getRepository()`"
+const getCustomRepositoryMessage =
+    "`getCustomRepository()` was removed — use a custom service class with `dataSource.getRepository()`"
+
 export const repositoryAbstract = (file: FileInfo, api: API) => {
     const j = api.jscodeshift
     const root = j(file.source)
     let hasChanges = false
     let hasTodos = false
+
+    const annotate = (
+        node: Parameters<typeof addTodoComment>[0],
+        message: string,
+    ) => {
+        if (hasTodoComment(node, message)) return
+        addTodoComment(node, message, j)
+        hasTodos = true
+    }
 
     // Find @EntityRepository decorators and add TODO
     root.find(j.Decorator, {
@@ -22,13 +38,8 @@ export const repositoryAbstract = (file: FileInfo, api: API) => {
             callee: { type: "Identifier", name: "EntityRepository" },
         },
     }).forEach((path) => {
-        addTodoComment(
-            path.node,
-            "`@EntityRepository` was removed — use a custom service class with `dataSource.getRepository()`",
-            j,
-        )
+        annotate(path.node, entityRepositoryMessage)
         hasChanges = true
-        hasTodos = true
     })
 
     // Find classes extending AbstractRepository and add TODO
@@ -48,27 +59,17 @@ export const repositoryAbstract = (file: FileInfo, api: API) => {
 
         if (name !== "AbstractRepository") return
 
-        addTodoComment(
-            path.node,
-            "`AbstractRepository` was removed — use a custom service class with `dataSource.getRepository()`",
-            j,
-        )
+        annotate(path.node, abstractRepositoryMessage)
         hasChanges = true
-        hasTodos = true
     })
 
     // Find getCustomRepository() calls and add TODO
     const addGetCustomRepoTodo = (path: ASTPath) => {
-        const message =
-            "`getCustomRepository()` was removed — use a custom service class with `dataSource.getRepository()`"
         const parentNode: Node = path.parent.node
-        if (parentNode.type === "ExpressionStatement") {
-            addTodoComment(parentNode, message, j)
-        } else {
-            addTodoComment(path.node, message, j)
-        }
+        const target =
+            parentNode.type === "ExpressionStatement" ? parentNode : path.node
+        annotate(target, getCustomRepositoryMessage)
         hasChanges = true
-        hasTodos = true
     }
 
     root.find(j.CallExpression, {

--- a/packages/codemod/test/transforms/v1/fixtures/migrations-get-all/migrations-get-all.input.ts
+++ b/packages/codemod/test/transforms/v1/fixtures/migrations-get-all/migrations-get-all.input.ts
@@ -1,1 +1,3 @@
+import "typeorm"
+
 const migrations = await migrationExecutor.getAllMigrations()

--- a/packages/codemod/test/transforms/v1/fixtures/migrations-get-all/migrations-get-all.output.ts
+++ b/packages/codemod/test/transforms/v1/fixtures/migrations-get-all/migrations-get-all.output.ts
@@ -1,1 +1,4 @@
+import "typeorm"
+
+// TODO(typeorm-v1): `getAllMigrations()` was removed — use `getPendingMigrations()`, `getExecutedMigrations()`, or `dataSource.migrations` instead
 const migrations = await migrationExecutor.getAllMigrations()

--- a/packages/codemod/test/transforms/v1/fixtures/query-runner-loaded-tables-views/query-runner-loaded-tables-views.input.ts
+++ b/packages/codemod/test/transforms/v1/fixtures/query-runner-loaded-tables-views/query-runner-loaded-tables-views.input.ts
@@ -1,2 +1,4 @@
+import "typeorm"
+
 const tables = queryRunner.loadedTables
 const views = queryRunner.loadedViews

--- a/packages/codemod/test/transforms/v1/fixtures/query-runner-loaded-tables-views/query-runner-loaded-tables-views.output.ts
+++ b/packages/codemod/test/transforms/v1/fixtures/query-runner-loaded-tables-views/query-runner-loaded-tables-views.output.ts
@@ -1,3 +1,5 @@
+import "typeorm"
+
 // TODO(typeorm-v1): `loadedTables` was removed — use `getTables()` / `getViews()` instead
 const tables = queryRunner.loadedTables
 // TODO(typeorm-v1): `loadedViews` was removed — use `getTables()` / `getViews()` instead

--- a/packages/codemod/test/transforms/v1/negative.test.ts
+++ b/packages/codemod/test/transforms/v1/negative.test.ts
@@ -1,0 +1,74 @@
+import { expect } from "chai"
+import { applyTransform } from "jscodeshift/src/testUtils"
+import type { Transform } from "jscodeshift"
+import { transforms } from "../../../src/transforms/v1"
+
+/**
+ * A realistic non-TypeORM file with property names, option keys, and method
+ * calls that coincidentally collide with TypeORM. A transform that skips the
+ * import-scope check would silently rewrite these. Covers the main failure
+ * mode flagged in the audit: codemods touching unrelated configs.
+ */
+const source = `
+// HTTP fetch options
+const response = await fetch(url, {
+    type: "sqlite",
+    flags: 0,
+    width: 9,
+    zerofill: true,
+})
+
+// Form config
+const field = {
+    name: "author",
+    readonly: true,
+    unsigned: false,
+    connectorPackage: "mysql2",
+    select: ["id", "name"],
+    relations: ["posts"],
+    lock: { mode: "pessimistic_partial_write" },
+}
+
+// Data grid config
+const grid = { busyTimeout: 5000, domain: "example.com" }
+
+// Unrelated builder-ish helpers
+qb.setNativeParameters({ key: "value" })
+qb.printSql()
+qb.onConflict("DO NOTHING")
+qb.orUpdate({ conflict_target: ["a"], overwrite: ["b"] })
+qb.loadedTables
+userStore.exist({})
+userStore.findOneById(1)
+mongoClient.stats()
+migrationRunner.getAllMigrations()
+
+// A class with an override that shares TypeORM's internal method name
+class MyBuilder {
+    replacePropertyNames(q: string) { return q }
+}
+`
+
+describe("v1 transforms — no typeorm import", () => {
+    for (const transform of transforms) {
+        const { name, fn } = transform as unknown as {
+            name: string
+            fn: Transform
+        }
+        it(`${name} does not modify a non-typeorm file`, () => {
+            const result = applyTransform(
+                { default: fn, parser: undefined } as {
+                    default: Transform
+                    parser: undefined
+                },
+                {},
+                { source, path: "not-typeorm.ts" },
+                { parser: "tsx" },
+            )
+            // jscodeshift returns an empty string when the transform returns
+            // undefined (no changes). A non-empty result means the transform
+            // rewrote the file — a scope-guard regression.
+            expect(result).to.equal("")
+        })
+    }
+})

--- a/packages/codemod/test/transforms/v1/negative.test.ts
+++ b/packages/codemod/test/transforms/v1/negative.test.ts
@@ -47,6 +47,21 @@ migrationRunner.getAllMigrations()
 class MyBuilder {
     replacePropertyNames(q: string) { return q }
 }
+
+// Real-world regression: nest-commander decorators use \`flags\` too, and
+// were getting stripped by datasource-sqlite-options before the scope guard.
+import { Command, CommandRunner, Option } from "nest-commander"
+
+@Command({ name: "basic", description: "A parameter parse" })
+export class BasicCommand extends CommandRunner {
+    @Option({
+        flags: "-n, --number [number]",
+        description: "A basic number parser",
+    })
+    parseNumber(val: string): number {
+        return Number(val)
+    }
+}
 `
 
 describe("v1 transforms — no typeorm import", () => {

--- a/packages/codemod/test/transforms/v1/parser-limits.test.ts
+++ b/packages/codemod/test/transforms/v1/parser-limits.test.ts
@@ -1,0 +1,36 @@
+import { expect } from "chai"
+import { applyTransform } from "jscodeshift/src/testUtils"
+import type { Transform } from "jscodeshift"
+import connectionToDataSource from "../../../src/transforms/v1/connection-to-datasource"
+
+/**
+ * jscodeshift's bundled parser rejects legacy-decorator + computed-class-field
+ * combinations. The README documents this as a known limitation. This test
+ * pins the current behaviour so a future jscodeshift upgrade that fixes the
+ * parser will flip this test, letting us drop the limitation from the README.
+ */
+describe("v1 transforms — parser limitations", () => {
+    const source = `
+export class UserPreferencesDto extends AbstractDto {
+    @ApiExpose({ enum: { DateFormat }, required: false })
+    [UserPreference.DateFormat]?: DateFormat
+}
+`
+
+    it("legacy-decorator + computed class field fails to parse (known limitation)", () => {
+        expect(() =>
+            applyTransform(
+                {
+                    default: connectionToDataSource,
+                    parser: undefined,
+                } as {
+                    default: Transform
+                    parser: undefined
+                },
+                {},
+                { source, path: "dto.ts" },
+                { parser: "tsx" },
+            ),
+        ).to.throw(/Unexpected token/)
+    })
+})


### PR DESCRIPTION
Five maintainability and rerun-safety fixes for the v1 codemod.

> Depends on #12372 — branch is based on `fix/codemod-import-scope-and-dts` so the negative-fixture test suite has the scope guards it asserts against. Rebase onto `master` once #12372 merges.

### Idempotent TODOs

Running the codemod twice used to stack duplicate TODO comments on every flagged node. `todo.ts` now exports `TODO_PREFIX`, `formatTodoLine`, and `hasTodoComment`, and every transform that adds a TODO (`relation-count`, `global-functions`, `query-builder-replace-property-names`, `query-builder-print-sql`, `query-builder-on-conflict`, `mongodb-stats`, `repository-abstract`, `query-runner-loaded-tables-views`, `migrations-get-all`, `datasource-mongodb`, `datasource-mssql`) guards the `addTodoComment` call with `hasTodoComment`. The prefix is the single source of truth shared between the writer and the dedup check so they cannot drift.

### Reusable prefix

`addTodoComment(node, message, j, prefix?)` now accepts an optional prefix. Defaults to `TODO(typeorm-v1):` for today; a v2 codemod can pass its own tag without touching this module.

### Extended TODO-attachment ancestors

Transforms that walk up to attach a TODO to an enclosing statement previously only recognised `ExpressionStatement`, `VariableDeclaration`, and `ReturnStatement`. Class-field initialisers and `export default` bodies fell through. Added `ClassProperty` and `ExportDefaultDeclaration` to the ancestor set in `query-builder-print-sql`, `migrations-get-all`, `global-functions`, and `query-runner-loaded-tables-views`.

Also revealed that `migrations-get-all` was silently no-op-ing for `const x = await ...getAllMigrations()` — it only walked to `ExpressionStatement`. The fixture's expected output is updated to include the (newly-attached) TODO.

### Surface transform errors

`run-transforms.ts` intercepts jscodeshift's stdout to track progress, and was swallowing the stack-trace lines that follow each `ERR` line. Users saw `Parse errors: N` with a single-line message and no stack. Stack-trace lines are now accumulated and attached to the most recent error; `print-summary.ts` renders them under each error in dimmed text.

### Negative fixtures

New `negative.test.ts` — for every v1 transform, asserts that running it against a realistic non-TypeORM file (no `import "typeorm"`) produces no changes. A scope-guard regression anywhere now fails a test instead of silently corrupting user code. Also adds the missing `fileImportsFrom` guards to `migrations-get-all` and `query-runner-loaded-tables-views`.

### Fixtures

`migrations-get-all` and `query-runner-loaded-tables-views` fixtures gain `import "typeorm"` so they still exercise the transform after the new scope guards.
