### PR TITLE
fix: apply default throw behavior in normalizeWhereCriteria when options is not provided

### DIFF
--- a/src/util/OrmUtils.ts
+++ b/src/util/OrmUtils.ts
@@ -662,8 +662,14 @@ export class OrmUtils {
         options?: InvalidFindOptionsWhereBehavior,
         path?: string,
     ): ObjectLiteral | ObjectLiteral[] {
-        if (!options) {
-            return criteria
+        // Apply documented default "throw" behavior when options are not
+        // provided (e.g. DataSource has no invalidWhereValuesBehavior set).
+        // Previously this returned `criteria` immediately, bypassing all
+        // null/undefined validation — contradicting the docs which state
+        // "throw" is the default for both null and undefined.
+        const resolvedOptions: InvalidFindOptionsWhereBehavior = options ?? {
+            null: "throw",
+            undefined: "throw",
         }
 
         // multiple criteria are possible at the top level
@@ -672,7 +678,7 @@ export class OrmUtils {
                 (criterion, index): ObjectLiteral =>
                     OrmUtils.normalizeWhereCriteria(
                         criterion,
-                        options,
+                        resolvedOptions,
                         String(index),
                     ),
             )
@@ -683,7 +689,7 @@ export class OrmUtils {
             const propertyPath = path ? `${path}.${key}` : key
 
             if (value === undefined) {
-                const behavior = options?.undefined ?? "throw"
+                const behavior = resolvedOptions.undefined ?? "throw"
                 if (behavior === "throw") {
                     throw new TypeORMError(
                         `Undefined value encountered in property '${propertyPath}' of a where condition. ` +
@@ -692,7 +698,7 @@ export class OrmUtils {
                 }
                 // else: "ignore" — skip this key
             } else if (value === null) {
-                const behavior = options?.null ?? "throw"
+                const behavior = resolvedOptions.null ?? "throw"
                 if (behavior === "throw") {
                     throw new TypeORMError(
                         `Null value encountered in property '${propertyPath}' of a where condition. ` +
@@ -706,7 +712,7 @@ export class OrmUtils {
             } else if (OrmUtils.isPlainObject(value)) {
                 const nested = OrmUtils.normalizeWhereCriteria(
                     value,
-                    options,
+                    resolvedOptions,
                     propertyPath,
                 )
                 if (Object.keys(nested).length > 0) {

--- a/test/unit/util/orm-utils.test.ts
+++ b/test/unit/util/orm-utils.test.ts
@@ -1,6 +1,7 @@
 import { expect } from "chai"
 import { runInNewContext } from "node:vm"
 import type { DeepPartial } from "../../../src"
+import { TypeORMError } from "../../../src"
 import { OrmUtils } from "../../../src/util/OrmUtils"
 
 describe(`OrmUtils`, () => {
@@ -268,6 +269,139 @@ describe(`OrmUtils`, () => {
                     new Uint8Array([1, 2, 4]),
                 ),
             ).to.equal(false)
+        })
+    })
+
+    describe("normalizeWhereCriteria", () => {
+        describe("default behavior when options is not provided", () => {
+            it("should throw TypeORMError for undefined values when no options are provided", () => {
+                expect(() => {
+                    OrmUtils.normalizeWhereCriteria(
+                        { col1: "value", col2: undefined },
+                        undefined,
+                    )
+                }).to.throw(TypeORMError, /Undefined value encountered/)
+            })
+
+            it("should throw TypeORMError for null values when no options are provided", () => {
+                expect(() => {
+                    OrmUtils.normalizeWhereCriteria(
+                        { col1: "value", col2: null },
+                        undefined,
+                    )
+                }).to.throw(TypeORMError, /Null value encountered/)
+            })
+
+            it("should include property path in error message", () => {
+                expect(() => {
+                    OrmUtils.normalizeWhereCriteria(
+                        { myColumn: undefined },
+                        undefined,
+                    )
+                }).to.throw(TypeORMError, /myColumn/)
+            })
+
+            it("should handle nested objects with undefined values", () => {
+                expect(() => {
+                    OrmUtils.normalizeWhereCriteria(
+                        { nested: { deepProp: undefined } },
+                        undefined,
+                    )
+                }).to.throw(
+                    TypeORMError,
+                    /Undefined value encountered in property 'nested.deepProp'/,
+                )
+            })
+
+            it("should handle nested objects with null values", () => {
+                expect(() => {
+                    OrmUtils.normalizeWhereCriteria(
+                        { nested: { deepProp: null } },
+                        undefined,
+                    )
+                }).to.throw(
+                    TypeORMError,
+                    /Null value encountered in property 'nested.deepProp'/,
+                )
+            })
+
+            it("should handle array criteria with undefined values", () => {
+                expect(() => {
+                    OrmUtils.normalizeWhereCriteria(
+                        [{ col1: "value" }, { col2: undefined }],
+                        undefined,
+                    )
+                }).to.throw(TypeORMError, /Undefined value encountered/)
+            })
+
+            it("should handle array criteria with null values", () => {
+                expect(() => {
+                    OrmUtils.normalizeWhereCriteria(
+                        [{ col1: "value" }, { col2: null }],
+                        undefined,
+                    )
+                }).to.throw(TypeORMError, /Null value encountered/)
+            })
+
+            it("should pass through valid values without throwing", () => {
+                const criteria = {
+                    col1: "value",
+                    col2: 42,
+                    col3: true,
+                }
+                const result = OrmUtils.normalizeWhereCriteria(
+                    criteria,
+                    undefined,
+                )
+                expect(result).to.deep.equal(criteria)
+            })
+        })
+
+        describe("with explicit options", () => {
+            it("should ignore undefined values when configured to ignore", () => {
+                const result = OrmUtils.normalizeWhereCriteria(
+                    { col1: "value", col2: undefined },
+                    { undefined: "ignore" },
+                )
+                expect(result).to.deep.equal({ col1: "value" })
+            })
+
+            it("should ignore null values when configured to ignore", () => {
+                const result = OrmUtils.normalizeWhereCriteria(
+                    { col1: "value", col2: null },
+                    { null: "ignore" },
+                )
+                expect(result).to.deep.equal({ col1: "value" })
+            })
+
+            it("should throw for undefined when explicitly configured to throw", () => {
+                expect(() => {
+                    OrmUtils.normalizeWhereCriteria(
+                        { col1: undefined },
+                        { undefined: "throw" },
+                    )
+                }).to.throw(TypeORMError, /Undefined value encountered/)
+            })
+
+            it("should throw for null when explicitly configured to throw", () => {
+                expect(() => {
+                    OrmUtils.normalizeWhereCriteria(
+                        { col1: null },
+                        { null: "throw" },
+                    )
+                }).to.throw(TypeORMError, /Null value encountered/)
+            })
+
+            it("should convert null to IsNull() when configured to sql-null", () => {
+                const result = OrmUtils.normalizeWhereCriteria(
+                    { col1: "value", col2: null },
+                    { null: "sql-null" },
+                ) as Record<string, unknown>
+                expect(result).to.have.property("col1", "value")
+                expect(result).to.have.property("col2")
+                // IsNull() returns a FindOperator instance
+                expect(result.col2).to.not.equal(null)
+            })
         })
     })
 })


### PR DESCRIPTION
## Summary
Fixes #12578

## Problem
`OrmUtils.normalizeWhereCriteria()` had an early return when `options` was `undefined` (i.e., `invalidWhereValuesBehavior` was not configured in the DataSource):

```typescript
if (!options) {
    return criteria // ← BUG: exits immediately without any validation
}
```

When no `invalidWhereValuesBehavior` config was set, **null and undefined values in WHERE clauses were silently passed through**, producing dangerous SQL like:

```sql
UPDATE "schema_x"."table_y" SET "col1" = $1 WHERE "col2" = null
-- This produces a no-op (NULL != NULL in SQL), silently skipping the update
```

### Why This Matters
1. **Silent Data Loss** — Updates/deletes silently affect zero rows with no error
2. **Upgrade Trap** — If a user later adds `invalidWhereValuesBehavior: { undefined: "ignore" }`, the behavior shifts from "silent no-op" to **unscoped UPDATE affecting ALL rows** — with no intermediate error to catch it
3. **Violates Documentation** — The [docs](https://typeorm.io/find-options#invalidwherevaluesbehavior) explicitly state the default is `{ null: "throw", undefined: "throw" }`

## Root Cause
The `if (!options)` guard on [line 660 of OrmUtils.ts](https://github.com/typeorm/typeorm/blob/master/src/util/OrmUtils.ts#L660) treated "no configuration" as "skip all validation". This is incorrect — "no configuration" should mean "apply documented defaults".

Note: `SelectQueryBuilder` was unaffected because it had its own inline fallback to `"throw"`. But `EntityManager` relied entirely on `OrmUtils.normalizeWhereCriteria()`, which was the broken path.

## Fix
Replace the early return with a nullish coalescing fallback to the documented defaults:

```typescript
// Before (broken):
if (!options) {
    return criteria  // skips ALL validation
}

// After (fixed):
const resolvedOptions: InvalidFindOptionsWhereBehavior = options ?? {
    null: "throw",
    undefined: "throw",
}
```

All downstream references now use `resolvedOptions` instead of `options`. The fix is minimal (6 lines changed in production code) and surgical — no behavioral change for any user who has already configured `invalidWhereValuesBehavior`.

## Backwards Compatibility

| Scenario | Before (broken) | After (fixed) |
|----------|-----------------|---------------|
| No config set | ⚠️ Silently passes null/undefined through | ✅ Throws `TypeORMError` (documented default) |
| `invalidWhereValuesBehavior: {}` | Individual defaults still apply | ✅ No change |
| `invalidWhereValuesBehavior: { null: "ignore" }` | Ignores null | ✅ No change |
| `invalidWhereValuesBehavior: { undefined: "throw" }` | Throws on undefined | ✅ No change |

**Breaking change note:** Users who were unknowingly relying on the broken behavior (passing null/undefined without errors) will now correctly see `TypeORMError` thrown. This is the intended and documented behavior.

## Tests Added
Added **13 comprehensive unit tests** in `test/unit/util/orm-utils.test.ts`:

### Default behavior (no options provided)
| Test | Description |
|------|-------------|
| ✅ | Throws `TypeORMError` for undefined values |
| ✅ | Throws `TypeORMError` for null values |
| ✅ | Includes property path in error messages (e.g., `"myColumn"`) |
| ✅ | Handles nested objects (e.g., `"nested.deepProp"`) |
| ✅ | Handles nested null in objects |
| ✅ | Handles array criteria with undefined |
| ✅ | Handles array criteria with null |
| ✅ | Passes valid values through without throwing |

### Explicit options
| Test | Description |
|------|-------------|
| ✅ | Ignores undefined when `{ undefined: "ignore" }` |
| ✅ | Ignores null when `{ null: "ignore" }` |
| ✅ | Throws for undefined when `{ undefined: "throw" }` |
| ✅ | Throws for null when `{ null: "throw" }` |
| ✅ | Converts null to `IsNull()` when `{ null: "sql-null" }` |

## Verification
Tested against the reproduction repo from the issue:
[https://github.com/samkessaram/typeorm-undefined-where-bug](https://github.com/samkessaram/typeorm-undefined-where-bug)

- **Before fix:** No error, silent bad SQL
- **After fix:** `TypeORMError` thrown as documented

## Checklist
- [x] Code follows the existing style in `OrmUtils.ts`
- [x] Fix is minimal and surgical (6 lines production, 136 lines tests)
- [x] All existing tests unaffected
- [x] New unit tests cover the bug + edge cases
- [x] Backwards compatible for all configured users
- [x] Matches documented behavior exactly