### PR TITLE
fix: Use ALTER COLUMN instead of DROP/ADD COLUMN when changing varchar length

### DIFF
--- a/src/driver/postgres/PostgresQueryRunner.ts
+++ b/src/driver/postgres/PostgresQueryRunner.ts
@@ -1328,7 +1328,6 @@ export class PostgresQueryRunner
 
         if (
             oldColumn.type !== newColumn.type ||
-            oldColumn.length !== newColumn.length ||
             newColumn.isArray !== oldColumn.isArray ||
             (!oldColumn.generatedType &&
                 newColumn.generatedType === "STORED") ||
@@ -1619,6 +1618,7 @@ export class PostgresQueryRunner
             }
 
             if (
+                oldColumn.length !== newColumn.length ||
                 newColumn.precision !== oldColumn.precision ||
                 newColumn.scale !== oldColumn.scale
             ) {


### PR DESCRIPTION
## Summary

Fixes a data loss bug in TypeORM migration generation. When a varchar column length is changed (e.g., length 50 → 51), TypeORM was generating migrations that used  + , causing data loss. Now it correctly uses  which preserves data.

## Changes

**File:** 

1. Removed  from the DROP/ADD condition (line 1331)
2. Added  to the ALTER COLUMN TYPE condition (line 1621)

## Testing

The fix ensures length-only changes trigger an ALTER COLUMN statement instead of drop/recreate.

Closes typeorm/typeorm#3357