### PR TITLE
fix(entity-manager): apply default throw behavior in normalizeWhereCriteria

### DIFF
--- a/src/util/OrmUtils.ts
+++ b/src/util/OrmUtils.ts
@@ -662,9 +662,10 @@ export class OrmUtils {
         options?: InvalidFindOptionsWhereBehavior,
         path?: string,
     ): ObjectLiteral | ObjectLiteral[] {
-        if (!options) {
-            return criteria
-        }
+        // When `invalidWhereValuesBehavior` is not configured the documented
+        // default behaviour applies (throw on null/undefined). This is handled
+        // below via `options?.null ?? "throw"` / `options?.undefined ?? "throw"`,
+        // so we must not short-circuit when `options` is undefined.
 
         // multiple criteria are possible at the top level
         if (!path && Array.isArray(criteria)) {

--- a/test/functional/null-undefined-handling/query-builders.test.ts
+++ b/test/functional/null-undefined-handling/query-builders.test.ts
@@ -9,6 +9,132 @@ import {
 import { Category } from "./entity/Category"
 import { Post } from "./entity/Post"
 
+describe("entity manager > invalidWhereValuesBehavior default behavior (no config)", () => {
+    // Regression test for https://github.com/typeorm/typeorm/issues/12578
+    // When `invalidWhereValuesBehavior` is not configured, the documented
+    // default ("throw") must apply to the update/delete/softDelete/restore paths.
+    let dataSources: DataSource[]
+
+    before(async () => {
+        dataSources = await createTestingConnections({
+            disabledDrivers: ["spanner"],
+            entities: [Post, Category],
+            schemaCreate: true,
+            dropSchema: true,
+            // intentionally no `invalidWhereValuesBehavior` configured
+        })
+    })
+    beforeEach(() => reloadTestingDatabases(dataSources))
+    after(() => closeTestingConnections(dataSources))
+
+    async function prepareData(connection: DataSource) {
+        const category = new Category()
+        category.name = "Test Category"
+        await connection.manager.save(category)
+
+        const post = new Post()
+        post.title = "Test Post"
+        post.text = "Some text"
+        post.category = category
+        await connection.manager.save(post)
+
+        return { category, post }
+    }
+
+    const cases: Array<{
+        method: "update" | "delete" | "softDelete" | "restore"
+        run: (connection: DataSource, criteria: any) => Promise<unknown>
+    }> = [
+        {
+            method: "update",
+            run: (connection, criteria) =>
+                connection.manager.update(Post, criteria, { title: "Updated" }),
+        },
+        {
+            method: "delete",
+            run: (connection, criteria) =>
+                connection.manager.delete(Post, criteria),
+        },
+        {
+            method: "softDelete",
+            run: (connection, criteria) =>
+                connection.manager.softDelete(Post, criteria),
+        },
+        {
+            method: "restore",
+            run: (connection, criteria) =>
+                connection.manager.restore(Post, criteria),
+        },
+    ]
+
+    for (const { method, run } of cases) {
+        it(`should throw by default for null values in EntityManager.${method}()`, async () => {
+            for (const connection of dataSources) {
+                await prepareData(connection)
+
+                try {
+                    await run(connection, { text: null } as any)
+                    expect.fail("Expected error")
+                } catch (error) {
+                    expect(error).to.be.instanceOf(TypeORMError)
+                    expect(error.message).to.include("Null value encountered")
+                }
+            }
+        })
+
+        it(`should throw by default for undefined values in EntityManager.${method}()`, async () => {
+            for (const connection of dataSources) {
+                await prepareData(connection)
+
+                try {
+                    await run(connection, { text: undefined } as any)
+                    expect.fail("Expected error")
+                } catch (error) {
+                    expect(error).to.be.instanceOf(TypeORMError)
+                    expect(error.message).to.include(
+                        "Undefined value encountered",
+                    )
+                }
+            }
+        })
+
+        it(`should throw by default for nested undefined values in EntityManager.${method}()`, async () => {
+            for (const connection of dataSources) {
+                await prepareData(connection)
+
+                try {
+                    await run(connection, {
+                        category: { name: undefined },
+                    } as any)
+                    expect.fail("Expected error")
+                } catch (error) {
+                    expect(error).to.be.instanceOf(TypeORMError)
+                    expect(error.message).to.include(
+                        "Undefined value encountered",
+                    )
+                }
+            }
+        })
+    }
+
+    it("should still execute with valid criteria when no config is set", async () => {
+        for (const connection of dataSources) {
+            const { post } = await prepareData(connection)
+
+            await connection.manager.update(
+                Post,
+                { title: "Test Post" },
+                { title: "Renamed" },
+            )
+
+            const updated = await connection.manager.findOneByOrFail(Post, {
+                id: post.id,
+            })
+            expect(updated.title).to.equal("Renamed")
+        }
+    })
+})
+
 describe("entity manager > invalidWhereValuesBehavior with throw", () => {
     let dataSources: DataSource[]
 


### PR DESCRIPTION
### Description of change

Fixes #12578.

**What**

`OrmUtils.normalizeWhereCriteria()` short-circuited with `if (!options) return criteria` whenever `invalidWhereValuesBehavior` was not configured on the `DataSource`. As a result, `EntityManager.update/delete/softDelete/restore` (and the matching `Repository` methods) silently accepted `null`/`undefined` where-values instead of throwing, even though the docs describe `'throw'` as the **default** behavior.

See: https://typeorm.io/docs/data-source/null-and-undefined-handling#throw-default-1

**Why**

This let buggy queries run unnoticed, e.g.:

```sql
UPDATE "schema_x"."table_y" SET "col1" = $1 WHERE "col2" = null
```

**How**

- Removed the early `if (!options) return criteria` guard in `normalizeWhereCriteria`. The function body already defaults to throwing via `options?.null ?? "throw"` / `options?.undefined ?? "throw"`, so omitting the config now correctly applies the documented default. The top-level array handling and recursion work unchanged with `options === undefined`.

This is backwards-compatible for anyone who has already configured `invalidWhereValuesBehavior`. The QueryBuilder `.where()` path is intentionally left untouched (it remains low-level), as covered by existing tests.

> Note: a follow-up PR (stacked on this one) hardens the `update/delete/softDelete/restore` paths so that, under the `ignore` setting, criteria that normalize down to empty are rejected instead of running an unscoped query. That behavior change is kept separate so this PR stays a focused fix for the documented default.

**How verified**

- `pnpm run typecheck` passes.
- New regression suite in `test/functional/null-undefined-handling/query-builders.test.ts` ("default behavior (no config)"):
  - default (no config) throw behavior for `null`, `undefined`, and nested `undefined` across `update`/`delete`/`softDelete`/`restore`;
  - valid criteria still execute when no config is set.
- Full `null-undefined-handling` suite (default / `throw` / `sql-null` / `ignore` / QueryBuilder) passes; the find-options path is unaffected.

### Pull-Request Checklist

- [x] Code is up-to-date with the `master` branch
- [x] This pull request links a relevant issue using a closing keyword: `Fixes #12578`
- [x] There are new or updated tests validating the change (`test/functional/null-undefined-handling/query-builders.test.ts`)
- [ ] Documentation has been updated to reflect this change — N/A (existing docs already describe the now-correct default behavior)
