### PR TITLE
docs: remove references to archived typeorm example repos

### DIFF
--- a/docs/docs/getting-started.md
+++ b/docs/docs/getting-started.md
@@ -1162,26 +1162,6 @@ The photo albums will be left joined and their metadata will be inner-joined.
 You'll use the query builder in your application a lot.
 Learn more about QueryBuilder [here](./query-builder/1-select-query-builder.md).
 
-## Samples
-
-There are a few repositories that you can clone and start with:
-
-- [Example how to use TypeORM with TypeScript](https://github.com/typeorm/typescript-example)
-- [Example how to use TypeORM with JavaScript](https://github.com/typeorm/javascript-example)
-- [Example how to use TypeORM with JavaScript and Babel](https://github.com/typeorm/babel-example)
-- [Example how to use TypeORM with TypeScript and SystemJS in Browser](https://github.com/typeorm/browser-example)
-- [Example how to use TypeORM with TypeScript and React in Browser](https://github.com/ItayGarin/typeorm-react-swc)
-- [Example how to use Express and TypeORM](https://github.com/typeorm/typescript-express-example)
-- [Example how to use Koa and TypeORM](https://github.com/typeorm/typescript-koa-example)
-- [Example how to use TypeORM with MongoDB](https://github.com/typeorm/mongo-typescript-example)
-- [Example how to use TypeORM in a Cordova app](https://github.com/typeorm/cordova-example)
-- [Example how to use TypeORM with an Ionic app](https://github.com/typeorm/ionic-example)
-- [Example how to use TypeORM with React Native](https://github.com/typeorm/react-native-example)
-- [Example how to use TypeORM with Nativescript-Vue](https://github.com/typeorm/nativescript-vue-typeorm-sample)
-- [Example how to use TypeORM with Nativescript-Angular](https://github.com/betov18x/nativescript-angular-typeorm-example)
-- [Example how to use TypeORM with Electron using JavaScript](https://github.com/typeorm/electron-javascript-example)
-- [Example how to use TypeORM with Electron using TypeScript](https://github.com/typeorm/electron-typescript-example)
-
 ## Extensions
 
 There are several extensions that simplify working with TypeORM and integrating it with other modules:

--- a/docs/docs/guides/5-usage-with-javascript.md
+++ b/docs/docs/guides/5-usage-with-javascript.md
@@ -105,5 +105,3 @@ module.exports = new EntitySchema({
     },
 })
 ```
-
-You can check out this example [typeorm/javascript-example](https://github.com/typeorm/javascript-example) to learn more.

--- a/docs/docs/help/2-supported-platforms.md
+++ b/docs/docs/help/2-supported-platforms.md
@@ -51,13 +51,13 @@ See [Using TypeORM with the Capacitor driver type](https://github.com/capacitor-
 ## Cordova / Ionic apps
 
 TypeORM is able to run on Cordova/Ionic apps using the
-[cordova-sqlite-storage](https://github.com/litehelpers/Cordova-sqlite-storage) plugin
+[cordova-sqlite-storage](https://github.com/litehelpers/Cordova-sqlite-storage) plugin.
 You have the option to choose between module loaders just like in browser package.
-For an example how to use TypeORM in Cordova see [typeorm/cordova-example](https://github.com/typeorm/cordova-example) and for Ionic see [typeorm/ionic-example](https://github.com/typeorm/ionic-example). **Important**: For use with Ionic, a custom webpack config file is needed! Please checkout the example to see the needed changes. Note that there is currently no support for transactions when using the [cordova-sqlite-storage](https://github.com/litehelpers/Cordova-sqlite-storage) plugin. See [Cordova SQLite limitations](https://github.com/storesafe/cordova-sqlite-storage#other-limitations) for more information.
+**Important**: For use with Ionic, a custom webpack config file is needed. Note that there is currently no support for transactions when using the [cordova-sqlite-storage](https://github.com/litehelpers/Cordova-sqlite-storage) plugin. See [Cordova SQLite limitations](https://github.com/storesafe/cordova-sqlite-storage#other-limitations) for more information.
 
 ## Expo
 
-TypeORM is able to run on Expo apps using the [Expo SQLite API](https://docs.expo.io/versions/latest/sdk/sqlite/). For an example how to use TypeORM in Expo see [typeorm/expo-example](https://github.com/typeorm/expo-example).
+TypeORM is able to run on Expo apps using the [Expo SQLite API](https://docs.expo.io/versions/latest/sdk/sqlite/).
 
 ## NativeScript
 
@@ -90,4 +90,4 @@ Checkout example [here](https://github.com/championswimmer/nativescript-vue-type
 
 ## React Native
 
-TypeORM is able to run on React Native apps using the [react-native-sqlite-storage](https://github.com/andpor/react-native-sqlite-storage) plugin. For an example see [typeorm/react-native-example](https://github.com/typeorm/react-native-example).
+TypeORM is able to run on React Native apps using the [react-native-sqlite-storage](https://github.com/andpor/react-native-sqlite-storage) plugin.


### PR DESCRIPTION
The `typeorm/*-example` repositories have been archived. This PR strips links to them from the docs.

Changes:

- `docs/docs/getting-started.md` — removes the whole "Samples" section; nearly all entries pointed at archived repos.
- `docs/docs/guides/5-usage-with-javascript.md` — drops the trailing "check out this example" pointer.
- `docs/docs/help/2-supported-platforms.md` — strips the archived-example clauses from the Cordova/Ionic, Expo, and React Native sections; technical guidance is kept.