### PR TITLE
fix: preserve postgres columns when changing varchar length

### DIFF
--- a/src/driver/postgres/PostgresQueryRunner.ts
+++ b/src/driver/postgres/PostgresQueryRunner.ts
@@ -2348,9 +2348,9 @@ export class PostgresQueryRunner
                     new Query(
                         `ALTER TABLE ${this.escapePath(table)} ALTER COLUMN "${
                             newColumn.name
-                        }" TYPE ${newColumn.type} COLLATE "${
-                            newColumn.collation
-                        }"`,
+                        }" TYPE ${this.driver.createFullType(
+                            newColumn,
+                        )} COLLATE "${newColumn.collation}"`,
                     ),
                 )
 
@@ -2362,7 +2362,9 @@ export class PostgresQueryRunner
                     new Query(
                         `ALTER TABLE ${this.escapePath(table)} ALTER COLUMN "${
                             newColumn.name
-                        }" TYPE ${newColumn.type} COLLATE ${oldCollation}`,
+                        }" TYPE ${this.driver.createFullType(
+                            oldColumn,
+                        )} COLLATE ${oldCollation}`,
                     ),
                 )
             }

--- a/src/driver/postgres/PostgresQueryRunner.ts
+++ b/src/driver/postgres/PostgresQueryRunner.ts
@@ -1328,7 +1328,6 @@ export class PostgresQueryRunner
 
         if (
             oldColumn.type !== newColumn.type ||
-            oldColumn.length !== newColumn.length ||
             newColumn.isArray !== oldColumn.isArray ||
             (!oldColumn.generatedType &&
                 newColumn.generatedType === "STORED") ||
@@ -1620,7 +1619,8 @@ export class PostgresQueryRunner
 
             if (
                 newColumn.precision !== oldColumn.precision ||
-                newColumn.scale !== oldColumn.scale
+                newColumn.scale !== oldColumn.scale ||
+                newColumn.length !== oldColumn.length
             ) {
                 upQueries.push(
                     new Query(

--- a/src/driver/postgres/PostgresQueryRunner.ts
+++ b/src/driver/postgres/PostgresQueryRunner.ts
@@ -2344,13 +2344,17 @@ export class PostgresQueryRunner
 
             // update column collation
             if (newColumn.collation !== oldColumn.collation) {
+                const newCollation = newColumn.collation
+                    ? `"${newColumn.collation}"`
+                    : `pg_catalog."default"` // if there's no new collation, use default
+
                 upQueries.push(
                     new Query(
                         `ALTER TABLE ${this.escapePath(table)} ALTER COLUMN "${
                             newColumn.name
                         }" TYPE ${this.driver.createFullType(
                             newColumn,
-                        )} COLLATE "${newColumn.collation}"`,
+                        )} COLLATE ${newCollation}`,
                     ),
                 )
 

--- a/src/driver/postgres/PostgresQueryRunner.ts
+++ b/src/driver/postgres/PostgresQueryRunner.ts
@@ -1617,11 +1617,14 @@ export class PostgresQueryRunner
                 oldColumn.name = newColumn.name
             }
 
-            if (
+            const isTypeChanged =
                 newColumn.precision !== oldColumn.precision ||
                 newColumn.scale !== oldColumn.scale ||
                 newColumn.length !== oldColumn.length
-            ) {
+            const isCollationChanged =
+                newColumn.collation !== oldColumn.collation
+
+            if (isTypeChanged && !isCollationChanged) {
                 upQueries.push(
                     new Query(
                         `ALTER TABLE ${this.escapePath(table)} ALTER COLUMN "${
@@ -2343,7 +2346,7 @@ export class PostgresQueryRunner
             }
 
             // update column collation
-            if (newColumn.collation !== oldColumn.collation) {
+            if (isCollationChanged) {
                 const newCollation = newColumn.collation
                     ? `"${newColumn.collation}"`
                     : `pg_catalog."default"` // if there's no new collation, use default

--- a/src/driver/postgres/PostgresQueryRunner.ts
+++ b/src/driver/postgres/PostgresQueryRunner.ts
@@ -2468,11 +2468,15 @@ export class PostgresQueryRunner
                 }
             }
 
-            const newTableColumn = clonedTable.columns.find(
+            const newTableColumnIndex = clonedTable.columns.findIndex(
                 (column) => column.name === newColumn.name,
             )
-            clonedTable.columns[clonedTable.columns.indexOf(newTableColumn!)] =
-                newColumn.clone()
+            if (newTableColumnIndex === -1)
+                throw new TypeORMError(
+                    `Column "${newColumn.name}" was not found in the "${table.name}" table.`,
+                )
+
+            clonedTable.columns[newTableColumnIndex] = newColumn.clone()
         }
 
         await this.executeQueries(upQueries, downQueries)

--- a/src/driver/postgres/PostgresQueryRunner.ts
+++ b/src/driver/postgres/PostgresQueryRunner.ts
@@ -2467,6 +2467,12 @@ export class PostgresQueryRunner
                     // )
                 }
             }
+
+            const newTableColumn = clonedTable.columns.find(
+                (column) => column.name === newColumn.name,
+            )
+            clonedTable.columns[clonedTable.columns.indexOf(newTableColumn!)] =
+                newColumn.clone()
         }
 
         await this.executeQueries(upQueries, downQueries)

--- a/test/functional/schema-builder/collation/collation-changes/collation-changes.test.ts
+++ b/test/functional/schema-builder/collation/collation-changes/collation-changes.test.ts
@@ -36,47 +36,102 @@ describe("schema builder > collation > collation changes", () => {
                     (c) => c.propertyName === COLUMN_NAME,
                 )!
                 const OLD_COLLATION = col.collation
+
+                try {
+                    col.collation = NEW_COLLATION
+
+                    // capture generated up queries
+                    const sqlInMemory = await connection.driver
+                        .createSchemaBuilder()
+                        .log()
+                    const tableName = meta.tableName
+                    const expectedUp = `ALTER TABLE "${tableName}" ALTER COLUMN "${COLUMN_NAME}" TYPE character varying(100) COLLATE "${NEW_COLLATION}"`
+                    const expectedDown = `ALTER TABLE "${tableName}" ALTER COLUMN "${COLUMN_NAME}" TYPE character varying(100) COLLATE "${OLD_COLLATION}"`
+
+                    // assert that the expected queries are in the generated SQL
+                    const upJoined = sqlInMemory.upQueries
+                        .map((q) => q.query.replaceAll(/\s+/g, " ").trim())
+                        .join(" ")
+                    expect(upJoined).to.include(expectedUp)
+                    const downJoined = sqlInMemory.downQueries
+                        .map((q) => q.query.replaceAll(/\s+/g, " ").trim())
+                        .join(" ")
+                    expect(downJoined).to.include(expectedDown)
+
+                    // assert that collation changes are applied to the database
+                    const queryRunner = connection.createQueryRunner()
+
+                    try {
+                        let table = await queryRunner.getTable(meta.tableName)
+                        const originColumn = table!.columns.find(
+                            (c) => c.name === COLUMN_NAME,
+                        )!
+                        // old collation should be appeared
+                        expect(originColumn.collation).to.equal(OLD_COLLATION)
+
+                        await connection.synchronize()
+
+                        table = await queryRunner.getTable(meta.tableName)
+                        const appliedColumn = table!.columns.find(
+                            (c) => c.name === COLUMN_NAME,
+                        )!
+                        // new collation should be appeared
+                        expect(appliedColumn.collation).to.equal(NEW_COLLATION)
+                    } finally {
+                        await queryRunner.release()
+                    }
+                } finally {
+                    col.collation = OLD_COLLATION
+                }
+            }),
+        )
+    })
+
+    it("ALTER ... COLLATE query should preserve length changes", async () => {
+        await Promise.all(
+            dataSources.map(async (connection) => {
+                const meta = connection.getMetadata(Item)
+                const col = meta.columns.find(
+                    (c) => c.propertyName === COLUMN_NAME,
+                )!
+                const OLD_COLLATION = col.collation
+                col.length = "500"
                 col.collation = NEW_COLLATION
 
-                // capture generated up queries
                 const sqlInMemory = await connection.driver
                     .createSchemaBuilder()
                     .log()
                 const tableName = meta.tableName
-                const expectedUp = `ALTER TABLE "${tableName}" ALTER COLUMN "${COLUMN_NAME}" TYPE character varying COLLATE "${NEW_COLLATION}"`
-                const expectedDown = `ALTER TABLE "${tableName}" ALTER COLUMN "${COLUMN_NAME}" TYPE character varying COLLATE "${OLD_COLLATION}"`
+                const expectedUp = `ALTER TABLE "${tableName}" ALTER COLUMN "${COLUMN_NAME}" TYPE character varying(500) COLLATE "${NEW_COLLATION}"`
+                const expectedDown = `ALTER TABLE "${tableName}" ALTER COLUMN "${COLUMN_NAME}" TYPE character varying(100) COLLATE "${OLD_COLLATION}"`
+                const strippedLengthUp = `ALTER TABLE "${tableName}" ALTER COLUMN "${COLUMN_NAME}" TYPE character varying COLLATE "${NEW_COLLATION}"`
 
-                // assert that the expected queries are in the generated SQL
                 const upJoined = sqlInMemory.upQueries
                     .map((q) => q.query.replaceAll(/\s+/g, " ").trim())
                     .join(" ")
                 expect(upJoined).to.include(expectedUp)
+                expect(upJoined).to.not.include(strippedLengthUp)
+
                 const downJoined = sqlInMemory.downQueries
                     .map((q) => q.query.replaceAll(/\s+/g, " ").trim())
                     .join(" ")
                 expect(downJoined).to.include(expectedDown)
 
-                // assert that collation changes are applied to the database
                 const queryRunner = connection.createQueryRunner()
 
                 try {
-                    let table = await queryRunner.getTable(meta.tableName)
-                    const originColumn = table!.columns.find(
-                        (c) => c.name === COLUMN_NAME,
-                    )!
-                    // old collation should be appeared
-                    expect(originColumn.collation).to.equal(OLD_COLLATION)
-
                     await connection.synchronize()
 
-                    table = await queryRunner.getTable(meta.tableName)
+                    const table = await queryRunner.getTable(meta.tableName)
                     const appliedColumn = table!.columns.find(
                         (c) => c.name === COLUMN_NAME,
                     )!
-                    // new collation should be appeared
+                    expect(appliedColumn.length).to.equal("500")
                     expect(appliedColumn.collation).to.equal(NEW_COLLATION)
                 } finally {
                     await queryRunner.release()
+                    col.length = "100"
+                    col.collation = OLD_COLLATION
                 }
             }),
         )

--- a/test/functional/schema-builder/collation/collation-changes/collation-changes.test.ts
+++ b/test/functional/schema-builder/collation/collation-changes/collation-changes.test.ts
@@ -136,4 +136,51 @@ describe("schema builder > collation > collation changes", () => {
             }),
         )
     })
+
+    it("ALTER ... COLLATE query should use default when collation is removed", async () => {
+        await Promise.all(
+            dataSources.map(async (connection) => {
+                const meta = connection.getMetadata(Item)
+                const col = meta.columns.find(
+                    (c) => c.propertyName === COLUMN_NAME,
+                )!
+                const OLD_COLLATION = col.collation
+                col.collation = undefined
+
+                const sqlInMemory = await connection.driver
+                    .createSchemaBuilder()
+                    .log()
+                const tableName = meta.tableName
+                const expectedUp = `ALTER TABLE "${tableName}" ALTER COLUMN "${COLUMN_NAME}" TYPE character varying(100) COLLATE pg_catalog."default"`
+                const expectedDown = `ALTER TABLE "${tableName}" ALTER COLUMN "${COLUMN_NAME}" TYPE character varying(100) COLLATE "${OLD_COLLATION}"`
+                const undefinedCollationUp = `ALTER TABLE "${tableName}" ALTER COLUMN "${COLUMN_NAME}" TYPE character varying(100) COLLATE "undefined"`
+
+                const upJoined = sqlInMemory.upQueries
+                    .map((q) => q.query.replaceAll(/\s+/g, " ").trim())
+                    .join(" ")
+                expect(upJoined).to.include(expectedUp)
+                expect(upJoined).to.not.include(undefinedCollationUp)
+
+                const downJoined = sqlInMemory.downQueries
+                    .map((q) => q.query.replaceAll(/\s+/g, " ").trim())
+                    .join(" ")
+                expect(downJoined).to.include(expectedDown)
+
+                const queryRunner = connection.createQueryRunner()
+
+                try {
+                    await connection.synchronize()
+
+                    const table = await queryRunner.getTable(meta.tableName)
+                    const appliedColumn = table!.columns.find(
+                        (c) => c.name === COLUMN_NAME,
+                    )!
+                    expect(appliedColumn.collation).to.be.undefined
+                } finally {
+                    await queryRunner.release()
+                    col.collation = OLD_COLLATION
+                }
+            }),
+        )
+    })
 })

--- a/test/functional/schema-builder/collation/collation-changes/collation-changes.test.ts
+++ b/test/functional/schema-builder/collation/collation-changes/collation-changes.test.ts
@@ -114,11 +114,25 @@ describe("schema builder > collation > collation changes", () => {
                         .join(" ")
                     expect(upJoined).to.include(expectedUp)
                     expect(upJoined).to.not.include(strippedLengthUp)
+                    const columnTypeUpQueries = sqlInMemory.upQueries.filter(
+                        (q) =>
+                            q.query.includes(
+                                `ALTER COLUMN "${COLUMN_NAME}" TYPE`,
+                            ),
+                    )
+                    expect(columnTypeUpQueries).to.have.length(1)
 
                     const downJoined = sqlInMemory.downQueries
                         .map((q) => q.query.replaceAll(/\s+/g, " ").trim())
                         .join(" ")
                     expect(downJoined).to.include(expectedDown)
+                    const columnTypeDownQueries =
+                        sqlInMemory.downQueries.filter((q) =>
+                            q.query.includes(
+                                `ALTER COLUMN "${COLUMN_NAME}" TYPE`,
+                            ),
+                        )
+                    expect(columnTypeDownQueries).to.have.length(1)
 
                     const queryRunner = connection.createQueryRunner()
 

--- a/test/functional/schema-builder/collation/collation-changes/collation-changes.test.ts
+++ b/test/functional/schema-builder/collation/collation-changes/collation-changes.test.ts
@@ -94,43 +94,48 @@ describe("schema builder > collation > collation changes", () => {
                 const col = meta.columns.find(
                     (c) => c.propertyName === COLUMN_NAME,
                 )!
+                const OLD_LENGTH = col.length
                 const OLD_COLLATION = col.collation
-                col.length = "500"
-                col.collation = NEW_COLLATION
-
-                const sqlInMemory = await connection.driver
-                    .createSchemaBuilder()
-                    .log()
-                const tableName = meta.tableName
-                const expectedUp = `ALTER TABLE "${tableName}" ALTER COLUMN "${COLUMN_NAME}" TYPE character varying(500) COLLATE "${NEW_COLLATION}"`
-                const expectedDown = `ALTER TABLE "${tableName}" ALTER COLUMN "${COLUMN_NAME}" TYPE character varying(100) COLLATE "${OLD_COLLATION}"`
-                const strippedLengthUp = `ALTER TABLE "${tableName}" ALTER COLUMN "${COLUMN_NAME}" TYPE character varying COLLATE "${NEW_COLLATION}"`
-
-                const upJoined = sqlInMemory.upQueries
-                    .map((q) => q.query.replaceAll(/\s+/g, " ").trim())
-                    .join(" ")
-                expect(upJoined).to.include(expectedUp)
-                expect(upJoined).to.not.include(strippedLengthUp)
-
-                const downJoined = sqlInMemory.downQueries
-                    .map((q) => q.query.replaceAll(/\s+/g, " ").trim())
-                    .join(" ")
-                expect(downJoined).to.include(expectedDown)
-
-                const queryRunner = connection.createQueryRunner()
 
                 try {
-                    await connection.synchronize()
+                    col.length = "500"
+                    col.collation = NEW_COLLATION
 
-                    const table = await queryRunner.getTable(meta.tableName)
-                    const appliedColumn = table!.columns.find(
-                        (c) => c.name === COLUMN_NAME,
-                    )!
-                    expect(appliedColumn.length).to.equal("500")
-                    expect(appliedColumn.collation).to.equal(NEW_COLLATION)
+                    const sqlInMemory = await connection.driver
+                        .createSchemaBuilder()
+                        .log()
+                    const tableName = meta.tableName
+                    const expectedUp = `ALTER TABLE "${tableName}" ALTER COLUMN "${COLUMN_NAME}" TYPE character varying(500) COLLATE "${NEW_COLLATION}"`
+                    const expectedDown = `ALTER TABLE "${tableName}" ALTER COLUMN "${COLUMN_NAME}" TYPE character varying(100) COLLATE "${OLD_COLLATION}"`
+                    const strippedLengthUp = `ALTER TABLE "${tableName}" ALTER COLUMN "${COLUMN_NAME}" TYPE character varying COLLATE "${NEW_COLLATION}"`
+
+                    const upJoined = sqlInMemory.upQueries
+                        .map((q) => q.query.replaceAll(/\s+/g, " ").trim())
+                        .join(" ")
+                    expect(upJoined).to.include(expectedUp)
+                    expect(upJoined).to.not.include(strippedLengthUp)
+
+                    const downJoined = sqlInMemory.downQueries
+                        .map((q) => q.query.replaceAll(/\s+/g, " ").trim())
+                        .join(" ")
+                    expect(downJoined).to.include(expectedDown)
+
+                    const queryRunner = connection.createQueryRunner()
+
+                    try {
+                        await connection.synchronize()
+
+                        const table = await queryRunner.getTable(meta.tableName)
+                        const appliedColumn = table!.columns.find(
+                            (c) => c.name === COLUMN_NAME,
+                        )!
+                        expect(appliedColumn.length).to.equal("500")
+                        expect(appliedColumn.collation).to.equal(NEW_COLLATION)
+                    } finally {
+                        await queryRunner.release()
+                    }
                 } finally {
-                    await queryRunner.release()
-                    col.length = "100"
+                    col.length = OLD_LENGTH
                     col.collation = OLD_COLLATION
                 }
             }),
@@ -145,39 +150,43 @@ describe("schema builder > collation > collation changes", () => {
                     (c) => c.propertyName === COLUMN_NAME,
                 )!
                 const OLD_COLLATION = col.collation
-                col.collation = undefined
-
-                const sqlInMemory = await connection.driver
-                    .createSchemaBuilder()
-                    .log()
-                const tableName = meta.tableName
-                const expectedUp = `ALTER TABLE "${tableName}" ALTER COLUMN "${COLUMN_NAME}" TYPE character varying(100) COLLATE pg_catalog."default"`
-                const expectedDown = `ALTER TABLE "${tableName}" ALTER COLUMN "${COLUMN_NAME}" TYPE character varying(100) COLLATE "${OLD_COLLATION}"`
-                const undefinedCollationUp = `ALTER TABLE "${tableName}" ALTER COLUMN "${COLUMN_NAME}" TYPE character varying(100) COLLATE "undefined"`
-
-                const upJoined = sqlInMemory.upQueries
-                    .map((q) => q.query.replaceAll(/\s+/g, " ").trim())
-                    .join(" ")
-                expect(upJoined).to.include(expectedUp)
-                expect(upJoined).to.not.include(undefinedCollationUp)
-
-                const downJoined = sqlInMemory.downQueries
-                    .map((q) => q.query.replaceAll(/\s+/g, " ").trim())
-                    .join(" ")
-                expect(downJoined).to.include(expectedDown)
-
-                const queryRunner = connection.createQueryRunner()
 
                 try {
-                    await connection.synchronize()
+                    col.collation = undefined
 
-                    const table = await queryRunner.getTable(meta.tableName)
-                    const appliedColumn = table!.columns.find(
-                        (c) => c.name === COLUMN_NAME,
-                    )!
-                    expect(appliedColumn.collation).to.be.undefined
+                    const sqlInMemory = await connection.driver
+                        .createSchemaBuilder()
+                        .log()
+                    const tableName = meta.tableName
+                    const expectedUp = `ALTER TABLE "${tableName}" ALTER COLUMN "${COLUMN_NAME}" TYPE character varying(100) COLLATE pg_catalog."default"`
+                    const expectedDown = `ALTER TABLE "${tableName}" ALTER COLUMN "${COLUMN_NAME}" TYPE character varying(100) COLLATE "${OLD_COLLATION}"`
+                    const undefinedCollationUp = `ALTER TABLE "${tableName}" ALTER COLUMN "${COLUMN_NAME}" TYPE character varying(100) COLLATE "undefined"`
+
+                    const upJoined = sqlInMemory.upQueries
+                        .map((q) => q.query.replaceAll(/\s+/g, " ").trim())
+                        .join(" ")
+                    expect(upJoined).to.include(expectedUp)
+                    expect(upJoined).to.not.include(undefinedCollationUp)
+
+                    const downJoined = sqlInMemory.downQueries
+                        .map((q) => q.query.replaceAll(/\s+/g, " ").trim())
+                        .join(" ")
+                    expect(downJoined).to.include(expectedDown)
+
+                    const queryRunner = connection.createQueryRunner()
+
+                    try {
+                        await connection.synchronize()
+
+                        const table = await queryRunner.getTable(meta.tableName)
+                        const appliedColumn = table!.columns.find(
+                            (c) => c.name === COLUMN_NAME,
+                        )!
+                        expect(appliedColumn.collation).to.be.undefined
+                    } finally {
+                        await queryRunner.release()
+                    }
                 } finally {
-                    await queryRunner.release()
                     col.collation = OLD_COLLATION
                 }
             }),

--- a/test/functional/schema-builder/column/change/change-column/change-column.test.ts
+++ b/test/functional/schema-builder/column/change/change-column/change-column.test.ts
@@ -112,6 +112,44 @@ describe("schema builder > change column", () => {
             }),
         ))
 
+    it("should update cached column length after changing column length", () =>
+        Promise.all(
+            dataSources.map(async (dataSource) => {
+                if (dataSource.driver.options.type !== "postgres") return
+
+                const queryRunner = dataSource.createQueryRunner()
+
+                try {
+                    const table = await queryRunner.getTable("post")
+                    const oldColumn = table!.findColumnByName("name")!
+                    const newColumn = oldColumn.clone()
+                    newColumn.length = "500"
+
+                    queryRunner.enableSqlMemory()
+
+                    await queryRunner.changeColumn(
+                        "post",
+                        oldColumn.name,
+                        newColumn,
+                    )
+                    queryRunner.clearSqlMemory()
+
+                    await queryRunner.changeColumn(
+                        "post",
+                        oldColumn.name,
+                        newColumn.clone(),
+                    )
+
+                    const sqlInMemory = queryRunner.getMemorySql()
+                    expect(sqlInMemory.upQueries).to.be.empty
+                    expect(sqlInMemory.downQueries).to.be.empty
+                } finally {
+                    queryRunner.disableSqlMemory()
+                    await queryRunner.release()
+                }
+            }),
+        ))
+
     it("should correctly change column type", () =>
         Promise.all(
             dataSources.map(async (dataSource) => {

--- a/test/functional/schema-builder/column/change/change-column/change-column.test.ts
+++ b/test/functional/schema-builder/column/change/change-column/change-column.test.ts
@@ -58,6 +58,30 @@ describe("schema builder > change column", () => {
                 nameColumn.length = "500"
                 textColumn.length = "300"
 
+                if (dataSource.driver.options.type === "postgres") {
+                    const sqlInMemory = await dataSource.driver
+                        .createSchemaBuilder()
+                        .log()
+                    const upQueries = sqlInMemory.upQueries.map(
+                        (query) => query.query,
+                    )
+                    const downQueries = sqlInMemory.downQueries.map(
+                        (query) => query.query,
+                    )
+
+                    expect(
+                        upQueries.some((query) =>
+                            query.includes("DROP COLUMN"),
+                        ),
+                    ).to.be.false
+                    expect(upQueries).to.include(
+                        'ALTER TABLE "post" ALTER COLUMN "name" TYPE character varying(500)',
+                    )
+                    expect(downQueries).to.include(
+                        'ALTER TABLE "post" ALTER COLUMN "name" TYPE character varying',
+                    )
+                }
+
                 await dataSource.synchronize()
 
                 const queryRunner = dataSource.createQueryRunner()

--- a/test/functional/schema-builder/column/change/change-column/change-column.test.ts
+++ b/test/functional/schema-builder/column/change/change-column/change-column.test.ts
@@ -150,6 +150,45 @@ describe("schema builder > change column", () => {
             }),
         ))
 
+    it("should throw when changed postgres column is absent from cached table", () =>
+        Promise.all(
+            dataSources.map(async (dataSource) => {
+                if (dataSource.driver.options.type !== "postgres") return
+
+                const queryRunner = dataSource.createQueryRunner()
+
+                try {
+                    const table = await queryRunner.getTable("post")
+                    const oldColumn = table!.findColumnByName("name")!.clone()
+                    oldColumn.name = "missing_name"
+
+                    const newColumn = oldColumn.clone()
+                    newColumn.length = "500"
+
+                    queryRunner.enableSqlMemory()
+
+                    let thrownError: Error | undefined
+                    try {
+                        await queryRunner.changeColumn(
+                            "post",
+                            oldColumn,
+                            newColumn,
+                        )
+                    } catch (error) {
+                        thrownError = error as Error
+                    }
+
+                    expect(thrownError).to.be.instanceOf(Error)
+                    expect(thrownError!.message).to.contain(
+                        `Column "missing_name" was not found in the "post" table.`,
+                    )
+                } finally {
+                    queryRunner.disableSqlMemory()
+                    await queryRunner.release()
+                }
+            }),
+        ))
+
     it("should correctly change column type", () =>
         Promise.all(
             dataSources.map(async (dataSource) => {


### PR DESCRIPTION
### Description of change

Postgres column length-only changes now use `ALTER TABLE ... ALTER COLUMN ... TYPE ...` instead of dropping and recreating the column.

Previously, `PostgresQueryRunner.changeColumn()` treated `oldColumn.length !== newColumn.length` as a destructive recreate condition. That generated `DROP COLUMN` / `ADD COLUMN` for simple varchar length updates, which can lose data.

This patch keeps destructive recreation for real type, array, and stored generated-column changes, while routing length-only changes through the existing type-alter query generation path.

Fixes #3357.

### Verification

- `corepack pnpm exec prettier --check src/driver/postgres/PostgresQueryRunner.ts test/functional/schema-builder/column/change/change-column/change-column.test.ts`
- `corepack pnpm run typecheck`
- `corepack pnpm run compile`
- `corepack pnpm exec mocha --no-config --file build/compiled/test/utils/test-setup.js build/compiled/test/functional/schema-builder/column/change/change-column/change-column.test.js --grep "should correctly change column length" --timeout 90000 --exit`

### Pull-Request Checklist

- [x] Code is up-to-date with the `master` branch
- [x] This pull request links a relevant issue using a closing keyword: `Fixes #3357`
- [x] There are new or updated tests validating the change (`tests/**.test.ts`)
- [x] Documentation has been updated to reflect this change (`docs/docs/**.md`) N/A - migration generation bug fix covered by regression test
