### PR TITLE
fix: enforce default invalid where behavior

### DIFF
--- a/src/util/OrmUtils.ts
+++ b/src/util/OrmUtils.ts
@@ -662,10 +662,6 @@ export class OrmUtils {
         options?: InvalidFindOptionsWhereBehavior,
         path?: string,
     ): ObjectLiteral | ObjectLiteral[] {
-        if (!options) {
-            return criteria
-        }
-
         // multiple criteria are possible at the top level
         if (!path && Array.isArray(criteria)) {
             return criteria.map(

--- a/test/functional/null-undefined-handling/query-builders.test.ts
+++ b/test/functional/null-undefined-handling/query-builders.test.ts
@@ -9,7 +9,7 @@ import {
 import { Category } from "./entity/Category"
 import { Post } from "./entity/Post"
 
-describe("entity manager > invalidWhereValuesBehavior with throw", () => {
+describe("entity manager > invalidWhereValuesBehavior with default throw", () => {
     let dataSources: DataSource[]
 
     before(async () => {
@@ -18,12 +18,6 @@ describe("entity manager > invalidWhereValuesBehavior with throw", () => {
             entities: [Post, Category],
             schemaCreate: true,
             dropSchema: true,
-            driverSpecific: {
-                invalidWhereValuesBehavior: {
-                    null: "throw",
-                    undefined: "throw",
-                },
-            },
         })
     })
     beforeEach(() => reloadTestingDatabases(dataSources))


### PR DESCRIPTION
Fixes #12578.

## Summary
- remove the early return in `OrmUtils.normalizeWhereCriteria` when no `invalidWhereValuesBehavior` is configured
- let the existing EntityManager mutation tests cover the default throw behavior instead of only explicit `{ null: "throw", undefined: "throw" }`

## Verification
- `pnpm run compile`
- `pnpm exec mocha --no-config --check-leaks --exit --file ./build/compiled/test/utils/test-setup.js --globals allowedDriverRequire build/compiled/test/functional/null-undefined-handling/query-builders.test.js`
- `pnpm exec prettier --check src/util/OrmUtils.ts test/functional/null-undefined-handling/query-builders.test.ts`
- `pnpm exec eslint src/util/OrmUtils.ts test/functional/null-undefined-handling/query-builders.test.ts`
- `pnpm run typecheck`

Note: I also accidentally started the default Mocha config once; the relevant null/undefined tests passed, but the full run stopped at `RedisQueryResultCache Integration` because this local machine has no container runtime available.

/claim #12578
