### PR TITLE
fix: alter Postgres varchar length in migrations

### DIFF
--- a/src/driver/postgres/PostgresQueryRunner.ts
+++ b/src/driver/postgres/PostgresQueryRunner.ts
@@ -1328,7 +1328,6 @@ export class PostgresQueryRunner
 
         if (
             oldColumn.type !== newColumn.type ||
-            oldColumn.length !== newColumn.length ||
             newColumn.isArray !== oldColumn.isArray ||
             (!oldColumn.generatedType &&
                 newColumn.generatedType === "STORED") ||
@@ -1620,7 +1619,8 @@ export class PostgresQueryRunner
 
             if (
                 newColumn.precision !== oldColumn.precision ||
-                newColumn.scale !== oldColumn.scale
+                newColumn.scale !== oldColumn.scale ||
+                newColumn.length !== oldColumn.length
             ) {
                 upQueries.push(
                     new Query(

--- a/test/github-issues/3357/issue-3357.test.ts
+++ b/test/github-issues/3357/issue-3357.test.ts
@@ -1,0 +1,66 @@
+import "reflect-metadata"
+import { expect } from "chai"
+import type { DataSource } from "../../../src"
+import { Table } from "../../../src/schema-builder/table/Table"
+import {
+    closeTestingConnections,
+    createTestingConnections,
+} from "../../utils/test-utils"
+
+describe("github issues > #3357 Postgres varchar length migrations alter column type", () => {
+    let dataSources: DataSource[]
+
+    before(async () => {
+        dataSources = await createTestingConnections({
+            enabledDrivers: ["postgres"],
+            schemaCreate: false,
+            dropSchema: true,
+        })
+    })
+
+    after(() => closeTestingConnections(dataSources))
+
+    it("should alter varchar length without dropping and recreating the column", () =>
+        Promise.all(
+            dataSources.map(async (dataSource) => {
+                const queryRunner = dataSource.createQueryRunner()
+
+                await queryRunner.createTable(
+                    new Table({
+                        name: "bug",
+                        columns: [
+                            {
+                                name: "example",
+                                type: "varchar",
+                                length: "50",
+                            },
+                        ],
+                    }),
+                )
+
+                const table = await queryRunner.getTable("bug")
+                const column = table!.findColumnByName("example")!
+                const newColumn = column.clone()
+                newColumn.length = "51"
+
+                queryRunner.enableSqlMemory()
+                await queryRunner.changeColumn(table!, column, newColumn)
+
+                const upQueries = queryRunner
+                    .getMemorySql()
+                    .upQueries.map((query) => query.query)
+
+                expect(upQueries).to.deep.equal([
+                    'ALTER TABLE "bug" ALTER COLUMN "example" TYPE character varying(51)',
+                ])
+                expect(upQueries).not.to.deep.include(
+                    'ALTER TABLE "bug" DROP COLUMN "example"',
+                )
+                expect(upQueries).not.to.deep.include(
+                    'ALTER TABLE "bug" ADD "example" character varying(51)',
+                )
+
+                await queryRunner.release()
+            }),
+        ))
+})


### PR DESCRIPTION
## Summary

Fixes #3357 by changing Postgres column length-only updates to emit `ALTER COLUMN ... TYPE` instead of dropping and recreating the column.

## Changes

- Stops treating `TableColumn.length` changes as a destructive Postgres column recreation trigger.
- Includes `length` in the existing Postgres `ALTER COLUMN ... TYPE` path used for precision/scale changes.
- Adds a regression test covering `varchar(50)` to `varchar(51)` migration SQL generation without `DROP COLUMN`/`ADD COLUMN`.

## Verification

```bash
git diff --check
# Intended focused test:
pnpm run test:fast -- test/github-issues/3357/issue-3357.test.ts
```

Results:

- `git diff --check` passed.
- Focused runtime test was not run in this environment: `pnpm` is not installed/in PATH, and the TypeORM Postgres test requires a configured Postgres test database.

## Payout

Opire bounty: https://app.opire.dev/issues/01HWJNZ5HQMVG2TCW6XHQQJ3QT

Payout wallet: `RTC29WwMjwcaFeTTQqKaMNmFUFLYz3f`