### PR TITLE
fix: preserve postgres varchar data on length change

### DIFF
--- a/src/driver/postgres/PostgresQueryRunner.ts
+++ b/src/driver/postgres/PostgresQueryRunner.ts
@@ -1328,7 +1328,6 @@ export class PostgresQueryRunner
 
         if (
             oldColumn.type !== newColumn.type ||
-            oldColumn.length !== newColumn.length ||
             newColumn.isArray !== oldColumn.isArray ||
             (!oldColumn.generatedType &&
                 newColumn.generatedType === "STORED") ||
@@ -1619,6 +1618,7 @@ export class PostgresQueryRunner
             }
 
             if (
+                newColumn.length !== oldColumn.length ||
                 newColumn.precision !== oldColumn.precision ||
                 newColumn.scale !== oldColumn.scale
             ) {
@@ -2348,9 +2348,9 @@ export class PostgresQueryRunner
                     new Query(
                         `ALTER TABLE ${this.escapePath(table)} ALTER COLUMN "${
                             newColumn.name
-                        }" TYPE ${newColumn.type} COLLATE "${
-                            newColumn.collation
-                        }"`,
+                        }" TYPE ${this.driver.createFullType(
+                            newColumn,
+                        )} COLLATE "${newColumn.collation}"`,
                     ),
                 )
 
@@ -2362,7 +2362,9 @@ export class PostgresQueryRunner
                     new Query(
                         `ALTER TABLE ${this.escapePath(table)} ALTER COLUMN "${
                             newColumn.name
-                        }" TYPE ${newColumn.type} COLLATE ${oldCollation}`,
+                        }" TYPE ${this.driver.createFullType(
+                            oldColumn,
+                        )} COLLATE ${oldCollation}`,
                     ),
                 )
             }

--- a/test/functional/schema-builder/collation/collation-changes/collation-changes.test.ts
+++ b/test/functional/schema-builder/collation/collation-changes/collation-changes.test.ts
@@ -43,8 +43,8 @@ describe("schema builder > collation > collation changes", () => {
                     .createSchemaBuilder()
                     .log()
                 const tableName = meta.tableName
-                const expectedUp = `ALTER TABLE "${tableName}" ALTER COLUMN "${COLUMN_NAME}" TYPE character varying COLLATE "${NEW_COLLATION}"`
-                const expectedDown = `ALTER TABLE "${tableName}" ALTER COLUMN "${COLUMN_NAME}" TYPE character varying COLLATE "${OLD_COLLATION}"`
+                const expectedUp = `ALTER TABLE "${tableName}" ALTER COLUMN "${COLUMN_NAME}" TYPE character varying(100) COLLATE "${NEW_COLLATION}"`
+                const expectedDown = `ALTER TABLE "${tableName}" ALTER COLUMN "${COLUMN_NAME}" TYPE character varying(100) COLLATE "${OLD_COLLATION}"`
 
                 // assert that the expected queries are in the generated SQL
                 const upJoined = sqlInMemory.upQueries

--- a/test/functional/schema-builder/column/change/change-column/change-column.test.ts
+++ b/test/functional/schema-builder/column/change/change-column/change-column.test.ts
@@ -88,6 +88,42 @@ describe("schema builder > change column", () => {
             }),
         ))
 
+    it("should preserve postgres column data when changing varchar length", () =>
+        Promise.all(
+            dataSources.map(async (dataSource) => {
+                if (dataSource.driver.options.type !== "postgres") return
+
+                const text = "data that must survive varchar length changes"
+                await dataSource.getRepository(Post).insert({
+                    id: 3357,
+                    version: "1",
+                    name: "issue-3357",
+                    text,
+                    tag: "issue-3357",
+                    likesCount: 1,
+                })
+
+                const postMetadata = dataSource.getMetadata(Post)
+                const textColumn =
+                    postMetadata.findColumnWithPropertyName("text")!
+                const oldLength = textColumn.length
+
+                try {
+                    textColumn.length = "300"
+
+                    await dataSource.synchronize()
+
+                    const post = await dataSource
+                        .getRepository(Post)
+                        .findOneByOrFail({ id: 3357 })
+
+                    expect(post.text).to.equal(text)
+                } finally {
+                    textColumn.length = oldLength
+                }
+            }),
+        ))
+
     it("should correctly change column type", () =>
         Promise.all(
             dataSources.map(async (dataSource) => {


### PR DESCRIPTION
### Description of change

Fixes #3357 by handling PostgreSQL varchar length changes with `ALTER COLUMN ... TYPE` instead of dropping and recreating the column.

Previously, `PostgresQueryRunner.changeColumn()` treated a `length` change as a destructive type incompatibility, so changing `varchar(50)` to `varchar(51)` generated a `DROP COLUMN` / `ADD COLUMN` sequence and lost existing data.

This change:

- removes `length` from the destructive recreate condition
- routes length-only changes through the existing non-destructive `ALTER COLUMN ... TYPE` path
- preserves type modifiers when altering column collation by using `createFullType()` instead of the bare column type
- adds a functional regression test that inserts data, changes a Postgres varchar length, synchronizes, and verifies the data is preserved
- updates the collation functional test expectations so the generated SQL preserves `character varying(100)`

### Pull-Request Checklist

- [x] Code is up-to-date with the `master` branch
- [x] `corepack pnpm exec prettier --check src/driver/postgres/PostgresQueryRunner.ts test/functional/schema-builder/column/change/change-column/change-column.test.ts test/functional/schema-builder/collation/collation-changes/collation-changes.test.ts` passes
- [x] `corepack pnpm run typecheck` passes
- [x] `corepack pnpm run compile` passes
- [ ] Functional test run requires a local `ormconfig.json`/Postgres configuration; attempted targeted run and it stopped at the missing `ormconfig.json` project setup requirement