### PR TITLE
fix(query-builder): treat take(0) as a limit when joins are present

### DIFF
--- a/src/query-builder/SelectQueryBuilder.ts
+++ b/src/query-builder/SelectQueryBuilder.ts
@@ -3488,8 +3488,15 @@ export class SelectQueryBuilder<Entity extends ObjectLiteral>
         // where we make two queries to find the data we need
         // first query find ids in skip and take range
         // and second query loads the actual data in given ids range
+        // a take of 0 is a meaningful limit (return no rows), so it must be
+        // detected explicitly rather than through truthiness; a skip of 0 is a
+        // no-op offset, so it is treated as unset (mirrors the checks in lazyCount)
         if (
-            (this.expressionMap.skip || this.expressionMap.take) &&
+            ((this.expressionMap.take !== undefined &&
+                this.expressionMap.take !== null) ||
+                (this.expressionMap.skip !== undefined &&
+                    this.expressionMap.skip !== null &&
+                    this.expressionMap.skip > 0)) &&
             this.expressionMap.joinAttributes.length > 0
         ) {
             // we are skipping order by here because its not working in subqueries anyway

--- a/test/github-issues/12666/entity/Category.ts
+++ b/test/github-issues/12666/entity/Category.ts
@@ -1,0 +1,10 @@
+import { Entity, PrimaryGeneratedColumn, Column } from "../../../../src"
+
+@Entity()
+export class Category {
+    @PrimaryGeneratedColumn()
+    id: number
+
+    @Column()
+    name: string
+}

--- a/test/github-issues/12666/entity/Post.ts
+++ b/test/github-issues/12666/entity/Post.ts
@@ -1,0 +1,21 @@
+import {
+    Entity,
+    PrimaryGeneratedColumn,
+    Column,
+    ManyToMany,
+    JoinTable,
+} from "../../../../src"
+import { Category } from "./Category"
+
+@Entity()
+export class Post {
+    @PrimaryGeneratedColumn()
+    id: number
+
+    @Column()
+    title: string
+
+    @ManyToMany(() => Category)
+    @JoinTable()
+    categories: Category[]
+}

--- a/test/github-issues/12666/issue-12666.test.ts
+++ b/test/github-issues/12666/issue-12666.test.ts
@@ -1,0 +1,98 @@
+import "reflect-metadata"
+import {
+    createTestingConnections,
+    closeTestingConnections,
+    reloadTestingDatabases,
+} from "../../utils/test-utils"
+import type { DataSource } from "../../../src/data-source/DataSource"
+import { expect } from "chai"
+import { Post } from "./entity/Post"
+import { Category } from "./entity/Category"
+
+describe("github issues > #12666 take(0) combined with a join returns all rows instead of an empty array", () => {
+    let dataSources: DataSource[]
+    before(async () => {
+        dataSources = await createTestingConnections({
+            entities: [__dirname + "/entity/*{.js,.ts}"],
+            disabledDrivers: ["spanner"],
+            schemaCreate: true,
+            dropSchema: true,
+        })
+    })
+    beforeEach(async () => {
+        await reloadTestingDatabases(dataSources)
+        await Promise.all(
+            dataSources.map(async (dataSource) => {
+                const categories = await dataSource
+                    .getRepository(Category)
+                    .save([{ name: "a" }, { name: "b" }, { name: "c" }])
+
+                await dataSource.getRepository(Post).save([
+                    {
+                        title: "post #1",
+                        categories: [categories[0], categories[1]],
+                    },
+                    {
+                        title: "post #2",
+                        categories: [categories[1], categories[2]],
+                    },
+                    {
+                        title: "post #3",
+                        categories: [categories[0], categories[2]],
+                    },
+                ])
+            }),
+        )
+    })
+    after(() => closeTestingConnections(dataSources))
+
+    it("should return an empty result set for take(0) with a join, like the no-join path already does", () =>
+        Promise.all(
+            dataSources.map(async (dataSource) => {
+                const withJoin = await dataSource
+                    .createQueryBuilder(Post, "post")
+                    .leftJoinAndSelect("post.categories", "category")
+                    .orderBy("post.id")
+                    .take(0)
+                    .getMany()
+                expect(withJoin).to.have.length(0)
+
+                // sanity: the no-join path is already correct and must stay so
+                const withoutJoin = await dataSource
+                    .createQueryBuilder(Post, "post")
+                    .orderBy("post.id")
+                    .take(0)
+                    .getMany()
+                expect(withoutJoin).to.have.length(0)
+            }),
+        ))
+
+    it("should report zero rows but the full count from getManyAndCount for take(0) with a join", () =>
+        Promise.all(
+            dataSources.map(async (dataSource) => {
+                const [rows, count] = await dataSource
+                    .createQueryBuilder(Post, "post")
+                    .leftJoinAndSelect("post.categories", "category")
+                    .orderBy("post.id")
+                    .take(0)
+                    .getManyAndCount()
+
+                expect(rows).to.have.length(0)
+                expect(count).to.equal(3)
+            }),
+        ))
+
+    it("should still return all rows for skip(0) with a join, since offset 0 is a no-op", () =>
+        Promise.all(
+            dataSources.map(async (dataSource) => {
+                const rows = await dataSource
+                    .createQueryBuilder(Post, "post")
+                    .leftJoinAndSelect("post.categories", "category")
+                    .orderBy("post.id")
+                    .skip(0)
+                    .getMany()
+
+                expect(rows).to.have.length(3)
+            }),
+        ))
+})


### PR DESCRIPTION
### Description of change

`take(0)` combined with a join (e.g. `leftJoinAndSelect`) returned every row instead of an empty result, and `getManyAndCount` returned all rows as the page.

The join pagination branch in `SelectQueryBuilder` is guarded by `(this.expressionMap.skip || this.expressionMap.take)`. With `take(0)`, `take` is `0` (falsy), so the branch is skipped and execution falls through to the plain path — which only copies `skip`/`take` into `limit`/`offset` when there are no joins. With a join present no `LIMIT` is emitted, so all rows come back. The no-join path already emits `LIMIT 0` and returns `[]`.

The fix detects `take`/`skip` the same way the existing `lazyCount` helper in this file does: `take` is set when it is not `undefined`/`null` (so `0` counts as a limit), and `skip` is set only when it is `> 0` (offset `0` is a no-op, so `skip(0)` keeps returning all rows).

### How I verified

Added `test/github-issues/12666`. On `master` the two `take(0)` assertions fail (3 rows instead of 0); with the fix all pass, and `skip(0)` with a join still returns every row. Full sqlite suite passes (3031 passing, 0 failing).

Fixes #12666

_AI-assisted: drafted with Claude, reviewed and verified by me._

### Pull-Request Checklist

- [x] Code is up-to-date with the `master` branch
- [x] This pull request links a relevant issue using a closing keyword: `Fixes #12666`
- [x] There are new or updated tests validating the change (`tests/**.test.ts`)
- [ ] Documentation has been updated to reflect this change (`docs/docs/**.md`) — N/A, bug fix with no documented behavior change
