### PR TITLE
fix(query-runner): auto-create user-defined schemas if not exists

### DIFF
--- a/src/driver/cockroachdb/CockroachQueryRunner.ts
+++ b/src/driver/cockroachdb/CockroachQueryRunner.ts
@@ -3221,8 +3221,8 @@ export class CockroachQueryRunner
             `SELECT "columns".*, "attr"."attgenerated" as "generated_type", ` +
             `pg_catalog.col_description((quote_ident(table_catalog) || '.' || quote_ident(table_schema) || '.' || quote_ident(table_name))::regclass::oid, ordinal_position) as description ` +
             `FROM "information_schema"."columns" ` +
-            `LEFT JOIN "pg_class" AS "cls" ON "cls"."relname" = "table_name" ` +
-            `LEFT JOIN "pg_namespace" AS "ns" ON "ns"."oid" = "cls"."relnamespace" AND "ns"."nspname" = "table_schema" ` +
+            `LEFT JOIN "pg_namespace" AS "ns" ON "ns"."nspname" = "table_schema" ` +
+            `LEFT JOIN "pg_class" AS "cls" ON "cls"."relnamespace" = "ns"."oid" AND "cls"."relname" = "table_name" ` +
             `LEFT JOIN "pg_attribute" AS "attr" ON "attr"."attrelid" = "cls"."oid" AND "attr"."attname" = "column_name" AND "attr"."attnum" = "ordinal_position" ` +
             `WHERE "is_hidden" = 'NO' AND ` +
             columnsCondiiton

--- a/src/driver/cockroachdb/CockroachQueryRunner.ts
+++ b/src/driver/cockroachdb/CockroachQueryRunner.ts
@@ -648,6 +648,10 @@ export class CockroachQueryRunner
         createForeignKeys: boolean = true,
         createIndices: boolean = true,
     ): Promise<void> {
+        const tableSchema = table.schema ?? (await this.getCurrentSchema())
+        const hasSchema = await this.hasSchema(tableSchema)
+        if (!hasSchema) await this.createSchema(tableSchema, true)
+
         if (ifNotExists) {
             const isTableExist = await this.hasTable(table)
             if (isTableExist) return Promise.resolve()

--- a/src/driver/cockroachdb/CockroachQueryRunner.ts
+++ b/src/driver/cockroachdb/CockroachQueryRunner.ts
@@ -649,8 +649,7 @@ export class CockroachQueryRunner
         createIndices: boolean = true,
     ): Promise<void> {
         const tableSchema = table.schema ?? (await this.getCurrentSchema())
-        const hasSchema = await this.hasSchema(tableSchema)
-        if (!hasSchema) await this.createSchema(tableSchema, true)
+        await this.createSchema(tableSchema, true)
 
         if (ifNotExists) {
             const isTableExist = await this.hasTable(table)

--- a/src/driver/postgres/PostgresQueryRunner.ts
+++ b/src/driver/postgres/PostgresQueryRunner.ts
@@ -575,6 +575,10 @@ export class PostgresQueryRunner
         createForeignKeys: boolean = true,
         createIndices: boolean = true,
     ): Promise<void> {
+        const tableSchema = table.schema ?? (await this.getCurrentSchema())
+        const hasSchema = await this.hasSchema(tableSchema)
+        if (!hasSchema) await this.createSchema(tableSchema, true)
+
         if (ifNotExists) {
             const isTableExist = await this.hasTable(table)
             if (isTableExist) return Promise.resolve()

--- a/src/driver/postgres/PostgresQueryRunner.ts
+++ b/src/driver/postgres/PostgresQueryRunner.ts
@@ -576,8 +576,7 @@ export class PostgresQueryRunner
         createIndices: boolean = true,
     ): Promise<void> {
         const tableSchema = table.schema ?? (await this.getCurrentSchema())
-        const hasSchema = await this.hasSchema(tableSchema)
-        if (!hasSchema) await this.createSchema(tableSchema, true)
+        await this.createSchema(tableSchema, true)
 
         if (ifNotExists) {
             const isTableExist = await this.hasTable(table)

--- a/src/driver/sap/SapQueryRunner.ts
+++ b/src/driver/sap/SapQueryRunner.ts
@@ -645,6 +645,10 @@ export class SapQueryRunner extends BaseQueryRunner implements QueryRunner {
         createForeignKeys: boolean = true,
         createIndices: boolean = true,
     ): Promise<void> {
+        const tableSchema = table.schema ?? (await this.getCurrentSchema())
+        const hasSchema = await this.hasSchema(tableSchema)
+        if (!hasSchema) await this.createSchema(tableSchema, true)
+
         if (ifNotExists) {
             const isTableExist = await this.hasTable(table)
             if (isTableExist) return Promise.resolve()

--- a/src/driver/sap/SapQueryRunner.ts
+++ b/src/driver/sap/SapQueryRunner.ts
@@ -646,8 +646,7 @@ export class SapQueryRunner extends BaseQueryRunner implements QueryRunner {
         createIndices: boolean = true,
     ): Promise<void> {
         const tableSchema = table.schema ?? (await this.getCurrentSchema())
-        const hasSchema = await this.hasSchema(tableSchema)
-        if (!hasSchema) await this.createSchema(tableSchema, true)
+        await this.createSchema(tableSchema, true)
 
         if (ifNotExists) {
             const isTableExist = await this.hasTable(table)

--- a/src/driver/sqlserver/SqlServerQueryRunner.ts
+++ b/src/driver/sqlserver/SqlServerQueryRunner.ts
@@ -438,7 +438,7 @@ export class SqlServerQueryRunner
      */
     async getSchemas(database?: string): Promise<string[]> {
         const query = database
-            ? `SELECT * FROM "${database}"."sys"."schema"`
+            ? `SELECT * FROM "${database}"."sys"."schemas"`
             : `SELECT * FROM "sys"."schemas"`
         const results: ObjectLiteral[] = await this.query(query)
         return results.map((result) => result["name"])
@@ -681,6 +681,18 @@ export class SqlServerQueryRunner
         createForeignKeys: boolean = true,
         createIndices: boolean = true,
     ): Promise<void> {
+        const currentSchema = await this.getCurrentSchema()
+        const currentDatabase = await this.getCurrentDatabase()
+        const tableDatabase = table.database ?? currentDatabase
+        const tableSchema = table.schema ?? currentSchema
+
+        const hasSchema = await this.hasSchema(tableSchema)
+
+        if (!hasSchema) {
+            const schemaPath = `${tableDatabase}.${tableSchema}`
+            await this.createSchema(schemaPath, true)
+        }
+
         if (ifNotExists) {
             const isTableExist = await this.hasTable(table)
             if (isTableExist) return Promise.resolve()

--- a/src/driver/sqlserver/SqlServerQueryRunner.ts
+++ b/src/driver/sqlserver/SqlServerQueryRunner.ts
@@ -681,17 +681,11 @@ export class SqlServerQueryRunner
         createForeignKeys: boolean = true,
         createIndices: boolean = true,
     ): Promise<void> {
-        const currentSchema = await this.getCurrentSchema()
-        const currentDatabase = await this.getCurrentDatabase()
-        const tableDatabase = table.database ?? currentDatabase
-        const tableSchema = table.schema ?? currentSchema
-
-        const hasSchema = await this.hasSchema(tableSchema)
-
-        if (!hasSchema) {
-            const schemaPath = `${tableDatabase}.${tableSchema}`
-            await this.createSchema(schemaPath, true)
-        }
+        const tableDatabase =
+            table.database ?? (await this.getCurrentDatabase())
+        const tableSchema = table.schema ?? (await this.getCurrentSchema())
+        const schemaPath = `${tableDatabase}.${tableSchema}`
+        await this.createSchema(schemaPath, true)
 
         if (ifNotExists) {
             const isTableExist = await this.hasTable(table)

--- a/test/functional/database-schema/enums/enums.test.ts
+++ b/test/functional/database-schema/enums/enums.test.ts
@@ -95,8 +95,6 @@ describe("database schema > enums", () => {
                     .createSchemaBuilder()
                     .log()
 
-                console.log(sqlInMemory.upQueries)
-
                 sqlInMemory.upQueries.length.should.be.equal(0)
                 sqlInMemory.downQueries.length.should.be.equal(0)
             }),

--- a/test/functional/multi-schema-and-database/custom-junction-schema/custom-junction-schema.test.ts
+++ b/test/functional/multi-schema-and-database/custom-junction-schema/custom-junction-schema.test.ts
@@ -14,7 +14,7 @@ describe("multi-schema-and-database > custom-junction-schema", () => {
     before(async () => {
         dataSources = await createTestingConnections({
             entities: [Post, Category],
-            enabledDrivers: ["mssql", "postgres"],
+            enabledDrivers: ["mssql", "postgres", "sap", "cockroachdb"],
         })
     })
     beforeEach(() => reloadTestingDatabases(dataSources))

--- a/test/functional/multi-schema-and-database/custom-junction-schema/custom-junction-schema.test.ts
+++ b/test/functional/multi-schema-and-database/custom-junction-schema/custom-junction-schema.test.ts
@@ -11,11 +11,12 @@ import { expect } from "chai"
 
 describe("multi-schema-and-database > custom-junction-schema", () => {
     let dataSources: DataSource[]
-    before(async () => {
+    before(async function () {
         dataSources = await createTestingConnections({
             entities: [Post, Category],
             enabledDrivers: ["mssql", "postgres", "sap", "cockroachdb"],
         })
+        if (!dataSources.length) this.skip()
     })
     beforeEach(() => reloadTestingDatabases(dataSources))
     after(() => closeTestingConnections(dataSources))

--- a/test/functional/multi-schema-and-database/multi-schema-and-database-basic-functionality/multi-schema-and-database-basic-functionality.test.ts
+++ b/test/functional/multi-schema-and-database/multi-schema-and-database-basic-functionality/multi-schema-and-database-basic-functionality.test.ts
@@ -13,6 +13,7 @@ import { Person } from "./entity/Person"
 import { Question } from "./entity/Question"
 import { Answer } from "./entity/Answer"
 import { DriverUtils } from "../../../../src/driver/DriverUtils"
+import type { DatabaseType } from "../../../../src"
 
 function getParameterPlaceholder(dataSource: DataSource): string | undefined {
     const driverType = dataSource.driver.options.type
@@ -86,176 +87,14 @@ function expectSqlByDriver(
 }
 
 describe("multi-schema-and-database > basic-functionality", () => {
-    describe("custom-table-schema", () => {
-        let dataSources: DataSource[]
-        before(async () => {
-            dataSources = await createTestingConnections({
-                entities: [Post, User, Category],
-                enabledDrivers: ["mssql", "postgres", "sap", "cockroachdb"],
-                schema: "custom",
-            })
-        })
-        beforeEach(() => reloadTestingDatabases(dataSources))
-        after(() => closeTestingConnections(dataSources))
-
-        it("should set the table database / schema", () =>
-            Promise.all(
-                dataSources.map(async (dataSource) => {
-                    const queryRunner = dataSource.createQueryRunner()
-                    const table = (await queryRunner.getTable("post"))!
-                    await queryRunner.release()
-
-                    expect(table.database).to.not.be.undefined
-                    expect(table.schema).to.be.equal("custom")
-                }),
-            ))
-
-        it("should correctly get the table primary keys when custom table schema used", () =>
-            Promise.all(
-                dataSources.map(async (dataSource) => {
-                    const queryRunner = dataSource.createQueryRunner()
-                    const table = (await queryRunner.getTable("post"))!
-                    await queryRunner.release()
-
-                    expect(table.primaryColumns).to.have.length(1)
-                    expect(table.findColumnByName("id")?.isGenerated).to.be.true
-                }),
-            ))
-
-        it("should correctly create tables when custom table schema used", () =>
-            Promise.all(
-                dataSources.map(async (dataSource) => {
-                    const queryRunner = dataSource.createQueryRunner()
-                    const table = await queryRunner.getTable("post")
-                    await queryRunner.release()
-
-                    const post = new Post()
-                    post.name = "Post #1"
-                    await dataSource.getRepository(Post).save(post)
-
-                    const sql = dataSource
-                        .createQueryBuilder(Post, "post")
-                        .where("post.id = :id", { id: 1 })
-                        .getSql()
-
-                    expectSqlByDriver(dataSource, sql, {
-                        parameterized: `SELECT "post"."id" AS "post_id", "post"."name" AS "post_name" FROM "custom"."post" "post" WHERE "post"."id" = :param`,
-                    })
-
-                    table!.name.should.be.equal("custom.post")
-                }),
-            ))
-
-        it("should correctly create tables when custom table schema used in Entity decorator", () =>
-            Promise.all(
-                dataSources.map(async (dataSource) => {
-                    const queryRunner = dataSource.createQueryRunner()
-                    const table = await queryRunner.getTable("userSchema.user")
-                    await queryRunner.release()
-
-                    const user = new User()
-                    user.name = "User #1"
-                    await dataSource.getRepository(User).save(user)
-
-                    const sql = dataSource
-                        .createQueryBuilder(User, "user")
-                        .where("user.id = :id", { id: 1 })
-                        .getSql()
-
-                    expectSqlByDriver(dataSource, sql, {
-                        parameterized: `SELECT "user"."id" AS "user_id", "user"."name" AS "user_name" FROM "userSchema"."user" "user" WHERE "user"."id" = :param`,
-                    })
-
-                    table!.name.should.be.equal("userSchema.user")
-                }),
-            ))
-
-        it("should correctly work with cross-schema queries", () =>
-            Promise.all(
-                dataSources.map(async (dataSource) => {
-                    const queryRunner = dataSource.createQueryRunner()
-                    const table = await queryRunner.getTable("guest.category")
-                    await queryRunner.release()
-
-                    const post = new Post()
-                    post.name = "Post #1"
-                    await dataSource.getRepository(Post).save(post)
-
-                    const category = new Category()
-                    category.name = "Category #1"
-                    category.post = post
-                    await dataSource.getRepository(Category).save(category)
-
-                    const loadedCategory = await dataSource
-                        .createQueryBuilder(Category, "category")
-                        .innerJoinAndSelect("category.post", "post")
-                        .where("category.id = :id", { id: 1 })
-                        .getOne()
-
-                    loadedCategory!.should.be.not.empty
-                    loadedCategory!.post.should.be.not.empty
-                    loadedCategory!.post.id.should.be.equal(1)
-
-                    const sql = dataSource
-                        .createQueryBuilder(Category, "category")
-                        .innerJoinAndSelect("category.post", "post")
-                        .where("category.id = :id", { id: 1 })
-                        .getSql()
-
-                    expectSqlByDriver(dataSource, sql, {
-                        parameterized:
-                            `SELECT "category"."id" AS "category_id", "category"."name" AS "category_name",` +
-                            ` "category"."postId" AS "category_postId", "post"."id" AS "post_id", "post"."name" AS "post_name"` +
-                            ` FROM "guest"."category" "category" INNER JOIN "custom"."post" "post" ON "post"."id"="category"."postId" WHERE "category"."id" = :param`,
-                    })
-
-                    table!.name.should.be.equal("guest.category")
-                }),
-            ))
-
-        it("should correctly work with QueryBuilder", () =>
-            Promise.all(
-                dataSources.map(async (dataSource) => {
-                    const post = new Post()
-                    post.name = "Post #1"
-                    await dataSource.getRepository(Post).save(post)
-
-                    const user = new User()
-                    user.name = "User #1"
-                    await dataSource.getRepository(User).save(user)
-
-                    const category = new Category()
-                    category.name = "Category #1"
-                    category.post = post
-                    await dataSource.getRepository(Category).save(category)
-
-                    const query = dataSource
-                        .createQueryBuilder()
-                        .select()
-                        .from(Category, "category")
-                        .addFrom(User, "user")
-                        .addFrom(Post, "post")
-                        .where("category.id = :id", { id: 1 })
-                        .andWhere("post.id = category.post")
-
-                    ;(await query.getRawOne())!.should.be.not.empty
-
-                    expectSqlByDriver(dataSource, query.getSql(), {
-                        parameterized:
-                            `SELECT * FROM "guest"."category" "category", "userSchema"."user" "user",` +
-                            ` "custom"."post" "post" WHERE "category"."id" = :param AND "post"."id" = "category"."postId"`,
-                    })
-                }),
-            ))
-    })
-
     describe("custom-table-schema-and-database", () => {
         let dataSources: DataSource[]
-        before(async () => {
+        before(async function () {
             dataSources = await createTestingConnections({
                 entities: [Question, Answer],
                 enabledDrivers: ["mssql"],
             })
+            if (!dataSources.length) this.skip()
         })
         beforeEach(() => reloadTestingDatabases(dataSources))
         after(() => closeTestingConnections(dataSources))
@@ -367,11 +206,12 @@ describe("multi-schema-and-database > basic-functionality", () => {
 
     describe("custom-database", () => {
         let dataSources: DataSource[]
-        before(async () => {
+        before(async function () {
             dataSources = await createTestingConnections({
                 entities: [Person],
                 enabledDrivers: ["mssql", "mysql"],
             })
+            if (!dataSources.length) this.skip()
         })
         beforeEach(() => reloadTestingDatabases(dataSources))
         after(() => closeTestingConnections(dataSources))
@@ -404,5 +244,192 @@ describe("multi-schema-and-database > basic-functionality", () => {
                     table!.name.should.be.equal(tablePath)
                 }),
             ))
+    })
+
+    describe("custom-table-schema", () => {
+        const drivers: DatabaseType[][] = [
+            // SAP throws error during connection if schema specified in connection options does not exist.
+            // only testing custom schema specified in Entity decorator
+            ["sap"],
+            ["mssql", "postgres", "cockroachdb"],
+        ]
+        for (const driver of drivers) {
+            describe(`${driver.join("|")}`, () => {
+                let dataSources: DataSource[]
+                before(async function () {
+                    dataSources = await createTestingConnections({
+                        entities: [User, Category, Post],
+                        enabledDrivers: driver,
+                        schema: driver.includes("sap") ? undefined : "custom",
+                    })
+                    if (!dataSources.length) this.skip()
+                })
+                beforeEach(() => reloadTestingDatabases(dataSources))
+                after(() => closeTestingConnections(dataSources))
+
+                it("should set the table database / schema", function () {
+                    if (driver.includes("sap")) this.skip()
+
+                    return Promise.all(
+                        dataSources.map(async (dataSource) => {
+                            const queryRunner = dataSource.createQueryRunner()
+                            const table = (await queryRunner.getTable("post"))!
+                            await queryRunner.release()
+
+                            expect(table.database).to.not.be.undefined
+                            expect(table.schema).to.be.equal("custom")
+                        }),
+                    )
+                })
+
+                it("should correctly get the table primary keys when custom table schema used", () =>
+                    Promise.all(
+                        dataSources.map(async (dataSource) => {
+                            const queryRunner = dataSource.createQueryRunner()
+                            const table = (await queryRunner.getTable("post"))!
+                            await queryRunner.release()
+
+                            expect(table.primaryColumns).to.have.length(1)
+                            expect(table.findColumnByName("id")?.isGenerated).to
+                                .be.true
+                        }),
+                    ))
+
+                it("should correctly create tables when custom table schema used", function () {
+                    if (driver.includes("sap")) this.skip()
+
+                    return Promise.all(
+                        dataSources.map(async (dataSource) => {
+                            const queryRunner = dataSource.createQueryRunner()
+                            const table = await queryRunner.getTable("post")
+                            await queryRunner.release()
+
+                            const post = new Post()
+                            post.name = "Post #1"
+                            await dataSource.getRepository(Post).save(post)
+
+                            const sql = dataSource
+                                .createQueryBuilder(Post, "post")
+                                .where("post.id = :id", { id: 1 })
+                                .getSql()
+
+                            expectSqlByDriver(dataSource, sql, {
+                                parameterized: `SELECT "post"."id" AS "post_id", "post"."name" AS "post_name" FROM "custom"."post" "post" WHERE "post"."id" = :param`,
+                            })
+
+                            table!.name.should.be.equal("custom.post")
+                        }),
+                    )
+                })
+
+                it("should correctly create tables when custom table schema used in Entity decorator", () =>
+                    Promise.all(
+                        dataSources.map(async (dataSource) => {
+                            const queryRunner = dataSource.createQueryRunner()
+                            const table =
+                                await queryRunner.getTable("userSchema.user")
+                            await queryRunner.release()
+
+                            const user = new User()
+                            user.name = "User #1"
+                            await dataSource.getRepository(User).save(user)
+
+                            const sql = dataSource
+                                .createQueryBuilder(User, "user")
+                                .where("user.id = :id", { id: 1 })
+                                .getSql()
+
+                            expectSqlByDriver(dataSource, sql, {
+                                parameterized: `SELECT "user"."id" AS "user_id", "user"."name" AS "user_name" FROM "userSchema"."user" "user" WHERE "user"."id" = :param`,
+                            })
+
+                            table!.name.should.be.equal("userSchema.user")
+                        }),
+                    ))
+
+                it("should correctly work with cross-schema queries", () =>
+                    Promise.all(
+                        dataSources.map(async (dataSource) => {
+                            const queryRunner = dataSource.createQueryRunner()
+                            const table =
+                                await queryRunner.getTable("guest.category")
+                            await queryRunner.release()
+
+                            const post = new Post()
+                            post.name = "Post #1"
+                            await dataSource.getRepository(Post).save(post)
+
+                            const category = new Category()
+                            category.name = "Category #1"
+                            category.post = post
+                            await dataSource
+                                .getRepository(Category)
+                                .save(category)
+
+                            const loadedCategory = await dataSource
+                                .createQueryBuilder(Category, "category")
+                                .innerJoinAndSelect("category.post", "post")
+                                .where("category.id = :id", { id: 1 })
+                                .getOne()
+
+                            loadedCategory!.should.be.not.empty
+                            loadedCategory!.post.should.be.not.empty
+                            loadedCategory!.post.id.should.be.equal(1)
+
+                            const sql = dataSource
+                                .createQueryBuilder(Category, "category")
+                                .innerJoinAndSelect("category.post", "post")
+                                .where("category.id = :id", { id: 1 })
+                                .getSql()
+
+                            expectSqlByDriver(dataSource, sql, {
+                                parameterized:
+                                    `SELECT "category"."id" AS "category_id", "category"."name" AS "category_name",` +
+                                    ` "category"."postId" AS "category_postId", "post"."id" AS "post_id", "post"."name" AS "post_name"` +
+                                    ` FROM "guest"."category" "category" INNER JOIN ${driver.includes("sap") ? "" : '"custom".'}"post" "post" ON "post"."id"="category"."postId" WHERE "category"."id" = :param`,
+                            })
+
+                            table!.name.should.be.equal("guest.category")
+                        }),
+                    ))
+
+                it("should correctly work with QueryBuilder", () =>
+                    Promise.all(
+                        dataSources.map(async (dataSource) => {
+                            const post = new Post()
+                            post.name = "Post #1"
+                            await dataSource.getRepository(Post).save(post)
+
+                            const user = new User()
+                            user.name = "User #1"
+                            await dataSource.getRepository(User).save(user)
+
+                            const category = new Category()
+                            category.name = "Category #1"
+                            category.post = post
+                            await dataSource
+                                .getRepository(Category)
+                                .save(category)
+
+                            const query = dataSource
+                                .createQueryBuilder()
+                                .select()
+                                .from(Category, "category")
+                                .addFrom(User, "user")
+                                .addFrom(Post, "post")
+                                .where("category.id = :id", { id: 1 })
+                                .andWhere("post.id = category.post")
+
+                            ;(await query.getRawOne())!.should.be.not.empty
+
+                            expectSqlByDriver(dataSource, query.getSql(), {
+                                parameterized:
+                                    `SELECT * FROM "guest"."category" "category", "userSchema"."user" "user",` +
+                                    ` ${driver.includes("sap") ? "" : '"custom".'}"post" "post" WHERE "category"."id" = :param AND "post"."id" = "category"."postId"`,
+                            })
+                        }),
+                    ))
+            })
+        }
     })
 })

--- a/test/functional/multi-schema-and-database/multi-schema-and-database-basic-functionality/multi-schema-and-database-basic-functionality.test.ts
+++ b/test/functional/multi-schema-and-database/multi-schema-and-database-basic-functionality/multi-schema-and-database-basic-functionality.test.ts
@@ -273,11 +273,15 @@ describe("multi-schema-and-database > basic-functionality", () => {
                     return Promise.all(
                         dataSources.map(async (dataSource) => {
                             const queryRunner = dataSource.createQueryRunner()
-                            const table = (await queryRunner.getTable("post"))!
-                            await queryRunner.release()
+                            try {
+                                const table =
+                                    (await queryRunner.getTable("post"))!
 
-                            expect(table.database).to.not.be.undefined
-                            expect(table.schema).to.be.equal("custom")
+                                expect(table.database).to.not.be.undefined
+                                expect(table.schema).to.be.equal("custom")
+                            } finally {
+                                await queryRunner.release()
+                            }
                         }),
                     )
                 })
@@ -286,12 +290,17 @@ describe("multi-schema-and-database > basic-functionality", () => {
                     Promise.all(
                         dataSources.map(async (dataSource) => {
                             const queryRunner = dataSource.createQueryRunner()
-                            const table = (await queryRunner.getTable("post"))!
-                            await queryRunner.release()
+                            try {
+                                const table =
+                                    (await queryRunner.getTable("post"))!
 
-                            expect(table.primaryColumns).to.have.length(1)
-                            expect(table.findColumnByName("id")?.isGenerated).to
-                                .be.true
+                                expect(table.primaryColumns).to.have.length(1)
+                                expect(
+                                    table.findColumnByName("id")?.isGenerated,
+                                ).to.be.true
+                            } finally {
+                                await queryRunner.release()
+                            }
                         }),
                     ))
 
@@ -301,23 +310,26 @@ describe("multi-schema-and-database > basic-functionality", () => {
                     return Promise.all(
                         dataSources.map(async (dataSource) => {
                             const queryRunner = dataSource.createQueryRunner()
-                            const table = await queryRunner.getTable("post")
-                            await queryRunner.release()
+                            try {
+                                const table = await queryRunner.getTable("post")
 
-                            const post = new Post()
-                            post.name = "Post #1"
-                            await dataSource.getRepository(Post).save(post)
+                                const post = new Post()
+                                post.name = "Post #1"
+                                await dataSource.getRepository(Post).save(post)
 
-                            const sql = dataSource
-                                .createQueryBuilder(Post, "post")
-                                .where("post.id = :id", { id: 1 })
-                                .getSql()
+                                const sql = dataSource
+                                    .createQueryBuilder(Post, "post")
+                                    .where("post.id = :id", { id: 1 })
+                                    .getSql()
 
-                            expectSqlByDriver(dataSource, sql, {
-                                parameterized: `SELECT "post"."id" AS "post_id", "post"."name" AS "post_name" FROM "custom"."post" "post" WHERE "post"."id" = :param`,
-                            })
+                                expectSqlByDriver(dataSource, sql, {
+                                    parameterized: `SELECT "post"."id" AS "post_id", "post"."name" AS "post_name" FROM "custom"."post" "post" WHERE "post"."id" = :param`,
+                                })
 
-                            table!.name.should.be.equal("custom.post")
+                                table!.name.should.be.equal("custom.post")
+                            } finally {
+                                await queryRunner.release()
+                            }
                         }),
                     )
                 })
@@ -326,24 +338,29 @@ describe("multi-schema-and-database > basic-functionality", () => {
                     Promise.all(
                         dataSources.map(async (dataSource) => {
                             const queryRunner = dataSource.createQueryRunner()
-                            const table =
-                                await queryRunner.getTable("userSchema.user")
-                            await queryRunner.release()
+                            try {
+                                const table =
+                                    await queryRunner.getTable(
+                                        "userSchema.user",
+                                    )
 
-                            const user = new User()
-                            user.name = "User #1"
-                            await dataSource.getRepository(User).save(user)
+                                const user = new User()
+                                user.name = "User #1"
+                                await dataSource.getRepository(User).save(user)
 
-                            const sql = dataSource
-                                .createQueryBuilder(User, "user")
-                                .where("user.id = :id", { id: 1 })
-                                .getSql()
+                                const sql = dataSource
+                                    .createQueryBuilder(User, "user")
+                                    .where("user.id = :id", { id: 1 })
+                                    .getSql()
 
-                            expectSqlByDriver(dataSource, sql, {
-                                parameterized: `SELECT "user"."id" AS "user_id", "user"."name" AS "user_name" FROM "userSchema"."user" "user" WHERE "user"."id" = :param`,
-                            })
+                                expectSqlByDriver(dataSource, sql, {
+                                    parameterized: `SELECT "user"."id" AS "user_id", "user"."name" AS "user_name" FROM "userSchema"."user" "user" WHERE "user"."id" = :param`,
+                                })
 
-                            table!.name.should.be.equal("userSchema.user")
+                                table!.name.should.be.equal("userSchema.user")
+                            } finally {
+                                await queryRunner.release()
+                            }
                         }),
                     ))
 
@@ -351,45 +368,48 @@ describe("multi-schema-and-database > basic-functionality", () => {
                     Promise.all(
                         dataSources.map(async (dataSource) => {
                             const queryRunner = dataSource.createQueryRunner()
-                            const table =
-                                await queryRunner.getTable("guest.category")
-                            await queryRunner.release()
+                            try {
+                                const table =
+                                    await queryRunner.getTable("guest.category")
 
-                            const post = new Post()
-                            post.name = "Post #1"
-                            await dataSource.getRepository(Post).save(post)
+                                const post = new Post()
+                                post.name = "Post #1"
+                                await dataSource.getRepository(Post).save(post)
 
-                            const category = new Category()
-                            category.name = "Category #1"
-                            category.post = post
-                            await dataSource
-                                .getRepository(Category)
-                                .save(category)
+                                const category = new Category()
+                                category.name = "Category #1"
+                                category.post = post
+                                await dataSource
+                                    .getRepository(Category)
+                                    .save(category)
 
-                            const loadedCategory = await dataSource
-                                .createQueryBuilder(Category, "category")
-                                .innerJoinAndSelect("category.post", "post")
-                                .where("category.id = :id", { id: 1 })
-                                .getOne()
+                                const loadedCategory = await dataSource
+                                    .createQueryBuilder(Category, "category")
+                                    .innerJoinAndSelect("category.post", "post")
+                                    .where("category.id = :id", { id: 1 })
+                                    .getOne()
 
-                            loadedCategory!.should.be.not.empty
-                            loadedCategory!.post.should.be.not.empty
-                            loadedCategory!.post.id.should.be.equal(1)
+                                loadedCategory!.should.be.not.empty
+                                loadedCategory!.post.should.be.not.empty
+                                loadedCategory!.post.id.should.be.equal(1)
 
-                            const sql = dataSource
-                                .createQueryBuilder(Category, "category")
-                                .innerJoinAndSelect("category.post", "post")
-                                .where("category.id = :id", { id: 1 })
-                                .getSql()
+                                const sql = dataSource
+                                    .createQueryBuilder(Category, "category")
+                                    .innerJoinAndSelect("category.post", "post")
+                                    .where("category.id = :id", { id: 1 })
+                                    .getSql()
 
-                            expectSqlByDriver(dataSource, sql, {
-                                parameterized:
-                                    `SELECT "category"."id" AS "category_id", "category"."name" AS "category_name",` +
-                                    ` "category"."postId" AS "category_postId", "post"."id" AS "post_id", "post"."name" AS "post_name"` +
-                                    ` FROM "guest"."category" "category" INNER JOIN ${driver.includes("sap") ? "" : '"custom".'}"post" "post" ON "post"."id"="category"."postId" WHERE "category"."id" = :param`,
-                            })
+                                expectSqlByDriver(dataSource, sql, {
+                                    parameterized:
+                                        `SELECT "category"."id" AS "category_id", "category"."name" AS "category_name",` +
+                                        ` "category"."postId" AS "category_postId", "post"."id" AS "post_id", "post"."name" AS "post_name"` +
+                                        ` FROM "guest"."category" "category" INNER JOIN ${driver.includes("sap") ? "" : '"custom".'}"post" "post" ON "post"."id"="category"."postId" WHERE "category"."id" = :param`,
+                                })
 
-                            table!.name.should.be.equal("guest.category")
+                                table!.name.should.be.equal("guest.category")
+                            } finally {
+                                await queryRunner.release()
+                            }
                         }),
                     ))
 

--- a/test/functional/multi-schema-and-database/multi-schema-and-database-basic-functionality/multi-schema-and-database-basic-functionality.test.ts
+++ b/test/functional/multi-schema-and-database/multi-schema-and-database-basic-functionality/multi-schema-and-database-basic-functionality.test.ts
@@ -14,13 +14,84 @@ import { Question } from "./entity/Question"
 import { Answer } from "./entity/Answer"
 import { DriverUtils } from "../../../../src/driver/DriverUtils"
 
+function getParameterPlaceholder(dataSource: DataSource): string | undefined {
+    const driverType = dataSource.driver.options.type
+
+    if (DriverUtils.isPostgresFamily(dataSource.driver)) return "$1"
+    if (driverType === "mssql") return "@0"
+    if (driverType === "sap") return "?"
+    if (DriverUtils.isMySQLFamily(dataSource.driver)) return "?"
+
+    return undefined
+}
+
+function getExpectedSqlByDriver(
+    dataSource: DataSource,
+    expected: {
+        postgres?: string
+        mssql?: string
+        sap?: string
+        mysql?: string
+    },
+): string | undefined {
+    const driverType = dataSource.driver.options.type
+
+    if (
+        DriverUtils.isPostgresFamily(dataSource.driver) &&
+        expected.postgres !== undefined
+    ) {
+        return expected.postgres
+    }
+    if (driverType === "mssql" && expected.mssql !== undefined) {
+        return expected.mssql
+    }
+    if (driverType === "sap" && expected.sap !== undefined) {
+        return expected.sap
+    }
+    if (
+        DriverUtils.isMySQLFamily(dataSource.driver) &&
+        expected.mysql !== undefined
+    ) {
+        return expected.mysql
+    }
+
+    return undefined
+}
+
+function expectSqlByDriver(
+    dataSource: DataSource,
+    sql: string,
+    expected: {
+        parameterized?: string
+        postgres?: string
+        mssql?: string
+        sap?: string
+        mysql?: string
+    },
+) {
+    const parameterPlaceholder = getParameterPlaceholder(dataSource)
+
+    if (
+        expected.parameterized !== undefined &&
+        parameterPlaceholder !== undefined
+    ) {
+        sql.should.be.equal(
+            expected.parameterized.replaceAll(":param", parameterPlaceholder),
+        )
+        return
+    }
+
+    const expectedSql = getExpectedSqlByDriver(dataSource, expected)
+    if (expectedSql !== undefined) sql.should.be.equal(expectedSql)
+}
+
 describe("multi-schema-and-database > basic-functionality", () => {
     describe("custom-table-schema", () => {
         let dataSources: DataSource[]
         before(async () => {
             dataSources = await createTestingConnections({
                 entities: [Post, User, Category],
-                enabledDrivers: ["mssql", "postgres"],
+                enabledDrivers: ["mssql", "postgres", "sap", "cockroachdb"],
                 schema: "custom",
             })
         })
@@ -67,15 +138,9 @@ describe("multi-schema-and-database > basic-functionality", () => {
                         .where("post.id = :id", { id: 1 })
                         .getSql()
 
-                    if (dataSource.driver.options.type === "postgres")
-                        sql.should.be.equal(
-                            `SELECT "post"."id" AS "post_id", "post"."name" AS "post_name" FROM "custom"."post" "post" WHERE "post"."id" = $1`,
-                        )
-
-                    if (dataSource.driver.options.type === "mssql")
-                        sql.should.be.equal(
-                            `SELECT "post"."id" AS "post_id", "post"."name" AS "post_name" FROM "custom"."post" "post" WHERE "post"."id" = @0`,
-                        )
+                    expectSqlByDriver(dataSource, sql, {
+                        parameterized: `SELECT "post"."id" AS "post_id", "post"."name" AS "post_name" FROM "custom"."post" "post" WHERE "post"."id" = :param`,
+                    })
 
                     table!.name.should.be.equal("custom.post")
                 }),
@@ -97,15 +162,9 @@ describe("multi-schema-and-database > basic-functionality", () => {
                         .where("user.id = :id", { id: 1 })
                         .getSql()
 
-                    if (dataSource.driver.options.type === "postgres")
-                        sql.should.be.equal(
-                            `SELECT "user"."id" AS "user_id", "user"."name" AS "user_name" FROM "userSchema"."user" "user" WHERE "user"."id" = $1`,
-                        )
-
-                    if (dataSource.driver.options.type === "mssql")
-                        sql.should.be.equal(
-                            `SELECT "user"."id" AS "user_id", "user"."name" AS "user_name" FROM "userSchema"."user" "user" WHERE "user"."id" = @0`,
-                        )
+                    expectSqlByDriver(dataSource, sql, {
+                        parameterized: `SELECT "user"."id" AS "user_id", "user"."name" AS "user_name" FROM "userSchema"."user" "user" WHERE "user"."id" = :param`,
+                    })
 
                     table!.name.should.be.equal("userSchema.user")
                 }),
@@ -143,19 +202,12 @@ describe("multi-schema-and-database > basic-functionality", () => {
                         .where("category.id = :id", { id: 1 })
                         .getSql()
 
-                    if (dataSource.driver.options.type === "postgres")
-                        sql.should.be.equal(
+                    expectSqlByDriver(dataSource, sql, {
+                        parameterized:
                             `SELECT "category"."id" AS "category_id", "category"."name" AS "category_name",` +
-                                ` "category"."postId" AS "category_postId", "post"."id" AS "post_id", "post"."name" AS "post_name"` +
-                                ` FROM "guest"."category" "category" INNER JOIN "custom"."post" "post" ON "post"."id"="category"."postId" WHERE "category"."id" = $1`,
-                        )
-
-                    if (dataSource.driver.options.type === "mssql")
-                        sql.should.be.equal(
-                            `SELECT "category"."id" AS "category_id", "category"."name" AS "category_name",` +
-                                ` "category"."postId" AS "category_postId", "post"."id" AS "post_id", "post"."name" AS "post_name"` +
-                                ` FROM "guest"."category" "category" INNER JOIN "custom"."post" "post" ON "post"."id"="category"."postId" WHERE "category"."id" = @0`,
-                        )
+                            ` "category"."postId" AS "category_postId", "post"."id" AS "post_id", "post"."name" AS "post_name"` +
+                            ` FROM "guest"."category" "category" INNER JOIN "custom"."post" "post" ON "post"."id"="category"."postId" WHERE "category"."id" = :param`,
+                    })
 
                     table!.name.should.be.equal("guest.category")
                 }),
@@ -188,21 +240,11 @@ describe("multi-schema-and-database > basic-functionality", () => {
 
                     ;(await query.getRawOne())!.should.be.not.empty
 
-                    if (dataSource.driver.options.type === "postgres")
-                        query
-                            .getSql()
-                            .should.be.equal(
-                                `SELECT * FROM "guest"."category" "category", "userSchema"."user" "user",` +
-                                    ` "custom"."post" "post" WHERE "category"."id" = $1 AND "post"."id" = "category"."postId"`,
-                            )
-
-                    if (dataSource.driver.options.type === "mssql")
-                        query
-                            .getSql()
-                            .should.be.equal(
-                                `SELECT * FROM "guest"."category" "category", "userSchema"."user" "user",` +
-                                    ` "custom"."post" "post" WHERE "category"."id" = @0 AND "post"."id" = "category"."postId"`,
-                            )
+                    expectSqlByDriver(dataSource, query.getSql(), {
+                        parameterized:
+                            `SELECT * FROM "guest"."category" "category", "userSchema"."user" "user",` +
+                            ` "custom"."post" "post" WHERE "category"."id" = :param AND "post"."id" = "category"."postId"`,
+                    })
                 }),
             ))
     })
@@ -354,15 +396,10 @@ describe("multi-schema-and-database > basic-functionality", () => {
                         .where("person.id = :id", { id: 1 })
                         .getSql()
 
-                    if (dataSource.driver.options.type === "mssql")
-                        sql.should.be.equal(
-                            `SELECT "person"."id" AS "person_id", "person"."name" AS "person_name" FROM "secondDB".."person" "person" WHERE "person"."id" = @0`,
-                        )
-
-                    if (DriverUtils.isMySQLFamily(dataSource.driver))
-                        sql.should.be.equal(
-                            "SELECT `person`.`id` AS `person_id`, `person`.`name` AS `person_name` FROM `secondDB`.`person` `person` WHERE `person`.`id` = ?",
-                        )
+                    expectSqlByDriver(dataSource, sql, {
+                        mssql: `SELECT "person"."id" AS "person_id", "person"."name" AS "person_name" FROM "secondDB".."person" "person" WHERE "person"."id" = @0`,
+                        mysql: "SELECT `person`.`id` AS `person_id`, `person`.`name` AS `person_name` FROM `secondDB`.`person` `person` WHERE `person`.`id` = ?",
+                    })
 
                     table!.name.should.be.equal(tablePath)
                 }),

--- a/test/functional/persistence/persistence-order/persistence-order.test.ts
+++ b/test/functional/persistence/persistence-order/persistence-order.test.ts
@@ -49,7 +49,7 @@ describe("persistence > order of persistence execution operations", () => {
         })
         beforeEach(() => reloadTestingDatabases(dataSources))
         after(() => closeTestingConnections(dataSources))
-        it("", () =>
+        it("should persist all entities in correct order", () =>
             Promise.all(
                 dataSources.map(async (dataSource) => {
                     // create first category and post and save them

--- a/test/utils/test-utils.ts
+++ b/test/utils/test-utils.ts
@@ -449,36 +449,6 @@ export async function createTestingConnections(
                 )
             }
 
-            // create new schemas
-            const schemaPaths: Set<string> = new Set()
-            connection.entityMetadatas
-                .filter((entityMetadata) => !!entityMetadata.schema)
-                .forEach((entityMetadata) => {
-                    let schema = entityMetadata.schema!
-
-                    if (entityMetadata.database) {
-                        schema = `${entityMetadata.database}.${schema}`
-                    }
-
-                    schemaPaths.add(schema)
-                })
-
-            const schema = connection.driver.options?.hasOwnProperty("schema")
-                ? (connection.driver.options as any).schema
-                : undefined
-
-            if (schema) {
-                schemaPaths.add(schema)
-            }
-
-            for (const schemaPath of schemaPaths) {
-                try {
-                    await queryRunner.createSchema(schemaPath, true)
-                } catch {
-                    // Do nothing
-                }
-            }
-
             await queryRunner.release()
         }),
     )


### PR DESCRIPTION
Closes #5382

### Description of change
This PR enables the automatic creation of a user-defined schema.

- PostgreSQL, CockroachDB, SAP HANA, and SQL Server now auto-create user-defined schema if provided during `@Entity({schema: ...})` or in `schema` option in DataSourceOptions supported by the driver.
- Removed `schema` creation logic from the `test-utils.ts`.
- Removed debug log from `database-schema/enums/enums.test.ts`.
- Added a test description in `persistence/persistence-order/persistence-order.test.ts`.
- Fix typo in `SELECT * FROM "${database}"."sys"."schema"` - `"sys"."schema"` -> `"sys"."schemas"`. (`SqlServerQueryRunner.ts`)
- Updated `columnsSql` query in CockroachDB loadTables to query correct columns from the schema and table.
  **Why:** Let's say we have two tables, `public.post` and `custom.post`, both having `name` as a column. With `columnsSql`, it was returning two columns `name` for the table `public.post`. As a result, CI was failing.


**Note:** SAP HANA driver with a custom schema (non-existing) defined in DataSourceOptions throws an error (skipped tests). In the test suite, only `@Entity({ schema: ... })` was tested.

### Testing
- [x] `multi-schema-and-database` test suite to pass

### Pull-Request Checklist

- [x] Code is up-to-date with the `master` branch
- [x] This pull request links relevant issues as `Fixes #5382`
- [x] There are new or updated tests validating the change (`tests/**.test.ts`)
- [ ] Documentation has been updated to reflect this change (`docs/docs/**.md`)