### PR TITLE
fix: alter postgres varchar length without recreating column

### DIFF
--- a/src/driver/postgres/PostgresQueryRunner.ts
+++ b/src/driver/postgres/PostgresQueryRunner.ts
@@ -2348,9 +2348,9 @@ export class PostgresQueryRunner
                     new Query(
                         `ALTER TABLE ${this.escapePath(table)} ALTER COLUMN "${
                             newColumn.name
-                        }" TYPE ${newColumn.type} COLLATE "${
-                            newColumn.collation
-                        }"`,
+                        }" TYPE ${this.driver.createFullType(
+                            newColumn,
+                        )} COLLATE "${newColumn.collation}"`,
                     ),
                 )
 
@@ -2362,7 +2362,9 @@ export class PostgresQueryRunner
                     new Query(
                         `ALTER TABLE ${this.escapePath(table)} ALTER COLUMN "${
                             newColumn.name
-                        }" TYPE ${newColumn.type} COLLATE ${oldCollation}`,
+                        }" TYPE ${this.driver.createFullType(
+                            oldColumn,
+                        )} COLLATE ${oldCollation}`,
                     ),
                 )
             }

--- a/src/driver/postgres/PostgresQueryRunner.ts
+++ b/src/driver/postgres/PostgresQueryRunner.ts
@@ -2344,13 +2344,17 @@ export class PostgresQueryRunner
 
             // update column collation
             if (newColumn.collation !== oldColumn.collation) {
+                const newCollation = newColumn.collation
+                    ? `"${newColumn.collation}"`
+                    : `pg_catalog."default"` // if there's no new collation, use default
+
                 upQueries.push(
                     new Query(
                         `ALTER TABLE ${this.escapePath(table)} ALTER COLUMN "${
                             newColumn.name
                         }" TYPE ${this.driver.createFullType(
                             newColumn,
-                        )} COLLATE "${newColumn.collation}"`,
+                        )} COLLATE ${newCollation}`,
                     ),
                 )
 

--- a/src/driver/postgres/PostgresQueryRunner.ts
+++ b/src/driver/postgres/PostgresQueryRunner.ts
@@ -1328,7 +1328,6 @@ export class PostgresQueryRunner
 
         if (
             oldColumn.type !== newColumn.type ||
-            oldColumn.length !== newColumn.length ||
             newColumn.isArray !== oldColumn.isArray ||
             (!oldColumn.generatedType &&
                 newColumn.generatedType === "STORED") ||
@@ -1619,6 +1618,7 @@ export class PostgresQueryRunner
             }
 
             if (
+                newColumn.length !== oldColumn.length ||
                 newColumn.precision !== oldColumn.precision ||
                 newColumn.scale !== oldColumn.scale
             ) {

--- a/test/functional/query-runner/change-column.test.ts
+++ b/test/functional/query-runner/change-column.test.ts
@@ -7,8 +7,48 @@ import {
     createTypeormMetadataTable,
 } from "../../utils/test-utils"
 import { TableColumn } from "../../../src"
-import type { PostgresDriver } from "../../../src/driver/postgres/PostgresDriver"
+import { PostgresDriver } from "../../../src/driver/postgres/PostgresDriver"
+import { PostgresQueryRunner } from "../../../src/driver/postgres/PostgresQueryRunner"
 import { DriverUtils } from "../../../src/driver/DriverUtils"
+import { Table } from "../../../src/schema-builder/table/Table"
+
+describe("query runner > change column > Postgres SQL memory", () => {
+    it("should alter Postgres varchar length without recreating the column", async () => {
+        const queryRunner = createPostgresQueryRunner()
+        const table = new Table({
+            name: "post",
+            columns: [
+                new TableColumn({
+                    name: "title",
+                    type: "character varying",
+                    length: "50",
+                }),
+            ],
+        })
+        const newColumn = new TableColumn({
+            name: "title",
+            type: "character varying",
+            length: "51",
+        })
+
+        queryRunner.enableSqlMemory()
+
+        await queryRunner.changeColumn(table, table.columns[0], newColumn)
+
+        const sqlInMemory = queryRunner.getMemorySql()
+        const upQueries = sqlInMemory.upQueries.map(({ query }) => query)
+        const downQueries = sqlInMemory.downQueries.map(({ query }) => query)
+
+        expect(upQueries).to.deep.equal([
+            'ALTER TABLE "post" ALTER COLUMN "title" TYPE character varying(51)',
+        ])
+        expect(downQueries).to.deep.equal([
+            'ALTER TABLE "post" ALTER COLUMN "title" TYPE character varying(50)',
+        ])
+        expect(upQueries.join("\n")).not.to.include("DROP COLUMN")
+        expect(upQueries.join("\n")).not.to.include("ADD")
+    })
+})
 
 describe("query runner > change column", () => {
     let dataSources: DataSource[]
@@ -270,3 +310,18 @@ describe("query runner > change column", () => {
             }),
         ))
 })
+
+function createPostgresQueryRunner(): PostgresQueryRunner {
+    const driver = Object.create(PostgresDriver.prototype) as PostgresDriver
+    const dataSource = { driver }
+
+    Object.assign(driver, {
+        database: "typeorm_test",
+        dataSource,
+        schema: "public",
+        searchSchema: "public",
+        spatialTypes: ["geometry", "geography"],
+    })
+
+    return new PostgresQueryRunner(driver, "master")
+}

--- a/test/functional/query-runner/change-column.test.ts
+++ b/test/functional/query-runner/change-column.test.ts
@@ -48,6 +48,44 @@ describe("query runner > change column > Postgres SQL memory", () => {
         expect(upQueries.join("\n")).not.to.include("DROP COLUMN")
         expect(upQueries.join("\n")).not.to.include("ADD")
     })
+
+    it("should preserve Postgres varchar length when changing collation", async () => {
+        const queryRunner = createPostgresQueryRunner()
+        const table = new Table({
+            name: "post",
+            columns: [
+                new TableColumn({
+                    name: "title",
+                    type: "character varying",
+                    length: "50",
+                    collation: "en_US",
+                }),
+            ],
+        })
+        const newColumn = new TableColumn({
+            name: "title",
+            type: "character varying",
+            length: "51",
+            collation: "fr_FR",
+        })
+
+        queryRunner.enableSqlMemory()
+
+        await queryRunner.changeColumn(table, table.columns[0], newColumn)
+
+        const sqlInMemory = queryRunner.getMemorySql()
+        const upQueries = sqlInMemory.upQueries.map(({ query }) => query)
+        const downQueries = sqlInMemory.downQueries.map(({ query }) => query)
+
+        expect(upQueries).to.deep.equal([
+            'ALTER TABLE "post" ALTER COLUMN "title" TYPE character varying(51)',
+            'ALTER TABLE "post" ALTER COLUMN "title" TYPE character varying(51) COLLATE "fr_FR"',
+        ])
+        expect(downQueries).to.deep.equal([
+            'ALTER TABLE "post" ALTER COLUMN "title" TYPE character varying(50)',
+            'ALTER TABLE "post" ALTER COLUMN "title" TYPE character varying(50) COLLATE "en_US"',
+        ])
+    })
 })
 
 describe("query runner > change column", () => {

--- a/test/functional/query-runner/change-column.test.ts
+++ b/test/functional/query-runner/change-column.test.ts
@@ -86,6 +86,41 @@ describe("query runner > change column > Postgres SQL memory", () => {
             'ALTER TABLE "post" ALTER COLUMN "title" TYPE character varying(50) COLLATE "en_US"',
         ])
     })
+
+    it("should reset Postgres varchar collation without using undefined", async () => {
+        const queryRunner = createPostgresQueryRunner()
+        const table = new Table({
+            name: "post",
+            columns: [
+                new TableColumn({
+                    name: "title",
+                    type: "character varying",
+                    length: "50",
+                    collation: "en_US",
+                }),
+            ],
+        })
+        const newColumn = new TableColumn({
+            name: "title",
+            type: "character varying",
+            length: "50",
+        })
+
+        queryRunner.enableSqlMemory()
+
+        await queryRunner.changeColumn(table, table.columns[0], newColumn)
+
+        const sqlInMemory = queryRunner.getMemorySql()
+        const upQueries = sqlInMemory.upQueries.map(({ query }) => query)
+        const downQueries = sqlInMemory.downQueries.map(({ query }) => query)
+
+        expect(upQueries).to.deep.equal([
+            'ALTER TABLE "post" ALTER COLUMN "title" TYPE character varying(50) COLLATE pg_catalog."default"',
+        ])
+        expect(downQueries).to.deep.equal([
+            'ALTER TABLE "post" ALTER COLUMN "title" TYPE character varying(50) COLLATE "en_US"',
+        ])
+    })
 })
 
 describe("query runner > change column", () => {


### PR DESCRIPTION
### Description

Fixes Postgres schema synchronization for varchar length changes so TypeORM emits an `ALTER COLUMN ... TYPE` statement instead of dropping and re-adding the column.

Changing a column from `character varying(50)` to `character varying(51)` previously went through the destructive column recreation path because `length` was treated like a type/array/generated-column change. This moves length differences into the existing safe type-alteration path used for precision and scale changes.

Fixes #3357.

### Tests

- `pnpm run compile`
- `pnpm exec mocha --no-config --timeout 90000 --exit build/compiled/test/functional/query-runner/change-column.test.js --grep "Postgres SQL memory"`
- `pnpm exec prettier --check src/driver/postgres/PostgresQueryRunner.ts test/functional/query-runner/change-column.test.ts`
- `pnpm exec eslint src/driver/postgres/PostgresQueryRunner.ts test/functional/query-runner/change-column.test.ts` (passes with existing warnings in `PostgresQueryRunner.ts`)
- `git diff --check`