### PR TITLE
fix: apply default throw behavior in normalizeWhereCriteria when options is undefined

### DIFF
--- a/src/util/OrmUtils.ts
+++ b/src/util/OrmUtils.ts
@@ -653,6 +653,11 @@ export class OrmUtils {
      * Recursively validates an object where clause, throwing for null/undefined
      * based on the provided invalidWhereValuesBehavior config.
      *
+     * When `options` is not provided (i.e. `invalidWhereValuesBehavior` is not
+     * configured in the DataSource), the documented defaults apply:
+     *   - undefined values → throw
+     *   - null values      → throw
+     *
      * @param criteria
      * @param options
      * @param path
@@ -662,8 +667,12 @@ export class OrmUtils {
         options?: InvalidFindOptionsWhereBehavior,
         path?: string,
     ): ObjectLiteral | ObjectLiteral[] {
-        if (!options) {
-            return criteria
+        // Apply documented defaults when invalidWhereValuesBehavior is not configured.
+        // Any explicitly supplied options override these defaults via spread.
+        const effectiveOptions: InvalidFindOptionsWhereBehavior = {
+            null: "throw",
+            undefined: "throw",
+            ...options,
         }
 
         // multiple criteria are possible at the top level
@@ -672,7 +681,7 @@ export class OrmUtils {
                 (criterion, index): ObjectLiteral =>
                     OrmUtils.normalizeWhereCriteria(
                         criterion,
-                        options,
+                        effectiveOptions,
                         String(index),
                     ),
             )
@@ -683,7 +692,7 @@ export class OrmUtils {
             const propertyPath = path ? `${path}.${key}` : key
 
             if (value === undefined) {
-                const behavior = options?.undefined ?? "throw"
+                const behavior = effectiveOptions.undefined ?? "throw"
                 if (behavior === "throw") {
                     throw new TypeORMError(
                         `Undefined value encountered in property '${propertyPath}' of a where condition. ` +
@@ -692,7 +701,7 @@ export class OrmUtils {
                 }
                 // else: "ignore" — skip this key
             } else if (value === null) {
-                const behavior = options?.null ?? "throw"
+                const behavior = effectiveOptions.null ?? "throw"
                 if (behavior === "throw") {
                     throw new TypeORMError(
                         `Null value encountered in property '${propertyPath}' of a where condition. ` +
@@ -706,7 +715,7 @@ export class OrmUtils {
             } else if (OrmUtils.isPlainObject(value)) {
                 const nested = OrmUtils.normalizeWhereCriteria(
                     value,
-                    options,
+                    effectiveOptions,
                     propertyPath,
                 )
                 if (Object.keys(nested).length > 0) {


### PR DESCRIPTION
## Summary

Fixes #12578

## Problem

`OrmUtils.normalizeWhereCriteria()` had an early return when `options` was `undefined` (i.e. `invalidWhereValuesBehavior` was not configured in the DataSource):

```ts
if (!options) {
    return criteria  // skips ALL null/undefined validation
}
```

This meant that when no `invalidWhereValuesBehavior` config was set, `null` and `undefined` values in WHERE clauses were silently passed through, producing dangerous SQL like:

```sql
UPDATE "schema_x"."table_y" SET "col1" = $1 WHERE "col2" = null
```

No error or warning was raised, making the bug invisible to developers.

Additionally, the risk noted in the issue: if a user later adds `invalidWhereValuesBehavior: { undefined: 'ignore' }` during an upgrade, the behavior silently shifts from "silent no-op" to "unscoped UPDATE affecting ALL rows" with no intermediate error state to catch it.

## Fix

Instead of bailing out when `options` is `undefined`, fall back to the documented defaults (`null: 'throw'`, `undefined: 'throw'`) and allow any user-supplied config to override them via object spread:

```ts
const effectiveOptions: InvalidFindOptionsWhereBehavior = {
    null: "throw",
    undefined: "throw",
    ...options,
}
```

All further logic uses `effectiveOptions` instead of `options`.

## Backwards Compatibility

- Users who already set `invalidWhereValuesBehavior` explicitly: ✅ no change — their config spreads over the defaults.
- Users who set `invalidWhereValuesBehavior: {}`: ✅ defaults apply (same as documented).
- Users with no config at all: ⚠️ now correctly throws on `null`/`undefined` in WHERE, **which is the documented default behavior** — previously this was silently broken.

## Testing

The reproduction repo from the issue can be used to verify: https://github.com/samkessaram/typeorm-undefined-where-bug

```bash
git clone https://github.com/samkessaram/typeorm-undefined-where-bug.git
cd typeorm-undefined-where-bug
npm install
npm start
```

Before this fix: no error thrown, silent bad SQL.
After this fix: `TypeORMError` thrown as documented.