### PR TITLE
docs: document soft-remove and recover alongside soft-delete

### DIFF
--- a/docs/docs/query-builder/4-delete-query-builder.md
+++ b/docs/docs/query-builder/4-delete-query-builder.md
@@ -53,3 +53,25 @@ await myDataSource
     .where("id = :id", { id: 1 })
     .execute()
 ```
+
+## `Soft-Remove` and `Recover`
+
+The `softDelete()` and `restore()` methods above run a single bulk `UPDATE` by criteria. That's efficient, but it doesn't load the entities, so it skips relation cascades and entity listeners or subscribers.
+
+When you need those, use the repository or entity manager `softRemove()` and `recover()` methods instead. They work on entity instances, like `remove()` and `save()`, cascade to related entities according to your cascade options, and fire the `@BeforeSoftRemove`, `@AfterSoftRemove`, `@BeforeRecover`, and `@AfterRecover` listeners.
+
+```typescript
+const repository = dataSource.getRepository(User)
+
+// load the entities, then soft-delete them
+// (cascades and the @...SoftRemove listeners run, unlike softDelete)
+const users = await repository.find()
+const softRemovedUsers = await repository.softRemove(users)
+
+// recover them later
+await repository.recover(softRemovedUsers)
+```
+
+Use `softDelete()` / `restore()` for efficient bulk updates by criteria, and `softRemove()` / `recover()` when you have loaded entities and need cascades or lifecycle hooks.
+
+See the [Repository API](../working-with-entity-manager/6-repository-api.md) and [Listeners and Subscribers](../listeners-and-subscribers.md) for more.


### PR DESCRIPTION
The soft-delete docs only cover the QueryBuilder `softDelete()` / `restore()`, so `softRemove()` / `recover()` are easy to miss, which is what #12251 ran into.

Added a short section to the delete page explaining the difference: `softDelete` / `restore` are bulk updates by criteria, while `softRemove` / `recover` work on entity instances and run cascades plus the `@BeforeSoftRemove` / `@AfterSoftRemove` / `@BeforeRecover` / `@AfterRecover` listeners. Includes a small example and links to the Repository API and Listeners and Subscribers pages.

Closes #12251