### PR TITLE
fix: alter postgres varchar length without dropping column

### DIFF
--- a/src/driver/postgres/PostgresQueryRunner.ts
+++ b/src/driver/postgres/PostgresQueryRunner.ts
@@ -1328,7 +1328,6 @@ export class PostgresQueryRunner
 
         if (
             oldColumn.type !== newColumn.type ||
-            oldColumn.length !== newColumn.length ||
             newColumn.isArray !== oldColumn.isArray ||
             (!oldColumn.generatedType &&
                 newColumn.generatedType === "STORED") ||
@@ -1619,6 +1618,7 @@ export class PostgresQueryRunner
             }
 
             if (
+                oldColumn.length !== newColumn.length ||
                 newColumn.precision !== oldColumn.precision ||
                 newColumn.scale !== oldColumn.scale
             ) {

--- a/test/unit/driver/postgres-query-runner-change-column.test.ts
+++ b/test/unit/driver/postgres-query-runner-change-column.test.ts
@@ -1,0 +1,57 @@
+import { expect } from "chai"
+import type { DataSource } from "../../../src/data-source/DataSource"
+import { PostgresDriver } from "../../../src/driver/postgres/PostgresDriver"
+import { PostgresQueryRunner } from "../../../src/driver/postgres/PostgresQueryRunner"
+import { DefaultNamingStrategy } from "../../../src/naming-strategy/DefaultNamingStrategy"
+import { Table } from "../../../src/schema-builder/table/Table"
+import { TableColumn } from "../../../src/schema-builder/table/TableColumn"
+
+describe("driver > postgres > change column", () => {
+    function createPostgresQueryRunner(): PostgresQueryRunner {
+        const driver = Object.create(PostgresDriver.prototype) as PostgresDriver
+
+        driver.dataSource = {
+            driver,
+            namingStrategy: new DefaultNamingStrategy(),
+        } as unknown as DataSource
+        driver.database = undefined
+        driver.schema = undefined
+        driver.searchSchema = undefined
+        driver.spatialTypes = []
+
+        const queryRunner = new PostgresQueryRunner(driver, "master")
+        queryRunner.enableSqlMemory()
+
+        return queryRunner
+    }
+
+    it("should alter varchar length without dropping the column", async () => {
+        const queryRunner = createPostgresQueryRunner()
+        const oldColumn = new TableColumn({
+            name: "example",
+            type: "character varying",
+            length: "50",
+        })
+        const table = new Table({
+            name: "bug",
+            columns: [oldColumn],
+        })
+        const newColumn = oldColumn.clone()
+        newColumn.length = "51"
+
+        await queryRunner.changeColumn(table, oldColumn, newColumn)
+
+        const sqlInMemory = queryRunner.getMemorySql()
+        const upQueries = sqlInMemory.upQueries.map(({ query }) => query)
+        const downQueries = sqlInMemory.downQueries.map(({ query }) => query)
+
+        expect(upQueries).to.deep.equal([
+            'ALTER TABLE "bug" ALTER COLUMN "example" TYPE character varying(51)',
+        ])
+        expect(downQueries).to.deep.equal([
+            'ALTER TABLE "bug" ALTER COLUMN "example" TYPE character varying(50)',
+        ])
+        expect(upQueries.join(" ")).not.to.include("DROP COLUMN")
+        expect(upQueries.join(" ")).not.to.include("ADD")
+    })
+})


### PR DESCRIPTION
### What changed

- Treat PostgreSQL column length changes like precision/scale changes, generating `ALTER COLUMN ... TYPE ...` instead of dropping and re-adding the column.
- Added a regression unit test for changing `character varying(50)` to `character varying(51)`.

Fixes #3357

/claim #3357

### Verification

- `corepack pnpm install --frozen-lockfile`
- `corepack pnpm run compile`
- `.\node_modules\.bin\mocha.cmd --no-config build\compiled\test\unit\driver\postgres-query-runner-change-column.test.js`

Prepared with Codex assistance and reviewed before submission.