### PR TITLE
refactor(postgres): use promise returning query overload

### DIFF
--- a/src/driver/postgres/PostgresDriver.ts
+++ b/src/driver/postgres/PostgresDriver.ts
@@ -1833,11 +1833,7 @@ export class PostgresDriver implements Driver {
     protected executeQuery(connection: any, query: string) {
         this.dataSource.logger.logQuery(query)
 
-        return new Promise((ok, fail) => {
-            connection.query(query, (err: any, result: any) =>
-                err ? fail(err) : ok(result),
-            )
-        })
+        return connection.query(query)
     }
 
     /**

--- a/src/driver/postgres/PostgresDriver.ts
+++ b/src/driver/postgres/PostgresDriver.ts
@@ -430,7 +430,7 @@ export class PostgresDriver implements Driver {
      * Makes any action after connection (e.g. create extensions in Postgres driver).
      */
     async afterConnect(): Promise<void> {
-        const [connection, release] = await this.obtainMasterConnection()
+        const connection = await this.obtainMasterConnection()
 
         const installExtensions =
             this.options.installExtensions === undefined ||
@@ -458,7 +458,7 @@ export class PostgresDriver implements Driver {
             "12.0",
         )
 
-        await release()
+        connection.release()
     }
 
     protected async getAvailableExtensions(connection: any) {
@@ -1401,20 +1401,12 @@ export class PostgresDriver implements Driver {
      * Used for replication.
      * If replication is not setup then returns default connection's database connection.
      */
-    async obtainMasterConnection(): Promise<[any, Function]> {
+    obtainMasterConnection(): Promise<any> {
         if (!this.master) {
             throw new TypeORMError("Driver not Connected")
         }
 
-        return new Promise((ok, fail) => {
-            this.master.connect((err: any, connection: any, release: any) => {
-                if (err) {
-                    fail(err)
-                } else {
-                    ok([connection, release])
-                }
-            })
-        })
+        return this.master.connect()
     }
 
     /**
@@ -1422,24 +1414,14 @@ export class PostgresDriver implements Driver {
      * Used for replication.
      * If replication is not setup then returns master (default) connection's database connection.
      */
-    async obtainSlaveConnection(): Promise<[any, Function]> {
+    obtainSlaveConnection(): Promise<any> {
         if (!this.slaves.length) {
             return this.obtainMasterConnection()
         }
 
         const random = Math.floor(Math.random() * this.slaves.length)
 
-        return new Promise((ok, fail) => {
-            this.slaves[random].connect(
-                (err: any, connection: any, release: any) => {
-                    if (err) {
-                        fail(err)
-                    } else {
-                        ok([connection, release])
-                    }
-                },
-            )
-        })
+        return this.slaves[random].connect()
     }
 
     /**
@@ -1784,29 +1766,26 @@ export class PostgresDriver implements Driver {
          */
         pool.on("error", poolErrorHandler)
 
-        return new Promise((ok, fail) => {
-            pool.connect((err: any, connection: any, release: Function) => {
-                if (err) return fail(err)
+        const connection = await pool.connect()
 
-                if (options.logNotifications) {
-                    connection.on("notice", (msg: any) => {
-                        if (msg) {
-                            this.dataSource.logger.log("info", msg.message)
-                        }
-                    })
-                    connection.on("notification", (msg: any) => {
-                        if (msg) {
-                            this.dataSource.logger.log(
-                                "info",
-                                `Received NOTIFY on channel ${msg.channel}: ${msg.payload}.`,
-                            )
-                        }
-                    })
+        if (options.logNotifications) {
+            connection.on("notice", (msg: any) => {
+                if (msg) {
+                    this.dataSource.logger.log("info", msg.message)
                 }
-                release()
-                ok(pool)
             })
-        })
+            connection.on("notification", (msg: any) => {
+                if (msg) {
+                    this.dataSource.logger.log(
+                        "info",
+                        `Received NOTIFY on channel ${msg.channel}: ${msg.payload}.`,
+                    )
+                }
+            })
+        }
+        connection.release()
+
+        return pool
     }
 
     /**
@@ -1819,9 +1798,7 @@ export class PostgresDriver implements Driver {
             await this.connectedQueryRunners[0].release()
         }
 
-        return new Promise<void>((ok, fail) => {
-            pool.end((err: any) => (err ? fail(err) : ok()))
-        })
+        await pool.end()
     }
 
     /**

--- a/src/driver/postgres/PostgresQueryRunner.ts
+++ b/src/driver/postgres/PostgresQueryRunner.ts
@@ -91,7 +91,7 @@ export class PostgresQueryRunner
         if (this.mode === "slave" && this.driver.isReplicated) {
             this.databaseConnectionPromise = this.driver
                 .obtainSlaveConnection()
-                .then(([connection, release]: any[]) => {
+                .then((connection) => {
                     this.driver.connectedQueryRunners.push(this)
                     this.databaseConnection = connection
 
@@ -102,7 +102,7 @@ export class PostgresQueryRunner
                             "error",
                             onErrorCallback,
                         )
-                        release(err)
+                        connection.release(err)
                     }
                     this.databaseConnection.on("error", onErrorCallback)
 
@@ -112,7 +112,7 @@ export class PostgresQueryRunner
             // master
             this.databaseConnectionPromise = this.driver
                 .obtainMasterConnection()
-                .then(([connection, release]: any[]) => {
+                .then((connection) => {
                     this.driver.connectedQueryRunners.push(this)
                     this.databaseConnection = connection
 
@@ -123,7 +123,7 @@ export class PostgresQueryRunner
                             "error",
                             onErrorCallback,
                         )
-                        release(err)
+                        connection.release(err)
                     }
                     this.databaseConnection.on("error", onErrorCallback)
 


### PR DESCRIPTION
Hello! I was monkey-patching typeorm to work with Bun.SQL and found out that some part of driver are using callback style query overload. It still is converted to promise, so I think this is a nice little change and also simplifies my monkey patch along the way. I tried to run the tests to best of my ability, seems that they are fine