### PR TITLE
fix: apply default invalid where behavior

### DIFF
--- a/src/entity-manager/EntityManager.ts
+++ b/src/entity-manager/EntityManager.ts
@@ -874,6 +874,17 @@ export class EntityManager {
                 criteria as ObjectLiteral | ObjectLiteral[],
                 this.dataSource.options.invalidWhereValuesBehavior,
             )
+            if (
+                OrmUtils.isCriteriaNullOrEmptyOrContainsEmpty(
+                    normalizedCriteria,
+                )
+            ) {
+                return Promise.reject(
+                    new TypeORMError(
+                        `Empty criteria(s) are not allowed for the update method.`,
+                    ),
+                )
+            }
             const qb = this.createQueryBuilder()
                 .update(target)
                 .set(partialEntity)
@@ -955,6 +966,17 @@ export class EntityManager {
                 criteria as ObjectLiteral | ObjectLiteral[],
                 this.dataSource.options.invalidWhereValuesBehavior,
             )
+            if (
+                OrmUtils.isCriteriaNullOrEmptyOrContainsEmpty(
+                    normalizedCriteria,
+                )
+            ) {
+                return Promise.reject(
+                    new TypeORMError(
+                        `Empty criteria(s) are not allowed for the delete method.`,
+                    ),
+                )
+            }
             return this.createQueryBuilder()
                 .delete()
                 .from(targetOrEntity)
@@ -1021,6 +1043,17 @@ export class EntityManager {
                 criteria as ObjectLiteral | ObjectLiteral[],
                 this.dataSource.options.invalidWhereValuesBehavior,
             )
+            if (
+                OrmUtils.isCriteriaNullOrEmptyOrContainsEmpty(
+                    normalizedCriteria,
+                )
+            ) {
+                return Promise.reject(
+                    new TypeORMError(
+                        `Empty criteria(s) are not allowed for the softDelete method.`,
+                    ),
+                )
+            }
             return this.createQueryBuilder()
                 .softDelete()
                 .from(targetOrEntity)
@@ -1072,6 +1105,17 @@ export class EntityManager {
                 criteria as ObjectLiteral | ObjectLiteral[],
                 this.dataSource.options.invalidWhereValuesBehavior,
             )
+            if (
+                OrmUtils.isCriteriaNullOrEmptyOrContainsEmpty(
+                    normalizedCriteria,
+                )
+            ) {
+                return Promise.reject(
+                    new TypeORMError(
+                        `Empty criteria(s) are not allowed for the restore method.`,
+                    ),
+                )
+            }
             return this.createQueryBuilder()
                 .restore()
                 .from(targetOrEntity)

--- a/src/entity-manager/EntityManager.ts
+++ b/src/entity-manager/EntityManager.ts
@@ -870,10 +870,15 @@ export class EntityManager {
 
             return qb.execute()
         } else {
-            const normalizedCriteria = OrmUtils.normalizeWhereCriteria(
-                criteria as ObjectLiteral | ObjectLiteral[],
-                this.dataSource.options.invalidWhereValuesBehavior,
-            )
+            let normalizedCriteria: ObjectLiteral | ObjectLiteral[]
+            try {
+                normalizedCriteria = this.normalizeMutationCriteria(
+                    target,
+                    criteria as ObjectLiteral | ObjectLiteral[],
+                )
+            } catch (error) {
+                return Promise.reject(error)
+            }
             if (
                 OrmUtils.isCriteriaNullOrEmptyOrContainsEmpty(
                     normalizedCriteria,
@@ -962,10 +967,15 @@ export class EntityManager {
                 .whereInIds(criteria)
                 .execute()
         } else {
-            const normalizedCriteria = OrmUtils.normalizeWhereCriteria(
-                criteria as ObjectLiteral | ObjectLiteral[],
-                this.dataSource.options.invalidWhereValuesBehavior,
-            )
+            let normalizedCriteria: ObjectLiteral | ObjectLiteral[]
+            try {
+                normalizedCriteria = this.normalizeMutationCriteria(
+                    targetOrEntity,
+                    criteria as ObjectLiteral | ObjectLiteral[],
+                )
+            } catch (error) {
+                return Promise.reject(error)
+            }
             if (
                 OrmUtils.isCriteriaNullOrEmptyOrContainsEmpty(
                     normalizedCriteria,
@@ -1039,10 +1049,15 @@ export class EntityManager {
                 .whereInIds(criteria)
                 .execute()
         } else {
-            const normalizedCriteria = OrmUtils.normalizeWhereCriteria(
-                criteria as ObjectLiteral | ObjectLiteral[],
-                this.dataSource.options.invalidWhereValuesBehavior,
-            )
+            let normalizedCriteria: ObjectLiteral | ObjectLiteral[]
+            try {
+                normalizedCriteria = this.normalizeMutationCriteria(
+                    targetOrEntity,
+                    criteria as ObjectLiteral | ObjectLiteral[],
+                )
+            } catch (error) {
+                return Promise.reject(error)
+            }
             if (
                 OrmUtils.isCriteriaNullOrEmptyOrContainsEmpty(
                     normalizedCriteria,
@@ -1101,10 +1116,15 @@ export class EntityManager {
                 .whereInIds(criteria)
                 .execute()
         } else {
-            const normalizedCriteria = OrmUtils.normalizeWhereCriteria(
-                criteria as ObjectLiteral | ObjectLiteral[],
-                this.dataSource.options.invalidWhereValuesBehavior,
-            )
+            let normalizedCriteria: ObjectLiteral | ObjectLiteral[]
+            try {
+                normalizedCriteria = this.normalizeMutationCriteria(
+                    targetOrEntity,
+                    criteria as ObjectLiteral | ObjectLiteral[],
+                )
+            } catch (error) {
+                return Promise.reject(error)
+            }
             if (
                 OrmUtils.isCriteriaNullOrEmptyOrContainsEmpty(
                     normalizedCriteria,
@@ -1122,6 +1142,75 @@ export class EntityManager {
                 .where(normalizedCriteria)
                 .execute()
         }
+    }
+
+    /**
+     * Normalizes mutation criteria with metadata when available so relation and
+     * embedded criteria are validated while object-valued columns are preserved.
+     *
+     * @param target Entity target or raw table name.
+     * @param criteria Mutation criteria.
+     * @returns Normalized mutation criteria.
+     */
+    private normalizeMutationCriteria<Entity extends ObjectLiteral>(
+        target: EntityTarget<Entity>,
+        criteria: ObjectLiteral | ObjectLiteral[],
+    ): ObjectLiteral | ObjectLiteral[] {
+        const behavior = this.dataSource.options.invalidWhereValuesBehavior
+
+        if (!this.dataSource.hasMetadata(target)) {
+            return OrmUtils.normalizeWhereCriteria(
+                criteria,
+                behavior,
+                undefined,
+                () => false,
+            )
+        }
+
+        const metadata = this.dataSource.getMetadata(target)
+
+        return OrmUtils.normalizeWhereCriteria(
+            criteria,
+            behavior,
+            undefined,
+            (propertyPath) => {
+                const parts = propertyPath.split(".")
+                let currentMetadata = metadata
+                let currentPath = ""
+
+                for (const part of parts) {
+                    currentPath = currentPath ? `${currentPath}.${part}` : part
+
+                    if (
+                        currentMetadata.findColumnWithPropertyPathStrict(
+                            currentPath,
+                        )
+                    ) {
+                        return false
+                    }
+
+                    const relation =
+                        currentMetadata.findRelationWithPropertyPath(
+                            currentPath,
+                        )
+                    if (relation) {
+                        currentMetadata = relation.inverseEntityMetadata
+                        currentPath = ""
+                        continue
+                    }
+
+                    if (
+                        currentMetadata.hasEmbeddedWithPropertyPath(currentPath)
+                    ) {
+                        continue
+                    }
+
+                    return false
+                }
+
+                return true
+            },
+        )
     }
 
     /**

--- a/src/util/OrmUtils.ts
+++ b/src/util/OrmUtils.ts
@@ -396,6 +396,27 @@ export class OrmUtils {
     }
 
     /**
+     * Checks whether criteria is empty or whether a top-level OR criteria array
+     * contains an empty branch.
+     *
+     * Empty OR branches are unsafe for write operations because QueryBuilder can
+     * turn them into an always-true predicate.
+     *
+     * @param criteria
+     */
+    public static isCriteriaNullOrEmptyOrContainsEmpty(
+        criteria: unknown,
+    ): boolean {
+        return (
+            OrmUtils.isCriteriaNullOrEmpty(criteria) ||
+            (Array.isArray(criteria) &&
+                criteria.some((criterion) =>
+                    OrmUtils.isCriteriaNullOrEmpty(criterion),
+                ))
+        )
+    }
+
+    /**
      * Checks if given criteria is a primitive value.
      * Primitive values are strings, numbers and dates.
      *
@@ -662,9 +683,7 @@ export class OrmUtils {
         options?: InvalidFindOptionsWhereBehavior,
         path?: string,
     ): ObjectLiteral | ObjectLiteral[] {
-        if (!options) {
-            return criteria
-        }
+        options ??= {}
 
         // multiple criteria are possible at the top level
         if (!path && Array.isArray(criteria)) {
@@ -678,7 +697,7 @@ export class OrmUtils {
             )
         }
 
-        const result: ObjectLiteral = {}
+        const result: ObjectLiteral = Object.create(null)
         for (const [key, value] of Object.entries(criteria)) {
             const propertyPath = path ? `${path}.${key}` : key
 

--- a/src/util/OrmUtils.ts
+++ b/src/util/OrmUtils.ts
@@ -677,11 +677,18 @@ export class OrmUtils {
      * @param criteria
      * @param options
      * @param path
+     * @param shouldNormalizeObject
+     *
+     * @returns normalized criteria
      */
     static normalizeWhereCriteria(
         criteria: ObjectLiteral | ObjectLiteral[],
         options?: InvalidFindOptionsWhereBehavior,
         path?: string,
+        shouldNormalizeObject?: (
+            propertyPath: string,
+            value: ObjectLiteral,
+        ) => boolean,
     ): ObjectLiteral | ObjectLiteral[] {
         options ??= {}
 
@@ -693,6 +700,7 @@ export class OrmUtils {
                         criterion,
                         options,
                         String(index),
+                        shouldNormalizeObject,
                     ),
             )
         }
@@ -723,10 +731,19 @@ export class OrmUtils {
                 }
                 // else: "ignore" — skip this key
             } else if (OrmUtils.isPlainObject(value)) {
+                if (
+                    shouldNormalizeObject &&
+                    !shouldNormalizeObject(propertyPath, value)
+                ) {
+                    result[key] = value
+                    continue
+                }
+
                 const nested = OrmUtils.normalizeWhereCriteria(
                     value,
                     options,
                     propertyPath,
+                    shouldNormalizeObject,
                 )
                 if (Object.keys(nested).length > 0) {
                     result[key] = nested

--- a/test/functional/null-undefined-handling/find-options.test.ts
+++ b/test/functional/null-undefined-handling/find-options.test.ts
@@ -1,5 +1,5 @@
 import { expect } from "chai"
-import type { DataSource } from "../../../src"
+import type { DataSource, FindOptionsWhere } from "../../../src"
 import { TypeORMError } from "../../../src"
 import {
     closeTestingConnections,
@@ -8,6 +8,10 @@ import {
 } from "../../utils/test-utils"
 import { Category } from "./entity/Category"
 import { Post } from "./entity/Post"
+
+function unsafeWhere<T>(where: unknown): FindOptionsWhere<T> {
+    return where as FindOptionsWhere<T>
+}
 
 describe("find options > null and undefined handling", () => {
     let dataSources: DataSource[]
@@ -223,10 +227,10 @@ describe("find options > null and undefined handling", () => {
                 dataSources.map(async (dataSource) => {
                     await prepareData(dataSource)
 
-                    // Empty object {} should be skipped — no join, no filter
+                    // Empty object {} should be skipped Ã¢â‚¬â€ no join, no filter
                     const posts = await dataSource.getRepository(Post).find({
                         where: {
-                            category: {} as any,
+                            category: unsafeWhere<Category>({}),
                         },
                     })
 
@@ -239,12 +243,12 @@ describe("find options > null and undefined handling", () => {
                 dataSources.map(async (dataSource) => {
                     await prepareData(dataSource)
 
-                    // { category: { name: null } } — null should throw by default
+                    // { category: { name: null } } Ã¢â‚¬â€ null should throw by default
                     try {
                         await dataSource.getRepository(Post).find({
-                            where: {
+                            where: unsafeWhere<Post>({
                                 category: { name: null },
-                            } as any,
+                            }),
                         })
                         expect.fail("Expected query to throw an error")
                     } catch (error) {
@@ -897,7 +901,7 @@ describe("find options > null and undefined handling", () => {
 
                     const posts = await dataSource.getRepository(Post).find({
                         where: {
-                            category: {} as any,
+                            category: unsafeWhere<Category>({}),
                         },
                     })
 
@@ -911,9 +915,7 @@ describe("find options > null and undefined handling", () => {
                     await prepareData(dataSource)
 
                     const posts = await dataSource.getRepository(Post).find({
-                        where: {
-                            category: { name: null },
-                        } as any,
+                        where: unsafeWhere<Post>({ category: { name: null } }),
                     })
 
                     // All 3 posts have a category, so all match when name filter is skipped

--- a/test/functional/null-undefined-handling/find-options.test.ts
+++ b/test/functional/null-undefined-handling/find-options.test.ts
@@ -227,7 +227,7 @@ describe("find options > null and undefined handling", () => {
                 dataSources.map(async (dataSource) => {
                     await prepareData(dataSource)
 
-                    // Empty object {} should be skipped Ã¢â‚¬â€ no join, no filter
+                    // Empty object {} should be skipped: no join, no filter
                     const posts = await dataSource.getRepository(Post).find({
                         where: {
                             category: unsafeWhere<Category>({}),
@@ -243,7 +243,7 @@ describe("find options > null and undefined handling", () => {
                 dataSources.map(async (dataSource) => {
                     await prepareData(dataSource)
 
-                    // { category: { name: null } } Ã¢â‚¬â€ null should throw by default
+                    // { category: { name: null } } should throw by default
                     try {
                         await dataSource.getRepository(Post).find({
                             where: unsafeWhere<Post>({

--- a/test/functional/null-undefined-handling/query-builders.test.ts
+++ b/test/functional/null-undefined-handling/query-builders.test.ts
@@ -1,5 +1,5 @@
 import { expect } from "chai"
-import type { DataSource } from "../../../src"
+import type { DataSource, FindOptionsWhere } from "../../../src"
 import { TypeORMError } from "../../../src"
 import {
     closeTestingConnections,
@@ -8,6 +8,10 @@ import {
 } from "../../utils/test-utils"
 import { Category } from "./entity/Category"
 import { Post } from "./entity/Post"
+
+function unsafeWhere<T>(where: unknown): FindOptionsWhere<T> {
+    return where as FindOptionsWhere<T>
+}
 
 describe("entity manager > invalidWhereValuesBehavior defaults", () => {
     let dataSources: DataSource[]
@@ -127,9 +131,13 @@ describe("entity manager > invalidWhereValuesBehavior with throw", () => {
             await prepareData(connection)
 
             try {
-                await connection.manager.update(Post, { text: null } as any, {
-                    title: "Updated",
-                })
+                await connection.manager.update(
+                    Post,
+                    unsafeWhere<Post>({ text: null }),
+                    {
+                        title: "Updated",
+                    },
+                )
                 expect.fail("Expected error")
             } catch (error) {
                 expect(error).to.be.instanceOf(TypeORMError)
@@ -161,7 +169,10 @@ describe("entity manager > invalidWhereValuesBehavior with throw", () => {
             await prepareData(connection)
 
             try {
-                await connection.manager.delete(Post, { text: null } as any)
+                await connection.manager.delete(
+                    Post,
+                    unsafeWhere<Post>({ text: null }),
+                )
                 expect.fail("Expected error")
             } catch (error) {
                 expect(error).to.be.instanceOf(TypeORMError)
@@ -175,9 +186,10 @@ describe("entity manager > invalidWhereValuesBehavior with throw", () => {
             await prepareData(connection)
 
             try {
-                await connection.manager.delete(Post, {
-                    text: undefined,
-                } as any)
+                await connection.manager.delete(
+                    Post,
+                    unsafeWhere<Post>({ text: undefined }),
+                )
                 expect.fail("Expected error")
             } catch (error) {
                 expect(error).to.be.instanceOf(TypeORMError)
@@ -191,9 +203,10 @@ describe("entity manager > invalidWhereValuesBehavior with throw", () => {
             await prepareData(connection)
 
             try {
-                await connection.manager.softDelete(Post, {
-                    text: null,
-                } as any)
+                await connection.manager.softDelete(
+                    Post,
+                    unsafeWhere<Post>({ text: null }),
+                )
                 expect.fail("Expected error")
             } catch (error) {
                 expect(error).to.be.instanceOf(TypeORMError)
@@ -207,9 +220,10 @@ describe("entity manager > invalidWhereValuesBehavior with throw", () => {
             await prepareData(connection)
 
             try {
-                await connection.manager.softDelete(Post, {
-                    text: undefined,
-                } as any)
+                await connection.manager.softDelete(
+                    Post,
+                    unsafeWhere<Post>({ text: undefined }),
+                )
                 expect.fail("Expected error")
             } catch (error) {
                 expect(error).to.be.instanceOf(TypeORMError)
@@ -223,9 +237,10 @@ describe("entity manager > invalidWhereValuesBehavior with throw", () => {
             await prepareData(connection)
 
             try {
-                await connection.manager.restore(Post, {
-                    text: null,
-                } as any)
+                await connection.manager.restore(
+                    Post,
+                    unsafeWhere<Post>({ text: null }),
+                )
                 expect.fail("Expected error")
             } catch (error) {
                 expect(error).to.be.instanceOf(TypeORMError)
@@ -239,9 +254,10 @@ describe("entity manager > invalidWhereValuesBehavior with throw", () => {
             await prepareData(connection)
 
             try {
-                await connection.manager.restore(Post, {
-                    text: undefined,
-                } as any)
+                await connection.manager.restore(
+                    Post,
+                    unsafeWhere<Post>({ text: undefined }),
+                )
                 expect.fail("Expected error")
             } catch (error) {
                 expect(error).to.be.instanceOf(TypeORMError)
@@ -257,7 +273,9 @@ describe("entity manager > invalidWhereValuesBehavior with throw", () => {
             try {
                 await connection
                     .getRepository(Post)
-                    .update({ text: null } as any, { title: "Updated" })
+                    .update(unsafeWhere<Post>({ text: null }), {
+                        title: "Updated",
+                    })
                 expect.fail("Expected error")
             } catch (error) {
                 expect(error).to.be.instanceOf(TypeORMError)
@@ -273,7 +291,7 @@ describe("entity manager > invalidWhereValuesBehavior with throw", () => {
             try {
                 await connection
                     .getRepository(Post)
-                    .delete({ text: null } as any)
+                    .delete(unsafeWhere<Post>({ text: null }))
                 expect.fail("Expected error")
             } catch (error) {
                 expect(error).to.be.instanceOf(TypeORMError)
@@ -289,7 +307,7 @@ describe("entity manager > invalidWhereValuesBehavior with throw", () => {
             try {
                 await connection.manager.update(
                     Post,
-                    { category: { name: null } } as any,
+                    unsafeWhere<Post>({ category: { name: null } }),
                     { title: "Updated" },
                 )
                 expect.fail("Expected error")
@@ -305,9 +323,10 @@ describe("entity manager > invalidWhereValuesBehavior with throw", () => {
             await prepareData(connection)
 
             try {
-                await connection.manager.delete(Post, {
-                    category: { name: undefined },
-                } as any)
+                await connection.manager.delete(
+                    Post,
+                    unsafeWhere<Post>({ category: { name: undefined } }),
+                )
                 expect.fail("Expected error")
             } catch (error) {
                 expect(error).to.be.instanceOf(TypeORMError)
@@ -340,7 +359,7 @@ describe("entity manager > invalidWhereValuesBehavior with sql-null", () => {
         for (const connection of dataSources) {
             const post = new Post()
             post.title = "Test Post"
-            post.text = null as any
+            post.text = null
             await connection.manager.save(post)
 
             const post2 = new Post()
@@ -349,9 +368,13 @@ describe("entity manager > invalidWhereValuesBehavior with sql-null", () => {
             await connection.manager.save(post2)
 
             // With sql-null, { text: null } should match rows where text IS NULL
-            await connection.manager.update(Post, { text: null } as any, {
-                title: "Updated",
-            })
+            await connection.manager.update(
+                Post,
+                unsafeWhere<Post>({ text: null }),
+                {
+                    title: "Updated",
+                },
+            )
 
             const updated = await connection.manager.findOneByOrFail(Post, {
                 id: post.id,
@@ -368,7 +391,7 @@ describe("entity manager > invalidWhereValuesBehavior with sql-null", () => {
         for (const connection of dataSources) {
             const post = new Post()
             post.title = "Test Post"
-            post.text = null as any
+            post.text = null
             await connection.manager.save(post)
 
             const post2 = new Post()
@@ -377,7 +400,10 @@ describe("entity manager > invalidWhereValuesBehavior with sql-null", () => {
             await connection.manager.save(post2)
 
             // With sql-null, { text: null } should delete rows where text IS NULL
-            await connection.manager.delete(Post, { text: null } as any)
+            await connection.manager.delete(
+                Post,
+                unsafeWhere<Post>({ text: null }),
+            )
 
             const remaining = await connection.manager.find(Post)
             expect(remaining.length).to.equal(1)
@@ -415,10 +441,10 @@ describe("entity manager > invalidWhereValuesBehavior with ignore", () => {
 
             // With ignore, { title: "Test Post", text: null } should strip text
             // and delete by title only
-            await connection.manager.delete(Post, {
-                title: "Test Post",
-                text: null,
-            } as any)
+            await connection.manager.delete(
+                Post,
+                unsafeWhere<Post>({ title: "Test Post", text: null }),
+            )
 
             const remaining = await connection.manager.find(Post)
             expect(remaining.length).to.equal(0)
@@ -434,10 +460,10 @@ describe("entity manager > invalidWhereValuesBehavior with ignore", () => {
 
             // With ignore, { title: "Test Post", text: undefined } should strip text
             // and delete by title only
-            await connection.manager.delete(Post, {
-                title: "Test Post",
-                text: undefined,
-            } as any)
+            await connection.manager.delete(
+                Post,
+                unsafeWhere<Post>({ title: "Test Post", text: undefined }),
+            )
 
             const remaining = await connection.manager.find(Post)
             expect(remaining.length).to.equal(0)
@@ -459,7 +485,10 @@ describe("entity manager > invalidWhereValuesBehavior with ignore", () => {
             // With ignore, nested null should be stripped, leaving only title
             await connection.manager.update(
                 Post,
-                { title: "Test Post", category: { name: null } } as any,
+                unsafeWhere<Post>({
+                    title: "Test Post",
+                    category: { name: null },
+                }),
                 { text: "Updated" },
             )
 
@@ -483,10 +512,13 @@ describe("entity manager > invalidWhereValuesBehavior with ignore", () => {
             await connection.manager.save(post)
 
             // With ignore, nested undefined should be stripped, leaving only title
-            await connection.manager.delete(Post, {
-                title: "Test Post",
-                category: { name: undefined },
-            } as any)
+            await connection.manager.delete(
+                Post,
+                unsafeWhere<Post>({
+                    title: "Test Post",
+                    category: { name: undefined },
+                }),
+            )
 
             const remaining = await connection.manager.find(Post)
             expect(remaining.length).to.equal(0)
@@ -503,7 +535,7 @@ describe("entity manager > invalidWhereValuesBehavior with ignore", () => {
             try {
                 await connection.manager.update(
                     Post,
-                    { text: undefined } as any,
+                    unsafeWhere<Post>({ text: undefined }),
                     { title: "Updated" },
                 )
                 expect.fail("Expected error")
@@ -603,7 +635,8 @@ describe("entity manager > invalidWhereValuesBehavior does NOT affect QB .where(
 
             // QB .where() with undefined should NOT throw even when invalidWhereValuesBehavior is set to "throw".
             // It passes undefined through as-is (pre-feature behavior), which means
-            // it creates WHERE text = NULL (always false). This is expected — QB is low-level.
+            // it creates WHERE text = NULL (always false). This is expected:
+            // QB is low-level.
             const posts = await connection
                 .createQueryBuilder(Post, "post")
                 .where({

--- a/test/functional/null-undefined-handling/query-builders.test.ts
+++ b/test/functional/null-undefined-handling/query-builders.test.ts
@@ -9,6 +9,85 @@ import {
 import { Category } from "./entity/Category"
 import { Post } from "./entity/Post"
 
+describe("entity manager > invalidWhereValuesBehavior defaults", () => {
+    let dataSources: DataSource[]
+
+    before(async () => {
+        dataSources = await createTestingConnections({
+            disabledDrivers: ["spanner"],
+            entities: [Post, Category],
+            schemaCreate: true,
+            dropSchema: true,
+        })
+    })
+    beforeEach(() => reloadTestingDatabases(dataSources))
+    after(() => closeTestingConnections(dataSources))
+
+    async function prepareData(connection: DataSource) {
+        const category = new Category()
+        category.name = "Test Category"
+        await connection.manager.save(category)
+
+        const post = new Post()
+        post.title = "Test Post"
+        post.text = "Some text"
+        post.category = category
+        await connection.manager.save(post)
+    }
+
+    it("should throw by default for undefined values in EntityManager.update()", async () => {
+        for (const connection of dataSources) {
+            await prepareData(connection)
+
+            try {
+                await connection.manager.update(
+                    Post,
+                    { text: undefined } as any,
+                    { title: "Updated" },
+                )
+                expect.fail("Expected error")
+            } catch (error) {
+                expect(error).to.be.instanceOf(TypeORMError)
+                expect(error.message).to.include("Undefined value encountered")
+            }
+        }
+    })
+
+    it("should throw by default for null values in EntityManager.delete()", async () => {
+        for (const connection of dataSources) {
+            await prepareData(connection)
+
+            try {
+                await connection.manager.delete(Post, { text: null } as any)
+                expect.fail("Expected error")
+            } catch (error) {
+                expect(error).to.be.instanceOf(TypeORMError)
+                expect(error.message).to.include("Null value encountered")
+            }
+        }
+    })
+
+    it("should throw by default for undefined values in OR criteria arrays", async () => {
+        for (const connection of dataSources) {
+            await prepareData(connection)
+
+            try {
+                await connection.manager.update(
+                    Post,
+                    [{ title: "No match" }, { text: undefined }] as any,
+                    { title: "Updated" },
+                )
+                expect.fail("Expected error")
+            } catch (error) {
+                expect(error).to.be.instanceOf(TypeORMError)
+                expect(error.message).to.include(
+                    "Undefined value encountered in property '1.text'",
+                )
+            }
+        }
+    })
+})
+
 describe("entity manager > invalidWhereValuesBehavior with throw", () => {
     let dataSources: DataSource[]
 
@@ -411,6 +490,59 @@ describe("entity manager > invalidWhereValuesBehavior with ignore", () => {
 
             const remaining = await connection.manager.find(Post)
             expect(remaining.length).to.equal(0)
+        }
+    })
+
+    it("should reject update when all criteria are stripped with ignore", async () => {
+        for (const connection of dataSources) {
+            const post = new Post()
+            post.title = "Test Post"
+            post.text = "text"
+            await connection.manager.save(post)
+
+            try {
+                await connection.manager.update(
+                    Post,
+                    { text: undefined } as any,
+                    { title: "Updated" },
+                )
+                expect.fail("Expected error")
+            } catch (error) {
+                expect(error).to.be.instanceOf(TypeORMError)
+                expect(error.message).to.include(
+                    "Empty criteria(s) are not allowed for the update method.",
+                )
+            }
+
+            const unchanged = await connection.manager.findOneByOrFail(Post, {
+                id: post.id,
+            })
+            expect(unchanged.title).to.equal("Test Post")
+        }
+    })
+
+    it("should reject OR criteria arrays when any branch is stripped empty with ignore", async () => {
+        for (const connection of dataSources) {
+            const post = new Post()
+            post.title = "Test Post"
+            post.text = "text"
+            await connection.manager.save(post)
+
+            try {
+                await connection.manager.delete(Post, [
+                    { title: "Test Post" },
+                    { text: undefined },
+                ] as any)
+                expect.fail("Expected error")
+            } catch (error) {
+                expect(error).to.be.instanceOf(TypeORMError)
+                expect(error.message).to.include(
+                    "Empty criteria(s) are not allowed for the delete method.",
+                )
+            }
+
+            const remaining = await connection.manager.find(Post)
+            expect(remaining.length).to.equal(1)
         }
     })
 })

--- a/test/functional/null-undefined-handling/query-builders.test.ts
+++ b/test/functional/null-undefined-handling/query-builders.test.ts
@@ -42,7 +42,7 @@ describe("entity manager > invalidWhereValuesBehavior defaults", () => {
             try {
                 await connection.manager.update(
                     Post,
-                    { text: undefined } as any,
+                    { text: undefined },
                     { title: "Updated" },
                 )
                 expect.fail("Expected error")
@@ -58,7 +58,7 @@ describe("entity manager > invalidWhereValuesBehavior defaults", () => {
             await prepareData(connection)
 
             try {
-                await connection.manager.delete(Post, { text: null } as any)
+                await connection.manager.delete(Post, { text: null })
                 expect.fail("Expected error")
             } catch (error) {
                 expect(error).to.be.instanceOf(TypeORMError)
@@ -74,7 +74,7 @@ describe("entity manager > invalidWhereValuesBehavior defaults", () => {
             try {
                 await connection.manager.update(
                     Post,
-                    [{ title: "No match" }, { text: undefined }] as any,
+                    [{ title: "No match" }, { text: undefined }],
                     { title: "Updated" },
                 )
                 expect.fail("Expected error")
@@ -145,7 +145,7 @@ describe("entity manager > invalidWhereValuesBehavior with throw", () => {
             try {
                 await connection.manager.update(
                     Post,
-                    { text: undefined } as any,
+                    { text: undefined },
                     { title: "Updated" },
                 )
                 expect.fail("Expected error")
@@ -532,7 +532,7 @@ describe("entity manager > invalidWhereValuesBehavior with ignore", () => {
                 await connection.manager.delete(Post, [
                     { title: "Test Post" },
                     { text: undefined },
-                ] as any)
+                ])
                 expect.fail("Expected error")
             } catch (error) {
                 expect(error).to.be.instanceOf(TypeORMError)


### PR DESCRIPTION
### Description of change

Fixes #12578
/claim #12578

Applies the documented default `invalidWhereValuesBehavior` when EntityManager normalizes write criteria without explicit options.

It also rejects write criteria that normalize to empty after `null`/`undefined` values are ignored, including empty branches in top-level OR criteria arrays, before `update`, `delete`, `softDelete`, and `restore` build the query.

Validation:

- `corepack pnpm run typecheck`
- `corepack pnpm exec prettier --check src/util/OrmUtils.ts src/entity-manager/EntityManager.ts test/functional/null-undefined-handling/query-builders.test.ts`
- `corepack pnpm run compile`
- `corepack pnpm exec mocha --no-config --require ./build/compiled/test/utils/test-setup.js --timeout 90000 build/compiled/test/functional/null-undefined-handling/query-builders.test.js`

Focused functional suite: 25 passing.

### Pull-Request Checklist

- [x] Code is up-to-date with the `master` branch
- [x] This pull request links a relevant issue using a closing keyword: `Fixes #NNNN`, `Closes #NNNN`, or `Resolves #NNNN`
- [x] There are new or updated tests validating the change (`tests/**.test.ts`)
- [x] Documentation has been updated to reflect this change (`docs/docs/**.md`) N/A - behavior now matches the existing documented default
