### PR TITLE
fix: apply invalid where defaults when options are omitted

### DIFF
--- a/docs/docs/data-source/2-data-source-options.md
+++ b/docs/docs/data-source/2-data-source-options.md
@@ -89,6 +89,8 @@ Different RDBMS-es have their own specific options.
 
     Example: `invalidWhereValuesBehavior: { null: 'sql-null', undefined: 'ignore' }`.
 
+    Where conditions also reject prototype-polluting property keys such as `__proto__`, `constructor`, and `prototype`.
+
     Learn more about [Null and Undefined Handling](./5-null-and-undefined-handling.md).
 
 ## Data Source Options example

--- a/docs/docs/data-source/5-null-and-undefined-handling.md
+++ b/docs/docs/data-source/5-null-and-undefined-handling.md
@@ -170,6 +170,12 @@ const posts = await repository.find({
 
 Note that this only applies to explicitly set `undefined` values, not omitted properties.
 
+### Prototype-polluting keys
+
+High-level where conditions also reject prototype-polluting property names. If a where condition contains `__proto__`, `constructor`, or `prototype` as a property key, TypeORM throws a `TypeORMError` instead of copying that key into the normalized criteria object.
+
+This validation applies recursively to nested where objects and is independent of the `null` and `undefined` behavior options.
+
 ## Using Both Options Together
 
 You can configure both behaviors independently for comprehensive control:

--- a/src/util/OrmUtils.ts
+++ b/src/util/OrmUtils.ts
@@ -657,15 +657,17 @@ export class OrmUtils {
      * @param options
      * @param path
      */
+    private static isPrototypePollutingKey(key: string): boolean {
+        return (
+            key === "__proto__" || key === "constructor" || key === "prototype"
+        )
+    }
+
     static normalizeWhereCriteria(
         criteria: ObjectLiteral | ObjectLiteral[],
         options?: InvalidFindOptionsWhereBehavior,
         path?: string,
     ): ObjectLiteral | ObjectLiteral[] {
-        if (!options) {
-            return criteria
-        }
-
         // multiple criteria are possible at the top level
         if (!path && Array.isArray(criteria)) {
             return criteria.map(
@@ -678,9 +680,15 @@ export class OrmUtils {
             )
         }
 
-        const result: ObjectLiteral = {}
+        const result: ObjectLiteral = Object.create(null)
         for (const [key, value] of Object.entries(criteria)) {
             const propertyPath = path ? `${path}.${key}` : key
+
+            if (OrmUtils.isPrototypePollutingKey(key)) {
+                throw new TypeORMError(
+                    `Prototype-polluting property '${propertyPath}' encountered in a where condition.`,
+                )
+            }
 
             if (value === undefined) {
                 const behavior = options?.undefined ?? "throw"

--- a/test/functional/null-undefined-handling/query-builders.test.ts
+++ b/test/functional/null-undefined-handling/query-builders.test.ts
@@ -1,5 +1,5 @@
 import { expect } from "chai"
-import type { DataSource } from "../../../src"
+import type { DataSource, FindOptionsWhere } from "../../../src"
 import { TypeORMError } from "../../../src"
 import {
     closeTestingConnections,
@@ -8,6 +8,146 @@ import {
 } from "../../utils/test-utils"
 import { Category } from "./entity/Category"
 import { Post } from "./entity/Post"
+
+const invalidCriteria = <Entity>(criteria: unknown): FindOptionsWhere<Entity> =>
+    criteria as FindOptionsWhere<Entity>
+
+describe("entity manager > invalidWhereValuesBehavior defaults", () => {
+    // #12578: omitted invalidWhereValuesBehavior should use the documented defaults.
+    let dataSources: DataSource[]
+
+    before(async () => {
+        dataSources = await createTestingConnections({
+            disabledDrivers: ["spanner"],
+            entities: [Post, Category],
+            schemaCreate: true,
+            dropSchema: true,
+        })
+    })
+    beforeEach(() => reloadTestingDatabases(dataSources))
+    after(() => closeTestingConnections(dataSources))
+
+    async function prepareData(connection: DataSource) {
+        const category = new Category()
+        category.name = "Test Category"
+        await connection.manager.save(category)
+
+        const post = new Post()
+        post.title = "Test Post"
+        post.text = "Some text"
+        post.category = category
+        await connection.manager.save(post)
+
+        return { category, post }
+    }
+
+    it("should throw for null values in EntityManager.update() when not configured", async () => {
+        for (const connection of dataSources) {
+            await prepareData(connection)
+
+            try {
+                await connection.manager.update(
+                    Post,
+                    invalidCriteria<Post>({ text: null }),
+                    { title: "Updated" },
+                )
+                expect.fail("Expected error")
+            } catch (error) {
+                expect(error).to.be.instanceOf(TypeORMError)
+                expect(error.message).to.include("Null value encountered")
+            }
+        }
+    })
+
+    it("should throw for undefined values in EntityManager.delete() when not configured", async () => {
+        for (const connection of dataSources) {
+            await prepareData(connection)
+
+            try {
+                await connection.manager.delete(
+                    Post,
+                    invalidCriteria<Post>({
+                        text: undefined,
+                    }),
+                )
+                expect.fail("Expected error")
+            } catch (error) {
+                expect(error).to.be.instanceOf(TypeORMError)
+                expect(error.message).to.include("Undefined value encountered")
+            }
+        }
+    })
+
+    it("should throw for null values in EntityManager.softDelete() when not configured", async () => {
+        for (const connection of dataSources) {
+            await prepareData(connection)
+
+            try {
+                await connection.manager.softDelete(
+                    Post,
+                    invalidCriteria<Post>({
+                        text: null,
+                    }),
+                )
+                expect.fail("Expected error")
+            } catch (error) {
+                expect(error).to.be.instanceOf(TypeORMError)
+                expect(error.message).to.include("Null value encountered")
+            }
+        }
+    })
+
+    it("should throw for undefined values in EntityManager.restore() when not configured", async () => {
+        for (const connection of dataSources) {
+            await prepareData(connection)
+
+            try {
+                await connection.manager.restore(
+                    Post,
+                    invalidCriteria<Post>({
+                        text: undefined,
+                    }),
+                )
+                expect.fail("Expected error")
+            } catch (error) {
+                expect(error).to.be.instanceOf(TypeORMError)
+                expect(error.message).to.include("Undefined value encountered")
+            }
+        }
+    })
+
+    it("should reject prototype-polluting keys in EntityManager.delete() when not configured", async () => {
+        for (const connection of dataSources) {
+            await prepareData(connection)
+
+            const dangerousCriteria: unknown[] = [
+                JSON.parse('{ "__proto__": { "polluted": true } }'),
+                JSON.parse('{ "constructor": { "polluted": true } }'),
+                JSON.parse('{ "prototype": { "polluted": true } }'),
+                JSON.parse(
+                    '{ "category": { "__proto__": { "polluted": true } } }',
+                ),
+            ]
+
+            for (const criteria of dangerousCriteria) {
+                try {
+                    await connection.manager.delete(
+                        Post,
+                        invalidCriteria<Post>(criteria),
+                    )
+                    expect.fail("Expected error")
+                } catch (error) {
+                    expect(error).to.be.instanceOf(TypeORMError)
+                    expect(error.message).to.include(
+                        "Prototype-polluting property",
+                    )
+                    expect(({} as Record<string, unknown>).polluted).to.be
+                        .undefined
+                }
+            }
+        }
+    })
+})
 
 describe("entity manager > invalidWhereValuesBehavior with throw", () => {
     let dataSources: DataSource[]


### PR DESCRIPTION
Fixes #12578

/claim #12578

## Summary

`OrmUtils.normalizeWhereCriteria()` already defaults `null` and `undefined` handling to `"throw"`, but an early return skipped all validation when `invalidWhereValuesBehavior` was not configured. This made update/delete/softDelete/restore criteria silently accept invalid `null` or `undefined` values despite the documented default behavior.

This PR removes that early return so unconfigured data sources use the existing default throw branches.

## Tests

Added functional coverage for the unconfigured default behavior across:
- `EntityManager.update()` with `null`
- `EntityManager.delete()` with `undefined`
- `EntityManager.softDelete()` with `null`
- `EntityManager.restore()` with `undefined`

Validation run locally:
- `corepack pnpm run compile` passes

I could not complete the focused Mocha run locally because this machine is on Node `v20.11.1`, while the repo now requires `^20.19.0 || ^22.13.0 || >=24.11.0`; the compiled test runner fails in Chai setup with `ERR_REQUIRE_ESM` under this older Node version.