### PR TITLE
fix: apply default invalid where behavior

### DIFF
--- a/src/util/OrmUtils.ts
+++ b/src/util/OrmUtils.ts
@@ -662,10 +662,6 @@ export class OrmUtils {
         options?: InvalidFindOptionsWhereBehavior,
         path?: string,
     ): ObjectLiteral | ObjectLiteral[] {
-        if (!options) {
-            return criteria
-        }
-
         // multiple criteria are possible at the top level
         if (!path && Array.isArray(criteria)) {
             return criteria.map(

--- a/test/unit/util/orm-utils.test.ts
+++ b/test/unit/util/orm-utils.test.ts
@@ -220,6 +220,28 @@ describe(`OrmUtils`, () => {
         })
     })
 
+    describe("normalizeWhereCriteria", () => {
+        it("should throw for undefined criteria values by default", () => {
+            expect(() =>
+                OrmUtils.normalizeWhereCriteria({ text: undefined }),
+            ).to.throw(
+                "Undefined value encountered in property 'text' of a where condition.",
+            )
+        })
+
+        it("should throw for null criteria values by default", () => {
+            expect(() => OrmUtils.normalizeWhereCriteria({ text: null })).to.throw(
+                "Null value encountered in property 'text' of a where condition.",
+            )
+        })
+
+        it("should preserve criteria without null or undefined values by default", () => {
+            expect(OrmUtils.normalizeWhereCriteria({ text: "safe" })).to.deep.equal(
+                { text: "safe" },
+            )
+        })
+    })
+
     describe("compare2Objects", () => {
         it("should compare two Map.", () => {
             expect(OrmUtils.deepCompare(new Map(), new Map())).to.equal(true)


### PR DESCRIPTION
## Summary

Fixes `OrmUtils.normalizeWhereCriteria()` so missing `invalidWhereValuesBehavior` options still use the documented default behavior for null and undefined where criteria.

Before this change, `normalizeWhereCriteria()` returned the criteria unchanged when `options` was not provided. That bypassed the existing `?? "throw"` defaults and allowed unsafe null or undefined criteria through paths such as `EntityManager.update()`.

## Changes

- Remove the early return when `invalidWhereValuesBehavior` options are omitted.
- Add unit coverage proving default undefined and null criteria throw.
- Add a safe-value regression check proving normal criteria are preserved.

## Verification

- `corepack pnpm run compile`
- `corepack pnpm exec mocha --no-config build\\compiled\\test\\unit\\util\\orm-utils.test.js`

Fixes #12578
