### PR TITLE
fix(postgres): use ALTER COLUMN TYPE instead of DROP and ADD when only length changes

### DIFF
--- a/src/driver/postgres/PostgresQueryRunner.ts
+++ b/src/driver/postgres/PostgresQueryRunner.ts
@@ -1326,39 +1326,17 @@ export class PostgresQueryRunner
                 `Column "${oldTableColumnOrName}" was not found in the "${table.name}" table.`,
             )
 
-        if (oldColumn.type !== newColumn.type || newColumn.isArray !== oldColumn.isArray ||
+        if (oldColumn.type !== newColumn.type ||
+            newColumn.isArray !== oldColumn.isArray ||
             (!oldColumn.generatedType && newColumn.generatedType === "STORED") ||
             (oldColumn.asExpression !== newColumn.asExpression && newColumn.generatedType === "STORED")
         ) {
-            // Type, array, or generated column changed - need to recreate column
+            // To avoid data conversion, we just recreate column
             await this.dropColumn(table, oldColumn)
             await this.addColumn(table, newColumn)
 
             // update cloned table
             clonedTable = table.clone()
-        } else if (oldColumn.length !== newColumn.length) {
-            // For PostgreSQL, when type stays the same and only length changes,
-            // we can safely use ALTER COLUMN TYPE without data loss (e.g., varchar(50) -> varchar(51))
-            // This avoids the destructive DROP + ADD pattern that causes data loss
-            const upType = this.driver.createFullType(newColumn)
-            const downType = this.driver.createFullType(oldColumn)
-
-            upQueries.push(
-                new Query(
-                    `ALTER TABLE ${this.escapePath(table)} ALTER COLUMN "${newColumn.name}" TYPE ${upType}`,
-                ),
-            )
-            downQueries.push(
-                new Query(
-                    `ALTER TABLE ${this.escapePath(table)} ALTER COLUMN "${newColumn.name}" TYPE ${downType}`,
-                ),
-            )
-
-            // Update the oldColumn in cloned table to reflect the change
-            const clonedTableColumn = clonedTable.columns.find(c => c.name === oldColumn.name)
-            if (clonedTableColumn) {
-                clonedTableColumn.length = newColumn.length
-            }
         } else {
             if (oldColumn.name !== newColumn.name) {
                 // rename column
@@ -1638,7 +1616,8 @@ export class PostgresQueryRunner
 
             if (
                 newColumn.precision !== oldColumn.precision ||
-                newColumn.scale !== oldColumn.scale
+                newColumn.scale !== oldColumn.scale ||
+                oldColumn.length !== newColumn.length
             ) {
                 upQueries.push(
                     new Query(

--- a/src/driver/postgres/PostgresQueryRunner.ts
+++ b/src/driver/postgres/PostgresQueryRunner.ts
@@ -1326,21 +1326,39 @@ export class PostgresQueryRunner
                 `Column "${oldTableColumnOrName}" was not found in the "${table.name}" table.`,
             )
 
-        if (
-            oldColumn.type !== newColumn.type ||
-            oldColumn.length !== newColumn.length ||
-            newColumn.isArray !== oldColumn.isArray ||
-            (!oldColumn.generatedType &&
-                newColumn.generatedType === "STORED") ||
-            (oldColumn.asExpression !== newColumn.asExpression &&
-                newColumn.generatedType === "STORED")
+        if (oldColumn.type !== newColumn.type || newColumn.isArray !== oldColumn.isArray ||
+            (!oldColumn.generatedType && newColumn.generatedType === "STORED") ||
+            (oldColumn.asExpression !== newColumn.asExpression && newColumn.generatedType === "STORED")
         ) {
-            // To avoid data conversion, we just recreate column
+            // Type, array, or generated column changed - need to recreate column
             await this.dropColumn(table, oldColumn)
             await this.addColumn(table, newColumn)
 
             // update cloned table
             clonedTable = table.clone()
+        } else if (oldColumn.length !== newColumn.length) {
+            // For PostgreSQL, when type stays the same and only length changes,
+            // we can safely use ALTER COLUMN TYPE without data loss (e.g., varchar(50) -> varchar(51))
+            // This avoids the destructive DROP + ADD pattern that causes data loss
+            const upType = this.driver.createFullType(newColumn)
+            const downType = this.driver.createFullType(oldColumn)
+
+            upQueries.push(
+                new Query(
+                    `ALTER TABLE ${this.escapePath(table)} ALTER COLUMN "${newColumn.name}" TYPE ${upType}`,
+                ),
+            )
+            downQueries.push(
+                new Query(
+                    `ALTER TABLE ${this.escapePath(table)} ALTER COLUMN "${newColumn.name}" TYPE ${downType}`,
+                ),
+            )
+
+            // Update the oldColumn in cloned table to reflect the change
+            const clonedTableColumn = clonedTable.columns.find(c => c.name === oldColumn.name)
+            if (clonedTableColumn) {
+                clonedTableColumn.length = newColumn.length
+            }
         } else {
             if (oldColumn.name !== newColumn.name) {
                 // rename column


### PR DESCRIPTION
## Summary
Fixes issue where changing a column's length (e.g., archar(50) ? archar(100)) in PostgreSQL would incorrectly trigger a DROP COLUMN + ADD COLUMN operation, causing data loss.

## Problem
The original code checked oldColumn.length !== newColumn.length and would drop and recreate the column whenever the length changed, even if the column type stayed the same. This caused unnecessary data loss and downtime.

## Solution
When only the length changes (type stays the same), PostgreSQL can safely use ALTER COLUMN TYPE without data loss. The fix separates the logic:

1. **Type/array/generated column changes** ? Still use DROP + ADD (data conversion required)
2. **Length-only changes** ? Use ALTER COLUMN ... TYPE (safe for PostgreSQL)

## Fixes
Fixes typeorm/typeorm#3357

## Testing
- Manual testing confirms varchar length changes no longer cause data loss
- Existing tests pass

---
*This PR is submitted for the  bounty on issue #3357*