### PR TITLE
fix: alter postgres column length without dropping data

### DIFF
--- a/src/driver/postgres/PostgresQueryRunner.ts
+++ b/src/driver/postgres/PostgresQueryRunner.ts
@@ -1326,14 +1326,15 @@ export class PostgresQueryRunner
                 `Column "${oldTableColumnOrName}" was not found in the "${table.name}" table.`,
             )
 
-        if (
-            oldColumn.type !== newColumn.type ||
-            oldColumn.length !== newColumn.length ||
-            newColumn.isArray !== oldColumn.isArray ||
-            (!oldColumn.generatedType &&
-                newColumn.generatedType === "STORED") ||
+        const isGeneratedColumnChanged =
+            (!oldColumn.generatedType && newColumn.generatedType === "STORED") ||
             (oldColumn.asExpression !== newColumn.asExpression &&
                 newColumn.generatedType === "STORED")
+
+        if (
+            oldColumn.type !== newColumn.type ||
+            newColumn.isArray !== oldColumn.isArray ||
+            isGeneratedColumnChanged
         ) {
             // To avoid data conversion, we just recreate column
             await this.dropColumn(table, oldColumn)
@@ -1616,6 +1617,23 @@ export class PostgresQueryRunner
                     clonedTable.columns.indexOf(oldTableColumn!)
                 ].name = newColumn.name
                 oldColumn.name = newColumn.name
+            }
+
+            if (oldColumn.length !== newColumn.length) {
+                upQueries.push(
+                    new Query(
+                        `ALTER TABLE ${this.escapePath(table)} ALTER COLUMN "${
+                            newColumn.name
+                        }" TYPE ${this.driver.createFullType(newColumn)}`,
+                    ),
+                )
+                downQueries.push(
+                    new Query(
+                        `ALTER TABLE ${this.escapePath(table)} ALTER COLUMN "${
+                            newColumn.name
+                        }" TYPE ${this.driver.createFullType(oldColumn)}`,
+                    ),
+                )
             }
 
             if (

--- a/test/functional/database-schema/column-length/postgres/column-length-postgres.test.ts
+++ b/test/functional/database-schema/column-length/postgres/column-length-postgres.test.ts
@@ -41,9 +41,19 @@ describe("database schema > column length > postgres", () => {
             }),
         ))
 
-    it("all types should update their size", () =>
+    // Regression test for #3357: length changes should not drop and recreate
+    // Postgres columns, because that loses existing data.
+    it("all types should update their size without dropping column data", () =>
         Promise.all(
             dataSources.map(async (dataSource) => {
+                await dataSource.getRepository(Post).save({
+                    id: 1,
+                    characterVarying: "character varying value",
+                    varchar: "varchar value",
+                    character: "character value",
+                    char: "char value",
+                })
+
                 const metadata = dataSource.getMetadata(Post)
                 metadata.findColumnWithPropertyName(
                     "characterVarying",
@@ -51,6 +61,26 @@ describe("database schema > column length > postgres", () => {
                 metadata.findColumnWithPropertyName("varchar")!.length = "100"
                 metadata.findColumnWithPropertyName("character")!.length = "100"
                 metadata.findColumnWithPropertyName("char")!.length = "100"
+
+                const sqlInMemory =
+                    await dataSource.driver.createSchemaBuilder().log()
+                const upQueries = sqlInMemory.upQueries.map(
+                    (query) => query.query,
+                )
+
+                expect(upQueries).to.include(
+                    `ALTER TABLE "post" ALTER COLUMN "varchar" TYPE character varying(100)`,
+                )
+                expect(
+                    upQueries.some((query) =>
+                        query.includes(`DROP COLUMN "varchar"`),
+                    ),
+                ).to.be.false
+                expect(
+                    upQueries.some((query) =>
+                        query.includes(`ADD "varchar"`),
+                    ),
+                ).to.be.false
 
                 await dataSource.synchronize(false)
 
@@ -70,6 +100,15 @@ describe("database schema > column length > postgres", () => {
                 expect(table!.findColumnByName("char")!.length).to.be.equal(
                     "100",
                 )
+
+                const post = await dataSource
+                    .getRepository(Post)
+                    .findOneBy({ id: 1 })
+
+                expect(post!.characterVarying).to.be.equal(
+                    "character varying value",
+                )
+                expect(post!.varchar).to.be.equal("varchar value")
             }),
         ))
 })


### PR DESCRIPTION
## Summary

Fixes #3357.

This changes Postgres column length migrations to alter the existing column type instead of dropping and recreating the column when only the length changes. PostgreSQL supports this through `ALTER TABLE ... ALTER COLUMN ... TYPE`, and using drop/add can lose existing data.

## Changes

- Avoid recreating Postgres columns when only `length` changes.
- Emit `ALTER TABLE ... ALTER COLUMN ... TYPE` for same-type length updates.
- Add regression coverage for varchar/character varying length updates.
- Assert the generated SQL does not contain `DROP COLUMN` / `ADD COLUMN` for the varchar case.
- Assert existing row data survives `synchronize(false)`.

## Testing

Not run in my local CLI environment because dependency install was blocked by DNS/network and Docker was unavailable.

Suggested validation:
- `pnpm install --frozen-lockfile`
- `jq 'map(select(.type == "postgres"))' ormconfig.sample.json > ormconfig.json`
- `pnpm run compile`
- `pnpm run test:fast -- ./build/compiled/test/functional/database-schema/column-length/postgres/column-length-postgres.test.js`
