### PR TITLE
fix: alter postgres varchar length without dropping column

### DIFF
--- a/src/driver/postgres/PostgresQueryRunner.ts
+++ b/src/driver/postgres/PostgresQueryRunner.ts
@@ -1326,9 +1326,17 @@ export class PostgresQueryRunner
                 `Column "${oldTableColumnOrName}" was not found in the "${table.name}" table.`,
             )
 
+        const isVarcharLengthChange =
+            oldColumn.length !== newColumn.length &&
+            newColumn.isArray === oldColumn.isArray &&
+            (oldColumn.type === "character varying" ||
+                oldColumn.type === "varchar") &&
+            (newColumn.type === "character varying" ||
+                newColumn.type === "varchar")
+
         if (
-            oldColumn.type !== newColumn.type ||
-            oldColumn.length !== newColumn.length ||
+            (oldColumn.type !== newColumn.type && !isVarcharLengthChange) ||
+            (oldColumn.length !== newColumn.length && !isVarcharLengthChange) ||
             newColumn.isArray !== oldColumn.isArray ||
             (!oldColumn.generatedType &&
                 newColumn.generatedType === "STORED") ||
@@ -1619,6 +1627,7 @@ export class PostgresQueryRunner
             }
 
             if (
+                newColumn.length !== oldColumn.length ||
                 newColumn.precision !== oldColumn.precision ||
                 newColumn.scale !== oldColumn.scale
             ) {

--- a/test/github-issues/3357/issue-3357.test.ts
+++ b/test/github-issues/3357/issue-3357.test.ts
@@ -1,0 +1,88 @@
+import "reflect-metadata"
+import { expect } from "chai"
+import { Table } from "../../../src"
+import type { DataSource } from "../../../src/data-source/DataSource"
+import {
+    closeTestingConnections,
+    createTestingConnections,
+} from "../../utils/test-utils"
+
+describe("github issues > #3357 Postgres varchar length change migrations should not drop columns", () => {
+    let dataSources: DataSource[]
+
+    before(async () => {
+        dataSources = await createTestingConnections({
+            enabledDrivers: ["postgres"],
+            schemaCreate: false,
+            dropSchema: true,
+        })
+    })
+
+    after(() => closeTestingConnections(dataSources))
+
+    it("should alter varchar length without dropping existing data", () =>
+        Promise.all(
+            dataSources.map(async (dataSource) => {
+                const queryRunner = dataSource.createQueryRunner()
+
+                await queryRunner.createTable(
+                    new Table({
+                        name: "bug",
+                        columns: [
+                            {
+                                name: "id",
+                                type: "int",
+                                isPrimary: true,
+                            },
+                            {
+                                name: "example",
+                                type: "varchar",
+                                length: "50",
+                            },
+                        ],
+                    }),
+                )
+
+                await queryRunner.query(
+                    `INSERT INTO "bug" ("id", "example") VALUES (1, 'kept')`,
+                )
+                queryRunner.clearSqlMemory()
+
+                const table = await queryRunner.getTable("bug")
+                const column = table!.findColumnByName("example")!
+                const changedColumn = column.clone()
+                changedColumn.length = "51"
+
+                await queryRunner.changeColumn(table!, column, changedColumn)
+
+                const queries = queryRunner
+                    .getMemorySql()
+                    .upQueries.map((query) => query.query)
+
+                expect(queries).to.include(
+                    `ALTER TABLE "bug" ALTER COLUMN "example" TYPE character varying(51)`,
+                )
+                expect(
+                    queries.some((query) =>
+                        query.includes(`DROP COLUMN "example"`),
+                    ),
+                ).to.be.false
+                expect(queries.some((query) => query.includes(`ADD "example"`)))
+                    .to.be.false
+
+                const rows = await queryRunner.query(
+                    `SELECT "example" FROM "bug" WHERE "id" = 1`,
+                )
+                expect(rows[0].example).to.equal("kept")
+
+                await queryRunner.executeMemoryDownSql()
+
+                const revertedTable = await queryRunner.getTable("bug")
+                expect(
+                    revertedTable!.findColumnByName("example")!.length,
+                ).to.equal("50")
+
+                await queryRunner.release()
+            }),
+        ))
+})


### PR DESCRIPTION
Description of change

Fixes #3357

This changes PostgreSQL column migration generation so a `varchar` / `character varying` length-only change uses `ALTER COLUMN ... TYPE` instead of dropping and re-adding the column.

Previously, changing a column from `varchar(50)` to `varchar(51)` went through the drop/add path, which can fail for non-null columns and risks losing existing data. The new behavior preserves the column and its data.

Verification:
- `corepack pnpm run compile`
- `corepack pnpm run test:fast -- --grep "#3357"`
- `corepack pnpm run typecheck`
- `git diff --check`

Pull-Request Checklist

- Code is up-to-date with the `master` branch
- This pull request links relevant issues as `Fixes #3357`
- There are new or updated tests validating the change (`tests/**.test.ts`)
- Documentation has been updated to reflect this change (`docs/docs/**.md`) N/A
