### PR TITLE
fix: apply defix: Apply default throw behavior in OrmUtils.normalizeWhereCriteria()

### DIFF
--- a/src/util/OrmUtils.ts
+++ b/src/util/OrmUtils.ts
@@ -662,8 +662,14 @@ export class OrmUtils {
         options?: InvalidFindOptionsWhereBehavior,
         path?: string,
     ): ObjectLiteral | ObjectLiteral[] {
-        if (!options) {
-            return criteria
+        // Fix #12578: when `options` is not provided, apply the documented
+        // default behavior: both null and undefined values must throw.
+        // Previously, `if (!options) return criteria` caused all validation
+        // to be skipped silently when no DataSource invalidWhereValuesBehavior
+        // was configured — leading to dangerous unscoped UPDATE/DELETE queries.
+        const resolvedOptions: InvalidFindOptionsWhereBehavior = options ?? {
+            null: "throw",
+            undefined: "throw",
         }
 
         // multiple criteria are possible at the top level
@@ -672,7 +678,7 @@ export class OrmUtils {
                 (criterion, index): ObjectLiteral =>
                     OrmUtils.normalizeWhereCriteria(
                         criterion,
-                        options,
+                        resolvedOptions,
                         String(index),
                     ),
             )
@@ -683,7 +689,7 @@ export class OrmUtils {
             const propertyPath = path ? `${path}.${key}` : key
 
             if (value === undefined) {
-                const behavior = options?.undefined ?? "throw"
+                const behavior = resolvedOptions.undefined ?? "throw"
                 if (behavior === "throw") {
                     throw new TypeORMError(
                         `Undefined value encountered in property '${propertyPath}' of a where condition. ` +
@@ -692,7 +698,7 @@ export class OrmUtils {
                 }
                 // else: "ignore" — skip this key
             } else if (value === null) {
-                const behavior = options?.null ?? "throw"
+                const behavior = resolvedOptions.null ?? "throw"
                 if (behavior === "throw") {
                     throw new TypeORMError(
                         `Null value encountered in property '${propertyPath}' of a where condition. ` +
@@ -706,7 +712,7 @@ export class OrmUtils {
             } else if (OrmUtils.isPlainObject(value)) {
                 const nested = OrmUtils.normalizeWhereCriteria(
                     value,
-                    options,
+                    resolvedOptions,
                     propertyPath,
                 )
                 if (Object.keys(nested).length > 0) {


### PR DESCRIPTION
Fixes #12578

### Description of change

According to the TypeORM documentation, when `invalidWhereValuesBehavior` is not configured in a `DataSource`, the default behavior should be `"throw"` — meaning `null` and `undefined` values in WHERE clauses should raise a `TypeORMError`.

However, the current implementation of `OrmUtils.normalizeWhereCriteria()` has an early return when `options` is not provided (`if (!options) return criteria`), which silently bypasses null/undefined validation. This means that when no `invalidWhereValuesBehavior` is set (the default case), ALL null/undefined values in WHERE clauses are silently ignored.

This PR fixes the bug by applying the documented default behavior `{ null: "throw", undefined: "throw" }` when options are not explicitly configured in the DataSource.

**Before:**
```typescript
static normalizeWhereCriteria(criteria, options?, path?) {
    if (!options) return criteria // ← silently skips validation
    // ...
}

After:

static normalizeWhereCriteria(criteria, options?, path?) {
    const resolvedOptions = options ?? {
        null: "throw",
        undefined: "throw",
    }
    // ... uses resolvedOptions throughout
}

