### PR TITLE
fix(mysql): preserve foreign key indexes when renaming tables

### DIFF
--- a/src/driver/mysql/MysqlQueryRunner.ts
+++ b/src/driver/mysql/MysqlQueryRunner.ts
@@ -681,7 +681,61 @@ export class MysqlQueryRunner extends BaseQueryRunner implements QueryRunner {
             : await this.getCachedTable(oldTableOrName)
         const newTable = oldTable.clone()
 
-        const { database } = this.driver.parseTableName(oldTable)
+        const { database, tableName } = this.driver.parseTableName(oldTable)
+
+        const generatedForeignKeyNames = newTable.foreignKeys
+            .filter((foreignKey) => {
+                return (
+                    foreignKey.name ===
+                    this.dataSource.namingStrategy.foreignKeyName(
+                        oldTable,
+                        foreignKey.columnNames,
+                        this.getTablePath(foreignKey),
+                        foreignKey.referencedColumnNames,
+                    )
+                )
+            })
+            .map((foreignKey) => foreignKey.name!)
+
+        // Same-named foreign key indexes are omitted from Table.indices, so
+        // load their structure before renaming the table.
+        let foreignKeyIndices: ObjectLiteral[] = []
+        if (generatedForeignKeyNames.length > 0) {
+            const currentDatabase =
+                database ?? (await this.getCurrentDatabase())
+            const placeholders = generatedForeignKeyNames
+                .map(() => "?")
+                .join(", ")
+            foreignKeyIndices = await this.query(
+                `SELECT \`INDEX_NAME\`, \`SEQ_IN_INDEX\`, \`COLUMN_NAME\`, \`NON_UNIQUE\`, \`INDEX_TYPE\`, \`SUB_PART\` ` +
+                    `FROM \`INFORMATION_SCHEMA\`.\`STATISTICS\` ` +
+                    `WHERE \`TABLE_SCHEMA\` = ? AND \`TABLE_NAME\` = ? ` +
+                    `AND \`INDEX_NAME\` IN (${placeholders}) ` +
+                    `ORDER BY \`INDEX_NAME\`, \`SEQ_IN_INDEX\``,
+                [currentDatabase, tableName, ...generatedForeignKeyNames],
+            )
+        }
+
+        const generatedForeignKeyIndexNames = new Set(
+            newTable.foreignKeys
+                .filter((foreignKey) => {
+                    const indexColumns = foreignKeyIndices.filter(
+                        (index) => index["INDEX_NAME"] === foreignKey.name,
+                    )
+                    return (
+                        indexColumns.length === foreignKey.columnNames.length &&
+                        indexColumns.every(
+                            (index, position) =>
+                                index["COLUMN_NAME"] ===
+                                    foreignKey.columnNames[position] &&
+                                Number(index["NON_UNIQUE"]) === 1 &&
+                                index["INDEX_TYPE"] === "BTREE" &&
+                                index["SUB_PART"] === null,
+                        )
+                    )
+                })
+                .map((foreignKey) => foreignKey.name!),
+        )
 
         newTable.name = database ? `${database}.${newTableName}` : newTableName
 
@@ -781,22 +835,32 @@ export class MysqlQueryRunner extends BaseQueryRunner implements QueryRunner {
                 )
 
             // build queries
-            let up =
-                `ALTER TABLE ${this.escapePath(newTable)} DROP FOREIGN KEY \`${
-                    foreignKey.name
-                }\`, ADD CONSTRAINT \`${newForeignKeyName}\` FOREIGN KEY (${columnNames}) ` +
+            const renameGeneratedIndex = generatedForeignKeyIndexNames.has(
+                foreignKey.name!,
+            )
+
+            let up = `ALTER TABLE ${this.escapePath(
+                newTable,
+            )} DROP FOREIGN KEY \`${foreignKey.name}\``
+            if (renameGeneratedIndex) {
+                up += `, DROP INDEX \`${foreignKey.name}\`, ADD INDEX \`${newForeignKeyName}\` (${columnNames})`
+            }
+            up +=
+                `, ADD CONSTRAINT \`${newForeignKeyName}\` FOREIGN KEY (${columnNames}) ` +
                 `REFERENCES ${this.escapePath(
                     this.getTablePath(foreignKey),
                 )}(${referencedColumnNames})`
             if (foreignKey.onDelete) up += ` ON DELETE ${foreignKey.onDelete}`
             if (foreignKey.onUpdate) up += ` ON UPDATE ${foreignKey.onUpdate}`
 
-            let down =
-                `ALTER TABLE ${this.escapePath(
-                    newTable,
-                )} DROP FOREIGN KEY \`${newForeignKeyName}\`, ADD CONSTRAINT \`${
-                    foreignKey.name
-                }\` FOREIGN KEY (${columnNames}) ` +
+            let down = `ALTER TABLE ${this.escapePath(
+                newTable,
+            )} DROP FOREIGN KEY \`${newForeignKeyName}\``
+            if (renameGeneratedIndex) {
+                down += `, DROP INDEX \`${newForeignKeyName}\`, ADD INDEX \`${foreignKey.name}\` (${columnNames})`
+            }
+            down +=
+                `, ADD CONSTRAINT \`${foreignKey.name}\` FOREIGN KEY (${columnNames}) ` +
                 `REFERENCES ${this.escapePath(
                     this.getTablePath(foreignKey),
                 )}(${referencedColumnNames})`

--- a/test/github-issues/12671/entity/Category.ts
+++ b/test/github-issues/12671/entity/Category.ts
@@ -1,0 +1,7 @@
+import { Entity, PrimaryGeneratedColumn } from "../../../../src"
+
+@Entity("issue_12671_categories")
+export class Category {
+    @PrimaryGeneratedColumn()
+    id: number
+}

--- a/test/github-issues/12671/entity/CircleReport.ts
+++ b/test/github-issues/12671/entity/CircleReport.ts
@@ -1,0 +1,33 @@
+import {
+    Column,
+    Entity,
+    Index,
+    JoinColumn,
+    ManyToOne,
+    PrimaryGeneratedColumn,
+} from "../../../../src"
+import { Category } from "./Category"
+
+@Index("IDX_12671_custom_covering", ["indexedCategoryId", "note"])
+@Entity("circle_reports")
+export class CircleReport {
+    @PrimaryGeneratedColumn()
+    id: number
+
+    @Column()
+    categoryId: number
+
+    @ManyToOne(() => Category, { onDelete: "CASCADE" })
+    @JoinColumn({ name: "categoryId" })
+    category: Category
+
+    @Column()
+    indexedCategoryId: number
+
+    @Column({ length: 32 })
+    note: string
+
+    @ManyToOne(() => Category, { onDelete: "CASCADE" })
+    @JoinColumn({ name: "indexedCategoryId" })
+    indexedCategory: Category
+}

--- a/test/github-issues/12671/entity/Report.ts
+++ b/test/github-issues/12671/entity/Report.ts
@@ -1,0 +1,33 @@
+import {
+    Column,
+    Entity,
+    Index,
+    JoinColumn,
+    ManyToOne,
+    PrimaryGeneratedColumn,
+} from "../../../../src"
+import { Category } from "./Category"
+
+@Index("IDX_12671_custom_covering", ["indexedCategoryId", "note"])
+@Entity("reports")
+export class Report {
+    @PrimaryGeneratedColumn()
+    id: number
+
+    @Column()
+    categoryId: number
+
+    @ManyToOne(() => Category, { onDelete: "CASCADE" })
+    @JoinColumn({ name: "categoryId" })
+    category: Category
+
+    @Column()
+    indexedCategoryId: number
+
+    @Column({ length: 32 })
+    note: string
+
+    @ManyToOne(() => Category, { onDelete: "CASCADE" })
+    @JoinColumn({ name: "indexedCategoryId" })
+    indexedCategory: Category
+}

--- a/test/github-issues/12671/issue-12671.test.ts
+++ b/test/github-issues/12671/issue-12671.test.ts
@@ -1,0 +1,172 @@
+import { expect } from "chai"
+import "reflect-metadata"
+
+import { type DataSource, TableIndex } from "../../../src"
+import {
+    closeTestingConnections,
+    createTestingConnections,
+} from "../../utils/test-utils"
+import { Category } from "./entity/Category"
+import { CircleReport } from "./entity/CircleReport"
+import { Report } from "./entity/Report"
+
+describe("github issues > #12671", () => {
+    let dataSources: DataSource[]
+
+    before(async () => {
+        const oldDataSources = await createTestingConnections({
+            enabledDrivers: ["mysql", "mariadb"],
+            entities: [Category, Report],
+            schemaCreate: true,
+            dropSchema: true,
+        })
+
+        await Promise.all(
+            oldDataSources.map(async (dataSource) => {
+                const queryRunner = dataSource.createQueryRunner()
+                const table = await queryRunner.getTable("reports")
+                const foreignKey = table!.foreignKeys.find(
+                    (candidate) =>
+                        candidate.columnNames.length === 1 &&
+                        candidate.columnNames[0] === "categoryId",
+                )!
+
+                await queryRunner.dropForeignKey(table!, foreignKey)
+                await queryRunner.query(
+                    `DROP INDEX \`${foreignKey.name}\` ON \`reports\``,
+                )
+                await queryRunner.createIndex(
+                    table!,
+                    new TableIndex({
+                        name: foreignKey.name,
+                        columnNames: foreignKey.columnNames,
+                    }),
+                )
+                await queryRunner.createForeignKey(table!, foreignKey)
+                await queryRunner.release()
+            }),
+        )
+        await closeTestingConnections(oldDataSources)
+
+        dataSources = await createTestingConnections({
+            enabledDrivers: ["mysql", "mariadb"],
+            entities: [Category, CircleReport],
+        })
+    })
+
+    after(() => closeTestingConnections(dataSources))
+
+    // Regression test for https://github.com/typeorm/typeorm/issues/12671
+    it("keeps generated foreign key indexes aligned after a table rename", () =>
+        Promise.all(
+            dataSources.map(async (dataSource) => {
+                const queryRunner = dataSource.createQueryRunner()
+                const oldTable = await queryRunner.getTable("reports")
+                expect(oldTable).to.exist
+
+                const oldForeignKeyNames = oldTable!.foreignKeys.map(
+                    (foreignKey) => foreignKey.name,
+                )
+                const oldImplicitForeignKey = oldTable!.foreignKeys.find(
+                    (foreignKey) =>
+                        foreignKey.columnNames.length === 1 &&
+                        foreignKey.columnNames[0] === "categoryId",
+                )!
+                expect(oldForeignKeyNames).to.have.length(2)
+                expect(oldTable!.indices.map((index) => index.name)).to.include(
+                    "IDX_12671_custom_covering",
+                )
+
+                queryRunner.clearSqlMemory()
+                await queryRunner.renameTable(oldTable!, "circle_reports")
+
+                const reloadQueryRunner = dataSource.createQueryRunner()
+                const renamedTable =
+                    await reloadQueryRunner.getTable("circle_reports")
+                expect(renamedTable).to.exist
+
+                const metadata = dataSource.getMetadata(CircleReport)
+                const newForeignKeyNames = metadata.foreignKeys.map(
+                    (foreignKey) => foreignKey.name,
+                )
+                expect(
+                    renamedTable!.foreignKeys.map(
+                        (foreignKey) => foreignKey.name,
+                    ),
+                ).to.have.members(newForeignKeyNames)
+
+                const implicitForeignKey = metadata.foreignKeys.find(
+                    (foreignKey) =>
+                        foreignKey.columnNames.length === 1 &&
+                        foreignKey.columnNames[0] === "categoryId",
+                )!
+                const coveringIndexForeignKey = metadata.foreignKeys.find(
+                    (foreignKey) =>
+                        foreignKey.columnNames.length === 1 &&
+                        foreignKey.columnNames[0] === "indexedCategoryId",
+                )!
+                const databaseIndices: { Key_name: string }[] =
+                    await reloadQueryRunner.query(
+                        "SHOW INDEX FROM `circle_reports`",
+                    )
+                const databaseIndexNames = databaseIndices.map(
+                    (index) => index.Key_name,
+                )
+                expect(databaseIndexNames).to.include(
+                    "IDX_12671_custom_covering",
+                )
+                expect(databaseIndexNames).not.to.include(
+                    coveringIndexForeignKey.name,
+                )
+
+                await reloadQueryRunner.query(
+                    "INSERT INTO `issue_12671_categories` (`id`) VALUES (1)",
+                )
+                await reloadQueryRunner.query(
+                    "INSERT INTO `circle_reports` (`categoryId`, `indexedCategoryId`, `note`) VALUES (1, 1, 'valid')",
+                )
+
+                const schemaLog = await dataSource.driver
+                    .createSchemaBuilder()
+                    .log()
+                expect(
+                    schemaLog.upQueries.some((query) =>
+                        query.query.includes("DROP INDEX"),
+                    ),
+                ).to.be.false
+                expect(schemaLog.upQueries).to.be.empty
+                expect(databaseIndexNames).to.include(implicitForeignKey.name)
+
+                await queryRunner.executeMemoryDownSql()
+
+                const downQueryRunner = dataSource.createQueryRunner()
+                expect(await downQueryRunner.hasTable("circle_reports")).to.be
+                    .false
+                const revertedTable = await downQueryRunner.getTable("reports")
+                expect(revertedTable).to.exist
+                expect(
+                    revertedTable!.foreignKeys.map(
+                        (foreignKey) => foreignKey.name,
+                    ),
+                ).to.have.members(oldForeignKeyNames)
+                expect(
+                    revertedTable!.indices.map((index) => index.name),
+                ).to.include("IDX_12671_custom_covering")
+                const revertedDatabaseIndices: { Key_name: string }[] =
+                    await downQueryRunner.query("SHOW INDEX FROM `reports`")
+                const revertedDatabaseIndexNames = revertedDatabaseIndices.map(
+                    (index) => index.Key_name,
+                )
+                expect(revertedDatabaseIndexNames).to.include(
+                    oldImplicitForeignKey.name,
+                )
+                expect(revertedDatabaseIndexNames).not.to.include(
+                    implicitForeignKey.name,
+                )
+
+                await downQueryRunner.release()
+                await reloadQueryRunner.release()
+                await queryRunner.release()
+            }),
+        ))
+})


### PR DESCRIPTION
### Description of change

Fixes #12671.

#### Problem

Renaming a MySQL table recalculates generated foreign key constraint names, but a supporting index that MySQL reuses can remain under the previous generated name. The MySQL schema loader identifies same-named foreign-key support indexes by matching index and constraint names. After the rename, the stale index is therefore loaded as an ordinary `TableIndex`, and the next schema diff emits an invalid `DROP INDEX` while the foreign key still depends on it.

#### Change

Before renaming, `MysqlQueryRunner` now inspects `INFORMATION_SCHEMA.STATISTICS` only for indexes whose names match generated foreign keys. It treats an index as generated support only when it is a non-unique BTREE over the exact ordered foreign key columns with no prefix lengths.

For those indexes, the existing reversible foreign-key `ALTER TABLE` now drops the old index and recreates it under the recalculated foreign key name. The down query performs the symmetric operation. This uses the existing `DROP INDEX` / `ADD INDEX` syntax instead of introducing a newer `RENAME INDEX` version requirement.

Custom foreign key names and differently named explicit or wider covering indexes are left unchanged. The regression test includes a custom covering index as that control case.

#### Tests

- Pre-fix reproduction on MySQL 8.0.44: `corepack pnpm run test:fast -- --grep "#12671"` ? expected failure, 0 passing / 1 failing; the next schema diff contained `DROP INDEX \`FK_7470a830c3002e44860c6aac32c\` ON \`circle_reports\``.
- `corepack pnpm run compile` ? passed.
- `corepack pnpm run test:fast -- --grep "#12671"` ? passed on MySQL 5.7.44, MySQL 8.0.44, and MariaDB 10.11.16; the final combined MySQL/MariaDB run reported 1 passing.
- `corepack pnpm run test:fast -- --grep "query runner > rename table"` ? passed, 3 passing.
- `corepack pnpm run test:fast -- --grep "schema builder > idempotency > up to date"` ? passed, 1 passing.
- `corepack pnpm run test:fast -- --grep "database schema > custom constraint names > (foreign key|index)"` ? passed, 8 passing.
- `corepack pnpm run test:fast` ? passed, 3,032 passing / 179 pending / 0 failing.
- `corepack pnpm run typecheck` ? passed.
- `corepack pnpm run lint` ? passed with zero errors on supported Node.js 24.11.0 (repository-wide warnings remain).
- `corepack pnpm run format:ci` ? could not provide a clean repository-wide result in this Windows checkout because CRLF conversion made Prettier report 3,721 files, including unchanged files. `corepack pnpm exec prettier --check src/driver/mysql/MysqlQueryRunner.ts test/github-issues/12671/issue-12671.test.ts test/github-issues/12671/entity/Category.ts test/github-issues/12671/entity/Report.ts test/github-issues/12671/entity/CircleReport.ts` passed, and the pre-commit Prettier hook passed for all five changed files.

#### Compatibility

The implementation uses MySQL-family syntax already used by the query runner and was exercised on MySQL 5.7.44, MySQL 8.0.44, and MariaDB 10.11.16. MySQL metadata does not expose index provenance, so an explicitly created plain index deliberately given exactly the generated foreign key name is treated as foreign-key-owned, consistent with the existing schema-loader convention. Differently named custom and covering indexes are preserved.

The same `renameTable()` implementation is present on `v0.3` and the current `v0` maintenance line, so a separate backport may be appropriate. Aurora MySQL has a separate query-runner implementation and is intentionally excluded because this behavior was not reproduced against Aurora.
