### PR TITLE
fix(postgres): alter varchar length without dropping column

### DIFF
--- a/src/driver/postgres/PostgresQueryRunner.ts
+++ b/src/driver/postgres/PostgresQueryRunner.ts
@@ -2370,13 +2370,17 @@ export class PostgresQueryRunner
 
             // update column collation
             if (newColumn.collation !== oldColumn.collation) {
+                const newCollation = newColumn.collation
+                    ? `"${newColumn.collation}"`
+                    : `pg_catalog."default"` // if there's no new collation, use default
+
                 upQueries.push(
                     new Query(
                         `ALTER TABLE ${this.escapePath(table)} ALTER COLUMN "${
                             newColumn.name
                         }" TYPE ${this.driver.createFullType(
                             newColumn,
-                        )} COLLATE "${newColumn.collation}"`,
+                        )} COLLATE ${newCollation}`,
                     ),
                 )
 

--- a/src/driver/postgres/PostgresQueryRunner.ts
+++ b/src/driver/postgres/PostgresQueryRunner.ts
@@ -2374,9 +2374,9 @@ export class PostgresQueryRunner
                     new Query(
                         `ALTER TABLE ${this.escapePath(table)} ALTER COLUMN "${
                             newColumn.name
-                        }" TYPE ${newColumn.type} COLLATE "${
-                            newColumn.collation
-                        }"`,
+                        }" TYPE ${this.driver.createFullType(
+                            newColumn,
+                        )} COLLATE "${newColumn.collation}"`,
                     ),
                 )
 
@@ -2388,7 +2388,9 @@ export class PostgresQueryRunner
                     new Query(
                         `ALTER TABLE ${this.escapePath(table)} ALTER COLUMN "${
                             newColumn.name
-                        }" TYPE ${newColumn.type} COLLATE ${oldCollation}`,
+                        }" TYPE ${this.driver.createFullType(
+                            oldColumn,
+                        )} COLLATE ${oldCollation}`,
                     ),
                 )
             }

--- a/src/driver/postgres/PostgresQueryRunner.ts
+++ b/src/driver/postgres/PostgresQueryRunner.ts
@@ -1640,6 +1640,7 @@ export class PostgresQueryRunner
                         }" TYPE ${this.driver.createFullType(oldColumn)}`,
                     ),
                 )
+                this.updateColumnTypeInClonedTable(clonedTable, newColumn)
             }
 
             if (
@@ -1660,6 +1661,7 @@ export class PostgresQueryRunner
                         }" TYPE ${this.driver.createFullType(oldColumn)}`,
                     ),
                 )
+                this.updateColumnTypeInClonedTable(clonedTable, newColumn)
             }
 
             if (
@@ -2510,6 +2512,27 @@ export class PostgresQueryRunner
 
     private isVarcharColumn(column: TableColumn): boolean {
         return column.type === "character varying" || column.type === "varchar"
+    }
+
+    private updateColumnTypeInClonedTable(
+        clonedTable: Table,
+        newColumn: TableColumn,
+    ): void {
+        const clonedColumn = clonedTable.columns.find(
+            (column) => column.name === newColumn.name,
+        )
+
+        if (!clonedColumn) {
+            return
+        }
+
+        clonedColumn.type = newColumn.type
+        clonedColumn.length = newColumn.length
+        clonedColumn.precision = newColumn.precision
+        clonedColumn.scale = newColumn.scale
+        clonedColumn.isArray = newColumn.isArray
+        clonedColumn.spatialFeatureType = newColumn.spatialFeatureType
+        clonedColumn.srid = newColumn.srid
     }
 
     /**

--- a/src/driver/postgres/PostgresQueryRunner.ts
+++ b/src/driver/postgres/PostgresQueryRunner.ts
@@ -1326,10 +1326,17 @@ export class PostgresQueryRunner
                 `Column "${oldTableColumnOrName}" was not found in the "${table.name}" table.`,
             )
 
-        if (
+        const isVarcharLengthOnlyChange = this.isVarcharLengthOnlyChange(
+            oldColumn,
+            newColumn,
+        )
+        const hasTypeChange =
             oldColumn.type !== newColumn.type ||
             oldColumn.length !== newColumn.length ||
-            newColumn.isArray !== oldColumn.isArray ||
+            newColumn.isArray !== oldColumn.isArray
+
+        if (
+            (hasTypeChange && !isVarcharLengthOnlyChange) ||
             (!oldColumn.generatedType &&
                 newColumn.generatedType === "STORED") ||
             (oldColumn.asExpression !== newColumn.asExpression &&
@@ -1616,6 +1623,23 @@ export class PostgresQueryRunner
                     clonedTable.columns.indexOf(oldTableColumn!)
                 ].name = newColumn.name
                 oldColumn.name = newColumn.name
+            }
+
+            if (isVarcharLengthOnlyChange) {
+                upQueries.push(
+                    new Query(
+                        `ALTER TABLE ${this.escapePath(table)} ALTER COLUMN "${
+                            newColumn.name
+                        }" TYPE ${this.driver.createFullType(newColumn)}`,
+                    ),
+                )
+                downQueries.push(
+                    new Query(
+                        `ALTER TABLE ${this.escapePath(table)} ALTER COLUMN "${
+                            newColumn.name
+                        }" TYPE ${this.driver.createFullType(oldColumn)}`,
+                    ),
+                )
             }
 
             if (
@@ -2465,6 +2489,27 @@ export class PostgresQueryRunner
 
         await this.executeQueries(upQueries, downQueries)
         this.replaceCachedTable(table, clonedTable)
+    }
+
+    private isVarcharLengthOnlyChange(
+        oldColumn: TableColumn,
+        newColumn: TableColumn,
+    ): boolean {
+        return (
+            this.isVarcharColumn(oldColumn) &&
+            this.isVarcharColumn(newColumn) &&
+            oldColumn.length !== newColumn.length &&
+            !oldColumn.isArray &&
+            !newColumn.isArray &&
+            !oldColumn.generatedType &&
+            !newColumn.generatedType &&
+            !oldColumn.asExpression &&
+            !newColumn.asExpression
+        )
+    }
+
+    private isVarcharColumn(column: TableColumn): boolean {
+        return column.type === "character varying" || column.type === "varchar"
     }
 
     /**

--- a/test/functional/schema-builder/column/change/change-column/change-column.test.ts
+++ b/test/functional/schema-builder/column/change/change-column/change-column.test.ts
@@ -88,6 +88,47 @@ describe("schema builder > change column", () => {
             }),
         ))
 
+    it("should change postgres varchar length without dropping the column", () =>
+        Promise.all(
+            dataSources.map(async (dataSource) => {
+                if (dataSource.driver.options.type !== "postgres") return
+
+                const postMetadata = dataSource.getMetadata(Post)
+                const nameColumn =
+                    postMetadata.findColumnWithPropertyName("name")!
+                nameColumn.length = "500"
+
+                try {
+                    const sqlInMemory = await dataSource.driver
+                        .createSchemaBuilder()
+                        .log()
+                    const upQueries = sqlInMemory.upQueries.map((query) =>
+                        query.query.replaceAll(/\s+/g, " ").trim(),
+                    )
+                    const downQueries = sqlInMemory.downQueries.map((query) =>
+                        query.query.replaceAll(/\s+/g, " ").trim(),
+                    )
+
+                    expect(upQueries).to.include(
+                        `ALTER TABLE "post" ALTER COLUMN "name" TYPE character varying(500)`,
+                    )
+                    expect(downQueries).to.include(
+                        `ALTER TABLE "post" ALTER COLUMN "name" TYPE character varying(255)`,
+                    )
+                    expect(
+                        upQueries.some((query) =>
+                            query.includes(`DROP COLUMN "name"`),
+                        ),
+                    ).to.be.false
+                    expect(
+                        upQueries.some((query) => query.includes(`ADD "name"`)),
+                    ).to.be.false
+                } finally {
+                    nameColumn.length = "255"
+                }
+            }),
+        ))
+
     it("should correctly change column type", () =>
         Promise.all(
             dataSources.map(async (dataSource) => {

--- a/test/github-issues/3357/issue-3357.test.ts
+++ b/test/github-issues/3357/issue-3357.test.ts
@@ -85,6 +85,42 @@ describe("github issues > #3357 migration generation drops columns", () => {
             `ALTER TABLE "bug" ALTER COLUMN "example" TYPE character varying(50) COLLATE pg_catalog."default"`,
         ])
     })
+
+    it("uses postgres default when clearing a varchar collation", async () => {
+        const driver = createPostgresDriverStub()
+        const queryRunner = new TestPostgresQueryRunner(driver, "master")
+        const table = new Table({
+            name: "bug",
+            columns: [
+                {
+                    name: "example",
+                    type: "character varying",
+                    length: "50",
+                    collation: "C",
+                },
+            ],
+        })
+        queryRunner.seedCachedTable(table)
+        const oldColumn = table.findColumnByName("example")!
+        const newColumn = oldColumn.clone()
+        newColumn.collation = undefined
+
+        queryRunner.enableSqlMemory()
+
+        await queryRunner.changeColumn(table, oldColumn, newColumn)
+
+        const upQueries = normalizeQueries(queryRunner.getMemorySql().upQueries)
+        const downQueries = normalizeQueries(
+            queryRunner.getMemorySql().downQueries,
+        )
+
+        expect(upQueries).to.deep.equal([
+            `ALTER TABLE "bug" ALTER COLUMN "example" TYPE character varying(50) COLLATE pg_catalog."default"`,
+        ])
+        expect(downQueries).to.deep.equal([
+            `ALTER TABLE "bug" ALTER COLUMN "example" TYPE character varying(50) COLLATE "C"`,
+        ])
+    })
 })
 
 class TestPostgresQueryRunner extends PostgresQueryRunner {

--- a/test/github-issues/3357/issue-3357.test.ts
+++ b/test/github-issues/3357/issue-3357.test.ts
@@ -1,0 +1,92 @@
+import { expect } from "chai"
+import { PostgresQueryRunner } from "../../../src/driver/postgres/PostgresQueryRunner"
+import type { Query } from "../../../src/driver/Query"
+import { DefaultNamingStrategy } from "../../../src/naming-strategy/DefaultNamingStrategy"
+import { Table } from "../../../src/schema-builder/table/Table"
+import type { TableColumn } from "../../../src/schema-builder/table/TableColumn"
+
+describe("github issues > #3357 migration generation drops columns", () => {
+    it("uses ALTER COLUMN TYPE when changing postgres varchar length", async () => {
+        const driver = createPostgresDriverStub()
+        const queryRunner = new PostgresQueryRunner(driver, "master")
+        const table = new Table({
+            name: "bug",
+            columns: [
+                {
+                    name: "example",
+                    type: "character varying",
+                    length: "50",
+                },
+            ],
+        })
+        const oldColumn = table.findColumnByName("example")!
+        const newColumn = oldColumn.clone()
+        newColumn.length = "51"
+
+        queryRunner.enableSqlMemory()
+
+        await queryRunner.changeColumn(table, oldColumn, newColumn)
+
+        const upQueries = normalizeQueries(queryRunner.getMemorySql().upQueries)
+        const downQueries = normalizeQueries(
+            queryRunner.getMemorySql().downQueries,
+        )
+
+        expect(upQueries).to.deep.equal([
+            `ALTER TABLE "bug" ALTER COLUMN "example" TYPE character varying(51)`,
+        ])
+        expect(downQueries).to.deep.equal([
+            `ALTER TABLE "bug" ALTER COLUMN "example" TYPE character varying(50)`,
+        ])
+    })
+})
+
+function createPostgresDriverStub(): any {
+    const driver: any = {
+        connectedQueryRunners: [],
+        database: undefined,
+        options: { type: "postgres" },
+        searchSchema: "public",
+        uuidGenerator: "uuid_generate_v4()",
+        buildTableName: (
+            tableName: string,
+            schema?: string,
+            database?: string,
+        ) => [database, schema, tableName].filter(Boolean).join("."),
+        createFullType: (column: TableColumn) => {
+            let type = column.type
+
+            if (column.length) {
+                type += `(${column.length})`
+            }
+
+            if (column.isArray) {
+                type += " array"
+            }
+
+            return type
+        },
+        parseTableName: (target: Table | string) => {
+            const name = typeof target === "string" ? target : target.name
+            const parts = name.split(".")
+
+            return {
+                database: parts.length === 3 ? parts[0] : undefined,
+                schema: parts.length >= 2 ? parts[parts.length - 2] : undefined,
+                tableName: parts[parts.length - 1],
+            }
+        },
+    }
+
+    driver.dataSource = {
+        driver,
+        hasMetadata: () => false,
+        namingStrategy: new DefaultNamingStrategy(),
+    }
+
+    return driver
+}
+
+function normalizeQueries(queries: Query[]): string[] {
+    return queries.map((query) => query.query.replaceAll(/\s+/g, " ").trim())
+}

--- a/test/github-issues/3357/issue-3357.test.ts
+++ b/test/github-issues/3357/issue-3357.test.ts
@@ -1,5 +1,6 @@
 import { expect } from "chai"
 import { PostgresQueryRunner } from "../../../src/driver/postgres/PostgresQueryRunner"
+import type { PostgresDriver } from "../../../src/driver/postgres/PostgresDriver"
 import type { Query } from "../../../src/driver/Query"
 import { DefaultNamingStrategy } from "../../../src/naming-strategy/DefaultNamingStrategy"
 import { Table } from "../../../src/schema-builder/table/Table"
@@ -8,7 +9,7 @@ import type { TableColumn } from "../../../src/schema-builder/table/TableColumn"
 describe("github issues > #3357 migration generation drops columns", () => {
     it("uses ALTER COLUMN TYPE when changing postgres varchar length", async () => {
         const driver = createPostgresDriverStub()
-        const queryRunner = new PostgresQueryRunner(driver, "master")
+        const queryRunner = new TestPostgresQueryRunner(driver, "master")
         const table = new Table({
             name: "bug",
             columns: [
@@ -19,6 +20,7 @@ describe("github issues > #3357 migration generation drops columns", () => {
                 },
             ],
         })
+        queryRunner.seedCachedTable(table)
         const oldColumn = table.findColumnByName("example")!
         const newColumn = oldColumn.clone()
         newColumn.length = "51"
@@ -38,11 +40,25 @@ describe("github issues > #3357 migration generation drops columns", () => {
         expect(downQueries).to.deep.equal([
             `ALTER TABLE "bug" ALTER COLUMN "example" TYPE character varying(50)`,
         ])
+
+        const cachedColumn = queryRunner.getCachedColumn("example")
+        expect(cachedColumn?.type).to.equal("character varying")
+        expect(cachedColumn?.length).to.equal("51")
     })
 })
 
-function createPostgresDriverStub(): any {
-    const driver: any = {
+class TestPostgresQueryRunner extends PostgresQueryRunner {
+    seedCachedTable(table: Table): void {
+        this.loadedTables = [table]
+    }
+
+    getCachedColumn(columnName: string): TableColumn | undefined {
+        return this.loadedTables[0]?.findColumnByName(columnName)
+    }
+}
+
+function createPostgresDriverStub(): PostgresDriver {
+    const driver = {
         connectedQueryRunners: [],
         database: undefined,
         options: { type: "postgres" },
@@ -76,13 +92,13 @@ function createPostgresDriverStub(): any {
                 tableName: parts[parts.length - 1],
             }
         },
-    }
+    } as unknown as PostgresDriver
 
     driver.dataSource = {
         driver,
         hasMetadata: () => false,
         namingStrategy: new DefaultNamingStrategy(),
-    }
+    } as unknown as PostgresDriver["dataSource"]
 
     return driver
 }

--- a/test/github-issues/3357/issue-3357.test.ts
+++ b/test/github-issues/3357/issue-3357.test.ts
@@ -6,6 +6,8 @@ import { DefaultNamingStrategy } from "../../../src/naming-strategy/DefaultNamin
 import { Table } from "../../../src/schema-builder/table/Table"
 import type { TableColumn } from "../../../src/schema-builder/table/TableColumn"
 
+// This regression stays in test/github-issues because it verifies generated SQL
+// and QueryRunner table-cache state without requiring a live Postgres database.
 describe("github issues > #3357 migration generation drops columns", () => {
     it("uses ALTER COLUMN TYPE when changing postgres varchar length", async () => {
         const driver = createPostgresDriverStub()

--- a/test/github-issues/3357/issue-3357.test.ts
+++ b/test/github-issues/3357/issue-3357.test.ts
@@ -47,6 +47,44 @@ describe("github issues > #3357 migration generation drops columns", () => {
         expect(cachedColumn?.type).to.equal("character varying")
         expect(cachedColumn?.length).to.equal("51")
     })
+
+    it("keeps varchar length when changing postgres varchar length and collation", async () => {
+        const driver = createPostgresDriverStub()
+        const queryRunner = new TestPostgresQueryRunner(driver, "master")
+        const table = new Table({
+            name: "bug",
+            columns: [
+                {
+                    name: "example",
+                    type: "character varying",
+                    length: "50",
+                },
+            ],
+        })
+        queryRunner.seedCachedTable(table)
+        const oldColumn = table.findColumnByName("example")!
+        const newColumn = oldColumn.clone()
+        newColumn.length = "51"
+        newColumn.collation = "C"
+
+        queryRunner.enableSqlMemory()
+
+        await queryRunner.changeColumn(table, oldColumn, newColumn)
+
+        const upQueries = normalizeQueries(queryRunner.getMemorySql().upQueries)
+        const downQueries = normalizeQueries(
+            queryRunner.getMemorySql().downQueries,
+        )
+
+        expect(upQueries).to.deep.equal([
+            `ALTER TABLE "bug" ALTER COLUMN "example" TYPE character varying(51)`,
+            `ALTER TABLE "bug" ALTER COLUMN "example" TYPE character varying(51) COLLATE "C"`,
+        ])
+        expect(downQueries).to.deep.equal([
+            `ALTER TABLE "bug" ALTER COLUMN "example" TYPE character varying(50)`,
+            `ALTER TABLE "bug" ALTER COLUMN "example" TYPE character varying(50) COLLATE pg_catalog."default"`,
+        ])
+    })
 })
 
 class TestPostgresQueryRunner extends PostgresQueryRunner {


### PR DESCRIPTION
### Description of change

Fixes #3357

/claim #3357

Postgres migrations currently recreate a column when only the `varchar` / `character varying` length changes. That generates `DROP COLUMN` and `ADD COLUMN`, which can lose existing data.

This change routes ordinary non-array, non-generated `varchar` / `character varying` length-only changes through `ALTER TABLE ... ALTER COLUMN ... TYPE ...` instead. Other type, array, and generated-column changes keep the existing recreate-column behavior.

Verification:

- Added a database-free regression for issue #3357; before the fix it failed with `DROP COLUMN "example"` and `ADD "example" character varying(51) NOT NULL`.
- Added a Postgres schema-builder regression asserting generated migration SQL uses `ALTER COLUMN ... TYPE` and does not include `DROP COLUMN` / `ADD` for the changed column.
- Ran `\.\node_modules\.bin\mocha.cmd --no-config --require ts-node/register test/github-issues/3357/issue-3357.test.ts`.
- Ran `\.\node_modules\.bin\tsc.cmd --noEmit --pretty false`.
- Ran `\.\node_modules\.bin\lint-staged.cmd`.
- Ran `\.\node_modules\.bin\prettier.cmd --check src/driver/postgres/PostgresQueryRunner.ts test/github-issues/3357/issue-3357.test.ts test/functional/schema-builder/column/change/change-column/change-column.test.ts`.

I did not run the full database-backed suite locally because this environment does not have the project `ormconfig.json` and local Postgres test service configured.

### Pull-Request Checklist

- [x] Code is up-to-date with the `master` branch
- [x] This pull request links a relevant issue using a closing keyword: `Fixes #3357`
- [x] There are new or updated tests validating the change (`tests/**.test.ts`)
- [x] Documentation has been updated to reflect this change (`docs/docs/**.md`) N/A: bug fix with no user-facing docs change