### PR TITLE
fix: preserve postgres character column data when changing length

### DIFF
--- a/src/driver/postgres/PostgresQueryRunner.ts
+++ b/src/driver/postgres/PostgresQueryRunner.ts
@@ -1326,9 +1326,15 @@ export class PostgresQueryRunner
                 `Column "${oldTableColumnOrName}" was not found in the "${table.name}" table.`,
             )
 
+        const isSafeCharacterTypeChange =
+            this.isCharacterType(oldColumn.type) &&
+            this.isCharacterType(newColumn.type) &&
+            oldColumn.isArray === newColumn.isArray
+
         if (
-            oldColumn.type !== newColumn.type ||
-            oldColumn.length !== newColumn.length ||
+            (!isSafeCharacterTypeChange &&
+                (oldColumn.type !== newColumn.type ||
+                    oldColumn.length !== newColumn.length)) ||
             newColumn.isArray !== oldColumn.isArray ||
             (!oldColumn.generatedType &&
                 newColumn.generatedType === "STORED") ||
@@ -1616,6 +1622,33 @@ export class PostgresQueryRunner
                     clonedTable.columns.indexOf(oldTableColumn!)
                 ].name = newColumn.name
                 oldColumn.name = newColumn.name
+            }
+
+            if (
+                isSafeCharacterTypeChange &&
+                (oldColumn.type !== newColumn.type ||
+                    oldColumn.length !== newColumn.length)
+            ) {
+                const column = clonedTable.columns.find(
+                    (column) => column.name === newColumn.name,
+                )
+                column!.type = newColumn.type
+                column!.length = newColumn.length
+
+                upQueries.push(
+                    new Query(
+                        `ALTER TABLE ${this.escapePath(table)} ALTER COLUMN "${
+                            newColumn.name
+                        }" TYPE ${this.driver.createFullType(newColumn)}`,
+                    ),
+                )
+                downQueries.push(
+                    new Query(
+                        `ALTER TABLE ${this.escapePath(table)} ALTER COLUMN "${
+                            newColumn.name
+                        }" TYPE ${this.driver.createFullType(oldColumn)}`,
+                    ),
+                )
             }
 
             if (
@@ -5186,6 +5219,17 @@ export class PostgresQueryRunner
             c += ` DEFAULT ${this.driver.uuidGenerator}`
 
         return c
+    }
+
+    protected isCharacterType(type: string): boolean {
+        type = type.toLowerCase()
+
+        return [
+            "character varying",
+            "varchar",
+            "character",
+            "char",
+        ].includes(type)
     }
 
     /**

--- a/src/driver/postgres/PostgresQueryRunner.ts
+++ b/src/driver/postgres/PostgresQueryRunner.ts
@@ -2377,13 +2377,18 @@ export class PostgresQueryRunner
 
             // update column collation
             if (newColumn.collation !== oldColumn.collation) {
+                const column = clonedTable.columns.find(
+                    (column) => column.name === newColumn.name,
+                )
+                column!.collation = newColumn.collation
+
                 upQueries.push(
                     new Query(
                         `ALTER TABLE ${this.escapePath(table)} ALTER COLUMN "${
                             newColumn.name
-                        }" TYPE ${newColumn.type} COLLATE "${
-                            newColumn.collation
-                        }"`,
+                        }" TYPE ${this.driver.createFullType(
+                            newColumn,
+                        )} COLLATE "${newColumn.collation}"`,
                     ),
                 )
 
@@ -2395,7 +2400,9 @@ export class PostgresQueryRunner
                     new Query(
                         `ALTER TABLE ${this.escapePath(table)} ALTER COLUMN "${
                             newColumn.name
-                        }" TYPE ${newColumn.type} COLLATE ${oldCollation}`,
+                        }" TYPE ${this.driver.createFullType(
+                            oldColumn,
+                        )} COLLATE ${oldCollation}`,
                     ),
                 )
             }

--- a/src/driver/postgres/PostgresQueryRunner.ts
+++ b/src/driver/postgres/PostgresQueryRunner.ts
@@ -1330,11 +1330,15 @@ export class PostgresQueryRunner
             this.isCharacterType(oldColumn.type) &&
             this.isCharacterType(newColumn.type) &&
             oldColumn.isArray === newColumn.isArray
+        const typeOrLengthChanged =
+            oldColumn.type !== newColumn.type ||
+            oldColumn.length !== newColumn.length
+        const characterTypeChanged =
+            isSafeCharacterTypeChange && typeOrLengthChanged
+        const collationChanged = newColumn.collation !== oldColumn.collation
 
         if (
-            (!isSafeCharacterTypeChange &&
-                (oldColumn.type !== newColumn.type ||
-                    oldColumn.length !== newColumn.length)) ||
+            (!characterTypeChanged && typeOrLengthChanged) ||
             newColumn.isArray !== oldColumn.isArray ||
             (!oldColumn.generatedType &&
                 newColumn.generatedType === "STORED") ||
@@ -1624,29 +1628,43 @@ export class PostgresQueryRunner
                 oldColumn.name = newColumn.name
             }
 
-            if (
-                isSafeCharacterTypeChange &&
-                (oldColumn.type !== newColumn.type ||
-                    oldColumn.length !== newColumn.length)
-            ) {
+            if (characterTypeChanged) {
                 const column = clonedTable.columns.find(
                     (column) => column.name === newColumn.name,
                 )
                 column!.type = newColumn.type
                 column!.length = newColumn.length
+                if (collationChanged) {
+                    column!.collation = newColumn.collation
+                }
+
+                const newCollation = collationChanged
+                    ? newColumn.collation
+                        ? ` COLLATE "${newColumn.collation}"`
+                        : ` COLLATE pg_catalog."default"`
+                    : ""
+                const oldCollation = collationChanged
+                    ? oldColumn.collation
+                        ? ` COLLATE "${oldColumn.collation}"`
+                        : ` COLLATE pg_catalog."default"`
+                    : ""
 
                 upQueries.push(
                     new Query(
                         `ALTER TABLE ${this.escapePath(table)} ALTER COLUMN "${
                             newColumn.name
-                        }" TYPE ${this.driver.createFullType(newColumn)}`,
+                        }" TYPE ${this.driver.createFullType(
+                            newColumn,
+                        )}${newCollation}`,
                     ),
                 )
                 downQueries.push(
                     new Query(
                         `ALTER TABLE ${this.escapePath(table)} ALTER COLUMN "${
                             newColumn.name
-                        }" TYPE ${this.driver.createFullType(oldColumn)}`,
+                        }" TYPE ${this.driver.createFullType(
+                            oldColumn,
+                        )}${oldCollation}`,
                     ),
                 )
             }
@@ -2376,11 +2394,15 @@ export class PostgresQueryRunner
             }
 
             // update column collation
-            if (newColumn.collation !== oldColumn.collation) {
+            if (collationChanged && !characterTypeChanged) {
                 const column = clonedTable.columns.find(
                     (column) => column.name === newColumn.name,
                 )
                 column!.collation = newColumn.collation
+
+                const newCollation = newColumn.collation
+                    ? `"${newColumn.collation}"`
+                    : `pg_catalog."default"`
 
                 upQueries.push(
                     new Query(
@@ -2388,7 +2410,7 @@ export class PostgresQueryRunner
                             newColumn.name
                         }" TYPE ${this.driver.createFullType(
                             newColumn,
-                        )} COLLATE "${newColumn.collation}"`,
+                        )} COLLATE ${newCollation}`,
                     ),
                 )
 

--- a/test/functional/query-runner/change-column.test.ts
+++ b/test/functional/query-runner/change-column.test.ts
@@ -6,7 +6,7 @@ import {
     createTestingConnections,
     createTypeormMetadataTable,
 } from "../../utils/test-utils"
-import { TableColumn } from "../../../src"
+import { Table, TableColumn } from "../../../src"
 import type { PostgresDriver } from "../../../src/driver/postgres/PostgresDriver"
 import { DriverUtils } from "../../../src/driver/DriverUtils"
 
@@ -101,6 +101,72 @@ describe("query runner > change column", () => {
                 table!.findColumnByName("text")!.isPrimary.should.be.false
                 expect(table!.findColumnByName("text")!.default).to.be.undefined
 
+                await queryRunner.release()
+            }),
+        ))
+
+    it("should preserve postgres character column data when changing length", () =>
+        Promise.all(
+            dataSources.map(async (dataSource) => {
+                if (dataSource.driver.options.type !== "postgres") return
+
+                // Regression test for #3357: changing varchar length should not drop and recreate the column.
+                const queryRunner = dataSource.createQueryRunner()
+
+                await queryRunner.createTable(
+                    new Table({
+                        name: "change_column_length",
+                        columns: [
+                            {
+                                name: "id",
+                                type: "int",
+                                isPrimary: true,
+                            },
+                            {
+                                name: "example",
+                                type: "character varying",
+                                length: "50",
+                            },
+                        ],
+                    }),
+                    true,
+                )
+                await queryRunner.query(
+                    `INSERT INTO "change_column_length"("id", "example") VALUES (1, 'kept')`,
+                )
+
+                let table = await queryRunner.getTable("change_column_length")
+                const exampleColumn = table!.findColumnByName("example")!
+                const changedExampleColumn = exampleColumn.clone()
+                changedExampleColumn.length = "51"
+
+                await queryRunner.changeColumn(
+                    table!,
+                    exampleColumn,
+                    changedExampleColumn,
+                )
+
+                table = await queryRunner.getTable("change_column_length")
+                table!
+                    .findColumnByName("example")!
+                    .length!.should.be.equal("51")
+
+                const rows = await queryRunner.query(
+                    `SELECT "example" FROM "change_column_length" WHERE "id" = 1`,
+                )
+                rows[0].example.should.be.equal("kept")
+
+                const upQueries = queryRunner
+                    .getMemorySql()
+                    .upQueries.map((query) => query.query)
+                expect(upQueries).to.include(
+                    `ALTER TABLE "change_column_length" ALTER COLUMN "example" TYPE character varying(51)`,
+                )
+                expect(upQueries).not.to.include(
+                    `ALTER TABLE "change_column_length" DROP COLUMN "example"`,
+                )
+
+                await queryRunner.dropTable("change_column_length", true)
                 await queryRunner.release()
             }),
         ))

--- a/test/functional/query-runner/change-column.test.ts
+++ b/test/functional/query-runner/change-column.test.ts
@@ -113,61 +113,65 @@ describe("query runner > change column", () => {
                 // Regression test for #3357: changing varchar length should not drop and recreate the column.
                 const queryRunner = dataSource.createQueryRunner()
 
-                await queryRunner.createTable(
-                    new Table({
-                        name: "change_column_length",
-                        columns: [
-                            {
-                                name: "id",
-                                type: "int",
-                                isPrimary: true,
-                            },
-                            {
-                                name: "example",
-                                type: "character varying",
-                                length: "50",
-                            },
-                        ],
-                    }),
-                    true,
-                )
-                await queryRunner.query(
-                    `INSERT INTO "change_column_length"("id", "example") VALUES (1, 'kept')`,
-                )
+                try {
+                    await queryRunner.createTable(
+                        new Table({
+                            name: "change_column_length",
+                            columns: [
+                                {
+                                    name: "id",
+                                    type: "int",
+                                    isPrimary: true,
+                                },
+                                {
+                                    name: "example",
+                                    type: "character varying",
+                                    length: "50",
+                                },
+                            ],
+                        }),
+                        true,
+                    )
+                    await queryRunner.query(
+                        `INSERT INTO "change_column_length"("id", "example") VALUES (1, 'kept')`,
+                    )
 
-                let table = await queryRunner.getTable("change_column_length")
-                const exampleColumn = table!.findColumnByName("example")!
-                const changedExampleColumn = exampleColumn.clone()
-                changedExampleColumn.length = "51"
+                    let table = await queryRunner.getTable(
+                        "change_column_length",
+                    )
+                    const exampleColumn = table!.findColumnByName("example")!
+                    const changedExampleColumn = exampleColumn.clone()
+                    changedExampleColumn.length = "51"
 
-                await queryRunner.changeColumn(
-                    table!,
-                    exampleColumn,
-                    changedExampleColumn,
-                )
+                    await queryRunner.changeColumn(
+                        table!,
+                        exampleColumn,
+                        changedExampleColumn,
+                    )
 
-                table = await queryRunner.getTable("change_column_length")
-                table!
-                    .findColumnByName("example")!
-                    .length!.should.be.equal("51")
+                    table = await queryRunner.getTable("change_column_length")
+                    table!
+                        .findColumnByName("example")!
+                        .length!.should.be.equal("51")
 
-                const rows = await queryRunner.query(
-                    `SELECT "example" FROM "change_column_length" WHERE "id" = 1`,
-                )
-                rows[0].example.should.be.equal("kept")
+                    const rows = await queryRunner.query(
+                        `SELECT "example" FROM "change_column_length" WHERE "id" = 1`,
+                    )
+                    rows[0].example.should.be.equal("kept")
 
-                const upQueries = queryRunner
-                    .getMemorySql()
-                    .upQueries.map((query) => query.query)
-                expect(upQueries).to.include(
-                    `ALTER TABLE "change_column_length" ALTER COLUMN "example" TYPE character varying(51)`,
-                )
-                expect(upQueries).not.to.include(
-                    `ALTER TABLE "change_column_length" DROP COLUMN "example"`,
-                )
-
-                await queryRunner.dropTable("change_column_length", true)
-                await queryRunner.release()
+                    const upQueries = queryRunner
+                        .getMemorySql()
+                        .upQueries.map((query) => query.query)
+                    expect(upQueries).to.include(
+                        `ALTER TABLE "change_column_length" ALTER COLUMN "example" TYPE character varying(51)`,
+                    )
+                    expect(upQueries).not.to.include(
+                        `ALTER TABLE "change_column_length" DROP COLUMN "example"`,
+                    )
+                } finally {
+                    await queryRunner.dropTable("change_column_length", true)
+                    await queryRunner.release()
+                }
             }),
         ))
 

--- a/test/functional/schema-builder/collation/collation-changes/collation-changes.test.ts
+++ b/test/functional/schema-builder/collation/collation-changes/collation-changes.test.ts
@@ -38,47 +38,124 @@ describe("schema builder > collation > collation changes", () => {
                 const OLD_COLLATION = col.collation
                 col.collation = NEW_COLLATION
 
-                // capture generated up queries
-                const sqlInMemory = await connection.driver
-                    .createSchemaBuilder()
-                    .log()
-                const tableName = meta.tableName
-                const expectedUp = `ALTER TABLE "${tableName}" ALTER COLUMN "${COLUMN_NAME}" TYPE character varying(100) COLLATE "${NEW_COLLATION}"`
-                const expectedDown = `ALTER TABLE "${tableName}" ALTER COLUMN "${COLUMN_NAME}" TYPE character varying(100) COLLATE "${OLD_COLLATION}"`
+                try {
+                    // capture generated up queries
+                    const sqlInMemory = await connection.driver
+                        .createSchemaBuilder()
+                        .log()
+                    const tableName = meta.tableName
+                    const expectedUp = `ALTER TABLE "${tableName}" ALTER COLUMN "${COLUMN_NAME}" TYPE character varying(100) COLLATE "${NEW_COLLATION}"`
+                    const expectedDown = `ALTER TABLE "${tableName}" ALTER COLUMN "${COLUMN_NAME}" TYPE character varying(100) COLLATE "${OLD_COLLATION}"`
 
-                // assert that the expected queries are in the generated SQL
-                const upJoined = sqlInMemory.upQueries
-                    .map((q) => q.query.replaceAll(/\s+/g, " ").trim())
-                    .join(" ")
-                expect(upJoined).to.include(expectedUp)
-                const downJoined = sqlInMemory.downQueries
-                    .map((q) => q.query.replaceAll(/\s+/g, " ").trim())
-                    .join(" ")
-                expect(downJoined).to.include(expectedDown)
+                    // assert that the expected queries are in the generated SQL
+                    const upJoined = sqlInMemory.upQueries
+                        .map((q) => q.query.replaceAll(/\s+/g, " ").trim())
+                        .join(" ")
+                    expect(upJoined).to.include(expectedUp)
+                    const downJoined = sqlInMemory.downQueries
+                        .map((q) => q.query.replaceAll(/\s+/g, " ").trim())
+                        .join(" ")
+                    expect(downJoined).to.include(expectedDown)
 
-                // assert that collation changes are applied to the database
-                const queryRunner = connection.createQueryRunner()
+                    // assert that collation changes are applied to the database
+                    const queryRunner = connection.createQueryRunner()
+
+                    try {
+                        let table = await queryRunner.getTable(meta.tableName)
+                        const originColumn = table!.columns.find(
+                            (c) => c.name === COLUMN_NAME,
+                        )!
+                        // old collation should be appeared
+                        expect(originColumn.collation).to.equal(OLD_COLLATION)
+
+                        await connection.synchronize()
+
+                        table = await queryRunner.getTable(meta.tableName)
+                        const appliedColumn = table!.columns.find(
+                            (c) => c.name === COLUMN_NAME,
+                        )!
+                        // new collation should be appeared
+                        expect(appliedColumn.collation).to.equal(NEW_COLLATION)
+                        // changing collation should not drop the varchar length modifier
+                        expect(appliedColumn.length).to.equal("100")
+                    } finally {
+                        await queryRunner.release()
+                    }
+                } finally {
+                    col.collation = OLD_COLLATION
+                }
+            }),
+        )
+    })
+
+    it("ALTER ... COLLATE query should be valid when collation is removed", async () => {
+        await Promise.all(
+            dataSources.map(async (connection) => {
+                const meta = connection.getMetadata(Item)
+                const col = meta.columns.find(
+                    (c) => c.propertyName === COLUMN_NAME,
+                )!
+                const OLD_COLLATION = col.collation
+                col.collation = undefined
 
                 try {
-                    let table = await queryRunner.getTable(meta.tableName)
-                    const originColumn = table!.columns.find(
-                        (c) => c.name === COLUMN_NAME,
-                    )!
-                    // old collation should be appeared
-                    expect(originColumn.collation).to.equal(OLD_COLLATION)
+                    const sqlInMemory = await connection.driver
+                        .createSchemaBuilder()
+                        .log()
+                    const tableName = meta.tableName
+                    const expectedUp = `ALTER TABLE "${tableName}" ALTER COLUMN "${COLUMN_NAME}" TYPE character varying(100) COLLATE pg_catalog."default"`
+                    const expectedDown = `ALTER TABLE "${tableName}" ALTER COLUMN "${COLUMN_NAME}" TYPE character varying(100) COLLATE "${OLD_COLLATION}"`
 
-                    await connection.synchronize()
+                    const upJoined = sqlInMemory.upQueries
+                        .map((q) => q.query.replaceAll(/\s+/g, " ").trim())
+                        .join(" ")
+                    expect(upJoined).to.include(expectedUp)
+                    expect(upJoined).not.to.include(`COLLATE "undefined"`)
 
-                    table = await queryRunner.getTable(meta.tableName)
-                    const appliedColumn = table!.columns.find(
-                        (c) => c.name === COLUMN_NAME,
-                    )!
-                    // new collation should be appeared
-                    expect(appliedColumn.collation).to.equal(NEW_COLLATION)
-                    // changing collation should not drop the varchar length modifier
-                    expect(appliedColumn.length).to.equal("100")
+                    const downJoined = sqlInMemory.downQueries
+                        .map((q) => q.query.replaceAll(/\s+/g, " ").trim())
+                        .join(" ")
+                    expect(downJoined).to.include(expectedDown)
                 } finally {
-                    await queryRunner.release()
+                    col.collation = OLD_COLLATION
+                }
+            }),
+        )
+    })
+
+    it("should combine varchar length and collation changes in one ALTER TYPE query", async () => {
+        await Promise.all(
+            dataSources.map(async (connection) => {
+                const meta = connection.getMetadata(Item)
+                const col = meta.columns.find(
+                    (c) => c.propertyName === COLUMN_NAME,
+                )!
+                const OLD_COLLATION = col.collation
+                const OLD_LENGTH = col.length
+                col.collation = NEW_COLLATION
+                col.length = "101"
+
+                try {
+                    const sqlInMemory = await connection.driver
+                        .createSchemaBuilder()
+                        .log()
+                    const tableName = meta.tableName
+                    const expectedUp = `ALTER TABLE "${tableName}" ALTER COLUMN "${COLUMN_NAME}" TYPE character varying(101) COLLATE "${NEW_COLLATION}"`
+
+                    const upQueries = sqlInMemory.upQueries.map((q) =>
+                        q.query.replaceAll(/\s+/g, " ").trim(),
+                    )
+                    expect(upQueries).to.include(expectedUp)
+                    expect(
+                        upQueries.filter((query) =>
+                            query.includes(
+                                `ALTER COLUMN "${COLUMN_NAME}" TYPE`,
+                            ),
+                        ),
+                    ).to.have.length(1)
+                } finally {
+                    col.collation = OLD_COLLATION
+                    col.length = OLD_LENGTH
                 }
             }),
         )

--- a/test/functional/schema-builder/collation/collation-changes/collation-changes.test.ts
+++ b/test/functional/schema-builder/collation/collation-changes/collation-changes.test.ts
@@ -43,8 +43,8 @@ describe("schema builder > collation > collation changes", () => {
                     .createSchemaBuilder()
                     .log()
                 const tableName = meta.tableName
-                const expectedUp = `ALTER TABLE "${tableName}" ALTER COLUMN "${COLUMN_NAME}" TYPE character varying COLLATE "${NEW_COLLATION}"`
-                const expectedDown = `ALTER TABLE "${tableName}" ALTER COLUMN "${COLUMN_NAME}" TYPE character varying COLLATE "${OLD_COLLATION}"`
+                const expectedUp = `ALTER TABLE "${tableName}" ALTER COLUMN "${COLUMN_NAME}" TYPE character varying(100) COLLATE "${NEW_COLLATION}"`
+                const expectedDown = `ALTER TABLE "${tableName}" ALTER COLUMN "${COLUMN_NAME}" TYPE character varying(100) COLLATE "${OLD_COLLATION}"`
 
                 // assert that the expected queries are in the generated SQL
                 const upJoined = sqlInMemory.upQueries
@@ -75,6 +75,8 @@ describe("schema builder > collation > collation changes", () => {
                     )!
                     // new collation should be appeared
                     expect(appliedColumn.collation).to.equal(NEW_COLLATION)
+                    // changing collation should not drop the varchar length modifier
+                    expect(appliedColumn.length).to.equal("100")
                 } finally {
                     await queryRunner.release()
                 }


### PR DESCRIPTION
Fixes #3357.

Postgres can safely alter character/varchar length changes in place with `ALTER TABLE ... ALTER COLUMN ... TYPE`, so `changeColumn` no longer drops and recreates character columns for length/type alias changes.

This avoids data loss for migrations such as `character varying(50)` -> `character varying(51)`.

Added a regression test that verifies existing data survives the length change and that the generated SQL uses `ALTER COLUMN TYPE` rather than `DROP COLUMN`.