### PR TITLE
fix: TreeRepository closure table schema-qualified path breaks innerJoin

### DIFF
--- a/src/repository/TreeRepository.ts
+++ b/src/repository/TreeRepository.ts
@@ -182,7 +182,7 @@ export class TreeRepository<
 
             return this.createQueryBuilder(alias)
                 .innerJoin(
-                    this.metadata.closureJunctionTable.tablePath,
+                    this.metadata.closureJunctionTable.tableNameWithoutPrefix,
                     closureTableAlias,
                     joinCondition,
                 )
@@ -365,7 +365,7 @@ export class TreeRepository<
 
             return this.createQueryBuilder(alias)
                 .innerJoin(
-                    this.metadata.closureJunctionTable.tablePath,
+                    this.metadata.closureJunctionTable.tableNameWithoutPrefix,
                     closureTableAlias,
                     joinCondition,
                 )


### PR DESCRIPTION
## Description

When a schema is set on the DataSource or @Entity decorator, `closureJunctionTable.tablePath` returns a schema-qualified name (e.g. `"public"."zone_closure"`) which `SelectQueryBuilder.innerJoin()` interprets as `alias.property`, causing:

```
TypeORMError: "public" alias was not found. Maybe you forgot to join it?
```

This breaks `TreeRepository.findAncestors()` and `findDescendants()` for closure-table trees when schema is configured.

## Root Cause

`TreeRepository.createDescendantsQueryBuilder()` and `createAncestorsQueryBuilder()` both pass `this.metadata.closureJunctionTable.tablePath` to `innerJoin()`. When schema is set, `tablePath` includes the schema qualification (e.g. `"public"."zone_closure"`), and the dotted format is parsed as `alias.property` rather than a table identifier.

This was introduced in #12110 (typeorm 0.3.29) as part of a fix for #10263.

## Fix

Changed `tablePath` to `tableNameWithoutPrefix` in both query builders. The unqualified table name is sufficient for `innerJoin()` — the schema is handled by the database driver at query execution time via the connection configuration.

## Related

- Fixes #12588
- The fix for #10263 (PR #12110) is preserved — the relation metadata logic was not changed