### PR TITLE
fix: use ALTER COLUMN instead of DROP+ADD when only column length cha…

### DIFF
--- a/src/driver/aurora-mysql/AuroraMysqlQueryRunner.ts
+++ b/src/driver/aurora-mysql/AuroraMysqlQueryRunner.ts
@@ -889,7 +889,6 @@ export class AuroraMysqlQueryRunner
             (newColumn.isGenerated !== oldColumn.isGenerated &&
                 newColumn.generationStrategy !== "uuid") ||
             oldColumn.type !== newColumn.type ||
-            oldColumn.length !== newColumn.length ||
             oldColumn.generatedType !== newColumn.generatedType
         ) {
             await this.dropColumn(table, oldColumn)
@@ -1038,7 +1037,10 @@ export class AuroraMysqlQueryRunner
                 oldColumn.name = newColumn.name
             }
 
-            if (this.isColumnChanged(oldColumn, newColumn, true)) {
+            if (
+                oldColumn.length !== newColumn.length ||
+                this.isColumnChanged(oldColumn, newColumn, true)
+            ) {
                 upQueries.push(
                     new Query(
                         `ALTER TABLE ${this.escapePath(table)} CHANGE \`${

--- a/src/driver/cockroachdb/CockroachQueryRunner.ts
+++ b/src/driver/cockroachdb/CockroachQueryRunner.ts
@@ -1403,7 +1403,6 @@ export class CockroachQueryRunner
 
         if (
             oldColumn.type !== newColumn.type ||
-            oldColumn.length !== newColumn.length ||
             newColumn.isArray !== oldColumn.isArray ||
             oldColumn.generatedType !== newColumn.generatedType ||
             oldColumn.asExpression !== newColumn.asExpression
@@ -1657,6 +1656,7 @@ export class CockroachQueryRunner
             }
 
             if (
+                oldColumn.length !== newColumn.length ||
                 newColumn.precision !== oldColumn.precision ||
                 newColumn.scale !== oldColumn.scale
             ) {

--- a/src/driver/mysql/MysqlQueryRunner.ts
+++ b/src/driver/mysql/MysqlQueryRunner.ts
@@ -1138,7 +1138,6 @@ export class MysqlQueryRunner extends BaseQueryRunner implements QueryRunner {
             (newColumn.isGenerated !== oldColumn.isGenerated &&
                 newColumn.generationStrategy !== "uuid") ||
             oldColumn.type !== newColumn.type ||
-            oldColumn.length !== newColumn.length ||
             (oldColumn.generatedType &&
                 newColumn.generatedType &&
                 oldColumn.generatedType !== newColumn.generatedType) ||
@@ -1319,7 +1318,10 @@ export class MysqlQueryRunner extends BaseQueryRunner implements QueryRunner {
                 oldColumn.name = newColumn.name
             }
 
-            if (this.isColumnChanged(oldColumn, newColumn, true, true)) {
+            if (
+                oldColumn.length !== newColumn.length ||
+                this.isColumnChanged(oldColumn, newColumn, true, true)
+            ) {
                 upQueries.push(
                     new Query(
                         `ALTER TABLE ${this.escapePath(table)} CHANGE \`${

--- a/src/driver/oracle/OracleQueryRunner.ts
+++ b/src/driver/oracle/OracleQueryRunner.ts
@@ -1146,7 +1146,6 @@ export class OracleQueryRunner extends BaseQueryRunner implements QueryRunner {
             (newColumn.isGenerated !== oldColumn.isGenerated &&
                 newColumn.generationStrategy !== "uuid") ||
             oldColumn.type !== newColumn.type ||
-            oldColumn.length !== newColumn.length ||
             oldColumn.generatedType !== newColumn.generatedType ||
             oldColumn.asExpression !== newColumn.asExpression
         ) {
@@ -1370,7 +1369,10 @@ export class OracleQueryRunner extends BaseQueryRunner implements QueryRunner {
                 oldColumn.name = newColumn.name
             }
 
-            if (this.isColumnChanged(oldColumn, newColumn, true)) {
+            if (
+                oldColumn.length !== newColumn.length ||
+                this.isColumnChanged(oldColumn, newColumn, true)
+            ) {
                 let defaultUp: string = ""
                 let defaultDown: string = ""
                 let nullableUp: string = ""

--- a/src/driver/postgres/PostgresQueryRunner.ts
+++ b/src/driver/postgres/PostgresQueryRunner.ts
@@ -1328,7 +1328,6 @@ export class PostgresQueryRunner
 
         if (
             oldColumn.type !== newColumn.type ||
-            oldColumn.length !== newColumn.length ||
             newColumn.isArray !== oldColumn.isArray ||
             (!oldColumn.generatedType &&
                 newColumn.generatedType === "STORED") ||
@@ -1619,6 +1618,7 @@ export class PostgresQueryRunner
             }
 
             if (
+                oldColumn.length !== newColumn.length ||
                 newColumn.precision !== oldColumn.precision ||
                 newColumn.scale !== oldColumn.scale
             ) {

--- a/src/driver/sap/SapQueryRunner.ts
+++ b/src/driver/sap/SapQueryRunner.ts
@@ -1366,11 +1366,10 @@ export class SapQueryRunner extends BaseQueryRunner implements QueryRunner {
             (newColumn.isGenerated !== oldColumn.isGenerated &&
                 newColumn.generationStrategy !== "uuid") ||
             newColumn.type !== oldColumn.type ||
-            newColumn.length !== oldColumn.length ||
             (newColumn.asExpression ?? "").trim() !==
                 (oldColumn.asExpression ?? "").trim()
         ) {
-            // SQL Server does not support changing of IDENTITY column, so we must drop column and recreate it again.
+            // SAP does not support changing of IDENTITY column, so we must drop column and recreate it again.
             // Also, we recreate column if column type changed
             await this.dropColumn(table, oldColumn)
             await this.addColumn(table, newColumn)
@@ -1584,7 +1583,10 @@ export class SapQueryRunner extends BaseQueryRunner implements QueryRunner {
                 oldColumn.name = newColumn.name
             }
 
-            if (this.isColumnChanged(oldColumn, newColumn, true)) {
+            if (
+                newColumn.length !== oldColumn.length ||
+                this.isColumnChanged(oldColumn, newColumn, true)
+            ) {
                 upQueries.push(
                     new Query(
                         `ALTER TABLE ${this.escapePath(

--- a/src/driver/sqlserver/SqlServerQueryRunner.ts
+++ b/src/driver/sqlserver/SqlServerQueryRunner.ts
@@ -1371,7 +1371,6 @@ export class SqlServerQueryRunner
             (newColumn.isGenerated !== oldColumn.isGenerated &&
                 newColumn.generationStrategy !== "uuid") ||
             newColumn.type !== oldColumn.type ||
-            newColumn.length !== oldColumn.length ||
             newColumn.asExpression !== oldColumn.asExpression ||
             newColumn.generatedType !== oldColumn.generatedType
         ) {
@@ -1707,6 +1706,7 @@ export class SqlServerQueryRunner
             }
 
             if (
+                newColumn.length !== oldColumn.length ||
                 this.isColumnChanged(oldColumn, newColumn, false, false, false)
             ) {
                 upQueries.push(


### PR DESCRIPTION
…nges

Changing a varchar length previously triggered a full DROP+ADD cycle in multiple drivers, destroying all column data. Length changes are safe to perform via ALTER COLUMN TYPE (Postgres/CockroachDB), CHANGE COLUMN (MySQL/Aurora), MODIFY (Oracle), ALTER COLUMN (SQL Server), or ALTER (SAP HANA) — all of which preserve existing data.

Fixes: #3357

<!--
  😀 Wonderful!  Thank you for opening a pull request for TypeORM.

  Please fill in the information below to expedite the review
  and (hopefully) merge of your change.

  If unsure about something.. just do as best as you're able,
  or reach out through our community support channels!
  https://github.com/typeorm/typeorm/blob/master/docs/support.md
  https://github.com/typeorm/typeorm/blob/master/CONTRIBUTING.md
-->

### Description of change

Fixes #3357

**What:** When only a column's length changes (e.g. varchar(100) → varchar(200)), TypeORM was incorrectly triggering a DROP+ADD cycle instead of a safe ALTER. This silently destroys all data in that column.

**Why:** The `oldColumn.length !== newColumn.length` condition was in the DROP+ADD branch instead of the ALTER branch.

**Fix:** Moved the length check to the ALTER COLUMN TYPE / CHANGE COLUMN / MODIFY condition in all 7 affected drivers: PostgreSQL, CockroachDB, MySQL, Aurora MySQL, Oracle, SQL Server, SAP HANA.

**Verified:** TypeScript compiles clean. Existing tests pass.
-->

### Pull-Request Checklist

<!--
  Please make sure to review and check all of the following.

  If an item is not applicable, you can add "N/A" to the end.
-->

- [ ] Code is up-to-date with the `master` branch
- [ ] This pull request links relevant issues as `Fixes #00000`
- [ ] There are new or updated tests validating the change (`tests/**.test.ts`)
- [ ] Documentation has been updated to reflect this change (`docs/docs/**.md`)

> 🛡️ **Security fixes:** Do not submit security fixes as public PRs — the diff exposes the vulnerability. Use [GitHub Security Advisories](https://github.com/typeorm/typeorm/security/advisories/new) instead.

<!--
  🎉 Thank you for contributing and making TypeORM even better!
-->
