### PR TITLE
fix: remove migrationsRun option from dataSource settings on MigrationGenerateCommand

### DIFF
--- a/src/commands/MigrationGenerateCommand.ts
+++ b/src/commands/MigrationGenerateCommand.ts
@@ -85,9 +85,10 @@ export class MigrationGenerateCommand implements yargs.CommandModule {
                 path.resolve(process.cwd(), args.dataSource as string),
             )
             dataSource.setOptions({
+                subscribers: [],
                 synchronize: false,
                 dropSchema: false,
-                logging: false,
+                logging: ["query", "error", "schema"],
             })
             await dataSource.initialize()
 

--- a/src/commands/MigrationGenerateCommand.ts
+++ b/src/commands/MigrationGenerateCommand.ts
@@ -86,7 +86,6 @@ export class MigrationGenerateCommand implements yargs.CommandModule {
             )
             dataSource.setOptions({
                 synchronize: false,
-                migrationsRun: false,
                 dropSchema: false,
                 logging: false,
             })


### PR DESCRIPTION
This option should be honored from the previous configuration. Fixes #12431

<!--
  😀 Wonderful!  Thank you for opening a pull request for TypeORM.

  Please fill in the information below to expedite the review
  and (hopefully) merge of your change.

  If unsure about something.. just do as best as you're able,
  or reach out through our community support channels!
  https://github.com/typeorm/typeorm/blob/master/docs/support.md
  https://github.com/typeorm/typeorm/blob/master/CONTRIBUTING.md
-->

### Description of change

This change will allow to run existing migrations before generating a new one avoiding duplication of existing queries.
<!--
  Please describe:
  - what the change is intended to do
  - why this change is needed
  - how you've verified it
  - any other context that will help reviewers understand the change

  In some cases it may be helpful to include the current behavior
  and the new behavior.
-->

### Pull-Request Checklist

<!--
  Please make sure to review and check all of the following.

  If an item is not applicable, you can add "N/A" to the end.
-->

- [x] Code is up-to-date with the `master` branch
- [x] This pull request links relevant issues as `Fixes #00000`
- [ ] There are new or updated tests validating the change (`tests/**.test.ts`)
- [ ] Documentation has been updated to reflect this change (`docs/docs/**.md`)

> 🛡️ **Security fixes:** Do not submit security fixes as public PRs — the diff exposes the vulnerability. Use [GitHub Security Advisories](https://github.com/typeorm/typeorm/security/advisories/new) instead.

<!--
  🎉 Thank you for contributing and making TypeORM even better!
-->
