### PR TITLE
fix: alter postgres varchar length without dropping data

### DIFF
--- a/src/driver/postgres/PostgresQueryRunner.ts
+++ b/src/driver/postgres/PostgresQueryRunner.ts
@@ -1326,9 +1326,18 @@ export class PostgresQueryRunner
                 `Column "${oldTableColumnOrName}" was not found in the "${table.name}" table.`,
             )
 
+        const lengthChanged = oldColumn.length !== newColumn.length
+        const collationChanged = oldColumn.collation !== newColumn.collation
+        const canAlterLength =
+            lengthChanged &&
+            oldColumn.type === newColumn.type &&
+            this.driver.withLengthColumnTypes.indexOf(
+                newColumn.type as ColumnType,
+            ) !== -1
+
         if (
             oldColumn.type !== newColumn.type ||
-            oldColumn.length !== newColumn.length ||
+            (lengthChanged && !canAlterLength) ||
             newColumn.isArray !== oldColumn.isArray ||
             (!oldColumn.generatedType &&
                 newColumn.generatedType === "STORED") ||
@@ -1616,6 +1625,30 @@ export class PostgresQueryRunner
                     clonedTable.columns.indexOf(oldTableColumn!)
                 ].name = newColumn.name
                 oldColumn.name = newColumn.name
+            }
+
+            if (canAlterLength && !collationChanged) {
+                upQueries.push(
+                    new Query(
+                        `ALTER TABLE ${this.escapePath(table)} ALTER COLUMN "${
+                            newColumn.name
+                        }" TYPE ${this.driver.createFullType(newColumn)}`,
+                    ),
+                )
+                downQueries.push(
+                    new Query(
+                        `ALTER TABLE ${this.escapePath(table)} ALTER COLUMN "${
+                            newColumn.name
+                        }" TYPE ${this.driver.createFullType(oldColumn)}`,
+                    ),
+                )
+            }
+
+            if (canAlterLength) {
+                const clonedColumn = clonedTable.columns.find(
+                    (column) => column.name === newColumn.name,
+                )
+                if (clonedColumn) clonedColumn.length = newColumn.length
             }
 
             if (
@@ -2343,14 +2376,18 @@ export class PostgresQueryRunner
             }
 
             // update column collation
-            if (newColumn.collation !== oldColumn.collation) {
+            if (collationChanged) {
+                const newCollation = newColumn.collation
+                    ? `"${newColumn.collation}"`
+                    : `pg_catalog."default"`
+
                 upQueries.push(
                     new Query(
                         `ALTER TABLE ${this.escapePath(table)} ALTER COLUMN "${
                             newColumn.name
-                        }" TYPE ${newColumn.type} COLLATE "${
-                            newColumn.collation
-                        }"`,
+                        }" TYPE ${this.driver.createFullType(
+                            newColumn,
+                        )} COLLATE ${newCollation}`,
                     ),
                 )
 
@@ -2362,9 +2399,16 @@ export class PostgresQueryRunner
                     new Query(
                         `ALTER TABLE ${this.escapePath(table)} ALTER COLUMN "${
                             newColumn.name
-                        }" TYPE ${newColumn.type} COLLATE ${oldCollation}`,
+                        }" TYPE ${this.driver.createFullType(
+                            oldColumn,
+                        )} COLLATE ${oldCollation}`,
                     ),
                 )
+
+                const clonedColumn = clonedTable.columns.find(
+                    (column) => column.name === newColumn.name,
+                )
+                if (clonedColumn) clonedColumn.collation = newColumn.collation
             }
 
             if (newColumn.generatedType !== oldColumn.generatedType) {

--- a/test/functional/query-runner/change-column.test.ts
+++ b/test/functional/query-runner/change-column.test.ts
@@ -6,7 +6,7 @@ import {
     createTestingConnections,
     createTypeormMetadataTable,
 } from "../../utils/test-utils"
-import { TableColumn } from "../../../src"
+import { Table, TableColumn } from "../../../src"
 import type { PostgresDriver } from "../../../src/driver/postgres/PostgresDriver"
 import { DriverUtils } from "../../../src/driver/DriverUtils"
 
@@ -178,6 +178,82 @@ describe("query runner > change column", () => {
                 table!.findColumnByName("id")!.isGenerated.should.be.false
                 expect(table!.findColumnByName("id")!.generationStrategy).to.be
                     .undefined
+
+                await queryRunner.release()
+            }),
+        ))
+
+    it("should preserve data when changing a Postgres varchar length", () =>
+        Promise.all(
+            dataSources.map(async (dataSource) => {
+                if (dataSource.driver.options.type !== "postgres") return
+
+                const queryRunner = dataSource.createQueryRunner()
+                await queryRunner.createTable(
+                    new Table({
+                        name: "bug",
+                        columns: [
+                            {
+                                name: "id",
+                                type: "int",
+                                isPrimary: true,
+                            },
+                            {
+                                name: "example",
+                                type: "varchar",
+                                length: "50",
+                            },
+                        ],
+                    }),
+                )
+
+                await queryRunner.query(
+                    `INSERT INTO "bug"("id", "example") VALUES (1, 'kept')`,
+                )
+                queryRunner.clearSqlMemory()
+
+                let table = await queryRunner.getTable("bug")
+                const oldColumn = table!.findColumnByName("example")!
+                const newColumn = oldColumn.clone()
+                newColumn.length = "51"
+                newColumn.collation = "C"
+
+                await queryRunner.changeColumn(table!, oldColumn, newColumn)
+
+                const memorySql = queryRunner.getMemorySql()
+                expect(
+                    memorySql.upQueries.filter((query) =>
+                        query.query.includes('ALTER COLUMN "example" TYPE'),
+                    ),
+                ).to.have.length(1)
+                expect(
+                    memorySql.downQueries.filter((query) =>
+                        query.query.includes('ALTER COLUMN "example" TYPE'),
+                    ),
+                ).to.have.length(1)
+
+                table = await queryRunner.getTable("bug")
+                table!.findColumnByName("example")!.length.should.equal("51")
+                expect(table!.findColumnByName("example")!.collation).to.equal(
+                    "C",
+                )
+
+                let rows = await queryRunner.query(
+                    `SELECT "example" FROM "bug" WHERE "id" = 1`,
+                )
+                expect(rows[0].example).to.equal("kept")
+
+                await queryRunner.executeMemoryDownSql()
+
+                table = await queryRunner.getTable("bug")
+                table!.findColumnByName("example")!.length.should.equal("50")
+                expect(table!.findColumnByName("example")!.collation).to.be
+                    .undefined
+
+                rows = await queryRunner.query(
+                    `SELECT "example" FROM "bug" WHERE "id" = 1`,
+                )
+                expect(rows[0].example).to.equal("kept")
 
                 await queryRunner.release()
             }),


### PR DESCRIPTION
## Summary

Fixes #3357.

Postgres currently recreates a column when only the length of a length-aware column changes, for example `varchar(50)` -> `varchar(51)`. That generates a `DROP COLUMN` followed by `ADD COLUMN`, which loses existing data during schema sync or generated migrations.

This change keeps those changes on the regular `ALTER COLUMN ... TYPE ...` path when the column type itself is unchanged and the type supports length.

## Changes

- Detect length-only changes for Postgres column types that support length.
- Use `ALTER TABLE ... ALTER COLUMN ... TYPE ...` instead of dropping/recreating the column.
- Keep the QueryRunner cached table metadata in sync after length-only changes.
- Add functional regression coverage for changing a `varchar` length while preserving existing row data.
- Verify the generated down query restores the previous length without dropping data.

## Testing

- `corepack pnpm run typecheck`
- `corepack pnpm run compile`
- `corepack pnpm exec prettier --check src/driver/postgres/PostgresQueryRunner.ts test/functional/query-runner/change-column.test.ts`
- `corepack pnpm run lint -- src/driver/postgres/PostgresQueryRunner.ts test/functional/query-runner/change-column.test.ts`
- `corepack pnpm exec mocha --no-config --exit --timeout 90000 --file ./build/compiled/test/utils/test-setup.js ./build/compiled/test/functional/query-runner/change-column.test.js`