### PR TITLE
fix: normalizeWhereCriteria should apply default behaviors

### DIFF
--- a/src/util/OrmUtils.ts
+++ b/src/util/OrmUtils.ts
@@ -662,9 +662,7 @@ export class OrmUtils {
         options?: InvalidFindOptionsWhereBehavior,
         path?: string,
     ): ObjectLiteral | ObjectLiteral[] {
-        if (!options) {
-            return criteria
-        }
+        options = options ?? {}
 
         // multiple criteria are possible at the top level
         if (!path && Array.isArray(criteria)) {

--- a/test/unit/util/orm-utils.test.ts
+++ b/test/unit/util/orm-utils.test.ts
@@ -270,4 +270,38 @@ describe(`OrmUtils`, () => {
             ).to.equal(false)
         })
     })
+    describe("normalizeWhereCriteria", () => {
+        it("should throw by default if criteria contains undefined and options are not provided", () => {
+            expect(() => {
+                OrmUtils.normalizeWhereCriteria({ name: undefined })
+            }).to.throw(
+                "Undefined value encountered in property 'name' of a where condition.",
+            )
+        })
+
+        it("should throw by default if criteria contains null and options are not provided", () => {
+            expect(() => {
+                OrmUtils.normalizeWhereCriteria({ name: null })
+            }).to.throw(
+                "Null value encountered in property 'name' of a where condition.",
+            )
+        })
+
+        it("should not throw if criteria contains undefined and undefined behavior is ignore", () => {
+            expect(() => {
+                OrmUtils.normalizeWhereCriteria(
+                    { name: undefined },
+                    { undefined: "ignore" },
+                )
+            }).not.to.throw()
+        })
+
+        it("should ignore undefined values when behavior is ignore", () => {
+            const result = OrmUtils.normalizeWhereCriteria(
+                { name: undefined, age: 30 },
+                { undefined: "ignore" },
+            )
+            expect(result).to.deep.equal({ age: 30 })
+        })
+    })
 })


### PR DESCRIPTION
Resolves #12578.

If `invalidWhereValuesBehavior` is not set, `normalizeWhereCriteria` was returning the criteria directly instead of applying the default `throw` behavior for undefined and null values. This PR defaults `options` to an empty object, allowing the normal validation rules to apply. 

/opire try