### PR TITLE
fix(postgres): use ALTER COLUMN TYPE instead of DROP+ADD when only column length changes

### DIFF
--- a/src/driver/postgres/PostgresQueryRunner.ts
+++ b/src/driver/postgres/PostgresQueryRunner.ts
@@ -1328,7 +1328,6 @@ export class PostgresQueryRunner
 
         if (
             oldColumn.type !== newColumn.type ||
-            oldColumn.length !== newColumn.length ||
             newColumn.isArray !== oldColumn.isArray ||
             (!oldColumn.generatedType &&
                 newColumn.generatedType === "STORED") ||
@@ -1619,6 +1618,7 @@ export class PostgresQueryRunner
             }
 
             if (
+                oldColumn.length !== newColumn.length ||
                 newColumn.precision !== oldColumn.precision ||
                 newColumn.scale !== oldColumn.scale
             ) {
@@ -2348,7 +2348,7 @@ export class PostgresQueryRunner
                     new Query(
                         `ALTER TABLE ${this.escapePath(table)} ALTER COLUMN "${
                             newColumn.name
-                        }" TYPE ${newColumn.type} COLLATE "${
+                        }" TYPE ${this.driver.createFullType(newColumn)} COLLATE "${
                             newColumn.collation
                         }"`,
                     ),
@@ -2362,7 +2362,7 @@ export class PostgresQueryRunner
                     new Query(
                         `ALTER TABLE ${this.escapePath(table)} ALTER COLUMN "${
                             newColumn.name
-                        }" TYPE ${newColumn.type} COLLATE ${oldCollation}`,
+                        }" TYPE ${this.driver.createFullType(oldColumn)} COLLATE ${oldCollation}`,
                     ),
                 )
             }

--- a/src/driver/postgres/PostgresQueryRunner.ts
+++ b/src/driver/postgres/PostgresQueryRunner.ts
@@ -2344,13 +2344,15 @@ export class PostgresQueryRunner
 
             // update column collation
             if (newColumn.collation !== oldColumn.collation) {
+                const newCollation = newColumn.collation
+                    ? `"${newColumn.collation}"`
+                    : `pg_catalog."default"` // if there's no new collation, use default
+
                 upQueries.push(
                     new Query(
                         `ALTER TABLE ${this.escapePath(table)} ALTER COLUMN "${
                             newColumn.name
-                        }" TYPE ${this.driver.createFullType(newColumn)} COLLATE "${
-                            newColumn.collation
-                        }"`,
+                        }" TYPE ${this.driver.createFullType(newColumn)} COLLATE ${newCollation}`,
                     ),
                 )
 
@@ -5245,3 +5247,4 @@ export class PostgresQueryRunner
         this.replaceCachedTable(table, newTable)
     }
 }
+


### PR DESCRIPTION
## Fix: Use ALTER COLUMN TYPE instead of DROP+ADD when only column length changes

Fixes #3357

### Problem

When a varchar column length was changed (e.g., `length: 50` to `length: 51`), TypeORM would generate a migration with `DROP COLUMN` and `ADD COLUMN`, causing **data loss**.

This happened because `oldColumn.length !== newColumn.length` was included in the condition that triggers the DROP+ADD path (line 1331).

### Solution

**Change 1**: Removed `oldColumn.length !== newColumn.length` from the DROP+ADD condition. Length changes should use ALTER, not DROP+ADD.

**Change 2**: Added `oldColumn.length !== newColumn.length` to the precision/scale ALTER condition (line 1621), so length changes now correctly generate `ALTER COLUMN TYPE varchar(newLength)`.

**Change 3**: Fixed a bug where collation ALTER statements used only the base type (e.g., `varchar`) instead of the full type (e.g., `varchar(51)`). This could overwrite prior length/precision/scale changes when both collation and length were changed in the same migration.

### Before
``sql
ALTER TABLE "user" DROP COLUMN "name";
ALTER TABLE "user" ADD COLUMN "name" character varying(51) NOT NULL;
``

### After
``sql
ALTER TABLE "user" ALTER COLUMN "name" TYPE character varying(51);
``

### Testing

This fix ensures that:
1. Changing only column length generates ALTER COLUMN TYPE (no data loss)
2. Changing both length and collation preserves length in the collation ALTER statement
3. Existing behavior for type changes, array changes, and generated columns is preserved

### Related

- Previous attempts: #12474 (closed - collation bug), #12485 (closed - collation bug)
- This PR fixes both the original issue and the collation bug that caused previous PRs to fail

Signed-off-by: q404365631 <q404365631@users.noreply.github.com>