### PR TITLE
fix: apply default invalid where value behavior

### DIFF
--- a/src/util/OrmUtils.ts
+++ b/src/util/OrmUtils.ts
@@ -658,8 +658,7 @@ export class OrmUtils {
      * each own key a null/undefined value is thrown on, skipped, or converted
      * to IsNull() per the configured behavior. Only plain FindOptionsWhere
      * objects are normalized; anything else (entity/class instances,
-     * FindOperators, arrays, Date, Buffer, primitives) — and the criteria when
-     * no behavior is configured — is returned untouched.
+     * FindOperators, arrays, Date, Buffer, primitives) is returned untouched.
      *
      * @param criteria
      * @param options
@@ -670,10 +669,6 @@ export class OrmUtils {
         options?: InvalidFindOptionsWhereBehavior,
         path?: string,
     ): any {
-        if (!options) {
-            return criteria
-        }
-
         // multiple criteria are possible at the top level
         if (!path && Array.isArray(criteria)) {
             return criteria.map((criterion, index): ObjectLiteral =>

--- a/test/functional/null-undefined-handling/query-builders.test.ts
+++ b/test/functional/null-undefined-handling/query-builders.test.ts
@@ -9,6 +9,97 @@ import {
 import { Category } from "./entity/Category"
 import { Post } from "./entity/Post"
 
+describe("entity manager > invalidWhereValuesBehavior with default behavior", () => {
+    let dataSources: DataSource[]
+
+    before(async () => {
+        dataSources = await createTestingConnections({
+            disabledDrivers: ["spanner"],
+            entities: [Post, Category],
+            schemaCreate: true,
+            dropSchema: true,
+        })
+    })
+    beforeEach(() => reloadTestingDatabases(dataSources))
+    after(() => closeTestingConnections(dataSources))
+
+    async function prepareData(connection: DataSource) {
+        const category = new Category()
+        category.name = "Test Category"
+        await connection.manager.save(category)
+
+        const post = new Post()
+        post.title = "Test Post"
+        post.text = "Some text"
+        post.category = category
+        await connection.manager.save(post)
+    }
+
+    it("should throw error for null values in EntityManager.update() by default", async () => {
+        for (const connection of dataSources) {
+            await prepareData(connection)
+
+            try {
+                await connection.manager.update(Post, { text: null } as any, {
+                    title: "Updated",
+                })
+                expect.fail("Expected error")
+            } catch (error) {
+                expect(error).to.be.instanceOf(TypeORMError)
+                expect(error.message).to.include("Null value encountered")
+            }
+        }
+    })
+
+    it("should throw error for undefined values in EntityManager.delete() by default", async () => {
+        for (const connection of dataSources) {
+            await prepareData(connection)
+
+            try {
+                await connection.manager.delete(Post, {
+                    text: undefined,
+                } as any)
+                expect.fail("Expected error")
+            } catch (error) {
+                expect(error).to.be.instanceOf(TypeORMError)
+                expect(error.message).to.include("Undefined value encountered")
+            }
+        }
+    })
+
+    it("should throw error for nested null values in EntityManager.softDelete() by default", async () => {
+        for (const connection of dataSources) {
+            await prepareData(connection)
+
+            try {
+                await connection.manager.softDelete(Post, {
+                    category: { name: null },
+                } as any)
+                expect.fail("Expected error")
+            } catch (error) {
+                expect(error).to.be.instanceOf(TypeORMError)
+                expect(error.message).to.include("Null value encountered")
+            }
+        }
+    })
+
+    it("should throw error for nested undefined values in EntityManager.restore() by default", async () => {
+        for (const connection of dataSources) {
+            await prepareData(connection)
+
+            try {
+                await connection.manager.restore(Post, {
+                    category: { name: undefined },
+                } as any)
+                expect.fail("Expected error")
+            } catch (error) {
+                expect(error).to.be.instanceOf(TypeORMError)
+                expect(error.message).to.include("Undefined value encountered")
+            }
+        }
+    })
+})
+
 describe("entity manager > invalidWhereValuesBehavior with throw", () => {
     let dataSources: DataSource[]
 


### PR DESCRIPTION
## Summary

Fixes #12578.

Make `OrmUtils.normalizeWhereCriteria()` enforce the documented default `invalidWhereValuesBehavior` behavior.

When `invalidWhereValuesBehavior` is not configured, TypeORM 1.0 documentation says `null` and `undefined` in high-level where criteria should throw by default. `normalizeWhereCriteria()` currently returns the criteria unchanged when the options object is missing, so `EntityManager.update()`, `delete()`, `softDelete()`, and `restore()` can bypass that documented default.

This change removes that early return and lets the existing `?? "throw"` defaults run for null and undefined values.

## Tests

Added coverage for the default behavior in `EntityManager` criteria:

- `update()` throws for `null`
- `delete()` throws for `undefined`
- `softDelete()` throws for nested `null`
- `restore()` throws for nested `undefined`

## Verification

Installed dependencies with `pnpm@10.33.4`, compiled the project, and ran the affected functional test file against `sqljs`.

```text
pnpm run compile
mocha --no-config --file build/compiled/test/utils/test-setup.js build/compiled/test/functional/null-undefined-handling/query-builders.test.js --timeout 90000 --exit

24 passing
```

Local test config used:

```json
[
  {
    "skip": false,
    "type": "sqljs",
    "logging": false
  }
]
```

## Bounty context

Prepared for the Opire bounty seen in the public bounty list:

`$300.00` for `typeorm/typeorm`: `OrmUtils.normalizeWhereCriteria() does not implement described default behaviour for invalidWhereValuesBehavior`.

Opire bounty: https://app.opire.dev/issues/01KVF9XSZYWYWB798QEBTYQVYD
