### PR TITLE
ci: add healthcheck for oracle

### DIFF
--- a/.github/workflows/tests-linux.yml
+++ b/.github/workflows/tests-linux.yml
@@ -208,7 +208,6 @@ jobs:
 
       - run: jq 'map(select(.type == "oracle"))' ormconfig.sample.json > ormconfig.json
       - run: docker compose up oracle --no-recreate --wait
-      - run: sleep 3 # wait for oracle to be fully ready
       - run: pnpm exec c8 pnpm run test:ci
 
       - uses: ./.github/actions/upload-coverage

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -106,6 +106,15 @@ services:
     environment:
       ORACLE_PWD: "oracle"
       ORACLE_SID: "FREE"
+    healthcheck:
+      test:
+        [
+          "CMD-SHELL",
+          "echo 'EXIT' | sqlplus -L typeorm/oracle@localhost:1521/FREEPDB1",
+        ]
+      interval: 10s
+      timeout: 5s
+      retries: 5
     volumes:
       # - oracle-data:/opt/oracle/oradata
       - ./docker/oracle/startup:/opt/oracle/scripts/startup:ro


### PR DESCRIPTION
### Description of change
Added a health check for Oracle. Sometimes tests fail because the user `typeorm` is not ready via the init sql scripts. See `docker/oracle/01_init.sql`. 
Removed `sleep` from `tests-linux.yml` as now the `run: docker compose up oracle --no-recreate --wait` will wait until it's healthy.

Failing action: https://github.com/typeorm/typeorm/actions/runs/27741791548/job/82070618050?pr=12589


Logs from `docker inspect typeorm-oracle`:
```json
"Health": {
                "Status": "healthy",
                "FailingStreak": 0,
                "Log": [
                    {
                        "Start": "2026-06-19T00:58:02.663102654+05:30",
                        "End": "2026-06-19T00:58:02.714371443+05:30",
                        "ExitCode": 1,
                        "Output": "\nSQL*Plus: Release 23.0.0.0.0 - Production on Thu Jun 18 19:28:02 2026\nVersion 23.7.0.25.01\n\nCopyright (c) 1982, 2025, Oracle.  All rights reserved.\n\nERROR:\nORA-12514: Cannot connect to database. Service FREEPDB1 is not registered with\nthe listener at host 127.0.0.1 port 1521.\n(CONNECTION_ID=VI0suH7sAFDgYwIAEqwTqQ==)\nHelp: https://docs.oracle.com/error-help/db/ora-12514/\n\n\nSP2-0751: Unable to connect to Oracle.  Exiting SQL*Plus\nHelp: https://docs.oracle.com/error-help/db/sp2-0751/\n"
                    },
                    {
                        "Start": "2026-06-19T00:58:07.715341965+05:30",
                        "End": "2026-06-19T00:58:07.775540178+05:30",
                        "ExitCode": 1,
                        "Output": "\nSQL*Plus: Release 23.0.0.0.0 - Production on Thu Jun 18 19:28:07 2026\nVersion 23.7.0.25.01\n\nCopyright (c) 1982, 2025, Oracle.  All rights reserved.\n\nERROR:\nORA-12514: Cannot connect to database. Service FREEPDB1 is not registered with\nthe listener at host 127.0.0.1 port 1521.\n(CONNECTION_ID=VI0tBaSYANjgYwIAEqxpgw==)\nHelp: https://docs.oracle.com/error-help/db/ora-12514/\n\n\nSP2-0751: Unable to connect to Oracle.  Exiting SQL*Plus\nHelp: https://docs.oracle.com/error-help/db/sp2-0751/\n"
                    },
                    {
                        "Start": "2026-06-19T00:58:12.77704615+05:30",
                        "End": "2026-06-19T00:58:12.841586331+05:30",
                        "ExitCode": 1,
                        "Output": "\nSQL*Plus: Release 23.0.0.0.0 - Production on Thu Jun 18 19:28:12 2026\nVersion 23.7.0.25.01\n\nCopyright (c) 1982, 2025, Oracle.  All rights reserved.\n\nERROR:\nORA-28547: connection to server failed, probable Oracle Net admin error\nHelp: https://docs.oracle.com/error-help/db/ora-28547/\n\n\nSP2-0751: Unable to connect to Oracle.  Exiting SQL*Plus\nHelp: https://docs.oracle.com/error-help/db/sp2-0751/\n"
                    },
                    {
                        "Start": "2026-06-19T00:58:17.843153724+05:30",
                        "End": "2026-06-19T00:58:19.093941587+05:30",
                        "ExitCode": 1,
                        "Output": "\nSQL*Plus: Release 23.0.0.0.0 - Production on Thu Jun 18 19:28:17 2026\nVersion 23.7.0.25.01\n\nCopyright (c) 1982, 2025, Oracle.  All rights reserved.\n\nERROR:\nORA-01017: invalid credential or not authorized; logon denied\nHelp: https://docs.oracle.com/error-help/db/ora-01017/\n\n\nSP2-0751: Unable to connect to Oracle.  Exiting SQL*Plus\nHelp: https://docs.oracle.com/error-help/db/sp2-0751/\n"
                    },
                    {
                        "Start": "2026-06-19T00:58:24.094787526+05:30",
                        "End": "2026-06-19T00:58:24.18767444+05:30",
                        "ExitCode": 0,
                        "Output": "\nSQL*Plus: Release 23.0.0.0.0 - Production on Thu Jun 18 19:28:24 2026\nVersion 23.7.0.25.01\n\nCopyright (c) 1982, 2025, Oracle.  All rights reserved.\n\n\nConnected to:\nOracle Database 23ai Free Release 23.0.0.0.0 - Develop, Learn, and Run for Free\nVersion 23.7.0.25.01\n\nSQL> Disconnected from Oracle Database 23ai Free Release 23.0.0.0.0 - Develop, Learn, and Run for Free\nVersion 23.7.0.25.01\n"
                    }
                ]
            }
```

- [x] Code is up-to-date with the `master` branch
- [ ] This pull request links a relevant issue using a closing keyword:
      `Fixes #NNNN`, `Closes #NNNN`, or `Resolves #NNNN`
- [ ] There are new or updated tests validating the change (`tests/**.test.ts`)
- [ ] Documentation has been updated to reflect this change (`docs/docs/**.md`)