### PR TITLE
fix: alter postgres varchar length without column recreation

### DIFF
--- a/src/driver/postgres/PostgresQueryRunner.ts
+++ b/src/driver/postgres/PostgresQueryRunner.ts
@@ -1328,7 +1328,6 @@ export class PostgresQueryRunner
 
         if (
             oldColumn.type !== newColumn.type ||
-            oldColumn.length !== newColumn.length ||
             newColumn.isArray !== oldColumn.isArray ||
             (!oldColumn.generatedType &&
                 newColumn.generatedType === "STORED") ||
@@ -1622,6 +1621,23 @@ export class PostgresQueryRunner
                 newColumn.precision !== oldColumn.precision ||
                 newColumn.scale !== oldColumn.scale
             ) {
+                upQueries.push(
+                    new Query(
+                        `ALTER TABLE ${this.escapePath(table)} ALTER COLUMN "${
+                            newColumn.name
+                        }" TYPE ${this.driver.createFullType(newColumn)}`,
+                    ),
+                )
+                downQueries.push(
+                    new Query(
+                        `ALTER TABLE ${this.escapePath(table)} ALTER COLUMN "${
+                            newColumn.name
+                        }" TYPE ${this.driver.createFullType(oldColumn)}`,
+                    ),
+                )
+            }
+
+            if (newColumn.length !== oldColumn.length) {
                 upQueries.push(
                     new Query(
                         `ALTER TABLE ${this.escapePath(table)} ALTER COLUMN "${

--- a/test/github-issues/3357/entity/Bug.ts
+++ b/test/github-issues/3357/entity/Bug.ts
@@ -1,0 +1,10 @@
+import { Column, Entity, PrimaryGeneratedColumn } from "../../../../src"
+
+@Entity()
+export class Bug {
+    @PrimaryGeneratedColumn()
+    id: number
+
+    @Column({ length: 50 })
+    example: string
+}

--- a/test/github-issues/3357/issue-3357.test.ts
+++ b/test/github-issues/3357/issue-3357.test.ts
@@ -1,0 +1,65 @@
+import "reflect-metadata"
+import { expect } from "chai"
+import type { DataSource } from "../../../src"
+import {
+    closeTestingConnections,
+    createTestingConnections,
+} from "../../utils/test-utils"
+import { Bug } from "./entity/Bug"
+
+describe("github issues > #3357 Migration generation drops and creates columns instead of altering", () => {
+    let dataSources: DataSource[]
+
+    before(async () => {
+        dataSources = await createTestingConnections({
+            enabledDrivers: ["postgres"],
+            entities: [Bug],
+            schemaCreate: true,
+            dropSchema: true,
+        })
+    })
+
+    after(() => closeTestingConnections(dataSources))
+
+    it("should alter varchar length without dropping the column", () =>
+        Promise.all(
+            dataSources.map(async (dataSource) => {
+                await dataSource.getRepository(Bug).save({
+                    example: "kept-value",
+                })
+
+                const metadata = dataSource.getMetadata(Bug)
+                const exampleColumn =
+                    metadata.findColumnWithPropertyName("example")!
+                exampleColumn.length = "51"
+
+                const sqlInMemory = await dataSource.driver
+                    .createSchemaBuilder()
+                    .log()
+                const upQueries = sqlInMemory.upQueries.map(
+                    (query) => query.query,
+                )
+
+                expect(upQueries).to.include(
+                    `ALTER TABLE "bug" ALTER COLUMN "example" TYPE character varying(51)`,
+                )
+                expect(upQueries.join("\n")).not.to.include("DROP COLUMN")
+
+                await dataSource.synchronize()
+
+                const rows = await dataSource.getRepository(Bug).find()
+                expect(rows).to.have.length(1)
+                expect(rows[0].example).to.equal("kept-value")
+
+                const queryRunner = dataSource.createQueryRunner()
+                try {
+                    const table = await queryRunner.getTable("bug")
+                    expect(table!.findColumnByName("example")!.length).to.equal(
+                        "51",
+                    )
+                } finally {
+                    await queryRunner.release()
+                }
+            }),
+        ))
+})


### PR DESCRIPTION
Closes #3357.

## Summary
- changes Postgres column-length updates to use `ALTER COLUMN ... TYPE` instead of dropping/re-adding the column
- keeps type/array/generated-column changes on the existing recreation path
- adds a regression test for varchar length changes that asserts no `DROP COLUMN` is generated and existing row data is preserved

## Verification
- `pnpm install --frozen-lockfile`
- `pnpm exec prettier --check src\driver\postgres\PostgresQueryRunner.ts test\github-issues\3357\issue-3357.test.ts test\github-issues\3357\entity\Bug.ts`
- `pnpm exec tsc --noEmit --pretty false`
- `pnpm run compile`

I could not run the Postgres integration test locally because this checkout does not have a valid `ormconfig.json` with Postgres credentials.