### PR TITLE
fix(sqlite): tolerate whitespace in CONSTRAINT clauses when loading tables

### DIFF
--- a/src/driver/sqlite-abstract/AbstractSqliteQueryRunner.ts
+++ b/src/driver/sqlite-abstract/AbstractSqliteQueryRunner.ts
@@ -1704,7 +1704,7 @@ export abstract class AbstractSqliteQueryRunner
                     referencedTableName: string
                 }[] = []
                 const fkRegex =
-                    /CONSTRAINT "([^"]*)" FOREIGN KEY ?\((.*?)\) REFERENCES "([^"]*)"/g
+                    /CONSTRAINT "([^"]*)"\s+FOREIGN KEY\s*\(([^)]*)\)\s+REFERENCES\s+"([^"]*)"/g
                 while ((fkResult = fkRegex.exec(sql)) !== null) {
                     fkMappings.push({
                         name: fkResult[1],
@@ -1758,7 +1758,8 @@ export abstract class AbstractSqliteQueryRunner
                 // find unique constraints from CREATE TABLE sql
                 let uniqueRegexResult
                 const uniqueMappings: { name: string; columns: string[] }[] = []
-                const uniqueRegex = /CONSTRAINT "([^"]*)" UNIQUE ?\((.*?)\)/g
+                const uniqueRegex =
+                    /CONSTRAINT "([^"]*)"\s+UNIQUE\s*\(([^)]*)\)/g
                 while ((uniqueRegexResult = uniqueRegex.exec(sql)) !== null) {
                     uniqueMappings.push({
                         name: uniqueRegexResult[1],
@@ -1823,7 +1824,7 @@ export abstract class AbstractSqliteQueryRunner
                 // build checks
                 let result
                 const regexp =
-                    /CONSTRAINT "([^"]*)" CHECK ?(\(.*?\))([,]|[)]$)/g
+                    /CONSTRAINT "([^"]*)"\s+CHECK\s*(\(.*?\))\s*(,|\)$)/gs
                 while ((result = regexp.exec(sql)) !== null) {
                     table.checks.push(
                         new TableCheck({

--- a/test/github-issues/99999/issue-99999.test.ts
+++ b/test/github-issues/99999/issue-99999.test.ts
@@ -1,0 +1,49 @@
+import { expect } from "chai"
+import "reflect-metadata"
+import type { DataSource } from "../../../src/data-source/DataSource"
+import {
+    closeTestingConnections,
+    createTestingConnections,
+    reloadTestingDatabases,
+} from "../../utils/test-utils"
+
+describe("github issues > sqlite multi-line CONSTRAINT clauses parse correctly", () => {
+    let connections: DataSource[]
+    before(async () => {
+        connections = await createTestingConnections({
+            migrations: [__dirname + "/migrations/*{.js,.ts}"],
+            enabledDrivers: ["better-sqlite3", "sqljs"],
+        })
+    })
+    beforeEach(() => reloadTestingDatabases(connections))
+    after(() => closeTestingConnections(connections))
+
+    it("should preserve FOREIGN KEY / UNIQUE / CHECK constraint names when their clauses span multiple lines in CREATE TABLE", () =>
+        Promise.all(
+            connections.map(async (connection) => {
+                await connection.runMigrations()
+                const queryRunner = connection.createQueryRunner()
+                const table = await queryRunner.getTable("post")
+                await queryRunner.release()
+
+                expect(table).to.exist
+
+                const fk = table!.foreignKeys.find(
+                    (it) => it.referencedTableName === "author",
+                )
+                expect(fk, "FK on author should be parsed").to.exist
+                expect(fk!.name).to.equal("FK_post_authorId")
+
+                const unique = table!.uniques.find((it) =>
+                    it.columnNames.includes("slug"),
+                )
+                expect(unique, "UNIQUE on slug should be parsed").to.exist
+                expect(unique!.name).to.equal("UQ_post_slug")
+
+                const check = table!.checks.find(
+                    (it) => it.name === "CHK_post_slug",
+                )
+                expect(check, "CHECK CHK_post_slug should be parsed").to.exist
+            }),
+        ))
+})

--- a/test/github-issues/99999/migrations/init.ts
+++ b/test/github-issues/99999/migrations/init.ts
@@ -1,0 +1,33 @@
+import type { MigrationInterface, QueryRunner } from "../../../../src"
+
+export class CreateDatabase implements MigrationInterface {
+    name = "CreateDatabase1779543766080"
+
+    async up(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(
+            `CREATE TABLE "author" ("id" integer PRIMARY KEY AUTOINCREMENT NOT NULL, "name" varchar NOT NULL)`,
+        )
+
+        // Each CONSTRAINT clause below intentionally spans multiple lines.
+        // The SQLite driver parses these names back out of sqlite_master.sql
+        // with regexes; before the fix those regexes required a literal
+        // single space between keywords (e.g. `) REFERENCES`, `UNIQUE (`,
+        // `CHECK (`), so newlines inside the clauses caused name extraction
+        // to fail.
+        await queryRunner.query(
+            `CREATE TABLE "post" (
+                "id" integer PRIMARY KEY AUTOINCREMENT NOT NULL,
+                "authorId" integer NOT NULL,
+                "slug" varchar NOT NULL,
+                CONSTRAINT "FK_post_authorId" FOREIGN KEY ("authorId")
+                    REFERENCES "author" ("id") ON DELETE CASCADE,
+                CONSTRAINT "UQ_post_slug" UNIQUE
+                    ("slug"),
+                CONSTRAINT "CHK_post_slug" CHECK
+                    (slug <> '')
+            )`,
+        )
+    }
+
+    async down(_queryRunner: QueryRunner): Promise<void> {}
+}


### PR DESCRIPTION
Had this issue with the constraint names in our migrations not being picked up — turns out it's because they're read back from the migration's SQL directly with a regex, and it doesn't tolerate extra whitespace (e.g. a newline between `)` and `REFERENCES`). Switch the fixed-space separators to `\s+` / `\s*` so any whitespace works.