### PR TITLE
fix: preserve postgres varchar data when changing length

### DIFF
--- a/src/driver/postgres/PostgresQueryRunner.ts
+++ b/src/driver/postgres/PostgresQueryRunner.ts
@@ -1326,9 +1326,21 @@ export class PostgresQueryRunner
                 `Column "${oldTableColumnOrName}" was not found in the "${table.name}" table.`,
             )
 
+        const oldColumnType = this.driver.normalizeType({
+            type: oldColumn.type as ColumnType,
+        })
+        const newColumnType = this.driver.normalizeType({
+            type: newColumn.type as ColumnType,
+        })
+        const isVarcharLengthChanged =
+            oldColumn.length !== newColumn.length &&
+            oldColumnType === newColumnType &&
+            oldColumnType === "character varying"
+
         if (
-            oldColumn.type !== newColumn.type ||
-            oldColumn.length !== newColumn.length ||
+            oldColumnType !== newColumnType ||
+            (oldColumn.length !== newColumn.length &&
+                !isVarcharLengthChanged) ||
             newColumn.isArray !== oldColumn.isArray ||
             (!oldColumn.generatedType &&
                 newColumn.generatedType === "STORED") ||
@@ -1636,6 +1648,30 @@ export class PostgresQueryRunner
                         }" TYPE ${this.driver.createFullType(oldColumn)}`,
                     ),
                 )
+            }
+
+            if (isVarcharLengthChanged) {
+                upQueries.push(
+                    new Query(
+                        `ALTER TABLE ${this.escapePath(table)} ALTER COLUMN "${
+                            newColumn.name
+                        }" TYPE ${this.driver.createFullType(newColumn)}`,
+                    ),
+                )
+                downQueries.push(
+                    new Query(
+                        `ALTER TABLE ${this.escapePath(table)} ALTER COLUMN "${
+                            newColumn.name
+                        }" TYPE ${this.driver.createFullType(oldColumn)}`,
+                    ),
+                )
+
+                const alteredColumn = clonedTable.findColumnByName(
+                    newColumn.name,
+                )
+                if (alteredColumn) {
+                    alteredColumn.length = newColumn.length
+                }
             }
 
             if (

--- a/test/functional/query-runner/change-column.test.ts
+++ b/test/functional/query-runner/change-column.test.ts
@@ -6,7 +6,7 @@ import {
     createTestingConnections,
     createTypeormMetadataTable,
 } from "../../utils/test-utils"
-import { TableColumn } from "../../../src"
+import { Table, TableColumn } from "../../../src"
 import type { PostgresDriver } from "../../../src/driver/postgres/PostgresDriver"
 import { DriverUtils } from "../../../src/driver/DriverUtils"
 
@@ -178,6 +178,82 @@ describe("query runner > change column", () => {
                 table!.findColumnByName("id")!.isGenerated.should.be.false
                 expect(table!.findColumnByName("id")!.generationStrategy).to.be
                     .undefined
+
+                await queryRunner.release()
+            }),
+        ))
+
+    it("should alter postgres varchar length without losing column data", () =>
+        Promise.all(
+            dataSources.map(async (dataSource) => {
+                if (dataSource.driver.options.type !== "postgres") return
+
+                let queryRunner = dataSource.createQueryRunner()
+
+                await queryRunner.createTable(
+                    new Table({
+                        name: "change_column_varchar_length_post",
+                        columns: [
+                            {
+                                name: "id",
+                                type: "integer",
+                                isPrimary: true,
+                            },
+                            {
+                                name: "name",
+                                type: "varchar",
+                                length: "50",
+                            },
+                        ],
+                    }),
+                )
+                await queryRunner.query(
+                    `INSERT INTO "change_column_varchar_length_post"("id", "name") VALUES (1, 'hello')`,
+                )
+
+                let table = await queryRunner.getTable(
+                    "change_column_varchar_length_post",
+                )
+                const oldColumn = table!.findColumnByName("name")!
+                const newColumn = oldColumn.clone()
+                newColumn.type = "varchar"
+                newColumn.length = "51"
+
+                queryRunner.enableSqlMemory()
+                await queryRunner.changeColumn(table!, oldColumn, newColumn)
+
+                const upQueries = queryRunner
+                    .getMemorySql()
+                    .upQueries.map(({ query }) => query)
+                expect(upQueries).to.deep.equal([
+                    `ALTER TABLE "change_column_varchar_length_post" ALTER COLUMN "name" TYPE varchar(51)`,
+                ])
+                queryRunner.disableSqlMemory()
+                await queryRunner.release()
+
+                queryRunner = dataSource.createQueryRunner()
+                table = await queryRunner.getTable(
+                    "change_column_varchar_length_post",
+                )
+                await queryRunner.changeColumn(
+                    table!,
+                    table!.findColumnByName("name")!,
+                    new TableColumn({
+                        ...table!.findColumnByName("name")!,
+                        type: "varchar",
+                        length: "51",
+                    }),
+                )
+
+                const rows = await queryRunner.query(
+                    `SELECT "name" FROM "change_column_varchar_length_post" WHERE "id" = 1`,
+                )
+                expect(rows).to.deep.equal([{ name: "hello" }])
+
+                table = await queryRunner.getTable(
+                    "change_column_varchar_length_post",
+                )
+                expect(table!.findColumnByName("name")!.length).to.equal("51")
 
                 await queryRunner.release()
             }),


### PR DESCRIPTION
Fixes #3357.

### Summary
- avoid recreating Postgres varchar/character varying columns when only the length changes
- normalize Postgres column types before destructive change detection so `varchar` and `character varying` aliases are treated equivalently
- emit `ALTER COLUMN ... TYPE` for varchar length changes instead
- keep the query runner table cache in sync after the non-destructive alter
- add a functional regression test covering generated SQL and preserving existing data for the `varchar` alias case

### Tests
- `pnpm run typecheck`
- `pnpm exec prettier --check src/driver/postgres/PostgresQueryRunner.ts test/functional/query-runner/change-column.test.ts`
- `pnpm exec eslint src/driver/postgres/PostgresQueryRunner.ts test/functional/query-runner/change-column.test.ts`
- `pnpm run compile`
- `pnpm exec mocha --no-config --require ./build/compiled/test/utils/test-setup.js build/compiled/test/functional/query-runner/change-column.test.js --grep "postgres varchar length" --timeout 90000 --exit`