### PR TITLE
fix(security): validate limit() in Update/SoftDelete query builders

### DIFF
--- a/src/query-builder/QueryBuilder.ts
+++ b/src/query-builder/QueryBuilder.ts
@@ -1722,4 +1722,30 @@ export abstract class QueryBuilder<Entity extends ObjectLiteral> {
             }
         }
     }
+
+    protected normalizeNumber(num: any) {
+        if (typeof num === "number" || num === undefined || num === null)
+            return num
+
+        return Number(num)
+    }
+
+    /**
+     * Normalizes and validates a numeric query parameter,
+     * throwing if the result is NaN.
+     *
+     * @param label
+     * @param num
+     */
+    protected validateNumericInput(
+        label: string,
+        num: number | undefined,
+    ): number | undefined {
+        const normalized = this.normalizeNumber(num)
+        if (normalized !== undefined && isNaN(normalized))
+            throw new TypeORMError(
+                `Provided "${label}" value is not a number. Please provide a numeric value.`,
+            )
+        return normalized
+    }
 }

--- a/src/query-builder/SelectQueryBuilder.ts
+++ b/src/query-builder/SelectQueryBuilder.ts
@@ -1489,15 +1489,7 @@ export class SelectQueryBuilder<Entity extends ObjectLiteral>
      * @param limit
      */
     limit(limit?: number): this {
-        this.expressionMap.limit = this.normalizeNumber(limit)
-        if (
-            this.expressionMap.limit !== undefined &&
-            isNaN(this.expressionMap.limit)
-        )
-            throw new TypeORMError(
-                `Provided "limit" value is not a number. Please provide a numeric value.`,
-            )
-
+        this.expressionMap.limit = this.validateNumericInput("limit", limit)
         return this
     }
 
@@ -1509,15 +1501,7 @@ export class SelectQueryBuilder<Entity extends ObjectLiteral>
      * @param offset
      */
     offset(offset?: number): this {
-        this.expressionMap.offset = this.normalizeNumber(offset)
-        if (
-            this.expressionMap.offset !== undefined &&
-            isNaN(this.expressionMap.offset)
-        )
-            throw new TypeORMError(
-                `Provided "offset" value is not a number. Please provide a numeric value.`,
-            )
-
+        this.expressionMap.offset = this.validateNumericInput("offset", offset)
         return this
     }
 
@@ -1527,15 +1511,7 @@ export class SelectQueryBuilder<Entity extends ObjectLiteral>
      * @param take
      */
     take(take?: number): this {
-        this.expressionMap.take = this.normalizeNumber(take)
-        if (
-            this.expressionMap.take !== undefined &&
-            isNaN(this.expressionMap.take)
-        )
-            throw new TypeORMError(
-                `Provided "take" value is not a number. Please provide a numeric value.`,
-            )
-
+        this.expressionMap.take = this.validateNumericInput("take", take)
         return this
     }
 
@@ -1545,15 +1521,7 @@ export class SelectQueryBuilder<Entity extends ObjectLiteral>
      * @param skip
      */
     skip(skip?: number): this {
-        this.expressionMap.skip = this.normalizeNumber(skip)
-        if (
-            this.expressionMap.skip !== undefined &&
-            isNaN(this.expressionMap.skip)
-        )
-            throw new TypeORMError(
-                `Provided "skip" value is not a number. Please provide a numeric value.`,
-            )
-
+        this.expressionMap.skip = this.validateNumericInput("skip", skip)
         return this
     }
 
@@ -3902,18 +3870,6 @@ export class SelectQueryBuilder<Entity extends ObjectLiteral>
     ): this {
         ObjectUtils.assign(this.expressionMap, expressionMap)
         return this
-    }
-
-    /**
-     * Normalizes a give number - converts to int if possible.
-     *
-     * @param num
-     */
-    protected normalizeNumber(num: any) {
-        if (typeof num === "number" || num === undefined || num === null)
-            return num
-
-        return Number(num)
     }
 
     /**

--- a/src/query-builder/SoftDeleteQueryBuilder.ts
+++ b/src/query-builder/SoftDeleteQueryBuilder.ts
@@ -428,7 +428,7 @@ export class SoftDeleteQueryBuilder<Entity extends ObjectLiteral>
      * @param limit
      */
     limit(limit?: number): this {
-        this.expressionMap.limit = limit
+        this.expressionMap.limit = this.validateNumericInput("limit", limit)
         return this
     }
 

--- a/src/query-builder/UpdateQueryBuilder.ts
+++ b/src/query-builder/UpdateQueryBuilder.ts
@@ -461,7 +461,7 @@ export class UpdateQueryBuilder<Entity extends ObjectLiteral>
      * @param limit
      */
     limit(limit?: number): this {
-        this.expressionMap.limit = limit
+        this.expressionMap.limit = this.validateNumericInput("limit", limit)
         return this
     }
 

--- a/test/functional/query-builder/sql-injection/sql-injection.test.ts
+++ b/test/functional/query-builder/sql-injection/sql-injection.test.ts
@@ -357,6 +357,70 @@ describe("query builder > sql injection", () => {
             ))
     })
 
+    describe("UpdateQueryBuilder limit validation", () => {
+        it("should reject non-numeric limit", () =>
+            Promise.all(
+                dataSources.map(async (dataSource) => {
+                    if (!DriverUtils.isMySQLFamily(dataSource.driver)) return
+
+                    expect(() => {
+                        dataSource
+                            .createQueryBuilder()
+                            .update(Post)
+                            .set({ text: "updated" })
+                            .limit("1; DROP TABLE post" as any)
+                    }).to.throw(/not a number/)
+                }),
+            ))
+
+        it("should accept valid numeric limit", () =>
+            Promise.all(
+                dataSources.map(async (dataSource) => {
+                    if (!DriverUtils.isMySQLFamily(dataSource.driver)) return
+
+                    expect(() => {
+                        dataSource
+                            .createQueryBuilder()
+                            .update(Post)
+                            .set({ text: "updated" })
+                            .limit(10)
+                    }).to.not.throw()
+                }),
+            ))
+    })
+
+    describe("SoftDeleteQueryBuilder limit validation", () => {
+        it("should reject non-numeric limit", () =>
+            Promise.all(
+                dataSources.map(async (dataSource) => {
+                    if (!DriverUtils.isMySQLFamily(dataSource.driver)) return
+
+                    expect(() => {
+                        dataSource
+                            .createQueryBuilder()
+                            .softDelete()
+                            .from(Post)
+                            .limit("1; DROP TABLE post" as any)
+                    }).to.throw(/not a number/)
+                }),
+            ))
+
+        it("should accept valid numeric limit", () =>
+            Promise.all(
+                dataSources.map(async (dataSource) => {
+                    if (!DriverUtils.isMySQLFamily(dataSource.driver)) return
+
+                    expect(() => {
+                        dataSource
+                            .createQueryBuilder()
+                            .softDelete()
+                            .from(Post)
+                            .limit(10)
+                    }).to.not.throw()
+                }),
+            ))
+    })
+
     describe("orWhere", () => {
         for (const malicious of maliciousInputs) {
             it(`should prevent injection with: ${malicious}`, () =>


### PR DESCRIPTION
<!--
  😀 Wonderful!  Thank you for opening a pull request for TypeORM.

  Please fill in the information below to expedite the review
  and (hopefully) merge of your change.

  If unsure about something.. just do as best as you're able,
  or reach out through our community support channels!
  https://github.com/typeorm/typeorm/blob/master/docs/support.md
  https://github.com/typeorm/typeorm/blob/master/CONTRIBUTING.md
-->

### Description of change

- Move `normalizeNumber()` from `SelectQueryBuilder` to base `QueryBuilder`
- Add `validateNumericInput()` to base `QueryBuilder` to deduplicate the normalize + validate + throw pattern
- Apply validation to `limit()` in `UpdateQueryBuilder` and `SoftDeleteQueryBuilder`
- Consolidate `SelectQueryBuilder`'s `limit()`/`offset()`/`take()`/`skip()` to use `validateNumericInput()`
- Add tests for both builders


<!--
  Please describe:
  - what the change is intended to do
  - why this change is needed
  - how you've verified it
  - any other context that will help reviewers understand the change

  In some cases it may be helpful to include the current behavior
  and the new behavior.
-->

### Pull-Request Checklist

<!--
  Please make sure to review and check all of the following.

  If an item is not applicable, you can add "N/A" to the end.
-->

- [x] Code is up-to-date with the `master` branch
- [x] This pull request links relevant issues as `Fixes #00000`
- [x] There are new or updated tests validating the change (`tests/**.test.ts`)
- [x] Documentation has been updated to reflect this change (`docs/docs/**.md`)

> 🛡️ **Security fixes:** Do not submit security fixes as public PRs — the diff exposes the vulnerability. Use [GitHub Security Advisories](https://github.com/typeorm/typeorm/security/advisories/new) instead.

<!--
  🎉 Thank you for contributing and making TypeORM even better!
-->
