### PR TITLE
fix(entity-manager): reject where criteria that normalize to empty

### DIFF
--- a/docs/docs/data-source/5-null-and-undefined-handling.md
+++ b/docs/docs/data-source/5-null-and-undefined-handling.md
@@ -228,6 +228,28 @@ await manager.delete(Post, { text: null }) // Respects invalidWhereValuesBehavio
 await manager.softDelete(Post, { text: null }) // Respects invalidWhereValuesBehavior
 ```
 
+:::warning Empty criteria are rejected
+With `'ignore'`, every invalid property is skipped. If that leaves the where
+condition empty, the write methods (`update`, `delete`, `softDelete`, `restore`)
+throw `Empty criteria(s) are not allowed` instead of running an **unscoped**
+query against every row. This also applies to `OR` arrays — a branch that is
+stripped down to `{}` is dropped so it cannot widen the condition to `1=1`:
+
+```typescript
+// invalidWhereValuesBehavior: { undefined: "ignore" }
+
+// Throws — nothing is left to filter on, so the whole table is NOT touched
+await manager.delete(Post, { text: undefined })
+
+// Only deletes rows matching `id = 1`; the empty `{ text: undefined }` branch
+// is dropped instead of matching every row
+await manager.delete(Post, [{ text: undefined }, { id: 1 }])
+```
+
+To intentionally affect every row, use the dedicated `updateAll` / `deleteAll`
+methods.
+:::
+
 ### QueryBuilder with setFindOptions
 
 ```typescript

--- a/src/entity-manager/EntityManager.ts
+++ b/src/entity-manager/EntityManager.ts
@@ -874,6 +874,16 @@ export class EntityManager {
                 criteria as ObjectLiteral | ObjectLiteral[],
                 this.dataSource.options.invalidWhereValuesBehavior,
             )
+            // normalization (e.g. invalidWhereValuesBehavior.ignore) may have
+            // stripped every property, leaving criteria that would translate
+            // into an unscoped UPDATE affecting all rows — reject it instead.
+            if (OrmUtils.isWhereCriteriaEmpty(normalizedCriteria)) {
+                return Promise.reject(
+                    new TypeORMError(
+                        `Empty criteria(s) are not allowed for the update method.`,
+                    ),
+                )
+            }
             const qb = this.createQueryBuilder()
                 .update(target)
                 .set(partialEntity)
@@ -955,6 +965,16 @@ export class EntityManager {
                 criteria as ObjectLiteral | ObjectLiteral[],
                 this.dataSource.options.invalidWhereValuesBehavior,
             )
+            // normalization (e.g. invalidWhereValuesBehavior.ignore) may have
+            // stripped every property, leaving criteria that would translate
+            // into an unscoped DELETE affecting all rows — reject it instead.
+            if (OrmUtils.isWhereCriteriaEmpty(normalizedCriteria)) {
+                return Promise.reject(
+                    new TypeORMError(
+                        `Empty criteria(s) are not allowed for the delete method.`,
+                    ),
+                )
+            }
             return this.createQueryBuilder()
                 .delete()
                 .from(targetOrEntity)
@@ -1021,6 +1041,16 @@ export class EntityManager {
                 criteria as ObjectLiteral | ObjectLiteral[],
                 this.dataSource.options.invalidWhereValuesBehavior,
             )
+            // normalization (e.g. invalidWhereValuesBehavior.ignore) may have
+            // stripped every property, leaving criteria that would translate
+            // into an unscoped soft-delete affecting all rows — reject it instead.
+            if (OrmUtils.isWhereCriteriaEmpty(normalizedCriteria)) {
+                return Promise.reject(
+                    new TypeORMError(
+                        `Empty criteria(s) are not allowed for the softDelete method.`,
+                    ),
+                )
+            }
             return this.createQueryBuilder()
                 .softDelete()
                 .from(targetOrEntity)
@@ -1072,6 +1102,16 @@ export class EntityManager {
                 criteria as ObjectLiteral | ObjectLiteral[],
                 this.dataSource.options.invalidWhereValuesBehavior,
             )
+            // normalization (e.g. invalidWhereValuesBehavior.ignore) may have
+            // stripped every property, leaving criteria that would translate
+            // into an unscoped restore affecting all rows — reject it instead.
+            if (OrmUtils.isWhereCriteriaEmpty(normalizedCriteria)) {
+                return Promise.reject(
+                    new TypeORMError(
+                        `Empty criteria(s) are not allowed for the restore method.`,
+                    ),
+                )
+            }
             return this.createQueryBuilder()
                 .restore()
                 .from(targetOrEntity)

--- a/src/util/OrmUtils.ts
+++ b/src/util/OrmUtils.ts
@@ -662,9 +662,10 @@ export class OrmUtils {
         options?: InvalidFindOptionsWhereBehavior,
         path?: string,
     ): ObjectLiteral | ObjectLiteral[] {
-        if (!options) {
-            return criteria
-        }
+        // When `invalidWhereValuesBehavior` is not configured the documented
+        // default behaviour applies (throw on null/undefined). This is handled
+        // below via `options?.null ?? "throw"` / `options?.undefined ?? "throw"`,
+        // so we must not short-circuit when `options` is undefined.
 
         // multiple criteria are possible at the top level
         if (!path && Array.isArray(criteria)) {

--- a/src/util/OrmUtils.ts
+++ b/src/util/OrmUtils.ts
@@ -396,6 +396,32 @@ export class OrmUtils {
     }
 
     /**
+     * Checks whether a where criteria carries no effective conditions and would
+     * therefore translate into an unscoped (affecting every row) query.
+     *
+     * Unlike {@link isCriteriaNullOrEmpty} this also treats an array whose every
+     * element is itself empty (e.g. `[{}]`) as empty. It is meant to be used on
+     * criteria produced by {@link normalizeWhereCriteria}, where the
+     * `invalidWhereValuesBehavior.ignore` setting can strip every property and
+     * leave an empty object/array behind.
+     *
+     * @param criteria
+     */
+    public static isWhereCriteriaEmpty(criteria: unknown): boolean {
+        if (OrmUtils.isCriteriaNullOrEmpty(criteria)) {
+            return true
+        }
+
+        if (Array.isArray(criteria)) {
+            return criteria.every((criterion) =>
+                OrmUtils.isWhereCriteriaEmpty(criterion),
+            )
+        }
+
+        return false
+    }
+
+    /**
      * Checks if given criteria is a primitive value.
      * Primitive values are strings, numbers and dates.
      *
@@ -667,15 +693,28 @@ export class OrmUtils {
         // below via `options?.null ?? "throw"` / `options?.undefined ?? "throw"`,
         // so we must not short-circuit when `options` is undefined.
 
-        // multiple criteria are possible at the top level
+        // multiple criteria are possible at the top level (OR conditions)
         if (!path && Array.isArray(criteria)) {
-            return criteria.map(
-                (criterion, index): ObjectLiteral =>
-                    OrmUtils.normalizeWhereCriteria(
-                        criterion,
-                        options,
-                        String(index),
-                    ),
+            return (
+                criteria
+                    .map(
+                        (criterion, index): ObjectLiteral =>
+                            OrmUtils.normalizeWhereCriteria(
+                                criterion,
+                                options,
+                                String(index),
+                            ) as ObjectLiteral,
+                    )
+                    // A branch that normalized to {} (e.g. all of its properties
+                    // were stripped by the "ignore" behavior) would be rendered
+                    // as `1=1` and make the whole OR-condition unscoped, so it is
+                    // dropped here. If every branch is dropped the resulting empty
+                    // array is rejected by the callers' empty-criteria guards.
+                    .filter(
+                        (criterion) =>
+                            !OrmUtils.isPlainObject(criterion) ||
+                            Object.keys(criterion).length > 0,
+                    )
             )
         }
 

--- a/test/functional/null-undefined-handling/query-builders.test.ts
+++ b/test/functional/null-undefined-handling/query-builders.test.ts
@@ -9,6 +9,132 @@ import {
 import { Category } from "./entity/Category"
 import { Post } from "./entity/Post"
 
+describe("entity manager > invalidWhereValuesBehavior default behavior (no config)", () => {
+    // Regression test for https://github.com/typeorm/typeorm/issues/12578
+    // When `invalidWhereValuesBehavior` is not configured, the documented
+    // default ("throw") must apply to the update/delete/softDelete/restore paths.
+    let dataSources: DataSource[]
+
+    before(async () => {
+        dataSources = await createTestingConnections({
+            disabledDrivers: ["spanner"],
+            entities: [Post, Category],
+            schemaCreate: true,
+            dropSchema: true,
+            // intentionally no `invalidWhereValuesBehavior` configured
+        })
+    })
+    beforeEach(() => reloadTestingDatabases(dataSources))
+    after(() => closeTestingConnections(dataSources))
+
+    async function prepareData(connection: DataSource) {
+        const category = new Category()
+        category.name = "Test Category"
+        await connection.manager.save(category)
+
+        const post = new Post()
+        post.title = "Test Post"
+        post.text = "Some text"
+        post.category = category
+        await connection.manager.save(post)
+
+        return { category, post }
+    }
+
+    const cases: Array<{
+        method: "update" | "delete" | "softDelete" | "restore"
+        run: (connection: DataSource, criteria: any) => Promise<unknown>
+    }> = [
+        {
+            method: "update",
+            run: (connection, criteria) =>
+                connection.manager.update(Post, criteria, { title: "Updated" }),
+        },
+        {
+            method: "delete",
+            run: (connection, criteria) =>
+                connection.manager.delete(Post, criteria),
+        },
+        {
+            method: "softDelete",
+            run: (connection, criteria) =>
+                connection.manager.softDelete(Post, criteria),
+        },
+        {
+            method: "restore",
+            run: (connection, criteria) =>
+                connection.manager.restore(Post, criteria),
+        },
+    ]
+
+    for (const { method, run } of cases) {
+        it(`should throw by default for null values in EntityManager.${method}()`, async () => {
+            for (const connection of dataSources) {
+                await prepareData(connection)
+
+                try {
+                    await run(connection, { text: null } as any)
+                    expect.fail("Expected error")
+                } catch (error) {
+                    expect(error).to.be.instanceOf(TypeORMError)
+                    expect(error.message).to.include("Null value encountered")
+                }
+            }
+        })
+
+        it(`should throw by default for undefined values in EntityManager.${method}()`, async () => {
+            for (const connection of dataSources) {
+                await prepareData(connection)
+
+                try {
+                    await run(connection, { text: undefined } as any)
+                    expect.fail("Expected error")
+                } catch (error) {
+                    expect(error).to.be.instanceOf(TypeORMError)
+                    expect(error.message).to.include(
+                        "Undefined value encountered",
+                    )
+                }
+            }
+        })
+
+        it(`should throw by default for nested undefined values in EntityManager.${method}()`, async () => {
+            for (const connection of dataSources) {
+                await prepareData(connection)
+
+                try {
+                    await run(connection, {
+                        category: { name: undefined },
+                    } as any)
+                    expect.fail("Expected error")
+                } catch (error) {
+                    expect(error).to.be.instanceOf(TypeORMError)
+                    expect(error.message).to.include(
+                        "Undefined value encountered",
+                    )
+                }
+            }
+        })
+    }
+
+    it("should still execute with valid criteria when no config is set", async () => {
+        for (const connection of dataSources) {
+            const { post } = await prepareData(connection)
+
+            await connection.manager.update(
+                Post,
+                { title: "Test Post" },
+                { title: "Renamed" },
+            )
+
+            const updated = await connection.manager.findOneByOrFail(Post, {
+                id: post.id,
+            })
+            expect(updated.title).to.equal("Renamed")
+        }
+    })
+})
+
 describe("entity manager > invalidWhereValuesBehavior with throw", () => {
     let dataSources: DataSource[]
 

--- a/test/functional/null-undefined-handling/query-builders.test.ts
+++ b/test/functional/null-undefined-handling/query-builders.test.ts
@@ -539,6 +539,103 @@ describe("entity manager > invalidWhereValuesBehavior with ignore", () => {
             expect(remaining.length).to.equal(0)
         }
     })
+
+    it("should reject EntityManager.delete() when ignore strips all criteria", async () => {
+        for (const connection of dataSources) {
+            const post = new Post()
+            post.title = "Test Post"
+            post.text = "text"
+            await connection.manager.save(post)
+
+            // With ignore, { text: undefined } strips to {} which would otherwise
+            // become an unscoped DELETE affecting every row — it must be rejected.
+            try {
+                await connection.manager.delete(Post, {
+                    text: undefined,
+                } as any)
+                expect.fail("Expected error")
+            } catch (error) {
+                expect(error).to.be.instanceOf(TypeORMError)
+                expect(error.message).to.include("Empty criteria")
+            }
+
+            const remaining = await connection.manager.find(Post)
+            expect(remaining.length).to.equal(1)
+        }
+    })
+
+    it("should reject EntityManager.update() when ignore strips all criteria", async () => {
+        for (const connection of dataSources) {
+            const post = new Post()
+            post.title = "Test Post"
+            post.text = "text"
+            await connection.manager.save(post)
+
+            try {
+                await connection.manager.update(Post, { text: null } as any, {
+                    title: "Updated",
+                })
+                expect.fail("Expected error")
+            } catch (error) {
+                expect(error).to.be.instanceOf(TypeORMError)
+                expect(error.message).to.include("Empty criteria")
+            }
+
+            const notUpdated = await connection.manager.findOneByOrFail(Post, {
+                id: post.id,
+            })
+            expect(notUpdated.title).to.equal("Test Post")
+        }
+    })
+
+    it("should drop the empty branch of an OR-array instead of matching all rows", async () => {
+        for (const connection of dataSources) {
+            const target = new Post()
+            target.title = "Target"
+            target.text = "text"
+            await connection.manager.save(target)
+
+            const bystander = new Post()
+            bystander.title = "Bystander"
+            bystander.text = "text"
+            await connection.manager.save(bystander)
+
+            // With ignore, [{ text: undefined }, { id: target.id }] normalizes to
+            // [{}, { id: target.id }]. The empty branch must be dropped, otherwise
+            // it becomes `1=1 OR id = ?` and deletes every row.
+            await connection.manager.delete(Post, [
+                { text: undefined },
+                { id: target.id },
+            ] as any)
+
+            const remaining = await connection.manager.find(Post)
+            expect(remaining.length).to.equal(1)
+            expect(remaining[0].title).to.equal("Bystander")
+        }
+    })
+
+    it("should reject an OR-array whose every branch is stripped to empty", async () => {
+        for (const connection of dataSources) {
+            const post = new Post()
+            post.title = "Test Post"
+            post.text = "text"
+            await connection.manager.save(post)
+
+            try {
+                await connection.manager.delete(Post, [
+                    { text: undefined },
+                    { text: null },
+                ] as any)
+                expect.fail("Expected error")
+            } catch (error) {
+                expect(error).to.be.instanceOf(TypeORMError)
+                expect(error.message).to.include("Empty criteria")
+            }
+
+            const remaining = await connection.manager.find(Post)
+            expect(remaining.length).to.equal(1)
+        }
+    })
 })
 
 describe("entity manager > invalidWhereValuesBehavior does NOT affect QB .where()", () => {


### PR DESCRIPTION
### Description of change

Closes #12578.

Follow-up hardening for #12578. **Stacked on top of #12625 — please review/merge that first.** Until #12625 is merged, the diff here also shows its single commit; the net new change in this PR is the empty-criteria handling below.

**What & why**

Once #12625 makes `'throw'` the real default, the remaining risk noted in the issue is the `ignore` path. `EntityManager.update/delete/softDelete/restore` only check for empty criteria **before** normalization. With `invalidWhereValuesBehavior.ignore`, `normalizeWhereCriteria` can strip every property and leave:

- an empty object `{}`, or
- a partially-empty OR-array such as `[{}, { id: 1 }]`,

which `QueryBuilder` renders with a `1=1` clause — an **unscoped** UPDATE/DELETE affecting every row. This is exactly the escalation described in the issue's *Risk* section.

**How**

- Added `OrmUtils.isWhereCriteriaEmpty()` and guarded the four write paths so criteria that normalize to empty are rejected with the existing `Empty criteria(s) are not allowed` error instead of running unscoped.
- In `normalizeWhereCriteria`, top-level OR-branches that normalize to `{}` are dropped, so a single stripped branch can no longer widen the whole condition to `1=1 OR ...`. If every branch is dropped, the resulting empty array is rejected by the guards above.
- Documented the behavior in `docs/docs/data-source/5-null-and-undefined-handling.md`, pointing users to `updateAll`/`deleteAll` for intentional all-row operations.

**Behavior change:** under `ignore`, a call that previously ran unscoped (e.g. `delete(Post, { text: undefined })` silently deleting all rows) now throws. This is intentionally kept out of #12625 so the fix for the documented default stays minimal.

**How verified**

- `pnpm run typecheck` passes.
- New tests in `test/functional/null-undefined-handling/query-builders.test.ts`:
  - all-stripped criteria are rejected for `update`/`delete`;
  - a partially-empty OR-array applies only the real branch (one row affected, the other preserved);
  - an all-empty OR-array is rejected.
- Full `null-undefined-handling` suite passes; the find-options and QueryBuilder `.where()` paths are unaffected.

### Pull-Request Checklist

- [x] Code is up-to-date with the `master` branch
- [x] This pull request links a relevant issue using a closing keyword: `Closes #12578`
- [x] There are new or updated tests validating the change (`test/functional/null-undefined-handling/query-builders.test.ts`)
- [x] Documentation has been updated to reflect this change (`docs/docs/data-source/5-null-and-undefined-handling.md`)
