### PR TITLE
test: make Postgres custom extension installation test reusable locally

### DIFF
--- a/test/functional/driver/postgres/data-source-options.test.ts
+++ b/test/functional/driver/postgres/data-source-options.test.ts
@@ -53,7 +53,15 @@ describe("driver > postgres > DataSource options > custom extension installation
         })
     })
     beforeEach(() => reloadTestingDatabases(dataSources))
-    after(() => closeTestingConnections(dataSources))
+    after(async () => {
+        await Promise.all(
+            dataSources.map(async (dataSource) => {
+                await dataSource.query("DROP EXTENSION IF EXISTS tablefunc")
+                await dataSource.query("DROP EXTENSION IF EXISTS xml2")
+            }),
+        )
+        await closeTestingConnections(dataSources)
+    })
 
     it("should install specified extensions after connection", () =>
         Promise.all(


### PR DESCRIPTION
<!--
  😀 Wonderful!  Thank you for opening a pull request for TypeORM.

  Please fill in the information below to expedite the review
  and (hopefully) merge of your change.

  If unsure about something.. just do as best as you're able,
  or reach out through our community support channels!
  https://github.com/typeorm/typeorm/blob/master/docs/support.md
  https://github.com/typeorm/typeorm/blob/master/CONTRIBUTING.md
-->

### Description of change

I've faced an issue that after running the test suite, the extensions stay installed, this broke re-run of the test in the same file locally (the other test expects no extensions installed). This change clears the two extensions that are installed during the test.

In the other hand, this "bug" in the test may indicate, that the `applicationName` for Postgres doesn't do anything in terms of the installed extension (see the changed file fully to understand it).

<!--
  Please describe:
  - what the change is intended to do
  - why this change is needed
  - how you've verified it
  - any other context that will help reviewers understand the change

  In some cases it may be helpful to include the current behavior
  and the new behavior.
-->

### Pull-Request Checklist

<!--
  Please make sure to review and check all of the following.

  If an item is not applicable, you can add "N/A" to the end.
-->

- [x] Code is up-to-date with the `master` branch
- [ ] This pull request links relevant issues as `Fixes #00000`
- [x] There are new or updated tests validating the change (`tests/**.test.ts`)
- [ ] Documentation has been updated to reflect this change (`docs/docs/**.md`)

> 🛡️ **Security fixes:** Do not submit security fixes as public PRs — the diff exposes the vulnerability. Use [GitHub Security Advisories](https://github.com/typeorm/typeorm/security/advisories/new) instead.

<!--
  🎉 Thank you for contributing and making TypeORM even better!
-->
