### PR TITLE
fix: honor take(0) when joins are present

### DIFF
--- a/src/query-builder/SelectQueryBuilder.ts
+++ b/src/query-builder/SelectQueryBuilder.ts
@@ -2995,8 +2995,7 @@ export class SelectQueryBuilder<Entity extends ObjectLiteral>
         ) {
             selectionPath = (
                 this.dataSource.driver as
-                    | AbstractSqliteDriver
-                    | ReactNativeDriver
+                    AbstractSqliteDriver | ReactNativeDriver
             ).wrapWithJsonFunction(selectionPath, column, false)
         }
 
@@ -3490,7 +3489,8 @@ export class SelectQueryBuilder<Entity extends ObjectLiteral>
         // first query find ids in skip and take range
         // and second query loads the actual data in given ids range
         if (
-            (this.expressionMap.skip != null ||
+            ((this.expressionMap.skip != null &&
+                this.expressionMap.skip !== 0) ||
                 this.expressionMap.take != null) &&
             this.expressionMap.joinAttributes.length > 0
         ) {

--- a/src/query-builder/SelectQueryBuilder.ts
+++ b/src/query-builder/SelectQueryBuilder.ts
@@ -2995,7 +2995,8 @@ export class SelectQueryBuilder<Entity extends ObjectLiteral>
         ) {
             selectionPath = (
                 this.dataSource.driver as
-                    AbstractSqliteDriver | ReactNativeDriver
+                    | AbstractSqliteDriver
+                    | ReactNativeDriver
             ).wrapWithJsonFunction(selectionPath, column, false)
         }
 
@@ -3489,7 +3490,8 @@ export class SelectQueryBuilder<Entity extends ObjectLiteral>
         // first query find ids in skip and take range
         // and second query loads the actual data in given ids range
         if (
-            (this.expressionMap.skip || this.expressionMap.take) &&
+            (this.expressionMap.skip != null ||
+                this.expressionMap.take != null) &&
             this.expressionMap.joinAttributes.length > 0
         ) {
             // we are skipping order by here because its not working in subqueries anyway

--- a/test/functional/query-builder/select/query-builder-select.test.ts
+++ b/test/functional/query-builder/select/query-builder-select.test.ts
@@ -832,6 +832,7 @@ describe("query builder > select", () => {
                 }),
             ))
 
+        // Regression test for #12666.
         it("should return empty array when take(0) is used in actual query execution with joins", () =>
             Promise.all(
                 dataSources.map(async (dataSource) => {

--- a/test/functional/query-builder/select/query-builder-select.test.ts
+++ b/test/functional/query-builder/select/query-builder-select.test.ts
@@ -831,6 +831,36 @@ describe("query builder > select", () => {
                     expect(posts.length).to.equal(0)
                 }),
             ))
+
+        it("should return empty array when take(0) is used in actual query execution with joins", () =>
+            Promise.all(
+                dataSources.map(async (dataSource) => {
+                    // Insert some test data
+                    await dataSource.getRepository(Post).save([
+                        {
+                            id: "1",
+                            title: "Post 1",
+                            description: "Description 1",
+                            rating: 1,
+                        },
+                        {
+                            id: "2",
+                            title: "Post 2",
+                            description: "Description 2",
+                            rating: 2,
+                        },
+                    ])
+
+                    const posts = await dataSource
+                        .createQueryBuilder(Post, "post")
+                        .leftJoinAndSelect("post.category", "category")
+                        .take(0)
+                        .getMany()
+
+                    expect(posts).to.be.an("array")
+                    expect(posts.length).to.equal(0)
+                }),
+            ))
     })
 
     describe("column order in select statement", () => {


### PR DESCRIPTION
Fixes #12666

Use a nullish check for skip/take in the joined pagination branch so take(0) still routes through the distinct-id path and returns an empty result. Includes a regression test for left joins.