### PR TITLE
chore(legacy-naming-strategies): bump to 1.0.0-beta.3

### DIFF
--- a/packages/legacy-naming-strategies/package.json
+++ b/packages/legacy-naming-strategies/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@typeorm/legacy-naming-strategies",
-  "version": "1.0.0-beta.2",
+  "version": "1.0.0-beta.3",
   "description": "Legacy naming strategies for TypeORM",
   "homepage": "https://typeorm.io",
   "bugs": {
@@ -47,12 +47,12 @@
     "mocha": "^11.7.5",
     "prettier": "^3.8.3",
     "ts-node": "^10.9.2",
-    "typeorm": "1.0.0-beta.2",
+    "typeorm": "1.0.0-beta.3",
     "typescript": "^5.9.3",
     "typescript-eslint": "^8.59.2"
   },
   "peerDependencies": {
-    "typeorm": "^1.0.0-beta.2"
+    "typeorm": "^1.0.0-beta.3"
   },
   "engines": {
     "node": ">=20"

--- a/packages/legacy-naming-strategies/pnpm-lock.yaml
+++ b/packages/legacy-naming-strategies/pnpm-lock.yaml
@@ -45,8 +45,8 @@ importers:
         specifier: ^10.9.2
         version: 10.9.2(@types/node@20.19.39)(typescript@5.9.3)
       typeorm:
-        specifier: 1.0.0-beta.2
-        version: 1.0.0-beta.2(ts-node@10.9.2(@types/node@20.19.39)(typescript@5.9.3))
+        specifier: 1.0.0-beta.3
+        version: 1.0.0-beta.3(ts-node@10.9.2(@types/node@20.19.39)(typescript@5.9.3))
       typescript:
         specifier: ^5.9.3
         version: 5.9.3
@@ -818,9 +818,9 @@ packages:
     resolution: {integrity: sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==}
     engines: {node: '>= 0.8.0'}
 
-  typeorm@1.0.0-beta.2:
-    resolution: {integrity: sha512-mGEbsJUn+RNqFAA7dOF1tzJwZd7k59KURxJPDeH2D8cE1ItOTnCwtzRY46FbZigd/C49dEF0UzES2BJmKPiRqA==}
-    engines: {node: ^20.19.0 || ^22.12.0 || >=24.11.0}
+  typeorm@1.0.0-beta.3:
+    resolution: {integrity: sha512-CsyJgP9u9r9tRzVHSECDxNLx98H37sWhE0P80mIqZn/2op6kWKKraUFEXz/BltRcLje9vuEhCuSwSY20vq5CPw==}
+    engines: {node: ^20.19.0 || ^22.13.0 || >=24.11.0}
     hasBin: true
     peerDependencies:
       '@google-cloud/spanner': ^8.0.0
@@ -1688,7 +1688,7 @@ snapshots:
     dependencies:
       prelude-ls: 1.2.1
 
-  typeorm@1.0.0-beta.2(ts-node@10.9.2(@types/node@20.19.39)(typescript@5.9.3)):
+  typeorm@1.0.0-beta.3(ts-node@10.9.2(@types/node@20.19.39)(typescript@5.9.3)):
     dependencies:
       '@sqltools/formatter': 1.2.5
       ansis: 4.2.0

--- a/packages/legacy-naming-strategies/sonar-project.properties
+++ b/packages/legacy-naming-strategies/sonar-project.properties
@@ -1,0 +1,6 @@
+sonar.projectKey=typeorm-legacy-naming-strategies
+sonar.organization=typeorm
+sonar.sources=src
+sonar.tests=test
+sonar.javascript.lcov.reportPaths=coverage/lcov.info
+sonar.qualitygate.wait=true


### PR DESCRIPTION
## Summary

- Bumps `@typeorm/legacy-naming-strategies` self-version from `1.0.0-beta.2` → `1.0.0-beta.3` to align with the just-published `typeorm@1.0.0-beta.3`.
- Bumps the `typeorm` devDependency and peerDependency to `1.0.0-beta.3` / `^1.0.0-beta.3`.
- Refreshes `packages/legacy-naming-strategies/pnpm-lock.yaml` to resolve the new typeorm version.

This is the inter-package version sync that a monorepo tool would otherwise handle automatically.

## Test plan

- [x] `package.json` bumped (self version, devDep typeorm, peerDep typeorm)
- [x] `pnpm install` updated lockfile (resolves typeorm 1.0.0-beta.3)
- [ ] After merge, maintainer will pull master, build `dist/`, and manually publish `@typeorm/legacy-naming-strategies@1.0.0-beta.3` to npm with `--tag beta`.