### PR TITLE
feat(save): add skipExistingRecordCheck option to SaveOptions

### DIFF
--- a/docs/docs/working-with-entity-manager/6-repository-api.md
+++ b/docs/docs/working-with-entity-manager/6-repository-api.md
@@ -98,10 +98,15 @@ const user = await repository.preload(partialUser)
   It saves all given entities in a single transaction (in the case of entity, manager is not transactional).
   Also supports partial updating since all undefined properties are skipped.
   Returns the saved entity/entities.
+  Accepts an optional [`SaveOptions`](#additional-options) object as the last argument to control transaction, chunking, reloading, and other persistence behaviour — including `skipExistingRecordCheck` to skip the existence SELECT for insertable entities, which is useful for bulk-insert scenarios.
 
 ```typescript
 await repository.save(user)
 await repository.save([category1, category2, category3])
+
+// performance optimisation: skip the SELECT that checks whether each insertable
+// entity already exists when you know all entities are new
+await repository.save(newUsers, { skipExistingRecordCheck: true })
 ```
 
 - `remove` - Removes a given entity or array of entities.
@@ -515,11 +520,16 @@ Optional `SaveOptions` can be passed as parameter for `save`.
 - `transaction`: boolean - By default transactions are enabled and all queries in persistence operation are wrapped into the transaction. You can disable this behaviour by setting `{ transaction: false }` in the persistence options.
 - `chunk`: number - Breaks save execution into multiple groups of chunks. For example, if you want to save 100.000 objects but you have issues with saving them, you can break them into 10 groups of 10.000 objects (by setting `{ chunk: 10000 }`) and save each group separately. This option is needed to perform very big insertions when you have issues with underlying driver parameter number limitation.
 - `reload`: boolean - Flag to determine whether the entity that is being persisted should be reloaded during the persistence operation. It will work only on databases which do not support RETURNING / OUTPUT statement. Enabled by default.
+- `skipExistingRecordCheck`: boolean - When set to `true`, skips the SELECT query that TypeORM normally issues to determine whether each insertable entity already exists in the database, treating those entities as new and always issuing an INSERT. Relations that are cascade-update-only (i.e. `cascade: ['update']` without `cascade: ['insert']`) are not affected and still perform their normal existence check. Use this as a performance optimization for bulk-insert scenarios where you are certain none of the directly saved entities exist yet. Disabled by default.
 
 Example:
 
 ```typescript
+// break a large batch into chunks
 userRepository.save(users, { chunk: 1000 })
+
+// skip existence check for guaranteed-new entities (bulk insert optimisation)
+userRepository.save(newUsers, { skipExistingRecordCheck: true })
 ```
 
 Optional `RemoveOptions` can be passed as parameter for `remove` and `delete`.

--- a/src/persistence/EntityPersistExecutor.ts
+++ b/src/persistence/EntityPersistExecutor.ts
@@ -110,10 +110,38 @@ export class EntityPersistExecutor {
                 // load database entities for all subjects we have
                 // next step is to load database entities for all operate subjects
                 // console.time("loading...");
-                await new SubjectDatabaseEntityLoader(
-                    queryRunner,
-                    subjects,
-                ).load(this.mode)
+                if (
+                    this.mode === "save" &&
+                    this.options?.skipExistingRecordCheck
+                ) {
+                    // Subjects that can be inserted are assumed new: mark them
+                    // loaded (no databaseEntity) so the executor always INSERTs.
+                    // Subjects that can only be updated (e.g. cascade: ['update']
+                    // without cascade: ['insert']) still need the DB lookup so
+                    // mustBeUpdated evaluates correctly for them.
+                    const updateOnlySubjects = subjects.filter(
+                        (s) => !s.canBeInserted && s.canBeUpdated,
+                    )
+                    subjects.forEach((subject) => {
+                        if (
+                            subject.canBeInserted &&
+                            subject.identifier &&
+                            !subject.databaseEntity
+                        )
+                            subject.databaseEntityLoaded = true
+                    })
+                    if (updateOnlySubjects.length > 0) {
+                        await new SubjectDatabaseEntityLoader(
+                            queryRunner,
+                            updateOnlySubjects,
+                        ).load(this.mode)
+                    }
+                } else {
+                    await new SubjectDatabaseEntityLoader(
+                        queryRunner,
+                        subjects,
+                    ).load(this.mode)
+                }
                 // console.timeEnd("loading...");
 
                 // console.time("other subjects...");

--- a/src/repository/SaveOptions.ts
+++ b/src/repository/SaveOptions.ts
@@ -36,4 +36,14 @@ export interface SaveOptions {
      * Enabled by default.
      */
     reload?: boolean
+
+    /**
+     * When set to true, skips the SELECT query that checks whether each insertable entity
+     * already exists in the database, treating those entities as new and always issuing an
+     * INSERT. Relations that are cascade-update-only (cascade: ['update'] without
+     * cascade: ['insert']) are not affected and still perform their normal existence check.
+     * Use this as a performance optimization for bulk-insert scenarios where you are certain
+     * none of the directly saved entities exist in the database yet.
+     */
+    skipExistingRecordCheck?: boolean
 }

--- a/test/functional/persistence/persistence-options/skip-existing-record-check/entity/Post.ts
+++ b/test/functional/persistence/persistence-options/skip-existing-record-check/entity/Post.ts
@@ -1,0 +1,12 @@
+import { Entity } from "../../../../../../src/decorator/entity/Entity"
+import { PrimaryColumn } from "../../../../../../src/decorator/columns/PrimaryColumn"
+import { Column } from "../../../../../../src/decorator/columns/Column"
+
+@Entity()
+export class Post {
+    @PrimaryColumn()
+    id: number
+
+    @Column()
+    title: string
+}

--- a/test/functional/persistence/persistence-options/skip-existing-record-check/persistence-options-skip-existing-record-check.test.ts
+++ b/test/functional/persistence/persistence-options/skip-existing-record-check/persistence-options-skip-existing-record-check.test.ts
@@ -1,0 +1,99 @@
+import "reflect-metadata"
+import {
+    closeTestingConnections,
+    createTestingConnections,
+    reloadTestingDatabases,
+} from "../../../../utils/test-utils"
+import { Post } from "./entity/Post"
+import type { DataSource } from "../../../../../src/data-source/DataSource"
+import sinon from "sinon"
+import { expect } from "chai"
+
+describe("persistence > persistence options > skipExistingRecordCheck", () => {
+    let dataSources: DataSource[]
+    before(async () => {
+        dataSources = await createTestingConnections({
+            __dirname,
+            disabledDrivers: ["spanner"],
+        })
+    })
+    beforeEach(() => reloadTestingDatabases(dataSources))
+    after(() => closeTestingConnections(dataSources))
+
+    it("should insert the entity into the database", () =>
+        Promise.all(
+            dataSources.map(async (dataSource) => {
+                const post = new Post()
+                post.id = 1
+                post.title = "Hello"
+
+                await dataSource.manager.save(Post, post, {
+                    skipExistingRecordCheck: true,
+                })
+
+                const saved = await dataSource.manager.findOneBy(Post, { id: 1 })
+                expect(saved).to.not.be.null
+                expect(saved!.title).to.equal("Hello")
+            }),
+        ))
+
+    it("should not issue a SELECT to check whether insertable entities exist", () =>
+        // Each branch creates its own QueryRunner and spies on that instance,
+        // so there is no shared prototype to double-wrap across concurrent drivers.
+        Promise.all(
+            dataSources.map(async (dataSource) => {
+                const queryRunner = dataSource.createQueryRunner()
+                const selectQueries: string[] = []
+                const querySpy = sinon.spy(queryRunner, "query")
+
+                try {
+                    const post = new Post()
+                    post.id = 2
+                    post.title = "Skip check"
+
+                    await dataSource
+                        .createEntityManager(queryRunner)
+                        .save(Post, post, {
+                            skipExistingRecordCheck: true,
+                            // disable reload so no post-INSERT SELECT is issued
+                            reload: false,
+                        })
+
+                    querySpy.args.forEach(([sql]: [string]) => {
+                        if (/^\s*SELECT/i.test(sql)) selectQueries.push(sql)
+                    })
+
+                    expect(selectQueries).to.be.empty
+                } finally {
+                    sinon.restore()
+                    await queryRunner.release()
+                }
+            }),
+        ))
+
+    it("should issue a SELECT to check whether entities exist without the option (control case)", () =>
+        Promise.all(
+            dataSources.map(async (dataSource) => {
+                const queryRunner = dataSource.createQueryRunner()
+                const querySpy = sinon.spy(queryRunner, "query")
+
+                try {
+                    const post = new Post()
+                    post.id = 3
+                    post.title = "With check"
+
+                    await dataSource
+                        .createEntityManager(queryRunner)
+                        .save(Post, post, { reload: false })
+
+                    const hasSelect = querySpy.args.some(([sql]: [string]) =>
+                        /^\s*SELECT/i.test(sql),
+                    )
+                    expect(hasSelect).to.be.true
+                } finally {
+                    sinon.restore()
+                    await queryRunner.release()
+                }
+            }),
+        ))
+})


### PR DESCRIPTION
## Summary

- Adds a new `skipExistingRecordCheck` option to `SaveOptions`
- When `true`, skips the SELECT query in `EntityPersistExecutor` that checks whether
  each entity already exists, forcing an INSERT for every entity
- Logic lives in `EntityPersistExecutor` (the save orchestrator); `SubjectDatabaseEntityLoader`
  is unchanged

## Motivation

In bulk-insert scenarios where the caller knows none of the entities exist yet, the
SELECT roundtrip that determines INSERT vs UPDATE is unnecessary overhead.

## How it works

When the option is set, `EntityPersistExecutor` marks each subject's
`databaseEntityLoaded = true` (without setting `databaseEntity`). This drives the
existing `Subject` decision logic so `mustBeInserted = true` and `mustBeUpdated = false`.

## Usage

await repository.save(entities, { skipExistingRecordCheck: true })