### PR TITLE
fix: throw by default for null/undefined in update/delete where criteria

### DIFF
--- a/docs/docs/data-source/5-null-and-undefined-handling.md
+++ b/docs/docs/data-source/5-null-and-undefined-handling.md
@@ -41,6 +41,12 @@ const posts = await repository.find({
 })
 ```
 
+:::note
+This default throw behavior applies to **plain object** criteria (the `where` option, and plain objects passed to `update`, `delete`, `softDelete`, and `restore`). When an **entity class instance** is passed as criteria, it is passed through unchanged — all of its set columns, including nullable foreign keys that happen to be `null`, become part of the `WHERE` clause. If you don't want a `null` column to act as a filter, omit it from the criteria or use a plain object instead.
+
+When `null` or `undefined` values are configured to be ignored (see below) and that leaves a write operation (`update`, `delete`, `softDelete`, `restore`) with no remaining conditions, TypeORM throws instead of running an unfiltered query that would affect every row.
+:::
+
 ## Configuration
 
 You can customize how null and undefined values are handled using the `invalidWhereValuesBehavior` option in your data source configuration:

--- a/src/entity-manager/EntityManager.ts
+++ b/src/entity-manager/EntityManager.ts
@@ -877,9 +877,9 @@ export class EntityManager {
             if (OrmUtils.isNormalizedCriteriaUnfiltered(normalizedCriteria)) {
                 return Promise.reject(
                     new TypeORMError(
-                        `All where conditions for the update method were removed because their values were ` +
-                            `null/undefined and 'invalidWhereValuesBehavior' is set to 'ignore'. ` +
-                            `Refusing to run an unfiltered query that would affect every row.`,
+                        `The where criteria for the update method resolved to an empty filter that would match every row. ` +
+                            `This happens when every value is null and/or undefined and skipped via 'invalidWhereValuesBehavior', ` +
+                            `or when an empty criteria object is passed. Refusing to run an unfiltered query.`,
                     ),
                 )
             }
@@ -967,9 +967,9 @@ export class EntityManager {
             if (OrmUtils.isNormalizedCriteriaUnfiltered(normalizedCriteria)) {
                 return Promise.reject(
                     new TypeORMError(
-                        `All where conditions for the delete method were removed because their values were ` +
-                            `null/undefined and 'invalidWhereValuesBehavior' is set to 'ignore'. ` +
-                            `Refusing to run an unfiltered query that would affect every row.`,
+                        `The where criteria for the delete method resolved to an empty filter that would match every row. ` +
+                            `This happens when every value is null and/or undefined and skipped via 'invalidWhereValuesBehavior', ` +
+                            `or when an empty criteria object is passed. Refusing to run an unfiltered query.`,
                     ),
                 )
             }
@@ -1042,9 +1042,9 @@ export class EntityManager {
             if (OrmUtils.isNormalizedCriteriaUnfiltered(normalizedCriteria)) {
                 return Promise.reject(
                     new TypeORMError(
-                        `All where conditions for the softDelete method were removed because their values were ` +
-                            `null/undefined and 'invalidWhereValuesBehavior' is set to 'ignore'. ` +
-                            `Refusing to run an unfiltered query that would affect every row.`,
+                        `The where criteria for the softDelete method resolved to an empty filter that would match every row. ` +
+                            `This happens when every value is null and/or undefined and skipped via 'invalidWhereValuesBehavior', ` +
+                            `or when an empty criteria object is passed. Refusing to run an unfiltered query.`,
                     ),
                 )
             }
@@ -1102,9 +1102,9 @@ export class EntityManager {
             if (OrmUtils.isNormalizedCriteriaUnfiltered(normalizedCriteria)) {
                 return Promise.reject(
                     new TypeORMError(
-                        `All where conditions for the restore method were removed because their values were ` +
-                            `null/undefined and 'invalidWhereValuesBehavior' is set to 'ignore'. ` +
-                            `Refusing to run an unfiltered query that would affect every row.`,
+                        `The where criteria for the restore method resolved to an empty filter that would match every row. ` +
+                            `This happens when every value is null and/or undefined and skipped via 'invalidWhereValuesBehavior', ` +
+                            `or when an empty criteria object is passed. Refusing to run an unfiltered query.`,
                     ),
                 )
             }

--- a/src/entity-manager/EntityManager.ts
+++ b/src/entity-manager/EntityManager.ts
@@ -877,8 +877,8 @@ export class EntityManager {
             if (OrmUtils.isNormalizedCriteriaUnfiltered(normalizedCriteria)) {
                 return Promise.reject(
                     new TypeORMError(
-                        `The where criteria for the update method resolved to an empty filter ` +
-                            `(its values were null/undefined and ignored, or an entity with no set columns was passed). ` +
+                        `All where conditions for the update method were removed because their values were ` +
+                            `null/undefined and 'invalidWhereValuesBehavior' is set to 'ignore'. ` +
                             `Refusing to run an unfiltered query that would affect every row.`,
                     ),
                 )
@@ -967,8 +967,8 @@ export class EntityManager {
             if (OrmUtils.isNormalizedCriteriaUnfiltered(normalizedCriteria)) {
                 return Promise.reject(
                     new TypeORMError(
-                        `The where criteria for the delete method resolved to an empty filter ` +
-                            `(its values were null/undefined and ignored, or an entity with no set columns was passed). ` +
+                        `All where conditions for the delete method were removed because their values were ` +
+                            `null/undefined and 'invalidWhereValuesBehavior' is set to 'ignore'. ` +
                             `Refusing to run an unfiltered query that would affect every row.`,
                     ),
                 )
@@ -1042,8 +1042,8 @@ export class EntityManager {
             if (OrmUtils.isNormalizedCriteriaUnfiltered(normalizedCriteria)) {
                 return Promise.reject(
                     new TypeORMError(
-                        `The where criteria for the softDelete method resolved to an empty filter ` +
-                            `(its values were null/undefined and ignored, or an entity with no set columns was passed). ` +
+                        `All where conditions for the softDelete method were removed because their values were ` +
+                            `null/undefined and 'invalidWhereValuesBehavior' is set to 'ignore'. ` +
                             `Refusing to run an unfiltered query that would affect every row.`,
                     ),
                 )
@@ -1102,8 +1102,8 @@ export class EntityManager {
             if (OrmUtils.isNormalizedCriteriaUnfiltered(normalizedCriteria)) {
                 return Promise.reject(
                     new TypeORMError(
-                        `The where criteria for the restore method resolved to an empty filter ` +
-                            `(its values were null/undefined and ignored, or an entity with no set columns was passed). ` +
+                        `All where conditions for the restore method were removed because their values were ` +
+                            `null/undefined and 'invalidWhereValuesBehavior' is set to 'ignore'. ` +
                             `Refusing to run an unfiltered query that would affect every row.`,
                     ),
                 )

--- a/src/entity-manager/EntityManager.ts
+++ b/src/entity-manager/EntityManager.ts
@@ -877,8 +877,8 @@ export class EntityManager {
             if (OrmUtils.isNormalizedCriteriaUnfiltered(normalizedCriteria)) {
                 return Promise.reject(
                     new TypeORMError(
-                        `All where conditions for the update method were removed because their values were ` +
-                            `null/undefined and 'invalidWhereValuesBehavior' is set to 'ignore'. ` +
+                        `The where criteria for the update method resolved to an empty filter ` +
+                            `(its values were null/undefined and ignored, or an entity with no set columns was passed). ` +
                             `Refusing to run an unfiltered query that would affect every row.`,
                     ),
                 )
@@ -967,8 +967,8 @@ export class EntityManager {
             if (OrmUtils.isNormalizedCriteriaUnfiltered(normalizedCriteria)) {
                 return Promise.reject(
                     new TypeORMError(
-                        `All where conditions for the delete method were removed because their values were ` +
-                            `null/undefined and 'invalidWhereValuesBehavior' is set to 'ignore'. ` +
+                        `The where criteria for the delete method resolved to an empty filter ` +
+                            `(its values were null/undefined and ignored, or an entity with no set columns was passed). ` +
                             `Refusing to run an unfiltered query that would affect every row.`,
                     ),
                 )
@@ -1042,8 +1042,8 @@ export class EntityManager {
             if (OrmUtils.isNormalizedCriteriaUnfiltered(normalizedCriteria)) {
                 return Promise.reject(
                     new TypeORMError(
-                        `All where conditions for the softDelete method were removed because their values were ` +
-                            `null/undefined and 'invalidWhereValuesBehavior' is set to 'ignore'. ` +
+                        `The where criteria for the softDelete method resolved to an empty filter ` +
+                            `(its values were null/undefined and ignored, or an entity with no set columns was passed). ` +
                             `Refusing to run an unfiltered query that would affect every row.`,
                     ),
                 )
@@ -1102,8 +1102,8 @@ export class EntityManager {
             if (OrmUtils.isNormalizedCriteriaUnfiltered(normalizedCriteria)) {
                 return Promise.reject(
                     new TypeORMError(
-                        `All where conditions for the restore method were removed because their values were ` +
-                            `null/undefined and 'invalidWhereValuesBehavior' is set to 'ignore'. ` +
+                        `The where criteria for the restore method resolved to an empty filter ` +
+                            `(its values were null/undefined and ignored, or an entity with no set columns was passed). ` +
                             `Refusing to run an unfiltered query that would affect every row.`,
                     ),
                 )

--- a/src/entity-manager/EntityManager.ts
+++ b/src/entity-manager/EntityManager.ts
@@ -874,6 +874,15 @@ export class EntityManager {
                 criteria as ObjectLiteral | ObjectLiteral[],
                 this.dataSource.options.invalidWhereValuesBehavior,
             )
+            if (OrmUtils.isNormalizedCriteriaUnfiltered(normalizedCriteria)) {
+                return Promise.reject(
+                    new TypeORMError(
+                        `All where conditions for the update method were removed because their values were ` +
+                            `null/undefined and 'invalidWhereValuesBehavior' is set to 'ignore'. ` +
+                            `Refusing to run an unfiltered query that would affect every row.`,
+                    ),
+                )
+            }
             const qb = this.createQueryBuilder()
                 .update(target)
                 .set(partialEntity)
@@ -955,6 +964,15 @@ export class EntityManager {
                 criteria as ObjectLiteral | ObjectLiteral[],
                 this.dataSource.options.invalidWhereValuesBehavior,
             )
+            if (OrmUtils.isNormalizedCriteriaUnfiltered(normalizedCriteria)) {
+                return Promise.reject(
+                    new TypeORMError(
+                        `All where conditions for the delete method were removed because their values were ` +
+                            `null/undefined and 'invalidWhereValuesBehavior' is set to 'ignore'. ` +
+                            `Refusing to run an unfiltered query that would affect every row.`,
+                    ),
+                )
+            }
             return this.createQueryBuilder()
                 .delete()
                 .from(targetOrEntity)
@@ -1021,6 +1039,15 @@ export class EntityManager {
                 criteria as ObjectLiteral | ObjectLiteral[],
                 this.dataSource.options.invalidWhereValuesBehavior,
             )
+            if (OrmUtils.isNormalizedCriteriaUnfiltered(normalizedCriteria)) {
+                return Promise.reject(
+                    new TypeORMError(
+                        `All where conditions for the softDelete method were removed because their values were ` +
+                            `null/undefined and 'invalidWhereValuesBehavior' is set to 'ignore'. ` +
+                            `Refusing to run an unfiltered query that would affect every row.`,
+                    ),
+                )
+            }
             return this.createQueryBuilder()
                 .softDelete()
                 .from(targetOrEntity)
@@ -1072,6 +1099,15 @@ export class EntityManager {
                 criteria as ObjectLiteral | ObjectLiteral[],
                 this.dataSource.options.invalidWhereValuesBehavior,
             )
+            if (OrmUtils.isNormalizedCriteriaUnfiltered(normalizedCriteria)) {
+                return Promise.reject(
+                    new TypeORMError(
+                        `All where conditions for the restore method were removed because their values were ` +
+                            `null/undefined and 'invalidWhereValuesBehavior' is set to 'ignore'. ` +
+                            `Refusing to run an unfiltered query that would affect every row.`,
+                    ),
+                )
+            }
             return this.createQueryBuilder()
                 .restore()
                 .from(targetOrEntity)

--- a/src/util/OrmUtils.ts
+++ b/src/util/OrmUtils.ts
@@ -396,6 +396,26 @@ export class OrmUtils {
     }
 
     /**
+     * Checks whether an already-normalized where criteria would produce an
+     * unfiltered query (an empty object, an empty array, or an OR array in which
+     * any branch is empty). This can happen when 'invalidWhereValuesBehavior' is
+     * set to 'ignore' and every where value is null/undefined, in which case
+     * running the query would affect every row.
+     *
+     * @param criteria
+     */
+    public static isNormalizedCriteriaUnfiltered(criteria: unknown): boolean {
+        if (Array.isArray(criteria)) {
+            return (
+                criteria.length === 0 ||
+                criteria.some(OrmUtils.isCriteriaNullOrEmpty)
+            )
+        }
+
+        return OrmUtils.isCriteriaNullOrEmpty(criteria)
+    }
+
+    /**
      * Checks if given criteria is a primitive value.
      * Primitive values are strings, numbers and dates.
      *
@@ -662,29 +682,36 @@ export class OrmUtils {
         options?: InvalidFindOptionsWhereBehavior,
         path?: string,
     ): ObjectLiteral | ObjectLiteral[] {
-        if (!options) {
-            return criteria
-        }
-
-        // multiple criteria are possible at the top level
+        // multiple criteria are possible at the top level (OR semantics)
         if (!path && Array.isArray(criteria)) {
-            return criteria.map(
-                (criterion, index): ObjectLiteral =>
-                    OrmUtils.normalizeWhereCriteria(
-                        criterion,
-                        options,
-                        String(index),
-                    ),
+            return criteria.map((criterion, index) =>
+                OrmUtils.normalizeWhereCriteria(
+                    criterion,
+                    options,
+                    String(index),
+                ),
             )
         }
 
+        // Non-plain-objects (entity instances, primitives, null/undefined,
+        // FindOperators, nested arrays) are not filter maps and are passed through
+        // unchanged. Entity instances may carry nullable columns (e.g. foreign keys)
+        // that are intentionally part of the where condition, so we don't validate them.
+        if (!OrmUtils.isPlainObject(criteria)) {
+            return criteria
+        }
+
+        // Resolve the behavior once. The documented default is "throw".
+        const undefinedBehavior = options?.undefined ?? "throw"
+        const nullBehavior = options?.null ?? "throw"
+
         const result: ObjectLiteral = {}
         for (const [key, value] of Object.entries(criteria)) {
+            if (key === "__proto__") continue
             const propertyPath = path ? `${path}.${key}` : key
 
             if (value === undefined) {
-                const behavior = options?.undefined ?? "throw"
-                if (behavior === "throw") {
+                if (undefinedBehavior === "throw") {
                     throw new TypeORMError(
                         `Undefined value encountered in property '${propertyPath}' of a where condition. ` +
                             `Set 'invalidWhereValuesBehavior.undefined' to 'ignore' in connection options to skip properties with undefined values.`,
@@ -692,14 +719,13 @@ export class OrmUtils {
                 }
                 // else: "ignore" — skip this key
             } else if (value === null) {
-                const behavior = options?.null ?? "throw"
-                if (behavior === "throw") {
+                if (nullBehavior === "throw") {
                     throw new TypeORMError(
                         `Null value encountered in property '${propertyPath}' of a where condition. ` +
                             `To match with SQL NULL, the IsNull() operator must be used. ` +
                             `Set 'invalidWhereValuesBehavior.null' to 'ignore' or 'sql-null' in connection options to skip or handle null values.`,
                     )
-                } else if (behavior === "sql-null") {
+                } else if (nullBehavior === "sql-null") {
                     result[key] = IsNull()
                 }
                 // else: "ignore" — skip this key

--- a/src/util/OrmUtils.ts
+++ b/src/util/OrmUtils.ts
@@ -397,11 +397,14 @@ export class OrmUtils {
 
     /**
      * Checks whether an already-normalized where criteria would produce an
-     * unfiltered query (an empty object, an empty array, or an OR array in which
-     * any branch is empty). This can happen when 'invalidWhereValuesBehavior' is
-     * set to 'ignore' and every where value is null/undefined, or when an entity
-     * instance with no set columns is passed, in which case running the query
-     * would affect every row.
+     * unfiltered query (an empty plain object, an empty array, or an OR array in
+     * which any branch is an empty plain object). This can happen when
+     * 'invalidWhereValuesBehavior' is set to 'ignore' and every where value is
+     * null/undefined, in which case running the query would affect every row.
+     *
+     * Only plain objects are considered: non-plain criteria (entity instances,
+     * ObjectId, etc.) are normalized to themselves and are not the responsibility
+     * of this guard.
      *
      * @param criteria
      */
@@ -409,24 +412,11 @@ export class OrmUtils {
         if (Array.isArray(criteria)) {
             return (
                 criteria.length === 0 ||
-                criteria.some((branch) =>
-                    OrmUtils.isNormalizedCriteriaUnfiltered(branch),
-                )
+                criteria.some(OrmUtils.isCriteriaNullOrEmpty)
             )
         }
 
-        if (OrmUtils.isCriteriaNullOrEmpty(criteria)) {
-            return true
-        }
-
-        // isCriteriaNullOrEmpty only treats *plain* objects as empty; an entity
-        // instance (or any other non-plain object) with no own enumerable keys
-        // would still normalize to an empty WHERE, so detect that here as well.
-        return (
-            typeof criteria === "object" &&
-            criteria !== null &&
-            Object.keys(criteria).length === 0
-        )
+        return OrmUtils.isCriteriaNullOrEmpty(criteria)
     }
 
     /**

--- a/src/util/OrmUtils.ts
+++ b/src/util/OrmUtils.ts
@@ -399,8 +399,9 @@ export class OrmUtils {
      * Checks whether an already-normalized where criteria would produce an
      * unfiltered query (an empty object, an empty array, or an OR array in which
      * any branch is empty). This can happen when 'invalidWhereValuesBehavior' is
-     * set to 'ignore' and every where value is null/undefined, in which case
-     * running the query would affect every row.
+     * set to 'ignore' and every where value is null/undefined, or when an entity
+     * instance with no set columns is passed, in which case running the query
+     * would affect every row.
      *
      * @param criteria
      */
@@ -408,11 +409,24 @@ export class OrmUtils {
         if (Array.isArray(criteria)) {
             return (
                 criteria.length === 0 ||
-                criteria.some(OrmUtils.isCriteriaNullOrEmpty)
+                criteria.some((branch) =>
+                    OrmUtils.isNormalizedCriteriaUnfiltered(branch),
+                )
             )
         }
 
-        return OrmUtils.isCriteriaNullOrEmpty(criteria)
+        if (OrmUtils.isCriteriaNullOrEmpty(criteria)) {
+            return true
+        }
+
+        // isCriteriaNullOrEmpty only treats *plain* objects as empty; an entity
+        // instance (or any other non-plain object) with no own enumerable keys
+        // would still normalize to an empty WHERE, so detect that here as well.
+        return (
+            typeof criteria === "object" &&
+            criteria !== null &&
+            Object.keys(criteria).length === 0
+        )
     }
 
     /**

--- a/test/functional/null-undefined-handling/query-builders.test.ts
+++ b/test/functional/null-undefined-handling/query-builders.test.ts
@@ -598,6 +598,31 @@ describe("entity manager > invalidWhereValuesBehavior default (unconfigured)", (
             await expect(connection.manager.delete(Post, post)).to.be.fulfilled
         }
     })
+
+    it("should refuse an explicitly empty OR branch even without 'ignore' configured", async () => {
+        for (const connection of dataSources) {
+            await prepareData(connection)
+
+            // no invalidWhereValuesBehavior is configured here, so the guard is
+            // not about ignored null/undefined — an empty criteria object passed
+            // directly must still be refused.
+            try {
+                await connection.manager.delete(Post, [
+                    { title: "Test Post" },
+                    {},
+                ] as any)
+                expect.fail("Expected error")
+            } catch (error) {
+                expect(error).to.be.instanceOf(TypeORMError)
+                expect(error.message).to.include(
+                    "Refusing to run an unfiltered",
+                )
+            }
+
+            const remaining = await connection.manager.find(Post)
+            expect(remaining.length).to.equal(1)
+        }
+    })
 })
 
 describe("entity manager > invalidWhereValuesBehavior unfiltered-write guard", () => {

--- a/test/functional/null-undefined-handling/query-builders.test.ts
+++ b/test/functional/null-undefined-handling/query-builders.test.ts
@@ -484,3 +484,212 @@ describe("entity manager > invalidWhereValuesBehavior does NOT affect QB .where(
         }
     })
 })
+
+describe("entity manager > invalidWhereValuesBehavior default (unconfigured)", () => {
+    let dataSources: DataSource[]
+
+    before(async () => {
+        dataSources = await createTestingConnections({
+            disabledDrivers: ["spanner"],
+            entities: [Post, Category],
+            schemaCreate: true,
+            dropSchema: true,
+            // intentionally no driverSpecific.invalidWhereValuesBehavior:
+            // the documented default behavior ("throw") must still apply.
+        })
+    })
+    beforeEach(() => reloadTestingDatabases(dataSources))
+    after(() => closeTestingConnections(dataSources))
+
+    async function prepareData(connection: DataSource) {
+        const post = new Post()
+        post.title = "Test Post"
+        post.text = "Some text"
+        await connection.manager.save(post)
+        return post
+    }
+
+    const writeMethods = ["update", "delete", "softDelete", "restore"] as const
+
+    for (const method of writeMethods) {
+        it(`should throw by default for null values in EntityManager.${method}()`, async () => {
+            for (const connection of dataSources) {
+                await prepareData(connection)
+
+                const args: any[] = [Post, { text: null }]
+                if (method === "update") args.push({ title: "Updated" })
+
+                try {
+                    await (connection.manager as any)[method](...args)
+                    expect.fail("Expected error")
+                } catch (error) {
+                    expect(error).to.be.instanceOf(TypeORMError)
+                    expect(error.message).to.include("Null value encountered")
+                }
+            }
+        })
+
+        it(`should throw by default for undefined values in EntityManager.${method}()`, async () => {
+            for (const connection of dataSources) {
+                await prepareData(connection)
+
+                const args: any[] = [Post, { text: undefined }]
+                if (method === "update") args.push({ title: "Updated" })
+
+                try {
+                    await (connection.manager as any)[method](...args)
+                    expect.fail("Expected error")
+                } catch (error) {
+                    expect(error).to.be.instanceOf(TypeORMError)
+                    expect(error.message).to.include(
+                        "Undefined value encountered",
+                    )
+                }
+            }
+        })
+    }
+
+    it("should throw by default for nested null values in EntityManager.update()", async () => {
+        for (const connection of dataSources) {
+            await prepareData(connection)
+
+            try {
+                await connection.manager.update(
+                    Post,
+                    { category: { name: null } } as any,
+                    { title: "Updated" },
+                )
+                expect.fail("Expected error")
+            } catch (error) {
+                expect(error).to.be.instanceOf(TypeORMError)
+                expect(error.message).to.include("Null value encountered")
+            }
+        }
+    })
+
+    it("should throw by default for null values in an array (OR) criteria", async () => {
+        for (const connection of dataSources) {
+            await prepareData(connection)
+
+            try {
+                await connection.manager.delete(Post, [
+                    { title: "Test Post" },
+                    { text: null },
+                ] as any)
+                expect.fail("Expected error")
+            } catch (error) {
+                expect(error).to.be.instanceOf(TypeORMError)
+                expect(error.message).to.include("Null value encountered")
+            }
+        }
+    })
+
+    it("should NOT throw when an entity class instance with a null column is passed (passthrough)", async () => {
+        for (const connection of dataSources) {
+            // a plain object { text: null } would throw by default, but an entity
+            // class instance is not validated — its set columns (including a null
+            // nullable column) are passed through to the WHERE as-is, so this
+            // resolves instead of throwing.
+            const post = new Post()
+            post.title = "Test Post"
+            post.text = null
+            await connection.manager.save(post)
+
+            await expect(connection.manager.delete(Post, post)).to.be.fulfilled
+        }
+    })
+})
+
+describe("entity manager > invalidWhereValuesBehavior unfiltered-write guard", () => {
+    let dataSources: DataSource[]
+
+    before(async () => {
+        dataSources = await createTestingConnections({
+            disabledDrivers: ["spanner"],
+            entities: [Post, Category],
+            schemaCreate: true,
+            dropSchema: true,
+            driverSpecific: {
+                invalidWhereValuesBehavior: {
+                    null: "ignore",
+                    undefined: "ignore",
+                },
+            },
+        })
+    })
+    beforeEach(() => reloadTestingDatabases(dataSources))
+    after(() => closeTestingConnections(dataSources))
+
+    async function prepareData(connection: DataSource) {
+        const post = new Post()
+        post.title = "Test Post"
+        post.text = "text"
+        await connection.manager.save(post)
+        return post
+    }
+
+    it("should refuse EntityManager.delete() when all criteria are stripped", async () => {
+        for (const connection of dataSources) {
+            await prepareData(connection)
+
+            try {
+                await connection.manager.delete(Post, { text: null } as any)
+                expect.fail("Expected error")
+            } catch (error) {
+                expect(error).to.be.instanceOf(TypeORMError)
+                expect(error.message).to.include(
+                    "Refusing to run an unfiltered",
+                )
+            }
+
+            // the row must still be there — nothing was deleted
+            const remaining = await connection.manager.find(Post)
+            expect(remaining.length).to.equal(1)
+        }
+    })
+
+    it("should refuse EntityManager.update() when all criteria are stripped", async () => {
+        for (const connection of dataSources) {
+            await prepareData(connection)
+
+            try {
+                await connection.manager.update(
+                    Post,
+                    { text: undefined } as any,
+                    { title: "Updated" },
+                )
+                expect.fail("Expected error")
+            } catch (error) {
+                expect(error).to.be.instanceOf(TypeORMError)
+                expect(error.message).to.include(
+                    "Refusing to run an unfiltered",
+                )
+            }
+
+            const reloaded = await connection.manager.find(Post)
+            expect(reloaded[0].title).to.equal("Test Post")
+        }
+    })
+
+    it("should refuse an OR array criteria when any branch is stripped to empty", async () => {
+        for (const connection of dataSources) {
+            await prepareData(connection)
+
+            try {
+                await connection.manager.delete(Post, [
+                    { title: "Test Post" },
+                    { text: null },
+                ] as any)
+                expect.fail("Expected error")
+            } catch (error) {
+                expect(error).to.be.instanceOf(TypeORMError)
+                expect(error.message).to.include(
+                    "Refusing to run an unfiltered",
+                )
+            }
+
+            const remaining = await connection.manager.find(Post)
+            expect(remaining.length).to.equal(1)
+        }
+    })
+})

--- a/test/unit/util/orm-utils.test.ts
+++ b/test/unit/util/orm-utils.test.ts
@@ -1,6 +1,6 @@
 import { expect } from "chai"
 import { runInNewContext } from "node:vm"
-import type { DeepPartial, IsNull } from "../../../src"
+import type { DeepPartial } from "../../../src"
 import { InstanceChecker } from "../../../src/util/InstanceChecker"
 import { OrmUtils } from "../../../src/util/OrmUtils"
 
@@ -305,9 +305,7 @@ describe(`OrmUtils`, () => {
                 { null: "sql-null" },
             ) as { status: unknown }
             expect(InstanceChecker.isFindOperator(result.status)).to.equal(true)
-            expect((result.status as ReturnType<typeof IsNull>).type).to.equal(
-                "isNull",
-            )
+            expect((result.status as { type: string }).type).to.equal("isNull")
         })
 
         it("passes entity class instances through unchanged (no validation)", () => {
@@ -390,12 +388,35 @@ describe(`OrmUtils`, () => {
             ).to.equal(true)
         })
 
+        it("reports an entity instance with no set columns as unfiltered", () => {
+            class User {}
+            expect(
+                OrmUtils.isNormalizedCriteriaUnfiltered(new User()),
+            ).to.equal(true)
+            // also when it appears as a branch of an OR array
+            expect(
+                OrmUtils.isNormalizedCriteriaUnfiltered([
+                    { id: 1 },
+                    new User(),
+                ]),
+            ).to.equal(true)
+        })
+
         it("reports populated criteria as filtered", () => {
             expect(OrmUtils.isNormalizedCriteriaUnfiltered({ id: 1 })).to.equal(
                 false,
             )
             expect(
                 OrmUtils.isNormalizedCriteriaUnfiltered([{ id: 1 }]),
+            ).to.equal(false)
+        })
+
+        it("reports an entity instance with set columns as filtered", () => {
+            class User {
+                id = 1
+            }
+            expect(
+                OrmUtils.isNormalizedCriteriaUnfiltered(new User()),
             ).to.equal(false)
         })
     })

--- a/test/unit/util/orm-utils.test.ts
+++ b/test/unit/util/orm-utils.test.ts
@@ -1,6 +1,7 @@
 import { expect } from "chai"
 import { runInNewContext } from "node:vm"
-import type { DeepPartial } from "../../../src"
+import type { DeepPartial, IsNull } from "../../../src"
+import { InstanceChecker } from "../../../src/util/InstanceChecker"
 import { OrmUtils } from "../../../src/util/OrmUtils"
 
 describe(`OrmUtils`, () => {
@@ -267,6 +268,134 @@ describe(`OrmUtils`, () => {
                     crossRealmArray,
                     new Uint8Array([1, 2, 4]),
                 ),
+            ).to.equal(false)
+        })
+    })
+
+    describe("normalizeWhereCriteria", () => {
+        it("throws on undefined values by default (no options)", () => {
+            expect(() =>
+                OrmUtils.normalizeWhereCriteria({ name: undefined }),
+            ).to.throw(/Undefined value.*'name'/)
+        })
+
+        it("throws on null values by default (no options)", () => {
+            expect(() =>
+                OrmUtils.normalizeWhereCriteria({ email: null }),
+            ).to.throw(/Null value.*'email'/)
+        })
+
+        it("throws on undefined in nested objects with the full path", () => {
+            expect(() =>
+                OrmUtils.normalizeWhereCriteria({ user: { id: undefined } }),
+            ).to.throw(/Undefined value.*'user\.id'/)
+        })
+
+        it("ignores undefined when options.undefined is 'ignore'", () => {
+            const result = OrmUtils.normalizeWhereCriteria(
+                { name: "Alice", email: undefined },
+                { undefined: "ignore" },
+            )
+            expect(result).to.deep.equal({ name: "Alice" })
+        })
+
+        it("transforms null to IsNull() when options.null is 'sql-null'", () => {
+            const result = OrmUtils.normalizeWhereCriteria(
+                { status: null },
+                { null: "sql-null" },
+            ) as { status: unknown }
+            expect(InstanceChecker.isFindOperator(result.status)).to.equal(true)
+            expect((result.status as ReturnType<typeof IsNull>).type).to.equal(
+                "isNull",
+            )
+        })
+
+        it("passes entity class instances through unchanged (no validation)", () => {
+            class User {
+                id = 1
+                name = "Alice"
+                parentId: number | null = null
+                deletedAt: Date | undefined = undefined
+            }
+            const entity = new User()
+            // default behavior is "throw", but entity instances are not validated
+            const result = OrmUtils.normalizeWhereCriteria(entity)
+            expect(result).to.equal(entity)
+            expect(result).to.deep.equal({
+                id: 1,
+                name: "Alice",
+                parentId: null,
+                deletedAt: undefined,
+            })
+        })
+
+        it("does not validate entity instances even when options request throw", () => {
+            class User {
+                id = 1
+                parentId: number | null = null
+            }
+            const entity = new User()
+            expect(() =>
+                OrmUtils.normalizeWhereCriteria(entity, { null: "throw" }),
+            ).to.not.throw()
+        })
+
+        it("throws on null/undefined in array criteria (OR semantics)", () => {
+            expect(() =>
+                OrmUtils.normalizeWhereCriteria([
+                    { id: 1 },
+                    { name: undefined },
+                ]),
+            ).to.throw(/Undefined value.*'1\.name'/)
+
+            expect(() =>
+                OrmUtils.normalizeWhereCriteria([{ email: null }]),
+            ).to.throw(/Null value.*'0\.email'/)
+        })
+
+        it("normalizes valid array criteria without throwing", () => {
+            const result = OrmUtils.normalizeWhereCriteria([
+                { id: 1 },
+                { name: "Bob" },
+            ])
+            expect(result).to.deep.equal([{ id: 1 }, { name: "Bob" }])
+        })
+
+        it("returns null/undefined/primitive criteria without throwing", () => {
+            expect(OrmUtils.normalizeWhereCriteria(null as any)).to.equal(null)
+            expect(OrmUtils.normalizeWhereCriteria(undefined as any)).to.equal(
+                undefined,
+            )
+            expect(OrmUtils.normalizeWhereCriteria(1 as any)).to.equal(1)
+        })
+
+        it("ignores the __proto__ key when iterating", () => {
+            const result = OrmUtils.normalizeWhereCriteria(
+                JSON.parse('{ "__proto__": { "polluted": true }, "id": 1 }'),
+            )
+            expect(result).to.deep.equal({ id: 1 })
+            expect(({} as any).polluted).to.equal(undefined)
+        })
+    })
+
+    describe("isNormalizedCriteriaUnfiltered", () => {
+        it("reports empty objects and arrays as unfiltered", () => {
+            expect(OrmUtils.isNormalizedCriteriaUnfiltered({})).to.equal(true)
+            expect(OrmUtils.isNormalizedCriteriaUnfiltered([])).to.equal(true)
+        })
+
+        it("reports an OR array with an empty branch as unfiltered", () => {
+            expect(
+                OrmUtils.isNormalizedCriteriaUnfiltered([{ id: 1 }, {}]),
+            ).to.equal(true)
+        })
+
+        it("reports populated criteria as filtered", () => {
+            expect(OrmUtils.isNormalizedCriteriaUnfiltered({ id: 1 })).to.equal(
+                false,
+            )
+            expect(
+                OrmUtils.isNormalizedCriteriaUnfiltered([{ id: 1 }]),
             ).to.equal(false)
         })
     })

--- a/test/unit/util/orm-utils.test.ts
+++ b/test/unit/util/orm-utils.test.ts
@@ -388,20 +388,6 @@ describe(`OrmUtils`, () => {
             ).to.equal(true)
         })
 
-        it("reports an entity instance with no set columns as unfiltered", () => {
-            class User {}
-            expect(
-                OrmUtils.isNormalizedCriteriaUnfiltered(new User()),
-            ).to.equal(true)
-            // also when it appears as a branch of an OR array
-            expect(
-                OrmUtils.isNormalizedCriteriaUnfiltered([
-                    { id: 1 },
-                    new User(),
-                ]),
-            ).to.equal(true)
-        })
-
         it("reports populated criteria as filtered", () => {
             expect(OrmUtils.isNormalizedCriteriaUnfiltered({ id: 1 })).to.equal(
                 false,
@@ -411,12 +397,21 @@ describe(`OrmUtils`, () => {
             ).to.equal(false)
         })
 
-        it("reports an entity instance with set columns as filtered", () => {
-            class User {
-                id = 1
+        it("does not flag non-plain criteria such as entity instances or value objects", () => {
+            // the guard only polices empty plain objects/arrays; non-plain
+            // criteria (entity instances, ObjectId, etc.) are not its concern,
+            // even when they expose no enumerable keys
+            class User {}
+            class ObjectIdLike {
+                toHexString() {
+                    return "507f1f77bcf86cd799439011"
+                }
             }
             expect(
                 OrmUtils.isNormalizedCriteriaUnfiltered(new User()),
+            ).to.equal(false)
+            expect(
+                OrmUtils.isNormalizedCriteriaUnfiltered(new ObjectIdLike()),
             ).to.equal(false)
         })
     })


### PR DESCRIPTION
Fixes #12578. Supersedes #12579

## Problem

`OrmUtils.normalizeWhereCriteria()` returned criteria **unvalidated** when `invalidWhereValuesBehavior` was not configured, because an early `if (!options) return criteria` short-circuited before the per-key default-throw logic ran. As a result `update()`, `delete()`, `softDelete()` and `restore()` silently accepted `null`/`undefined` in where conditions (e.g. `UPDATE "t" SET ... WHERE "col" = null`) while `find()` correctly threw.

These write methods build their `WHERE` via `QueryBuilder.getWhereCondition()` → `getPredicates()`, which performs **no** null/undefined validation (unlike `SelectQueryBuilder.buildWhere`, the `find()` path). So `normalizeWhereCriteria` is the only validator on the write path — there is no downstream safety net.

## Changes

- **Remove the early `if (!options) return`** and resolve the behavior once at the top of `normalizeWhereCriteria`, defaulting to the documented `"throw"` (matching `find()`).
- **Validate plain-object criteria only.** Entity class instances (and other non-plain objects) pass through unchanged via an early return — their set columns, including nullable foreign keys that happen to be `null`, are intentionally part of the `WHERE`. This keeps `softDelete(entity)` working as before and is what the `isPlainObject` check guards (per @alumni's review).
- **Refuse unfiltered writes.** When values are ignored (`invalidWhereValuesBehavior: { … "ignore" }`) and normalization strips a criteria down to something that would touch every row (empty `{}`, or an OR array with an empty branch), the operation now rejects instead of running an unscoped `UPDATE`/`DELETE`. New `OrmUtils.isNormalizedCriteriaUnfiltered()` helper, applied at all four `EntityManager` call sites.
- Resolve `null`/`undefined` behavior in a single place, add a `__proto__` guard, and tidy the OR-array recursion.
- Docs: clarify that the default-throw applies to plain-object criteria, that entity instances pass through unchanged, and that ignored values which strip a write to empty now throw.

## Tests

- **Unit** (`test/unit/util/orm-utils.test.ts`): default-throw for null/undefined, nested paths, `ignore`, `sql-null` → `IsNull()`, entity-instance passthrough, OR-array semantics, primitive/null criteria, `__proto__` guard, and `isNormalizedCriteriaUnfiltered`.
- **Functional** (`test/functional/null-undefined-handling/query-builders.test.ts`): a new **default (unconfigured)** suite covering `update`/`delete`/`softDelete`/`restore` throwing by default — the real regression gap, since every existing throw test explicitly set options — plus nested/array cases, entity-instance passthrough, and the unfiltered-write guard.

## Backport note

On `master` the per-key logic already defaulted to `"throw"`, so this is a single cohesive change. The `v0.3` branch defaults to `"ignore"` and is structured differently; per @alumni the **plain-object-check structure** is backportable to `v0.3` while the **default-throw flip is not**. That backport will be a separate PR against `v0.3`.