### PR TITLE
fix(codemod): handle typeof type queries and use getStringValue consistently

### DIFF
--- a/packages/codemod/src/transforms/v1/connection-to-datasource.ts
+++ b/packages/codemod/src/transforms/v1/connection-to-datasource.ts
@@ -100,6 +100,16 @@ export const connectionToDataSource = (file: FileInfo, api: API) => {
             }
         })
 
+        // TSTypeQuery (e.g. const x: typeof Connection = ...)
+        root.find(j.TSTypeQuery, {
+            exprName: { name: oldName },
+        }).forEach((path) => {
+            if (path.node.exprName.type === "Identifier") {
+                path.node.exprName.name = newName
+                hasChanges = true
+            }
+        })
+
         // NewExpression (e.g. new Connection(...))
         root.find(j.NewExpression, {
             callee: { type: "Identifier", name: oldName },

--- a/packages/codemod/src/transforms/v1/datasource-sqlite-type.ts
+++ b/packages/codemod/src/transforms/v1/datasource-sqlite-type.ts
@@ -1,6 +1,6 @@
 import path from "node:path"
-import type { API, FileInfo } from "jscodeshift"
-import { setStringValue } from "../ast-helpers"
+import type { API, ASTNode, FileInfo } from "jscodeshift"
+import { getStringValue, setStringValue } from "../ast-helpers"
 
 export const name = path.basename(__filename, path.extname(__filename))
 export const description = "replace `sqlite` driver with `better-sqlite3`"
@@ -10,14 +10,23 @@ export const datasourceSqliteType = (file: FileInfo, api: API) => {
     const root = j(file.source)
     let hasChanges = false
 
-    // TSX parser uses ObjectProperty (not Property) and StringLiteral
-    root.find(j.ObjectProperty, {
-        key: { type: "Identifier", name: "type" },
-        value: { type: "StringLiteral", value: "sqlite" },
-    }).forEach((path) => {
-        setStringValue(path.node.value, "better-sqlite3")
+    // Match both Property (Esprima) and ObjectProperty (Babel) node shapes
+    // and both Identifier (`type:`) and string-literal (`"type":`) keys.
+    // Use `getStringValue` rather than filtering on `StringLiteral` directly
+    // so behaviour stays consistent with the rest of the transforms.
+    const visit = (node: { key: ASTNode; value: ASTNode }) => {
+        const keyName =
+            node.key.type === "Identifier"
+                ? node.key.name
+                : getStringValue(node.key)
+        if (keyName !== "type") return
+        if (getStringValue(node.value) !== "sqlite") return
+        setStringValue(node.value, "better-sqlite3")
         hasChanges = true
-    })
+    }
+
+    root.find(j.Property).forEach((p) => visit(p.node))
+    root.find(j.ObjectProperty).forEach((p) => visit(p.node))
 
     return hasChanges ? root.toSource() : undefined
 }

--- a/packages/codemod/test/transforms/v1/fixtures/connection-to-datasource/connection-to-datasource.input.ts
+++ b/packages/codemod/test/transforms/v1/fixtures/connection-to-datasource/connection-to-datasource.input.ts
@@ -10,6 +10,11 @@ await connection.connect()
 console.log(connection.isConnected)
 await connection.close()
 
+// TSTypeQuery: `typeof Connection` in a type position should rename
+function makeDs(ctor: typeof Connection, options: ConnectionOptions) {
+    return new ctor(options)
+}
+
 // Property access on typed variables: .connection → .dataSource
 function migrate(queryRunner: QueryRunner) {
     const ds = queryRunner.connection

--- a/packages/codemod/test/transforms/v1/fixtures/connection-to-datasource/connection-to-datasource.output.ts
+++ b/packages/codemod/test/transforms/v1/fixtures/connection-to-datasource/connection-to-datasource.output.ts
@@ -10,6 +10,11 @@ await connection.initialize()
 console.log(connection.isInitialized)
 await connection.destroy()
 
+// TSTypeQuery: `typeof Connection` in a type position should rename
+function makeDs(ctor: typeof DataSource, options: DataSourceOptions) {
+    return new ctor(options)
+}
+
 // Property access on typed variables: .connection → .dataSource
 function migrate(queryRunner: QueryRunner) {
     const ds = queryRunner.dataSource

--- a/packages/codemod/test/transforms/v1/fixtures/datasource-sqlite-type/datasource-sqlite-type.input.ts
+++ b/packages/codemod/test/transforms/v1/fixtures/datasource-sqlite-type/datasource-sqlite-type.input.ts
@@ -16,3 +16,10 @@ const loggerConfig = {
     type: "sqlite",
     level: "info",
 }
+
+// String-literal keys (e.g. JSON-style quoted `"type"`) must also be rewritten
+// prettier-ignore
+const quoted = {
+    "type": "sqlite",
+    "database": "db.sqlite",
+}

--- a/packages/codemod/test/transforms/v1/fixtures/datasource-sqlite-type/datasource-sqlite-type.output.ts
+++ b/packages/codemod/test/transforms/v1/fixtures/datasource-sqlite-type/datasource-sqlite-type.output.ts
@@ -16,3 +16,10 @@ const loggerConfig = {
     type: "sqlite",
     level: "info",
 }
+
+// String-literal keys (e.g. JSON-style quoted `"type"`) must also be rewritten
+// prettier-ignore
+const quoted = {
+    "type": "better-sqlite3",
+    "database": "db.sqlite",
+}


### PR DESCRIPTION
Two small correctness and consistency fixes for v1 transforms.

### `typeof Connection` in type positions

`connection-to-datasource` renamed `Connection` in `TSTypeReference` (e.g. `const x: Connection = ...`) but not in `TSTypeQuery` (`typeof Connection`). That left references like `function f(ctor: typeof Connection)` pointing to the old name after the import itself was renamed to `DataSource`, breaking the file.

Fixed by mirroring the `TSTypeReference` loop against `TSTypeQuery` for every renamed symbol.

### `getStringValue` consistency in `datasource-sqlite-type`

`datasource-sqlite-type` matched the `type: "sqlite"` property by filtering on `j.ObjectProperty` with a hardcoded `value: { type: "StringLiteral", value: "sqlite" }`. That diverged from every other transform, which reads values via `getStringValue` (matching both `StringLiteral` and `Literal` nodes) and normalises keys uniformly.

Rewrote using `getStringValue` / `setStringValue`, visiting both `Property` and `ObjectProperty` shapes. Identifier and quoted-string keys are both matched, which also silently fixes the "quoted-key miss" edge case for this transform.
