### PR TITLE
fix: apply default invalid where behavior in normalized criteria

### DIFF
--- a/src/entity-manager/EntityManager.ts
+++ b/src/entity-manager/EntityManager.ts
@@ -874,6 +874,15 @@ export class EntityManager {
                 criteria as ObjectLiteral | ObjectLiteral[],
                 this.dataSource.options.invalidWhereValuesBehavior,
             )
+
+            if (OrmUtils.isCriteriaNullOrEmpty(normalizedCriteria)) {
+                return Promise.reject(
+                    new TypeORMError(
+                        `Empty criteria(s) are not allowed for the update method.`,
+                    ),
+                )
+            }
+
             const qb = this.createQueryBuilder()
                 .update(target)
                 .set(partialEntity)
@@ -955,6 +964,15 @@ export class EntityManager {
                 criteria as ObjectLiteral | ObjectLiteral[],
                 this.dataSource.options.invalidWhereValuesBehavior,
             )
+
+            if (OrmUtils.isCriteriaNullOrEmpty(normalizedCriteria)) {
+                return Promise.reject(
+                    new TypeORMError(
+                        `Empty criteria(s) are not allowed for the delete method.`,
+                    ),
+                )
+            }
+
             return this.createQueryBuilder()
                 .delete()
                 .from(targetOrEntity)
@@ -1021,6 +1039,15 @@ export class EntityManager {
                 criteria as ObjectLiteral | ObjectLiteral[],
                 this.dataSource.options.invalidWhereValuesBehavior,
             )
+
+            if (OrmUtils.isCriteriaNullOrEmpty(normalizedCriteria)) {
+                return Promise.reject(
+                    new TypeORMError(
+                        `Empty criteria(s) are not allowed for the softDelete method.`,
+                    ),
+                )
+            }
+
             return this.createQueryBuilder()
                 .softDelete()
                 .from(targetOrEntity)
@@ -1072,6 +1099,15 @@ export class EntityManager {
                 criteria as ObjectLiteral | ObjectLiteral[],
                 this.dataSource.options.invalidWhereValuesBehavior,
             )
+
+            if (OrmUtils.isCriteriaNullOrEmpty(normalizedCriteria)) {
+                return Promise.reject(
+                    new TypeORMError(
+                        `Empty criteria(s) are not allowed for the restore method.`,
+                    ),
+                )
+            }
+
             return this.createQueryBuilder()
                 .restore()
                 .from(targetOrEntity)

--- a/src/util/OrmUtils.ts
+++ b/src/util/OrmUtils.ts
@@ -674,6 +674,10 @@ export class OrmUtils {
             )
         }
 
+        if (!OrmUtils.isPlainObject(criteria)) {
+            return criteria
+        }
+
         const result: ObjectLiteral = {}
         for (const [key, value] of Object.entries(criteria)) {
             if (key === "__proto__") continue

--- a/src/util/OrmUtils.ts
+++ b/src/util/OrmUtils.ts
@@ -389,7 +389,13 @@ export class OrmUtils {
             criteria === undefined ||
             criteria === null ||
             criteria === "" ||
-            (Array.isArray(criteria) && criteria.length === 0) ||
+            (Array.isArray(criteria) &&
+                (criteria.length === 0 ||
+                    criteria.some(
+                        (criterion) =>
+                            OrmUtils.isPlainObject(criterion) &&
+                            Object.keys(criterion).length === 0,
+                    ))) ||
             (OrmUtils.isPlainObject(criteria) &&
                 Object.keys(criteria).length === 0)
         )

--- a/src/util/OrmUtils.ts
+++ b/src/util/OrmUtils.ts
@@ -676,6 +676,8 @@ export class OrmUtils {
 
         const result: ObjectLiteral = {}
         for (const [key, value] of Object.entries(criteria)) {
+            if (key === "__proto__") continue
+
             const propertyPath = path ? `${path}.${key}` : key
 
             if (value === undefined) {

--- a/src/util/OrmUtils.ts
+++ b/src/util/OrmUtils.ts
@@ -684,7 +684,7 @@ export class OrmUtils {
             return criteria
         }
 
-        const result: ObjectLiteral = {}
+        const result: ObjectLiteral = Object.create(null)
         for (const [key, value] of Object.entries(criteria)) {
             if (key === "__proto__") continue
 

--- a/src/util/OrmUtils.ts
+++ b/src/util/OrmUtils.ts
@@ -662,10 +662,6 @@ export class OrmUtils {
         options?: InvalidFindOptionsWhereBehavior,
         path?: string,
     ): ObjectLiteral | ObjectLiteral[] {
-        if (!options) {
-            return criteria
-        }
-
         // multiple criteria are possible at the top level
         if (!path && Array.isArray(criteria)) {
             return criteria.map(

--- a/test/functional/null-undefined-handling/query-builders.test.ts
+++ b/test/functional/null-undefined-handling/query-builders.test.ts
@@ -1,5 +1,5 @@
 import { expect } from "chai"
-import type { DataSource } from "../../../src"
+import type { DataSource, FindOptionsWhere } from "../../../src"
 import { TypeORMError } from "../../../src"
 import {
     closeTestingConnections,
@@ -25,8 +25,10 @@ describe("entity manager > invalidWhereValuesBehavior with default behavior", ()
 
     it("should throw error for null values in EntityManager.delete() by default", async () => {
         for (const connection of dataSources) {
+            const criteria = { text: null } as unknown as FindOptionsWhere<Post>
+
             try {
-                await connection.manager.delete(Post, { text: null } as any)
+                await connection.manager.delete(Post, criteria)
                 expect.fail("Expected error")
             } catch (error) {
                 expect(error).to.be.instanceOf(TypeORMError)
@@ -37,10 +39,12 @@ describe("entity manager > invalidWhereValuesBehavior with default behavior", ()
 
     it("should throw error for undefined values in EntityManager.delete() by default", async () => {
         for (const connection of dataSources) {
+            const criteria = {
+                text: undefined,
+            } as unknown as FindOptionsWhere<Post>
+
             try {
-                await connection.manager.delete(Post, {
-                    text: undefined,
-                } as any)
+                await connection.manager.delete(Post, criteria)
                 expect.fail("Expected error")
             } catch (error) {
                 expect(error).to.be.instanceOf(TypeORMError)

--- a/test/functional/null-undefined-handling/query-builders.test.ts
+++ b/test/functional/null-undefined-handling/query-builders.test.ts
@@ -9,6 +9,47 @@ import {
 import { Category } from "./entity/Category"
 import { Post } from "./entity/Post"
 
+describe("entity manager > invalidWhereValuesBehavior with default behavior", () => {
+    let dataSources: DataSource[]
+
+    before(async () => {
+        dataSources = await createTestingConnections({
+            disabledDrivers: ["spanner"],
+            entities: [Post, Category],
+            schemaCreate: true,
+            dropSchema: true,
+        })
+    })
+    beforeEach(() => reloadTestingDatabases(dataSources))
+    after(() => closeTestingConnections(dataSources))
+
+    it("should throw error for null values in EntityManager.delete() by default", async () => {
+        for (const connection of dataSources) {
+            try {
+                await connection.manager.delete(Post, { text: null } as any)
+                expect.fail("Expected error")
+            } catch (error) {
+                expect(error).to.be.instanceOf(TypeORMError)
+                expect(error.message).to.include("Null value encountered")
+            }
+        }
+    })
+
+    it("should throw error for undefined values in EntityManager.delete() by default", async () => {
+        for (const connection of dataSources) {
+            try {
+                await connection.manager.delete(Post, {
+                    text: undefined,
+                } as any)
+                expect.fail("Expected error")
+            } catch (error) {
+                expect(error).to.be.instanceOf(TypeORMError)
+                expect(error.message).to.include("Undefined value encountered")
+            }
+        }
+    })
+})
+
 describe("entity manager > invalidWhereValuesBehavior with throw", () => {
     let dataSources: DataSource[]
 

--- a/test/functional/null-undefined-handling/query-builders.test.ts
+++ b/test/functional/null-undefined-handling/query-builders.test.ts
@@ -52,6 +52,73 @@ describe("entity manager > invalidWhereValuesBehavior with default behavior", ()
             }
         }
     })
+
+    it("should throw error for criteria that become empty after normalization", async () => {
+        for (const connection of dataSources) {
+            const createPlainCriteria = () =>
+                JSON.parse(`{"__proto__":{"text":"Some text"}}`)
+            const criteriaCases: Array<
+                [
+                    string,
+                    () => FindOptionsWhere<Post> | FindOptionsWhere<Post>[],
+                ]
+            > = [
+                [
+                    "object",
+                    () =>
+                        createPlainCriteria() as unknown as FindOptionsWhere<Post>,
+                ],
+                [
+                    "array",
+                    () =>
+                        [
+                            createPlainCriteria(),
+                        ] as unknown as FindOptionsWhere<Post>[],
+                ],
+            ]
+
+            for (const [criteriaType, createCriteria] of criteriaCases) {
+                const operations: Array<[string, () => Promise<unknown>]> = [
+                    [
+                        "update",
+                        () =>
+                            connection.manager.update(Post, createCriteria(), {
+                                title: "Updated",
+                            }),
+                    ],
+                    [
+                        "delete",
+                        () => connection.manager.delete(Post, createCriteria()),
+                    ],
+                    [
+                        "softDelete",
+                        () =>
+                            connection.manager.softDelete(
+                                Post,
+                                createCriteria(),
+                            ),
+                    ],
+                    [
+                        "restore",
+                        () =>
+                            connection.manager.restore(Post, createCriteria()),
+                    ],
+                ]
+
+                for (const [method, operation] of operations) {
+                    try {
+                        await operation()
+                        expect.fail(`Expected ${method} ${criteriaType} error`)
+                    } catch (error) {
+                        expect(error).to.be.instanceOf(TypeORMError)
+                        expect(error.message).to.include(
+                            `Empty criteria(s) are not allowed for the ${method} method.`,
+                        )
+                    }
+                }
+            }
+        }
+    })
 })
 
 describe("entity manager > invalidWhereValuesBehavior with throw", () => {

--- a/test/unit/util/orm-utils.test.ts
+++ b/test/unit/util/orm-utils.test.ts
@@ -5,6 +5,14 @@ import { OrmUtils } from "../../../src/util/OrmUtils"
 
 describe(`OrmUtils`, () => {
     describe("normalizeWhereCriteria", () => {
+        it("keeps non-plain criteria objects unchanged", () => {
+            class NonPlainCriteria {}
+
+            const criteria = new NonPlainCriteria() as ObjectLiteral
+
+            expect(OrmUtils.normalizeWhereCriteria(criteria)).to.equal(criteria)
+        })
+
         it("does not create inherited keys from __proto__", () => {
             const criteria = JSON.parse(
                 `{"__proto__":{"polluted":true},"nested":{"__proto__":{"polluted":true},"safe":"value"}}`,

--- a/test/unit/util/orm-utils.test.ts
+++ b/test/unit/util/orm-utils.test.ts
@@ -1,9 +1,34 @@
 import { expect } from "chai"
 import { runInNewContext } from "node:vm"
-import type { DeepPartial } from "../../../src"
+import type { DeepPartial, ObjectLiteral } from "../../../src"
 import { OrmUtils } from "../../../src/util/OrmUtils"
 
 describe(`OrmUtils`, () => {
+    describe("normalizeWhereCriteria", () => {
+        it("does not create inherited keys from __proto__", () => {
+            const criteria = JSON.parse(
+                `{"__proto__":{"polluted":true},"nested":{"__proto__":{"polluted":true},"safe":"value"}}`,
+            ) as ObjectLiteral
+            const normalized = OrmUtils.normalizeWhereCriteria(
+                criteria,
+            ) as ObjectLiteral
+            const nested = normalized.nested as ObjectLiteral
+
+            expect(Object.keys(normalized)).to.deep.equal(["nested"])
+            expect(Object.keys(nested)).to.deep.equal(["safe"])
+
+            const inheritedKeys: string[] = []
+            for (const key in normalized) {
+                inheritedKeys.push(key)
+            }
+            for (const key in nested) {
+                inheritedKeys.push(key)
+            }
+
+            expect(inheritedKeys).not.to.include("polluted")
+        })
+    })
+
     describe("parseSqlCheckExpression", () => {
         it("parses a simple CHECK constraint", () => {
             // Spaces between CHECK values

--- a/test/unit/util/orm-utils.test.ts
+++ b/test/unit/util/orm-utils.test.ts
@@ -35,6 +35,18 @@ describe(`OrmUtils`, () => {
 
             expect(inheritedKeys).not.to.include("polluted")
         })
+
+        it("uses null-prototype objects for normalized criteria", () => {
+            const normalized = OrmUtils.normalizeWhereCriteria({
+                nested: {
+                    safe: "value",
+                },
+            }) as ObjectLiteral
+            const nested = normalized.nested as ObjectLiteral
+
+            expect(Object.getPrototypeOf(normalized)).to.equal(null)
+            expect(Object.getPrototypeOf(nested)).to.equal(null)
+        })
     })
 
     describe("parseSqlCheckExpression", () => {


### PR DESCRIPTION
### Summary

- make `OrmUtils.normalizeWhereCriteria()` apply the documented default `throw` behavior when `invalidWhereValuesBehavior` is omitted
- add regression coverage for default `null` and `undefined` handling in high-level `EntityManager.delete()` criteria

### Why

`normalizeWhereCriteria()` already defaults `null` and `undefined` behavior to `"throw"` inside its validation logic, but it returned the original criteria early when no options object was provided. High-level mutation APIs pass omitted `dataSource.options.invalidWhereValuesBehavior` through this helper, so default validation was bypassed.

Fixes #12578.

### Verification

- `npx -y node@20.19.0 ./node_modules/prettier/bin/prettier.cjs --check src/util/OrmUtils.ts test/functional/null-undefined-handling/query-builders.test.ts`
- `npx -y node@20.19.0 ./node_modules/gulp/bin/gulp.js clean`
- `npx -y node@20.19.0 ./node_modules/typescript/bin/tsc --pretty false`
- direct `OrmUtils.normalizeWhereCriteria` assertions for default `null` and `undefined` behavior
- focused null/undefined handling mocha suite (`47 passing`)
- `git diff --check`