### PR TITLE
fix: honor default invalid where behavior

### DIFF
--- a/src/util/OrmUtils.ts
+++ b/src/util/OrmUtils.ts
@@ -662,10 +662,6 @@ export class OrmUtils {
         options?: InvalidFindOptionsWhereBehavior,
         path?: string,
     ): ObjectLiteral | ObjectLiteral[] {
-        if (!options) {
-            return criteria
-        }
-
         // multiple criteria are possible at the top level
         if (!path && Array.isArray(criteria)) {
             return criteria.map(

--- a/test/functional/null-undefined-handling/query-builders.test.ts
+++ b/test/functional/null-undefined-handling/query-builders.test.ts
@@ -9,6 +9,65 @@ import {
 import { Category } from "./entity/Category"
 import { Post } from "./entity/Post"
 
+describe("entity manager > invalidWhereValuesBehavior defaults", () => {
+    let dataSources: DataSource[]
+
+    before(async () => {
+        dataSources = await createTestingConnections({
+            disabledDrivers: ["spanner"],
+            entities: [Post, Category],
+            schemaCreate: true,
+            dropSchema: true,
+        })
+    })
+    beforeEach(() => reloadTestingDatabases(dataSources))
+    after(() => closeTestingConnections(dataSources))
+
+    async function prepareData(connection: DataSource) {
+        const category = new Category()
+        category.name = "Test Category"
+        await connection.manager.save(category)
+
+        const post = new Post()
+        post.title = "Test Post"
+        post.text = "Some text"
+        post.category = category
+        await connection.manager.save(post)
+    }
+
+    it("should throw error for undefined values in EntityManager.update()", async () => {
+        for (const connection of dataSources) {
+            await prepareData(connection)
+
+            try {
+                await connection.manager.update(
+                    Post,
+                    { text: undefined } as any,
+                    { title: "Updated" },
+                )
+                expect.fail("Expected error")
+            } catch (error) {
+                expect(error).to.be.instanceOf(TypeORMError)
+                expect(error.message).to.include("Undefined value encountered")
+            }
+        }
+    })
+
+    it("should throw error for null values in EntityManager.delete()", async () => {
+        for (const connection of dataSources) {
+            await prepareData(connection)
+
+            try {
+                await connection.manager.delete(Post, { text: null } as any)
+                expect.fail("Expected error")
+            } catch (error) {
+                expect(error).to.be.instanceOf(TypeORMError)
+                expect(error.message).to.include("Null value encountered")
+            }
+        }
+    })
+})
+
 describe("entity manager > invalidWhereValuesBehavior with throw", () => {
     let dataSources: DataSource[]
 


### PR DESCRIPTION
### Description of change

Fixes #12578.

OrmUtils.normalizeWhereCriteria() returned criteria unchanged when invalidWhereValuesBehavior was not configured, which bypassed the documented default behavior for null and undefined where values.

This removes that early return so the existing default `"throw"` behavior is applied even when the data source does not explicitly configure invalidWhereValuesBehavior.

I also added regression coverage for the default configuration path in EntityManager.update() and EntityManager.delete().

### Verification

- `tsc --noEmit`
- `mocha --no-config --require build/compiled/test/utils/test-setup.js "build/compiled/test/functional/null-undefined-handling/query-builders.test.js" --timeout 90000 --exit` — 22 passing

### Pull-Request Checklist

- [x] Code is up-to-date with the `master` branch
- [x] This pull request links a relevant issue using a closing keyword: Fixes #12578
- [x] There are new or updated tests validating the change (`tests/**.test.ts`)
- [x] Documentation has been updated to reflect this change (N/A — existing docs already describe `throw` as the default)
