### PR TITLE
fix: normalization of FindOptionsWhere for arrays and Buffers

### DIFF
--- a/src/data-source/BaseDataSourceOptions.ts
+++ b/src/data-source/BaseDataSourceOptions.ts
@@ -1,12 +1,13 @@
-import type { EntitySchema } from "../entity-schema/EntitySchema"
-import type { LoggerOptions } from "../logger/LoggerOptions"
-import type { NamingStrategyInterface } from "../naming-strategy/NamingStrategyInterface"
-import type { DatabaseType } from "../driver/types/DatabaseType"
-import type { IsolationLevel } from "../driver/types/IsolationLevel"
-import type { Logger } from "../logger/Logger"
-import type { DataSource } from "../data-source/DataSource"
 import type { QueryResultCache } from "../cache/QueryResultCache"
 import type { MixedList } from "../common/MixedList"
+import type { DataSource } from "../data-source/DataSource"
+import type { DatabaseType } from "../driver/types/DatabaseType"
+import type { InvalidFindOptionsWhereBehavior } from "../driver/types/InvalidFindOptionsWhereBehavior"
+import type { IsolationLevel } from "../driver/types/IsolationLevel"
+import type { EntitySchema } from "../entity-schema/EntitySchema"
+import type { Logger } from "../logger/Logger"
+import type { LoggerOptions } from "../logger/LoggerOptions"
+import type { NamingStrategyInterface } from "../naming-strategy/NamingStrategyInterface"
 
 /**
  * BaseDataSourceOptions is set of DataSourceOptions shared by all database types.
@@ -223,20 +224,5 @@ export interface BaseDataSourceOptions {
     /**
      * Controls how null and undefined values are handled in find operations.
      */
-    readonly invalidWhereValuesBehavior?: {
-        /**
-         * How to handle null values in where conditions.
-         * - 'ignore': Skip null properties
-         * - 'sql-null': Transform null to SQL NULL
-         * - 'throw': Throw an error when null is encountered (default)
-         */
-        readonly null?: "ignore" | "sql-null" | "throw"
-
-        /**
-         * How to handle undefined values in where conditions.
-         * - 'ignore': Skip undefined properties
-         * - 'throw': Throw an error when undefined is encountered (default)
-         */
-        readonly undefined?: "ignore" | "throw"
-    }
+    readonly invalidWhereValuesBehavior?: InvalidFindOptionsWhereBehavior
 }

--- a/src/driver/types/InvalidFindOptionsWhereBehavior.ts
+++ b/src/driver/types/InvalidFindOptionsWhereBehavior.ts
@@ -1,0 +1,16 @@
+export type InvalidFindOptionsWhereBehavior = {
+    /**
+     * How to handle null values in where conditions.
+     * - 'ignore': Skip null properties
+     * - 'sql-null': Transform null to SQL NULL
+     * - 'throw': Throw an error when null is encountered (default)
+     */
+    readonly null?: "ignore" | "sql-null" | "throw"
+
+    /**
+     * How to handle undefined values in where conditions.
+     * - 'ignore': Skip undefined properties
+     * - 'throw': Throw an error when undefined is encountered (default)
+     */
+    readonly undefined?: "ignore" | "throw"
+}

--- a/src/entity-manager/EntityManager.ts
+++ b/src/entity-manager/EntityManager.ts
@@ -871,7 +871,7 @@ export class EntityManager {
             return qb.execute()
         } else {
             const normalizedCriteria = OrmUtils.normalizeWhereCriteria(
-                criteria as ObjectLiteral,
+                criteria as ObjectLiteral | ObjectLiteral[],
                 this.dataSource.options.invalidWhereValuesBehavior,
             )
             const qb = this.createQueryBuilder()
@@ -952,7 +952,7 @@ export class EntityManager {
                 .execute()
         } else {
             const normalizedCriteria = OrmUtils.normalizeWhereCriteria(
-                criteria as ObjectLiteral,
+                criteria as ObjectLiteral | ObjectLiteral[],
                 this.dataSource.options.invalidWhereValuesBehavior,
             )
             return this.createQueryBuilder()
@@ -1018,7 +1018,7 @@ export class EntityManager {
                 .execute()
         } else {
             const normalizedCriteria = OrmUtils.normalizeWhereCriteria(
-                criteria as ObjectLiteral,
+                criteria as ObjectLiteral | ObjectLiteral[],
                 this.dataSource.options.invalidWhereValuesBehavior,
             )
             return this.createQueryBuilder()
@@ -1069,7 +1069,7 @@ export class EntityManager {
                 .execute()
         } else {
             const normalizedCriteria = OrmUtils.normalizeWhereCriteria(
-                criteria as ObjectLiteral,
+                criteria as ObjectLiteral | ObjectLiteral[],
                 this.dataSource.options.invalidWhereValuesBehavior,
             )
             return this.createQueryBuilder()

--- a/src/util/OrmUtils.ts
+++ b/src/util/OrmUtils.ts
@@ -4,10 +4,10 @@ import type {
     PrimitiveCriteria,
     SinglePrimitiveCriteria,
 } from "../common/PrimitiveCriteria"
-import { areUint8ArraysEqual, isUint8Array } from "./Uint8ArrayUtils"
-import { InstanceChecker } from "./InstanceChecker"
+import type { InvalidFindOptionsWhereBehavior } from "../driver/types/InvalidFindOptionsWhereBehavior"
 import { TypeORMError } from "../error"
 import { IsNull } from "../find-options/operator/IsNull"
+import { areUint8ArraysEqual, isUint8Array } from "./Uint8ArrayUtils"
 
 export class OrmUtils {
     // -------------------------------------------------------------------------
@@ -655,22 +655,30 @@ export class OrmUtils {
      *
      * @param criteria
      * @param options
-     * @param options.null
-     * @param options.undefined
      * @param path
      */
     static normalizeWhereCriteria(
-        criteria: ObjectLiteral,
-        options?: {
-            null?: "ignore" | "sql-null" | "throw"
-            undefined?: "ignore" | "throw"
-        },
+        criteria: ObjectLiteral | ObjectLiteral[],
+        options?: InvalidFindOptionsWhereBehavior,
         path?: string,
-    ): ObjectLiteral {
-        if (!options) return criteria
+    ): ObjectLiteral | ObjectLiteral[] {
+        if (!options) {
+            return criteria
+        }
+
+        // multiple criteria are possible at the top level
+        if (!path && Array.isArray(criteria)) {
+            return criteria.map(
+                (criterion, index): ObjectLiteral =>
+                    OrmUtils.normalizeWhereCriteria(
+                        criterion,
+                        options,
+                        String(index),
+                    ),
+            )
+        }
 
         const result: ObjectLiteral = {}
-
         for (const [key, value] of Object.entries(criteria)) {
             const propertyPath = path ? `${path}.${key}` : key
 
@@ -682,7 +690,7 @@ export class OrmUtils {
                             `Set 'invalidWhereValuesBehavior.undefined' to 'ignore' in connection options to skip properties with undefined values.`,
                     )
                 }
-                // "ignore" — skip this key
+                // else: "ignore" — skip this key
             } else if (value === null) {
                 const behavior = options?.null ?? "throw"
                 if (behavior === "throw") {
@@ -694,13 +702,8 @@ export class OrmUtils {
                 } else if (behavior === "sql-null") {
                     result[key] = IsNull()
                 }
-                // "ignore" — skip this key
-            } else if (
-                typeof value === "object" &&
-                !Array.isArray(value) &&
-                !(value instanceof Date) &&
-                !InstanceChecker.isFindOperator(value)
-            ) {
+                // else: "ignore" — skip this key
+            } else if (OrmUtils.isPlainObject(value)) {
                 const nested = OrmUtils.normalizeWhereCriteria(
                     value,
                     options,

--- a/test/functional/null-undefined-handling/entity/Category.ts
+++ b/test/functional/null-undefined-handling/entity/Category.ts
@@ -14,7 +14,7 @@ export class Category {
     @Column()
     name: string
 
-    @Column({ nullable: true, type: "varchar" })
+    @Column({ nullable: true, type: String })
     slug: string | null
 
     @OneToMany(() => Post, (post) => post.category)

--- a/test/functional/null-undefined-handling/entity/Post.ts
+++ b/test/functional/null-undefined-handling/entity/Post.ts
@@ -15,7 +15,7 @@ export class Post {
     @Column()
     title: string
 
-    @Column({ nullable: true, type: "varchar" })
+    @Column({ nullable: true, type: String })
     text: string | null
 
     @ManyToOne(() => Category, { nullable: true })

--- a/test/functional/null-undefined-handling/entity/StoredFile.ts
+++ b/test/functional/null-undefined-handling/entity/StoredFile.ts
@@ -1,0 +1,28 @@
+import {
+    Column,
+    Entity,
+    PrimaryColumn,
+    ValueTransformer,
+} from "../../../../src"
+
+const bigintTransformer: ValueTransformer = {
+    to: (value: bigint) => value,
+    from: (value: string) => BigInt(value),
+}
+
+@Entity()
+export class StoredFile {
+    // Buffer is created as a blob column by default, but we want a short binary
+    @PrimaryColumn("varbinary", { length: 16 })
+    guid: Buffer
+
+    @Column()
+    name: string
+
+    // the driver return strings for bigint values, so we need to transform them to bigint
+    @Column("bigint", { transformer: bigintTransformer })
+    size: bigint
+
+    @Column({ default: false })
+    public: boolean
+}

--- a/test/functional/null-undefined-handling/find-options.test.ts
+++ b/test/functional/null-undefined-handling/find-options.test.ts
@@ -1,5 +1,4 @@
-import "reflect-metadata"
-import "../../utils/test-setup"
+import { expect } from "chai"
 import type { DataSource } from "../../../src"
 import { TypeORMError } from "../../../src"
 import {
@@ -7,9 +6,8 @@ import {
     createTestingConnections,
     reloadTestingDatabases,
 } from "../../utils/test-utils"
-import { Post } from "./entity/Post"
 import { Category } from "./entity/Category"
-import { expect } from "chai"
+import { Post } from "./entity/Post"
 
 describe("find options > null and undefined handling", () => {
     let dataSources: DataSource[]

--- a/test/functional/null-undefined-handling/find-options.test.ts
+++ b/test/functional/null-undefined-handling/find-options.test.ts
@@ -705,6 +705,26 @@ describe("find options > null and undefined handling", () => {
                     expect(postWithRepo?.title).to.equal("Post #2")
                 }),
             ))
+
+        it("should handle array FindOptionsWhere values correctly", () =>
+            Promise.all(
+                dataSources.map(async (dataSource) => {
+                    await prepareData(dataSource)
+
+                    const posts = await dataSource.getRepository(Post).find({
+                        where: [
+                            { title: "Post #1" },
+                            { category: { name: "Category #1" } },
+                        ],
+                        order: { title: "ASC" },
+                    })
+
+                    expect(posts.map((post) => post.title)).to.deep.equal([
+                        "Post #1",
+                        "Post #2",
+                    ])
+                }),
+            ))
     })
 
     describe("with ignore behavior", () => {

--- a/test/functional/null-undefined-handling/parameter-types.test.ts
+++ b/test/functional/null-undefined-handling/parameter-types.test.ts
@@ -1,0 +1,100 @@
+import { expect } from "chai"
+import type { DataSource } from "../../../src"
+import {
+    closeTestingConnections,
+    createTestingConnections,
+} from "../../utils/test-utils"
+import { StoredFile } from "./entity/StoredFile"
+
+describe("find options > parameter types when invalidWhereValues is configured", () => {
+    let dataSources: DataSource[]
+
+    before(async () => {
+        dataSources = await createTestingConnections({
+            enabledDrivers: ["sap"],
+            entities: [StoredFile],
+            schemaCreate: true,
+            dropSchema: true,
+            driverSpecific: {
+                invalidWhereValuesBehavior: {
+                    null: "throw",
+                    undefined: "throw",
+                },
+            },
+        })
+
+        await Promise.all(
+            dataSources.map(async (dataSource) => {
+                const fileRepository = dataSource.getRepository(StoredFile)
+
+                const files = fileRepository.create([
+                    {
+                        guid: Buffer.from(
+                            "1234567890abcdef1234567890abcdef",
+                            "hex",
+                        ),
+                        name: "file1.txt",
+                        size: 9007199254740993n,
+                        public: true,
+                    },
+                    {
+                        guid: Buffer.from(
+                            "abcdef1234567890abcdef1234567890",
+                            "hex",
+                        ),
+                        name: "file2.txt",
+                        size: 9007199254740995n,
+                    },
+                ])
+
+                await fileRepository.save(files)
+            }),
+        )
+    })
+    after(() => closeTestingConnections(dataSources))
+
+    it("should correctly use Buffer values in find options", () =>
+        Promise.all(
+            dataSources.map(async (dataSource) => {
+                const fileRepository = dataSource.getRepository(StoredFile)
+
+                const fileFoundByBuffer = await fileRepository.findOneBy({
+                    guid: Buffer.from(
+                        "1234567890abcdef1234567890abcdef",
+                        "hex",
+                    ),
+                })
+                expect(fileFoundByBuffer).to.contain({
+                    name: "file1.txt",
+                })
+            }),
+        ))
+
+    it("should correctly use BigInt values in find options", () =>
+        Promise.all(
+            dataSources.map(async (dataSource) => {
+                const fileRepository = dataSource.getRepository(StoredFile)
+
+                const fileFoundByBigInt = await fileRepository.findOneBy({
+                    size: 9007199254740995n,
+                })
+                expect(fileFoundByBigInt).to.contain({
+                    name: "file2.txt",
+                })
+            }),
+        ))
+
+    it("should correctly use Boolean values in find options", () =>
+        Promise.all(
+            dataSources.map(async (dataSource) => {
+                const fileRepository = dataSource.getRepository(StoredFile)
+
+                const fileFoundByBoolean = await fileRepository.findOneBy({
+                    public: true,
+                })
+                expect(fileFoundByBoolean).to.contain({
+                    name: "file1.txt",
+                })
+            }),
+        ))
+})

--- a/test/functional/null-undefined-handling/query-builders.test.ts
+++ b/test/functional/null-undefined-handling/query-builders.test.ts
@@ -1,5 +1,4 @@
-import "reflect-metadata"
-import "../../utils/test-setup"
+import { expect } from "chai"
 import type { DataSource } from "../../../src"
 import { TypeORMError } from "../../../src"
 import {
@@ -7,9 +6,8 @@ import {
     createTestingConnections,
     reloadTestingDatabases,
 } from "../../utils/test-utils"
-import { Post } from "./entity/Post"
 import { Category } from "./entity/Category"
-import { expect } from "chai"
+import { Post } from "./entity/Post"
 
 describe("entity manager > invalidWhereValuesBehavior with throw", () => {
     let dataSources: DataSource[]


### PR DESCRIPTION
### Description of change

Fixes #12574.

When `invalidWhereBehavior` is configured, the following things are breaking:
- disjunctive `FindOptionsWhere` (array of `FindOptionsWhere`)
- using any `Buffer`/`bigint`/etc in `FindOptionsWhere` values

This PR fixes that by recursing `normalizeWhereValues` only when necessary.

### Pull-Request Checklist

- [x] Code is up-to-date with the `master` branch
- [x] This pull request links a relevant issue using a closing keyword:
      `Fixes #NNNN`, `Closes #NNNN`, or `Resolves #NNNN`
- [x] There are new or updated tests validating the change (`tests/**.test.ts`)
- [ ] Documentation has been updated to reflect this change (`docs/docs/**.md`)
