### PR TITLE
fix: alter postgres varchar length without dropping column

### DIFF
--- a/src/driver/postgres/PostgresQueryRunner.ts
+++ b/src/driver/postgres/PostgresQueryRunner.ts
@@ -2348,9 +2348,9 @@ export class PostgresQueryRunner
                     new Query(
                         `ALTER TABLE ${this.escapePath(table)} ALTER COLUMN "${
                             newColumn.name
-                        }" TYPE ${newColumn.type} COLLATE "${
-                            newColumn.collation
-                        }"`,
+                        }" TYPE ${this.driver.createFullType(
+                            newColumn,
+                        )} COLLATE "${newColumn.collation}"`,
                     ),
                 )
 
@@ -2362,7 +2362,9 @@ export class PostgresQueryRunner
                     new Query(
                         `ALTER TABLE ${this.escapePath(table)} ALTER COLUMN "${
                             newColumn.name
-                        }" TYPE ${newColumn.type} COLLATE ${oldCollation}`,
+                        }" TYPE ${this.driver.createFullType(
+                            oldColumn,
+                        )} COLLATE ${oldCollation}`,
                     ),
                 )
             }

--- a/src/driver/postgres/PostgresQueryRunner.ts
+++ b/src/driver/postgres/PostgresQueryRunner.ts
@@ -1636,6 +1636,13 @@ export class PostgresQueryRunner
                         }" TYPE ${this.driver.createFullType(oldColumn)}`,
                     ),
                 )
+
+                const column = clonedTable.columns.find(
+                    (column) => column.name === newColumn.name,
+                )
+                column!.length = newColumn.length
+                column!.precision = newColumn.precision
+                column!.scale = newColumn.scale
             }
 
             if (

--- a/src/driver/postgres/PostgresQueryRunner.ts
+++ b/src/driver/postgres/PostgresQueryRunner.ts
@@ -1328,7 +1328,6 @@ export class PostgresQueryRunner
 
         if (
             oldColumn.type !== newColumn.type ||
-            oldColumn.length !== newColumn.length ||
             newColumn.isArray !== oldColumn.isArray ||
             (!oldColumn.generatedType &&
                 newColumn.generatedType === "STORED") ||
@@ -1619,6 +1618,7 @@ export class PostgresQueryRunner
             }
 
             if (
+                newColumn.length !== oldColumn.length ||
                 newColumn.precision !== oldColumn.precision ||
                 newColumn.scale !== oldColumn.scale
             ) {

--- a/test/github-issues/3357/issue-3357.test.ts
+++ b/test/github-issues/3357/issue-3357.test.ts
@@ -121,4 +121,65 @@ describe("github issues > #3357 postgres varchar length changes", () => {
                 }
             }),
         ))
+
+    it("should keep cached column length after altering varchar length", () =>
+        Promise.all(
+            dataSources.map(async (dataSource) => {
+                const queryRunner = dataSource.createQueryRunner()
+
+                try {
+                    await queryRunner.createTable(
+                        new Table({
+                            name: "bug3357_cached_length",
+                            columns: [
+                                {
+                                    name: "example",
+                                    type: "character varying",
+                                    length: "50",
+                                },
+                            ],
+                        }),
+                        true,
+                    )
+
+                    const table = await queryRunner.getTable(
+                        "bug3357_cached_length",
+                    )
+                    const column = table!.findColumnByName("example")!
+                    const lengthChangedColumn = column.clone()
+                    lengthChangedColumn.length = "51"
+
+                    queryRunner.enableSqlMemory()
+                    await queryRunner.changeColumn(
+                        table!,
+                        column,
+                        lengthChangedColumn,
+                    )
+                    queryRunner.clearSqlMemory()
+
+                    const collationChangedColumn = lengthChangedColumn.clone()
+                    collationChangedColumn.collation = "C"
+
+                    await queryRunner.changeColumn(
+                        "bug3357_cached_length",
+                        "example",
+                        collationChangedColumn,
+                    )
+                    const sqlInMemory = queryRunner.getMemorySql()
+
+                    expect(
+                        sqlInMemory.upQueries.map((query) => query.query),
+                    ).to.eql([
+                        'ALTER TABLE "bug3357_cached_length" ALTER COLUMN "example" TYPE character varying(51) COLLATE "C"',
+                    ])
+                    expect(
+                        sqlInMemory.downQueries.map((query) => query.query),
+                    ).to.eql([
+                        'ALTER TABLE "bug3357_cached_length" ALTER COLUMN "example" TYPE character varying(51) COLLATE pg_catalog."default"',
+                    ])
+                } finally {
+                    await queryRunner.release()
+                }
+            }),
+        ))
 })

--- a/test/github-issues/3357/issue-3357.test.ts
+++ b/test/github-issues/3357/issue-3357.test.ts
@@ -25,41 +25,100 @@ describe("github issues > #3357 postgres varchar length changes", () => {
             dataSources.map(async (dataSource) => {
                 const queryRunner = dataSource.createQueryRunner()
 
-                await queryRunner.createTable(
-                    new Table({
-                        name: "bug3357",
-                        columns: [
-                            {
-                                name: "example",
-                                type: "character varying",
-                                length: "50",
-                            },
-                        ],
-                    }),
-                    true,
-                )
+                try {
+                    await queryRunner.createTable(
+                        new Table({
+                            name: "bug3357",
+                            columns: [
+                                {
+                                    name: "example",
+                                    type: "character varying",
+                                    length: "50",
+                                },
+                            ],
+                        }),
+                        true,
+                    )
 
-                const table = await queryRunner.getTable("bug3357")
-                const column = table!.findColumnByName("example")!
-                const changedColumn = column.clone()
-                changedColumn.length = "51"
+                    const table = await queryRunner.getTable("bug3357")
+                    const column = table!.findColumnByName("example")!
+                    const changedColumn = column.clone()
+                    changedColumn.length = "51"
 
-                queryRunner.enableSqlMemory()
-                await queryRunner.changeColumn(table!, column, changedColumn)
-                const sqlInMemory = queryRunner.getMemorySql()
+                    queryRunner.enableSqlMemory()
+                    await queryRunner.changeColumn(
+                        table!,
+                        column,
+                        changedColumn,
+                    )
+                    const sqlInMemory = queryRunner.getMemorySql()
 
-                expect(
-                    sqlInMemory.upQueries.map((query) => query.query),
-                ).to.eql([
-                    'ALTER TABLE "bug3357" ALTER COLUMN "example" TYPE character varying(51)',
-                ])
-                expect(
-                    sqlInMemory.downQueries.map((query) => query.query),
-                ).to.eql([
-                    'ALTER TABLE "bug3357" ALTER COLUMN "example" TYPE character varying(50)',
-                ])
+                    expect(
+                        sqlInMemory.upQueries.map((query) => query.query),
+                    ).to.eql([
+                        'ALTER TABLE "bug3357" ALTER COLUMN "example" TYPE character varying(51)',
+                    ])
+                    expect(
+                        sqlInMemory.downQueries.map((query) => query.query),
+                    ).to.eql([
+                        'ALTER TABLE "bug3357" ALTER COLUMN "example" TYPE character varying(50)',
+                    ])
+                } finally {
+                    await queryRunner.release()
+                }
+            }),
+        ))
 
-                await queryRunner.release()
+    it("should preserve varchar length when changing collation", () =>
+        Promise.all(
+            dataSources.map(async (dataSource) => {
+                const queryRunner = dataSource.createQueryRunner()
+
+                try {
+                    await queryRunner.createTable(
+                        new Table({
+                            name: "bug3357_collation",
+                            columns: [
+                                {
+                                    name: "example",
+                                    type: "character varying",
+                                    length: "50",
+                                },
+                            ],
+                        }),
+                        true,
+                    )
+
+                    const table =
+                        await queryRunner.getTable("bug3357_collation")
+                    const column = table!.findColumnByName("example")!
+                    const changedColumn = column.clone()
+                    changedColumn.length = "51"
+                    changedColumn.collation = "C"
+
+                    queryRunner.enableSqlMemory()
+                    await queryRunner.changeColumn(
+                        table!,
+                        column,
+                        changedColumn,
+                    )
+                    const sqlInMemory = queryRunner.getMemorySql()
+
+                    expect(
+                        sqlInMemory.upQueries.map((query) => query.query),
+                    ).to.eql([
+                        'ALTER TABLE "bug3357_collation" ALTER COLUMN "example" TYPE character varying(51)',
+                        'ALTER TABLE "bug3357_collation" ALTER COLUMN "example" TYPE character varying(51) COLLATE "C"',
+                    ])
+                    expect(
+                        sqlInMemory.downQueries.map((query) => query.query),
+                    ).to.eql([
+                        'ALTER TABLE "bug3357_collation" ALTER COLUMN "example" TYPE character varying(50)',
+                        'ALTER TABLE "bug3357_collation" ALTER COLUMN "example" TYPE character varying(50) COLLATE pg_catalog."default"',
+                    ])
+                } finally {
+                    await queryRunner.release()
+                }
             }),
         ))
 })

--- a/test/github-issues/3357/issue-3357.test.ts
+++ b/test/github-issues/3357/issue-3357.test.ts
@@ -1,0 +1,65 @@
+import "reflect-metadata"
+import { expect } from "chai"
+import type { DataSource } from "../../../src"
+import { Table } from "../../../src"
+import {
+    closeTestingConnections,
+    createTestingConnections,
+} from "../../utils/test-utils"
+
+describe("github issues > #3357 postgres varchar length changes", () => {
+    let dataSources: DataSource[]
+
+    before(async () => {
+        dataSources = await createTestingConnections({
+            enabledDrivers: ["postgres"],
+            schemaCreate: false,
+            dropSchema: true,
+        })
+    })
+
+    after(() => closeTestingConnections(dataSources))
+
+    it("should alter varchar length without dropping and recreating the column", () =>
+        Promise.all(
+            dataSources.map(async (dataSource) => {
+                const queryRunner = dataSource.createQueryRunner()
+
+                await queryRunner.createTable(
+                    new Table({
+                        name: "bug3357",
+                        columns: [
+                            {
+                                name: "example",
+                                type: "character varying",
+                                length: "50",
+                            },
+                        ],
+                    }),
+                    true,
+                )
+
+                const table = await queryRunner.getTable("bug3357")
+                const column = table!.findColumnByName("example")!
+                const changedColumn = column.clone()
+                changedColumn.length = "51"
+
+                queryRunner.enableSqlMemory()
+                await queryRunner.changeColumn(table!, column, changedColumn)
+                const sqlInMemory = queryRunner.getMemorySql()
+
+                expect(
+                    sqlInMemory.upQueries.map((query) => query.query),
+                ).to.eql([
+                    'ALTER TABLE "bug3357" ALTER COLUMN "example" TYPE character varying(51)',
+                ])
+                expect(
+                    sqlInMemory.downQueries.map((query) => query.query),
+                ).to.eql([
+                    'ALTER TABLE "bug3357" ALTER COLUMN "example" TYPE character varying(50)',
+                ])
+
+                await queryRunner.release()
+            }),
+        ))
+})


### PR DESCRIPTION
### Description of change

Fixes #3357 by handling PostgreSQL column length-only changes with `ALTER COLUMN ... TYPE` instead of dropping and recreating the column.

Previously, `PostgresQueryRunner.changeColumn()` treated a `length` change the same as an incompatible type change and recreated the column. For cases such as `character varying(50)` -> `character varying(51)`, that generated:

```sql
ALTER TABLE "bug" DROP COLUMN "example";
ALTER TABLE "bug" ADD "example" character varying(51);
```

which can cause data loss.

This change removes `length` from the destructive-recreate condition and lets the existing type alteration branch emit:

```sql
ALTER TABLE "bug" ALTER COLUMN "example" TYPE character varying(51);
```

A regression test was added for PostgreSQL varchar length changes.

### Pull-Request Checklist

- [x] Code is up-to-date with the `master` branch
- [x] `pnpm run compile` passes
- [x] `pnpm exec prettier --check src/driver/postgres/PostgresQueryRunner.ts test/github-issues/3357/issue-3357.test.ts` passes
- [ ] Tests pass locally with a PostgreSQL `ormconfig.json` configured
