### PR TITLE
fix: alter postgres varchar length without column recreation

### DIFF
--- a/src/driver/postgres/PostgresQueryRunner.ts
+++ b/src/driver/postgres/PostgresQueryRunner.ts
@@ -1328,7 +1328,6 @@ export class PostgresQueryRunner
 
         if (
             oldColumn.type !== newColumn.type ||
-            oldColumn.length !== newColumn.length ||
             newColumn.isArray !== oldColumn.isArray ||
             (!oldColumn.generatedType &&
                 newColumn.generatedType === "STORED") ||
@@ -1619,6 +1618,7 @@ export class PostgresQueryRunner
             }
 
             if (
+                newColumn.length !== oldColumn.length ||
                 newColumn.precision !== oldColumn.precision ||
                 newColumn.scale !== oldColumn.scale
             ) {
@@ -1636,6 +1636,13 @@ export class PostgresQueryRunner
                         }" TYPE ${this.driver.createFullType(oldColumn)}`,
                     ),
                 )
+
+                const column = clonedTable.columns.find(
+                    (column) => column.name === newColumn.name,
+                )
+                column!.length = newColumn.length
+                column!.precision = newColumn.precision
+                column!.scale = newColumn.scale
             }
 
             if (
@@ -2344,13 +2351,17 @@ export class PostgresQueryRunner
 
             // update column collation
             if (newColumn.collation !== oldColumn.collation) {
+                const newCollation = newColumn.collation
+                    ? `"${newColumn.collation}"`
+                    : `pg_catalog."default"`
+
                 upQueries.push(
                     new Query(
                         `ALTER TABLE ${this.escapePath(table)} ALTER COLUMN "${
                             newColumn.name
-                        }" TYPE ${newColumn.type} COLLATE "${
-                            newColumn.collation
-                        }"`,
+                        }" TYPE ${this.driver.createFullType(
+                            newColumn,
+                        )} COLLATE ${newCollation}`,
                     ),
                 )
 
@@ -2362,9 +2373,16 @@ export class PostgresQueryRunner
                     new Query(
                         `ALTER TABLE ${this.escapePath(table)} ALTER COLUMN "${
                             newColumn.name
-                        }" TYPE ${newColumn.type} COLLATE ${oldCollation}`,
+                        }" TYPE ${this.driver.createFullType(
+                            oldColumn,
+                        )} COLLATE ${oldCollation}`,
                     ),
                 )
+
+                const column = clonedTable.columns.find(
+                    (column) => column.name === newColumn.name,
+                )
+                column!.collation = newColumn.collation
             }
 
             if (newColumn.generatedType !== oldColumn.generatedType) {

--- a/test/functional/schema-builder/column/change/change-column/change-column.test.ts
+++ b/test/functional/schema-builder/column/change/change-column/change-column.test.ts
@@ -88,6 +88,71 @@ describe("schema builder > change column", () => {
             }),
         ))
 
+    it("should alter postgres varchar length without dropping the column", () =>
+        Promise.all(
+            dataSources.map(async (dataSource) => {
+                if (dataSource.driver.options.type !== "postgres") return
+
+                await dataSource.getRepository(Post).insert({
+                    id: 3357,
+                    version: "1",
+                    name: "preserved value",
+                    text: "text",
+                    tag: "tag",
+                    likesCount: 1,
+                })
+
+                const postMetadata = dataSource.getMetadata(Post)
+                const nameColumn =
+                    postMetadata.findColumnWithPropertyName("name")!
+                const originalLength = nameColumn.length
+                const originalCollation = nameColumn.collation
+                nameColumn.length = "500"
+                nameColumn.collation = "C"
+
+                try {
+                    // #3357: varchar length changes should preserve data and
+                    // keep full type details when combined with collation.
+                    const sqlInMemory = await dataSource.driver
+                        .createSchemaBuilder()
+                        .log()
+                    const upQueries = sqlInMemory.upQueries.map(
+                        ({ query }) => query,
+                    )
+
+                    expect(upQueries).to.include(
+                        `ALTER TABLE "post" ALTER COLUMN "name" TYPE character varying(500)`,
+                    )
+                    expect(upQueries).to.include(
+                        `ALTER TABLE "post" ALTER COLUMN "name" TYPE character varying(500) COLLATE "C"`,
+                    )
+                    expect(
+                        upQueries.some((query) =>
+                            query.includes(`DROP COLUMN "name"`),
+                        ),
+                    ).to.be.false
+                    expect(
+                        upQueries.some((query) => query.includes(`ADD "name"`)),
+                    ).to.be.false
+
+                    await dataSource.synchronize()
+
+                    const post = await dataSource
+                        .getRepository(Post)
+                        .findOneByOrFail({ id: 3357 })
+                    expect(post.name).to.equal("preserved value")
+
+                    const sqlAfterSync = await dataSource.driver
+                        .createSchemaBuilder()
+                        .log()
+                    expect(sqlAfterSync.upQueries).to.have.length(0)
+                } finally {
+                    nameColumn.length = originalLength
+                    nameColumn.collation = originalCollation
+                }
+            }),
+        ))
+
     it("should correctly change column type", () =>
         Promise.all(
             dataSources.map(async (dataSource) => {


### PR DESCRIPTION
### Description of change

Fixes #3357.

Postgres `changeColumn` no longer treats varchar length-only changes as a reason to drop and recreate the column. Instead, the existing `ALTER COLUMN ... TYPE` path now handles length changes, preserving column data.

The patch also keeps full type details when a type change is combined with collation, and updates the cached table column after length/precision/scale/collation changes.

Added a functional regression test that:
- asserts changing a Postgres varchar length generates `ALTER COLUMN ... TYPE`
- asserts no `DROP COLUMN` / `ADD COLUMN` query is generated for the changed column
- verifies an existing row is preserved after `synchronize()`
- verifies a follow-up schema diff is clean after sync

Verification:
- `pnpm run compile`
- `pnpm exec prettier --check src/driver/postgres/PostgresQueryRunner.ts test/functional/schema-builder/column/change/change-column/change-column.test.ts`
- `pnpm exec mocha --no-config --file build/compiled/test/utils/test-setup.js build/compiled/test/functional/schema-builder/column/change/change-column/change-column.test.js`

### Pull-Request Checklist

- [x] Code is up-to-date with the `master` branch
- [x] This pull request links relevant issues as `Fixes #00000`
- [x] There are new or updated tests validating the change (`tests/**.test.ts`)
- [x] Documentation has been updated to reflect this change (`docs/docs/**.md`) N/A, behavior bug fix only