### PR TITLE
fix: apply default invalidWhereValuesBehavior in normalizeWhereCriteria

### DIFF
--- a/src/util/OrmUtils.ts
+++ b/src/util/OrmUtils.ts
@@ -380,7 +380,7 @@ export class OrmUtils {
     }
 
     /**
-     * Checks whether the given criteria is null or wholly empty — `null`,
+     * Checks whether the given criteria is null or wholly empty â€” `null`,
      * `undefined`, `""`, an empty array, or an empty plain object. Does not
      * recurse into array elements, so it is safe on self-referential/cyclic
      * arrays. Per-element OR-branch emptiness (an array containing an empty
@@ -658,8 +658,8 @@ export class OrmUtils {
      * each own key a null/undefined value is thrown on, skipped, or converted
      * to IsNull() per the configured behavior. Only plain FindOptionsWhere
      * objects are normalized; anything else (entity/class instances,
-     * FindOperators, arrays, Date, Buffer, primitives) — and the criteria when
-     * no behavior is configured — is returned untouched.
+     * FindOperators, arrays, Date, Buffer, primitives) is returned untouched.
+     * When no behavior is configured, null and undefined throw by default.
      *
      * @param criteria
      * @param options
@@ -670,10 +670,6 @@ export class OrmUtils {
         options?: InvalidFindOptionsWhereBehavior,
         path?: string,
     ): any {
-        if (!options) {
-            return criteria
-        }
-
         // multiple criteria are possible at the top level
         if (!path && Array.isArray(criteria)) {
             return criteria.map(
@@ -686,8 +682,8 @@ export class OrmUtils {
             )
         }
 
-        // Only iterate a plain object criteria. Anything else — an entity/class
-        // instance, a FindOperator, an array, Date, Buffer, a primitive — is
+        // Only iterate a plain object criteria. Anything else â€” an entity/class
+        // instance, a FindOperator, an array, Date, Buffer, a primitive â€” is
         // passed through untouched (its keys are not a bag of column
         // conditions). Validating those properly would need entity metadata,
         // which is out of scope here.
@@ -708,7 +704,7 @@ export class OrmUtils {
                             `Set 'invalidWhereValuesBehavior.undefined' to 'ignore' in connection options to skip properties with undefined values.`,
                     )
                 }
-                // else: "ignore" — skip this key
+                // else: "ignore" â€” skip this key
             } else if (value === null) {
                 const behavior = options?.null ?? "throw"
                 if (behavior === "throw") {
@@ -720,7 +716,7 @@ export class OrmUtils {
                 } else if (behavior === "sql-null") {
                     result[key] = IsNull()
                 }
-                // else: "ignore" — skip this key
+                // else: "ignore" â€” skip this key
             } else if (OrmUtils.isPlainObject(value)) {
                 const nested = OrmUtils.normalizeWhereCriteria(
                     value,

--- a/test/unit/util/orm-utils.test.ts
+++ b/test/unit/util/orm-utils.test.ts
@@ -272,12 +272,16 @@ describe(`OrmUtils`, () => {
     })
 
     describe("normalizeWhereCriteria", () => {
-        it("returns criteria unchanged when no options are provided", () => {
-            const criteria = { name: null, email: undefined }
-            expect(OrmUtils.normalizeWhereCriteria(criteria)).to.equal(criteria)
+        it("throws on null/undefined by default when no options are provided", () => {
+            expect(() =>
+                OrmUtils.normalizeWhereCriteria({ name: undefined }),
+            ).to.throw(/Undefined value.*'name'/)
+            expect(() =>
+                OrmUtils.normalizeWhereCriteria({ email: null }),
+            ).to.throw(/Null value.*'email'/)
         })
 
-        it("throws on null/undefined by default when options are provided", () => {
+        it("throws on null/undefined by default when empty options are provided", () => {
             expect(() =>
                 OrmUtils.normalizeWhereCriteria({ name: undefined }, {}),
             ).to.throw(/Undefined value.*'name'/)
@@ -302,7 +306,7 @@ describe(`OrmUtils`, () => {
             }
             const entity = new User()
             // an entity instance is not a plain object, so it is returned
-            // untouched — its null column is not validated/stripped even under
+            // untouched â€” its null column is not validated/stripped even under
             // "throw" (proper handling would need entity metadata)
             expect(
                 OrmUtils.normalizeWhereCriteria(entity, { null: "throw" }),
@@ -369,7 +373,7 @@ describe(`OrmUtils`, () => {
             // is not empty regardless of its elements. Per-element OR-branch
             // emptiness (e.g. [{}] / [[]]) is enforced where object criteria is
             // validated (EntityManager.normalizeAndValidateWhereCriteria), not
-            // here — this keeps it usable for primitive id-arrays and cheap.
+            // here â€” this keeps it usable for primitive id-arrays and cheap.
             expect(OrmUtils.isCriteriaNullOrEmpty([{}])).to.equal(false)
             expect(OrmUtils.isCriteriaNullOrEmpty([[]])).to.equal(false)
             expect(OrmUtils.isCriteriaNullOrEmpty([{ id: 1 }])).to.equal(false)
@@ -383,7 +387,7 @@ describe(`OrmUtils`, () => {
         it("does not recurse on a self-referential array", () => {
             const cyclic: any[] = []
             cyclic.push(cyclic)
-            // shallow check — must not throw a RangeError and a non-empty
+            // shallow check â€” must not throw a RangeError and a non-empty
             // (self-referential) array is not treated as empty
             expect(OrmUtils.isCriteriaNullOrEmpty(cyclic)).to.equal(false)
         })


### PR DESCRIPTION
Title:
fix: apply default invalidWhereValuesBehavior in normalizeWhereCriteria

Body:
## Summary

- remove the early return from `OrmUtils.normalizeWhereCriteria` when `invalidWhereValuesBehavior` is not configured
- make null and undefined throw by default for plain where criteria, matching the documented TypeORM 1.0 behavior
- update the unit coverage for the no-options case

## Verification

- `.\node_modules\.bin\mocha.cmd --no-config --require ts-node/register --timeout 90000 test/unit/util/orm-utils.test.ts --grep "normalizeWhereCriteria"`
- `.\node_modules\.bin\mocha.cmd --no-config --require ts-node/register --timeout 90000 test/unit/util/orm-utils.test.ts`

Closes #12578
