### PR TITLE
fix(data-source): prevent connection leaks in DataSource.initialize()

### DIFF
--- a/docs/docs/data-source/1-data-source.md
+++ b/docs/docs/data-source/1-data-source.md
@@ -8,6 +8,10 @@ establishes the initial database connection or connection pool depending on the 
 
 To establish the initial connection/connection pool, you must call the `initialize` method of your `DataSource` instance.
 
+`initialize` must only be called once: calling it again while a previous call is still in progress, or after it has
+succeeded, rejects with a `CannotConnectAlreadyConnectedError`. If initialization fails, the partially established
+connection is cleaned up and `initialize` can safely be called again.
+
 Disconnection (closing all connections in the pool) occurs when the `destroy` method is called.
 
 Generally, you call the `initialize` method of the `DataSource` instance on the application bootstrap,

--- a/src/data-source/DataSource.ts
+++ b/src/data-source/DataSource.ts
@@ -128,6 +128,8 @@ export class DataSource {
 
     readonly relationIdLoader: RelationIdLoader
 
+    private isInitializing = false
+
     // -------------------------------------------------------------------------
     // Constructor
     // -------------------------------------------------------------------------
@@ -236,45 +238,64 @@ export class DataSource {
      * but it also can setup a connection pool with database to use.
      */
     async initialize(): Promise<this> {
-        if (this.isInitialized) throw new CannotConnectAlreadyConnectedError()
+        if (this.isInitialized || this.isInitializing)
+            throw new CannotConnectAlreadyConnectedError()
 
-        // validate isolationLevel before connecting
-        validateIsolationLevel(
-            this.driver.supportedIsolationLevels,
-            this.options.isolationLevel,
-        )
-
-        // connect to the database via its driver
-        await this.driver.connect()
-
-        // connect to the cache-specific database if cache is enabled
-        if (this.queryResultCache) await this.queryResultCache.connect()
-
-        // set connected status for the current connection
-        ObjectUtils.assign(this, { isInitialized: true })
-
+        this.isInitializing = true
         try {
-            // build all metadatas registered in the current connection
-            await this.buildMetadatas()
+            // validate isolationLevel before connecting
+            validateIsolationLevel(
+                this.driver.supportedIsolationLevels,
+                this.options.isolationLevel,
+            )
 
-            await this.driver.afterConnect()
+            // connect to the database via its driver
+            await this.driver.connect()
 
-            // if option is set - drop schema once connection is done
-            if (this.options.dropSchema) await this.dropDatabase()
+            try {
+                // connect to the cache-specific database if cache is enabled
+                if (this.queryResultCache) await this.queryResultCache.connect()
 
-            // if option is set - automatically synchronize a schema
-            if (this.options.migrationsRun)
-                await this.runMigrations({
-                    transaction: this.options.migrationsTransactionMode,
-                })
+                // set connected status for the current connection
+                ObjectUtils.assign(this, { isInitialized: true })
 
-            // if option is set - automatically synchronize a schema
-            if (this.options.synchronize) await this.synchronize()
-        } catch (error) {
-            // if for some reason build metadata fail (for example validation error during entity metadata check)
-            // connection needs to be closed
-            await this.destroy()
-            throw error
+                // build all metadatas registered in the current connection
+                await this.buildMetadatas()
+
+                await this.driver.afterConnect()
+
+                // if option is set - drop schema once connection is done
+                if (this.options.dropSchema) await this.dropDatabase()
+
+                // if option is set - automatically synchronize a schema
+                if (this.options.migrationsRun)
+                    await this.runMigrations({
+                        transaction: this.options.migrationsTransactionMode,
+                    })
+
+                // if option is set - automatically synchronize a schema
+                if (this.options.synchronize) await this.synchronize()
+            } catch (error) {
+                // if for some reason build metadata fail (for example validation error during entity metadata check)
+                // connection needs to be closed
+                if (this.isInitialized) {
+                    await this.destroy()
+                } else {
+                    // the cache provider may have partially connected before
+                    // failing; clean it up without masking the original error
+                    if (this.queryResultCache) {
+                        try {
+                            await this.queryResultCache.disconnect()
+                        } catch {
+                            // ignore
+                        }
+                    }
+                    await this.driver.disconnect()
+                }
+                throw error
+            }
+        } finally {
+            this.isInitializing = false
         }
 
         return this

--- a/src/data-source/DataSource.ts
+++ b/src/data-source/DataSource.ts
@@ -281,8 +281,8 @@ export class DataSource {
                 if (this.isInitialized) {
                     await this.destroy()
                 } else {
-                    // the cache provider may have partially connected before
-                    // failing; clean it up without masking the original error
+                    // clean up whatever partially connected, without letting
+                    // a cleanup failure mask the original error
                     if (this.queryResultCache) {
                         try {
                             await this.queryResultCache.disconnect()
@@ -290,7 +290,11 @@ export class DataSource {
                             // ignore
                         }
                     }
-                    await this.driver.disconnect()
+                    try {
+                        await this.driver.disconnect()
+                    } catch {
+                        // ignore
+                    }
                 }
                 throw error
             }

--- a/test/functional/data-source/data-source.test.ts
+++ b/test/functional/data-source/data-source.test.ts
@@ -1,9 +1,11 @@
 import { expect } from "chai"
 import "reflect-metadata"
+import sinon from "sinon"
 import {
     CannotConnectAlreadyConnectedError,
     CannotExecuteNotConnectedError,
 } from "../../../src"
+import type { QueryResultCache } from "../../../src/cache/QueryResultCache"
 import { DataSource } from "../../../src/data-source/DataSource"
 import type { PostgresDataSourceOptions } from "../../../src/driver/postgres/PostgresDataSourceOptions"
 import { EntityManager } from "../../../src/entity-manager/EntityManager"
@@ -30,6 +32,103 @@ import { SiteLocation } from "./entity/SiteLocation"
 import { Site } from "./entity/Site"
 
 describe("DataSource", () => {
+    describe("when cache initialization fails", () => {
+        it("should disconnect the database driver", async () => {
+            const cacheConnectionError = new Error(
+                "query cache connection failed",
+            )
+            const failingCacheProvider: QueryResultCache = {
+                connect() {
+                    return Promise.reject(cacheConnectionError)
+                },
+                async disconnect() {},
+                async synchronize() {},
+                getFromCache() {
+                    return Promise.resolve(undefined)
+                },
+                async storeInCache() {},
+                isExpired() {
+                    return false
+                },
+                async clear() {},
+                async remove() {},
+            }
+            const dataSource = new DataSource({
+                type: "better-sqlite3",
+                database: ":memory:",
+                cache: {
+                    provider: () => failingCacheProvider,
+                },
+            })
+            const disconnectSpy = sinon.spy(dataSource.driver, "disconnect")
+            const cacheDisconnectSpy = sinon.spy(
+                failingCacheProvider,
+                "disconnect",
+            )
+
+            try {
+                await expect(dataSource.initialize()).to.be.rejectedWith(
+                    cacheConnectionError,
+                )
+                expect(disconnectSpy).to.have.been.calledOnce
+                expect(cacheDisconnectSpy).to.have.been.calledOnce
+                expect(dataSource.isInitialized).to.be.false
+            } finally {
+                if (disconnectSpy.notCalled) {
+                    await dataSource.driver.disconnect()
+                }
+            }
+        })
+    })
+
+    describe("while initialization is in progress", () => {
+        it("should reject another initialization attempt", async () => {
+            const dataSource = new DataSource({
+                type: "better-sqlite3",
+                database: ":memory:",
+            })
+            const originalConnect = dataSource.driver.connect.bind(
+                dataSource.driver,
+            )
+            let allowConnection!: () => void
+            const connectionGate = new Promise<void>((resolve) => {
+                allowConnection = resolve
+            })
+            let reportConnectionStarted!: () => void
+            const connectionStarted = new Promise<void>((resolve) => {
+                reportConnectionStarted = resolve
+            })
+            const connectStub = sinon.stub(dataSource.driver, "connect")
+            connectStub.onFirstCall().callsFake(async () => {
+                reportConnectionStarted()
+                await connectionGate
+                await originalConnect()
+            })
+            connectStub
+                .onSecondCall()
+                .rejects(new Error("driver connect called more than once"))
+
+            const firstInitialization = dataSource.initialize()
+            await connectionStarted
+            const secondInitialization = dataSource.initialize()
+            allowConnection()
+
+            try {
+                // assert the rejection first so a handler is attached to the
+                // already-rejected promise within the same tick it was created
+                await expect(secondInitialization).to.be.rejectedWith(
+                    CannotConnectAlreadyConnectedError,
+                )
+                await expect(firstInitialization).to.be.fulfilled
+                expect(connectStub).to.have.been.calledOnce
+            } finally {
+                if (dataSource.isInitialized) {
+                    await dataSource.destroy()
+                }
+            }
+        })
+    })
+
     describe("before connection is established", () => {
         let dataSource: DataSource
         before(() => {

--- a/test/functional/data-source/data-source.test.ts
+++ b/test/functional/data-source/data-source.test.ts
@@ -32,6 +32,7 @@ import { SiteLocation } from "./entity/SiteLocation"
 import { Site } from "./entity/Site"
 
 describe("DataSource", () => {
+    // regression test for github issue #12705
     describe("when cache initialization fails", () => {
         it("should disconnect the database driver", async () => {
             const cacheConnectionError = new Error(
@@ -81,6 +82,7 @@ describe("DataSource", () => {
         })
     })
 
+    // regression test for github issue #12705
     describe("while initialization is in progress", () => {
         it("should reject another initialization attempt", async () => {
             const dataSource = new DataSource({
@@ -124,6 +126,12 @@ describe("DataSource", () => {
             } finally {
                 if (dataSource.isInitialized) {
                     await dataSource.destroy()
+                } else {
+                    try {
+                        await dataSource.driver.disconnect()
+                    } catch {
+                        // the driver may never have connected
+                    }
                 }
             }
         })


### PR DESCRIPTION
Fixes #12705

### Description of change

`DataSource.initialize()` could leak database connections in two ways:

1. **Concurrent calls both connected the driver.** The `isInitialized` guard is only set *after* `driver.connect()` resolves, so two overlapping `initialize()` calls both passed the check and each opened a driver connection/pool — one of them leaked.
2. **A cache connection failure leaked the driver connection.** `queryResultCache.connect()` runs after the driver connects but *before* the existing cleanup `try/catch` began, so if the cache failed to connect, `initialize()` rejected with the driver still connected and no way to release it.

**New behavior:**

- A private `isInitializing` flag makes an overlapping `initialize()` call reject with `CannotConnectAlreadyConnectedError` — the same error already thrown when calling `initialize()` on an initialized DataSource, so no new API surface. The flag is cleared in a `finally`, so a *failed* initialize can still be retried, as before.
- The entire post-connect sequence is now covered by the cleanup `try/catch`. On failure **before** `isInitialized` is set (a cache connect failure), the driver is disconnected directly — `destroy()` cannot be used on that path because it throws `CannotExecuteNotConnectedError` when the DataSource is not initialized. A best-effort `queryResultCache.disconnect()` runs first (errors ignored) to release providers that partially connected before throwing, without masking the original error. On failure **after** `isInitialized` is set, behavior is unchanged: `destroy()` is called and the error re-thrown.

**Behavioral note for reviewers:** code that previously raced two `initialize()` calls and appeared to work (while silently double-connecting the driver) will now get a rejection on the second call. Rejecting is consistent with the existing double-initialize semantics; if you'd rather coalesce (return the in-flight promise so concurrent callers all resolve together), I'm happy to switch — rejecting seemed like the more conservative default.

**Verification:** two new regression tests in `test/functional/data-source/data-source.test.ts`, both using `better-sqlite3` in-memory so they need no external services, and both failing against `master`:

- *when cache initialization fails → should disconnect the database driver* — asserts the driver and the cache provider are disconnected and `isInitialized` stays `false`.
- *while initialization is in progress → should reject another initialization attempt* — gates `driver.connect()` to hold the first call mid-flight, asserts the second call rejects with `CannotConnectAlreadyConnectedError` and that `connect()` was only invoked once.

### Pull-Request Checklist

- [x] Code is up-to-date with the `master` branch
- [x] This pull request links a relevant issue using a closing keyword:
      `Fixes #NNNN`, `Closes #NNNN`, or `Resolves #NNNN` — Fixes #12705
- [x] There are new or updated tests validating the change (`tests/**.test.ts`)
- [x] Documentation has been updated to reflect this change (`docs/docs/**.md`) — noted in the DataSource docs that `initialize()` rejects concurrent or repeated calls and that a failed initialization can be retried
