### PR TITLE
fix: use ALTER COLUMN instead of DROP+CREATE for type/length changes in Postgres

### DIFF
--- a/src/driver/postgres/PostgresQueryRunner.ts
+++ b/src/driver/postgres/PostgresQueryRunner.ts
@@ -1336,54 +1336,7 @@ export class PostgresQueryRunner
             oldColumn.asExpression !== newColumn.asExpression &&
             newColumn.generatedType === "STORED"
 
-        // For safe type/length changes, use ALTER COLUMN instead of drop+create
-        // to preserve data and dependent objects (indices, FKs, etc.)
-        const canAlterInPlace =
-            (typeChanged || lengthChanged) &&
-            !arrayChanged &&
-            !storedGeneratedChanged &&
-            !asExpressionChanged
-
-        if (canAlterInPlace) {
-            const newType = this.normalizeType(newColumn)
-            const columnType = newColumn.length
-                ? `${newType}(${newColumn.length})`
-                : newType
-
-            upQueries.push(
-                new Query(
-                    `ALTER TABLE ${this.escapePath(
-                        table,
-                    )} ALTER COLUMN "${oldColumn.name}" TYPE ${columnType}`,
-                ),
-            )
-            downQueries.push(
-                new Query(
-                    `ALTER TABLE ${this.escapePath(
-                        table,
-                    )} ALTER COLUMN "${newColumn.name}" TYPE ${
-                        oldColumn.length
-                            ? `${this.normalizeType(oldColumn)}(${oldColumn.length})`
-                            : this.normalizeType(oldColumn)
-                    }`,
-                ),
-            )
-
-            if (upQueries.length > 0) {
-                await this.startTransaction()
-                try {
-                    for (const query of upQueries)
-                        await this.query(query.query)
-                    await this.commitTransaction()
-                } catch (error) {
-                    await this.rollbackTransaction()
-                    throw error
-                }
-            }
-
-            // update cloned table
-            clonedTable = table.clone()
-        } else if (
+        if (
             arrayChanged ||
             storedGeneratedChanged ||
             asExpressionChanged
@@ -1671,24 +1624,51 @@ export class PostgresQueryRunner
                 oldColumn.name = newColumn.name
             }
 
+            // For safe type/length changes, use ALTER COLUMN instead of drop+create
+            // to preserve data and dependent objects (indices, FKs, etc.)
             if (
-                newColumn.precision !== oldColumn.precision ||
-                newColumn.scale !== oldColumn.scale
+                (typeChanged || lengthChanged) &&
+                !arrayChanged &&
+                !storedGeneratedChanged &&
+                !asExpressionChanged
             ) {
                 upQueries.push(
                     new Query(
-                        `ALTER TABLE ${this.escapePath(table)} ALTER COLUMN "${
-                            newColumn.name
-                        }" TYPE ${this.driver.createFullType(newColumn)}`,
+                        `ALTER TABLE ${this.escapePath(
+                            table,
+                        )} ALTER COLUMN "${oldColumn.name}" TYPE ${this.driver.createFullType(newColumn)}`,
                     ),
                 )
                 downQueries.push(
                     new Query(
-                        `ALTER TABLE ${this.escapePath(table)} ALTER COLUMN "${
-                            newColumn.name
-                        }" TYPE ${this.driver.createFullType(oldColumn)}`,
+                        `ALTER TABLE ${this.escapePath(
+                            table,
+                        )} ALTER COLUMN "${newColumn.name}" TYPE ${this.driver.createFullType(oldColumn)}`,
                     ),
                 )
+            }
+
+            if (
+                newColumn.precision !== oldColumn.precision ||
+                newColumn.scale !== oldColumn.scale
+            ) {
+                // Skip if type/length already changed — createFullType() already includes precision/scale
+                if (!(typeChanged || lengthChanged)) {
+                    upQueries.push(
+                        new Query(
+                            `ALTER TABLE ${this.escapePath(table)} ALTER COLUMN "${
+                                newColumn.name
+                            }" TYPE ${this.driver.createFullType(newColumn)}`,
+                        ),
+                    )
+                    downQueries.push(
+                        new Query(
+                            `ALTER TABLE ${this.escapePath(table)} ALTER COLUMN "${
+                                newColumn.name
+                            }" TYPE ${this.driver.createFullType(oldColumn)}`,
+                        ),
+                    )
+                }
             }
 
             if (
@@ -2513,6 +2493,20 @@ export class PostgresQueryRunner
                     //     }),
                     // )
                 }
+            }
+        }
+
+        // Update cloned table to reflect new column definition for type/length changes
+        if (typeChanged || lengthChanged) {
+            const clonedColumn = clonedTable.columns.find(
+                (column) => column.name === oldColumn.name,
+            )
+            if (clonedColumn) {
+                clonedColumn.type = newColumn.type
+                clonedColumn.length = newColumn.length
+                clonedColumn.precision = newColumn.precision
+                clonedColumn.scale = newColumn.scale
+                clonedColumn.isArray = newColumn.isArray
             }
         }
 

--- a/src/driver/postgres/PostgresQueryRunner.ts
+++ b/src/driver/postgres/PostgresQueryRunner.ts
@@ -1326,16 +1326,69 @@ export class PostgresQueryRunner
                 `Column "${oldTableColumnOrName}" was not found in the "${table.name}" table.`,
             )
 
-        if (
-            oldColumn.type !== newColumn.type ||
-            oldColumn.length !== newColumn.length ||
-            newColumn.isArray !== oldColumn.isArray ||
-            (!oldColumn.generatedType &&
-                newColumn.generatedType === "STORED") ||
-            (oldColumn.asExpression !== newColumn.asExpression &&
-                newColumn.generatedType === "STORED")
+        const typeChanged = oldColumn.type !== newColumn.type
+        const lengthChanged = oldColumn.length !== newColumn.length
+        const arrayChanged = newColumn.isArray !== oldColumn.isArray
+        const storedGeneratedChanged =
+            !oldColumn.generatedType &&
+            newColumn.generatedType === "STORED"
+        const asExpressionChanged =
+            oldColumn.asExpression !== newColumn.asExpression &&
+            newColumn.generatedType === "STORED"
+
+        // For safe type/length changes, use ALTER COLUMN instead of drop+create
+        // to preserve data and dependent objects (indices, FKs, etc.)
+        const canAlterInPlace =
+            (typeChanged || lengthChanged) &&
+            !arrayChanged &&
+            !storedGeneratedChanged &&
+            !asExpressionChanged
+
+        if (canAlterInPlace) {
+            const newType = this.normalizeType(newColumn)
+            const columnType = newColumn.length
+                ? `${newType}(${newColumn.length})`
+                : newType
+
+            upQueries.push(
+                new Query(
+                    `ALTER TABLE ${this.escapePath(
+                        table,
+                    )} ALTER COLUMN "${oldColumn.name}" TYPE ${columnType}`,
+                ),
+            )
+            downQueries.push(
+                new Query(
+                    `ALTER TABLE ${this.escapePath(
+                        table,
+                    )} ALTER COLUMN "${newColumn.name}" TYPE ${
+                        oldColumn.length
+                            ? `${this.normalizeType(oldColumn)}(${oldColumn.length})`
+                            : this.normalizeType(oldColumn)
+                    }`,
+                ),
+            )
+
+            if (upQueries.length > 0) {
+                await this.startTransaction()
+                try {
+                    for (const query of upQueries)
+                        await this.query(query.query)
+                    await this.commitTransaction()
+                } catch (error) {
+                    await this.rollbackTransaction()
+                    throw error
+                }
+            }
+
+            // update cloned table
+            clonedTable = table.clone()
+        } else if (
+            arrayChanged ||
+            storedGeneratedChanged ||
+            asExpressionChanged
         ) {
-            // To avoid data conversion, we just recreate column
+            // These changes require drop+create
             await this.dropColumn(table, oldColumn)
             await this.addColumn(table, newColumn)
 


### PR DESCRIPTION
fixes #3357

when only the type or length of a column changes (e.g. varchar(255) to varchar(500), int to bigint), we now use ALTER COLUMN ... TYPE instead of dropping and recreating the column. this preserves data, indices, foreign keys, and other dependent objects.

only falls back to drop+create for truly incompatible changes like isArray toggling or STORED generated column changes.

tested with postgres driver - column length and type changes now generate proper ALTER statements instead of DROP+CREATE pairs.