### PR TITLE
fix: throw error instead of silently returning undefined for invalid ORM utils

### DIFF
--- a/src/util/OrmUtils.ts
+++ b/src/util/OrmUtils.ts
@@ -663,7 +663,7 @@ export class OrmUtils {
         path?: string,
     ): ObjectLiteral | ObjectLiteral[] {
         if (!options) {
-            return criteria
+            options = { undefined: "throw" } as InvalidFindOptionsWhereBehavior
         }
 
         // multiple criteria are possible at the top level


### PR DESCRIPTION
## Description

When using ORM utilities with invalid/undefined values, the current behavior silently returns undefined, making debugging difficult. This PR changes the behavior to throw a descriptive error instead.

## Related Issue
Closes #12578

## Checklist
- [x] Code change
- [x] Compiled / tested locally