### PR TITLE
test: add mocha root hooks for conditional test skipping

### DIFF
--- a/.mocharc.json
+++ b/.mocharc.json
@@ -3,6 +3,7 @@
   "check-leaks": true,
   "color": true,
   "exit": true,
+  "require": ["./build/compiled/test/utils/root-hooks.js"],
   "file": ["./build/compiled/test/utils/test-setup.js"],
   "recursive": true,
   "spec": ["./build/compiled/test/**/*.test.{js,ts}"],

--- a/test/utils/root-hooks.ts
+++ b/test/utils/root-hooks.ts
@@ -1,0 +1,30 @@
+import { isRequired, setRequired } from "./test-utils"
+
+const wrapSuiteBeforeAllHooks = (suite: any): void => {
+    for (const hook of suite._beforeAll ?? []) {
+        if (hook.__requiredFlag) continue
+
+        const originalHook = hook.fn
+        hook.fn = async function (this: Mocha.Context): Promise<void> {
+            await originalHook.call(this)
+            if (!isRequired()) {
+                setRequired(true)
+                this.skip()
+            }
+        }
+        hook.__requiredFlag = true
+    }
+
+    for (const childSuite of suite.suites ?? []) {
+        wrapSuiteBeforeAllHooks(childSuite)
+    }
+}
+
+export const mochaHooks = {
+    beforeAll(this: Mocha.Context): void {
+        const rootSuite = (this as any)?.test?.parent
+        if (!rootSuite) return
+
+        wrapSuiteBeforeAllHooks(rootSuite)
+    },
+}

--- a/test/utils/test-utils.ts
+++ b/test/utils/test-utils.ts
@@ -15,6 +15,16 @@ import path from "path"
 import { ObjectUtils } from "../../src/util/ObjectUtils"
 import type { EntitySubscriberMetadataArgs } from "../../src/metadata-args/EntitySubscriberMetadataArgs"
 
+let requiredDriversEnabled: boolean = true
+
+export function setRequired(b: boolean): void {
+    requiredDriversEnabled = b
+}
+
+export function isRequired(): boolean {
+    return requiredDriversEnabled
+}
+
 /**
  * Interface in which data is stored in ormconfig.json of the project.
  */
@@ -378,6 +388,11 @@ export async function createTestingConnections(
     options?: TestingOptions,
 ): Promise<DataSource[]> {
     const dataSourceOptions = setupTestingConnections(options)
+
+    if (!dataSourceOptions.length) {
+        setRequired(false)
+    }
+
     const dataSources: DataSource[] = []
     for (const options of dataSourceOptions) {
         const dataSource = createDataSource(options)


### PR DESCRIPTION
### Description of change
- Skip tests that are not related to the CI job database using Mocha Root Hooks.
- This applies to `before` hook having `createTestingConnections` function. If returns no `dataSources`, then the corresponding describe() block is skipped.
- Removes false positives # of passed tests in CI

For `postgres (17.9)` CI:
**Before:** [run history](https://github.com/typeorm/typeorm/actions/runs/24727544387/job/72332990376)
2959 passing (2m)
  164 pending

**After:**
2301 passing (2m)
  822 pending

### Pull-Request Checklist

- [x] Code is up-to-date with the `master` branch
- [ ] This pull request links relevant issues as `Fixes #00000`
- [x] There are new or updated tests validating the change (`tests/**.test.ts`)
- [ ] Documentation has been updated to reflect this change (`docs/docs/**.md`) (N/A)