### PR TITLE
fix: apply default invalid where value behavior

### DIFF
--- a/docs/docs/data-source/5-null-and-undefined-handling.md
+++ b/docs/docs/data-source/5-null-and-undefined-handling.md
@@ -228,6 +228,12 @@ await manager.delete(Post, { text: null }) // Respects invalidWhereValuesBehavio
 await manager.softDelete(Post, { text: null }) // Respects invalidWhereValuesBehavior
 ```
 
+Write operations that require criteria (`update`, `delete`, `softDelete`, and
+`restore`) also reject empty criteria before executing. If
+`invalidWhereValuesBehavior` removes every usable condition, or removes every
+usable condition from one branch of an OR array, TypeORM treats the criteria as
+empty and throws instead of running a broad write.
+
 ### QueryBuilder with setFindOptions
 
 ```typescript

--- a/src/entity-manager/EntityManager.ts
+++ b/src/entity-manager/EntityManager.ts
@@ -22,6 +22,10 @@ import type { ObjectId } from "../driver/mongodb/typings"
 import type { InsertResult } from "../query-builder/result/InsertResult"
 import type { UpdateResult } from "../query-builder/result/UpdateResult"
 import type { DeleteResult } from "../query-builder/result/DeleteResult"
+import type {
+    WhereClause,
+    WhereClauseCondition,
+} from "../query-builder/WhereClause"
 import type { FindOptionsWhere } from "../find-options/FindOptionsWhere"
 import type { IsolationLevel } from "../driver/types/IsolationLevel"
 import { ObjectUtils } from "../util/ObjectUtils"
@@ -874,10 +878,25 @@ export class EntityManager {
                 criteria as ObjectLiteral | ObjectLiteral[],
                 this.dataSource.options.invalidWhereValuesBehavior,
             )
+            if (OrmUtils.isNormalizedCriteriaNullOrEmpty(normalizedCriteria)) {
+                return Promise.reject(
+                    new TypeORMError(
+                        `Empty criteria(s) are not allowed for the update method.`,
+                    ),
+                )
+            }
+
             const qb = this.createQueryBuilder()
                 .update(target)
                 .set(partialEntity)
                 .where(normalizedCriteria)
+            if (this.hasEmptyWhereCondition(qb.expressionMap.wheres)) {
+                return Promise.reject(
+                    new TypeORMError(
+                        `Empty criteria(s) are not allowed for the update method.`,
+                    ),
+                )
+            }
 
             if (options?.returning !== undefined) {
                 qb.returning(options.returning)
@@ -955,11 +974,27 @@ export class EntityManager {
                 criteria as ObjectLiteral | ObjectLiteral[],
                 this.dataSource.options.invalidWhereValuesBehavior,
             )
-            return this.createQueryBuilder()
+            if (OrmUtils.isNormalizedCriteriaNullOrEmpty(normalizedCriteria)) {
+                return Promise.reject(
+                    new TypeORMError(
+                        `Empty criteria(s) are not allowed for the delete method.`,
+                    ),
+                )
+            }
+
+            const qb = this.createQueryBuilder()
                 .delete()
                 .from(targetOrEntity)
                 .where(normalizedCriteria)
-                .execute()
+            if (this.hasEmptyWhereCondition(qb.expressionMap.wheres)) {
+                return Promise.reject(
+                    new TypeORMError(
+                        `Empty criteria(s) are not allowed for the delete method.`,
+                    ),
+                )
+            }
+
+            return qb.execute()
         }
     }
 
@@ -1021,11 +1056,27 @@ export class EntityManager {
                 criteria as ObjectLiteral | ObjectLiteral[],
                 this.dataSource.options.invalidWhereValuesBehavior,
             )
-            return this.createQueryBuilder()
+            if (OrmUtils.isNormalizedCriteriaNullOrEmpty(normalizedCriteria)) {
+                return Promise.reject(
+                    new TypeORMError(
+                        `Empty criteria(s) are not allowed for the softDelete method.`,
+                    ),
+                )
+            }
+
+            const qb = this.createQueryBuilder()
                 .softDelete()
                 .from(targetOrEntity)
                 .where(normalizedCriteria)
-                .execute()
+            if (this.hasEmptyWhereCondition(qb.expressionMap.wheres)) {
+                return Promise.reject(
+                    new TypeORMError(
+                        `Empty criteria(s) are not allowed for the softDelete method.`,
+                    ),
+                )
+            }
+
+            return qb.execute()
         }
     }
 
@@ -1072,11 +1123,27 @@ export class EntityManager {
                 criteria as ObjectLiteral | ObjectLiteral[],
                 this.dataSource.options.invalidWhereValuesBehavior,
             )
-            return this.createQueryBuilder()
+            if (OrmUtils.isNormalizedCriteriaNullOrEmpty(normalizedCriteria)) {
+                return Promise.reject(
+                    new TypeORMError(
+                        `Empty criteria(s) are not allowed for the restore method.`,
+                    ),
+                )
+            }
+
+            const qb = this.createQueryBuilder()
                 .restore()
                 .from(targetOrEntity)
                 .where(normalizedCriteria)
-                .execute()
+            if (this.hasEmptyWhereCondition(qb.expressionMap.wheres)) {
+                return Promise.reject(
+                    new TypeORMError(
+                        `Empty criteria(s) are not allowed for the restore method.`,
+                    ),
+                )
+            }
+
+            return qb.execute()
         }
     }
 
@@ -1204,6 +1271,31 @@ export class EntityManager {
         where?: FindOptionsWhere<Entity> | FindOptionsWhere<Entity>[],
     ): Promise<number | null> {
         return this.callAggregateFun(entityClass, "MAX", columnName, where)
+    }
+
+    private hasEmptyWhereCondition(wheres: WhereClause[]): boolean {
+        return wheres.some((where) =>
+            this.isWhereClauseConditionEmpty(where.condition),
+        )
+    }
+
+    private isWhereClauseConditionEmpty(
+        condition: WhereClauseCondition,
+    ): boolean {
+        if (Array.isArray(condition)) {
+            return (
+                condition.length === 0 ||
+                condition.some((where) =>
+                    this.isWhereClauseConditionEmpty(where.condition),
+                )
+            )
+        }
+
+        if (typeof condition === "object" && "condition" in condition) {
+            return this.isWhereClauseConditionEmpty(condition.condition)
+        }
+
+        return false
     }
 
     private async callAggregateFun<Entity extends ObjectLiteral>(

--- a/src/util/OrmUtils.ts
+++ b/src/util/OrmUtils.ts
@@ -396,6 +396,24 @@ export class OrmUtils {
     }
 
     /**
+     * Checks if normalized criteria are empty or contain an empty OR branch.
+     *
+     * @param criteria
+     */
+    public static isNormalizedCriteriaNullOrEmpty(criteria: unknown): boolean {
+        if (Array.isArray(criteria)) {
+            return (
+                criteria.length === 0 ||
+                criteria.some((criterion) =>
+                    OrmUtils.isNormalizedCriteriaNullOrEmpty(criterion),
+                )
+            )
+        }
+
+        return OrmUtils.isCriteriaNullOrEmpty(criteria)
+    }
+
+    /**
      * Checks if given criteria is a primitive value.
      * Primitive values are strings, numbers and dates.
      *
@@ -555,11 +573,12 @@ export class OrmUtils {
 
     // Checks if it's an object made by Object.create(null), {} or new Object()
     private static isPlainObject(item: any) {
-        if (item === null || item === undefined) {
+        if (typeof item !== "object" || item === null) {
             return false
         }
 
-        return !item.constructor || item.constructor === Object
+        const prototype = Object.getPrototypeOf(item)
+        return prototype === null || prototype === Object.prototype
     }
 
     private static mergeArrayKey(
@@ -651,7 +670,7 @@ export class OrmUtils {
 
     /**
      * Recursively validates an object where clause, throwing for null/undefined
-     * based on the provided invalidWhereValuesBehavior config.
+     * based on the provided invalidWhereValuesBehavior config or defaults.
      *
      * @param criteria
      * @param options
@@ -662,8 +681,13 @@ export class OrmUtils {
         options?: InvalidFindOptionsWhereBehavior,
         path?: string,
     ): ObjectLiteral | ObjectLiteral[] {
-        if (!options) {
-            return criteria
+        if (criteria === null || criteria === undefined) {
+            const propertyPath = path ? ` at '${path}'` : ""
+            const received = criteria === null ? "null" : "undefined"
+
+            throw new TypeORMError(
+                `Invalid where criteria${propertyPath}. Expected an object, but received ${received}.`,
+            )
         }
 
         // multiple criteria are possible at the top level
@@ -679,6 +703,15 @@ export class OrmUtils {
         }
 
         const result: ObjectLiteral = {}
+        const setResultKey = (key: string, value: unknown) => {
+            Object.defineProperty(result, key, {
+                value,
+                enumerable: true,
+                configurable: true,
+                writable: true,
+            })
+        }
+
         for (const [key, value] of Object.entries(criteria)) {
             const propertyPath = path ? `${path}.${key}` : key
 
@@ -700,20 +733,25 @@ export class OrmUtils {
                             `Set 'invalidWhereValuesBehavior.null' to 'ignore' or 'sql-null' in connection options to skip or handle null values.`,
                     )
                 } else if (behavior === "sql-null") {
-                    result[key] = IsNull()
+                    setResultKey(key, IsNull())
                 }
                 // else: "ignore" — skip this key
             } else if (OrmUtils.isPlainObject(value)) {
+                if (Object.keys(value).length === 0) {
+                    setResultKey(key, value)
+                    continue
+                }
+
                 const nested = OrmUtils.normalizeWhereCriteria(
                     value,
                     options,
                     propertyPath,
                 )
                 if (Object.keys(nested).length > 0) {
-                    result[key] = nested
+                    setResultKey(key, nested)
                 }
             } else {
-                result[key] = value
+                setResultKey(key, value)
             }
         }
 

--- a/test/functional/null-undefined-handling/query-builders.test.ts
+++ b/test/functional/null-undefined-handling/query-builders.test.ts
@@ -1,6 +1,10 @@
 import { expect } from "chai"
-import type { DataSource } from "../../../src"
-import { TypeORMError } from "../../../src"
+import type {
+    DataSource,
+    EntitySchemaColumnOptions,
+    FindOptionsWhere,
+} from "../../../src"
+import { EntitySchema, Table, TypeORMError } from "../../../src"
 import {
     closeTestingConnections,
     createTestingConnections,
@@ -8,6 +12,346 @@ import {
 } from "../../utils/test-utils"
 import { Category } from "./entity/Category"
 import { Post } from "./entity/Post"
+
+const specialColumnColumns: Record<string, EntitySchemaColumnOptions> =
+    Object.create(null)
+specialColumnColumns["id"] = {
+    type: Number,
+    primary: true,
+}
+specialColumnColumns["constructor"] = {
+    type: String,
+}
+specialColumnColumns["prototype"] = {
+    type: String,
+}
+specialColumnColumns["value"] = {
+    type: String,
+}
+
+const SpecialColumnSchema = new EntitySchema({
+    name: "SpecialColumn",
+    columns: specialColumnColumns,
+})
+
+const postWhere = (criteria: unknown): FindOptionsWhere<Post> =>
+    criteria as FindOptionsWhere<Post>
+
+const postWhereArray = (criteria: unknown): FindOptionsWhere<Post>[] =>
+    criteria as FindOptionsWhere<Post>[]
+
+describe("entity manager > invalidWhereValuesBehavior defaults", () => {
+    let dataSources: DataSource[]
+
+    before(async () => {
+        dataSources = await createTestingConnections({
+            disabledDrivers: ["spanner"],
+            entities: [Post, Category, SpecialColumnSchema],
+            schemaCreate: true,
+            dropSchema: true,
+        })
+    })
+    beforeEach(() => reloadTestingDatabases(dataSources))
+    after(() => closeTestingConnections(dataSources))
+
+    async function prepareData(connection: DataSource) {
+        const category = new Category()
+        category.name = "Test Category"
+        await connection.manager.save(category)
+
+        const post = new Post()
+        post.title = "Test Post"
+        post.text = "Some text"
+        post.category = category
+        await connection.manager.save(post)
+
+        return { category, post }
+    }
+
+    async function expectEmptyCriteriaError(
+        methodName: string,
+        run: () => Promise<unknown>,
+    ) {
+        try {
+            await run()
+            expect.fail("Expected error")
+        } catch (error) {
+            expect(error).to.be.instanceOf(TypeORMError)
+            expect(error.message).to.include(
+                `Empty criteria(s) are not allowed for the ${methodName} method.`,
+            )
+        }
+    }
+
+    async function expectInvalidWhereCriteriaError(
+        run: () => Promise<unknown>,
+    ) {
+        try {
+            await run()
+            expect.fail("Expected error")
+        } catch (error) {
+            expect(error).to.be.instanceOf(TypeORMError)
+            expect(error.message).to.include("Invalid where criteria at")
+        }
+    }
+
+    it("should throw error for null values in EntityManager.update() by default", async () => {
+        for (const connection of dataSources) {
+            const { post } = await prepareData(connection)
+
+            try {
+                await connection.manager.update(
+                    Post,
+                    postWhere({ text: null }),
+                    {
+                        title: "Updated",
+                    },
+                )
+                expect.fail("Expected error")
+            } catch (error) {
+                expect(error).to.be.instanceOf(TypeORMError)
+                expect(error.message).to.include("Null value encountered")
+            }
+
+            const reloaded = await connection.manager.findOneByOrFail(Post, {
+                id: post.id,
+            })
+            expect(reloaded.title).to.equal("Test Post")
+        }
+    })
+
+    it("should throw error for undefined values in EntityManager.delete() by default", async () => {
+        for (const connection of dataSources) {
+            await prepareData(connection)
+
+            try {
+                await connection.manager.delete(
+                    Post,
+                    postWhere({
+                        text: undefined,
+                    }),
+                )
+                expect.fail("Expected error")
+            } catch (error) {
+                expect(error).to.be.instanceOf(TypeORMError)
+                expect(error.message).to.include("Undefined value encountered")
+            }
+
+            const remaining = await connection.manager.find(Post)
+            expect(remaining.length).to.equal(1)
+        }
+    })
+
+    it("should validate nested plain objects with constructor properties by default", async () => {
+        for (const connection of dataSources) {
+            const { post } = await prepareData(connection)
+
+            try {
+                await connection.manager.update(
+                    Post,
+                    postWhere({
+                        category: {
+                            constructor: "plain-object-property",
+                            id: undefined,
+                        },
+                    }),
+                    { title: "Updated" },
+                )
+                expect.fail("Expected error")
+            } catch (error) {
+                expect(error).to.be.instanceOf(TypeORMError)
+                expect(error.message).to.include(
+                    "Undefined value encountered in property 'category.id'",
+                )
+            }
+
+            const reloaded = await connection.manager.findOneByOrFail(Post, {
+                id: post.id,
+            })
+            expect(reloaded.title).to.equal("Test Post")
+        }
+    })
+
+    it("should reject empty relation criteria and OR branches by default", async () => {
+        for (const connection of dataSources) {
+            const { post } = await prepareData(connection)
+            const emptyRelationCriteria = postWhere({ category: {} })
+            const mixedEmptyRelationCriteria = postWhereArray([
+                { id: post.id },
+                emptyRelationCriteria,
+            ])
+
+            await expectEmptyCriteriaError("update", () =>
+                connection.manager.update(Post, emptyRelationCriteria, {
+                    title: "Updated",
+                }),
+            )
+            await expectEmptyCriteriaError("delete", () =>
+                connection.manager.delete(Post, emptyRelationCriteria),
+            )
+            await expectEmptyCriteriaError("softDelete", () =>
+                connection.manager.softDelete(Post, emptyRelationCriteria),
+            )
+            await expectEmptyCriteriaError("restore", () =>
+                connection.manager.restore(Post, emptyRelationCriteria),
+            )
+
+            await expectEmptyCriteriaError("update", () =>
+                connection.manager.update(Post, mixedEmptyRelationCriteria, {
+                    title: "Updated",
+                }),
+            )
+            await expectEmptyCriteriaError("delete", () =>
+                connection.manager.delete(Post, mixedEmptyRelationCriteria),
+            )
+            await expectEmptyCriteriaError("softDelete", () =>
+                connection.manager.softDelete(Post, mixedEmptyRelationCriteria),
+            )
+            await expectEmptyCriteriaError("restore", () =>
+                connection.manager.restore(Post, mixedEmptyRelationCriteria),
+            )
+
+            const reloaded = await connection.manager.findOneByOrFail(Post, {
+                id: post.id,
+            })
+            expect(reloaded.title).to.equal("Test Post")
+        }
+    })
+
+    it("should reject malformed OR branches by default", async () => {
+        for (const connection of dataSources) {
+            const { post } = await prepareData(connection)
+            const criteriaWithNullBranch = postWhereArray([
+                { id: post.id },
+                null,
+            ])
+            const criteriaWithUndefinedBranch = postWhereArray([
+                { id: post.id },
+                undefined,
+            ])
+
+            await expectInvalidWhereCriteriaError(() =>
+                connection.manager.update(Post, criteriaWithNullBranch, {
+                    title: "Updated",
+                }),
+            )
+            await expectInvalidWhereCriteriaError(() =>
+                connection.manager.delete(Post, criteriaWithUndefinedBranch),
+            )
+            await expectInvalidWhereCriteriaError(() =>
+                connection.manager.softDelete(Post, criteriaWithNullBranch),
+            )
+            await expectInvalidWhereCriteriaError(() =>
+                connection.manager.restore(Post, criteriaWithUndefinedBranch),
+            )
+
+            const reloaded = await connection.manager.findOneByOrFail(Post, {
+                id: post.id,
+            })
+            expect(reloaded.title).to.equal("Test Post")
+        }
+    })
+
+    it("should preserve constructor and prototype as valid criteria property names", async () => {
+        for (const connection of dataSources) {
+            const repository = connection.getRepository("SpecialColumn")
+
+            await repository.insert({
+                id: 1,
+                constructor: "ctor-match",
+                prototype: "proto-one",
+                value: "first",
+            })
+            await repository.insert({
+                id: 2,
+                constructor: "ctor-other",
+                prototype: "proto-two",
+                value: "second",
+            })
+
+            await connection.manager.update(
+                "SpecialColumn",
+                { constructor: "ctor-match" },
+                { value: "updated-by-constructor" },
+            )
+            await connection.manager.update(
+                "SpecialColumn",
+                { prototype: "proto-one" },
+                { value: "updated-by-prototype" },
+            )
+
+            const updated = await repository.findOneByOrFail({ id: 1 })
+            expect(updated.value).to.equal("updated-by-prototype")
+
+            await connection.manager.delete("SpecialColumn", {
+                constructor: "ctor-other",
+            })
+
+            const remaining = await repository.find()
+            expect(remaining.length).to.equal(1)
+            expect(remaining[0].value).to.equal("updated-by-prototype")
+        }
+    })
+
+    it("should support string table targets without entity metadata", async () => {
+        for (const connection of dataSources) {
+            const tableName = "raw_string_target"
+            const queryRunner = connection.createQueryRunner()
+            let tableCreated = false
+
+            try {
+                await queryRunner.createTable(
+                    new Table({
+                        name: tableName,
+                        columns: [
+                            {
+                                name: "id",
+                                type: "int",
+                                isPrimary: true,
+                            },
+                            {
+                                name: "value",
+                                type: "varchar",
+                            },
+                        ],
+                    }),
+                    true,
+                )
+                tableCreated = true
+
+                await connection.manager.insert(tableName, [
+                    { id: 1, value: "first" },
+                    { id: 2, value: "second" },
+                ])
+
+                await connection.manager.update(
+                    tableName,
+                    { value: "first" },
+                    { value: "updated" },
+                )
+                await connection.manager.delete(tableName, {
+                    value: "second",
+                })
+
+                const remaining = await connection
+                    .createQueryBuilder()
+                    .select("target.value", "value")
+                    .from(tableName, "target")
+                    .orderBy("target.id")
+                    .getRawMany()
+
+                expect(remaining.map((row) => row.value)).to.deep.equal([
+                    "updated",
+                ])
+            } finally {
+                if (tableCreated) {
+                    await queryRunner.dropTable(tableName, true)
+                }
+                await queryRunner.release()
+            }
+        }
+    })
+})
 
 describe("entity manager > invalidWhereValuesBehavior with throw", () => {
     let dataSources: DataSource[]
@@ -48,9 +392,13 @@ describe("entity manager > invalidWhereValuesBehavior with throw", () => {
             await prepareData(connection)
 
             try {
-                await connection.manager.update(Post, { text: null } as any, {
-                    title: "Updated",
-                })
+                await connection.manager.update(
+                    Post,
+                    postWhere({ text: null }),
+                    {
+                        title: "Updated",
+                    },
+                )
                 expect.fail("Expected error")
             } catch (error) {
                 expect(error).to.be.instanceOf(TypeORMError)
@@ -66,7 +414,7 @@ describe("entity manager > invalidWhereValuesBehavior with throw", () => {
             try {
                 await connection.manager.update(
                     Post,
-                    { text: undefined } as any,
+                    postWhere({ text: undefined }),
                     { title: "Updated" },
                 )
                 expect.fail("Expected error")
@@ -82,7 +430,7 @@ describe("entity manager > invalidWhereValuesBehavior with throw", () => {
             await prepareData(connection)
 
             try {
-                await connection.manager.delete(Post, { text: null } as any)
+                await connection.manager.delete(Post, postWhere({ text: null }))
                 expect.fail("Expected error")
             } catch (error) {
                 expect(error).to.be.instanceOf(TypeORMError)
@@ -96,9 +444,12 @@ describe("entity manager > invalidWhereValuesBehavior with throw", () => {
             await prepareData(connection)
 
             try {
-                await connection.manager.delete(Post, {
-                    text: undefined,
-                } as any)
+                await connection.manager.delete(
+                    Post,
+                    postWhere({
+                        text: undefined,
+                    }),
+                )
                 expect.fail("Expected error")
             } catch (error) {
                 expect(error).to.be.instanceOf(TypeORMError)
@@ -112,9 +463,12 @@ describe("entity manager > invalidWhereValuesBehavior with throw", () => {
             await prepareData(connection)
 
             try {
-                await connection.manager.softDelete(Post, {
-                    text: null,
-                } as any)
+                await connection.manager.softDelete(
+                    Post,
+                    postWhere({
+                        text: null,
+                    }),
+                )
                 expect.fail("Expected error")
             } catch (error) {
                 expect(error).to.be.instanceOf(TypeORMError)
@@ -128,9 +482,12 @@ describe("entity manager > invalidWhereValuesBehavior with throw", () => {
             await prepareData(connection)
 
             try {
-                await connection.manager.softDelete(Post, {
-                    text: undefined,
-                } as any)
+                await connection.manager.softDelete(
+                    Post,
+                    postWhere({
+                        text: undefined,
+                    }),
+                )
                 expect.fail("Expected error")
             } catch (error) {
                 expect(error).to.be.instanceOf(TypeORMError)
@@ -144,9 +501,12 @@ describe("entity manager > invalidWhereValuesBehavior with throw", () => {
             await prepareData(connection)
 
             try {
-                await connection.manager.restore(Post, {
-                    text: null,
-                } as any)
+                await connection.manager.restore(
+                    Post,
+                    postWhere({
+                        text: null,
+                    }),
+                )
                 expect.fail("Expected error")
             } catch (error) {
                 expect(error).to.be.instanceOf(TypeORMError)
@@ -160,9 +520,12 @@ describe("entity manager > invalidWhereValuesBehavior with throw", () => {
             await prepareData(connection)
 
             try {
-                await connection.manager.restore(Post, {
-                    text: undefined,
-                } as any)
+                await connection.manager.restore(
+                    Post,
+                    postWhere({
+                        text: undefined,
+                    }),
+                )
                 expect.fail("Expected error")
             } catch (error) {
                 expect(error).to.be.instanceOf(TypeORMError)
@@ -178,7 +541,7 @@ describe("entity manager > invalidWhereValuesBehavior with throw", () => {
             try {
                 await connection
                     .getRepository(Post)
-                    .update({ text: null } as any, { title: "Updated" })
+                    .update(postWhere({ text: null }), { title: "Updated" })
                 expect.fail("Expected error")
             } catch (error) {
                 expect(error).to.be.instanceOf(TypeORMError)
@@ -194,7 +557,7 @@ describe("entity manager > invalidWhereValuesBehavior with throw", () => {
             try {
                 await connection
                     .getRepository(Post)
-                    .delete({ text: null } as any)
+                    .delete(postWhere({ text: null }))
                 expect.fail("Expected error")
             } catch (error) {
                 expect(error).to.be.instanceOf(TypeORMError)
@@ -210,7 +573,7 @@ describe("entity manager > invalidWhereValuesBehavior with throw", () => {
             try {
                 await connection.manager.update(
                     Post,
-                    { category: { name: null } } as any,
+                    postWhere({ category: { name: null } }),
                     { title: "Updated" },
                 )
                 expect.fail("Expected error")
@@ -226,9 +589,12 @@ describe("entity manager > invalidWhereValuesBehavior with throw", () => {
             await prepareData(connection)
 
             try {
-                await connection.manager.delete(Post, {
-                    category: { name: undefined },
-                } as any)
+                await connection.manager.delete(
+                    Post,
+                    postWhere({
+                        category: { name: undefined },
+                    }),
+                )
                 expect.fail("Expected error")
             } catch (error) {
                 expect(error).to.be.instanceOf(TypeORMError)
@@ -326,6 +692,114 @@ describe("entity manager > invalidWhereValuesBehavior with ignore", () => {
     })
     beforeEach(() => reloadTestingDatabases(dataSources))
     after(() => closeTestingConnections(dataSources))
+
+    async function expectEmptyCriteriaError(
+        methodName: string,
+        run: () => Promise<unknown>,
+    ) {
+        try {
+            await run()
+            expect.fail("Expected error")
+        } catch (error) {
+            expect(error).to.be.instanceOf(TypeORMError)
+            expect(error.message).to.include(
+                `Empty criteria(s) are not allowed for the ${methodName} method.`,
+            )
+        }
+    }
+
+    it("should reject update when ignored criteria become empty", async () => {
+        for (const connection of dataSources) {
+            const post = new Post()
+            post.title = "Test Post"
+            post.text = "text"
+            await connection.manager.save(post)
+
+            const post2 = new Post()
+            post2.title = "Other Post"
+            post2.text = "text"
+            await connection.manager.save(post2)
+
+            try {
+                await connection.manager.update(
+                    Post,
+                    postWhere({ text: undefined }),
+                    { title: "Updated" },
+                )
+                expect.fail("Expected error")
+            } catch (error) {
+                expect(error).to.be.instanceOf(TypeORMError)
+                expect(error.message).to.include(
+                    "Empty criteria(s) are not allowed for the update method.",
+                )
+            }
+
+            const remaining = await connection.manager.find(Post)
+            expect(remaining.map(({ title }) => title).sort()).to.deep.equal([
+                "Other Post",
+                "Test Post",
+            ])
+        }
+    })
+
+    it("should reject delete when an ignored OR branch becomes empty", async () => {
+        for (const connection of dataSources) {
+            const post = new Post()
+            post.title = "Test Post"
+            post.text = "text"
+            await connection.manager.save(post)
+
+            try {
+                await connection.manager.delete(
+                    Post,
+                    postWhereArray([
+                        { title: "Missing Post" },
+                        { text: undefined },
+                    ]),
+                )
+                expect.fail("Expected error")
+            } catch (error) {
+                expect(error).to.be.instanceOf(TypeORMError)
+                expect(error.message).to.include(
+                    "Empty criteria(s) are not allowed for the delete method.",
+                )
+            }
+
+            const remaining = await connection.manager.find(Post)
+            expect(remaining.length).to.equal(1)
+            expect(remaining[0].title).to.equal("Test Post")
+        }
+    })
+
+    it("should reject softDelete and restore when ignored criteria become empty", async () => {
+        for (const connection of dataSources) {
+            const post = new Post()
+            post.title = "Test Post"
+            post.text = "text"
+            await connection.manager.save(post)
+
+            await expectEmptyCriteriaError("softDelete", () =>
+                connection.manager.softDelete(
+                    Post,
+                    postWhere({
+                        text: undefined,
+                    }),
+                ),
+            )
+            await expectEmptyCriteriaError("restore", () =>
+                connection.manager.restore(
+                    Post,
+                    postWhere({
+                        text: null,
+                    }),
+                ),
+            )
+
+            const remaining = await connection.manager.find(Post)
+            expect(remaining.length).to.equal(1)
+            expect(remaining[0].title).to.equal("Test Post")
+        }
+    })
 
     it("should strip null criteria in EntityManager.delete() with ignore", async () => {
         for (const connection of dataSources) {

--- a/test/unit/util/orm-utils.test.ts
+++ b/test/unit/util/orm-utils.test.ts
@@ -1,7 +1,13 @@
 import { expect } from "chai"
 import { runInNewContext } from "node:vm"
+import { TypeORMError } from "../../../src"
 import type { DeepPartial } from "../../../src"
 import { OrmUtils } from "../../../src/util/OrmUtils"
+
+const whereCriteria = (
+    criteria: unknown,
+): Parameters<typeof OrmUtils.normalizeWhereCriteria>[0] =>
+    criteria as Parameters<typeof OrmUtils.normalizeWhereCriteria>[0]
 
 describe(`OrmUtils`, () => {
     describe("parseSqlCheckExpression", () => {
@@ -163,6 +169,143 @@ describe(`OrmUtils`, () => {
             const result = OrmUtils.mergeDeep({}, { foo })
             expect(result).to.have.property("foo")
             expect(result.foo).to.equal(foo)
+        })
+    })
+
+    describe("normalizeWhereCriteria", () => {
+        it("throws for undefined properties when behavior options are omitted", () => {
+            expect(() =>
+                OrmUtils.normalizeWhereCriteria({
+                    text: undefined,
+                }),
+            )
+                .to.throw(TypeORMError)
+                .with.property(
+                    "message",
+                    "Undefined value encountered in property 'text' of a where condition. Set 'invalidWhereValuesBehavior.undefined' to 'ignore' in connection options to skip properties with undefined values.",
+                )
+        })
+
+        it("throws for null properties when behavior options are omitted", () => {
+            expect(() =>
+                OrmUtils.normalizeWhereCriteria({
+                    text: null,
+                }),
+            )
+                .to.throw(TypeORMError)
+                .with.property(
+                    "message",
+                    "Null value encountered in property 'text' of a where condition. To match with SQL NULL, the IsNull() operator must be used. Set 'invalidWhereValuesBehavior.null' to 'ignore' or 'sql-null' in connection options to skip or handle null values.",
+                )
+        })
+
+        it("uses default throw behavior for option keys that are omitted", () => {
+            expect(() =>
+                OrmUtils.normalizeWhereCriteria(
+                    {
+                        title: "Post",
+                        text: null,
+                    },
+                    { undefined: "ignore" },
+                ),
+            ).to.throw(TypeORMError, "Null value encountered")
+
+            expect(() =>
+                OrmUtils.normalizeWhereCriteria(
+                    {
+                        title: "Post",
+                        text: undefined,
+                    },
+                    { null: "ignore" },
+                ),
+            ).to.throw(TypeORMError, "Undefined value encountered")
+        })
+
+        it("detects empty normalized criteria and empty OR branches", () => {
+            expect(OrmUtils.isNormalizedCriteriaNullOrEmpty({})).to.equal(true)
+            expect(
+                OrmUtils.isNormalizedCriteriaNullOrEmpty([{ title: "Post" }]),
+            ).to.equal(false)
+            expect(
+                OrmUtils.isNormalizedCriteriaNullOrEmpty([
+                    { title: "Post" },
+                    {},
+                ]),
+            ).to.equal(true)
+        })
+
+        it("preserves empty nested objects as criteria values", () => {
+            const normalized = OrmUtils.normalizeWhereCriteria({
+                payload: {},
+            })
+
+            expect(normalized).to.deep.equal({ payload: {} })
+            expect(
+                OrmUtils.isNormalizedCriteriaNullOrEmpty(normalized),
+            ).to.equal(false)
+        })
+
+        it("throws TypeORMError for malformed OR-array elements", () => {
+            expect(() =>
+                OrmUtils.normalizeWhereCriteria(whereCriteria([null])),
+            ).to.throw(
+                TypeORMError,
+                "Invalid where criteria at '0'. Expected an object, but received null.",
+            )
+
+            expect(() =>
+                OrmUtils.normalizeWhereCriteria(whereCriteria([undefined])),
+            ).to.throw(
+                TypeORMError,
+                "Invalid where criteria at '0'. Expected an object, but received undefined.",
+            )
+        })
+
+        it("preserves __proto__ as an own property without changing the result prototype", () => {
+            const criteria = JSON.parse(
+                `{"__proto__":{"polluted":true},"title":"Post"}`,
+            )
+
+            const normalized = OrmUtils.normalizeWhereCriteria(
+                criteria,
+            ) as Record<string, unknown>
+
+            expect(
+                Object.prototype.hasOwnProperty.call(normalized, "__proto__"),
+            ).to.equal(true)
+            expect(normalized["__proto__"]).to.deep.equal({ polluted: true })
+            expect(Object.getPrototypeOf(normalized)).to.equal(Object.prototype)
+            expect(Object.prototype).not.to.have.property("polluted")
+        })
+
+        it("validates nested plain objects that define constructor properties", () => {
+            expect(() =>
+                OrmUtils.normalizeWhereCriteria({
+                    category: {
+                        constructor: "plain-object-property",
+                        id: undefined,
+                    },
+                }),
+            ).to.throw(
+                TypeORMError,
+                "Undefined value encountered in property 'category.id'",
+            )
+        })
+
+        it("keeps constructor and prototype as criteria property names", () => {
+            const normalized = OrmUtils.normalizeWhereCriteria({
+                constructor: "ctor",
+                prototype: "proto",
+            }) as Record<string, unknown>
+
+            expect(
+                Object.prototype.hasOwnProperty.call(normalized, "constructor"),
+            ).to.equal(true)
+            expect(
+                Object.prototype.hasOwnProperty.call(normalized, "prototype"),
+            ).to.equal(true)
+            expect(normalized["constructor"]).to.equal("ctor")
+            expect(normalized["prototype"]).to.equal("proto")
         })
     })
 


### PR DESCRIPTION
Fixes #12578.

`OrmUtils.normalizeWhereCriteria()` returned criteria unchanged when `invalidWhereValuesBehavior` was omitted, so update/delete-style operations skipped the documented default behavior for `null` and `undefined` where values.

This change keeps normalization active with the documented defaults:

- `undefined` defaults to `throw`
- `null` defaults to `throw`
- partial configs still default omitted keys to `throw`

It also guards write operations after normalization so `ignore` mode cannot strip criteria down to an empty object or an empty OR branch and accidentally run a broad write.

Additional safety covered:

- rejects criteria that normalize to empty for `update`, `delete`, `softDelete`, and `restore`
- rejects empty OR branches after ignored invalid values are stripped
- rejects empty relation predicates after QueryBuilder proves they produce empty conditions
- rejects malformed OR-array entries with a controlled `TypeORMError`
- preserves `__proto__` as an own data property without changing object prototypes
- treats plain objects by actual prototype instead of trusting a `constructor` property
- preserves empty object values during normalization so valid object predicates are not stripped early
- keeps `constructor` and `prototype` usable as where column names
- keeps string table targets without entity metadata working
- documents that write operations reject criteria that normalize to empty

Validation run locally:

```powershell
pnpm run compile
pnpm exec mocha build\compiled\test\unit\util\orm-utils.test.js
pnpm exec prettier --check docs\docs\data-source\5-null-and-undefined-handling.md src\entity-manager\EntityManager.ts src\util\OrmUtils.ts test\functional\null-undefined-handling\query-builders.test.ts test\unit\util\orm-utils.test.ts
git diff --check
```

Results:

- compile passed
- compiled Mocha run passed: 3033 passing, 179 pending
- touched-file Prettier check passed
- diff whitespace check passed