### PR TITLE
fix: sanitize generated migration class names

### DIFF
--- a/src/commands/CommandUtils.ts
+++ b/src/commands/CommandUtils.ts
@@ -4,6 +4,7 @@ import { TypeORMError } from "../error"
 import type { DataSource } from "../data-source"
 import { InstanceChecker } from "../util/InstanceChecker"
 import { importOrRequireFile } from "../util/ImportUtils"
+import { camelCase } from "../util/StringUtils"
 
 /**
  * Command line utils functions.
@@ -123,5 +124,22 @@ export class CommandUtils {
         return timestampOptionArgument
             ? new Date(Number(timestampOptionArgument)).getTime()
             : Date.now()
+    }
+
+    static getMigrationClassName(name: string, timestamp: number): string {
+        const identifierName = camelCase(
+            name.replaceAll(/[^\p{ID_Continue}$\u200C\u200D]+/gu, " "),
+            true,
+        ).replaceAll(/[^\p{ID_Continue}$\u200C\u200D]+/gu, "")
+
+        if (!identifierName) {
+            return `Migration${timestamp}`
+        }
+
+        if (/^[\p{ID_Start}$_]/u.test(identifierName)) {
+            return `${identifierName}${timestamp}`
+        }
+
+        return `Migration${identifierName}${timestamp}`
     }
 }

--- a/src/commands/MigrationCreateCommand.ts
+++ b/src/commands/MigrationCreateCommand.ts
@@ -2,7 +2,6 @@ import ansi from "ansis"
 import path from "path"
 import type yargs from "yargs"
 import { PlatformTools } from "../platform/PlatformTools"
-import { camelCase } from "../util/StringUtils"
 import { CommandUtils } from "./CommandUtils"
 
 /**
@@ -83,12 +82,14 @@ export class MigrationCreateCommand implements yargs.CommandModule {
      * @param timestamp
      */
     protected static getTemplate(name: string, timestamp: number): string {
+        const migrationName = CommandUtils.getMigrationClassName(
+            name,
+            timestamp,
+        )
+
         return `import { MigrationInterface, QueryRunner } from "typeorm";
 
-export class ${camelCase(
-            name,
-            true,
-        )}${timestamp} implements MigrationInterface {
+export class ${migrationName} implements MigrationInterface {
 
     public async up(queryRunner: QueryRunner): Promise<void> {
     }
@@ -111,6 +112,10 @@ export class ${camelCase(
         timestamp: number,
         esm: boolean,
     ): string {
+        const migrationName = CommandUtils.getMigrationClassName(
+            name,
+            timestamp,
+        )
         const exportMethod = esm ? "export" : "module.exports ="
         return `/**
  * @typedef {import('typeorm').MigrationInterface} MigrationInterface
@@ -121,7 +126,7 @@ export class ${camelCase(
  * @class
  * @implements {MigrationInterface}
  */
-${exportMethod} class ${camelCase(name, true)}${timestamp} {
+${exportMethod} class ${migrationName} {
 
     /**
      * @param {QueryRunner} queryRunner

--- a/src/commands/MigrationGenerateCommand.ts
+++ b/src/commands/MigrationGenerateCommand.ts
@@ -5,7 +5,6 @@ import process from "process"
 import type yargs from "yargs"
 import type { DataSource } from "../data-source"
 import { PlatformTools } from "../platform/PlatformTools"
-import { camelCase } from "../util/StringUtils"
 import { CommandUtils } from "./CommandUtils"
 
 /**
@@ -238,7 +237,10 @@ export class MigrationGenerateCommand implements yargs.CommandModule {
         upSqls: string[],
         downSqls: string[],
     ): string {
-        const migrationName = `${camelCase(name, true)}${timestamp}`
+        const migrationName = CommandUtils.getMigrationClassName(
+            name,
+            timestamp,
+        )
 
         return `import { MigrationInterface, QueryRunner } from "typeorm";
 
@@ -274,7 +276,10 @@ ${downSqls.join(`
         downSqls: string[],
         esm: boolean,
     ): string {
-        const migrationName = `${camelCase(name, true)}${timestamp}`
+        const migrationName = CommandUtils.getMigrationClassName(
+            name,
+            timestamp,
+        )
 
         const exportMethod = esm ? "export" : "module.exports ="
 

--- a/test/github-issues/12415/issue-12415.test.ts
+++ b/test/github-issues/12415/issue-12415.test.ts
@@ -1,0 +1,51 @@
+import { expect } from "chai"
+import { MigrationCreateCommand } from "../../../src/commands/MigrationCreateCommand"
+import { MigrationGenerateCommand } from "../../../src/commands/MigrationGenerateCommand"
+
+class TestableMigrationGenerateCommand extends MigrationGenerateCommand {
+    static getTypeScriptTemplate(name: string, timestamp: number): string {
+        return super.getTemplate(name, timestamp, [], [])
+    }
+
+    static getJavaScriptTemplate(name: string, timestamp: number): string {
+        return super.getJavascriptTemplate(name, timestamp, [], [], false)
+    }
+}
+
+class TestableMigrationCreateCommand extends MigrationCreateCommand {
+    static getTypeScriptTemplate(name: string, timestamp: number): string {
+        return super.getTemplate(name, timestamp)
+    }
+}
+
+describe("github issues > #12415 migration class names", () => {
+    it("generates valid migration class names from filenames with invalid identifier characters", () => {
+        const timestamp = 1610975184784
+        const typeScriptTemplate =
+            TestableMigrationGenerateCommand.getTypeScriptTemplate(
+                "refresh#2",
+                timestamp,
+            )
+        const javaScriptTemplate =
+            TestableMigrationGenerateCommand.getJavaScriptTemplate(
+                "refresh#2",
+                timestamp,
+            )
+
+        for (const template of [typeScriptTemplate, javaScriptTemplate]) {
+            expect(template).to.contain(`class Refresh2${timestamp}`)
+            expect(template).to.contain(`name = 'Refresh2${timestamp}'`)
+            expect(template).not.to.contain(`Refresh#2${timestamp}`)
+        }
+    })
+
+    it("prefixes migration class names that do not start with an identifier character", () => {
+        const timestamp = 1610975184784
+        const template = TestableMigrationCreateCommand.getTypeScriptTemplate(
+            "2-refresh",
+            timestamp,
+        )
+
+        expect(template).to.contain(`class Migration2Refresh${timestamp}`)
+    })
+})


### PR DESCRIPTION
### Description of change

Sanitizes generated migration class names so filenames containing characters that are not valid TypeScript identifier characters (for example `refresh#2`) no longer produce invalid migration classes.

The fallback also handles names that start with a non-identifier character by prefixing `Migration`.

Fixes #12415

### Pull-Request Checklist

- [x] Code is up-to-date with the `master` branch
- [x] `npm run lint` passes with this change
- [x] `npm test` passes with this change
- [x] This pull request links relevant issues as `Fixes #12415`
- [x] There are new or updated unit tests validating the change

### Testing

- `pnpm install --frozen-lockfile`
- `pnpm run compile`
- `pnpm exec tsc --noEmit --pretty false`
- `pnpm exec mocha --no-config --require ts-node/register test/github-issues/12415/issue-12415.test.ts`
- `pnpm exec prettier --check src/commands/CommandUtils.ts src/commands/MigrationCreateCommand.ts src/commands/MigrationGenerateCommand.ts test/github-issues/12415/issue-12415.test.ts`
- `pnpm exec eslint src/commands/CommandUtils.ts src/commands/MigrationCreateCommand.ts src/commands/MigrationGenerateCommand.ts test/github-issues/12415/issue-12415.test.ts`
