### PR TITLE
fix(postgres): use ALTER COLUMN TYPE for length-only changes to prevent data loss

### DIFF
--- a/src/driver/postgres/PostgresQueryRunner.ts
+++ b/src/driver/postgres/PostgresQueryRunner.ts
@@ -1326,20 +1326,39 @@ export class PostgresQueryRunner
                 `Column "${oldTableColumnOrName}" was not found in the "${table.name}" table.`,
             )
 
-        if (
-            oldColumn.type !== newColumn.type ||
-            oldColumn.length !== newColumn.length ||
-            newColumn.isArray !== oldColumn.isArray ||
-            (!oldColumn.generatedType &&
-                newColumn.generatedType === "STORED") ||
-            (oldColumn.asExpression !== newColumn.asExpression &&
-                newColumn.generatedType === "STORED")
-        ) {
-            // To avoid data conversion, we just recreate column
+        // Check if only length changed on a string type — safe to ALTER without data loss
+        const onlyLengthChanged =
+            oldColumn.type === newColumn.type &&
+            oldColumn.length !== newColumn.length &&
+            newColumn.isArray === oldColumn.isArray &&
+            !(!oldColumn.generatedType && newColumn.generatedType === "STORED") &&
+            !(oldColumn.asExpression !== newColumn.asExpression && newColumn.generatedType === "STORED")
+
+        const needsRecreate =
+            !onlyLengthChanged && (
+                oldColumn.type !== newColumn.type ||
+                oldColumn.length !== newColumn.length ||
+                newColumn.isArray !== oldColumn.isArray ||
+                (!oldColumn.generatedType &&
+                    newColumn.generatedType === "STORED") ||
+                (oldColumn.asExpression !== newColumn.asExpression &&
+                    newColumn.generatedType === "STORED")
+            )
+
+        if (needsRecreate) {
             await this.dropColumn(table, oldColumn)
             await this.addColumn(table, newColumn)
-
-            // update cloned table
+            clonedTable = table.clone()
+        } else if (onlyLengthChanged) {
+            // Use ALTER COLUMN TYPE to change length — preserves existing data
+            const newType = newColumn.length ? `${newColumn.type}(${newColumn.length})` : newColumn.type
+            const oldType = oldColumn.length ? `${oldColumn.type}(${oldColumn.length})` : oldColumn.type
+            upQueries.push(new Query(
+                `ALTER TABLE ${this.escapePath(table)} ALTER COLUMN "${oldColumn.name}" TYPE ${newType}`
+            ))
+            downQueries.push(new Query(
+                `ALTER TABLE ${this.escapePath(table)} ALTER COLUMN "${oldColumn.name}" TYPE ${oldType}`
+            ))
             clonedTable = table.clone()
         } else {
             if (oldColumn.name !== newColumn.name) {


### PR DESCRIPTION
## Problem

Fixes #3357

When a PostgreSQL column's **length** changes (e.g.  → ), TypeORM generates:

```sql
ALTER TABLE "example" DROP COLUMN "col"
ALTER TABLE "example" ADD "col" character varying(100)
```

This **destroys all existing data** in that column.

## Root Cause

 lumped  changes together with actual type changes in the recreate condition (lines 1330-1340). A length-only change on  does not require column recreation — PostgreSQL supports it natively with .

## Fix

Detect length-only changes (same type, same array flag, no generated column change) and use safe :

```sql
ALTER TABLE "example" ALTER COLUMN "col" TYPE character varying(100)
```

This preserves all existing data.

## Testing



## Checklist
- [x] Bug fix (non-breaking change)
- [x] Existing tests pass
- [x] Addresses data loss issue reported in #3357