### PR TITLE
fix(codemod): rename .connection on EntityMetadata, ColumnMetadata, IndexMetadata

### DIFF
--- a/packages/codemod/src/transforms/v1/connection-to-datasource.ts
+++ b/packages/codemod/src/transforms/v1/connection-to-datasource.ts
@@ -54,6 +54,10 @@ export const connectionToDataSource = (file: FileInfo, api: API) => {
         "DeleteQueryBuilder",
         "SoftDeleteQueryBuilder",
         "RelationQueryBuilder",
+        // Metadata classes (renamed in #12249)
+        "EntityMetadata",
+        "ColumnMetadata",
+        "IndexMetadata",
     ])
 
     // Collect local names imported from "typeorm" that need renaming

--- a/packages/codemod/test/transforms/v1/fixtures/connection-to-datasource/connection-to-datasource.input.ts
+++ b/packages/codemod/test/transforms/v1/fixtures/connection-to-datasource/connection-to-datasource.input.ts
@@ -18,6 +18,15 @@ function migrate(queryRunner: QueryRunner) {
 const runner: QueryRunner = getRunner()
 const ds2 = runner.connection
 
+// Metadata types also had `.connection` renamed to `.dataSource` (#12249)
+function useEntityMetadata(meta: EntityMetadata) {
+    return meta.connection.getRepository(meta.target)
+}
+
+function useColumnMetadata(col: ColumnMetadata) {
+    return col.connection.driver
+}
+
 // Should NOT be transformed — not TypeORM typed
 const ds3 = event.connection
 const ds4 = this.connection

--- a/packages/codemod/test/transforms/v1/fixtures/connection-to-datasource/connection-to-datasource.output.ts
+++ b/packages/codemod/test/transforms/v1/fixtures/connection-to-datasource/connection-to-datasource.output.ts
@@ -18,6 +18,15 @@ function migrate(queryRunner: QueryRunner) {
 const runner: QueryRunner = getRunner()
 const ds2 = runner.dataSource
 
+// Metadata types also had `.connection` renamed to `.dataSource` (#12249)
+function useEntityMetadata(meta: EntityMetadata) {
+    return meta.dataSource.getRepository(meta.target)
+}
+
+function useColumnMetadata(col: ColumnMetadata) {
+    return col.dataSource.driver
+}
+
 // Should NOT be transformed — not TypeORM typed
 const ds3 = event.connection
 const ds4 = this.connection


### PR DESCRIPTION
Reported by Lucian: `meta.connection.getMetadata(...)` was left unchanged when `meta` is typed `EntityMetadata`. Same for `ColumnMetadata` and `IndexMetadata`.

`connection-to-datasource` already renames `.connection` → `.dataSource` on typed references to `QueryRunner`, `EntityManager`, `Repository`, `TreeRepository`, `MongoRepository`, and the `*QueryBuilder` classes. The metadata classes were missed — their `.connection` property was renamed to `.dataSource` in #12249, same breaking change.

Extends `typesWithConnectionProp` with `EntityMetadata`, `ColumnMetadata`, and `IndexMetadata`. Fixture gains typed-parameter cases for `EntityMetadata` and `ColumnMetadata` to pin the behavior.