### PR TITLE
fix(persistence): keep many-to-many junction rows when the relation is not loaded

### DIFF
--- a/src/persistence/subject-builder/ManyToManySubjectBuilder.ts
+++ b/src/persistence/subject-builder/ManyToManySubjectBuilder.ts
@@ -122,6 +122,9 @@ export class ManyToManySubjectBuilder {
         let relatedEntities: ObjectLiteral[] = relation.getEntityValue(
             subject.entity!,
         )
+        if (relatedEntities === undefined)
+            // if relation is undefined then it was not loaded - nothing to update
+            return
         // if value set to null its equal if we set it to empty array - all items must be removed from the database
         relatedEntities ??= []
         if (!Array.isArray(relatedEntities)) return

--- a/test/functional/persistence/many-to-many/persistence-many-to-many.test.ts
+++ b/test/functional/persistence/many-to-many/persistence-many-to-many.test.ts
@@ -291,6 +291,52 @@ describe("persistence > many-to-many", function () {
             }),
         ))
 
+    // regression test for github issue #12710
+    it("should not remove junction rows of an entity saved in the same call without its relation loaded", () =>
+        Promise.all(
+            dataSources.map(async (dataSource) => {
+                const postRepository = dataSource.getRepository(Post)
+                const categoryRepository = dataSource.getRepository(Category)
+
+                const category1 = new Category()
+                category1.name = "Animals"
+                await categoryRepository.save(category1)
+
+                const category2 = new Category()
+                category2.name = "Nature"
+                await categoryRepository.save(category2)
+
+                const post1 = new Post()
+                post1.title = "post #1"
+                post1.categories = [category1]
+
+                const post2 = new Post()
+                post2.title = "post #2"
+                post2.categories = [category2]
+                await postRepository.save([post1, post2])
+
+                // load post1 WITH its categories and post2 WITHOUT them,
+                // so post2's categories stay undefined (not loaded)
+                const loadedPost1 = await postRepository.findOneOrFail({
+                    where: { id: post1.id },
+                    relations: { categories: true },
+                })
+                const loadedPost2 = await postRepository.findOneOrFail({
+                    where: { id: post2.id },
+                })
+
+                loadedPost1.title = "post #1 renamed"
+                loadedPost2.title = "post #2 renamed"
+                await postRepository.save([loadedPost1, loadedPost2])
+
+                const reloadedPost2 = await postRepository.findOneOrFail({
+                    where: { id: post2.id },
+                    relations: { categories: true },
+                })
+                expect(reloadedPost2.categories!.length).to.be.equal(1)
+            }),
+        ))
+
     it("remove all elements from many-to-many relation if parent entity is removed", () =>
         Promise.all(
             dataSources.map(async (dataSource) => {


### PR DESCRIPTION
Fixes #12710

### Description of change

Saving several entities in one `save()` call (or via a cascade) silently deleted every many-to-many junction row of any entity in the batch whose relation property was not loaded, whenever another entity in the same persistence group had that relation loaded.

**Root cause:** the `prefer-nullish-coalescing` style refactor (cab8fcb0e, #12340) changed `ManyToManySubjectBuilder.buildForSubjectRelation` from

```ts
if (relatedEntities === null) relatedEntities = []
if (!Array.isArray(relatedEntities)) return
```

to

```ts
relatedEntities ??= []
if (!Array.isArray(relatedEntities)) return
```

`??=` also matches `undefined`, so an unloaded relation — which previously fell through to the `!Array.isArray` guard and was skipped — became "relation set to empty, remove all junction rows". The removal only materializes when another subject in the same group has the relation loaded (that makes `SubjectDatabaseEntityLoader` fetch the database-side relation ids for the whole target group), which is why single-entity saves look fine and the data loss surfaces on batch saves and cascades. The same refactor kept the explicit `undefined → return` guard in the sibling `OneToManySubjectBuilder` — only the many-to-many builder lost it.

**Fix:** restore the `undefined → skip` guard, mirroring `OneToManySubjectBuilder`. `null` still means "remove all bindings" and non-array values (e.g. lazy-relation promises) are still skipped, so the documented 1.0 semantics are all preserved:

- `undefined` (not loaded) → junction rows left intact (this was broken)
- `null` / `[]` → all junction rows removed (unchanged, still covered by the existing tests in the same file)

**Verification:**

- New regression test in `test/functional/persistence/many-to-many/persistence-many-to-many.test.ts`: two posts saved in one call, one loaded with its categories and one without; asserts the unloaded one keeps its junction row. It fails on `master` (the junction row is deleted) and passes with this fix.
- Full local sqlite test leg passes (3039 passing).
- A standalone reproduction script is included in #12710; against this branch it shows both junction rows surviving.

### Pull-Request Checklist

- [x] Code is up-to-date with the `master` branch
- [x] This pull request links a relevant issue using a closing keyword:
      `Fixes #NNNN`, `Closes #NNNN`, or `Resolves #NNNN` — Fixes #12710
- [x] There are new or updated tests validating the change (`tests/**.test.ts`)
- [ ] Documentation has been updated to reflect this change (`docs/docs/**.md`) — N/A (restores the documented behavior from the 1.0 upgrade guide; no documented behavior changes)
