### PR TITLE
fix: throw by default and guard against empty criteria

### DIFF
--- a/docs/docs/data-source/5-null-and-undefined-handling.md
+++ b/docs/docs/data-source/5-null-and-undefined-handling.md
@@ -79,6 +79,10 @@ const posts = await repository.find({
 })
 ```
 
+:::warning
+For mutation methods (`update`, `delete`, `softDelete`, `restore`), if ignoring `null` values results in an empty criteria object or array (i.e., all criteria properties are ignored), TypeORM will throw a `TypeORMError` to prevent executing an accidental query that affects all rows in the database.
+:::
+
 #### `'sql-null'`
 
 JavaScript `null` values are transformed into SQL `NULL` conditions:
@@ -145,6 +149,10 @@ const posts = await repository.find({
     },
 })
 ```
+
+:::warning
+For mutation methods (`update`, `delete`, `softDelete`, `restore`), if ignoring `undefined` values results in an empty criteria object or array (i.e., all criteria properties are ignored), TypeORM will throw a `TypeORMError` to prevent executing an accidental query that affects all rows in the database.
+:::
 
 #### `'throw'` (default)
 

--- a/src/entity-manager/EntityManager.ts
+++ b/src/entity-manager/EntityManager.ts
@@ -834,7 +834,7 @@ export class EntityManager {
      * @param partialEntity
      * @param options
      */
-    update<Entity extends ObjectLiteral>(
+    async update<Entity extends ObjectLiteral>(
         target: EntityTarget<Entity>,
         criteria:
             | string
@@ -935,7 +935,7 @@ export class EntityManager {
      * @param targetOrEntity
      * @param criteria
      */
-    delete<Entity extends ObjectLiteral>(
+    async delete<Entity extends ObjectLiteral>(
         targetOrEntity: EntityTarget<Entity>,
         criteria:
             | string
@@ -1014,7 +1014,7 @@ export class EntityManager {
      * @param targetOrEntity
      * @param criteria
      */
-    softDelete<Entity extends ObjectLiteral>(
+    async softDelete<Entity extends ObjectLiteral>(
         targetOrEntity: EntityTarget<Entity>,
         criteria:
             | string
@@ -1078,7 +1078,7 @@ export class EntityManager {
      * @param targetOrEntity
      * @param criteria
      */
-    restore<Entity extends ObjectLiteral>(
+    async restore<Entity extends ObjectLiteral>(
         targetOrEntity: EntityTarget<Entity>,
         criteria:
             | string

--- a/src/entity-manager/EntityManager.ts
+++ b/src/entity-manager/EntityManager.ts
@@ -874,6 +874,19 @@ export class EntityManager {
                 criteria as ObjectLiteral | ObjectLiteral[],
                 this.dataSource.options.invalidWhereValuesBehavior,
             )
+            if (
+                OrmUtils.isCriteriaNullOrEmpty(normalizedCriteria) ||
+                (Array.isArray(normalizedCriteria) &&
+                    normalizedCriteria.some((c) =>
+                        OrmUtils.isCriteriaNullOrEmpty(c),
+                    ))
+            ) {
+                return Promise.reject(
+                    new TypeORMError(
+                        `Empty criteria(s) are not allowed for the update method.`,
+                    ),
+                )
+            }
             const qb = this.createQueryBuilder()
                 .update(target)
                 .set(partialEntity)
@@ -955,6 +968,19 @@ export class EntityManager {
                 criteria as ObjectLiteral | ObjectLiteral[],
                 this.dataSource.options.invalidWhereValuesBehavior,
             )
+            if (
+                OrmUtils.isCriteriaNullOrEmpty(normalizedCriteria) ||
+                (Array.isArray(normalizedCriteria) &&
+                    normalizedCriteria.some((c) =>
+                        OrmUtils.isCriteriaNullOrEmpty(c),
+                    ))
+            ) {
+                return Promise.reject(
+                    new TypeORMError(
+                        `Empty criteria(s) are not allowed for the delete method.`,
+                    ),
+                )
+            }
             return this.createQueryBuilder()
                 .delete()
                 .from(targetOrEntity)
@@ -1021,6 +1047,19 @@ export class EntityManager {
                 criteria as ObjectLiteral | ObjectLiteral[],
                 this.dataSource.options.invalidWhereValuesBehavior,
             )
+            if (
+                OrmUtils.isCriteriaNullOrEmpty(normalizedCriteria) ||
+                (Array.isArray(normalizedCriteria) &&
+                    normalizedCriteria.some((c) =>
+                        OrmUtils.isCriteriaNullOrEmpty(c),
+                    ))
+            ) {
+                return Promise.reject(
+                    new TypeORMError(
+                        `Empty criteria(s) are not allowed for the softDelete method.`,
+                    ),
+                )
+            }
             return this.createQueryBuilder()
                 .softDelete()
                 .from(targetOrEntity)
@@ -1072,6 +1111,19 @@ export class EntityManager {
                 criteria as ObjectLiteral | ObjectLiteral[],
                 this.dataSource.options.invalidWhereValuesBehavior,
             )
+            if (
+                OrmUtils.isCriteriaNullOrEmpty(normalizedCriteria) ||
+                (Array.isArray(normalizedCriteria) &&
+                    normalizedCriteria.some((c) =>
+                        OrmUtils.isCriteriaNullOrEmpty(c),
+                    ))
+            ) {
+                return Promise.reject(
+                    new TypeORMError(
+                        `Empty criteria(s) are not allowed for the restore method.`,
+                    ),
+                )
+            }
             return this.createQueryBuilder()
                 .restore()
                 .from(targetOrEntity)

--- a/src/util/OrmUtils.ts
+++ b/src/util/OrmUtils.ts
@@ -662,9 +662,7 @@ export class OrmUtils {
         options?: InvalidFindOptionsWhereBehavior,
         path?: string,
     ): ObjectLiteral | ObjectLiteral[] {
-        if (!options) {
-            return criteria
-        }
+        const effectiveOptions = options || {}
 
         // multiple criteria are possible at the top level
         if (!path && Array.isArray(criteria)) {
@@ -683,7 +681,7 @@ export class OrmUtils {
             const propertyPath = path ? `${path}.${key}` : key
 
             if (value === undefined) {
-                const behavior = options?.undefined ?? "throw"
+                const behavior = effectiveOptions.undefined ?? "throw"
                 if (behavior === "throw") {
                     throw new TypeORMError(
                         `Undefined value encountered in property '${propertyPath}' of a where condition. ` +
@@ -692,7 +690,7 @@ export class OrmUtils {
                 }
                 // else: "ignore" — skip this key
             } else if (value === null) {
-                const behavior = options?.null ?? "throw"
+                const behavior = effectiveOptions.null ?? "throw"
                 if (behavior === "throw") {
                     throw new TypeORMError(
                         `Null value encountered in property '${propertyPath}' of a where condition. ` +

--- a/test/functional/null-undefined-handling/query-builders.test.ts
+++ b/test/functional/null-undefined-handling/query-builders.test.ts
@@ -484,3 +484,125 @@ describe("entity manager > invalidWhereValuesBehavior does NOT affect QB .where(
         }
     })
 })
+
+describe("entity manager > default behavior (throw) without explicit invalidWhereValuesBehavior options", () => {
+    let dataSources: DataSource[]
+
+    before(async () => {
+        dataSources = await createTestingConnections({
+            disabledDrivers: ["spanner"],
+            entities: [Post, Category],
+            schemaCreate: true,
+            dropSchema: true,
+        })
+    })
+    beforeEach(() => reloadTestingDatabases(dataSources))
+    after(() => closeTestingConnections(dataSources))
+
+    async function prepareData(connection: DataSource) {
+        const category = new Category()
+        category.name = "Test Category"
+        await connection.manager.save(category)
+
+        const post = new Post()
+        post.title = "Test Post"
+        post.text = "Some text"
+        post.category = category
+        await connection.manager.save(post)
+
+        return { category, post }
+    }
+
+    it("should throw error for null values in EntityManager.update() by default", async () => {
+        for (const connection of dataSources) {
+            await prepareData(connection)
+
+            try {
+                await connection.manager.update(Post, { text: null } as any, {
+                    title: "Updated",
+                })
+                expect.fail("Expected error")
+            } catch (error) {
+                expect(error).to.be.instanceOf(TypeORMError)
+                expect(error.message).to.include("Null value encountered")
+            }
+        }
+    })
+
+    it("should throw error for undefined values in EntityManager.update() by default", async () => {
+        for (const connection of dataSources) {
+            await prepareData(connection)
+
+            try {
+                await connection.manager.update(
+                    Post,
+                    { text: undefined } as any,
+                    { title: "Updated" },
+                )
+                expect.fail("Expected error")
+            } catch (error) {
+                expect(error).to.be.instanceOf(TypeORMError)
+                expect(error.message).to.include("Undefined value encountered")
+            }
+        }
+    })
+
+    it("should throw error for null values in EntityManager.delete() by default", async () => {
+        for (const connection of dataSources) {
+            await prepareData(connection)
+
+            try {
+                await connection.manager.delete(Post, { text: null } as any)
+                expect.fail("Expected error")
+            } catch (error) {
+                expect(error).to.be.instanceOf(TypeORMError)
+                expect(error.message).to.include("Null value encountered")
+            }
+        }
+    })
+
+    it("should throw error for undefined values in EntityManager.delete() by default", async () => {
+        for (const connection of dataSources) {
+            await prepareData(connection)
+
+            try {
+                await connection.manager.delete(Post, {
+                    text: undefined,
+                } as any)
+                expect.fail("Expected error")
+            } catch (error) {
+                expect(error).to.be.instanceOf(TypeORMError)
+                expect(error.message).to.include("Undefined value encountered")
+            }
+        }
+    })
+
+    it("should throw error if normalized criteria resolves to empty in EntityManager.update() with ignore", async () => {
+        const ignoreSources = await createTestingConnections({
+            disabledDrivers: ["spanner"],
+            entities: [Post, Category],
+            schemaCreate: true,
+            dropSchema: true,
+            driverSpecific: {
+                invalidWhereValuesBehavior: {
+                    null: "ignore",
+                    undefined: "ignore",
+                },
+            },
+        })
+        try {
+            for (const connection of ignoreSources) {
+                await prepareData(connection)
+                try {
+                    await connection.manager.update(Post, { text: undefined } as any, { title: "Updated" })
+                    expect.fail("Expected error due to empty criteria after normalization")
+                } catch (error) {
+                    expect(error).to.be.instanceOf(TypeORMError)
+                    expect(error.message).to.include("Empty criteria(s) are not allowed")
+                }
+            }
+        } finally {
+            await closeTestingConnections(ignoreSources)
+        }
+    })
+})

--- a/test/functional/null-undefined-handling/query-builders.test.ts
+++ b/test/functional/null-undefined-handling/query-builders.test.ts
@@ -518,7 +518,7 @@ describe("entity manager > default behavior (throw) without explicit invalidWher
             await prepareData(connection)
 
             try {
-                await connection.manager.update(Post, { text: null } as any, {
+                await connection.manager.update(Post, { text: null }, {
                     title: "Updated",
                 })
                 expect.fail("Expected error")
@@ -536,7 +536,7 @@ describe("entity manager > default behavior (throw) without explicit invalidWher
             try {
                 await connection.manager.update(
                     Post,
-                    { text: undefined } as any,
+                    { text: undefined },
                     { title: "Updated" },
                 )
                 expect.fail("Expected error")
@@ -552,7 +552,7 @@ describe("entity manager > default behavior (throw) without explicit invalidWher
             await prepareData(connection)
 
             try {
-                await connection.manager.delete(Post, { text: null } as any)
+                await connection.manager.delete(Post, { text: null })
                 expect.fail("Expected error")
             } catch (error) {
                 expect(error).to.be.instanceOf(TypeORMError)
@@ -568,7 +568,7 @@ describe("entity manager > default behavior (throw) without explicit invalidWher
             try {
                 await connection.manager.delete(Post, {
                     text: undefined,
-                } as any)
+                })
                 expect.fail("Expected error")
             } catch (error) {
                 expect(error).to.be.instanceOf(TypeORMError)
@@ -594,7 +594,7 @@ describe("entity manager > default behavior (throw) without explicit invalidWher
             for (const connection of ignoreSources) {
                 await prepareData(connection)
                 try {
-                    await connection.manager.update(Post, { text: undefined } as any, { title: "Updated" })
+                    await connection.manager.update(Post, { text: undefined }, { title: "Updated" })
                     expect.fail("Expected error due to empty criteria after normalization")
                 } catch (error) {
                     expect(error).to.be.instanceOf(TypeORMError)


### PR DESCRIPTION
**What the change is intended to do**:
      1. Fixes `OrmUtils.normalizeWhereCriteria()` to not return early when
  `invalidWhereValuesBehavior` is not configured, allowing it to correctly fall back to the
  default `throw` behavior for `null` and `undefined`.
      2. Adds a post-normalization check inside `EntityManager` (`update`, `delete`, `softDelete`,
  and `restore`) to throw an error if the normalized criteria resolves to an empty object or array.
  This prevents accidental unscoped updates/deletes affecting all rows.

    - **Why this change is needed**:
      Without this, passing `null`/`undefined` in where conditions failed to trigger the
  documented default throwing behavior unless `invalidWhereValuesBehavior` was explicitly
  configured. Additionally, ignoring `undefined` properties could lead to silent, unscoped
  updates/deletes.

    - **How you've verified it**:
      Added 5 new functional tests in `test/functional/null-undefined-handling/query-builders.test.
  ts` to verify the throwing behavior and the empty criteria protection. All tests compile and
  pass successfully.

    ### Pull-Request Checklist

    - [x] Code is up-to-date with the `master` branch
    - [x] This pull request links a relevant issue using a closing keyword: Closes #12578
    - [x] There are new or updated tests validating the change (`tests/**.test.ts`)
    - [ ] Documentation has been updated to reflect this change (`docs/docs/**.md`) - N/A