### PR TITLE
fix(entity-manager): default invalidWhereValuesBehavior to throw on the write path

### DIFF
--- a/src/data-source/BaseDataSourceOptions.ts
+++ b/src/data-source/BaseDataSourceOptions.ts
@@ -219,7 +219,8 @@ export interface BaseDataSourceOptions {
     readonly isolateWhereStatements?: boolean
 
     /**
-     * Controls how null and undefined values are handled in find operations.
+     * Controls how null/undefined values in where criteria are handled by find
+     * and write methods (update/delete/softDelete/restore). Defaults to "throw".
      */
     readonly invalidWhereValuesBehavior?: InvalidFindOptionsWhereBehavior
 }

--- a/src/util/OrmUtils.ts
+++ b/src/util/OrmUtils.ts
@@ -656,10 +656,12 @@ export class OrmUtils {
     /**
      * Applies invalidWhereValuesBehavior to a plain-object where criteria: for
      * each own key a null/undefined value is thrown on, skipped, or converted
-     * to IsNull() per the configured behavior. Only plain FindOptionsWhere
-     * objects are normalized; anything else (entity/class instances,
-     * FindOperators, arrays, Date, Buffer, primitives) — and the criteria when
-     * no behavior is configured — is returned untouched.
+     * to IsNull() per the configured behavior. A top-level array (OR list) is
+     * normalized element by element. Anything else — an entity/class instance,
+     * a FindOperator, Date, Buffer, a primitive — is returned untouched.
+     *
+     * When no behavior is configured, both sub-options default to "throw", so a
+     * null/undefined value throws by default — matching the read/find path.
      *
      * @param criteria
      * @param options
@@ -670,9 +672,8 @@ export class OrmUtils {
         options?: InvalidFindOptionsWhereBehavior,
         path?: string,
     ): any {
-        if (!options) {
-            return criteria
-        }
+        // default to "throw" when unconfigured, matching the read/find path
+        options ??= {}
 
         // multiple criteria are possible at the top level
         if (!path && Array.isArray(criteria)) {

--- a/test/functional/null-undefined-handling/query-builders.test.ts
+++ b/test/functional/null-undefined-handling/query-builders.test.ts
@@ -717,3 +717,123 @@ describe("entity manager > invalidWhereValuesBehavior does NOT affect QB .where(
         }
     })
 })
+
+describe("entity manager > invalidWhereValuesBehavior default (unconfigured)", () => {
+    let dataSources: DataSource[]
+
+    // no invalidWhereValuesBehavior configured: the write path must default to
+    // "throw" on null/undefined, matching the read/find path
+    before(async () => {
+        dataSources = await createTestingConnections({
+            disabledDrivers: ["spanner"],
+            entities: [Post, Category],
+            schemaCreate: true,
+            dropSchema: true,
+        })
+    })
+    beforeEach(() => reloadTestingDatabases(dataSources))
+    after(() => closeTestingConnections(dataSources))
+
+    async function prepareData(connection: DataSource) {
+        const post = new Post()
+        post.title = "Test Post"
+        post.text = "Some text"
+        await connection.manager.save(post)
+        return { post }
+    }
+
+    it("EntityManager.delete throws on a null value by default and leaves the row", async () => {
+        for (const connection of dataSources) {
+            const { post } = await prepareData(connection)
+
+            try {
+                await connection.manager.delete(Post, { text: null } as any)
+                expect.fail("Expected error")
+            } catch (error) {
+                expect(error).to.be.instanceOf(TypeORMError)
+                expect(error.message).to.include("Null value encountered")
+            }
+
+            expect(
+                await connection.manager.findOneBy(Post, { id: post.id }),
+            ).to.not.equal(null)
+        }
+    })
+
+    it("EntityManager.update throws on an undefined value by default", async () => {
+        for (const connection of dataSources) {
+            await prepareData(connection)
+            try {
+                await connection.manager.update(
+                    Post,
+                    { text: undefined } as any,
+                    { title: "Updated" },
+                )
+                expect.fail("Expected error")
+            } catch (error) {
+                expect(error).to.be.instanceOf(TypeORMError)
+                expect(error.message).to.include("Undefined value encountered")
+            }
+        }
+    })
+
+    it("throws on a null value inside an array (OR) criteria by default", async () => {
+        for (const connection of dataSources) {
+            const { post } = await prepareData(connection)
+            try {
+                await connection.manager.delete(Post, [
+                    { text: null },
+                    { id: post.id },
+                ] as any)
+                expect.fail("Expected error")
+            } catch (error) {
+                expect(error).to.be.instanceOf(TypeORMError)
+                expect(error.message).to.include("Null value encountered")
+            }
+        }
+    })
+
+    it("EntityManager.softDelete throws on a null value by default", async () => {
+        for (const connection of dataSources) {
+            await prepareData(connection)
+            try {
+                await connection.manager.softDelete(Post, {
+                    text: null,
+                } as any)
+                expect.fail("Expected error")
+            } catch (error) {
+                expect(error).to.be.instanceOf(TypeORMError)
+                expect(error.message).to.include("Null value encountered")
+            }
+        }
+    })
+
+    it("passes entity class instances through (does not throw) even when unconfigured", async () => {
+        for (const connection of dataSources) {
+            // a fully populated instance (no null columns) deletes its row —
+            // entity instances bypass normalization, so no default-throw applies
+            const entity = new Post()
+            entity.title = "Loaded"
+            entity.text = "value"
+            await connection.manager.save(entity)
+
+            await connection.manager.delete(Post, entity)
+            expect(
+                await connection.manager.findOneBy(Post, { id: entity.id }),
+            ).to.equal(null)
+        }
+    })
+
+    it("matches the read path: findBy also throws on null by default", async () => {
+        for (const connection of dataSources) {
+            await prepareData(connection)
+            try {
+                await connection.manager.findBy(Post, { text: null } as any)
+                expect.fail("Expected error")
+            } catch (error) {
+                expect(error).to.be.instanceOf(TypeORMError)
+                expect(error.message).to.include("Null value encountered")
+            }
+        }
+    })
+})

--- a/test/unit/util/orm-utils.test.ts
+++ b/test/unit/util/orm-utils.test.ts
@@ -272,12 +272,22 @@ describe(`OrmUtils`, () => {
     })
 
     describe("normalizeWhereCriteria", () => {
-        it("returns criteria unchanged when no options are provided", () => {
-            const criteria = { name: null, email: undefined }
-            expect(OrmUtils.normalizeWhereCriteria(criteria)).to.equal(criteria)
+        it("throws on null/undefined by default when no options are provided", () => {
+            // unconfigured invalidWhereValuesBehavior defaults to "throw",
+            // matching the read/find path
+            expect(() =>
+                OrmUtils.normalizeWhereCriteria({ name: null }),
+            ).to.throw(/Null value.*'name'/)
+            expect(() =>
+                OrmUtils.normalizeWhereCriteria({ email: undefined }),
+            ).to.throw(/Undefined value.*'email'/)
+            // a criteria with no null/undefined is normalized and returned
+            expect(
+                OrmUtils.normalizeWhereCriteria({ name: "Alice" }),
+            ).to.deep.equal({ name: "Alice" })
         })
 
-        it("throws on null/undefined by default when options are provided", () => {
+        it("throws on null/undefined by default when empty options are provided", () => {
             expect(() =>
                 OrmUtils.normalizeWhereCriteria({ name: undefined }, {}),
             ).to.throw(/Undefined value.*'name'/)


### PR DESCRIPTION
Closes #12578. 

## Problem

`invalidWhereValuesBehavior`'s documented default is **throw**, and the read/find path already honours it — `SelectQueryBuilder.buildWhere` resolves each sub-option with `?? "throw"`. The **write path** did not: `OrmUtils.normalizeWhereCriteria` short-circuited with `if (!options) return criteria` when the option was unset, so `update` / `delete` / `softDelete` / `restore` with a plain-object criteria containing `null`/`undefined` ran silently (`col = NULL`) instead of throwing. That's the bug reported in #12578 (repro: https://github.com/samkessaram/typeorm-undefined-where-bug).

## Change

Default the options inside `normalizeWhereCriteria` (`options ??= {}`), so the existing per-key `options?.null ?? "throw"` / `?.undefined ?? "throw"` fallbacks apply. The write path now matches the read path:

- plain object `{ text: null }` / `{ text: undefined }` → **throws** by default
- array (OR) `[{ text: null }, { id: 1 }]` → **throws** by default
- nested plain `{ category: { name: null } }` → **throws** by default
- entity instances / `FindOperator` / `Date` / `Buffer` / primitives → **pass through** unchanged (the `isPlainObject` guard from #12629 runs before the key loop) — so `delete(entityInstance)` and the tree-repository soft-delete paths are unaffected
- configured `ignore` / `sql-null` → unchanged

No read-path change (already correct); the #12629 empty-criteria (`WHERE 1=1`) guards stay.

## Notes

- This is intended for **v1 / master** only. The legacy `v0` line keeps the lenient write default (it carries only #12629's empty-criteria fix).
- Deep validation of entity-instance criteria (defaulting entity nulls to `ignore` / strip) needs entity metadata and is intentionally left as a follow-up.

## Tests

- **Functional** — new `invalidWhereValuesBehavior default (unconfigured)` block: `delete`/`update`/`softDelete` throw on null/undefined by default; array-criteria null throws; entity-instance passthrough (no throw, deletes its row); read/write parity (`findBy` also throws).
- **Unit** — `normalizeWhereCriteria` now throws by default with no options (and with empty `{}` options); entity/`Date`/`Uint8Array`/primitive passthrough retained.
- Full suite audited locally on better-sqlite3 (persistence, query-builder, repository, tree-tables, relations/cascades/transaction/columns/embedded) — no pre-existing unconfigured plain-object null/undefined write relied on the old silent behaviour.