### PR TITLE
fix: preserve postgres varchar data on length changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - **cli:** init command reading package.json from two folders up ([#11789](https://github.com/typeorm/typeorm/issues/11789)) ([dd55218](https://github.com/typeorm/typeorm/commit/dd55218648eb449937e22e1e7c88182db0048f1d))
 - **deps:** upgrade glob to fix CVE-2025-64756 ([#11784](https://github.com/typeorm/typeorm/issues/11784)) ([dc74f53](https://github.com/typeorm/typeorm/commit/dc74f5374ef5ec83d53045e4bca99cb9ff7d49d4))
 - **mongodb:** add missing `findBy` method to MongoEntityManager ([#11814](https://github.com/typeorm/typeorm/issues/11814)) ([38715bb](https://github.com/typeorm/typeorm/commit/38715bbd4169cae2910aac035cd2b05bddbaec5c))
+- **postgres:** preserve data when generated migrations change `varchar` column lengths ([#3357](https://github.com/typeorm/typeorm/issues/3357))
 - **redis:** version detection logic ([#11815](https://github.com/typeorm/typeorm/issues/11815)) ([6f486e5](https://github.com/typeorm/typeorm/commit/6f486e5a67c007287949be119f233fb2b4fb7a59))
 - typesense doc sync ([#11807](https://github.com/typeorm/typeorm/issues/11807)) ([d0b5454](https://github.com/typeorm/typeorm/commit/d0b54544e9e43a5330c0485d41551128224fe4d3))
 

--- a/src/driver/postgres/PostgresQueryRunner.ts
+++ b/src/driver/postgres/PostgresQueryRunner.ts
@@ -1326,9 +1326,16 @@ export class PostgresQueryRunner
                 `Column "${oldTableColumnOrName}" was not found in the "${table.name}" table.`,
             )
 
+        const isLengthOnlyChange =
+            oldColumn.type === newColumn.type &&
+            oldColumn.length !== newColumn.length &&
+            this.driver.withLengthColumnTypes.includes(
+                oldColumn.type as ColumnType,
+            )
+
         if (
             oldColumn.type !== newColumn.type ||
-            oldColumn.length !== newColumn.length ||
+            (oldColumn.length !== newColumn.length && !isLengthOnlyChange) ||
             newColumn.isArray !== oldColumn.isArray ||
             (!oldColumn.generatedType &&
                 newColumn.generatedType === "STORED") ||
@@ -1619,6 +1626,7 @@ export class PostgresQueryRunner
             }
 
             if (
+                isLengthOnlyChange ||
                 newColumn.precision !== oldColumn.precision ||
                 newColumn.scale !== oldColumn.scale
             ) {
@@ -2348,9 +2356,9 @@ export class PostgresQueryRunner
                     new Query(
                         `ALTER TABLE ${this.escapePath(table)} ALTER COLUMN "${
                             newColumn.name
-                        }" TYPE ${newColumn.type} COLLATE "${
-                            newColumn.collation
-                        }"`,
+                        }" TYPE ${this.driver.createFullType(
+                            newColumn,
+                        )} COLLATE "${newColumn.collation}"`,
                     ),
                 )
 
@@ -2362,7 +2370,9 @@ export class PostgresQueryRunner
                     new Query(
                         `ALTER TABLE ${this.escapePath(table)} ALTER COLUMN "${
                             newColumn.name
-                        }" TYPE ${newColumn.type} COLLATE ${oldCollation}`,
+                        }" TYPE ${this.driver.createFullType(
+                            oldColumn,
+                        )} COLLATE ${oldCollation}`,
                     ),
                 )
             }

--- a/test/functional/schema-builder/column/change/change-column/change-column.test.ts
+++ b/test/functional/schema-builder/column/change/change-column/change-column.test.ts
@@ -50,6 +50,15 @@ describe("schema builder > change column", () => {
     it("should correctly change column length", () =>
         Promise.all(
             dataSources.map(async (dataSource) => {
+                await dataSource.getRepository(Post).save({
+                    id: 1,
+                    version: "v1",
+                    name: "existing name",
+                    text: "existing text",
+                    tag: "tag",
+                    likesCount: 1,
+                })
+
                 const postMetadata = dataSource.getMetadata(Post)
                 const nameColumn =
                     postMetadata.findColumnWithPropertyName("name")!
@@ -70,6 +79,16 @@ describe("schema builder > change column", () => {
                 postTable!
                     .findColumnByName("text")!
                     .length.should.be.equal("300")
+
+                if (dataSource.driver.options.type === "postgres") {
+                    // Regression for #3357: varchar length changes must not
+                    // recreate the column and lose existing row data.
+                    const loadedPost = await dataSource
+                        .getRepository(Post)
+                        .findOneByOrFail({ id: 1 })
+                    loadedPost.name.should.be.equal("existing name")
+                    loadedPost.text.should.be.equal("existing text")
+                }
 
                 if (
                     DriverUtils.isMySQLFamily(dataSource.driver) ||


### PR DESCRIPTION
/claim #3357

## Summary

- Avoid recreating PostgreSQL columns when only the length changes for length-capable column types such as `varchar` / `character varying`.
- Reuse the existing `ALTER COLUMN ... TYPE ...` path for length-only changes, preserving table data instead of generating a drop/add column sequence.
- Add regression coverage to ensure a PostgreSQL length change keeps existing row values.

## Why

PostgreSQL supports changing `varchar(n)` length in place. TypeORM currently treats a length change like a type change in `PostgresQueryRunner.changeColumn()`, which drops and recreates the column. That can produce data-loss migrations for cases like `varchar(50)` to `varchar(51)`.

## Validation

- `npm run typecheck`
- `npm run lint -- src\driver\postgres\PostgresQueryRunner.ts test\functional\schema-builder\column\change\change-column\change-column.test.ts`
- `git diff --check`

Note: I could not run the PostgreSQL integration test locally because this environment does not have a configured PostgreSQL test database. The lint run reports existing warnings in `PostgresQueryRunner.ts` but no errors.