### PR TITLE
fix: apply default invalid where behavior

### DIFF
--- a/src/entity-manager/EntityManager.ts
+++ b/src/entity-manager/EntityManager.ts
@@ -870,10 +870,29 @@ export class EntityManager {
 
             return qb.execute()
         } else {
-            const normalizedCriteria = OrmUtils.normalizeWhereCriteria(
-                criteria as ObjectLiteral | ObjectLiteral[],
-                this.dataSource.options.invalidWhereValuesBehavior,
-            )
+            const normalizedCriteria = this.dataSource.hasMetadata(target)
+                ? OrmUtils.normalizeWhereCriteriaWithMetadata(
+                      criteria as ObjectLiteral | ObjectLiteral[],
+                      this.dataSource.getMetadata(target),
+                      this.dataSource.options.invalidWhereValuesBehavior,
+                  )
+                : OrmUtils.normalizeWhereCriteria(
+                      criteria as ObjectLiteral | ObjectLiteral[],
+                      this.dataSource.options.invalidWhereValuesBehavior,
+                  )
+
+            if (
+                OrmUtils.isCriteriaNullOrEmptyOrContainsEmpty(
+                    normalizedCriteria,
+                )
+            ) {
+                return Promise.reject(
+                    new TypeORMError(
+                        `Empty criteria(s) are not allowed for the update method.`,
+                    ),
+                )
+            }
+
             const qb = this.createQueryBuilder()
                 .update(target)
                 .set(partialEntity)
@@ -951,10 +970,31 @@ export class EntityManager {
                 .whereInIds(criteria)
                 .execute()
         } else {
-            const normalizedCriteria = OrmUtils.normalizeWhereCriteria(
-                criteria as ObjectLiteral | ObjectLiteral[],
-                this.dataSource.options.invalidWhereValuesBehavior,
+            const normalizedCriteria = this.dataSource.hasMetadata(
+                targetOrEntity,
             )
+                ? OrmUtils.normalizeWhereCriteriaWithMetadata(
+                      criteria as ObjectLiteral | ObjectLiteral[],
+                      this.dataSource.getMetadata(targetOrEntity),
+                      this.dataSource.options.invalidWhereValuesBehavior,
+                  )
+                : OrmUtils.normalizeWhereCriteria(
+                      criteria as ObjectLiteral | ObjectLiteral[],
+                      this.dataSource.options.invalidWhereValuesBehavior,
+                  )
+
+            if (
+                OrmUtils.isCriteriaNullOrEmptyOrContainsEmpty(
+                    normalizedCriteria,
+                )
+            ) {
+                return Promise.reject(
+                    new TypeORMError(
+                        `Empty criteria(s) are not allowed for the delete method.`,
+                    ),
+                )
+            }
+
             return this.createQueryBuilder()
                 .delete()
                 .from(targetOrEntity)
@@ -1017,10 +1057,31 @@ export class EntityManager {
                 .whereInIds(criteria)
                 .execute()
         } else {
-            const normalizedCriteria = OrmUtils.normalizeWhereCriteria(
-                criteria as ObjectLiteral | ObjectLiteral[],
-                this.dataSource.options.invalidWhereValuesBehavior,
+            const normalizedCriteria = this.dataSource.hasMetadata(
+                targetOrEntity,
             )
+                ? OrmUtils.normalizeWhereCriteriaWithMetadata(
+                      criteria as ObjectLiteral | ObjectLiteral[],
+                      this.dataSource.getMetadata(targetOrEntity),
+                      this.dataSource.options.invalidWhereValuesBehavior,
+                  )
+                : OrmUtils.normalizeWhereCriteria(
+                      criteria as ObjectLiteral | ObjectLiteral[],
+                      this.dataSource.options.invalidWhereValuesBehavior,
+                  )
+
+            if (
+                OrmUtils.isCriteriaNullOrEmptyOrContainsEmpty(
+                    normalizedCriteria,
+                )
+            ) {
+                return Promise.reject(
+                    new TypeORMError(
+                        `Empty criteria(s) are not allowed for the softDelete method.`,
+                    ),
+                )
+            }
+
             return this.createQueryBuilder()
                 .softDelete()
                 .from(targetOrEntity)
@@ -1068,10 +1129,31 @@ export class EntityManager {
                 .whereInIds(criteria)
                 .execute()
         } else {
-            const normalizedCriteria = OrmUtils.normalizeWhereCriteria(
-                criteria as ObjectLiteral | ObjectLiteral[],
-                this.dataSource.options.invalidWhereValuesBehavior,
+            const normalizedCriteria = this.dataSource.hasMetadata(
+                targetOrEntity,
             )
+                ? OrmUtils.normalizeWhereCriteriaWithMetadata(
+                      criteria as ObjectLiteral | ObjectLiteral[],
+                      this.dataSource.getMetadata(targetOrEntity),
+                      this.dataSource.options.invalidWhereValuesBehavior,
+                  )
+                : OrmUtils.normalizeWhereCriteria(
+                      criteria as ObjectLiteral | ObjectLiteral[],
+                      this.dataSource.options.invalidWhereValuesBehavior,
+                  )
+
+            if (
+                OrmUtils.isCriteriaNullOrEmptyOrContainsEmpty(
+                    normalizedCriteria,
+                )
+            ) {
+                return Promise.reject(
+                    new TypeORMError(
+                        `Empty criteria(s) are not allowed for the restore method.`,
+                    ),
+                )
+            }
+
             return this.createQueryBuilder()
                 .restore()
                 .from(targetOrEntity)

--- a/src/util/OrmUtils.ts
+++ b/src/util/OrmUtils.ts
@@ -7,6 +7,7 @@ import type {
 import type { InvalidFindOptionsWhereBehavior } from "../driver/types/InvalidFindOptionsWhereBehavior"
 import { TypeORMError } from "../error"
 import { IsNull } from "../find-options/operator/IsNull"
+import type { EntityMetadata } from "../metadata/EntityMetadata"
 import { areUint8ArraysEqual, isUint8Array } from "./Uint8ArrayUtils"
 
 export class OrmUtils {
@@ -395,6 +396,16 @@ export class OrmUtils {
         )
     }
 
+    public static isCriteriaNullOrEmptyOrContainsEmpty(
+        criteria: unknown,
+    ): boolean {
+        return (
+            OrmUtils.isCriteriaNullOrEmpty(criteria) ||
+            (Array.isArray(criteria) &&
+                criteria.some((item) => OrmUtils.isCriteriaNullOrEmpty(item)))
+        )
+    }
+
     /**
      * Checks if given criteria is a primitive value.
      * Primitive values are strings, numbers and dates.
@@ -662,10 +673,6 @@ export class OrmUtils {
         options?: InvalidFindOptionsWhereBehavior,
         path?: string,
     ): ObjectLiteral | ObjectLiteral[] {
-        if (!options) {
-            return criteria
-        }
-
         // multiple criteria are possible at the top level
         if (!path && Array.isArray(criteria)) {
             return criteria.map(
@@ -700,7 +707,7 @@ export class OrmUtils {
                             `Set 'invalidWhereValuesBehavior.null' to 'ignore' or 'sql-null' in connection options to skip or handle null values.`,
                     )
                 } else if (behavior === "sql-null") {
-                    result[key] = IsNull()
+                    OrmUtils.setNormalizedWhereValue(result, key, IsNull())
                 }
                 // else: "ignore" — skip this key
             } else if (OrmUtils.isPlainObject(value)) {
@@ -710,13 +717,126 @@ export class OrmUtils {
                     propertyPath,
                 )
                 if (Object.keys(nested).length > 0) {
-                    result[key] = nested
+                    OrmUtils.setNormalizedWhereValue(result, key, nested)
                 }
             } else {
-                result[key] = value
+                OrmUtils.setNormalizedWhereValue(result, key, value)
             }
         }
 
         return result
+    }
+
+    static normalizeWhereCriteriaWithMetadata(
+        criteria: ObjectLiteral | ObjectLiteral[],
+        metadata: EntityMetadata,
+        options?: InvalidFindOptionsWhereBehavior,
+    ): ObjectLiteral | ObjectLiteral[] {
+        if (Array.isArray(criteria)) {
+            return criteria.map((criterion, index): ObjectLiteral =>
+                OrmUtils.normalizeWhereCriteriaObjectWithMetadata(
+                    criterion,
+                    metadata,
+                    options,
+                    String(index),
+                ),
+            )
+        }
+
+        return OrmUtils.normalizeWhereCriteriaObjectWithMetadata(
+            criteria,
+            metadata,
+            options,
+        )
+    }
+
+    private static normalizeWhereCriteriaObjectWithMetadata(
+        criteria: ObjectLiteral,
+        metadata: EntityMetadata,
+        options?: InvalidFindOptionsWhereBehavior,
+        path?: string,
+        metadataPath?: string,
+    ): ObjectLiteral {
+        const result: ObjectLiteral = {}
+
+        for (const [key, value] of Object.entries(criteria)) {
+            const propertyPath = path ? `${path}.${key}` : key
+            const metadataPropertyPath = metadataPath
+                ? `${metadataPath}.${key}`
+                : key
+
+            if (value === undefined) {
+                const behavior = options?.undefined ?? "throw"
+                if (behavior === "throw") {
+                    throw new TypeORMError(
+                        `Undefined value encountered in property '${propertyPath}' of a where condition. ` +
+                            `Set 'invalidWhereValuesBehavior.undefined' to 'ignore' in connection options to skip properties with undefined values.`,
+                    )
+                }
+            } else if (value === null) {
+                const behavior = options?.null ?? "throw"
+                if (behavior === "throw") {
+                    throw new TypeORMError(
+                        `Null value encountered in property '${propertyPath}' of a where condition. ` +
+                            `To match with SQL NULL, the IsNull() operator must be used. ` +
+                            `Set 'invalidWhereValuesBehavior.null' to 'ignore' or 'sql-null' in connection options to skip or handle null values.`,
+                    )
+                } else if (behavior === "sql-null") {
+                    OrmUtils.setNormalizedWhereValue(result, key, IsNull())
+                }
+            } else if (OrmUtils.isPlainObject(value)) {
+                if (metadata.hasEmbeddedWithPropertyPath(metadataPropertyPath)) {
+                    const nested =
+                        OrmUtils.normalizeWhereCriteriaObjectWithMetadata(
+                            value,
+                            metadata,
+                            options,
+                            propertyPath,
+                            metadataPropertyPath,
+                        )
+
+                    if (Object.keys(nested).length > 0) {
+                        OrmUtils.setNormalizedWhereValue(result, key, nested)
+                    }
+                } else if (
+                    metadata.hasRelationWithPropertyPath(metadataPropertyPath)
+                ) {
+                    const relation =
+                        metadata.findRelationWithPropertyPath(
+                            metadataPropertyPath,
+                        )!
+                    const nested =
+                        OrmUtils.normalizeWhereCriteriaObjectWithMetadata(
+                            value,
+                            relation.inverseEntityMetadata,
+                            options,
+                            propertyPath,
+                        )
+
+                    if (Object.keys(nested).length > 0) {
+                        OrmUtils.setNormalizedWhereValue(result, key, nested)
+                    }
+                } else {
+                    OrmUtils.setNormalizedWhereValue(result, key, value)
+                }
+            } else {
+                OrmUtils.setNormalizedWhereValue(result, key, value)
+            }
+        }
+
+        return result
+    }
+
+    private static setNormalizedWhereValue(
+        target: ObjectLiteral,
+        key: string,
+        value: unknown,
+    ) {
+        Object.defineProperty(target, key, {
+            configurable: true,
+            enumerable: true,
+            value,
+            writable: true,
+        })
     }
 }

--- a/test/functional/null-undefined-handling/entity/Post.ts
+++ b/test/functional/null-undefined-handling/entity/Post.ts
@@ -18,6 +18,9 @@ export class Post {
     @Column({ nullable: true, type: String })
     text: string | null
 
+    @Column({ nullable: true, type: "simple-json" })
+    payload: Record<string, unknown> | null
+
     @ManyToOne(() => Category, { nullable: true })
     @JoinColumn()
     category: Category | null

--- a/test/functional/null-undefined-handling/query-builders.test.ts
+++ b/test/functional/null-undefined-handling/query-builders.test.ts
@@ -1,6 +1,7 @@
 import { expect } from "chai"
 import type { DataSource } from "../../../src"
-import { TypeORMError } from "../../../src"
+import { Table, TypeORMError } from "../../../src"
+import { OrmUtils } from "../../../src/util/OrmUtils"
 import {
     closeTestingConnections,
     createTestingConnections,
@@ -8,6 +9,277 @@ import {
 } from "../../utils/test-utils"
 import { Category } from "./entity/Category"
 import { Post } from "./entity/Post"
+
+describe("entity manager > invalidWhereValuesBehavior default behavior", () => {
+    let dataSources: DataSource[]
+
+    before(async () => {
+        dataSources = await createTestingConnections({
+            disabledDrivers: ["spanner"],
+            entities: [Post, Category],
+            schemaCreate: true,
+            dropSchema: true,
+        })
+    })
+    beforeEach(() => reloadTestingDatabases(dataSources))
+    after(() => closeTestingConnections(dataSources))
+
+    async function prepareData(connection: DataSource) {
+        const category = new Category()
+        category.name = "Test Category"
+        await connection.manager.save(category)
+
+        const post = new Post()
+        post.title = "Test Post"
+        post.text = "Some text"
+        post.category = category
+        await connection.manager.save(post)
+    }
+
+    async function prepareRawMutationTable(connection: DataSource) {
+        const queryRunner = connection.createQueryRunner()
+
+        await queryRunner.connect()
+        try {
+            await queryRunner.dropTable("raw_mutation_target", true)
+            await queryRunner.createTable(
+                new Table({
+                    name: "raw_mutation_target",
+                    columns: [
+                        {
+                            name: "id",
+                            type: "int",
+                            isPrimary: true,
+                        },
+                        {
+                            name: "title",
+                            type: "varchar",
+                        },
+                        {
+                            name: "text",
+                            type: "varchar",
+                            isNullable: true,
+                        },
+                    ],
+                }),
+            )
+        } finally {
+            await queryRunner.release()
+        }
+
+        await connection
+            .createQueryBuilder()
+            .insert()
+            .into("raw_mutation_target")
+            .values([
+                { id: 1, title: "Raw", text: "text" },
+                { id: 2, title: "Delete", text: "text" },
+            ])
+            .execute()
+    }
+
+    it("should throw by default for invalid EntityManager mutation criteria", async () => {
+        for (const connection of dataSources) {
+            await prepareData(connection)
+
+            const cases: Array<{
+                name: string
+                execute: () => Promise<unknown>
+                message: string
+            }> = [
+                {
+                    name: "update with undefined",
+                    execute: () =>
+                        connection.manager.update(
+                            Post,
+                            { text: undefined },
+                            { title: "Updated" },
+                        ),
+                    message: "Undefined value encountered",
+                },
+                {
+                    name: "update with null",
+                    execute: () =>
+                        connection.manager.update(Post, { text: null }, {
+                            title: "Updated",
+                        }),
+                    message: "Null value encountered",
+                },
+                {
+                    name: "delete with undefined",
+                    execute: () =>
+                        connection.manager.delete(Post, {
+                            text: undefined,
+                        }),
+                    message: "Undefined value encountered",
+                },
+                {
+                    name: "delete with null",
+                    execute: () =>
+                        connection.manager.delete(Post, { text: null }),
+                    message: "Null value encountered",
+                },
+                {
+                    name: "softDelete with undefined",
+                    execute: () =>
+                        connection.manager.softDelete(Post, {
+                            text: undefined,
+                        }),
+                    message: "Undefined value encountered",
+                },
+                {
+                    name: "softDelete with null",
+                    execute: () =>
+                        connection.manager.softDelete(Post, {
+                            text: null,
+                        }),
+                    message: "Null value encountered",
+                },
+                {
+                    name: "restore with undefined",
+                    execute: () =>
+                        connection.manager.restore(Post, {
+                            text: undefined,
+                        }),
+                    message: "Undefined value encountered",
+                },
+                {
+                    name: "restore with null",
+                    execute: () =>
+                        connection.manager.restore(Post, {
+                            text: null,
+                        }),
+                    message: "Null value encountered",
+                },
+            ]
+
+            for (const testCase of cases) {
+                try {
+                    await testCase.execute()
+                    expect.fail(`Expected ${testCase.name} to throw an error`)
+                } catch (error) {
+                    expect(error).to.be.instanceOf(TypeORMError)
+                    expect(error.message).to.include(testCase.message)
+                }
+            }
+        }
+    })
+
+    it("should support raw table-name targets without entity metadata", async () => {
+        for (const connection of dataSources) {
+            await prepareRawMutationTable(connection)
+
+            await connection.manager.update(
+                "raw_mutation_target",
+                { title: "Raw" },
+                { text: "Updated" },
+            )
+            await connection.manager.delete("raw_mutation_target", {
+                title: "Delete",
+            })
+
+            const updatedRows = await connection
+                .createQueryBuilder()
+                .select("raw.text", "text")
+                .from("raw_mutation_target", "raw")
+                .where("raw.title = :title", { title: "Raw" })
+                .getRawMany<{ text: string }>()
+            const deletedRows = await connection
+                .createQueryBuilder()
+                .select("raw.id", "id")
+                .from("raw_mutation_target", "raw")
+                .where("raw.title = :title", { title: "Delete" })
+                .getRawMany<{ id: number }>()
+
+            expect(updatedRows[0].text).to.equal("Updated")
+            expect(deletedRows.length).to.equal(0)
+        }
+    })
+
+    it("should preserve empty simple-json mutation criteria", () => {
+        for (const connection of dataSources) {
+            const normalized = OrmUtils.normalizeWhereCriteriaWithMetadata(
+                { payload: {} },
+                connection.getMetadata(Post),
+            )
+
+            expect(normalized).to.deep.equal({ payload: {} })
+        }
+    })
+
+    it("should not descend into simple-json mutation criteria values", () => {
+        for (const connection of dataSources) {
+            const normalized = OrmUtils.normalizeWhereCriteriaWithMetadata(
+                { payload: { nullable: null } },
+                connection.getMetadata(Post),
+            )
+
+            expect(normalized).to.deep.equal({
+                payload: { nullable: null },
+            })
+        }
+    })
+
+    it("should reject mutation criteria that normalize to empty", async () => {
+        for (const connection of dataSources) {
+            const cases: Array<{
+                name: string
+                execute: () => Promise<unknown>
+                message: string
+            }> = [
+                {
+                    name: "update with empty nested relation",
+                    execute: () =>
+                        connection.manager.update(
+                            Post,
+                            { category: {} },
+                            { title: "Updated" },
+                        ),
+                    message: "update method",
+                },
+                {
+                    name: "delete with empty nested relation",
+                    execute: () =>
+                        connection.manager.delete(Post, { category: {} }),
+                    message: "delete method",
+                },
+                {
+                    name: "softDelete with empty nested relation",
+                    execute: () =>
+                        connection.manager.softDelete(Post, { category: {} }),
+                    message: "softDelete method",
+                },
+                {
+                    name: "restore with empty nested relation",
+                    execute: () =>
+                        connection.manager.restore(Post, { category: {} }),
+                    message: "restore method",
+                },
+                {
+                    name: "delete with empty OR branch",
+                    execute: () =>
+                        connection.manager.delete(Post, [
+                            { category: {} },
+                            { title: "Test Post" },
+                        ]),
+                    message: "delete method",
+                },
+            ]
+
+            for (const testCase of cases) {
+                try {
+                    await testCase.execute()
+                    expect.fail(`Expected ${testCase.name} to throw an error`)
+                } catch (error) {
+                    expect(error).to.be.instanceOf(TypeORMError)
+                    expect(error.message).to.include(
+                        `Empty criteria(s) are not allowed for the ${testCase.message}.`,
+                    )
+                }
+            }
+        }
+    })
+})
 
 describe("entity manager > invalidWhereValuesBehavior with throw", () => {
     let dataSources: DataSource[]

--- a/test/unit/util/orm-utils.test.ts
+++ b/test/unit/util/orm-utils.test.ts
@@ -1,9 +1,56 @@
 import { expect } from "chai"
 import { runInNewContext } from "node:vm"
 import type { DeepPartial } from "../../../src"
+import { TypeORMError } from "../../../src"
 import { OrmUtils } from "../../../src/util/OrmUtils"
 
 describe(`OrmUtils`, () => {
+    describe("normalizeWhereCriteria", () => {
+        it("throws for undefined where values by default", () => {
+            expect(() =>
+                OrmUtils.normalizeWhereCriteria({ text: undefined }),
+            ).to.throw(
+                TypeORMError,
+                "Undefined value encountered in property 'text' of a where condition.",
+            )
+        })
+
+        it("throws for null where values by default", () => {
+            expect(() =>
+                OrmUtils.normalizeWhereCriteria({ text: null }),
+            ).to.throw(
+                TypeORMError,
+                "Null value encountered in property 'text' of a where condition.",
+            )
+        })
+
+        it("throws for invalid values in array criteria by default", () => {
+            expect(() =>
+                OrmUtils.normalizeWhereCriteria([
+                    { text: "valid" },
+                    { text: undefined },
+                ]),
+            ).to.throw(
+                TypeORMError,
+                "Undefined value encountered in property '1.text' of a where condition.",
+            )
+        })
+
+        it("does not mutate the result prototype for __proto__ criteria", () => {
+            const criteria = JSON.parse(`{"__proto__":{"polluted":true}}`)
+
+            const normalized = OrmUtils.normalizeWhereCriteria(criteria)
+
+            expect(Object.getPrototypeOf(normalized)).to.equal(Object.prototype)
+            expect(
+                Object.prototype.hasOwnProperty.call(normalized, "__proto__"),
+            ).to.equal(true)
+            expect((normalized as any).__proto__).to.deep.equal({
+                polluted: true,
+            })
+        })
+    })
+
     describe("parseSqlCheckExpression", () => {
         it("parses a simple CHECK constraint", () => {
             // Spaces between CHECK values


### PR DESCRIPTION
Fixes #12578.
/claim #12578

This removes the early return from OrmUtils.normalizeWhereCriteria() when invalidWhereValuesBehavior is not configured, allowing the documented default behavior to apply. With no explicit options, null and undefined where values now throw instead of being returned unchanged.

It also adds regression coverage at two levels:
- unit coverage for OrmUtils.normalizeWhereCriteria() default null/undefined handling, including array criteria and JSON-derived __proto__ keys
- functional coverage proving EntityManager update/delete/softDelete/restore throw by default when mutation criteria contain null or undefined

Additional hardening:
- EntityManager mutation criteria use metadata-aware normalization so object-valued columns such as simple-json/json/jsonb are preserved as column values.
- Normalized empty criteria are rejected before QueryBuilder execution, preventing WHERE 1=1 mutations after normalization.
- Raw table-name targets without entity metadata still work by falling back to non-metadata normalization.
- The raw table regression test uses QueryRunner/Table and QueryBuilder reads instead of SQLite-specific SQL.

Validation:
- pnpm run compile
- pnpm exec mocha --no-config ./build/compiled/test/unit/util/orm-utils.test.js (18 passing)
- pnpm exec mocha --no-config --require ./build/compiled/test/utils/test-setup.js --timeout 90000 ./build/compiled/test/functional/null-undefined-handling/query-builders.test.js (25 passing)