### PR TITLE
fix(postgres): use alter column type instead of drop and add for type length isarray changes

### DIFF
--- a/src/driver/postgres/PostgresQueryRunner.ts
+++ b/src/driver/postgres/PostgresQueryRunner.ts
@@ -1621,19 +1621,24 @@ export class PostgresQueryRunner
                 newColumn.isArray !== oldColumn.isArray
             ) {
                 // Use buildEnumName() for enum/simple-enum types since createFullType()
-                // would produce invalid "TYPE enum" / "TYPE simple-enum" SQL
-                const isEnumType =
-                    oldColumn.type === "enum" ||
-                    oldColumn.type === "simple-enum" ||
+                // would produce invalid "TYPE enum" / "TYPE simple-enum" SQL.
+                // Check each side independently: only use buildEnumName for the side
+                // that is actually enum — prevents enum→non-enum or non-enum→enum
+                // from referencing the wrong type name.
+                const upIsEnum =
                     newColumn.type === "enum" ||
                     newColumn.type === "simple-enum"
 
-                const upType = isEnumType
+                const downIsEnum =
+                    oldColumn.type === "enum" ||
+                    oldColumn.type === "simple-enum"
+
+                const upType = upIsEnum
                     ? this.buildEnumName(table, newColumn) +
                       (newColumn.isArray ? "[]" : "")
                     : this.driver.createFullType(newColumn)
 
-                const downType = isEnumType
+                const downType = downIsEnum
                     ? this.buildEnumName(table, oldColumn) +
                       (oldColumn.isArray ? "[]" : "")
                     : this.driver.createFullType(oldColumn)
@@ -1648,6 +1653,24 @@ export class PostgresQueryRunner
                         `ALTER TABLE ${this.escapePath(table)} ALTER COLUMN "${newColumn.name}" TYPE ${downType}`,
                     ),
                 )
+
+                // When converting non-enum→enum, create the enum type first
+                // (addColumn already does this, changeColumn must too)
+                if (upIsEnum && !downIsEnum && newColumn.enum) {
+                    upQueries.splice(
+                        upQueries.length - 1,
+                        0,
+                        this.createEnumTypeSql(table, newColumn),
+                    )
+                }
+                // For the down migration: create old enum type if it was enum
+                if (downIsEnum && !upIsEnum && oldColumn.enum) {
+                    downQueries.splice(
+                        downQueries.length - 1,
+                        0,
+                        this.createEnumTypeSql(table, oldColumn),
+                    )
+                }
             }
 
             if (

--- a/src/driver/postgres/PostgresQueryRunner.ts
+++ b/src/driver/postgres/PostgresQueryRunner.ts
@@ -1339,22 +1339,6 @@ export class PostgresQueryRunner
             // update cloned table
             clonedTable = table.clone()
         } else {
-            if (
-                oldColumn.type !== newColumn.type ||
-                oldColumn.length !== newColumn.length ||
-                newColumn.isArray !== oldColumn.isArray
-            ) {
-                upQueries.push(
-                    new Query(
-                        `ALTER TABLE ${this.escapePath(table)} ALTER COLUMN "${newColumn.name}" TYPE ${this.driver.createFullType(newColumn)}`,
-                    ),
-                )
-                downQueries.push(
-                    new Query(
-                        `ALTER TABLE ${this.escapePath(table)} ALTER COLUMN "${newColumn.name}" TYPE ${this.driver.createFullType(oldColumn)}`,
-                    ),
-                )
-            }
             if (oldColumn.name !== newColumn.name) {
                 // rename column
                 upQueries.push(
@@ -1629,6 +1613,41 @@ export class PostgresQueryRunner
                     clonedTable.columns.indexOf(oldTableColumn!)
                 ].name = newColumn.name
                 oldColumn.name = newColumn.name
+            }
+
+            if (
+                oldColumn.type !== newColumn.type ||
+                oldColumn.length !== newColumn.length ||
+                newColumn.isArray !== oldColumn.isArray
+            ) {
+                // Use buildEnumName() for enum/simple-enum types since createFullType()
+                // would produce invalid "TYPE enum" / "TYPE simple-enum" SQL
+                const isEnumType =
+                    oldColumn.type === "enum" ||
+                    oldColumn.type === "simple-enum" ||
+                    newColumn.type === "enum" ||
+                    newColumn.type === "simple-enum"
+
+                const upType = isEnumType
+                    ? this.buildEnumName(table, newColumn) +
+                      (newColumn.isArray ? "[]" : "")
+                    : this.driver.createFullType(newColumn)
+
+                const downType = isEnumType
+                    ? this.buildEnumName(table, oldColumn) +
+                      (oldColumn.isArray ? "[]" : "")
+                    : this.driver.createFullType(oldColumn)
+
+                upQueries.push(
+                    new Query(
+                        `ALTER TABLE ${this.escapePath(table)} ALTER COLUMN "${newColumn.name}" TYPE ${upType}`,
+                    ),
+                )
+                downQueries.push(
+                    new Query(
+                        `ALTER TABLE ${this.escapePath(table)} ALTER COLUMN "${newColumn.name}" TYPE ${downType}`,
+                    ),
+                )
             }
 
             if (

--- a/src/driver/postgres/PostgresQueryRunner.ts
+++ b/src/driver/postgres/PostgresQueryRunner.ts
@@ -1327,9 +1327,6 @@ export class PostgresQueryRunner
             )
 
         if (
-            oldColumn.type !== newColumn.type ||
-            oldColumn.length !== newColumn.length ||
-            newColumn.isArray !== oldColumn.isArray ||
             (!oldColumn.generatedType &&
                 newColumn.generatedType === "STORED") ||
             (oldColumn.asExpression !== newColumn.asExpression &&
@@ -1342,6 +1339,22 @@ export class PostgresQueryRunner
             // update cloned table
             clonedTable = table.clone()
         } else {
+            if (
+                oldColumn.type !== newColumn.type ||
+                oldColumn.length !== newColumn.length ||
+                newColumn.isArray !== oldColumn.isArray
+            ) {
+                upQueries.push(
+                    new Query(
+                        `ALTER TABLE ${this.escapePath(table)} ALTER COLUMN "${newColumn.name}" TYPE ${this.driver.createFullType(newColumn)}`,
+                    ),
+                )
+                downQueries.push(
+                    new Query(
+                        `ALTER TABLE ${this.escapePath(table)} ALTER COLUMN "${newColumn.name}" TYPE ${this.driver.createFullType(oldColumn)}`,
+                    ),
+                )
+            }
             if (oldColumn.name !== newColumn.name) {
                 // rename column
                 upQueries.push(


### PR DESCRIPTION
## What
Changes migration generation to use `ALTER COLUMN ... TYPE` instead of `DROP COLUMN` + `ADD COLUMN` when a column's type, length, or `isArray` changes in PostgreSQL.

## Why
Previously, when changing a column type/length (e.g. `varchar(50)` → `varchar(51)`), TypeORM would generate:
```sql
ALTER TABLE "bug" DROP COLUMN "example"
ALTER TABLE "bug" ADD "example" character varying(51)
```
This causes **data loss** because the column is dropped and recreated empty.

The correct behavior is:
```sql
ALTER TABLE "bug" ALTER COLUMN "example" TYPE character varying(51)
```

## How
- Removed `type`, `length`, and `isArray` from the DROP+ADD condition in `PostgresQueryRunner.changeColumn()`
- Added new `ALTER COLUMN ... TYPE` handling for these cases inside the safe `else` block
- Uses existing `this.driver.createFullType()` which correctly constructs the full type string including length (e.g. `character varying(51)`)

## Example
Before this fix, for `@Column({ length: 50 })` → `@Column({ length: 51 })`:
```sql
ALTER TABLE "bug" DROP COLUMN "example"     -- DATA LOSS!
ALTER TABLE "bug" ADD "example" varchar(51)
```

After this fix:
```sql
ALTER TABLE "bug" ALTER COLUMN "example" TYPE varchar(51)  -- preserves data
```

## Checklist
- [x] Fix compiled successfully (`pnpm run compile`)
- [x] Uses existing `createFullType()` helper for full type construction
- [x] Backward compatible — required column changes still work
- [x] Follows same pattern as existing precision/scale ALTER COLUMN handling

Fixes #3357