### PR TITLE
fix(mssql): enhance handling of generated columns in metadata queries

### DIFF
--- a/src/driver/sqlserver/SqlServerQueryRunner.ts
+++ b/src/driver/sqlserver/SqlServerQueryRunner.ts
@@ -719,6 +719,7 @@ export class SqlServerQueryRunner
         if (generatedColumns.length > 0) {
             const parsedTableName = this.driver.parseTableName(table)
             parsedTableName.schema ??= await this.getCurrentSchema()
+            parsedTableName.database ??= await this.getCurrentDatabase()
 
             for (const column of generatedColumns) {
                 const insertQuery = this.insertTypeormMetadataSql({
@@ -801,6 +802,7 @@ export class SqlServerQueryRunner
         if (generatedColumns.length > 0) {
             const parsedTableName = this.driver.parseTableName(table)
             parsedTableName.schema ??= await this.getCurrentSchema()
+            parsedTableName.database ??= await this.getCurrentDatabase()
 
             for (const column of generatedColumns) {
                 const deleteQuery = this.deleteTypeormMetadataSql({
@@ -894,19 +896,13 @@ export class SqlServerQueryRunner
             : await this.getCachedTable(oldTableOrName)
         const newTable = oldTable.clone()
 
-        // we need database name and schema name to rename FK constraints
-        let dbName: string | undefined = undefined
-        let schemaName: string | undefined = undefined
-        let oldTableName: string = oldTable.name
-        const splittedName = oldTable.name.split(".")
-        if (splittedName.length === 3) {
-            dbName = splittedName[0]
-            oldTableName = splittedName[2]
-            if (splittedName[1] !== "") schemaName = splittedName[1]
-        } else if (splittedName.length === 2) {
-            schemaName = splittedName[0]
-            oldTableName = splittedName[1]
-        }
+        let {
+            tableName: oldTableName,
+            database: dbName,
+            schema: schemaName,
+        } = this.driver.parseTableName(oldTable.name)
+        dbName ??= await this.getCurrentDatabase()
+        schemaName ??= await this.getCurrentSchema()
 
         newTable.name = this.driver.buildTableName(
             newTableName,
@@ -943,16 +939,16 @@ export class SqlServerQueryRunner
         )
         if (hasGeneratedColumns) {
             const updateQuery = this.updateTypeormMetadataSql({
-                database: dbName ?? currentDB,
-                schema: schemaName ?? (await this.getCurrentSchema()),
+                database: dbName,
+                schema: schemaName,
                 table: oldTableName,
                 type: MetadataTableType.GENERATED_COLUMN,
                 valueToSet: { table: newTableName },
             })
 
             const revertUpdateQuery = this.updateTypeormMetadataSql({
-                database: dbName ?? currentDB,
-                schema: schemaName ?? (await this.getCurrentSchema()),
+                database: dbName,
+                schema: schemaName,
                 table: newTableName,
                 type: MetadataTableType.GENERATED_COLUMN,
                 valueToSet: { table: oldTableName },
@@ -1284,6 +1280,7 @@ export class SqlServerQueryRunner
         if (column.generatedType && column.asExpression) {
             const parsedTableName = this.driver.parseTableName(table)
             parsedTableName.schema ??= await this.getCurrentSchema()
+            parsedTableName.database ??= await this.getCurrentDatabase()
 
             const insertQuery = this.insertTypeormMetadataSql({
                 database: parsedTableName.database,
@@ -2199,8 +2196,8 @@ export class SqlServerQueryRunner
 
         if (column.generatedType && column.asExpression) {
             const parsedTableName = this.driver.parseTableName(table)
-
             parsedTableName.schema ??= await this.getCurrentSchema()
+            parsedTableName.database ??= await this.getCurrentDatabase()
 
             const deleteQuery = this.deleteTypeormMetadataSql({
                 database: parsedTableName.database,

--- a/src/driver/sqlserver/SqlServerQueryRunner.ts
+++ b/src/driver/sqlserver/SqlServerQueryRunner.ts
@@ -938,6 +938,30 @@ export class SqlServerQueryRunner
             ),
         )
 
+        const hasGeneratedColumns = oldTable.columns.some(
+            (col) => col.generatedType && col.asExpression,
+        )
+        if (hasGeneratedColumns) {
+            const updateQuery = this.updateTypeormMetadataSql({
+                database: dbName ?? currentDB,
+                schema: schemaName ?? (await this.getCurrentSchema()),
+                table: oldTableName,
+                type: MetadataTableType.GENERATED_COLUMN,
+                valueToSet: { table: newTableName },
+            })
+
+            const revertUpdateQuery = this.updateTypeormMetadataSql({
+                database: dbName ?? currentDB,
+                schema: schemaName ?? (await this.getCurrentSchema()),
+                table: newTableName,
+                type: MetadataTableType.GENERATED_COLUMN,
+                valueToSet: { table: oldTableName },
+            })
+
+            upQueries.push(updateQuery)
+            downQueries.push(revertUpdateQuery)
+        }
+
         // rename primary key constraint
         if (
             newTable.primaryColumns.length > 0 &&
@@ -1259,7 +1283,6 @@ export class SqlServerQueryRunner
 
         if (column.generatedType && column.asExpression) {
             const parsedTableName = this.driver.parseTableName(table)
-
             parsedTableName.schema ??= await this.getCurrentSchema()
 
             const insertQuery = this.insertTypeormMetadataSql({
@@ -1373,7 +1396,8 @@ export class SqlServerQueryRunner
             newColumn.type !== oldColumn.type ||
             newColumn.length !== oldColumn.length ||
             newColumn.asExpression !== oldColumn.asExpression ||
-            newColumn.generatedType !== oldColumn.generatedType
+            newColumn.generatedType !== oldColumn.generatedType ||
+            (!!oldColumn.asExpression && newColumn.name !== oldColumn.name)
         ) {
             // SQL Server does not support changing of IDENTITY column, so we must drop column and recreate it again.
             // Also, we recreate column if column type changed

--- a/test/functional/database-schema/generated-columns/mssql/generated-columns-mssql.test.ts
+++ b/test/functional/database-schema/generated-columns/mssql/generated-columns-mssql.test.ts
@@ -9,257 +9,427 @@ import {
 import { expect } from "chai"
 
 describe("database schema > generated columns > mssql", () => {
-    let dataSources: DataSource[]
-    before(async () => {
-        dataSources = await createTestingConnections({
-            entities: [__dirname + "/entity/*{.js,.ts}"],
-            enabledDrivers: ["mssql"],
-            schemaCreate: true,
-            dropSchema: true,
+    for (const schema of [undefined, "customSchema"]) {
+        describe(`schema: ${schema ?? "dbo"}`, () => {
+            let dataSources: DataSource[]
+            before(async function () {
+                dataSources = await createTestingConnections({
+                    entities: [__dirname + "/entity/*{.js,.ts}"],
+                    enabledDrivers: ["mssql"],
+                    schemaCreate: false,
+                    dropSchema: true,
+                    schema: schema,
+                })
+                if (!dataSources.length) this.skip()
+            })
+            beforeEach(() => reloadTestingDatabases(dataSources))
+            after(() => closeTestingConnections(dataSources))
+
+            it("should not generate queries when no model changes", () =>
+                Promise.all(
+                    dataSources.map(async (dataSource) => {
+                        const sqlInMemory = await dataSource.driver
+                            .createSchemaBuilder()
+                            .log()
+
+                        sqlInMemory.upQueries.length.should.be.equal(0)
+                        sqlInMemory.downQueries.length.should.be.equal(0)
+                    }),
+                ))
+
+            it("should create table with generated columns", () =>
+                Promise.all(
+                    dataSources.map(async (dataSource) => {
+                        const queryRunner = dataSource.createQueryRunner()
+                        try {
+                            const table = await queryRunner.getTable("post")
+                            const virtualFullName =
+                                table!.findColumnByName("virtualFullName")
+                            const storedFullName =
+                                table!.findColumnByName("storedFullName")
+                            const name = table!.findColumnByName("name")
+                            const nameHash = table!.findColumnByName("nameHash")
+
+                            expect(virtualFullName!.asExpression).to.be.equal(
+                                `concat("firstName",' ',"lastName")`,
+                            )
+                            expect(virtualFullName!.generatedType).to.be.equal(
+                                "VIRTUAL",
+                            )
+                            expect(storedFullName!.asExpression).to.be.equal(
+                                `CONCAT("firstName",' ',"lastName")`,
+                            )
+                            expect(storedFullName!.generatedType).to.be.equal(
+                                "STORED",
+                            )
+
+                            expect(name!.generatedType).to.be.equal("STORED")
+                            expect(name!.asExpression).to.be.equal(
+                                `"firstName" + ' ' + "lastName"`,
+                            )
+
+                            expect(nameHash!.generatedType).to.be.equal(
+                                "VIRTUAL",
+                            )
+                            expect(nameHash!.asExpression).to.be.equal(
+                                `HashBytes('MD5',coalesce("firstName",'0'))`,
+                            )
+                        } finally {
+                            await queryRunner.release()
+                        }
+                    }),
+                ))
+
+            it("should add generated column and revert add", () =>
+                Promise.all(
+                    dataSources.map(async (dataSource) => {
+                        const queryRunner = dataSource.createQueryRunner()
+                        try {
+                            let table = await queryRunner.getTable("post")
+
+                            let storedColumn: TableColumn | undefined =
+                                new TableColumn({
+                                    name: "storedColumn",
+                                    type: "varchar",
+                                    length: "200",
+                                    generatedType: "STORED",
+                                    asExpression: `"firstName" + ' ' + "lastName"`,
+                                })
+
+                            let virtualColumn: TableColumn | undefined =
+                                new TableColumn({
+                                    name: "virtualColumn",
+                                    type: "varchar",
+                                    length: "200",
+                                    generatedType: "VIRTUAL",
+                                    asExpression: `"firstName" + ' ' + "lastName"`,
+                                })
+
+                            await queryRunner.addColumn(table!, storedColumn)
+                            await queryRunner.addColumn(table!, virtualColumn)
+
+                            table = await queryRunner.getTable("post")
+
+                            storedColumn =
+                                table!.findColumnByName("storedColumn")
+                            expect(storedColumn!.generatedType).to.be.equal(
+                                "STORED",
+                            )
+                            expect(storedColumn!.asExpression).to.be.equal(
+                                `"firstName" + ' ' + "lastName"`,
+                            )
+
+                            virtualColumn =
+                                table!.findColumnByName("virtualColumn")
+                            expect(virtualColumn!.generatedType).to.be.equal(
+                                "VIRTUAL",
+                            )
+                            expect(virtualColumn!.asExpression).to.be.equal(
+                                `"firstName" + ' ' + "lastName"`,
+                            )
+
+                            // revert changes
+                            await queryRunner.executeMemoryDownSql()
+
+                            table = await queryRunner.getTable("post")
+                            expect(table!.findColumnByName("storedColumn")).to
+                                .be.undefined
+                            expect(table!.findColumnByName("virtualColumn")).to
+                                .be.undefined
+
+                            // check if generated column records removed from typeorm_metadata table
+                            const metadataRecords = await queryRunner.query(
+                                `SELECT * FROM "${schema ?? "dbo"}"."typeorm_metadata" WHERE "table" = 'post' AND "name" IN ('storedColumn', 'virtualColumn') AND "schema" = '${schema ?? "dbo"}'`,
+                            )
+                            metadataRecords.length.should.be.equal(0)
+                        } finally {
+                            await queryRunner.release()
+                        }
+                    }),
+                ))
+
+            it("should drop generated column and revert drop", () =>
+                Promise.all(
+                    dataSources.map(async (dataSource) => {
+                        const queryRunner = dataSource.createQueryRunner()
+                        try {
+                            let table = await queryRunner.getTable("post")
+                            await queryRunner.dropColumn(
+                                table!,
+                                "storedFullName",
+                            )
+                            await queryRunner.dropColumn(
+                                table!,
+                                "virtualFullName",
+                            )
+
+                            table = await queryRunner.getTable("post")
+                            expect(table!.findColumnByName("storedFullName")).to
+                                .be.undefined
+                            expect(table!.findColumnByName("virtualFullName"))
+                                .to.be.undefined
+
+                            // check if generated column records removed from typeorm_metadata table
+                            const metadataRecords = await queryRunner.query(
+                                `SELECT * FROM "${schema ?? "dbo"}"."typeorm_metadata" WHERE "table" = 'post' AND "name" IN ('storedFullName', 'virtualFullName') AND "schema" = '${schema ?? "dbo"}'`,
+                            )
+                            metadataRecords.length.should.be.equal(0)
+
+                            // revert changes
+                            await queryRunner.executeMemoryDownSql()
+
+                            table = await queryRunner.getTable("post")
+
+                            const storedFullName =
+                                table!.findColumnByName("storedFullName")
+                            expect(storedFullName!.generatedType).to.be.equal(
+                                "STORED",
+                            )
+                            expect(storedFullName!.asExpression).to.be.equal(
+                                `CONCAT("firstName",' ',"lastName")`,
+                            )
+
+                            const virtualFullName =
+                                table!.findColumnByName("virtualFullName")
+                            expect(virtualFullName!.generatedType).to.be.equal(
+                                "VIRTUAL",
+                            )
+                            expect(virtualFullName!.asExpression).to.be.equal(
+                                `concat("firstName",' ',"lastName")`,
+                            )
+                        } finally {
+                            await queryRunner.release()
+                        }
+                    }),
+                ))
+
+            it("should change generated column and revert change", () =>
+                Promise.all(
+                    dataSources.map(async (dataSource) => {
+                        const queryRunner = dataSource.createQueryRunner()
+                        try {
+                            let table = await queryRunner.getTable("post")
+
+                            let storedFullName =
+                                table!.findColumnByName("storedFullName")
+                            const changedStoredFullName =
+                                storedFullName!.clone()
+                            changedStoredFullName.asExpression = `concat('Mr. ',"firstName",' ',"lastName")`
+
+                            let name = table!.findColumnByName("name")
+                            const changedName = name!.clone()
+
+                            changedName.generatedType = undefined
+                            changedName.asExpression = undefined
+
+                            await queryRunner.changeColumns(table!, [
+                                {
+                                    oldColumn: storedFullName!,
+                                    newColumn: changedStoredFullName,
+                                },
+                                { oldColumn: name!, newColumn: changedName },
+                            ])
+
+                            table = await queryRunner.getTable("post")
+
+                            storedFullName =
+                                table!.findColumnByName("storedFullName")
+                            expect(storedFullName!.asExpression).to.be.equal(
+                                `concat('Mr. ',"firstName",' ',"lastName")`,
+                            )
+
+                            name = table!.findColumnByName("name")
+                            expect(name!.generatedType).to.be.undefined
+                            expect(name!.asExpression).to.be.undefined
+
+                            // check if generated column records removed from typeorm_metadata table
+                            const metadataRecords = await queryRunner.query(
+                                `SELECT * FROM "${schema ?? "dbo"}"."typeorm_metadata" WHERE "table" = 'post' AND "name" = 'name' AND "schema" = '${schema ?? "dbo"}'`,
+                            )
+                            metadataRecords.length.should.be.equal(0)
+
+                            // revert changes
+                            await queryRunner.executeMemoryDownSql()
+
+                            table = await queryRunner.getTable("post")
+
+                            storedFullName =
+                                table!.findColumnByName("storedFullName")!
+                            expect(storedFullName.asExpression).to.be.equal(
+                                `CONCAT("firstName",' ',"lastName")`,
+                            )
+
+                            name = table!.findColumnByName("name")!
+                            expect(name.generatedType).to.be.equal("STORED")
+                            expect(name.asExpression).to.be.equal(
+                                `"firstName" + ' ' + "lastName"`,
+                            )
+                        } finally {
+                            await queryRunner.release()
+                        }
+                    }),
+                ))
+            it("should rename generated column metadata row and revert rename", () =>
+                Promise.all(
+                    dataSources.map(async (dataSource) => {
+                        const queryRunner = dataSource.createQueryRunner()
+                        try {
+                            let table = await queryRunner.getTable("post")
+                            if (table)
+                                await queryRunner.renameColumn(
+                                    table,
+                                    "storedFullName",
+                                    "storedFullNameRenamed",
+                                )
+
+                            table = await queryRunner.getTable("post")
+
+                            const oldColumn =
+                                table!.findColumnByName("storedFullName")
+                            expect(oldColumn).to.be.undefined
+
+                            const renamedColumn = table!.findColumnByName(
+                                "storedFullNameRenamed",
+                            )
+                            expect(renamedColumn!.asExpression).to.be.equal(
+                                `CONCAT("firstName",' ',"lastName")`,
+                            )
+
+                            const oldMetadataRecords = await queryRunner.query(
+                                `SELECT * FROM "${schema ?? "dbo"}"."typeorm_metadata" WHERE "table" = 'post' AND "name" = 'storedFullName' AND "schema" = '${schema ?? "dbo"}'`,
+                            )
+                            oldMetadataRecords.length.should.be.equal(0)
+
+                            const renamedMetadataRecords =
+                                await queryRunner.query(
+                                    `SELECT * FROM "${schema ?? "dbo"}"."typeorm_metadata" WHERE "table" = 'post' AND "name" = 'storedFullNameRenamed' AND "schema" = '${schema ?? "dbo"}'`,
+                                )
+                            renamedMetadataRecords.length.should.be.equal(1)
+
+                            // revert changes
+                            await queryRunner.executeMemoryDownSql()
+
+                            table = await queryRunner.getTable("post")
+
+                            const revertedColumn =
+                                table!.findColumnByName("storedFullName")
+                            expect(revertedColumn!.asExpression).to.be.equal(
+                                `CONCAT("firstName",' ',"lastName")`,
+                            )
+                            expect(
+                                table!.findColumnByName(
+                                    "storedFullNameRenamed",
+                                ),
+                            ).to.be.undefined
+
+                            const revertedMetadataRecords =
+                                await queryRunner.query(
+                                    `SELECT * FROM "${schema ?? "dbo"}"."typeorm_metadata" WHERE "table" = 'post' AND "name" = 'storedFullName' AND "schema" = '${schema ?? "dbo"}'`,
+                                )
+                            revertedMetadataRecords.length.should.be.equal(1)
+
+                            const revertedRenamedMetadataRecords =
+                                await queryRunner.query(
+                                    `SELECT * FROM "${schema ?? "dbo"}"."typeorm_metadata" WHERE "table" = 'post' AND "name" = 'storedFullNameRenamed' AND "schema" = '${schema ?? "dbo"}'`,
+                                )
+                            revertedRenamedMetadataRecords.length.should.be.equal(
+                                0,
+                            )
+                        } finally {
+                            await queryRunner.release()
+                        }
+                    }),
+                ))
+
+            it("should rename table with generated columns and revert rename", () =>
+                Promise.all(
+                    dataSources.map(async (dataSource) => {
+                        const queryRunner = dataSource.createQueryRunner()
+                        try {
+                            let table = await queryRunner.getTable("post")
+                            await queryRunner.renameTable(table!, "postRenamed")
+
+                            table = await queryRunner.getTable("postRenamed")
+
+                            const storedFullName =
+                                table!.findColumnByName("storedFullName")
+                            expect(storedFullName!.asExpression).to.be.equal(
+                                `CONCAT("firstName",' ',"lastName")`,
+                            )
+
+                            const name = table!.findColumnByName("name")
+                            expect(name!.asExpression).to.be.equal(
+                                `"firstName" + ' ' + "lastName"`,
+                            )
+
+                            // check if generated column records exist in typeorm_metadata table with new table name
+                            const metadataRecords = await queryRunner.query(
+                                `SELECT * FROM "${schema ?? "dbo"}"."typeorm_metadata" WHERE "table" = 'postRenamed' AND "name" IN ('storedFullName', 'name') AND "schema" = '${schema ?? "dbo"}'`,
+                            )
+                            expect(metadataRecords.length).to.be.equal(2)
+
+                            // revert changes
+                            await queryRunner.executeMemoryDownSql()
+
+                            table = await queryRunner.getTable("post")
+
+                            const revertedFullName =
+                                table!.findColumnByName("storedFullName")
+                            expect(revertedFullName!.asExpression).to.be.equal(
+                                `CONCAT("firstName",' ',"lastName")`,
+                            )
+
+                            const revertedName = table!.findColumnByName("name")
+                            expect(revertedName!.asExpression).to.be.equal(
+                                `"firstName" + ' ' + "lastName"`,
+                            )
+
+                            // check if generated column records exist in typeorm_metadata table with old table name
+                            const revertedMetadataRecords =
+                                await queryRunner.query(
+                                    `SELECT * FROM "${schema ?? "dbo"}"."typeorm_metadata" WHERE "table" = 'post' AND "name" IN ('storedFullName', 'name') AND "schema" = '${schema ?? "dbo"}'`,
+                                )
+                            expect(revertedMetadataRecords.length).to.be.equal(
+                                2,
+                            )
+                        } finally {
+                            await queryRunner.release()
+                        }
+                    }),
+                ))
+
+            it("should remove data from 'typeorm_metadata' when table dropped", () =>
+                Promise.all(
+                    dataSources.map(async (dataSource) => {
+                        const queryRunner = dataSource.createQueryRunner()
+                        try {
+                            const table = await queryRunner.getTable("post")
+                            const generatedColumns = table!.columns.filter(
+                                (it) => it.generatedType,
+                            )
+
+                            await queryRunner.dropTable(table!)
+
+                            // check if generated column records removed from typeorm_metadata table
+                            let metadataRecords = await queryRunner.query(
+                                `SELECT * FROM "${schema ?? "dbo"}"."typeorm_metadata" WHERE "table" = 'post' AND "schema" = '${schema ?? "dbo"}'`,
+                            )
+                            expect(metadataRecords.length).to.be.equal(0)
+
+                            // revert changes
+                            await queryRunner.executeMemoryDownSql()
+
+                            metadataRecords = await queryRunner.query(
+                                `SELECT * FROM "${schema ?? "dbo"}"."typeorm_metadata" WHERE "table" = 'post' AND "schema" = '${schema ?? "dbo"}'`,
+                            )
+                            expect(metadataRecords.length).to.be.equal(
+                                generatedColumns.length,
+                            )
+                        } finally {
+                            await queryRunner.release()
+                        }
+                    }),
+                ))
         })
-    })
-    beforeEach(() => reloadTestingDatabases(dataSources))
-    after(() => closeTestingConnections(dataSources))
-
-    it("should not generate queries when no model changes", () =>
-        Promise.all(
-            dataSources.map(async (dataSource) => {
-                const sqlInMemory = await dataSource.driver
-                    .createSchemaBuilder()
-                    .log()
-
-                sqlInMemory.upQueries.length.should.be.equal(0)
-                sqlInMemory.downQueries.length.should.be.equal(0)
-            }),
-        ))
-
-    it("should create table with generated columns", () =>
-        Promise.all(
-            dataSources.map(async (dataSource) => {
-                const queryRunner = dataSource.createQueryRunner()
-                const table = await queryRunner.getTable("post")
-                const virtualFullName =
-                    table!.findColumnByName("virtualFullName")!
-                const storedFullName =
-                    table!.findColumnByName("storedFullName")!
-                const name = table!.findColumnByName("name")!
-                const nameHash = table!.findColumnByName("nameHash")!
-
-                virtualFullName.asExpression!.should.be.equal(
-                    `concat("firstName",' ',"lastName")`,
-                )
-                virtualFullName.generatedType!.should.be.equal("VIRTUAL")
-                storedFullName.asExpression!.should.be.equal(
-                    `CONCAT("firstName",' ',"lastName")`,
-                )
-                storedFullName.generatedType!.should.be.equal("STORED")
-
-                name.generatedType!.should.be.equal("STORED")
-                name.asExpression!.should.be.equal(
-                    `"firstName" + ' ' + "lastName"`,
-                )
-
-                nameHash.generatedType!.should.be.equal("VIRTUAL")
-                nameHash.asExpression!.should.be.equal(
-                    `HashBytes('MD5',coalesce("firstName",'0'))`,
-                )
-
-                await queryRunner.release()
-            }),
-        ))
-
-    it("should add generated column and revert add", () =>
-        Promise.all(
-            dataSources.map(async (dataSource) => {
-                const queryRunner = dataSource.createQueryRunner()
-
-                let table = await queryRunner.getTable("post")
-
-                let storedColumn = new TableColumn({
-                    name: "storedColumn",
-                    type: "varchar",
-                    length: "200",
-                    generatedType: "STORED",
-                    asExpression: `"firstName" + ' ' + "lastName"`,
-                })
-
-                let virtualColumn = new TableColumn({
-                    name: "virtualColumn",
-                    type: "varchar",
-                    length: "200",
-                    generatedType: "VIRTUAL",
-                    asExpression: `"firstName" + ' ' + "lastName"`,
-                })
-
-                await queryRunner.addColumn(table!, storedColumn)
-                await queryRunner.addColumn(table!, virtualColumn)
-
-                table = await queryRunner.getTable("post")
-
-                storedColumn = table!.findColumnByName("storedColumn")!
-                storedColumn.should.be.exist
-                storedColumn!.generatedType!.should.be.equal("STORED")
-                storedColumn!.asExpression!.should.be.equal(
-                    `"firstName" + ' ' + "lastName"`,
-                )
-
-                virtualColumn = table!.findColumnByName("virtualColumn")!
-                virtualColumn.should.be.exist
-                virtualColumn!.generatedType!.should.be.equal("VIRTUAL")
-                virtualColumn!.asExpression!.should.be.equal(
-                    `"firstName" + ' ' + "lastName"`,
-                )
-
-                // revert changes
-                await queryRunner.executeMemoryDownSql()
-
-                table = await queryRunner.getTable("post")
-                expect(table!.findColumnByName("storedColumn")).to.be.undefined
-                expect(table!.findColumnByName("virtualColumn")).to.be.undefined
-
-                // check if generated column records removed from typeorm_metadata table
-                const metadataRecords = await queryRunner.query(
-                    `SELECT * FROM "typeorm_metadata" WHERE "table" = 'post' AND "name" IN ('storedColumn', 'virtualColumn')`,
-                )
-                metadataRecords.length.should.be.equal(0)
-
-                await queryRunner.release()
-            }),
-        ))
-
-    it("should drop generated column and revert drop", () =>
-        Promise.all(
-            dataSources.map(async (dataSource) => {
-                const queryRunner = dataSource.createQueryRunner()
-
-                let table = await queryRunner.getTable("post")
-                await queryRunner.dropColumn(table!, "storedFullName")
-                await queryRunner.dropColumn(table!, "virtualFullName")
-
-                table = await queryRunner.getTable("post")
-                expect(table!.findColumnByName("storedFullName")).to.be
-                    .undefined
-                expect(table!.findColumnByName("virtualFullName")).to.be
-                    .undefined
-
-                // check if generated column records removed from typeorm_metadata table
-                const metadataRecords = await queryRunner.query(
-                    `SELECT * FROM "typeorm_metadata" WHERE "table" = 'post' AND "name" IN ('storedFullName', 'virtualFullName')`,
-                )
-                metadataRecords.length.should.be.equal(0)
-
-                // revert changes
-                await queryRunner.executeMemoryDownSql()
-
-                table = await queryRunner.getTable("post")
-
-                const storedFullName =
-                    table!.findColumnByName("storedFullName")!
-                storedFullName.should.be.exist
-                storedFullName!.generatedType!.should.be.equal("STORED")
-                storedFullName!.asExpression!.should.be.equal(
-                    `CONCAT("firstName",' ',"lastName")`,
-                )
-
-                const virtualFullName =
-                    table!.findColumnByName("virtualFullName")!
-                virtualFullName.should.be.exist
-                virtualFullName!.generatedType!.should.be.equal("VIRTUAL")
-                virtualFullName!.asExpression!.should.be.equal(
-                    `concat("firstName",' ',"lastName")`,
-                )
-
-                await queryRunner.release()
-            }),
-        ))
-
-    it("should change generated column and revert change", () =>
-        Promise.all(
-            dataSources.map(async (dataSource) => {
-                const queryRunner = dataSource.createQueryRunner()
-
-                let table = await queryRunner.getTable("post")
-
-                let storedFullName = table!.findColumnByName("storedFullName")!
-                const changedStoredFullName = storedFullName.clone()
-                changedStoredFullName.asExpression = `concat('Mr. ',"firstName",' ',"lastName")`
-
-                let name = table!.findColumnByName("name")!
-                const changedName = name.clone()
-                changedName.generatedType = undefined
-                changedName.asExpression = undefined
-
-                await queryRunner.changeColumns(table!, [
-                    {
-                        oldColumn: storedFullName,
-                        newColumn: changedStoredFullName,
-                    },
-                    { oldColumn: name, newColumn: changedName },
-                ])
-
-                table = await queryRunner.getTable("post")
-
-                storedFullName = table!.findColumnByName("storedFullName")!
-                storedFullName!.asExpression!.should.be.equal(
-                    `concat('Mr. ',"firstName",' ',"lastName")`,
-                )
-
-                name = table!.findColumnByName("name")!
-                expect(name!.generatedType).to.be.undefined
-                expect(name!.asExpression).to.be.undefined
-
-                // check if generated column records removed from typeorm_metadata table
-                const metadataRecords = await queryRunner.query(
-                    `SELECT * FROM "typeorm_metadata" WHERE "table" = 'post' AND "name" = 'name'`,
-                )
-                metadataRecords.length.should.be.equal(0)
-
-                // revert changes
-                await queryRunner.executeMemoryDownSql()
-
-                table = await queryRunner.getTable("post")
-
-                storedFullName = table!.findColumnByName("storedFullName")!
-                storedFullName!.asExpression!.should.be.equal(
-                    `CONCAT("firstName",' ',"lastName")`,
-                )
-
-                name = table!.findColumnByName("name")!
-                name.generatedType!.should.be.equal("STORED")
-                name.asExpression!.should.be.equal(
-                    `"firstName" + ' ' + "lastName"`,
-                )
-
-                await queryRunner.release()
-            }),
-        ))
-
-    it("should remove data from 'typeorm_metadata' when table dropped", () =>
-        Promise.all(
-            dataSources.map(async (dataSource) => {
-                const queryRunner = dataSource.createQueryRunner()
-                const table = await queryRunner.getTable("post")
-                const generatedColumns = table!.columns.filter(
-                    (it) => it.generatedType,
-                )
-
-                await queryRunner.dropTable(table!)
-
-                // check if generated column records removed from typeorm_metadata table
-                let metadataRecords = await queryRunner.query(
-                    `SELECT * FROM "typeorm_metadata" WHERE "table" = 'post'`,
-                )
-                metadataRecords.length.should.be.equal(0)
-
-                // revert changes
-                await queryRunner.executeMemoryDownSql()
-
-                metadataRecords = await queryRunner.query(
-                    `SELECT * FROM "typeorm_metadata" WHERE "table" = 'post'`,
-                )
-                metadataRecords.length.should.be.equal(generatedColumns.length)
-
-                await queryRunner.release()
-            }),
-        ))
+    }
 })

--- a/test/functional/database-schema/generated-columns/mssql/generated-columns-mssql.test.ts
+++ b/test/functional/database-schema/generated-columns/mssql/generated-columns-mssql.test.ts
@@ -9,427 +9,355 @@ import {
 import { expect } from "chai"
 
 describe("database schema > generated columns > mssql", () => {
-    for (const schema of [undefined, "customSchema"]) {
-        describe(`schema: ${schema ?? "dbo"}`, () => {
-            let dataSources: DataSource[]
-            before(async function () {
-                dataSources = await createTestingConnections({
-                    entities: [__dirname + "/entity/*{.js,.ts}"],
-                    enabledDrivers: ["mssql"],
-                    schemaCreate: false,
-                    dropSchema: true,
-                    schema: schema,
-                })
-                if (!dataSources.length) this.skip()
-            })
-            beforeEach(() => reloadTestingDatabases(dataSources))
-            after(() => closeTestingConnections(dataSources))
-
-            it("should not generate queries when no model changes", () =>
-                Promise.all(
-                    dataSources.map(async (dataSource) => {
-                        const sqlInMemory = await dataSource.driver
-                            .createSchemaBuilder()
-                            .log()
-
-                        sqlInMemory.upQueries.length.should.be.equal(0)
-                        sqlInMemory.downQueries.length.should.be.equal(0)
-                    }),
-                ))
-
-            it("should create table with generated columns", () =>
-                Promise.all(
-                    dataSources.map(async (dataSource) => {
-                        const queryRunner = dataSource.createQueryRunner()
-                        try {
-                            const table = await queryRunner.getTable("post")
-                            const virtualFullName =
-                                table!.findColumnByName("virtualFullName")
-                            const storedFullName =
-                                table!.findColumnByName("storedFullName")
-                            const name = table!.findColumnByName("name")
-                            const nameHash = table!.findColumnByName("nameHash")
-
-                            expect(virtualFullName!.asExpression).to.be.equal(
-                                `concat("firstName",' ',"lastName")`,
-                            )
-                            expect(virtualFullName!.generatedType).to.be.equal(
-                                "VIRTUAL",
-                            )
-                            expect(storedFullName!.asExpression).to.be.equal(
-                                `CONCAT("firstName",' ',"lastName")`,
-                            )
-                            expect(storedFullName!.generatedType).to.be.equal(
-                                "STORED",
-                            )
-
-                            expect(name!.generatedType).to.be.equal("STORED")
-                            expect(name!.asExpression).to.be.equal(
-                                `"firstName" + ' ' + "lastName"`,
-                            )
-
-                            expect(nameHash!.generatedType).to.be.equal(
-                                "VIRTUAL",
-                            )
-                            expect(nameHash!.asExpression).to.be.equal(
-                                `HashBytes('MD5',coalesce("firstName",'0'))`,
-                            )
-                        } finally {
-                            await queryRunner.release()
-                        }
-                    }),
-                ))
-
-            it("should add generated column and revert add", () =>
-                Promise.all(
-                    dataSources.map(async (dataSource) => {
-                        const queryRunner = dataSource.createQueryRunner()
-                        try {
-                            let table = await queryRunner.getTable("post")
-
-                            let storedColumn: TableColumn | undefined =
-                                new TableColumn({
-                                    name: "storedColumn",
-                                    type: "varchar",
-                                    length: "200",
-                                    generatedType: "STORED",
-                                    asExpression: `"firstName" + ' ' + "lastName"`,
-                                })
-
-                            let virtualColumn: TableColumn | undefined =
-                                new TableColumn({
-                                    name: "virtualColumn",
-                                    type: "varchar",
-                                    length: "200",
-                                    generatedType: "VIRTUAL",
-                                    asExpression: `"firstName" + ' ' + "lastName"`,
-                                })
-
-                            await queryRunner.addColumn(table!, storedColumn)
-                            await queryRunner.addColumn(table!, virtualColumn)
-
-                            table = await queryRunner.getTable("post")
-
-                            storedColumn =
-                                table!.findColumnByName("storedColumn")
-                            expect(storedColumn!.generatedType).to.be.equal(
-                                "STORED",
-                            )
-                            expect(storedColumn!.asExpression).to.be.equal(
-                                `"firstName" + ' ' + "lastName"`,
-                            )
-
-                            virtualColumn =
-                                table!.findColumnByName("virtualColumn")
-                            expect(virtualColumn!.generatedType).to.be.equal(
-                                "VIRTUAL",
-                            )
-                            expect(virtualColumn!.asExpression).to.be.equal(
-                                `"firstName" + ' ' + "lastName"`,
-                            )
-
-                            // revert changes
-                            await queryRunner.executeMemoryDownSql()
-
-                            table = await queryRunner.getTable("post")
-                            expect(table!.findColumnByName("storedColumn")).to
-                                .be.undefined
-                            expect(table!.findColumnByName("virtualColumn")).to
-                                .be.undefined
-
-                            // check if generated column records removed from typeorm_metadata table
-                            const metadataRecords = await queryRunner.query(
-                                `SELECT * FROM "${schema ?? "dbo"}"."typeorm_metadata" WHERE "table" = 'post' AND "name" IN ('storedColumn', 'virtualColumn') AND "schema" = '${schema ?? "dbo"}'`,
-                            )
-                            metadataRecords.length.should.be.equal(0)
-                        } finally {
-                            await queryRunner.release()
-                        }
-                    }),
-                ))
-
-            it("should drop generated column and revert drop", () =>
-                Promise.all(
-                    dataSources.map(async (dataSource) => {
-                        const queryRunner = dataSource.createQueryRunner()
-                        try {
-                            let table = await queryRunner.getTable("post")
-                            await queryRunner.dropColumn(
-                                table!,
-                                "storedFullName",
-                            )
-                            await queryRunner.dropColumn(
-                                table!,
-                                "virtualFullName",
-                            )
-
-                            table = await queryRunner.getTable("post")
-                            expect(table!.findColumnByName("storedFullName")).to
-                                .be.undefined
-                            expect(table!.findColumnByName("virtualFullName"))
-                                .to.be.undefined
-
-                            // check if generated column records removed from typeorm_metadata table
-                            const metadataRecords = await queryRunner.query(
-                                `SELECT * FROM "${schema ?? "dbo"}"."typeorm_metadata" WHERE "table" = 'post' AND "name" IN ('storedFullName', 'virtualFullName') AND "schema" = '${schema ?? "dbo"}'`,
-                            )
-                            metadataRecords.length.should.be.equal(0)
-
-                            // revert changes
-                            await queryRunner.executeMemoryDownSql()
-
-                            table = await queryRunner.getTable("post")
-
-                            const storedFullName =
-                                table!.findColumnByName("storedFullName")
-                            expect(storedFullName!.generatedType).to.be.equal(
-                                "STORED",
-                            )
-                            expect(storedFullName!.asExpression).to.be.equal(
-                                `CONCAT("firstName",' ',"lastName")`,
-                            )
-
-                            const virtualFullName =
-                                table!.findColumnByName("virtualFullName")
-                            expect(virtualFullName!.generatedType).to.be.equal(
-                                "VIRTUAL",
-                            )
-                            expect(virtualFullName!.asExpression).to.be.equal(
-                                `concat("firstName",' ',"lastName")`,
-                            )
-                        } finally {
-                            await queryRunner.release()
-                        }
-                    }),
-                ))
-
-            it("should change generated column and revert change", () =>
-                Promise.all(
-                    dataSources.map(async (dataSource) => {
-                        const queryRunner = dataSource.createQueryRunner()
-                        try {
-                            let table = await queryRunner.getTable("post")
-
-                            let storedFullName =
-                                table!.findColumnByName("storedFullName")
-                            const changedStoredFullName =
-                                storedFullName!.clone()
-                            changedStoredFullName.asExpression = `concat('Mr. ',"firstName",' ',"lastName")`
-
-                            let name = table!.findColumnByName("name")
-                            const changedName = name!.clone()
-
-                            changedName.generatedType = undefined
-                            changedName.asExpression = undefined
-
-                            await queryRunner.changeColumns(table!, [
-                                {
-                                    oldColumn: storedFullName!,
-                                    newColumn: changedStoredFullName,
-                                },
-                                { oldColumn: name!, newColumn: changedName },
-                            ])
-
-                            table = await queryRunner.getTable("post")
-
-                            storedFullName =
-                                table!.findColumnByName("storedFullName")
-                            expect(storedFullName!.asExpression).to.be.equal(
-                                `concat('Mr. ',"firstName",' ',"lastName")`,
-                            )
-
-                            name = table!.findColumnByName("name")
-                            expect(name!.generatedType).to.be.undefined
-                            expect(name!.asExpression).to.be.undefined
-
-                            // check if generated column records removed from typeorm_metadata table
-                            const metadataRecords = await queryRunner.query(
-                                `SELECT * FROM "${schema ?? "dbo"}"."typeorm_metadata" WHERE "table" = 'post' AND "name" = 'name' AND "schema" = '${schema ?? "dbo"}'`,
-                            )
-                            metadataRecords.length.should.be.equal(0)
-
-                            // revert changes
-                            await queryRunner.executeMemoryDownSql()
-
-                            table = await queryRunner.getTable("post")
-
-                            storedFullName =
-                                table!.findColumnByName("storedFullName")!
-                            expect(storedFullName.asExpression).to.be.equal(
-                                `CONCAT("firstName",' ',"lastName")`,
-                            )
-
-                            name = table!.findColumnByName("name")!
-                            expect(name.generatedType).to.be.equal("STORED")
-                            expect(name.asExpression).to.be.equal(
-                                `"firstName" + ' ' + "lastName"`,
-                            )
-                        } finally {
-                            await queryRunner.release()
-                        }
-                    }),
-                ))
-            it("should rename generated column metadata row and revert rename", () =>
-                Promise.all(
-                    dataSources.map(async (dataSource) => {
-                        const queryRunner = dataSource.createQueryRunner()
-                        try {
-                            let table = await queryRunner.getTable("post")
-                            if (table)
-                                await queryRunner.renameColumn(
-                                    table,
-                                    "storedFullName",
-                                    "storedFullNameRenamed",
-                                )
-
-                            table = await queryRunner.getTable("post")
-
-                            const oldColumn =
-                                table!.findColumnByName("storedFullName")
-                            expect(oldColumn).to.be.undefined
-
-                            const renamedColumn = table!.findColumnByName(
-                                "storedFullNameRenamed",
-                            )
-                            expect(renamedColumn!.asExpression).to.be.equal(
-                                `CONCAT("firstName",' ',"lastName")`,
-                            )
-
-                            const oldMetadataRecords = await queryRunner.query(
-                                `SELECT * FROM "${schema ?? "dbo"}"."typeorm_metadata" WHERE "table" = 'post' AND "name" = 'storedFullName' AND "schema" = '${schema ?? "dbo"}'`,
-                            )
-                            oldMetadataRecords.length.should.be.equal(0)
-
-                            const renamedMetadataRecords =
-                                await queryRunner.query(
-                                    `SELECT * FROM "${schema ?? "dbo"}"."typeorm_metadata" WHERE "table" = 'post' AND "name" = 'storedFullNameRenamed' AND "schema" = '${schema ?? "dbo"}'`,
-                                )
-                            renamedMetadataRecords.length.should.be.equal(1)
-
-                            // revert changes
-                            await queryRunner.executeMemoryDownSql()
-
-                            table = await queryRunner.getTable("post")
-
-                            const revertedColumn =
-                                table!.findColumnByName("storedFullName")
-                            expect(revertedColumn!.asExpression).to.be.equal(
-                                `CONCAT("firstName",' ',"lastName")`,
-                            )
-                            expect(
-                                table!.findColumnByName(
-                                    "storedFullNameRenamed",
-                                ),
-                            ).to.be.undefined
-
-                            const revertedMetadataRecords =
-                                await queryRunner.query(
-                                    `SELECT * FROM "${schema ?? "dbo"}"."typeorm_metadata" WHERE "table" = 'post' AND "name" = 'storedFullName' AND "schema" = '${schema ?? "dbo"}'`,
-                                )
-                            revertedMetadataRecords.length.should.be.equal(1)
-
-                            const revertedRenamedMetadataRecords =
-                                await queryRunner.query(
-                                    `SELECT * FROM "${schema ?? "dbo"}"."typeorm_metadata" WHERE "table" = 'post' AND "name" = 'storedFullNameRenamed' AND "schema" = '${schema ?? "dbo"}'`,
-                                )
-                            revertedRenamedMetadataRecords.length.should.be.equal(
-                                0,
-                            )
-                        } finally {
-                            await queryRunner.release()
-                        }
-                    }),
-                ))
-
-            it("should rename table with generated columns and revert rename", () =>
-                Promise.all(
-                    dataSources.map(async (dataSource) => {
-                        const queryRunner = dataSource.createQueryRunner()
-                        try {
-                            let table = await queryRunner.getTable("post")
-                            await queryRunner.renameTable(table!, "postRenamed")
-
-                            table = await queryRunner.getTable("postRenamed")
-
-                            const storedFullName =
-                                table!.findColumnByName("storedFullName")
-                            expect(storedFullName!.asExpression).to.be.equal(
-                                `CONCAT("firstName",' ',"lastName")`,
-                            )
-
-                            const name = table!.findColumnByName("name")
-                            expect(name!.asExpression).to.be.equal(
-                                `"firstName" + ' ' + "lastName"`,
-                            )
-
-                            // check if generated column records exist in typeorm_metadata table with new table name
-                            const metadataRecords = await queryRunner.query(
-                                `SELECT * FROM "${schema ?? "dbo"}"."typeorm_metadata" WHERE "table" = 'postRenamed' AND "name" IN ('storedFullName', 'name') AND "schema" = '${schema ?? "dbo"}'`,
-                            )
-                            expect(metadataRecords.length).to.be.equal(2)
-
-                            // revert changes
-                            await queryRunner.executeMemoryDownSql()
-
-                            table = await queryRunner.getTable("post")
-
-                            const revertedFullName =
-                                table!.findColumnByName("storedFullName")
-                            expect(revertedFullName!.asExpression).to.be.equal(
-                                `CONCAT("firstName",' ',"lastName")`,
-                            )
-
-                            const revertedName = table!.findColumnByName("name")
-                            expect(revertedName!.asExpression).to.be.equal(
-                                `"firstName" + ' ' + "lastName"`,
-                            )
-
-                            // check if generated column records exist in typeorm_metadata table with old table name
-                            const revertedMetadataRecords =
-                                await queryRunner.query(
-                                    `SELECT * FROM "${schema ?? "dbo"}"."typeorm_metadata" WHERE "table" = 'post' AND "name" IN ('storedFullName', 'name') AND "schema" = '${schema ?? "dbo"}'`,
-                                )
-                            expect(revertedMetadataRecords.length).to.be.equal(
-                                2,
-                            )
-                        } finally {
-                            await queryRunner.release()
-                        }
-                    }),
-                ))
-
-            it("should remove data from 'typeorm_metadata' when table dropped", () =>
-                Promise.all(
-                    dataSources.map(async (dataSource) => {
-                        const queryRunner = dataSource.createQueryRunner()
-                        try {
-                            const table = await queryRunner.getTable("post")
-                            const generatedColumns = table!.columns.filter(
-                                (it) => it.generatedType,
-                            )
-
-                            await queryRunner.dropTable(table!)
-
-                            // check if generated column records removed from typeorm_metadata table
-                            let metadataRecords = await queryRunner.query(
-                                `SELECT * FROM "${schema ?? "dbo"}"."typeorm_metadata" WHERE "table" = 'post' AND "schema" = '${schema ?? "dbo"}'`,
-                            )
-                            expect(metadataRecords.length).to.be.equal(0)
-
-                            // revert changes
-                            await queryRunner.executeMemoryDownSql()
-
-                            metadataRecords = await queryRunner.query(
-                                `SELECT * FROM "${schema ?? "dbo"}"."typeorm_metadata" WHERE "table" = 'post' AND "schema" = '${schema ?? "dbo"}'`,
-                            )
-                            expect(metadataRecords.length).to.be.equal(
-                                generatedColumns.length,
-                            )
-                        } finally {
-                            await queryRunner.release()
-                        }
-                    }),
-                ))
+    let dataSources: DataSource[]
+    before(async () => {
+        dataSources = await createTestingConnections({
+            entities: [__dirname + "/entity/*{.js,.ts}"],
+            enabledDrivers: ["mssql"],
+            schemaCreate: true,
+            dropSchema: true,
         })
-    }
+    })
+    beforeEach(() => reloadTestingDatabases(dataSources))
+    after(() => closeTestingConnections(dataSources))
+
+    it("should not generate queries when no model changes", () =>
+        Promise.all(
+            dataSources.map(async (dataSource) => {
+                const sqlInMemory = await dataSource.driver
+                    .createSchemaBuilder()
+                    .log()
+
+                sqlInMemory.upQueries.length.should.be.equal(0)
+                sqlInMemory.downQueries.length.should.be.equal(0)
+            }),
+        ))
+
+    it("should create table with generated columns", () =>
+        Promise.all(
+            dataSources.map(async (dataSource) => {
+                await using queryRunner = dataSource.createQueryRunner()
+                const table = await queryRunner.getTable("post")
+                const virtualFullName =
+                    table!.findColumnByName("virtualFullName")!
+                const storedFullName =
+                    table!.findColumnByName("storedFullName")!
+                const name = table!.findColumnByName("name")!
+                const nameHash = table!.findColumnByName("nameHash")!
+
+                virtualFullName.asExpression!.should.be.equal(
+                    `concat("firstName",' ',"lastName")`,
+                )
+                virtualFullName.generatedType!.should.be.equal("VIRTUAL")
+                storedFullName.asExpression!.should.be.equal(
+                    `CONCAT("firstName",' ',"lastName")`,
+                )
+                storedFullName.generatedType!.should.be.equal("STORED")
+
+                name.generatedType!.should.be.equal("STORED")
+                name.asExpression!.should.be.equal(
+                    `"firstName" + ' ' + "lastName"`,
+                )
+
+                nameHash.generatedType!.should.be.equal("VIRTUAL")
+                nameHash.asExpression!.should.be.equal(
+                    `HashBytes('MD5',coalesce("firstName",'0'))`,
+                )
+            }),
+        ))
+
+    it("should add generated column and revert add", () =>
+        Promise.all(
+            dataSources.map(async (dataSource) => {
+                await using queryRunner = dataSource.createQueryRunner()
+
+                let table = await queryRunner.getTable("post")
+
+                let storedColumn = new TableColumn({
+                    name: "storedColumn",
+                    type: "varchar",
+                    length: "200",
+                    generatedType: "STORED",
+                    asExpression: `"firstName" + ' ' + "lastName"`,
+                })
+
+                let virtualColumn = new TableColumn({
+                    name: "virtualColumn",
+                    type: "varchar",
+                    length: "200",
+                    generatedType: "VIRTUAL",
+                    asExpression: `"firstName" + ' ' + "lastName"`,
+                })
+
+                await queryRunner.addColumn(table!, storedColumn)
+                await queryRunner.addColumn(table!, virtualColumn)
+
+                table = await queryRunner.getTable("post")
+
+                storedColumn = table!.findColumnByName("storedColumn")!
+                storedColumn.should.be.exist
+                storedColumn!.generatedType!.should.be.equal("STORED")
+                storedColumn!.asExpression!.should.be.equal(
+                    `"firstName" + ' ' + "lastName"`,
+                )
+
+                virtualColumn = table!.findColumnByName("virtualColumn")!
+                virtualColumn.should.be.exist
+                virtualColumn!.generatedType!.should.be.equal("VIRTUAL")
+                virtualColumn!.asExpression!.should.be.equal(
+                    `"firstName" + ' ' + "lastName"`,
+                )
+
+                // revert changes
+                await queryRunner.executeMemoryDownSql()
+
+                table = await queryRunner.getTable("post")
+                expect(table!.findColumnByName("storedColumn")).to.be.undefined
+                expect(table!.findColumnByName("virtualColumn")).to.be.undefined
+
+                // check if generated column records removed from typeorm_metadata table
+                const metadataRecords = await queryRunner.query(
+                    `SELECT * FROM "typeorm_metadata" WHERE "table" = 'post' AND "name" IN ('storedColumn', 'virtualColumn')`,
+                )
+                metadataRecords.length.should.be.equal(0)
+            }),
+        ))
+
+    it("should drop generated column and revert drop", () =>
+        Promise.all(
+            dataSources.map(async (dataSource) => {
+                await using queryRunner = dataSource.createQueryRunner()
+
+                let table = await queryRunner.getTable("post")
+                await queryRunner.dropColumn(table!, "storedFullName")
+                await queryRunner.dropColumn(table!, "virtualFullName")
+
+                table = await queryRunner.getTable("post")
+                expect(table!.findColumnByName("storedFullName")).to.be
+                    .undefined
+                expect(table!.findColumnByName("virtualFullName")).to.be
+                    .undefined
+
+                // check if generated column records removed from typeorm_metadata table
+                const metadataRecords = await queryRunner.query(
+                    `SELECT * FROM "typeorm_metadata" WHERE "table" = 'post' AND "name" IN ('storedFullName', 'virtualFullName')`,
+                )
+                metadataRecords.length.should.be.equal(0)
+
+                // revert changes
+                await queryRunner.executeMemoryDownSql()
+
+                table = await queryRunner.getTable("post")
+
+                const storedFullName =
+                    table!.findColumnByName("storedFullName")!
+                storedFullName.should.be.exist
+                storedFullName!.generatedType!.should.be.equal("STORED")
+                storedFullName!.asExpression!.should.be.equal(
+                    `CONCAT("firstName",' ',"lastName")`,
+                )
+
+                const virtualFullName =
+                    table!.findColumnByName("virtualFullName")!
+                virtualFullName.should.be.exist
+                virtualFullName!.generatedType!.should.be.equal("VIRTUAL")
+                virtualFullName!.asExpression!.should.be.equal(
+                    `concat("firstName",' ',"lastName")`,
+                )
+            }),
+        ))
+
+    it("should change generated column and revert change", () =>
+        Promise.all(
+            dataSources.map(async (dataSource) => {
+                await using queryRunner = dataSource.createQueryRunner()
+
+                let table = await queryRunner.getTable("post")
+
+                let storedFullName = table!.findColumnByName("storedFullName")!
+                const changedStoredFullName = storedFullName.clone()
+                changedStoredFullName.asExpression = `concat('Mr. ',"firstName",' ',"lastName")`
+
+                let name = table!.findColumnByName("name")!
+                const changedName = name.clone()
+                changedName.generatedType = undefined
+                changedName.asExpression = undefined
+
+                await queryRunner.changeColumns(table!, [
+                    {
+                        oldColumn: storedFullName,
+                        newColumn: changedStoredFullName,
+                    },
+                    { oldColumn: name, newColumn: changedName },
+                ])
+
+                table = await queryRunner.getTable("post")
+
+                storedFullName = table!.findColumnByName("storedFullName")!
+                storedFullName!.asExpression!.should.be.equal(
+                    `concat('Mr. ',"firstName",' ',"lastName")`,
+                )
+
+                name = table!.findColumnByName("name")!
+                expect(name!.generatedType).to.be.undefined
+                expect(name!.asExpression).to.be.undefined
+
+                // check if generated column records removed from typeorm_metadata table
+                const metadataRecords = await queryRunner.query(
+                    `SELECT * FROM "typeorm_metadata" WHERE "table" = 'post' AND "name" = 'name'`,
+                )
+                metadataRecords.length.should.be.equal(0)
+
+                // revert changes
+                await queryRunner.executeMemoryDownSql()
+
+                table = await queryRunner.getTable("post")
+
+                storedFullName = table!.findColumnByName("storedFullName")!
+                storedFullName!.asExpression!.should.be.equal(
+                    `CONCAT("firstName",' ',"lastName")`,
+                )
+
+                name = table!.findColumnByName("name")!
+                name.generatedType!.should.be.equal("STORED")
+                name.asExpression!.should.be.equal(
+                    `"firstName" + ' ' + "lastName"`,
+                )
+            }),
+        ))
+
+    it("should rename generated column metadata row and revert rename", () =>
+        Promise.all(
+            dataSources.map(async (dataSource) => {
+                await using queryRunner = dataSource.createQueryRunner()
+
+                let table = await queryRunner.getTable("post")
+                await queryRunner.renameColumn(
+                    table!,
+                    "storedFullName",
+                    "storedFullNameRenamed",
+                )
+
+                table = await queryRunner.getTable("post")
+
+                const oldColumn = table!.findColumnByName("storedFullName")
+                expect(oldColumn).to.be.undefined
+
+                const renamedColumn = table!.findColumnByName(
+                    "storedFullNameRenamed",
+                )
+                expect(renamedColumn!.asExpression).to.be.equal(
+                    `CONCAT("firstName",' ',"lastName")`,
+                )
+
+                const oldMetadataRecords = await queryRunner.query(
+                    `SELECT * FROM "typeorm_metadata" WHERE "table" = 'post' AND "name" = 'storedFullName'`,
+                )
+                oldMetadataRecords.length.should.be.equal(0)
+
+                const renamedMetadataRecords = await queryRunner.query(
+                    `SELECT * FROM "typeorm_metadata" WHERE "table" = 'post' AND "name" = 'storedFullNameRenamed'`,
+                )
+                renamedMetadataRecords.length.should.be.equal(1)
+
+                // revert changes
+                await queryRunner.executeMemoryDownSql()
+
+                table = await queryRunner.getTable("post")
+
+                const revertedColumn = table!.findColumnByName("storedFullName")
+                expect(revertedColumn!.asExpression).to.be.equal(
+                    `CONCAT("firstName",' ',"lastName")`,
+                )
+                expect(table!.findColumnByName("storedFullNameRenamed")).to.be
+                    .undefined
+
+                const revertedMetadataRecords = await queryRunner.query(
+                    `SELECT * FROM "typeorm_metadata" WHERE "table" = 'post' AND "name" = 'storedFullName'`,
+                )
+                revertedMetadataRecords.length.should.be.equal(1)
+
+                const revertedRenamedMetadataRecords = await queryRunner.query(
+                    `SELECT * FROM "typeorm_metadata" WHERE "table" = 'post' AND "name" = 'storedFullNameRenamed'`,
+                )
+                revertedRenamedMetadataRecords.length.should.be.equal(0)
+            }),
+        ))
+
+    it("should rename table with generated columns and revert rename", () =>
+        Promise.all(
+            dataSources.map(async (dataSource) => {
+                await using queryRunner = dataSource.createQueryRunner()
+
+                let table = await queryRunner.getTable("post")
+                await queryRunner.renameTable(table!, "postRenamed")
+
+                table = await queryRunner.getTable("postRenamed")
+
+                const storedFullName = table!.findColumnByName("storedFullName")
+                expect(storedFullName!.asExpression).to.be.equal(
+                    `CONCAT("firstName",' ',"lastName")`,
+                )
+
+                const name = table!.findColumnByName("name")
+                expect(name!.asExpression).to.be.equal(
+                    `"firstName" + ' ' + "lastName"`,
+                )
+
+                // check if generated column records exist in typeorm_metadata table with new table name
+                const metadataRecords = await queryRunner.query(
+                    `SELECT * FROM "typeorm_metadata" WHERE "table" = 'postRenamed' AND "name" IN ('storedFullName', 'name')`,
+                )
+                expect(metadataRecords.length).to.be.equal(2)
+
+                // revert changes
+                await queryRunner.executeMemoryDownSql()
+
+                table = await queryRunner.getTable("post")
+
+                const revertedFullName =
+                    table!.findColumnByName("storedFullName")
+                expect(revertedFullName!.asExpression).to.be.equal(
+                    `CONCAT("firstName",' ',"lastName")`,
+                )
+
+                const revertedName = table!.findColumnByName("name")
+                expect(revertedName!.asExpression).to.be.equal(
+                    `"firstName" + ' ' + "lastName"`,
+                )
+
+                // check if generated column records exist in typeorm_metadata table with old table name
+                const revertedMetadataRecords = await queryRunner.query(
+                    `SELECT * FROM "typeorm_metadata" WHERE "table" = 'post' AND "name" IN ('storedFullName', 'name')`,
+                )
+                expect(revertedMetadataRecords.length).to.be.equal(2)
+            }),
+        ))
+
+    it("should remove data from 'typeorm_metadata' when table dropped", () =>
+        Promise.all(
+            dataSources.map(async (dataSource) => {
+                await using queryRunner = dataSource.createQueryRunner()
+                const table = await queryRunner.getTable("post")
+                const generatedColumns = table!.columns.filter(
+                    (it) => it.generatedType,
+                )
+
+                await queryRunner.dropTable(table!)
+
+                // check if generated column records removed from typeorm_metadata table
+                let metadataRecords = await queryRunner.query(
+                    `SELECT * FROM "typeorm_metadata" WHERE "table" = 'post'`,
+                )
+                metadataRecords.length.should.be.equal(0)
+
+                // revert changes
+                await queryRunner.executeMemoryDownSql()
+
+                metadataRecords = await queryRunner.query(
+                    `SELECT * FROM "typeorm_metadata" WHERE "table" = 'post'`,
+                )
+                metadataRecords.length.should.be.equal(generatedColumns.length)
+            }),
+        ))
 })


### PR DESCRIPTION
### Description of change
- Updates `typeorm_metadata` if the table is renamed, keeping the metadata table in sync.
- `DROP+ADD` a column on column rename if the column is a generated column with an expression instead of `ALTER`.
  **Why:** SQL Server driver throws error: `Error: Cannot alter column 'someColumn' because it is 'COMPUTED'.`

### Pull-Request Checklist

- [x] Code is up-to-date with the `master` branch
- [ ] This pull request links relevant issues as `Fixes #00000`
- [x] There are new or updated tests validating the change (`tests/**.test.ts`)
- [ ] Documentation has been updated to reflect this change (`docs/docs/**.md`) (N/A)