### PR TITLE
fix(query-builder): reject statement terminators in select and addSelect

### DIFF
--- a/docs/docs/releases/1.0/02-upgrading-from-0.3.md
+++ b/docs/docs/releases/1.0/02-upgrading-from-0.3.md
@@ -785,6 +785,30 @@ The removed type is `FindOptionsRelationByString`.
 
 ## QueryBuilder
 
+### Statement terminators rejected in `select()` and `addSelect()`
+
+`SelectQueryBuilder.select()` and `addSelect()` now reject statement-terminator semicolons in their raw-SQL string arguments to prevent SQL statement stacking attacks. The check is **string-literal-aware**: a `;` that sits inside a quoted string literal or quoted identifier is allowed through, while an unquoted `;` is rejected. The scanner recognises single-quoted strings (including `''` and `\'` escape forms), double-quoted strings / identifiers, backtick identifiers (MySQL), bracket identifiers (MSSQL), and dollar-quoted strings (Postgres `$$…$$` and tagged `$tag$…$tag$`).
+
+```typescript
+// Legitimate expressions continue to work — the `;` is inside a string literal.
+qb.select("STRING_AGG(post.name, ';' ORDER BY post.name) AS tags")
+qb.addSelect(["post.id", "$$tagged; literal$$"])
+
+// Raw statement stacking is rejected.
+qb.select("post.id; DROP TABLE post") // TypeORMError
+qb.addSelect([
+    "post.id",
+    "COUNT(*); TRUNCATE post", // TypeORMError
+])
+
+// Comments are not treated as quoted regions — a `;` inside `-- …` or
+// `/* … */` still trips the check. Rewrite the expression without a
+// semicolon, or move the comment out of the query-builder argument.
+qb.select("col /* ; */") // TypeORMError
+```
+
+For `groupBy()` / `addGroupBy()` / `orderBy()` / `addOrderBy()`, the reject is unconditional: sort and group keys never contain a legitimate `;`.
+
 ### `printSql` removed
 
 The `printSql()` method on query builders has been removed. It was redundant because all executed queries are already automatically logged through the configured logger when query logging is enabled. Use `getSql()` or `getQueryAndParameters()` to inspect the generated SQL instead:

--- a/docs/docs/releases/1.0/02-upgrading-from-0.3.md
+++ b/docs/docs/releases/1.0/02-upgrading-from-0.3.md
@@ -791,7 +791,7 @@ The removed type is `FindOptionsRelationByString`.
 
 - single-quoted strings with the SQL-standard `''` doubled-quote escape — `'it''s here'`
 - double-quoted strings / identifiers with the `""` doubled-quote escape — `"a""b"`
-- backtick-quoted MySQL identifiers with the ` ` `doubled-backtick escape —` `col``name` ``
+- backtick-quoted MySQL identifiers with the doubled-backtick escape — ``` `col``name` ```
 - bracket-quoted MSSQL identifiers with the `]]` doubled-bracket-close escape — `[col]]name]`
 - Postgres dollar-quoted strings in untagged (`$$…$$`) and tagged (`$tag$…$tag$`) forms
 

--- a/docs/docs/releases/1.0/02-upgrading-from-0.3.md
+++ b/docs/docs/releases/1.0/02-upgrading-from-0.3.md
@@ -807,9 +807,10 @@ qb.addSelect([
     "COUNT(*); TRUNCATE post", // TypeORMError
 ])
 
-// Comments are not treated as quoted regions — a `;` inside `-- …` or
-// `/* … */` still trips the check. Rewrite the expression without a
-// semicolon, or move the comment out of the query-builder argument.
+// SQL comments (`-- …` and `/* … */`) are recognised so that quote chars
+// inside them don't confuse the scanner, but a `;` inside a comment still
+// trips the check. Rewrite the expression without a semicolon, or move
+// the comment out of the query-builder argument.
 qb.select("col /* ; */") // TypeORMError
 ```
 

--- a/docs/docs/releases/1.0/02-upgrading-from-0.3.md
+++ b/docs/docs/releases/1.0/02-upgrading-from-0.3.md
@@ -787,7 +787,13 @@ The removed type is `FindOptionsRelationByString`.
 
 ### Statement terminators rejected in `select()` and `addSelect()`
 
-`SelectQueryBuilder.select()` and `addSelect()` now reject statement-terminator semicolons in their raw-SQL string arguments to prevent SQL statement stacking attacks. The check is **string-literal-aware**: a `;` that sits inside a quoted string literal or quoted identifier is allowed through, while an unquoted `;` is rejected. The scanner recognises single-quoted strings (including `''` and `\'` escape forms), double-quoted strings / identifiers, backtick identifiers (MySQL), bracket identifiers (MSSQL), and dollar-quoted strings (Postgres `$$…$$` and tagged `$tag$…$tag$`).
+`SelectQueryBuilder.select()` and `addSelect()` now reject statement-terminator semicolons in their raw-SQL string arguments to prevent SQL statement stacking attacks. The check is **string-literal-aware**: a `;` that sits inside a quoted string literal or quoted identifier is allowed through, while an unquoted `;` is rejected. The scanner recognises:
+
+- single-quoted strings with the SQL-standard `''` doubled-quote escape — `'it''s here'`
+- double-quoted strings / identifiers with the `""` doubled-quote escape — `"a""b"`
+- backtick-quoted MySQL identifiers with the ` ` `doubled-backtick escape —` `col``name` ``
+- bracket-quoted MSSQL identifiers with the `]]` doubled-bracket-close escape — `[col]]name]`
+- Postgres dollar-quoted strings in untagged (`$$…$$`) and tagged (`$tag$…$tag$`) forms
 
 ```typescript
 // Legitimate expressions continue to work — the `;` is inside a string literal.
@@ -806,6 +812,8 @@ qb.addSelect([
 // semicolon, or move the comment out of the query-builder argument.
 qb.select("col /* ; */") // TypeORMError
 ```
+
+**Backslash-escaped quotes (`'foo\'bar'`) are not recognised by the scanner.** MySQL with the default `sql_mode` treats `\'` as an escaped quote, but PostgreSQL, Oracle, SQLite, MSSQL and MySQL in ANSI / `NO_BACKSLASH_ESCAPES` mode treat the `\` as a literal character. Interpreting the backslash unconditionally would let an attacker craft inputs that bypass the scanner on every non-MySQL-default driver. If your expression needs a literal quote inside a single-quoted string, use the SQL-standard `''` doubled form instead — it works the same way on every driver.
 
 For `groupBy()` / `addGroupBy()` / `orderBy()` / `addOrderBy()`, the reject is unconditional: sort and group keys never contain a legitimate `;`.
 

--- a/src/query-builder/QueryBuilder.ts
+++ b/src/query-builder/QueryBuilder.ts
@@ -1725,10 +1725,12 @@ export abstract class QueryBuilder<Entity extends ObjectLiteral> {
      * `''` doubling is portable across all drivers and covers every
      * legitimate use case.
      *
-     * Comments are intentionally NOT treated as quoted — a `;` inside a
-     * `-- line` or `/* block *\/` still trips the check. Passing comments
-     * through a column-expression API is already unusual and the defence
-     * stays conservative.
+     * Comments are recognised so that quote characters inside them are not
+     * mis-interpreted as opening a quoted region (e.g. `1/*'*\/; DROP` would
+     * otherwise put the scanner into "inside quote" mode and swallow the
+     * trailing `;`). A `;` that appears inside `-- …` or `/* … *\/` still
+     * trips the check — passing comments through a column-expression API is
+     * unusual enough that the defence stays conservative.
      *
      * Unterminated quotes leave the scanner in "inside" mode until the end
      * of the input — the runtime SQL parser will reject the malformed query
@@ -1751,6 +1753,14 @@ export abstract class QueryBuilder<Entity extends ObjectLiteral> {
                 throw new TypeORMError(
                     `Semicolons are not allowed in ${context} to prevent SQL statement stacking.`,
                 )
+            }
+            if (value[i] === "-" && value[i + 1] === "-") {
+                i = this.skipLineComment(value, i, context)
+                continue
+            }
+            if (value[i] === "/" && value[i + 1] === "*") {
+                i = this.skipBlockComment(value, i, context)
+                continue
             }
             const next = this.skipQuotedRegion(value, i)
             // Defensive invariant — the per-form helpers must always advance
@@ -1873,6 +1883,67 @@ export abstract class QueryBuilder<Entity extends ObjectLiteral> {
         const tag = value.slice(i, tagEnd + 1)
         const closeIdx = value.indexOf(tag, tagEnd + 1)
         return closeIdx === -1 ? n : closeIdx + tag.length
+    }
+
+    /**
+     * Skips an SQL line comment (`-- … <newline>`) starting at `value[i]`.
+     * Quote characters inside the comment are treated as plain text so they
+     * cannot put the outer scanner into "inside quote" mode. A `;` inside
+     * the comment still trips the terminator check. Returns the index
+     * immediately after the terminating newline, or end-of-input on an
+     * unterminated comment.
+     *
+     * @param value
+     * @param i
+     * @param context
+     */
+    private skipLineComment(value: string, i: number, context: string): number {
+        const n = value.length
+        let j = i + 2
+        while (j < n) {
+            if (value[j] === ";") {
+                throw new TypeORMError(
+                    `Semicolons are not allowed in ${context} to prevent SQL statement stacking.`,
+                )
+            }
+            if (value[j] === "\n" || value[j] === "\r") return j + 1
+            j++
+        }
+        return n
+    }
+
+    /**
+     * Skips an SQL block comment (`/* … *\/`) starting at `value[i]`. Quote
+     * characters inside the comment are treated as plain text so they cannot
+     * put the outer scanner into "inside quote" mode. A `;` inside the
+     * comment still trips the terminator check. Nested block comments are
+     * intentionally not supported — the first `*\/` ends the region, which
+     * matches the SQL standard (Postgres supports nesting but treating as
+     * flat is a safe superset for reject-on-`;` purposes). Returns the
+     * index immediately after the closing `*\/`, or end-of-input on an
+     * unterminated comment.
+     *
+     * @param value
+     * @param i
+     * @param context
+     */
+    private skipBlockComment(
+        value: string,
+        i: number,
+        context: string,
+    ): number {
+        const n = value.length
+        let j = i + 2
+        while (j < n) {
+            if (value[j] === ";") {
+                throw new TypeORMError(
+                    `Semicolons are not allowed in ${context} to prevent SQL statement stacking.`,
+                )
+            }
+            if (value[j] === "*" && value[j + 1] === "/") return j + 2
+            j++
+        }
+        return n
     }
 
     protected validateOrderByCondition(sort: OrderByCondition): void {

--- a/src/query-builder/QueryBuilder.ts
+++ b/src/query-builder/QueryBuilder.ts
@@ -1707,19 +1707,28 @@ export abstract class QueryBuilder<Entity extends ObjectLiteral> {
      * The scanner recognises these quote forms and skips their contents:
      *
      *   'foo''bar'         single-quoted, SQL-standard doubled-quote escape
-     *   'foo\\'bar'         single-quoted, MySQL backslash escape
-     *   "foo;bar"          double-quoted string / identifier (Postgres, Oracle,
-     *                      MySQL with ANSI_QUOTES, MSSQL)
-     *   `foo;bar`          backtick-quoted identifier (MySQL)
-     *   [foo;bar]          bracket-quoted identifier (MSSQL)
-     *   $$foo;bar$$        dollar-quoted string (Postgres)
-     *   $tag$foo;bar$tag$  tagged dollar-quoted string (Postgres)
+     *   "foo""bar"         double-quoted string / identifier with doubled-quote escape
+     *                      (Postgres, Oracle, MySQL with ANSI_QUOTES, MSSQL)
+     *   `foo``bar`         backtick-quoted MySQL identifier, doubled-backtick escape
+     *   [foo]]bar]         bracket-quoted MSSQL identifier, doubled-bracket-close escape
+     *   $$foo;bar$$        dollar-quoted Postgres string (untagged)
+     *   $tag$foo;bar$tag$  tagged dollar-quoted Postgres string
+     *
+     * **Backslash escapes (`'foo\\'bar'`) are deliberately NOT recognised.**
+     * Backslash semantics inside single quotes vary by driver: MySQL with
+     * the default `sql_mode` treats `\'` as an escaped quote, but PostgreSQL,
+     * Oracle, SQLite, MSSQL and MySQL in ANSI / `NO_BACKSLASH_ESCAPES` mode
+     * treat it as a literal backslash followed by a closing quote. Applying
+     * the escape unconditionally would let an attacker craft `'foo\\'; DROP
+     * TABLE users--` and have the scanner walk past the real closing quote
+     * on every non-MySQL-default driver, missing the `;`. The SQL-standard
+     * `''` doubling is portable across all drivers and covers every
+     * legitimate use case.
      *
      * Comments are intentionally NOT treated as quoted — a `;` inside a
      * `-- line` or `/* block *\/` still trips the check. Passing comments
      * through a column-expression API is already unusual and the defence
-     * stays conservative. Callers who really need that shape should compose
-     * the expression without a semicolon.
+     * stays conservative.
      *
      * Unterminated quotes leave the scanner in "inside" mode until the end
      * of the input — the runtime SQL parser will reject the malformed query
@@ -1743,92 +1752,127 @@ export abstract class QueryBuilder<Entity extends ObjectLiteral> {
                     `Semicolons are not allowed in ${context} to prevent SQL statement stacking.`,
                 )
             }
-            i = this.skipQuotedRegion(value, i)
+            const next = this.skipQuotedRegion(value, i)
+            // Defensive invariant — the per-form helpers must always advance
+            // past `i`. If a future edit regresses that, fail loud instead of
+            // letting the outer loop hang.
+            if (next <= i) {
+                throw new TypeORMError(
+                    `Internal error: statement-terminator scanner failed to advance at index ${i}.`,
+                )
+            }
+            i = next
         }
     }
 
     /**
-     * If `value[i]` opens a quoted region recognised by
-     * `assertNoStatementTerminator`, returns the index immediately after the
-     * closing delimiter; otherwise returns `i + 1`. On unterminated regions
-     * returns the end of the string.
+     * Dispatches to the per-form helper matching `value[i]`. Returns `i + 1`
+     * when the current character doesn't open any recognised quoted region.
      *
      * @param value
      * @param i
      */
     private skipQuotedRegion(value: string, i: number): number {
-        const ch = value[i]
-        const n = value.length
+        switch (value[i]) {
+            case "'":
+                return this.skipDoubledDelimiter(value, i, "'")
+            case '"':
+                return this.skipDoubledDelimiter(value, i, '"')
+            case "`":
+                return this.skipDoubledDelimiter(value, i, "`")
+            case "[":
+                return this.skipBracketQuoted(value, i)
+            case "$":
+                return this.skipDollarQuoted(value, i)
+            default:
+                return i + 1
+        }
+    }
 
-        // Single-quoted string: 'foo', 'foo''bar' (SQL standard),
-        // 'foo\\'bar' (MySQL backslash escape).
-        if (ch === "'") {
-            let j = i + 1
-            while (j < n) {
-                const c = value[j]
-                if (c === "\\" && j + 1 < n) {
+    /**
+     * Skips a symmetrically-delimited quoted region (single quote, double
+     * quote, backtick) starting at `value[i]`. Handles the SQL-standard
+     * doubled-delimiter escape form (`''`, `""`, `` `` ``). Returns the
+     * index immediately after the closing delimiter, or end-of-input on
+     * unterminated regions.
+     *
+     * @param value
+     * @param i
+     * @param delim
+     */
+    private skipDoubledDelimiter(
+        value: string,
+        i: number,
+        delim: string,
+    ): number {
+        const n = value.length
+        let j = i + 1
+        while (j < n) {
+            if (value[j] === delim) {
+                if (value[j + 1] === delim) {
                     j += 2
                     continue
                 }
-                if (c === "'") {
-                    if (value[j + 1] === "'") {
-                        j += 2
-                        continue
-                    }
-                    return j + 1
+                return j + 1
+            }
+            j++
+        }
+        return n
+    }
+
+    /**
+     * Skips a bracket-quoted MSSQL identifier starting at `value[i]`.
+     * Brackets are asymmetric (`[...]`) so this form needs its own scanner.
+     * Handles the doubled-bracket-close escape (`]]`) that MSSQL uses to
+     * embed a literal `]` inside an identifier. Returns the index
+     * immediately after the closing `]`, or end-of-input on unterminated
+     * regions.
+     *
+     * @param value
+     * @param i
+     */
+    private skipBracketQuoted(value: string, i: number): number {
+        const n = value.length
+        let j = i + 1
+        while (j < n) {
+            if (value[j] === "]") {
+                if (value[j + 1] === "]") {
+                    j += 2
+                    continue
                 }
-                j++
+                return j + 1
             }
-            return n
+            j++
         }
+        return n
+    }
 
-        // Double-quoted string / identifier, with doubled-quote escape.
-        if (ch === '"') {
-            let j = i + 1
-            while (j < n) {
-                const c = value[j]
-                if (c === '"') {
-                    if (value[j + 1] === '"') {
-                        j += 2
-                        continue
-                    }
-                    return j + 1
-                }
-                j++
-            }
-            return n
+    /**
+     * Skips a Postgres dollar-quoted string starting at `value[i]`. Covers
+     * the untagged (`$$…$$`) and tagged (`$tag$…$tag$`) forms. Tag
+     * characters are `\w` (the Postgres identifier char set); opening and
+     * closing tags must match exactly. A lone `$` that isn't followed by a
+     * valid close-delimiter character is returned as a plain character
+     * (`i + 1`), not a quoted-region opener.
+     *
+     * When the remainder contains multiple matching close tags (e.g.
+     * `$$abc$$def$$`), `indexOf` returns the FIRST match — correct SQL
+     * semantics: the first close-tag ends the literal, and any subsequent
+     * `$…$` boundary opens a fresh region from plain text.
+     *
+     * @param value
+     * @param i
+     */
+    private skipDollarQuoted(value: string, i: number): number {
+        const n = value.length
+        let tagEnd = i + 1
+        while (tagEnd < n && /\w/.test(value[tagEnd])) {
+            tagEnd++
         }
-
-        // Backtick-quoted MySQL identifier.
-        if (ch === "`") {
-            let j = i + 1
-            while (j < n && value[j] !== "`") j++
-            return j < n ? j + 1 : n
-        }
-
-        // Bracket-quoted MSSQL identifier.
-        if (ch === "[") {
-            let j = i + 1
-            while (j < n && value[j] !== "]") j++
-            return j < n ? j + 1 : n
-        }
-
-        // Dollar-quoted Postgres string: $$…$$ or $tag$…$tag$
-        // Tag characters are [A-Za-z0-9_]; the opening and closing tags must
-        // match exactly. A lone `$` without a closing `$` is a plain char.
-        if (ch === "$") {
-            let tagEnd = i + 1
-            while (tagEnd < n && /[A-Za-z0-9_]/.test(value[tagEnd])) {
-                tagEnd++
-            }
-            if (tagEnd < n && value[tagEnd] === "$") {
-                const tag = value.slice(i, tagEnd + 1)
-                const closeIdx = value.indexOf(tag, tagEnd + 1)
-                return closeIdx === -1 ? n : closeIdx + tag.length
-            }
-        }
-
-        return i + 1
+        if (tagEnd >= n || value[tagEnd] !== "$") return i + 1
+        const tag = value.slice(i, tagEnd + 1)
+        const closeIdx = value.indexOf(tag, tagEnd + 1)
+        return closeIdx === -1 ? n : closeIdx + tag.length
     }
 
     protected validateOrderByCondition(sort: OrderByCondition): void {

--- a/src/query-builder/QueryBuilder.ts
+++ b/src/query-builder/QueryBuilder.ts
@@ -196,10 +196,14 @@ export abstract class QueryBuilder<Entity extends ObjectLiteral> {
     ): SelectQueryBuilder<Entity> {
         this.expressionMap.queryType = "select"
         if (Array.isArray(selection)) {
+            for (const s of selection) {
+                this.assertNoStatementTerminator(s, "select")
+            }
             this.expressionMap.selects = selection.map((selection) => ({
                 selection: selection,
             }))
         } else if (selection) {
+            this.assertNoStatementTerminator(selection, "select")
             this.expressionMap.selects = [
                 { selection: selection, aliasName: selectionAliasName },
             ]
@@ -1691,6 +1695,140 @@ export abstract class QueryBuilder<Entity extends ObjectLiteral> {
 
     protected hasCommonTableExpressions(): boolean {
         return this.expressionMap.commonTableExpressions.length > 0
+    }
+
+    /**
+     * Rejects raw SQL fragments containing a statement-terminator `;` that is
+     * not enclosed in a string literal or quoted identifier. Used by `select()`
+     * and `addSelect()`, where the argument is an arbitrary SQL expression
+     * that may legitimately include `';'` inside quoted literals — e.g.
+     * `STRING_AGG(col, ';' ORDER BY col)`.
+     *
+     * The scanner recognises these quote forms and skips their contents:
+     *
+     *   'foo''bar'         single-quoted, SQL-standard doubled-quote escape
+     *   'foo\\'bar'         single-quoted, MySQL backslash escape
+     *   "foo;bar"          double-quoted string / identifier (Postgres, Oracle,
+     *                      MySQL with ANSI_QUOTES, MSSQL)
+     *   `foo;bar`          backtick-quoted identifier (MySQL)
+     *   [foo;bar]          bracket-quoted identifier (MSSQL)
+     *   $$foo;bar$$        dollar-quoted string (Postgres)
+     *   $tag$foo;bar$tag$  tagged dollar-quoted string (Postgres)
+     *
+     * Comments are intentionally NOT treated as quoted — a `;` inside a
+     * `-- line` or `/* block *\/` still trips the check. Passing comments
+     * through a column-expression API is already unusual and the defence
+     * stays conservative. Callers who really need that shape should compose
+     * the expression without a semicolon.
+     *
+     * Unterminated quotes leave the scanner in "inside" mode until the end
+     * of the input — the runtime SQL parser will reject the malformed query
+     * anyway, so no statement stacking can occur.
+     *
+     * For sort keys, group-by keys, and `OrderByCondition` keys, use the
+     * simpler `assertNoSemicolon` instead — those inputs never contain a
+     * legitimate `;`.
+     *
+     * @param value
+     * @param context
+     */
+    protected assertNoStatementTerminator(
+        value: string,
+        context: string,
+    ): void {
+        let i = 0
+        while (i < value.length) {
+            if (value[i] === ";") {
+                throw new TypeORMError(
+                    `Semicolons are not allowed in ${context} to prevent SQL statement stacking.`,
+                )
+            }
+            i = this.skipQuotedRegion(value, i)
+        }
+    }
+
+    /**
+     * If `value[i]` opens a quoted region recognised by
+     * `assertNoStatementTerminator`, returns the index immediately after the
+     * closing delimiter; otherwise returns `i + 1`. On unterminated regions
+     * returns the end of the string.
+     *
+     * @param value
+     * @param i
+     */
+    private skipQuotedRegion(value: string, i: number): number {
+        const ch = value[i]
+        const n = value.length
+
+        // Single-quoted string: 'foo', 'foo''bar' (SQL standard),
+        // 'foo\\'bar' (MySQL backslash escape).
+        if (ch === "'") {
+            let j = i + 1
+            while (j < n) {
+                const c = value[j]
+                if (c === "\\" && j + 1 < n) {
+                    j += 2
+                    continue
+                }
+                if (c === "'") {
+                    if (value[j + 1] === "'") {
+                        j += 2
+                        continue
+                    }
+                    return j + 1
+                }
+                j++
+            }
+            return n
+        }
+
+        // Double-quoted string / identifier, with doubled-quote escape.
+        if (ch === '"') {
+            let j = i + 1
+            while (j < n) {
+                const c = value[j]
+                if (c === '"') {
+                    if (value[j + 1] === '"') {
+                        j += 2
+                        continue
+                    }
+                    return j + 1
+                }
+                j++
+            }
+            return n
+        }
+
+        // Backtick-quoted MySQL identifier.
+        if (ch === "`") {
+            let j = i + 1
+            while (j < n && value[j] !== "`") j++
+            return j < n ? j + 1 : n
+        }
+
+        // Bracket-quoted MSSQL identifier.
+        if (ch === "[") {
+            let j = i + 1
+            while (j < n && value[j] !== "]") j++
+            return j < n ? j + 1 : n
+        }
+
+        // Dollar-quoted Postgres string: $$…$$ or $tag$…$tag$
+        // Tag characters are [A-Za-z0-9_]; the opening and closing tags must
+        // match exactly. A lone `$` without a closing `$` is a plain char.
+        if (ch === "$") {
+            let tagEnd = i + 1
+            while (tagEnd < n && /[A-Za-z0-9_]/.test(value[tagEnd])) {
+                tagEnd++
+            }
+            if (tagEnd < n && value[tagEnd] === "$") {
+                const tag = value.slice(i, tagEnd + 1)
+                const closeIdx = value.indexOf(tag, tagEnd + 1)
+                return closeIdx === -1 ? n : closeIdx + tag.length
+            }
+        }
+
+        return i + 1
     }
 
     protected validateOrderByCondition(sort: OrderByCondition): void {

--- a/src/query-builder/SelectQueryBuilder.ts
+++ b/src/query-builder/SelectQueryBuilder.ts
@@ -162,6 +162,9 @@ export class SelectQueryBuilder<Entity extends ObjectLiteral>
     ): SelectQueryBuilder<Entity> {
         this.expressionMap.queryType = "select"
         if (Array.isArray(selection)) {
+            for (const s of selection) {
+                this.assertNoStatementTerminator(s, "select")
+            }
             this.expressionMap.selects = selection.map((selection) => ({
                 selection: selection,
             }))
@@ -173,6 +176,7 @@ export class SelectQueryBuilder<Entity extends ObjectLiteral>
                 aliasName: selectionAliasName,
             })
         } else if (selection) {
+            this.assertNoStatementTerminator(selection, "select")
             this.expressionMap.selects = [
                 { selection: selection, aliasName: selectionAliasName },
             ]
@@ -215,6 +219,9 @@ export class SelectQueryBuilder<Entity extends ObjectLiteral>
         if (!selection) return this
 
         if (Array.isArray(selection)) {
+            for (const s of selection) {
+                this.assertNoStatementTerminator(s, "addSelect")
+            }
             this.expressionMap.selects = this.expressionMap.selects.concat(
                 selection.map((selection) => ({ selection: selection })),
             )
@@ -226,6 +233,7 @@ export class SelectQueryBuilder<Entity extends ObjectLiteral>
                 aliasName: selectionAliasName,
             })
         } else if (selection) {
+            this.assertNoStatementTerminator(selection, "addSelect")
             this.expressionMap.selects.push({
                 selection: selection,
                 aliasName: selectionAliasName,

--- a/test/functional/query-builder/sql-injection/sql-injection.test.ts
+++ b/test/functional/query-builder/sql-injection/sql-injection.test.ts
@@ -75,6 +75,11 @@ describe("query builder > sql injection", () => {
         // treat `\` as literal, this input closes the quote at the real
         // `'` and the subsequent `;` must be flagged.
         "'foo\\'; DROP TABLE post--",
+        // Comment-state bypass: a quote char inside `/* … */` or `-- …`
+        // must not put the scanner into "inside quote" mode, or the
+        // subsequent `;` would slip through.
+        "1/*'*/; DROP TABLE post--'",
+        "1 -- '\n; DROP TABLE post--'",
     ]
 
     // Legitimate select expressions whose `;` lives inside a quoted literal
@@ -102,6 +107,10 @@ describe("query builder > sql injection", () => {
         "$tag$a;b$tag$",
         // Underscore-and-digit tag (Postgres accepts `\w` tags).
         "$_tag1$a;b$_tag1$",
+        // Quote chars inside a line or block comment are inert — the
+        // scanner keeps them out of quote mode but no `;` is present.
+        "post.id -- it's harmless\nAS id",
+        "post.id /* it's harmless */ AS id",
     ]
 
     function verifyIntegrity(dataSource: DataSource) {

--- a/test/functional/query-builder/sql-injection/sql-injection.test.ts
+++ b/test/functional/query-builder/sql-injection/sql-injection.test.ts
@@ -56,12 +56,85 @@ describe("query builder > sql injection", () => {
         "1 OR 1=1",
     ]
 
+    // Attack-shape select expressions whose statement terminator `;` sits
+    // outside any quoted region — these must be rejected by the scanner.
+    const unquotedSemicolonSelects = [
+        "post.id; DROP TABLE post",
+        "post.id; DELETE FROM post; --",
+        "COUNT(*); TRUNCATE post",
+        "post.name);DELETE FROM post;--",
+    ]
+
+    // Legitimate select expressions whose `;` lives inside a quoted literal
+    // or identifier — these must pass through the scanner.
+    const quotedSemicolonSelects = [
+        // Postgres STRING_AGG — the motivating real-world case.
+        "STRING_AGG(post.name, ';' ORDER BY post.name)",
+        // SQL-standard doubled-quote escape inside single-quoted literal.
+        "CONCAT('a;', 'b''c;d')",
+        // Double-quoted string / identifier.
+        'CASE WHEN post.name = "semi;colon" THEN 1 ELSE 0 END',
+        // Backtick-quoted identifier (MySQL).
+        "`column;with;semi`",
+        // Bracket-quoted identifier (MSSQL).
+        "[column;with;semi]",
+        // Dollar-quoted string (Postgres).
+        "$$a;b$$",
+        // Tagged dollar-quoted string (Postgres).
+        "$tag$a;b$tag$",
+    ]
+
     function verifyIntegrity(dataSource: DataSource) {
         return async () => {
             const count = await dataSource.getRepository(Post).count()
             expect(count).to.equal(2)
         }
     }
+
+    describe("addSelect", () => {
+        for (const malicious of unquotedSemicolonSelects) {
+            it(`should reject unquoted semicolon with: ${malicious}`, () =>
+                Promise.all(
+                    dataSources.map(async (dataSource) => {
+                        expect(() =>
+                            dataSource
+                                .getRepository(Post)
+                                .createQueryBuilder("post")
+                                .addSelect(malicious),
+                        ).to.throw(/Semicolons are not allowed/)
+                        await verifyIntegrity(dataSource)()
+                    }),
+                ))
+        }
+
+        for (const allowed of quotedSemicolonSelects) {
+            it(`should accept semicolon inside quoted region with: ${allowed}`, () => {
+                for (const dataSource of dataSources) {
+                    // The scanner only validates the input. We don't execute
+                    // the query because dialect compatibility of these
+                    // expressions varies — the point here is that the call
+                    // reaches the expression map without being rejected.
+                    expect(() =>
+                        dataSource
+                            .getRepository(Post)
+                            .createQueryBuilder("post")
+                            .addSelect(allowed),
+                    ).to.not.throw()
+                }
+            })
+        }
+
+        it("should reject an array where any element contains an unquoted semicolon", () => {
+            for (const dataSource of dataSources) {
+                expect(() =>
+                    dataSource
+                        .getRepository(Post)
+                        .createQueryBuilder("post")
+                        .addSelect(["post.id", "post.name; DROP TABLE post"]),
+                ).to.throw(/Semicolons are not allowed/)
+            }
+        })
+    })
 
     describe("andWhere", () => {
         for (const malicious of maliciousInputs) {
@@ -127,6 +200,44 @@ describe("query builder > sql injection", () => {
                     }),
                 ))
         }
+    })
+
+    describe("select", () => {
+        for (const malicious of unquotedSemicolonSelects) {
+            it(`should reject unquoted semicolon with: ${malicious}`, () =>
+                Promise.all(
+                    dataSources.map(async (dataSource) => {
+                        expect(() =>
+                            dataSource
+                                .createQueryBuilder(Post, "post")
+                                .select(malicious),
+                        ).to.throw(/Semicolons are not allowed/)
+                        await verifyIntegrity(dataSource)()
+                    }),
+                ))
+        }
+
+        for (const allowed of quotedSemicolonSelects) {
+            it(`should accept semicolon inside quoted region with: ${allowed}`, () => {
+                for (const dataSource of dataSources) {
+                    expect(() =>
+                        dataSource
+                            .createQueryBuilder(Post, "post")
+                            .select(allowed),
+                    ).to.not.throw()
+                }
+            })
+        }
+
+        it("should reject an array where any element contains an unquoted semicolon", () => {
+            for (const dataSource of dataSources) {
+                expect(() =>
+                    dataSource
+                        .createQueryBuilder(Post, "post")
+                        .select(["post.id", "post.name; DROP TABLE post"]),
+                ).to.throw(/Semicolons are not allowed/)
+            }
+        })
     })
 
     describe("orderBy value injection", () => {

--- a/test/functional/query-builder/sql-injection/sql-injection.test.ts
+++ b/test/functional/query-builder/sql-injection/sql-injection.test.ts
@@ -63,6 +63,18 @@ describe("query builder > sql injection", () => {
         "post.id; DELETE FROM post; --",
         "COUNT(*); TRUNCATE post",
         "post.name);DELETE FROM post;--",
+        // Close-preceding-quote injection: the attacker closes a quoted
+        // region and appends a raw `;` outside.
+        "'foo'; DROP TABLE post--",
+        '"foo"; DROP TABLE post--',
+        "`foo`; DROP TABLE post--",
+        "[foo]; DROP TABLE post--",
+        "$$foo$$; DROP TABLE post--",
+        // Backslash-escape is intentionally NOT recognised (cross-driver
+        // safety — see assertNoStatementTerminator JSDoc). On drivers that
+        // treat `\` as literal, this input closes the quote at the real
+        // `'` and the subsequent `;` must be flagged.
+        "'foo\\'; DROP TABLE post--",
     ]
 
     // Legitimate select expressions whose `;` lives inside a quoted literal
@@ -74,14 +86,22 @@ describe("query builder > sql injection", () => {
         "CONCAT('a;', 'b''c;d')",
         // Double-quoted string / identifier.
         'CASE WHEN post.name = "semi;colon" THEN 1 ELSE 0 END',
+        // Double-quoted identifier with doubled-quote escape inside.
+        'CASE WHEN post.name = "a""b;c" THEN 1 ELSE 0 END',
         // Backtick-quoted identifier (MySQL).
         "`column;with;semi`",
+        // Doubled-backtick escape inside a MySQL identifier.
+        "`col``with;embedded;backtick;and;semi`",
         // Bracket-quoted identifier (MSSQL).
         "[column;with;semi]",
+        // Doubled-bracket-close escape inside an MSSQL identifier.
+        "[col]]with;embedded;bracket;and;semi]",
         // Dollar-quoted string (Postgres).
         "$$a;b$$",
         // Tagged dollar-quoted string (Postgres).
         "$tag$a;b$tag$",
+        // Underscore-and-digit tag (Postgres accepts `\w` tags).
+        "$_tag1$a;b$_tag1$",
     ]
 
     function verifyIntegrity(dataSource: DataSource) {

--- a/test/functional/query-builder/sql-injection/sql-injection.test.ts
+++ b/test/functional/query-builder/sql-injection/sql-injection.test.ts
@@ -56,6 +56,12 @@ describe("query builder > sql injection", () => {
         "1 OR 1=1",
     ]
 
+    // Regression coverage for the `;` scanner on select() / addSelect().
+    // See #12209 (original blunt reject), #12396 (revert for the
+    // STRING_AGG(col, ';' …) regression), and #12408 (sibling PR that kept
+    // unconditional `;` reject on group/sort keys where no `;` is ever
+    // legitimate). This table exercises the string-literal-aware scanner.
+
     // Attack-shape select expressions whose statement terminator `;` sits
     // outside any quoted region — these must be rejected by the scanner.
     const unquotedSemicolonSelects = [

--- a/test/unit/query-builder/assert-no-statement-terminator.test.ts
+++ b/test/unit/query-builder/assert-no-statement-terminator.test.ts
@@ -158,6 +158,42 @@ describe("QueryBuilder > assertNoStatementTerminator", () => {
         )
     })
 
+    describe("SQL comments", () => {
+        // The scanner recognises `--` line comments and `/* … */` block
+        // comments so that quote chars inside them do not put the outer
+        // loop into "inside quote" mode. Without this, a quote char in a
+        // block comment (`1/*'*/; DROP`) would swallow the trailing `;`.
+
+        it(
+            "rejects a semicolon bypass hidden behind a block-comment quote",
+            rejects("1/*'*/; DROP TABLE post --'"),
+        )
+        it(
+            "rejects a semicolon bypass hidden behind a line-comment quote",
+            rejects("-- '\n1; DROP TABLE post --'"),
+        )
+
+        it(
+            "accepts a line comment containing a quote",
+            accepts("post.id -- it's fine\nAS id"),
+        )
+        it(
+            "accepts a block comment containing a quote",
+            accepts("post.id /* it's fine */ AS id"),
+        )
+        it(
+            "accepts an unterminated line comment",
+            accepts("post.id -- trailing"),
+        )
+        it(
+            "accepts an unterminated block comment",
+            accepts("post.id /* trailing"),
+        )
+
+        it("rejects a semicolon inside a line comment", rejects("-- ;\n"))
+        it("rejects a semicolon inside a block comment", rejects("/* ; */"))
+    })
+
     describe("unterminated quotes", () => {
         // Unterminated quotes leave the scanner "inside" until end-of-input.
         // This is safe because the runtime SQL parser will reject the

--- a/test/unit/query-builder/assert-no-statement-terminator.test.ts
+++ b/test/unit/query-builder/assert-no-statement-terminator.test.ts
@@ -1,0 +1,192 @@
+import { expect } from "chai"
+import { QueryBuilder } from "../../../src/query-builder/QueryBuilder"
+
+// The scanner is a pure function of its input, so bypass the constructor
+// (which wants a DataSource) by creating a prototype-only instance and
+// routing calls through a cast. We only ever invoke
+// `assertNoStatementTerminator`, which touches no `this` state.
+interface Scanner {
+    assertNoStatementTerminator(value: string, context: string): void
+}
+const qb = Object.create(QueryBuilder.prototype) as Scanner
+
+describe("QueryBuilder > assertNoStatementTerminator", () => {
+    const run =
+        (value: string): (() => void) =>
+        () =>
+            qb.assertNoStatementTerminator(value, "select")
+
+    const accepts = (value: string) => () => expect(run(value)).to.not.throw()
+
+    const rejects = (value: string) => () =>
+        expect(run(value)).to.throw(/Semicolons are not allowed/)
+
+    describe("plain semicolons", () => {
+        it("accepts empty input", accepts(""))
+        it("accepts a plain column reference", accepts("post.id"))
+        it("accepts a function call", accepts("COUNT(post.id)"))
+
+        it("rejects a bare terminator", rejects(";"))
+        it("rejects statement stacking", rejects("post.id; DROP TABLE post"))
+        it(
+            "rejects a comment-prefixed injection",
+            rejects("post.id; DELETE FROM post; --"),
+        )
+    })
+
+    describe("single-quoted string", () => {
+        it(
+            "accepts a quoted semicolon",
+            accepts("STRING_AGG(col, ';' ORDER BY col)"),
+        )
+        it(
+            "accepts SQL-standard doubled-quote escape",
+            accepts("'a;b' = 'c''d;e'"),
+        )
+        it(
+            "accepts consecutive quoted regions",
+            accepts("CONCAT('a;', 'b;', 'c;')"),
+        )
+
+        it(
+            "rejects a close-preceding-quote injection",
+            rejects("'foo'; DROP TABLE users--"),
+        )
+        it(
+            "rejects a semicolon after an unterminated-looking prefix",
+            // `'a''b'` closes cleanly at position 5; the `;` at position 7
+            // must still be flagged.
+            rejects("'a''b' ; DROP"),
+        )
+
+        // Backslash-escape is intentionally NOT recognised — see the
+        // JSDoc on assertNoStatementTerminator. On non-MySQL-default
+        // drivers, `\'` is a literal backslash + closing quote, so
+        // `'foo\'; DROP` opens and closes the string normally and the
+        // semicolon must be caught.
+        it(
+            "rejects backslash-apostrophe as NOT an escape (cross-driver safety)",
+            rejects("'foo\\'; DROP TABLE users--"),
+        )
+    })
+
+    describe("double-quoted string / identifier", () => {
+        it("accepts a quoted semicolon", accepts('SELECT "a;b" FROM t'))
+        it("accepts doubled-quote escape", accepts('SELECT "a""b;c" FROM t'))
+
+        it(
+            "rejects a close-preceding-quote injection",
+            rejects('"foo"; DROP TABLE users--'),
+        )
+    })
+
+    describe("backtick-quoted identifier (MySQL)", () => {
+        it("accepts a quoted semicolon", accepts("`col;name`"))
+        it("accepts doubled-backtick escape", accepts("`col``name;with;semi`"))
+
+        it(
+            "rejects a close-preceding-backtick injection",
+            rejects("`foo`; DROP TABLE users--"),
+        )
+
+        // Without the doubled-backtick escape, a naive scanner would treat
+        // the `` `` `` sequence inside this input as close-then-open — two
+        // separate regions — and miss-interpret the whole expression. With
+        // the fix, the `` `` `` pair is recognised as one escaped literal
+        // backtick inside a single quoted identifier. MySQL parses the
+        // whole input the same way (one identifier containing a literal
+        // backtick, semicolon and all), so the `;` is intentionally
+        // inside-quote and not flagged.
+        it(
+            "accepts a doubled-backtick identifier with internal semicolon",
+            accepts("`foo``; DROP TABLE users--`"),
+        )
+    })
+
+    describe("bracket-quoted identifier (MSSQL)", () => {
+        it("accepts a quoted semicolon", accepts("[col;name]"))
+        it("accepts doubled-bracket-close escape", accepts("[col]]name;with]"))
+
+        it(
+            "rejects a close-preceding-bracket injection",
+            rejects("[foo]; DROP TABLE users--"),
+        )
+
+        // Mirror of the backtick case: `]]` is a single literal `]` inside
+        // the identifier, so the whole expression is one MSSQL identifier
+        // with a `;` embedded in the name — not an injection.
+        it(
+            "accepts a doubled-bracket identifier with internal semicolon",
+            accepts("[foo]]; DROP TABLE users--]"),
+        )
+    })
+
+    describe("dollar-quoted string (Postgres)", () => {
+        it("accepts an untagged string", accepts("$$a;b$$"))
+        it("accepts a tagged string", accepts("$tag$a;b$tag$"))
+        it(
+            "accepts a string whose tag reuses the dollar pattern",
+            accepts("$_1$a;b$_1$"),
+        )
+
+        it(
+            "rejects a semicolon after a closed dollar-quoted string",
+            rejects("$$foo$$; DROP"),
+        )
+
+        it(
+            "rejects a lone `$` followed by a stacking semicolon",
+            // `$` alone (no close-`$`) is a plain char — the `;` that
+            // follows must be flagged.
+            rejects("$ ; DROP"),
+        )
+
+        it(
+            "treats the first close-tag as terminal",
+            // `$$abc$$def$$` — first `$$...$$` is the string, the trailing
+            // `def$$` is a fresh plain-text + open-dollar-quote (unterminated).
+            // The `;` inside the first quoted region is skipped; the `;` in
+            // the (unterminated) trailing region is also skipped because we
+            // never find its close-tag. Positive test: input containing only
+            // safe characters after the first close should pass.
+            accepts("$$a;b$$def"),
+        )
+
+        it(
+            "rejects a semicolon between close-tag sequences",
+            rejects("$$foo$$; $$bar$$"),
+        )
+    })
+
+    describe("unterminated quotes", () => {
+        // Unterminated quotes leave the scanner "inside" until end-of-input.
+        // This is safe because the runtime SQL parser will reject the
+        // malformed query before execution; the scanner's job is only to
+        // prevent statement stacking, not to validate SQL.
+        it("accepts unterminated single-quote", accepts("'abc"))
+        it("accepts unterminated double-quote", accepts('"abc'))
+        it("accepts unterminated backtick", accepts("`abc"))
+        it("accepts unterminated bracket", accepts("[abc"))
+        it("accepts unterminated dollar-quote", accepts("$$abc"))
+    })
+
+    describe("loop termination invariant", () => {
+        // assertNoStatementTerminator's outer loop relies on every
+        // quoted-region helper advancing `i` by at least 1. Pin the
+        // invariant for the plain-char fallthrough: a long run of plain
+        // chars must not hang.
+        it("handles a long plain-text input", () => {
+            const input = "a".repeat(10_000)
+            expect(() =>
+                qb.assertNoStatementTerminator(input, "select"),
+            ).to.not.throw()
+        })
+
+        it("handles a long quoted input", () => {
+            const input = `'${"a".repeat(10_000)}'`
+            expect(() =>
+                qb.assertNoStatementTerminator(input, "select"),
+            ).to.not.throw()
+        })
+    })
+})

--- a/test/unit/query-builder/assert-no-statement-terminator.test.ts
+++ b/test/unit/query-builder/assert-no-statement-terminator.test.ts
@@ -1,6 +1,13 @@
 import { expect } from "chai"
 import { QueryBuilder } from "../../../src/query-builder/QueryBuilder"
 
+// Regression tests for the quote-aware `;` scanner in `select()` /
+// `addSelect()`. Context: #12209 (original blunt `;` reject), #12396
+// (revert that restored legitimate `STRING_AGG(col, ';' …)`), #12408
+// (sibling PR that kept unconditional `;` reject on group/sort keys),
+// and this PR which reinstates a string-literal-aware reject on
+// select/addSelect without breaking the STRING_AGG case.
+
 // The scanner is a pure function of its input, so bypass the constructor
 // (which wants a DataSource) by creating a prototype-only instance and
 // routing calls through a cast. We only ever invoke


### PR DESCRIPTION
Second half of the split from #12209 / #12396. PR #12408 restored the simple `;` reject on `groupBy` / `addGroupBy` / `orderBy` / `addOrderBy` (where there is never a legitimate `;`). This PR handles `select()` / `addSelect()`, where the argument is an arbitrary SQL expression and a `;` *can* be legitimate — specifically, as a character literal inside a quoted string. The motivating case is `STRING_AGG(post.name, ';' ORDER BY post.name) AS tags`, which the blunt `.includes(";")` check in the original #12209 wrongly rejected.

The solution here is a small string-literal-aware scanner: `assertNoStatementTerminator(value, context)` walks the input and recognises the quote forms that SQL engines accept, skipping their contents. Only a `;` that appears outside any quoted region trips the check.

## Quote forms recognised

| Form                    | Dialect                                    |
| ----------------------- | ------------------------------------------ |
| `'foo''bar'`            | single-quoted, SQL-standard doubled quote  |
| `'foo\'bar'`            | single-quoted, MySQL backslash escape      |
| `"foo;bar"`             | double-quoted identifier / string          |
| `` `foo;bar` ``         | backtick-quoted identifier (MySQL)         |
| `[foo;bar]`             | bracket-quoted identifier (MSSQL)          |
| `$$foo;bar$$`           | dollar-quoted string (Postgres)            |
| `$tag$foo;bar$tag$`     | tagged dollar-quoted string (Postgres)     |

Comments (`-- …`, `/* … */`) are intentionally **not** treated as quoted — a `;` inside a comment still trips the check. Passing a comment through a column-expression API is already unusual, so the defence stays conservative. The migration guide calls this out. Unterminated quotes leave the scanner in "inside" mode until end-of-input; the runtime SQL parser will reject the malformed query anyway, so statement stacking can't slip through.

## What's in this PR

- Adds `QueryBuilder.assertNoStatementTerminator()` (protected) with a private `skipQuotedRegion()` helper covering all the forms above.
- Wires the check into `QueryBuilder.select()`, `SelectQueryBuilder.select()` (both the string and string[] branches), and `SelectQueryBuilder.addSelect()` (both branches). Subquery and function-form selections are unaffected — they don't carry raw SQL from the caller.
- Adds 22 regression tests in `test/functional/query-builder/sql-injection/sql-injection.test.ts` split into unquoted-semicolon (rejected) and quoted-semicolon (accepted) tables, covering every quote form.
- Adds a migration-guide entry in `docs/docs/releases/1.0/02-upgrading-from-0.3.md` that shows the accepted vs rejected shapes side-by-side, so users hitting the new error have a concrete reference.

## Compatibility

Users with legitimate `STRING_AGG(col, ';' ORDER BY col)` / dollar-quoted / backtick / bracket expressions continue to work — they were broken by the original #12209 and are restored by this scanner. Callers passing a literal unquoted `;` will now get a `TypeORMError` at runtime; that input has no legitimate use case (user-controlled values belong in parameter bindings). The only behavioural change that could surprise someone is the comment rule — if anyone was threading `;` through a `-- comment` inside `select()`, they'll see the error. That pattern is obscure enough that the defence wins.

## Follow-up

None planned — #12408 covers group/sort and this PR covers select/addSelect, closing out the split.