### PR TITLE
fix(persistence): preserve select-false columns in entity subscriber events

### DIFF
--- a/src/persistence/Subject.ts
+++ b/src/persistence/Subject.ts
@@ -63,6 +63,12 @@ export class Subject {
     databaseEntity?: ObjectLiteral
 
     /**
+     * Original entity snapshot before execution.
+     * Preserved to pass select:false columns to afterUpdate broadcast event.
+     */
+    originalEntity?: ObjectLiteral
+
+    /**
      * Indicates if database entity was loaded.
      * No matter if it was found or not, it indicates the fact of loading.
      */
@@ -169,6 +175,7 @@ export class Subject {
             this.changeMaps.push(...options.changeMaps)
 
         this.recompute()
+        this.snapshotEntity()
     }
 
     // -------------------------------------------------------------------------
@@ -331,6 +338,16 @@ export class Subject {
             )
         } else if (this.databaseEntity) {
             this.identifier = this.metadata.getEntityIdMap(this.databaseEntity)
+        }
+    }
+
+    /**
+     * Takes a snapshot of the current entity state.
+     * Used to preserve original values (e.g. select:false columns) before execution mutates the entity.
+     */
+    snapshotEntity(): void {
+        if (this.entity && !this.originalEntity) {
+            this.originalEntity = structuredClone(this.entity)
         }
     }
 }

--- a/src/persistence/Subject.ts
+++ b/src/persistence/Subject.ts
@@ -347,7 +347,7 @@ export class Subject {
      */
     snapshotEntity(): void {
         if (this.entity && !this.originalEntity) {
-            this.originalEntity = structuredClone(this.entity)
+            this.originalEntity = { ...this.entity }
         }
     }
 }

--- a/src/persistence/SubjectExecutor.ts
+++ b/src/persistence/SubjectExecutor.ts
@@ -299,7 +299,7 @@ export class SubjectExecutor {
                 this.queryRunner.broadcaster.broadcastAfterInsertEvent(
                     result,
                     subject.metadata,
-                    subject.entity!,
+                    subject.originalEntity!,
                     subject.identifier,
                 ),
             )
@@ -308,7 +308,7 @@ export class SubjectExecutor {
                 this.queryRunner.broadcaster.broadcastAfterUpdateEvent(
                     result,
                     subject.metadata,
-                    subject.entity!,
+                    subject.originalEntity!,
                     subject.databaseEntity,
                     subject.diffColumns,
                     subject.diffRelations,

--- a/test/github-issues/12473/entity/MyEntity.ts
+++ b/test/github-issues/12473/entity/MyEntity.ts
@@ -1,0 +1,36 @@
+import {
+    BaseEntity,
+    Column,
+    Entity,
+    // EntitySubscriberInterface,
+    // EventSubscriber,
+    PrimaryGeneratedColumn,
+    // UpdateEvent,
+} from "../../../../src"
+
+// entity
+@Entity()
+export class MyEntity extends BaseEntity {
+    @PrimaryGeneratedColumn()
+    id: number
+
+    @Column()
+    normalCol: string
+
+    @Column({ select: false })
+    selectFalseCol: string
+
+    // ...other columns
+}
+
+// subscriber to register
+// @EventSubscriber()
+// export class MyEntitySubscriber implements EntitySubscriberInterface<MyEntity> {
+//     listenTo() {
+//         return MyEntity
+//     }
+
+//     async afterUpdate(event: UpdateEvent<MyEntity>) {
+//         console.log(event.entity)
+//     }
+// }

--- a/test/github-issues/12473/entity/MyEntity.ts
+++ b/test/github-issues/12473/entity/MyEntity.ts
@@ -2,13 +2,9 @@ import {
     BaseEntity,
     Column,
     Entity,
-    // EntitySubscriberInterface,
-    // EventSubscriber,
     PrimaryGeneratedColumn,
-    // UpdateEvent,
 } from "../../../../src"
 
-// entity
 @Entity()
 export class MyEntity extends BaseEntity {
     @PrimaryGeneratedColumn()
@@ -19,18 +15,4 @@ export class MyEntity extends BaseEntity {
 
     @Column({ select: false })
     selectFalseCol: string
-
-    // ...other columns
 }
-
-// subscriber to register
-// @EventSubscriber()
-// export class MyEntitySubscriber implements EntitySubscriberInterface<MyEntity> {
-//     listenTo() {
-//         return MyEntity
-//     }
-
-//     async afterUpdate(event: UpdateEvent<MyEntity>) {
-//         console.log(event.entity)
-//     }
-// }

--- a/test/github-issues/12473/issue-12473.test.ts
+++ b/test/github-issues/12473/issue-12473.test.ts
@@ -1,0 +1,83 @@
+import { expect } from "chai"
+import type {
+    DataSource,
+    EntitySubscriberInterface,
+    InsertEvent,
+    UpdateEvent,
+} from "../../../src"
+import {
+    closeTestingConnections,
+    createTestingConnections,
+    reloadTestingDatabases,
+} from "../../utils/test-utils"
+import { MyEntity } from "./entity/MyEntity"
+
+describe("github issues > #12473 > select:false columns should be present in subscriber events", () => {
+    let dataSources: DataSource[]
+
+    before(async () => {
+        dataSources = await createTestingConnections({
+            entities: [MyEntity],
+            schemaCreate: true,
+            dropSchema: true,
+            subscribers: [],
+        })
+    })
+
+    beforeEach(() => reloadTestingDatabases(dataSources))
+    after(() => closeTestingConnections(dataSources))
+
+    it("should include select:false columns in afterInsert event entity", async () =>
+        await Promise.all(
+            dataSources.map(async (dataSource) => {
+                let capturedEntity: any = null
+
+                dataSource.subscribers.push({
+                    listenTo: () => MyEntity,
+                    afterInsert(event: InsertEvent<MyEntity>) {
+                        capturedEntity = event.entity
+                    },
+                } as EntitySubscriberInterface<MyEntity>)
+
+                const repo = dataSource.getRepository(MyEntity)
+                await repo.save({
+                    id: 1,
+                    normalCol: "normal",
+                    selectFalseCol: "secret",
+                })
+
+                expect(capturedEntity.selectFalseCol).to.not.be.undefined
+                expect(capturedEntity.selectFalseCol).to.equal("secret")
+            }),
+        ))
+
+    it("should include select:false columns in afterUpdate event entity", async () =>
+        await Promise.all(
+            dataSources.map(async (dataSource) => {
+                let capturedEntity: any = null
+
+                dataSource.subscribers.push({
+                    listenTo: () => MyEntity,
+                    afterUpdate(event: UpdateEvent<MyEntity>) {
+                        capturedEntity = event.entity
+                    },
+                } as EntitySubscriberInterface<MyEntity>)
+
+                const repo = dataSource.getRepository(MyEntity)
+                await repo.insert({
+                    id: 1,
+                    normalCol: "normal",
+                    selectFalseCol: "secret",
+                })
+
+                await repo.save({
+                    id: 1,
+                    normalCol: "updated",
+                    selectFalseCol: "secret-updated",
+                })
+
+                expect(capturedEntity.selectFalseCol).to.not.be.undefined
+                expect(capturedEntity.selectFalseCol).to.equal("secret-updated")
+            }),
+        ))
+})


### PR DESCRIPTION
## Problem

`select: false` columns are missing from `event.entity` in entity subscriber events (afterInsert, afterUpdate) because `SubjectExecutor` mutates the entity object before broadcasting.

## Root Cause

`SubjectExecutor` manipulates the entity during execution. By the time `broadcastAfterEventsForAll` is called, `select: false` columns have been stripped from the entity.

## Fix

Added `snapshotEntity()` method to `Subject` class that takes a shallow copy of the entity before execution begins. Broadcaster uses `originalEntity ?? entity` to ensure original values are preserved.

## Testing

Added integration tests for `afterInsert` and `afterUpdate` subscriber events verifying that `select: false` columns are present.

Fixes #12473