### PR TITLE
fix: apply default throw behavior in normalizeWhereCriteria when no options configured

### DIFF
--- a/src/util/OrmUtils.ts
+++ b/src/util/OrmUtils.ts
@@ -663,7 +663,7 @@ export class OrmUtils {
         path?: string,
     ): ObjectLiteral | ObjectLiteral[] {
         if (!options) {
-            return criteria
+            options = {}
         }
 
         // multiple criteria are possible at the top level


### PR DESCRIPTION
## Problem

When `invalidWhereValuesBehavior` is not set on the DataSource, `OrmUtils.normalizeWhereCriteria()` returns `criteria` unchanged instead of applying the documented default behavior (throw on `undefined`/`null` values).

This causes silent data hazards: UPDATE/DELETE queries execute with unscoped WHERE clauses like `WHERE col = null` without any warning.

Documented default (from https://typeorm.io/docs/data-source/null-and-undefined-handling):
> `'throw'` (default) — JavaScript `undefined` values cause a `TypeORMError` to be thrown

## Root cause

```typescript
// src/util/OrmUtils.ts L669
if (!options) {
    return criteria  // ← skips all validation when DataSource has no invalidWhereValuesBehavior
}
```

All call sites in `EntityManager.ts` pass `this.dataSource.options.invalidWhereValuesBehavior`, which is `undefined` when unconfigured.

## Fix

```typescript
if (!options) {
    options = {}  // allow ?? defaults to apply: undefined→"throw", null→"throw"
}
```

With an empty options object, the existing `??` expressions apply the documented defaults:
- `options?.undefined ?? "throw"` → `"throw"`
- `options?.null ?? "throw"` → `"throw"`

## Affected operations

All four `EntityManager` paths that call `normalizeWhereCriteria`:
- `update()`
- `delete()`
- `softDelete()`
- `restore()`

The `SelectQueryBuilder` already handles defaults correctly inline and is unaffected.

Closes #12578
