### PR TITLE
fix: apply default invalid where behavior

### DIFF
--- a/src/util/OrmUtils.ts
+++ b/src/util/OrmUtils.ts
@@ -662,8 +662,9 @@ export class OrmUtils {
         options?: InvalidFindOptionsWhereBehavior,
         path?: string,
     ): ObjectLiteral | ObjectLiteral[] {
-        if (!options) {
-            return criteria
+        const effectiveOptions = options ?? {
+            null: "throw",
+            undefined: "throw",
         }
 
         // multiple criteria are possible at the top level
@@ -672,18 +673,18 @@ export class OrmUtils {
                 (criterion, index): ObjectLiteral =>
                     OrmUtils.normalizeWhereCriteria(
                         criterion,
-                        options,
+                        effectiveOptions,
                         String(index),
                     ),
             )
         }
 
-        const result: ObjectLiteral = {}
+        const result: ObjectLiteral = Object.create(null)
         for (const [key, value] of Object.entries(criteria)) {
             const propertyPath = path ? `${path}.${key}` : key
 
             if (value === undefined) {
-                const behavior = options?.undefined ?? "throw"
+                const behavior = effectiveOptions.undefined ?? "throw"
                 if (behavior === "throw") {
                     throw new TypeORMError(
                         `Undefined value encountered in property '${propertyPath}' of a where condition. ` +
@@ -692,7 +693,7 @@ export class OrmUtils {
                 }
                 // else: "ignore" — skip this key
             } else if (value === null) {
-                const behavior = options?.null ?? "throw"
+                const behavior = effectiveOptions.null ?? "throw"
                 if (behavior === "throw") {
                     throw new TypeORMError(
                         `Null value encountered in property '${propertyPath}' of a where condition. ` +
@@ -706,7 +707,7 @@ export class OrmUtils {
             } else if (OrmUtils.isPlainObject(value)) {
                 const nested = OrmUtils.normalizeWhereCriteria(
                     value,
-                    options,
+                    effectiveOptions,
                     propertyPath,
                 )
                 if (Object.keys(nested).length > 0) {

--- a/test/functional/null-undefined-handling/query-builders.test.ts
+++ b/test/functional/null-undefined-handling/query-builders.test.ts
@@ -238,6 +238,62 @@ describe("entity manager > invalidWhereValuesBehavior with throw", () => {
     })
 })
 
+describe("entity manager > invalidWhereValuesBehavior defaults", () => {
+    let dataSources: DataSource[]
+
+    before(async () => {
+        dataSources = await createTestingConnections({
+            disabledDrivers: ["spanner"],
+            entities: [Post, Category],
+            schemaCreate: true,
+            dropSchema: true,
+        })
+    })
+    after(() => closeTestingConnections(dataSources))
+
+    async function expectAllWriteMethodsToReject(
+        criteria: Record<string, unknown>,
+        message: string,
+    ) {
+        for (const connection of dataSources) {
+            const operations: Array<[string, () => Promise<unknown>]> = [
+                [
+                    "update",
+                    () =>
+                        connection.manager.update(Post, criteria, {
+                            title: "Updated",
+                        }),
+                ],
+                ["delete", () => connection.manager.delete(Post, criteria)],
+                [
+                    "softDelete",
+                    () => connection.manager.softDelete(Post, criteria),
+                ],
+                ["restore", () => connection.manager.restore(Post, criteria)],
+            ]
+
+            for (const [method, execute] of operations) {
+                try {
+                    await execute()
+                    expect.fail(`Expected ${method} to reject`)
+                } catch (error) {
+                    expect(error).to.be.instanceOf(TypeORMError)
+                    expect(error.message).to.include(message)
+                }
+            }
+        }
+    }
+
+    it("throws for undefined criteria without explicit configuration", () =>
+        expectAllWriteMethodsToReject(
+            { text: undefined },
+            "Undefined value encountered",
+        ))
+
+    it("throws for null criteria without explicit configuration", () =>
+        expectAllWriteMethodsToReject({ text: null }, "Null value encountered"))
+})
+
 describe("entity manager > invalidWhereValuesBehavior with sql-null", () => {
     let dataSources: DataSource[]
 

--- a/test/unit/util/orm-utils.test.ts
+++ b/test/unit/util/orm-utils.test.ts
@@ -270,4 +270,30 @@ describe(`OrmUtils`, () => {
             ).to.equal(false)
         })
     })
+
+    describe("normalizeWhereCriteria", () => {
+        it("uses throw behavior by default", () => {
+            expect(() =>
+                OrmUtils.normalizeWhereCriteria({ value: undefined }),
+            ).to.throw("Undefined value encountered")
+            expect(() =>
+                OrmUtils.normalizeWhereCriteria({ value: null }),
+            ).to.throw("Null value encountered")
+        })
+
+        it("copies __proto__ as an own property without changing the prototype", () => {
+            const criteria = JSON.parse(
+                '{"__proto__":{"polluted":true},"id":1}',
+            )
+            const result = OrmUtils.normalizeWhereCriteria(criteria)
+            const normalized = result as Record<string, unknown>
+
+            expect(Object.getPrototypeOf(result)).to.equal(null)
+            expect(Object.hasOwn(result, "__proto__")).to.equal(true)
+            expect(normalized["__proto__"]).to.deep.equal({ polluted: true })
+            expect(({} as Record<string, unknown>)["polluted"]).to.equal(
+                undefined,
+            )
+        })
+    })
 })


### PR DESCRIPTION
### Description of change

Fixes #12578

- Apply the documented throw defaults when `invalidWhereValuesBehavior` is omitted.
- Normalize criteria into a null-prototype object so JSON `__proto__` keys cannot mutate the accumulator.
- Add unit and functional coverage for update, delete, soft-delete, and restore paths.

Verification:
- TypeScript: `tsc --noEmit`
- Unit tests: 16 passing
- Functional null/undefined handling via SQL.js: 22 passing
- ESLint on touched files (`--quiet`)
- Prettier on touched files

### Pull-Request Checklist

- [x] Code is up-to-date with the `master` branch
- [x] This pull request links a relevant issue using a closing keyword
- [x] There are new or updated tests validating the change
- [x] Documentation is already consistent with this behavior; no documentation change is required
