### PR TITLE
fix: apply default invalid where value behavior

### DIFF
--- a/src/util/OrmUtils.ts
+++ b/src/util/OrmUtils.ts
@@ -656,10 +656,11 @@ export class OrmUtils {
     /**
      * Applies invalidWhereValuesBehavior to a plain-object where criteria: for
      * each own key a null/undefined value is thrown on, skipped, or converted
-     * to IsNull() per the configured behavior. Only plain FindOptionsWhere
-     * objects are normalized; anything else (entity/class instances,
-     * FindOperators, arrays, Date, Buffer, primitives) — and the criteria when
-     * no behavior is configured — is returned untouched.
+     * to IsNull() per the configured behavior. Plain FindOptionsWhere objects
+     * and top-level arrays of them are normalized; anything else
+     * (entity/class instances, FindOperators, Date, Buffer, primitives) is
+     * returned untouched. When no behavior is configured, null and undefined
+     * values default to "throw".
      *
      * @param criteria
      * @param options

--- a/src/util/OrmUtils.ts
+++ b/src/util/OrmUtils.ts
@@ -670,10 +670,6 @@ export class OrmUtils {
         options?: InvalidFindOptionsWhereBehavior,
         path?: string,
     ): any {
-        if (!options) {
-            return criteria
-        }
-
         // multiple criteria are possible at the top level
         if (!path && Array.isArray(criteria)) {
             return criteria.map(

--- a/test/functional/null-undefined-handling/query-builders.test.ts
+++ b/test/functional/null-undefined-handling/query-builders.test.ts
@@ -9,6 +9,53 @@ import {
 import { Category } from "./entity/Category"
 import { Post } from "./entity/Post"
 
+describe("entity manager > invalidWhereValuesBehavior defaults", () => {
+    let dataSources: DataSource[]
+
+    before(async () => {
+        dataSources = await createTestingConnections({
+            disabledDrivers: ["spanner"],
+            entities: [Post, Category],
+            schemaCreate: true,
+            dropSchema: true,
+        })
+    })
+    beforeEach(() => reloadTestingDatabases(dataSources))
+    after(() => closeTestingConnections(dataSources))
+
+    it("should throw error for null values in EntityManager.update() by default", async () => {
+        for (const connection of dataSources) {
+            try {
+                await connection.manager.update(
+                    Post,
+                    { text: null },
+                    { title: "Updated" },
+                )
+                expect.fail("Expected error")
+            } catch (error) {
+                expect(error).to.be.instanceOf(TypeORMError)
+                expect(error.message).to.include("Null value encountered")
+            }
+        }
+    })
+
+    it("should throw error for undefined values in EntityManager.update() by default", async () => {
+        for (const connection of dataSources) {
+            try {
+                await connection.manager.update(
+                    Post,
+                    { text: undefined },
+                    { title: "Updated" },
+                )
+                expect.fail("Expected error")
+            } catch (error) {
+                expect(error).to.be.instanceOf(TypeORMError)
+                expect(error.message).to.include("Undefined value encountered")
+            }
+        }
+    })
+})
+
 describe("entity manager > invalidWhereValuesBehavior with throw", () => {
     let dataSources: DataSource[]
 

--- a/test/unit/util/orm-utils.test.ts
+++ b/test/unit/util/orm-utils.test.ts
@@ -272,9 +272,13 @@ describe(`OrmUtils`, () => {
     })
 
     describe("normalizeWhereCriteria", () => {
-        it("returns criteria unchanged when no options are provided", () => {
-            const criteria = { name: null, email: undefined }
-            expect(OrmUtils.normalizeWhereCriteria(criteria)).to.equal(criteria)
+        it("throws on null/undefined when no options are provided", () => {
+            expect(() =>
+                OrmUtils.normalizeWhereCriteria({ name: undefined }),
+            ).to.throw(/Undefined value.*'name'/)
+            expect(() =>
+                OrmUtils.normalizeWhereCriteria({ email: null }),
+            ).to.throw(/Null value.*'email'/)
         })
 
         it("throws on null/undefined by default when options are provided", () => {


### PR DESCRIPTION
### Description of change

Fixes #12578

When `invalidWhereValuesBehavior` is omitted, `OrmUtils.normalizeWhereCriteria()` now applies its existing default `throw` behavior instead of returning the criteria unchanged. This keeps EntityManager mutation methods aligned with the documented defaults for null and undefined where values.

The regression coverage updates the existing OrmUtils unit suite and adds functional EntityManager.update() coverage for both null and undefined criteria without adding `any` casts or a per-issue test directory.

Validation:
- TypeScript typecheck passes
- Prettier check passes
- ESLint reports no errors
- 83 related unit and functional tests pass with the sql.js driver

/claim #12578

### Pull-Request Checklist

- [x] Code is up-to-date with the `master` branch
- [x] This pull request links a relevant issue using a closing keyword: `Fixes #12578`
- [x] There are new or updated tests validating the change (`tests/**.test.ts`)
- [x] Documentation has been updated to reflect this change — N/A, the documented default is unchanged
