### PR TITLE
feat: add sqlite option to preserve foreign keys during migrations

### DIFF
--- a/docs/docs/drivers/sqlite.md
+++ b/docs/docs/drivers/sqlite.md
@@ -22,7 +22,7 @@ See [Data Source Options](../data-source/2-data-source-options.md) for the commo
 
 ### Common sqlite data source options
 
-- `preserveForeignKeysDuringMigrations` - Keeps SQLite foreign-key checks enabled during migrations (default `false`).
+- `preserveForeignKeysDuringMigrations` - Keeps SQLite foreign-key checks enabled during migrations and schema synchronization (default `false`).
 
 ### `better-sqlite3` data source options
 

--- a/docs/docs/drivers/sqlite.md
+++ b/docs/docs/drivers/sqlite.md
@@ -20,6 +20,10 @@ npm install sql.js
 
 See [Data Source Options](../data-source/2-data-source-options.md) for the common data source options.
 
+### Common sqlite data source options
+
+- `preserveForeignKeysDuringMigrations` - Keeps SQLite foreign-key checks enabled during migrations (default `false`).
+
 ### `better-sqlite3` data source options
 
 - `database` - Database path. For example, `"mydb.sqlite"`.

--- a/src/driver/better-sqlite3/BetterSqlite3DataSourceOptions.ts
+++ b/src/driver/better-sqlite3/BetterSqlite3DataSourceOptions.ts
@@ -1,4 +1,4 @@
-import type { AbstractSqliteDataSourceOptions } from "../sqlite-abstract/AbstractSqliteDataSourceOptions";
+import type { AbstractSqliteDataSourceOptions } from "../sqlite-abstract/AbstractSqliteDataSourceOptions"
 
 /**
  * Sqlite-specific connection options.

--- a/src/driver/better-sqlite3/BetterSqlite3DataSourceOptions.ts
+++ b/src/driver/better-sqlite3/BetterSqlite3DataSourceOptions.ts
@@ -1,4 +1,4 @@
-import {AbstractSqliteDataSourceOptions} from "../sqlite-abstract/AbstractSqliteDataSourceOptions";
+import type { AbstractSqliteDataSourceOptions } from "../sqlite-abstract/AbstractSqliteDataSourceOptions";
 
 /**
  * Sqlite-specific connection options.

--- a/src/driver/better-sqlite3/BetterSqlite3DataSourceOptions.ts
+++ b/src/driver/better-sqlite3/BetterSqlite3DataSourceOptions.ts
@@ -1,9 +1,9 @@
-import type { BaseDataSourceOptions } from "../../data-source/BaseDataSourceOptions"
+import {AbstractSqliteDataSourceOptions} from "../sqlite-abstract/AbstractSqliteDataSourceOptions";
 
 /**
  * Sqlite-specific connection options.
  */
-export interface BetterSqlite3DataSourceOptions extends BaseDataSourceOptions {
+export interface BetterSqlite3DataSourceOptions extends AbstractSqliteDataSourceOptions {
     /**
      * Database type.
      */

--- a/src/driver/better-sqlite3/BetterSqlite3QueryRunner.ts
+++ b/src/driver/better-sqlite3/BetterSqlite3QueryRunner.ts
@@ -64,16 +64,20 @@ export class BetterSqlite3QueryRunner extends AbstractSqliteQueryRunner {
      * Called before migrations are run.
      */
     async beforeMigration(): Promise<void> {
-        const databaseConnection = await this.connect()
-        databaseConnection.pragma("foreign_keys = OFF")
+        if (!this.driver.options.preserveForeignKeysDuringMigrations) {
+            const databaseConnection = await this.connect()
+            databaseConnection.pragma("foreign_keys = OFF")
+        }
     }
 
     /**
      * Called after migrations are run.
      */
     async afterMigration(): Promise<void> {
-        const databaseConnection = await this.connect()
-        databaseConnection.pragma("foreign_keys = ON")
+        if (!this.driver.options.preserveForeignKeysDuringMigrations) {
+            const databaseConnection = await this.connect()
+            databaseConnection.pragma("foreign_keys = ON")
+        }
     }
 
     /**

--- a/src/driver/better-sqlite3/BetterSqlite3QueryRunner.ts
+++ b/src/driver/better-sqlite3/BetterSqlite3QueryRunner.ts
@@ -74,10 +74,8 @@ export class BetterSqlite3QueryRunner extends AbstractSqliteQueryRunner {
      * Called after migrations are run.
      */
     async afterMigration(): Promise<void> {
-        if (!this.driver.options.preserveForeignKeysDuringMigrations) {
-            const databaseConnection = await this.connect()
-            databaseConnection.pragma("foreign_keys = ON")
-        }
+        const databaseConnection = await this.connect()
+        databaseConnection.pragma("foreign_keys = ON")
     }
 
     /**

--- a/src/driver/capacitor/CapacitorDataSourceOptions.ts
+++ b/src/driver/capacitor/CapacitorDataSourceOptions.ts
@@ -1,4 +1,4 @@
-import type { AbstractSqliteDataSourceOptions } from "../sqlite-abstract/AbstractSqliteDataSourceOptions";
+import type { AbstractSqliteDataSourceOptions } from "../sqlite-abstract/AbstractSqliteDataSourceOptions"
 
 /**
  * Sqlite-specific connection options.

--- a/src/driver/capacitor/CapacitorDataSourceOptions.ts
+++ b/src/driver/capacitor/CapacitorDataSourceOptions.ts
@@ -1,4 +1,4 @@
-import {AbstractSqliteDataSourceOptions} from "../sqlite-abstract/AbstractSqliteDataSourceOptions";
+import type { AbstractSqliteDataSourceOptions } from "../sqlite-abstract/AbstractSqliteDataSourceOptions";
 
 /**
  * Sqlite-specific connection options.

--- a/src/driver/capacitor/CapacitorDataSourceOptions.ts
+++ b/src/driver/capacitor/CapacitorDataSourceOptions.ts
@@ -1,9 +1,9 @@
-import type { BaseDataSourceOptions } from "../../data-source/BaseDataSourceOptions"
+import {AbstractSqliteDataSourceOptions} from "../sqlite-abstract/AbstractSqliteDataSourceOptions";
 
 /**
  * Sqlite-specific connection options.
  */
-export interface CapacitorDataSourceOptions extends BaseDataSourceOptions {
+export interface CapacitorDataSourceOptions extends AbstractSqliteDataSourceOptions {
     /**
      * Database type.
      */

--- a/src/driver/capacitor/CapacitorQueryRunner.ts
+++ b/src/driver/capacitor/CapacitorQueryRunner.ts
@@ -40,9 +40,7 @@ export class CapacitorQueryRunner extends AbstractSqliteQueryRunner {
      * Called after migrations are run.
      */
     async afterMigration(): Promise<void> {
-        if (!this.driver.options.preserveForeignKeysDuringMigrations) {
-            await this.query(`PRAGMA foreign_keys = ON`)
-        }
+        await this.query(`PRAGMA foreign_keys = ON`)
     }
 
     async executeSet(set: { statement: string; values?: any[] }[]) {

--- a/src/driver/capacitor/CapacitorQueryRunner.ts
+++ b/src/driver/capacitor/CapacitorQueryRunner.ts
@@ -31,14 +31,18 @@ export class CapacitorQueryRunner extends AbstractSqliteQueryRunner {
      * Called before migrations are run.
      */
     async beforeMigration(): Promise<void> {
-        await this.query(`PRAGMA foreign_keys = OFF`)
+        if (!this.driver.options.preserveForeignKeysDuringMigrations) {
+            await this.query(`PRAGMA foreign_keys = OFF`)
+        }
     }
 
     /**
      * Called after migrations are run.
      */
     async afterMigration(): Promise<void> {
-        await this.query(`PRAGMA foreign_keys = ON`)
+        if (!this.driver.options.preserveForeignKeysDuringMigrations) {
+            await this.query(`PRAGMA foreign_keys = ON`)
+        }
     }
 
     async executeSet(set: { statement: string; values?: any[] }[]) {

--- a/src/driver/cordova/CordovaDataSourceOptions.ts
+++ b/src/driver/cordova/CordovaDataSourceOptions.ts
@@ -1,4 +1,4 @@
-import type { AbstractSqliteDataSourceOptions } from "../sqlite-abstract/AbstractSqliteDataSourceOptions";
+import type { AbstractSqliteDataSourceOptions } from "../sqlite-abstract/AbstractSqliteDataSourceOptions"
 
 /**
  * Sqlite-specific connection options.

--- a/src/driver/cordova/CordovaDataSourceOptions.ts
+++ b/src/driver/cordova/CordovaDataSourceOptions.ts
@@ -1,9 +1,9 @@
-import type { BaseDataSourceOptions } from "../../data-source/BaseDataSourceOptions"
+import type { AbstractSqliteDataSourceOptions } from "../sqlite-abstract/AbstractSqliteDataSourceOptions";
 
 /**
  * Sqlite-specific connection options.
  */
-export interface CordovaDataSourceOptions extends BaseDataSourceOptions {
+export interface CordovaDataSourceOptions extends AbstractSqliteDataSourceOptions {
     /**
      * Database type.
      */

--- a/src/driver/cordova/CordovaQueryRunner.ts
+++ b/src/driver/cordova/CordovaQueryRunner.ts
@@ -41,9 +41,7 @@ export class CordovaQueryRunner extends AbstractSqliteQueryRunner {
      * Called after migrations are run.
      */
     async afterMigration(): Promise<void> {
-        if (!this.driver.options.preserveForeignKeysDuringMigrations) {
-            await this.query(`PRAGMA foreign_keys = ON`)
-        }
+        await this.query(`PRAGMA foreign_keys = ON`)
     }
 
     /**

--- a/src/driver/cordova/CordovaQueryRunner.ts
+++ b/src/driver/cordova/CordovaQueryRunner.ts
@@ -32,14 +32,18 @@ export class CordovaQueryRunner extends AbstractSqliteQueryRunner {
      * Called before migrations are run.
      */
     async beforeMigration(): Promise<void> {
-        await this.query(`PRAGMA foreign_keys = OFF`)
+        if (!this.driver.options.preserveForeignKeysDuringMigrations) {
+            await this.query(`PRAGMA foreign_keys = OFF`)
+        }
     }
 
     /**
      * Called after migrations are run.
      */
     async afterMigration(): Promise<void> {
-        await this.query(`PRAGMA foreign_keys = ON`)
+        if (!this.driver.options.preserveForeignKeysDuringMigrations) {
+            await this.query(`PRAGMA foreign_keys = ON`)
+        }
     }
 
     /**

--- a/src/driver/expo/ExpoDataSourceOptions.ts
+++ b/src/driver/expo/ExpoDataSourceOptions.ts
@@ -1,4 +1,4 @@
-import {AbstractSqliteDataSourceOptions} from "../sqlite-abstract/AbstractSqliteDataSourceOptions";
+import type { AbstractSqliteDataSourceOptions } from "../sqlite-abstract/AbstractSqliteDataSourceOptions";
 
 /**
  * Expo SQLite-specific connection options.

--- a/src/driver/expo/ExpoDataSourceOptions.ts
+++ b/src/driver/expo/ExpoDataSourceOptions.ts
@@ -1,4 +1,4 @@
-import type { AbstractSqliteDataSourceOptions } from "../sqlite-abstract/AbstractSqliteDataSourceOptions";
+import type { AbstractSqliteDataSourceOptions } from "../sqlite-abstract/AbstractSqliteDataSourceOptions"
 
 /**
  * Expo SQLite-specific connection options.

--- a/src/driver/expo/ExpoDataSourceOptions.ts
+++ b/src/driver/expo/ExpoDataSourceOptions.ts
@@ -1,9 +1,9 @@
-import type { BaseDataSourceOptions } from "../../data-source/BaseDataSourceOptions"
+import {AbstractSqliteDataSourceOptions} from "../sqlite-abstract/AbstractSqliteDataSourceOptions";
 
 /**
  * Expo SQLite-specific connection options.
  */
-export interface ExpoDataSourceOptions extends BaseDataSourceOptions {
+export interface ExpoDataSourceOptions extends AbstractSqliteDataSourceOptions {
     /**
      * Database type.
      */

--- a/src/driver/expo/ExpoQueryRunner.ts
+++ b/src/driver/expo/ExpoQueryRunner.ts
@@ -25,9 +25,7 @@ export class ExpoQueryRunner extends AbstractSqliteQueryRunner {
     }
 
     async afterMigration(): Promise<void> {
-        if (!this.driver.options.preserveForeignKeysDuringMigrations) {
-            await this.query("PRAGMA foreign_keys = ON")
-        }
+        await this.query("PRAGMA foreign_keys = ON")
     }
 
     async query(

--- a/src/driver/expo/ExpoQueryRunner.ts
+++ b/src/driver/expo/ExpoQueryRunner.ts
@@ -19,11 +19,15 @@ export class ExpoQueryRunner extends AbstractSqliteQueryRunner {
     }
 
     async beforeMigration(): Promise<void> {
-        await this.query("PRAGMA foreign_keys = OFF")
+        if (!this.driver.options.preserveForeignKeysDuringMigrations) {
+            await this.query("PRAGMA foreign_keys = OFF")
+        }
     }
 
     async afterMigration(): Promise<void> {
-        await this.query("PRAGMA foreign_keys = ON")
+        if (!this.driver.options.preserveForeignKeysDuringMigrations) {
+            await this.query("PRAGMA foreign_keys = ON")
+        }
     }
 
     async query(

--- a/src/driver/nativescript/NativescriptDataSourceOptions.ts
+++ b/src/driver/nativescript/NativescriptDataSourceOptions.ts
@@ -1,9 +1,9 @@
-import type { BaseDataSourceOptions } from "../../data-source/BaseDataSourceOptions"
+import {AbstractSqliteDataSourceOptions} from "../sqlite-abstract/AbstractSqliteDataSourceOptions";
 
 /**
  * NativeScript-specific connection options.
  */
-export interface NativescriptDataSourceOptions extends BaseDataSourceOptions {
+export interface NativescriptDataSourceOptions extends AbstractSqliteDataSourceOptions {
     /**
      * Database type.
      */

--- a/src/driver/nativescript/NativescriptDataSourceOptions.ts
+++ b/src/driver/nativescript/NativescriptDataSourceOptions.ts
@@ -1,4 +1,4 @@
-import {AbstractSqliteDataSourceOptions} from "../sqlite-abstract/AbstractSqliteDataSourceOptions";
+import type { AbstractSqliteDataSourceOptions } from "../sqlite-abstract/AbstractSqliteDataSourceOptions";
 
 /**
  * NativeScript-specific connection options.

--- a/src/driver/nativescript/NativescriptDataSourceOptions.ts
+++ b/src/driver/nativescript/NativescriptDataSourceOptions.ts
@@ -1,4 +1,4 @@
-import type { AbstractSqliteDataSourceOptions } from "../sqlite-abstract/AbstractSqliteDataSourceOptions";
+import type { AbstractSqliteDataSourceOptions } from "../sqlite-abstract/AbstractSqliteDataSourceOptions"
 
 /**
  * NativeScript-specific connection options.

--- a/src/driver/nativescript/NativescriptQueryRunner.ts
+++ b/src/driver/nativescript/NativescriptQueryRunner.ts
@@ -31,14 +31,18 @@ export class NativescriptQueryRunner extends AbstractSqliteQueryRunner {
      * Called before migrations are run.
      */
     async beforeMigration(): Promise<void> {
-        await this.query(`PRAGMA foreign_keys = OFF`)
+        if (!this.driver.options.preserveForeignKeysDuringMigrations) {
+            await this.query(`PRAGMA foreign_keys = OFF`)
+        }
     }
 
     /**
      * Called after migrations are run.
      */
     async afterMigration(): Promise<void> {
-        await this.query(`PRAGMA foreign_keys = ON`)
+        if (!this.driver.options.preserveForeignKeysDuringMigrations) {
+            await this.query(`PRAGMA foreign_keys = ON`)
+        }
     }
 
     /**

--- a/src/driver/nativescript/NativescriptQueryRunner.ts
+++ b/src/driver/nativescript/NativescriptQueryRunner.ts
@@ -40,9 +40,7 @@ export class NativescriptQueryRunner extends AbstractSqliteQueryRunner {
      * Called after migrations are run.
      */
     async afterMigration(): Promise<void> {
-        if (!this.driver.options.preserveForeignKeysDuringMigrations) {
-            await this.query(`PRAGMA foreign_keys = ON`)
-        }
+        await this.query(`PRAGMA foreign_keys = ON`)
     }
 
     /**

--- a/src/driver/react-native/ReactNativeDataSourceOptions.ts
+++ b/src/driver/react-native/ReactNativeDataSourceOptions.ts
@@ -1,4 +1,4 @@
-import type { AbstractSqliteDataSourceOptions } from "../sqlite-abstract/AbstractSqliteDataSourceOptions";
+import type { AbstractSqliteDataSourceOptions } from "../sqlite-abstract/AbstractSqliteDataSourceOptions"
 
 /**
  * Sqlite-specific connection options.

--- a/src/driver/react-native/ReactNativeDataSourceOptions.ts
+++ b/src/driver/react-native/ReactNativeDataSourceOptions.ts
@@ -1,4 +1,4 @@
-import {AbstractSqliteDataSourceOptions} from "../sqlite-abstract/AbstractSqliteDataSourceOptions";
+import type { AbstractSqliteDataSourceOptions } from "../sqlite-abstract/AbstractSqliteDataSourceOptions";
 
 /**
  * Sqlite-specific connection options.

--- a/src/driver/react-native/ReactNativeDataSourceOptions.ts
+++ b/src/driver/react-native/ReactNativeDataSourceOptions.ts
@@ -1,9 +1,9 @@
-import type { BaseDataSourceOptions } from "../../data-source/BaseDataSourceOptions"
+import {AbstractSqliteDataSourceOptions} from "../sqlite-abstract/AbstractSqliteDataSourceOptions";
 
 /**
  * Sqlite-specific connection options.
  */
-export interface ReactNativeDataSourceOptions extends BaseDataSourceOptions {
+export interface ReactNativeDataSourceOptions extends AbstractSqliteDataSourceOptions {
     /**
      * Database type.
      */
@@ -26,6 +26,7 @@ export interface ReactNativeDataSourceOptions extends BaseDataSourceOptions {
     readonly location: string
 
     readonly poolSize?: never
+
     /**
      * Encryption key for encryption supported databases
      */

--- a/src/driver/react-native/ReactNativeQueryRunner.ts
+++ b/src/driver/react-native/ReactNativeQueryRunner.ts
@@ -42,9 +42,7 @@ export class ReactNativeQueryRunner extends AbstractSqliteQueryRunner {
      * Called after migrations are run.
      */
     async afterMigration(): Promise<void> {
-        if (!this.driver.options.preserveForeignKeysDuringMigrations) {
-            await this.query(`PRAGMA foreign_keys = ON`)
-        }
+        await this.query(`PRAGMA foreign_keys = ON`)
     }
 
     /**

--- a/src/driver/react-native/ReactNativeQueryRunner.ts
+++ b/src/driver/react-native/ReactNativeQueryRunner.ts
@@ -33,14 +33,18 @@ export class ReactNativeQueryRunner extends AbstractSqliteQueryRunner {
      * Called before migrations are run.
      */
     async beforeMigration(): Promise<void> {
-        await this.query(`PRAGMA foreign_keys = OFF`)
+        if (!this.driver.options.preserveForeignKeysDuringMigrations) {
+            await this.query(`PRAGMA foreign_keys = OFF`)
+        }
     }
 
     /**
      * Called after migrations are run.
      */
     async afterMigration(): Promise<void> {
-        await this.query(`PRAGMA foreign_keys = ON`)
+        if (!this.driver.options.preserveForeignKeysDuringMigrations) {
+            await this.query(`PRAGMA foreign_keys = ON`)
+        }
     }
 
     /**

--- a/src/driver/sqlite-abstract/AbstractSqliteDataSourceOptions.ts
+++ b/src/driver/sqlite-abstract/AbstractSqliteDataSourceOptions.ts
@@ -1,4 +1,4 @@
-import type { BaseDataSourceOptions } from "../../data-source/BaseDataSourceOptions";
+import type { BaseDataSourceOptions } from "../../data-source/BaseDataSourceOptions"
 
 /**
  * Sqlite-specific connection options.

--- a/src/driver/sqlite-abstract/AbstractSqliteDataSourceOptions.ts
+++ b/src/driver/sqlite-abstract/AbstractSqliteDataSourceOptions.ts
@@ -1,4 +1,4 @@
-import {BaseDataSourceOptions} from "../../data-source/BaseDataSourceOptions";
+import type { BaseDataSourceOptions } from "../../data-source/BaseDataSourceOptions";
 
 /**
  * Sqlite-specific connection options.

--- a/src/driver/sqlite-abstract/AbstractSqliteDataSourceOptions.ts
+++ b/src/driver/sqlite-abstract/AbstractSqliteDataSourceOptions.ts
@@ -1,0 +1,15 @@
+import {BaseDataSourceOptions} from "../../data-source/BaseDataSourceOptions";
+
+/**
+ * Sqlite-specific connection options.
+ */
+export interface AbstractSqliteDataSourceOptions extends BaseDataSourceOptions {
+    /**
+     * Keeps SQLite foreign-key checks enabled during migrations.
+     *
+     * By default, TypeORM disables them while migrations run.
+     *
+     * @default false
+     */
+    readonly preserveForeignKeysDuringMigrations?: boolean
+}

--- a/src/driver/sqljs/SqljsDataSourceOptions.ts
+++ b/src/driver/sqljs/SqljsDataSourceOptions.ts
@@ -1,4 +1,4 @@
-import type { AbstractSqliteDataSourceOptions } from "../sqlite-abstract/AbstractSqliteDataSourceOptions";
+import type { AbstractSqliteDataSourceOptions } from "../sqlite-abstract/AbstractSqliteDataSourceOptions"
 
 /**
  * Sql.js-specific connection options.

--- a/src/driver/sqljs/SqljsDataSourceOptions.ts
+++ b/src/driver/sqljs/SqljsDataSourceOptions.ts
@@ -1,4 +1,4 @@
-import {AbstractSqliteDataSourceOptions} from "../sqlite-abstract/AbstractSqliteDataSourceOptions";
+import type { AbstractSqliteDataSourceOptions } from "../sqlite-abstract/AbstractSqliteDataSourceOptions";
 
 /**
  * Sql.js-specific connection options.

--- a/src/driver/sqljs/SqljsDataSourceOptions.ts
+++ b/src/driver/sqljs/SqljsDataSourceOptions.ts
@@ -1,9 +1,9 @@
-import type { BaseDataSourceOptions } from "../../data-source/BaseDataSourceOptions"
+import {AbstractSqliteDataSourceOptions} from "../sqlite-abstract/AbstractSqliteDataSourceOptions";
 
 /**
  * Sql.js-specific connection options.
  */
-export interface SqljsDataSourceOptions extends BaseDataSourceOptions {
+export interface SqljsDataSourceOptions extends AbstractSqliteDataSourceOptions {
     /**
      * Database type.
      */

--- a/src/driver/sqljs/SqljsQueryRunner.ts
+++ b/src/driver/sqljs/SqljsQueryRunner.ts
@@ -41,14 +41,18 @@ export class SqljsQueryRunner extends AbstractSqliteQueryRunner {
      * Called before migrations are run.
      */
     async beforeMigration(): Promise<void> {
-        await this.query(`PRAGMA foreign_keys = OFF`)
+        if (!this.driver.options.preserveForeignKeysDuringMigrations) {
+            await this.query(`PRAGMA foreign_keys = OFF`)
+        }
     }
 
     /**
      * Called after migrations are run.
      */
     async afterMigration(): Promise<void> {
-        await this.query(`PRAGMA foreign_keys = ON`)
+        if (!this.driver.options.preserveForeignKeysDuringMigrations) {
+            await this.query(`PRAGMA foreign_keys = ON`)
+        }
     }
 
     private async flush() {

--- a/src/driver/sqljs/SqljsQueryRunner.ts
+++ b/src/driver/sqljs/SqljsQueryRunner.ts
@@ -50,9 +50,7 @@ export class SqljsQueryRunner extends AbstractSqliteQueryRunner {
      * Called after migrations are run.
      */
     async afterMigration(): Promise<void> {
-        if (!this.driver.options.preserveForeignKeysDuringMigrations) {
-            await this.query(`PRAGMA foreign_keys = ON`)
-        }
+        await this.query(`PRAGMA foreign_keys = ON`)
     }
 
     private async flush() {

--- a/test/functional/driver/abstract-sqlite/abstract-sqlite-preserve-foreign-keys-during-migrations.test.ts
+++ b/test/functional/driver/abstract-sqlite/abstract-sqlite-preserve-foreign-keys-during-migrations.test.ts
@@ -1,0 +1,47 @@
+import { createTestingConnections } from "../../../utils/test-utils"
+import type { MigrationInterface, QueryRunner } from "../../../../src"
+import { expect } from "chai"
+
+describe("preserveForeignKeysDuringMigrations option", () => {
+    let foreignKeysDuringMigration: number | undefined = undefined
+
+    class Migration1000000000000 implements MigrationInterface {
+        async up(queryRunner: QueryRunner): Promise<void> {
+            const result = await queryRunner.query("PRAGMA FOREIGN_KEYS")
+            foreignKeysDuringMigration = result[0].foreign_keys
+        }
+
+        down(_queryRunner: QueryRunner): Promise<never> {
+            throw new Error("Method not implemented.")
+        }
+    }
+
+    beforeEach(() => {
+        foreignKeysDuringMigration = undefined
+    })
+
+    it("should turn off foreign keys by default", async () => {
+        const connections = await createTestingConnections({
+            enabledDrivers: ["better-sqlite3"],
+            migrations: [Migration1000000000000],
+            dropSchema: true,
+        })
+
+        await connections[0].runMigrations()
+        expect(foreignKeysDuringMigration).to.equal(0)
+    })
+
+    it("should preserve foreign keys when enabled", async () => {
+        const connections = await createTestingConnections({
+            enabledDrivers: ["better-sqlite3"],
+            migrations: [Migration1000000000000],
+            dropSchema: true,
+            driverSpecific: {
+                preserveForeignKeysDuringMigrations: true,
+            },
+        })
+
+        await connections[0].runMigrations()
+        expect(foreignKeysDuringMigration).to.equal(1)
+    })
+})


### PR DESCRIPTION
allow to keep sqlite foreign_keys enabled during migration

### Description of change

I added an option to preserve `PRAGMA foreign_keys = ON` for all sqlite drivers. At the moment foreign keys are always getting disabled during migrations. If you write migrations by hand you can migrate without violating the foreign keys. This option allows you to keep foreign keys enabled all the time. This way foreign keys cannot be violated at any time.

### Pull-Request Checklist

- [x] Code is up-to-date with the `master` branch
- [ ] This pull request links a relevant issue using a closing keyword:
      `Fixes #NNNN`, `Closes #NNNN`, or `Resolves #NNNN` N/A (minor change)
- [ ] There are new or updated tests validating the change (`tests/**.test.ts`) N/A
- [x] Documentation has been updated to reflect this change (`docs/docs/**.md`)
