### PR TITLE
chore(legacy-naming-strategies): bump to 1.0.0

### DIFF
--- a/packages/legacy-naming-strategies/package.json
+++ b/packages/legacy-naming-strategies/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@typeorm/legacy-naming-strategies",
-  "version": "1.0.0-beta.3",
+  "version": "1.0.0",
   "description": "Legacy naming strategies for TypeORM",
   "homepage": "https://typeorm.io",
   "bugs": {
@@ -47,12 +47,12 @@
     "mocha": "^11.7.5",
     "prettier": "^3.8.3",
     "ts-node": "^10.9.2",
-    "typeorm": "1.0.0-beta.3",
+    "typeorm": "1.0.0",
     "typescript": "^5.9.3",
     "typescript-eslint": "^8.59.2"
   },
   "peerDependencies": {
-    "typeorm": "^1.0.0-beta.3"
+    "typeorm": "^1.0.0"
   },
   "engines": {
     "node": ">=20"

--- a/packages/legacy-naming-strategies/pnpm-lock.yaml
+++ b/packages/legacy-naming-strategies/pnpm-lock.yaml
@@ -45,8 +45,8 @@ importers:
         specifier: ^10.9.2
         version: 10.9.2(@types/node@20.19.39)(typescript@5.9.3)
       typeorm:
-        specifier: 1.0.0-beta.3
-        version: 1.0.0-beta.3(ts-node@10.9.2(@types/node@20.19.39)(typescript@5.9.3))
+        specifier: 1.0.0
+        version: 1.0.0(ts-node@10.9.2(@types/node@20.19.39)(typescript@5.9.3))
       typescript:
         specifier: ^5.9.3
         version: 5.9.3
@@ -818,8 +818,8 @@ packages:
     resolution: {integrity: sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==}
     engines: {node: '>= 0.8.0'}
 
-  typeorm@1.0.0-beta.3:
-    resolution: {integrity: sha512-CsyJgP9u9r9tRzVHSECDxNLx98H37sWhE0P80mIqZn/2op6kWKKraUFEXz/BltRcLje9vuEhCuSwSY20vq5CPw==}
+  typeorm@1.0.0:
+    resolution: {integrity: sha512-2mSKNqucP8vo+xQLP59xlHUcqLvG6qajxA7q7tnhJgeZjTrA6lK/Ar7LRyiAxdXhyXmGbIPsArPmcUB9Xg+M7w==}
     engines: {node: ^20.19.0 || ^22.13.0 || >=24.11.0}
     hasBin: true
     peerDependencies:
@@ -1688,7 +1688,7 @@ snapshots:
     dependencies:
       prelude-ls: 1.2.1
 
-  typeorm@1.0.0-beta.3(ts-node@10.9.2(@types/node@20.19.39)(typescript@5.9.3)):
+  typeorm@1.0.0(ts-node@10.9.2(@types/node@20.19.39)(typescript@5.9.3)):
     dependencies:
       '@sqltools/formatter': 1.2.5
       ansis: 4.2.0


### PR DESCRIPTION
## Summary

Bumps `@typeorm/legacy-naming-strategies` to its first stable release, **v1.0.0**, following the publication of `typeorm@1.0.0`.

- `version`: `1.0.0-beta.3` → `1.0.0`
- `devDependencies.typeorm`: `1.0.0-beta.3` → `1.0.0`
- `peerDependencies.typeorm`: `^1.0.0-beta.3` → `^1.0.0`
- Inner `pnpm-lock.yaml` regenerated

## Test plan

- [x] `pnpm run build` in `packages/legacy-naming-strategies` — clean
- [x] `pnpm run test` in `packages/legacy-naming-strategies` — 4/4 passing
- [ ] After merge: `npm publish` from `packages/legacy-naming-strategies` (manual publish — no automated workflow for this package)
- [ ] `pnpm view @typeorm/legacy-naming-strategies@latest version` → `1.0.0`
