### PR TITLE
fix(migration): preserve data when altering column type/length

### DIFF
--- a/src/driver/aurora-mysql/AuroraMysqlQueryRunner.ts
+++ b/src/driver/aurora-mysql/AuroraMysqlQueryRunner.ts
@@ -888,8 +888,6 @@ export class AuroraMysqlQueryRunner
         if (
             (newColumn.isGenerated !== oldColumn.isGenerated &&
                 newColumn.generationStrategy !== "uuid") ||
-            oldColumn.type !== newColumn.type ||
-            oldColumn.length !== newColumn.length ||
             oldColumn.generatedType !== newColumn.generatedType
         ) {
             await this.dropColumn(table, oldColumn)

--- a/src/driver/cockroachdb/CockroachQueryRunner.ts
+++ b/src/driver/cockroachdb/CockroachQueryRunner.ts
@@ -1402,13 +1402,10 @@ export class CockroachQueryRunner
             )
 
         if (
-            oldColumn.type !== newColumn.type ||
-            oldColumn.length !== newColumn.length ||
-            newColumn.isArray !== oldColumn.isArray ||
             oldColumn.generatedType !== newColumn.generatedType ||
             oldColumn.asExpression !== newColumn.asExpression
         ) {
-            // To avoid data conversion, we just recreate column
+            // To avoid data conversion for generated columns, we recreate column
             await this.dropColumn(table, oldColumn)
             await this.addColumn(table, newColumn)
 
@@ -1654,6 +1651,28 @@ export class CockroachQueryRunner
                     clonedTable.columns.indexOf(oldTableColumn!)
                 ].name = newColumn.name
                 oldColumn.name = newColumn.name
+            }
+
+            // Handle column type changes without data loss
+            if (
+                oldColumn.type !== newColumn.type ||
+                oldColumn.length !== newColumn.length ||
+                newColumn.isArray !== oldColumn.isArray
+            ) {
+                upQueries.push(
+                    new Query(
+                        `ALTER TABLE ${this.escapePath(table)} ALTER COLUMN "${
+                            newColumn.name
+                        }" TYPE ${this.driver.createFullType(newColumn)}`,
+                    ),
+                )
+                downQueries.push(
+                    new Query(
+                        `ALTER TABLE ${this.escapePath(table)} ALTER COLUMN "${
+                            newColumn.name
+                        }" TYPE ${this.driver.createFullType(oldColumn)}`,
+                    ),
+                )
             }
 
             if (

--- a/src/driver/mysql/MysqlQueryRunner.ts
+++ b/src/driver/mysql/MysqlQueryRunner.ts
@@ -1137,8 +1137,6 @@ export class MysqlQueryRunner extends BaseQueryRunner implements QueryRunner {
         if (
             (newColumn.isGenerated !== oldColumn.isGenerated &&
                 newColumn.generationStrategy !== "uuid") ||
-            oldColumn.type !== newColumn.type ||
-            oldColumn.length !== newColumn.length ||
             (oldColumn.generatedType &&
                 newColumn.generatedType &&
                 oldColumn.generatedType !== newColumn.generatedType) ||

--- a/src/driver/oracle/OracleQueryRunner.ts
+++ b/src/driver/oracle/OracleQueryRunner.ts
@@ -1145,13 +1145,10 @@ export class OracleQueryRunner extends BaseQueryRunner implements QueryRunner {
         if (
             (newColumn.isGenerated !== oldColumn.isGenerated &&
                 newColumn.generationStrategy !== "uuid") ||
-            oldColumn.type !== newColumn.type ||
-            oldColumn.length !== newColumn.length ||
             oldColumn.generatedType !== newColumn.generatedType ||
             oldColumn.asExpression !== newColumn.asExpression
         ) {
             // Oracle does not support changing of IDENTITY column, so we must drop column and recreate it again.
-            // Also, we recreate column if column type changed
             await this.dropColumn(table, oldColumn)
             await this.addColumn(table, newColumn)
 
@@ -1368,6 +1365,27 @@ export class OracleQueryRunner extends BaseQueryRunner implements QueryRunner {
                     clonedTable.columns.indexOf(oldTableColumn!)
                 ].name = newColumn.name
                 oldColumn.name = newColumn.name
+            }
+
+            // Handle column type changes without data loss
+            if (
+                oldColumn.type !== newColumn.type ||
+                oldColumn.length !== newColumn.length
+            ) {
+                upQueries.push(
+                    new Query(
+                        `ALTER TABLE ${this.escapePath(table)} MODIFY ("${
+                            newColumn.name
+                        }" ${this.driver.createFullType(newColumn)})`,
+                    ),
+                )
+                downQueries.push(
+                    new Query(
+                        `ALTER TABLE ${this.escapePath(table)} MODIFY ("${
+                            newColumn.name
+                        }" ${this.driver.createFullType(oldColumn)})`,
+                    ),
+                )
             }
 
             if (this.isColumnChanged(oldColumn, newColumn, true)) {

--- a/src/driver/postgres/PostgresQueryRunner.ts
+++ b/src/driver/postgres/PostgresQueryRunner.ts
@@ -1326,16 +1326,18 @@ export class PostgresQueryRunner
                 `Column "${oldTableColumnOrName}" was not found in the "${table.name}" table.`,
             )
 
-        if (
-            oldColumn.type !== newColumn.type ||
-            oldColumn.length !== newColumn.length ||
-            newColumn.isArray !== oldColumn.isArray ||
-            (!oldColumn.generatedType &&
+        // Check if only generated type changes (STORED) - these need drop/add
+        const onlyGeneratedTypeChanged =
+            oldColumn.type === newColumn.type &&
+            oldColumn.length === newColumn.length &&
+            newColumn.isArray === oldColumn.isArray &&
+            ((!oldColumn.generatedType &&
                 newColumn.generatedType === "STORED") ||
-            (oldColumn.asExpression !== newColumn.asExpression &&
-                newColumn.generatedType === "STORED")
-        ) {
-            // To avoid data conversion, we just recreate column
+                (oldColumn.asExpression !== newColumn.asExpression &&
+                    newColumn.generatedType === "STORED"))
+
+        if (onlyGeneratedTypeChanged) {
+            // For generated column type changes, we need to recreate the column
             await this.dropColumn(table, oldColumn)
             await this.addColumn(table, newColumn)
 
@@ -1616,6 +1618,28 @@ export class PostgresQueryRunner
                     clonedTable.columns.indexOf(oldTableColumn!)
                 ].name = newColumn.name
                 oldColumn.name = newColumn.name
+            }
+
+            // Handle column type changes without data loss
+            if (
+                oldColumn.type !== newColumn.type ||
+                oldColumn.length !== newColumn.length ||
+                newColumn.isArray !== oldColumn.isArray
+            ) {
+                upQueries.push(
+                    new Query(
+                        `ALTER TABLE ${this.escapePath(table)} ALTER COLUMN "${
+                            newColumn.name
+                        }" TYPE ${this.driver.createFullType(newColumn)}`,
+                    ),
+                )
+                downQueries.push(
+                    new Query(
+                        `ALTER TABLE ${this.escapePath(table)} ALTER COLUMN "${
+                            newColumn.name
+                        }" TYPE ${this.driver.createFullType(oldColumn)}`,
+                    ),
+                )
             }
 
             if (

--- a/src/driver/spanner/SpannerQueryRunner.ts
+++ b/src/driver/spanner/SpannerQueryRunner.ts
@@ -988,19 +988,38 @@ export class SpannerQueryRunner extends BaseQueryRunner implements QueryRunner {
 
         if (
             oldColumn.name !== newColumn.name ||
-            oldColumn.type !== newColumn.type ||
-            oldColumn.length !== newColumn.length ||
-            oldColumn.isArray !== newColumn.isArray ||
             oldColumn.generatedType !== newColumn.generatedType ||
             oldColumn.asExpression !== newColumn.asExpression
         ) {
-            // To avoid data conversion, we just recreate column
+            // To avoid data conversion, we just recreate column (for renames and generated column changes)
             await this.dropColumn(table, oldColumn)
             await this.addColumn(table, newColumn)
 
             // update cloned table
             clonedTable = table.clone()
         } else {
+            // Handle column type changes without data loss
+            if (
+                oldColumn.type !== newColumn.type ||
+                oldColumn.length !== newColumn.length ||
+                oldColumn.isArray !== newColumn.isArray
+            ) {
+                upQueries.push(
+                    new Query(
+                        `ALTER TABLE ${this.escapePath(table)} ALTER COLUMN "${
+                            newColumn.name
+                        }" ${this.driver.createFullType(newColumn)}`,
+                    ),
+                )
+                downQueries.push(
+                    new Query(
+                        `ALTER TABLE ${this.escapePath(table)} ALTER COLUMN "${
+                            newColumn.name
+                        }" ${this.driver.createFullType(oldColumn)}`,
+                    ),
+                )
+            }
+
             if (
                 newColumn.precision !== oldColumn.precision ||
                 newColumn.scale !== oldColumn.scale

--- a/src/driver/sqlserver/SqlServerQueryRunner.ts
+++ b/src/driver/sqlserver/SqlServerQueryRunner.ts
@@ -1370,13 +1370,10 @@ export class SqlServerQueryRunner
         if (
             (newColumn.isGenerated !== oldColumn.isGenerated &&
                 newColumn.generationStrategy !== "uuid") ||
-            newColumn.type !== oldColumn.type ||
-            newColumn.length !== oldColumn.length ||
             newColumn.asExpression !== oldColumn.asExpression ||
             newColumn.generatedType !== oldColumn.generatedType
         ) {
             // SQL Server does not support changing of IDENTITY column, so we must drop column and recreate it again.
-            // Also, we recreate column if column type changed
             await this.dropColumn(table, oldColumn)
             await this.addColumn(table, newColumn)
 
@@ -1704,6 +1701,39 @@ export class SqlServerQueryRunner
                     clonedTable.columns.indexOf(oldTableColumn!)
                 ].name = newColumn.name
                 oldColumn.name = newColumn.name
+            }
+
+            // Handle column type changes without data loss
+            if (
+                oldColumn.type !== newColumn.type ||
+                oldColumn.length !== newColumn.length
+            ) {
+                upQueries.push(
+                    new Query(
+                        `ALTER TABLE ${this.escapePath(
+                            table,
+                        )} ALTER COLUMN ${this.buildCreateColumnSql(
+                            table,
+                            newColumn,
+                            true,
+                            false,
+                            true,
+                        )}`,
+                    ),
+                )
+                downQueries.push(
+                    new Query(
+                        `ALTER TABLE ${this.escapePath(
+                            table,
+                        )} ALTER COLUMN ${this.buildCreateColumnSql(
+                            table,
+                            oldColumn,
+                            true,
+                            false,
+                            true,
+                        )}`,
+                    ),
+                )
             }
 
             if (


### PR DESCRIPTION
## Description
Fixes a critical data loss bug where TypeORM's migration generation would DROP and CREATE columns instead of using ALTER statements when column properties like type or length changed.

## Problem
- Schema synchronization with column type/length changes triggered DROP COLUMN + ADD COLUMN
- This permanently deleted existing data in affected columns
- Affected all drivers: PostgreSQL, MySQL, Aurora MySQL, CockroachDB, Oracle, SQL Server, Spanner

## Solution
- Column type/length changes now use ALTER TABLE ... ALTER/MODIFY COLUMN
- Data is preserved during migration
- DROP/CREATE only happens for changes that require it (e.g., IDENTITY/generated columns)

## Fixes
- Migration generation drops and creates columns instead of altering resulting in data loss