### PR TITLE
fix: expand virtual columns in where clauses

### DIFF
--- a/src/query-builder/QueryBuilder.ts
+++ b/src/query-builder/QueryBuilder.ts
@@ -724,7 +724,11 @@ export abstract class QueryBuilder<Entity extends ObjectLiteral> {
      * @param statement
      */
     protected replacePropertyNamesForTheWholeQuery(statement: string) {
-        const replacements: { [key: string]: { [key: string]: string } } = {}
+        const replacements: {
+            [key: string]: {
+                [key: string]: { expression: string; isVirtual?: boolean }
+            }
+        } = {}
 
         for (const alias of this.expressionMap.aliases) {
             if (!alias.hasMetadata) continue
@@ -735,6 +739,33 @@ export abstract class QueryBuilder<Entity extends ObjectLiteral> {
 
             if (!replacements[replaceAliasNamePrefix]) {
                 replacements[replaceAliasNamePrefix] = {}
+            }
+
+            const columnReplacements = new Map<
+                ColumnMetadata,
+                { expression: string; isVirtual?: boolean }
+            >()
+            const buildColumnReplacement = (column: ColumnMetadata) => {
+                const replacement = columnReplacements.get(column)
+                if (replacement) {
+                    return replacement
+                }
+
+                let columnReplacement: {
+                    expression: string
+                    isVirtual?: boolean
+                }
+                if (column.isVirtualProperty && column.query) {
+                    columnReplacement = {
+                        expression: `(${column.query(this.escape(alias.name))})`,
+                        isVirtual: true,
+                    }
+                } else {
+                    columnReplacement = { expression: column.databaseName }
+                }
+
+                columnReplacements.set(column, columnReplacement)
+                return columnReplacement
             }
 
             // Insert & overwrite the replacements from least to most relevant in our replacements object.
@@ -750,7 +781,7 @@ export abstract class QueryBuilder<Entity extends ObjectLiteral> {
                 if (relation.joinColumns.length > 0)
                     replacements[replaceAliasNamePrefix][
                         relation.propertyPath
-                    ] = relation.joinColumns[0].databaseName
+                    ] = { expression: relation.joinColumns[0].databaseName }
             }
 
             for (const relation of alias.metadata.relations) {
@@ -762,24 +793,25 @@ export abstract class QueryBuilder<Entity extends ObjectLiteral> {
                     const propertyKey = `${relation.propertyPath}.${
                         joinColumn.referencedColumn!.propertyPath
                     }`
-                    replacements[replaceAliasNamePrefix][propertyKey] =
-                        joinColumn.databaseName
+                    replacements[replaceAliasNamePrefix][propertyKey] = {
+                        expression: joinColumn.databaseName,
+                    }
                 }
             }
 
             for (const column of alias.metadata.columns) {
                 replacements[replaceAliasNamePrefix][column.databaseName] =
-                    column.databaseName
+                    buildColumnReplacement(column)
             }
 
             for (const column of alias.metadata.columns) {
                 replacements[replaceAliasNamePrefix][column.propertyName] =
-                    column.databaseName
+                    buildColumnReplacement(column)
             }
 
             for (const column of alias.metadata.columns) {
                 replacements[replaceAliasNamePrefix][column.propertyPath] =
-                    column.databaseName
+                    buildColumnReplacement(column)
             }
         }
 
@@ -810,18 +842,26 @@ export abstract class QueryBuilder<Entity extends ObjectLiteral> {
                         pre = matches[1]
                         p = matches[3]
 
-                        if (replacements[matches[2]][p]) {
+                        const replacement = replacements[matches[2]][p]
+                        if (replacement) {
+                            if (replacement.isVirtual) {
+                                return `${pre}${replacement.expression}`
+                            }
                             return `${pre}${this.escape(
                                 matches[2].slice(0, -1),
-                            )}.${this.escape(replacements[matches[2]][p])}`
+                            )}.${this.escape(replacement.expression)}`
                         }
                     } else {
                         match = matches[0]
                         pre = matches[1]
                         p = matches[2]
 
-                        if (replacements[""][p]) {
-                            return `${pre}${this.escape(replacements[""][p])}`
+                        const replacement = replacements[""][p]
+                        if (replacement) {
+                            if (replacement.isVirtual) {
+                                return `${pre}${replacement.expression}`
+                            }
+                            return `${pre}${this.escape(replacement.expression)}`
                         }
                     }
                     return match

--- a/test/functional/columns/virtual-columns/virtual-columns.test.ts
+++ b/test/functional/columns/virtual-columns/virtual-columns.test.ts
@@ -143,6 +143,97 @@ describe("column > virtual columns", () => {
             expect(query).to.equal(expectedQuery)
         }))
 
+    it("should expand virtual columns in string where expressions", () =>
+        dataSources.map((dataSource) => {
+            const query = dataSource
+                .createQueryBuilder(Company, "Company")
+                .select(["Company.name", "Company.totalEmployeesCount"])
+                .where("Company.totalEmployeesCount > 2")
+                .getSql()
+
+            let expectedVirtualColumn = `"Company"."totalEmployeesCount"`
+            let expectedSubQuery = `(SELECT COUNT("name") FROM "employees" WHERE "companyName" = "Company"."name") > 2`
+            if (DriverUtils.isMySQLFamily(dataSource.driver)) {
+                expectedVirtualColumn = expectedVirtualColumn.replaceAll(
+                    '"',
+                    "`",
+                )
+                expectedSubQuery = expectedSubQuery.replaceAll('"', "`")
+            }
+
+            expect(query).not.to.include(expectedVirtualColumn)
+            expect(query).to.include(expectedSubQuery)
+
+            const joinedQuery = dataSource
+                .createQueryBuilder(Company, "company")
+                .leftJoin("company.employees", "employee")
+                .leftJoin("employee.timesheets", "timesheet")
+                .where("timesheet.totalActivityHours > 0")
+                .getSql()
+
+            let expectedJoinedVirtualColumn = `"timesheet"."totalActivityHours"`
+            let expectedJoinedSubQuery = `(SELECT SUM("hours") FROM "activities" WHERE "timesheetId" = "timesheet"."id") > 0`
+            if (DriverUtils.isMySQLFamily(dataSource.driver)) {
+                expectedJoinedVirtualColumn =
+                    expectedJoinedVirtualColumn.replaceAll('"', "`")
+                expectedJoinedSubQuery = expectedJoinedSubQuery.replaceAll(
+                    '"',
+                    "`",
+                )
+            }
+
+            expect(joinedQuery).not.to.include(expectedJoinedVirtualColumn)
+            expect(joinedQuery).to.include(expectedJoinedSubQuery)
+        }))
+
+    it("should build each virtual column replacement once per alias", () =>
+        dataSources.map((dataSource) => {
+            const totalEmployeesCountMetadata = dataSource
+                .getMetadata(Company)
+                .columns.find(
+                    (columnMetadata) =>
+                        columnMetadata.propertyName === "totalEmployeesCount",
+                )!
+            const originalQuery = totalEmployeesCountMetadata.query!
+            let queryCalls = 0
+            totalEmployeesCountMetadata.query = (alias) => {
+                queryCalls += 1
+                return originalQuery(alias)
+            }
+
+            try {
+                dataSource
+                    .createQueryBuilder(Company, "Company")
+                    .select("Company.name")
+                    .where("Company.totalEmployeesCount > 2")
+                    .getSql()
+
+                expect(queryCalls).to.equal(1)
+            } finally {
+                totalEmployeesCountMetadata.query = originalQuery
+            }
+        }))
+
+    it("should expand virtual columns with dotted aliases", () =>
+        dataSources.map((dataSource) => {
+            const alias = "custom.companies"
+            const query = dataSource
+                .createQueryBuilder(Company, alias)
+                .select(`${alias}.name`)
+                .where(`${alias}.totalEmployeesCount > 2`)
+                .getSql()
+
+            let expectedSubQuery = `(SELECT COUNT("name") FROM "employees" WHERE "companyName" = "custom.companies"."name") > 2`
+            let unexpectedSplitAlias = `"custom"."companies"."name"`
+            if (DriverUtils.isMySQLFamily(dataSource.driver)) {
+                expectedSubQuery = expectedSubQuery.replaceAll('"', "`")
+                unexpectedSplitAlias = unexpectedSplitAlias.replaceAll('"', "`")
+            }
+
+            expect(query).to.include(expectedSubQuery)
+            expect(query).not.to.include(unexpectedSplitAlias)
+        }))
+
     it("should be able to save and find sub-select data in the database", () =>
         Promise.all(
             dataSources.map(async (dataSource) => {


### PR DESCRIPTION
### Description of change

Fixes #11616.

String WHERE clauses that reference a `@VirtualColumn` currently go through final property-name replacement as if the virtual column were a physical database column, producing SQL such as `"user"."fullName"`. This change preserves the existing physical-column replacement behavior while expanding virtual-column property references to the configured `query(alias)` expression.

The added coverage verifies both the main alias and a joined alias, matching the reported use case.

### Pull-Request Checklist

- [x] Code is up-to-date with the `master` branch
- [ ] `npm run lint` passes with this change
- [ ] `npm test` passes with this change
- [x] This pull request links relevant issues as `Fixes #11616`

### Validation

- `pnpm exec tsc --noEmit --pretty false`
- `pnpm run compile`
- `pnpm exec mocha --no-config --file build/compiled/test/utils/test-setup.js build/compiled/test/functional/columns/virtual-columns/virtual-columns.test.js --timeout 90000 --exit`
- `pnpm exec prettier --check src/query-builder/QueryBuilder.ts test/functional/columns/virtual-columns/virtual-columns.test.ts`
- Commit hook ran `eslint --fix` and `prettier --write` on staged TypeScript files
- `pnpm exec eslint src/query-builder/QueryBuilder.ts test/functional/columns/virtual-columns/virtual-columns.test.ts` completed with existing warnings only, no errors
