### PR TITLE
fix: apply default invalid where behavior

### DIFF
--- a/src/util/OrmUtils.ts
+++ b/src/util/OrmUtils.ts
@@ -662,10 +662,6 @@ export class OrmUtils {
         options?: InvalidFindOptionsWhereBehavior,
         path?: string,
     ): ObjectLiteral | ObjectLiteral[] {
-        if (!options) {
-            return criteria
-        }
-
         // multiple criteria are possible at the top level
         if (!path && Array.isArray(criteria)) {
             return criteria.map(

--- a/test/functional/null-undefined-handling/query-builders.test.ts
+++ b/test/functional/null-undefined-handling/query-builders.test.ts
@@ -238,6 +238,60 @@ describe("entity manager > invalidWhereValuesBehavior with throw", () => {
     })
 })
 
+describe("entity manager > invalidWhereValuesBehavior default", () => {
+    let dataSources: DataSource[]
+
+    before(async () => {
+        dataSources = await createTestingConnections({
+            disabledDrivers: ["spanner"],
+            entities: [Post, Category],
+            schemaCreate: true,
+            dropSchema: true,
+        })
+    })
+    beforeEach(() => reloadTestingDatabases(dataSources))
+    after(() => closeTestingConnections(dataSources))
+
+    async function prepareData(connection: DataSource) {
+        const post = new Post()
+        post.title = "Test Post"
+        post.text = "Some text"
+        await connection.manager.save(post)
+    }
+
+    it("should throw error for undefined values in EntityManager.update() by default", async () => {
+        for (const connection of dataSources) {
+            await prepareData(connection)
+
+            try {
+                await connection.manager.update(
+                    Post,
+                    { text: undefined } as any,
+                    { title: "Updated" },
+                )
+                expect.fail("Expected error")
+            } catch (error) {
+                expect(error).to.be.instanceOf(TypeORMError)
+                expect(error.message).to.include("Undefined value encountered")
+            }
+        }
+    })
+
+    it("should throw error for null values in EntityManager.delete() by default", async () => {
+        for (const connection of dataSources) {
+            await prepareData(connection)
+
+            try {
+                await connection.manager.delete(Post, { text: null } as any)
+                expect.fail("Expected error")
+            } catch (error) {
+                expect(error).to.be.instanceOf(TypeORMError)
+                expect(error.message).to.include("Null value encountered")
+            }
+        }
+    })
+})
+
 describe("entity manager > invalidWhereValuesBehavior with sql-null", () => {
     let dataSources: DataSource[]
 


### PR DESCRIPTION
## Summary

- apply the documented default `invalidWhereValuesBehavior` fallback in `OrmUtils.normalizeWhereCriteria()` even when the data source option is not configured
- add regression coverage for default null/undefined behavior on `EntityManager.update()` and `EntityManager.delete()` criteria

Fixes #12578.

## Tests

- `pnpm run compile`
- `pnpm exec mocha --no-config --file build/compiled/test/utils/test-setup.js --timeout 90000 --exit build/compiled/test/functional/null-undefined-handling/query-builders.test.js`
- `pnpm exec prettier --check src/util/OrmUtils.ts test/functional/null-undefined-handling/query-builders.test.ts`