### PR TITLE
fix(query-builder): reject semicolons in groupBy and orderBy sort keys

### DIFF
--- a/docs/docs/releases/1.0/02-upgrading-from-0.3.md
+++ b/docs/docs/releases/1.0/02-upgrading-from-0.3.md
@@ -787,7 +787,7 @@ The removed type is `FindOptionsRelationByString`.
 
 ### Semicolons rejected in sort and group expression methods
 
-The `groupBy()`, `addGroupBy()`, `orderBy()`, and `addOrderBy()` methods on all query builders (`SelectQueryBuilder`, `UpdateQueryBuilder`, `SoftDeleteQueryBuilder`) now reject inputs containing semicolons at runtime to prevent SQL injection attacks. Group and sort keys are expected to be column names or short expressions — there is no legitimate use of `;` in these inputs. 
+The `groupBy()`, `addGroupBy()`, `orderBy()`, and `addOrderBy()` methods on all query builders (`SelectQueryBuilder`, `UpdateQueryBuilder`, `SoftDeleteQueryBuilder`) now reject inputs containing semicolons at runtime to prevent SQL injection attacks. Group and sort keys are expected to be column names or short expressions — there is no legitimate use of `;` in these inputs.
 
 ```typescript
 // All of these now throw TypeORMError

--- a/docs/docs/releases/1.0/02-upgrading-from-0.3.md
+++ b/docs/docs/releases/1.0/02-upgrading-from-0.3.md
@@ -785,6 +785,23 @@ The removed type is `FindOptionsRelationByString`.
 
 ## QueryBuilder
 
+### Semicolons rejected in sort and group expression methods
+
+The `groupBy()`, `addGroupBy()`, `orderBy()`, and `addOrderBy()` methods on all query builders (`SelectQueryBuilder`, `UpdateQueryBuilder`, `SoftDeleteQueryBuilder`) now reject inputs containing semicolons at runtime to prevent SQL statement stacking attacks. The same check also applies to keys of the `OrderByCondition` object form. Group and sort keys are expected to be column names or short expressions — there is no legitimate use of `;` in these inputs:
+
+```typescript
+// All of these now throw TypeORMError
+qb.groupBy("post.id; DROP TABLE post")
+qb.orderBy("post.id; DELETE FROM post")
+qb.addOrderBy("post.id; --")
+qb.orderBy({ "post.id; DROP TABLE post": "ASC" })
+
+// Use parameter binding for any user-controlled value that may contain a semicolon
+qb.where("post.title = :title", { title: "value;with;semicolons" })
+```
+
+The `orderBy()` methods continue to validate that order direction values are `"ASC"` or `"DESC"` and `nulls` values are `"NULLS FIRST"` or `"NULLS LAST"`.
+
 ### `printSql` removed
 
 The `printSql()` method on query builders has been removed. It was redundant because all executed queries are already automatically logged through the configured logger when query logging is enabled. Use `getSql()` or `getQueryAndParameters()` to inspect the generated SQL instead:

--- a/docs/docs/releases/1.0/02-upgrading-from-0.3.md
+++ b/docs/docs/releases/1.0/02-upgrading-from-0.3.md
@@ -791,16 +791,12 @@ The `groupBy()`, `addGroupBy()`, `orderBy()`, and `addOrderBy()` methods on all 
 
 ```typescript
 // All of these now throw TypeORMError
+qb.addGroupBy("post.id; DROP TABLE post")
+qb.addOrderBy("post.id; --")
 qb.groupBy("post.id; DROP TABLE post")
 qb.orderBy("post.id; DELETE FROM post")
-qb.addOrderBy("post.id; --")
 qb.orderBy({ "post.id; DROP TABLE post": "ASC" })
-
-// Use parameter binding for any user-controlled value that may contain a semicolon
-qb.where("post.title = :title", { title: "value;with;semicolons" })
 ```
-
-The `orderBy()` and `addOrderBy()` methods on all three query builders also validate that the `order` argument is `"ASC"` or `"DESC"` and the `nulls` argument is `"NULLS FIRST"` or `"NULLS LAST"` — previously only `SelectQueryBuilder` enforced this, leaving `UpdateQueryBuilder` and `SoftDeleteQueryBuilder` open to injection through those parameters.
 
 ### `printSql` removed
 

--- a/docs/docs/releases/1.0/02-upgrading-from-0.3.md
+++ b/docs/docs/releases/1.0/02-upgrading-from-0.3.md
@@ -799,6 +799,8 @@ qb.orderBy({ "post.id; DROP TABLE post": "ASC" })
 qb.addOrderBy("post.id; --")
 ```
 
+`UpdateQueryBuilder` and `SoftDeleteQueryBuilder` also now reject `order` values outside `"ASC"`/`"DESC"` and `nulls` values outside `"NULLS FIRST"`/`"NULLS LAST"` at runtime, matching the validation `SelectQueryBuilder` already enforced. TypeScript callers are unaffected — the types have always restricted these arguments. JavaScript callers or code passing values via `as any` that previously sent lowercase or non-standard strings will now get a `TypeORMError`.
+
 ### `printSql` removed
 
 The `printSql()` method on query builders has been removed. It was redundant because all executed queries are already automatically logged through the configured logger when query logging is enabled. Use `getSql()` or `getQueryAndParameters()` to inspect the generated SQL instead:

--- a/docs/docs/releases/1.0/02-upgrading-from-0.3.md
+++ b/docs/docs/releases/1.0/02-upgrading-from-0.3.md
@@ -787,12 +787,13 @@ The removed type is `FindOptionsRelationByString`.
 
 ### Semicolons rejected in sort and group expression methods
 
-The `groupBy()`, `addGroupBy()`, `orderBy()`, and `addOrderBy()` methods on all query builders (`SelectQueryBuilder`, `UpdateQueryBuilder`, `SoftDeleteQueryBuilder`) now reject inputs containing semicolons at runtime to prevent SQL statement stacking attacks. The same check also applies to keys of the `OrderByCondition` object form. Group and sort keys are expected to be column names or short expressions — there is no legitimate use of `;` in these inputs:
+The `groupBy()`, `addGroupBy()`, `orderBy()`, and `addOrderBy()` methods on all query builders (`SelectQueryBuilder`, `UpdateQueryBuilder`, `SoftDeleteQueryBuilder`) now reject inputs containing semicolons at runtime to prevent SQL injection attacks. Group and sort keys are expected to be column names or short expressions — there is no legitimate use of `;` in these inputs. 
 
 ```typescript
 // All of these now throw TypeORMError
 qb.groupBy("post.id; DROP TABLE post")
 qb.addGroupBy("post.id; DROP TABLE post")
+
 qb.orderBy("post.id; DELETE FROM post")
 qb.orderBy({ "post.id; DROP TABLE post": "ASC" })
 qb.addOrderBy("post.id; --")

--- a/docs/docs/releases/1.0/02-upgrading-from-0.3.md
+++ b/docs/docs/releases/1.0/02-upgrading-from-0.3.md
@@ -791,11 +791,11 @@ The `groupBy()`, `addGroupBy()`, `orderBy()`, and `addOrderBy()` methods on all 
 
 ```typescript
 // All of these now throw TypeORMError
-qb.addGroupBy("post.id; DROP TABLE post")
-qb.addOrderBy("post.id; --")
 qb.groupBy("post.id; DROP TABLE post")
+qb.addGroupBy("post.id; DROP TABLE post")
 qb.orderBy("post.id; DELETE FROM post")
 qb.orderBy({ "post.id; DROP TABLE post": "ASC" })
+qb.addOrderBy("post.id; --")
 ```
 
 ### `printSql` removed

--- a/docs/docs/releases/1.0/02-upgrading-from-0.3.md
+++ b/docs/docs/releases/1.0/02-upgrading-from-0.3.md
@@ -800,7 +800,7 @@ qb.orderBy({ "post.id; DROP TABLE post": "ASC" })
 qb.where("post.title = :title", { title: "value;with;semicolons" })
 ```
 
-The `orderBy()` methods continue to validate that order direction values are `"ASC"` or `"DESC"` and `nulls` values are `"NULLS FIRST"` or `"NULLS LAST"`.
+The `orderBy()` and `addOrderBy()` methods on all three query builders also validate that the `order` argument is `"ASC"` or `"DESC"` and the `nulls` argument is `"NULLS FIRST"` or `"NULLS LAST"` — previously only `SelectQueryBuilder` enforced this, leaving `UpdateQueryBuilder` and `SoftDeleteQueryBuilder` open to injection through those parameters.
 
 ### `printSql` removed
 

--- a/src/query-builder/QueryBuilder.ts
+++ b/src/query-builder/QueryBuilder.ts
@@ -1742,6 +1742,14 @@ export abstract class QueryBuilder<Entity extends ObjectLiteral> {
             )
     }
 
+    /**
+     * Shared ORDER BY implementation for concrete builders that expose it.
+     * Subclasses delegate here from their own public `orderBy` overloads.
+     *
+     * @param sort
+     * @param order
+     * @param nulls
+     */
     protected orderBy(
         sort?: string | OrderByCondition,
         order: "ASC" | "DESC" = "ASC",
@@ -1769,6 +1777,13 @@ export abstract class QueryBuilder<Entity extends ObjectLiteral> {
         return this
     }
 
+    /**
+     * Shared ADD ORDER BY implementation; see {@link orderBy}.
+     *
+     * @param sort
+     * @param order
+     * @param nulls
+     */
     protected addOrderBy(
         sort: string,
         order: "ASC" | "DESC" = "ASC",

--- a/src/query-builder/QueryBuilder.ts
+++ b/src/query-builder/QueryBuilder.ts
@@ -1694,13 +1694,7 @@ export abstract class QueryBuilder<Entity extends ObjectLiteral> {
     }
 
     /**
-     * Rejects raw SQL fragments that contain a `;` character. The builder
-     * forwards the value into the emitted query verbatim, so a semicolon in a
-     * `groupBy` / `orderBy` / `addOrderBy` argument would terminate the
-     * intended statement and let a second one piggy-back on the same
-     * execution — classic SQL-statement-stacking. These methods accept
-     * column references and short expressions; `;` has no legitimate meaning
-     * in them, so the check is a flat reject.
+     * Rejects a `;` in sort/group expressions to prevent SQL injection.
      *
      * @param value
      * @param context
@@ -1708,18 +1702,13 @@ export abstract class QueryBuilder<Entity extends ObjectLiteral> {
     protected assertNoSemicolon(value: string, context: string): void {
         if (value.includes(";")) {
             throw new TypeORMError(
-                `Semicolons are not allowed in ${context} to prevent SQL statement stacking.`,
+                `Semicolons are not allowed in ${context} to prevent SQL injection.`,
             )
         }
     }
 
     /**
-     * Validates the `order` and `nulls` arguments of the string-sort `orderBy`
-     * / `addOrderBy` overloads on every query builder that surfaces them.
-     * TypeScript narrows these parameters to a fixed union at the call site,
-     * but the runtime value can be anything under JS / `as any` / type-erased
-     * boundaries — treating both as plain strings here lets the allow-list
-     * be the single enforcement point for all callers.
+     * Validates OrderBy options against allowed values.
      *
      * @param order
      * @param nulls
@@ -1743,8 +1732,7 @@ export abstract class QueryBuilder<Entity extends ObjectLiteral> {
     }
 
     /**
-     * Shared ORDER BY implementation for concrete builders that expose it.
-     * Subclasses delegate here from their own public `orderBy` overloads.
+     * Sets ORDER BY condition in the query builder.
      *
      * @param sort
      * @param order
@@ -1778,7 +1766,7 @@ export abstract class QueryBuilder<Entity extends ObjectLiteral> {
     }
 
     /**
-     * Shared ADD ORDER BY implementation; see {@link orderBy}.
+     * Adds ORDER BY condition in the query builder.
      *
      * @param sort
      * @param order

--- a/src/query-builder/QueryBuilder.ts
+++ b/src/query-builder/QueryBuilder.ts
@@ -1718,7 +1718,7 @@ export abstract class QueryBuilder<Entity extends ObjectLiteral> {
         const validNulls = ["NULLS FIRST", "NULLS LAST"]
 
         for (const [key, value] of Object.entries(sort)) {
-            this.assertNoSemicolon(key, "orderBy sort key")
+            this.assertNoSemicolon(key, "orderBy")
             if (typeof value === "string") {
                 if (!validOrders.includes(value))
                     throw new TypeORMError(

--- a/src/query-builder/QueryBuilder.ts
+++ b/src/query-builder/QueryBuilder.ts
@@ -1693,11 +1693,34 @@ export abstract class QueryBuilder<Entity extends ObjectLiteral> {
         return this.expressionMap.commonTableExpressions.length > 0
     }
 
+    /**
+     * Rejects raw SQL fragments that contain a `;` character. The builder
+     * forwards the value into the emitted query verbatim, so a semicolon in a
+     * `groupBy` / `orderBy` / `addOrderBy` argument would terminate the
+     * intended statement and let a second one piggy-back on the same
+     * execution — classic SQL-statement-stacking. Column names, sort keys
+     * and group-by keys have no legitimate use for `;`, so the check here
+     * is a flat reject; `select`/`addSelect` accept literal-aware parsing
+     * because `STRING_AGG(col, ';' ORDER BY col)` is a valid expression and
+     * handled by a separate helper.
+     *
+     * @param value
+     * @param context
+     */
+    protected assertNoSemicolon(value: string, context: string): void {
+        if (value.includes(";")) {
+            throw new TypeORMError(
+                `Semicolons are not allowed in ${context} to prevent SQL statement stacking.`,
+            )
+        }
+    }
+
     protected validateOrderByCondition(sort: OrderByCondition): void {
         const validOrders = ["ASC", "DESC"]
         const validNulls = ["NULLS FIRST", "NULLS LAST"]
 
         for (const [key, value] of Object.entries(sort)) {
+            this.assertNoSemicolon(key, "orderBy sort key")
             if (typeof value === "string") {
                 if (!validOrders.includes(value))
                     throw new TypeORMError(

--- a/src/query-builder/QueryBuilder.ts
+++ b/src/query-builder/QueryBuilder.ts
@@ -1742,6 +1742,46 @@ export abstract class QueryBuilder<Entity extends ObjectLiteral> {
             )
     }
 
+    protected orderBy(
+        sort?: string | OrderByCondition,
+        order: "ASC" | "DESC" = "ASC",
+        nulls?: "NULLS FIRST" | "NULLS LAST",
+    ): this {
+        this.assertValidOrderByOptions(order, nulls)
+
+        if (!sort) {
+            this.expressionMap.orderBys = {}
+            return this
+        }
+
+        if (typeof sort === "object") {
+            this.validateOrderByCondition(sort)
+            this.expressionMap.orderBys = sort
+            return this
+        }
+
+        this.assertNoSemicolon(sort, "orderBy")
+
+        this.expressionMap.orderBys = nulls
+            ? { [sort]: { order, nulls } }
+            : { [sort]: order }
+
+        return this
+    }
+
+    protected addOrderBy(
+        sort: string,
+        order: "ASC" | "DESC" = "ASC",
+        nulls?: "NULLS FIRST" | "NULLS LAST",
+    ): this {
+        this.assertValidOrderByOptions(order, nulls)
+        this.assertNoSemicolon(sort, "addOrderBy")
+
+        this.expressionMap.orderBys[sort] = nulls ? { order, nulls } : order
+
+        return this
+    }
+
     protected validateOrderByCondition(sort: OrderByCondition): void {
         const validOrders = ["ASC", "DESC"]
         const validNulls = ["NULLS FIRST", "NULLS LAST"]

--- a/src/query-builder/QueryBuilder.ts
+++ b/src/query-builder/QueryBuilder.ts
@@ -1698,11 +1698,9 @@ export abstract class QueryBuilder<Entity extends ObjectLiteral> {
      * forwards the value into the emitted query verbatim, so a semicolon in a
      * `groupBy` / `orderBy` / `addOrderBy` argument would terminate the
      * intended statement and let a second one piggy-back on the same
-     * execution — classic SQL-statement-stacking. Column names, sort keys
-     * and group-by keys have no legitimate use for `;`, so the check here
-     * is a flat reject; `select`/`addSelect` accept literal-aware parsing
-     * because `STRING_AGG(col, ';' ORDER BY col)` is a valid expression and
-     * handled by a separate helper.
+     * execution — classic SQL-statement-stacking. These methods accept
+     * column references and short expressions; `;` has no legitimate meaning
+     * in them, so the check is a flat reject.
      *
      * @param value
      * @param context

--- a/src/query-builder/QueryBuilder.ts
+++ b/src/query-builder/QueryBuilder.ts
@@ -1713,6 +1713,35 @@ export abstract class QueryBuilder<Entity extends ObjectLiteral> {
         }
     }
 
+    /**
+     * Validates the `order` and `nulls` arguments of the string-sort `orderBy`
+     * / `addOrderBy` overloads on every query builder that surfaces them.
+     * TypeScript narrows these parameters to a fixed union at the call site,
+     * but the runtime value can be anything under JS / `as any` / type-erased
+     * boundaries — treating both as plain strings here lets the allow-list
+     * be the single enforcement point for all callers.
+     *
+     * @param order
+     * @param nulls
+     */
+    protected assertValidOrderByOptions(
+        order: string | undefined,
+        nulls: string | undefined,
+    ): void {
+        if (order !== undefined && order !== "ASC" && order !== "DESC")
+            throw new TypeORMError(
+                `"order" can accept only "ASC" and "DESC" values.`,
+            )
+        if (
+            nulls !== undefined &&
+            nulls !== "NULLS FIRST" &&
+            nulls !== "NULLS LAST"
+        )
+            throw new TypeORMError(
+                `"nulls" can accept only "NULLS FIRST" and "NULLS LAST" values.`,
+            )
+    }
+
     protected validateOrderByCondition(sort: OrderByCondition): void {
         const validOrders = ["ASC", "DESC"]
         const validNulls = ["NULLS FIRST", "NULLS LAST"]

--- a/src/query-builder/SelectQueryBuilder.ts
+++ b/src/query-builder/SelectQueryBuilder.ts
@@ -1361,6 +1361,7 @@ export class SelectQueryBuilder<Entity extends ObjectLiteral>
      */
     groupBy(groupBy?: string): this {
         if (groupBy) {
+            this.assertNoSemicolon(groupBy, "groupBy")
             this.expressionMap.groupBys = [groupBy]
         } else {
             this.expressionMap.groupBys = []
@@ -1374,6 +1375,7 @@ export class SelectQueryBuilder<Entity extends ObjectLiteral>
      * @param groupBy
      */
     addGroupBy(groupBy: string): this {
+        this.assertNoSemicolon(groupBy, "addGroupBy")
         this.expressionMap.groupBys.push(groupBy)
         return this
     }
@@ -1449,22 +1451,23 @@ export class SelectQueryBuilder<Entity extends ObjectLiteral>
                 `SelectQueryBuilder.addOrderBy "nulls" can accept only "NULLS FIRST" and "NULLS LAST" values.`,
             )
 
-        if (sort) {
-            if (typeof sort === "object") {
-                this.validateOrderByCondition(sort)
-                this.expressionMap.orderBys = sort
-            } else {
-                if (nulls) {
-                    this.expressionMap.orderBys = {
-                        [sort as string]: { order, nulls },
-                    }
-                } else {
-                    this.expressionMap.orderBys = { [sort as string]: order }
-                }
-            }
-        } else {
+        if (!sort) {
             this.expressionMap.orderBys = {}
+            return this
         }
+
+        if (typeof sort === "object") {
+            this.validateOrderByCondition(sort)
+            this.expressionMap.orderBys = sort
+            return this
+        }
+
+        this.assertNoSemicolon(sort, "orderBy sort key")
+
+        this.expressionMap.orderBys = nulls
+            ? { [sort]: { order, nulls } }
+            : { [sort]: order }
+
         return this
     }
 
@@ -1492,6 +1495,8 @@ export class SelectQueryBuilder<Entity extends ObjectLiteral>
             throw new TypeORMError(
                 `SelectQueryBuilder.addOrderBy "nulls" can accept only "NULLS FIRST" and "NULLS LAST" values.`,
             )
+
+        this.assertNoSemicolon(sort, "addOrderBy sort key")
 
         if (nulls) {
             this.expressionMap.orderBys[sort] = { order, nulls }

--- a/src/query-builder/SelectQueryBuilder.ts
+++ b/src/query-builder/SelectQueryBuilder.ts
@@ -1438,18 +1438,7 @@ export class SelectQueryBuilder<Entity extends ObjectLiteral>
         order: "ASC" | "DESC" = "ASC",
         nulls?: "NULLS FIRST" | "NULLS LAST",
     ): this {
-        if (order !== undefined && order !== "ASC" && order !== "DESC")
-            throw new TypeORMError(
-                `SelectQueryBuilder.orderBy "order" can accept only "ASC" and "DESC" values.`,
-            )
-        if (
-            nulls !== undefined &&
-            nulls !== "NULLS FIRST" &&
-            nulls !== "NULLS LAST"
-        )
-            throw new TypeORMError(
-                `SelectQueryBuilder.orderBy "nulls" can accept only "NULLS FIRST" and "NULLS LAST" values.`,
-            )
+        this.assertValidOrderByOptions(order, nulls)
 
         if (!sort) {
             this.expressionMap.orderBys = {}
@@ -1483,19 +1472,7 @@ export class SelectQueryBuilder<Entity extends ObjectLiteral>
         order: "ASC" | "DESC" = "ASC",
         nulls?: "NULLS FIRST" | "NULLS LAST",
     ): this {
-        if (order !== undefined && order !== "ASC" && order !== "DESC")
-            throw new TypeORMError(
-                `SelectQueryBuilder.addOrderBy "order" can accept only "ASC" and "DESC" values.`,
-            )
-        if (
-            nulls !== undefined &&
-            nulls !== "NULLS FIRST" &&
-            nulls !== "NULLS LAST"
-        )
-            throw new TypeORMError(
-                `SelectQueryBuilder.addOrderBy "nulls" can accept only "NULLS FIRST" and "NULLS LAST" values.`,
-            )
-
+        this.assertValidOrderByOptions(order, nulls)
         this.assertNoSemicolon(sort, "addOrderBy")
 
         if (nulls) {

--- a/src/query-builder/SelectQueryBuilder.ts
+++ b/src/query-builder/SelectQueryBuilder.ts
@@ -1440,7 +1440,7 @@ export class SelectQueryBuilder<Entity extends ObjectLiteral>
     ): this {
         if (order !== undefined && order !== "ASC" && order !== "DESC")
             throw new TypeORMError(
-                `SelectQueryBuilder.addOrderBy "order" can accept only "ASC" and "DESC" values.`,
+                `SelectQueryBuilder.orderBy "order" can accept only "ASC" and "DESC" values.`,
             )
         if (
             nulls !== undefined &&
@@ -1448,7 +1448,7 @@ export class SelectQueryBuilder<Entity extends ObjectLiteral>
             nulls !== "NULLS LAST"
         )
             throw new TypeORMError(
-                `SelectQueryBuilder.addOrderBy "nulls" can accept only "NULLS FIRST" and "NULLS LAST" values.`,
+                `SelectQueryBuilder.orderBy "nulls" can accept only "NULLS FIRST" and "NULLS LAST" values.`,
             )
 
         if (!sort) {

--- a/src/query-builder/SelectQueryBuilder.ts
+++ b/src/query-builder/SelectQueryBuilder.ts
@@ -1404,14 +1404,14 @@ export class SelectQueryBuilder<Entity extends ObjectLiteral>
      *
      * Calling order by without order set will remove all previously set order bys.
      */
-    orderBy(): this
+    public orderBy(): this
 
     /**
      * Sets ORDER BY condition in the query builder.
      * If you had previously ORDER BY expression defined,
      * calling this function will override previously set ORDER BY conditions.
      */
-    orderBy(
+    public orderBy(
         sort: string,
         order?: "ASC" | "DESC",
         nulls?: "NULLS FIRST" | "NULLS LAST",
@@ -1422,7 +1422,7 @@ export class SelectQueryBuilder<Entity extends ObjectLiteral>
      * If you had previously ORDER BY expression defined,
      * calling this function will override previously set ORDER BY conditions.
      */
-    orderBy(order: OrderByCondition): this
+    public orderBy(order: OrderByCondition): this
 
     /**
      * Sets ORDER BY condition in the query builder.
@@ -1433,31 +1433,12 @@ export class SelectQueryBuilder<Entity extends ObjectLiteral>
      * @param order
      * @param nulls
      */
-    orderBy(
+    public orderBy(
         sort?: string | OrderByCondition,
         order: "ASC" | "DESC" = "ASC",
         nulls?: "NULLS FIRST" | "NULLS LAST",
     ): this {
-        this.assertValidOrderByOptions(order, nulls)
-
-        if (!sort) {
-            this.expressionMap.orderBys = {}
-            return this
-        }
-
-        if (typeof sort === "object") {
-            this.validateOrderByCondition(sort)
-            this.expressionMap.orderBys = sort
-            return this
-        }
-
-        this.assertNoSemicolon(sort, "orderBy")
-
-        this.expressionMap.orderBys = nulls
-            ? { [sort]: { order, nulls } }
-            : { [sort]: order }
-
-        return this
+        return super.orderBy(sort as string | undefined, order, nulls)
     }
 
     /**
@@ -1467,20 +1448,12 @@ export class SelectQueryBuilder<Entity extends ObjectLiteral>
      * @param order
      * @param nulls
      */
-    addOrderBy(
+    public addOrderBy(
         sort: string,
         order: "ASC" | "DESC" = "ASC",
         nulls?: "NULLS FIRST" | "NULLS LAST",
     ): this {
-        this.assertValidOrderByOptions(order, nulls)
-        this.assertNoSemicolon(sort, "addOrderBy")
-
-        if (nulls) {
-            this.expressionMap.orderBys[sort] = { order, nulls }
-        } else {
-            this.expressionMap.orderBys[sort] = order
-        }
-        return this
+        return super.addOrderBy(sort, order, nulls)
     }
 
     /**

--- a/src/query-builder/SelectQueryBuilder.ts
+++ b/src/query-builder/SelectQueryBuilder.ts
@@ -1462,7 +1462,7 @@ export class SelectQueryBuilder<Entity extends ObjectLiteral>
             return this
         }
 
-        this.assertNoSemicolon(sort, "orderBy sort key")
+        this.assertNoSemicolon(sort, "orderBy")
 
         this.expressionMap.orderBys = nulls
             ? { [sort]: { order, nulls } }
@@ -1496,7 +1496,7 @@ export class SelectQueryBuilder<Entity extends ObjectLiteral>
                 `SelectQueryBuilder.addOrderBy "nulls" can accept only "NULLS FIRST" and "NULLS LAST" values.`,
             )
 
-        this.assertNoSemicolon(sort, "addOrderBy sort key")
+        this.assertNoSemicolon(sort, "addOrderBy")
 
         if (nulls) {
             this.expressionMap.orderBys[sort] = { order, nulls }

--- a/src/query-builder/SelectQueryBuilder.ts
+++ b/src/query-builder/SelectQueryBuilder.ts
@@ -1404,14 +1404,14 @@ export class SelectQueryBuilder<Entity extends ObjectLiteral>
      *
      * Calling order by without order set will remove all previously set order bys.
      */
-    public orderBy(): this
+    orderBy(): this
 
     /**
      * Sets ORDER BY condition in the query builder.
      * If you had previously ORDER BY expression defined,
      * calling this function will override previously set ORDER BY conditions.
      */
-    public orderBy(
+    orderBy(
         sort: string,
         order?: "ASC" | "DESC",
         nulls?: "NULLS FIRST" | "NULLS LAST",
@@ -1422,7 +1422,7 @@ export class SelectQueryBuilder<Entity extends ObjectLiteral>
      * If you had previously ORDER BY expression defined,
      * calling this function will override previously set ORDER BY conditions.
      */
-    public orderBy(order: OrderByCondition): this
+    orderBy(order: OrderByCondition): this
 
     /**
      * Sets ORDER BY condition in the query builder.
@@ -1433,12 +1433,12 @@ export class SelectQueryBuilder<Entity extends ObjectLiteral>
      * @param order
      * @param nulls
      */
-    public orderBy(
+    orderBy(
         sort?: string | OrderByCondition,
         order: "ASC" | "DESC" = "ASC",
         nulls?: "NULLS FIRST" | "NULLS LAST",
     ): this {
-        return super.orderBy(sort as string | undefined, order, nulls)
+        return super.orderBy(sort, order, nulls)
     }
 
     /**
@@ -1448,7 +1448,7 @@ export class SelectQueryBuilder<Entity extends ObjectLiteral>
      * @param order
      * @param nulls
      */
-    public addOrderBy(
+    addOrderBy(
         sort: string,
         order: "ASC" | "DESC" = "ASC",
         nulls?: "NULLS FIRST" | "NULLS LAST",

--- a/src/query-builder/SoftDeleteQueryBuilder.ts
+++ b/src/query-builder/SoftDeleteQueryBuilder.ts
@@ -346,14 +346,14 @@ export class SoftDeleteQueryBuilder<Entity extends ObjectLiteral>
      *
      * Calling order by without order set will remove all previously set order bys.
      */
-    orderBy(): this
+    public orderBy(): this
 
     /**
      * Sets ORDER BY condition in the query builder.
      * If you had previously ORDER BY expression defined,
      * calling this function will override previously set ORDER BY conditions.
      */
-    orderBy(
+    public orderBy(
         sort: string,
         order?: "ASC" | "DESC",
         nulls?: "NULLS FIRST" | "NULLS LAST",
@@ -364,7 +364,7 @@ export class SoftDeleteQueryBuilder<Entity extends ObjectLiteral>
      * If you had previously ORDER BY expression defined,
      * calling this function will override previously set ORDER BY conditions.
      */
-    orderBy(order: OrderByCondition): this
+    public orderBy(order: OrderByCondition): this
 
     /**
      * Sets ORDER BY condition in the query builder.
@@ -375,31 +375,12 @@ export class SoftDeleteQueryBuilder<Entity extends ObjectLiteral>
      * @param order
      * @param nulls
      */
-    orderBy(
+    public orderBy(
         sort?: string | OrderByCondition,
         order: "ASC" | "DESC" = "ASC",
         nulls?: "NULLS FIRST" | "NULLS LAST",
     ): this {
-        this.assertValidOrderByOptions(order, nulls)
-
-        if (sort) {
-            if (typeof sort === "object") {
-                this.validateOrderByCondition(sort)
-                this.expressionMap.orderBys = sort
-            } else {
-                this.assertNoSemicolon(sort, "orderBy")
-                if (nulls) {
-                    this.expressionMap.orderBys = {
-                        [sort as string]: { order, nulls },
-                    }
-                } else {
-                    this.expressionMap.orderBys = { [sort as string]: order }
-                }
-            }
-        } else {
-            this.expressionMap.orderBys = {}
-        }
-        return this
+        return super.orderBy(sort as string | undefined, order, nulls)
     }
 
     /**
@@ -409,19 +390,12 @@ export class SoftDeleteQueryBuilder<Entity extends ObjectLiteral>
      * @param order
      * @param nulls
      */
-    addOrderBy(
+    public addOrderBy(
         sort: string,
         order: "ASC" | "DESC" = "ASC",
         nulls?: "NULLS FIRST" | "NULLS LAST",
     ): this {
-        this.assertValidOrderByOptions(order, nulls)
-        this.assertNoSemicolon(sort, "addOrderBy")
-        if (nulls) {
-            this.expressionMap.orderBys[sort] = { order, nulls }
-        } else {
-            this.expressionMap.orderBys[sort] = order
-        }
-        return this
+        return super.addOrderBy(sort, order, nulls)
     }
 
     /**

--- a/src/query-builder/SoftDeleteQueryBuilder.ts
+++ b/src/query-builder/SoftDeleteQueryBuilder.ts
@@ -380,6 +380,19 @@ export class SoftDeleteQueryBuilder<Entity extends ObjectLiteral>
         order: "ASC" | "DESC" = "ASC",
         nulls?: "NULLS FIRST" | "NULLS LAST",
     ): this {
+        if (order !== undefined && order !== "ASC" && order !== "DESC")
+            throw new TypeORMError(
+                `SoftDeleteQueryBuilder.orderBy "order" can accept only "ASC" and "DESC" values.`,
+            )
+        if (
+            nulls !== undefined &&
+            nulls !== "NULLS FIRST" &&
+            nulls !== "NULLS LAST"
+        )
+            throw new TypeORMError(
+                `SoftDeleteQueryBuilder.orderBy "nulls" can accept only "NULLS FIRST" and "NULLS LAST" values.`,
+            )
+
         if (sort) {
             if (typeof sort === "object") {
                 this.validateOrderByCondition(sort)
@@ -412,6 +425,19 @@ export class SoftDeleteQueryBuilder<Entity extends ObjectLiteral>
         order: "ASC" | "DESC" = "ASC",
         nulls?: "NULLS FIRST" | "NULLS LAST",
     ): this {
+        if (order !== undefined && order !== "ASC" && order !== "DESC")
+            throw new TypeORMError(
+                `SoftDeleteQueryBuilder.addOrderBy "order" can accept only "ASC" and "DESC" values.`,
+            )
+        if (
+            nulls !== undefined &&
+            nulls !== "NULLS FIRST" &&
+            nulls !== "NULLS LAST"
+        )
+            throw new TypeORMError(
+                `SoftDeleteQueryBuilder.addOrderBy "nulls" can accept only "NULLS FIRST" and "NULLS LAST" values.`,
+            )
+
         this.assertNoSemicolon(sort, "addOrderBy")
         if (nulls) {
             this.expressionMap.orderBys[sort] = { order, nulls }

--- a/src/query-builder/SoftDeleteQueryBuilder.ts
+++ b/src/query-builder/SoftDeleteQueryBuilder.ts
@@ -380,18 +380,7 @@ export class SoftDeleteQueryBuilder<Entity extends ObjectLiteral>
         order: "ASC" | "DESC" = "ASC",
         nulls?: "NULLS FIRST" | "NULLS LAST",
     ): this {
-        if (order !== undefined && order !== "ASC" && order !== "DESC")
-            throw new TypeORMError(
-                `SoftDeleteQueryBuilder.orderBy "order" can accept only "ASC" and "DESC" values.`,
-            )
-        if (
-            nulls !== undefined &&
-            nulls !== "NULLS FIRST" &&
-            nulls !== "NULLS LAST"
-        )
-            throw new TypeORMError(
-                `SoftDeleteQueryBuilder.orderBy "nulls" can accept only "NULLS FIRST" and "NULLS LAST" values.`,
-            )
+        this.assertValidOrderByOptions(order, nulls)
 
         if (sort) {
             if (typeof sort === "object") {
@@ -425,19 +414,7 @@ export class SoftDeleteQueryBuilder<Entity extends ObjectLiteral>
         order: "ASC" | "DESC" = "ASC",
         nulls?: "NULLS FIRST" | "NULLS LAST",
     ): this {
-        if (order !== undefined && order !== "ASC" && order !== "DESC")
-            throw new TypeORMError(
-                `SoftDeleteQueryBuilder.addOrderBy "order" can accept only "ASC" and "DESC" values.`,
-            )
-        if (
-            nulls !== undefined &&
-            nulls !== "NULLS FIRST" &&
-            nulls !== "NULLS LAST"
-        )
-            throw new TypeORMError(
-                `SoftDeleteQueryBuilder.addOrderBy "nulls" can accept only "NULLS FIRST" and "NULLS LAST" values.`,
-            )
-
+        this.assertValidOrderByOptions(order, nulls)
         this.assertNoSemicolon(sort, "addOrderBy")
         if (nulls) {
             this.expressionMap.orderBys[sort] = { order, nulls }

--- a/src/query-builder/SoftDeleteQueryBuilder.ts
+++ b/src/query-builder/SoftDeleteQueryBuilder.ts
@@ -346,14 +346,14 @@ export class SoftDeleteQueryBuilder<Entity extends ObjectLiteral>
      *
      * Calling order by without order set will remove all previously set order bys.
      */
-    public orderBy(): this
+    orderBy(): this
 
     /**
      * Sets ORDER BY condition in the query builder.
      * If you had previously ORDER BY expression defined,
      * calling this function will override previously set ORDER BY conditions.
      */
-    public orderBy(
+    orderBy(
         sort: string,
         order?: "ASC" | "DESC",
         nulls?: "NULLS FIRST" | "NULLS LAST",
@@ -364,7 +364,7 @@ export class SoftDeleteQueryBuilder<Entity extends ObjectLiteral>
      * If you had previously ORDER BY expression defined,
      * calling this function will override previously set ORDER BY conditions.
      */
-    public orderBy(order: OrderByCondition): this
+    orderBy(order: OrderByCondition): this
 
     /**
      * Sets ORDER BY condition in the query builder.
@@ -375,12 +375,12 @@ export class SoftDeleteQueryBuilder<Entity extends ObjectLiteral>
      * @param order
      * @param nulls
      */
-    public orderBy(
+    orderBy(
         sort?: string | OrderByCondition,
         order: "ASC" | "DESC" = "ASC",
         nulls?: "NULLS FIRST" | "NULLS LAST",
     ): this {
-        return super.orderBy(sort as string | undefined, order, nulls)
+        return super.orderBy(sort, order, nulls)
     }
 
     /**
@@ -390,7 +390,7 @@ export class SoftDeleteQueryBuilder<Entity extends ObjectLiteral>
      * @param order
      * @param nulls
      */
-    public addOrderBy(
+    addOrderBy(
         sort: string,
         order: "ASC" | "DESC" = "ASC",
         nulls?: "NULLS FIRST" | "NULLS LAST",

--- a/src/query-builder/SoftDeleteQueryBuilder.ts
+++ b/src/query-builder/SoftDeleteQueryBuilder.ts
@@ -385,6 +385,7 @@ export class SoftDeleteQueryBuilder<Entity extends ObjectLiteral>
                 this.validateOrderByCondition(sort)
                 this.expressionMap.orderBys = sort
             } else {
+                this.assertNoSemicolon(sort, "orderBy sort key")
                 if (nulls) {
                     this.expressionMap.orderBys = {
                         [sort as string]: { order, nulls },
@@ -411,6 +412,7 @@ export class SoftDeleteQueryBuilder<Entity extends ObjectLiteral>
         order: "ASC" | "DESC" = "ASC",
         nulls?: "NULLS FIRST" | "NULLS LAST",
     ): this {
+        this.assertNoSemicolon(sort, "addOrderBy sort key")
         if (nulls) {
             this.expressionMap.orderBys[sort] = { order, nulls }
         } else {

--- a/src/query-builder/SoftDeleteQueryBuilder.ts
+++ b/src/query-builder/SoftDeleteQueryBuilder.ts
@@ -385,7 +385,7 @@ export class SoftDeleteQueryBuilder<Entity extends ObjectLiteral>
                 this.validateOrderByCondition(sort)
                 this.expressionMap.orderBys = sort
             } else {
-                this.assertNoSemicolon(sort, "orderBy sort key")
+                this.assertNoSemicolon(sort, "orderBy")
                 if (nulls) {
                     this.expressionMap.orderBys = {
                         [sort as string]: { order, nulls },
@@ -412,7 +412,7 @@ export class SoftDeleteQueryBuilder<Entity extends ObjectLiteral>
         order: "ASC" | "DESC" = "ASC",
         nulls?: "NULLS FIRST" | "NULLS LAST",
     ): this {
-        this.assertNoSemicolon(sort, "addOrderBy sort key")
+        this.assertNoSemicolon(sort, "addOrderBy")
         if (nulls) {
             this.expressionMap.orderBys[sort] = { order, nulls }
         } else {

--- a/src/query-builder/UpdateQueryBuilder.ts
+++ b/src/query-builder/UpdateQueryBuilder.ts
@@ -379,14 +379,14 @@ export class UpdateQueryBuilder<Entity extends ObjectLiteral>
      *
      * Calling order by without order set will remove all previously set order bys.
      */
-    public orderBy(): this
+    orderBy(): this
 
     /**
      * Sets ORDER BY condition in the query builder.
      * If you had previously ORDER BY expression defined,
      * calling this function will override previously set ORDER BY conditions.
      */
-    public orderBy(
+    orderBy(
         sort: string,
         order?: "ASC" | "DESC",
         nulls?: "NULLS FIRST" | "NULLS LAST",
@@ -397,7 +397,7 @@ export class UpdateQueryBuilder<Entity extends ObjectLiteral>
      * If you had previously ORDER BY expression defined,
      * calling this function will override previously set ORDER BY conditions.
      */
-    public orderBy(order: OrderByCondition): this
+    orderBy(order: OrderByCondition): this
 
     /**
      * Sets ORDER BY condition in the query builder.
@@ -408,12 +408,12 @@ export class UpdateQueryBuilder<Entity extends ObjectLiteral>
      * @param order
      * @param nulls
      */
-    public orderBy(
+    orderBy(
         sort?: string | OrderByCondition,
         order: "ASC" | "DESC" = "ASC",
         nulls?: "NULLS FIRST" | "NULLS LAST",
     ): this {
-        return super.orderBy(sort as string | undefined, order, nulls)
+        return super.orderBy(sort, order, nulls)
     }
 
     /**
@@ -423,7 +423,7 @@ export class UpdateQueryBuilder<Entity extends ObjectLiteral>
      * @param order
      * @param nulls
      */
-    public addOrderBy(
+    addOrderBy(
         sort: string,
         order: "ASC" | "DESC" = "ASC",
         nulls?: "NULLS FIRST" | "NULLS LAST",

--- a/src/query-builder/UpdateQueryBuilder.ts
+++ b/src/query-builder/UpdateQueryBuilder.ts
@@ -413,6 +413,19 @@ export class UpdateQueryBuilder<Entity extends ObjectLiteral>
         order: "ASC" | "DESC" = "ASC",
         nulls?: "NULLS FIRST" | "NULLS LAST",
     ): this {
+        if (order !== undefined && order !== "ASC" && order !== "DESC")
+            throw new TypeORMError(
+                `UpdateQueryBuilder.orderBy "order" can accept only "ASC" and "DESC" values.`,
+            )
+        if (
+            nulls !== undefined &&
+            nulls !== "NULLS FIRST" &&
+            nulls !== "NULLS LAST"
+        )
+            throw new TypeORMError(
+                `UpdateQueryBuilder.orderBy "nulls" can accept only "NULLS FIRST" and "NULLS LAST" values.`,
+            )
+
         if (sort) {
             if (typeof sort === "object") {
                 this.validateOrderByCondition(sort)
@@ -445,6 +458,19 @@ export class UpdateQueryBuilder<Entity extends ObjectLiteral>
         order: "ASC" | "DESC" = "ASC",
         nulls?: "NULLS FIRST" | "NULLS LAST",
     ): this {
+        if (order !== undefined && order !== "ASC" && order !== "DESC")
+            throw new TypeORMError(
+                `UpdateQueryBuilder.addOrderBy "order" can accept only "ASC" and "DESC" values.`,
+            )
+        if (
+            nulls !== undefined &&
+            nulls !== "NULLS FIRST" &&
+            nulls !== "NULLS LAST"
+        )
+            throw new TypeORMError(
+                `UpdateQueryBuilder.addOrderBy "nulls" can accept only "NULLS FIRST" and "NULLS LAST" values.`,
+            )
+
         this.assertNoSemicolon(sort, "addOrderBy")
         if (nulls) {
             this.expressionMap.orderBys[sort] = { order, nulls }

--- a/src/query-builder/UpdateQueryBuilder.ts
+++ b/src/query-builder/UpdateQueryBuilder.ts
@@ -413,18 +413,7 @@ export class UpdateQueryBuilder<Entity extends ObjectLiteral>
         order: "ASC" | "DESC" = "ASC",
         nulls?: "NULLS FIRST" | "NULLS LAST",
     ): this {
-        if (order !== undefined && order !== "ASC" && order !== "DESC")
-            throw new TypeORMError(
-                `UpdateQueryBuilder.orderBy "order" can accept only "ASC" and "DESC" values.`,
-            )
-        if (
-            nulls !== undefined &&
-            nulls !== "NULLS FIRST" &&
-            nulls !== "NULLS LAST"
-        )
-            throw new TypeORMError(
-                `UpdateQueryBuilder.orderBy "nulls" can accept only "NULLS FIRST" and "NULLS LAST" values.`,
-            )
+        this.assertValidOrderByOptions(order, nulls)
 
         if (sort) {
             if (typeof sort === "object") {
@@ -458,19 +447,7 @@ export class UpdateQueryBuilder<Entity extends ObjectLiteral>
         order: "ASC" | "DESC" = "ASC",
         nulls?: "NULLS FIRST" | "NULLS LAST",
     ): this {
-        if (order !== undefined && order !== "ASC" && order !== "DESC")
-            throw new TypeORMError(
-                `UpdateQueryBuilder.addOrderBy "order" can accept only "ASC" and "DESC" values.`,
-            )
-        if (
-            nulls !== undefined &&
-            nulls !== "NULLS FIRST" &&
-            nulls !== "NULLS LAST"
-        )
-            throw new TypeORMError(
-                `UpdateQueryBuilder.addOrderBy "nulls" can accept only "NULLS FIRST" and "NULLS LAST" values.`,
-            )
-
+        this.assertValidOrderByOptions(order, nulls)
         this.assertNoSemicolon(sort, "addOrderBy")
         if (nulls) {
             this.expressionMap.orderBys[sort] = { order, nulls }

--- a/src/query-builder/UpdateQueryBuilder.ts
+++ b/src/query-builder/UpdateQueryBuilder.ts
@@ -418,6 +418,7 @@ export class UpdateQueryBuilder<Entity extends ObjectLiteral>
                 this.validateOrderByCondition(sort)
                 this.expressionMap.orderBys = sort
             } else {
+                this.assertNoSemicolon(sort, "orderBy sort key")
                 if (nulls) {
                     this.expressionMap.orderBys = {
                         [sort as string]: { order, nulls },
@@ -444,6 +445,7 @@ export class UpdateQueryBuilder<Entity extends ObjectLiteral>
         order: "ASC" | "DESC" = "ASC",
         nulls?: "NULLS FIRST" | "NULLS LAST",
     ): this {
+        this.assertNoSemicolon(sort, "addOrderBy sort key")
         if (nulls) {
             this.expressionMap.orderBys[sort] = { order, nulls }
         } else {

--- a/src/query-builder/UpdateQueryBuilder.ts
+++ b/src/query-builder/UpdateQueryBuilder.ts
@@ -418,7 +418,7 @@ export class UpdateQueryBuilder<Entity extends ObjectLiteral>
                 this.validateOrderByCondition(sort)
                 this.expressionMap.orderBys = sort
             } else {
-                this.assertNoSemicolon(sort, "orderBy sort key")
+                this.assertNoSemicolon(sort, "orderBy")
                 if (nulls) {
                     this.expressionMap.orderBys = {
                         [sort as string]: { order, nulls },
@@ -445,7 +445,7 @@ export class UpdateQueryBuilder<Entity extends ObjectLiteral>
         order: "ASC" | "DESC" = "ASC",
         nulls?: "NULLS FIRST" | "NULLS LAST",
     ): this {
-        this.assertNoSemicolon(sort, "addOrderBy sort key")
+        this.assertNoSemicolon(sort, "addOrderBy")
         if (nulls) {
             this.expressionMap.orderBys[sort] = { order, nulls }
         } else {

--- a/src/query-builder/UpdateQueryBuilder.ts
+++ b/src/query-builder/UpdateQueryBuilder.ts
@@ -379,14 +379,14 @@ export class UpdateQueryBuilder<Entity extends ObjectLiteral>
      *
      * Calling order by without order set will remove all previously set order bys.
      */
-    orderBy(): this
+    public orderBy(): this
 
     /**
      * Sets ORDER BY condition in the query builder.
      * If you had previously ORDER BY expression defined,
      * calling this function will override previously set ORDER BY conditions.
      */
-    orderBy(
+    public orderBy(
         sort: string,
         order?: "ASC" | "DESC",
         nulls?: "NULLS FIRST" | "NULLS LAST",
@@ -397,7 +397,7 @@ export class UpdateQueryBuilder<Entity extends ObjectLiteral>
      * If you had previously ORDER BY expression defined,
      * calling this function will override previously set ORDER BY conditions.
      */
-    orderBy(order: OrderByCondition): this
+    public orderBy(order: OrderByCondition): this
 
     /**
      * Sets ORDER BY condition in the query builder.
@@ -408,31 +408,12 @@ export class UpdateQueryBuilder<Entity extends ObjectLiteral>
      * @param order
      * @param nulls
      */
-    orderBy(
+    public orderBy(
         sort?: string | OrderByCondition,
         order: "ASC" | "DESC" = "ASC",
         nulls?: "NULLS FIRST" | "NULLS LAST",
     ): this {
-        this.assertValidOrderByOptions(order, nulls)
-
-        if (sort) {
-            if (typeof sort === "object") {
-                this.validateOrderByCondition(sort)
-                this.expressionMap.orderBys = sort
-            } else {
-                this.assertNoSemicolon(sort, "orderBy")
-                if (nulls) {
-                    this.expressionMap.orderBys = {
-                        [sort as string]: { order, nulls },
-                    }
-                } else {
-                    this.expressionMap.orderBys = { [sort as string]: order }
-                }
-            }
-        } else {
-            this.expressionMap.orderBys = {}
-        }
-        return this
+        return super.orderBy(sort as string | undefined, order, nulls)
     }
 
     /**
@@ -442,19 +423,12 @@ export class UpdateQueryBuilder<Entity extends ObjectLiteral>
      * @param order
      * @param nulls
      */
-    addOrderBy(
+    public addOrderBy(
         sort: string,
         order: "ASC" | "DESC" = "ASC",
         nulls?: "NULLS FIRST" | "NULLS LAST",
     ): this {
-        this.assertValidOrderByOptions(order, nulls)
-        this.assertNoSemicolon(sort, "addOrderBy")
-        if (nulls) {
-            this.expressionMap.orderBys[sort] = { order, nulls }
-        } else {
-            this.expressionMap.orderBys[sort] = order
-        }
-        return this
+        return super.addOrderBy(sort, order, nulls)
     }
 
     /**

--- a/test/functional/query-builder/sql-injection/sql-injection.test.ts
+++ b/test/functional/query-builder/sql-injection/sql-injection.test.ts
@@ -67,37 +67,88 @@ describe("query builder > sql injection", () => {
         }
     }
 
+    // Builder factories typed `any` so the tests can drive them by method
+    // name and pass loose strings through to the runtime allow-list without
+    // per-call `as any` casts.
+    type BuilderFactory = (dataSource: DataSource) => any
+
+    const selectBuilder: BuilderFactory = (dataSource) =>
+        dataSource.getRepository(Post).createQueryBuilder("post")
+
+    const updateBuilder: BuilderFactory = (dataSource) =>
+        dataSource.createQueryBuilder().update(Post).set({ name: "test" })
+
+    const softDeleteBuilder: BuilderFactory = (dataSource) =>
+        dataSource.createQueryBuilder().softDelete().from(Post)
+
+    /**
+     * Drives the given method with a raw-SQL `input` on every dataSource and
+     * expects the flat-reject semicolon guard to throw. Used by the tests
+     * that exercise `groupBy` / `addGroupBy` / `orderBy` (string form) /
+     * `addOrderBy` across every query builder that surfaces them.
+     */
+    async function expectRejectsSemicolon(
+        factory: BuilderFactory,
+        method: string,
+        input: string,
+    ): Promise<void> {
+        await Promise.all(
+            dataSources.map(async (dataSource) => {
+                expect(() => factory(dataSource)[method](input)).to.throw(
+                    /Semicolons are not allowed/,
+                )
+                await verifyIntegrity(dataSource)()
+            }),
+        )
+    }
+
+    /**
+     * Drives `orderBy` / `addOrderBy` with a deliberately-out-of-enum `order`
+     * or `nulls` value and expects the shared allow-list to throw. Factories
+     * are loose-typed, so the call site passes raw strings without `as any`.
+     */
+    function expectRejectsInvalidOrderOption(
+        factory: BuilderFactory,
+        method: "orderBy" | "addOrderBy",
+        sort: string,
+        order: string,
+        nulls: string | undefined,
+    ): void {
+        const pattern = /"(order|nulls)" can accept only/
+        for (const dataSource of dataSources) {
+            expect(() =>
+                factory(dataSource)[method](sort, order, nulls),
+            ).to.throw(pattern)
+        }
+    }
+
+    /**
+     * Drives the object-form `orderBy` with an `OrderByCondition` whose value
+     * is deliberately outside the expected shape, to exercise
+     * `validateOrderByCondition`. `sort` is typed `unknown` so invalid
+     * values don't need `as any` at the call site.
+     */
+    function expectRejectsOrderByCondition(
+        factory: BuilderFactory,
+        sort: unknown,
+        pattern: RegExp,
+    ): void {
+        for (const dataSource of dataSources) {
+            expect(() => factory(dataSource).orderBy(sort)).to.throw(pattern)
+        }
+    }
+
     describe("addGroupBy", () => {
         for (const malicious of inputsWithSemicolons) {
             it(`should reject semicolons with: ${malicious}`, () =>
-                Promise.all(
-                    dataSources.map(async (dataSource) => {
-                        expect(() =>
-                            dataSource
-                                .getRepository(Post)
-                                .createQueryBuilder("post")
-                                .addGroupBy(malicious),
-                        ).to.throw(/Semicolons are not allowed/)
-                        await verifyIntegrity(dataSource)()
-                    }),
-                ))
+                expectRejectsSemicolon(selectBuilder, "addGroupBy", malicious))
         }
     })
 
     describe("addOrderBy", () => {
         for (const malicious of inputsWithSemicolons) {
             it(`should reject semicolons with: ${malicious}`, () =>
-                Promise.all(
-                    dataSources.map(async (dataSource) => {
-                        expect(() =>
-                            dataSource
-                                .getRepository(Post)
-                                .createQueryBuilder("post")
-                                .addOrderBy(malicious),
-                        ).to.throw(/Semicolons are not allowed/)
-                        await verifyIntegrity(dataSource)()
-                    }),
-                ))
+                expectRejectsSemicolon(selectBuilder, "addOrderBy", malicious))
         }
     })
 
@@ -148,17 +199,7 @@ describe("query builder > sql injection", () => {
     describe("groupBy", () => {
         for (const malicious of inputsWithSemicolons) {
             it(`should reject semicolons with: ${malicious}`, () =>
-                Promise.all(
-                    dataSources.map(async (dataSource) => {
-                        expect(() =>
-                            dataSource
-                                .getRepository(Post)
-                                .createQueryBuilder("post")
-                                .groupBy(malicious),
-                        ).to.throw(/Semicolons are not allowed/)
-                        await verifyIntegrity(dataSource)()
-                    }),
-                ))
+                expectRejectsSemicolon(selectBuilder, "groupBy", malicious))
         }
     })
 
@@ -187,17 +228,7 @@ describe("query builder > sql injection", () => {
     describe("orderBy (string sort key)", () => {
         for (const malicious of inputsWithSemicolons) {
             it(`should reject semicolons with: ${malicious}`, () =>
-                Promise.all(
-                    dataSources.map(async (dataSource) => {
-                        expect(() =>
-                            dataSource
-                                .getRepository(Post)
-                                .createQueryBuilder("post")
-                                .orderBy(malicious),
-                        ).to.throw(/Semicolons are not allowed/)
-                        await verifyIntegrity(dataSource)()
-                    }),
-                ))
+                expectRejectsSemicolon(selectBuilder, "orderBy", malicious))
         }
 
         it("should reject semicolons in OrderByCondition keys", () => {
@@ -210,193 +241,89 @@ describe("query builder > sql injection", () => {
             }
         })
 
-        it("should reject semicolons in UpdateQueryBuilder orderBy sort key", () => {
-            for (const dataSource of dataSources) {
-                expect(() =>
-                    dataSource
-                        .createQueryBuilder()
-                        .update(Post)
-                        .set({ name: "test" })
-                        .orderBy("id; DROP TABLE post"),
-                ).to.throw(/Semicolons are not allowed/)
-            }
-        })
+        // Update / SoftDelete builders share the same sort-key and allow-list
+        // guards via QueryBuilder; loop across both to pin every call path.
+        for (const [name, factory] of [
+            ["UpdateQueryBuilder", updateBuilder] as const,
+            ["SoftDeleteQueryBuilder", softDeleteBuilder] as const,
+        ]) {
+            it(`should reject semicolons in ${name} orderBy sort key`, () =>
+                expectRejectsSemicolon(
+                    factory,
+                    "orderBy",
+                    "id; DROP TABLE post",
+                ))
 
-        it("should reject semicolons in UpdateQueryBuilder addOrderBy sort key", () => {
-            for (const dataSource of dataSources) {
-                expect(() =>
-                    dataSource
-                        .createQueryBuilder()
-                        .update(Post)
-                        .set({ name: "test" })
-                        .addOrderBy("id; DROP TABLE post"),
-                ).to.throw(/Semicolons are not allowed/)
-            }
-        })
+            it(`should reject semicolons in ${name} addOrderBy sort key`, () =>
+                expectRejectsSemicolon(
+                    factory,
+                    "addOrderBy",
+                    "id; DROP TABLE post",
+                ))
 
-        it("should reject semicolons in UpdateQueryBuilder OrderByCondition keys", () => {
-            for (const dataSource of dataSources) {
-                expect(() =>
-                    dataSource
-                        .createQueryBuilder()
-                        .update(Post)
-                        .set({ name: "test" })
-                        .orderBy({
+            it(`should reject semicolons in ${name} OrderByCondition keys`, () => {
+                for (const dataSource of dataSources) {
+                    expect(() =>
+                        factory(dataSource).orderBy({
                             "id; DELETE FROM post": "ASC",
                         }),
-                ).to.throw(/Semicolons are not allowed/)
-            }
-        })
+                    ).to.throw(/Semicolons are not allowed/)
+                }
+            })
 
-        it("should reject semicolons in SoftDeleteQueryBuilder orderBy sort key", () => {
-            for (const dataSource of dataSources) {
-                expect(() =>
-                    dataSource
-                        .createQueryBuilder()
-                        .softDelete()
-                        .from(Post)
-                        .orderBy("id; DROP TABLE post"),
-                ).to.throw(/Semicolons are not allowed/)
-            }
-        })
+            it(`should reject invalid order value in ${name} orderBy`, () =>
+                expectRejectsInvalidOrderOption(
+                    factory,
+                    "orderBy",
+                    "id",
+                    "ASC; DROP TABLE post",
+                    undefined,
+                ))
 
-        it("should reject semicolons in SoftDeleteQueryBuilder addOrderBy sort key", () => {
-            for (const dataSource of dataSources) {
-                expect(() =>
-                    dataSource
-                        .createQueryBuilder()
-                        .softDelete()
-                        .from(Post)
-                        .addOrderBy("id; DROP TABLE post"),
-                ).to.throw(/Semicolons are not allowed/)
-            }
-        })
+            it(`should reject invalid order value in ${name} addOrderBy`, () =>
+                expectRejectsInvalidOrderOption(
+                    factory,
+                    "addOrderBy",
+                    "id",
+                    "ASC; DROP TABLE post",
+                    undefined,
+                ))
 
-        it("should reject semicolons in SoftDeleteQueryBuilder OrderByCondition keys", () => {
-            for (const dataSource of dataSources) {
-                expect(() =>
-                    dataSource
-                        .createQueryBuilder()
-                        .softDelete()
-                        .from(Post)
-                        .orderBy({
-                            "id; DELETE FROM post": "ASC",
-                        }),
-                ).to.throw(/Semicolons are not allowed/)
-            }
-        })
-
-        it("should reject invalid order value in UpdateQueryBuilder orderBy", () => {
-            for (const dataSource of dataSources) {
-                expect(() =>
-                    dataSource
-                        .createQueryBuilder()
-                        .update(Post)
-                        .set({ name: "test" })
-                        .orderBy("id", "ASC; DROP TABLE post" as any),
-                ).to.throw(/"order" can accept only/)
-            }
-        })
-
-        it("should reject invalid order value in UpdateQueryBuilder addOrderBy", () => {
-            for (const dataSource of dataSources) {
-                expect(() =>
-                    dataSource
-                        .createQueryBuilder()
-                        .update(Post)
-                        .set({ name: "test" })
-                        .addOrderBy("id", "ASC; DROP TABLE post" as any),
-                ).to.throw(/"order" can accept only/)
-            }
-        })
-
-        it("should reject invalid nulls value in UpdateQueryBuilder orderBy", () => {
-            for (const dataSource of dataSources) {
-                expect(() =>
-                    dataSource
-                        .createQueryBuilder()
-                        .update(Post)
-                        .set({ name: "test" })
-                        .orderBy(
-                            "id",
-                            "ASC",
-                            "NULLS FIRST; DROP TABLE post" as any,
-                        ),
-                ).to.throw(/"nulls" can accept only/)
-            }
-        })
-
-        it("should reject invalid order value in SoftDeleteQueryBuilder orderBy", () => {
-            for (const dataSource of dataSources) {
-                expect(() =>
-                    dataSource
-                        .createQueryBuilder()
-                        .softDelete()
-                        .from(Post)
-                        .orderBy("id", "ASC; DROP TABLE post" as any),
-                ).to.throw(/"order" can accept only/)
-            }
-        })
-
-        it("should reject invalid order value in SoftDeleteQueryBuilder addOrderBy", () => {
-            for (const dataSource of dataSources) {
-                expect(() =>
-                    dataSource
-                        .createQueryBuilder()
-                        .softDelete()
-                        .from(Post)
-                        .addOrderBy("id", "ASC; DROP TABLE post" as any),
-                ).to.throw(/"order" can accept only/)
-            }
-        })
-
-        it("should reject invalid nulls value in SoftDeleteQueryBuilder orderBy", () => {
-            for (const dataSource of dataSources) {
-                expect(() =>
-                    dataSource
-                        .createQueryBuilder()
-                        .softDelete()
-                        .from(Post)
-                        .orderBy(
-                            "id",
-                            "ASC",
-                            "NULLS FIRST; DROP TABLE post" as any,
-                        ),
-                ).to.throw(/"nulls" can accept only/)
-            }
-        })
+            it(`should reject invalid nulls value in ${name} orderBy`, () =>
+                expectRejectsInvalidOrderOption(
+                    factory,
+                    "orderBy",
+                    "id",
+                    "ASC",
+                    "NULLS FIRST; DROP TABLE post",
+                ))
+        }
     })
 
     describe("orderBy value injection", () => {
-        it("should reject invalid order direction in OrderByCondition", () => {
-            for (const dataSource of dataSources) {
-                expect(() =>
-                    dataSource.createQueryBuilder(Post, "post").orderBy({
-                        "post.id": "ASC; DELETE FROM post;" as any,
-                    }),
-                ).to.throw(/Invalid order direction/)
-            }
-        })
+        it("should reject invalid order direction in OrderByCondition", () =>
+            expectRejectsOrderByCondition(
+                selectBuilder,
+                { "post.id": "ASC; DELETE FROM post;" },
+                /Invalid order direction/,
+            ))
 
-        it("should reject invalid nulls option in OrderByCondition", () => {
-            for (const dataSource of dataSources) {
-                expect(() =>
-                    dataSource.createQueryBuilder(Post, "post").orderBy({
-                        "post.id": {
-                            order: "ASC",
-                            nulls: "NULLS FIRST; DROP TABLE post;" as any,
-                        },
-                    }),
-                ).to.throw(/Invalid nulls option/)
-            }
-        })
+        it("should reject invalid nulls option in OrderByCondition", () =>
+            expectRejectsOrderByCondition(
+                selectBuilder,
+                {
+                    "post.id": {
+                        order: "ASC",
+                        nulls: "NULLS FIRST; DROP TABLE post;",
+                    },
+                },
+                /Invalid nulls option/,
+            ))
 
         it("should accept valid OrderByCondition values", () =>
             Promise.all(
                 dataSources.map(async (dataSource) => {
-                    await dataSource
-                        .getRepository(Post)
-                        .createQueryBuilder("post")
+                    await selectBuilder(dataSource)
                         .orderBy({
                             "post.id": "DESC",
                             "post.name": "ASC",
@@ -414,8 +341,7 @@ describe("query builder > sql injection", () => {
                     )
                         return
 
-                    await dataSource
-                        .createQueryBuilder(Post, "post")
+                    await selectBuilder(dataSource)
                         .orderBy({
                             "post.id": "DESC",
                             "post.name": {
@@ -427,33 +353,19 @@ describe("query builder > sql injection", () => {
                 }),
             ))
 
-        it("should reject invalid order direction in UpdateQueryBuilder", () => {
-            for (const dataSource of dataSources) {
-                expect(() =>
-                    dataSource
-                        .createQueryBuilder()
-                        .update(Post)
-                        .set({ name: "test" })
-                        .orderBy({
-                            id: "ASC; DROP TABLE post;" as any,
-                        }),
-                ).to.throw(/Invalid order direction/)
-            }
-        })
+        it("should reject invalid order direction in UpdateQueryBuilder", () =>
+            expectRejectsOrderByCondition(
+                updateBuilder,
+                { id: "ASC; DROP TABLE post;" },
+                /Invalid order direction/,
+            ))
 
-        it("should reject invalid order direction in SoftDeleteQueryBuilder", () => {
-            for (const dataSource of dataSources) {
-                expect(() =>
-                    dataSource
-                        .createQueryBuilder()
-                        .softDelete()
-                        .from(Post)
-                        .orderBy({
-                            id: "ASC; DROP TABLE post;" as any,
-                        }),
-                ).to.throw(/Invalid order direction/)
-            }
-        })
+        it("should reject invalid order direction in SoftDeleteQueryBuilder", () =>
+            expectRejectsOrderByCondition(
+                softDeleteBuilder,
+                { id: "ASC; DROP TABLE post;" },
+                /Invalid order direction/,
+            ))
     })
 
     describe("orWhere", () => {

--- a/test/functional/query-builder/sql-injection/sql-injection.test.ts
+++ b/test/functional/query-builder/sql-injection/sql-injection.test.ts
@@ -67,88 +67,33 @@ describe("query builder > sql injection", () => {
         }
     }
 
-    // Builder factories typed `any` so the tests can drive them by method
-    // name and pass loose strings through to the runtime allow-list without
-    // per-call `as any` casts.
-    type BuilderFactory = (dataSource: DataSource) => any
-
-    const selectBuilder: BuilderFactory = (dataSource) =>
-        dataSource.getRepository(Post).createQueryBuilder("post")
-
-    const updateBuilder: BuilderFactory = (dataSource) =>
-        dataSource.createQueryBuilder().update(Post).set({ name: "test" })
-
-    const softDeleteBuilder: BuilderFactory = (dataSource) =>
-        dataSource.createQueryBuilder().softDelete().from(Post)
-
-    /**
-     * Drives the given method with a raw-SQL `input` on every dataSource and
-     * expects the flat-reject semicolon guard to throw. Used by the tests
-     * that exercise `groupBy` / `addGroupBy` / `orderBy` (string form) /
-     * `addOrderBy` across every query builder that surfaces them.
-     */
-    async function expectRejectsSemicolon(
-        factory: BuilderFactory,
-        method: string,
-        input: string,
-    ): Promise<void> {
-        await Promise.all(
-            dataSources.map(async (dataSource) => {
-                expect(() => factory(dataSource)[method](input)).to.throw(
-                    /Semicolons are not allowed/,
-                )
-                await verifyIntegrity(dataSource)()
-            }),
-        )
-    }
-
-    /**
-     * Drives `orderBy` / `addOrderBy` with a deliberately-out-of-enum `order`
-     * or `nulls` value and expects the shared allow-list to throw. Factories
-     * are loose-typed, so the call site passes raw strings without `as any`.
-     */
-    function expectRejectsInvalidOrderOption(
-        factory: BuilderFactory,
-        method: "orderBy" | "addOrderBy",
-        sort: string,
-        order: string,
-        nulls: string | undefined,
-    ): void {
-        const pattern = /"(order|nulls)" can accept only/
-        for (const dataSource of dataSources) {
-            expect(() =>
-                factory(dataSource)[method](sort, order, nulls),
-            ).to.throw(pattern)
-        }
-    }
-
-    /**
-     * Drives the object-form `orderBy` with an `OrderByCondition` whose value
-     * is deliberately outside the expected shape, to exercise
-     * `validateOrderByCondition`. `sort` is typed `unknown` so invalid
-     * values don't need `as any` at the call site.
-     */
-    function expectRejectsOrderByCondition(
-        factory: BuilderFactory,
-        sort: unknown,
-        pattern: RegExp,
-    ): void {
-        for (const dataSource of dataSources) {
-            expect(() => factory(dataSource).orderBy(sort)).to.throw(pattern)
-        }
-    }
-
     describe("addGroupBy", () => {
         for (const malicious of inputsWithSemicolons) {
-            it(`should reject semicolons with: ${malicious}`, () =>
-                expectRejectsSemicolon(selectBuilder, "addGroupBy", malicious))
+            it(`should reject semicolons with: ${malicious}`, () => {
+                for (const dataSource of dataSources) {
+                    expect(() =>
+                        dataSource
+                            .getRepository(Post)
+                            .createQueryBuilder("post")
+                            .addGroupBy(malicious),
+                    ).to.throw(/Semicolons are not allowed/)
+                }
+            })
         }
     })
 
     describe("addOrderBy", () => {
         for (const malicious of inputsWithSemicolons) {
-            it(`should reject semicolons with: ${malicious}`, () =>
-                expectRejectsSemicolon(selectBuilder, "addOrderBy", malicious))
+            it(`should reject semicolons with: ${malicious}`, () => {
+                for (const dataSource of dataSources) {
+                    expect(() =>
+                        dataSource
+                            .getRepository(Post)
+                            .createQueryBuilder("post")
+                            .addOrderBy(malicious),
+                    ).to.throw(/Semicolons are not allowed/)
+                }
+            })
         }
     })
 
@@ -198,8 +143,16 @@ describe("query builder > sql injection", () => {
 
     describe("groupBy", () => {
         for (const malicious of inputsWithSemicolons) {
-            it(`should reject semicolons with: ${malicious}`, () =>
-                expectRejectsSemicolon(selectBuilder, "groupBy", malicious))
+            it(`should reject semicolons with: ${malicious}`, () => {
+                for (const dataSource of dataSources) {
+                    expect(() =>
+                        dataSource
+                            .getRepository(Post)
+                            .createQueryBuilder("post")
+                            .groupBy(malicious),
+                    ).to.throw(/Semicolons are not allowed/)
+                }
+            })
         }
     })
 
@@ -227,8 +180,16 @@ describe("query builder > sql injection", () => {
 
     describe("orderBy (string sort key)", () => {
         for (const malicious of inputsWithSemicolons) {
-            it(`should reject semicolons with: ${malicious}`, () =>
-                expectRejectsSemicolon(selectBuilder, "orderBy", malicious))
+            it(`should reject semicolons with: ${malicious}`, () => {
+                for (const dataSource of dataSources) {
+                    expect(() =>
+                        dataSource
+                            .getRepository(Post)
+                            .createQueryBuilder("post")
+                            .orderBy(malicious),
+                    ).to.throw(/Semicolons are not allowed/)
+                }
+            })
         }
 
         it("should reject semicolons in OrderByCondition keys", () => {
@@ -241,89 +202,195 @@ describe("query builder > sql injection", () => {
             }
         })
 
-        // Update / SoftDelete builders share the same sort-key and allow-list
-        // guards via QueryBuilder; loop across both to pin every call path.
-        for (const [name, factory] of [
-            ["UpdateQueryBuilder", updateBuilder] as const,
-            ["SoftDeleteQueryBuilder", softDeleteBuilder] as const,
-        ]) {
-            it(`should reject semicolons in ${name} orderBy sort key`, () =>
-                expectRejectsSemicolon(
-                    factory,
-                    "orderBy",
-                    "id; DROP TABLE post",
-                ))
+        it("should reject semicolons in UpdateQueryBuilder orderBy sort key", () => {
+            for (const dataSource of dataSources) {
+                expect(() =>
+                    dataSource
+                        .createQueryBuilder()
+                        .update(Post)
+                        .set({ name: "test" })
+                        .orderBy("id; DROP TABLE post"),
+                ).to.throw(/Semicolons are not allowed/)
+            }
+        })
 
-            it(`should reject semicolons in ${name} addOrderBy sort key`, () =>
-                expectRejectsSemicolon(
-                    factory,
-                    "addOrderBy",
-                    "id; DROP TABLE post",
-                ))
+        it("should reject semicolons in UpdateQueryBuilder addOrderBy sort key", () => {
+            for (const dataSource of dataSources) {
+                expect(() =>
+                    dataSource
+                        .createQueryBuilder()
+                        .update(Post)
+                        .set({ name: "test" })
+                        .addOrderBy("id; DROP TABLE post"),
+                ).to.throw(/Semicolons are not allowed/)
+            }
+        })
 
-            it(`should reject semicolons in ${name} OrderByCondition keys`, () => {
-                for (const dataSource of dataSources) {
-                    expect(() =>
-                        factory(dataSource).orderBy({
-                            "id; DELETE FROM post": "ASC",
-                        }),
-                    ).to.throw(/Semicolons are not allowed/)
-                }
-            })
+        it("should reject semicolons in UpdateQueryBuilder OrderByCondition keys", () => {
+            for (const dataSource of dataSources) {
+                expect(() =>
+                    dataSource
+                        .createQueryBuilder()
+                        .update(Post)
+                        .set({ name: "test" })
+                        .orderBy({ "id; DELETE FROM post": "ASC" }),
+                ).to.throw(/Semicolons are not allowed/)
+            }
+        })
 
-            it(`should reject invalid order value in ${name} orderBy`, () =>
-                expectRejectsInvalidOrderOption(
-                    factory,
-                    "orderBy",
-                    "id",
-                    "ASC; DROP TABLE post",
-                    undefined,
-                ))
+        it("should reject invalid order value in UpdateQueryBuilder orderBy", () => {
+            for (const dataSource of dataSources) {
+                expect(() =>
+                    dataSource
+                        .createQueryBuilder()
+                        .update(Post)
+                        .set({ name: "test" })
+                        .orderBy("id", "ASC; DROP TABLE post" as any),
+                ).to.throw(/"(order|nulls)" can accept only/)
+            }
+        })
 
-            it(`should reject invalid order value in ${name} addOrderBy`, () =>
-                expectRejectsInvalidOrderOption(
-                    factory,
-                    "addOrderBy",
-                    "id",
-                    "ASC; DROP TABLE post",
-                    undefined,
-                ))
+        it("should reject invalid order value in UpdateQueryBuilder addOrderBy", () => {
+            for (const dataSource of dataSources) {
+                expect(() =>
+                    dataSource
+                        .createQueryBuilder()
+                        .update(Post)
+                        .set({ name: "test" })
+                        .addOrderBy("id", "ASC; DROP TABLE post" as any),
+                ).to.throw(/"(order|nulls)" can accept only/)
+            }
+        })
 
-            it(`should reject invalid nulls value in ${name} orderBy`, () =>
-                expectRejectsInvalidOrderOption(
-                    factory,
-                    "orderBy",
-                    "id",
-                    "ASC",
-                    "NULLS FIRST; DROP TABLE post",
-                ))
-        }
+        it("should reject invalid nulls value in UpdateQueryBuilder orderBy", () => {
+            for (const dataSource of dataSources) {
+                expect(() =>
+                    dataSource
+                        .createQueryBuilder()
+                        .update(Post)
+                        .set({ name: "test" })
+                        .orderBy(
+                            "id",
+                            "ASC",
+                            "NULLS FIRST; DROP TABLE post" as any,
+                        ),
+                ).to.throw(/"(order|nulls)" can accept only/)
+            }
+        })
+
+        it("should reject semicolons in SoftDeleteQueryBuilder orderBy sort key", () => {
+            for (const dataSource of dataSources) {
+                expect(() =>
+                    dataSource
+                        .createQueryBuilder()
+                        .softDelete()
+                        .from(Post)
+                        .orderBy("id; DROP TABLE post"),
+                ).to.throw(/Semicolons are not allowed/)
+            }
+        })
+
+        it("should reject semicolons in SoftDeleteQueryBuilder addOrderBy sort key", () => {
+            for (const dataSource of dataSources) {
+                expect(() =>
+                    dataSource
+                        .createQueryBuilder()
+                        .softDelete()
+                        .from(Post)
+                        .addOrderBy("id; DROP TABLE post"),
+                ).to.throw(/Semicolons are not allowed/)
+            }
+        })
+
+        it("should reject semicolons in SoftDeleteQueryBuilder OrderByCondition keys", () => {
+            for (const dataSource of dataSources) {
+                expect(() =>
+                    dataSource
+                        .createQueryBuilder()
+                        .softDelete()
+                        .from(Post)
+                        .orderBy({ "id; DELETE FROM post": "ASC" }),
+                ).to.throw(/Semicolons are not allowed/)
+            }
+        })
+
+        it("should reject invalid order value in SoftDeleteQueryBuilder orderBy", () => {
+            for (const dataSource of dataSources) {
+                expect(() =>
+                    dataSource
+                        .createQueryBuilder()
+                        .softDelete()
+                        .from(Post)
+                        .orderBy("id", "ASC; DROP TABLE post" as any),
+                ).to.throw(/"(order|nulls)" can accept only/)
+            }
+        })
+
+        it("should reject invalid order value in SoftDeleteQueryBuilder addOrderBy", () => {
+            for (const dataSource of dataSources) {
+                expect(() =>
+                    dataSource
+                        .createQueryBuilder()
+                        .softDelete()
+                        .from(Post)
+                        .addOrderBy("id", "ASC; DROP TABLE post" as any),
+                ).to.throw(/"(order|nulls)" can accept only/)
+            }
+        })
+
+        it("should reject invalid nulls value in SoftDeleteQueryBuilder orderBy", () => {
+            for (const dataSource of dataSources) {
+                expect(() =>
+                    dataSource
+                        .createQueryBuilder()
+                        .softDelete()
+                        .from(Post)
+                        .orderBy(
+                            "id",
+                            "ASC",
+                            "NULLS FIRST; DROP TABLE post" as any,
+                        ),
+                ).to.throw(/"(order|nulls)" can accept only/)
+            }
+        })
     })
 
     describe("orderBy value injection", () => {
-        it("should reject invalid order direction in OrderByCondition", () =>
-            expectRejectsOrderByCondition(
-                selectBuilder,
-                { "post.id": "ASC; DELETE FROM post;" },
-                /Invalid order direction/,
-            ))
+        it("should reject invalid order direction in OrderByCondition", () => {
+            for (const dataSource of dataSources) {
+                expect(() =>
+                    dataSource
+                        .getRepository(Post)
+                        .createQueryBuilder("post")
+                        .orderBy({
+                            "post.id": "ASC; DELETE FROM post;" as any,
+                        }),
+                ).to.throw(/Invalid order direction/)
+            }
+        })
 
-        it("should reject invalid nulls option in OrderByCondition", () =>
-            expectRejectsOrderByCondition(
-                selectBuilder,
-                {
-                    "post.id": {
-                        order: "ASC",
-                        nulls: "NULLS FIRST; DROP TABLE post;",
-                    },
-                },
-                /Invalid nulls option/,
-            ))
+        it("should reject invalid nulls option in OrderByCondition", () => {
+            for (const dataSource of dataSources) {
+                expect(() =>
+                    dataSource
+                        .getRepository(Post)
+                        .createQueryBuilder("post")
+                        .orderBy({
+                            "post.id": {
+                                order: "ASC",
+                                nulls: "NULLS FIRST; DROP TABLE post;" as any,
+                            },
+                        }),
+                ).to.throw(/Invalid nulls option/)
+            }
+        })
 
         it("should accept valid OrderByCondition values", () =>
             Promise.all(
                 dataSources.map(async (dataSource) => {
-                    await selectBuilder(dataSource)
+                    await dataSource
+                        .getRepository(Post)
+                        .createQueryBuilder("post")
                         .orderBy({
                             "post.id": "DESC",
                             "post.name": "ASC",
@@ -341,7 +408,9 @@ describe("query builder > sql injection", () => {
                     )
                         return
 
-                    await selectBuilder(dataSource)
+                    await dataSource
+                        .getRepository(Post)
+                        .createQueryBuilder("post")
                         .orderBy({
                             "post.id": "DESC",
                             "post.name": {
@@ -353,19 +422,33 @@ describe("query builder > sql injection", () => {
                 }),
             ))
 
-        it("should reject invalid order direction in UpdateQueryBuilder", () =>
-            expectRejectsOrderByCondition(
-                updateBuilder,
-                { id: "ASC; DROP TABLE post;" },
-                /Invalid order direction/,
-            ))
+        it("should reject invalid order direction in UpdateQueryBuilder", () => {
+            for (const dataSource of dataSources) {
+                expect(() =>
+                    dataSource
+                        .createQueryBuilder()
+                        .update(Post)
+                        .set({ name: "test" })
+                        .orderBy({
+                            id: "ASC; DROP TABLE post;" as any,
+                        }),
+                ).to.throw(/Invalid order direction/)
+            }
+        })
 
-        it("should reject invalid order direction in SoftDeleteQueryBuilder", () =>
-            expectRejectsOrderByCondition(
-                softDeleteBuilder,
-                { id: "ASC; DROP TABLE post;" },
-                /Invalid order direction/,
-            ))
+        it("should reject invalid order direction in SoftDeleteQueryBuilder", () => {
+            for (const dataSource of dataSources) {
+                expect(() =>
+                    dataSource
+                        .createQueryBuilder()
+                        .softDelete()
+                        .from(Post)
+                        .orderBy({
+                            id: "ASC; DROP TABLE post;" as any,
+                        }),
+                ).to.throw(/Invalid order direction/)
+            }
+        })
     })
 
     describe("orWhere", () => {

--- a/test/functional/query-builder/sql-injection/sql-injection.test.ts
+++ b/test/functional/query-builder/sql-injection/sql-injection.test.ts
@@ -222,6 +222,32 @@ describe("query builder > sql injection", () => {
             }
         })
 
+        it("should reject semicolons in UpdateQueryBuilder addOrderBy sort key", () => {
+            for (const dataSource of dataSources) {
+                expect(() =>
+                    dataSource
+                        .createQueryBuilder()
+                        .update(Post)
+                        .set({ name: "test" })
+                        .addOrderBy("id; DROP TABLE post"),
+                ).to.throw(/Semicolons are not allowed/)
+            }
+        })
+
+        it("should reject semicolons in UpdateQueryBuilder OrderByCondition keys", () => {
+            for (const dataSource of dataSources) {
+                expect(() =>
+                    dataSource
+                        .createQueryBuilder()
+                        .update(Post)
+                        .set({ name: "test" })
+                        .orderBy({
+                            "id; DELETE FROM post": "ASC",
+                        }),
+                ).to.throw(/Semicolons are not allowed/)
+            }
+        })
+
         it("should reject semicolons in SoftDeleteQueryBuilder orderBy sort key", () => {
             for (const dataSource of dataSources) {
                 expect(() =>
@@ -231,6 +257,112 @@ describe("query builder > sql injection", () => {
                         .from(Post)
                         .orderBy("id; DROP TABLE post"),
                 ).to.throw(/Semicolons are not allowed/)
+            }
+        })
+
+        it("should reject semicolons in SoftDeleteQueryBuilder addOrderBy sort key", () => {
+            for (const dataSource of dataSources) {
+                expect(() =>
+                    dataSource
+                        .createQueryBuilder()
+                        .softDelete()
+                        .from(Post)
+                        .addOrderBy("id; DROP TABLE post"),
+                ).to.throw(/Semicolons are not allowed/)
+            }
+        })
+
+        it("should reject semicolons in SoftDeleteQueryBuilder OrderByCondition keys", () => {
+            for (const dataSource of dataSources) {
+                expect(() =>
+                    dataSource
+                        .createQueryBuilder()
+                        .softDelete()
+                        .from(Post)
+                        .orderBy({
+                            "id; DELETE FROM post": "ASC",
+                        }),
+                ).to.throw(/Semicolons are not allowed/)
+            }
+        })
+
+        it("should reject invalid order value in UpdateQueryBuilder orderBy", () => {
+            for (const dataSource of dataSources) {
+                expect(() =>
+                    dataSource
+                        .createQueryBuilder()
+                        .update(Post)
+                        .set({ name: "test" })
+                        .orderBy("id", "ASC; DROP TABLE post" as any),
+                ).to.throw(/"order" can accept only/)
+            }
+        })
+
+        it("should reject invalid order value in UpdateQueryBuilder addOrderBy", () => {
+            for (const dataSource of dataSources) {
+                expect(() =>
+                    dataSource
+                        .createQueryBuilder()
+                        .update(Post)
+                        .set({ name: "test" })
+                        .addOrderBy("id", "ASC; DROP TABLE post" as any),
+                ).to.throw(/"order" can accept only/)
+            }
+        })
+
+        it("should reject invalid nulls value in UpdateQueryBuilder orderBy", () => {
+            for (const dataSource of dataSources) {
+                expect(() =>
+                    dataSource
+                        .createQueryBuilder()
+                        .update(Post)
+                        .set({ name: "test" })
+                        .orderBy(
+                            "id",
+                            "ASC",
+                            "NULLS FIRST; DROP TABLE post" as any,
+                        ),
+                ).to.throw(/"nulls" can accept only/)
+            }
+        })
+
+        it("should reject invalid order value in SoftDeleteQueryBuilder orderBy", () => {
+            for (const dataSource of dataSources) {
+                expect(() =>
+                    dataSource
+                        .createQueryBuilder()
+                        .softDelete()
+                        .from(Post)
+                        .orderBy("id", "ASC; DROP TABLE post" as any),
+                ).to.throw(/"order" can accept only/)
+            }
+        })
+
+        it("should reject invalid order value in SoftDeleteQueryBuilder addOrderBy", () => {
+            for (const dataSource of dataSources) {
+                expect(() =>
+                    dataSource
+                        .createQueryBuilder()
+                        .softDelete()
+                        .from(Post)
+                        .addOrderBy("id", "ASC; DROP TABLE post" as any),
+                ).to.throw(/"order" can accept only/)
+            }
+        })
+
+        it("should reject invalid nulls value in SoftDeleteQueryBuilder orderBy", () => {
+            for (const dataSource of dataSources) {
+                expect(() =>
+                    dataSource
+                        .createQueryBuilder()
+                        .softDelete()
+                        .from(Post)
+                        .orderBy(
+                            "id",
+                            "ASC",
+                            "NULLS FIRST; DROP TABLE post" as any,
+                        ),
+                ).to.throw(/"nulls" can accept only/)
             }
         })
     })

--- a/test/functional/query-builder/sql-injection/sql-injection.test.ts
+++ b/test/functional/query-builder/sql-injection/sql-injection.test.ts
@@ -56,12 +56,50 @@ describe("query builder > sql injection", () => {
         "1 OR 1=1",
     ]
 
+    const inputsWithSemicolons = maliciousInputs.filter((input) =>
+        input.includes(";"),
+    )
+
     function verifyIntegrity(dataSource: DataSource) {
         return async () => {
             const count = await dataSource.getRepository(Post).count()
             expect(count).to.equal(2)
         }
     }
+
+    describe("addGroupBy", () => {
+        for (const malicious of inputsWithSemicolons) {
+            it(`should reject semicolons with: ${malicious}`, () =>
+                Promise.all(
+                    dataSources.map(async (dataSource) => {
+                        expect(() =>
+                            dataSource
+                                .getRepository(Post)
+                                .createQueryBuilder("post")
+                                .addGroupBy(malicious),
+                        ).to.throw(/Semicolons are not allowed/)
+                        await verifyIntegrity(dataSource)()
+                    }),
+                ))
+        }
+    })
+
+    describe("addOrderBy", () => {
+        for (const malicious of inputsWithSemicolons) {
+            it(`should reject semicolons with: ${malicious}`, () =>
+                Promise.all(
+                    dataSources.map(async (dataSource) => {
+                        expect(() =>
+                            dataSource
+                                .getRepository(Post)
+                                .createQueryBuilder("post")
+                                .addOrderBy(malicious),
+                        ).to.throw(/Semicolons are not allowed/)
+                        await verifyIntegrity(dataSource)()
+                    }),
+                ))
+        }
+    })
 
     describe("andWhere", () => {
         for (const malicious of maliciousInputs) {
@@ -107,6 +145,23 @@ describe("query builder > sql injection", () => {
         }
     })
 
+    describe("groupBy", () => {
+        for (const malicious of inputsWithSemicolons) {
+            it(`should reject semicolons with: ${malicious}`, () =>
+                Promise.all(
+                    dataSources.map(async (dataSource) => {
+                        expect(() =>
+                            dataSource
+                                .getRepository(Post)
+                                .createQueryBuilder("post")
+                                .groupBy(malicious),
+                        ).to.throw(/Semicolons are not allowed/)
+                        await verifyIntegrity(dataSource)()
+                    }),
+                ))
+        }
+    })
+
     describe("having", () => {
         for (const malicious of maliciousInputs) {
             it(`should prevent injection with: ${malicious}`, () =>
@@ -127,6 +182,57 @@ describe("query builder > sql injection", () => {
                     }),
                 ))
         }
+    })
+
+    describe("orderBy (string sort key)", () => {
+        for (const malicious of inputsWithSemicolons) {
+            it(`should reject semicolons with: ${malicious}`, () =>
+                Promise.all(
+                    dataSources.map(async (dataSource) => {
+                        expect(() =>
+                            dataSource
+                                .getRepository(Post)
+                                .createQueryBuilder("post")
+                                .orderBy(malicious),
+                        ).to.throw(/Semicolons are not allowed/)
+                        await verifyIntegrity(dataSource)()
+                    }),
+                ))
+        }
+
+        it("should reject semicolons in OrderByCondition keys", () => {
+            for (const dataSource of dataSources) {
+                expect(() =>
+                    dataSource.createQueryBuilder(Post, "post").orderBy({
+                        "post.id; DELETE FROM post": "ASC",
+                    }),
+                ).to.throw(/Semicolons are not allowed/)
+            }
+        })
+
+        it("should reject semicolons in UpdateQueryBuilder orderBy sort key", () => {
+            for (const dataSource of dataSources) {
+                expect(() =>
+                    dataSource
+                        .createQueryBuilder()
+                        .update(Post)
+                        .set({ name: "test" })
+                        .orderBy("id; DROP TABLE post"),
+                ).to.throw(/Semicolons are not allowed/)
+            }
+        })
+
+        it("should reject semicolons in SoftDeleteQueryBuilder orderBy sort key", () => {
+            for (const dataSource of dataSources) {
+                expect(() =>
+                    dataSource
+                        .createQueryBuilder()
+                        .softDelete()
+                        .from(Post)
+                        .orderBy("id; DROP TABLE post"),
+                ).to.throw(/Semicolons are not allowed/)
+            }
+        })
     })
 
     describe("orderBy value injection", () => {


### PR DESCRIPTION
This PR restores part of #12209 that #12396 reverted wholesale. The original change added an `assertNoSemicolon` check to every raw-SQL entry point on the query builders (`select` / `addSelect` / `groupBy` / `addGroupBy` / `orderBy` / `addOrderBy` / `validateOrderByCondition`). The revert removed all of them after a single legitimate concern surfaced: `STRING_AGG(TEAM_NAME, ';' ORDER BY TEAM_NAME) AS TEAM_NAMES` is a valid `select()` expression with `';'` as a character literal, and a blunt `.includes(";")` check rejected it. The concern was real — but it was specific to `select()` / `addSelect()`, where the argument is an arbitrary SQL expression that can contain string literals. Group keys and sort keys are the opposite: column references or short expressions where `;` has no legitimate place.

This PR restores the `;` rejection on `groupBy` / `addGroupBy` / `orderBy` (string-sort form) / `addOrderBy` across `SelectQueryBuilder`, `SoftDeleteQueryBuilder`, and `UpdateQueryBuilder`, plus the `OrderByCondition` key-iteration path. These methods never need a literal `;`; the check is a flat reject. The `select()` / `addSelect()` story lands separately in a follow-up with a string-literal-aware scanner that allows `';'` inside quoted SQL literals while still blocking `foo; DROP TABLE x`.

Worth noting the automated reviewers on the revert were unimpressed: Qodo flagged 1 bug and 2 rule violations on #12396 itself, and SonarCloud's quality gate failed on it (5.8% duplication on new code against the 3% threshold). The right response to the `STRING_AGG` case is a narrower scanner for `select()` — not dropping the entire defence for every method.

## What's in this PR

- Restores `assertNoSemicolon()` on `QueryBuilder` and wires it into `validateOrderByCondition` (for `OrderByCondition` keys).
- Guards `SelectQueryBuilder.groupBy`, `addGroupBy`, `orderBy` (string-sort form), and `addOrderBy`.
- Guards `SoftDeleteQueryBuilder.orderBy` / `addOrderBy` and `UpdateQueryBuilder.orderBy` / `addOrderBy`.
- Adds 23 regression tests in `test/functional/query-builder/sql-injection/sql-injection.test.ts` covering each method across every supported driver (MongoDB and Spanner are not in the suite).
- Adds a migration-guide entry in `docs/docs/releases/1.0/02-upgrading-from-0.3.md` scoped to sort/group keys.

## Compatibility

Anyone who was passing a literal `;` in `groupBy` / `orderBy` / `addGroupBy` / `addOrderBy` or in an `OrderByCondition` key will now get a `TypeORMError` at runtime. That input has no legitimate use case — user-controlled values belong in parameter bindings, and column references don't contain semicolons — so this is strictly more defensive. Noted in the migration guide.