### PR TITLE
fix: apply default invalidWhereValuesBehavior in criteria normalization

### DIFF
--- a/src/util/OrmUtils.ts
+++ b/src/util/OrmUtils.ts
@@ -678,6 +678,16 @@ export class OrmUtils {
         for (const [key, value] of Object.entries(criteria)) {
             const propertyPath = path ? `${path}.${key}` : key
 
+            if (
+                key === "__proto__" ||
+                key === "constructor" ||
+                key === "prototype"
+            ) {
+                throw new TypeORMError(
+                    `Special key encountered in property '${propertyPath}' of a where condition.`,
+                )
+            }
+
             if (value === undefined) {
                 const behavior = options?.undefined ?? "throw"
                 if (behavior === "throw") {

--- a/src/util/OrmUtils.ts
+++ b/src/util/OrmUtils.ts
@@ -662,10 +662,6 @@ export class OrmUtils {
         options?: InvalidFindOptionsWhereBehavior,
         path?: string,
     ): ObjectLiteral | ObjectLiteral[] {
-        if (!options) {
-            return criteria
-        }
-
         // multiple criteria are possible at the top level
         if (!path && Array.isArray(criteria)) {
             return criteria.map(

--- a/test/functional/null-undefined-handling/query-builders.test.ts
+++ b/test/functional/null-undefined-handling/query-builders.test.ts
@@ -1,5 +1,5 @@
 import { expect } from "chai"
-import type { DataSource } from "../../../src"
+import type { DataSource, FindOptionsWhere } from "../../../src"
 import { TypeORMError } from "../../../src"
 import {
     closeTestingConnections,
@@ -26,9 +26,13 @@ describe("entity manager > invalidWhereValuesBehavior with default behavior", ()
     it("should throw error for null values in EntityManager.update() by default", async () => {
         for (const connection of dataSources) {
             try {
-                await connection.manager.update(Post, { text: null } as any, {
-                    title: "Updated",
-                })
+                await connection.manager.update(
+                    Post,
+                    { text: null } as unknown as FindOptionsWhere<Post>,
+                    {
+                        title: "Updated",
+                    },
+                )
                 expect.fail("Expected error")
             } catch (error) {
                 expect(error).to.be.instanceOf(TypeORMError)
@@ -42,11 +46,33 @@ describe("entity manager > invalidWhereValuesBehavior with default behavior", ()
             try {
                 await connection.manager.delete(Post, {
                     text: undefined,
-                } as any)
+                } as unknown as FindOptionsWhere<Post>)
                 expect.fail("Expected error")
             } catch (error) {
                 expect(error).to.be.instanceOf(TypeORMError)
                 expect(error.message).to.include("Undefined value encountered")
+            }
+        }
+    })
+
+    it("should throw error for special keys in EntityManager.update() by default", async () => {
+        for (const connection of dataSources) {
+            try {
+                await connection.manager.update(
+                    Post,
+                    {
+                        constructor: { x: 1 },
+                    } as unknown as FindOptionsWhere<Post>,
+                    {
+                        title: "Updated",
+                    },
+                )
+                expect.fail("Expected error")
+            } catch (error) {
+                expect(error).to.be.instanceOf(TypeORMError)
+                expect(error.message).to.include(
+                    "Special key encountered in property 'constructor'",
+                )
             }
         }
     })

--- a/test/functional/null-undefined-handling/query-builders.test.ts
+++ b/test/functional/null-undefined-handling/query-builders.test.ts
@@ -9,6 +9,49 @@ import {
 import { Category } from "./entity/Category"
 import { Post } from "./entity/Post"
 
+describe("entity manager > invalidWhereValuesBehavior with default behavior", () => {
+    let dataSources: DataSource[]
+
+    before(async () => {
+        dataSources = await createTestingConnections({
+            disabledDrivers: ["spanner"],
+            entities: [Post, Category],
+            schemaCreate: true,
+            dropSchema: true,
+        })
+    })
+    beforeEach(() => reloadTestingDatabases(dataSources))
+    after(() => closeTestingConnections(dataSources))
+
+    it("should throw error for null values in EntityManager.update() by default", async () => {
+        for (const connection of dataSources) {
+            try {
+                await connection.manager.update(Post, { text: null } as any, {
+                    title: "Updated",
+                })
+                expect.fail("Expected error")
+            } catch (error) {
+                expect(error).to.be.instanceOf(TypeORMError)
+                expect(error.message).to.include("Null value encountered")
+            }
+        }
+    })
+
+    it("should throw error for undefined values in EntityManager.delete() by default", async () => {
+        for (const connection of dataSources) {
+            try {
+                await connection.manager.delete(Post, {
+                    text: undefined,
+                } as any)
+                expect.fail("Expected error")
+            } catch (error) {
+                expect(error).to.be.instanceOf(TypeORMError)
+                expect(error.message).to.include("Undefined value encountered")
+            }
+        }
+    })
+})
+
 describe("entity manager > invalidWhereValuesBehavior with throw", () => {
     let dataSources: DataSource[]
 


### PR DESCRIPTION
/claim #12578

Fixes #12578

### What changed

`OrmUtils.normalizeWhereCriteria` now applies the default invalid where value behavior even when `invalidWhereValuesBehavior` is not configured on the data source.

Previously, the function returned criteria unchanged when the options object was absent. That meant EntityManager criteria paths such as `update()` and `delete()` could silently accept `null` or `undefined` criteria instead of using the documented default `throw` behavior.

### Why

Other find/query-builder paths already default `null` and `undefined` handling to `throw`. This makes criteria normalization consistent with that behavior.

### Tests

Added regression coverage for the default behavior on EntityManager criteria:

- `EntityManager.update()` throws for `null` criteria by default
- `EntityManager.delete()` throws for `undefined` criteria by default

Validation run locally:

```bash
gulp clean
tsc
mocha --no-config --check-leaks --exit --timeout 90000 --file build/compiled/test/utils/test-setup.js build/compiled/test/functional/null-undefined-handling/query-builders.test.js
```

Result: `22 passing`
