### PR TITLE
fix(postgres): preserve varchar length during column changes

### DIFF
--- a/src/driver/postgres/PostgresQueryRunner.ts
+++ b/src/driver/postgres/PostgresQueryRunner.ts
@@ -1326,9 +1326,16 @@ export class PostgresQueryRunner
                 `Column "${oldTableColumnOrName}" was not found in the "${table.name}" table.`,
             )
 
+        const isOnlyLengthChanged =
+            oldColumn.type === newColumn.type &&
+            oldColumn.length !== newColumn.length &&
+            oldColumn.isArray === newColumn.isArray &&
+            oldColumn.generatedType === newColumn.generatedType &&
+            oldColumn.asExpression === newColumn.asExpression
+
         if (
             oldColumn.type !== newColumn.type ||
-            oldColumn.length !== newColumn.length ||
+            (!isOnlyLengthChanged && oldColumn.length !== newColumn.length) ||
             newColumn.isArray !== oldColumn.isArray ||
             (!oldColumn.generatedType &&
                 newColumn.generatedType === "STORED") ||
@@ -1620,7 +1627,8 @@ export class PostgresQueryRunner
 
             if (
                 newColumn.precision !== oldColumn.precision ||
-                newColumn.scale !== oldColumn.scale
+                newColumn.scale !== oldColumn.scale ||
+                isOnlyLengthChanged
             ) {
                 upQueries.push(
                     new Query(
@@ -2344,13 +2352,17 @@ export class PostgresQueryRunner
 
             // update column collation
             if (newColumn.collation !== oldColumn.collation) {
+                const newCollation = newColumn.collation
+                    ? `"${newColumn.collation}"`
+                    : `pg_catalog."default"` // if there's no new collation, use default
+
                 upQueries.push(
                     new Query(
                         `ALTER TABLE ${this.escapePath(table)} ALTER COLUMN "${
                             newColumn.name
-                        }" TYPE ${newColumn.type} COLLATE "${
-                            newColumn.collation
-                        }"`,
+                        }" TYPE ${this.driver.createFullType(
+                            newColumn,
+                        )} COLLATE ${newCollation}`,
                     ),
                 )
 
@@ -2362,7 +2374,9 @@ export class PostgresQueryRunner
                     new Query(
                         `ALTER TABLE ${this.escapePath(table)} ALTER COLUMN "${
                             newColumn.name
-                        }" TYPE ${newColumn.type} COLLATE ${oldCollation}`,
+                        }" TYPE ${this.driver.createFullType(
+                            oldColumn,
+                        )} COLLATE ${oldCollation}`,
                     ),
                 )
             }

--- a/src/driver/postgres/PostgresQueryRunner.ts
+++ b/src/driver/postgres/PostgresQueryRunner.ts
@@ -1332,6 +1332,7 @@ export class PostgresQueryRunner
             oldColumn.isArray === newColumn.isArray &&
             oldColumn.generatedType === newColumn.generatedType &&
             oldColumn.asExpression === newColumn.asExpression
+        const collationChanged = newColumn.collation !== oldColumn.collation
 
         if (
             oldColumn.type !== newColumn.type ||
@@ -1628,7 +1629,7 @@ export class PostgresQueryRunner
             if (
                 newColumn.precision !== oldColumn.precision ||
                 newColumn.scale !== oldColumn.scale ||
-                isOnlyLengthChanged
+                (isOnlyLengthChanged && !collationChanged)
             ) {
                 upQueries.push(
                     new Query(
@@ -2351,7 +2352,7 @@ export class PostgresQueryRunner
             }
 
             // update column collation
-            if (newColumn.collation !== oldColumn.collation) {
+            if (collationChanged) {
                 const newCollation = newColumn.collation
                     ? `"${newColumn.collation}"`
                     : `pg_catalog."default"` // if there's no new collation, use default

--- a/src/driver/postgres/PostgresQueryRunner.ts
+++ b/src/driver/postgres/PostgresQueryRunner.ts
@@ -2354,7 +2354,7 @@ export class PostgresQueryRunner
             // update column collation
             if (collationChanged) {
                 const newCollation = newColumn.collation
-                    ? `"${newColumn.collation}"`
+                    ? this.driver.escape(newColumn.collation)
                     : `pg_catalog."default"` // if there's no new collation, use default
 
                 upQueries.push(
@@ -2368,7 +2368,7 @@ export class PostgresQueryRunner
                 )
 
                 const oldCollation = oldColumn.collation
-                    ? `"${oldColumn.collation}"`
+                    ? this.driver.escape(oldColumn.collation)
                     : `pg_catalog."default"` // if there's no old collation, use default
 
                 downQueries.push(

--- a/test/functional/schema-builder/collation/collation-changes/collation-changes.test.ts
+++ b/test/functional/schema-builder/collation/collation-changes/collation-changes.test.ts
@@ -156,4 +156,37 @@ describe("schema builder > collation > collation changes", () => {
             }),
         )
     })
+
+    it("escapes quoted collation identifiers in generated SQL", async () => {
+        await Promise.all(
+            dataSources.map(async (connection) => {
+                const meta = connection.getMetadata(Item)
+                const col = meta.columns.find(
+                    (c) => c.propertyName === COLUMN_NAME,
+                )!
+                const OLD_COLLATION = col.collation
+                const quotedCollation = 'custom"collation'
+
+                try {
+                    col.collation = quotedCollation
+
+                    const sqlInMemory = await connection.driver
+                        .createSchemaBuilder()
+                        .log()
+                    const tableName = meta.tableName
+                    const upJoined = joinQueries(sqlInMemory.upQueries)
+                    const downJoined = joinQueries(sqlInMemory.downQueries)
+
+                    expect(upJoined).to.include(
+                        `ALTER TABLE "${tableName}" ALTER COLUMN "${COLUMN_NAME}" TYPE character varying(${COLUMN_LENGTH}) COLLATE "custom""collation"`,
+                    )
+                    expect(downJoined).to.include(
+                        `ALTER TABLE "${tableName}" ALTER COLUMN "${COLUMN_NAME}" TYPE character varying(${COLUMN_LENGTH}) COLLATE "${OLD_COLLATION}"`,
+                    )
+                } finally {
+                    col.collation = OLD_COLLATION
+                }
+            }),
+        )
+    })
 })

--- a/test/functional/schema-builder/collation/collation-changes/collation-changes.test.ts
+++ b/test/functional/schema-builder/collation/collation-changes/collation-changes.test.ts
@@ -115,11 +115,15 @@ describe("schema builder > collation > collation changes", () => {
                     const tableName = meta.tableName
                     const upJoined = joinQueries(sqlInMemory.upQueries)
                     expect(upJoined).to.include(
-                        `ALTER TABLE "${tableName}" ALTER COLUMN "${COLUMN_NAME}" TYPE character varying(${NEXT_COLUMN_LENGTH})`,
-                    )
-                    expect(upJoined).to.include(
                         `ALTER TABLE "${tableName}" ALTER COLUMN "${COLUMN_NAME}" TYPE character varying(${NEXT_COLUMN_LENGTH}) COLLATE "${NEW_COLLATION}"`,
                     )
+                    expect(
+                        sqlInMemory.upQueries.filter((query) =>
+                            query.query.includes(
+                                `ALTER TABLE "${tableName}" ALTER COLUMN "${COLUMN_NAME}" TYPE`,
+                            ),
+                        ),
+                    ).to.have.length(1)
                     expect(upJoined).not.to.include("DROP COLUMN")
                     expect(upJoined).not.to.include(
                         `TYPE character varying COLLATE "${NEW_COLLATION}"`,

--- a/test/functional/schema-builder/collation/collation-changes/collation-changes.test.ts
+++ b/test/functional/schema-builder/collation/collation-changes/collation-changes.test.ts
@@ -26,6 +26,11 @@ describe("schema builder > collation > collation changes", () => {
     after(() => closeTestingConnections(dataSources))
 
     const COLUMN_NAME = "name"
+    const COLUMN_LENGTH = "100"
+    const NEXT_COLUMN_LENGTH = "101"
+
+    const joinQueries = (queries: { query: string }[]) =>
+        queries.map((q) => q.query.replaceAll(/\s+/g, " ").trim()).join(" ")
 
     it("ALTER ... COLLATE query should be created", async () => {
         await Promise.all(
@@ -36,47 +41,113 @@ describe("schema builder > collation > collation changes", () => {
                     (c) => c.propertyName === COLUMN_NAME,
                 )!
                 const OLD_COLLATION = col.collation
-                col.collation = NEW_COLLATION
-
-                // capture generated up queries
-                const sqlInMemory = await connection.driver
-                    .createSchemaBuilder()
-                    .log()
-                const tableName = meta.tableName
-                const expectedUp = `ALTER TABLE "${tableName}" ALTER COLUMN "${COLUMN_NAME}" TYPE character varying COLLATE "${NEW_COLLATION}"`
-                const expectedDown = `ALTER TABLE "${tableName}" ALTER COLUMN "${COLUMN_NAME}" TYPE character varying COLLATE "${OLD_COLLATION}"`
-
-                // assert that the expected queries are in the generated SQL
-                const upJoined = sqlInMemory.upQueries
-                    .map((q) => q.query.replaceAll(/\s+/g, " ").trim())
-                    .join(" ")
-                expect(upJoined).to.include(expectedUp)
-                const downJoined = sqlInMemory.downQueries
-                    .map((q) => q.query.replaceAll(/\s+/g, " ").trim())
-                    .join(" ")
-                expect(downJoined).to.include(expectedDown)
-
-                // assert that collation changes are applied to the database
-                const queryRunner = connection.createQueryRunner()
+                const OLD_LENGTH = col.length
 
                 try {
-                    let table = await queryRunner.getTable(meta.tableName)
-                    const originColumn = table!.columns.find(
-                        (c) => c.name === COLUMN_NAME,
-                    )!
-                    // old collation should be appeared
-                    expect(originColumn.collation).to.equal(OLD_COLLATION)
+                    col.collation = NEW_COLLATION
+
+                    // capture generated up queries
+                    const sqlInMemory = await connection.driver
+                        .createSchemaBuilder()
+                        .log()
+                    const tableName = meta.tableName
+                    const expectedUp = `ALTER TABLE "${tableName}" ALTER COLUMN "${COLUMN_NAME}" TYPE character varying(${COLUMN_LENGTH}) COLLATE "${NEW_COLLATION}"`
+                    const expectedDown = `ALTER TABLE "${tableName}" ALTER COLUMN "${COLUMN_NAME}" TYPE character varying(${COLUMN_LENGTH}) COLLATE "${OLD_COLLATION}"`
+
+                    // assert that the expected queries are in the generated SQL
+                    const upJoined = joinQueries(sqlInMemory.upQueries)
+                    expect(upJoined).to.include(expectedUp)
+                    const downJoined = joinQueries(sqlInMemory.downQueries)
+                    expect(downJoined).to.include(expectedDown)
+
+                    // assert that collation changes are applied to the database
+                    const queryRunner = connection.createQueryRunner()
+                    try {
+                        let table = await queryRunner.getTable(meta.tableName)
+                        const originColumn = table!.columns.find(
+                            (c) => c.name === COLUMN_NAME,
+                        )!
+                        // old collation should be appeared
+                        expect(originColumn.collation).to.equal(OLD_COLLATION)
+                        expect(originColumn.length).to.equal(COLUMN_LENGTH)
+
+                        await connection.synchronize()
+
+                        table = await queryRunner.getTable(meta.tableName)
+                        const appliedColumn = table!.columns.find(
+                            (c) => c.name === COLUMN_NAME,
+                        )!
+                        // new collation should be appeared
+                        expect(appliedColumn.collation).to.equal(NEW_COLLATION)
+                        expect(appliedColumn.length).to.equal(COLUMN_LENGTH)
+                    } finally {
+                        await queryRunner.release()
+                    }
+                } finally {
+                    col.collation = OLD_COLLATION
+                    col.length = OLD_LENGTH
+                }
+            }),
+        )
+    })
+
+    it("should preserve data and length when varchar length and collation change together", async () => {
+        await Promise.all(
+            dataSources.map(async (connection) => {
+                const meta = connection.getMetadata(Item)
+                const col = meta.columns.find(
+                    (c) => c.propertyName === COLUMN_NAME,
+                )!
+                const OLD_COLLATION = col.collation
+                const OLD_LENGTH = col.length
+
+                try {
+                    await connection.getRepository(Item).save({
+                        name: "preserved",
+                    })
+
+                    col.collation = NEW_COLLATION
+                    col.length = NEXT_COLUMN_LENGTH
+
+                    const sqlInMemory = await connection.driver
+                        .createSchemaBuilder()
+                        .log()
+                    const tableName = meta.tableName
+                    const upJoined = joinQueries(sqlInMemory.upQueries)
+                    expect(upJoined).to.include(
+                        `ALTER TABLE "${tableName}" ALTER COLUMN "${COLUMN_NAME}" TYPE character varying(${NEXT_COLUMN_LENGTH})`,
+                    )
+                    expect(upJoined).to.include(
+                        `ALTER TABLE "${tableName}" ALTER COLUMN "${COLUMN_NAME}" TYPE character varying(${NEXT_COLUMN_LENGTH}) COLLATE "${NEW_COLLATION}"`,
+                    )
+                    expect(upJoined).not.to.include("DROP COLUMN")
+                    expect(upJoined).not.to.include(
+                        `TYPE character varying COLLATE "${NEW_COLLATION}"`,
+                    )
 
                     await connection.synchronize()
 
-                    table = await queryRunner.getTable(meta.tableName)
-                    const appliedColumn = table!.columns.find(
-                        (c) => c.name === COLUMN_NAME,
-                    )!
-                    // new collation should be appeared
-                    expect(appliedColumn.collation).to.equal(NEW_COLLATION)
+                    const stored = await connection
+                        .getRepository(Item)
+                        .findOneByOrFail({ name: "preserved" })
+                    expect(stored.name).to.equal("preserved")
+
+                    const queryRunner = connection.createQueryRunner()
+                    try {
+                        const table = await queryRunner.getTable(meta.tableName)
+                        const appliedColumn = table!.columns.find(
+                            (c) => c.name === COLUMN_NAME,
+                        )!
+                        expect(appliedColumn.collation).to.equal(NEW_COLLATION)
+                        expect(appliedColumn.length).to.equal(
+                            NEXT_COLUMN_LENGTH,
+                        )
+                    } finally {
+                        await queryRunner.release()
+                    }
                 } finally {
-                    await queryRunner.release()
+                    col.collation = OLD_COLLATION
+                    col.length = OLD_LENGTH
                 }
             }),
         )


### PR DESCRIPTION
Fixes #3357.

This changes PostgreSQL `changeColumn` so varchar length-only changes use `ALTER COLUMN ... TYPE ...` instead of dropping and re-adding the column. It also updates the collation-change path to use the full column type, so a collation update cannot accidentally erase the varchar length modifier.

What changed:
- Detect length-only changes and route them through the non-destructive `ALTER COLUMN TYPE` path.
- Preserve full column type information when generating `ALTER ... COLLATE` SQL.
- Cover both collation-only and length-plus-collation changes in the functional schema-builder suite.
- Assert generated SQL does not include `DROP COLUMN` for the length-plus-collation case and preserves stored data after synchronize.

Verification run locally:
- `corepack pnpm exec prettier --check src/driver/postgres/PostgresQueryRunner.ts test/functional/schema-builder/collation/collation-changes/collation-changes.test.ts`
- `corepack pnpm exec tsc --noEmit --pretty false`
- `corepack pnpm run compile`
- `git diff --check`
- `corepack pnpm exec eslint src/driver/postgres/PostgresQueryRunner.ts test/functional/schema-builder/collation/collation-changes/collation-changes.test.ts` (0 errors; existing PostgresQueryRunner warnings remain)
- A compiled SQL-memory smoke script confirmed:
  - length-only up query is `ALTER TABLE "post" ALTER COLUMN "example" TYPE character varying(51)`
  - length-plus-collation up query includes `ALTER TABLE "post" ALTER COLUMN "example" TYPE character varying(101) COLLATE "C"`
  - no generated SQL includes `DROP COLUMN`

I could not run the database-backed functional test locally because this machine does not have TypeORM's required `ormconfig.json` / local Postgres test configuration. The functional regression is included for CI.