### PR TITLE
fix(postgres): alter column length without dropping column

### DIFF
--- a/src/driver/postgres/PostgresQueryRunner.ts
+++ b/src/driver/postgres/PostgresQueryRunner.ts
@@ -1328,7 +1328,6 @@ export class PostgresQueryRunner
 
         if (
             oldColumn.type !== newColumn.type ||
-            oldColumn.length !== newColumn.length ||
             newColumn.isArray !== oldColumn.isArray ||
             (!oldColumn.generatedType &&
                 newColumn.generatedType === "STORED") ||
@@ -1619,6 +1618,7 @@ export class PostgresQueryRunner
             }
 
             if (
+                newColumn.length !== oldColumn.length ||
                 newColumn.precision !== oldColumn.precision ||
                 newColumn.scale !== oldColumn.scale
             ) {

--- a/test/functional/database-schema/column-length/postgres/column-length-postgres.test.ts
+++ b/test/functional/database-schema/column-length/postgres/column-length-postgres.test.ts
@@ -44,6 +44,14 @@ describe("database schema > column length > postgres", () => {
     it("all types should update their size", () =>
         Promise.all(
             dataSources.map(async (dataSource) => {
+                await dataSource.getRepository(Post).save({
+                    id: 1,
+                    characterVarying: "character varying value",
+                    varchar: "varchar value",
+                    character: "character value",
+                    char: "char value",
+                })
+
                 const metadata = dataSource.getMetadata(Post)
                 metadata.findColumnWithPropertyName(
                     "characterVarying",
@@ -51,6 +59,27 @@ describe("database schema > column length > postgres", () => {
                 metadata.findColumnWithPropertyName("varchar")!.length = "100"
                 metadata.findColumnWithPropertyName("character")!.length = "100"
                 metadata.findColumnWithPropertyName("char")!.length = "100"
+
+                const sqlInMemory = await dataSource.driver
+                    .createSchemaBuilder()
+                    .log()
+                const upQueries = sqlInMemory.upQueries
+                    .map((query) => query.query)
+                    .join(" ")
+
+                expect(upQueries).to.include(
+                    `ALTER TABLE "post" ALTER COLUMN "characterVarying" TYPE character varying(100)`,
+                )
+                expect(upQueries).to.include(
+                    `ALTER TABLE "post" ALTER COLUMN "varchar" TYPE character varying(100)`,
+                )
+                expect(upQueries).to.include(
+                    `ALTER TABLE "post" ALTER COLUMN "character" TYPE character(100)`,
+                )
+                expect(upQueries).to.include(
+                    `ALTER TABLE "post" ALTER COLUMN "char" TYPE character(100)`,
+                )
+                expect(upQueries).not.to.include("DROP COLUMN")
 
                 await dataSource.synchronize(false)
 
@@ -70,6 +99,17 @@ describe("database schema > column length > postgres", () => {
                 expect(table!.findColumnByName("char")!.length).to.be.equal(
                     "100",
                 )
+
+                const post = await dataSource
+                    .getRepository(Post)
+                    .findOneByOrFail({ id: 1 })
+
+                expect(post.characterVarying).to.equal(
+                    "character varying value",
+                )
+                expect(post.varchar).to.equal("varchar value")
+                expect(post.character.trim()).to.equal("character value")
+                expect(post.char.trim()).to.equal("char value")
             }),
         ))
 })


### PR DESCRIPTION
Fixes #3357.

### What changed

Postgres column length changes now use `ALTER COLUMN ... TYPE` instead of dropping and re-adding the column.

This avoids data loss when changing lengths such as `varchar(50)` to `varchar(51)`.