### PR TITLE
fix: avoid recreating postgres columns on length change

### DIFF
--- a/src/driver/postgres/PostgresQueryRunner.ts
+++ b/src/driver/postgres/PostgresQueryRunner.ts
@@ -2348,9 +2348,9 @@ export class PostgresQueryRunner
                     new Query(
                         `ALTER TABLE ${this.escapePath(table)} ALTER COLUMN "${
                             newColumn.name
-                        }" TYPE ${newColumn.type} COLLATE "${
-                            newColumn.collation
-                        }"`,
+                        }" TYPE ${this.driver.createFullType(
+                            newColumn,
+                        )} COLLATE "${newColumn.collation}"`,
                     ),
                 )
 
@@ -2362,7 +2362,9 @@ export class PostgresQueryRunner
                     new Query(
                         `ALTER TABLE ${this.escapePath(table)} ALTER COLUMN "${
                             newColumn.name
-                        }" TYPE ${newColumn.type} COLLATE ${oldCollation}`,
+                        }" TYPE ${this.driver.createFullType(
+                            oldColumn,
+                        )} COLLATE ${oldCollation}`,
                     ),
                 )
             }

--- a/src/driver/postgres/PostgresQueryRunner.ts
+++ b/src/driver/postgres/PostgresQueryRunner.ts
@@ -1328,7 +1328,6 @@ export class PostgresQueryRunner
 
         if (
             oldColumn.type !== newColumn.type ||
-            oldColumn.length !== newColumn.length ||
             newColumn.isArray !== oldColumn.isArray ||
             (!oldColumn.generatedType &&
                 newColumn.generatedType === "STORED") ||
@@ -1619,6 +1618,7 @@ export class PostgresQueryRunner
             }
 
             if (
+                newColumn.length !== oldColumn.length ||
                 newColumn.precision !== oldColumn.precision ||
                 newColumn.scale !== oldColumn.scale
             ) {

--- a/test/functional/schema-builder/collation/collation-changes/collation-changes.test.ts
+++ b/test/functional/schema-builder/collation/collation-changes/collation-changes.test.ts
@@ -81,4 +81,40 @@ describe("schema builder > collation > collation changes", () => {
             }),
         )
     })
+
+    it("preserves type modifiers when changing collation and length together", async () => {
+        await Promise.all(
+            dataSources.map(async (connection) => {
+                const meta = connection.getMetadata(Item)
+                const col = meta.columns.find(
+                    (c) => c.propertyName === COLUMN_NAME,
+                )!
+                const OLD_COLLATION = col.collation
+                const OLD_LENGTH = col.length
+                col.collation = NEW_COLLATION
+                col.length = "150"
+
+                const sqlInMemory = await connection.driver
+                    .createSchemaBuilder()
+                    .log()
+                const tableName = meta.tableName
+                const upJoined = sqlInMemory.upQueries
+                    .map((q) => q.query.replaceAll(/\s+/g, " ").trim())
+                    .join(" ")
+                const downJoined = sqlInMemory.downQueries
+                    .map((q) => q.query.replaceAll(/\s+/g, " ").trim())
+                    .join(" ")
+
+                expect(upJoined).to.include(
+                    `ALTER TABLE "${tableName}" ALTER COLUMN "${COLUMN_NAME}" TYPE character varying(150) COLLATE "${NEW_COLLATION}"`,
+                )
+                expect(downJoined).to.include(
+                    `ALTER TABLE "${tableName}" ALTER COLUMN "${COLUMN_NAME}" TYPE character varying(100) COLLATE "${OLD_COLLATION}"`,
+                )
+
+                col.collation = OLD_COLLATION
+                col.length = OLD_LENGTH
+            }),
+        )
+    })
 })

--- a/test/functional/schema-builder/column/change/change-column/change-column.test.ts
+++ b/test/functional/schema-builder/column/change/change-column/change-column.test.ts
@@ -88,6 +88,51 @@ describe("schema builder > change column", () => {
             }),
         ))
 
+    it("should preserve postgres column data when changing column length", () =>
+        Promise.all(
+            dataSources.map(async (dataSource) => {
+                if (dataSource.driver.options.type !== "postgres") return
+
+                await dataSource.manager.save(Post, {
+                    id: 1,
+                    version: "v1",
+                    name: "My persisted post",
+                    text: "body",
+                    tag: "tag",
+                    likesCount: 1,
+                })
+
+                const postMetadata = dataSource.getMetadata(Post)
+                const nameColumn =
+                    postMetadata.findColumnWithPropertyName("name")!
+                nameColumn.length = "500"
+
+                const sqlInMemory = await dataSource.driver
+                    .createSchemaBuilder()
+                    .log()
+                const upQueries = sqlInMemory.upQueries.map(
+                    (query) => query.query,
+                )
+
+                expect(upQueries).to.include(
+                    `ALTER TABLE "post" ALTER COLUMN "name" TYPE character varying(500)`,
+                )
+                expect(
+                    upQueries.some((query) =>
+                        query.includes(`DROP COLUMN "name"`),
+                    ),
+                ).to.be.false
+
+                await dataSource.synchronize()
+
+                const post = await dataSource.manager.findOneBy(Post, { id: 1 })
+                expect(post!.name).to.equal("My persisted post")
+
+                // revert changes
+                nameColumn.length = "255"
+            }),
+        ))
+
     it("should correctly change column type", () =>
         Promise.all(
             dataSources.map(async (dataSource) => {


### PR DESCRIPTION
### Description of change

Fixes #3357.

PostgreSQL column length changes currently go through the destructive recreate path in `PostgresQueryRunner.changeColumn`, so changing a column from `varchar(50)` to `varchar(51)` can generate `DROP COLUMN` + `ADD COLUMN` and lose existing data.

This change keeps length-only changes on the existing `ALTER COLUMN ... TYPE ...` path, alongside precision and scale changes. Type changes, array changes, and generated column changes still use the existing recreate path where needed.

I added a regression test that:
- saves an existing row
- changes the PostgreSQL column length
- verifies the generated SQL uses `ALTER TABLE "post" ALTER COLUMN "name" TYPE character varying(500)`
- verifies the generated SQL does not include `DROP COLUMN "name"`
- runs synchronization and confirms the row data is preserved

### Pull-Request Checklist

- [x] Code is up-to-date with the `master` branch
- [x] This pull request links relevant issues as `Fixes #3357`
- [x] There are new or updated tests validating the change (`tests/**.test.ts`)
- [x] Documentation has been updated to reflect this change (`docs/docs/**.md`) N/A, bug fix only

Testing run locally:

```bash
corepack pnpm install --frozen-lockfile
corepack pnpm run typecheck
corepack pnpm exec prettier --check src/driver/postgres/PostgresQueryRunner.ts test/functional/schema-builder/column/change/change-column/change-column.test.ts
corepack pnpm run lint -- src/driver/postgres/PostgresQueryRunner.ts test/functional/schema-builder/column/change/change-column/change-column.test.ts

Results:

TypeScript check passed
Prettier check passed
Lint passed with existing warnings in PostgresQueryRunner.ts
I could not run the PostgreSQL integration test locally because Docker is not available in this Windows environment