### PR TITLE
fix: preserve Buffer values in normalizeWhereCriteria

### DIFF
--- a/src/util/OrmUtils.ts
+++ b/src/util/OrmUtils.ts
@@ -699,6 +699,7 @@ export class OrmUtils {
                 typeof value === "object" &&
                 !Array.isArray(value) &&
                 !(value instanceof Date) &&
+                !isUint8Array(value) &&
                 !InstanceChecker.isFindOperator(value)
             ) {
                 const nested = OrmUtils.normalizeWhereCriteria(


### PR DESCRIPTION
## Summary

Fixes #12574.

Buffer parameters passed to TypeORM queries were being converted to plain objects, causing DB clients to reject them.

## Root Cause

`OrmUtils.normalizeWhereCriteria` recursively processes all object values as nested criteria. Since `typeof Buffer` is `'object'` and Buffer is not an Array, Date, or FindOperator, it was treated as nested criteria and its byte-index properties were copied into a plain object.

## Changes

- Added `!isUint8Array(value)` check to the recursive normalization condition in `normalizeWhereCriteria`

## Tests

Ran:

```
npm test
```

Result: Tests not run because the full test suite requires database connections (MySQL, Postgres, etc). The change is a single guard condition that can be reviewed by inspection.

## Risk

Risk level: low. The `isUint8Array` helper already exists in the codebase (`Uint8ArrayUtils.ts`) and is used elsewhere. This change only prevents Buffer/Uint8Array values from entering the recursive normalization path — they are now correctly passed through as leaf values.