### PR TITLE
fix: apply default 'throw' behavior in normalizeWhereCriteria when options not set

### DIFF
--- a/src/util/OrmUtils.ts
+++ b/src/util/OrmUtils.ts
@@ -662,8 +662,11 @@ export class OrmUtils {
         options?: InvalidFindOptionsWhereBehavior,
         path?: string,
     ): ObjectLiteral | ObjectLiteral[] {
-        if (!options) {
-            return criteria
+        // When options is not provided, use the documented default behavior
+        // (throw on undefined/null) rather than silently passing through
+        const resolvedOptions: InvalidFindOptionsWhereBehavior = options ?? {
+            undefined: "throw",
+            null: "throw",
         }
 
         // multiple criteria are possible at the top level
@@ -672,7 +675,7 @@ export class OrmUtils {
                 (criterion, index): ObjectLiteral =>
                     OrmUtils.normalizeWhereCriteria(
                         criterion,
-                        options,
+                        resolvedOptions,
                         String(index),
                     ),
             )
@@ -683,7 +686,7 @@ export class OrmUtils {
             const propertyPath = path ? `${path}.${key}` : key
 
             if (value === undefined) {
-                const behavior = options?.undefined ?? "throw"
+                const behavior = resolvedOptions.undefined ?? "throw"
                 if (behavior === "throw") {
                     throw new TypeORMError(
                         `Undefined value encountered in property '${propertyPath}' of a where condition. ` +
@@ -692,7 +695,7 @@ export class OrmUtils {
                 }
                 // else: "ignore" — skip this key
             } else if (value === null) {
-                const behavior = options?.null ?? "throw"
+                const behavior = resolvedOptions.null ?? "throw"
                 if (behavior === "throw") {
                     throw new TypeORMError(
                         `Null value encountered in property '${propertyPath}' of a where condition. ` +
@@ -706,7 +709,7 @@ export class OrmUtils {
             } else if (OrmUtils.isPlainObject(value)) {
                 const nested = OrmUtils.normalizeWhereCriteria(
                     value,
-                    options,
+                    resolvedOptions,
                     propertyPath,
                 )
                 if (Object.keys(nested).length > 0) {


### PR DESCRIPTION
## Fix #12578 — `normalizeWhereCriteria()` should default to 'throw' behavior

### Problem

When `invalidWhereValuesBehavior` is not configured in the DataSource options, `OrmUtils.normalizeWhereCriteria()` immediately returns the criteria without checking for `undefined`/`null` values:

```typescript
if (!options) {
    return criteria  // Bug: skips all validation
}
```

This contradicts the [documented default behavior](https://typeorm.io/docs/data-source/null-and-undefined-handling#throw-default-1), which states that `'throw'` is the default. As a result, UPDATE queries can silently execute with buggy filters like `WHERE col = null` without any warning.

### Solution

When `options` is not provided, resolve it to the documented defaults (`{ undefined: "throw", null: "throw" }`) instead of short-circuiting:

```typescript
const resolvedOptions: InvalidFindOptionsWhereBehavior = options ?? {
    undefined: "throw",
    null: "throw",
}
```

All internal references to `options` are updated to use `resolvedOptions`.

### Impact

- **With `invalidWhereValuesBehavior` configured**: No change — existing behavior is preserved
- **Without `invalidWhereValuesBehavior`**: Now correctly throws on `undefined`/`null` values in where conditions, matching the documented default

### Files changed

- `src/util/OrmUtils.ts` — Resolve `options` to documented defaults when not provided
