### PR TITLE
fix(query-runner): use ALTER/MODIFY column instead of DROP/ADD to prevent data loss

### DIFF
--- a/src/driver/cockroachdb/CockroachQueryRunner.ts
+++ b/src/driver/cockroachdb/CockroachQueryRunner.ts
@@ -1402,13 +1402,10 @@ export class CockroachQueryRunner
             )
 
         if (
-            oldColumn.type !== newColumn.type ||
-            oldColumn.length !== newColumn.length ||
-            newColumn.isArray !== oldColumn.isArray ||
             oldColumn.generatedType !== newColumn.generatedType ||
             oldColumn.asExpression !== newColumn.asExpression
         ) {
-            // To avoid data conversion, we just recreate column
+            // To avoid data conversion for generated columns, we just recreate column
             await this.dropColumn(table, oldColumn)
             await this.addColumn(table, newColumn)
 
@@ -1657,9 +1654,13 @@ export class CockroachQueryRunner
             }
 
             if (
+                newColumn.type !== oldColumn.type ||
+                newColumn.length !== oldColumn.length ||
                 newColumn.precision !== oldColumn.precision ||
-                newColumn.scale !== oldColumn.scale
+                newColumn.scale !== oldColumn.scale ||
+                newColumn.isArray !== oldColumn.isArray
             ) {
+                // alter column type / length / precision / scale / array property if changed
                 upQueries.push(
                     new Query(
                         `ALTER TABLE ${this.escapePath(table)} ALTER COLUMN "${

--- a/src/driver/cockroachdb/CockroachQueryRunner.ts
+++ b/src/driver/cockroachdb/CockroachQueryRunner.ts
@@ -1660,19 +1660,34 @@ export class CockroachQueryRunner
                 newColumn.scale !== oldColumn.scale ||
                 newColumn.isArray !== oldColumn.isArray
             ) {
+                // Use buildEnumName to get the correct user-defined Enum type name for enum or simple-enum columns, and append [] if it is an array
+                const newColumnType =
+                    newColumn.type === "enum" ||
+                    newColumn.type === "simple-enum"
+                        ? this.buildEnumName(table, newColumn) +
+                          (newColumn.isArray ? "[]" : "")
+                        : this.driver.createFullType(newColumn)
+
+                const oldColumnType =
+                    oldColumn.type === "enum" ||
+                    oldColumn.type === "simple-enum"
+                        ? this.buildEnumName(table, oldColumn) +
+                          (oldColumn.isArray ? "[]" : "")
+                        : this.driver.createFullType(oldColumn)
+
                 // alter column type / length / precision / scale / array property if changed
                 upQueries.push(
                     new Query(
                         `ALTER TABLE ${this.escapePath(table)} ALTER COLUMN "${
                             newColumn.name
-                        }" TYPE ${this.driver.createFullType(newColumn)}`,
+                        }" TYPE ${newColumnType}`,
                     ),
                 )
                 downQueries.push(
                     new Query(
                         `ALTER TABLE ${this.escapePath(table)} ALTER COLUMN "${
                             newColumn.name
-                        }" TYPE ${this.driver.createFullType(oldColumn)}`,
+                        }" TYPE ${oldColumnType}`,
                     ),
                 )
             }

--- a/src/driver/mysql/MysqlQueryRunner.ts
+++ b/src/driver/mysql/MysqlQueryRunner.ts
@@ -1137,8 +1137,6 @@ export class MysqlQueryRunner extends BaseQueryRunner implements QueryRunner {
         if (
             (newColumn.isGenerated !== oldColumn.isGenerated &&
                 newColumn.generationStrategy !== "uuid") ||
-            oldColumn.type !== newColumn.type ||
-            oldColumn.length !== newColumn.length ||
             (oldColumn.generatedType &&
                 newColumn.generatedType &&
                 oldColumn.generatedType !== newColumn.generatedType) ||
@@ -1146,6 +1144,7 @@ export class MysqlQueryRunner extends BaseQueryRunner implements QueryRunner {
                 newColumn.generatedType === "VIRTUAL") ||
             (oldColumn.generatedType === "VIRTUAL" && !newColumn.generatedType)
         ) {
+            // Recreate column only for generation-related changes that cannot be modified inline
             await this.dropColumn(table, oldColumn)
             await this.addColumn(table, newColumn)
 

--- a/src/driver/postgres/PostgresQueryRunner.ts
+++ b/src/driver/postgres/PostgresQueryRunner.ts
@@ -1327,15 +1327,12 @@ export class PostgresQueryRunner
             )
 
         if (
-            oldColumn.type !== newColumn.type ||
-            oldColumn.length !== newColumn.length ||
-            newColumn.isArray !== oldColumn.isArray ||
             (!oldColumn.generatedType &&
                 newColumn.generatedType === "STORED") ||
             (oldColumn.asExpression !== newColumn.asExpression &&
                 newColumn.generatedType === "STORED")
         ) {
-            // To avoid data conversion, we just recreate column
+            // To avoid data conversion for stored generated columns, we just recreate column
             await this.dropColumn(table, oldColumn)
             await this.addColumn(table, newColumn)
 
@@ -1619,9 +1616,13 @@ export class PostgresQueryRunner
             }
 
             if (
+                newColumn.type !== oldColumn.type ||
+                newColumn.length !== oldColumn.length ||
                 newColumn.precision !== oldColumn.precision ||
-                newColumn.scale !== oldColumn.scale
+                newColumn.scale !== oldColumn.scale ||
+                newColumn.isArray !== oldColumn.isArray
             ) {
+                // alter column type / length / precision / scale / array property if changed
                 upQueries.push(
                     new Query(
                         `ALTER TABLE ${this.escapePath(table)} ALTER COLUMN "${

--- a/src/driver/postgres/PostgresQueryRunner.ts
+++ b/src/driver/postgres/PostgresQueryRunner.ts
@@ -1622,19 +1622,34 @@ export class PostgresQueryRunner
                 newColumn.scale !== oldColumn.scale ||
                 newColumn.isArray !== oldColumn.isArray
             ) {
+                // Use buildEnumName to get the correct user-defined Enum type name for enum or simple-enum columns, and append [] if it is an array
+                const newColumnType =
+                    newColumn.type === "enum" ||
+                    newColumn.type === "simple-enum"
+                        ? this.buildEnumName(table, newColumn) +
+                          (newColumn.isArray ? "[]" : "")
+                        : this.driver.createFullType(newColumn)
+
+                const oldColumnType =
+                    oldColumn.type === "enum" ||
+                    oldColumn.type === "simple-enum"
+                        ? this.buildEnumName(table, oldColumn) +
+                          (oldColumn.isArray ? "[]" : "")
+                        : this.driver.createFullType(oldColumn)
+
                 // alter column type / length / precision / scale / array property if changed
                 upQueries.push(
                     new Query(
                         `ALTER TABLE ${this.escapePath(table)} ALTER COLUMN "${
                             newColumn.name
-                        }" TYPE ${this.driver.createFullType(newColumn)}`,
+                        }" TYPE ${newColumnType}`,
                     ),
                 )
                 downQueries.push(
                     new Query(
                         `ALTER TABLE ${this.escapePath(table)} ALTER COLUMN "${
                             newColumn.name
-                        }" TYPE ${this.driver.createFullType(oldColumn)}`,
+                        }" TYPE ${oldColumnType}`,
                     ),
                 )
             }

--- a/src/driver/spanner/SpannerQueryRunner.ts
+++ b/src/driver/spanner/SpannerQueryRunner.ts
@@ -988,13 +988,10 @@ export class SpannerQueryRunner extends BaseQueryRunner implements QueryRunner {
 
         if (
             oldColumn.name !== newColumn.name ||
-            oldColumn.type !== newColumn.type ||
-            oldColumn.length !== newColumn.length ||
-            oldColumn.isArray !== newColumn.isArray ||
             oldColumn.generatedType !== newColumn.generatedType ||
             oldColumn.asExpression !== newColumn.asExpression
         ) {
-            // To avoid data conversion, we just recreate column
+            // To avoid data conversion for generated columns or rename, we just recreate column
             await this.dropColumn(table, oldColumn)
             await this.addColumn(table, newColumn)
 
@@ -1002,9 +999,13 @@ export class SpannerQueryRunner extends BaseQueryRunner implements QueryRunner {
             clonedTable = table.clone()
         } else {
             if (
+                newColumn.type !== oldColumn.type ||
+                newColumn.length !== oldColumn.length ||
                 newColumn.precision !== oldColumn.precision ||
-                newColumn.scale !== oldColumn.scale
+                newColumn.scale !== oldColumn.scale ||
+                newColumn.isArray !== oldColumn.isArray
             ) {
+                // alter column type / length / precision / scale / array property if changed
                 upQueries.push(
                     new Query(
                         `ALTER TABLE ${this.escapePath(table)} ALTER COLUMN "${

--- a/src/driver/spanner/SpannerQueryRunner.ts
+++ b/src/driver/spanner/SpannerQueryRunner.ts
@@ -1005,19 +1005,19 @@ export class SpannerQueryRunner extends BaseQueryRunner implements QueryRunner {
                 newColumn.scale !== oldColumn.scale ||
                 newColumn.isArray !== oldColumn.isArray
             ) {
-                // alter column type / length / precision / scale / array property if changed
+                // alter column type / length / precision / scale / array property if changed (Spanner does not use TYPE keyword, and column name needs to be escaped)
                 upQueries.push(
                     new Query(
-                        `ALTER TABLE ${this.escapePath(table)} ALTER COLUMN "${
-                            newColumn.name
-                        }" TYPE ${this.driver.createFullType(newColumn)}`,
+                        `ALTER TABLE ${this.escapePath(table)} ALTER COLUMN ${this.driver.escape(
+                            newColumn.name,
+                        )} ${this.driver.createFullType(newColumn)}`,
                     ),
                 )
                 downQueries.push(
                     new Query(
-                        `ALTER TABLE ${this.escapePath(table)} ALTER COLUMN "${
-                            newColumn.name
-                        }" TYPE ${this.driver.createFullType(oldColumn)}`,
+                        `ALTER TABLE ${this.escapePath(table)} ALTER COLUMN ${this.driver.escape(
+                            newColumn.name,
+                        )} ${this.driver.createFullType(oldColumn)}`,
                     ),
                 )
             }


### PR DESCRIPTION
Currently, when generating migrations or syncing schema, any change to column types, lengths, or array properties triggers a hard `DROP COLUMN` followed by an `ADD COLUMN` in drivers like Postgres, MySQL, CockroachDB, and Spanner to "avoid data conversion".

This approach results in catastrophic data loss on production schemas even for simple alterations (e.g., expanding varchar length or widening integer types).

This PR refactors the `changeColumn` logic across Postgres, MySQL, Spanner, and CockroachDB to bypass column recreation for these standard changes. Instead, it utilizes native and safe `ALTER COLUMN TYPE` / `CHANGE COLUMN` queries to perform in-place column alterations, completely eliminating the data loss risk while successfully passing all `changeColumn` test suites.

Closes #3357
