### PR TITLE
fix: prevent transaction manager queries after rollback

### DIFF
--- a/src/entity-manager/EntityManager.ts
+++ b/src/entity-manager/EntityManager.ts
@@ -40,6 +40,9 @@ import { OrmUtils } from "../util/OrmUtils"
 export class EntityManager {
     readonly "@instanceof" = Symbol.for("EntityManager")
 
+    private static readonly transactionControlQueryRegex =
+        /^(?:START\s+TRANSACTION|BEGIN(?:\s+TRANSACTION)?|SET\s+TRANSACTION\b|COMMIT\b|ROLLBACK\b|SAVEPOINT\b|RELEASE\s+SAVEPOINT\b)/i
+
     // -------------------------------------------------------------------------
     // Public Properties
     // -------------------------------------------------------------------------
@@ -96,6 +99,10 @@ export class EntityManager {
             // dynamic: this.queryRunner = manager;
             ObjectUtils.assign(this.queryRunner, { manager: this })
         }
+    }
+
+    private static isTransactionControlQuery(query: string): boolean {
+        return EntityManager.transactionControlQueryRegex.test(query.trim())
     }
 
     // -------------------------------------------------------------------------
@@ -155,21 +162,59 @@ export class EntityManager {
         const queryRunner =
             this.queryRunner ?? this.dataSource.createQueryRunner()
 
+        const originalQueryRunnerQuery = queryRunner.query
+        const runQuery = queryRunner.query.bind(queryRunner) as (
+            query: string,
+            parameters?: any[] | ObjectLiteral,
+            useStructuredResult?: boolean,
+        ) => Promise<any>
+        let transactionManagerCanQuery = true
+        let transactionIsFinishing = false
+
+        queryRunner.query = ((
+            query: string,
+            parameters?: any[] | ObjectLiteral,
+            useStructuredResult?: boolean,
+        ) => {
+            const isTransactionControlQuery =
+                EntityManager.isTransactionControlQuery(query)
+
+            if (!transactionManagerCanQuery && !isTransactionControlQuery) {
+                return Promise.reject(
+                    new QueryRunnerProviderAlreadyReleasedError(),
+                )
+            }
+
+            if (transactionIsFinishing && isTransactionControlQuery) {
+                transactionManagerCanQuery = false
+            }
+
+            return runQuery(query, parameters, useStructuredResult)
+        }) as QueryRunner["query"]
+
         try {
             await queryRunner.startTransaction(isolation)
             const result = await runInTransaction(queryRunner.manager)
+            transactionIsFinishing = true
             await queryRunner.commitTransaction()
+            transactionManagerCanQuery = false
             return result
         } catch (err) {
+            transactionIsFinishing = true
             try {
                 // we throw original error even if rollback thrown an error
                 await queryRunner.rollbackTransaction()
             } catch (rollbackError) {}
+            transactionManagerCanQuery = false
             throw err
         } finally {
-            if (!this.queryRunner)
-                // if we used a new query runner provider then release it
-                await queryRunner.release()
+            try {
+                if (!this.queryRunner)
+                    // if we used a new query runner provider then release it
+                    await queryRunner.release()
+            } finally {
+                queryRunner.query = originalQueryRunnerQuery
+            }
         }
     }
 

--- a/test/github-issues/12645/issue-12645.test.ts
+++ b/test/github-issues/12645/issue-12645.test.ts
@@ -1,0 +1,82 @@
+import { expect } from "chai"
+import type { DataSource } from "../../../src/data-source/DataSource"
+import { EntityManager } from "../../../src/entity-manager/EntityManager"
+import { QueryRunnerProviderAlreadyReleasedError } from "../../../src/error/QueryRunnerProviderAlreadyReleasedError"
+import type { ObjectLiteral } from "../../../src/common/ObjectLiteral"
+import type { QueryRunner } from "../../../src/query-runner/QueryRunner"
+
+describe("github issues > #12645 transaction manager query race", () => {
+    // Regression test for https://github.com/typeorm/typeorm/issues/12645.
+    it("should prevent manager queries between rollback and query runner release", async () => {
+        const executedQueries: string[] = []
+        let transactionManager!: EntityManager
+        let queryAfterRollbackError: unknown
+
+        const dataSource = {
+            createQueryRunner: () => queryRunner,
+            query: (
+                query: string,
+                parameters?: any[] | ObjectLiteral,
+                queryRunner?: QueryRunner,
+            ) => {
+                if (!queryRunner) throw new Error("Expected a query runner")
+
+                return queryRunner.query(query, parameters)
+            },
+        } as unknown as DataSource
+
+        const queryRunner = {
+            isReleased: false,
+            isTransactionActive: false,
+            manager: undefined as unknown as EntityManager,
+            query: async (query: string) => {
+                executedQueries.push(query)
+                return []
+            },
+            startTransaction: async function () {
+                this.isTransactionActive = true
+                await this.query("START TRANSACTION")
+            },
+            commitTransaction: async function () {
+                await this.query("COMMIT")
+                this.isTransactionActive = false
+            },
+            rollbackTransaction: async function () {
+                await this.query("ROLLBACK")
+                this.isTransactionActive = false
+            },
+            release: async function () {
+                try {
+                    await transactionManager.query("UPDATE should_not_run")
+                } catch (error) {
+                    queryAfterRollbackError = error
+                }
+
+                this.isReleased = true
+            },
+        }
+
+        queryRunner.manager = new EntityManager(
+            dataSource,
+            queryRunner as unknown as QueryRunner,
+        )
+
+        const manager = new EntityManager(dataSource)
+        const originalError = new Error("transaction failed")
+
+        try {
+            await manager.transaction(async (entityManager) => {
+                transactionManager = entityManager
+                throw originalError
+            })
+            expect.fail("transaction should reject")
+        } catch (error) {
+            expect(error).to.equal(originalError)
+        }
+
+        expect(queryAfterRollbackError).to.be.instanceOf(
+            QueryRunnerProviderAlreadyReleasedError,
+        )
+        expect(executedQueries).to.deep.equal(["START TRANSACTION", "ROLLBACK"])
+    })
+})


### PR DESCRIPTION
### Description of change

Fixes #12645.

`EntityManager.transaction` now stops accepting non-transaction-control queries through the transaction query runner once the transaction is finalizing. This prevents delayed work using the transaction manager from issuing a write after rollback has reached the database but before the query runner is released.

Added a deterministic regression test that simulates a delayed transaction-manager query during release after rollback and verifies that it is rejected instead of being executed.

Verified with:

- `pnpm install --frozen-lockfile`
- `pnpm run test -- --grep "#12645"`
- `pnpm exec mocha --no-config build/compiled/test/github-issues/12645/issue-12645.test.js`

### Pull-Request Checklist

- [x] Code is up-to-date with the `master` branch
- [x] This pull request links a relevant issue using a closing keyword: `Fixes #12645`
- [x] There are new or updated tests validating the change (`tests/**.test.ts`)
- [x] Documentation has been updated to reflect this change (`docs/docs/**.md`) N/A: internal transaction race fix
