### PR TITLE
fix: apply default throw behavior when invalidWhereValuesBehavior unset (#12578)

### DIFF
--- a/src/util/OrmUtils.ts
+++ b/src/util/OrmUtils.ts
@@ -662,10 +662,6 @@ export class OrmUtils {
         options?: InvalidFindOptionsWhereBehavior,
         path?: string,
     ): ObjectLiteral | ObjectLiteral[] {
-        if (!options) {
-            return criteria
-        }
-
         // multiple criteria are possible at the top level
         if (!path && Array.isArray(criteria)) {
             return criteria.map(

--- a/test/functional/null-undefined-handling/query-builders.test.ts
+++ b/test/functional/null-undefined-handling/query-builders.test.ts
@@ -415,6 +415,69 @@ describe("entity manager > invalidWhereValuesBehavior with ignore", () => {
     })
 })
 
+describe("entity manager > default invalidWhereValuesBehavior when unset", () => {
+    let dataSources: DataSource[]
+
+    before(async () => {
+        dataSources = await createTestingConnections({
+            disabledDrivers: ["spanner"],
+            entities: [Post, Category],
+            schemaCreate: true,
+            dropSchema: true,
+        })
+    })
+    beforeEach(() => reloadTestingDatabases(dataSources))
+    after(() => closeTestingConnections(dataSources))
+
+    async function prepareData(connection: DataSource) {
+        const category = new Category()
+        category.name = "Test Category"
+        await connection.manager.save(category)
+
+        const post = new Post()
+        post.title = "Test Post"
+        post.text = "Some text"
+        post.category = category
+        await connection.manager.save(post)
+
+        return { category, post }
+    }
+
+    it("should throw for null values in EntityManager.update() by default", async () => {
+        for (const connection of dataSources) {
+            await prepareData(connection)
+
+            try {
+                await connection.manager.update(Post, { text: null } as any, {
+                    title: "Updated",
+                })
+                expect.fail("Expected error")
+            } catch (error) {
+                expect(error).to.be.instanceOf(TypeORMError)
+                expect(error.message).to.include("Null value encountered")
+            }
+        }
+    })
+
+    it("should throw for undefined values in EntityManager.update() by default", async () => {
+        for (const connection of dataSources) {
+            await prepareData(connection)
+
+            try {
+                await connection.manager.update(
+                    Post,
+                    { text: undefined } as any,
+                    { title: "Updated" },
+                )
+                expect.fail("Expected error")
+            } catch (error) {
+                expect(error).to.be.instanceOf(TypeORMError)
+                expect(error.message).to.include("Undefined value encountered")
+            }
+        }
+    })
+})
+
 describe("entity manager > invalidWhereValuesBehavior does NOT affect QB .where()", () => {
     let dataSources: DataSource[]
 


### PR DESCRIPTION
## Summary

Fixes #12578 by removing the early return in `OrmUtils.normalizeWhereCriteria()` when `invalidWhereValuesBehavior` is unset. The function already defaults null/undefined handling to `"throw"` per TypeORM 1.0 docs; the guard prevented that default from running on EntityManager update/delete paths.

## Changes

- Drop `if (!options) return criteria` so unset DataSource options use documented default throw behavior.
- Add regression tests for EntityManager.update() with null/undefined when `invalidWhereValuesBehavior` is not configured.

## Testing

```bash
npm install
npm run test -- --grep "default invalidWhereValuesBehavior when unset"
```

Fix is a one-line behavioral correction aligned with existing throw-path logic in the same function.

/opire try
/claim #12578


Solana wallet for bounty payout: `Do4v7foHJvRJLpRRoGaVPWX6DDEjX3yTK7J91gpwUQpE`