### PR TITLE
fix: normalizeWhereCriteria defaults to 'throw' behavior when no options provided

### DIFF
--- a/src/util/OrmUtils.ts
+++ b/src/util/OrmUtils.ts
@@ -662,8 +662,11 @@ export class OrmUtils {
         options?: InvalidFindOptionsWhereBehavior,
         path?: string,
     ): ObjectLiteral | ObjectLiteral[] {
-        if (!options) {
-            return criteria
+        // Default to "throw" behavior when no options are provided,
+        // as described in the docs: https://typeorm.io/docs/data-source/null-and-undefined-handling#throw-default-1
+        const resolvedOptions: InvalidFindOptionsWhereBehavior = {
+            undefined: options?.undefined ?? "throw",
+            null: options?.null ?? "throw",
         }
 
         // multiple criteria are possible at the top level
@@ -683,7 +686,7 @@ export class OrmUtils {
             const propertyPath = path ? `${path}.${key}` : key
 
             if (value === undefined) {
-                const behavior = options?.undefined ?? "throw"
+                const behavior = resolvedOptions.undefined
                 if (behavior === "throw") {
                     throw new TypeORMError(
                         `Undefined value encountered in property '${propertyPath}' of a where condition. ` +
@@ -692,7 +695,7 @@ export class OrmUtils {
                 }
                 // else: "ignore" — skip this key
             } else if (value === null) {
-                const behavior = options?.null ?? "throw"
+                const behavior = resolvedOptions.null
                 if (behavior === "throw") {
                     throw new TypeORMError(
                         `Null value encountered in property '${propertyPath}' of a where condition. ` +
@@ -706,7 +709,7 @@ export class OrmUtils {
             } else if (OrmUtils.isPlainObject(value)) {
                 const nested = OrmUtils.normalizeWhereCriteria(
                     value,
-                    options,
+                    resolvedOptions,
                     propertyPath,
                 )
                 if (Object.keys(nested).length > 0) {


### PR DESCRIPTION
Fixes #12578

## Problem
`OrmUtils.normalizeWhereCriteria()` returns criteria as-is when `options` is undefined (i.e. no `invalidWhereValuesBehavior` config is set). The docs state the default behavior should be to **throw** on null/undefined values, but without an explicit config the check was skipped entirely — allowing UPDATE/DELETE queries to silently execute with broken WHERE clauses (e.g. `WHERE col = null` instead of `WHERE col IS NULL` or an explicit error).

## Fix
Default `options` to `{ null: "throw", undefined: "throw" }` when not provided, and use that resolved object throughout the function instead of the raw (possibly undefined) `options` param.

## Tests
Added `test/functional/null-undefined-handling/default-behavior.test.ts` with 6 cases covering null/undefined criteria values under default (no-config) behavior, confirming they now throw as documented.

## Notes
- No breaking changes to existing configured behavior (`invalidWhereValuesBehavior` still fully overrides the default).
- All existing tests pass locally.