### PR TITLE
fix: guard metadata access in InsertQueryBuilder for raw-table upsert

### DIFF
--- a/src/query-builder/InsertQueryBuilder.ts
+++ b/src/query-builder/InsertQueryBuilder.ts
@@ -613,35 +613,37 @@ export class InsertQueryBuilder<
                     } else {
                         query += ` ${conflictTarget} DO UPDATE SET `
 
-                        updatePart.push(
-                            ...this.expressionMap
-                                .mainAlias!.metadata.columns.filter(
-                                    (column) =>
-                                        column.isUpdateDate &&
-                                        !overwrite?.includes(
-                                            column.databaseName,
-                                        ) &&
-                                        !(
-                                            (this.dataSource.driver.options
-                                                .type === "oracle" &&
-                                                this.getValueSets().length >
-                                                    1) ||
-                                            DriverUtils.isSQLiteFamily(
-                                                this.dataSource.driver,
-                                            ) ||
-                                            this.dataSource.driver.options
-                                                .type === "sap" ||
-                                            this.dataSource.driver.options
-                                                .type === "spanner"
-                                        ),
-                                )
-                                .map(
-                                    (column) =>
-                                        `${this.escape(
-                                            column.databaseName,
-                                        )} = DEFAULT`,
-                                ),
-                        )
+                        if (this.expressionMap.mainAlias!.hasMetadata) {
+                            updatePart.push(
+                                ...this.expressionMap
+                                    .mainAlias!.metadata.columns.filter(
+                                        (column) =>
+                                            column.isUpdateDate &&
+                                            !overwrite?.includes(
+                                                column.databaseName,
+                                            ) &&
+                                            !(
+                                                (this.dataSource.driver.options
+                                                    .type === "oracle" &&
+                                                    this.getValueSets().length >
+                                                        1) ||
+                                                DriverUtils.isSQLiteFamily(
+                                                    this.dataSource.driver,
+                                                ) ||
+                                                this.dataSource.driver.options
+                                                    .type === "sap" ||
+                                                this.dataSource.driver.options
+                                                    .type === "spanner"
+                                            ),
+                                    )
+                                    .map(
+                                        (column) =>
+                                            `${this.escape(
+                                                column.databaseName,
+                                            )} = DEFAULT`,
+                                    ),
+                            )
+                        }
 
                         query += updatePart.join(", ")
                     }

--- a/test/functional/query-builder/insert-on-conflict/query-builder-insert-on-conflict.test.ts
+++ b/test/functional/query-builder/insert-on-conflict/query-builder-insert-on-conflict.test.ts
@@ -202,6 +202,24 @@ describe("query builder > insert > on conflict", () => {
                     })
             }),
         ))
+    // https://github.com/typeorm/typeorm/issues/11549
+    it("should build orUpdate query when inserting into a raw table without entity metadata", () =>
+        Promise.all(
+            dataSources.map(async (dataSource) => {
+                const builder = dataSource
+                    .createQueryBuilder()
+                    .insert()
+                    .into("raw_upsert_table", ["id", "name"])
+                    .values([{ id: 1, name: "Category 1" }])
+                    .orUpdate(["name"], ["id"])
+
+                const sql = builder.getSql()
+
+                expect(sql).to.include(
+                    `ON CONFLICT ( "id" ) DO UPDATE SET "name" = EXCLUDED."name"`,
+                )
+            }),
+        ))
     it("should perform insertion using partial index and skipping update on no change", () =>
         Promise.all(
             dataSources.map(async (dataSource) => {


### PR DESCRIPTION
## Description

Fixes #11549. Building an upsert against a **raw table name** throws before the query can be generated:

```ts
dataSource.createQueryBuilder()
  .insert().into("some_table", ["id", "name"])
  .values({ id: 1, name: "a" })
  .orUpdate(["name"], ["id"])
  .getSql()
// TypeORMError: Cannot get entity metadata for the given alias "some_table"
```

In `InsertQueryBuilder.createInsertExpression()`, after assembling the `ON CONFLICT ... DO UPDATE SET` columns, the code unconditionally read `this.expressionMap.mainAlias!.metadata.columns` to append `UpdateDateColumn = DEFAULT` entries. A raw table has no entity metadata, so `Alias.metadata`'s getter throws. Every other metadata access in this method (the SQLite JSON branch, the MSSQL IDENTITY_INSERT branch, `getInsertedColumns`) is already guarded by `hasMetadata`; this was the lone unguarded read.

## Fix

Wrap the update-date-column block in `if (this.expressionMap.mainAlias!.hasMetadata) { … }`, matching the method's established guard pattern. A raw table has no `UpdateDateColumn`, so there is nothing to append.

## Tests

Added a DB-free test to `test/functional/query-builder/insert-on-conflict/` (per the compliance checklist, with the issue reference in a comment) that builds the raw-table upsert and asserts `getSql()` contains `ON CONFLICT ( "id" ) DO UPDATE SET "name" = EXCLUDED."name"`. Runs on the in-memory better-sqlite3 harness (same `on-conflict-do-update` path as Postgres). Verified break→red (`Cannot get entity metadata … InsertQueryBuilder.ts`) → restore→green; on-conflict describe 8/8 passing.

Closes #11549
