### PR TITLE
fix: apply default throw behavior in normalizeWhereCriteria when options not provided

### DIFF
--- a/src/util/OrmUtils.ts
+++ b/src/util/OrmUtils.ts
@@ -663,7 +663,7 @@ export class OrmUtils {
         path?: string,
     ): ObjectLiteral | ObjectLiteral[] {
         if (!options) {
-            return criteria
+            options = { undefined: "throw", null: "throw" }
         }
 
         // multiple criteria are possible at the top level


### PR DESCRIPTION
Fixes #12578

When `invalidWhereValuesBehavior` is not configured in the DataSource, `OrmUtils.normalizeWhereCriteria()` returns criteria immediately without any validation. This contradicts the documented default behavior where undefined/null values should cause a `TypeORMError` to be thrown.

**Before:**
```typescript
if (!options) return criteria
```

**After:**
```typescript
if (!options) { options = { undefined: "throw", null: "throw" } }
```

This is a 1-line change that aligns implementation with documentation at https://typeorm.io/docs/data-source/null-and-undefined-handling#throw-default-1

**Impact:**
- Before: UPDATE queries with undefined where values silently executed with `WHERE col = null`
- After: TypeORMError is thrown, alerting the developer to the unsafe query