### PR TITLE
fix: apply default throw behavior when invalidWhereValuesBehavior unset (#12578)

### DIFF
--- a/src/util/OrmUtils.ts
+++ b/src/util/OrmUtils.ts
@@ -662,10 +662,6 @@ export class OrmUtils {
         options?: InvalidFindOptionsWhereBehavior,
         path?: string,
     ): ObjectLiteral | ObjectLiteral[] {
-        if (!options) {
-            return criteria
-        }
-
         // multiple criteria are possible at the top level
         if (!path && Array.isArray(criteria)) {
             return criteria.map(

--- a/test/functional/null-undefined-handling/query-builders.test.ts
+++ b/test/functional/null-undefined-handling/query-builders.test.ts
@@ -415,6 +415,69 @@ describe("entity manager > invalidWhereValuesBehavior with ignore", () => {
     })
 })
 
+describe("entity manager > default invalidWhereValuesBehavior when unset", () => {
+    let dataSources: DataSource[]
+
+    before(async () => {
+        dataSources = await createTestingConnections({
+            disabledDrivers: ["spanner"],
+            entities: [Post, Category],
+            schemaCreate: true,
+            dropSchema: true,
+        })
+    })
+    beforeEach(() => reloadTestingDatabases(dataSources))
+    after(() => closeTestingConnections(dataSources))
+
+    async function prepareData(connection: DataSource) {
+        const category = new Category()
+        category.name = "Test Category"
+        await connection.manager.save(category)
+
+        const post = new Post()
+        post.title = "Test Post"
+        post.text = "Some text"
+        post.category = category
+        await connection.manager.save(post)
+
+        return { category, post }
+    }
+
+    it("should throw for null values in EntityManager.update() by default", async () => {
+        for (const connection of dataSources) {
+            await prepareData(connection)
+
+            try {
+                await connection.manager.update(Post, { text: null } as any, {
+                    title: "Updated",
+                })
+                expect.fail("Expected error")
+            } catch (error) {
+                expect(error).to.be.instanceOf(TypeORMError)
+                expect(error.message).to.include("Null value encountered")
+            }
+        }
+    })
+
+    it("should throw for undefined values in EntityManager.update() by default", async () => {
+        for (const connection of dataSources) {
+            await prepareData(connection)
+
+            try {
+                await connection.manager.update(
+                    Post,
+                    { text: undefined } as any,
+                    { title: "Updated" },
+                )
+                expect.fail("Expected error")
+            } catch (error) {
+                expect(error).to.be.instanceOf(TypeORMError)
+                expect(error.message).to.include("Undefined value encountered")
+            }
+        }
+    })
+})
+
 describe("entity manager > invalidWhereValuesBehavior does NOT affect QB .where()", () => {
     let dataSources: DataSource[]
 


### PR DESCRIPTION
## Summary

Fixes #12578: apply default `throw` behavior in `OrmUtils.normalizeWhereCriteria()` when `invalidWhereValuesBehavior` is unset on the DataSource.

## Problem

Early return `if (!options) return criteria` skipped documented TypeORM 1.0 defaults, allowing unsafe `EntityManager.update()` with `null`/`undefined` in WHERE clauses.

## Acceptance criteria

- [x] Unset `invalidWhereValuesBehavior` throws on `null`/`undefined` in where criteria (matches docs)
- [x] Regression tests: `default invalidWhereValuesBehavior when unset` in `query-builders.test.ts`
- [x] Minimal one-line behavioral fix in `OrmUtils.ts`

## Testing

```bash
npm install
npm run test -- --grep "default invalidWhereValuesBehavior when unset"
```

Fixes #12578

/opire try
/claim #12578


Solana wallet for bounty payout: `Do4v7foHJvRJLpRRoGaVPWX6DDEjX3yTK7J91gpwUQpE`