### PR TITLE
fix(entity-manager): validate where criteria in increment/decrement

### DIFF
--- a/src/entity-manager/EntityManager.ts
+++ b/src/entity-manager/EntityManager.ts
@@ -1470,8 +1470,8 @@ export class EntityManager {
 
     /**
      * Shared implementation of {@link increment} and {@link decrement}: builds a
-     * `column = column +/- value` UPDATE for the rows matched by the conditions,
-     * validating the criteria the same way the other write methods do.
+     * `column = column +/- value` UPDATE and delegates execution to {@link update},
+     * so the criteria handling stays aligned with the other write methods.
      */
     protected incrementOrDecrementBy<Entity extends ObjectLiteral>(
         operation: "increment" | "decrement",
@@ -1503,19 +1503,7 @@ export class EntityManager {
                     value,
             )
 
-        const { criteria: whereCriteria, isPrimitive } =
-            this.normalizeAndValidateWhereCriteria(conditions, operation)
-
-        const qb = this.createQueryBuilder<Entity>(entityClass as any, "entity")
-            .update(entityClass)
-            .set(values)
-        if (isPrimitive) {
-            qb.whereInIds(whereCriteria)
-        } else {
-            qb.where(whereCriteria)
-        }
-
-        return qb.execute()
+        return this.update(entityClass, conditions, values)
     }
 
     /**

--- a/src/entity-manager/EntityManager.ts
+++ b/src/entity-manager/EntityManager.ts
@@ -1436,32 +1436,13 @@ export class EntityManager {
         propertyPath: string,
         value: number | string,
     ): Promise<UpdateResult> {
-        const metadata = this.dataSource.getMetadata(entityClass)
-        const column = metadata.findColumnWithPropertyPath(propertyPath)
-        if (!column)
-            throw new TypeORMError(
-                `Column ${propertyPath} was not found in ${metadata.targetName} entity.`,
-            )
-
-        if (isNaN(Number(value)))
-            throw new TypeORMError(`Value "${value}" is not a number.`)
-
-        // convert possible embedded path "social.likes" into object { social: { like: () => value } }
-        const values: QueryDeepPartialEntity<Entity> = propertyPath
-            .split(".")
-            .reduceRight(
-                (value, key) => ({ [key]: value }) as any,
-                () =>
-                    this.dataSource.driver.escape(column.databaseName) +
-                    " + " +
-                    value,
-            )
-
-        return this.createQueryBuilder<Entity>(entityClass as any, "entity")
-            .update(entityClass)
-            .set(values)
-            .where(conditions)
-            .execute()
+        return this.incrementOrDecrementBy(
+            "increment",
+            entityClass,
+            conditions,
+            propertyPath,
+            value,
+        )
     }
 
     /**
@@ -1478,6 +1459,27 @@ export class EntityManager {
         propertyPath: string,
         value: number | string,
     ): Promise<UpdateResult> {
+        return this.incrementOrDecrementBy(
+            "decrement",
+            entityClass,
+            conditions,
+            propertyPath,
+            value,
+        )
+    }
+
+    /**
+     * Shared implementation of {@link increment} and {@link decrement}: builds a
+     * `column = column +/- value` UPDATE for the rows matched by the conditions,
+     * validating the criteria the same way the other write methods do.
+     */
+    protected incrementOrDecrementBy<Entity extends ObjectLiteral>(
+        operation: "increment" | "decrement",
+        entityClass: EntityTarget<Entity>,
+        conditions: FindOptionsWhere<Entity>,
+        propertyPath: string,
+        value: number | string,
+    ): Promise<UpdateResult> {
         const metadata = this.dataSource.getMetadata(entityClass)
         const column = metadata.findColumnWithPropertyPath(propertyPath)
         if (!column)
@@ -1488,6 +1490,8 @@ export class EntityManager {
         if (isNaN(Number(value)))
             throw new TypeORMError(`Value "${value}" is not a number.`)
 
+        const operator = operation === "increment" ? "+" : "-"
+
         // convert possible embedded path "social.likes" into object { social: { like: () => value } }
         const values: QueryDeepPartialEntity<Entity> = propertyPath
             .split(".")
@@ -1495,15 +1499,23 @@ export class EntityManager {
                 (value, key) => ({ [key]: value }) as any,
                 () =>
                     this.dataSource.driver.escape(column.databaseName) +
-                    " - " +
+                    ` ${operator} ` +
                     value,
             )
 
-        return this.createQueryBuilder<Entity>(entityClass as any, "entity")
+        const { criteria: whereCriteria, isPrimitive } =
+            this.normalizeAndValidateWhereCriteria(conditions, operation)
+
+        const qb = this.createQueryBuilder<Entity>(entityClass as any, "entity")
             .update(entityClass)
             .set(values)
-            .where(conditions)
-            .execute()
+        if (isPrimitive) {
+            qb.whereInIds(whereCriteria)
+        } else {
+            qb.where(whereCriteria)
+        }
+
+        return qb.execute()
     }
 
     /**

--- a/test/functional/repository/decrement/repository-decrement.test.ts
+++ b/test/functional/repository/decrement/repository-decrement.test.ts
@@ -183,6 +183,62 @@ describe("repository > decrement method", () => {
                         .rejected
                 }),
             ))
+
+        it("should throw on empty criteria and not touch any rows", () =>
+            Promise.all(
+                dataSources.map(async (dataSource) => {
+                    const post1 = new Post()
+                    post1.id = 1
+                    post1.title = "post #1"
+                    post1.counter = 5
+                    const post2 = new Post()
+                    post2.id = 2
+                    post2.title = "post #2"
+                    post2.counter = 5
+                    await dataSource.manager.save([post1, post2])
+
+                    // an empty criteria must not run an unfiltered UPDATE
+                    await dataSource
+                        .getRepository(Post)
+                        .decrement({}, "counter", 1)
+                        .should.be.rejectedWith(/Empty criteria/)
+
+                    const posts = await dataSource.manager.find(Post)
+                    posts.forEach((post) => post.counter.should.be.equal(5))
+                }),
+            ))
+    })
+
+    describe("invalidWhereValuesBehavior", () => {
+        let dataSources: DataSource[]
+        before(async () => {
+            dataSources = await createTestingConnections({
+                entities: [Post],
+                driverSpecific: {
+                    invalidWhereValuesBehavior: {
+                        null: "throw",
+                        undefined: "throw",
+                    },
+                },
+            })
+        })
+        beforeEach(() => reloadTestingDatabases(dataSources))
+        after(() => closeTestingConnections(dataSources))
+
+        it("should throw on a null value in the criteria", () =>
+            Promise.all(
+                dataSources.map(async (dataSource) => {
+                    const post = new Post()
+                    post.id = 1
+                    post.title = "post #1"
+                    post.counter = 5
+                    await dataSource.manager.save(post)
+
+                    await dataSource.manager
+                        .decrement(Post, { title: null } as any, "counter", 1)
+                        .should.be.rejectedWith(/Null value encountered/)
+                }),
+            ))
     })
 
     describe("bigint", () => {

--- a/test/functional/repository/increment/repository-increment.test.ts
+++ b/test/functional/repository/increment/repository-increment.test.ts
@@ -183,6 +183,62 @@ describe("repository > increment method", () => {
                         .rejected
                 }),
             ))
+
+        it("should throw on empty criteria and not touch any rows", () =>
+            Promise.all(
+                dataSources.map(async (dataSource) => {
+                    const post1 = new Post()
+                    post1.id = 1
+                    post1.title = "post #1"
+                    post1.counter = 1
+                    const post2 = new Post()
+                    post2.id = 2
+                    post2.title = "post #2"
+                    post2.counter = 1
+                    await dataSource.manager.save([post1, post2])
+
+                    // an empty criteria must not run an unfiltered UPDATE
+                    await dataSource
+                        .getRepository(Post)
+                        .increment({}, "counter", 5)
+                        .should.be.rejectedWith(/Empty criteria/)
+
+                    const posts = await dataSource.manager.find(Post)
+                    posts.forEach((post) => post.counter.should.be.equal(1))
+                }),
+            ))
+    })
+
+    describe("invalidWhereValuesBehavior", () => {
+        let dataSources: DataSource[]
+        before(async () => {
+            dataSources = await createTestingConnections({
+                entities: [Post],
+                driverSpecific: {
+                    invalidWhereValuesBehavior: {
+                        null: "throw",
+                        undefined: "throw",
+                    },
+                },
+            })
+        })
+        beforeEach(() => reloadTestingDatabases(dataSources))
+        after(() => closeTestingConnections(dataSources))
+
+        it("should throw on a null value in the criteria", () =>
+            Promise.all(
+                dataSources.map(async (dataSource) => {
+                    const post = new Post()
+                    post.id = 1
+                    post.title = "post #1"
+                    post.counter = 1
+                    await dataSource.manager.save(post)
+
+                    await dataSource.manager
+                        .increment(Post, { title: null } as any, "counter", 1)
+                        .should.be.rejectedWith(/Null value encountered/)
+                }),
+            ))
     })
 
     describe("bigint", () => {


### PR DESCRIPTION
## Problem

`EntityManager.increment()` / `decrement()` (and the `Repository` methods that delegate to them) built their `UPDATE` directly:

```ts
this.createQueryBuilder(entityClass, "entity")
    .update(entityClass)
    .set(values)
    .where(conditions)   // conditions went straight to the low-level QB .where()
    .execute()
```

This bypassed `normalizeAndValidateWhereCriteria` — the guard that `update` / `delete` / `softDelete` / `restore` use. Two consequences:

- **Empty criteria ran an unfiltered write.** `increment(User, {}, "points", 1)` rendered `UPDATE user SET points = points + 1` with no `WHERE` — every row. This is the same `WHERE 1=1` mass-update class of bug the empty-criteria guard was added to prevent. (Intentional all-row updates already have `updateAll`.)
- **`invalidWhereValuesBehavior` was ignored** for `null`/`undefined` values in the criteria, unlike the other write methods.

Flagged in review of #12690.

## Change

Route `conditions` through `normalizeAndValidateWhereCriteria` in both `increment` and `decrement`, mirroring `update` exactly (including the `isPrimitive` → `whereInIds` branch). They now reject empty criteria and honor `invalidWhereValuesBehavior`, consistent with the other write methods.

No change to the QueryBuilder layer; low-level `.where()` remains intentionally exempt.

## Tests

- `repository-increment` / `repository-decrement`: empty `{}` criteria throws `Empty criteria(s)` and leaves all rows untouched; with `invalidWhereValuesBehavior: { null: "throw" }` configured, a `null` in the criteria throws `Null value encountered`.
- Full increment/decrement suites pass (18/18 locally on better-sqlite3).

## Note

This is a behavior change: an empty criteria that previously ran silently now throws — the intended, safer default (consistent with #12629 for `update`/`delete`).
