### PR TITLE
fix: alter postgres column length without recreating column

### DIFF
--- a/src/driver/postgres/PostgresQueryRunner.ts
+++ b/src/driver/postgres/PostgresQueryRunner.ts
@@ -1328,7 +1328,6 @@ export class PostgresQueryRunner
 
         if (
             oldColumn.type !== newColumn.type ||
-            oldColumn.length !== newColumn.length ||
             newColumn.isArray !== oldColumn.isArray ||
             (!oldColumn.generatedType &&
                 newColumn.generatedType === "STORED") ||
@@ -1619,6 +1618,7 @@ export class PostgresQueryRunner
             }
 
             if (
+                newColumn.length !== oldColumn.length ||
                 newColumn.precision !== oldColumn.precision ||
                 newColumn.scale !== oldColumn.scale
             ) {

--- a/test/github-issues/3357/issue-3357.test.ts
+++ b/test/github-issues/3357/issue-3357.test.ts
@@ -1,0 +1,76 @@
+import "reflect-metadata"
+import { expect } from "chai"
+import { Table } from "../../../src"
+import type { DataSource } from "../../../src/data-source/DataSource"
+import {
+    closeTestingConnections,
+    createTestingConnections,
+} from "../../utils/test-utils"
+
+describe("github issues > #3357 postgres column length changes should not recreate columns", () => {
+    let dataSources: DataSource[]
+
+    before(async () => {
+        dataSources = await createTestingConnections({
+            enabledDrivers: ["postgres"],
+            schemaCreate: false,
+            dropSchema: true,
+        })
+    })
+
+    after(() => closeTestingConnections(dataSources))
+
+    it("should alter varchar length without dropping and adding the column", () =>
+        Promise.all(
+            dataSources.map(async (connection) => {
+                const queryRunner = connection.createQueryRunner()
+
+                await queryRunner.createTable(
+                    new Table({
+                        name: "bug",
+                        columns: [
+                            {
+                                name: "example",
+                                type: "character varying",
+                                length: "50",
+                            },
+                        ],
+                    }),
+                )
+
+                await queryRunner.query(`INSERT INTO "bug"("example") VALUES ($1)`, [
+                    "kept value",
+                ])
+
+                const table = await queryRunner.getTable("bug")
+                const oldColumn = table!.findColumnByName("example")!
+                const newColumn = oldColumn.clone()
+                newColumn.length = "51"
+
+                await queryRunner.changeColumn(table!, oldColumn, newColumn)
+
+                expect(
+                    queryRunner.getMemorySql().upQueries.map((q) => q.query),
+                ).to.include(
+                    'ALTER TABLE "bug" ALTER COLUMN "example" TYPE character varying(51)',
+                )
+                expect(
+                    queryRunner
+                        .getMemorySql()
+                        .upQueries.some((q) => q.query.includes("DROP COLUMN")),
+                ).to.be.false
+                expect(
+                    queryRunner
+                        .getMemorySql()
+                        .upQueries.some((q) => q.query.includes("ADD")),
+                ).to.be.false
+
+                const rows = await queryRunner.query(
+                    `SELECT "example" FROM "bug"`,
+                )
+                expect(rows[0].example).to.equal("kept value")
+
+                await queryRunner.release()
+            }),
+        ))
+})


### PR DESCRIPTION
### Description of change

Fixes Postgres column length changes so TypeORM emits an `ALTER COLUMN ... TYPE` query instead of dropping and re-adding the column. Recreating the column can cause data loss when only the varchar length changes.

Closes #3357.

### Pull-Request Checklist

- [x] Code is up-to-date with the `master` branch
- [x] `npm run format` for changed code — not run; change follows existing formatting
- [x] `npm run test` — focused regression test run instead
- [x] There are new or updated unit tests validating the change

### Verification

- `pnpm run typecheck`
- `pnpm run compile`
- `node ./node_modules/mocha/bin/mocha.js --no-config build/compiled/test/github-issues/3357/issue-3357.test.js --exit`

The regression test verifies that changing a Postgres `character varying(50)` column to `character varying(51)`:

- emits `ALTER TABLE "bug" ALTER COLUMN "example" TYPE character varying(51)`
- does not emit `DROP COLUMN`
- does not emit `ADD`
- preserves existing row data