### PR TITLE
fix: align abbreviate() Latin Extended-A word-boundary regex with shorten()

### DIFF
--- a/src/util/StringUtils.ts
+++ b/src/util/StringUtils.ts
@@ -56,7 +56,7 @@ export function titleCase(str: string): string {
  */
 export function abbreviate(str: string, abbrLettersCount: number = 1): string {
     const words = str
-        .replaceAll(/([a-z\xE0-\xFF])([A-Z\xC0\xDF])/g, "$1 $2")
+        .replaceAll(/([a-z\xE0-\xFF])([A-Z\xC0-\xDF])/g, "$1 $2")
         .split(" ")
     return words.reduce((res, word) => {
         res += word.slice(0, abbrLettersCount)

--- a/test/unit/util/string-utils.test.ts
+++ b/test/unit/util/string-utils.test.ts
@@ -1,5 +1,10 @@
 import { expect } from "chai"
-import { camelCase, snakeCase, hash } from "../../../src/util/StringUtils"
+import {
+    camelCase,
+    snakeCase,
+    hash,
+    abbreviate,
+} from "../../../src/util/StringUtils"
 import { RandomGenerator } from "../../../src/util/RandomGenerator"
 
 describe("StringUtils", () => {
@@ -211,6 +216,42 @@ describe("StringUtils", () => {
             const over = hash("hello", { length: 999 })
             expect(over).to.equal(full)
             expect(over).to.have.lengthOf(40)
+        })
+    })
+
+    describe("abbreviate", () => {
+        it("should abbreviate a single camelCase word", () => {
+            expect(abbreviate("UserShoppingCart")).to.equal("USC")
+        })
+
+        it("should abbreviate with a custom letter count", () => {
+            expect(abbreviate("UserShoppingCart", 2)).to.equal("UsShCa")
+        })
+
+        it("should treat uppercase Latin Extended-A characters (\\xC1-\\xDE) as word-boundary markers", () => {
+            // 'Á' = \xC1, 'Ä' = \xC4, 'Ñ' = \xD1 — uppercase accented Latin chars
+            // in the \xC1-\xDE range must be recognised as word-boundary markers
+            // (lowercase letter → accented uppercase = new word), just like A-Z and
+            // 'À' (\xC0) already are.
+            // "myÁbcDef": yÁ split → ["my","Ábc"], then cD split → ["my","Ábc","Def"]
+            expect(abbreviate("myÁbcDef")).to.equal("mÁD")
+            // "userÄbc": rÄ split → ["user","Äbc"]
+            expect(abbreviate("userÄbc")).to.equal("uÄ")
+            // "testÑhello": tÑ split → ["test","Ñhello"]
+            expect(abbreviate("testÑhello")).to.equal("tÑ")
+        })
+
+        it("should already handle \\xC0 (À) and \\xDF (ß) correctly before the fix", () => {
+            // These were already in the old character class as individual escapes,
+            // so their behaviour must be preserved by the fix.
+            expect(abbreviate("myÀbc")).to.equal("mÀ")
+            expect(abbreviate("myßabc")).to.equal("mß")
+        })
+
+        it("should leave ASCII abbreviation behaviour unchanged", () => {
+            expect(abbreviate("camelCase")).to.equal("cC")
+            expect(abbreviate("PascalCase")).to.equal("PC")
+            expect(abbreviate("hello_world")).to.equal("h")
         })
     })
 })


### PR DESCRIPTION
### Description of change

The `abbreviate()` helper in `src/util/StringUtils.ts` uses the character class `[A-Z\xC0\xDF]` to detect upper-case letters when inserting word-boundary spaces.  That class only includes two accented characters—`À` (`\xC0`) and `ß` (`\xDF`)—alongside plain `A-Z`.

The adjacent `shorten()` helper, which has the same purpose (splitting camelCase segment names into terms), uses the **range** `[A-Z\xC0-\xDF]`, which covers all 32 characters from `À` (`\xC0`) to `ß` (`\xDF`).

Because of the missing range in `abbreviate()`, uppercase accented Latin characters in `\xC1-\xDE` (Á Â Ã Ä Å Æ Ç È É Ê Ë Ì Í Î Ï Ð Ñ Ò Ó Ô Õ Ö Ø Ù Ú Û Ü Ý Þ) are not recognised as word-boundary markers.  A camelCase entity or column name that contains one of those characters as the start of a new word segment (e.g. `myÁbc`, `userÄItem`) produces a shorter and potentially non-unique alias.

**Before (buggy)**
```ts
abbreviate('myÁbcDef')   // → 'mD'   ❌  (should be 'mÁD')
abbreviate('userÄbc')    // → 'u'    ❌  (should be 'uÄ')
abbreviate('testÑhello') // → 't'    ❌  (should be 'tÑ')
```

**After (fixed)**
```ts
abbreviate('myÁbcDef')   // → 'mÁD'  ✔
abbreviate('userÄbc')    // → 'uÄ'   ✔
abbreviate('testÑhello') // → 'tÑ'   ✔
```

### Fix

One-character change in `src/util/StringUtils.ts`: `[A-Z\xC0\xDF]` → `[A-Z\xC0-\xDF]`.  This aligns `abbreviate()` with the already-correct regex used in `shorten()` (added alongside `abbreviate()` in the same file).

### Verification

```
./node_modules/.bin/mocha --no-config --exit build/compiled/test/unit/util/string-utils.test.js
  29 passing (36ms)
```

All 24 pre-existing tests pass unchanged, and 5 new `abbreviate()` tests are added (previously the function had no unit-test coverage).

> AI-assisted contribution: this fix was identified and implemented with AI tooling.

### Pull-Request Checklist

- [x] Code is up-to-date with the `master` branch
- [x] There are new or updated tests validating the change (`tests/**.test.ts`)
- [x] Documentation has been updated to reflect this change (N/A — internal utility)

Closes #12587
