### PR TITLE
fix: alter column type without data loss

### DIFF
--- a/docs/docs/migrations/09-api.md
+++ b/docs/docs/migrations/09-api.md
@@ -329,6 +329,11 @@ changeColumn(table: Table|string, oldColumn: TableColumn|string, newColumn: Tabl
 
 Changes a column in the table.
 
+When only the column type or length changes, the migration uses `ALTER COLUMN` (or equivalent) to
+modify the column in place, preserving existing data. Columns that change array type, generated
+type, or expression still require drop-and-recreate. Other property changes (name, nullable,
+default, unique, primary key) are applied alongside type/length changes in a single call.
+
 ---
 
 ```ts

--- a/src/driver/aurora-mysql/AuroraMysqlQueryRunner.ts
+++ b/src/driver/aurora-mysql/AuroraMysqlQueryRunner.ts
@@ -897,12 +897,15 @@ export class AuroraMysqlQueryRunner
             // update cloned table
             clonedTable = table.clone()
         } else {
+            let typeOrLengthChanged = false
             if (
                 oldColumn.type !== newColumn.type ||
                 (newColumn.length !== undefined &&
                     oldColumn.length !== newColumn.length)
             ) {
+                typeOrLengthChanged = true
                 // Use ALTER TABLE CHANGE for type/length changes to preserve data
+                // CHANGE can handle both rename and type change in one statement
                 upQueries.push(
                     new Query(
                         `ALTER TABLE ${this.escapePath(table)} CHANGE \`${
@@ -927,7 +930,7 @@ export class AuroraMysqlQueryRunner
                 )
             }
 
-            if (newColumn.name !== oldColumn.name) {
+            if (newColumn.name !== oldColumn.name && !typeOrLengthChanged) {
                 // We don't change any column properties, just rename it.
                 upQueries.push(
                     new Query(

--- a/src/driver/aurora-mysql/AuroraMysqlQueryRunner.ts
+++ b/src/driver/aurora-mysql/AuroraMysqlQueryRunner.ts
@@ -888,15 +888,41 @@ export class AuroraMysqlQueryRunner
         if (
             (newColumn.isGenerated !== oldColumn.isGenerated &&
                 newColumn.generationStrategy !== "uuid") ||
-            oldColumn.type !== newColumn.type ||
-            oldColumn.length !== newColumn.length ||
             oldColumn.generatedType !== newColumn.generatedType
         ) {
+            // Recreate column only for incompatible changes (generated type/strategy)
             await this.dropColumn(table, oldColumn)
             await this.addColumn(table, newColumn)
 
             // update cloned table
             clonedTable = table.clone()
+        } else if (
+            oldColumn.type !== newColumn.type ||
+            oldColumn.length !== newColumn.length
+        ) {
+            // Use ALTER TABLE CHANGE for type/length changes to preserve data
+            upQueries.push(
+                new Query(
+                    `ALTER TABLE ${this.escapePath(table)} CHANGE \`${
+                        newColumn.name
+                    }\` \`${newColumn.name}\` ${this.buildCreateColumnSql(
+                        newColumn,
+                        true,
+                        true,
+                    )}`,
+                ),
+            )
+            downQueries.push(
+                new Query(
+                    `ALTER TABLE ${this.escapePath(table)} CHANGE \`${
+                        newColumn.name
+                    }\` \`${newColumn.name}\` ${this.buildCreateColumnSql(
+                        oldColumn,
+                        true,
+                        true,
+                    )}`,
+                ),
+            )
         } else {
             if (newColumn.name !== oldColumn.name) {
                 // We don't change any column properties, just rename it.

--- a/src/driver/aurora-mysql/AuroraMysqlQueryRunner.ts
+++ b/src/driver/aurora-mysql/AuroraMysqlQueryRunner.ts
@@ -896,34 +896,37 @@ export class AuroraMysqlQueryRunner
 
             // update cloned table
             clonedTable = table.clone()
-        } else if (
-            oldColumn.type !== newColumn.type ||
-            oldColumn.length !== newColumn.length
-        ) {
-            // Use ALTER TABLE CHANGE for type/length changes to preserve data
-            upQueries.push(
-                new Query(
-                    `ALTER TABLE ${this.escapePath(table)} CHANGE \`${
-                        newColumn.name
-                    }\` \`${newColumn.name}\` ${this.buildCreateColumnSql(
-                        newColumn,
-                        true,
-                        true,
-                    )}`,
-                ),
-            )
-            downQueries.push(
-                new Query(
-                    `ALTER TABLE ${this.escapePath(table)} CHANGE \`${
-                        newColumn.name
-                    }\` \`${newColumn.name}\` ${this.buildCreateColumnSql(
-                        oldColumn,
-                        true,
-                        true,
-                    )}`,
-                ),
-            )
         } else {
+            if (
+                oldColumn.type !== newColumn.type ||
+                (newColumn.length !== undefined &&
+                    oldColumn.length !== newColumn.length)
+            ) {
+                // Use ALTER TABLE CHANGE for type/length changes to preserve data
+                upQueries.push(
+                    new Query(
+                        `ALTER TABLE ${this.escapePath(table)} CHANGE \`${
+                            oldColumn.name
+                        }\` \`${newColumn.name}\` ${this.buildCreateColumnSql(
+                            newColumn,
+                            true,
+                            true,
+                        )}`,
+                    ),
+                )
+                downQueries.push(
+                    new Query(
+                        `ALTER TABLE ${this.escapePath(table)} CHANGE \`${
+                            newColumn.name
+                        }\` \`${oldColumn.name}\` ${this.buildCreateColumnSql(
+                            oldColumn,
+                            true,
+                            true,
+                        )}`,
+                    ),
+                )
+            }
+
             if (newColumn.name !== oldColumn.name) {
                 // We don't change any column properties, just rename it.
                 upQueries.push(

--- a/src/driver/cockroachdb/CockroachQueryRunner.ts
+++ b/src/driver/cockroachdb/CockroachQueryRunner.ts
@@ -1410,26 +1410,29 @@ export class CockroachQueryRunner
             await this.dropColumn(table, oldColumn)
             await this.addColumn(table, newColumn)
             clonedTable = table.clone()
-        } else if (
-            oldColumn.type !== newColumn.type ||
-            oldColumn.length !== newColumn.length
-        ) {
-            // Use ALTER COLUMN TYPE for type/length changes to preserve data
-            upQueries.push(
-                new Query(
-                    `ALTER TABLE ${this.escapePath(table)} ALTER COLUMN "${
-                        newColumn.name
-                    }" TYPE ${this.driver.createFullType(newColumn)}`,
-                ),
-            )
-            downQueries.push(
-                new Query(
-                    `ALTER TABLE ${this.escapePath(table)} ALTER COLUMN "${
-                        newColumn.name
-                    }" TYPE ${this.driver.createFullType(oldColumn)}`,
-                ),
-            )
         } else {
+            if (
+                oldColumn.type !== newColumn.type ||
+                (newColumn.length !== undefined &&
+                    oldColumn.length !== newColumn.length)
+            ) {
+                // Use ALTER COLUMN TYPE for type/length changes to preserve data
+                upQueries.push(
+                    new Query(
+                        `ALTER TABLE ${this.escapePath(table)} ALTER COLUMN "${
+                            oldColumn.name
+                        }" TYPE ${this.driver.createFullType(newColumn)}`,
+                    ),
+                )
+                downQueries.push(
+                    new Query(
+                        `ALTER TABLE ${this.escapePath(table)} ALTER COLUMN "${
+                            oldColumn.name
+                        }" TYPE ${this.driver.createFullType(oldColumn)}`,
+                    ),
+                )
+            }
+
             if (oldColumn.name !== newColumn.name) {
                 // rename column
                 upQueries.push(

--- a/src/driver/cockroachdb/CockroachQueryRunner.ts
+++ b/src/driver/cockroachdb/CockroachQueryRunner.ts
@@ -1402,18 +1402,33 @@ export class CockroachQueryRunner
             )
 
         if (
-            oldColumn.type !== newColumn.type ||
-            oldColumn.length !== newColumn.length ||
             newColumn.isArray !== oldColumn.isArray ||
             oldColumn.generatedType !== newColumn.generatedType ||
             oldColumn.asExpression !== newColumn.asExpression
         ) {
-            // To avoid data conversion, we just recreate column
+            // Recreate column only for incompatible changes (array, generated type, expression)
             await this.dropColumn(table, oldColumn)
             await this.addColumn(table, newColumn)
-
-            // update cloned table
             clonedTable = table.clone()
+        } else if (
+            oldColumn.type !== newColumn.type ||
+            oldColumn.length !== newColumn.length
+        ) {
+            // Use ALTER COLUMN TYPE for type/length changes to preserve data
+            upQueries.push(
+                new Query(
+                    `ALTER TABLE ${this.escapePath(table)} ALTER COLUMN "${
+                        newColumn.name
+                    }" TYPE ${this.driver.createFullType(newColumn)}`,
+                ),
+            )
+            downQueries.push(
+                new Query(
+                    `ALTER TABLE ${this.escapePath(table)} ALTER COLUMN "${
+                        newColumn.name
+                    }" TYPE ${this.driver.createFullType(oldColumn)}`,
+                ),
+            )
         } else {
             if (oldColumn.name !== newColumn.name) {
                 // rename column

--- a/src/driver/mysql/MysqlQueryRunner.ts
+++ b/src/driver/mysql/MysqlQueryRunner.ts
@@ -1151,12 +1151,15 @@ export class MysqlQueryRunner extends BaseQueryRunner implements QueryRunner {
             // update cloned table
             clonedTable = table.clone()
         } else {
+            let typeOrLengthChanged = false
             if (
                 oldColumn.type !== newColumn.type ||
                 (newColumn.length !== undefined &&
                     oldColumn.length !== newColumn.length)
             ) {
+                typeOrLengthChanged = true
                 // Use ALTER TABLE CHANGE for type/length changes to preserve data
+                // CHANGE can handle both rename and type change in one statement
                 upQueries.push(
                     new Query(
                         `ALTER TABLE ${this.escapePath(table)} CHANGE \`${
@@ -1181,7 +1184,7 @@ export class MysqlQueryRunner extends BaseQueryRunner implements QueryRunner {
                 )
             }
 
-            if (newColumn.name !== oldColumn.name) {
+            if (newColumn.name !== oldColumn.name && !typeOrLengthChanged) {
                 // We don't change any column properties, just rename it.
                 upQueries.push(
                     new Query(

--- a/src/driver/mysql/MysqlQueryRunner.ts
+++ b/src/driver/mysql/MysqlQueryRunner.ts
@@ -1137,8 +1137,6 @@ export class MysqlQueryRunner extends BaseQueryRunner implements QueryRunner {
         if (
             (newColumn.isGenerated !== oldColumn.isGenerated &&
                 newColumn.generationStrategy !== "uuid") ||
-            oldColumn.type !== newColumn.type ||
-            oldColumn.length !== newColumn.length ||
             (oldColumn.generatedType &&
                 newColumn.generatedType &&
                 oldColumn.generatedType !== newColumn.generatedType) ||
@@ -1146,11 +1144,39 @@ export class MysqlQueryRunner extends BaseQueryRunner implements QueryRunner {
                 newColumn.generatedType === "VIRTUAL") ||
             (oldColumn.generatedType === "VIRTUAL" && !newColumn.generatedType)
         ) {
+            // Recreate column only for incompatible changes (generated type/strategy)
             await this.dropColumn(table, oldColumn)
             await this.addColumn(table, newColumn)
 
             // update cloned table
             clonedTable = table.clone()
+        } else if (
+            oldColumn.type !== newColumn.type ||
+            oldColumn.length !== newColumn.length
+        ) {
+            // Use ALTER TABLE CHANGE for type/length changes to preserve data
+            upQueries.push(
+                new Query(
+                    `ALTER TABLE ${this.escapePath(table)} CHANGE \`${
+                        newColumn.name
+                    }\` \`${newColumn.name}\` ${this.buildCreateColumnSql(
+                        newColumn,
+                        true,
+                        true,
+                    )}`,
+                ),
+            )
+            downQueries.push(
+                new Query(
+                    `ALTER TABLE ${this.escapePath(table)} CHANGE \`${
+                        newColumn.name
+                    }\` \`${newColumn.name}\` ${this.buildCreateColumnSql(
+                        oldColumn,
+                        true,
+                        true,
+                    )}`,
+                ),
+            )
         } else {
             if (newColumn.name !== oldColumn.name) {
                 // We don't change any column properties, just rename it.

--- a/src/driver/mysql/MysqlQueryRunner.ts
+++ b/src/driver/mysql/MysqlQueryRunner.ts
@@ -1150,34 +1150,37 @@ export class MysqlQueryRunner extends BaseQueryRunner implements QueryRunner {
 
             // update cloned table
             clonedTable = table.clone()
-        } else if (
-            oldColumn.type !== newColumn.type ||
-            oldColumn.length !== newColumn.length
-        ) {
-            // Use ALTER TABLE CHANGE for type/length changes to preserve data
-            upQueries.push(
-                new Query(
-                    `ALTER TABLE ${this.escapePath(table)} CHANGE \`${
-                        newColumn.name
-                    }\` \`${newColumn.name}\` ${this.buildCreateColumnSql(
-                        newColumn,
-                        true,
-                        true,
-                    )}`,
-                ),
-            )
-            downQueries.push(
-                new Query(
-                    `ALTER TABLE ${this.escapePath(table)} CHANGE \`${
-                        newColumn.name
-                    }\` \`${newColumn.name}\` ${this.buildCreateColumnSql(
-                        oldColumn,
-                        true,
-                        true,
-                    )}`,
-                ),
-            )
         } else {
+            if (
+                oldColumn.type !== newColumn.type ||
+                (newColumn.length !== undefined &&
+                    oldColumn.length !== newColumn.length)
+            ) {
+                // Use ALTER TABLE CHANGE for type/length changes to preserve data
+                upQueries.push(
+                    new Query(
+                        `ALTER TABLE ${this.escapePath(table)} CHANGE \`${
+                            oldColumn.name
+                        }\` \`${newColumn.name}\` ${this.buildCreateColumnSql(
+                            newColumn,
+                            true,
+                            true,
+                        )}`,
+                    ),
+                )
+                downQueries.push(
+                    new Query(
+                        `ALTER TABLE ${this.escapePath(table)} CHANGE \`${
+                            newColumn.name
+                        }\` \`${oldColumn.name}\` ${this.buildCreateColumnSql(
+                            oldColumn,
+                            true,
+                            true,
+                        )}`,
+                    ),
+                )
+            }
+
             if (newColumn.name !== oldColumn.name) {
                 // We don't change any column properties, just rename it.
                 upQueries.push(

--- a/src/driver/oracle/OracleQueryRunner.ts
+++ b/src/driver/oracle/OracleQueryRunner.ts
@@ -1145,18 +1145,34 @@ export class OracleQueryRunner extends BaseQueryRunner implements QueryRunner {
         if (
             (newColumn.isGenerated !== oldColumn.isGenerated &&
                 newColumn.generationStrategy !== "uuid") ||
-            oldColumn.type !== newColumn.type ||
-            oldColumn.length !== newColumn.length ||
             oldColumn.generatedType !== newColumn.generatedType ||
             oldColumn.asExpression !== newColumn.asExpression
         ) {
             // Oracle does not support changing of IDENTITY column, so we must drop column and recreate it again.
-            // Also, we recreate column if column type changed
             await this.dropColumn(table, oldColumn)
             await this.addColumn(table, newColumn)
 
             // update cloned table
             clonedTable = table.clone()
+        } else if (
+            oldColumn.type !== newColumn.type ||
+            oldColumn.length !== newColumn.length
+        ) {
+            // Use ALTER COLUMN TYPE for type/length changes to preserve data
+            upQueries.push(
+                new Query(
+                    `ALTER TABLE ${this.escapePath(table)} MODIFY "${
+                        newColumn.name
+                    }" ${this.driver.createFullType(newColumn)}`,
+                ),
+            )
+            downQueries.push(
+                new Query(
+                    `ALTER TABLE ${this.escapePath(table)} MODIFY "${
+                        newColumn.name
+                    }" ${this.driver.createFullType(oldColumn)}`,
+                ),
+            )
         } else {
             if (newColumn.name !== oldColumn.name) {
                 // rename column

--- a/src/driver/oracle/OracleQueryRunner.ts
+++ b/src/driver/oracle/OracleQueryRunner.ts
@@ -1154,26 +1154,29 @@ export class OracleQueryRunner extends BaseQueryRunner implements QueryRunner {
 
             // update cloned table
             clonedTable = table.clone()
-        } else if (
-            oldColumn.type !== newColumn.type ||
-            oldColumn.length !== newColumn.length
-        ) {
-            // Use ALTER COLUMN TYPE for type/length changes to preserve data
-            upQueries.push(
-                new Query(
-                    `ALTER TABLE ${this.escapePath(table)} MODIFY "${
-                        newColumn.name
-                    }" ${this.driver.createFullType(newColumn)}`,
-                ),
-            )
-            downQueries.push(
-                new Query(
-                    `ALTER TABLE ${this.escapePath(table)} MODIFY "${
-                        newColumn.name
-                    }" ${this.driver.createFullType(oldColumn)}`,
-                ),
-            )
         } else {
+            if (
+                oldColumn.type !== newColumn.type ||
+                (newColumn.length !== undefined &&
+                    oldColumn.length !== newColumn.length)
+            ) {
+                // Use ALTER COLUMN TYPE for type/length changes to preserve data
+                upQueries.push(
+                    new Query(
+                        `ALTER TABLE ${this.escapePath(table)} MODIFY "${
+                            oldColumn.name
+                        }" ${this.driver.createFullType(newColumn)}`,
+                    ),
+                )
+                downQueries.push(
+                    new Query(
+                        `ALTER TABLE ${this.escapePath(table)} MODIFY "${
+                            oldColumn.name
+                        }" ${this.driver.createFullType(oldColumn)}`,
+                    ),
+                )
+            }
+
             if (newColumn.name !== oldColumn.name) {
                 // rename column
                 upQueries.push(

--- a/src/driver/postgres/PostgresQueryRunner.ts
+++ b/src/driver/postgres/PostgresQueryRunner.ts
@@ -1339,26 +1339,29 @@ export class PostgresQueryRunner
 
             // update cloned table
             clonedTable = table.clone()
-        } else if (
-            oldColumn.type !== newColumn.type ||
-            oldColumn.length !== newColumn.length
-        ) {
-            // Use ALTER COLUMN TYPE for type/length changes to preserve data
-            upQueries.push(
-                new Query(
-                    `ALTER TABLE ${this.escapePath(table)} ALTER COLUMN "${
-                        newColumn.name
-                    }" TYPE ${this.driver.createFullType(newColumn)}`,
-                ),
-            )
-            downQueries.push(
-                new Query(
-                    `ALTER TABLE ${this.escapePath(table)} ALTER COLUMN "${
-                        newColumn.name
-                    }" TYPE ${this.driver.createFullType(oldColumn)}`,
-                ),
-            )
         } else {
+            if (
+                oldColumn.type !== newColumn.type ||
+                (newColumn.length !== undefined &&
+                    oldColumn.length !== newColumn.length)
+            ) {
+                // Use ALTER COLUMN TYPE for type/length changes to preserve data
+                upQueries.push(
+                    new Query(
+                        `ALTER TABLE ${this.escapePath(table)} ALTER COLUMN "${
+                            oldColumn.name
+                        }" TYPE ${this.driver.createFullType(newColumn)}`,
+                    ),
+                )
+                downQueries.push(
+                    new Query(
+                        `ALTER TABLE ${this.escapePath(table)} ALTER COLUMN "${
+                            oldColumn.name
+                        }" TYPE ${this.driver.createFullType(oldColumn)}`,
+                    ),
+                )
+            }
+
             if (oldColumn.name !== newColumn.name) {
                 // rename column
                 upQueries.push(

--- a/src/driver/postgres/PostgresQueryRunner.ts
+++ b/src/driver/postgres/PostgresQueryRunner.ts
@@ -1327,20 +1327,37 @@ export class PostgresQueryRunner
             )
 
         if (
-            oldColumn.type !== newColumn.type ||
-            oldColumn.length !== newColumn.length ||
             newColumn.isArray !== oldColumn.isArray ||
             (!oldColumn.generatedType &&
                 newColumn.generatedType === "STORED") ||
             (oldColumn.asExpression !== newColumn.asExpression &&
                 newColumn.generatedType === "STORED")
         ) {
-            // To avoid data conversion, we just recreate column
+            // Recreate column only for incompatible changes (array, generated type, expression)
             await this.dropColumn(table, oldColumn)
             await this.addColumn(table, newColumn)
 
             // update cloned table
             clonedTable = table.clone()
+        } else if (
+            oldColumn.type !== newColumn.type ||
+            oldColumn.length !== newColumn.length
+        ) {
+            // Use ALTER COLUMN TYPE for type/length changes to preserve data
+            upQueries.push(
+                new Query(
+                    `ALTER TABLE ${this.escapePath(table)} ALTER COLUMN "${
+                        newColumn.name
+                    }" TYPE ${this.driver.createFullType(newColumn)}`,
+                ),
+            )
+            downQueries.push(
+                new Query(
+                    `ALTER TABLE ${this.escapePath(table)} ALTER COLUMN "${
+                        newColumn.name
+                    }" TYPE ${this.driver.createFullType(oldColumn)}`,
+                ),
+            )
         } else {
             if (oldColumn.name !== newColumn.name) {
                 // rename column

--- a/src/driver/sap/SapQueryRunner.ts
+++ b/src/driver/sap/SapQueryRunner.ts
@@ -1365,18 +1365,34 @@ export class SapQueryRunner extends BaseQueryRunner implements QueryRunner {
         if (
             (newColumn.isGenerated !== oldColumn.isGenerated &&
                 newColumn.generationStrategy !== "uuid") ||
-            newColumn.type !== oldColumn.type ||
-            newColumn.length !== oldColumn.length ||
             (newColumn.asExpression ?? "").trim() !==
                 (oldColumn.asExpression ?? "").trim()
         ) {
-            // SQL Server does not support changing of IDENTITY column, so we must drop column and recreate it again.
-            // Also, we recreate column if column type changed
+            // SAP HANA does not support changing of IDENTITY column, so we must drop column and recreate it again.
             await this.dropColumn(table, oldColumn)
             await this.addColumn(table, newColumn)
 
             // update cloned table
             clonedTable = table.clone()
+        } else if (
+            newColumn.type !== oldColumn.type ||
+            newColumn.length !== oldColumn.length
+        ) {
+            // Use ALTER COLUMN TYPE for type/length changes to preserve data
+            upQueries.push(
+                new Query(
+                    `ALTER TABLE ${this.escapePath(table)} ALTER COLUMN "${
+                        newColumn.name
+                    }" ${this.driver.createFullType(newColumn)}`,
+                ),
+            )
+            downQueries.push(
+                new Query(
+                    `ALTER TABLE ${this.escapePath(table)} ALTER COLUMN "${
+                        newColumn.name
+                    }" ${this.driver.createFullType(oldColumn)}`,
+                ),
+            )
         } else {
             if (newColumn.name !== oldColumn.name) {
                 // rename column

--- a/src/driver/sap/SapQueryRunner.ts
+++ b/src/driver/sap/SapQueryRunner.ts
@@ -1374,26 +1374,29 @@ export class SapQueryRunner extends BaseQueryRunner implements QueryRunner {
 
             // update cloned table
             clonedTable = table.clone()
-        } else if (
-            newColumn.type !== oldColumn.type ||
-            newColumn.length !== oldColumn.length
-        ) {
-            // Use ALTER COLUMN TYPE for type/length changes to preserve data
-            upQueries.push(
-                new Query(
-                    `ALTER TABLE ${this.escapePath(table)} ALTER COLUMN "${
-                        newColumn.name
-                    }" ${this.driver.createFullType(newColumn)}`,
-                ),
-            )
-            downQueries.push(
-                new Query(
-                    `ALTER TABLE ${this.escapePath(table)} ALTER COLUMN "${
-                        newColumn.name
-                    }" ${this.driver.createFullType(oldColumn)}`,
-                ),
-            )
         } else {
+            if (
+                newColumn.type !== oldColumn.type ||
+                (newColumn.length !== undefined &&
+                    oldColumn.length !== newColumn.length)
+            ) {
+                // Use ALTER COLUMN TYPE for type/length changes to preserve data
+                upQueries.push(
+                    new Query(
+                        `ALTER TABLE ${this.escapePath(table)} ALTER COLUMN "${
+                            oldColumn.name
+                        }" ${this.driver.createFullType(newColumn)}`,
+                    ),
+                )
+                downQueries.push(
+                    new Query(
+                        `ALTER TABLE ${this.escapePath(table)} ALTER COLUMN "${
+                            oldColumn.name
+                        }" ${this.driver.createFullType(oldColumn)}`,
+                    ),
+                )
+            }
+
             if (newColumn.name !== oldColumn.name) {
                 // rename column
                 upQueries.push(

--- a/src/driver/spanner/SpannerQueryRunner.ts
+++ b/src/driver/spanner/SpannerQueryRunner.ts
@@ -988,18 +988,33 @@ export class SpannerQueryRunner extends BaseQueryRunner implements QueryRunner {
 
         if (
             oldColumn.name !== newColumn.name ||
-            oldColumn.type !== newColumn.type ||
-            oldColumn.length !== newColumn.length ||
             oldColumn.isArray !== newColumn.isArray ||
             oldColumn.generatedType !== newColumn.generatedType ||
             oldColumn.asExpression !== newColumn.asExpression
         ) {
-            // To avoid data conversion, we just recreate column
+            // Recreate column only for incompatible changes (rename, array, generated type, expression)
             await this.dropColumn(table, oldColumn)
             await this.addColumn(table, newColumn)
-
-            // update cloned table
             clonedTable = table.clone()
+        } else if (
+            oldColumn.type !== newColumn.type ||
+            oldColumn.length !== newColumn.length
+        ) {
+            // Use ALTER COLUMN TYPE for type/length changes to preserve data
+            upQueries.push(
+                new Query(
+                    `ALTER TABLE ${this.escapePath(table)} ALTER COLUMN "${
+                        newColumn.name
+                    }" TYPE ${this.driver.createFullType(newColumn)}`,
+                ),
+            )
+            downQueries.push(
+                new Query(
+                    `ALTER TABLE ${this.escapePath(table)} ALTER COLUMN "${
+                        newColumn.name
+                    }" TYPE ${this.driver.createFullType(oldColumn)}`,
+                ),
+            )
         } else {
             if (
                 newColumn.precision !== oldColumn.precision ||

--- a/src/driver/spanner/SpannerQueryRunner.ts
+++ b/src/driver/spanner/SpannerQueryRunner.ts
@@ -996,26 +996,29 @@ export class SpannerQueryRunner extends BaseQueryRunner implements QueryRunner {
             await this.dropColumn(table, oldColumn)
             await this.addColumn(table, newColumn)
             clonedTable = table.clone()
-        } else if (
-            oldColumn.type !== newColumn.type ||
-            oldColumn.length !== newColumn.length
-        ) {
-            // Use ALTER COLUMN TYPE for type/length changes to preserve data
-            upQueries.push(
-                new Query(
-                    `ALTER TABLE ${this.escapePath(table)} ALTER COLUMN "${
-                        newColumn.name
-                    }" TYPE ${this.driver.createFullType(newColumn)}`,
-                ),
-            )
-            downQueries.push(
-                new Query(
-                    `ALTER TABLE ${this.escapePath(table)} ALTER COLUMN "${
-                        newColumn.name
-                    }" TYPE ${this.driver.createFullType(oldColumn)}`,
-                ),
-            )
         } else {
+            if (
+                oldColumn.type !== newColumn.type ||
+                (newColumn.length !== undefined &&
+                    oldColumn.length !== newColumn.length)
+            ) {
+                // Use ALTER COLUMN TYPE for type/length changes to preserve data
+                upQueries.push(
+                    new Query(
+                        `ALTER TABLE ${this.escapePath(table)} ALTER COLUMN "${
+                            oldColumn.name
+                        }" TYPE ${this.driver.createFullType(newColumn)}`,
+                    ),
+                )
+                downQueries.push(
+                    new Query(
+                        `ALTER TABLE ${this.escapePath(table)} ALTER COLUMN "${
+                            oldColumn.name
+                        }" TYPE ${this.driver.createFullType(oldColumn)}`,
+                    ),
+                )
+            }
+
             if (
                 newColumn.precision !== oldColumn.precision ||
                 newColumn.scale !== oldColumn.scale

--- a/src/driver/sqlserver/SqlServerQueryRunner.ts
+++ b/src/driver/sqlserver/SqlServerQueryRunner.ts
@@ -1370,18 +1370,34 @@ export class SqlServerQueryRunner
         if (
             (newColumn.isGenerated !== oldColumn.isGenerated &&
                 newColumn.generationStrategy !== "uuid") ||
-            newColumn.type !== oldColumn.type ||
-            newColumn.length !== oldColumn.length ||
             newColumn.asExpression !== oldColumn.asExpression ||
             newColumn.generatedType !== oldColumn.generatedType
         ) {
             // SQL Server does not support changing of IDENTITY column, so we must drop column and recreate it again.
-            // Also, we recreate column if column type changed
             await this.dropColumn(table, oldColumn)
             await this.addColumn(table, newColumn)
 
             // update cloned table
             clonedTable = table.clone()
+        } else if (
+            newColumn.type !== oldColumn.type ||
+            newColumn.length !== oldColumn.length
+        ) {
+            // Use ALTER COLUMN TYPE for type/length changes to preserve data
+            upQueries.push(
+                new Query(
+                    `ALTER TABLE ${this.escapePath(table)} ALTER COLUMN "${
+                        newColumn.name
+                    }" ${this.driver.createFullType(newColumn)}`,
+                ),
+            )
+            downQueries.push(
+                new Query(
+                    `ALTER TABLE ${this.escapePath(table)} ALTER COLUMN "${
+                        newColumn.name
+                    }" ${this.driver.createFullType(oldColumn)}`,
+                ),
+            )
         } else {
             if (newColumn.name !== oldColumn.name) {
                 // we need database name and schema name to rename FK constraints

--- a/src/driver/sqlserver/SqlServerQueryRunner.ts
+++ b/src/driver/sqlserver/SqlServerQueryRunner.ts
@@ -1379,26 +1379,29 @@ export class SqlServerQueryRunner
 
             // update cloned table
             clonedTable = table.clone()
-        } else if (
-            newColumn.type !== oldColumn.type ||
-            newColumn.length !== oldColumn.length
-        ) {
-            // Use ALTER COLUMN TYPE for type/length changes to preserve data
-            upQueries.push(
-                new Query(
-                    `ALTER TABLE ${this.escapePath(table)} ALTER COLUMN "${
-                        newColumn.name
-                    }" ${this.driver.createFullType(newColumn)}`,
-                ),
-            )
-            downQueries.push(
-                new Query(
-                    `ALTER TABLE ${this.escapePath(table)} ALTER COLUMN "${
-                        newColumn.name
-                    }" ${this.driver.createFullType(oldColumn)}`,
-                ),
-            )
         } else {
+            if (
+                newColumn.type !== oldColumn.type ||
+                (newColumn.length !== undefined &&
+                    oldColumn.length !== newColumn.length)
+            ) {
+                // Use ALTER COLUMN TYPE for type/length changes to preserve data
+                upQueries.push(
+                    new Query(
+                        `ALTER TABLE ${this.escapePath(table)} ALTER COLUMN "${
+                            oldColumn.name
+                        }" ${this.driver.createFullType(newColumn)}`,
+                    ),
+                )
+                downQueries.push(
+                    new Query(
+                        `ALTER TABLE ${this.escapePath(table)} ALTER COLUMN "${
+                            oldColumn.name
+                        }" ${this.driver.createFullType(oldColumn)}`,
+                    ),
+                )
+            }
+
             if (newColumn.name !== oldColumn.name) {
                 // we need database name and schema name to rename FK constraints
                 let dbName: string | undefined = undefined


### PR DESCRIPTION
## Description

When a column's type or length changes (e.g., `varchar(250)` → `varchar(500)`), the `changeColumns` method in every query runner previously **dropped and recreated the column**, causing **complete data loss** for all existing rows.

This PR fixes the behavior to use `ALTER COLUMN TYPE` (or equivalent per-driver syntax) for type/length changes, preserving existing data. Drop+recreate is now reserved only for truly incompatible changes where no ALTER syntax exists.

## Root Cause

The `changeColumns` method in each query runner had a single condition combining:
- Type/length changes (safe to ALTER)
- Array/generateType/expression changes (require recreation)

Both were handled via `dropColumn()` + `addColumn()`, destroying data even when a non-destructive ALTER was possible.

## Fix

Split the condition into two branches:
1. **Drop+recreate**: Only for `isArray`, `generatedType`, `asExpression` changes
2. **ALTER COLUMN**: For `type` and `length` changes (data-preserving)

## Affected Drivers (all 8)

| Driver | ALTER Syntax Used |
|--------|------------------|
| PostgreSQL | `ALTER COLUMN ... TYPE` |
| MySQL | `CHANGE COLUMN` |
| Aurora MySQL | `CHANGE COLUMN` |
| CockroachDB | `ALTER COLUMN ... TYPE` |
| Oracle | `MODIFY` |
| SQL Server | `ALTER COLUMN` |
| SAP HANA | `ALTER COLUMN` |
| Spanner | `ALTER COLUMN ... TYPE` |

## Related Issues

- Fixes #9046 — varchar length change drops column
- Fixes #9254 — column length specified inline causes recreation  
- Fixes #9255 — varchar vs character varying type mismatch

## Testing

TypeScript compilation passes cleanly (`tsc --noEmit`). The existing `change-column.test.ts` covers the `queryRunner.changeColumn()` API path. The migration generator path (`schema:sync` / `migration:generate`) is tested through the `RdbmsSchemaBuilder` which calls `findChangedColumns` → `changeColumns`.

## Example

Before this fix:
```typescript
@Entity()
class User {
  @Column({ type: "varchar", length: 250 })
  name: string;
}

// Change to length: 500 → generated migration:
// DROP COLUMN "name"
// ADD COLUMN "name" varchar(500)  ← DATA LOST
```

After this fix:
```typescript
// Change to length: 500 → generated migration:
// ALTER TABLE "user" ALTER COLUMN "name" TYPE character varying(500)  ← DATA PRESERVED
```