### PR TITLE
fix: normalizeWhereCriteria default behavior throws on null/undefined (#12578)

### DIFF
--- a/src/util/OrmUtils.ts
+++ b/src/util/OrmUtils.ts
@@ -662,9 +662,7 @@ export class OrmUtils {
         options?: InvalidFindOptionsWhereBehavior,
         path?: string,
     ): ObjectLiteral | ObjectLiteral[] {
-        if (!options) {
-            return criteria
-        }
+        const opts = options ?? { null: "throw" as const, undefined: "throw" as const }
 
         // multiple criteria are possible at the top level
         if (!path && Array.isArray(criteria)) {
@@ -672,7 +670,7 @@ export class OrmUtils {
                 (criterion, index): ObjectLiteral =>
                     OrmUtils.normalizeWhereCriteria(
                         criterion,
-                        options,
+                        opts,
                         String(index),
                     ),
             )
@@ -683,7 +681,7 @@ export class OrmUtils {
             const propertyPath = path ? `${path}.${key}` : key
 
             if (value === undefined) {
-                const behavior = options?.undefined ?? "throw"
+                const behavior = opts?.undefined ?? "throw"
                 if (behavior === "throw") {
                     throw new TypeORMError(
                         `Undefined value encountered in property '${propertyPath}' of a where condition. ` +
@@ -692,7 +690,7 @@ export class OrmUtils {
                 }
                 // else: "ignore" — skip this key
             } else if (value === null) {
-                const behavior = options?.null ?? "throw"
+                const behavior = opts?.null ?? "throw"
                 if (behavior === "throw") {
                     throw new TypeORMError(
                         `Null value encountered in property '${propertyPath}' of a where condition. ` +
@@ -706,7 +704,7 @@ export class OrmUtils {
             } else if (OrmUtils.isPlainObject(value)) {
                 const nested = OrmUtils.normalizeWhereCriteria(
                     value,
-                    options,
+                    opts,
                     propertyPath,
                 )
                 if (Object.keys(nested).length > 0) {

--- a/test/functional/null-undefined-handling/default-behavior.test.ts
+++ b/test/functional/null-undefined-handling/default-behavior.test.ts
@@ -1,0 +1,38 @@
+import "reflect-metadata"
+import { expect } from "chai"
+import { OrmUtils } from "../../../../src/util/OrmUtils"
+
+describe("normalizeWhereCriteria default behavior (issue #12578)", () => {
+    it("should throw on undefined value when no options are provided", () => {
+        expect(() => OrmUtils.normalizeWhereCriteria({ id: undefined }))
+            .to.throw(/Undefined value encountered/)
+    })
+
+    it("should throw on null value when no options are provided", () => {
+        expect(() => OrmUtils.normalizeWhereCriteria({ id: null }))
+            .to.throw(/Null value encountered/)
+    })
+
+    it("should throw on nested undefined value when no options are provided", () => {
+        expect(() => OrmUtils.normalizeWhereCriteria({ user: { id: undefined } }))
+            .to.throw(/Undefined value encountered/)
+    })
+
+    it("should throw on nested null value when no options are provided", () => {
+        expect(() => OrmUtils.normalizeWhereCriteria({ user: { id: null } }))
+            .to.throw(/Null value encountered/)
+    })
+
+    it("should pass through valid criteria when no options are provided", () => {
+        const result = OrmUtils.normalizeWhereCriteria({ id: 1, name: "test" }) as any
+        expect(result).to.deep.equal({ id: 1, name: "test" })
+    })
+
+    it("should respect explicit ignore option for undefined", () => {
+        const result = OrmUtils.normalizeWhereCriteria(
+            { id: 1, name: undefined },
+            { undefined: "ignore", null: "throw" }
+        ) as any
+        expect(result).to.deep.equal({ id: 1 })
+    })
+})


### PR DESCRIPTION
## Problem

OrmUtils.normalizeWhereCriteria() returns criteria as-is when options is undefined, bypassing the documented default throw behavior for null/undefined values. This means UPDATE/DELETE queries silently execute with buggy WHERE clauses (e.g. WHERE col = null).

## Fix

Replace the early return with a default options object that defaults to throw for both null and undefined, then use opts instead of options throughout the function including recursive calls. This matches the documented behavior at https://typeorm.io/docs/data-source/null-and-undefined-handling#throw-default-1

## Tests

Added test/functional/null-undefined-handling/default-behavior.test.ts with 6 test cases covering default throw behavior and explicit ignore option.

Closes #12578