### PR TITLE
fix: default invalid where values behavior to throw

### DIFF
--- a/src/entity-manager/EntityManager.ts
+++ b/src/entity-manager/EntityManager.ts
@@ -870,10 +870,15 @@ export class EntityManager {
 
             return qb.execute()
         } else {
-            const normalizedCriteria = OrmUtils.normalizeWhereCriteria(
-                criteria as ObjectLiteral | ObjectLiteral[],
-                this.dataSource.options.invalidWhereValuesBehavior,
-            )
+            let normalizedCriteria: any
+            try {
+                normalizedCriteria = OrmUtils.normalizeWhereCriteria(
+                    criteria as ObjectLiteral | ObjectLiteral[],
+                    this.dataSource.options.invalidWhereValuesBehavior,
+                )
+            } catch (err) {
+                return Promise.reject(err)
+            }
             if (OrmUtils.isCriteriaNullOrEmpty(normalizedCriteria)) {
                 return Promise.reject(
                     new TypeORMError(
@@ -958,10 +963,15 @@ export class EntityManager {
                 .whereInIds(criteria)
                 .execute()
         } else {
-            const normalizedCriteria = OrmUtils.normalizeWhereCriteria(
-                criteria as ObjectLiteral | ObjectLiteral[],
-                this.dataSource.options.invalidWhereValuesBehavior,
-            )
+            let normalizedCriteria: any
+            try {
+                normalizedCriteria = OrmUtils.normalizeWhereCriteria(
+                    criteria as ObjectLiteral | ObjectLiteral[],
+                    this.dataSource.options.invalidWhereValuesBehavior,
+                )
+            } catch (err) {
+                return Promise.reject(err)
+            }
             if (OrmUtils.isCriteriaNullOrEmpty(normalizedCriteria)) {
                 return Promise.reject(
                     new TypeORMError(
@@ -1031,10 +1041,15 @@ export class EntityManager {
                 .whereInIds(criteria)
                 .execute()
         } else {
-            const normalizedCriteria = OrmUtils.normalizeWhereCriteria(
-                criteria as ObjectLiteral | ObjectLiteral[],
-                this.dataSource.options.invalidWhereValuesBehavior,
-            )
+            let normalizedCriteria: any
+            try {
+                normalizedCriteria = OrmUtils.normalizeWhereCriteria(
+                    criteria as ObjectLiteral | ObjectLiteral[],
+                    this.dataSource.options.invalidWhereValuesBehavior,
+                )
+            } catch (err) {
+                return Promise.reject(err)
+            }
             if (OrmUtils.isCriteriaNullOrEmpty(normalizedCriteria)) {
                 return Promise.reject(
                     new TypeORMError(
@@ -1089,10 +1104,15 @@ export class EntityManager {
                 .whereInIds(criteria)
                 .execute()
         } else {
-            const normalizedCriteria = OrmUtils.normalizeWhereCriteria(
-                criteria as ObjectLiteral | ObjectLiteral[],
-                this.dataSource.options.invalidWhereValuesBehavior,
-            )
+            let normalizedCriteria: any
+            try {
+                normalizedCriteria = OrmUtils.normalizeWhereCriteria(
+                    criteria as ObjectLiteral | ObjectLiteral[],
+                    this.dataSource.options.invalidWhereValuesBehavior,
+                )
+            } catch (err) {
+                return Promise.reject(err)
+            }
             if (OrmUtils.isCriteriaNullOrEmpty(normalizedCriteria)) {
                 return Promise.reject(
                     new TypeORMError(

--- a/src/entity-manager/EntityManager.ts
+++ b/src/entity-manager/EntityManager.ts
@@ -874,6 +874,13 @@ export class EntityManager {
                 criteria as ObjectLiteral | ObjectLiteral[],
                 this.dataSource.options.invalidWhereValuesBehavior,
             )
+            if (OrmUtils.isCriteriaNullOrEmpty(normalizedCriteria)) {
+                return Promise.reject(
+                    new TypeORMError(
+                        `Empty criteria(s) are not allowed for the update method.`,
+                    ),
+                )
+            }
             const qb = this.createQueryBuilder()
                 .update(target)
                 .set(partialEntity)
@@ -955,6 +962,13 @@ export class EntityManager {
                 criteria as ObjectLiteral | ObjectLiteral[],
                 this.dataSource.options.invalidWhereValuesBehavior,
             )
+            if (OrmUtils.isCriteriaNullOrEmpty(normalizedCriteria)) {
+                return Promise.reject(
+                    new TypeORMError(
+                        `Empty criteria(s) are not allowed for the delete method.`,
+                    ),
+                )
+            }
             return this.createQueryBuilder()
                 .delete()
                 .from(targetOrEntity)
@@ -1021,6 +1035,13 @@ export class EntityManager {
                 criteria as ObjectLiteral | ObjectLiteral[],
                 this.dataSource.options.invalidWhereValuesBehavior,
             )
+            if (OrmUtils.isCriteriaNullOrEmpty(normalizedCriteria)) {
+                return Promise.reject(
+                    new TypeORMError(
+                        `Empty criteria(s) are not allowed for the softDelete method.`,
+                    ),
+                )
+            }
             return this.createQueryBuilder()
                 .softDelete()
                 .from(targetOrEntity)
@@ -1072,6 +1093,13 @@ export class EntityManager {
                 criteria as ObjectLiteral | ObjectLiteral[],
                 this.dataSource.options.invalidWhereValuesBehavior,
             )
+            if (OrmUtils.isCriteriaNullOrEmpty(normalizedCriteria)) {
+                return Promise.reject(
+                    new TypeORMError(
+                        `Empty criteria(s) are not allowed for the restore method.`,
+                    ),
+                )
+            }
             return this.createQueryBuilder()
                 .restore()
                 .from(targetOrEntity)

--- a/src/util/OrmUtils.ts
+++ b/src/util/OrmUtils.ts
@@ -682,6 +682,15 @@ export class OrmUtils {
 
         const result: ObjectLiteral = {}
         for (const [key, value] of Object.entries(criteria)) {
+            if (
+                key === "__proto__" ||
+                key === "constructor" ||
+                key === "prototype"
+            ) {
+                throw new TypeORMError(
+                    `Prototype pollution key '${key}' is not allowed in where criteria.`,
+                )
+            }
             const propertyPath = path ? `${path}.${key}` : key
 
             if (value === undefined) {

--- a/src/util/OrmUtils.ts
+++ b/src/util/OrmUtils.ts
@@ -662,20 +662,22 @@ export class OrmUtils {
         options?: InvalidFindOptionsWhereBehavior,
         path?: string,
     ): ObjectLiteral | ObjectLiteral[] {
-        if (!options) {
-            return criteria
+        const normalizedOptions = options ?? {
+            null: "throw",
+            undefined: "throw",
         }
 
         // multiple criteria are possible at the top level
         if (!path && Array.isArray(criteria)) {
-            return criteria.map(
+            const normalized = criteria.map(
                 (criterion, index): ObjectLiteral =>
                     OrmUtils.normalizeWhereCriteria(
                         criterion,
-                        options,
+                        normalizedOptions,
                         String(index),
-                    ),
+                    ) as ObjectLiteral,
             )
+            return normalized.filter((c) => Object.keys(c).length > 0)
         }
 
         const result: ObjectLiteral = {}
@@ -683,7 +685,7 @@ export class OrmUtils {
             const propertyPath = path ? `${path}.${key}` : key
 
             if (value === undefined) {
-                const behavior = options?.undefined ?? "throw"
+                const behavior = normalizedOptions.undefined ?? "throw"
                 if (behavior === "throw") {
                     throw new TypeORMError(
                         `Undefined value encountered in property '${propertyPath}' of a where condition. ` +
@@ -692,7 +694,7 @@ export class OrmUtils {
                 }
                 // else: "ignore" — skip this key
             } else if (value === null) {
-                const behavior = options?.null ?? "throw"
+                const behavior = normalizedOptions.null ?? "throw"
                 if (behavior === "throw") {
                     throw new TypeORMError(
                         `Null value encountered in property '${propertyPath}' of a where condition. ` +
@@ -706,7 +708,7 @@ export class OrmUtils {
             } else if (OrmUtils.isPlainObject(value)) {
                 const nested = OrmUtils.normalizeWhereCriteria(
                     value,
-                    options,
+                    normalizedOptions,
                     propertyPath,
                 )
                 if (Object.keys(nested).length > 0) {

--- a/test/github-issues/12578/entity/Post.ts
+++ b/test/github-issues/12578/entity/Post.ts
@@ -1,0 +1,21 @@
+import {
+    Entity,
+    PrimaryGeneratedColumn,
+    Column,
+    DeleteDateColumn,
+} from "../../../../src"
+
+@Entity()
+export class Post {
+    @PrimaryGeneratedColumn()
+    id: number
+
+    @Column({ nullable: true })
+    title: string
+
+    @Column({ nullable: true })
+    description: string
+
+    @DeleteDateColumn()
+    deletedAt?: Date
+}

--- a/test/github-issues/12578/issue-12578.test.ts
+++ b/test/github-issues/12578/issue-12578.test.ts
@@ -1,0 +1,154 @@
+import "reflect-metadata"
+import { expect } from "chai"
+import type { DataSource } from "../../../src"
+import { OrmUtils } from "../../../src/util/OrmUtils"
+import { TypeORMError } from "../../../src/error"
+import {
+    closeTestingConnections,
+    createTestingConnections,
+    reloadTestingDatabases,
+} from "../../utils/test-utils"
+import { Post } from "./entity/Post"
+
+describe("github issues > #12578 default invalidWhereValuesBehavior is throw", () => {
+    describe("OrmUtils.normalizeWhereCriteria", () => {
+        it("should throw on undefined by default", () => {
+            expect(() => {
+                OrmUtils.normalizeWhereCriteria({ title: undefined })
+            }).to.throw(TypeORMError, /Undefined value encountered/)
+        })
+
+        it("should throw on null by default", () => {
+            expect(() => {
+                OrmUtils.normalizeWhereCriteria({ title: null })
+            }).to.throw(TypeORMError, /Null value encountered/)
+        })
+
+        it("should respect options if provided", () => {
+            const res1 = OrmUtils.normalizeWhereCriteria(
+                { title: undefined },
+                { undefined: "ignore" },
+            )
+            expect(res1).to.deep.equal({})
+
+            const res2 = OrmUtils.normalizeWhereCriteria(
+                { title: null },
+                { null: "ignore" },
+            )
+            expect(res2).to.deep.equal({})
+        })
+    })
+
+    describe("EntityManager mutation safety guards", () => {
+        let dataSources: DataSource[]
+
+        before(async () => {
+            dataSources = await createTestingConnections({
+                entities: [Post],
+                schemaCreate: true,
+                dropSchema: true,
+                enabledDrivers: ["better-sqlite3", "sqljs"],
+            })
+        })
+        beforeEach(() => reloadTestingDatabases(dataSources))
+        after(() => closeTestingConnections(dataSources))
+
+        it("should throw when updating with criteria that normalizes to empty", () =>
+            Promise.all(
+                dataSources.map(async (dataSource) => {
+                    const manager = dataSource.manager
+
+                    // Default behavior throws on undefined
+                    await expect(
+                        Promise.resolve().then(() =>
+                            manager.update(
+                                Post,
+                                { title: undefined },
+                                { description: "updated" },
+                            ),
+                        ),
+                    ).to.be.rejectedWith(TypeORMError)
+                }),
+            ))
+
+        it("should throw when updating with criteria that normalizes to empty under ignore options", () =>
+            Promise.all(
+                dataSources.map(async (dataSource) => {
+                    ;(dataSource.options as any).invalidWhereValuesBehavior = {
+                        undefined: "ignore",
+                    }
+                    const manager = dataSource.manager
+
+                    await expect(
+                        Promise.resolve().then(() =>
+                            manager.update(
+                                Post,
+                                { title: undefined },
+                                { description: "updated" },
+                            ),
+                        ),
+                    ).to.be.rejectedWith(TypeORMError, /Empty criteria/)
+
+                    delete (dataSource.options as any)
+                        .invalidWhereValuesBehavior
+                }),
+            ))
+
+        it("should throw when deleting with criteria that normalizes to empty", () =>
+            Promise.all(
+                dataSources.map(async (dataSource) => {
+                    ;(dataSource.options as any).invalidWhereValuesBehavior = {
+                        undefined: "ignore",
+                    }
+                    const manager = dataSource.manager
+
+                    await expect(
+                        Promise.resolve().then(() =>
+                            manager.delete(Post, { title: undefined }),
+                        ),
+                    ).to.be.rejectedWith(TypeORMError, /Empty criteria/)
+
+                    delete (dataSource.options as any)
+                        .invalidWhereValuesBehavior
+                }),
+            ))
+
+        it("should throw when softDeleting with criteria that normalizes to empty", () =>
+            Promise.all(
+                dataSources.map(async (dataSource) => {
+                    ;(dataSource.options as any).invalidWhereValuesBehavior = {
+                        undefined: "ignore",
+                    }
+                    const manager = dataSource.manager
+
+                    await expect(
+                        Promise.resolve().then(() =>
+                            manager.softDelete(Post, { title: undefined }),
+                        ),
+                    ).to.be.rejectedWith(TypeORMError, /Empty criteria/)
+
+                    delete (dataSource.options as any)
+                        .invalidWhereValuesBehavior
+                }),
+            ))
+
+        it("should throw when restoring with criteria that normalizes to empty", () =>
+            Promise.all(
+                dataSources.map(async (dataSource) => {
+                    ;(dataSource.options as any).invalidWhereValuesBehavior = {
+                        undefined: "ignore",
+                    }
+                    const manager = dataSource.manager
+
+                    await expect(
+                        Promise.resolve().then(() =>
+                            manager.restore(Post, { title: undefined }),
+                        ),
+                    ).to.be.rejectedWith(TypeORMError, /Empty criteria/)
+
+                    delete (dataSource.options as any)
+                        .invalidWhereValuesBehavior
+                }),
+            ))
+    })
+})

--- a/test/github-issues/12578/issue-12578.test.ts
+++ b/test/github-issues/12578/issue-12578.test.ts
@@ -37,6 +37,31 @@ describe("github issues > #12578 default invalidWhereValuesBehavior is throw", (
             )
             expect(res2).to.deep.equal({})
         })
+
+        it("should throw on prototype pollution keys", () => {
+            const pollution1 = JSON.parse('{"__proto__": {"corrupted": true}}')
+            expect(() => {
+                OrmUtils.normalizeWhereCriteria(pollution1)
+            }).to.throw(TypeORMError, /Prototype pollution key/)
+
+            const pollution2 = {}
+            Object.defineProperty(pollution2, "constructor", {
+                value: {},
+                enumerable: true,
+            })
+            expect(() => {
+                OrmUtils.normalizeWhereCriteria(pollution2)
+            }).to.throw(TypeORMError, /Prototype pollution key/)
+
+            const pollution3 = {}
+            Object.defineProperty(pollution3, "prototype", {
+                value: {},
+                enumerable: true,
+            })
+            expect(() => {
+                OrmUtils.normalizeWhereCriteria(pollution3)
+            }).to.throw(TypeORMError, /Prototype pollution key/)
+        })
     })
 
     describe("EntityManager mutation safety guards", () => {
@@ -59,13 +84,12 @@ describe("github issues > #12578 default invalidWhereValuesBehavior is throw", (
                     const manager = dataSource.manager
 
                     // Default behavior throws on undefined
+                    // Verifies it returns a rejected promise and does not throw synchronously
                     await expect(
-                        Promise.resolve().then(() =>
-                            manager.update(
-                                Post,
-                                { title: undefined },
-                                { description: "updated" },
-                            ),
+                        manager.update(
+                            Post,
+                            { title: undefined },
+                            { description: "updated" },
                         ),
                     ).to.be.rejectedWith(TypeORMError)
                 }),
@@ -74,80 +98,92 @@ describe("github issues > #12578 default invalidWhereValuesBehavior is throw", (
         it("should throw when updating with criteria that normalizes to empty under ignore options", () =>
             Promise.all(
                 dataSources.map(async (dataSource) => {
-                    ;(dataSource.options as any).invalidWhereValuesBehavior = {
-                        undefined: "ignore",
+                    const options = dataSource.options as {
+                        invalidWhereValuesBehavior?: typeof dataSource.options.invalidWhereValuesBehavior
                     }
-                    const manager = dataSource.manager
+                    const originalBehavior = options.invalidWhereValuesBehavior
+                    try {
+                        options.invalidWhereValuesBehavior = {
+                            undefined: "ignore",
+                        }
+                        const manager = dataSource.manager
 
-                    await expect(
-                        Promise.resolve().then(() =>
+                        await expect(
                             manager.update(
                                 Post,
                                 { title: undefined },
                                 { description: "updated" },
                             ),
-                        ),
-                    ).to.be.rejectedWith(TypeORMError, /Empty criteria/)
-
-                    delete (dataSource.options as any)
-                        .invalidWhereValuesBehavior
+                        ).to.be.rejectedWith(TypeORMError, /Empty criteria/)
+                    } finally {
+                        options.invalidWhereValuesBehavior = originalBehavior
+                    }
                 }),
             ))
 
         it("should throw when deleting with criteria that normalizes to empty", () =>
             Promise.all(
                 dataSources.map(async (dataSource) => {
-                    ;(dataSource.options as any).invalidWhereValuesBehavior = {
-                        undefined: "ignore",
+                    const options = dataSource.options as {
+                        invalidWhereValuesBehavior?: typeof dataSource.options.invalidWhereValuesBehavior
                     }
-                    const manager = dataSource.manager
+                    const originalBehavior = options.invalidWhereValuesBehavior
+                    try {
+                        options.invalidWhereValuesBehavior = {
+                            undefined: "ignore",
+                        }
+                        const manager = dataSource.manager
 
-                    await expect(
-                        Promise.resolve().then(() =>
+                        await expect(
                             manager.delete(Post, { title: undefined }),
-                        ),
-                    ).to.be.rejectedWith(TypeORMError, /Empty criteria/)
-
-                    delete (dataSource.options as any)
-                        .invalidWhereValuesBehavior
+                        ).to.be.rejectedWith(TypeORMError, /Empty criteria/)
+                    } finally {
+                        options.invalidWhereValuesBehavior = originalBehavior
+                    }
                 }),
             ))
 
         it("should throw when softDeleting with criteria that normalizes to empty", () =>
             Promise.all(
                 dataSources.map(async (dataSource) => {
-                    ;(dataSource.options as any).invalidWhereValuesBehavior = {
-                        undefined: "ignore",
+                    const options = dataSource.options as {
+                        invalidWhereValuesBehavior?: typeof dataSource.options.invalidWhereValuesBehavior
                     }
-                    const manager = dataSource.manager
+                    const originalBehavior = options.invalidWhereValuesBehavior
+                    try {
+                        options.invalidWhereValuesBehavior = {
+                            undefined: "ignore",
+                        }
+                        const manager = dataSource.manager
 
-                    await expect(
-                        Promise.resolve().then(() =>
+                        await expect(
                             manager.softDelete(Post, { title: undefined }),
-                        ),
-                    ).to.be.rejectedWith(TypeORMError, /Empty criteria/)
-
-                    delete (dataSource.options as any)
-                        .invalidWhereValuesBehavior
+                        ).to.be.rejectedWith(TypeORMError, /Empty criteria/)
+                    } finally {
+                        options.invalidWhereValuesBehavior = originalBehavior
+                    }
                 }),
             ))
 
         it("should throw when restoring with criteria that normalizes to empty", () =>
             Promise.all(
                 dataSources.map(async (dataSource) => {
-                    ;(dataSource.options as any).invalidWhereValuesBehavior = {
-                        undefined: "ignore",
+                    const options = dataSource.options as {
+                        invalidWhereValuesBehavior?: typeof dataSource.options.invalidWhereValuesBehavior
                     }
-                    const manager = dataSource.manager
+                    const originalBehavior = options.invalidWhereValuesBehavior
+                    try {
+                        options.invalidWhereValuesBehavior = {
+                            undefined: "ignore",
+                        }
+                        const manager = dataSource.manager
 
-                    await expect(
-                        Promise.resolve().then(() =>
+                        await expect(
                             manager.restore(Post, { title: undefined }),
-                        ),
-                    ).to.be.rejectedWith(TypeORMError, /Empty criteria/)
-
-                    delete (dataSource.options as any)
-                        .invalidWhereValuesBehavior
+                        ).to.be.rejectedWith(TypeORMError, /Empty criteria/)
+                    } finally {
+                        options.invalidWhereValuesBehavior = originalBehavior
+                    }
                 }),
             ))
     })


### PR DESCRIPTION
This PR resolves #12578 by:\n1. Restoring the documented default behavior for invalidWhereValuesBehavior (defaulting to throw TypeORMError on null and undefined when options are omitted).\n2. Adding strict safety checks in EntityManager (update, delete, softDelete, and restore) to reject criteria that normalize to an empty object, preventing accidental unscoped mass mutation queries.