### PR TITLE
test: onDelete cascade generates DB migrations

### DIFF
--- a/test/functional/schema-builder/foreign-key/cascade-change/cascade-change.test.ts
+++ b/test/functional/schema-builder/foreign-key/cascade-change/cascade-change.test.ts
@@ -1,0 +1,87 @@
+import "reflect-metadata"
+import {
+    closeTestingConnections,
+    createTestingConnections,
+    reloadTestingDatabases,
+    setupSingleTestingConnection,
+} from "../../../../utils/test-utils"
+import { DataSource } from "../../../../../src"
+import { expect } from "chai"
+
+describe("schema builder > foreign key > cascade option change (issue #1986)", () => {
+    let dataSources: DataSource[]
+    before(async () => {
+        dataSources = await createTestingConnections({
+            entities: [__dirname + "/entity/v1/*{.js,.ts}"],
+            enabledDrivers: ["mysql"],
+        })
+    })
+    beforeEach(() => reloadTestingDatabases(dataSources))
+    after(() => closeTestingConnections([...dataSources]))
+
+    it("should NOT generate migration when cascade: true is added (ORM-level only, not database FK)", () =>
+        Promise.all(
+            dataSources.map(async function (dataSource) {
+                const options = setupSingleTestingConnection(
+                    dataSource.options.type,
+                    {
+                        entities: [__dirname + "/entity/v2/*{.js,.ts}"],
+                        dropSchema: false,
+                        schemaCreate: false,
+                    },
+                )!
+                const newDataSource = new DataSource(options)
+                await newDataSource.initialize()
+                const sqlInMemory = await newDataSource.driver
+                    .createSchemaBuilder()
+                    .log()
+
+                const upQueries = sqlInMemory.upQueries.map(
+                    (query) => query.query,
+                )
+
+                expect(upQueries.length).to.equal(0)
+
+                await newDataSource.destroy()
+            }),
+        ))
+
+    it("should generate migration when onDelete: CASCADE is explicitly added to existing relation (owning side)", () =>
+        Promise.all(
+            dataSources.map(async function (dataSource) {
+                const options = setupSingleTestingConnection(
+                    dataSource.options.type,
+                    {
+                        entities: [__dirname + "/entity/v3/*{.js,.ts}"],
+                        dropSchema: false,
+                        schemaCreate: false,
+                    },
+                )!
+                const newDataSource = new DataSource(options)
+                await newDataSource.initialize()
+                const sqlInMemory = await newDataSource.driver
+                    .createSchemaBuilder()
+                    .log()
+
+                const upQueries = sqlInMemory.upQueries.map(
+                    (query) => query.query,
+                )
+
+                expect(upQueries.length).to.be.greaterThan(0)
+
+                const dropQuery = upQueries.find((q) =>
+                    q.match(/ALTER TABLE [`"]?post[`"]? DROP FOREIGN KEY/),
+                )
+                const createQuery = upQueries.find((q) =>
+                    q.match(
+                        /ALTER TABLE [`"]?post[`"]?.*ADD.*CONSTRAINT.*ON DELETE CASCADE/,
+                    ),
+                )
+
+                expect(dropQuery).to.exist
+                expect(createQuery).to.exist
+
+                await newDataSource.destroy()
+            }),
+        ))
+})

--- a/test/functional/schema-builder/foreign-key/cascade-change/cascade-change.test.ts
+++ b/test/functional/schema-builder/foreign-key/cascade-change/cascade-change.test.ts
@@ -32,17 +32,20 @@ describe("schema builder > foreign key > cascade option change (issue #1986)", (
                 )!
                 const newDataSource = new DataSource(options)
                 await newDataSource.initialize()
-                const sqlInMemory = await newDataSource.driver
-                    .createSchemaBuilder()
-                    .log()
 
-                const upQueries = sqlInMemory.upQueries.map(
-                    (query) => query.query,
-                )
+                try {
+                    const sqlInMemory = await newDataSource.driver
+                        .createSchemaBuilder()
+                        .log()
 
-                expect(upQueries.length).to.equal(0)
+                    const upQueries = sqlInMemory.upQueries.map(
+                        (query) => query.query,
+                    )
 
-                await newDataSource.destroy()
+                    expect(upQueries.length).to.equal(0)
+                } finally {
+                    await newDataSource.destroy()
+                }
             }),
         ))
 
@@ -59,29 +62,32 @@ describe("schema builder > foreign key > cascade option change (issue #1986)", (
                 )!
                 const newDataSource = new DataSource(options)
                 await newDataSource.initialize()
-                const sqlInMemory = await newDataSource.driver
-                    .createSchemaBuilder()
-                    .log()
 
-                const upQueries = sqlInMemory.upQueries.map(
-                    (query) => query.query,
-                )
+                try {
+                    const sqlInMemory = await newDataSource.driver
+                        .createSchemaBuilder()
+                        .log()
 
-                expect(upQueries.length).to.be.greaterThan(0)
+                    const upQueries = sqlInMemory.upQueries.map(
+                        (query) => query.query,
+                    )
 
-                const dropQuery = upQueries.find((q) =>
-                    q.match(/ALTER TABLE [`"]?post[`"]? DROP FOREIGN KEY/),
-                )
-                const createQuery = upQueries.find((q) =>
-                    q.match(
-                        /ALTER TABLE [`"]?post[`"]?.*ADD.*CONSTRAINT.*ON DELETE CASCADE/,
-                    ),
-                )
+                    expect(upQueries.length).to.be.greaterThan(0)
 
-                expect(dropQuery).to.exist
-                expect(createQuery).to.exist
+                    const dropQuery = upQueries.find((q) =>
+                        q.match(/ALTER TABLE [`"]?post[`"]? DROP FOREIGN KEY/),
+                    )
+                    const createQuery = upQueries.find((q) =>
+                        q.match(
+                            /ALTER TABLE [`"]?post[`"]?.*ADD.*CONSTRAINT.*ON DELETE CASCADE/,
+                        ),
+                    )
 
-                await newDataSource.destroy()
+                    expect(dropQuery).to.exist
+                    expect(createQuery).to.exist
+                } finally {
+                    await newDataSource.destroy()
+                }
             }),
         ))
 })

--- a/test/functional/schema-builder/foreign-key/cascade-change/entity/v1/Post.ts
+++ b/test/functional/schema-builder/foreign-key/cascade-change/entity/v1/Post.ts
@@ -1,0 +1,22 @@
+import {
+    Column,
+    Entity,
+    JoinColumn,
+    ManyToOne,
+    PrimaryGeneratedColumn,
+} from "../../../../../../../src/index"
+import { User } from "./User"
+
+@Entity()
+export class Post {
+    @PrimaryGeneratedColumn()
+    id: number
+
+    @Column()
+    title: string
+
+    // v1: No cascade option
+    @ManyToOne(() => User)
+    @JoinColumn()
+    author: User
+}

--- a/test/functional/schema-builder/foreign-key/cascade-change/entity/v1/User.ts
+++ b/test/functional/schema-builder/foreign-key/cascade-change/entity/v1/User.ts
@@ -1,0 +1,14 @@
+import {
+    Column,
+    Entity,
+    PrimaryGeneratedColumn,
+} from "../../../../../../../src/index"
+
+@Entity()
+export class User {
+    @PrimaryGeneratedColumn()
+    id: number
+
+    @Column()
+    name: string
+}

--- a/test/functional/schema-builder/foreign-key/cascade-change/entity/v2/Post.ts
+++ b/test/functional/schema-builder/foreign-key/cascade-change/entity/v2/Post.ts
@@ -1,0 +1,22 @@
+import {
+    Column,
+    Entity,
+    JoinColumn,
+    ManyToOne,
+    PrimaryGeneratedColumn,
+} from "../../../../../../../src/index"
+import { User } from "./User"
+
+@Entity()
+export class Post {
+    @PrimaryGeneratedColumn()
+    id: number
+
+    @Column()
+    title: string
+
+    // v2: With cascade: true
+    @ManyToOne(() => User, { cascade: true })
+    @JoinColumn()
+    author: User
+}

--- a/test/functional/schema-builder/foreign-key/cascade-change/entity/v2/User.ts
+++ b/test/functional/schema-builder/foreign-key/cascade-change/entity/v2/User.ts
@@ -1,0 +1,14 @@
+import {
+    Column,
+    Entity,
+    PrimaryGeneratedColumn,
+} from "../../../../../../../src/index"
+
+@Entity()
+export class User {
+    @PrimaryGeneratedColumn()
+    id: number
+
+    @Column()
+    name: string
+}

--- a/test/functional/schema-builder/foreign-key/cascade-change/entity/v3/Post.ts
+++ b/test/functional/schema-builder/foreign-key/cascade-change/entity/v3/Post.ts
@@ -1,0 +1,22 @@
+import {
+    Column,
+    Entity,
+    JoinColumn,
+    ManyToOne,
+    PrimaryGeneratedColumn,
+} from "../../../../../../../src/index"
+import { User } from "./User"
+
+@Entity()
+export class Post {
+    @PrimaryGeneratedColumn()
+    id: number
+
+    @Column()
+    title: string
+
+    // v3: With explicit onDelete: CASCADE
+    @ManyToOne(() => User, { onDelete: "CASCADE" })
+    @JoinColumn()
+    author: User
+}

--- a/test/functional/schema-builder/foreign-key/cascade-change/entity/v3/User.ts
+++ b/test/functional/schema-builder/foreign-key/cascade-change/entity/v3/User.ts
@@ -1,0 +1,14 @@
+import {
+    Column,
+    Entity,
+    PrimaryGeneratedColumn,
+} from "../../../../../../../src/index"
+
+@Entity()
+export class User {
+    @PrimaryGeneratedColumn()
+    id: number
+
+    @Column()
+    name: string
+}


### PR DESCRIPTION
<!--
  😀 Wonderful!  Thank you for opening a pull request for TypeORM.

  Please fill in the information below to expedite the review
  and (hopefully) merge of your change.

  If unsure about something.. just do as best as you're able,
  or reach out through our community support channels!
  https://github.com/typeorm/typeorm/blob/master/docs/support.md
  https://github.com/typeorm/typeorm/blob/master/CONTRIBUTING.md
-->

### Description of change

Fixes: #1986
Adds tests clarifying that database-level cascade migrations are generated by onDelete option, not by cascade option.

### Pull-Request Checklist

<!--
  Please make sure to review and check all of the following.

  If an item is not applicable, you can add "N/A" to the end.
-->

- [X] Code is up-to-date with the `master` branch
- [X] This pull request links relevant issues as `Fixes #00000`
- [X] There are new or updated tests validating the change (`tests/**.test.ts`)
- [ ] Documentation has been updated to reflect this change (`docs/docs/**.md`)

