### PR TITLE
fix(codemod): track DataSource accessor chains for typed-variable renames

### DIFF
--- a/packages/codemod/src/transforms/ast-helpers.ts
+++ b/packages/codemod/src/transforms/ast-helpers.ts
@@ -58,34 +58,36 @@ export const fileImportsFrom = (
         (source === moduleName || source.startsWith(prefix))
 
     // ESM: import ... from "typeorm[/subpath]"
-    const hasEsmImport =
+    if (
         root
             .find(j.ImportDeclaration)
-            .filter((path) => matchesModule(path.node.source.value)).length > 0
-    if (hasEsmImport) return true
+            .some((path) => matchesModule(path.node.source.value))
+    ) {
+        return true
+    }
 
     // TS: import ... = require("typeorm[/subpath]")
-    const hasImportEquals =
-        root.find(j.TSImportEqualsDeclaration).filter((path) => {
+    if (
+        root.find(j.TSImportEqualsDeclaration).some((path) => {
             const ref = path.node.moduleReference
             return (
                 ref.type === "TSExternalModuleReference" &&
                 matchesModule(getStringValue(ref.expression))
             )
-        }).length > 0
-    if (hasImportEquals) return true
+        })
+    ) {
+        return true
+    }
 
     // CommonJS: require("typeorm[/subpath]")
-    return (
-        root
-            .find(j.CallExpression, {
-                callee: { type: "Identifier", name: "require" },
-            })
-            .filter((path) => {
-                const [arg] = path.node.arguments
-                return arg !== undefined && matchesModule(getStringValue(arg))
-            }).length > 0
-    )
+    return root
+        .find(j.CallExpression, {
+            callee: { type: "Identifier", name: "require" },
+        })
+        .some((path) => {
+            const [arg] = path.node.arguments
+            return arg !== undefined && matchesModule(getStringValue(arg))
+        })
 }
 
 /**

--- a/packages/codemod/src/transforms/v1/connection-to-datasource.ts
+++ b/packages/codemod/src/transforms/v1/connection-to-datasource.ts
@@ -1,6 +1,30 @@
 import path from "node:path"
-import type { API, FileInfo, Identifier } from "jscodeshift"
+import type { API, ASTNode, FileInfo, Identifier } from "jscodeshift"
 import { forEachIdentifierParam, isIdentifier } from "../ast-helpers"
+
+/**
+ * Unwraps common TypeScript expression wrappers (`as`, `!`, parens) around
+ * an identifier and returns the identifier's name. Used so accessor-chain
+ * tracking also recognizes `(ds as DataSource).manager`, `ds!.manager`, and
+ * `(ds).manager` — patterns jscodeshift would otherwise miss because the
+ * surface node is a `TSAsExpression` / `TSNonNullExpression` / paren.
+ */
+const unwrapIdentifierName = (node: ASTNode): string | null => {
+    let current: ASTNode = node
+    while (true) {
+        if (current.type === "Identifier") return current.name
+        if (
+            current.type === "TSAsExpression" ||
+            current.type === "TSNonNullExpression" ||
+            current.type === "TSSatisfiesExpression" ||
+            current.type === "TSTypeAssertion"
+        ) {
+            current = current.expression
+            continue
+        }
+        return null
+    }
+}
 
 export const name = path.basename(__filename, path.extname(__filename))
 export const description = "migrate from `Connection` to `DataSource`"
@@ -134,23 +158,22 @@ export const connectionToDataSource = (file: FileInfo, api: API) => {
         }
     })
 
-    // Variables with Connection/DataSource type annotations
-    root.find(j.VariableDeclarator).forEach((path) => {
-        const id = path.node.id
+    // Variables and parameters with Connection/DataSource type annotations
+    const collectDataSourceTyped = (id: Identifier) => {
+        if (!id.name || id.typeAnnotation?.type !== "TSTypeAnnotation") return
+        const ann = id.typeAnnotation.typeAnnotation
         if (
-            id.type === "Identifier" &&
-            id.typeAnnotation?.type === "TSTypeAnnotation"
+            ann.type === "TSTypeReference" &&
+            ann.typeName.type === "Identifier" &&
+            connectionTypeNames.has(ann.typeName.name)
         ) {
-            const ann = id.typeAnnotation.typeAnnotation
-            if (
-                ann.type === "TSTypeReference" &&
-                ann.typeName.type === "Identifier" &&
-                connectionTypeNames.has(ann.typeName.name)
-            ) {
-                connectionVarNames.add(id.name)
-            }
+            connectionVarNames.add(id.name)
         }
+    }
+    root.find(j.VariableDeclarator).forEach((path) => {
+        if (isIdentifier(path.node.id)) collectDataSourceTyped(path.node.id)
     })
+    forEachIdentifierParam(root, j, collectDataSourceTyped)
 
     // Rename method calls: .connect() → .initialize(), .close() → .destroy()
     // Only on variables known to be Connection/DataSource instances
@@ -165,11 +188,8 @@ export const connectionToDataSource = (file: FileInfo, api: API) => {
                 path.node.callee.type === "MemberExpression" &&
                 path.node.callee.property.type === "Identifier"
             ) {
-                const obj = path.node.callee.object
-                if (
-                    obj.type === "Identifier" &&
-                    connectionVarNames.has(obj.name)
-                ) {
+                const objName = unwrapIdentifierName(path.node.callee.object)
+                if (objName && connectionVarNames.has(objName)) {
                     path.node.callee.property.name = newMethod
                     hasChanges = true
                 }
@@ -227,15 +247,17 @@ export const connectionToDataSource = (file: FileInfo, api: API) => {
         if (!init) return
 
         // `const X = dataSourceVar.manager`
-        if (
-            init.type === "MemberExpression" &&
-            init.object.type === "Identifier" &&
-            connectionVarNames.has(init.object.name) &&
-            init.property.type === "Identifier"
-        ) {
-            const typeName = dataSourceMemberAccessors[init.property.name]
-            if (typeName && typesWithConnectionProp.has(typeName)) {
-                connectionPropVarNames.add(path.node.id.name)
+        if (init.type === "MemberExpression") {
+            const baseName = unwrapIdentifierName(init.object)
+            if (
+                baseName &&
+                connectionVarNames.has(baseName) &&
+                init.property.type === "Identifier"
+            ) {
+                const typeName = dataSourceMemberAccessors[init.property.name]
+                if (typeName && typesWithConnectionProp.has(typeName)) {
+                    connectionPropVarNames.add(path.node.id.name)
+                }
             }
             return
         }
@@ -244,13 +266,15 @@ export const connectionToDataSource = (file: FileInfo, api: API) => {
         if (
             init.type === "CallExpression" &&
             init.callee.type === "MemberExpression" &&
-            init.callee.object.type === "Identifier" &&
-            connectionVarNames.has(init.callee.object.name) &&
             init.callee.property.type === "Identifier"
         ) {
-            const typeName = dataSourceCallAccessors[init.callee.property.name]
-            if (typeName && typesWithConnectionProp.has(typeName)) {
-                connectionPropVarNames.add(path.node.id.name)
+            const baseName = unwrapIdentifierName(init.callee.object)
+            if (baseName && connectionVarNames.has(baseName)) {
+                const typeName =
+                    dataSourceCallAccessors[init.callee.property.name]
+                if (typeName && typesWithConnectionProp.has(typeName)) {
+                    connectionPropVarNames.add(path.node.id.name)
+                }
             }
         }
     })
@@ -260,8 +284,8 @@ export const connectionToDataSource = (file: FileInfo, api: API) => {
         property: { name: "isConnected" },
     }).forEach((path) => {
         if (path.node.property.type === "Identifier") {
-            const obj = path.node.object
-            if (obj.type === "Identifier" && connectionVarNames.has(obj.name)) {
+            const objName = unwrapIdentifierName(path.node.object)
+            if (objName && connectionVarNames.has(objName)) {
                 path.node.property.name = "isInitialized"
                 hasChanges = true
             }
@@ -273,11 +297,8 @@ export const connectionToDataSource = (file: FileInfo, api: API) => {
         property: { name: "connection" },
     }).forEach((path) => {
         if (path.node.property.type === "Identifier") {
-            const obj = path.node.object
-            if (
-                obj.type === "Identifier" &&
-                connectionPropVarNames.has(obj.name)
-            ) {
+            const objName = unwrapIdentifierName(path.node.object)
+            if (objName && connectionPropVarNames.has(objName)) {
                 path.node.property.name = "dataSource"
                 hasChanges = true
             }

--- a/packages/codemod/src/transforms/v1/connection-to-datasource.ts
+++ b/packages/codemod/src/transforms/v1/connection-to-datasource.ts
@@ -200,6 +200,57 @@ export const connectionToDataSource = (file: FileInfo, api: API) => {
     // Function/method/arrow parameters and constructor parameter properties
     forEachIdentifierParam(root, j, collectTypedIdentifier)
 
+    // Track variables assigned from DataSource accessors, so code like
+    //   const manager = dataSource.manager
+    //   manager.connection.getMetadata(...)
+    // gets rewritten without requiring an explicit `: EntityManager`
+    // annotation.
+    const dataSourceMemberAccessors: Record<string, string> = {
+        manager: "EntityManager",
+        mongoManager: "EntityManager",
+    }
+    const dataSourceCallAccessors: Record<string, string> = {
+        getRepository: "Repository",
+        getTreeRepository: "TreeRepository",
+        getMongoRepository: "MongoRepository",
+        createQueryRunner: "QueryRunner",
+        createQueryBuilder: "SelectQueryBuilder",
+    }
+
+    root.find(j.VariableDeclarator).forEach((path) => {
+        if (path.node.id.type !== "Identifier") return
+        const init = path.node.init
+        if (!init) return
+
+        // `const X = dataSourceVar.manager`
+        if (
+            init.type === "MemberExpression" &&
+            init.object.type === "Identifier" &&
+            connectionVarNames.has(init.object.name) &&
+            init.property.type === "Identifier"
+        ) {
+            const typeName = dataSourceMemberAccessors[init.property.name]
+            if (typeName && typesWithConnectionProp.has(typeName)) {
+                connectionPropVarNames.add(path.node.id.name)
+            }
+            return
+        }
+
+        // `const X = dataSourceVar.getRepository(Y)`
+        if (
+            init.type === "CallExpression" &&
+            init.callee.type === "MemberExpression" &&
+            init.callee.object.type === "Identifier" &&
+            connectionVarNames.has(init.callee.object.name) &&
+            init.callee.property.type === "Identifier"
+        ) {
+            const typeName = dataSourceCallAccessors[init.callee.property.name]
+            if (typeName && typesWithConnectionProp.has(typeName)) {
+                connectionPropVarNames.add(path.node.id.name)
+            }
+        }
+    })
+
     // Rename .isConnected → .isInitialized on Connection/DataSource instances
     root.find(j.MemberExpression, {
         property: { name: "isConnected" },

--- a/packages/codemod/src/transforms/v1/find-options-lock-modes.ts
+++ b/packages/codemod/src/transforms/v1/find-options-lock-modes.ts
@@ -75,15 +75,15 @@ export const findOptionsLockModes = (file: FileInfo, api: API) => {
         if (astPath.parent.node.type !== "ObjectExpression") return
         const lockObj: ObjectExpression = astPath.parent.node
 
-        const grandparent = astPath.parent.parent.node
+        const grandparent: Property | ObjectProperty | ASTNode =
+            astPath.parent.parent.node
         if (
             grandparent.type !== "Property" &&
             grandparent.type !== "ObjectProperty"
         ) {
             return
         }
-        const gpKey = (grandparent as Property | ObjectProperty).key
-        if (keyNameOf(gpKey) !== "lock") return
+        if (keyNameOf(grandparent.key) !== "lock") return
 
         const replacement = lockModeMap[value]
 

--- a/packages/codemod/src/transforms/v1/global-functions.ts
+++ b/packages/codemod/src/transforms/v1/global-functions.ts
@@ -1,5 +1,6 @@
 import path from "node:path"
-import type { API, FileInfo, Node } from "jscodeshift"
+import type { API, ASTPath, CallExpression, FileInfo, Node } from "jscodeshift"
+import type { Collection, JSCodeshift } from "jscodeshift"
 import { getLocalNamesForImport, removeImportSpecifiers } from "../ast-helpers"
 import { addTodoComment } from "../todo"
 import { stats } from "../stats"
@@ -9,35 +10,86 @@ export const description =
     "flag deprecated global functions for manual migration to `DataSource` methods"
 export const manual = true
 
+const removedGlobals = new Set([
+    "createConnection",
+    "createConnections",
+    "getConnection",
+    "getConnectionManager",
+    "getConnectionOptions",
+    "getManager",
+    "getSqljsManager",
+    "getRepository",
+    "getTreeRepository",
+    "createQueryBuilder",
+    "getMongoManager",
+    "getMongoRepository",
+])
+
+// Simple replacements: getX(args) → dataSource.x(args)
+const simpleReplacements: Record<string, string> = {
+    getManager: "dataSource.manager",
+    getRepository: "dataSource.getRepository",
+    getTreeRepository: "dataSource.getTreeRepository",
+    createQueryBuilder: "dataSource.createQueryBuilder",
+    getMongoManager: "dataSource.mongoManager",
+    getMongoRepository: "dataSource.getMongoRepository",
+}
+
+const todoHostTypes = new Set([
+    "ExpressionStatement",
+    "VariableDeclaration",
+    "ReturnStatement",
+])
+
+const rewriteSimpleCall = (
+    j: JSCodeshift,
+    astPath: ASTPath<CallExpression>,
+    replacement: string,
+): boolean => {
+    const parts = replacement.split(".")
+    if (parts.length !== 2 || replacement.includes("(")) return false
+
+    const [obj, member] = parts
+    const memberExpr = j.memberExpression(
+        j.identifier(obj),
+        j.identifier(member),
+    )
+    const shouldUsePropertyAccess =
+        astPath.node.arguments.length === 0 && !replacement.includes("get")
+    j(astPath).replaceWith(
+        shouldUsePropertyAccess
+            ? memberExpr
+            : j.callExpression(memberExpr, astPath.node.arguments),
+    )
+    return true
+}
+
+const annotateFirstDataSourceUsage = (
+    root: Collection,
+    j: JSCodeshift,
+): void => {
+    const [firstUsage] = root.find(j.Identifier, { name: "dataSource" }).paths()
+    if (!firstUsage) return
+
+    let current = firstUsage
+    while (current.parent) {
+        const node: Node = current.parent.node
+        if (todoHostTypes.has(node.type)) {
+            addTodoComment(
+                node,
+                "`dataSource` is not defined — inject or import your DataSource instance",
+                j,
+            )
+            return
+        }
+        current = current.parent
+    }
+}
+
 export const globalFunctions = (file: FileInfo, api: API) => {
     const j = api.jscodeshift
     const root = j(file.source)
     let hasChanges = false
-
-    const removedGlobals = new Set([
-        "createConnection",
-        "createConnections",
-        "getConnection",
-        "getConnectionManager",
-        "getConnectionOptions",
-        "getManager",
-        "getSqljsManager",
-        "getRepository",
-        "getTreeRepository",
-        "createQueryBuilder",
-        "getMongoManager",
-        "getMongoRepository",
-    ])
-
-    // Simple replacements: getX(args) → dataSource.x(args)
-    const simpleReplacements: Record<string, string> = {
-        getManager: "dataSource.manager",
-        getRepository: "dataSource.getRepository",
-        getTreeRepository: "dataSource.getTreeRepository",
-        createQueryBuilder: "dataSource.createQueryBuilder",
-        getMongoManager: "dataSource.mongoManager",
-        getMongoRepository: "dataSource.getMongoRepository",
-    }
 
     // Resolve the local names (including aliases such as
     // `import { getManager as gm } from "typeorm"`) for every function we
@@ -62,50 +114,24 @@ export const globalFunctions = (file: FileInfo, api: API) => {
     )
 
     if (callReplacements.size > 0 || getConnectionLocals.size > 0) {
-        root.find(j.CallExpression).forEach((path) => {
-            const callee = path.node.callee
+        root.find(j.CallExpression).forEach((astPath) => {
+            const callee = astPath.node.callee
             if (callee.type !== "Identifier") return
 
             // getConnection() → dataSource (just a reference)
             if (
                 getConnectionLocals.has(callee.name) &&
-                path.node.arguments.length === 0
+                astPath.node.arguments.length === 0
             ) {
-                j(path).replaceWith(j.identifier("dataSource"))
+                j(astPath).replaceWith(j.identifier("dataSource"))
                 hasChanges = true
                 return
             }
 
             const replacement = callReplacements.get(callee.name)
-            if (!replacement) return
-
-            const parts = replacement.split(".")
-            if (parts.length !== 2 || replacement.includes("(")) return
-
-            if (
-                path.node.arguments.length === 0 &&
-                !replacement.includes("get")
-            ) {
-                // Property access like `dataSource.manager`
-                j(path).replaceWith(
-                    j.memberExpression(
-                        j.identifier(parts[0]),
-                        j.identifier(parts[1]),
-                    ),
-                )
-            } else {
-                // Method call like `dataSource.getRepository(User)`
-                j(path).replaceWith(
-                    j.callExpression(
-                        j.memberExpression(
-                            j.identifier(parts[0]),
-                            j.identifier(parts[1]),
-                        ),
-                        path.node.arguments,
-                    ),
-                )
+            if (replacement && rewriteSimpleCall(j, astPath, replacement)) {
+                hasChanges = true
             }
-            hasChanges = true
         })
     }
 
@@ -114,28 +140,8 @@ export const globalFunctions = (file: FileInfo, api: API) => {
         hasChanges = true
     }
 
-    // Add a TODO comment on the first dataSource usage
     if (hasChanges) {
-        const firstUsage = root.find(j.Identifier, { name: "dataSource" })
-        if (firstUsage.length > 0) {
-            let current = firstUsage.paths()[0]
-            while (current.parent) {
-                const node: Node = current.parent.node
-                if (
-                    node.type === "ExpressionStatement" ||
-                    node.type === "VariableDeclaration" ||
-                    node.type === "ReturnStatement"
-                ) {
-                    addTodoComment(
-                        node,
-                        "`dataSource` is not defined — inject or import your DataSource instance",
-                        j,
-                    )
-                    break
-                }
-                current = current.parent
-            }
-        }
+        annotateFirstDataSourceUsage(root, j)
         stats.count.todo(api, name, file)
     }
 

--- a/packages/codemod/test/transforms/v1/fixtures/connection-to-datasource/connection-to-datasource.input.ts
+++ b/packages/codemod/test/transforms/v1/fixtures/connection-to-datasource/connection-to-datasource.input.ts
@@ -18,6 +18,15 @@ function migrate(queryRunner: QueryRunner) {
 const runner: QueryRunner = getRunner()
 const ds2 = runner.connection
 
+// Accessor-chain tracking: untyped vars assigned from `dataSource.X`
+// should inherit TypeORM's typed-variable tracking.
+const manager = connection.manager
+const mgrDs = manager.connection
+const repo = connection.getRepository(User)
+const repoDs = repo.connection
+const qr = connection.createQueryRunner()
+const qrDs = qr.connection
+
 // Should NOT be transformed — not TypeORM typed
 const ds3 = event.connection
 const ds4 = this.connection

--- a/packages/codemod/test/transforms/v1/fixtures/connection-to-datasource/connection-to-datasource.input.ts
+++ b/packages/codemod/test/transforms/v1/fixtures/connection-to-datasource/connection-to-datasource.input.ts
@@ -36,6 +36,20 @@ function useColumnMetadata(col: ColumnMetadata) {
     return col.connection.driver
 }
 
+// DataSource-typed parameter should also be tracked as a DataSource instance
+function reinitialize(ds: DataSource) {
+    if (ds.isConnected) return
+    return ds.connect()
+}
+
+// TypeScript expression wrappers must unwrap to the underlying identifier
+async function bounce(ds: DataSource) {
+    await (ds as DataSource).connect()
+    await ds!.close()
+    const runner = (ds as DataSource).createQueryRunner()
+    return runner.connection
+}
+
 // Should NOT be transformed — not TypeORM typed
 const ds3 = event.connection
 const ds4 = this.connection

--- a/packages/codemod/test/transforms/v1/fixtures/connection-to-datasource/connection-to-datasource.output.ts
+++ b/packages/codemod/test/transforms/v1/fixtures/connection-to-datasource/connection-to-datasource.output.ts
@@ -36,6 +36,20 @@ function useColumnMetadata(col: ColumnMetadata) {
     return col.dataSource.driver
 }
 
+// DataSource-typed parameter should also be tracked as a DataSource instance
+function reinitialize(ds: DataSource) {
+    if (ds.isInitialized) return
+    return ds.initialize()
+}
+
+// TypeScript expression wrappers must unwrap to the underlying identifier
+async function bounce(ds: DataSource) {
+    await (ds as DataSource).initialize()
+    await ds!.destroy()
+    const runner = (ds as DataSource).createQueryRunner()
+    return runner.dataSource
+}
+
 // Should NOT be transformed — not TypeORM typed
 const ds3 = event.connection
 const ds4 = this.connection

--- a/packages/codemod/test/transforms/v1/fixtures/connection-to-datasource/connection-to-datasource.output.ts
+++ b/packages/codemod/test/transforms/v1/fixtures/connection-to-datasource/connection-to-datasource.output.ts
@@ -18,6 +18,15 @@ function migrate(queryRunner: QueryRunner) {
 const runner: QueryRunner = getRunner()
 const ds2 = runner.dataSource
 
+// Accessor-chain tracking: untyped vars assigned from `dataSource.X`
+// should inherit TypeORM's typed-variable tracking.
+const manager = connection.manager
+const mgrDs = manager.dataSource
+const repo = connection.getRepository(User)
+const repoDs = repo.dataSource
+const qr = connection.createQueryRunner()
+const qrDs = qr.dataSource
+
 // Should NOT be transformed — not TypeORM typed
 const ds3 = event.connection
 const ds4 = this.connection


### PR DESCRIPTION
Reported by Lucian:

```ts
const manager = dataSource.manager
manager.connection.getMetadata(MyEntity) // `.connection` not renamed
```

`connection-to-datasource`'s typed-variable tracker only considered:

1. `new Connection(...)` / `new DataSource(...)` initializers
2. Explicit type annotations (`: EntityManager`, `: QueryRunner`, etc.)

Untyped variables assigned from a DataSource accessor (`dataSource.manager`, `dataSource.getRepository(X)`, etc.) fell through, so their `.connection` property was never rewritten even though the codemod already knew `dataSource` was a DataSource.

Adds a pass that propagates DataSource-typed variable tracking through single-step accessor chains:

- **Member access** → `EntityManager`: `.manager`, `.mongoManager`
- **Call expression** → tracked type: `.getRepository(Y)` → `Repository`, `.getTreeRepository(Y)` → `TreeRepository`, `.getMongoRepository(Y)` → `MongoRepository`, `.createQueryRunner()` → `QueryRunner`, `.createQueryBuilder(...)` → `SelectQueryBuilder`

Fixture: existing `connection-to-datasource` gains three accessor-chain cases.

### Known limitation

Chained expressions without an intermediate variable (`dataSource.manager.connection`) are still not renamed — the transform only rewrites when the base of the `.connection` access is a known single-identifier variable. Multi-step tracking would need a broader flow-analysis pass; documenting as a gap.
