### PR TITLE
fix(codemod): harden scope and type-name detection across more AST shapes

### DIFF
--- a/packages/codemod/src/cli/run-transforms.ts
+++ b/packages/codemod/src/cli/run-transforms.ts
@@ -237,11 +237,24 @@ const runOneTransform = async (
         // buffered during the run are printed against the real terminal
         // instead of being re-captured by the interceptor.
         process.stdout.write = originalWrite
-        printUnclassifiedOutput(
-            interceptor.unclassifiedOutput,
-            interceptor.getSuppressedOutputCount(),
-            originalWrite,
-        )
+        try {
+            printUnclassifiedOutput(
+                interceptor.unclassifiedOutput,
+                interceptor.getSuppressedOutputCount(),
+                originalWrite,
+            )
+        } catch (printErr) {
+            // A failing diagnostic must never mask the original transform
+            // error. Leave a breadcrumb on stderr so the print failure is
+            // still visible, then fall through to rethrow `err`.
+            process.stderr.write(
+                `Warning: failed to print buffered worker output: ${
+                    printErr instanceof Error
+                        ? printErr.message
+                        : String(printErr)
+                }\n`,
+            )
+        }
         throw err
     } finally {
         process.stdout.write = originalWrite

--- a/packages/codemod/src/cli/run-transforms.ts
+++ b/packages/codemod/src/cli/run-transforms.ts
@@ -246,14 +246,21 @@ const runOneTransform = async (
         } catch (printErr) {
             // A failing diagnostic must never mask the original transform
             // error. Leave a breadcrumb on stderr so the print failure is
-            // still visible, then fall through to rethrow `err`.
-            process.stderr.write(
-                `Warning: failed to print buffered worker output: ${
-                    printErr instanceof Error
-                        ? printErr.message
-                        : String(printErr)
-                }\n`,
-            )
+            // still visible, then fall through to rethrow `err`. The
+            // stderr write itself is also guarded — on EPIPE (e.g. the
+            // output is piped to `head` in CI) writing to stderr would
+            // throw and mask `err` just the same.
+            try {
+                process.stderr.write(
+                    `Warning: failed to print buffered worker output: ${
+                        printErr instanceof Error
+                            ? printErr.message
+                            : String(printErr)
+                    }\n`,
+                )
+            } catch {
+                // stderr is broken too — nothing more to do.
+            }
         }
         throw err
     } finally {

--- a/packages/codemod/src/cli/run-transforms.ts
+++ b/packages/codemod/src/cli/run-transforms.ts
@@ -235,19 +235,13 @@ const runOneTransform = async (
         )
         // Restore stdout first so worker warnings/stack traces that were
         // buffered during the run are printed against the real terminal
-        // instead of being re-captured by the interceptor. Guard the print
-        // in try/catch: a best-effort diagnostic must never mask the
-        // original transform error.
+        // instead of being re-captured by the interceptor.
         process.stdout.write = originalWrite
-        try {
-            printUnclassifiedOutput(
-                interceptor.unclassifiedOutput,
-                interceptor.getSuppressedOutputCount(),
-                originalWrite,
-            )
-        } catch {
-            // Swallow — the original `err` is what the user cares about.
-        }
+        printUnclassifiedOutput(
+            interceptor.unclassifiedOutput,
+            interceptor.getSuppressedOutputCount(),
+            originalWrite,
+        )
         throw err
     } finally {
         process.stdout.write = originalWrite

--- a/packages/codemod/src/transforms/ast-helpers.ts
+++ b/packages/codemod/src/transforms/ast-helpers.ts
@@ -41,11 +41,12 @@ export const isIdentifier = (node: { type: string }): node is Identifier =>
     node.type === "Identifier"
 
 /**
- * Checks whether the file contains an import from the given module. Matches
- * both the exact module name (`"typeorm"`) and any sub-path (`"typeorm/..."`),
- * and recognizes ESM `import`, TypeScript `import = require(...)`, and
- * CommonJS `require(...)` forms so that `.js`/`.jsx` callers still pass the
- * scope guard.
+ * Checks whether the file references the given module as an import or a
+ * re-export source. Matches the exact module name (`"typeorm"`) and any
+ * sub-path (`"typeorm/..."`), and recognises ESM `import`, ESM
+ * `export … from "…"` / `export * from "…"`, TypeScript
+ * `import = require(...)`, and CommonJS `require(...)` forms so barrel
+ * files and `.js`/`.jsx` callers still pass the scope guard.
  */
 export const fileImportsFrom = (
     root: Collection,
@@ -62,6 +63,24 @@ export const fileImportsFrom = (
         root
             .find(j.ImportDeclaration)
             .some((path) => matchesModule(path.node.source.value))
+    ) {
+        return true
+    }
+
+    // ESM: export { X } from "typeorm[/subpath]" / export * from "…"
+    // Barrel files that only re-export TypeORM APIs have no import at all,
+    // but their re-export source still counts as a reference to the module.
+    if (
+        root
+            .find(j.ExportNamedDeclaration)
+            .some((path) => matchesModule(path.node.source?.value))
+    ) {
+        return true
+    }
+    if (
+        root
+            .find(j.ExportAllDeclaration)
+            .some((path) => matchesModule(path.node.source?.value))
     ) {
         return true
     }

--- a/packages/codemod/src/transforms/ast-helpers.ts
+++ b/packages/codemod/src/transforms/ast-helpers.ts
@@ -694,15 +694,25 @@ export const renameMemberMethod = (
  * name — e.g. `Repository<User>` → `"Repository"`, `Repository<User> | null`
  * → `"Repository"`, `typeof Repository` → `"Repository"`. Returns null when
  * the annotation doesn't root on a TSTypeReference with an Identifier name.
+ *
+ * When `typeormNamespaceNames` is passed, qualified references like
+ * `ns.Repository<User>` are only returned if `ns` is one of the provided
+ * namespace locals — otherwise the qualified reference is rejected so that
+ * unrelated namespaces (`Foo.Repository<T>` from some-other-lib) are not
+ * mistaken for TypeORM types. Without the parameter, any qualifier is
+ * accepted, which matches legacy callers that don't care about provenance.
  */
 // Walks the members of a union/intersection type and prefers the first
 // TypeORM-family name (so `FooBar | Repository<T>` or `null | Repository<T>`
 // classify correctly). Falls back to the first non-null root name to keep
 // pre-existing behavior for callers that don't care about TypeORM gating.
-const findUnionOrIntersectionRoot = (types: ASTNode[]): string | null => {
+const findUnionOrIntersectionRoot = (
+    types: ASTNode[],
+    typeormNamespaceNames?: ReadonlySet<string>,
+): string | null => {
     let firstName: string | null = null
     for (const member of types) {
-        const name = getTypeReferenceRootName(member)
+        const name = getTypeReferenceRootName(member, typeormNamespaceNames)
         if (!name) continue
         if (
             TYPEORM_REPOSITORY_TYPES.has(name) ||
@@ -717,19 +727,36 @@ const findUnionOrIntersectionRoot = (types: ASTNode[]): string | null => {
 
 // Returns the rightmost segment of a `TSQualifiedName` (`a.b.c` in type
 // position) — always an `Identifier` in valid TS, since the nesting lives
-// on `.left`. So a single access covers any depth — `typeorm.Repository`
-// and `ns.sub.Repository` both resolve to `"Repository"`, matching bare
-// `Repository<T>` for classification.
-const getQualifiedNameRightmost = (node: ASTNode): string | null => {
-    const n = node as { right: ASTNode }
-    if (n.right.type === "Identifier") {
-        return n.right.name
+// on `.left`. When `typeormNamespaceNames` is provided, the leftmost segment
+// is checked against the set of typeorm namespace locals and the rightmost
+// name is only returned if the qualifier matches — so `typeorm.Repository`
+// resolves to `"Repository"` while `other.Repository` returns null, avoiding
+// false-positive classification of identically-named types from other
+// modules. Without the parameter, any qualifier is accepted (legacy
+// behaviour for callers that only look at the rightmost segment).
+const getQualifiedNameRightmost = (
+    node: ASTNode,
+    typeormNamespaceNames?: ReadonlySet<string>,
+): string | null => {
+    const n = node as { left: ASTNode; right: ASTNode }
+    if (n.right.type !== "Identifier") return null
+
+    if (typeormNamespaceNames !== undefined) {
+        // Walk down `.left` to the leftmost identifier (qualifier root).
+        let leftmost: ASTNode = n.left
+        while (leftmost.type === "TSQualifiedName") {
+            leftmost = (leftmost as { left: ASTNode }).left
+        }
+        if (leftmost.type !== "Identifier") return null
+        if (!typeormNamespaceNames.has(leftmost.name)) return null
     }
-    return null
+
+    return n.right.name
 }
 
 export const getTypeReferenceRootName = (
     node: ASTNode | null,
+    typeormNamespaceNames?: ReadonlySet<string>,
 ): string | null => {
     if (!node) return null
     if (node.type === "TSTypeReference") {
@@ -741,7 +768,7 @@ export const getTypeReferenceRootName = (
         // (namespace-import access). Without this branch,
         // `import * as typeorm from "typeorm"` callers would be missed.
         if (n.typeName.type === "TSQualifiedName") {
-            return getQualifiedNameRightmost(n.typeName)
+            return getQualifiedNameRightmost(n.typeName, typeormNamespaceNames)
         }
     }
     // `const X: typeof Repository` — TSTypeQuery wraps the referenced
@@ -753,15 +780,18 @@ export const getTypeReferenceRootName = (
             return n.exprName.name
         }
         if (n.exprName.type === "TSQualifiedName") {
-            return getQualifiedNameRightmost(n.exprName)
+            return getQualifiedNameRightmost(n.exprName, typeormNamespaceNames)
         }
     }
     if (node.type === "TSTypeAnnotation") {
         const n = node as { typeAnnotation: ASTNode }
-        return getTypeReferenceRootName(n.typeAnnotation)
+        return getTypeReferenceRootName(n.typeAnnotation, typeormNamespaceNames)
     }
     if (node.type === "TSUnionType" || node.type === "TSIntersectionType") {
-        return findUnionOrIntersectionRoot((node as { types: ASTNode[] }).types)
+        return findUnionOrIntersectionRoot(
+            (node as { types: ASTNode[] }).types,
+            typeormNamespaceNames,
+        )
     }
     return null
 }
@@ -877,9 +907,10 @@ const recordTypedIdentifier = (
     id: ASTNode,
     annotation: ASTNode | null,
     bindings: RepositoryBindings,
+    typeormNamespaceNames: ReadonlySet<string>,
 ): void => {
     if (id.type !== "Identifier") return
-    const typeName = getTypeReferenceRootName(annotation)
+    const typeName = getTypeReferenceRootName(annotation, typeormNamespaceNames)
     if (!typeName) return
     const bucket = classifyRepositoryTypeName(typeName, bindings, false)
     bucket?.add(id.name)
@@ -928,11 +959,17 @@ const collectDeclaratorBindings = (
     root: Collection,
     j: JSCodeshift,
     bindings: RepositoryBindings,
+    typeormNamespaceNames: ReadonlySet<string>,
 ): void => {
     root.find(j.VariableDeclarator).forEach((p) => {
         const id = p.node.id
         if (id.type !== "Identifier") return
-        recordTypedIdentifier(id, id.typeAnnotation ?? null, bindings)
+        recordTypedIdentifier(
+            id,
+            id.typeAnnotation ?? null,
+            bindings,
+            typeormNamespaceNames,
+        )
         const init = p.node.init
         if (init && isRepositoryReturningCall(init)) {
             bindings.locals.add(id.name)
@@ -954,17 +991,26 @@ const collectFunctionParamBindings = (
     root: Collection,
     j: JSCodeshift,
     bindings: RepositoryBindings,
+    typeormNamespaceNames: ReadonlySet<string>,
 ): void => {
     const visit = (node: { params: ASTNode[] }) => {
         for (const param of node.params) {
             const unwrapped = unwrapParameterIdentifier(param)
             if (!unwrapped) continue
-            recordTypedIdentifier(unwrapped.id, unwrapped.annotation, bindings)
+            recordTypedIdentifier(
+                unwrapped.id,
+                unwrapped.annotation,
+                bindings,
+                typeormNamespaceNames,
+            )
             if (
                 unwrapped.isParameterProperty &&
                 unwrapped.id.type === "Identifier"
             ) {
-                const typeName = getTypeReferenceRootName(unwrapped.annotation)
+                const typeName = getTypeReferenceRootName(
+                    unwrapped.annotation,
+                    typeormNamespaceNames,
+                )
                 if (typeName) {
                     const classBucket = classifyRepositoryTypeName(
                         typeName,
@@ -989,13 +1035,17 @@ const collectClassPropertyBindings = (
     root: Collection,
     j: JSCodeshift,
     bindings: RepositoryBindings,
+    typeormNamespaceNames: ReadonlySet<string>,
 ): void => {
     root.find(j.ClassProperty).forEach((p) => {
         const key = p.node.key
         if (key.type !== "Identifier") return
         const annotation =
             (p.node as { typeAnnotation?: ASTNode }).typeAnnotation ?? null
-        const typeName = getTypeReferenceRootName(annotation)
+        const typeName = getTypeReferenceRootName(
+            annotation,
+            typeormNamespaceNames,
+        )
         if (!typeName) return
         const bucket = classifyRepositoryTypeName(typeName, bindings, true)
         bucket?.add(key.name)
@@ -1012,9 +1062,17 @@ export const collectRepositoryBindings = (
         dataSourceLocals: new Set(),
         dataSourceClassProps: new Set(),
     }
-    collectDeclaratorBindings(root, j, bindings)
-    collectFunctionParamBindings(root, j, bindings)
-    collectClassPropertyBindings(root, j, bindings)
+    // Qualified type references like `typeorm.Repository<T>` must only be
+    // classified as TypeORM receivers when the qualifier is an actual
+    // namespace-local of `import * as typeorm from "typeorm"` (or the
+    // `import ns = require("typeorm")` variants). Without this gate, a
+    // file containing both a typeorm import and `Foo.Repository<T>` from
+    // some-other-lib would treat `Foo.Repository`-typed bindings as
+    // Repository receivers and mis-rewrite their method calls.
+    const typeormNamespaceNames = getNamespaceLocalNames(root, j, "typeorm")
+    collectDeclaratorBindings(root, j, bindings, typeormNamespaceNames)
+    collectFunctionParamBindings(root, j, bindings, typeormNamespaceNames)
+    collectClassPropertyBindings(root, j, bindings, typeormNamespaceNames)
     return bindings
 }
 

--- a/packages/codemod/src/transforms/ast-helpers.ts
+++ b/packages/codemod/src/transforms/ast-helpers.ts
@@ -43,8 +43,8 @@ export const isIdentifier = (node: { type: string }): node is Identifier =>
 /**
  * Checks whether the file references the given module as an import or a
  * re-export source. Matches the exact module name (`"typeorm"`) and any
- * sub-path (`"typeorm/..."`), and recognises ESM `import`, ESM
- * `export … from "…"` / `export * from "…"`, TypeScript
+ * sub-path (`"typeorm/..."`), and recognizes ESM `import`, ESM
+ * `export { X } from "..."` / `export * from "..."`, TypeScript
  * `import = require(...)`, and CommonJS `require(...)` forms so barrel
  * files and `.js`/`.jsx` callers still pass the scope guard.
  */
@@ -67,7 +67,7 @@ export const fileImportsFrom = (
         return true
     }
 
-    // ESM: export { X } from "typeorm[/subpath]" / export * from "…"
+    // ESM: export { X } from "typeorm[/subpath]" / export * from "..."
     // Barrel files that only re-export TypeORM APIs have no import at all,
     // but their re-export source still counts as a reference to the module.
     if (
@@ -715,10 +715,11 @@ const findUnionOrIntersectionRoot = (types: ASTNode[]): string | null => {
     return firstName
 }
 
-// Walks a possibly-nested `TSQualifiedName` (`a.b.c` in type position) and
-// returns the rightmost identifier name — for `typeorm.Repository` we want
-// `"Repository"` so namespace-qualified annotations classify the same way
-// as bare `Repository<T>`.
+// Returns the rightmost segment of a `TSQualifiedName` (`a.b.c` in type
+// position) — always an `Identifier` in valid TS, since the nesting lives
+// on `.left`. So a single access covers any depth — `typeorm.Repository`
+// and `ns.sub.Repository` both resolve to `"Repository"`, matching bare
+// `Repository<T>` for classification.
 const getQualifiedNameRightmost = (node: ASTNode): string | null => {
     const n = node as { right: ASTNode }
     if (n.right.type === "Identifier") {

--- a/packages/codemod/src/transforms/ast-helpers.ts
+++ b/packages/codemod/src/transforms/ast-helpers.ts
@@ -715,6 +715,18 @@ const findUnionOrIntersectionRoot = (types: ASTNode[]): string | null => {
     return firstName
 }
 
+// Walks a possibly-nested `TSQualifiedName` (`a.b.c` in type position) and
+// returns the rightmost identifier name — for `typeorm.Repository` we want
+// `"Repository"` so namespace-qualified annotations classify the same way
+// as bare `Repository<T>`.
+const getQualifiedNameRightmost = (node: ASTNode): string | null => {
+    const n = node as { right: ASTNode }
+    if (n.right.type === "Identifier") {
+        return n.right.name
+    }
+    return null
+}
+
 export const getTypeReferenceRootName = (
     node: ASTNode | null,
 ): string | null => {
@@ -724,6 +736,12 @@ export const getTypeReferenceRootName = (
         if (n.typeName.type === "Identifier") {
             return n.typeName.name
         }
+        // `typeorm.Repository<User>` — TSTypeReference wraps a TSQualifiedName
+        // (namespace-import access). Without this branch,
+        // `import * as typeorm from "typeorm"` callers would be missed.
+        if (n.typeName.type === "TSQualifiedName") {
+            return getQualifiedNameRightmost(n.typeName)
+        }
     }
     // `const X: typeof Repository` — TSTypeQuery wraps the referenced
     // identifier in `exprName`. Without this branch, type-of annotations on
@@ -732,6 +750,9 @@ export const getTypeReferenceRootName = (
         const n = node as { exprName: ASTNode }
         if (n.exprName.type === "Identifier") {
             return n.exprName.name
+        }
+        if (n.exprName.type === "TSQualifiedName") {
+            return getQualifiedNameRightmost(n.exprName)
         }
     }
     if (node.type === "TSTypeAnnotation") {

--- a/packages/codemod/src/transforms/v1/connection-to-datasource.ts
+++ b/packages/codemod/src/transforms/v1/connection-to-datasource.ts
@@ -86,12 +86,17 @@ const ensureDataSourceOptionsTypeImport = (
     })
     if (hasIt) return
 
-    // Prefer augmenting an existing `import type { ... } from "typeorm"`;
-    // else fall back to a new type-only import line.
+    // Prefer augmenting an existing `import type { ... } from "typeorm"`
+    // — but only when that declaration is a pure named-specifier form.
+    // Pushing an `ImportSpecifier` into a namespace or default-only import
+    // (`import type * as ns` / `import type D`) produces invalid TS.
     let augmented = false
     typeormImports.forEach((p) => {
         if (augmented) return
         if ((p.node as { importKind?: string }).importKind !== "type") return
+        const specifiers = p.node.specifiers ?? []
+        const onlyNamed = specifiers.every((s) => s.type === "ImportSpecifier")
+        if (!onlyNamed) return
         p.node.specifiers?.push(
             j.importSpecifier(j.identifier("DataSourceOptions")),
         )

--- a/packages/codemod/src/transforms/v1/connection-to-datasource.ts
+++ b/packages/codemod/src/transforms/v1/connection-to-datasource.ts
@@ -467,15 +467,25 @@ export const connectionToDataSource = (file: FileInfo, api: API) => {
         ensureDataSourceOptionsTypeImport(root, j)
     }
 
-    // Re-export source paths (`export { X } from "typeorm/driver/..."`)
-    // follow the same deep-path rewrite rules as import sources so barrel
-    // files that re-export renamed modules end up pointing at the v1 path.
+    // Re-export source paths (`export { X } from "typeorm/driver/..."` and
+    // `export * from "typeorm/driver/..."`) follow the same deep-path rewrite
+    // rules as import sources so barrel files that re-export renamed modules
+    // end up pointing at the v1 path.
     root.find(j.ExportNamedDeclaration).forEach((exportPath) => {
         const source = exportPath.node.source?.value
         if (typeof source !== "string") return
         const rewritten = rewriteTypeormPath(source)
         if (rewritten !== source) {
             exportPath.node.source!.value = rewritten
+            hasChanges = true
+        }
+    })
+    root.find(j.ExportAllDeclaration).forEach((exportPath) => {
+        const source = exportPath.node.source.value
+        if (typeof source !== "string") return
+        const rewritten = rewriteTypeormPath(source)
+        if (rewritten !== source) {
+            exportPath.node.source.value = rewritten
             hasChanges = true
         }
     })

--- a/packages/codemod/src/transforms/v1/connection-to-datasource.ts
+++ b/packages/codemod/src/transforms/v1/connection-to-datasource.ts
@@ -10,6 +10,7 @@ import {
     expandLocalNamesForImports,
     fileImportsFrom,
     forEachIdentifierParam,
+    getNamespaceLocalNames,
     getStringValue,
     getTypeReferenceRootName,
     isIdentifier,
@@ -664,6 +665,11 @@ export const connectionToDataSource = (file: FileInfo, api: API) => {
         "typeorm",
         new Set(["Connection", "DataSource"]),
     )
+    // Namespace-import locals for "typeorm" — used to gate qualified type
+    // references (`typeorm.Repository<T>`) inside `getTypeReferenceRootName`
+    // so array-element lookups don't mistake `Foo.Repository[]` from another
+    // library for a TypeORM receiver.
+    const typeormNamespaceNames = getNamespaceLocalNames(root, j, "typeorm")
     const connectionVarNames = new Set<string>()
 
     root.find(j.VariableDeclarator).forEach((path) => {
@@ -1051,6 +1057,7 @@ export const connectionToDataSource = (file: FileInfo, api: API) => {
                 resolved =
                     getTypeReferenceRootName(
                         (inner as { elementType: ASTNode }).elementType,
+                        typeormNamespaceNames,
                     ) ?? null
                 return
             }
@@ -1065,7 +1072,11 @@ export const connectionToDataSource = (file: FileInfo, api: API) => {
                     }
                 ).typeParameters?.params
                 if (params && params.length > 0) {
-                    resolved = getTypeReferenceRootName(params[0]) ?? null
+                    resolved =
+                        getTypeReferenceRootName(
+                            params[0],
+                            typeormNamespaceNames,
+                        ) ?? null
                 }
             }
         })

--- a/packages/codemod/test/transforms/ast-helpers.test.ts
+++ b/packages/codemod/test/transforms/ast-helpers.test.ts
@@ -96,6 +96,40 @@ describe("ast-helpers", () => {
             const root = j('const fs = require("node:fs")')
             expect(fileImportsFrom(root, j, "typeorm")).to.be.false
         })
+
+        it("matches ESM named re-export from the exact module", () => {
+            const root = j('export { DataSource } from "typeorm"')
+            expect(fileImportsFrom(root, j, "typeorm")).to.be.true
+        })
+
+        it("matches ESM named re-export from a sub-path", () => {
+            const root = j(
+                'export { SapDataSourceOptions } from "typeorm/driver/sap/SapDataSourceOptions"',
+            )
+            expect(fileImportsFrom(root, j, "typeorm")).to.be.true
+        })
+
+        it("matches ESM `export *` from the exact module", () => {
+            const root = j('export * from "typeorm"')
+            expect(fileImportsFrom(root, j, "typeorm")).to.be.true
+        })
+
+        it("matches ESM `export *` from a sub-path", () => {
+            const root = j(
+                'export * from "typeorm/driver/sap/SapDataSourceOptions"',
+            )
+            expect(fileImportsFrom(root, j, "typeorm")).to.be.true
+        })
+
+        it("does not match re-exports from a prefix-sharing module", () => {
+            const root = j('export * from "typeorm-extension"')
+            expect(fileImportsFrom(root, j, "typeorm")).to.be.false
+        })
+
+        it("does not match a local re-export without a source", () => {
+            const root = j("const foo = 1; export { foo }")
+            expect(fileImportsFrom(root, j, "typeorm")).to.be.false
+        })
     })
 
     describe("getLocalNamesForImport", () => {

--- a/packages/codemod/test/transforms/v1/fixtures/connection-to-datasource/connection-to-datasource-barrel-only.input.ts
+++ b/packages/codemod/test/transforms/v1/fixtures/connection-to-datasource/connection-to-datasource-barrel-only.input.ts
@@ -1,6 +1,9 @@
 // Barrel files that only re-export TypeORM APIs (no `import` statements
 // at all) still need the Connection → DataSource rewrite. Without the
 // re-export check in `fileImportsFrom`, this file would be skipped.
+// `export * from "typeorm/.../ConnectionOptions"` must also have its
+// source path rewritten alongside named-re-export sources.
 export { Connection, ConnectionOptions } from "typeorm"
 export { Connection as LegacyConn } from "typeorm"
+export * from "typeorm/connection/ConnectionOptions"
 export * from "typeorm/driver/sap/SapDataSourceOptions"

--- a/packages/codemod/test/transforms/v1/fixtures/connection-to-datasource/connection-to-datasource-barrel-only.input.ts
+++ b/packages/codemod/test/transforms/v1/fixtures/connection-to-datasource/connection-to-datasource-barrel-only.input.ts
@@ -1,0 +1,6 @@
+// Barrel files that only re-export TypeORM APIs (no `import` statements
+// at all) still need the Connection → DataSource rewrite. Without the
+// re-export check in `fileImportsFrom`, this file would be skipped.
+export { Connection, ConnectionOptions } from "typeorm"
+export { Connection as LegacyConn } from "typeorm"
+export * from "typeorm/driver/sap/SapConnectionOptions"

--- a/packages/codemod/test/transforms/v1/fixtures/connection-to-datasource/connection-to-datasource-barrel-only.input.ts
+++ b/packages/codemod/test/transforms/v1/fixtures/connection-to-datasource/connection-to-datasource-barrel-only.input.ts
@@ -2,8 +2,11 @@
 // at all) still need the Connection → DataSource rewrite. Without the
 // re-export check in `fileImportsFrom`, this file would be skipped.
 // `export * from "typeorm/.../ConnectionOptions"` must also have its
-// source path rewritten alongside named-re-export sources.
+// source path rewritten alongside named-re-export sources. Bare and
+// non-typeorm `export *` sources must be left alone.
 export { Connection, ConnectionOptions } from "typeorm"
 export { Connection as LegacyConn } from "typeorm"
 export * from "typeorm/connection/ConnectionOptions"
 export * from "typeorm/driver/sap/SapDataSourceOptions"
+export * from "typeorm"
+export * from "some-other-lib"

--- a/packages/codemod/test/transforms/v1/fixtures/connection-to-datasource/connection-to-datasource-barrel-only.input.ts
+++ b/packages/codemod/test/transforms/v1/fixtures/connection-to-datasource/connection-to-datasource-barrel-only.input.ts
@@ -3,4 +3,4 @@
 // re-export check in `fileImportsFrom`, this file would be skipped.
 export { Connection, ConnectionOptions } from "typeorm"
 export { Connection as LegacyConn } from "typeorm"
-export * from "typeorm/driver/sap/SapConnectionOptions"
+export * from "typeorm/driver/sap/SapDataSourceOptions"

--- a/packages/codemod/test/transforms/v1/fixtures/connection-to-datasource/connection-to-datasource-barrel-only.output.ts
+++ b/packages/codemod/test/transforms/v1/fixtures/connection-to-datasource/connection-to-datasource-barrel-only.output.ts
@@ -1,0 +1,6 @@
+// Barrel files that only re-export TypeORM APIs (no `import` statements
+// at all) still need the Connection → DataSource rewrite. Without the
+// re-export check in `fileImportsFrom`, this file would be skipped.
+export { DataSource, DataSourceOptions } from "typeorm"
+export { DataSource as LegacyConn } from "typeorm"
+export * from "typeorm/driver/sap/SapConnectionOptions"

--- a/packages/codemod/test/transforms/v1/fixtures/connection-to-datasource/connection-to-datasource-barrel-only.output.ts
+++ b/packages/codemod/test/transforms/v1/fixtures/connection-to-datasource/connection-to-datasource-barrel-only.output.ts
@@ -1,6 +1,9 @@
 // Barrel files that only re-export TypeORM APIs (no `import` statements
 // at all) still need the Connection → DataSource rewrite. Without the
 // re-export check in `fileImportsFrom`, this file would be skipped.
+// `export * from "typeorm/.../ConnectionOptions"` must also have its
+// source path rewritten alongside named-re-export sources.
 export { DataSource, DataSourceOptions } from "typeorm"
 export { DataSource as LegacyConn } from "typeorm"
+export * from "typeorm/connection/DataSourceOptions"
 export * from "typeorm/driver/sap/SapDataSourceOptions"

--- a/packages/codemod/test/transforms/v1/fixtures/connection-to-datasource/connection-to-datasource-barrel-only.output.ts
+++ b/packages/codemod/test/transforms/v1/fixtures/connection-to-datasource/connection-to-datasource-barrel-only.output.ts
@@ -2,8 +2,11 @@
 // at all) still need the Connection → DataSource rewrite. Without the
 // re-export check in `fileImportsFrom`, this file would be skipped.
 // `export * from "typeorm/.../ConnectionOptions"` must also have its
-// source path rewritten alongside named-re-export sources.
+// source path rewritten alongside named-re-export sources. Bare and
+// non-typeorm `export *` sources must be left alone.
 export { DataSource, DataSourceOptions } from "typeorm"
 export { DataSource as LegacyConn } from "typeorm"
 export * from "typeorm/connection/DataSourceOptions"
 export * from "typeorm/driver/sap/SapDataSourceOptions"
+export * from "typeorm"
+export * from "some-other-lib"

--- a/packages/codemod/test/transforms/v1/fixtures/connection-to-datasource/connection-to-datasource-barrel-only.output.ts
+++ b/packages/codemod/test/transforms/v1/fixtures/connection-to-datasource/connection-to-datasource-barrel-only.output.ts
@@ -3,4 +3,4 @@
 // re-export check in `fileImportsFrom`, this file would be skipped.
 export { DataSource, DataSourceOptions } from "typeorm"
 export { DataSource as LegacyConn } from "typeorm"
-export * from "typeorm/driver/sap/SapConnectionOptions"
+export * from "typeorm/driver/sap/SapDataSourceOptions"

--- a/packages/codemod/test/transforms/v1/fixtures/connection-to-datasource/connection-to-datasource-type-import-ns.input.ts
+++ b/packages/codemod/test/transforms/v1/fixtures/connection-to-datasource/connection-to-datasource-type-import-ns.input.ts
@@ -1,7 +1,9 @@
 // Pre-existing namespace-only type import must not be augmented with a
 // named `DataSourceOptions` specifier — that produces invalid TS. The
 // codemod should skip it and emit a fresh `import type { DataSourceOptions }`
-// line instead, leaving the namespace import untouched.
+// line instead, leaving the namespace import untouched. `Typeorm.Connection`
+// below is a `TSQualifiedName` in type position; the transform does not
+// rewrite those, so it survives unchanged.
 import type * as Typeorm from "typeorm"
 import type { SapConnectionOptions } from "typeorm"
 

--- a/packages/codemod/test/transforms/v1/fixtures/connection-to-datasource/connection-to-datasource-type-import-ns.input.ts
+++ b/packages/codemod/test/transforms/v1/fixtures/connection-to-datasource/connection-to-datasource-type-import-ns.input.ts
@@ -1,0 +1,11 @@
+// Pre-existing namespace-only type import must not be augmented with a
+// named `DataSourceOptions` specifier — that produces invalid TS. The
+// codemod should skip it and emit a fresh `import type { DataSourceOptions }`
+// line instead, leaving the namespace import untouched.
+import type * as Typeorm from "typeorm"
+import type { SapConnectionOptions } from "typeorm"
+
+export const makeOptions = (): SapConnectionOptions =>
+    ({ type: "sap" }) as SapConnectionOptions
+
+export type TopLevel = Typeorm.Connection

--- a/packages/codemod/test/transforms/v1/fixtures/connection-to-datasource/connection-to-datasource-type-import-ns.output.ts
+++ b/packages/codemod/test/transforms/v1/fixtures/connection-to-datasource/connection-to-datasource-type-import-ns.output.ts
@@ -1,7 +1,9 @@
 // Pre-existing namespace-only type import must not be augmented with a
 // named `DataSourceOptions` specifier — that produces invalid TS. The
 // codemod should skip it and emit a fresh `import type { DataSourceOptions }`
-// line instead, leaving the namespace import untouched.
+// line instead, leaving the namespace import untouched. `Typeorm.Connection`
+// below is a `TSQualifiedName` in type position; the transform does not
+// rewrite those, so it survives unchanged.
 import type * as Typeorm from "typeorm"
 import type { DataSourceOptions } from "typeorm"
 

--- a/packages/codemod/test/transforms/v1/fixtures/connection-to-datasource/connection-to-datasource-type-import-ns.output.ts
+++ b/packages/codemod/test/transforms/v1/fixtures/connection-to-datasource/connection-to-datasource-type-import-ns.output.ts
@@ -1,0 +1,13 @@
+// Pre-existing namespace-only type import must not be augmented with a
+// named `DataSourceOptions` specifier — that produces invalid TS. The
+// codemod should skip it and emit a fresh `import type { DataSourceOptions }`
+// line instead, leaving the namespace import untouched.
+import type * as Typeorm from "typeorm"
+import type { DataSourceOptions } from "typeorm"
+
+export const makeOptions = (): Extract<DataSourceOptions, { type: "sap" }> =>
+    ({
+        type: "sap",
+    }) as Extract<DataSourceOptions, { type: "sap" }>
+
+export type TopLevel = Typeorm.Connection

--- a/packages/codemod/test/transforms/v1/fixtures/repository-find-by-ids/repository-find-by-ids-foreign-namespace.input.ts
+++ b/packages/codemod/test/transforms/v1/fixtures/repository-find-by-ids/repository-find-by-ids-foreign-namespace.input.ts
@@ -1,0 +1,17 @@
+import * as typeorm from "typeorm"
+import * as other from "some-other-lib"
+
+declare class User {}
+
+// `typeorm.Repository<User>` must be classified as a TypeORM receiver —
+// `load` should have its `.findByIds` rewritten.
+async function load(typeormRepo: typeorm.Repository<User>) {
+    return typeormRepo.findByIds([1, 2, 3])
+}
+
+// `other.Repository<User>` has the same rightmost name but belongs to an
+// unrelated namespace. The classifier must reject it so `otherRepo.findByIds`
+// stays intact.
+async function unrelated(otherRepo: other.Repository<User>) {
+    return otherRepo.findByIds([4, 5, 6])
+}

--- a/packages/codemod/test/transforms/v1/fixtures/repository-find-by-ids/repository-find-by-ids-foreign-namespace.output.ts
+++ b/packages/codemod/test/transforms/v1/fixtures/repository-find-by-ids/repository-find-by-ids-foreign-namespace.output.ts
@@ -1,0 +1,21 @@
+import * as typeorm from "typeorm"
+import * as other from "some-other-lib"
+
+import { In } from "typeorm"
+
+declare class User {}
+
+// `typeorm.Repository<User>` must be classified as a TypeORM receiver —
+// `load` should have its `.findByIds` rewritten.
+async function load(typeormRepo: typeorm.Repository<User>) {
+    return typeormRepo.findBy({
+        id: In([1, 2, 3]),
+    })
+}
+
+// `other.Repository<User>` has the same rightmost name but belongs to an
+// unrelated namespace. The classifier must reject it so `otherRepo.findByIds`
+// stays intact.
+async function unrelated(otherRepo: other.Repository<User>) {
+    return otherRepo.findByIds([4, 5, 6])
+}


### PR DESCRIPTION
Follow-ups for Qodo review items flagged after #12391 merged.

## Changes

- **`ensureDataSourceOptionsTypeImport`**: skip typeorm type-only imports that carry a default or namespace specifier — only a purely named type-only import is safe to augment with `DataSourceOptions`.
- **`fileImportsFrom`**: recognise `export { X } from "typeorm"` and `export * from "typeorm/..."` as references so barrel files with no imports still pass the scope guard. Adds a `connection-to-datasource-barrel-only` fixture.
- **`getTypeReferenceRootName`**: resolve `typeorm.Repository<User>` (`TSQualifiedName` inside `TSTypeReference` / `TSTypeQuery`) to the rightmost identifier so `import * as typeorm` callers classify the same as bare `Repository<T>`.
- **`runOneTransform`**: drop the swallowing try/catch around `printUnclassifiedOutput` — a failure there is signal, not noise, and should surface rather than be silenced.