### PR TITLE
fix: apply default throw behavior in normalizeWhereCriteria when options is not provided

### DIFF
--- a/src/util/OrmUtils.ts
+++ b/src/util/OrmUtils.ts
@@ -663,7 +663,7 @@ export class OrmUtils {
         path?: string,
     ): ObjectLiteral | ObjectLiteral[] {
         if (!options) {
-            return criteria
+            options = { null: "throw", undefined: "throw" }
         }
 
         // multiple criteria are possible at the top level


### PR DESCRIPTION
## Description

When `DataSource` is configured without `invalidWhereValuesBehavior`, `normalizeWhereCriteria()` was returning criteria immediately without validation, silently allowing undefined/null values in WHERE clauses. This caused UPDATE queries to execute with buggy filters like `WHERE col = NULL` instead of throwing an error as documented.

The default behavior per [TypeORM docs](https://typeorm.io/docs/data-source/null-and-undefined-handling#throw-default-1) is `throw` for both null and undefined values. This fix applies those defaults when no options are provided rather than skipping validation entirely.

## Risk

If invalidWhereValuesBehavior: { undefined: "ignore" } is later added (e.g. during a version upgrade), the update() path changes from "silent no-op" to "unscoped UPDATE affecting ALL rows" — with no intermediate error state to catch it.

Fixes #12578