### PR TITLE
fix: avoid recreating Postgres varchar columns on length changes

### DIFF
--- a/src/driver/postgres/PostgresQueryRunner.ts
+++ b/src/driver/postgres/PostgresQueryRunner.ts
@@ -1328,7 +1328,6 @@ export class PostgresQueryRunner
 
         if (
             oldColumn.type !== newColumn.type ||
-            oldColumn.length !== newColumn.length ||
             newColumn.isArray !== oldColumn.isArray ||
             (!oldColumn.generatedType &&
                 newColumn.generatedType === "STORED") ||
@@ -1619,6 +1618,7 @@ export class PostgresQueryRunner
             }
 
             if (
+                newColumn.length !== oldColumn.length ||
                 newColumn.precision !== oldColumn.precision ||
                 newColumn.scale !== oldColumn.scale
             ) {
@@ -2344,13 +2344,17 @@ export class PostgresQueryRunner
 
             // update column collation
             if (newColumn.collation !== oldColumn.collation) {
+                const newCollation = newColumn.collation
+                    ? `"${newColumn.collation}"`
+                    : `pg_catalog."default"` // if there's no new collation, use default
+
                 upQueries.push(
                     new Query(
                         `ALTER TABLE ${this.escapePath(table)} ALTER COLUMN "${
                             newColumn.name
-                        }" TYPE ${newColumn.type} COLLATE "${
-                            newColumn.collation
-                        }"`,
+                        }" TYPE ${this.driver.createFullType(
+                            newColumn,
+                        )} COLLATE ${newCollation}`,
                     ),
                 )
 
@@ -2362,7 +2366,9 @@ export class PostgresQueryRunner
                     new Query(
                         `ALTER TABLE ${this.escapePath(table)} ALTER COLUMN "${
                             newColumn.name
-                        }" TYPE ${newColumn.type} COLLATE ${oldCollation}`,
+                        }" TYPE ${this.driver.createFullType(
+                            oldColumn,
+                        )} COLLATE ${oldCollation}`,
                     ),
                 )
             }

--- a/test/github-issues/3357/issue-3357.test.ts
+++ b/test/github-issues/3357/issue-3357.test.ts
@@ -1,0 +1,111 @@
+import "reflect-metadata"
+import { expect } from "chai"
+import { PostgresQueryRunner } from "../../../src/driver/postgres/PostgresQueryRunner"
+import { Table } from "../../../src/schema-builder/table/Table"
+import { TableColumn } from "../../../src/schema-builder/table/TableColumn"
+
+describe("github issues > #3357 Postgres varchar length changes", () => {
+    it("alters the column type instead of recreating the column", async () => {
+        const queryRunner = createPostgresQueryRunner()
+
+        const oldColumn = new TableColumn({
+            name: "example",
+            type: "character varying",
+            length: "50",
+        })
+        const newColumn = new TableColumn({
+            name: "example",
+            type: "character varying",
+            length: "51",
+        })
+        const table = new Table({
+            name: "bug",
+            columns: [oldColumn],
+        })
+
+        queryRunner.enableSqlMemory()
+        await queryRunner.changeColumn(table, oldColumn, newColumn)
+
+        const sqlInMemory = queryRunner.getMemorySql()
+        const upQueries = sqlInMemory.upQueries.map(({ query }) => query)
+        const downQueries = sqlInMemory.downQueries.map(({ query }) => query)
+
+        expect(upQueries).to.deep.equal([
+            'ALTER TABLE "bug" ALTER COLUMN "example" TYPE character varying(51)',
+        ])
+        expect(downQueries).to.deep.equal([
+            'ALTER TABLE "bug" ALTER COLUMN "example" TYPE character varying(50)',
+        ])
+    })
+
+    it("preserves column length when collation changes with the type", async () => {
+        const queryRunner = createPostgresQueryRunner()
+
+        const oldColumn = new TableColumn({
+            name: "example",
+            type: "character varying",
+            length: "50",
+        })
+        const newColumn = new TableColumn({
+            name: "example",
+            type: "character varying",
+            length: "51",
+            collation: "en_US",
+        })
+        const table = new Table({
+            name: "bug",
+            columns: [oldColumn],
+        })
+
+        queryRunner.enableSqlMemory()
+        await queryRunner.changeColumn(table, oldColumn, newColumn)
+
+        const sqlInMemory = queryRunner.getMemorySql()
+        const upQueries = sqlInMemory.upQueries.map(({ query }) => query)
+        const downQueries = sqlInMemory.downQueries.map(({ query }) => query)
+
+        expect(upQueries).to.deep.equal([
+            'ALTER TABLE "bug" ALTER COLUMN "example" TYPE character varying(51)',
+            'ALTER TABLE "bug" ALTER COLUMN "example" TYPE character varying(51) COLLATE "en_US"',
+        ])
+        expect(downQueries).to.deep.equal([
+            'ALTER TABLE "bug" ALTER COLUMN "example" TYPE character varying(50)',
+            'ALTER TABLE "bug" ALTER COLUMN "example" TYPE character varying(50) COLLATE pg_catalog."default"',
+        ])
+    })
+})
+
+function createPostgresQueryRunner() {
+    const driver: any = {
+        searchSchema: "public",
+        parseTableName(target: Table | string) {
+            if (typeof target === "string") {
+                return {
+                    tableName: target,
+                    schema: undefined,
+                    database: undefined,
+                }
+            }
+
+            return {
+                tableName: target.name,
+                schema: target.schema,
+                database: target.database,
+            }
+        },
+        buildTableName(tableName: string, schema?: string): string {
+            return schema ? `${schema}.${tableName}` : tableName
+        },
+        createFullType(column: TableColumn): string {
+            return column.length
+                ? `${column.type}(${column.length})`
+                : `${column.type}`
+        },
+    }
+
+    driver.dataSource = {
+        driver,
+    }
+
+    return new PostgresQueryRunner(driver, "master")
+}


### PR DESCRIPTION
## Summary

Fixes Postgres schema diff generation for varchar length-only changes so TypeORM emits `ALTER TABLE ... ALTER COLUMN ... TYPE ...` instead of dropping and recreating the column.

## Root cause

`PostgresQueryRunner.changeColumn()` treated `oldColumn.length !== newColumn.length` as a reason to recreate the column. For cases such as `character varying(50)` to `character varying(51)`, that generated destructive `DROP COLUMN` / `ADD COLUMN` queries and risked data loss.

## Changes

- Let type changes still recreate the column where needed.
- Handle length changes through the existing `ALTER COLUMN ... TYPE ...` path alongside precision and scale changes.
- Add a regression test for issue #3357 that asserts Postgres varchar length changes generate non-destructive SQL.

## Checks

- `pnpm run compile`
- `pnpm exec mocha --no-config --exit build/compiled/test/github-issues/3357/issue-3357.test.js`
- `pnpm exec prettier --check src/driver/postgres/PostgresQueryRunner.ts test/github-issues/3357/issue-3357.test.ts`

Fixes #3357