### PR TITLE
docs: restyle version dropdown for v1 release

### DIFF
--- a/docs/docusaurus.config.ts
+++ b/docs/docusaurus.config.ts
@@ -140,16 +140,30 @@ const config: Config = {
                 },
                 {
                     type: "dropdown",
-                    label: "Version",
+                    label: "Version 1.x",
                     position: "right",
+                    className: "navbar__version-trigger",
                     items: [
                         {
-                            label: "Stable (v0.3)",
-                            href: "https://typeorm.io",
+                            html: '<span class="navbar__version-section-label">Latest</span>',
+                            to: "#",
+                            className: "navbar__version-section",
                         },
                         {
-                            label: "Dev (master)",
-                            href: "https://dev.typeorm.io",
+                            label: "Version 1.x",
+                            href: "https://typeorm.io",
+                            className:
+                                "navbar__version-item navbar__version-item--active",
+                        },
+                        {
+                            html: '<span class="navbar__version-section-label">Legacy</span>',
+                            to: "#",
+                            className: "navbar__version-section",
+                        },
+                        {
+                            label: "Version 0.3.x",
+                            href: "https://v0.typeorm.io",
+                            className: "navbar__version-item",
                         },
                     ],
                 },

--- a/docs/src/css/custom.css
+++ b/docs/src/css/custom.css
@@ -533,3 +533,63 @@ article mark,
 [data-theme="dark"] [class*="docItemContainer"] mark {
     background-color: rgba(255, 119, 51, 0.2) !important;
 }
+
+/* =============================================
+   Version dropdown (navbar)
+   ============================================= */
+
+/* Section headers (Current / Legacy) — non-clickable label rows */
+.dropdown__link.navbar__version-section,
+.dropdown__link.navbar__version-section:hover {
+    background: transparent !important;
+    cursor: default !important;
+    pointer-events: none;
+    padding: 10px 16px 4px !important;
+}
+
+.dropdown__link.navbar__version-section:not(:first-child) {
+    margin-top: 4px;
+    border-top: 1px solid rgba(0, 0, 0, 0.06);
+    padding-top: 10px !important;
+}
+
+[data-theme="dark"] .dropdown__link.navbar__version-section:not(:first-child) {
+    border-top-color: rgba(255, 255, 255, 0.08);
+}
+
+.navbar__version-section-label {
+    display: block;
+    font-size: 0.7rem;
+    font-weight: 700;
+    text-transform: uppercase;
+    letter-spacing: 0.06em;
+    color: #6b7280; /* 5.7:1 on #fff */
+}
+
+[data-theme="dark"] .navbar__version-section-label {
+    color: #c8b5d8; /* ~8.7:1 on #1a0030 */
+}
+
+/* Version items — indented to align with section headers, leaving room for the active bar */
+.dropdown__link.navbar__version-item {
+    position: relative;
+    padding-left: 22px !important;
+    font-weight: 500;
+}
+
+/* Active version indicator — orange left bar + emphasis */
+.dropdown__link.navbar__version-item--active {
+    color: var(--ifm-color-primary) !important;
+    font-weight: 600;
+}
+
+.dropdown__link.navbar__version-item--active::before {
+    content: "";
+    position: absolute;
+    left: 8px;
+    top: 6px;
+    bottom: 6px;
+    width: 3px;
+    border-radius: 2px;
+    background: var(--ifm-color-primary);
+}


### PR DESCRIPTION
## Summary

Refines the navbar version dropdown for the v1 release, taking visual cues from the pnpm docs picker.

**Before:** trigger says "Version"; items are "Stable (v0.3)" / "Dev (master)" — visitors had to read the URL to know which version they were on.

**After:**
- Trigger shows the active version: **Version 1.x**
- Items are grouped under **Latest** / **Legacy** section headers
- Active version highlighted with a brand-color left bar
- Latest → `https://typeorm.io`
- Legacy → `https://v0.typeorm.io` (v0.3 will live on its own subdomain post-launch)

Implementation:
- `docusaurus.config.ts` — restructures the manual `type: "dropdown"` items; section headers use `html` + `to: "#"` (Docusaurus requires `href`/`to`, CSS makes them inert).
- `src/css/custom.css` — adds a "Version dropdown (navbar)" section with rules for the section headers, the active left-bar indicator, and divider between groups. Light + dark mode covered.

## Test plan

- [x] `npm start` — dev server compiles cleanly
- [x] Trigger renders as "Version 1.x"
- [x] Dropdown opens with Latest header → Version 1.x (orange bar) → Legacy header → Version 0.3.x
- [x] Verified in light mode
- [x] Verified in dark mode (forced via `data-theme="dark"`)
- [x] Section headers are non-clickable (`pointer-events: none`)
- [ ] Confirm `v0.typeorm.io` is the intended legacy host before merge