### PR TITLE
fix: apply default invalid where behavior

### DIFF
--- a/src/util/OrmUtils.ts
+++ b/src/util/OrmUtils.ts
@@ -662,10 +662,6 @@ export class OrmUtils {
         options?: InvalidFindOptionsWhereBehavior,
         path?: string,
     ): ObjectLiteral | ObjectLiteral[] {
-        if (!options) {
-            return criteria
-        }
-
         // multiple criteria are possible at the top level
         if (!path && Array.isArray(criteria)) {
             return criteria.map(

--- a/test/unit/util/orm-utils.test.ts
+++ b/test/unit/util/orm-utils.test.ts
@@ -1,6 +1,6 @@
 import { expect } from "chai"
 import { runInNewContext } from "node:vm"
-import type { DeepPartial } from "../../../src"
+import { TypeORMError, type DeepPartial } from "../../../src"
 import { OrmUtils } from "../../../src/util/OrmUtils"
 
 describe(`OrmUtils`, () => {
@@ -268,6 +268,51 @@ describe(`OrmUtils`, () => {
                     new Uint8Array([1, 2, 4]),
                 ),
             ).to.equal(false)
+        })
+    })
+
+    describe("normalizeWhereCriteria", () => {
+        it("should throw for undefined values by default", () => {
+            expect(() =>
+                OrmUtils.normalizeWhereCriteria({ text: undefined }),
+            ).to.throw(
+                TypeORMError,
+                "Undefined value encountered in property 'text' of a where condition.",
+            )
+        })
+
+        it("should throw for null values by default", () => {
+            expect(() =>
+                OrmUtils.normalizeWhereCriteria({ text: null }),
+            ).to.throw(
+                TypeORMError,
+                "Null value encountered in property 'text' of a where condition.",
+            )
+        })
+
+        it("should throw with indexed paths for top-level criteria arrays by default", () => {
+            expect(() =>
+                OrmUtils.normalizeWhereCriteria([{ text: undefined }]),
+            ).to.throw(
+                TypeORMError,
+                "Undefined value encountered in property '0.text' of a where condition.",
+            )
+        })
+
+        it("should still honor explicit ignore behavior", () => {
+            expect(
+                OrmUtils.normalizeWhereCriteria(
+                    {
+                        title: "Post #1",
+                        text: undefined,
+                        category: null,
+                    },
+                    {
+                        undefined: "ignore",
+                        null: "ignore",
+                    },
+                ),
+            ).to.deep.equal({ title: "Post #1" })
         })
     })
 })


### PR DESCRIPTION
Fixes #12578

## Summary
`OrmUtils.normalizeWhereCriteria()` already defaults `null` and `undefined` handling to `"throw"` inside the traversal, but it returned early when no `invalidWhereValuesBehavior` options were provided. This PR removes that early return so the documented default behavior is applied.

## Changes
- Remove the early return for missing `invalidWhereValuesBehavior` options.
- Add unit coverage for default `undefined` and `null` throw behavior.
- Add coverage for top-level criteria arrays and explicit `ignore` behavior to preserve configured behavior.

## Verification
- `.\node_modules\.bin\prettier.CMD --write src\util\OrmUtils.ts test\unit\util\orm-utils.test.ts`
- `.\node_modules\.bin\tsc.CMD --noEmit --pretty false`
- `.\node_modules\.bin\mocha.CMD --no-config --require ts-node/register --require reflect-metadata test\unit\util\orm-utils.test.ts --timeout 90000 --exit`

Result: `18 passing`.

Note: `pnpm install --frozen-lockfile` needed the official npm registry because the configured mirror returned 404 for `@sap/hana-client@2.28.20`. The target unit test and typecheck passed after dependencies were installed.
