### PR TITLE
fix(postgres): preserve data when varchar length changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - **cli:** init command reading package.json from two folders up ([#11789](https://github.com/typeorm/typeorm/issues/11789)) ([dd55218](https://github.com/typeorm/typeorm/commit/dd55218648eb449937e22e1e7c88182db0048f1d))
 - **deps:** upgrade glob to fix CVE-2025-64756 ([#11784](https://github.com/typeorm/typeorm/issues/11784)) ([dc74f53](https://github.com/typeorm/typeorm/commit/dc74f5374ef5ec83d53045e4bca99cb9ff7d49d4))
 - **mongodb:** add missing `findBy` method to MongoEntityManager ([#11814](https://github.com/typeorm/typeorm/issues/11814)) ([38715bb](https://github.com/typeorm/typeorm/commit/38715bbd4169cae2910aac035cd2b05bddbaec5c))
+- **postgres:** avoid dropping columns when changing varchar length ([#3357](https://github.com/typeorm/typeorm/issues/3357))
 - **redis:** version detection logic ([#11815](https://github.com/typeorm/typeorm/issues/11815)) ([6f486e5](https://github.com/typeorm/typeorm/commit/6f486e5a67c007287949be119f233fb2b4fb7a59))
 - typesense doc sync ([#11807](https://github.com/typeorm/typeorm/issues/11807)) ([d0b5454](https://github.com/typeorm/typeorm/commit/d0b54544e9e43a5330c0485d41551128224fe4d3))
 

--- a/src/driver/postgres/PostgresQueryRunner.ts
+++ b/src/driver/postgres/PostgresQueryRunner.ts
@@ -2348,9 +2348,9 @@ export class PostgresQueryRunner
                     new Query(
                         `ALTER TABLE ${this.escapePath(table)} ALTER COLUMN "${
                             newColumn.name
-                        }" TYPE ${newColumn.type} COLLATE "${
-                            newColumn.collation
-                        }"`,
+                        }" TYPE ${this.driver.createFullType(
+                            newColumn,
+                        )} COLLATE "${newColumn.collation}"`,
                     ),
                 )
 
@@ -2362,7 +2362,9 @@ export class PostgresQueryRunner
                     new Query(
                         `ALTER TABLE ${this.escapePath(table)} ALTER COLUMN "${
                             newColumn.name
-                        }" TYPE ${newColumn.type} COLLATE ${oldCollation}`,
+                        }" TYPE ${this.driver.createFullType(
+                            oldColumn,
+                        )} COLLATE ${oldCollation}`,
                     ),
                 )
             }

--- a/src/driver/postgres/PostgresQueryRunner.ts
+++ b/src/driver/postgres/PostgresQueryRunner.ts
@@ -2344,19 +2344,23 @@ export class PostgresQueryRunner
 
             // update column collation
             if (newColumn.collation !== oldColumn.collation) {
+                const newCollation = newColumn.collation
+                    ? `"${newColumn.collation}"`
+                    : `pg_catalog."default"`
+
                 upQueries.push(
                     new Query(
                         `ALTER TABLE ${this.escapePath(table)} ALTER COLUMN "${
                             newColumn.name
                         }" TYPE ${this.driver.createFullType(
                             newColumn,
-                        )} COLLATE "${newColumn.collation}"`,
+                        )} COLLATE ${newCollation}`,
                     ),
                 )
 
                 const oldCollation = oldColumn.collation
                     ? `"${oldColumn.collation}"`
-                    : `pg_catalog."default"` // if there's no old collation, use default
+                    : `pg_catalog."default"`
 
                 downQueries.push(
                     new Query(

--- a/src/driver/postgres/PostgresQueryRunner.ts
+++ b/src/driver/postgres/PostgresQueryRunner.ts
@@ -1328,7 +1328,6 @@ export class PostgresQueryRunner
 
         if (
             oldColumn.type !== newColumn.type ||
-            oldColumn.length !== newColumn.length ||
             newColumn.isArray !== oldColumn.isArray ||
             (!oldColumn.generatedType &&
                 newColumn.generatedType === "STORED") ||
@@ -1619,6 +1618,7 @@ export class PostgresQueryRunner
             }
 
             if (
+                newColumn.length !== oldColumn.length ||
                 newColumn.precision !== oldColumn.precision ||
                 newColumn.scale !== oldColumn.scale
             ) {

--- a/test/functional/database-schema/column-length/postgres/column-length-postgres.test.ts
+++ b/test/functional/database-schema/column-length/postgres/column-length-postgres.test.ts
@@ -85,6 +85,7 @@ describe("database schema > column length > postgres", () => {
             }),
         ))
 
+    // regression test for #3357
     it("should preserve data when varchar length changes", () =>
         Promise.all(
             dataSources.map(async (dataSource) => {

--- a/test/functional/database-schema/column-length/postgres/column-length-postgres.test.ts
+++ b/test/functional/database-schema/column-length/postgres/column-length-postgres.test.ts
@@ -72,4 +72,34 @@ describe("database schema > column length > postgres", () => {
                 )
             }),
         ))
+
+    it("should preserve data when varchar length changes", () =>
+        Promise.all(
+            dataSources.map(async (dataSource) => {
+                await dataSource
+                    .createQueryBuilder()
+                    .insert()
+                    .into(Post)
+                    .values({
+                        id: 1,
+                        characterVarying: "character varying value",
+                        varchar: "varchar value",
+                        character: "character value",
+                        char: "char value",
+                    })
+                    .execute()
+
+                const metadata = dataSource.getMetadata(Post)
+                metadata.findColumnWithPropertyName("varchar")!.length = "100"
+
+                await dataSource.synchronize(false)
+
+                const post = await dataSource
+                    .createQueryBuilder(Post, "post")
+                    .where("post.id = :id", { id: 1 })
+                    .getOneOrFail()
+
+                expect(post.varchar).to.be.equal("varchar value")
+            }),
+        ))
 })

--- a/test/functional/database-schema/column-length/postgres/column-length-postgres.test.ts
+++ b/test/functional/database-schema/column-length/postgres/column-length-postgres.test.ts
@@ -10,13 +10,25 @@ import {
 
 describe("database schema > column length > postgres", () => {
     let dataSources: DataSource[]
+
+    function resetPostColumnLengths(dataSource: DataSource) {
+        const metadata = dataSource.getMetadata(Post)
+        metadata.findColumnWithPropertyName("characterVarying")!.length = "50"
+        metadata.findColumnWithPropertyName("varchar")!.length = "50"
+        metadata.findColumnWithPropertyName("character")!.length = "50"
+        metadata.findColumnWithPropertyName("char")!.length = "50"
+    }
+
     before(async () => {
         dataSources = await createTestingConnections({
             entities: [Post],
             enabledDrivers: ["postgres"],
         })
     })
-    beforeEach(() => reloadTestingDatabases(dataSources))
+    beforeEach(() => {
+        dataSources.forEach(resetPostColumnLengths)
+        return reloadTestingDatabases(dataSources)
+    })
     after(() => closeTestingConnections(dataSources))
 
     it("all types should create with correct size", () =>
@@ -76,6 +88,11 @@ describe("database schema > column length > postgres", () => {
     it("should preserve data when varchar length changes", () =>
         Promise.all(
             dataSources.map(async (dataSource) => {
+                const metadata = dataSource.getMetadata(Post)
+                metadata.findColumnWithPropertyName("varchar")!.length = "50"
+
+                await dataSource.synchronize(true)
+
                 await dataSource
                     .createQueryBuilder()
                     .insert()
@@ -89,7 +106,6 @@ describe("database schema > column length > postgres", () => {
                     })
                     .execute()
 
-                const metadata = dataSource.getMetadata(Post)
                 metadata.findColumnWithPropertyName("varchar")!.length = "100"
 
                 await dataSource.synchronize(false)

--- a/test/functional/database-schema/column-length/postgres/column-length-postgres.test.ts
+++ b/test/functional/database-schema/column-length/postgres/column-length-postgres.test.ts
@@ -85,7 +85,7 @@ describe("database schema > column length > postgres", () => {
             }),
         ))
 
-    // #3357
+    // #3357 regression test
     it("should preserve data when varchar length changes", () =>
         Promise.all(
             dataSources.map(async (dataSource) => {

--- a/test/functional/database-schema/column-length/postgres/column-length-postgres.test.ts
+++ b/test/functional/database-schema/column-length/postgres/column-length-postgres.test.ts
@@ -90,9 +90,6 @@ describe("database schema > column length > postgres", () => {
         Promise.all(
             dataSources.map(async (dataSource) => {
                 const metadata = dataSource.getMetadata(Post)
-                metadata.findColumnWithPropertyName("varchar")!.length = "50"
-
-                await dataSource.synchronize(true)
 
                 await dataSource
                     .createQueryBuilder()

--- a/test/functional/database-schema/column-length/postgres/column-length-postgres.test.ts
+++ b/test/functional/database-schema/column-length/postgres/column-length-postgres.test.ts
@@ -85,7 +85,7 @@ describe("database schema > column length > postgres", () => {
             }),
         ))
 
-    // regression test for #3357
+    // #3357
     it("should preserve data when varchar length changes", () =>
         Promise.all(
             dataSources.map(async (dataSource) => {

--- a/test/unit/query-runner/postgres-change-column.test.ts
+++ b/test/unit/query-runner/postgres-change-column.test.ts
@@ -88,4 +88,33 @@ describe("PostgresQueryRunner changeColumn", () => {
             'ALTER TABLE "bug" ALTER COLUMN "example" TYPE character varying(51)',
         ])
     })
+
+    it("preserves varchar length when changing length and collation together", async () => {
+        const queryRunner = createQueryRunner()
+        const oldColumn = new TableColumn({
+            name: "example",
+            type: "character varying",
+            length: "50",
+            collation: "en_US",
+            isNullable: true,
+        })
+        const newColumn = oldColumn.clone()
+        newColumn.length = "51"
+        newColumn.collation = "C"
+        const table = new Table({
+            name: "bug",
+            columns: [oldColumn],
+        })
+
+        await queryRunner.changeColumn(table, oldColumn, newColumn)
+
+        const upQueries = queryRunner
+            .getMemorySql()
+            .upQueries.map((query) => query.query)
+
+        expect(upQueries).to.deep.equal([
+            'ALTER TABLE "bug" ALTER COLUMN "example" TYPE character varying(51)',
+            'ALTER TABLE "bug" ALTER COLUMN "example" TYPE character varying(51) COLLATE "C"',
+        ])
+    })
 })

--- a/test/unit/query-runner/postgres-change-column.test.ts
+++ b/test/unit/query-runner/postgres-change-column.test.ts
@@ -1,15 +1,28 @@
 import "reflect-metadata"
 import { expect } from "chai"
+import type { PostgresDriver } from "../../../src/driver/postgres/PostgresDriver"
 import { PostgresQueryRunner } from "../../../src/driver/postgres/PostgresQueryRunner"
 import { Table } from "../../../src/schema-builder/table/Table"
 import { TableColumn } from "../../../src/schema-builder/table/TableColumn"
 
 describe("PostgresQueryRunner changeColumn", () => {
+    type MinimalPostgresDriver = Pick<
+        PostgresDriver,
+        | "database"
+        | "searchSchema"
+        | "options"
+        | "parseTableName"
+        | "createFullType"
+        | "buildTableName"
+        | "dataSource"
+    >
+
     function createQueryRunner() {
-        const driver: any = {
+        const driver = {
             database: "test",
             searchSchema: "public",
             options: { type: "postgres" },
+            dataSource: undefined as unknown as PostgresDriver["dataSource"],
             parseTableName(target: Table | string) {
                 if (typeof target === "string") {
                     return { schema: undefined, tableName: target }
@@ -29,7 +42,7 @@ describe("PostgresQueryRunner changeColumn", () => {
             ) {
                 return [database, schema, tableName].filter(Boolean).join(".")
             },
-        }
+        } satisfies MinimalPostgresDriver
 
         driver.dataSource = {
             driver,
@@ -39,9 +52,12 @@ describe("PostgresQueryRunner changeColumn", () => {
                 indexName: () => "IDX_test",
                 foreignKeyName: () => "FK_test",
             },
-        }
+        } as unknown as PostgresDriver["dataSource"]
 
-        const queryRunner = new PostgresQueryRunner(driver, "master")
+        const queryRunner = new PostgresQueryRunner(
+            driver as PostgresDriver,
+            "master",
+        )
         queryRunner.enableSqlMemory()
 
         return queryRunner

--- a/test/unit/query-runner/postgres-change-column.test.ts
+++ b/test/unit/query-runner/postgres-change-column.test.ts
@@ -117,4 +117,31 @@ describe("PostgresQueryRunner changeColumn", () => {
             'ALTER TABLE "bug" ALTER COLUMN "example" TYPE character varying(51) COLLATE "C"',
         ])
     })
+
+    it("uses default collation when removing varchar collation", async () => {
+        const queryRunner = createQueryRunner()
+        const oldColumn = new TableColumn({
+            name: "example",
+            type: "character varying",
+            length: "50",
+            collation: "en_US",
+            isNullable: true,
+        })
+        const newColumn = oldColumn.clone()
+        newColumn.collation = undefined
+        const table = new Table({
+            name: "bug",
+            columns: [oldColumn],
+        })
+
+        await queryRunner.changeColumn(table, oldColumn, newColumn)
+
+        const upQueries = queryRunner
+            .getMemorySql()
+            .upQueries.map((query) => query.query)
+
+        expect(upQueries).to.deep.equal([
+            'ALTER TABLE "bug" ALTER COLUMN "example" TYPE character varying(50) COLLATE pg_catalog."default"',
+        ])
+    })
 })

--- a/test/unit/query-runner/postgres-change-column.test.ts
+++ b/test/unit/query-runner/postgres-change-column.test.ts
@@ -1,0 +1,75 @@
+import "reflect-metadata"
+import { expect } from "chai"
+import { PostgresQueryRunner } from "../../../src/driver/postgres/PostgresQueryRunner"
+import { Table } from "../../../src/schema-builder/table/Table"
+import { TableColumn } from "../../../src/schema-builder/table/TableColumn"
+
+describe("PostgresQueryRunner changeColumn", () => {
+    function createQueryRunner() {
+        const driver: any = {
+            database: "test",
+            searchSchema: "public",
+            options: { type: "postgres" },
+            parseTableName(target: Table | string) {
+                if (typeof target === "string") {
+                    return { schema: undefined, tableName: target }
+                }
+
+                return { schema: target.schema, tableName: target.name }
+            },
+            createFullType(column: TableColumn) {
+                return column.length
+                    ? `${column.type}(${column.length})`
+                    : column.type
+            },
+            buildTableName(
+                tableName: string,
+                schema?: string,
+                database?: string,
+            ) {
+                return [database, schema, tableName].filter(Boolean).join(".")
+            },
+        }
+
+        driver.dataSource = {
+            driver,
+            namingStrategy: {
+                primaryKeyName: () => "PK_test",
+                uniqueConstraintName: () => "UQ_test",
+                indexName: () => "IDX_test",
+                foreignKeyName: () => "FK_test",
+            },
+        }
+
+        const queryRunner = new PostgresQueryRunner(driver, "master")
+        queryRunner.enableSqlMemory()
+
+        return queryRunner
+    }
+
+    it("changes varchar length without dropping and re-adding the column", async () => {
+        const queryRunner = createQueryRunner()
+        const oldColumn = new TableColumn({
+            name: "example",
+            type: "character varying",
+            length: "50",
+            isNullable: true,
+        })
+        const newColumn = oldColumn.clone()
+        newColumn.length = "51"
+        const table = new Table({
+            name: "bug",
+            columns: [oldColumn],
+        })
+
+        await queryRunner.changeColumn(table, oldColumn, newColumn)
+
+        const upQueries = queryRunner
+            .getMemorySql()
+            .upQueries.map((query) => query.query)
+
+        expect(upQueries).to.deep.equal([
+            'ALTER TABLE "bug" ALTER COLUMN "example" TYPE character varying(51)',
+        ])
+    })
+})


### PR DESCRIPTION
Fixes #3357.

Postgres schema sync previously treated a column length change like a type change and recreated the column with DROP COLUMN + ADD COLUMN. That loses existing data for cases such as varchar(50) -> varchar(51).

This change keeps destructive recreate behavior for actual type/array/generated-column changes, but routes length-only changes through ALTER COLUMN TYPE, alongside existing precision/scale changes.

Verification:
- corepack pnpm run compile
- node .\node_modules\mocha\bin\mocha.js --no-config build\compiled\test\unit\query-runner\postgres-change-column.test.js
- corepack pnpm exec prettier --check src/driver/postgres/PostgresQueryRunner.ts test/unit/query-runner/postgres-change-column.test.ts test/functional/database-schema/column-length/postgres/column-length-postgres.test.ts

I also added a Postgres functional regression test for data preservation. I could not run that DB-backed test locally because this machine does not have a Postgres server on localhost:5432.
