### PR TITLE
fix: use default throw behavior for null/undefined where values when options unset

### DIFF
--- a/src/util/OrmUtils.ts
+++ b/src/util/OrmUtils.ts
@@ -663,7 +663,7 @@ export class OrmUtils {
         path?: string,
     ): ObjectLiteral | ObjectLiteral[] {
         if (!options) {
-            return criteria
+            options = {}
         }
 
         // multiple criteria are possible at the top level


### PR DESCRIPTION
Fixes #12578

When `DataSource` is configured without `invalidWhereValuesBehavior`, `normalizeWhereCriteria()` now defaults to `{ null: "throw", undefined: "throw" }` instead of silently returning criteria unchecked.

**Before:** `if (!options) return criteria` — skips validation entirely
**After:** `if (!options) options = {}` — uses built-in defaults (`?? "throw"`)

This matches the documented default behavior described at https://typeorm.io/docs/data-source/null-and-undefined-handling#throw-default-1