### PR TITLE
fix(postgres): avoid drop and recreate for length-only column changes

### DIFF
--- a/src/driver/postgres/PostgresQueryRunner.ts
+++ b/src/driver/postgres/PostgresQueryRunner.ts
@@ -1328,7 +1328,6 @@ export class PostgresQueryRunner
 
         if (
             oldColumn.type !== newColumn.type ||
-            oldColumn.length !== newColumn.length ||
             newColumn.isArray !== oldColumn.isArray ||
             (!oldColumn.generatedType &&
                 newColumn.generatedType === "STORED") ||
@@ -1619,6 +1618,7 @@ export class PostgresQueryRunner
             }
 
             if (
+                newColumn.length !== oldColumn.length ||
                 newColumn.precision !== oldColumn.precision ||
                 newColumn.scale !== oldColumn.scale
             ) {
@@ -2348,9 +2348,9 @@ export class PostgresQueryRunner
                     new Query(
                         `ALTER TABLE ${this.escapePath(table)} ALTER COLUMN "${
                             newColumn.name
-                        }" TYPE ${newColumn.type} COLLATE "${
-                            newColumn.collation
-                        }"`,
+                        }" TYPE ${this.driver.createFullType(
+                            newColumn,
+                        )} COLLATE "${newColumn.collation}"`,
                     ),
                 )
 
@@ -2362,7 +2362,9 @@ export class PostgresQueryRunner
                     new Query(
                         `ALTER TABLE ${this.escapePath(table)} ALTER COLUMN "${
                             newColumn.name
-                        }" TYPE ${newColumn.type} COLLATE ${oldCollation}`,
+                        }" TYPE ${this.driver.createFullType(
+                            oldColumn,
+                        )} COLLATE ${oldCollation}`,
                     ),
                 )
             }

--- a/test/github-issues/3357/entity/Post.ts
+++ b/test/github-issues/3357/entity/Post.ts
@@ -1,0 +1,12 @@
+import { Column, Entity, PrimaryGeneratedColumn } from "../../../../src"
+
+@Entity()
+export class Post {
+    @PrimaryGeneratedColumn()
+    id: number
+
+    @Column("character varying", {
+        length: 50,
+    })
+    name: string
+}

--- a/test/github-issues/3357/issue-3357.test.ts
+++ b/test/github-issues/3357/issue-3357.test.ts
@@ -1,0 +1,73 @@
+import "reflect-metadata"
+import { expect } from "chai"
+import type { DataSource } from "../../../src"
+import {
+    closeTestingConnections,
+    createTestingConnections,
+} from "../../utils/test-utils"
+import { Post } from "./entity/Post"
+
+describe("github issues > #3357 postgres migration generation should not drop columns on varchar length changes", () => {
+    let dataSources: DataSource[]
+
+    before(async () => {
+        dataSources = await createTestingConnections({
+            entities: [Post],
+            enabledDrivers: ["postgres"],
+            schemaCreate: true,
+            dropSchema: true,
+        })
+    })
+    after(() => closeTestingConnections(dataSources))
+
+    it("should alter the column type when only varchar length changes", () =>
+        Promise.all(
+            dataSources.map(async (dataSource) => {
+                const postMetadata = dataSource.getMetadata(Post)
+                postMetadata.findColumnWithPropertyName("name")!.length = "100"
+
+                const sqlInMemory = await dataSource.driver
+                    .createSchemaBuilder()
+                    .log()
+                const upQueries = sqlInMemory.upQueries
+                    .map((query) => query.query)
+                    .join("\n")
+
+                expect(upQueries).to.contain(
+                    'ALTER TABLE "post" ALTER COLUMN "name" TYPE character varying(100)',
+                )
+                expect(upQueries).not.to.contain("DROP COLUMN")
+                expect(upQueries).not.to.contain("ADD COLUMN")
+            }),
+        ))
+
+    it("should keep the length modifier when varchar length and collation change", () =>
+        Promise.all(
+            dataSources.map(async (dataSource) => {
+                const postMetadata = dataSource.getMetadata(Post)
+                const nameColumn =
+                    postMetadata.findColumnWithPropertyName("name")!
+                nameColumn.length = "100"
+                nameColumn.collation = "C"
+
+                const sqlInMemory = await dataSource.driver
+                    .createSchemaBuilder()
+                    .log()
+                const upQueries = sqlInMemory.upQueries
+                    .map((query) => query.query)
+                    .join("\n")
+
+                expect(upQueries).to.contain(
+                    'ALTER TABLE "post" ALTER COLUMN "name" TYPE character varying(100)',
+                )
+                expect(upQueries).to.contain(
+                    'ALTER TABLE "post" ALTER COLUMN "name" TYPE character varying(100) COLLATE "C"',
+                )
+                expect(upQueries).not.to.contain(
+                    'TYPE character varying COLLATE "C"',
+                )
+                expect(upQueries).not.to.contain("DROP COLUMN")
+                expect(upQueries).not.to.contain("ADD COLUMN")
+            }),
+        ))
+})


### PR DESCRIPTION
### Summary

This PR fixes PostgreSQL schema/migration generation for length-only column changes.

Previously, `PostgresQueryRunner.changeColumn` treated `oldColumn.length !== newColumn.length` as a destructive change and routed it through:

```ts
await this.dropColumn(table, oldColumn)
await this.addColumn(table, newColumn)
```

For PostgreSQL `character varying(50)` -> `character varying(100)`, that can generate data-loss-prone migration SQL. The patch keeps type/array/stored-generated changes on the recreate path, but routes length-only changes through the existing:

```sql
ALTER TABLE ... ALTER COLUMN ... TYPE ...
```

branch.

### Changed files

```text
src/driver/postgres/PostgresQueryRunner.ts
test/github-issues/3357/entity/Post.ts
test/github-issues/3357/issue-3357.test.ts
```

### Tests

```text
pnpm run typecheck
pnpm run compile
pnpm run test:fast -- --grep "github issues > #3357"
pnpm run test:fast -- --grep "database schema > column length > postgres"
```

Results:

```text
typecheck: passed
compile: passed
github issues > #3357: 1 passing
database schema > column length > postgres: 2 passing
```

### Notes

The broader `schema builder > change column` suite was also sampled. Its length-related tests passed, but later unrelated UUID tests failed in the local portable PostgreSQL environment because that build does not provide `uuid-ossp`.

Closes #3357.
