### PR TITLE
fix(postgres): preserve varchar columns when changing length

### DIFF
--- a/src/driver/postgres/PostgresQueryRunner.ts
+++ b/src/driver/postgres/PostgresQueryRunner.ts
@@ -1328,7 +1328,6 @@ export class PostgresQueryRunner
 
         if (
             oldColumn.type !== newColumn.type ||
-            oldColumn.length !== newColumn.length ||
             newColumn.isArray !== oldColumn.isArray ||
             (!oldColumn.generatedType &&
                 newColumn.generatedType === "STORED") ||
@@ -1618,10 +1617,14 @@ export class PostgresQueryRunner
                 oldColumn.name = newColumn.name
             }
 
-            if (
+            const typeChanged =
+                newColumn.length !== oldColumn.length ||
                 newColumn.precision !== oldColumn.precision ||
                 newColumn.scale !== oldColumn.scale
-            ) {
+
+            const collationChanged = newColumn.collation !== oldColumn.collation
+
+            if (typeChanged && !collationChanged) {
                 upQueries.push(
                     new Query(
                         `ALTER TABLE ${this.escapePath(table)} ALTER COLUMN "${
@@ -2343,14 +2346,18 @@ export class PostgresQueryRunner
             }
 
             // update column collation
-            if (newColumn.collation !== oldColumn.collation) {
+            if (collationChanged) {
+                const newCollation = newColumn.collation
+                    ? `"${newColumn.collation}"`
+                    : `pg_catalog."default"` // if there's no new collation, use default
+
                 upQueries.push(
                     new Query(
                         `ALTER TABLE ${this.escapePath(table)} ALTER COLUMN "${
                             newColumn.name
-                        }" TYPE ${newColumn.type} COLLATE "${
-                            newColumn.collation
-                        }"`,
+                        }" TYPE ${this.driver.createFullType(
+                            newColumn,
+                        )} COLLATE ${newCollation}`,
                     ),
                 )
 
@@ -2362,7 +2369,9 @@ export class PostgresQueryRunner
                     new Query(
                         `ALTER TABLE ${this.escapePath(table)} ALTER COLUMN "${
                             newColumn.name
-                        }" TYPE ${newColumn.type} COLLATE ${oldCollation}`,
+                        }" TYPE ${this.driver.createFullType(
+                            oldColumn,
+                        )} COLLATE ${oldCollation}`,
                     ),
                 )
             }

--- a/test/functional/schema-builder/collation/collation-changes/collation-changes.test.ts
+++ b/test/functional/schema-builder/collation/collation-changes/collation-changes.test.ts
@@ -43,8 +43,8 @@ describe("schema builder > collation > collation changes", () => {
                     .createSchemaBuilder()
                     .log()
                 const tableName = meta.tableName
-                const expectedUp = `ALTER TABLE "${tableName}" ALTER COLUMN "${COLUMN_NAME}" TYPE character varying COLLATE "${NEW_COLLATION}"`
-                const expectedDown = `ALTER TABLE "${tableName}" ALTER COLUMN "${COLUMN_NAME}" TYPE character varying COLLATE "${OLD_COLLATION}"`
+                const expectedUp = `ALTER TABLE "${tableName}" ALTER COLUMN "${COLUMN_NAME}" TYPE character varying(100) COLLATE "${NEW_COLLATION}"`
+                const expectedDown = `ALTER TABLE "${tableName}" ALTER COLUMN "${COLUMN_NAME}" TYPE character varying(100) COLLATE "${OLD_COLLATION}"`
 
                 // assert that the expected queries are in the generated SQL
                 const upJoined = sqlInMemory.upQueries

--- a/test/functional/schema-builder/column/change/varchar-length/entity/Bug.ts
+++ b/test/functional/schema-builder/column/change/varchar-length/entity/Bug.ts
@@ -1,0 +1,17 @@
+import {
+    Column,
+    Entity,
+    PrimaryGeneratedColumn,
+} from "../../../../../../../src"
+
+export const OLD_COLLATION = "POSIX"
+export const NEW_COLLATION = "C"
+
+@Entity("bug")
+export class Bug {
+    @PrimaryGeneratedColumn()
+    id: number
+
+    @Column({ length: 50, collation: OLD_COLLATION })
+    example: string
+}

--- a/test/functional/schema-builder/column/change/varchar-length/varchar-length.test.ts
+++ b/test/functional/schema-builder/column/change/varchar-length/varchar-length.test.ts
@@ -1,0 +1,130 @@
+import { expect } from "chai"
+import "reflect-metadata"
+import type { DataSource } from "../../../../../../src"
+import {
+    closeTestingConnections,
+    createTestingConnections,
+    reloadTestingDatabases,
+} from "../../../../../utils/test-utils"
+import { Bug, NEW_COLLATION, OLD_COLLATION } from "./entity/Bug"
+
+describe("schema builder > column > change > varchar length", () => {
+    let dataSources: DataSource[]
+
+    before(async () => {
+        dataSources = await createTestingConnections({
+            enabledDrivers: ["postgres"],
+            entities: [Bug],
+            schemaCreate: true,
+            dropSchema: true,
+        })
+    })
+
+    beforeEach(() => reloadTestingDatabases(dataSources))
+    after(() => closeTestingConnections(dataSources))
+
+    const normalizeQueries = (queries: { query: string }[]) =>
+        queries.map((query) => query.query.replaceAll(/\s+/g, " ").trim())
+
+    it("should alter varchar length without dropping and adding the column", () =>
+        Promise.all(
+            dataSources.map(async (connection) => {
+                await connection.getRepository(Bug).save({
+                    example: "kept value",
+                })
+
+                const metadata = connection.getMetadata(Bug)
+                const exampleColumn =
+                    metadata.findColumnWithPropertyName("example")!
+                const originalLength = exampleColumn.length
+
+                try {
+                    exampleColumn.length = "51"
+
+                    const sqlInMemory = await connection.driver
+                        .createSchemaBuilder()
+                        .log()
+
+                    const upQueries = normalizeQueries(sqlInMemory.upQueries)
+                    const downQueries = normalizeQueries(
+                        sqlInMemory.downQueries,
+                    )
+
+                    expect(upQueries).to.include(
+                        `ALTER TABLE "bug" ALTER COLUMN "example" TYPE character varying(51)`,
+                    )
+                    expect(downQueries).to.include(
+                        `ALTER TABLE "bug" ALTER COLUMN "example" TYPE character varying(50)`,
+                    )
+                    expect(upQueries.join(" ")).to.not.include(
+                        `DROP COLUMN "example"`,
+                    )
+                    expect(upQueries.join(" ")).to.not.include(`ADD "example"`)
+
+                    await connection.synchronize()
+
+                    const row = await connection
+                        .getRepository(Bug)
+                        .findOneByOrFail({ id: 1 })
+
+                    expect(row.example).to.equal("kept value")
+                } finally {
+                    exampleColumn.length = originalLength
+                }
+            }),
+        ))
+
+    it("should preserve varchar length when changing collation", () =>
+        Promise.all(
+            dataSources.map(async (connection) => {
+                await connection.getRepository(Bug).save({
+                    example: "kept value",
+                })
+
+                const metadata = connection.getMetadata(Bug)
+                const exampleColumn =
+                    metadata.findColumnWithPropertyName("example")!
+                const originalLength = exampleColumn.length
+                const originalCollation = exampleColumn.collation
+
+                try {
+                    exampleColumn.length = "51"
+                    exampleColumn.collation = NEW_COLLATION
+
+                    const sqlInMemory = await connection.driver
+                        .createSchemaBuilder()
+                        .log()
+
+                    const upQueries = normalizeQueries(sqlInMemory.upQueries)
+                    const downQueries = normalizeQueries(
+                        sqlInMemory.downQueries,
+                    )
+                    const upTypeQueries = upQueries.filter((query) =>
+                        query.includes(`ALTER COLUMN "example" TYPE`),
+                    )
+
+                    expect(upTypeQueries).to.deep.equal([
+                        `ALTER TABLE "bug" ALTER COLUMN "example" TYPE character varying(51) COLLATE "${NEW_COLLATION}"`,
+                    ])
+                    expect(downQueries).to.include(
+                        `ALTER TABLE "bug" ALTER COLUMN "example" TYPE character varying(50) COLLATE "${OLD_COLLATION}"`,
+                    )
+                    expect(upQueries.join(" ")).to.not.include(
+                        `DROP COLUMN "example"`,
+                    )
+                    expect(upQueries.join(" ")).to.not.include(`ADD "example"`)
+
+                    await connection.synchronize()
+
+                    const row = await connection
+                        .getRepository(Bug)
+                        .findOneByOrFail({ id: 1 })
+
+                    expect(row.example).to.equal("kept value")
+                } finally {
+                    exampleColumn.length = originalLength
+                    exampleColumn.collation = originalCollation
+                }
+            }),
+        ))
+})


### PR DESCRIPTION
Fixes #3357.

### Summary
- Treat Postgres varchar length changes as an `ALTER TYPE` operation instead of dropping and re-adding the column.
- Preserve the full varchar type modifier when collation changes are generated.
- Add functional regression coverage for varchar length changes, including the combined length + collation case.

### Checks
- `pnpm exec prettier --check src/driver/postgres/PostgresQueryRunner.ts test/functional/schema-builder/column/change/varchar-length/entity/Bug.ts test/functional/schema-builder/column/change/varchar-length/varchar-length.test.ts test/functional/schema-builder/collation/collation-changes/collation-changes.test.ts`
- `pnpm run typecheck`
- `pnpm run compile`

### Notes
- The targeted PostgreSQL integration test requires a local `ormconfig.json` and PostgreSQL instance, so I could not complete that run in this local environment.
