### PR TITLE
fix(sap): support inserting entity with only generated defaults

### DIFF
--- a/src/query-builder/InsertQueryBuilder.ts
+++ b/src/query-builder/InsertQueryBuilder.ts
@@ -802,12 +802,13 @@ export class InsertQueryBuilder<
                     return false
 
                 // if user did not specified such list then return all columns except auto-increment one
-                // for Oracle we return auto-increment column as well because Oracle does not support DEFAULT VALUES expression
+                // for Oracle and SAP HANA we return auto-increment column as well because they do not support DEFAULT VALUES expression
                 if (
                     column.isGenerated &&
                     column.generationStrategy === "increment" &&
                     !(this.dataSource.driver.options.type === "spanner") &&
                     !(this.dataSource.driver.options.type === "oracle") &&
+                    !(this.dataSource.driver.options.type === "sap") &&
                     !DriverUtils.isSQLiteFamily(this.dataSource.driver) &&
                     !DriverUtils.isMySQLFamily(this.dataSource.driver) &&
                     !(this.dataSource.driver.options.type === "aurora-mysql") &&
@@ -1602,6 +1603,15 @@ export class InsertQueryBuilder<
                     column.generationStrategy === "uuid"
                 ) {
                     expression += "GENERATE_UUID()" // Produces a random universally unique identifier (UUID) as a STRING value.
+                } else if (
+                    this.dataSource.driver.options.type === "sap" &&
+                    column.isGenerated &&
+                    column.generationStrategy === "increment"
+                ) {
+                    // SAP HANA does not support the bare `DEFAULT VALUES` form,
+                    // but it does accept `DEFAULT` inside a VALUES list — use it
+                    // so generated identity columns get their sequence value.
+                    expression += "DEFAULT"
                 } else {
                     expression += "NULL" // otherwise simply use NULL and pray if column is nullable
                 }

--- a/test/github-issues/11349/entity/Product.ts
+++ b/test/github-issues/11349/entity/Product.ts
@@ -1,0 +1,18 @@
+import { Entity } from "../../../../src/decorator/entity/Entity"
+import { Column } from "../../../../src/decorator/columns/Column"
+import { PrimaryGeneratedColumn } from "../../../../src/decorator/columns/PrimaryGeneratedColumn"
+
+@Entity()
+export class Product {
+    @PrimaryGeneratedColumn()
+    id: number
+}
+
+@Entity()
+export class ProductWithOptional {
+    @PrimaryGeneratedColumn()
+    id: number
+
+    @Column({ nullable: true })
+    name: string | null
+}

--- a/test/github-issues/11349/issue-11349.test.ts
+++ b/test/github-issues/11349/issue-11349.test.ts
@@ -1,0 +1,55 @@
+import { expect } from "chai"
+import "reflect-metadata"
+
+import type { DataSource } from "../../../src"
+import {
+    closeTestingConnections,
+    createTestingConnections,
+    reloadTestingDatabases,
+} from "../../utils/test-utils"
+import { Product, ProductWithOptional } from "./entity/Product"
+
+describe("github issues > #11349 SAP HANA: cannot save entity only with defaults", () => {
+    let dataSources: DataSource[]
+
+    before(async () => {
+        dataSources = await createTestingConnections({
+            entities: [Product, ProductWithOptional],
+        })
+    })
+    beforeEach(() => reloadTestingDatabases(dataSources))
+    after(() => closeTestingConnections(dataSources))
+
+    it("should insert an entity that has only a generated primary key", () =>
+        Promise.all(
+            dataSources.map(async (dataSource) => {
+                const product = new Product()
+                await dataSource.manager.save(product)
+
+                expect(product.id).to.be.a("number")
+
+                const loaded = await dataSource.manager.findOneByOrFail(
+                    Product,
+                    { id: product.id },
+                )
+                expect(loaded.id).to.equal(product.id)
+            }),
+        ))
+
+    it("should insert an entity that only has defaults / nullable columns", () =>
+        Promise.all(
+            dataSources.map(async (dataSource) => {
+                const product = new ProductWithOptional()
+                await dataSource.manager.save(product)
+
+                expect(product.id).to.be.a("number")
+
+                const loaded = await dataSource.manager.findOneByOrFail(
+                    ProductWithOptional,
+                    { id: product.id },
+                )
+                expect(loaded.id).to.equal(product.id)
+                expect(loaded.name).to.be.null
+            }),
+        ))
+})


### PR DESCRIPTION
## What

Fixes #11349 — saving a SAP HANA entity whose only column is a `@PrimaryGeneratedColumn()` fails with `sql syntax error: incorrect syntax near "DEFAULT"`.

## Root cause

`InsertQueryBuilder.getInsertedColumns()` drops auto-increment columns from the column list for everyone except Oracle / Spanner / SQLite-family / MySQL-family / MSSQL (when overriding). When the user-supplied entity has no other columns, the column list becomes empty and the builder falls through to:

```ts
query += ` DEFAULT VALUES`
```

SAP HANA does not accept the bare `DEFAULT VALUES` form. Oracle has the same limitation and already gets the column kept + a `DEFAULT` token in the VALUES list. SAP was missing both halves of that workaround, even though `INSERT INTO "t" ("id") VALUES (DEFAULT)` is valid SAP HANA syntax.

## Fix

Two scoped changes inside `src/query-builder/InsertQueryBuilder.ts`:

1. `getInsertedColumns()` — extend the Oracle exemption to SAP so generated `increment` columns stay in the insert list (column 806 region).
2. `createColumnValueExpression()` — when SAP is the driver and the column is a generated `increment` with no user-supplied value, emit `DEFAULT` instead of falling through to the `NULL` fallback. The `NULL` fallback still applies for nullable non-default columns, preserving existing behavior for those.

This mirrors the existing Oracle pattern and stays inside `InsertQueryBuilder`. No driver / query-runner / subject-executor changes.

## Testing

Added a regression test at `test/github-issues/11349/`:

- `Product` — entity with **only** a `@PrimaryGeneratedColumn()`. Saves and round-trips.
- `ProductWithOptional` — PK plus a nullable column with no default. Saves and confirms the nullable column resolves to `null`, proving the `NULL` fallback path is still reachable.

The test uses `createTestingConnections` with no `enabledDrivers` filter, so every configured driver runs it — SAP gets the new path, everyone else exercises the unchanged `DEFAULT` / `DEFAULT VALUES` paths and must remain green.

Local verification of the prod suite for SAP requires the SAP HANA driver and a HANA instance, which I don't have available — the test was written to be driver-agnostic so CI exercises it on every configured backend (the previous predecessor PR was flagged for casting the driver type via `as any`, which this avoids).

## Notes

- Predecessor PR #12500 was closed because it touched `SapQueryRunner` + `SubjectExecutor` and used raw string interpolation. This change is two lines + one `else if` branch in `InsertQueryBuilder.ts`, scoped strictly to `column.isGenerated && generationStrategy === "increment"` on SAP — nullable-no-default columns keep the current `NULL` fallback.
- Quick grep over `test/functional` confirmed no test asserts exact SAP `INSERT … VALUES` SQL strings, so changing the emitted column list shape for SAP won't break snapshot-style assertions.

Fixes #11349.