### PR TITLE
fix: alter postgres varchar length without dropping column

### DIFF
--- a/src/driver/postgres/PostgresQueryRunner.ts
+++ b/src/driver/postgres/PostgresQueryRunner.ts
@@ -1326,9 +1326,12 @@ export class PostgresQueryRunner
                 `Column "${oldTableColumnOrName}" was not found in the "${table.name}" table.`,
             )
 
+        const lengthChanged = oldColumn.length !== newColumn.length
+        const shouldAlterLength = this.isSafeLengthChange(oldColumn, newColumn)
+
         if (
             oldColumn.type !== newColumn.type ||
-            oldColumn.length !== newColumn.length ||
+            (lengthChanged && !shouldAlterLength) ||
             newColumn.isArray !== oldColumn.isArray ||
             (!oldColumn.generatedType &&
                 newColumn.generatedType === "STORED") ||
@@ -1616,6 +1619,30 @@ export class PostgresQueryRunner
                     clonedTable.columns.indexOf(oldTableColumn!)
                 ].name = newColumn.name
                 oldColumn.name = newColumn.name
+            }
+
+            if (lengthChanged && shouldAlterLength) {
+                upQueries.push(
+                    new Query(
+                        `ALTER TABLE ${this.escapePath(table)} ALTER COLUMN "${
+                            newColumn.name
+                        }" TYPE ${this.driver.createFullType(newColumn)}`,
+                    ),
+                )
+                downQueries.push(
+                    new Query(
+                        `ALTER TABLE ${this.escapePath(table)} ALTER COLUMN "${
+                            newColumn.name
+                        }" TYPE ${this.driver.createFullType(oldColumn)}`,
+                    ),
+                )
+
+                const changedColumn = clonedTable.columns.find(
+                    (column) => column.name === newColumn.name,
+                )
+                if (changedColumn) {
+                    changedColumn.length = newColumn.length
+                }
             }
 
             if (
@@ -2348,9 +2375,9 @@ export class PostgresQueryRunner
                     new Query(
                         `ALTER TABLE ${this.escapePath(table)} ALTER COLUMN "${
                             newColumn.name
-                        }" TYPE ${newColumn.type} COLLATE "${
-                            newColumn.collation
-                        }"`,
+                        }" TYPE ${this.driver.createFullType(
+                            newColumn,
+                        )} COLLATE "${newColumn.collation}"`,
                     ),
                 )
 
@@ -2362,7 +2389,9 @@ export class PostgresQueryRunner
                     new Query(
                         `ALTER TABLE ${this.escapePath(table)} ALTER COLUMN "${
                             newColumn.name
-                        }" TYPE ${newColumn.type} COLLATE ${oldCollation}`,
+                        }" TYPE ${this.driver.createFullType(
+                            oldColumn,
+                        )} COLLATE ${oldCollation}`,
                     ),
                 )
             }
@@ -2465,6 +2494,23 @@ export class PostgresQueryRunner
 
         await this.executeQueries(upQueries, downQueries)
         this.replaceCachedTable(table, clonedTable)
+    }
+
+    protected isSafeLengthChange(
+        oldColumn: TableColumn,
+        newColumn: TableColumn,
+    ): boolean {
+        if (
+            oldColumn.type !== newColumn.type ||
+            oldColumn.isArray !== newColumn.isArray ||
+            oldColumn.isArray
+        ) {
+            return false
+        }
+
+        return ["character varying", "varchar", "character", "char"].includes(
+            oldColumn.type,
+        )
     }
 
     /**

--- a/test/functional/database-schema/column-length/postgres/column-length-postgres.test.ts
+++ b/test/functional/database-schema/column-length/postgres/column-length-postgres.test.ts
@@ -44,6 +44,19 @@ describe("database schema > column length > postgres", () => {
     it("all types should update their size", () =>
         Promise.all(
             dataSources.map(async (dataSource) => {
+                const characterVaryingValue = "a".repeat(50)
+                const varcharValue = "b".repeat(50)
+                const characterValue = "c".repeat(50)
+                const charValue = "d".repeat(50)
+
+                await dataSource.getRepository(Post).save({
+                    id: 1,
+                    characterVarying: characterVaryingValue,
+                    varchar: varcharValue,
+                    character: characterValue,
+                    char: charValue,
+                })
+
                 const metadata = dataSource.getMetadata(Post)
                 metadata.findColumnWithPropertyName(
                     "characterVarying",
@@ -51,6 +64,33 @@ describe("database schema > column length > postgres", () => {
                 metadata.findColumnWithPropertyName("varchar")!.length = "100"
                 metadata.findColumnWithPropertyName("character")!.length = "100"
                 metadata.findColumnWithPropertyName("char")!.length = "100"
+
+                const sqlInMemory = await dataSource.driver
+                    .createSchemaBuilder()
+                    .log()
+                const upQueries = sqlInMemory.upQueries.map(
+                    (query) => query.query,
+                )
+
+                expect(upQueries).to.include(
+                    'ALTER TABLE "post" ALTER COLUMN "characterVarying" TYPE character varying(100)',
+                )
+                expect(upQueries).to.include(
+                    'ALTER TABLE "post" ALTER COLUMN "varchar" TYPE character varying(100)',
+                )
+                expect(upQueries).to.include(
+                    'ALTER TABLE "post" ALTER COLUMN "character" TYPE character(100)',
+                )
+                expect(upQueries).to.include(
+                    'ALTER TABLE "post" ALTER COLUMN "char" TYPE character(100)',
+                )
+                expect(upQueries.some((query) => query.includes("DROP COLUMN")))
+                    .to.be.false
+                expect(
+                    upQueries.some((query) =>
+                        query.includes('ADD "characterVarying"'),
+                    ),
+                ).to.be.false
 
                 await dataSource.synchronize(false)
 
@@ -70,6 +110,14 @@ describe("database schema > column length > postgres", () => {
                 expect(table!.findColumnByName("char")!.length).to.be.equal(
                     "100",
                 )
+
+                const post = await dataSource
+                    .getRepository(Post)
+                    .findOneByOrFail({ id: 1 })
+                expect(post.characterVarying).to.be.equal(characterVaryingValue)
+                expect(post.varchar).to.be.equal(varcharValue)
+                expect(post.character).to.be.equal(characterValue)
+                expect(post.char).to.be.equal(charValue)
             }),
         ))
 })


### PR DESCRIPTION
### Description of change

Fixes #3357.

Postgres length-only changes for `character varying`, `varchar`, `character`, and `char` columns now use `ALTER TABLE ... ALTER COLUMN ... TYPE ...` instead of dropping and recreating the column. This avoids data loss when generating migrations or synchronizing schema changes that only alter the column length.

The updated functional test now inserts data before changing column lengths, checks the generated SQL does not include `DROP COLUMN`/`ADD`, synchronizes the schema, and verifies the stored values are preserved.

This also uses `createFullType()` for collation type changes so length/precision details are kept when the type expression is rebuilt.

Verification:

- `pnpm exec prettier --check src/driver/postgres/PostgresQueryRunner.ts test/functional/database-schema/column-length/postgres/column-length-postgres.test.ts`
- `pnpm run compile`
- `pnpm exec lint-staged`
- Local no-database sanity check against `PostgresQueryRunner.changeColumn()` confirmed the generated SQL uses `ALTER COLUMN ... TYPE` and does not include `DROP COLUMN` or `ADD` for the affected Postgres string types.

I could not run the Postgres functional test locally because this environment does not have Docker/Postgres installed.

### Pull-Request Checklist

- [x] Code is up-to-date with the `master` branch
- [x] This pull request links relevant issues as `Fixes #3357`
- [x] There are new or updated tests validating the change (`tests/**.test.ts`)
- [x] Documentation has been updated to reflect this change (`docs/docs/**.md`) - N/A, bug fix with no documentation-facing behavior change