### PR TITLE
ci: pin all GitHub Actions to commit SHAs

### DIFF
--- a/.github/actions/setup-node/action.yml
+++ b/.github/actions/setup-node/action.yml
@@ -17,9 +17,9 @@ inputs:
 runs:
   using: composite
   steps:
-    - uses: pnpm/action-setup@v5
+    - uses: pnpm/action-setup@b307475762933b98ed359c036b0e51f26b63b74b # v5.0.0
 
-    - uses: actions/setup-node@v6
+    - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
       with:
         node-version: ${{ inputs.node-version }}
         cache: pnpm
@@ -28,7 +28,7 @@ runs:
       shell: bash
       working-directory: ${{ inputs.working-directory || '.' }}
 
-    - uses: actions/download-artifact@v8
+    - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
       if: inputs.download-build == 'true'
       with:
         name: build

--- a/.github/actions/upload-coverage/action.yml
+++ b/.github/actions/upload-coverage/action.yml
@@ -9,7 +9,7 @@ inputs:
 runs:
   using: composite
   steps:
-    - uses: actions/upload-artifact@v7
+    - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
       with:
         name: coverage-${{ inputs.name }}
         path: coverage/lcov.info

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,10 @@
+version: 2
+updates:
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+    groups:
+      github-actions:
+        patterns:
+          - "*"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,6 +5,14 @@ updates:
     schedule:
       interval: weekly
     groups:
-      github-actions:
+      github-actions-official:
         patterns:
-          - "*"
+          - "actions/*"
+          - "github/*"
+      github-actions-third-party:
+        patterns:
+          - "pnpm/*"
+          - "dorny/*"
+          - "SonarSource/*"
+          - "cloudflare/*"
+          - "amannn/*"

--- a/.github/workflows/assign-milestone.yml
+++ b/.github/workflows/assign-milestone.yml
@@ -14,7 +14,7 @@ jobs:
       issues: write
       pull-requests: write
     steps:
-      - uses: actions/github-script@v8
+      - uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0
         with:
           script: |
             const branch = context.ref.replace('refs/heads/', '')

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -27,14 +27,14 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@v4
+        uses: github/codeql-action/init@3ce22a6e336a7fcc318bc58ae1986395bdc83ba7 # v4.35.4
         with:
           languages: javascript-typescript
 
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@v4
+        uses: github/codeql-action/analyze@3ce22a6e336a7fcc318bc58ae1986395bdc83ba7 # v4.35.4
         with:
           category: "/language:javascript-typescript"

--- a/.github/workflows/deploy-docs-cloudflare-pages.yml
+++ b/.github/workflows/deploy-docs-cloudflare-pages.yml
@@ -19,10 +19,10 @@ jobs:
       contents: read
       deployments: write
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - uses: ./.github/actions/build-docs
 
-      - uses: cloudflare/wrangler-action@v3
+      - uses: cloudflare/wrangler-action@9acf94ace14e7dc412b076f2c5c20b8ce93c79cd # v3.15.0
         with:
           apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}

--- a/.github/workflows/mutation-test.yml
+++ b/.github/workflows/mutation-test.yml
@@ -43,7 +43,7 @@ jobs:
           --health-retries 5
 
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - uses: ./.github/actions/setup-node
 
       - run: |
@@ -61,7 +61,7 @@ jobs:
         env:
           STRYKER_DASHBOARD_API_KEY: ${{ secrets.STRYKER_DASHBOARD_API_KEY }}
 
-      - uses: actions/upload-artifact@v7
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: mutation-testing
           path: ./reports/mutation/mutation.html

--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -24,8 +24,8 @@ jobs:
     outputs:
       changes: ${{ steps.detect-changes.outputs.changes }}
     steps:
-      - uses: actions/checkout@v6
-      - uses: dorny/paths-filter@v4
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: dorny/paths-filter@fbd0ab8f3e69293af611ebaee6363fc25e6d187d # v4.0.1
         id: detect-changes
         with:
           filters: |
@@ -48,7 +48,7 @@ jobs:
     if: needs.detect-changes.outputs.changes != '[]'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
       - uses: ./.github/actions/setup-node

--- a/.github/workflows/publish-package.yml
+++ b/.github/workflows/publish-package.yml
@@ -93,11 +93,11 @@ jobs:
       matrix:
         include: ${{ fromJson(needs.setup.outputs.matrix) }}
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           ref: ${{ matrix.ref || github.ref }}
 
-      - uses: pnpm/action-setup@v5
+      - uses: pnpm/action-setup@b307475762933b98ed359c036b0e51f26b63b74b # v5.0.0
 
       - name: Check if there are new commits since last publish (nightly) or if it's a release
         id: publishable
@@ -141,7 +141,7 @@ jobs:
       # registry-url is deliberately omitted: with Trusted Publishing, the npm
       # CLI handles OIDC auth automatically. Setting registry-url would create
       # an .npmrc with an empty auth token placeholder that blocks the OIDC flow.
-      - uses: actions/setup-node@v6
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         if: steps.publishable.outputs.should_publish == 'true'
         with:
           node-version: ${{ matrix.node || '24' }}

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -18,7 +18,7 @@ jobs:
     permissions:
       pull-requests: read
     steps:
-      - uses: amannn/action-semantic-pull-request@v6
+      - uses: amannn/action-semantic-pull-request@48f256284bd46cdaab1048c3721360e808335d50 # v6.1.1
         with:
           types: |
             build

--- a/.github/workflows/tests-linux.yml
+++ b/.github/workflows/tests-linux.yml
@@ -11,7 +11,7 @@ jobs:
   better-sqlite3:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - uses: ./.github/actions/setup-node
         with:
           node-version: ${{ inputs.node-version }}
@@ -46,7 +46,7 @@ jobs:
           --health-timeout 5s
           --health-retries 5
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - uses: ./.github/actions/setup-node
         with:
           node-version: ${{ inputs.node-version }}
@@ -76,7 +76,7 @@ jobs:
         ports:
           - "27017:27017"
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - uses: ./.github/actions/setup-node
         with:
           node-version: ${{ inputs.node-version }}
@@ -101,7 +101,7 @@ jobs:
           ACCEPT_EULA: Y
           MSSQL_PID: Express
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - uses: ./.github/actions/setup-node
         with:
           node-version: ${{ inputs.node-version }}
@@ -136,7 +136,7 @@ jobs:
           MYSQL_PASSWORD: password
           MYSQL_DATABASE: typeorm
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - uses: ./.github/actions/setup-node
         with:
           node-version: ${{ inputs.node-version }}
@@ -176,7 +176,7 @@ jobs:
           MYSQL_PASSWORD: password
           MYSQL_DATABASE: typeorm
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - uses: ./.github/actions/setup-node
         with:
           node-version: ${{ inputs.node-version }}
@@ -197,7 +197,7 @@ jobs:
   oracle:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - run: docker compose up oracle --detach
 
@@ -237,7 +237,7 @@ jobs:
           --health-timeout 5s
           --health-retries 5
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - uses: ./.github/actions/setup-node
         with:
           node-version: ${{ inputs.node-version }}
@@ -253,7 +253,7 @@ jobs:
   sap:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - run: docker compose up hanaexpress --detach
 
@@ -283,7 +283,7 @@ jobs:
           SPANNER_INSTANCE_ID: typeorm
           SPANNER_DATABASE_ID: typeorm
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - uses: ./.github/actions/setup-node
         with:
           node-version: ${{ inputs.node-version }}
@@ -303,7 +303,7 @@ jobs:
   sqljs:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - uses: ./.github/actions/setup-node
         with:
           node-version: ${{ inputs.node-version }}

--- a/.github/workflows/tests-windows.yml
+++ b/.github/workflows/tests-windows.yml
@@ -11,7 +11,7 @@ jobs:
   better-sqlite3:
     runs-on: windows-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - uses: ./.github/actions/setup-node
         with:
           node-version: ${{ inputs.node-version }}
@@ -27,7 +27,7 @@ jobs:
   sqljs:
     runs-on: windows-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - uses: ./.github/actions/setup-node
         with:
           node-version: ${{ inputs.node-version }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -16,9 +16,9 @@ jobs:
     outputs:
       changes: ${{ steps.detect-changes.outputs.changes }}
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
-      - uses: dorny/paths-filter@v4
+      - uses: dorny/paths-filter@fbd0ab8f3e69293af611ebaee6363fc25e6d187d # v4.0.1
         id: detect-changes
         with:
           filters: |
@@ -71,7 +71,7 @@ jobs:
     needs: detect-changes
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - uses: ./.github/actions/build-docs
 
   build:
@@ -79,11 +79,11 @@ jobs:
     needs: detect-changes
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - uses: ./.github/actions/setup-node
       - run: pnpm run compile
 
-      - uses: actions/upload-artifact@v7
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: build
           path: build/
@@ -92,7 +92,7 @@ jobs:
   format:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - uses: ./.github/actions/setup-node
       - run: pnpm run format:ci
 
@@ -101,7 +101,7 @@ jobs:
     needs: detect-changes
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - uses: ./.github/actions/setup-node
       - run: pnpm run lint
       - run: pnpm install --frozen-lockfile
@@ -132,7 +132,7 @@ jobs:
     needs: detect-changes
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0 # SonarQube needs full history for blame and PR diffing against master
       - uses: ./.github/actions/setup-node
@@ -140,7 +140,7 @@ jobs:
           working-directory: packages/codemod
       - run: pnpm exec c8 pnpm test
         working-directory: packages/codemod
-      - uses: SonarSource/sonarqube-scan-action@v7
+      - uses: SonarSource/sonarqube-scan-action@c7ee0f9df90b7aa20e8dcf9695dcfe2e7da5b4f2 # v7.2.1
         if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
         with:
           projectBaseDir: packages/codemod
@@ -152,7 +152,7 @@ jobs:
     needs: detect-changes
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0 # SonarQube needs full history for blame and PR diffing against master
       - uses: ./.github/actions/setup-node
@@ -160,7 +160,7 @@ jobs:
           working-directory: packages/legacy-naming-strategies
       - run: pnpm exec c8 pnpm test
         working-directory: packages/legacy-naming-strategies
-      - uses: SonarSource/sonarqube-scan-action@v7
+      - uses: SonarSource/sonarqube-scan-action@c7ee0f9df90b7aa20e8dcf9695dcfe2e7da5b4f2 # v7.2.1
         if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
         with:
           projectBaseDir: packages/legacy-naming-strategies
@@ -172,15 +172,15 @@ jobs:
     runs-on: ubuntu-latest
     needs: [detect-changes, tests-linux, tests-windows]
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0 # SonarQube needs full history for blame and PR diffing against master
-      - uses: actions/download-artifact@v7
+      - uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7.0.0
         with:
           pattern: coverage-*
           path: coverage/
 
-      - uses: SonarSource/sonarqube-scan-action@v7
+      - uses: SonarSource/sonarqube-scan-action@c7ee0f9df90b7aa20e8dcf9695dcfe2e7da5b4f2 # v7.2.1
         if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
         env:
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}


### PR DESCRIPTION
<!--
  😀 Wonderful!  Thank you for opening a pull request for TypeORM.

  Please fill in the information below to expedite the review
  and (hopefully) merge of your change.

  If unsure about something.. just do as best as you're able,
  or reach out through our community support channels!
  https://github.com/typeorm/typeorm/blob/master/docs/support.md
  https://github.com/typeorm/typeorm/blob/master/CONTRIBUTING.md
-->

### Description of change

Pin all third-party GitHub Actions to commit SHAs to prevent supply chain attacks via mutable version tags. Add Dependabot config for automated SHA updates.

<!--
  Please describe:
  - what the change is intended to do
  - why this change is needed
  - how you've verified it
  - any other context that will help reviewers understand the change

  In some cases it may be helpful to include the current behavior
  and the new behavior.
-->

### Pull-Request Checklist

<!--
  Please make sure to review and check all of the following.

  If an item is not applicable, you can add "N/A" to the end.
-->

- [x] Code is up-to-date with the `master` branch
- [x] This pull request links relevant issues as `Fixes #00000`
- [x] There are new or updated tests validating the change (`tests/**.test.ts`)
- [x] Documentation has been updated to reflect this change (`docs/docs/**.md`)

> 🛡️ **Security fixes:** Do not submit security fixes as public PRs — the diff exposes the vulnerability. Use [GitHub Security Advisories](https://github.com/typeorm/typeorm/security/advisories/new) instead.

<!--
  🎉 Thank you for contributing and making TypeORM even better!
-->
