### PR TITLE
fix: apply default throw behavior in normalizeWhereCriteria

### DIFF
--- a/src/util/OrmUtils.ts
+++ b/src/util/OrmUtils.ts
@@ -662,10 +662,6 @@ export class OrmUtils {
         options?: InvalidFindOptionsWhereBehavior,
         path?: string,
     ): ObjectLiteral | ObjectLiteral[] {
-        if (!options) {
-            return criteria
-        }
-
         // multiple criteria are possible at the top level
         if (!path && Array.isArray(criteria)) {
             return criteria.map(

--- a/test/unit/util/orm-utils.test.ts
+++ b/test/unit/util/orm-utils.test.ts
@@ -204,6 +204,23 @@ describe(`OrmUtils`, () => {
         })
     })
 
+    describe("normalizeWhereCriteria", () => {
+        it("should throw for undefined values by default when options are omitted", () => {
+            expect(() =>
+                OrmUtils.normalizeWhereCriteria({ text: undefined }),
+            ).to.throw(
+                "Undefined value encountered in property 'text' of a where condition.",
+            )
+        })
+
+        it("should throw for null values by default when options are omitted", () => {
+            expect(() => OrmUtils.normalizeWhereCriteria({ text: null })).to
+                .throw(
+                    "Null value encountered in property 'text' of a where condition.",
+                )
+        })
+    })
+
     describe("getArraysDiff", () => {
         it("should return array difference", () => {
             const a = [1, 2, 3]


### PR DESCRIPTION
## Description of change

Fixes #12578.

`OrmUtils.normalizeWhereCriteria()` currently returns criteria unchanged when `invalidWhereValuesBehavior` is omitted. That bypasses the documented default behavior where `null` and `undefined` values should throw.

This change removes the early return so the existing default branches (`?? "throw"`) are applied even when options are not configured.

## Pull-Request Checklist

- [x] Code is up-to-date with the `master` branch
- [x] This pull request links a relevant issue using a closing keyword: Fixes #12578
- [x] There are new or updated tests validating the change (`test/unit/util/orm-utils.test.ts`)
- [ ] Documentation has been updated to reflect this change (`docs/docs/**/*.md`)