### PR TITLE
fix: apply default invalidWhereValuesBehavior in normalizeWhereCriteria

### DIFF
--- a/src/entity-manager/EntityManager.ts
+++ b/src/entity-manager/EntityManager.ts
@@ -834,7 +834,7 @@ export class EntityManager {
      * @param partialEntity
      * @param options
      */
-    update<Entity extends ObjectLiteral>(
+    async update<Entity extends ObjectLiteral>(
         target: EntityTarget<Entity>,
         criteria:
             | string
@@ -922,7 +922,7 @@ export class EntityManager {
      * @param targetOrEntity
      * @param criteria
      */
-    delete<Entity extends ObjectLiteral>(
+    async delete<Entity extends ObjectLiteral>(
         targetOrEntity: EntityTarget<Entity>,
         criteria:
             | string
@@ -988,7 +988,7 @@ export class EntityManager {
      * @param targetOrEntity
      * @param criteria
      */
-    softDelete<Entity extends ObjectLiteral>(
+    async softDelete<Entity extends ObjectLiteral>(
         targetOrEntity: EntityTarget<Entity>,
         criteria:
             | string
@@ -1039,7 +1039,7 @@ export class EntityManager {
      * @param targetOrEntity
      * @param criteria
      */
-    restore<Entity extends ObjectLiteral>(
+    async restore<Entity extends ObjectLiteral>(
         targetOrEntity: EntityTarget<Entity>,
         criteria:
             | string

--- a/src/util/OrmUtils.ts
+++ b/src/util/OrmUtils.ts
@@ -662,10 +662,6 @@ export class OrmUtils {
         options?: InvalidFindOptionsWhereBehavior,
         path?: string,
     ): ObjectLiteral | ObjectLiteral[] {
-        if (!options) {
-            return criteria
-        }
-
         // multiple criteria are possible at the top level
         if (!path && Array.isArray(criteria)) {
             return criteria.map(

--- a/test/functional/null-undefined-handling/query-builders.test.ts
+++ b/test/functional/null-undefined-handling/query-builders.test.ts
@@ -25,31 +25,57 @@ describe("entity manager > invalidWhereValuesBehavior defaults to throw", () => 
 
     it("should throw error for undefined values in EntityManager.update()", async () => {
         for (const connection of dataSources) {
-            try {
-                await connection.manager.update(
-                    Post,
-                    { text: undefined } as any,
-                    { title: "Updated" },
-                )
-                expect.fail("Expected error")
-            } catch (error) {
-                expect(error).to.be.instanceOf(TypeORMError)
-                expect(error.message).to.include("Undefined value encountered")
-            }
+            await connection.manager
+                .update(Post, { text: undefined }, { title: "Updated" })
+                .then(() => expect.fail("Expected error"))
+                .catch((error) => {
+                    expect(error).to.be.instanceOf(TypeORMError)
+                    expect(error.message).to.include(
+                        "Undefined value encountered",
+                    )
+                })
         }
     })
 
     it("should throw error for null values in EntityManager.update()", async () => {
         for (const connection of dataSources) {
-            try {
-                await connection.manager.update(Post, { text: null } as any, {
-                    title: "Updated",
+            await connection.manager
+                .update(Post, { text: null }, { title: "Updated" })
+                .then(() => expect.fail("Expected error"))
+                .catch((error) => {
+                    expect(error).to.be.instanceOf(TypeORMError)
+                    expect(error.message).to.include("Null value encountered")
                 })
-                expect.fail("Expected error")
-            } catch (error) {
-                expect(error).to.be.instanceOf(TypeORMError)
-                expect(error.message).to.include("Null value encountered")
-            }
+        }
+    })
+
+    it("should return rejected promises for default invalid where values", async () => {
+        for (const connection of dataSources) {
+            await connection.manager
+                .delete(Post, { text: undefined })
+                .then(() => expect.fail("Expected error"))
+                .catch((error) => {
+                    expect(error).to.be.instanceOf(TypeORMError)
+                    expect(error.message).to.include(
+                        "Undefined value encountered",
+                    )
+                })
+
+            await connection.manager
+                .softDelete(Post, { text: null })
+                .then(() => expect.fail("Expected error"))
+                .catch((error) => {
+                    expect(error).to.be.instanceOf(TypeORMError)
+                    expect(error.message).to.include("Null value encountered")
+                })
+
+            await connection.manager
+                .restore(Post, { text: null })
+                .then(() => expect.fail("Expected error"))
+                .catch((error) => {
+                    expect(error).to.be.instanceOf(TypeORMError)
+                    expect(error.message).to.include("Null value encountered")
+                })
         }
     })
 })

--- a/test/functional/null-undefined-handling/query-builders.test.ts
+++ b/test/functional/null-undefined-handling/query-builders.test.ts
@@ -9,6 +9,51 @@ import {
 import { Category } from "./entity/Category"
 import { Post } from "./entity/Post"
 
+describe("entity manager > invalidWhereValuesBehavior defaults to throw", () => {
+    let dataSources: DataSource[]
+
+    before(async () => {
+        dataSources = await createTestingConnections({
+            disabledDrivers: ["spanner"],
+            entities: [Post, Category],
+            schemaCreate: true,
+            dropSchema: true,
+        })
+    })
+    beforeEach(() => reloadTestingDatabases(dataSources))
+    after(() => closeTestingConnections(dataSources))
+
+    it("should throw error for undefined values in EntityManager.update()", async () => {
+        for (const connection of dataSources) {
+            try {
+                await connection.manager.update(
+                    Post,
+                    { text: undefined } as any,
+                    { title: "Updated" },
+                )
+                expect.fail("Expected error")
+            } catch (error) {
+                expect(error).to.be.instanceOf(TypeORMError)
+                expect(error.message).to.include("Undefined value encountered")
+            }
+        }
+    })
+
+    it("should throw error for null values in EntityManager.update()", async () => {
+        for (const connection of dataSources) {
+            try {
+                await connection.manager.update(Post, { text: null } as any, {
+                    title: "Updated",
+                })
+                expect.fail("Expected error")
+            } catch (error) {
+                expect(error).to.be.instanceOf(TypeORMError)
+                expect(error.message).to.include("Null value encountered")
+            }
+        }
+    })
+})
+
 describe("entity manager > invalidWhereValuesBehavior with throw", () => {
     let dataSources: DataSource[]
 

--- a/test/unit/util/orm-utils.test.ts
+++ b/test/unit/util/orm-utils.test.ts
@@ -1,9 +1,33 @@
 import { expect } from "chai"
 import { runInNewContext } from "node:vm"
-import type { DeepPartial } from "../../../src"
+import { TypeORMError, type DeepPartial } from "../../../src"
 import { OrmUtils } from "../../../src/util/OrmUtils"
 
 describe(`OrmUtils`, () => {
+    describe("normalizeWhereCriteria", () => {
+        it("throws for undefined where values by default", () => {
+            expect(() =>
+                OrmUtils.normalizeWhereCriteria({
+                    text: undefined,
+                }),
+            ).to.throw(
+                TypeORMError,
+                "Undefined value encountered in property 'text' of a where condition. Set 'invalidWhereValuesBehavior.undefined' to 'ignore' in connection options to skip properties with undefined values.",
+            )
+        })
+
+        it("throws for null where values by default", () => {
+            expect(() =>
+                OrmUtils.normalizeWhereCriteria({
+                    text: null,
+                }),
+            ).to.throw(
+                TypeORMError,
+                "Null value encountered in property 'text' of a where condition. To match with SQL NULL, the IsNull() operator must be used. Set 'invalidWhereValuesBehavior.null' to 'ignore' or 'sql-null' in connection options to skip or handle null values.",
+            )
+        })
+    })
+
     describe("parseSqlCheckExpression", () => {
         it("parses a simple CHECK constraint", () => {
             // Spaces between CHECK values


### PR DESCRIPTION
Fixes #12578.

### Description of change

`OrmUtils.normalizeWhereCriteria()` currently returns the original criteria when no `invalidWhereValuesBehavior` options are passed. That bypasses the documented default behavior for `null` and `undefined` values.

This removes the early return so the existing defaults (`null` and `undefined` both default to `"throw"`) are applied by high-level APIs such as `EntityManager.update()`.

Added tests:

- default `OrmUtils.normalizeWhereCriteria()` behavior for `null` / `undefined`
- default `EntityManager.update()` behavior without `invalidWhereValuesBehavior` configured

### Validation

- `pnpm run compile`
- `pnpm exec mocha --no-config --exit build/compiled/test/unit/util/orm-utils.test.js`
- `pnpm exec mocha --no-config --file build/compiled/test/utils/test-setup.js --exit build/compiled/test/functional/null-undefined-handling/query-builders.test.js`

### Pull-Request Checklist

- [x] Code is up-to-date with the `master` branch
- [x] This pull request links a relevant issue using a closing keyword: `Fixes #NNNN`, `Closes #NNNN`, or `Resolves #NNNN`
- [x] There are new or updated tests validating the change (`tests/**.test.ts`)
- [x] Documentation has been updated to reflect this change (`docs/docs/**.md`) N/A, this restores the behavior described by existing docs.
