### PR TITLE
fix: apply default throw behavior in normalizeWhereCriteria when options is undefined

### DIFF
--- a/src/util/OrmUtils.ts
+++ b/src/util/OrmUtils.ts
@@ -663,7 +663,7 @@ export class OrmUtils {
         path?: string,
     ): ObjectLiteral | ObjectLiteral[] {
         if (!options) {
-            return criteria
+            options = {}
         }
 
         // multiple criteria are possible at the top level

--- a/test/unit/util/orm-utils.test.ts
+++ b/test/unit/util/orm-utils.test.ts
@@ -2,6 +2,7 @@ import { expect } from "chai"
 import { runInNewContext } from "node:vm"
 import type { DeepPartial } from "../../../src"
 import { OrmUtils } from "../../../src/util/OrmUtils"
+import { IsNull } from "../../../src"
 
 describe(`OrmUtils`, () => {
     describe("parseSqlCheckExpression", () => {
@@ -268,6 +269,97 @@ describe(`OrmUtils`, () => {
                     new Uint8Array([1, 2, 4]),
                 ),
             ).to.equal(false)
+        })
+    })
+
+    describe("normalizeWhereCriteria", () => {
+        it("should pass through valid criteria when options is undefined", () => {
+            const criteria = { name: "test", age: 25 }
+            const result = OrmUtils.normalizeWhereCriteria(criteria, undefined)
+            expect(result).to.deep.equal({ name: "test", age: 25 })
+        })
+
+        it("should throw on undefined value when options is undefined (default throw behavior)", () => {
+            expect(() =>
+                OrmUtils.normalizeWhereCriteria(
+                    { name: undefined },
+                    undefined,
+                ),
+            ).to.throw(
+                /Undefined value encountered in property 'name'/,
+            )
+        })
+
+        it("should throw on null value when options is undefined (default throw behavior)", () => {
+            expect(() =>
+                OrmUtils.normalizeWhereCriteria({ name: null }, undefined),
+            ).to.throw(
+                /Null value encountered in property 'name'/,
+            )
+        })
+
+        it("should throw on undefined value when options is empty object (explicit defaults)", () => {
+            expect(() =>
+                OrmUtils.normalizeWhereCriteria({ name: undefined }, {}),
+            ).to.throw(
+                /Undefined value encountered in property 'name'/,
+            )
+        })
+
+        it("should ignore undefined value when options.undefined is 'ignore'", () => {
+            const result = OrmUtils.normalizeWhereCriteria(
+                { name: undefined, age: 25 },
+                { undefined: "ignore" },
+            )
+            expect(result).to.deep.equal({ age: 25 })
+        })
+
+        it("should ignore null value when options.null is 'ignore'", () => {
+            const result = OrmUtils.normalizeWhereCriteria(
+                { name: null, age: 25 },
+                { null: "ignore" },
+            )
+            expect(result).to.deep.equal({ age: 25 })
+        })
+
+        it("should convert null to IsNull() when options.null is 'sql-null'", () => {
+            const result = OrmUtils.normalizeWhereCriteria(
+                { name: null, age: 25 },
+                { null: "sql-null" },
+            ) as Record<string, unknown>
+            expect(result["age"]).to.equal(25)
+            // IsNull() returns a FindOperator — verify it replaces null
+            expect(result["name"]).to.not.be.null
+            expect(result["name"]).to.not.be.undefined
+        })
+
+        it("should apply default throw behavior for arrays when options is undefined", () => {
+            const criteria = [{ name: "valid" }, { name: null }]
+            expect(() =>
+                OrmUtils.normalizeWhereCriteria(criteria, undefined),
+            ).to.throw(
+                /Null value encountered in property '1.name'/,
+            )
+        })
+
+        it("should process arrays of criteria when all values are valid", () => {
+            const criteria = [{ name: "Alice" }, { name: "Bob" }]
+            const result = OrmUtils.normalizeWhereCriteria(
+                criteria,
+                undefined,
+            )
+            expect(result).to.deep.equal([{ name: "Alice" }, { name: "Bob" }])
+        })
+
+        it("should handle nested objects and throw on deep undefined when options is undefined", () => {
+            expect(() =>
+                OrmUtils.normalizeWhereCriteria(
+                    { user: { email: undefined } },
+                    undefined,
+                ),
+            ).to.throw(
+                /Undefined value encountered in property 'user.email'/,
+            )
         })
     })
 })


### PR DESCRIPTION
## Problem

Fixes #12578

`OrmUtils.normalizeWhereCriteria()` receives `options` from `DataSource.options.invalidWhereValuesBehavior`. When users do not configure this option, it is `undefined`.

The current code:

```typescript
if (!options) {
    return criteria  // BUG: returns unchanged, skipping all validation
}
```

This means calls to `EntityManager.update()`, `.delete()`, `.softDelete()`, and `.restore()` with `{ someField: undefined }` or `{ someField: null }` silently pass through instead of throwing — regardless of the documented default behavior.

## Fix

Default `options` to `{}` when undefined:

```typescript
if (!options) {
    options = {}
}
```

With `options = {}`, the `?? 'throw'` expressions in the existing code apply the documented defaults for both `undefined` and `null` values.

## Tests

Added 9 unit tests to `test/unit/util/orm-utils.test.ts`:

1. Valid criteria pass through when options is undefined
2. Undefined value throws when options is undefined (the bug)
3. Null value throws when options is undefined (the bug)
4. Undefined value throws for explicit empty options object
5. `ignore` behavior for undefined values still works
6. `ignore` behavior for null values still works
7. `sql-null` converts null to IsNull()
8. Array criteria with null throws when options is undefined
9. Nested paths include full property path in error message

/opire try