### PR TITLE
fix(codemod): recognize typeorm deep-path imports

### DIFF
--- a/packages/codemod/src/transforms/ast-helpers.ts
+++ b/packages/codemod/src/transforms/ast-helpers.ts
@@ -41,16 +41,24 @@ export const isIdentifier = (node: { type: string }): node is Identifier =>
     node.type === "Identifier"
 
 /**
- * Checks whether the file contains an import from the given module.
+ * Checks whether the file contains an import from the given module. Matches
+ * both the exact module name (`import ... from "typeorm"`) and any sub-path
+ * (`import ... from "typeorm/driver/sap/SapConnectionOptions"`) so that files
+ * which only reach into deep paths still pass the scope guard.
  */
 export const fileImportsFrom = (
     root: Collection,
     j: JSCodeshift,
     moduleName: string,
 ): boolean => {
+    const prefix = `${moduleName}/`
     return (
-        root.find(j.ImportDeclaration, {
-            source: { value: moduleName },
+        root.find(j.ImportDeclaration).filter((importPath) => {
+            const source = importPath.node.source.value
+            return (
+                typeof source === "string" &&
+                (source === moduleName || source.startsWith(prefix))
+            )
         }).length > 0
     )
 }

--- a/packages/codemod/src/transforms/v1/connection-to-datasource.ts
+++ b/packages/codemod/src/transforms/v1/connection-to-datasource.ts
@@ -95,19 +95,19 @@ export const connectionToDataSource = (file: FileInfo, api: API) => {
             }
         })
 
-        // Also rewrite deep-path module specifiers that embed a renamed
-        // symbol: `typeorm/driver/sap/SapConnectionOptions` →
-        // `typeorm/driver/sap/SapDataSourceOptions`.
+        // Also rewrite deep-path module specifiers that point to a renamed
+        // module file: `typeorm/driver/sap/SapConnectionOptions` →
+        // `typeorm/driver/sap/SapDataSourceOptions`. Only rewrite when the
+        // final path segment is an exact rename key — otherwise a path that
+        // merely contains a rename token as a substring would get mangled.
         if (source.startsWith(typeormPathPrefix)) {
-            for (const [oldName, newName] of Object.entries(typeRenames)) {
-                if (source.includes(oldName)) {
-                    const rewritten = source.split(oldName).join(newName)
-                    if (rewritten !== source) {
-                        path.node.source.value = rewritten
-                        hasChanges = true
-                    }
-                    break
-                }
+            const lastSlash = source.lastIndexOf("/")
+            const lastSegment = source.slice(lastSlash + 1)
+            const renamedSegment = typeRenames[lastSegment]
+            if (renamedSegment) {
+                path.node.source.value =
+                    source.slice(0, lastSlash + 1) + renamedSegment
+                hasChanges = true
             }
         }
     })

--- a/packages/codemod/src/transforms/v1/connection-to-datasource.ts
+++ b/packages/codemod/src/transforms/v1/connection-to-datasource.ts
@@ -84,6 +84,15 @@ export const connectionToDataSource = (file: FileInfo, api: API) => {
         "IndexMetadata",
     ])
 
+    // Full-path overrides for deep imports where the v1 module also moved
+    // to a different directory. The generic last-segment swap below cannot
+    // handle these because swapping only the filename leaves the old
+    // directory intact (e.g. `typeorm/driver/sqlite/` was removed in v1).
+    const deepPathRewrites: Record<string, string> = {
+        "typeorm/driver/sqlite/SqliteConnectionOptions":
+            "typeorm/driver/better-sqlite3/BetterSqlite3DataSourceOptions",
+    }
+
     // Collect local names imported from "typeorm" (including deep sub-paths
     // like `typeorm/driver/sap/SapConnectionOptions`) that need renaming.
     const localRenames = new Map<string, string>()
@@ -123,19 +132,25 @@ export const connectionToDataSource = (file: FileInfo, api: API) => {
             }
         })
 
-        // Also rewrite deep-path module specifiers that point to a renamed
-        // module file: `typeorm/driver/sap/SapConnectionOptions` →
-        // `typeorm/driver/sap/SapDataSourceOptions`. Only rewrite when the
-        // final path segment is an exact rename key — otherwise a path that
-        // merely contains a rename token as a substring would get mangled.
+        // Rewrite deep-path module specifiers. First consult
+        // `deepPathRewrites` for full-path overrides (needed when the v1
+        // module moved to a different directory, e.g. `sqlite` →
+        // `better-sqlite3`); otherwise swap only the last path segment when
+        // it's an exact rename key.
         if (source.startsWith(typeormPathPrefix)) {
-            const lastSlash = source.lastIndexOf("/")
-            const lastSegment = source.slice(lastSlash + 1)
-            const renamedSegment = typeRenames[lastSegment]
-            if (renamedSegment) {
-                path.node.source.value =
-                    source.slice(0, lastSlash + 1) + renamedSegment
+            const fullPathRewrite = deepPathRewrites[source]
+            if (fullPathRewrite) {
+                path.node.source.value = fullPathRewrite
                 hasChanges = true
+            } else {
+                const lastSlash = source.lastIndexOf("/")
+                const lastSegment = source.slice(lastSlash + 1)
+                const renamedSegment = typeRenames[lastSegment]
+                if (renamedSegment) {
+                    path.node.source.value =
+                        source.slice(0, lastSlash + 1) + renamedSegment
+                    hasChanges = true
+                }
             }
         }
     })

--- a/packages/codemod/src/transforms/v1/connection-to-datasource.ts
+++ b/packages/codemod/src/transforms/v1/connection-to-datasource.ts
@@ -56,11 +56,19 @@ export const connectionToDataSource = (file: FileInfo, api: API) => {
         "RelationQueryBuilder",
     ])
 
-    // Collect local names imported from "typeorm" that need renaming
+    // Collect local names imported from "typeorm" (including deep sub-paths
+    // like `typeorm/driver/sap/SapConnectionOptions`) that need renaming.
     const localRenames = new Map<string, string>()
-    root.find(j.ImportDeclaration, {
-        source: { value: "typeorm" },
-    }).forEach((path) => {
+    const typeormPathPrefix = "typeorm/"
+    root.find(j.ImportDeclaration).forEach((path) => {
+        const source = path.node.source.value
+        if (
+            typeof source !== "string" ||
+            (source !== "typeorm" && !source.startsWith(typeormPathPrefix))
+        ) {
+            return
+        }
+
         path.node.specifiers?.forEach((spec) => {
             if (
                 spec.type === "ImportSpecifier" &&
@@ -86,6 +94,22 @@ export const connectionToDataSource = (file: FileInfo, api: API) => {
                 }
             }
         })
+
+        // Also rewrite deep-path module specifiers that embed a renamed
+        // symbol: `typeorm/driver/sap/SapConnectionOptions` →
+        // `typeorm/driver/sap/SapDataSourceOptions`.
+        if (source.startsWith(typeormPathPrefix)) {
+            for (const [oldName, newName] of Object.entries(typeRenames)) {
+                if (source.includes(oldName)) {
+                    const rewritten = source.split(oldName).join(newName)
+                    if (rewritten !== source) {
+                        path.node.source.value = rewritten
+                        hasChanges = true
+                    }
+                    break
+                }
+            }
+        }
     })
 
     // Rename only identifiers that were imported from "typeorm"

--- a/packages/codemod/src/transforms/v1/connection-to-datasource.ts
+++ b/packages/codemod/src/transforms/v1/connection-to-datasource.ts
@@ -1,6 +1,11 @@
 import path from "node:path"
 import type { API, ASTNode, FileInfo, Identifier } from "jscodeshift"
-import { forEachIdentifierParam, isIdentifier } from "../ast-helpers"
+import {
+    forEachIdentifierParam,
+    getStringValue,
+    isIdentifier,
+    setStringValue,
+} from "../ast-helpers"
 
 /**
  * Unwraps common TypeScript expression wrappers (`as`, `!`, parens) around
@@ -97,6 +102,24 @@ export const connectionToDataSource = (file: FileInfo, api: API) => {
     // like `typeorm/driver/sap/SapConnectionOptions`) that need renaming.
     const localRenames = new Map<string, string>()
     const typeormPathPrefix = "typeorm/"
+
+    // Returns the rewritten module path for a `typeorm[/...]` import, or the
+    // original when no rewrite applies. Consults `deepPathRewrites` first for
+    // cross-directory moves, then falls back to swapping the last path
+    // segment when it's an exact rename key.
+    const rewriteTypeormPath = (source: string): string => {
+        if (!source.startsWith(typeormPathPrefix)) return source
+        const fullPathRewrite = deepPathRewrites[source]
+        if (fullPathRewrite) return fullPathRewrite
+        const lastSlash = source.lastIndexOf("/")
+        // No slash or trailing slash → no segment to rewrite
+        if (lastSlash === -1 || lastSlash === source.length - 1) return source
+        const lastSegment = source.slice(lastSlash + 1)
+        const renamedSegment = typeRenames[lastSegment]
+        if (!renamedSegment) return source
+        return source.slice(0, lastSlash + 1) + renamedSegment
+    }
+
     root.find(j.ImportDeclaration).forEach((path) => {
         const source = path.node.source.value
         if (
@@ -132,26 +155,63 @@ export const connectionToDataSource = (file: FileInfo, api: API) => {
             }
         })
 
-        // Rewrite deep-path module specifiers. First consult
-        // `deepPathRewrites` for full-path overrides (needed when the v1
-        // module moved to a different directory, e.g. `sqlite` →
-        // `better-sqlite3`); otherwise swap only the last path segment when
-        // it's an exact rename key.
-        if (source.startsWith(typeormPathPrefix)) {
-            const fullPathRewrite = deepPathRewrites[source]
-            if (fullPathRewrite) {
-                path.node.source.value = fullPathRewrite
-                hasChanges = true
-            } else {
-                const lastSlash = source.lastIndexOf("/")
-                const lastSegment = source.slice(lastSlash + 1)
-                const renamedSegment = typeRenames[lastSegment]
-                if (renamedSegment) {
-                    path.node.source.value =
-                        source.slice(0, lastSlash + 1) + renamedSegment
-                    hasChanges = true
-                }
+        const rewritten = rewriteTypeormPath(source)
+        if (rewritten !== source) {
+            path.node.source.value = rewritten
+            hasChanges = true
+        }
+    })
+
+    // CommonJS `require("typeorm[/...]")` — rewrite both the module path and
+    // any destructured identifiers (`const { Connection } = require(...)`).
+    // Identifiers collected here are added to `localRenames` so the shared
+    // NewExpression/TSTypeReference rewrite loop below picks them up.
+    root.find(j.CallExpression, {
+        callee: { type: "Identifier", name: "require" },
+    }).forEach((callPath) => {
+        const [arg] = callPath.node.arguments
+        if (!arg) return
+        const source = getStringValue(arg)
+        if (
+            typeof source !== "string" ||
+            (source !== "typeorm" && !source.startsWith(typeormPathPrefix))
+        ) {
+            return
+        }
+
+        // Rewrite the require() path
+        const rewrittenSource = rewriteTypeormPath(source)
+        if (rewrittenSource !== source) {
+            setStringValue(arg, rewrittenSource)
+            hasChanges = true
+        }
+
+        // Rewrite destructured identifiers on `const { X } = require(...)`
+        const parent = callPath.parent.node
+        if (parent.type !== "VariableDeclarator") return
+        const id = parent.id
+        if (id.type !== "ObjectPattern") return
+
+        for (const prop of id.properties) {
+            if (prop.type !== "Property" && prop.type !== "ObjectProperty") {
+                continue
             }
+            if (prop.key.type !== "Identifier") continue
+            const oldImported: string = prop.key.name
+            const newName: string | undefined = typeRenames[oldImported]
+            if (!newName) continue
+
+            const localName: string =
+                prop.value.type === "Identifier" ? prop.value.name : oldImported
+            localRenames.set(localName, newName)
+
+            // Rename the source-side key
+            prop.key.name = newName
+            // When un-aliased (shorthand), rename the binding too
+            if (prop.value.type === "Identifier" && prop.shorthand) {
+                prop.value.name = newName
+            }
+            hasChanges = true
         }
     })
 

--- a/packages/codemod/test/transforms/v1/fixtures/connection-to-datasource/connection-to-datasource.input.ts
+++ b/packages/codemod/test/transforms/v1/fixtures/connection-to-datasource/connection-to-datasource.input.ts
@@ -1,6 +1,9 @@
 import { Connection, ConnectionOptions, QueryRunner } from "typeorm"
 import type { SapConnectionOptions } from "typeorm/driver/sap/SapConnectionOptions"
 
+// Deep path whose final segment is NOT an exact rename key must be left alone
+import { something } from "typeorm/driver/sap/ThingsConnectionHelper"
+
 const options: ConnectionOptions = {
     type: "postgres",
     database: "test",

--- a/packages/codemod/test/transforms/v1/fixtures/connection-to-datasource/connection-to-datasource.input.ts
+++ b/packages/codemod/test/transforms/v1/fixtures/connection-to-datasource/connection-to-datasource.input.ts
@@ -1,5 +1,9 @@
 import { Connection, ConnectionOptions, QueryRunner } from "typeorm"
 import type { SapConnectionOptions } from "typeorm/driver/sap/SapConnectionOptions"
+import type { BetterSqlite3ConnectionOptions } from "typeorm/driver/better-sqlite3/BetterSqlite3ConnectionOptions"
+
+// Cross-directory rename: the `sqlite/` directory was removed in v1
+import type { SqliteConnectionOptions } from "typeorm/driver/sqlite/SqliteConnectionOptions"
 
 // Deep path whose final segment is NOT an exact rename key must be left alone
 import { something } from "typeorm/driver/sap/ThingsConnectionHelper"

--- a/packages/codemod/test/transforms/v1/fixtures/connection-to-datasource/connection-to-datasource.input.ts
+++ b/packages/codemod/test/transforms/v1/fixtures/connection-to-datasource/connection-to-datasource.input.ts
@@ -63,6 +63,14 @@ async function bounce(ds: DataSource) {
     return runner.connection
 }
 
+// CommonJS require(): destructured identifier + deep-path both rewrite
+const { Connection: LegacyConn } = require("typeorm")
+const {
+    SapConnectionOptions: LegacySapOpts,
+} = require("typeorm/driver/sap/SapConnectionOptions")
+
+const cjs = new LegacyConn(options)
+
 // Should NOT be transformed — not TypeORM typed
 const ds3 = event.connection
 const ds4 = this.connection

--- a/packages/codemod/test/transforms/v1/fixtures/connection-to-datasource/connection-to-datasource.input.ts
+++ b/packages/codemod/test/transforms/v1/fixtures/connection-to-datasource/connection-to-datasource.input.ts
@@ -1,8 +1,14 @@
 import { Connection, ConnectionOptions, QueryRunner } from "typeorm"
+import type { SapConnectionOptions } from "typeorm/driver/sap/SapConnectionOptions"
 
 const options: ConnectionOptions = {
     type: "postgres",
     database: "test",
+}
+
+const sapOptions: SapConnectionOptions = {
+    type: "sap",
+    database: "hana",
 }
 
 const connection = new Connection(options)

--- a/packages/codemod/test/transforms/v1/fixtures/connection-to-datasource/connection-to-datasource.output.ts
+++ b/packages/codemod/test/transforms/v1/fixtures/connection-to-datasource/connection-to-datasource.output.ts
@@ -63,6 +63,14 @@ async function bounce(ds: DataSource) {
     return runner.dataSource
 }
 
+// CommonJS require(): destructured identifier + deep-path both rewrite
+const { DataSource: LegacyConn } = require("typeorm")
+const {
+    SapDataSourceOptions: LegacySapOpts,
+} = require("typeorm/driver/sap/SapDataSourceOptions")
+
+const cjs = new DataSource(options)
+
 // Should NOT be transformed — not TypeORM typed
 const ds3 = event.connection
 const ds4 = this.connection

--- a/packages/codemod/test/transforms/v1/fixtures/connection-to-datasource/connection-to-datasource.output.ts
+++ b/packages/codemod/test/transforms/v1/fixtures/connection-to-datasource/connection-to-datasource.output.ts
@@ -1,8 +1,14 @@
 import { DataSource, DataSourceOptions, QueryRunner } from "typeorm"
+import type { SapDataSourceOptions } from "typeorm/driver/sap/SapDataSourceOptions"
 
 const options: DataSourceOptions = {
     type: "postgres",
     database: "test",
+}
+
+const sapOptions: SapDataSourceOptions = {
+    type: "sap",
+    database: "hana",
 }
 
 const connection = new DataSource(options)

--- a/packages/codemod/test/transforms/v1/fixtures/connection-to-datasource/connection-to-datasource.output.ts
+++ b/packages/codemod/test/transforms/v1/fixtures/connection-to-datasource/connection-to-datasource.output.ts
@@ -1,5 +1,9 @@
 import { DataSource, DataSourceOptions, QueryRunner } from "typeorm"
 import type { SapDataSourceOptions } from "typeorm/driver/sap/SapDataSourceOptions"
+import type { BetterSqlite3DataSourceOptions } from "typeorm/driver/better-sqlite3/BetterSqlite3DataSourceOptions"
+
+// Cross-directory rename: the `sqlite/` directory was removed in v1
+import type { BetterSqlite3DataSourceOptions } from "typeorm/driver/better-sqlite3/BetterSqlite3DataSourceOptions"
 
 // Deep path whose final segment is NOT an exact rename key must be left alone
 import { something } from "typeorm/driver/sap/ThingsConnectionHelper"

--- a/packages/codemod/test/transforms/v1/fixtures/connection-to-datasource/connection-to-datasource.output.ts
+++ b/packages/codemod/test/transforms/v1/fixtures/connection-to-datasource/connection-to-datasource.output.ts
@@ -1,6 +1,9 @@
 import { DataSource, DataSourceOptions, QueryRunner } from "typeorm"
 import type { SapDataSourceOptions } from "typeorm/driver/sap/SapDataSourceOptions"
 
+// Deep path whose final segment is NOT an exact rename key must be left alone
+import { something } from "typeorm/driver/sap/ThingsConnectionHelper"
+
 const options: DataSourceOptions = {
     type: "postgres",
     database: "test",


### PR DESCRIPTION
Reported by Lucian: the codemod silently skipped files that only imported from sub-paths (e.g. `import type { SapConnectionOptions } from 'typeorm/driver/sap/SapConnectionOptions'`). Two issues combined to cause this:

### Scope guard was exact-match

`fileImportsFrom(root, j, "typeorm")` matched only the exact source string `"typeorm"`. Files that reached into TypeORM's compiled layout via `typeorm/...` failed the scope check entirely, so none of the transforms processed them. The guard now accepts both `"typeorm"` and any `"typeorm/..."` sub-path.

### `connection-to-datasource` didn't scan deep-path imports

Even with the scope guard loose, the rename loop in `connection-to-datasource` still filtered imports by `source: { value: "typeorm" }`. `SapConnectionOptions` imported from `typeorm/driver/sap/SapConnectionOptions` was left untouched. The loop now scans both exact `"typeorm"` and `"typeorm/..."` imports, and additionally rewrites the module-path string when it embeds a renamed symbol (`typeorm/driver/sap/SapConnectionOptions` → `typeorm/driver/sap/SapDataSourceOptions`).

Fixture: existing `connection-to-datasource` gains a `SapConnectionOptions` deep-path import to pin the behaviour.
