### PR TITLE
fix: do not run npm install

### DIFF
--- a/.husky/commit-msg
+++ b/.husky/commit-msg
@@ -1,1 +1,0 @@
-[ -x .git/hooks/commit-msg ] && .git/hooks/commit-msg "$1"

--- a/src/commands/InitCommand.ts
+++ b/src/commands/InitCommand.ts
@@ -45,12 +45,6 @@ export class InitCommand implements yargs.CommandModule {
                 describe:
                     "Set to true if docker-compose must be generated as well. False by default.",
             })
-            .option("pm", {
-                alias: "manager",
-                choices: ["npm", "yarn"],
-                default: "npm",
-                describe: "Install packages, expected values are npm or yarn.",
-            })
             .option("ms", {
                 alias: "module",
                 choices: ["commonjs", "esm"],
@@ -69,7 +63,6 @@ export class InitCommand implements yargs.CommandModule {
             const projectName = args.name
                 ? path.basename(args.name as any)
                 : undefined
-            const installNpm = args.pm === "yarn" ? false : true
             const projectIsEsm = args.ms === "esm"
             await CommandUtils.createFile(
                 basePath + "/package.json",
@@ -146,12 +139,9 @@ export class InitCommand implements yargs.CommandModule {
                 )
             }
 
-            console.log(ansi.green`Please wait, installing dependencies...`)
-            if (args.pm && installNpm) {
-                await InitCommand.executeCommand("npm install", basePath)
-            } else {
-                await InitCommand.executeCommand("yarn install", basePath)
-            }
+            console.log(
+                ansi.green`Please verify the package.json file and install dependencies using your preferred package manager.`,
+            )
 
             console.log(ansi.green`Done! Start playing with a new project!`)
         } catch (err) {

--- a/src/commands/InitCommand.ts
+++ b/src/commands/InitCommand.ts
@@ -1,6 +1,5 @@
 import ansi from "ansis"
-import { exec } from "child_process"
-import path from "path"
+import path from "node:path"
 import type yargs from "yargs"
 import { TypeORMError } from "../error"
 import { PlatformTools } from "../platform/PlatformTools"
@@ -153,17 +152,6 @@ export class InitCommand implements yargs.CommandModule {
     // -------------------------------------------------------------------------
     // Protected Static Methods
     // -------------------------------------------------------------------------
-
-    protected static executeCommand(command: string, cwd: string) {
-        return new Promise<string>((ok, fail) => {
-            exec(command, { cwd }, (error: any, stdout: any, stderr: any) => {
-                if (stdout) return ok(stdout)
-                if (stderr) return fail(stderr)
-                if (error) return fail(error)
-                ok("")
-            })
-        })
-    }
 
     /**
      * Gets contents of the ormconfig file.


### PR DESCRIPTION
### Description of change

Remove the `npm install` command that was executed automatically.

This was always assuming the developers are using `npm` (or `yarn`), but there are lot more package managers. Normally we should also let the users verify what they install and not force certain packages on them, e.g. if they use `pnpm`, they could have `minimumReleaseAge` which npm ignores.

Our docs (the "Initialize a new TypeORM project" section on the "Using CLI" page) was already instructing users to run `npm install` - so documentation does not need updating (this is just a fix to get the intended and documented behavior).

NX for example does not install anything, it instructs the users to verify the git diff and do the rest themselves.

Also: this will stop our tests from interfering with our own `node_modules` (and reduce CI time).

### Pull-Request Checklist

- [x] Code is up-to-date with the `master` branch
- [ ] This pull request links relevant issues as `Fixes #00000`
- [ ] There are new or updated tests validating the change (`tests/**.test.ts`)
- [ ] Documentation has been updated to reflect this change (`docs/docs/**.md`)
