### PR TITLE
fix: throw for default invalid where values

### DIFF
--- a/src/util/OrmUtils.ts
+++ b/src/util/OrmUtils.ts
@@ -662,10 +662,6 @@ export class OrmUtils {
         options?: InvalidFindOptionsWhereBehavior,
         path?: string,
     ): ObjectLiteral | ObjectLiteral[] {
-        if (!options) {
-            return criteria
-        }
-
         // multiple criteria are possible at the top level
         if (!path && Array.isArray(criteria)) {
             return criteria.map(

--- a/test/functional/null-undefined-handling/query-builders.test.ts
+++ b/test/functional/null-undefined-handling/query-builders.test.ts
@@ -9,6 +9,61 @@ import {
 import { Category } from "./entity/Category"
 import { Post } from "./entity/Post"
 
+// #12578
+describe("entity manager > invalidWhereValuesBehavior default behavior", () => {
+    let dataSources: DataSource[]
+
+    before(async () => {
+        dataSources = await createTestingConnections({
+            disabledDrivers: ["spanner"],
+            entities: [Post, Category],
+            schemaCreate: true,
+            dropSchema: true,
+        })
+    })
+    beforeEach(() => reloadTestingDatabases(dataSources))
+    after(() => closeTestingConnections(dataSources))
+
+    async function prepareData(connection: DataSource) {
+        const post = new Post()
+        post.title = "Test Post"
+        post.text = "Some text"
+        await connection.manager.save(post)
+    }
+
+    it("should throw error for undefined values in EntityManager.update() by default", async () => {
+        for (const connection of dataSources) {
+            await prepareData(connection)
+
+            try {
+                await connection.manager.update(
+                    Post,
+                    { text: undefined } as any,
+                    { title: "Updated" },
+                )
+                expect.fail("Expected error")
+            } catch (error) {
+                expect(error).to.be.instanceOf(TypeORMError)
+                expect(error.message).to.include("Undefined value encountered")
+            }
+        }
+    })
+
+    it("should throw error for null values in EntityManager.delete() by default", async () => {
+        for (const connection of dataSources) {
+            await prepareData(connection)
+
+            try {
+                await connection.manager.delete(Post, { text: null } as any)
+                expect.fail("Expected error")
+            } catch (error) {
+                expect(error).to.be.instanceOf(TypeORMError)
+                expect(error.message).to.include("Null value encountered")
+            }
+        }
+    })
+})
+
 describe("entity manager > invalidWhereValuesBehavior with throw", () => {
     let dataSources: DataSource[]
 

--- a/test/unit/util/orm-utils.test.ts
+++ b/test/unit/util/orm-utils.test.ts
@@ -220,6 +220,30 @@ describe(`OrmUtils`, () => {
         })
     })
 
+    describe("normalizeWhereCriteria", () => {
+        it("should throw for undefined values when no behavior is configured", () => {
+            expect(() =>
+                OrmUtils.normalizeWhereCriteria({ id: undefined }),
+            ).to.throw(
+                "Undefined value encountered in property 'id' of a where condition.",
+            )
+        })
+
+        it("should throw for null values when no behavior is configured", () => {
+            expect(() =>
+                OrmUtils.normalizeWhereCriteria({ id: null }),
+            ).to.throw(
+                "Null value encountered in property 'id' of a where condition.",
+            )
+        })
+
+        it("should preserve valid criteria when no behavior is configured", () => {
+            expect(OrmUtils.normalizeWhereCriteria({ id: 1 })).to.deep.equal({
+                id: 1,
+            })
+        })
+    })
+
     describe("compare2Objects", () => {
         it("should compare two Map.", () => {
             expect(OrmUtils.deepCompare(new Map(), new Map())).to.equal(true)


### PR DESCRIPTION
## What changed

- Remove the early return from `OrmUtils.normalizeWhereCriteria()` when `invalidWhereValuesBehavior` is not configured.
- Add unit coverage for the default behavior with `undefined`, `null`, and valid criteria.

## Why

`normalizeWhereCriteria()` already defaults both `undefined` and `null` handling to `throw` inside the function. The early return skipped that default validation whenever no explicit `invalidWhereValuesBehavior` option was passed, so invalid where criteria could pass through unchanged.

Fixes #12578.

## Checks

- `./node_modules/.bin/prettier --check src/util/OrmUtils.ts test/unit/util/orm-utils.test.ts`
- `./node_modules/.bin/gulp clean && ./node_modules/.bin/tsc`
- `./node_modules/.bin/mocha --no-config build/compiled/test/unit/util/orm-utils.test.js`
