### PR TITLE
Fix default invalid where behavior after normalization

### DIFF
--- a/src/entity-manager/EntityManager.ts
+++ b/src/entity-manager/EntityManager.ts
@@ -98,6 +98,18 @@ export class EntityManager {
         }
     }
 
+    private hasEmptyNormalizedCriteria(
+        criteria: ObjectLiteral | ObjectLiteral[],
+    ): boolean {
+        return (
+            OrmUtils.isCriteriaNullOrEmpty(criteria) ||
+            (Array.isArray(criteria) &&
+                criteria.some((criterion) =>
+                    OrmUtils.isCriteriaNullOrEmpty(criterion),
+                ))
+        )
+    }
+
     // -------------------------------------------------------------------------
     // Public Methods
     // -------------------------------------------------------------------------
@@ -874,6 +886,14 @@ export class EntityManager {
                 criteria as ObjectLiteral | ObjectLiteral[],
                 this.dataSource.options.invalidWhereValuesBehavior,
             )
+            if (this.hasEmptyNormalizedCriteria(normalizedCriteria)) {
+                return Promise.reject(
+                    new TypeORMError(
+                        `Empty criteria(s) are not allowed for the update method.`,
+                    ),
+                )
+            }
+
             const qb = this.createQueryBuilder()
                 .update(target)
                 .set(partialEntity)
@@ -955,6 +975,14 @@ export class EntityManager {
                 criteria as ObjectLiteral | ObjectLiteral[],
                 this.dataSource.options.invalidWhereValuesBehavior,
             )
+            if (this.hasEmptyNormalizedCriteria(normalizedCriteria)) {
+                return Promise.reject(
+                    new TypeORMError(
+                        `Empty criteria(s) are not allowed for the delete method.`,
+                    ),
+                )
+            }
+
             return this.createQueryBuilder()
                 .delete()
                 .from(targetOrEntity)
@@ -1021,6 +1049,14 @@ export class EntityManager {
                 criteria as ObjectLiteral | ObjectLiteral[],
                 this.dataSource.options.invalidWhereValuesBehavior,
             )
+            if (this.hasEmptyNormalizedCriteria(normalizedCriteria)) {
+                return Promise.reject(
+                    new TypeORMError(
+                        `Empty criteria(s) are not allowed for the softDelete method.`,
+                    ),
+                )
+            }
+
             return this.createQueryBuilder()
                 .softDelete()
                 .from(targetOrEntity)
@@ -1072,6 +1108,14 @@ export class EntityManager {
                 criteria as ObjectLiteral | ObjectLiteral[],
                 this.dataSource.options.invalidWhereValuesBehavior,
             )
+            if (this.hasEmptyNormalizedCriteria(normalizedCriteria)) {
+                return Promise.reject(
+                    new TypeORMError(
+                        `Empty criteria(s) are not allowed for the restore method.`,
+                    ),
+                )
+            }
+
             return this.createQueryBuilder()
                 .restore()
                 .from(targetOrEntity)

--- a/src/util/OrmUtils.ts
+++ b/src/util/OrmUtils.ts
@@ -559,7 +559,24 @@ export class OrmUtils {
             return false
         }
 
-        return !item.constructor || item.constructor === Object
+        if (Object.prototype.toString.call(item) !== "[object Object]") {
+            return false
+        }
+
+        const prototype = Object.getPrototypeOf(item)
+        if (prototype === null) {
+            return true
+        }
+
+        const constructor =
+            Object.prototype.hasOwnProperty.call(prototype, "constructor") &&
+            prototype.constructor
+
+        return (
+            typeof constructor === "function" &&
+            Function.prototype.toString.call(constructor) ===
+                Function.prototype.toString.call(Object)
+        )
     }
 
     private static mergeArrayKey(
@@ -662,10 +679,6 @@ export class OrmUtils {
         options?: InvalidFindOptionsWhereBehavior,
         path?: string,
     ): ObjectLiteral | ObjectLiteral[] {
-        if (!options) {
-            return criteria
-        }
-
         // multiple criteria are possible at the top level
         if (!path && Array.isArray(criteria)) {
             return criteria.map(

--- a/test/functional/null-undefined-handling/query-builders.test.ts
+++ b/test/functional/null-undefined-handling/query-builders.test.ts
@@ -401,6 +401,59 @@ describe("entity manager > invalidWhereValuesBehavior with ignore", () => {
         }
     })
 
+    it("should reject EntityManager.delete() when ignore strips all criteria", async () => {
+        for (const connection of dataSources) {
+            const post = new Post()
+            post.title = "Test Post"
+            post.text = "text"
+            await connection.manager.save(post)
+
+            try {
+                await connection.manager.delete(Post, {
+                    text: null,
+                } as any)
+                expect.fail("Expected error")
+            } catch (error) {
+                expect(error).to.be.instanceOf(TypeORMError)
+                expect(error.message).to.include(
+                    "Empty criteria(s) are not allowed for the delete method.",
+                )
+            }
+
+            const remaining = await connection.manager.find(Post)
+            expect(remaining.length).to.equal(1)
+        }
+    })
+
+    it("should reject EntityManager.delete() when ignore strips an OR branch to empty criteria", async () => {
+        for (const connection of dataSources) {
+            const post = new Post()
+            post.title = "Test Post"
+            post.text = "text"
+            await connection.manager.save(post)
+
+            try {
+                await connection.manager.delete(Post, [
+                    {
+                        text: null,
+                    },
+                    {
+                        title: "Test Post",
+                    },
+                ] as any)
+                expect.fail("Expected error")
+            } catch (error) {
+                expect(error).to.be.instanceOf(TypeORMError)
+                expect(error.message).to.include(
+                    "Empty criteria(s) are not allowed for the delete method.",
+                )
+            }
+
+            const remaining = await connection.manager.find(Post)
+            expect(remaining.length).to.equal(1)
+        }
+    })
+
     it("should strip nested null criteria in EntityManager.update() with ignore", async () => {
         for (const connection of dataSources) {
             const category = new Category()

--- a/test/unit/util/orm-utils.test.ts
+++ b/test/unit/util/orm-utils.test.ts
@@ -272,9 +272,24 @@ describe(`OrmUtils`, () => {
     })
 
     describe("normalizeWhereCriteria", () => {
-        it("returns criteria unchanged when no options are provided", () => {
-            const criteria = { name: null, email: undefined }
-            expect(OrmUtils.normalizeWhereCriteria(criteria)).to.equal(criteria)
+        it("throws on undefined by default when no options are provided", () => {
+            expect(() =>
+                OrmUtils.normalizeWhereCriteria({ name: undefined }),
+            ).to.throw(/Undefined value.*'name'/)
+        })
+
+        it("throws on null by default when no options are provided", () => {
+            expect(() =>
+                OrmUtils.normalizeWhereCriteria({ email: null }),
+            ).to.throw(/Null value.*'email'/)
+        })
+
+        it("treats cross-realm plain objects as plain criteria", () => {
+            const criteria = runInNewContext("({ name: undefined })")
+
+            expect(() => OrmUtils.normalizeWhereCriteria(criteria)).to.throw(
+                /Undefined value.*'name'/,
+            )
         })
 
         it("throws on null/undefined by default when options are provided", () => {


### PR DESCRIPTION
Follow-up to #12629 for the remaining #12578 behavior.\n\nThis keeps the scope small:\n- make default unconfigured invalid where behavior throw for both null and undefined\n- treat cross-realm plain objects as plain where criteria while still passing entity/class instances through unchanged\n- reject write criteria that normalize to an empty object, including an empty OR branch, before passing them to .where({})\n\nValidation:\n- pnpm run compile\n- pnpm exec mocha --no-config ./build/compiled/test/unit/util/orm-utils.test.js\n- pnpm exec mocha --no-config --file ./build/compiled/test/utils/test-setup.js ./build/compiled/test/functional/null-undefined-handling/query-builders.test.js --timeout 90000\n- pnpm exec prettier --check src/entity-manager/EntityManager.ts src/util/OrmUtils.ts test/unit/util/orm-utils.test.ts test/functional/null-undefined-handling/query-builders.test.ts\n- git diff --check HEAD^ HEAD\n\nThis PR is based on #12629's branch so the diff only shows the follow-up changes. If #12629 merges first, this can be retargeted to master.