### PR TITLE
fix: normalizeWhereCriteria should throw by default when DataSource options not configured

### DIFF
--- a/src/util/OrmUtils.ts
+++ b/src/util/OrmUtils.ts
@@ -662,10 +662,6 @@ export class OrmUtils {
         options?: InvalidFindOptionsWhereBehavior,
         path?: string,
     ): ObjectLiteral | ObjectLiteral[] {
-        if (!options) {
-            return criteria
-        }
-
         // multiple criteria are possible at the top level
         if (!path && Array.isArray(criteria)) {
             return criteria.map(

--- a/test/unit/util/orm-utils.test.ts
+++ b/test/unit/util/orm-utils.test.ts
@@ -270,4 +270,36 @@ describe(`OrmUtils`, () => {
             ).to.equal(false)
         })
     })
+
+    describe("normalizeWhereCriteria", () => {
+        it("should throw by default when options/DataSource config is not set", () => {
+            // Regression test for #12578
+            // When DataSource has no invalidWhereValuesBehavior configured,
+            // normalizeWhereCriteria should default to 'throw' behavior
+            expect(() => {
+                OrmUtils.normalizeWhereCriteria({ name: undefined })
+            }).to.throw("Undefined value encountered")
+
+            expect(() => {
+                OrmUtils.normalizeWhereCriteria({ name: null })
+            }).to.throw("Null value encountered")
+        })
+
+        it("should not throw when options.undefined is 'ignore'", () => {
+            const result = OrmUtils.normalizeWhereCriteria(
+                { name: undefined, title: "hello" },
+                { undefined: "ignore" },
+            )
+            expect(result).to.deep.equal({ title: "hello" })
+        })
+
+        it("should throw when options.undefined is 'throw'", () => {
+            expect(() => {
+                OrmUtils.normalizeWhereCriteria(
+                    { name: undefined },
+                    { undefined: "throw" },
+                )
+            }).to.throw("Undefined value encountered")
+        })
+    })
 })


### PR DESCRIPTION
## Description

Fixes #12578

When `DataSource` is created without `invalidWhereValuesBehavior` configuration, `OrmUtils.normalizeWhereCriteria()` should default to `throw` behavior for both `null` and `undefined` values — as documented.

## Root Cause

The early return at `OrmUtils.ts:665-667`:
```typescript
if (!options) {
    return criteria
}
```
skipped all validation when no `invalidWhereValuesBehavior` was configured. This caused undefined/null values to silently pass through in WHERE criteria, leading to buggy UPDATE queries.

## Fix

Removed the early return. The existing code already handles defaults correctly:
- `options?.undefined ?? "throw"` → throws on undefined
- `options?.null ?? "throw"` → throws on null

This matches the documented default behavior. No behavioral change for explicitly configured DataSources.

## Checklist
- [x] Bug fix (non-breaking change)
- [x] Existing tests continue to pass
- [x] No new dependencies
