### PR TITLE
fix: apply default invalid where behavior

### DIFF
--- a/src/util/OrmUtils.ts
+++ b/src/util/OrmUtils.ts
@@ -662,10 +662,6 @@ export class OrmUtils {
         options?: InvalidFindOptionsWhereBehavior,
         path?: string,
     ): ObjectLiteral | ObjectLiteral[] {
-        if (!options) {
-            return criteria
-        }
-
         // multiple criteria are possible at the top level
         if (!path && Array.isArray(criteria)) {
             return criteria.map(
@@ -678,8 +674,14 @@ export class OrmUtils {
             )
         }
 
+        if (!OrmUtils.isPlainObject(criteria)) {
+            return criteria
+        }
+
         const result: ObjectLiteral = {}
         for (const [key, value] of Object.entries(criteria)) {
+            if (key === "__proto__") continue
+
             const propertyPath = path ? `${path}.${key}` : key
 
             if (value === undefined) {

--- a/test/unit/util/orm-utils.test.ts
+++ b/test/unit/util/orm-utils.test.ts
@@ -270,4 +270,39 @@ describe(`OrmUtils`, () => {
             ).to.equal(false)
         })
     })
+
+    describe("normalizeWhereCriteria", () => {
+        it("throws for undefined values by default", () => {
+            expect(() =>
+                OrmUtils.normalizeWhereCriteria({ name: undefined }),
+            ).to.throw(
+                "Undefined value encountered in property 'name' of a where condition.",
+            )
+        })
+
+        it("does not validate class instances as where criteria objects", () => {
+            class User {
+                id = 1
+                profileId = null
+            }
+
+            const user = new User()
+
+            expect(
+                OrmUtils.normalizeWhereCriteria(user, {
+                    null: "throw",
+                    undefined: "throw",
+                }),
+            ).to.equal(user)
+        })
+
+        it("ignores __proto__ criteria keys", () => {
+            const result = OrmUtils.normalizeWhereCriteria(
+                JSON.parse('{ "__proto__": { "polluted": true }, "id": 1 }'),
+            ) as Record<string, unknown>
+
+            expect(result).to.deep.equal({ id: 1 })
+            expect(Object.getPrototypeOf(result)).to.equal(Object.prototype)
+        })
+    })
 })


### PR DESCRIPTION
## Summary
- make `OrmUtils.normalizeWhereCriteria()` apply the documented default `throw` behavior even when `invalidWhereValuesBehavior` is not configured
- keep non-plain criteria objects, such as entity class instances, passing through unchanged so nullable instance fields are not stripped or rejected
- skip `__proto__` keys while normalizing criteria to avoid mutating the returned object's prototype

Closes #12578

## Test Plan
- `pnpm run compile`
- `pnpm exec mocha --no-config ./build/compiled/test/unit/util/orm-utils.test.js`
- `pnpm exec prettier --check src/util/OrmUtils.ts test/unit/util/orm-utils.test.ts`
- `git diff --check`