### PR TITLE
fix: respect per-migration transaction setting on revert

### DIFF
--- a/src/migration/MigrationExecutor.ts
+++ b/src/migration/MigrationExecutor.ts
@@ -453,10 +453,11 @@ export class MigrationExecutor {
         )
         this.dataSource.logger.logSchemaBuild(`Now reverting it...`)
 
+        // defaults for single migration
         const txModeDefault = {
             each: true,
             none: false,
-            all: false,
+            all: true, // safe to set this to true for a single migration
         }[this.transaction]
 
         let migrationTransactionMode = txModeDefault

--- a/src/migration/MigrationExecutor.ts
+++ b/src/migration/MigrationExecutor.ts
@@ -453,9 +453,20 @@ export class MigrationExecutor {
         )
         this.dataSource.logger.logSchemaBuild(`Now reverting it...`)
 
-        // start transaction if its not started yet
+        const txModeDefault = {
+            each: true,
+            none: false,
+            all: false,
+        }[this.transaction]
+
+        let migrationTransactionMode = txModeDefault
+        if (migrationToRevert.instance?.transaction !== undefined) {
+            migrationTransactionMode = migrationToRevert.instance.transaction
+        }
+
+        // start transaction if its not started yet and the migration requires it
         let transactionStartedByUs = false
-        if (this.transaction !== "none" && !queryRunner.isTransactionActive) {
+        if (migrationTransactionMode && !queryRunner.isTransactionActive) {
             await queryRunner.startTransaction()
             transactionStartedByUs = true
         }

--- a/test/github-issues/9981/issue-9981.test.ts
+++ b/test/github-issues/9981/issue-9981.test.ts
@@ -1,0 +1,41 @@
+import "reflect-metadata"
+import {
+    closeTestingConnections,
+    createTestingConnections,
+    reloadTestingDatabases,
+} from "../../utils/test-utils"
+import type { DataSource } from "../../../src/data-source/DataSource"
+
+describe("github issues > #9981 --revert should respect transaction=false when using --transaction modes", () => {
+    let dataSources: DataSource[]
+
+    before(async () => {
+        dataSources = await createTestingConnections({
+            __dirname,
+            enabledDrivers: ["postgres"],
+        })
+    })
+
+    beforeEach(() => reloadTestingDatabases(dataSources))
+    after(() => closeTestingConnections(dataSources))
+
+    describe("with transaction: 'each'", () => {
+        it("should revert migration with transaction=false", () =>
+            Promise.all(
+                dataSources.map(async (dataSource) => {
+                    await dataSource.runMigrations({ transaction: "each" })
+                    await dataSource.undoLastMigration({ transaction: "each" })
+                }),
+            ))
+    })
+
+    describe("with transaction: 'none'", () => {
+        it("should revert migration with transaction=false", () =>
+            Promise.all(
+                dataSources.map(async (dataSource) => {
+                    await dataSource.runMigrations({ transaction: "none" })
+                    await dataSource.undoLastMigration({ transaction: "none" })
+                }),
+            ))
+    })
+})

--- a/test/github-issues/9981/issue-9981.test.ts
+++ b/test/github-issues/9981/issue-9981.test.ts
@@ -38,4 +38,14 @@ describe("github issues > #9981 --revert should respect transaction=false when u
                 }),
             ))
     })
+
+    describe("with transaction: 'all'", () => {
+        it("should revert migration with transaction=false", () =>
+            Promise.all(
+                dataSources.map(async (dataSource) => {
+                    await dataSource.runMigrations({ transaction: "each" }) // since overrides not allowed with transaction: "all"
+                    await dataSource.undoLastMigration({ transaction: "all" })
+                }),
+            ))
+    })
 })

--- a/test/github-issues/9981/migration/0000000000001-CreateUsers.ts
+++ b/test/github-issues/9981/migration/0000000000001-CreateUsers.ts
@@ -1,0 +1,30 @@
+import type { MigrationInterface } from "../../../../src/migration/MigrationInterface"
+import type { QueryRunner } from "../../../../src/query-runner/QueryRunner"
+import { Table } from "../../../../src/schema-builder/table/Table"
+
+export class CreateUsers0000000000001 implements MigrationInterface {
+    public async up(queryRunner: QueryRunner) {
+        await queryRunner.createTable(
+            new Table({
+                name: "users",
+                columns: [
+                    {
+                        name: "id",
+                        type: "int",
+                        isPrimary: true,
+                        isGenerated: true,
+                        generationStrategy: "increment",
+                    },
+                    {
+                        name: "name",
+                        type: "varchar",
+                    },
+                ],
+            }),
+        )
+    }
+
+    public async down(queryRunner: QueryRunner) {
+        await queryRunner.dropTable("users")
+    }
+}

--- a/test/github-issues/9981/migration/0000000000002-CreateIndexConcurrently.ts
+++ b/test/github-issues/9981/migration/0000000000002-CreateIndexConcurrently.ts
@@ -1,0 +1,18 @@
+import type { MigrationInterface } from "../../../../src/migration/MigrationInterface"
+import type { QueryRunner } from "../../../../src/query-runner/QueryRunner"
+
+export class CreateIndexConcurrently0000000000002 implements MigrationInterface {
+    public transaction = false
+
+    public async up(queryRunner: QueryRunner) {
+        await queryRunner.query(
+            `CREATE INDEX CONCURRENTLY "IDX_USER_NAME" ON "users" ("name")`,
+        )
+    }
+
+    public async down(queryRunner: QueryRunner) {
+        await queryRunner.query(
+            `CREATE UNIQUE INDEX CONCURRENTLY "IDX_USER_ID" ON "users" ("id")`,
+        )
+    }
+}


### PR DESCRIPTION
### Description of change

Fixes #9981: Migration revert now respects `transaction = false`

When reverting migrations with `--transaction each`, migrations that set `transaction = false` will no longer be wrapped in a transaction. This allows non-transactional statements like `CREATE INDEX CONCURRENTLY` to work correctly during revert.

### Pull-Request Checklist
- [X] Code is up-to-date with the `master` branch
- [X] This pull request links relevant issues as `Fixes #00000`
- [X] There are new or updated tests validating the change (`tests/**.test.ts`)
- [ ] Documentation has been updated to reflect this change (`docs/docs/**.md`)