### PR TITLE
fix(persistence): restore bigint precision for single JoinColumn relations

### DIFF
--- a/src/metadata/ColumnMetadata.ts
+++ b/src/metadata/ColumnMetadata.ts
@@ -690,29 +690,19 @@ export class ColumnMetadata {
                 entity[this.relationMetadata.propertyName] &&
                 ObjectUtils.isObject(entity[this.relationMetadata.propertyName])
             ) {
-                if (this.relationMetadata.joinColumns.length > 1) {
-                    const map = this.relationMetadata.joinColumns.reduce(
-                        (map, joinColumn) => {
-                            const value =
-                                joinColumn.referencedColumn!.getEntityValueMap(
-                                    entity[this.relationMetadata!.propertyName],
-                                )
-                            if (value === undefined) return map
-                            return OrmUtils.mergeDeep(map, value)
-                        },
-                        {},
-                    )
-                    if (Object.keys(map).length > 0)
-                        return { [this.propertyName]: map }
-                } else {
-                    const value =
-                        this.relationMetadata.joinColumns[0].referencedColumn!.getEntityValue(
-                            entity[this.relationMetadata!.propertyName],
-                        )
-                    if (value) {
-                        return { [this.propertyName]: value }
-                    }
-                }
+                const map = this.relationMetadata.joinColumns.reduce(
+                    (map, joinColumn) => {
+                        const value =
+                            joinColumn.referencedColumn!.getEntityValueMap(
+                                entity[this.relationMetadata!.propertyName],
+                            )
+                        if (value === undefined) return map
+                        return OrmUtils.mergeDeep(map, value)
+                    },
+                    {},
+                )
+                if (Object.keys(map).length > 0)
+                    return { [this.propertyName]: map }
 
                 return undefined
             } else {

--- a/src/metadata/ColumnMetadata.ts
+++ b/src/metadata/ColumnMetadata.ts
@@ -705,12 +705,20 @@ export class ColumnMetadata {
                     if (Object.keys(map).length > 0)
                         return { [this.propertyName]: map }
                 } else {
-                    const value =
-                        this.relationMetadata.joinColumns[0].referencedColumn!.getEntityValue(
-                            entity[this.relationMetadata!.propertyName],
-                        )
-                    if (value) {
-                        return { [this.propertyName]: value }
+                    const referencedColumn =
+                        this.relationMetadata.joinColumns[0].referencedColumn!
+                    const value = referencedColumn.getEntityValue(
+                        entity[this.relationMetadata!.propertyName],
+                    )
+                    if (!value) return undefined
+
+                    const isBigint =
+                        (referencedColumn.generationStrategy === "increment" ||
+                            referencedColumn.generationStrategy === "rowid") &&
+                        referencedColumn.type === "bigint"
+
+                    return {
+                        [this.propertyName]: isBigint ? String(value) : value,
                     }
                 }
 

--- a/test/functional/columns/bigint-join-column/bigint-join-column.test.ts
+++ b/test/functional/columns/bigint-join-column/bigint-join-column.test.ts
@@ -1,0 +1,61 @@
+import "reflect-metadata"
+import { expect } from "chai"
+import type { DataSource } from "../../../../src/data-source/DataSource"
+import {
+    closeTestingConnections,
+    createTestingConnections,
+    reloadTestingDatabases,
+} from "../../../utils/test-utils"
+import { Product } from "./entity/Product"
+import { License } from "./entity/License"
+
+describe("columns > bigint join column precision", () => {
+    let dataSources: DataSource[]
+
+    before(async () => {
+        dataSources = await createTestingConnections({
+            entities: [__dirname + "/entity/*{.js,.ts}"],
+            enabledDrivers: ["postgres", "mysql"],
+        })
+    })
+    beforeEach(() => reloadTestingDatabases(dataSources))
+    after(() => closeTestingConnections(dataSources))
+
+    it("should preserve bigint precision when FK set via relation object", () =>
+        Promise.all(
+            dataSources.map(async (dataSource) => {
+                const product = new Product()
+                const savedProduct = await dataSource.manager.save(product)
+                const productId = savedProduct.id
+
+                const license = new License()
+                license.id = "1"
+                license.product = savedProduct
+                await dataSource.manager.save(license)
+
+                const [row] = await dataSource.query(
+                    `SELECT product_id FROM licenses_bigint_jc WHERE id = 1`,
+                )
+                expect(String(row.product_id)).to.equal(String(productId))
+            }),
+        ))
+
+    it("should preserve bigint precision when FK set directly as string", () =>
+        Promise.all(
+            dataSources.map(async (dataSource) => {
+                const product = new Product()
+                const savedProduct = await dataSource.manager.save(product)
+                const productId = savedProduct.id
+
+                const license = new License()
+                license.id = "2"
+                license.productId = String(productId)
+                await dataSource.manager.save(license)
+
+                const [row] = await dataSource.query(
+                    `SELECT product_id FROM licenses_bigint_jc WHERE id = 2`,
+                )
+                expect(String(row.product_id)).to.equal(String(productId))
+            }),
+        ))
+})

--- a/test/functional/columns/bigint-join-column/entity/License.ts
+++ b/test/functional/columns/bigint-join-column/entity/License.ts
@@ -1,0 +1,21 @@
+import {
+    Column,
+    Entity,
+    JoinColumn,
+    ManyToOne,
+    PrimaryColumn,
+} from "../../../../../src"
+import { Product } from "./Product"
+
+@Entity("licenses_bigint_jc")
+export class License {
+    @PrimaryColumn("bigint", { name: "id" })
+    id: string
+
+    @Column("bigint", { name: "product_id", nullable: true })
+    productId: string | null
+
+    @ManyToOne(() => Product, (product) => product.licenses)
+    @JoinColumn([{ name: "product_id", referencedColumnName: "id" }])
+    product: Product
+}

--- a/test/functional/columns/bigint-join-column/entity/Product.ts
+++ b/test/functional/columns/bigint-join-column/entity/Product.ts
@@ -1,0 +1,11 @@
+import { Entity, OneToMany, PrimaryGeneratedColumn } from "../../../../../src"
+import { License } from "./License"
+
+@Entity("products_bigint_jc")
+export class Product {
+    @PrimaryGeneratedColumn({ type: "bigint" })
+    id: string
+
+    @OneToMany(() => License, (license) => license.product)
+    licenses: License[]
+}


### PR DESCRIPTION
<!--
  😀 Wonderful!  Thank you for opening a pull request for TypeORM.

  Please fill in the information below to expedite the review
  and (hopefully) merge of your change.

  If unsure about something.. just do as best as you're able,
  or reach out through our community support channels!
  https://github.com/typeorm/typeorm/blob/master/docs/support.md
  https://github.com/typeorm/typeorm/blob/master/CONTRIBUTING.md
-->

### Description of change

<!--
  Please describe:
  - what the change is intended to do
  - why this change is needed
  - how you've verified it
  - any other context that will help reviewers understand the change

  In some cases it may be helpful to include the current behavior
  and the new behavior.
-->

Relates to #12337

#10672 split `getEntityValueMap()` into separate paths for single vs composite JoinColumns. The single-key path switched from `getEntityValueMap()` → `createValueMap()` to `getEntityValue()`, which bypasses the `String()` bigint protection added in #720. This restores the unified code path for both single and composite JoinColumns.

### Pull-Request Checklist

<!--
  Please make sure to review and check all of the following.

  If an item is not applicable, you can add "N/A" to the end.
-->

- [x] Code is up-to-date with the `master` branch
- [x] This pull request links relevant issues as `Fixes #00000`
- [x] There are new or updated tests validating the change (`tests/**.test.ts`)
- [x] Documentation has been updated to reflect this change (`docs/docs/**.md`)

> 🛡️ **Security fixes:** Do not submit security fixes as public PRs — the diff exposes the vulnerability. Use [GitHub Security Advisories](https://github.com/typeorm/typeorm/security/advisories/new) instead.

<!--
  🎉 Thank you for contributing and making TypeORM even better!
-->
