### PR TITLE
fix: alter postgres varchar length without dropping column

### DIFF
--- a/src/driver/postgres/PostgresQueryRunner.ts
+++ b/src/driver/postgres/PostgresQueryRunner.ts
@@ -1326,21 +1326,48 @@ export class PostgresQueryRunner
                 `Column "${oldTableColumnOrName}" was not found in the "${table.name}" table.`,
             )
 
-        if (
-            oldColumn.type !== newColumn.type ||
-            oldColumn.length !== newColumn.length ||
-            newColumn.isArray !== oldColumn.isArray ||
-            (!oldColumn.generatedType &&
-                newColumn.generatedType === "STORED") ||
+        const isGeneratedColumnChange =
+            (!oldColumn.generatedType && newColumn.generatedType === "STORED") ||
             (oldColumn.asExpression !== newColumn.asExpression &&
                 newColumn.generatedType === "STORED")
-        ) {
-            // To avoid data conversion, we just recreate column
-            await this.dropColumn(table, oldColumn)
-            await this.addColumn(table, newColumn)
+        const isColumnTypeChange = oldColumn.type !== newColumn.type
+        const isColumnLengthChange = oldColumn.length !== newColumn.length
+        const isColumnArrayChange = newColumn.isArray !== oldColumn.isArray
 
-            // update cloned table
-            clonedTable = table.clone()
+        if (
+            isColumnTypeChange ||
+            isColumnLengthChange ||
+            isColumnArrayChange ||
+            isGeneratedColumnChange
+        ) {
+            if (
+                isColumnLengthChange &&
+                !isColumnTypeChange &&
+                !isColumnArrayChange &&
+                !isGeneratedColumnChange
+            ) {
+                upQueries.push(
+                    new Query(
+                        `ALTER TABLE ${this.escapePath(table)} ALTER COLUMN "${
+                            newColumn.name
+                        }" TYPE ${this.driver.createFullType(newColumn)}`,
+                    ),
+                )
+                downQueries.push(
+                    new Query(
+                        `ALTER TABLE ${this.escapePath(table)} ALTER COLUMN "${
+                            newColumn.name
+                        }" TYPE ${this.driver.createFullType(oldColumn)}`,
+                    ),
+                )
+            } else {
+                // To avoid data conversion, we just recreate column
+                await this.dropColumn(table, oldColumn)
+                await this.addColumn(table, newColumn)
+
+                // update cloned table
+                clonedTable = table.clone()
+            }
         } else {
             if (oldColumn.name !== newColumn.name) {
                 // rename column

--- a/test/github-issues/3357/entity/Post.ts
+++ b/test/github-issues/3357/entity/Post.ts
@@ -1,0 +1,10 @@
+import { Column, Entity, PrimaryGeneratedColumn } from "../../../../../src"
+
+@Entity()
+export class Post {
+    @PrimaryGeneratedColumn()
+    id: number
+
+    @Column({ length: 50 })
+    example: string
+}

--- a/test/github-issues/3357/issue-3357.test.ts
+++ b/test/github-issues/3357/issue-3357.test.ts
@@ -1,0 +1,54 @@
+import { expect } from "chai"
+import "reflect-metadata"
+import type { DataSource } from "../../../src"
+import {
+    closeTestingConnections,
+    createTestingConnections,
+    reloadTestingDatabases,
+} from "../../utils/test-utils"
+import { Post } from "./entity/Post"
+
+describe("github issues > #3357 migration generation should alter varchar length", () => {
+    let dataSources: DataSource[]
+
+    before(async () => {
+        dataSources = await createTestingConnections({
+            enabledDrivers: ["postgres"],
+            entities: [__dirname + "/entity/*{.js,.ts}"],
+            schemaCreate: true,
+            dropSchema: true,
+        })
+    })
+
+    beforeEach(() => reloadTestingDatabases(dataSources))
+    after(() => closeTestingConnections(dataSources))
+
+    it("uses ALTER COLUMN TYPE instead of DROP and ADD when varchar length changes", async () => {
+        await Promise.all(
+            dataSources.map(async (dataSource) => {
+                const postMetadata = dataSource.getMetadata(Post)
+                const exampleColumn =
+                    postMetadata.findColumnWithPropertyName("example")!
+                exampleColumn.length = "51"
+
+                const sqlInMemory = await dataSource.driver
+                    .createSchemaBuilder()
+                    .log()
+
+                const upQueries = sqlInMemory.upQueries.map((query) =>
+                    query.query.replaceAll(/\s+/g, " ").trim(),
+                )
+
+                expect(upQueries).to.include(
+                    `ALTER TABLE "post" ALTER COLUMN "example" TYPE character varying(51)`,
+                )
+                expect(upQueries.join(" ")).not.to.include(
+                    `DROP COLUMN "example"`,
+                )
+                expect(upQueries.join(" ")).not.to.include(`ADD "example"`)
+
+                exampleColumn.length = "50"
+            }),
+        )
+    })
+})


### PR DESCRIPTION
## Summary

Fixes #3357.

Postgres varchar length changes are now emitted as ALTER COLUMN TYPE instead of DROP COLUMN followed by ADD COLUMN, avoiding data loss during schema synchronization / migration generation.

## Changes

- Detect length-only column changes in PostgresQueryRunner.changeColumn
- Generate reversible ALTER COLUMN TYPE statements for length-only changes
- Add a regression test for issue #3357 ensuring DROP/ADD is not generated

## Testing

- git diff --check
- Full test run was not possible in this Codex environment because Corepack could not create its pnpm cache directory due local filesystem permissions.

/opire try