### PR TITLE
fix: throw for default invalid where values

### DIFF
--- a/src/entity-manager/EntityManager.ts
+++ b/src/entity-manager/EntityManager.ts
@@ -98,6 +98,40 @@ export class EntityManager {
         }
     }
 
+    private createEmptyCriteriaError(methodName: string): TypeORMError {
+        return new TypeORMError(
+            `Empty criteria(s) are not allowed for the ${methodName} method.`,
+        )
+    }
+
+    private normalizeWhereCriteria(
+        criteria: ObjectLiteral | ObjectLiteral[],
+        methodName: string,
+    ): ObjectLiteral | ObjectLiteral[] {
+        const normalizedCriteria = OrmUtils.normalizeWhereCriteria(
+            criteria,
+            this.dataSource.options.invalidWhereValuesBehavior,
+        )
+
+        if (Array.isArray(normalizedCriteria)) {
+            const nonEmptyCriteria = normalizedCriteria.filter(
+                (criterion) => !OrmUtils.isCriteriaNullOrEmpty(criterion),
+            )
+
+            if (nonEmptyCriteria.length === 0) {
+                throw this.createEmptyCriteriaError(methodName)
+            }
+
+            return nonEmptyCriteria
+        }
+
+        if (OrmUtils.isCriteriaNullOrEmpty(normalizedCriteria)) {
+            throw this.createEmptyCriteriaError(methodName)
+        }
+
+        return normalizedCriteria
+    }
+
     // -------------------------------------------------------------------------
     // Public Methods
     // -------------------------------------------------------------------------
@@ -851,11 +885,7 @@ export class EntityManager {
     ): Promise<UpdateResult> {
         // if user passed empty criteria or empty list of criterias, then throw an error
         if (OrmUtils.isCriteriaNullOrEmpty(criteria)) {
-            return Promise.reject(
-                new TypeORMError(
-                    `Empty criteria(s) are not allowed for the update method.`,
-                ),
-            )
+            return Promise.reject(this.createEmptyCriteriaError("update"))
         }
 
         if (OrmUtils.isPrimitiveCriteria(criteria)) {
@@ -870,9 +900,9 @@ export class EntityManager {
 
             return qb.execute()
         } else {
-            const normalizedCriteria = OrmUtils.normalizeWhereCriteria(
+            const normalizedCriteria = this.normalizeWhereCriteria(
                 criteria as ObjectLiteral | ObjectLiteral[],
-                this.dataSource.options.invalidWhereValuesBehavior,
+                "update",
             )
             const qb = this.createQueryBuilder()
                 .update(target)
@@ -937,11 +967,7 @@ export class EntityManager {
     ): Promise<DeleteResult> {
         // if user passed empty criteria or empty list of criterias, then throw an error
         if (OrmUtils.isCriteriaNullOrEmpty(criteria)) {
-            return Promise.reject(
-                new TypeORMError(
-                    `Empty criteria(s) are not allowed for the delete method.`,
-                ),
-            )
+            return Promise.reject(this.createEmptyCriteriaError("delete"))
         }
 
         if (OrmUtils.isPrimitiveCriteria(criteria)) {
@@ -951,9 +977,9 @@ export class EntityManager {
                 .whereInIds(criteria)
                 .execute()
         } else {
-            const normalizedCriteria = OrmUtils.normalizeWhereCriteria(
+            const normalizedCriteria = this.normalizeWhereCriteria(
                 criteria as ObjectLiteral | ObjectLiteral[],
-                this.dataSource.options.invalidWhereValuesBehavior,
+                "delete",
             )
             return this.createQueryBuilder()
                 .delete()
@@ -1003,11 +1029,7 @@ export class EntityManager {
     ): Promise<UpdateResult> {
         // if user passed empty criteria or empty list of criterias, then throw an error
         if (OrmUtils.isCriteriaNullOrEmpty(criteria)) {
-            return Promise.reject(
-                new TypeORMError(
-                    `Empty criteria(s) are not allowed for the softDelete method.`,
-                ),
-            )
+            return Promise.reject(this.createEmptyCriteriaError("softDelete"))
         }
 
         if (OrmUtils.isPrimitiveCriteria(criteria)) {
@@ -1017,9 +1039,9 @@ export class EntityManager {
                 .whereInIds(criteria)
                 .execute()
         } else {
-            const normalizedCriteria = OrmUtils.normalizeWhereCriteria(
+            const normalizedCriteria = this.normalizeWhereCriteria(
                 criteria as ObjectLiteral | ObjectLiteral[],
-                this.dataSource.options.invalidWhereValuesBehavior,
+                "softDelete",
             )
             return this.createQueryBuilder()
                 .softDelete()
@@ -1054,11 +1076,7 @@ export class EntityManager {
     ): Promise<UpdateResult> {
         // if user passed empty criteria or empty list of criterias, then throw an error
         if (OrmUtils.isCriteriaNullOrEmpty(criteria)) {
-            return Promise.reject(
-                new TypeORMError(
-                    `Empty criteria(s) are not allowed for the restore method.`,
-                ),
-            )
+            return Promise.reject(this.createEmptyCriteriaError("restore"))
         }
 
         if (OrmUtils.isPrimitiveCriteria(criteria)) {
@@ -1068,9 +1086,9 @@ export class EntityManager {
                 .whereInIds(criteria)
                 .execute()
         } else {
-            const normalizedCriteria = OrmUtils.normalizeWhereCriteria(
+            const normalizedCriteria = this.normalizeWhereCriteria(
                 criteria as ObjectLiteral | ObjectLiteral[],
-                this.dataSource.options.invalidWhereValuesBehavior,
+                "restore",
             )
             return this.createQueryBuilder()
                 .restore()

--- a/src/util/OrmUtils.ts
+++ b/src/util/OrmUtils.ts
@@ -662,10 +662,6 @@ export class OrmUtils {
         options?: InvalidFindOptionsWhereBehavior,
         path?: string,
     ): ObjectLiteral | ObjectLiteral[] {
-        if (!options) {
-            return criteria
-        }
-
         // multiple criteria are possible at the top level
         if (!path && Array.isArray(criteria)) {
             return criteria.map(
@@ -680,6 +676,9 @@ export class OrmUtils {
 
         const result: ObjectLiteral = {}
         for (const [key, value] of Object.entries(criteria)) {
+            // Match merge behavior and avoid mutating result's prototype.
+            if (key === "__proto__") continue
+
             const propertyPath = path ? `${path}.${key}` : key
 
             if (value === undefined) {

--- a/test/functional/null-undefined-handling/query-builders.test.ts
+++ b/test/functional/null-undefined-handling/query-builders.test.ts
@@ -133,6 +133,50 @@ describe("entity manager > invalidWhereValuesBehavior default", () => {
             expect(updated.text).to.equal("Updated text")
         }
     })
+
+    it("should reject criteria that normalize to empty", async () => {
+        for (const connection of dataSources) {
+            const post = await prepareData(connection)
+            const dangerousCriteria = () =>
+                JSON.parse(`{"__proto__":{"polluted":true}}`)
+
+            await expectInvalidCriteriaError(
+                () =>
+                    connection.manager.update(Post, dangerousCriteria(), {
+                        text: "Updated text",
+                    }),
+                "Empty criteria(s)",
+            )
+
+            await expectInvalidCriteriaError(
+                () =>
+                    connection.manager.delete(Post, [
+                        dangerousCriteria(),
+                    ] as any),
+                "Empty criteria(s)",
+            )
+
+            await expectInvalidCriteriaError(
+                () => connection.manager.softDelete(Post, dangerousCriteria()),
+                "Empty criteria(s)",
+            )
+
+            await expectInvalidCriteriaError(
+                () =>
+                    connection.manager.restore(Post, [
+                        dangerousCriteria(),
+                    ] as any),
+                "Empty criteria(s)",
+            )
+
+            const unchanged = await connection.manager.findOneByOrFail(Post, {
+                id: post.id,
+            })
+            expect(unchanged.text).to.equal("Some text")
+            expect(await connection.manager.count(Post)).to.equal(1)
+            expect(({} as any).polluted).to.be.undefined
+        }
+    })
 })
 
 describe("entity manager > invalidWhereValuesBehavior with throw", () => {

--- a/test/functional/null-undefined-handling/query-builders.test.ts
+++ b/test/functional/null-undefined-handling/query-builders.test.ts
@@ -9,6 +9,132 @@ import {
 import { Category } from "./entity/Category"
 import { Post } from "./entity/Post"
 
+describe("entity manager > invalidWhereValuesBehavior default", () => {
+    let dataSources: DataSource[]
+
+    before(async () => {
+        dataSources = await createTestingConnections({
+            disabledDrivers: ["spanner"],
+            entities: [Post, Category],
+            schemaCreate: true,
+            dropSchema: true,
+        })
+    })
+    beforeEach(() => reloadTestingDatabases(dataSources))
+    after(() => closeTestingConnections(dataSources))
+
+    async function prepareData(connection: DataSource) {
+        const post = new Post()
+        post.title = "Test Post"
+        post.text = "Some text"
+        await connection.manager.save(post)
+
+        return post
+    }
+
+    async function expectInvalidCriteriaError(
+        action: () => Promise<unknown>,
+        message: string,
+    ) {
+        try {
+            await action()
+            expect.fail("Expected error")
+        } catch (error) {
+            expect(error).to.be.instanceOf(TypeORMError)
+            expect(error.message).to.include(message)
+        }
+    }
+
+    it("should throw for null and undefined criteria by default", async () => {
+        for (const connection of dataSources) {
+            await prepareData(connection)
+
+            await expectInvalidCriteriaError(
+                () =>
+                    connection.manager.update(
+                        Post,
+                        { text: undefined } as any,
+                        { title: "Updated" },
+                    ),
+                "Undefined value encountered",
+            )
+
+            await expectInvalidCriteriaError(
+                () =>
+                    connection.manager.update(Post, { text: null } as any, {
+                        title: "Updated",
+                    }),
+                "Null value encountered",
+            )
+
+            await expectInvalidCriteriaError(
+                () =>
+                    connection.manager.delete(Post, {
+                        text: undefined,
+                    } as any),
+                "Undefined value encountered",
+            )
+
+            await expectInvalidCriteriaError(
+                () => connection.manager.delete(Post, { text: null } as any),
+                "Null value encountered",
+            )
+
+            await expectInvalidCriteriaError(
+                () =>
+                    connection.manager.softDelete(Post, {
+                        text: undefined,
+                    } as any),
+                "Undefined value encountered",
+            )
+
+            await expectInvalidCriteriaError(
+                () =>
+                    connection.manager.softDelete(Post, {
+                        text: null,
+                    } as any),
+                "Null value encountered",
+            )
+
+            await expectInvalidCriteriaError(
+                () =>
+                    connection.manager.restore(Post, {
+                        text: undefined,
+                    } as any),
+                "Undefined value encountered",
+            )
+
+            await expectInvalidCriteriaError(
+                () =>
+                    connection.manager.restore(Post, {
+                        text: null,
+                    } as any),
+                "Null value encountered",
+            )
+        }
+    })
+
+    it("should not treat prototype pollution keys as criteria", async () => {
+        for (const connection of dataSources) {
+            const post = await prepareData(connection)
+            const criteria = JSON.parse(
+                `{"__proto__":{"polluted":true},"title":"Test Post"}`,
+            )
+
+            await connection.manager.update(Post, criteria, {
+                text: "Updated text",
+            })
+
+            expect(({} as any).polluted).to.be.undefined
+
+            const updated = await connection.manager.findOneByOrFail(Post, {
+                id: post.id,
+            })
+            expect(updated.text).to.equal("Updated text")
+        }
+    })
+})
+
 describe("entity manager > invalidWhereValuesBehavior with throw", () => {
     let dataSources: DataSource[]
 


### PR DESCRIPTION
## Summary
- remove the early return in `OrmUtils.normalizeWhereCriteria` so the documented default `throw` behavior applies when `invalidWhereValuesBehavior` is not configured
- add functional coverage for EntityManager `update`, `delete`, `softDelete`, and `restore` with default null/undefined criteria
- avoid copying `__proto__` while normalizing criteria, matching the existing merge guard and preventing the result object's prototype from being mutated

Fixes #12578.

## Tests
- `corepack pnpm run compile`
- `corepack pnpm exec mocha --no-config --check-leaks --color --exit --timeout 90000 --file build/compiled/test/utils/test-setup.js build/compiled/test/functional/null-undefined-handling/query-builders.test.js`
- `corepack pnpm exec lint-staged`