### PR TITLE
fix(postgres): use ALTER COLUMN TYPE instead of DROP/ADD when column length changes

### DIFF
--- a/src/driver/postgres/PostgresQueryRunner.ts
+++ b/src/driver/postgres/PostgresQueryRunner.ts
@@ -1619,25 +1619,9 @@ export class PostgresQueryRunner
 
             if (
                 newColumn.precision !== oldColumn.precision ||
-                newColumn.scale !== oldColumn.scale
+                newColumn.scale !== oldColumn.scale ||
+                oldColumn.length !== newColumn.length
             ) {
-                upQueries.push(
-                    new Query(
-                        `ALTER TABLE ${this.escapePath(table)} ALTER COLUMN "${
-                            newColumn.name
-                        }" TYPE ${this.driver.createFullType(newColumn)}`,
-                    ),
-                )
-                downQueries.push(
-                    new Query(
-                        `ALTER TABLE ${this.escapePath(table)} ALTER COLUMN "${
-                            newColumn.name
-                        }" TYPE ${this.driver.createFullType(oldColumn)}`,
-                    ),
-                )
-            }
-
-            if (oldColumn.length !== newColumn.length) {
                 upQueries.push(
                     new Query(
                         `ALTER TABLE ${this.escapePath(table)} ALTER COLUMN "${
@@ -2364,7 +2348,7 @@ export class PostgresQueryRunner
                     new Query(
                         `ALTER TABLE ${this.escapePath(table)} ALTER COLUMN "${
                             newColumn.name
-                        }" TYPE ${newColumn.type} COLLATE "${
+                        }" TYPE ${this.driver.createFullType(newColumn)} COLLATE "${
                             newColumn.collation
                         }"`,
                     ),
@@ -2378,7 +2362,7 @@ export class PostgresQueryRunner
                     new Query(
                         `ALTER TABLE ${this.escapePath(table)} ALTER COLUMN "${
                             newColumn.name
-                        }" TYPE ${newColumn.type} COLLATE ${oldCollation}`,
+                        }" TYPE ${this.driver.createFullType(oldColumn)} COLLATE ${oldCollation}`,
                     ),
                 )
             }

--- a/src/driver/postgres/PostgresQueryRunner.ts
+++ b/src/driver/postgres/PostgresQueryRunner.ts
@@ -1328,7 +1328,6 @@ export class PostgresQueryRunner
 
         if (
             oldColumn.type !== newColumn.type ||
-            oldColumn.length !== newColumn.length ||
             newColumn.isArray !== oldColumn.isArray ||
             (!oldColumn.generatedType &&
                 newColumn.generatedType === "STORED") ||
@@ -1622,6 +1621,23 @@ export class PostgresQueryRunner
                 newColumn.precision !== oldColumn.precision ||
                 newColumn.scale !== oldColumn.scale
             ) {
+                upQueries.push(
+                    new Query(
+                        `ALTER TABLE ${this.escapePath(table)} ALTER COLUMN "${
+                            newColumn.name
+                        }" TYPE ${this.driver.createFullType(newColumn)}`,
+                    ),
+                )
+                downQueries.push(
+                    new Query(
+                        `ALTER TABLE ${this.escapePath(table)} ALTER COLUMN "${
+                            newColumn.name
+                        }" TYPE ${this.driver.createFullType(oldColumn)}`,
+                    ),
+                )
+            }
+
+            if (oldColumn.length !== newColumn.length) {
                 upQueries.push(
                     new Query(
                         `ALTER TABLE ${this.escapePath(table)} ALTER COLUMN "${


### PR DESCRIPTION
## Problem

Fixes #3357

When a column's **length** changes (e.g. `varchar(50)` → `varchar(51)`), TypeORM's PostgreSQL migration generator was producing a destructive sequence:

```sql
ALTER TABLE "example" DROP COLUMN "field"
ALTER TABLE "example" ADD "field" character varying(51)
```

This silently **destroys all data** in that column.

## Root Cause

In `PostgresQueryRunner.changeColumn`, the condition for the DROP+ADD path included `oldColumn.length !== newColumn.length`. A length-only change does not require column recreation — PostgreSQL supports `ALTER COLUMN TYPE` for this.

## Fix

- Removed `oldColumn.length !== newColumn.length` from the DROP+ADD condition
- Added a dedicated block to handle length changes using `ALTER COLUMN TYPE`, following the same pattern already used for `precision`/`scale` changes

Now the generated migration for a length-only change is:

```sql
ALTER TABLE "example" ALTER COLUMN "field" TYPE character varying(51)
```

This preserves all existing data.

## Testing

The fix mirrors the existing handling for `precision`/`scale` changes, which uses the same `ALTER COLUMN TYPE` approach safely.