### PR TITLE
test(codemod): pin that find-options string transforms leave non-array values alone

### DIFF
--- a/packages/codemod/test/transforms/v1/fixtures/find-options-string-relations/find-options-string-relations.input.ts
+++ b/packages/codemod/test/transforms/v1/fixtures/find-options-string-relations/find-options-string-relations.input.ts
@@ -1,3 +1,13 @@
 const users = await repository.find({
     relations: ["profile", "posts", "posts.comments"],
 })
+
+// Should NOT be transformed — value is a function call, not an array literal.
+const dynamic = await repository.find({
+    relations: computeRelations(),
+})
+
+// Should NOT be transformed — pre-existing object-style already uses v1 shape.
+const explicit = await repository.find({
+    relations: { profile: true },
+})

--- a/packages/codemod/test/transforms/v1/fixtures/find-options-string-relations/find-options-string-relations.output.ts
+++ b/packages/codemod/test/transforms/v1/fixtures/find-options-string-relations/find-options-string-relations.output.ts
@@ -7,3 +7,13 @@ const users = await repository.find({
         },
     },
 })
+
+// Should NOT be transformed — value is a function call, not an array literal.
+const dynamic = await repository.find({
+    relations: computeRelations(),
+})
+
+// Should NOT be transformed — pre-existing object-style already uses v1 shape.
+const explicit = await repository.find({
+    relations: { profile: true },
+})

--- a/packages/codemod/test/transforms/v1/fixtures/find-options-string-select/find-options-string-select.input.ts
+++ b/packages/codemod/test/transforms/v1/fixtures/find-options-string-select/find-options-string-select.input.ts
@@ -1,3 +1,14 @@
 const users = await repository.find({
     select: ["id", "name", "email"],
 })
+
+// Should NOT be transformed — value is a function call, not an array literal.
+// The codemod can only rewrite statically-known string arrays.
+const dynamic = await repository.find({
+    select: computeSelect(),
+})
+
+// Should NOT be transformed — pre-existing object-style already uses v1 shape.
+const explicit = await repository.find({
+    select: { id: true, name: true },
+})

--- a/packages/codemod/test/transforms/v1/fixtures/find-options-string-select/find-options-string-select.input.ts
+++ b/packages/codemod/test/transforms/v1/fixtures/find-options-string-select/find-options-string-select.input.ts
@@ -5,9 +5,13 @@ const users = await repository.find({
 })
 
 // Should NOT be transformed — value is a function call, not an array literal.
-// The codemod can only rewrite statically-known string arrays.
 const dynamic = await repository.find({
     select: computeSelect(),
+})
+
+// Pinned: an array literal after a dynamic call still transforms independently
+const mixed = await repository.find({
+    select: ["id", "name"],
 })
 
 // Should NOT be transformed — pre-existing object-style already uses v1 shape.

--- a/packages/codemod/test/transforms/v1/fixtures/find-options-string-select/find-options-string-select.output.ts
+++ b/packages/codemod/test/transforms/v1/fixtures/find-options-string-select/find-options-string-select.output.ts
@@ -5,3 +5,14 @@ const users = await repository.find({
         email: true,
     },
 })
+
+// Should NOT be transformed — value is a function call, not an array literal.
+// The codemod can only rewrite statically-known string arrays.
+const dynamic = await repository.find({
+    select: computeSelect(),
+})
+
+// Should NOT be transformed — pre-existing object-style already uses v1 shape.
+const explicit = await repository.find({
+    select: { id: true, name: true },
+})

--- a/packages/codemod/test/transforms/v1/fixtures/find-options-string-select/find-options-string-select.output.ts
+++ b/packages/codemod/test/transforms/v1/fixtures/find-options-string-select/find-options-string-select.output.ts
@@ -9,9 +9,16 @@ const users = await repository.find({
 })
 
 // Should NOT be transformed — value is a function call, not an array literal.
-// The codemod can only rewrite statically-known string arrays.
 const dynamic = await repository.find({
     select: computeSelect(),
+})
+
+// Pinned: an array literal after a dynamic call still transforms independently
+const mixed = await repository.find({
+    select: {
+        id: true,
+        name: true,
+    },
 })
 
 // Should NOT be transformed — pre-existing object-style already uses v1 shape.


### PR DESCRIPTION
Reported by Lucian: `find({ select: computeSelect() })` wasn't rewritten and it wasn't clear whether the codemod had stopped processing the file or simply couldn't migrate a dynamic value. The latter is correct — `find-options-string-select` (and `-relations`) can only rewrite statically-known string arrays; a function call returns at runtime so the transform can't produce an equivalent object literal at AST time.

Extends each fixture with two additional cases:

- `find({ select: computeSelect() })` — value is a call expression, left unchanged
- `find({ select: { id: true } })` — value is already the v1 object shape, left unchanged

Pins the current (correct) early-return behavior so a future regression fails loudly.