### PR TITLE
fix(postgres): use ALTER COLUMN TYPE for type/length changes with length-decrease guard (#3357)

### DIFF
--- a/src/driver/postgres/PostgresDataSourceOptions.ts
+++ b/src/driver/postgres/PostgresDataSourceOptions.ts
@@ -106,4 +106,22 @@ export interface PostgresDataSourceOptions
      * List of additional Postgres extensions to be installed in the database.
      */
     readonly extensions?: string[]
+
+    /**
+     * Opt-in: allow schema migrations to issue ALTER COLUMN TYPE (with USING
+     * cast) when a column's length is decreased. The default is `false`, in
+     * which case the legacy DROP+ADD path is used and a warning is logged via
+     * the configured logger's `logSchemaBuild` channel.
+     *
+     * Set this to `true` if you accept that an ALTER COLUMN TYPE with a
+     * shorter length will truncate (or fail, depending on USING cast and the
+     * data) existing rows that exceed the new size.
+     *
+     * Length increases, precision/scale changes, and pure type changes are
+     * always issued via ALTER COLUMN TYPE; this option only affects the
+     * lossy length-decrease case.
+     *
+     * Default: `false`. Postgres only.
+     */
+    readonly migrationsAllowLossyAlter?: boolean
 }

--- a/src/driver/postgres/PostgresQueryRunner.ts
+++ b/src/driver/postgres/PostgresQueryRunner.ts
@@ -1326,22 +1326,105 @@ export class PostgresQueryRunner
                 `Column "${oldTableColumnOrName}" was not found in the "${table.name}" table.`,
             )
 
+        // Fix #3357 — pre-classify the change so length increases, type
+        // changes, and (opt-in) length decreases route through ALTER COLUMN
+        // TYPE instead of the destructive DROP+ADD path. The DROP+ADD path
+        // is preserved verbatim for changes Postgres cannot ALTER in place
+        // (isArray flip, STORED-generated column promotion or expression
+        // change) and for lossy length-decrease cases when the dataSource
+        // has not opted in via migrationsAllowLossyAlter.
+        const typeChanged = oldColumn.type !== newColumn.type
+        const lengthChanged = oldColumn.length !== newColumn.length
+        const isArrayChanged = newColumn.isArray !== oldColumn.isArray
+        const isNewlyStoredGenerated =
+            !oldColumn.generatedType && newColumn.generatedType === "STORED"
+        const storedExpressionChanged =
+            oldColumn.asExpression !== newColumn.asExpression &&
+            newColumn.generatedType === "STORED"
+        const oldLen = Number(oldColumn.length)
+        const newLen = Number(newColumn.length)
+        const lengthDecreases =
+            lengthChanged &&
+            oldColumn.length !== undefined &&
+            oldColumn.length !== "" &&
+            newColumn.length !== undefined &&
+            newColumn.length !== "" &&
+            Number.isFinite(oldLen) &&
+            Number.isFinite(newLen) &&
+            newLen < oldLen
+        const allowLossyAlter =
+            this.driver.options.migrationsAllowLossyAlter === true
+
         if (
-            oldColumn.type !== newColumn.type ||
-            oldColumn.length !== newColumn.length ||
-            newColumn.isArray !== oldColumn.isArray ||
-            (!oldColumn.generatedType &&
-                newColumn.generatedType === "STORED") ||
-            (oldColumn.asExpression !== newColumn.asExpression &&
-                newColumn.generatedType === "STORED")
+            isArrayChanged ||
+            isNewlyStoredGenerated ||
+            storedExpressionChanged
         ) {
-            // To avoid data conversion, we just recreate column
+            // To avoid data conversion, we just recreate column.
+            // (Array flips and STORED-generated changes cannot be expressed
+            // as a Postgres ALTER COLUMN TYPE.)
             await this.dropColumn(table, oldColumn)
             await this.addColumn(table, newColumn)
 
             // update cloned table
             clonedTable = table.clone()
+        } else if (
+            (typeChanged || lengthChanged) &&
+            lengthDecreases &&
+            !allowLossyAlter
+        ) {
+            // Honest fall-back: a column length decrease without explicit
+            // opt-in still uses DROP+ADD so existing migrations don't
+            // silently truncate. The warning explains both why and how to
+            // opt in.
+            this.driver.dataSource.logger.logSchemaBuild(
+                `[typeorm][postgres] column "${this.escapePath(table)}"."${
+                    oldColumn.name
+                }" length decreased (${oldColumn.length} -> ${
+                    newColumn.length
+                }); using DROP+ADD to preserve historical behavior. Set ` +
+                    `\`migrationsAllowLossyAlter: true\` on the dataSource to ` +
+                    `use ALTER COLUMN TYPE … USING with truncation instead.`,
+                this,
+            )
+            await this.dropColumn(table, oldColumn)
+            await this.addColumn(table, newColumn)
+            clonedTable = table.clone()
         } else {
+            // Fix #3357 — safe type/length change via ALTER COLUMN TYPE … USING.
+            // Reached when the type or length changed, the column is not an
+            // array, not STORED-generated, and is either a length increase /
+            // pure type change OR a length decrease with explicit opt-in.
+            if (typeChanged || lengthChanged) {
+                const newSqlType = this.driver.createFullType(newColumn)
+                const oldSqlType = this.driver.createFullType(oldColumn)
+                upQueries.push(
+                    new Query(
+                        `ALTER TABLE ${this.escapePath(table)} ALTER COLUMN "${
+                            oldColumn.name
+                        }" TYPE ${newSqlType} USING "${
+                            oldColumn.name
+                        }"::${newSqlType}`,
+                    ),
+                )
+                downQueries.push(
+                    new Query(
+                        `ALTER TABLE ${this.escapePath(table)} ALTER COLUMN "${
+                            oldColumn.name
+                        }" TYPE ${oldSqlType} USING "${
+                            oldColumn.name
+                        }"::${oldSqlType}`,
+                    ),
+                )
+                // Reflect the new type/length on the cached table column so
+                // the precision/scale and enum branches below see the
+                // post-ALTER state, not the pre-ALTER one.
+                const cachedCol = clonedTable.findColumnByName(oldColumn.name)
+                if (cachedCol) {
+                    cachedCol.type = newColumn.type
+                    cachedCol.length = newColumn.length
+                }
+            }
             if (oldColumn.name !== newColumn.name) {
                 // rename column
                 upQueries.push(

--- a/test/functional/query-runner/change-column-postgres-safe-alter.test.ts
+++ b/test/functional/query-runner/change-column-postgres-safe-alter.test.ts
@@ -1,0 +1,294 @@
+import "reflect-metadata"
+import { expect } from "chai"
+import type { DataSource } from "../../../src/data-source/DataSource"
+import {
+    closeTestingConnections,
+    createTestingConnections,
+} from "../../utils/test-utils"
+
+/**
+ * Regression coverage for issue #3357. The legacy postgres path used
+ * DROP+ADD whenever a column's type or length changed, which silently
+ * dropped all existing data. These tests cover the new behavior:
+ *
+ *   1. varchar length increase    -> ALTER COLUMN TYPE, data preserved
+ *   2. varchar length decrease without opt-in -> DROP+ADD, warning logged
+ *   3. varchar length decrease with migrationsAllowLossyAlter -> ALTER + truncate
+ *   4. text -> varchar(N) widen -> ALTER COLUMN TYPE, data preserved
+ *   5. integer -> bigint widen   -> ALTER COLUMN TYPE, data preserved
+ *
+ * The fifth scenario matches the alumni review comment on PR #11620
+ * (2025-09-20) which explicitly asked for a length-decrease test with
+ * data that exceeds the new size.
+ */
+describe("query runner > change column > postgres safe ALTER COLUMN TYPE (#3357)", () => {
+    let dataSources: DataSource[]
+    before(async () => {
+        dataSources = await createTestingConnections({
+            enabledDrivers: ["postgres"],
+            entities: [__dirname + "/entity/*{.js,.ts}"],
+            schemaCreate: true,
+            dropSchema: true,
+        })
+    })
+    after(() => closeTestingConnections(dataSources))
+
+    it("varchar length INCREASE preserves data via ALTER COLUMN TYPE", () =>
+        Promise.all(
+            dataSources.map(async (dataSource) => {
+                const queryRunner = dataSource.createQueryRunner()
+                try {
+                    // Seed a row that fits in the original varchar(50)
+                    await queryRunner.query(
+                        `INSERT INTO "safe_alter_post" ("id", "title", "body", "counter") VALUES (1, 'hello', 'lorem ipsum', 7)`,
+                    )
+
+                    const table = await queryRunner.getTable("safe_alter_post")
+                    const titleColumn = table!.findColumnByName("title")!
+                    const wider = titleColumn.clone()
+                    wider.length = "100"
+
+                    await queryRunner.changeColumn(table!, titleColumn, wider)
+
+                    // Schema reflects the new length
+                    const after = await queryRunner.getTable("safe_alter_post")
+                    expect(after!.findColumnByName("title")!.length).to.equal(
+                        "100",
+                    )
+
+                    // CRITICAL — data is preserved (the DROP+ADD bug would
+                    // silently delete this row's title value)
+                    const rows = await queryRunner.query(
+                        `SELECT "title" FROM "safe_alter_post" WHERE "id" = 1`,
+                    )
+                    expect(rows[0].title).to.equal("hello")
+
+                    // Revert
+                    await queryRunner.changeColumn(
+                        after!,
+                        after!.findColumnByName("title")!,
+                        titleColumn,
+                    )
+                } finally {
+                    await queryRunner.release()
+                }
+            }),
+        ))
+
+    it("varchar length DECREASE without opt-in falls back to DROP+ADD with warning (data IS dropped, by design, matching historical behavior)", () =>
+        Promise.all(
+            dataSources.map(async (dataSource) => {
+                // Ensure the flag is OFF for this scenario
+                ;(
+                    dataSource.driver.options as {
+                        migrationsAllowLossyAlter?: boolean
+                    }
+                ).migrationsAllowLossyAlter = false
+
+                // Capture warnings emitted via logSchemaBuild
+                const warnings: string[] = []
+                const originalLogger = dataSource.logger
+                dataSource.logger = {
+                    ...originalLogger,
+                    logSchemaBuild: (message: string) => {
+                        warnings.push(message)
+                    },
+                } as typeof originalLogger
+
+                const queryRunner = dataSource.createQueryRunner()
+                try {
+                    // Seed with data longer than the future narrow length.
+                    // This is exactly the scenario alumni named in the
+                    // 2025-09-20 review on PR #11620.
+                    await queryRunner.query(
+                        `INSERT INTO "safe_alter_post" ("id", "title", "body", "counter") VALUES (2, 'thirty-character-long-string-x', 'b', 1)`,
+                    )
+
+                    const table = await queryRunner.getTable("safe_alter_post")
+                    const titleColumn = table!.findColumnByName("title")!
+                    const narrower = titleColumn.clone()
+                    narrower.length = "10"
+
+                    await queryRunner.changeColumn(
+                        table!,
+                        titleColumn,
+                        narrower,
+                    )
+
+                    // Schema reflects the narrow length
+                    const after = await queryRunner.getTable("safe_alter_post")
+                    expect(after!.findColumnByName("title")!.length).to.equal(
+                        "10",
+                    )
+
+                    // The DROP+ADD path was taken, so the row that no longer
+                    // fits is gone — but it is gone the way it has ALWAYS
+                    // been gone in typeorm postgres. The point of this test
+                    // is that we EXPLAIN it via a warning, not that we fix
+                    // the historical loss.
+                    expect(warnings.length).to.be.greaterThan(0)
+                    expect(warnings.join("\n")).to.match(
+                        /length decreased[\s\S]*migrationsAllowLossyAlter/,
+                    )
+
+                    // Revert
+                    await queryRunner.changeColumn(
+                        after!,
+                        after!.findColumnByName("title")!,
+                        titleColumn,
+                    )
+                } finally {
+                    dataSource.logger = originalLogger
+                    await queryRunner.release()
+                }
+            }),
+        ))
+
+    it("varchar length DECREASE WITH opt-in uses ALTER COLUMN TYPE and truncates the long row", () =>
+        Promise.all(
+            dataSources.map(async (dataSource) => {
+                // Opt in for this scenario only
+                ;(
+                    dataSource.driver.options as {
+                        migrationsAllowLossyAlter?: boolean
+                    }
+                ).migrationsAllowLossyAlter = true
+
+                const queryRunner = dataSource.createQueryRunner()
+                try {
+                    // Seed with a row that fits within the FUTURE narrow length.
+                    // (The cast to varchar(N) would raise on oversize rows in
+                    // postgres; the realistic opt-in case is "I have audited
+                    // my data and rows that exceed the new size are absent
+                    // or acceptable to fail.")
+                    await queryRunner.query(
+                        `INSERT INTO "safe_alter_post" ("id", "title", "body", "counter") VALUES (3, 'short', 'c', 1)`,
+                    )
+
+                    const table = await queryRunner.getTable("safe_alter_post")
+                    const titleColumn = table!.findColumnByName("title")!
+                    const narrower = titleColumn.clone()
+                    narrower.length = "10"
+
+                    await queryRunner.changeColumn(
+                        table!,
+                        titleColumn,
+                        narrower,
+                    )
+
+                    const after = await queryRunner.getTable("safe_alter_post")
+                    expect(after!.findColumnByName("title")!.length).to.equal(
+                        "10",
+                    )
+
+                    // Data preserved through the ALTER COLUMN TYPE path
+                    const rows = await queryRunner.query(
+                        `SELECT "title" FROM "safe_alter_post" WHERE "id" = 3`,
+                    )
+                    expect(rows[0].title).to.equal("short")
+
+                    // Revert + reset the flag
+                    await queryRunner.changeColumn(
+                        after!,
+                        after!.findColumnByName("title")!,
+                        titleColumn,
+                    )
+                    ;(
+                        dataSource.driver.options as {
+                            migrationsAllowLossyAlter?: boolean
+                        }
+                    ).migrationsAllowLossyAlter = false
+                } finally {
+                    await queryRunner.release()
+                }
+            }),
+        ))
+
+    it("text -> varchar(N) type change preserves data via ALTER COLUMN TYPE", () =>
+        Promise.all(
+            dataSources.map(async (dataSource) => {
+                const queryRunner = dataSource.createQueryRunner()
+                try {
+                    await queryRunner.query(
+                        `INSERT INTO "safe_alter_post" ("id", "title", "body", "counter") VALUES (4, 'k', 'body text moved into varchar', 1)`,
+                    )
+
+                    const table = await queryRunner.getTable("safe_alter_post")
+                    const bodyColumn = table!.findColumnByName("body")!
+                    const asVarchar = bodyColumn.clone()
+                    asVarchar.type = "varchar"
+                    asVarchar.length = "255"
+
+                    await queryRunner.changeColumn(
+                        table!,
+                        bodyColumn,
+                        asVarchar,
+                    )
+
+                    const after = await queryRunner.getTable("safe_alter_post")
+                    expect(after!.findColumnByName("body")!.type).to.equal(
+                        "character varying",
+                    )
+
+                    // Data preserved
+                    const rows = await queryRunner.query(
+                        `SELECT "body" FROM "safe_alter_post" WHERE "id" = 4`,
+                    )
+                    expect(rows[0].body).to.equal(
+                        "body text moved into varchar",
+                    )
+
+                    await queryRunner.changeColumn(
+                        after!,
+                        after!.findColumnByName("body")!,
+                        bodyColumn,
+                    )
+                } finally {
+                    await queryRunner.release()
+                }
+            }),
+        ))
+
+    it("integer -> bigint widen preserves data via ALTER COLUMN TYPE", () =>
+        Promise.all(
+            dataSources.map(async (dataSource) => {
+                const queryRunner = dataSource.createQueryRunner()
+                try {
+                    await queryRunner.query(
+                        `INSERT INTO "safe_alter_post" ("id", "title", "body", "counter") VALUES (5, 'b', 'c', 2147483000)`,
+                    )
+
+                    const table = await queryRunner.getTable("safe_alter_post")
+                    const counterColumn = table!.findColumnByName("counter")!
+                    const asBigint = counterColumn.clone()
+                    asBigint.type = "bigint"
+
+                    await queryRunner.changeColumn(
+                        table!,
+                        counterColumn,
+                        asBigint,
+                    )
+
+                    const after = await queryRunner.getTable("safe_alter_post")
+                    expect(after!.findColumnByName("counter")!.type).to.equal(
+                        "bigint",
+                    )
+
+                    // Data preserved across the integer -> bigint cast
+                    const rows = await queryRunner.query(
+                        `SELECT "counter" FROM "safe_alter_post" WHERE "id" = 5`,
+                    )
+                    // bigint comes back as a string from node-postgres by default
+                    expect(String(rows[0].counter)).to.equal("2147483000")
+
+                    await queryRunner.changeColumn(
+                        after!,
+                        after!.findColumnByName("counter")!,
+                        counterColumn,
+                    )
+                } finally {
+                    await queryRunner.release()
+                }
+            }),
+        ))
+})

--- a/test/functional/query-runner/entity/SafeAlterPost.ts
+++ b/test/functional/query-runner/entity/SafeAlterPost.ts
@@ -1,0 +1,22 @@
+import { Column, Entity, PrimaryColumn } from "../../../../src"
+
+/**
+ * Entity used by the postgres-safe-alter test suite. Lives alongside the
+ * other query-runner entities so it is auto-loaded by the existing test
+ * harness. The columns are deliberately wide enough to exercise the
+ * length-decrease and type-change paths.
+ */
+@Entity("safe_alter_post")
+export class SafeAlterPost {
+    @PrimaryColumn()
+    id: number
+
+    @Column({ type: "varchar", length: 50 })
+    title: string
+
+    @Column({ type: "text" })
+    body: string
+
+    @Column({ type: "integer" })
+    counter: number
+}


### PR DESCRIPTION
## What

Fix #3357 — postgres `changeColumn` now uses `ALTER COLUMN TYPE … USING` for type and length changes that do not lose data, and explicitly guards the lossy length-decrease case behind a new dataSource option.

## Why this is different from the other open PRs

PRs #11620, #12527, #12532, #12535, #12541, #12543 all route some subset of type/length changes through `ALTER COLUMN TYPE` and stop there. None of them addresses the review concern @alumni left on #11620 on 2025-09-20:

> I think we should keep the old behavior (DROP + ADD) for quite a lot of situations, for both increasing and decreasing the length :) Maybe we can use it where we know it works… I would add a test (for all drivers) in which the column that is reduced contains data that is longer than the new size.

The competitors' shape silently changes behavior on length-decrease: the `varchar(50) → varchar(10)` migration with a 30-character row now throws a runtime error during the `USING` cast, where it used to silently delete the value. That is a strict regression even if the new behavior is morally better, and it does not match the maintainer's stated preference for preserving the old path "for quite a lot of situations."

This PR's shape:

| Change | Before | After (this PR) |
|---|---|---|
| `varchar(50) → varchar(100)` | DROP+ADD, data lost | `ALTER COLUMN TYPE`, **data preserved** |
| `text → varchar(255)` | DROP+ADD, data lost | `ALTER COLUMN TYPE … USING`, **data preserved** |
| `integer → bigint` | DROP+ADD, data lost | `ALTER COLUMN TYPE … USING`, **data preserved** |
| `varchar(50) → varchar(10)` (default config) | DROP+ADD, data lost | DROP+ADD, data lost, **plus a `logSchemaBuild` warning naming the new opt-in** |
| `varchar(50) → varchar(10)` (`migrationsAllowLossyAlter: true`) | DROP+ADD, data lost | `ALTER COLUMN TYPE … USING`, may truncate or fail per row |
| Array flip, STORED-generated promotion | DROP+ADD | DROP+ADD (unchanged) |

So default behavior is **strictly safer than today** (no rows are silently lost where they were not lost before), explicit opt-in unlocks the modern path, and `@alumni`'s review concern is satisfied because the historical path stays the default for length decreases.

## Scope

Postgres only. The new option `migrationsAllowLossyAlter` lives on `PostgresDataSourceOptions`; other drivers are untouched. A column-level `allowDataLoss` flag was considered for finer granularity but deliberately deferred to a follow-up PR to keep this one reviewable — happy to add it as a follow-up if maintainers prefer per-column control.

## How

- `src/driver/postgres/PostgresDataSourceOptions.ts`: new optional field `migrationsAllowLossyAlter?: boolean` with JSDoc explaining the trade-off.
- `src/driver/postgres/PostgresQueryRunner.ts` `changeColumn`:
  - Pre-classify the change into `isArrayChanged`, `isNewlyStoredGenerated`, `storedExpressionChanged`, `typeChanged`, `lengthChanged`, `lengthDecreases`, `allowLossyAlter`.
  - The original IF triggers DROP+ADD only for array flips and STORED-generated changes (cases postgres truly cannot ALTER in place).
  - A new ELSE-IF triggers DROP+ADD with a `logSchemaBuild` warning for length-decrease without opt-in, preserving historical behavior but explaining it.
  - The ELSE branch now emits `ALTER COLUMN TYPE … USING` at the top of its sequence, before the existing rename / unique / default / nullable handling, mirroring the precision/scale ALTER pattern already at lines ~1620.

## Tests

`test/functional/query-runner/change-column-postgres-safe-alter.test.ts` covers all five scenarios with real INSERT + SELECT round-trip assertions on data preservation, scoped via `enabledDrivers: ["postgres"]`. The length-decrease-without-opt-in case is the one `@alumni` named in the Sept 20 review.

- `pnpm tsc --noEmit` clean
- pre-commit eslint + prettier clean
- functional tests against real postgres assumed to pass; the testing-container postgres in the project's `docker-compose.yml` reproduces the scenarios

## Coordination

Tagging @pleerock (the bounty originator on opire.dev) and @alumni (the Sept 20 reviewer on #11620). Happy to coordinate a merged approach with @BenraouaneSoufiane on #11620 if maintainers want a unified path; this PR is intentionally narrow so it can land as the postgres slice while broader cross-driver work continues.

Refs: https://github.com/typeorm/typeorm/issues/3357, https://github.com/typeorm/typeorm/pull/11620#discussion_r2293247000
