### PR TITLE
fix(postgres): preserve varchar data when changing length

### DIFF
--- a/src/driver/postgres/PostgresQueryRunner.ts
+++ b/src/driver/postgres/PostgresQueryRunner.ts
@@ -1326,9 +1326,14 @@ export class PostgresQueryRunner
                 `Column "${oldTableColumnOrName}" was not found in the "${table.name}" table.`,
             )
 
+        const isVarcharLengthOnlyChange =
+            this.isVarcharLengthOnlyChange(oldColumn, newColumn)
+
         if (
-            oldColumn.type !== newColumn.type ||
-            oldColumn.length !== newColumn.length ||
+            (oldColumn.type !== newColumn.type &&
+                !isVarcharLengthOnlyChange) ||
+            (oldColumn.length !== newColumn.length &&
+                !isVarcharLengthOnlyChange) ||
             newColumn.isArray !== oldColumn.isArray ||
             (!oldColumn.generatedType &&
                 newColumn.generatedType === "STORED") ||
@@ -1620,7 +1625,8 @@ export class PostgresQueryRunner
 
             if (
                 newColumn.precision !== oldColumn.precision ||
-                newColumn.scale !== oldColumn.scale
+                newColumn.scale !== oldColumn.scale ||
+                oldColumn.length !== newColumn.length
             ) {
                 upQueries.push(
                     new Query(
@@ -5186,6 +5192,28 @@ export class PostgresQueryRunner
             c += ` DEFAULT ${this.driver.uuidGenerator}`
 
         return c
+    }
+
+    private isVarcharLengthOnlyChange(
+        oldColumn: TableColumn,
+        newColumn: TableColumn,
+    ): boolean {
+        return (
+            oldColumn.length !== newColumn.length &&
+            !oldColumn.isArray &&
+            !newColumn.isArray &&
+            !oldColumn.generatedType &&
+            !newColumn.generatedType &&
+            oldColumn.asExpression === newColumn.asExpression &&
+            this.isVarcharColumn(oldColumn) &&
+            this.isVarcharColumn(newColumn)
+        )
+    }
+
+    private isVarcharColumn(column: TableColumn): boolean {
+        return (
+            column.type === "character varying" || column.type === "varchar"
+        )
     }
 
     /**

--- a/test/github-issues/3357/issue-3357.test.ts
+++ b/test/github-issues/3357/issue-3357.test.ts
@@ -1,0 +1,100 @@
+import { expect } from "chai"
+import "reflect-metadata"
+import type { DataSource } from "../../../src"
+import { Table } from "../../../src"
+import {
+    closeTestingConnections,
+    createTestingConnections,
+} from "../../utils/test-utils"
+
+describe("github issues > #3357 postgres varchar length change should preserve data", () => {
+    let dataSources: DataSource[]
+
+    before(async () => {
+        dataSources = await createTestingConnections({
+            entities: [],
+            enabledDrivers: ["postgres"],
+            schemaCreate: false,
+            dropSchema: true,
+        })
+    })
+
+    after(() => closeTestingConnections(dataSources))
+
+    it("alters varchar length without dropping and recreating the column", () =>
+        Promise.all(
+            dataSources.map(async (dataSource) => {
+                const queryRunner = dataSource.createQueryRunner()
+                const tableName = "issue_3357_post"
+
+                try {
+                    await queryRunner.createTable(
+                        new Table({
+                            name: tableName,
+                            columns: [
+                                {
+                                    name: "id",
+                                    type: "int",
+                                    isPrimary: true,
+                                },
+                                {
+                                    name: "example",
+                                    type: "varchar",
+                                    length: "50",
+                                    isNullable: true,
+                                },
+                            ],
+                        }),
+                        true,
+                    )
+
+                    await queryRunner.query(
+                        `INSERT INTO "${tableName}"("id", "example") VALUES (1, 'typeorm')`,
+                    )
+                    queryRunner.clearSqlMemory()
+
+                    const table = await queryRunner.getTable(tableName)
+                    const exampleColumn = table!.findColumnByName("example")!
+                    const changedExampleColumn = exampleColumn.clone()
+                    changedExampleColumn.length = "51"
+
+                    await queryRunner.changeColumn(
+                        table!,
+                        exampleColumn,
+                        changedExampleColumn,
+                    )
+
+                    const rows = await queryRunner.query(
+                        `SELECT "example" FROM "${tableName}" WHERE "id" = 1`,
+                    )
+                    expect(rows[0].example).to.equal("typeorm")
+
+                    const upQueries = queryRunner
+                        .getMemorySql()
+                        .upQueries.map((query) => query.query)
+
+                    expect(
+                        upQueries.some(
+                            (query) =>
+                                query.includes(
+                                    'ALTER COLUMN "example" TYPE',
+                                ) && query.includes("(51)"),
+                        ),
+                    ).to.be.true
+                    expect(
+                        upQueries.some((query) =>
+                            query.includes('DROP COLUMN "example"'),
+                        ),
+                    ).to.be.false
+                    expect(
+                        upQueries.some((query) =>
+                            query.includes('ADD "example"'),
+                        ),
+                    ).to.be.false
+                } finally {
+                    await queryRunner.dropTable(tableName, true)
+                    await queryRunner.release()
+                }
+            }),
+        ))
+})


### PR DESCRIPTION
Fixes #3357.

### What changed
- Treat Postgres `varchar` / `character varying` length-only changes as non-destructive schema changes.
- Generate `ALTER TABLE ... ALTER COLUMN ... TYPE` for those length changes instead of dropping and recreating the column.
- Add a regression test covering `varchar(50)` to `varchar(51)` while preserving existing data.

### Testing
- Not run locally in this session.