### PR TITLE
Fix default invalid where criteria handling

### DIFF
--- a/src/util/OrmUtils.ts
+++ b/src/util/OrmUtils.ts
@@ -662,10 +662,6 @@ export class OrmUtils {
         options?: InvalidFindOptionsWhereBehavior,
         path?: string,
     ): ObjectLiteral | ObjectLiteral[] {
-        if (!options) {
-            return criteria
-        }
-
         // multiple criteria are possible at the top level
         if (!path && Array.isArray(criteria)) {
             return criteria.map(

--- a/test/functional/null-undefined-handling/query-builders.test.ts
+++ b/test/functional/null-undefined-handling/query-builders.test.ts
@@ -9,6 +9,69 @@ import {
 import { Category } from "./entity/Category"
 import { Post } from "./entity/Post"
 
+describe("entity manager > invalidWhereValuesBehavior defaults to throw", () => {
+    let dataSources: DataSource[]
+
+    before(async () => {
+        dataSources = await createTestingConnections({
+            disabledDrivers: ["spanner"],
+            entities: [Post, Category],
+            schemaCreate: true,
+            dropSchema: true,
+        })
+    })
+    beforeEach(() => reloadTestingDatabases(dataSources))
+    after(() => closeTestingConnections(dataSources))
+
+    async function prepareData(connection: DataSource) {
+        const category = new Category()
+        category.name = "Test Category"
+        await connection.manager.save(category)
+
+        const post = new Post()
+        post.title = "Test Post"
+        post.text = "Some text"
+        post.category = category
+        await connection.manager.save(post)
+
+        return { category, post }
+    }
+
+    it("should throw error for null values in EntityManager.update() without explicit invalidWhereValuesBehavior config", async () => {
+        for (const connection of dataSources) {
+            await prepareData(connection)
+
+            try {
+                await connection.manager.update(Post, { text: null } as any, {
+                    title: "Updated",
+                })
+                expect.fail("Expected error")
+            } catch (error) {
+                expect(error).to.be.instanceOf(TypeORMError)
+                expect(error.message).to.include("Null value encountered")
+            }
+        }
+    })
+
+    it("should throw error for undefined values in EntityManager.update() without explicit invalidWhereValuesBehavior config", async () => {
+        for (const connection of dataSources) {
+            await prepareData(connection)
+
+            try {
+                await connection.manager.update(
+                    Post,
+                    { text: undefined } as any,
+                    { title: "Updated" },
+                )
+                expect.fail("Expected error")
+            } catch (error) {
+                expect(error).to.be.instanceOf(TypeORMError)
+                expect(error.message).to.include("Undefined value encountered")
+            }
+        }
+    })
+})
+
 describe("entity manager > invalidWhereValuesBehavior with throw", () => {
     let dataSources: DataSource[]
 


### PR DESCRIPTION
## Summary

Fix default `invalidWhereValuesBehavior` handling in `OrmUtils.normalizeWhereCriteria()` so high-level mutation APIs still throw for invalid `where` values when the option is not explicitly configured.

## Why

Closes #12578.

The docs already describe `'throw'` as the default behavior for `invalidWhereValuesBehavior`, including for high-level `EntityManager` and repository methods. In practice, `normalizeWhereCriteria()` returned early when the option object was absent, which bypassed the existing default-throw logic.

That meant calls like `EntityManager.update()` could silently proceed with `null` or `undefined` criteria instead of raising a `TypeORMError`.

## What changed

- removed the early return when `options` is undefined in `OrmUtils.normalizeWhereCriteria()`
- added regression coverage for default no-config `EntityManager.update()` handling of `null` and `undefined` criteria

## Validation

Ran:

`pnpm exec mocha --no-config --file ./build/compiled/test/utils/test-setup.js ./build/compiled/test/functional/null-undefined-handling/query-builders.test.js`

Result:

- 22 passing

## Checklist

- [x] Code is up-to-date with the `master` branch
- [x] This pull request links a relevant issue using a closing keyword
- [x] There are new or updated tests validating the change
- [ ] Documentation has been updated to reflect this change

Docs note: I left docs unchecked because the existing docs already describe the intended default behavior correctly; this PR brings the implementation back in line with that documented behavior rather than changing the docs contract.