### PR TITLE
fix: apply default invalid where value behavior in normalizeWhereCriteria

### DIFF
--- a/src/util/OrmUtils.ts
+++ b/src/util/OrmUtils.ts
@@ -662,10 +662,6 @@ export class OrmUtils {
         options?: InvalidFindOptionsWhereBehavior,
         path?: string,
     ): ObjectLiteral | ObjectLiteral[] {
-        if (!options) {
-            return criteria
-        }
-
         // multiple criteria are possible at the top level
         if (!path && Array.isArray(criteria)) {
             return criteria.map(

--- a/test/functional/null-undefined-handling/query-builders.test.ts
+++ b/test/functional/null-undefined-handling/query-builders.test.ts
@@ -9,6 +9,67 @@ import {
 import { Category } from "./entity/Category"
 import { Post } from "./entity/Post"
 
+describe("entity manager > invalidWhereValuesBehavior with default behavior", () => {
+    let dataSources: DataSource[]
+
+    before(async () => {
+        dataSources = await createTestingConnections({
+            disabledDrivers: ["spanner"],
+            entities: [Post, Category],
+            schemaCreate: true,
+            dropSchema: true,
+        })
+    })
+    beforeEach(() => reloadTestingDatabases(dataSources))
+    after(() => closeTestingConnections(dataSources))
+
+    async function prepareData(connection: DataSource) {
+        const category = new Category()
+        category.name = "Test Category"
+        await connection.manager.save(category)
+
+        const post = new Post()
+        post.title = "Test Post"
+        post.text = "Some text"
+        post.category = category
+        await connection.manager.save(post)
+    }
+
+    it("should throw error for null values in EntityManager.update() by default", async () => {
+        for (const connection of dataSources) {
+            await prepareData(connection)
+
+            try {
+                await connection.manager.update(Post, { text: null } as any, {
+                    title: "Updated",
+                })
+                expect.fail("Expected error")
+            } catch (error) {
+                expect(error).to.be.instanceOf(TypeORMError)
+                expect(error.message).to.include("Null value encountered")
+            }
+        }
+    })
+
+    it("should throw error for undefined values in EntityManager.update() by default", async () => {
+        for (const connection of dataSources) {
+            await prepareData(connection)
+
+            try {
+                await connection.manager.update(
+                    Post,
+                    { text: undefined } as any,
+                    { title: "Updated" },
+                )
+                expect.fail("Expected error")
+            } catch (error) {
+                expect(error).to.be.instanceOf(TypeORMError)
+                expect(error.message).to.include("Undefined value encountered")
+            }
+        }
+    })
+})
+
 describe("entity manager > invalidWhereValuesBehavior with throw", () => {
     let dataSources: DataSource[]
 


### PR DESCRIPTION
Fixes #12578.

## Summary

`OrmUtils.normalizeWhereCriteria()` returned the input criteria unchanged whenever `options` was omitted, so the documented default behavior for `invalidWhereValuesBehavior` was not applied. This meant the helper did not throw for nullish where values even though the default behavior should be `throw` for both `null` and `undefined`.

This change lets the method fall through to its existing default behavior map when no options object is provided, while preserving explicit option overrides.

The regression coverage now lives in the existing functional `null-undefined-handling` suite instead of a per-issue test file.

## Validation

Using a temporary local `ormconfig.json` with the `sqljs` driver:

- `cmd /c node_modules\.bin\mocha.cmd --no-config --require ts-node/register test\functional\null-undefined-handling\query-builders.test.ts --grep "default behavior"` -> `2 passing`
- `cmd /c node_modules\.bin\mocha.cmd --no-config --require ts-node/register test\functional\null-undefined-handling\query-builders.test.ts --grep "with throw"` -> `12 passing`
- `cmd /c node_modules\.bin\mocha.cmd --no-config --require ts-node/register test\functional\null-undefined-handling\query-builders.test.ts` -> `22 passing`
- `git diff --check`