### PR TITLE
fix: only normalize plain-object where criteria, pass entity instances through

### DIFF
--- a/src/util/OrmUtils.ts
+++ b/src/util/OrmUtils.ts
@@ -4,7 +4,6 @@ import {
     PrimitiveCriteria,
     SinglePrimitiveCriteria,
 } from "../common/PrimitiveCriteria"
-import { InstanceChecker } from "./InstanceChecker"
 import { TypeORMError } from "../error"
 import { IsNull } from "../find-options/operator/IsNull"
 
@@ -608,14 +607,26 @@ export class OrmUtils {
     ): ObjectLiteral {
         if (!options) return criteria
 
+        // Entity class instances (and other non-plain objects) are passed through
+        // unchanged: their set columns — including nullable foreign keys — are
+        // intentionally part of the where condition and must not be validated or
+        // stripped. Only plain objects (FindOptionsWhere) are normalized.
+        if (!OrmUtils.isPlainObject(criteria)) {
+            return criteria
+        }
+
+        // Resolve the behavior once. The default remains "ignore".
+        const undefinedBehavior = options.undefined || "ignore"
+        const nullBehavior = options.null || "ignore"
+
         const result: ObjectLiteral = {}
 
         for (const [key, value] of Object.entries(criteria)) {
+            if (key === "__proto__") continue
             const propertyPath = path ? `${path}.${key}` : key
 
             if (value === undefined) {
-                const behavior = options.undefined || "ignore"
-                if (behavior === "throw") {
+                if (undefinedBehavior === "throw") {
                     throw new TypeORMError(
                         `Undefined value encountered in property '${propertyPath}' of a where condition. ` +
                             `Set 'invalidWhereValuesBehavior.undefined' to 'ignore' in connection options to skip properties with undefined values.`,
@@ -623,23 +634,17 @@ export class OrmUtils {
                 }
                 // "ignore" — skip this key
             } else if (value === null) {
-                const behavior = options.null || "ignore"
-                if (behavior === "throw") {
+                if (nullBehavior === "throw") {
                     throw new TypeORMError(
                         `Null value encountered in property '${propertyPath}' of a where condition. ` +
                             `To match with SQL NULL, the IsNull() operator must be used. ` +
                             `Set 'invalidWhereValuesBehavior.null' to 'ignore' or 'sql-null' in connection options to skip or handle null values.`,
                     )
-                } else if (behavior === "sql-null") {
+                } else if (nullBehavior === "sql-null") {
                     result[key] = IsNull()
                 }
                 // "ignore" — skip this key
-            } else if (
-                typeof value === "object" &&
-                !Array.isArray(value) &&
-                !(value instanceof Date) &&
-                !InstanceChecker.isFindOperator(value)
-            ) {
+            } else if (OrmUtils.isPlainObject(value)) {
                 const nested = OrmUtils.normalizeWhereCriteria(
                     value,
                     options,

--- a/test/functional/null-undefined-handling/query-builders.test.ts
+++ b/test/functional/null-undefined-handling/query-builders.test.ts
@@ -236,6 +236,26 @@ describe("entity manager > invalidWhereValuesBehavior with throw", () => {
             }
         }
     })
+
+    it("should NOT throw for an entity class instance with a null column (passthrough)", async () => {
+        for (const connection of dataSources) {
+            // a plain object { text: null } throws under this config, but an
+            // entity class instance is not validated — its set columns, including
+            // a null nullable column, are passed through to the WHERE as-is.
+            const post = new Post()
+            post.title = "Test Post"
+            post.text = null
+            await connection.manager.save(post)
+
+            let threw = false
+            try {
+                await connection.manager.delete(Post, post)
+            } catch (error) {
+                threw = true
+            }
+            expect(threw).to.equal(false)
+        }
+    })
 })
 
 describe("entity manager > invalidWhereValuesBehavior with sql-null", () => {

--- a/test/unit/util/orm-utils.test.ts
+++ b/test/unit/util/orm-utils.test.ts
@@ -202,4 +202,59 @@ describe(`OrmUtils`, () => {
             expect(objCopy2).to.equal(undefined)
         })
     })
+
+    describe("normalizeWhereCriteria", () => {
+        it("returns criteria unchanged when no options are provided", () => {
+            const criteria = { name: null, email: undefined }
+            expect(OrmUtils.normalizeWhereCriteria(criteria)).to.equal(criteria)
+        })
+
+        it("defaults to ignoring null and undefined on plain objects", () => {
+            const result = OrmUtils.normalizeWhereCriteria(
+                { name: "Alice", email: null, phone: undefined },
+                {},
+            )
+            expect(result).to.deep.equal({ name: "Alice" })
+        })
+
+        it("throws on null/undefined when configured to throw", () => {
+            expect(() =>
+                OrmUtils.normalizeWhereCriteria(
+                    { name: undefined },
+                    { undefined: "throw" },
+                ),
+            ).to.throw(/Undefined value.*'name'/)
+            expect(() =>
+                OrmUtils.normalizeWhereCriteria(
+                    { email: null },
+                    { null: "throw" },
+                ),
+            ).to.throw(/Null value.*'email'/)
+        })
+
+        it("passes entity class instances through unchanged (not validated)", () => {
+            class User {
+                id = 1
+                name = "Alice"
+                parentId: number | null = null
+                deletedAt: Date | undefined = undefined
+            }
+            const entity = new User()
+            // even with throw configured, an entity instance is not validated
+            const result = OrmUtils.normalizeWhereCriteria(entity, {
+                null: "throw",
+                undefined: "throw",
+            })
+            expect(result).to.equal(entity)
+        })
+
+        it("ignores the __proto__ key when iterating", () => {
+            const result = OrmUtils.normalizeWhereCriteria(
+                JSON.parse('{ "__proto__": { "polluted": true }, "id": 1 }'),
+                {},
+            )
+            expect(result).to.deep.equal({ id: 1 })
+            expect(({} as any).polluted).to.equal(undefined)
+        })
+    })
 })


### PR DESCRIPTION
Refs #12578. Backport companion to #12611 (master).

Per @alumni's review of #12579, this splits out the **plain-object check** as the part that is safe to land on `v0.3`, **without** the default-value change (master keeps `v0.3`'s `ignore` default; the default-throw flip is master-only).

## Problem

On `v0.3`, `OrmUtils.normalizeWhereCriteria()` iterated *any* object — including entity class instances — whenever `invalidWhereValuesBehavior` was configured. A loaded entity carries all its columns, so a nullable foreign key that happens to be `null` (or an unset `undefined` column) could be silently stripped, turned into `IS NULL`, or made to throw, even though those columns are intentionally part of the `WHERE`.

## Changes

- Add an `isPlainObject` early-return: entity instances (and other non-plain objects) pass through unchanged; only plain `FindOptionsWhere` objects are normalized.
- Resolve the `null`/`undefined` behavior once at the top of the function (single determination instead of per-key fallbacks). **The default stays `"ignore"` on `v0.3`** — no behavior change to the default.
- Use `isPlainObject` for nested recursion (consistent with the top-level check), and guard against the `__proto__` key while iterating.

## What is intentionally NOT here

- The default-value flip to `"throw"` (the fix for #12578's symptom) ships on **master** only (#12611). `v0.3` keeps its `"ignore"` default.

## Tests

- Unit (`test/unit/util/orm-utils.test.ts`): no-options passthrough, default-`ignore` on plain objects, throw-when-configured, **entity-instance passthrough even when throw is configured**, and the `__proto__` guard.
- Functional (`test/functional/null-undefined-handling/query-builders.test.ts`): an entity class instance with a `null` column passed to `delete()` does not throw under the `throw` config. All existing `invalidWhereValuesBehavior` tests continue to pass.