### PR TITLE
fix(capacitor): expose affected rows in default query result (#12358)

### DIFF
--- a/src/driver/capacitor/CapacitorQueryRunner.ts
+++ b/src/driver/capacitor/CapacitorQueryRunner.ts
@@ -68,6 +68,7 @@ export class CapacitorQueryRunner extends AbstractSqliteQueryRunner {
 
         const spaceIndex = query.indexOf(" ")
         const command = spaceIndex === -1 ? query : query.slice(0, spaceIndex)
+        const isWriteQuery = ["INSERT", "UPDATE", "DELETE"].includes(command)
 
         try {
             let raw: any
@@ -102,6 +103,9 @@ export class CapacitorQueryRunner extends AbstractSqliteQueryRunner {
             }
 
             if (!useStructuredResult) {
+                if (isWriteQuery) {
+                    return result
+                }
                 return result.raw
             }
 

--- a/test/github-issues/12358/issue-12358.test.ts
+++ b/test/github-issues/12358/issue-12358.test.ts
@@ -1,0 +1,38 @@
+import { expect } from "chai"
+import "reflect-metadata"
+import { CapacitorQueryRunner } from "../../../src/driver/capacitor/CapacitorQueryRunner"
+
+describe("github issues > #12358 capacitor affected rows", () => {
+    it("should return affected rows in default query result (without structured result)", async () => {
+        const mockConnection = {
+            run: async () => ({
+                changes: {
+                    changes: 1,
+                    lastId: 1,
+                },
+            }),
+            query: async () => ({ values: [] }),
+            execute: async () => ({}),
+        }
+
+        const mockDriver: any = {
+            dataSource: {
+                logger: {
+                    logQuery: () => {},
+                    logQueryError: () => {},
+                },
+            },
+        }
+
+        const runner = new CapacitorQueryRunner(mockDriver)
+
+        runner.connect = async () => mockConnection as any
+
+        const result: any = await runner.query("DELETE FROM test WHERE id = 1")
+
+        console.log("DEFAULT RESULT:", result)
+
+        expect(result).to.have.property("affected")
+        expect(result.affected).to.equal(1)
+    })
+})


### PR DESCRIPTION
Fixes #12358

## Description
The Capacitor driver computed affected rows internally but did not expose them
in default query results unless structured result mode was used.

## Solution
- Return `QueryResult` for write queries (INSERT, UPDATE, DELETE)
- Ensure `affected` rows are accessible in default query usage
- Added test to reproduce and verify the issue

## Notes
- Mock connection is used to simulate Capacitor environment