### PR TITLE
fix: apply default invalidWhereValuesBehavior

### DIFF
--- a/docs/docs/data-source/5-null-and-undefined-handling.md
+++ b/docs/docs/data-source/5-null-and-undefined-handling.md
@@ -6,6 +6,8 @@ Passing a known `null` value is disallowed by TypeScript (when you've enabled `s
 
 The way in which `null` and `undefined` values are handled can be customised through the `invalidWhereValuesBehavior` configuration option in your data source options. This applies to high-level operations such as find operations, repository methods, and EntityManager methods (update, delete, softDelete, restore).
 
+Write operations that require criteria (`update`, `delete`, `softDelete`, and `restore`) reject empty criteria before executing. They also reject object criteria that become empty after TypeORM applies `invalidWhereValuesBehavior` and other where-condition normalization. If criteria are provided as an OR array, every element in that array must still contain usable conditions after normalization.
+
 :::warning
 This setting does **not** affect QueryBuilder's `.where()`, `.andWhere()`, or `.orWhere()` methods. QueryBuilder is a low-level API where null/undefined values pass through as-is. Use the `IsNull()` operator or parameterized conditions in QueryBuilder for explicit null handling.
 :::

--- a/src/entity-manager/EntityManager.ts
+++ b/src/entity-manager/EntityManager.ts
@@ -22,7 +22,10 @@ import type { ObjectId } from "../driver/mongodb/typings"
 import type { InsertResult } from "../query-builder/result/InsertResult"
 import type { UpdateResult } from "../query-builder/result/UpdateResult"
 import type { DeleteResult } from "../query-builder/result/DeleteResult"
-import type { WhereClauseCondition } from "../query-builder/WhereClause"
+import type {
+    WhereClause,
+    WhereClauseCondition,
+} from "../query-builder/WhereClause"
 import type { FindOptionsWhere } from "../find-options/FindOptionsWhere"
 import type { IsolationLevel } from "../driver/types/IsolationLevel"
 import { ObjectUtils } from "../util/ObjectUtils"
@@ -875,10 +878,7 @@ export class EntityManager {
                 criteria as ObjectLiteral | ObjectLiteral[],
                 this.dataSource.options.invalidWhereValuesBehavior,
             )
-            if (
-                OrmUtils.isNormalizedCriteriaEmpty(normalizedCriteria) ||
-                this.hasEmptyWhereCondition(target, normalizedCriteria)
-            ) {
+            if (OrmUtils.isNormalizedCriteriaEmpty(normalizedCriteria)) {
                 return Promise.reject(
                     new TypeORMError(
                         `Empty criteria(s) are not allowed for the update method.`,
@@ -890,6 +890,13 @@ export class EntityManager {
                 .update(target)
                 .set(partialEntity)
                 .where(normalizedCriteria)
+            if (this.hasEmptyWhereCondition(qb.expressionMap.wheres)) {
+                return Promise.reject(
+                    new TypeORMError(
+                        `Empty criteria(s) are not allowed for the update method.`,
+                    ),
+                )
+            }
 
             if (options?.returning !== undefined) {
                 qb.returning(options.returning)
@@ -967,10 +974,7 @@ export class EntityManager {
                 criteria as ObjectLiteral | ObjectLiteral[],
                 this.dataSource.options.invalidWhereValuesBehavior,
             )
-            if (
-                OrmUtils.isNormalizedCriteriaEmpty(normalizedCriteria) ||
-                this.hasEmptyWhereCondition(targetOrEntity, normalizedCriteria)
-            ) {
+            if (OrmUtils.isNormalizedCriteriaEmpty(normalizedCriteria)) {
                 return Promise.reject(
                     new TypeORMError(
                         `Empty criteria(s) are not allowed for the delete method.`,
@@ -978,11 +982,19 @@ export class EntityManager {
                 )
             }
 
-            return this.createQueryBuilder()
+            const qb = this.createQueryBuilder()
                 .delete()
                 .from(targetOrEntity)
                 .where(normalizedCriteria)
-                .execute()
+            if (this.hasEmptyWhereCondition(qb.expressionMap.wheres)) {
+                return Promise.reject(
+                    new TypeORMError(
+                        `Empty criteria(s) are not allowed for the delete method.`,
+                    ),
+                )
+            }
+
+            return qb.execute()
         }
     }
 
@@ -1044,10 +1056,7 @@ export class EntityManager {
                 criteria as ObjectLiteral | ObjectLiteral[],
                 this.dataSource.options.invalidWhereValuesBehavior,
             )
-            if (
-                OrmUtils.isNormalizedCriteriaEmpty(normalizedCriteria) ||
-                this.hasEmptyWhereCondition(targetOrEntity, normalizedCriteria)
-            ) {
+            if (OrmUtils.isNormalizedCriteriaEmpty(normalizedCriteria)) {
                 return Promise.reject(
                     new TypeORMError(
                         `Empty criteria(s) are not allowed for the softDelete method.`,
@@ -1055,11 +1064,19 @@ export class EntityManager {
                 )
             }
 
-            return this.createQueryBuilder()
+            const qb = this.createQueryBuilder()
                 .softDelete()
                 .from(targetOrEntity)
                 .where(normalizedCriteria)
-                .execute()
+            if (this.hasEmptyWhereCondition(qb.expressionMap.wheres)) {
+                return Promise.reject(
+                    new TypeORMError(
+                        `Empty criteria(s) are not allowed for the softDelete method.`,
+                    ),
+                )
+            }
+
+            return qb.execute()
         }
     }
 
@@ -1106,10 +1123,7 @@ export class EntityManager {
                 criteria as ObjectLiteral | ObjectLiteral[],
                 this.dataSource.options.invalidWhereValuesBehavior,
             )
-            if (
-                OrmUtils.isNormalizedCriteriaEmpty(normalizedCriteria) ||
-                this.hasEmptyWhereCondition(targetOrEntity, normalizedCriteria)
-            ) {
+            if (OrmUtils.isNormalizedCriteriaEmpty(normalizedCriteria)) {
                 return Promise.reject(
                     new TypeORMError(
                         `Empty criteria(s) are not allowed for the restore method.`,
@@ -1117,11 +1131,19 @@ export class EntityManager {
                 )
             }
 
-            return this.createQueryBuilder()
+            const qb = this.createQueryBuilder()
                 .restore()
                 .from(targetOrEntity)
                 .where(normalizedCriteria)
-                .execute()
+            if (this.hasEmptyWhereCondition(qb.expressionMap.wheres)) {
+                return Promise.reject(
+                    new TypeORMError(
+                        `Empty criteria(s) are not allowed for the restore method.`,
+                    ),
+                )
+            }
+
+            return qb.execute()
         }
     }
 
@@ -1251,16 +1273,8 @@ export class EntityManager {
         return this.callAggregateFun(entityClass, "MAX", columnName, where)
     }
 
-    private hasEmptyWhereCondition<Entity extends ObjectLiteral>(
-        target: EntityTarget<Entity>,
-        criteria: ObjectLiteral | ObjectLiteral[],
-    ): boolean {
-        const metadata = this.dataSource.getMetadata(target)
-        const qb = this.createQueryBuilder(target, metadata.name).where(
-            criteria,
-        )
-
-        return qb.expressionMap.wheres.some((where) =>
+    private hasEmptyWhereCondition(wheres: WhereClause[]): boolean {
+        return wheres.some((where) =>
             this.isWhereClauseConditionEmpty(where.condition),
         )
     }

--- a/src/entity-manager/EntityManager.ts
+++ b/src/entity-manager/EntityManager.ts
@@ -874,6 +874,14 @@ export class EntityManager {
                 criteria as ObjectLiteral | ObjectLiteral[],
                 this.dataSource.options.invalidWhereValuesBehavior,
             )
+            if (OrmUtils.isNormalizedCriteriaEmpty(normalizedCriteria)) {
+                return Promise.reject(
+                    new TypeORMError(
+                        `Empty criteria(s) are not allowed for the update method.`,
+                    ),
+                )
+            }
+
             const qb = this.createQueryBuilder()
                 .update(target)
                 .set(partialEntity)
@@ -955,6 +963,14 @@ export class EntityManager {
                 criteria as ObjectLiteral | ObjectLiteral[],
                 this.dataSource.options.invalidWhereValuesBehavior,
             )
+            if (OrmUtils.isNormalizedCriteriaEmpty(normalizedCriteria)) {
+                return Promise.reject(
+                    new TypeORMError(
+                        `Empty criteria(s) are not allowed for the delete method.`,
+                    ),
+                )
+            }
+
             return this.createQueryBuilder()
                 .delete()
                 .from(targetOrEntity)
@@ -1021,6 +1037,14 @@ export class EntityManager {
                 criteria as ObjectLiteral | ObjectLiteral[],
                 this.dataSource.options.invalidWhereValuesBehavior,
             )
+            if (OrmUtils.isNormalizedCriteriaEmpty(normalizedCriteria)) {
+                return Promise.reject(
+                    new TypeORMError(
+                        `Empty criteria(s) are not allowed for the softDelete method.`,
+                    ),
+                )
+            }
+
             return this.createQueryBuilder()
                 .softDelete()
                 .from(targetOrEntity)
@@ -1072,6 +1096,14 @@ export class EntityManager {
                 criteria as ObjectLiteral | ObjectLiteral[],
                 this.dataSource.options.invalidWhereValuesBehavior,
             )
+            if (OrmUtils.isNormalizedCriteriaEmpty(normalizedCriteria)) {
+                return Promise.reject(
+                    new TypeORMError(
+                        `Empty criteria(s) are not allowed for the restore method.`,
+                    ),
+                )
+            }
+
             return this.createQueryBuilder()
                 .restore()
                 .from(targetOrEntity)

--- a/src/entity-manager/EntityManager.ts
+++ b/src/entity-manager/EntityManager.ts
@@ -22,6 +22,7 @@ import type { ObjectId } from "../driver/mongodb/typings"
 import type { InsertResult } from "../query-builder/result/InsertResult"
 import type { UpdateResult } from "../query-builder/result/UpdateResult"
 import type { DeleteResult } from "../query-builder/result/DeleteResult"
+import type { WhereClauseCondition } from "../query-builder/WhereClause"
 import type { FindOptionsWhere } from "../find-options/FindOptionsWhere"
 import type { IsolationLevel } from "../driver/types/IsolationLevel"
 import { ObjectUtils } from "../util/ObjectUtils"
@@ -874,7 +875,10 @@ export class EntityManager {
                 criteria as ObjectLiteral | ObjectLiteral[],
                 this.dataSource.options.invalidWhereValuesBehavior,
             )
-            if (OrmUtils.isNormalizedCriteriaEmpty(normalizedCriteria)) {
+            if (
+                OrmUtils.isNormalizedCriteriaEmpty(normalizedCriteria) ||
+                this.hasEmptyWhereCondition(target, normalizedCriteria)
+            ) {
                 return Promise.reject(
                     new TypeORMError(
                         `Empty criteria(s) are not allowed for the update method.`,
@@ -963,7 +967,10 @@ export class EntityManager {
                 criteria as ObjectLiteral | ObjectLiteral[],
                 this.dataSource.options.invalidWhereValuesBehavior,
             )
-            if (OrmUtils.isNormalizedCriteriaEmpty(normalizedCriteria)) {
+            if (
+                OrmUtils.isNormalizedCriteriaEmpty(normalizedCriteria) ||
+                this.hasEmptyWhereCondition(targetOrEntity, normalizedCriteria)
+            ) {
                 return Promise.reject(
                     new TypeORMError(
                         `Empty criteria(s) are not allowed for the delete method.`,
@@ -1037,7 +1044,10 @@ export class EntityManager {
                 criteria as ObjectLiteral | ObjectLiteral[],
                 this.dataSource.options.invalidWhereValuesBehavior,
             )
-            if (OrmUtils.isNormalizedCriteriaEmpty(normalizedCriteria)) {
+            if (
+                OrmUtils.isNormalizedCriteriaEmpty(normalizedCriteria) ||
+                this.hasEmptyWhereCondition(targetOrEntity, normalizedCriteria)
+            ) {
                 return Promise.reject(
                     new TypeORMError(
                         `Empty criteria(s) are not allowed for the softDelete method.`,
@@ -1096,7 +1106,10 @@ export class EntityManager {
                 criteria as ObjectLiteral | ObjectLiteral[],
                 this.dataSource.options.invalidWhereValuesBehavior,
             )
-            if (OrmUtils.isNormalizedCriteriaEmpty(normalizedCriteria)) {
+            if (
+                OrmUtils.isNormalizedCriteriaEmpty(normalizedCriteria) ||
+                this.hasEmptyWhereCondition(targetOrEntity, normalizedCriteria)
+            ) {
                 return Promise.reject(
                     new TypeORMError(
                         `Empty criteria(s) are not allowed for the restore method.`,
@@ -1236,6 +1249,39 @@ export class EntityManager {
         where?: FindOptionsWhere<Entity> | FindOptionsWhere<Entity>[],
     ): Promise<number | null> {
         return this.callAggregateFun(entityClass, "MAX", columnName, where)
+    }
+
+    private hasEmptyWhereCondition<Entity extends ObjectLiteral>(
+        target: EntityTarget<Entity>,
+        criteria: ObjectLiteral | ObjectLiteral[],
+    ): boolean {
+        const metadata = this.dataSource.getMetadata(target)
+        const qb = this.createQueryBuilder(target, metadata.name).where(
+            criteria,
+        )
+
+        return qb.expressionMap.wheres.some((where) =>
+            this.isWhereClauseConditionEmpty(where.condition),
+        )
+    }
+
+    private isWhereClauseConditionEmpty(
+        condition: WhereClauseCondition,
+    ): boolean {
+        if (Array.isArray(condition)) {
+            return (
+                condition.length === 0 ||
+                condition.some((where) =>
+                    this.isWhereClauseConditionEmpty(where.condition),
+                )
+            )
+        }
+
+        if (typeof condition === "object" && "condition" in condition) {
+            return this.isWhereClauseConditionEmpty(condition.condition)
+        }
+
+        return false
     }
 
     private async callAggregateFun<Entity extends ObjectLiteral>(

--- a/src/util/OrmUtils.ts
+++ b/src/util/OrmUtils.ts
@@ -573,11 +573,12 @@ export class OrmUtils {
 
     // Checks if it's an object made by Object.create(null), {} or new Object()
     private static isPlainObject(item: any) {
-        if (item === null || item === undefined) {
+        if (typeof item !== "object" || item === null) {
             return false
         }
 
-        return !item.constructor || item.constructor === Object
+        const prototype = Object.getPrototypeOf(item)
+        return prototype === null || prototype === Object.prototype
     }
 
     private static mergeArrayKey(

--- a/src/util/OrmUtils.ts
+++ b/src/util/OrmUtils.ts
@@ -694,11 +694,7 @@ export class OrmUtils {
 
         const result: ObjectLiteral = {}
         for (const [key, value] of Object.entries(criteria)) {
-            if (
-                key === "__proto__" ||
-                key === "constructor" ||
-                key === "prototype"
-            ) {
+            if (key === "__proto__") {
                 continue
             }
 

--- a/src/util/OrmUtils.ts
+++ b/src/util/OrmUtils.ts
@@ -676,6 +676,14 @@ export class OrmUtils {
 
         const result: ObjectLiteral = {}
         for (const [key, value] of Object.entries(criteria)) {
+            if (
+                key === "__proto__" ||
+                key === "constructor" ||
+                key === "prototype"
+            ) {
+                continue
+            }
+
             const propertyPath = path ? `${path}.${key}` : key
 
             if (value === undefined) {

--- a/src/util/OrmUtils.ts
+++ b/src/util/OrmUtils.ts
@@ -396,6 +396,24 @@ export class OrmUtils {
     }
 
     /**
+     * Checks if normalized object criteria no longer contain usable conditions.
+     *
+     * @param criteria
+     */
+    public static isNormalizedCriteriaEmpty(criteria: unknown): boolean {
+        if (Array.isArray(criteria)) {
+            return (
+                criteria.length === 0 ||
+                criteria.every((criterion) =>
+                    OrmUtils.isCriteriaNullOrEmpty(criterion),
+                )
+            )
+        }
+
+        return OrmUtils.isCriteriaNullOrEmpty(criteria)
+    }
+
+    /**
      * Checks if given criteria is a primitive value.
      * Primitive values are strings, numbers and dates.
      *

--- a/src/util/OrmUtils.ts
+++ b/src/util/OrmUtils.ts
@@ -404,7 +404,7 @@ export class OrmUtils {
         if (Array.isArray(criteria)) {
             return (
                 criteria.length === 0 ||
-                criteria.every((criterion) =>
+                criteria.some((criterion) =>
                     OrmUtils.isCriteriaNullOrEmpty(criterion),
                 )
             )

--- a/src/util/OrmUtils.ts
+++ b/src/util/OrmUtils.ts
@@ -651,7 +651,7 @@ export class OrmUtils {
 
     /**
      * Recursively validates an object where clause, throwing for null/undefined
-     * based on the provided invalidWhereValuesBehavior config.
+     * based on the provided invalidWhereValuesBehavior config or its defaults.
      *
      * @param criteria
      * @param options
@@ -662,10 +662,6 @@ export class OrmUtils {
         options?: InvalidFindOptionsWhereBehavior,
         path?: string,
     ): ObjectLiteral | ObjectLiteral[] {
-        if (!options) {
-            return criteria
-        }
-
         // multiple criteria are possible at the top level
         if (!path && Array.isArray(criteria)) {
             return criteria.map(
@@ -704,6 +700,11 @@ export class OrmUtils {
                 }
                 // else: "ignore" — skip this key
             } else if (OrmUtils.isPlainObject(value)) {
+                if (Object.keys(value).length === 0) {
+                    result[key] = value
+                    continue
+                }
+
                 const nested = OrmUtils.normalizeWhereCriteria(
                     value,
                     options,

--- a/test/functional/null-undefined-handling/query-builders.test.ts
+++ b/test/functional/null-undefined-handling/query-builders.test.ts
@@ -1,6 +1,8 @@
 import { expect } from "chai"
 import type { DataSource } from "../../../src"
-import { TypeORMError } from "../../../src"
+import { EntitySchema } from "../../../src/entity-schema/EntitySchema"
+import type { EntitySchemaColumnOptions } from "../../../src/entity-schema/EntitySchemaColumnOptions"
+import { TypeORMError } from "../../../src/error/TypeORMError"
 import {
     closeTestingConnections,
     createTestingConnections,
@@ -9,13 +11,34 @@ import {
 import { Category } from "./entity/Category"
 import { Post } from "./entity/Post"
 
+const specialColumnColumns: Record<string, EntitySchemaColumnOptions> =
+    Object.create(null)
+specialColumnColumns["id"] = {
+    type: Number,
+    primary: true,
+}
+specialColumnColumns["constructor"] = {
+    type: String,
+}
+specialColumnColumns["prototype"] = {
+    type: String,
+}
+specialColumnColumns["value"] = {
+    type: String,
+}
+
+const SpecialColumnSchema = new EntitySchema({
+    name: "SpecialColumn",
+    columns: specialColumnColumns,
+})
+
 describe("entity manager > invalidWhereValuesBehavior with default behavior", () => {
     let dataSources: DataSource[]
 
     before(async () => {
         dataSources = await createTestingConnections({
             disabledDrivers: ["spanner"],
-            entities: [Post, Category],
+            entities: [Post, Category, SpecialColumnSchema],
             schemaCreate: true,
             dropSchema: true,
         })
@@ -39,9 +62,7 @@ describe("entity manager > invalidWhereValuesBehavior with default behavior", ()
 
     function createDangerousOnlyCriteria(): Record<string, unknown> {
         return JSON.parse(`{
-            "__proto__": { "polluted": true },
-            "constructor": { "polluted": true },
-            "prototype": { "polluted": true }
+            "__proto__": { "polluted": true }
         }`)
     }
 
@@ -169,6 +190,48 @@ describe("entity manager > invalidWhereValuesBehavior with default behavior", ()
                 id: post.id,
             })
             expect(reloaded.title).to.equal("Test Post")
+        }
+    })
+
+    it("should preserve constructor and prototype as valid criteria property names", async () => {
+        for (const connection of dataSources) {
+            const repository = connection.getRepository("SpecialColumn")
+
+            await repository.insert({
+                id: 1,
+                constructor: "ctor-match",
+                prototype: "proto-one",
+                value: "first",
+            })
+            await repository.insert({
+                id: 2,
+                constructor: "ctor-other",
+                prototype: "proto-two",
+                value: "second",
+            })
+
+            await connection.manager.update(
+                "SpecialColumn",
+                { constructor: "ctor-match" },
+                { value: "updated-by-constructor" },
+            )
+            await connection.manager.update(
+                "SpecialColumn",
+                { prototype: "proto-one" },
+                { value: "updated-by-prototype" },
+            )
+
+            const updated = await repository.findOneByOrFail({ id: 1 })
+            expect(updated.value).to.equal("updated-by-prototype")
+
+            await connection.manager.delete("SpecialColumn", {
+                constructor: "ctor-other",
+            })
+
+            const remaining = await repository.find()
+            expect(remaining.map((row) => row.value)).to.deep.equal([
+                "updated-by-prototype",
+            ])
         }
     })
 })

--- a/test/functional/null-undefined-handling/query-builders.test.ts
+++ b/test/functional/null-undefined-handling/query-builders.test.ts
@@ -212,9 +212,15 @@ describe("entity manager > invalidWhereValuesBehavior with throw", () => {
             await prepareData(connection)
 
             try {
-                await connection.manager.update(Post, { text: null } as any, {
-                    title: "Updated",
-                })
+                await connection.manager.update(
+                    Post,
+                    {
+                        text: null,
+                    },
+                    {
+                        title: "Updated",
+                    },
+                )
                 expect.fail("Expected error")
             } catch (error) {
                 expect(error).to.be.instanceOf(TypeORMError)
@@ -230,7 +236,7 @@ describe("entity manager > invalidWhereValuesBehavior with throw", () => {
             try {
                 await connection.manager.update(
                     Post,
-                    { text: undefined } as any,
+                    { text: undefined },
                     { title: "Updated" },
                 )
                 expect.fail("Expected error")
@@ -246,7 +252,9 @@ describe("entity manager > invalidWhereValuesBehavior with throw", () => {
             await prepareData(connection)
 
             try {
-                await connection.manager.delete(Post, { text: null } as any)
+                await connection.manager.delete(Post, {
+                    text: null,
+                })
                 expect.fail("Expected error")
             } catch (error) {
                 expect(error).to.be.instanceOf(TypeORMError)
@@ -262,7 +270,7 @@ describe("entity manager > invalidWhereValuesBehavior with throw", () => {
             try {
                 await connection.manager.delete(Post, {
                     text: undefined,
-                } as any)
+                })
                 expect.fail("Expected error")
             } catch (error) {
                 expect(error).to.be.instanceOf(TypeORMError)
@@ -278,7 +286,7 @@ describe("entity manager > invalidWhereValuesBehavior with throw", () => {
             try {
                 await connection.manager.softDelete(Post, {
                     text: null,
-                } as any)
+                })
                 expect.fail("Expected error")
             } catch (error) {
                 expect(error).to.be.instanceOf(TypeORMError)
@@ -294,7 +302,7 @@ describe("entity manager > invalidWhereValuesBehavior with throw", () => {
             try {
                 await connection.manager.softDelete(Post, {
                     text: undefined,
-                } as any)
+                })
                 expect.fail("Expected error")
             } catch (error) {
                 expect(error).to.be.instanceOf(TypeORMError)
@@ -310,7 +318,7 @@ describe("entity manager > invalidWhereValuesBehavior with throw", () => {
             try {
                 await connection.manager.restore(Post, {
                     text: null,
-                } as any)
+                })
                 expect.fail("Expected error")
             } catch (error) {
                 expect(error).to.be.instanceOf(TypeORMError)
@@ -326,7 +334,7 @@ describe("entity manager > invalidWhereValuesBehavior with throw", () => {
             try {
                 await connection.manager.restore(Post, {
                     text: undefined,
-                } as any)
+                })
                 expect.fail("Expected error")
             } catch (error) {
                 expect(error).to.be.instanceOf(TypeORMError)
@@ -340,9 +348,13 @@ describe("entity manager > invalidWhereValuesBehavior with throw", () => {
             await prepareData(connection)
 
             try {
-                await connection
-                    .getRepository(Post)
-                    .update({ text: null } as any, { title: "Updated" })
+                await connection.getRepository(Post).update(
+                    // @ts-expect-error - null should be marked as unsafe by default
+                    {
+                        text: null,
+                    },
+                    { title: "Updated" },
+                )
                 expect.fail("Expected error")
             } catch (error) {
                 expect(error).to.be.instanceOf(TypeORMError)
@@ -356,9 +368,12 @@ describe("entity manager > invalidWhereValuesBehavior with throw", () => {
             await prepareData(connection)
 
             try {
-                await connection
-                    .getRepository(Post)
-                    .delete({ text: null } as any)
+                await connection.getRepository(Post).delete(
+                    // @ts-expect-error - null should be marked as unsafe by default
+                    {
+                        text: null,
+                    },
+                )
                 expect.fail("Expected error")
             } catch (error) {
                 expect(error).to.be.instanceOf(TypeORMError)
@@ -374,7 +389,11 @@ describe("entity manager > invalidWhereValuesBehavior with throw", () => {
             try {
                 await connection.manager.update(
                     Post,
-                    { category: { name: null } } as any,
+                    {
+                        category: {
+                            name: null,
+                        },
+                    },
                     { title: "Updated" },
                 )
                 expect.fail("Expected error")
@@ -392,7 +411,7 @@ describe("entity manager > invalidWhereValuesBehavior with throw", () => {
             try {
                 await connection.manager.delete(Post, {
                     category: { name: undefined },
-                } as any)
+                })
                 expect.fail("Expected error")
             } catch (error) {
                 expect(error).to.be.instanceOf(TypeORMError)
@@ -425,7 +444,7 @@ describe("entity manager > invalidWhereValuesBehavior with sql-null", () => {
         for (const connection of dataSources) {
             const post = new Post()
             post.title = "Test Post"
-            post.text = null as any
+            post.text = null
             await connection.manager.save(post)
 
             const post2 = new Post()
@@ -434,9 +453,15 @@ describe("entity manager > invalidWhereValuesBehavior with sql-null", () => {
             await connection.manager.save(post2)
 
             // With sql-null, { text: null } should match rows where text IS NULL
-            await connection.manager.update(Post, { text: null } as any, {
-                title: "Updated",
-            })
+            await connection.manager.update(
+                Post,
+                {
+                    text: null,
+                },
+                {
+                    title: "Updated",
+                },
+            )
 
             const updated = await connection.manager.findOneByOrFail(Post, {
                 id: post.id,
@@ -453,7 +478,7 @@ describe("entity manager > invalidWhereValuesBehavior with sql-null", () => {
         for (const connection of dataSources) {
             const post = new Post()
             post.title = "Test Post"
-            post.text = null as any
+            post.text = null
             await connection.manager.save(post)
 
             const post2 = new Post()
@@ -462,7 +487,9 @@ describe("entity manager > invalidWhereValuesBehavior with sql-null", () => {
             await connection.manager.save(post2)
 
             // With sql-null, { text: null } should delete rows where text IS NULL
-            await connection.manager.delete(Post, { text: null } as any)
+            await connection.manager.delete(Post, {
+                text: null,
+            })
 
             const remaining = await connection.manager.find(Post)
             expect(remaining.length).to.equal(1)
@@ -503,7 +530,7 @@ describe("entity manager > invalidWhereValuesBehavior with ignore", () => {
             await connection.manager.delete(Post, {
                 title: "Test Post",
                 text: null,
-            } as any)
+            })
 
             const remaining = await connection.manager.find(Post)
             expect(remaining.length).to.equal(0)
@@ -522,7 +549,7 @@ describe("entity manager > invalidWhereValuesBehavior with ignore", () => {
             await connection.manager.delete(Post, {
                 title: "Test Post",
                 text: undefined,
-            } as any)
+            })
 
             const remaining = await connection.manager.find(Post)
             expect(remaining.length).to.equal(0)
@@ -544,7 +571,12 @@ describe("entity manager > invalidWhereValuesBehavior with ignore", () => {
             // With ignore, nested null should be stripped, leaving only title
             await connection.manager.update(
                 Post,
-                { title: "Test Post", category: { name: null } } as any,
+                {
+                    title: "Test Post",
+                    category: {
+                        name: null,
+                    },
+                },
                 { text: "Updated" },
             )
 
@@ -571,7 +603,7 @@ describe("entity manager > invalidWhereValuesBehavior with ignore", () => {
             await connection.manager.delete(Post, {
                 title: "Test Post",
                 category: { name: undefined },
-            } as any)
+            })
 
             const remaining = await connection.manager.find(Post)
             expect(remaining.length).to.equal(0)

--- a/test/functional/null-undefined-handling/query-builders.test.ts
+++ b/test/functional/null-undefined-handling/query-builders.test.ts
@@ -9,6 +9,69 @@ import {
 import { Category } from "./entity/Category"
 import { Post } from "./entity/Post"
 
+describe("entity manager > invalidWhereValuesBehavior with default behavior", () => {
+    let dataSources: DataSource[]
+
+    before(async () => {
+        dataSources = await createTestingConnections({
+            disabledDrivers: ["spanner"],
+            entities: [Post, Category],
+            schemaCreate: true,
+            dropSchema: true,
+        })
+    })
+    beforeEach(() => reloadTestingDatabases(dataSources))
+    after(() => closeTestingConnections(dataSources))
+
+    async function prepareData(connection: DataSource) {
+        const category = new Category()
+        category.name = "Test Category"
+        await connection.manager.save(category)
+
+        const post = new Post()
+        post.title = "Test Post"
+        post.text = "Some text"
+        post.category = category
+        await connection.manager.save(post)
+
+        return { category, post }
+    }
+
+    it("should throw error for null values in EntityManager.update() by default", async () => {
+        for (const connection of dataSources) {
+            await prepareData(connection)
+
+            // Regression test for #12578: omitted options should still
+            // use the documented default invalidWhereValuesBehavior.
+            try {
+                await connection.manager.update(Post, { text: null } as any, {
+                    title: "Updated",
+                })
+                expect.fail("Expected error")
+            } catch (error) {
+                expect(error).to.be.instanceOf(TypeORMError)
+                expect(error.message).to.include("Null value encountered")
+            }
+        }
+    })
+
+    it("should throw error for undefined values in EntityManager.delete() by default", async () => {
+        for (const connection of dataSources) {
+            await prepareData(connection)
+
+            try {
+                await connection.manager.delete(Post, {
+                    text: undefined,
+                } as any)
+                expect.fail("Expected error")
+            } catch (error) {
+                expect(error).to.be.instanceOf(TypeORMError)
+                expect(error.message).to.include("Undefined value encountered")
+            }
+        }
+    })
+})
+
 describe("entity manager > invalidWhereValuesBehavior with throw", () => {
     let dataSources: DataSource[]
 

--- a/test/functional/null-undefined-handling/query-builders.test.ts
+++ b/test/functional/null-undefined-handling/query-builders.test.ts
@@ -45,6 +45,12 @@ describe("entity manager > invalidWhereValuesBehavior with default behavior", ()
         }`)
     }
 
+    function createMixedDangerousCriteria(
+        post: Post,
+    ): Record<string, unknown>[] {
+        return [{ id: post.id }, createDangerousOnlyCriteria()]
+    }
+
     async function expectEmptyCriteriaError(
         methodName: string,
         run: () => Promise<unknown>,
@@ -118,6 +124,45 @@ describe("entity manager > invalidWhereValuesBehavior with default behavior", ()
             )
             await expectEmptyCriteriaError("restore", () =>
                 connection.manager.restore(Post, createDangerousOnlyCriteria()),
+            )
+
+            const reloaded = await connection.manager.findOneByOrFail(Post, {
+                id: post.id,
+            })
+            expect(reloaded.title).to.equal("Test Post")
+        }
+    })
+
+    it("should reject OR criteria with an empty normalized branch by default", async () => {
+        for (const connection of dataSources) {
+            const { post } = await prepareData(connection)
+
+            await expectEmptyCriteriaError("update", () =>
+                connection.manager.update(
+                    Post,
+                    createMixedDangerousCriteria(post),
+                    {
+                        title: "Updated",
+                    },
+                ),
+            )
+            await expectEmptyCriteriaError("delete", () =>
+                connection.manager.delete(
+                    Post,
+                    createMixedDangerousCriteria(post),
+                ),
+            )
+            await expectEmptyCriteriaError("softDelete", () =>
+                connection.manager.softDelete(
+                    Post,
+                    createMixedDangerousCriteria(post),
+                ),
+            )
+            await expectEmptyCriteriaError("restore", () =>
+                connection.manager.restore(
+                    Post,
+                    createMixedDangerousCriteria(post),
+                ),
             )
 
             const reloaded = await connection.manager.findOneByOrFail(Post, {

--- a/test/functional/null-undefined-handling/query-builders.test.ts
+++ b/test/functional/null-undefined-handling/query-builders.test.ts
@@ -44,9 +44,13 @@ describe("entity manager > invalidWhereValuesBehavior with default behavior", ()
             // Regression test for #12578: omitted options should still
             // use the documented default invalidWhereValuesBehavior.
             try {
-                await connection.manager.update(Post, { text: null } as any, {
-                    title: "Updated",
-                })
+                await connection.manager.update(
+                    Post,
+                    { text: null },
+                    {
+                        title: "Updated",
+                    },
+                )
                 expect.fail("Expected error")
             } catch (error) {
                 expect(error).to.be.instanceOf(TypeORMError)
@@ -62,7 +66,7 @@ describe("entity manager > invalidWhereValuesBehavior with default behavior", ()
             try {
                 await connection.manager.delete(Post, {
                     text: undefined,
-                } as any)
+                })
                 expect.fail("Expected error")
             } catch (error) {
                 expect(error).to.be.instanceOf(TypeORMError)

--- a/test/functional/null-undefined-handling/query-builders.test.ts
+++ b/test/functional/null-undefined-handling/query-builders.test.ts
@@ -3,6 +3,7 @@ import type { DataSource } from "../../../src"
 import { EntitySchema } from "../../../src/entity-schema/EntitySchema"
 import type { EntitySchemaColumnOptions } from "../../../src/entity-schema/EntitySchemaColumnOptions"
 import { TypeORMError } from "../../../src/error/TypeORMError"
+import { Table } from "../../../src/schema-builder/table/Table"
 import {
     closeTestingConnections,
     createTestingConnections,
@@ -310,6 +311,61 @@ describe("entity manager > invalidWhereValuesBehavior with default behavior", ()
             expect(remaining.map((row) => row.value)).to.deep.equal([
                 "updated-by-prototype",
             ])
+        }
+    })
+
+    it("should support string table targets without entity metadata", async () => {
+        for (const connection of dataSources) {
+            const tableName = "raw_string_target"
+            const queryRunner = connection.createQueryRunner()
+
+            await queryRunner.createTable(
+                new Table({
+                    name: tableName,
+                    columns: [
+                        {
+                            name: "id",
+                            type: "int",
+                            isPrimary: true,
+                        },
+                        {
+                            name: "value",
+                            type: "varchar",
+                        },
+                    ],
+                }),
+                true,
+            )
+
+            try {
+                await connection.manager.insert(tableName, [
+                    { id: 1, value: "first" },
+                    { id: 2, value: "second" },
+                ])
+
+                await connection.manager.update(
+                    tableName,
+                    { value: "first" },
+                    { value: "updated" },
+                )
+                await connection.manager.delete(tableName, {
+                    value: "second",
+                })
+
+                const remaining = await connection
+                    .createQueryBuilder()
+                    .select("target.value", "value")
+                    .from(tableName, "target")
+                    .orderBy("target.id")
+                    .getRawMany()
+
+                expect(remaining.map((row) => row.value)).to.deep.equal([
+                    "updated",
+                ])
+            } finally {
+                await queryRunner.dropTable(tableName, true)
+                await queryRunner.release()
+            }
         }
     })
 })

--- a/test/functional/null-undefined-handling/query-builders.test.ts
+++ b/test/functional/null-undefined-handling/query-builders.test.ts
@@ -37,6 +37,29 @@ describe("entity manager > invalidWhereValuesBehavior with default behavior", ()
         return { category, post }
     }
 
+    function createDangerousOnlyCriteria(): Record<string, unknown> {
+        return JSON.parse(`{
+            "__proto__": { "polluted": true },
+            "constructor": { "polluted": true },
+            "prototype": { "polluted": true }
+        }`)
+    }
+
+    async function expectEmptyCriteriaError(
+        methodName: string,
+        run: () => Promise<unknown>,
+    ) {
+        try {
+            await run()
+            expect.fail("Expected error")
+        } catch (error) {
+            expect(error).to.be.instanceOf(TypeORMError)
+            expect(error.message).to.include(
+                `Empty criteria(s) are not allowed for the ${methodName} method.`,
+            )
+        }
+    }
+
     it("should throw error for null values in EntityManager.update() by default", async () => {
         for (const connection of dataSources) {
             await prepareData(connection)
@@ -72,6 +95,35 @@ describe("entity manager > invalidWhereValuesBehavior with default behavior", ()
                 expect(error).to.be.instanceOf(TypeORMError)
                 expect(error.message).to.include("Undefined value encountered")
             }
+        }
+    })
+
+    it("should reject criteria that normalize to empty by default", async () => {
+        for (const connection of dataSources) {
+            const { post } = await prepareData(connection)
+
+            await expectEmptyCriteriaError("update", () =>
+                connection.manager.update(Post, createDangerousOnlyCriteria(), {
+                    title: "Updated",
+                }),
+            )
+            await expectEmptyCriteriaError("delete", () =>
+                connection.manager.delete(Post, createDangerousOnlyCriteria()),
+            )
+            await expectEmptyCriteriaError("softDelete", () =>
+                connection.manager.softDelete(
+                    Post,
+                    createDangerousOnlyCriteria(),
+                ),
+            )
+            await expectEmptyCriteriaError("restore", () =>
+                connection.manager.restore(Post, createDangerousOnlyCriteria()),
+            )
+
+            const reloaded = await connection.manager.findOneByOrFail(Post, {
+                id: post.id,
+            })
+            expect(reloaded.title).to.equal("Test Post")
         }
     })
 })

--- a/test/functional/null-undefined-handling/query-builders.test.ts
+++ b/test/functional/null-undefined-handling/query-builders.test.ts
@@ -72,6 +72,16 @@ describe("entity manager > invalidWhereValuesBehavior with default behavior", ()
         return [{ id: post.id }, createDangerousOnlyCriteria()]
     }
 
+    function createEmptyRelationCriteria(): Record<string, unknown> {
+        return { category: {} }
+    }
+
+    function createMixedEmptyRelationCriteria(
+        post: Post,
+    ): Record<string, unknown>[] {
+        return [{ id: post.id }, createEmptyRelationCriteria()]
+    }
+
     async function expectEmptyCriteriaError(
         methodName: string,
         run: () => Promise<unknown>,
@@ -183,6 +193,74 @@ describe("entity manager > invalidWhereValuesBehavior with default behavior", ()
                 connection.manager.restore(
                     Post,
                     createMixedDangerousCriteria(post),
+                ),
+            )
+
+            const reloaded = await connection.manager.findOneByOrFail(Post, {
+                id: post.id,
+            })
+            expect(reloaded.title).to.equal("Test Post")
+        }
+    })
+
+    it("should reject criteria with an empty relation object by default", async () => {
+        for (const connection of dataSources) {
+            const { post } = await prepareData(connection)
+
+            await expectEmptyCriteriaError("update", () =>
+                connection.manager.update(Post, createEmptyRelationCriteria(), {
+                    title: "Updated",
+                }),
+            )
+            await expectEmptyCriteriaError("delete", () =>
+                connection.manager.delete(Post, createEmptyRelationCriteria()),
+            )
+            await expectEmptyCriteriaError("softDelete", () =>
+                connection.manager.softDelete(
+                    Post,
+                    createEmptyRelationCriteria(),
+                ),
+            )
+            await expectEmptyCriteriaError("restore", () =>
+                connection.manager.restore(Post, createEmptyRelationCriteria()),
+            )
+
+            const reloaded = await connection.manager.findOneByOrFail(Post, {
+                id: post.id,
+            })
+            expect(reloaded.title).to.equal("Test Post")
+        }
+    })
+
+    it("should reject OR criteria with an empty relation branch by default", async () => {
+        for (const connection of dataSources) {
+            const { post } = await prepareData(connection)
+
+            await expectEmptyCriteriaError("update", () =>
+                connection.manager.update(
+                    Post,
+                    createMixedEmptyRelationCriteria(post),
+                    {
+                        title: "Updated",
+                    },
+                ),
+            )
+            await expectEmptyCriteriaError("delete", () =>
+                connection.manager.delete(
+                    Post,
+                    createMixedEmptyRelationCriteria(post),
+                ),
+            )
+            await expectEmptyCriteriaError("softDelete", () =>
+                connection.manager.softDelete(
+                    Post,
+                    createMixedEmptyRelationCriteria(post),
+                ),
+            )
+            await expectEmptyCriteriaError("restore", () =>
+                connection.manager.restore(
+                    Post,
+                    createMixedEmptyRelationCriteria(post),
                 ),
             )
 

--- a/test/functional/null-undefined-handling/query-builders.test.ts
+++ b/test/functional/null-undefined-handling/query-builders.test.ts
@@ -233,6 +233,33 @@ describe("entity manager > invalidWhereValuesBehavior with default behavior", ()
         }
     })
 
+    it("should validate nested plain objects with constructor properties by default", async () => {
+        for (const connection of dataSources) {
+            await prepareData(connection)
+
+            try {
+                await connection.manager.update(
+                    Post,
+                    {
+                        category: {
+                            constructor: "plain-object-property",
+                            id: undefined,
+                        },
+                    },
+                    {
+                        title: "Updated",
+                    },
+                )
+                expect.fail("Expected error")
+            } catch (error) {
+                expect(error).to.be.instanceOf(TypeORMError)
+                expect(error.message).to.include(
+                    "Undefined value encountered in property 'category.id'",
+                )
+            }
+        }
+    })
+
     it("should reject OR criteria with an empty relation branch by default", async () => {
         for (const connection of dataSources) {
             const { post } = await prepareData(connection)

--- a/test/unit/util/orm-utils.test.ts
+++ b/test/unit/util/orm-utils.test.ts
@@ -1,6 +1,5 @@
 import { expect } from "chai"
 import { runInNewContext } from "node:vm"
-import { TypeORMError } from "../../../src"
 import type { DeepPartial } from "../../../src"
 import { OrmUtils } from "../../../src/util/OrmUtils"
 
@@ -218,83 +217,6 @@ describe(`OrmUtils`, () => {
                 extraItems: [4],
                 missingItems: [1],
             })
-        })
-    })
-
-    // Complements the #12578 functional coverage with helper-level edge cases.
-    describe("normalizeWhereCriteria", () => {
-        it("should throw for null values by default when options are omitted", () => {
-            expect(() =>
-                OrmUtils.normalizeWhereCriteria({
-                    a: { id: 1 },
-                    b: null,
-                }),
-            ).to.throw(TypeORMError, "Null value encountered in property 'b'")
-        })
-
-        it("should throw for undefined values by default when options are omitted", () => {
-            expect(() =>
-                OrmUtils.normalizeWhereCriteria({
-                    a: { id: 1 },
-                    b: undefined,
-                }),
-            ).to.throw(
-                TypeORMError,
-                "Undefined value encountered in property 'b'",
-            )
-        })
-
-        it("should validate nested array criteria by default", () => {
-            expect(() =>
-                OrmUtils.normalizeWhereCriteria([
-                    {
-                        a: { id: null },
-                    },
-                ]),
-            ).to.throw(
-                TypeORMError,
-                "Null value encountered in property '0.a.id'",
-            )
-        })
-
-        it("should preserve empty object criteria by default", () => {
-            expect(
-                OrmUtils.normalizeWhereCriteria({
-                    json: {},
-                }),
-            ).to.deep.equal({ json: {} })
-        })
-
-        it("should skip dangerous keys when normalizing criteria", () => {
-            const normalized = OrmUtils.normalizeWhereCriteria(
-                JSON.parse(`{
-                    "__proto__": { "polluted": true },
-                    "constructor": { "polluted": true },
-                    "prototype": { "polluted": true },
-                    "safe": { "id": 1 }
-                }`),
-            )
-
-            expect(normalized).to.deep.equal({ safe: { id: 1 } })
-            expect(Object.getPrototypeOf(normalized)).to.equal(Object.prototype)
-            expect("polluted" in normalized).to.equal(false)
-            expect(Object.prototype).not.to.have.property("polluted")
-        })
-
-        it("should preserve ignore behavior when configured", () => {
-            expect(
-                OrmUtils.normalizeWhereCriteria(
-                    {
-                        a: { id: 1 },
-                        b: null,
-                        c: undefined,
-                    },
-                    {
-                        null: "ignore",
-                        undefined: "ignore",
-                    },
-                ),
-            ).to.deep.equal({ a: { id: 1 } })
         })
     })
 

--- a/test/unit/util/orm-utils.test.ts
+++ b/test/unit/util/orm-utils.test.ts
@@ -221,6 +221,7 @@ describe(`OrmUtils`, () => {
         })
     })
 
+    // Complements the #12578 functional coverage with helper-level edge cases.
     describe("normalizeWhereCriteria", () => {
         it("should throw for null values by default when options are omitted", () => {
             expect(() =>

--- a/test/unit/util/orm-utils.test.ts
+++ b/test/unit/util/orm-utils.test.ts
@@ -1,5 +1,6 @@
 import { expect } from "chai"
 import { runInNewContext } from "node:vm"
+import { TypeORMError } from "../../../src"
 import type { DeepPartial } from "../../../src"
 import { OrmUtils } from "../../../src/util/OrmUtils"
 
@@ -217,6 +218,66 @@ describe(`OrmUtils`, () => {
                 extraItems: [4],
                 missingItems: [1],
             })
+        })
+    })
+
+    describe("normalizeWhereCriteria", () => {
+        it("should throw for null values by default when options are omitted", () => {
+            expect(() =>
+                OrmUtils.normalizeWhereCriteria({
+                    a: { id: 1 },
+                    b: null,
+                }),
+            ).to.throw(TypeORMError, "Null value encountered in property 'b'")
+        })
+
+        it("should throw for undefined values by default when options are omitted", () => {
+            expect(() =>
+                OrmUtils.normalizeWhereCriteria({
+                    a: { id: 1 },
+                    b: undefined,
+                }),
+            ).to.throw(
+                TypeORMError,
+                "Undefined value encountered in property 'b'",
+            )
+        })
+
+        it("should validate nested array criteria by default", () => {
+            expect(() =>
+                OrmUtils.normalizeWhereCriteria([
+                    {
+                        a: { id: null },
+                    },
+                ]),
+            ).to.throw(
+                TypeORMError,
+                "Null value encountered in property '0.a.id'",
+            )
+        })
+
+        it("should preserve empty object criteria by default", () => {
+            expect(
+                OrmUtils.normalizeWhereCriteria({
+                    json: {},
+                }),
+            ).to.deep.equal({ json: {} })
+        })
+
+        it("should preserve ignore behavior when configured", () => {
+            expect(
+                OrmUtils.normalizeWhereCriteria(
+                    {
+                        a: { id: 1 },
+                        b: null,
+                        c: undefined,
+                    },
+                    {
+                        null: "ignore",
+                        undefined: "ignore",
+                    },
+                ),
+            ).to.deep.equal({ a: { id: 1 } })
         })
     })
 

--- a/test/unit/util/orm-utils.test.ts
+++ b/test/unit/util/orm-utils.test.ts
@@ -276,6 +276,8 @@ describe(`OrmUtils`, () => {
             )
 
             expect(normalized).to.deep.equal({ safe: { id: 1 } })
+            expect(Object.getPrototypeOf(normalized)).to.equal(Object.prototype)
+            expect("polluted" in normalized).to.equal(false)
             expect(Object.prototype).not.to.have.property("polluted")
         })
 

--- a/test/unit/util/orm-utils.test.ts
+++ b/test/unit/util/orm-utils.test.ts
@@ -265,6 +265,20 @@ describe(`OrmUtils`, () => {
             ).to.deep.equal({ json: {} })
         })
 
+        it("should skip dangerous keys when normalizing criteria", () => {
+            const normalized = OrmUtils.normalizeWhereCriteria(
+                JSON.parse(`{
+                    "__proto__": { "polluted": true },
+                    "constructor": { "polluted": true },
+                    "prototype": { "polluted": true },
+                    "safe": { "id": 1 }
+                }`),
+            )
+
+            expect(normalized).to.deep.equal({ safe: { id: 1 } })
+            expect(Object.prototype).not.to.have.property("polluted")
+        })
+
         it("should preserve ignore behavior when configured", () => {
             expect(
                 OrmUtils.normalizeWhereCriteria(


### PR DESCRIPTION
Fixes #12578.

## Summary

`OrmUtils.normalizeWhereCriteria()` returned criteria unchanged when `invalidWhereValuesBehavior` was unset, bypassing the documented default behavior for TypeORM 1.0. This patch lets omitted options flow through the existing defaults so `null` and `undefined` throw by default.

The patch also preserves empty object criteria such as `{ json: {} }`, so fixing the omitted-options path does not drop valid object-valued predicates.

## Tests

- `corepack pnpm exec lint-staged`
- `corepack pnpm exec mocha --no-config -r ts-node/register test/unit/util/orm-utils.test.ts`
- `corepack pnpm run typecheck`
- `corepack pnpm run compile`
- `corepack pnpm exec mocha --no-config --file build/compiled/test/utils/test-setup.js build/compiled/test/unit/util/orm-utils.test.js`
- `corepack pnpm exec prettier --check src/util/OrmUtils.ts test/unit/util/orm-utils.test.ts`
- `git diff --check -- src\util\OrmUtils.ts test\unit\util\orm-utils.test.ts`