### PR TITLE
fix(query-builder): guard nulls in orderBy object shorthand

### DIFF
--- a/src/query-builder/SelectQueryBuilder.ts
+++ b/src/query-builder/SelectQueryBuilder.ts
@@ -2606,8 +2606,9 @@ export class SelectQueryBuilder<Entity extends ObjectLiteral>
                         typeof orderBys[columnName] === "string"
                             ? orderBys[columnName]
                             : orderBys[columnName].order +
-                              " " +
-                              orderBys[columnName].nulls
+                              (orderBys[columnName].nulls
+                                  ? " " + orderBys[columnName].nulls
+                                  : "")
 
                     if (/[;'"\\]/.test(orderValue))
                         throw new TypeORMError(

--- a/src/query-builder/SoftDeleteQueryBuilder.ts
+++ b/src/query-builder/SoftDeleteQueryBuilder.ts
@@ -582,7 +582,7 @@ export class SoftDeleteQueryBuilder<Entity extends ObjectLiteral>
                             return columnName + " " + orderBys[columnName]
                         } else {
                             const { order, nulls } = orderBys[columnName] as any
-                            return columnName + " " + order + " " + nulls
+                            return columnName + " " + order + (nulls ? " " + nulls : "")
                         }
                     })
                     .join(", ")

--- a/src/query-builder/SoftDeleteQueryBuilder.ts
+++ b/src/query-builder/SoftDeleteQueryBuilder.ts
@@ -582,7 +582,12 @@ export class SoftDeleteQueryBuilder<Entity extends ObjectLiteral>
                             return columnName + " " + orderBys[columnName]
                         } else {
                             const { order, nulls } = orderBys[columnName] as any
-                            return columnName + " " + order + (nulls ? " " + nulls : "")
+                            return (
+                                columnName +
+                                " " +
+                                order +
+                                (nulls ? " " + nulls : "")
+                            )
                         }
                     })
                     .join(", ")

--- a/src/query-builder/UpdateQueryBuilder.ts
+++ b/src/query-builder/UpdateQueryBuilder.ts
@@ -778,7 +778,12 @@ export class UpdateQueryBuilder<Entity extends ObjectLiteral>
                             return columnName + " " + orderBys[columnName]
                         } else {
                             const { order, nulls } = orderBys[columnName] as any
-                            return columnName + " " + order + (nulls ? " " + nulls : "")
+                            return (
+                                columnName +
+                                " " +
+                                order +
+                                (nulls ? " " + nulls : "")
+                            )
                         }
                     })
                     .join(", ")

--- a/src/query-builder/UpdateQueryBuilder.ts
+++ b/src/query-builder/UpdateQueryBuilder.ts
@@ -778,7 +778,7 @@ export class UpdateQueryBuilder<Entity extends ObjectLiteral>
                             return columnName + " " + orderBys[columnName]
                         } else {
                             const { order, nulls } = orderBys[columnName] as any
-                            return columnName + " " + order + " " + nulls
+                            return columnName + " " + order + (nulls ? " " + nulls : "")
                         }
                     })
                     .join(", ")

--- a/test/functional/query-builder/order-by/query-builder-order-by.test.ts
+++ b/test/functional/query-builder/order-by/query-builder-order-by.test.ts
@@ -354,4 +354,17 @@ describe("query builder > order-by", () => {
                 expect(result.length).to.be.equal(5)
             }),
         ))
+
+    it("should not produce 'undefined' in SQL when orderBy object shorthand omits nulls", () =>
+        Promise.all(
+            dataSources.map(async (dataSource) => {
+                const query = dataSource.manager
+                    .createQueryBuilder(Post, "post")
+                    .orderBy({ "post.myOrder": { order: "ASC" } })
+
+                const sql = query.getSql()
+                expect(sql).to.not.include("undefined")
+                expect(sql).to.include("ORDER BY")
+            }),
+        ))
 })


### PR DESCRIPTION
## Problem

When `orderBy` is called with the object shorthand and no `nulls` property, the generated SQL contains a literal `undefined` token, producing a syntax error on all drivers.

**Reproduction (SQLite):**

```ts
await dataSource
    .getRepository(Post)
    .createQueryBuilder("post")
    .orderBy({ "post.id": { order: "ASC" } })
    .getMany();
// → SELECT ... FROM "post" "post" ORDER BY "post"."id" ASC undefined
// → QueryFailedError: near "undefined": syntax error
```

`nulls` is typed as optional in `OrderByCondition`, so `{ order: 'ASC' }` is valid, but the value ends up `undefined` at runtime.

## Root cause

`SelectQueryBuilder.buildOrderByExpression` (around line 2608) unconditionally concatenated:

```ts
orderBys[columnName].order + " " + orderBys[columnName].nulls
```

When `nulls` is `undefined`, that produces `"ASC undefined"`.

## Fix

Guard the nulls segment so it is only appended when the value is present:

```ts
orderBys[columnName].order +
    (orderBys[columnName].nulls ? " " + orderBys[columnName].nulls : "")
```

## Reproduction confirmed on `master`

Tested with SQLite. The `ORDER BY "post"."id" ASC undefined` error is reproducible on current `master` and is resolved by this change.


Closes #8103