### PR TITLE
fix: alter postgres varchar length without column recreation

### DIFF
--- a/src/driver/postgres/PostgresQueryRunner.ts
+++ b/src/driver/postgres/PostgresQueryRunner.ts
@@ -1328,7 +1328,6 @@ export class PostgresQueryRunner
 
         if (
             oldColumn.type !== newColumn.type ||
-            oldColumn.length !== newColumn.length ||
             newColumn.isArray !== oldColumn.isArray ||
             (!oldColumn.generatedType &&
                 newColumn.generatedType === "STORED") ||
@@ -1619,6 +1618,7 @@ export class PostgresQueryRunner
             }
 
             if (
+                newColumn.length !== oldColumn.length ||
                 newColumn.precision !== oldColumn.precision ||
                 newColumn.scale !== oldColumn.scale
             ) {
@@ -2348,9 +2348,9 @@ export class PostgresQueryRunner
                     new Query(
                         `ALTER TABLE ${this.escapePath(table)} ALTER COLUMN "${
                             newColumn.name
-                        }" TYPE ${newColumn.type} COLLATE "${
-                            newColumn.collation
-                        }"`,
+                        }" TYPE ${this.driver.createFullType(
+                            newColumn,
+                        )} COLLATE "${newColumn.collation}"`,
                     ),
                 )
 
@@ -2362,7 +2362,9 @@ export class PostgresQueryRunner
                     new Query(
                         `ALTER TABLE ${this.escapePath(table)} ALTER COLUMN "${
                             newColumn.name
-                        }" TYPE ${newColumn.type} COLLATE ${oldCollation}`,
+                        }" TYPE ${this.driver.createFullType(
+                            oldColumn,
+                        )} COLLATE ${oldCollation}`,
                     ),
                 )
             }

--- a/test/functional/schema-builder/collation/collation-changes/collation-changes.test.ts
+++ b/test/functional/schema-builder/collation/collation-changes/collation-changes.test.ts
@@ -38,45 +38,49 @@ describe("schema builder > collation > collation changes", () => {
                 const OLD_COLLATION = col.collation
                 col.collation = NEW_COLLATION
 
-                // capture generated up queries
-                const sqlInMemory = await connection.driver
-                    .createSchemaBuilder()
-                    .log()
-                const tableName = meta.tableName
-                const expectedUp = `ALTER TABLE "${tableName}" ALTER COLUMN "${COLUMN_NAME}" TYPE character varying COLLATE "${NEW_COLLATION}"`
-                const expectedDown = `ALTER TABLE "${tableName}" ALTER COLUMN "${COLUMN_NAME}" TYPE character varying COLLATE "${OLD_COLLATION}"`
-
-                // assert that the expected queries are in the generated SQL
-                const upJoined = sqlInMemory.upQueries
-                    .map((q) => q.query.replaceAll(/\s+/g, " ").trim())
-                    .join(" ")
-                expect(upJoined).to.include(expectedUp)
-                const downJoined = sqlInMemory.downQueries
-                    .map((q) => q.query.replaceAll(/\s+/g, " ").trim())
-                    .join(" ")
-                expect(downJoined).to.include(expectedDown)
-
-                // assert that collation changes are applied to the database
-                const queryRunner = connection.createQueryRunner()
-
                 try {
-                    let table = await queryRunner.getTable(meta.tableName)
-                    const originColumn = table!.columns.find(
-                        (c) => c.name === COLUMN_NAME,
-                    )!
-                    // old collation should be appeared
-                    expect(originColumn.collation).to.equal(OLD_COLLATION)
+                    // capture generated up queries
+                    const sqlInMemory = await connection.driver
+                        .createSchemaBuilder()
+                        .log()
+                    const tableName = meta.tableName
+                    const expectedUp = `ALTER TABLE "${tableName}" ALTER COLUMN "${COLUMN_NAME}" TYPE character varying(100) COLLATE "${NEW_COLLATION}"`
+                    const expectedDown = `ALTER TABLE "${tableName}" ALTER COLUMN "${COLUMN_NAME}" TYPE character varying(100) COLLATE "${OLD_COLLATION}"`
 
-                    await connection.synchronize()
+                    // assert that the expected queries are in the generated SQL
+                    const upJoined = sqlInMemory.upQueries
+                        .map((q) => q.query.replaceAll(/\s+/g, " ").trim())
+                        .join(" ")
+                    expect(upJoined).to.include(expectedUp)
+                    const downJoined = sqlInMemory.downQueries
+                        .map((q) => q.query.replaceAll(/\s+/g, " ").trim())
+                        .join(" ")
+                    expect(downJoined).to.include(expectedDown)
 
-                    table = await queryRunner.getTable(meta.tableName)
-                    const appliedColumn = table!.columns.find(
-                        (c) => c.name === COLUMN_NAME,
-                    )!
-                    // new collation should be appeared
-                    expect(appliedColumn.collation).to.equal(NEW_COLLATION)
+                    // assert that collation changes are applied to the database
+                    const queryRunner = connection.createQueryRunner()
+
+                    try {
+                        let table = await queryRunner.getTable(meta.tableName)
+                        const originColumn = table!.columns.find(
+                            (c) => c.name === COLUMN_NAME,
+                        )!
+                        // old collation should be appeared
+                        expect(originColumn.collation).to.equal(OLD_COLLATION)
+
+                        await connection.synchronize()
+
+                        table = await queryRunner.getTable(meta.tableName)
+                        const appliedColumn = table!.columns.find(
+                            (c) => c.name === COLUMN_NAME,
+                        )!
+                        // new collation should be appeared
+                        expect(appliedColumn.collation).to.equal(NEW_COLLATION)
+                    } finally {
+                        await queryRunner.release()
+                    }
                 } finally {
-                    await queryRunner.release()
+                    col.collation = OLD_COLLATION
                 }
             }),
         )

--- a/test/functional/schema-builder/column/change/change-column/change-column.test.ts
+++ b/test/functional/schema-builder/column/change/change-column/change-column.test.ts
@@ -88,6 +88,36 @@ describe("schema builder > change column", () => {
             }),
         ))
 
+    it("should generate non-destructive postgres query for varchar length changes (#3357)", () =>
+        Promise.all(
+            dataSources.map(async (dataSource) => {
+                if (dataSource.driver.options.type !== "postgres") return
+
+                const postMetadata = dataSource.getMetadata(Post)
+                const nameColumn =
+                    postMetadata.findColumnWithPropertyName("name")!
+                const originalLength = nameColumn.length
+                nameColumn.length = "500"
+
+                try {
+                    const sqlInMemory = await dataSource.driver
+                        .createSchemaBuilder()
+                        .log()
+                    const upQueries = sqlInMemory.upQueries.map(
+                        ({ query }) => query,
+                    )
+
+                    expect(upQueries).to.include(
+                        `ALTER TABLE "post" ALTER COLUMN "name" TYPE character varying(500)`,
+                    )
+                    expect(upQueries.join("\n")).not.to.contain("DROP COLUMN")
+                    expect(upQueries.join("\n")).not.to.contain(`ADD "name"`)
+                } finally {
+                    nameColumn.length = originalLength
+                }
+            }),
+        ))
+
     it("should correctly change column type", () =>
         Promise.all(
             dataSources.map(async (dataSource) => {


### PR DESCRIPTION
Fixes #3357.

## Summary

Postgres treated varchar length changes as destructive type changes, so generated migrations dropped and recreated columns. This preserves existing data by emitting `ALTER COLUMN ... TYPE` for length-only changes instead.

Also preserves the full column type when applying Postgres collation changes, so a `varchar(100)` column does not become unbounded `varchar` during `ALTER COLUMN ... TYPE ... COLLATE`.

## Tests

- `pnpm run typecheck`
- `pnpm exec prettier --check src/driver/postgres/PostgresQueryRunner.ts test/functional/schema-builder/column/change/change-column/change-column.test.ts test/functional/schema-builder/collation/collation-changes/collation-changes.test.ts`

Note: the focused Postgres integration path requires TypeORM's `ormconfig.json` and a configured Postgres test database for local execution.
