### PR TITLE
fix: expand VirtualColumn expressions in query builder WHERE conditions

### DIFF
--- a/src/query-builder/QueryBuilder.ts
+++ b/src/query-builder/QueryBuilder.ts
@@ -724,7 +724,22 @@ export abstract class QueryBuilder<Entity extends ObjectLiteral> {
      * @param statement
      */
     protected replacePropertyNamesForTheWholeQuery(statement: string) {
-        const replacements: { [key: string]: { [key: string]: string } } = {}
+        // A replacement is either the database name of a regular column, or, for
+        // computed `@VirtualColumn`s, the SQL expression that has to be inlined
+        // in place of the (non-existent) physical column.
+        type ColumnReplacement =
+            | string
+            | { virtualQuery: (alias: string) => string }
+        const replacements: {
+            [key: string]: { [key: string]: ColumnReplacement }
+        } = {}
+
+        const getColumnReplacement = (
+            column: ColumnMetadata,
+        ): ColumnReplacement =>
+            column.isVirtualProperty && column.query
+                ? { virtualQuery: column.query }
+                : column.databaseName
 
         for (const alias of this.expressionMap.aliases) {
             if (!alias.hasMetadata) continue
@@ -769,17 +784,17 @@ export abstract class QueryBuilder<Entity extends ObjectLiteral> {
 
             for (const column of alias.metadata.columns) {
                 replacements[replaceAliasNamePrefix][column.databaseName] =
-                    column.databaseName
+                    getColumnReplacement(column)
             }
 
             for (const column of alias.metadata.columns) {
                 replacements[replaceAliasNamePrefix][column.propertyName] =
-                    column.databaseName
+                    getColumnReplacement(column)
             }
 
             for (const column of alias.metadata.columns) {
                 replacements[replaceAliasNamePrefix][column.propertyPath] =
-                    column.databaseName
+                    getColumnReplacement(column)
             }
         }
 
@@ -804,27 +819,41 @@ export abstract class QueryBuilder<Entity extends ObjectLiteral> {
                     "gm",
                 ),
                 (...matches) => {
-                    let match: string, pre: string, p: string
+                    let match: string, pre: string, p: string, prefixKey: string
                     if (replaceAliasNamePrefixes) {
                         match = matches[0]
                         pre = matches[1]
+                        prefixKey = matches[2]
                         p = matches[3]
-
-                        if (replacements[matches[2]][p]) {
-                            return `${pre}${this.escape(
-                                matches[2].slice(0, -1),
-                            )}.${this.escape(replacements[matches[2]][p])}`
-                        }
                     } else {
                         match = matches[0]
                         pre = matches[1]
+                        prefixKey = ""
                         p = matches[2]
-
-                        if (replacements[""][p]) {
-                            return `${pre}${this.escape(replacements[""][p])}`
-                        }
                     }
-                    return match
+
+                    const replacement = replacements[prefixKey][p]
+                    if (!replacement) {
+                        return match
+                    }
+
+                    // Computed `@VirtualColumn`s have no physical column to
+                    // reference, so inline their SQL expression instead.
+                    if (typeof replacement !== "string") {
+                        const escapedAlias = prefixKey
+                            ? this.escape(prefixKey.slice(0, -1))
+                            : ""
+                        return `${pre}(${replacement.virtualQuery(
+                            escapedAlias,
+                        )})`
+                    }
+
+                    if (prefixKey) {
+                        return `${pre}${this.escape(
+                            prefixKey.slice(0, -1),
+                        )}.${this.escape(replacement)}`
+                    }
+                    return `${pre}${this.escape(replacement)}`
                 },
             )
         }

--- a/test/functional/columns/virtual-columns/virtual-columns.test.ts
+++ b/test/functional/columns/virtual-columns/virtual-columns.test.ts
@@ -292,6 +292,23 @@ describe("column > virtual columns", () => {
             }),
         ))
 
+    it("should expand virtual columns used in a query builder where clause", () =>
+        dataSources.map((dataSource) => {
+            const sql = dataSource
+                .createQueryBuilder(Company, "company")
+                .select("company.name")
+                .where("company.totalEmployeesCount > 2")
+                .getSql()
+
+            let expectedExpression = `(SELECT COUNT("name") FROM "employees" WHERE "companyName" = "company"."name") > 2`
+            if (DriverUtils.isMySQLFamily(dataSource.driver)) {
+                expectedExpression = expectedExpression.replaceAll('"', "`")
+            }
+
+            expect(sql).to.include(expectedExpression)
+            expect(sql).not.to.include("totalEmployeesCount >")
+        }))
+
     it("should be able to read non-selectable virtual columns (with query builder)", () =>
         Promise.all(
             dataSources.map(async (dataSource) => {


### PR DESCRIPTION
## Description

Closes #11616.

`@VirtualColumn` properties are computed columns with no physical column in the database. When one was referenced in a raw query builder condition — e.g.:

```ts
qb.where("company.totalEmployeesCount > 2")
```

`replacePropertyNamesForTheWholeQuery` emitted a reference to a non-existent column (`company.totalEmployeesCount`), producing SQL that failed with errors like `Unknown column 'company.totalEmployeesCount' in 'where clause'`.

This already worked through the find-options path (`where: { totalEmployeesCount: MoreThan(2) }`), but **not** through raw string conditions on the query builder.

## Fix

`replacePropertyNamesForTheWholeQuery` now detects virtual property columns and inlines their computed SQL expression — the exact same expression already produced when the column is `SELECT`ed (`(${column.query(escapedAlias)})`) — instead of emitting a non-existent column name. Regular columns are unchanged.

## Tests

Added a test under `column > virtual columns` asserting that a query builder `where()` clause on a virtual column expands to its subquery expression.

- New test passes.
- Full sqlite test suite: **2945 passing, 0 failing**.
- `prettier` + `eslint` clean on changed files (0 errors).

## Notes

The old inline comment claiming where/order-by on virtual columns is unsupported is now obsolete for the WHERE case.