### PR TITLE
fix: preserve explicit join column type

### DIFF
--- a/src/metadata-builder/RelationJoinColumnBuilder.ts
+++ b/src/metadata-builder/RelationJoinColumnBuilder.ts
@@ -83,6 +83,12 @@ export class RelationJoinColumnBuilder {
                 columns,
                 uniqueConstraint: undefined,
             } // this case is possible for one-to-one non owning side and relations with createForeignKeyConstraints = false
+        if (!this.columnsHaveCompatibleTypes(columns, referencedColumns))
+            return {
+                foreignKey: undefined,
+                columns,
+                uniqueConstraint: undefined,
+            }
 
         const foreignKey = new ForeignKeyMetadata({
             name: joinColumns[0]?.foreignKeyConstraintName,
@@ -125,6 +131,21 @@ export class RelationJoinColumnBuilder {
     // -------------------------------------------------------------------------
     // Protected Methods
     // -------------------------------------------------------------------------
+
+    private columnsHaveCompatibleTypes(
+        columns: ColumnMetadata[],
+        referencedColumns: ColumnMetadata[],
+    ): boolean {
+        return columns.every((column, index) => {
+            const referencedColumn = referencedColumns[index]
+            if (!referencedColumn) return false
+
+            return (
+                this.dataSource.driver.normalizeType(column) ===
+                this.dataSource.driver.normalizeType(referencedColumn)
+            )
+        })
+    }
 
     /**
      * Collects referenced columns from the given join column args.
@@ -270,7 +291,9 @@ export class RelationJoinColumnBuilder {
                 relationalColumn = OrmUtils.cloneObject(relationalColumn)
             }
             relationalColumn.referencedColumn = referencedColumn // its important to set it here because we need to set referenced column for user defined join column
-            relationalColumn.type = referencedColumn.type // also since types of relational column and join column must be equal we override user defined column type
+            if (relationalColumn.isVirtual) {
+                relationalColumn.type = referencedColumn.type
+            }
             relationalColumn.relationMetadata = relation
             relationalColumn.build(this.dataSource)
             return relationalColumn

--- a/test/functional/relations/join-column-type-precedence/join-column-type-precedence.test.ts
+++ b/test/functional/relations/join-column-type-precedence/join-column-type-precedence.test.ts
@@ -1,0 +1,81 @@
+import "reflect-metadata"
+import { expect } from "chai"
+import {
+    Column,
+    DataSource,
+    Entity,
+    JoinColumn,
+    OneToOne,
+    PrimaryGeneratedColumn,
+} from "../../../../src"
+import { MssqlParameter } from "../../../../src/driver/sqlserver/MssqlParameter"
+import { SqlServerDriver } from "../../../../src/driver/sqlserver/SqlServerDriver"
+
+describe("relations > join column type precedence", () => {
+    let dataSource: MetadataOnlyDataSource | undefined
+
+    afterEach(async () => {
+        if (dataSource?.isInitialized) {
+            await dataSource.destroy()
+        }
+        dataSource = undefined
+    })
+
+    it("should preserve the explicit local column type when a join column references a different type (#12440)", async () => {
+        dataSource = new MetadataOnlyDataSource({
+            type: "mssql",
+            host: "localhost",
+            username: "test",
+            password: "test",
+            database: "test",
+            entities: [Vehicle, ProductItemSubscription],
+        })
+
+        await dataSource.buildMetadatasForTest()
+
+        const vehicleMetadata = dataSource.getMetadata(Vehicle)
+        const idColumn = vehicleMetadata.findColumnWithPropertyName("id")!
+        const subscriptionRelation =
+            vehicleMetadata.findRelationWithPropertyPath("_subscription")!
+        const joinColumn = subscriptionRelation.joinColumns[0]
+
+        expect(idColumn.type).to.equal(Number)
+        expect(joinColumn.type).to.equal(Number)
+        expect(joinColumn.referencedColumn!.type).to.equal("varchar")
+        expect(subscriptionRelation.foreignKeys).to.be.empty
+        expect(vehicleMetadata.foreignKeys).to.be.empty
+
+        const parameter = (
+            dataSource.driver as SqlServerDriver
+        ).parametrizeValue(idColumn, 2212)
+
+        expect(parameter).to.be.instanceOf(MssqlParameter)
+        expect(parameter.value).to.equal(2212)
+        expect(parameter.type).to.equal("int")
+    })
+})
+
+class MetadataOnlyDataSource extends DataSource {
+    buildMetadatasForTest(): Promise<void> {
+        return this.buildMetadatas()
+    }
+}
+
+@Entity()
+class ProductItemSubscription {
+    @PrimaryGeneratedColumn()
+    id: number
+
+    @Column("varchar", { name: "linkId", length: 24 })
+    linkId: string
+}
+
+@Entity()
+class Vehicle {
+    @PrimaryGeneratedColumn()
+    id: number
+
+    @OneToOne(() => ProductItemSubscription)
+    @JoinColumn({ name: "id", referencedColumnName: "linkId" })
+    _subscription: ProductItemSubscription
+}


### PR DESCRIPTION
Fixes #12440.

## Summary

When a user-defined local column is also used as a join column, keep that local column's declared type instead of overwriting it with the referenced column type.

This prevents MSSQL parameter wrapping from treating a numeric local primary column as `varchar` when the relation references a `varchar` column on the target entity.

When the local and referenced join column types are incompatible, TypeORM now skips FK metadata creation for that relation while preserving join columns for query building.

## Tests

- `pnpm run typecheck`
- `pnpm run compile`
- `pnpm exec prettier --check src/metadata-builder/RelationJoinColumnBuilder.ts test/functional/relations/join-column-type-precedence/join-column-type-precedence.test.ts`
- `pnpm exec mocha --no-config build/compiled/test/functional/relations/join-column-type-precedence/join-column-type-precedence.test.js`
