### PR TITLE
fix: prevent data loss when changing column length in PostgreSQL

### DIFF
--- a/src/driver/postgres/PostgresQueryRunner.ts
+++ b/src/driver/postgres/PostgresQueryRunner.ts
@@ -1326,7 +1326,35 @@ export class PostgresQueryRunner
                 `Column "${oldTableColumnOrName}" was not found in the "${table.name}" table.`,
             )
 
-        if (
+        // Check if only length changed (safe to ALTER without data loss)
+        const onlyLengthChanged =
+            oldColumn.type === newColumn.type &&
+            oldColumn.length !== newColumn.length &&
+            newColumn.isArray === oldColumn.isArray &&
+            oldColumn.generatedType === newColumn.generatedType &&
+            oldColumn.asExpression === newColumn.asExpression
+
+        if (onlyLengthChanged) {
+            // Safe: ALTER COLUMN TYPE preserves data when only length changes
+            const newType = this.dataSource.driver.createFullType(newColumn)
+            upQueries.push(
+                new Query(
+                    `ALTER TABLE ${this.escapePath(table)} ALTER COLUMN "${
+                        oldColumn.name
+                    }" TYPE ${newType}`,
+                ),
+            )
+            downQueries.push(
+                new Query(
+                    `ALTER TABLE ${this.escapePath(table)} ALTER COLUMN "${
+                        newColumn.name
+                    }" TYPE ${this.dataSource.driver.createFullType(oldColumn)}`,
+                ),
+            )
+
+            // update cloned table
+            clonedTable = table.clone()
+        } else if (
             oldColumn.type !== newColumn.type ||
             oldColumn.length !== newColumn.length ||
             newColumn.isArray !== oldColumn.isArray ||

--- a/test/github-issues/3357/entity/Post.ts
+++ b/test/github-issues/3357/entity/Post.ts
@@ -1,0 +1,13 @@
+import { Entity, PrimaryGeneratedColumn, Column } from "../../../../src"
+
+@Entity()
+export class Post {
+    @PrimaryGeneratedColumn()
+    id: number
+
+    @Column({ type: "varchar", length: 50 })
+    title: string
+
+    @Column({ type: "text" })
+    content: string
+}

--- a/test/github-issues/3357/issue-3357.ts
+++ b/test/github-issues/3357/issue-3357.ts
@@ -1,0 +1,62 @@
+import "reflect-metadata"
+import { DataSource } from "../../../../src"
+import { Post } from "./entity/Post"
+
+describe("github issues > #3357 Migration generation drops and creates columns instead of altering", () => {
+    let dataSource: DataSource
+
+    before(async () => {
+        dataSource = new DataSource({
+            type: "postgres",
+            host: "localhost",
+            port: 5432,
+            username: "test",
+            password: "test",
+            database: "test",
+            entities: [Post],
+            synchronize: false,
+            dropSchema: true,
+        })
+        await dataSource.initialize()
+        await dataSource.synchronize()
+    })
+
+    after(async () => {
+        await dataSource.destroy()
+    })
+
+    it("should use ALTER COLUMN TYPE instead of DROP+ADD when only length changes", async () => {
+        // Insert test data
+        const post = new Post()
+        post.title = "Test Post with exactly 50 characters in the title"
+        post.content = "This is test content"
+        await dataSource.manager.save(post)
+
+        // Get the original data
+        const originalPost = await dataSource.manager.findOne(Post, {
+            where: { id: post.id },
+        })
+        
+        // Simulate schema change: increase varchar length from 50 to 100
+        const queryRunner = dataSource.createQueryRunner()
+        await queryRunner.connect()
+
+        // This should use ALTER COLUMN TYPE, not DROP+ADD
+        const table = await queryRunner.getTable("post")
+        const oldColumn = table!.findColumnByName("title")!
+        const newColumn = oldColumn.clone()
+        newColumn.length = "100"
+
+        await queryRunner.changeColumn(table!, oldColumn, newColumn)
+        await queryRunner.release()
+
+        // Verify data is preserved
+        const postAfterMigration = await dataSource.manager.findOne(Post, {
+            where: { id: post.id },
+        })
+
+        postAfterMigration!.should.be.exist
+        postAfterMigration!.title.should.be.equal(originalPost!.title)
+        postAfterMigration!.content.should.be.equal(originalPost!.content)
+    })
+})


### PR DESCRIPTION
# Fix: Migration generation drops and creates columns instead of altering (Issue #3357)

## Problem

When changing only the length of a VARCHAR column (e.g., from 50 to 51 characters), TypeORM's migration generator produces `DROP COLUMN` + `ADD COLUMN` statements instead of `ALTER COLUMN TYPE`. This causes **complete data loss** for the affected column.

### Example

**Entity change:**
```typescript
// Before
@Column({ type: "varchar", length: 50 })
title: string

// After
@Column({ type: "varchar", length: 51 })
title: string
```

**Current (buggy) migration:**
```sql
ALTER TABLE "post" DROP COLUMN "title";
ALTER TABLE "post" ADD "title" varchar(51) NOT NULL;
-- ❌ ALL DATA IN "title" COLUMN IS LOST!
```

**Expected (correct) migration:**
```sql
ALTER TABLE "post" ALTER COLUMN "title" TYPE varchar(51);
-- ✅ Data is preserved
```

## Root Cause

**Location:** `src/driver/postgres/PostgresQueryRunner.ts:1329-1343`

The `changeColumn()` method treats length changes the same as type changes, triggering a DROP+ADD operation:

```typescript
if (
    oldColumn.type !== newColumn.type ||
    oldColumn.length !== newColumn.length ||  // ← Triggers DROP+ADD for length changes!
    // ... other conditions
) {
    // To avoid data conversion, we just recreate column
    await this.dropColumn(table, oldColumn)  // ❌ DATA LOSS
    await this.addColumn(table, newColumn)
}
```

## Solution

Separate length-only changes from incompatible type changes:

1. **Length-only changes** → Use `ALTER COLUMN TYPE` (safe, preserves data)
2. **Type changes** → Keep existing DROP+ADD behavior (necessary for incompatible types)

### Implementation

Added a check for length-only changes before the DROP+ADD logic:

```typescript
// Check if only length changed (safe to ALTER without data loss)
const onlyLengthChanged =
    oldColumn.type === newColumn.type &&
    oldColumn.length !== newColumn.length &&
    newColumn.isArray === oldColumn.isArray &&
    oldColumn.generatedType === newColumn.generatedType &&
    oldColumn.asExpression === newColumn.asExpression

if (onlyLengthChanged) {
    // Safe: ALTER COLUMN TYPE preserves data when only length changes
    const newType = this.dataSource.driver.createFullType(newColumn)
    upQueries.push(
        new Query(
            `ALTER TABLE ${this.escapePath(table)} ALTER COLUMN "${
                oldColumn.name
            }" TYPE ${newType}`,
        ),
    )
    // ... down query
} else if (/* existing conditions */) {
    // Keep DROP+ADD for incompatible changes
    await this.dropColumn(table, oldColumn)
    await this.addColumn(table, newColumn)
}
```

## Testing

Added test case: `test/github-issues/3357/issue-3357.ts`

**Test scenario:**
1. Create table with `varchar(50)` column
2. Insert data
3. Change column length to `varchar(100)`
4. Verify data is preserved after migration

## Impact

- **Severity:** Critical (data loss)
- **Affected:** All PostgreSQL users changing VARCHAR/CHAR column lengths
- **Fix:** Safe, backward-compatible (only affects length-only changes)

## Related Issues

- Original issue: #3357 (2018, 8 years old)
- Affects: PostgreSQL driver (similar fix may be needed for other drivers)

---

**Fixes #3357**
