### PR TITLE
feat(postgres): add postgres.js support

### DIFF
--- a/.github/workflows/mutation-test.yml
+++ b/.github/workflows/mutation-test.yml
@@ -54,6 +54,7 @@ jobs:
               "mariadb" \
               "mysql" \
               "postgres" \
+              "postgres-js" \
               "sqljs" \
             > ormconfig.json
 

--- a/.github/workflows/tests-linux.yml
+++ b/.github/workflows/tests-linux.yml
@@ -220,6 +220,11 @@ jobs:
       fail-fast: false
       matrix:
         postgres-version: ["14.22", "17.9"]
+        postgres-client:
+          - name: pg
+            type: postgres
+          - name: postgres-js
+            type: postgres-js
 
     services:
       postgres:
@@ -242,12 +247,12 @@ jobs:
           node-version: ${{ inputs.node-version }}
           download-build: true
 
-      - run: jq 'map(select(.type == "postgres"))' ormconfig.sample.json > ormconfig.json
+      - run: jq --arg type '${{ matrix.postgres-client.type }}' 'map(select(.type == $type))' ormconfig.sample.json > ormconfig.json
       - run: pnpm exec c8 pnpm run test:ci
 
       - uses: ./.github/actions/upload-coverage
         with:
-          name: postgres-${{ matrix.postgres-version }}-node-${{ inputs.node-version }}-linux
+          name: postgres-${{ matrix.postgres-client.name }}-${{ matrix.postgres-version }}-node-${{ inputs.node-version }}-linux
 
   sap:
     runs-on: ubuntu-latest

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -22,6 +22,83 @@ Please include as much of the information listed below as you can to help us bet
 
 This information will help us triage your report more quickly.
 
+## Security Model and Scope
+
+TypeORM is an ORM _and_ a SQL-building toolkit. Understanding which of its inputs are
+trusted is essential to knowing what constitutes a vulnerability. Please read this section
+before filing an advisory — reports outside this scope will be closed with a reference to
+this policy.
+
+### What TypeORM guarantees
+
+**Values are safe.** Any untrusted _data_ supplied in a value position — entity values,
+criteria values, named parameters, pagination values — is bound as a query parameter or
+correctly escaped as a literal.
+
+**Database content is treated as data.** Whatever comes back from the database — values,
+result sets, database-reported metadata — is handled as untrusted data wherever TypeORM
+processes it: during entity hydration, and in anything TypeORM generates from database
+state, including code and files emitted by the CLI.
+
+Bugs in these guarantees are vulnerabilities and we want to hear about them. In scope:
+
+- Untrusted runtime data reaching a generated query unescaped — or, for non-SQL drivers,
+  being interpreted as query operators rather than values — through a documented API used
+  as documented. This includes TypeORM's _internal_ query generation interpolating entity
+  data.
+- Parameter-binding or literal-escaping defects in a driver.
+- Defects in identifier escaping where TypeORM applies it.
+- Database-derived content escaping its context in TypeORM's output: prototype pollution
+  or code execution while processing results, or injection into code, files, or commands
+  generated from database state.
+- Amplification of an existing prototype-pollution primitive: object iteration in
+  query-building, result-processing, or code-generation paths must not pick up inherited
+  keys, so that a polluted runtime cannot alter generated queries or emitted code through
+  TypeORM. (The pollution source itself remains a vulnerability in whatever introduced
+  it; such reports are assessed at reduced severity.)
+
+### What TypeORM does not guarantee
+
+**Identifiers and SQL expressions are code, not data.** QueryBuilder builds SQL. By
+design, any argument documented to accept an identifier or a SQL fragment — projections,
+condition strings, sort and grouping expressions, aliases, computed expressions — is
+emitted as the developer wrote it, because expressing arbitrary SQL is the point of those
+positions. They **cannot be escaped without breaking documented functionality**, and the
+API does not promise they are injection-safe.
+
+Passing untrusted input into such a position is an application vulnerability, equivalent
+to concatenating user input into a raw query. Reports that require the application to do
+so are out of scope. Use parameter binding for all untrusted data; never build identifiers
+or expressions from user input.
+
+**Schema definitions are trusted code.** Entity definitions, migration objects, and their
+options are design-time inputs authored by the developer. DDL generated from them is not
+hardened against a hostile schema: an attacker who controls your schema definitions
+already controls your application. Reports premised on untrusted input reaching schema or
+migration definitions are out of scope. (We still accept — and appreciate — pull requests
+that escape identifier-only positions as defense-in-depth; those are handled as regular
+hardening changes, not advisories.)
+
+**Configuration is trusted code.** Connection options, data source configuration, CLI
+arguments, and migration files are developer-authored inputs, on par with application
+source. Reports requiring an attacker to control them are out of scope.
+
+**Runtime guards are best-effort, not security boundaries.** TypeORM sometimes adds
+validations that catch common application mistakes before they reach the database. These
+guards are conveniences layered on top of the model above; they do not move the trust
+boundary, and they are not, and cannot be, complete. A bypass of such a guard that
+restores previously documented behavior is a regular bug — please file it as an ordinary
+issue — not a vulnerability.
+
+### Severity expectations
+
+CVSS scores should reflect TypeORM's contract, not a hypothetical application that pipes
+untrusted input into a code position. A report whose attack vector is "the application
+passes attacker-controlled input into an identifier, expression, or schema slot" describes
+an application vulnerability and will be assessed accordingly. Before filing, check
+existing advisories and recent releases — duplicates of an already-tracked mechanism will
+be closed as such.
+
 ## What to Expect
 
 We aim to acknowledge reports within 72 hours. After triage, the maintainers will work on a fix in a private fork and coordinate a public disclosure with a CVE when appropriate. We will release a patch as soon as possible depending on complexity.

--- a/docs/docs/data-source/2-data-source-options.md
+++ b/docs/docs/data-source/2-data-source-options.md
@@ -9,7 +9,7 @@ Different RDBMS-es have their own specific options.
 
 - `type` - RDBMS type. You must specify what database engine you use.
   Possible values are:
-  "mysql", "postgres", "cockroachdb", "sap", "spanner", "mariadb", "cordova", "react-native", "nativescript", "sqljs", "oracle", "mssql", "mongodb", "aurora-mysql", "aurora-postgres", "expo", "better-sqlite3", "capacitor".
+  "mysql", "postgres", "postgres-js", "cockroachdb", "sap", "spanner", "mariadb", "cordova", "react-native", "nativescript", "sqljs", "oracle", "mssql", "mongodb", "aurora-mysql", "aurora-postgres", "expo", "better-sqlite3", "capacitor".
   This option is **required**.
 
 - `extra` - Extra options to be passed to the underlying driver.

--- a/docs/docs/drivers/postgres.md
+++ b/docs/docs/drivers/postgres.md
@@ -1,6 +1,6 @@
 # Postgres / CockroachDB
 
-PostgreSQL, CockroachDB and Amazon Aurora Postgres are supported as TypeORM drivers.
+PostgreSQL, CockroachDB and Amazon Aurora Postgres are supported as TypeORM drivers. PostgreSQL can use either the [`pg`](https://node-postgres.com/) client with `type: "postgres"` or [Postgres.js](https://github.com/porsager/postgres) with `type: "postgres-js"`. Both client choices use TypeORM's same PostgreSQL dialect, metadata, schema builder, migrations, repositories and query APIs.
 
 Databases that are PostgreSQL-compatible can also be used with TypeORM via the `postgres` data source type.
 
@@ -8,19 +8,111 @@ To use YugabyteDB, refer to [their ORM docs](https://docs.yugabyte.com/stable/dr
 
 ## Installation
 
+For `pg`:
+
 ```shell
 npm install pg
 ```
 
-For streaming support:
+Install `pg-query-stream` as well when your application uses `QueryRunner.stream()` with `pg`:
 
 ```shell
 npm install pg-query-stream
 ```
 
+For Postgres.js:
+
+```shell
+npm install postgres
+```
+
+Postgres.js streaming uses its built-in cursor API and does not require `pg-query-stream`.
+
+## Configuration
+
+With `pg`:
+
+```typescript
+import { DataSource } from "typeorm"
+
+export const dataSource = new DataSource({
+    type: "postgres",
+    host: "localhost",
+    port: 5432,
+    username: "app",
+    password: "secret",
+    database: "app",
+    entities: [User],
+})
+```
+
+With Postgres.js, the portable configuration is identical apart from `type`:
+
+```typescript
+import { DataSource } from "typeorm"
+
+export const dataSource = new DataSource({
+    type: "postgres-js",
+    host: "localhost",
+    port: 5432,
+    username: "app",
+    password: "secret",
+    database: "app",
+    entities: [User],
+})
+```
+
+## Migrating from `pg` to Postgres.js
+
+For a standard TypeORM configuration, migration is two changes:
+
+```diff
+ dependencies: {
+-    "pg": "^8.0.0"
++    "postgres": "^3.4.9"
+ }
+
+ const dataSource = new DataSource({
+-    type: "postgres",
++    type: "postgres-js",
+     // the rest of the portable options stay unchanged
+ })
+```
+
+Your entities, migrations, subscribers, repositories and application calls stay unchanged. Portable Data Source options such as credentials, `poolSize`, `connectTimeoutMS`, `applicationName`, replication and logging also keep their TypeORM-level meaning.
+
+Do not copy `pg` APIs or quirks into the new configuration. The `extra` object belongs to the selected client: use `pg` options with `type: "postgres"` and native Postgres.js options with `type: "postgres-js"`. TypeORM translates only the common migration aliases listed below. Unknown Postgres.js-native keys pass through unchanged.
+
+### Postgres.js compatibility mappings
+
+`connectTimeoutMS` always uses milliseconds at the TypeORM API boundary; TypeORM converts it to Postgres.js seconds internally. Explicit Postgres.js-native keys in `extra` take precedence over TypeORM values and translated aliases.
+
+| TypeORM or common `pg` input    | Postgres.js behavior                                       | Migration guidance                                                                              |
+| ------------------------------- | ---------------------------------------------------------- | ----------------------------------------------------------------------------------------------- |
+| `poolSize`                      | `max`                                                      | No configuration change required.                                                               |
+| `connectTimeoutMS`              | `connect_timeout`, milliseconds converted to seconds       | Keep the TypeORM option in milliseconds.                                                        |
+| `applicationName`               | `connection.application_name`                              | No configuration change required. If unset, Postgres.js keeps its native `postgres.js` default. |
+| `extra.connectionTimeoutMillis` | `extra.connect_timeout`, milliseconds converted to seconds | Prefer native `connect_timeout`; it wins if both are present.                                   |
+| `extra.idleTimeoutMillis`       | `extra.idle_timeout`, milliseconds converted to seconds    | Prefer native `idle_timeout`; it wins if both are present.                                      |
+| `extra.application_name`        | `extra.connection.application_name`                        | Prefer native `connection.application_name`; it wins if both are present.                       |
+| `extra.allowExitOnIdle`         | Unsupported and reported with a warning                    | Remove it. Close the DataSource normally; shutdown awaits `sql.end()`.                          |
+| `extra.maxUses`                 | Unsupported and reported with a warning                    | Use native `max_lifetime` for time-based connection recycling.                                  |
+| `extra.query_timeout`           | Unsupported and reported with a warning                    | Use `extra.connection.statement_timeout` or application-level cancellation.                     |
+
+`nativeDriver`, `poolErrorHandler` and `pg-query-stream` are `pg`-only. Postgres.js reports query errors on the query promise instead of emulating a global pool error event.
+
+### Verified Postgres.js behavior
+
+- Replication uses separate master and slave pools and preserves per-node `applicationName` values.
+- `QueryRunner.stream()` uses Postgres.js cursors, emits ordered object rows and propagates cursor errors.
+- `parseInt8` is `false` by default, so int8 values remain strings. With `true`, safe int8 values become numbers; values outside JavaScript's safe integer range remain strings to avoid precision loss. Numeric and decimal values remain strings.
+- `logNotifications: true` logs PostgreSQL NOTICE and LISTEN/NOTIFY messages once at `info` level while preserving native user callbacks in `extra`.
+- Concurrent calls on one reserved Postgres.js QueryRunner are serialized, preserving transaction and session state.
+- `destroy()` releases tracked QueryRunners and awaits every master/slave Postgres.js pool shutdown.
+
 ## Data Source Options
 
-See [Data Source Options](../data-source/2-data-source-options.md) for the common data source options. You can use the data source type `postgres`, `cockroachdb` or `aurora-postgres` to connect to the respective databases.
+See [Data Source Options](../data-source/2-data-source-options.md) for the common data source options. Use `postgres` for `pg`, `postgres-js` for Postgres.js, or `cockroachdb` / `aurora-postgres` for their respective databases.
 
 - `url` - Connection url where the connection is performed. Please note that other data source options will override parameters set from url.
 
@@ -38,11 +130,13 @@ See [Data Source Options](../data-source/2-data-source-options.md) for the commo
 
 - `connectTimeoutMS` - The milliseconds before a timeout occurs during the initial connection to the postgres server. If `undefined`, or set to `0`, there is no timeout. Defaults to `undefined`.
 
-- `ssl` - Object with ssl parameters. See [TLS/SSL](https://node-postgres.com/features/ssl).
+- `ssl` - Object with SSL parameters supported by the selected client.
 
 - `uuidExtension` - The Postgres extension to use when generating UUIDs. Defaults to `uuid-ossp`. It can be changed to `pgcrypto` if the `uuid-ossp` extension is unavailable.
 
-- `poolErrorHandler` - A function that gets called when the underlying pool emits `'error'` event. Takes a single parameter (error instance) and defaults to logging with `warn` level.
+- `nativeDriver` - `pg`-only. An optional `pg-native` driver object.
+
+- `poolErrorHandler` - `pg`-only. A function called when the `pg` pool emits an `'error'` event. Postgres.js keeps errors query-local and does not emulate this global event.
 
 - `maxTransactionRetries` - A maximum number of transaction retries in case of a 40001 error. Defaults to 5.
 
@@ -54,13 +148,13 @@ See [Data Source Options](../data-source/2-data-source-options.md) for the commo
 
 - `applicationName` - A string visible in statistics and logs to help referencing an application to a connection (default: `undefined`)
 
-- `parseInt8` - A boolean to enable parsing 64-bit integers (int8) as JavaScript numbers. By default, `int8` (bigint) values are returned as strings to avoid overflows. JavaScript numbers are IEEE-754 and lose precision over the maximum safe integer (`Number.MAX_SAFE_INTEGER = +2^53`). If you require the full 64-bit range consider working with the returned strings or converting them to native `bigint` instead of using this option.
+- `parseInt8` - A boolean to enable parsing safe 64-bit integers (int8) as JavaScript numbers. By default, values are returned as strings. Postgres.js leaves values outside `Number.MAX_SAFE_INTEGER` as strings even when enabled, avoiding silent precision loss.
 
-Additional options can be added to the `extra` object and will be passed directly to the client library. See more in `pg`'s documentation for [Pool](https://node-postgres.com/apis/pool#new-pool) and [Client](https://node-postgres.com/apis/client#new-client).
+Additional options in `extra` go to the selected client library. See `pg`'s [Pool](https://node-postgres.com/apis/pool#new-pool) and [Client](https://node-postgres.com/apis/client#new-client) options, or the Postgres.js [connection options](https://github.com/porsager/postgres#connection-details).
 
 ## Column Types
 
-### Column types for `postgres`
+### Column types for `postgres` and `postgres-js`
 
 `int`, `int2`, `int4`, `int8`, `smallint`, `integer`, `bigint`, `decimal`, `numeric`, `real`, `float`, `float4`, `float8`, `double precision`, `money`, `character varying`, `varchar`, `character`, `char`, `text`, `citext`, `hstore`, `bytea`, `bit`, `varbit`, `bit varying`, `timetz`, `timestamptz`, `timestamp`, `timestamp without time zone`, `timestamp with time zone`, `date`, `time`, `time without time zone`, `time with time zone`, `interval`, `bool`, `boolean`, `enum`, `point`, `line`, `lseg`, `box`, `path`, `polygon`, `circle`, `cidr`, `inet`, `macaddr`, `macaddr8`, `tsvector`, `tsquery`, `uuid`, `xml`, `json`, `jsonb`, `jsonpath`, `int4range`, `int8range`, `numrange`, `tsrange`, `tstzrange`, `daterange`, `int4multirange`, `int8multirange`, `nummultirange`, `tsmultirange`, `tstzmultirange`, `multidaterange`, `geometry`, `geography`, `cube`, `ltree`, `vector`, `halfvec`.
 

--- a/ormconfig.sample.json
+++ b/ormconfig.sample.json
@@ -103,6 +103,16 @@
   },
   {
     "skip": false,
+    "type": "postgres-js",
+    "host": "localhost",
+    "port": 5432,
+    "username": "username",
+    "password": "password",
+    "database": "typeorm",
+    "logging": false
+  },
+  {
+    "skip": false,
     "type": "sap",
     "host": "localhost",
     "port": 39041,

--- a/package.json
+++ b/package.json
@@ -141,6 +141,7 @@
     "pg": "^8.22.0",
     "pg-query-stream": "^4.16.0",
     "pkg-pr-new": "^0.0.75",
+    "postgres": "^3.4.9",
     "prettier": "^3.9.4",
     "prettier-plugin-packagejson": "^3.0.2",
     "prettier-plugin-toml": "^2.0.6",
@@ -167,6 +168,7 @@
     "pg": "^8.5.1",
     "pg-native": "^3.0.0",
     "pg-query-stream": "^4.0.0",
+    "postgres": "^3.4.9",
     "redis": "^5.0.0 || ^6.0.0",
     "sql.js": "^1.4.0",
     "ts-node": "^10.9.2",
@@ -204,6 +206,9 @@
       "optional": true
     },
     "pg-query-stream": {
+      "optional": true
+    },
+    "postgres": {
       "optional": true
     },
     "redis": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -162,6 +162,9 @@ importers:
       pkg-pr-new:
         specifier: ^0.0.75
         version: 0.0.75
+      postgres:
+        specifier: ^3.4.9
+        version: 3.4.9
       prettier:
         specifier: ^3.9.4
         version: 3.9.4
@@ -3192,6 +3195,10 @@ packages:
   postgres-interval@1.2.0:
     resolution: {integrity: sha512-9ZhXKM/rw350N1ovuWHbGxnGh/SNJ4cnxHiM0rxE4VN41wsg8P8zWn9hv/buK00RP4WvlOyr/RBDiptyxVbkZQ==}
     engines: {node: '>=0.10.0'}
+
+  postgres@3.4.9:
+    resolution: {integrity: sha512-GD3qdB0x1z9xgFI6cdRD6xu2Sp2WCOEoe3mtnyB5Ee0XrrL5Pe+e4CCnJrRMnL1zYtRDZmQQVbvOttLnKDLnaw==}
+    engines: {node: '>=12'}
 
   prebuild-install@7.1.3:
     resolution: {integrity: sha512-8Mf2cbV7x1cXPUILADGI3wuhfqWvtiLA1iclTDbFRZkgRQS0NqsPZphna9V+HyTEadheuPmjaJMsbzKQFOzLug==}
@@ -7442,6 +7449,8 @@ snapshots:
   postgres-interval@1.2.0:
     dependencies:
       xtend: 4.0.2
+
+  postgres@3.4.9: {}
 
   prebuild-install@7.1.3:
     dependencies:

--- a/src/commands/InitCommand.ts
+++ b/src/commands/InitCommand.ts
@@ -26,6 +26,7 @@ export class InitCommand implements yargs.CommandModule {
                 describe: "Database type you'll use in your project.",
                 choices: [
                     "postgres",
+                    "postgres-js",
                     "mysql",
                     "mariadb",
                     "better-sqlite3",
@@ -196,8 +197,9 @@ export class InitCommand implements yargs.CommandModule {
                 break
 
             case "postgres":
+            case "postgres-js":
                 dbSettings = [
-                    'type: "postgres"',
+                    `type: "${database}"`,
                     'host: "localhost"',
                     "port: 5432",
                     'username: "root"',
@@ -604,6 +606,7 @@ AppDataSource.initialize().then(async () => {
 
 `
             case "postgres":
+            case "postgres-js":
                 return `services:
 
   postgres:
@@ -744,6 +747,10 @@ Steps to run this project:
             case "cockroachdb":
                 packageJson.dependencies["pg"] =
                     ourPackageJson.devDependencies.pg
+                break
+            case "postgres-js":
+                packageJson.dependencies.postgres =
+                    ourPackageJson.devDependencies.postgres
                 break
             case "better-sqlite3":
                 packageJson.dependencies["better-sqlite3"] =

--- a/src/data-source/DataSourceOptions.ts
+++ b/src/data-source/DataSourceOptions.ts
@@ -10,6 +10,7 @@ import type { MysqlDataSourceOptions } from "../driver/mysql/MysqlDataSourceOpti
 import type { NativescriptDataSourceOptions } from "../driver/nativescript/NativescriptDataSourceOptions"
 import type { OracleDataSourceOptions } from "../driver/oracle/OracleDataSourceOptions"
 import type { PostgresDataSourceOptions } from "../driver/postgres/PostgresDataSourceOptions"
+import type { PostgresJsDataSourceOptions } from "../driver/postgres/PostgresJsDataSourceOptions"
 import type { ReactNativeDataSourceOptions } from "../driver/react-native/ReactNativeDataSourceOptions"
 import type { SapDataSourceOptions } from "../driver/sap/SapDataSourceOptions"
 import type { SpannerDataSourceOptions } from "../driver/spanner/SpannerDataSourceOptions"
@@ -32,6 +33,7 @@ export type DataSourceOptions =
     | NativescriptDataSourceOptions
     | OracleDataSourceOptions
     | PostgresDataSourceOptions
+    | PostgresJsDataSourceOptions
     | ReactNativeDataSourceOptions
     | SapDataSourceOptions
     | SpannerDataSourceOptions

--- a/src/driver/DriverFactory.ts
+++ b/src/driver/DriverFactory.ts
@@ -59,6 +59,7 @@ export class DriverFactory {
             case "oracle":
                 return new OracleDriver(dataSource)
             case "postgres":
+            case "postgres-js":
                 return new PostgresDriver(dataSource)
             case "react-native":
                 return new ReactNativeDriver(dataSource)
@@ -84,6 +85,7 @@ export class DriverFactory {
                     "nativescript",
                     "oracle",
                     "postgres",
+                    "postgres-js",
                     "react-native",
                     "sap",
                     "spanner",

--- a/src/driver/DriverUtils.ts
+++ b/src/driver/DriverUtils.ts
@@ -41,9 +41,12 @@ export class DriverUtils {
     }
 
     static isPostgresFamily(driver: Driver): boolean {
-        return ["postgres", "aurora-postgres", "cockroachdb"].includes(
-            driver.options.type,
-        )
+        return [
+            "postgres",
+            "postgres-js",
+            "aurora-postgres",
+            "cockroachdb",
+        ].includes(driver.options.type)
     }
 
     /**

--- a/src/driver/postgres/PostgresDriver.ts
+++ b/src/driver/postgres/PostgresDriver.ts
@@ -32,7 +32,17 @@ import type { IsolationLevel } from "../types/IsolationLevel"
 import type { UpsertType } from "../types/UpsertType"
 import type { PostgresConnectionCredentialsOptions } from "./PostgresConnectionCredentialsOptions"
 import type { PostgresDataSourceOptions } from "./PostgresDataSourceOptions"
+import type { PostgresJsDataSourceOptions } from "./PostgresJsDataSourceOptions"
+import {
+    PostgresJsJsonParameter,
+    PostgresJsPool,
+    PostgresJsQueryStream,
+    type PostgresJsFactory,
+} from "./PostgresJsPool"
 import { PostgresQueryRunner } from "./PostgresQueryRunner"
+
+type PostgresDriverOptions =
+    PostgresDataSourceOptions | PostgresJsDataSourceOptions
 
 /**
  * Organizes communication with PostgreSQL DBMS.
@@ -105,7 +115,7 @@ export class PostgresDriver implements Driver {
     /**
      * DataSource options.
      */
-    options: PostgresDataSourceOptions
+    options: PostgresDriverOptions
 
     /**
      * Version of Postgres. Requires a SQL query to the DB, so it is set on the first
@@ -361,7 +371,7 @@ export class PostgresDriver implements Driver {
         }
 
         this.dataSource = dataSource
-        this.options = dataSource.options as PostgresDataSourceOptions
+        this.options = dataSource.options as PostgresDriverOptions
         this.isReplicated = this.options.replication ? true : false
         if (this.options.useUTC) {
             process.env.PGTZ = "UTC"
@@ -722,7 +732,7 @@ export class PostgresDriver implements Driver {
      */
     async disconnect(): Promise<void> {
         if (!this.master) {
-            throw new ConnectionIsNotSetError("postgres")
+            throw new ConnectionIsNotSetError(this.options.type)
         }
 
         await this.closePool(this.master)
@@ -763,6 +773,7 @@ export class PostgresDriver implements Driver {
         if (value === null || value === undefined) return value
 
         if (columnMetadata.type === Boolean) {
+            if (this.options.type === "postgres-js") return value === true
             return value === true ? 1 : 0
         } else if (columnMetadata.type === "date") {
             return DateUtils.mixedDateToDateString(value, {
@@ -799,10 +810,16 @@ export class PostgresDriver implements Driver {
             }
             return value
         } else if (
-            ["json", "jsonb", ...this.spatialTypes].indexOf(
-                columnMetadata.type,
-            ) >= 0
+            columnMetadata.type === "json" ||
+            columnMetadata.type === "jsonb"
         ) {
+            if (this.options.type === "postgres-js") {
+                return columnMetadata.isArray
+                    ? value
+                    : new PostgresJsJsonParameter(value)
+            }
+            return JSON.stringify(value)
+        } else if (this.spatialTypes.indexOf(columnMetadata.type) >= 0) {
             return JSON.stringify(value)
         } else if (
             columnMetadata.type === "vector" ||
@@ -930,8 +947,19 @@ export class PostgresDriver implements Driver {
         } else if (columnMetadata.type === "simple-json") {
             value = DateUtils.stringToSimpleJson(value)
         } else if (columnMetadata.type === "cube") {
-            value = value.replaceAll(/[()\s]+/g, "") // remove whitespace
-            if (columnMetadata.isArray) {
+            if (columnMetadata.isArray && Array.isArray(value)) {
+                value = value.map((cube) => {
+                    if (cube === null || cube === undefined) return undefined
+                    return String(cube)
+                        .replaceAll(/[()\s]+/g, "")
+                        .split(",")
+                        .filter(Boolean)
+                        .map(Number)
+                })
+            } else {
+                value = value.replaceAll(/[()\s]+/g, "") // remove whitespace
+            }
+            if (columnMetadata.isArray && !Array.isArray(value)) {
                 /**
                  * Strips these groups from `{"1,2,3","",NULL}`:
                  * 1. ["1,2,3", undefined]  <- cube of arity 3
@@ -953,7 +981,7 @@ export class PostgresDriver implements Driver {
                         value.push(undefined)
                     }
                 }
-            } else {
+            } else if (!columnMetadata.isArray) {
                 value = value.split(",").filter(Boolean).map(Number)
             }
         } else if (
@@ -1687,6 +1715,10 @@ export class PostgresDriver implements Driver {
      * Loads postgres query stream package.
      */
     loadStreamDependency() {
+        if (this.options.type === "postgres-js") {
+            return PostgresJsQueryStream
+        }
+
         try {
             return PlatformTools.load("pg-query-stream")
         } catch {
@@ -1705,6 +1737,19 @@ export class PostgresDriver implements Driver {
      * If driver dependency is not given explicitly, then try to load it via "require".
      */
     protected loadDependencies(): void {
+        if (this.options.type === "postgres-js") {
+            try {
+                this.postgres =
+                    this.options.driver ?? PlatformTools.load("postgres")
+            } catch {
+                throw new DriverPackageNotInstalledError(
+                    "Postgres.js",
+                    "postgres",
+                )
+            }
+            return
+        }
+
         try {
             const postgres = this.options.driver ?? PlatformTools.load("pg")
             this.postgres = postgres
@@ -1727,11 +1772,56 @@ export class PostgresDriver implements Driver {
      * @param credentials
      */
     protected async createPool(
-        options: PostgresDataSourceOptions,
+        options: PostgresDriverOptions,
         credentials: PostgresConnectionCredentialsOptions,
     ): Promise<any> {
         const { logger } = this.dataSource
         credentials = Object.assign({}, credentials)
+
+        if (options.type === "postgres-js") {
+            const pool = new PostgresJsPool(
+                this.postgres as PostgresJsFactory,
+                options,
+                credentials,
+                (message) => logger.log("warn", message),
+            )
+
+            return new Promise((ok, fail) => {
+                pool.connect((err, connection, release) => {
+                    if (err) return fail(err)
+
+                    if (options.logNotifications) {
+                        connection?.on("notice", (msg) => {
+                            if (msg && typeof msg === "object") {
+                                logger.log(
+                                    "info",
+                                    String(
+                                        (msg as Record<string, unknown>)
+                                            .message,
+                                    ),
+                                )
+                            }
+                        })
+                        connection?.on("notification", (msg) => {
+                            if (msg && typeof msg === "object") {
+                                const notification = msg as Record<
+                                    string,
+                                    unknown
+                                >
+                                logger.log(
+                                    "info",
+                                    `Received NOTIFY on channel ${String(
+                                        notification.channel,
+                                    )}: ${String(notification.payload)}.`,
+                                )
+                            }
+                        })
+                    }
+                    release?.()
+                    ok(pool)
+                })
+            })
+        }
 
         // build connection options for the driver
         // See: https://github.com/brianc/node-postgres/tree/master/packages/pg-pool#create

--- a/src/driver/postgres/PostgresJsDataSourceOptions.ts
+++ b/src/driver/postgres/PostgresJsDataSourceOptions.ts
@@ -1,0 +1,21 @@
+import type postgres from "postgres"
+
+import type { PostgresDataSourceOptions } from "./PostgresDataSourceOptions"
+
+/**
+ * Postgres.js-specific connection options.
+ */
+export type PostgresJsDataSourceOptions = Omit<
+    PostgresDataSourceOptions,
+    "type" | "driver" | "nativeDriver" | "poolErrorHandler"
+> & {
+    /**
+     * Database client type.
+     */
+    readonly type: "postgres-js"
+
+    /**
+     * Postgres.js factory. Defaults to `require("postgres")`.
+     */
+    readonly driver?: typeof postgres
+}

--- a/src/driver/postgres/PostgresJsPool.ts
+++ b/src/driver/postgres/PostgresJsPool.ts
@@ -1,0 +1,718 @@
+import { EventEmitter } from "node:events"
+import { Readable } from "node:stream"
+
+import type { PostgresConnectionCredentialsOptions } from "./PostgresConnectionCredentialsOptions"
+import type { PostgresJsDataSourceOptions } from "./PostgresJsDataSourceOptions"
+
+type PostgresJsRow = Record<string, unknown>
+type PostgresJsNotice = Record<string, unknown>
+type PostgresJsOptions = Record<string, unknown>
+type PostgresJsListener = (...args: unknown[]) => void
+
+interface PostgresJsResult<
+    Row extends PostgresJsRow = PostgresJsRow,
+> extends Array<Row> {
+    count?: number | null
+    command?: string
+}
+
+interface PostgresJsPendingQuery<
+    Row extends PostgresJsRow = PostgresJsRow,
+> extends PromiseLike<PostgresJsResult<Row>> {
+    cursor(batchSize?: number): AsyncIterable<Row[]>
+}
+
+interface PostgresJsSql {
+    unsafe(
+        query: string,
+        parameters?: unknown[],
+    ): PostgresJsPendingQuery<PostgresJsRow>
+    reserve(): Promise<PostgresJsReservedSql>
+    end(): Promise<void>
+}
+
+interface PostgresJsReservedSql extends PostgresJsSql {
+    release(): void
+}
+
+export interface PostgresJsFactory {
+    (options?: PostgresJsOptions): PostgresJsSql
+    (url: string, options?: PostgresJsOptions): PostgresJsSql
+}
+
+export interface PostgresJsQueryResult<
+    Row extends PostgresJsRow = PostgresJsRow,
+> {
+    rows: Row[]
+    rowCount: number
+    command?: string
+}
+
+export interface PostgresJsMappedOptions {
+    url?: string
+    options: PostgresJsOptions
+}
+
+/**
+ * Marks a value that Postgres.js should encode with PostgreSQL's JSON codec.
+ *
+ * Postgres.js discovers the target OID before binding an unsafe query. Keeping
+ * the original JavaScript value behind an object prevents arrays and dates
+ * from being mistaken for PostgreSQL array or timestamp parameters.
+ */
+export class PostgresJsJsonParameter {
+    constructor(readonly value: unknown) {}
+
+    toJSON(): unknown {
+        return this.value
+    }
+
+    toString(): string {
+        return JSON.stringify(this.value) ?? ""
+    }
+}
+
+class PostgresJsSerializedJsonParameter extends PostgresJsJsonParameter {
+    constructor(
+        private readonly serialized: string,
+        value: unknown,
+    ) {
+        super(value)
+    }
+
+    override toString(): string {
+        return this.serialized
+    }
+}
+
+interface PostgresJsOptionCallbacks {
+    onNotice?: (notice: PostgresJsNotice) => void
+    onNotification?: (channel: string, payload: string) => void
+    onWarning?: (message: string) => void
+}
+
+const unsupportedPgOptions: Record<string, string> = {
+    allowExitOnIdle:
+        "Remove it and close the DataSource normally; Postgres.js shuts down through sql.end().",
+    maxUses:
+        'Postgres.js has no use-count equivalent; use "max_lifetime" for time-based recycling.',
+    query_timeout:
+        'Use "connection.statement_timeout" or application-level cancellation.',
+}
+
+/**
+ * Marker consumed by {@link PostgresJsConnection.query} to create a cursor stream.
+ */
+export class PostgresJsQueryStream {
+    constructor(
+        readonly query: string,
+        readonly parameters?: unknown[],
+        readonly batchSize: number = 100,
+    ) {}
+}
+
+/**
+ * Maps TypeORM's PostgreSQL options to Postgres.js without mutating the input.
+ *
+ * @param dataSourceOptions TypeORM DataSource options.
+ * @param credentials Credentials for the selected pool.
+ * @param callbacks Adapter diagnostics and notice forwarding.
+ * @returns Postgres.js URL overload and native options.
+ */
+export function buildPostgresJsOptions(
+    dataSourceOptions: PostgresJsDataSourceOptions,
+    credentials: PostgresConnectionCredentialsOptions,
+    callbacks: PostgresJsOptionCallbacks = {},
+): PostgresJsMappedOptions {
+    const extra = { ...(dataSourceOptions.extra ?? {}) }
+    const nativeConnection = isRecord(extra.connection)
+        ? { ...extra.connection }
+        : {}
+    const nativeTypes = isRecord(extra.types) ? { ...extra.types } : {}
+
+    addDefaultPostgresJsType(nativeTypes, "typeormDate", 1082, {
+        serialize: (value) =>
+            value instanceof Date
+                ? value.toISOString().slice(0, 10)
+                : String(value),
+        parse: String,
+    })
+    addDefaultPostgresJsType(nativeTypes, "typeormInterval", 1186, {
+        serialize: String,
+        parse: parsePostgresInterval,
+    })
+    addDefaultPostgresJsType(nativeTypes, "typeormPoint", 600, {
+        serialize: String,
+        parse: parsePostgresPoint,
+    })
+    addDefaultPostgresJsType(nativeTypes, "typeormCircle", 718, {
+        serialize: String,
+        parse: parsePostgresCircle,
+    })
+
+    if (dataSourceOptions.parseInt8) {
+        if (!hasParserForOid(nativeTypes, 20)) {
+            nativeTypes.typeormInt8 = {
+                to: 20,
+                from: [20],
+                serialize: String,
+                parse: parseSafeInteger,
+            }
+        }
+    }
+    extra.types = nativeTypes
+
+    for (const [key, guidance] of Object.entries(unsupportedPgOptions)) {
+        if (key in extra) {
+            callbacks.onWarning?.(
+                `Postgres.js does not support pg option "${key}". ${guidance}`,
+            )
+            delete extra[key]
+        }
+    }
+
+    mapMillisecondAlias(extra, "connectionTimeoutMillis", "connect_timeout")
+    mapMillisecondAlias(extra, "idleTimeoutMillis", "idle_timeout")
+
+    if (
+        nativeConnection.application_name === undefined &&
+        extra.application_name !== undefined
+    ) {
+        nativeConnection.application_name = extra.application_name
+    }
+    delete extra.application_name
+    delete extra.connection
+
+    const userOnNotice = extra.onnotice
+    if (typeof userOnNotice === "function" || callbacks.onNotice) {
+        extra.onnotice = (notice: PostgresJsNotice) => {
+            if (typeof userOnNotice === "function") userOnNotice(notice)
+            callbacks.onNotice?.(notice)
+        }
+    }
+
+    const userOnNotify = extra.onnotify
+    if (typeof userOnNotify === "function" || callbacks.onNotification) {
+        extra.onnotify = (channel: string, payload: string) => {
+            if (typeof userOnNotify === "function") {
+                userOnNotify(channel, payload)
+            }
+            callbacks.onNotification?.(channel, payload)
+        }
+    }
+
+    const connection = compact({
+        application_name:
+            dataSourceOptions.applicationName ?? credentials.applicationName,
+        ...nativeConnection,
+    })
+
+    return {
+        url: credentials.url,
+        options: compact({
+            host: credentials.host,
+            port: credentials.port,
+            user: credentials.username,
+            password: credentials.password,
+            database: credentials.database,
+            ssl: credentials.ssl,
+            max: dataSourceOptions.poolSize,
+            connect_timeout: millisecondsToSeconds(
+                dataSourceOptions.connectTimeoutMS,
+            ),
+            connection:
+                Object.keys(connection).length > 0 ? connection : undefined,
+            ...extra,
+        }),
+    }
+}
+
+/**
+ * pg-shaped pool facade used by the shared PostgreSQL driver.
+ */
+export class PostgresJsPool {
+    private readonly events = new EventEmitter()
+    private readonly sql: PostgresJsSql
+    private endPromise?: Promise<void>
+
+    constructor(
+        factory: PostgresJsFactory,
+        dataSourceOptions: PostgresJsDataSourceOptions,
+        credentials: PostgresConnectionCredentialsOptions,
+        onWarning?: (message: string) => void,
+    ) {
+        const mapped = buildPostgresJsOptions(dataSourceOptions, credentials, {
+            onNotice: (notice) => this.events.emit("notice", notice),
+            onNotification: (channel, payload) =>
+                this.events.emit("notification", { channel, payload }),
+            onWarning,
+        })
+        this.sql = mapped.url
+            ? factory(mapped.url, mapped.options)
+            : factory(mapped.options)
+    }
+
+    on(event: string, listener: PostgresJsListener): this {
+        this.events.on(event, listener)
+        return this
+    }
+
+    removeListener(event: string, listener: PostgresJsListener): this {
+        this.events.removeListener(event, listener)
+        return this
+    }
+
+    connect(
+        callback: (
+            error: unknown,
+            connection?: PostgresJsConnection,
+            release?: (error?: unknown) => void,
+        ) => void,
+    ): void {
+        void this.sql.reserve().then(
+            (reserved) => {
+                const release = releaseOnce(reserved)
+                callback(
+                    null,
+                    new PostgresJsConnection(reserved, this.events, release),
+                    release,
+                )
+            },
+            (error: unknown) => callback(error),
+        )
+    }
+
+    async query(
+        query: string,
+        parameters?: unknown[],
+    ): Promise<PostgresJsQueryResult> {
+        const reserved = await this.sql.reserve()
+        try {
+            return await executeQuery(reserved, query, parameters)
+        } finally {
+            reserved.release()
+        }
+    }
+
+    end(callback?: (error?: unknown) => void): Promise<void> {
+        this.endPromise ??= this.sql.end()
+        if (callback) {
+            void this.endPromise.then(
+                () => callback(),
+                (error: unknown) => callback(error),
+            )
+        }
+        return this.endPromise
+    }
+}
+
+export class PostgresJsConnection {
+    private queryTail: Promise<void> = Promise.resolve()
+
+    constructor(
+        private readonly reserved: PostgresJsReservedSql,
+        private readonly events: EventEmitter,
+        private readonly releaseReserved: (error?: unknown) => void,
+    ) {}
+
+    on(event: string, listener: PostgresJsListener): this {
+        this.events.on(event, listener)
+        return this
+    }
+
+    removeListener(event: string, listener: PostgresJsListener): this {
+        this.events.removeListener(event, listener)
+        return this
+    }
+
+    release(error?: unknown): void {
+        this.releaseReserved(error)
+    }
+
+    query(query: PostgresJsQueryStream): Readable
+    query(
+        query: string,
+        callback: (error: unknown, result?: PostgresJsQueryResult) => void,
+    ): void
+    query(query: string, parameters?: unknown[]): Promise<PostgresJsQueryResult>
+    query(
+        query: string,
+        parameters: unknown[],
+        callback: (error: unknown, result?: PostgresJsQueryResult) => void,
+    ): void
+    query(
+        query: string | PostgresJsQueryStream,
+        parametersOrCallback?:
+            | unknown[]
+            | ((error: unknown, result?: PostgresJsQueryResult) => void),
+        callback?: (error: unknown, result?: PostgresJsQueryResult) => void,
+    ): Promise<PostgresJsQueryResult> | Readable | void {
+        if (query instanceof PostgresJsQueryStream) {
+            const before = this.queryTail
+            let finish: (() => void) | undefined
+            this.queryTail = new Promise<void>((resolve) => {
+                finish = resolve
+            })
+            return createCursorStream(this.reserved, query, before, () =>
+                finish?.(),
+            )
+        }
+
+        const parameters = Array.isArray(parametersOrCallback)
+            ? parametersOrCallback
+            : undefined
+        const queryCallback =
+            typeof parametersOrCallback === "function"
+                ? parametersOrCallback
+                : callback
+        const pending = this.queryTail.then(() =>
+            executeQuery(this.reserved, query, parameters),
+        )
+        this.queryTail = pending.then(
+            () => undefined,
+            () => undefined,
+        )
+
+        if (queryCallback) {
+            void pending.then(
+                (result) => queryCallback(null, result),
+                (error: unknown) => queryCallback(error),
+            )
+            return
+        }
+
+        return pending
+    }
+}
+
+/**
+ * Creates a backpressure-aware stream over cursor batches.
+ *
+ * @param reserved Reserved Postgres.js connection.
+ * @param query Cursor query marker.
+ * @param before Prior connection work that must finish before the cursor starts.
+ * @param finish Releases the connection queue after the cursor finishes.
+ * @returns Object-mode row stream.
+ */
+function createCursorStream(
+    reserved: PostgresJsReservedSql,
+    query: PostgresJsQueryStream,
+    before: Promise<void> = Promise.resolve(),
+    finish: () => void = () => undefined,
+): Readable {
+    /** @yields {PostgresJsRow} Rows from each cursor batch. */
+    async function* rows() {
+        await before
+        try {
+            const pending = reserved.unsafe(
+                query.query,
+                preparePostgresJsParameters(query.parameters),
+            )
+            for await (const batch of pending.cursor(query.batchSize)) {
+                yield* batch
+            }
+        } finally {
+            finish()
+        }
+    }
+
+    return Readable.from(rows(), { objectMode: true, highWaterMark: 1 })
+}
+
+/**
+ * Executes and normalizes one Postgres.js query.
+ *
+ * @param reserved Reserved Postgres.js connection.
+ * @param query SQL text.
+ * @param parameters Positional parameters.
+ * @returns pg-shaped query result.
+ */
+async function executeQuery(
+    reserved: Pick<PostgresJsReservedSql, "unsafe">,
+    query: string,
+    parameters?: unknown[],
+): Promise<PostgresJsQueryResult> {
+    const result = await reserved.unsafe(
+        query,
+        preparePostgresJsParameters(parameters),
+    )
+    const rows = Array.from(result)
+    return {
+        rows,
+        rowCount: result.count ?? rows.length,
+        command: result.command,
+    }
+}
+
+/**
+ * Converts values whose pg wire representation differs from Postgres.js.
+ *
+ * PostgreSQL array OIDs created after a Postgres.js connection starts do not
+ * have a native serializer registered on that connection. A text array
+ * literal remains lossless for both built-in and newly-created array types.
+ * JSON strings are wrapped so Postgres.js does not stringify TypeORM/raw-SQL
+ * JSON a second time after target-type discovery.
+ *
+ * @param parameters TypeORM positional parameters.
+ * @returns Parameters safe for Postgres.js unsafe queries.
+ */
+function preparePostgresJsParameters(
+    parameters?: unknown[],
+): unknown[] | undefined {
+    if (!parameters) return parameters
+
+    let changed = false
+    const prepared = parameters.map((parameter) => {
+        const value = preparePostgresJsParameter(parameter)
+        if (value !== parameter) changed = true
+        return value
+    })
+    return changed ? prepared : parameters
+}
+
+/**
+ * Converts one TypeORM parameter for Postgres.js binding.
+ *
+ * @param value TypeORM parameter value.
+ * @returns Postgres.js-compatible parameter value.
+ */
+function preparePostgresJsParameter(value: unknown): unknown {
+    if (value === undefined) return null
+    if (value instanceof PostgresJsJsonParameter) return value
+    if (Array.isArray(value)) return serializePostgresArray(value)
+
+    if (typeof value === "string") {
+        try {
+            return new PostgresJsSerializedJsonParameter(
+                value,
+                JSON.parse(value),
+            )
+        } catch {
+            return value
+        }
+    }
+
+    return value
+}
+
+/**
+ * Installs a TypeORM compatibility codec unless a native codec owns the OID.
+ *
+ * @param types Postgres.js native type map.
+ * @param name Internal codec name.
+ * @param oid PostgreSQL OID.
+ * @param codec Value serializer and parser.
+ * @param codec.serialize Value serializer.
+ * @param codec.parse Value parser.
+ */
+function addDefaultPostgresJsType(
+    types: Record<string, unknown>,
+    name: string,
+    oid: number,
+    codec: {
+        serialize: (value: unknown) => string
+        parse: (raw: string) => unknown
+    },
+): void {
+    if (hasParserForOid(types, oid)) return
+    types[name] = { to: oid, from: [oid], ...codec }
+}
+
+/**
+ * Parses PostgreSQL's standard point text representation.
+ *
+ * @param raw PostgreSQL point.
+ * @returns Point coordinates.
+ */
+function parsePostgresPoint(raw: string): { x: number; y: number } {
+    const [x, y] = raw.slice(1, -1).split(",").map(Number)
+    return { x, y }
+}
+
+/**
+ * Parses PostgreSQL's standard circle text representation.
+ *
+ * @param raw PostgreSQL circle.
+ * @returns Circle center and radius.
+ */
+function parsePostgresCircle(raw: string): {
+    x: number
+    y: number
+    radius: number
+} {
+    const match = /^<\(([^,]+),([^)]+)\),([^>]+)>$/.exec(raw)
+    if (!match) return { x: Number.NaN, y: Number.NaN, radius: Number.NaN }
+    return {
+        x: Number(match[1]),
+        y: Number(match[2]),
+        radius: Number(match[3]),
+    }
+}
+
+/**
+ * Parses PostgreSQL's default interval text into TypeORM's established shape.
+ *
+ * @param raw PostgreSQL interval.
+ * @returns Present interval components.
+ */
+function parsePostgresInterval(raw: string): Record<string, number> {
+    const match =
+        /^(?:([+-]?\d+)\s+years?\s*)?(?:([+-]?\d+)\s+mons?\s*)?(?:([+-]?\d+)\s+days?\s*)?(?:([+-])?(\d+):(\d{2}):(\d{2})(?:\.(\d{1,6}))?)?$/.exec(
+            raw,
+        )
+    if (!match) return {}
+
+    const interval: Record<string, number> = {}
+    const assign = (name: string, value: string | undefined) => {
+        if (value !== undefined && Number(value) !== 0) {
+            interval[name] = Number(value)
+        }
+    }
+    assign("years", match[1])
+    assign("months", match[2])
+    assign("days", match[3])
+
+    const sign = match[4] === "-" ? -1 : 1
+    assign("hours", match[5] && String(sign * Number(match[5])))
+    assign("minutes", match[6] && String(sign * Number(match[6])))
+    assign("seconds", match[7] && String(sign * Number(match[7])))
+    if (match[8]) {
+        const milliseconds =
+            (sign * Number(`${match[8]}${"0".repeat(6 - match[8].length)}`)) /
+            1000
+        if (milliseconds !== 0) interval.milliseconds = milliseconds
+    }
+    return interval
+}
+
+/**
+ * Serializes an array using PostgreSQL's text array format.
+ *
+ * @param values Array parameter.
+ * @returns PostgreSQL array literal.
+ */
+function serializePostgresArray(values: unknown[]): string {
+    return `{${values.map(serializePostgresArrayItem).join(",")}}`
+}
+
+/**
+ * Serializes one nested PostgreSQL array item.
+ *
+ * @param value Array item.
+ * @returns Escaped PostgreSQL array item.
+ */
+function serializePostgresArrayItem(value: unknown): string {
+    if (value === null || value === undefined) return "NULL"
+    if (Array.isArray(value)) return serializePostgresArray(value)
+
+    let serialized: string
+    if (value instanceof Date) {
+        serialized = value.toISOString()
+    } else if (value instanceof Uint8Array) {
+        serialized = `\\x${Buffer.from(value).toString("hex")}`
+    } else if (value instanceof PostgresJsJsonParameter) {
+        serialized = value.toString()
+    } else if (typeof value === "object") {
+        serialized = JSON.stringify(value)
+    } else {
+        serialized = String(value)
+    }
+
+    return `"${serialized.replaceAll(/(["\\])/g, "\\$1")}"`
+}
+
+/**
+ * Makes a reserved connection release callback idempotent.
+ *
+ * @param reserved Reserved Postgres.js connection.
+ * @returns Idempotent release callback.
+ */
+function releaseOnce(
+    reserved: Pick<PostgresJsReservedSql, "release">,
+): (error?: unknown) => void {
+    let released = false
+    return () => {
+        if (released) return
+        released = true
+        reserved.release()
+    }
+}
+
+/**
+ * Maps a millisecond pg option to its second-based Postgres.js name.
+ *
+ * @param options Mutable native option copy.
+ * @param pgName pg option name.
+ * @param postgresJsName Postgres.js option name.
+ */
+function mapMillisecondAlias(
+    options: PostgresJsOptions,
+    pgName: string,
+    postgresJsName: string,
+): void {
+    if (
+        options[postgresJsName] === undefined &&
+        options[pgName] !== undefined
+    ) {
+        options[postgresJsName] = millisecondsToSeconds(options[pgName])
+    }
+    delete options[pgName]
+}
+
+/**
+ * Converts numeric milliseconds to seconds without coercing other values.
+ *
+ * @param value Millisecond value.
+ * @returns Seconds or the original non-number value.
+ */
+function millisecondsToSeconds(value: unknown): unknown {
+    return typeof value === "number" ? value / 1000 : value
+}
+
+/**
+ * Removes undefined values before invoking Postgres.js.
+ *
+ * @param value Native option object.
+ * @returns A shallow copy without undefined entries.
+ */
+function compact<T extends Record<string, unknown>>(value: T): T {
+    return Object.fromEntries(
+        Object.entries(value).filter(([, item]) => item !== undefined),
+    ) as T
+}
+
+/**
+ * Checks whether an option can be safely spread as an object.
+ *
+ * @param value Candidate option.
+ * @returns Whether value is a non-array object.
+ */
+function isRecord(value: unknown): value is Record<string, unknown> {
+    return typeof value === "object" && value !== null && !Array.isArray(value)
+}
+
+/**
+ * Checks whether native Postgres.js types already own an OID parser.
+ *
+ * @param types Native Postgres.js custom types.
+ * @param oid PostgreSQL type OID.
+ * @returns Whether the OID is already handled.
+ */
+function hasParserForOid(types: Record<string, unknown>, oid: number): boolean {
+    return Object.values(types).some((type) => {
+        if (!isRecord(type)) return false
+        const from = type.from
+        return Array.isArray(from) && from.includes(oid)
+    })
+}
+
+/**
+ * Parses int8 values only while they remain lossless JavaScript integers.
+ *
+ * @param raw PostgreSQL text value.
+ * @returns A number when safe, otherwise the original string.
+ */
+function parseSafeInteger(raw: unknown): unknown {
+    const parsed = Number(raw)
+    return Number.isSafeInteger(parsed) ? parsed : raw
+}

--- a/src/driver/types/DatabaseType.ts
+++ b/src/driver/types/DatabaseType.ts
@@ -16,6 +16,7 @@ export type DatabaseType =
     | "nativescript"
     | "oracle"
     | "postgres"
+    | "postgres-js"
     | "react-native"
     | "sap"
     | "spanner"

--- a/src/metadata-builder/EntityMetadataBuilder.ts
+++ b/src/metadata-builder/EntityMetadataBuilder.ts
@@ -758,7 +758,10 @@ export class EntityMetadataBuilder {
             })
 
         // Only PostgreSQL supports exclusion constraints.
-        if (this.dataSource.driver.options.type === "postgres") {
+        if (
+            this.dataSource.driver.options.type === "postgres" ||
+            this.dataSource.driver.options.type === "postgres-js"
+        ) {
             entityMetadata.exclusions = this.metadataArgsStorage
                 .filterExclusions(entityMetadata.inheritanceTree)
                 .map((args) => {

--- a/src/metadata-builder/EntityMetadataValidator.ts
+++ b/src/metadata-builder/EntityMetadataValidator.ts
@@ -186,7 +186,10 @@ export class EntityMetadataValidator {
         }
 
         // Postgres supports only STORED generated columns.
-        if (driver.options.type === "postgres") {
+        if (
+            driver.options.type === "postgres" ||
+            driver.options.type === "postgres-js"
+        ) {
             const virtualColumn = entityMetadata.columns.find(
                 (column) =>
                     column.asExpression &&

--- a/src/persistence/EntityPersistExecutor.ts
+++ b/src/persistence/EntityPersistExecutor.ts
@@ -148,7 +148,11 @@ export class EntityPersistExecutor {
             // CockroachDB uses the pg package over a single connection too.
             const driverType = this.dataSource.options.type
             let executors: SubjectExecutor[]
-            if (driverType === "postgres" || driverType === "cockroachdb") {
+            if (
+                driverType === "postgres" ||
+                driverType === "postgres-js" ||
+                driverType === "cockroachdb"
+            ) {
                 executors = []
                 for (const entities of entitiesInChunks) {
                     executors.push(await buildExecutor(entities))

--- a/src/persistence/SubjectDatabaseEntityLoader.ts
+++ b/src/persistence/SubjectDatabaseEntityLoader.ts
@@ -150,7 +150,11 @@ export class SubjectDatabaseEntityLoader {
         // Avoid concurrent queries on the same pg client; see #12238.
         // CockroachDB uses the pg package over a single connection too.
         const driverType = this.queryRunner.dataSource.options.type
-        if (driverType === "postgres" || driverType === "cockroachdb") {
+        if (
+            driverType === "postgres" ||
+            driverType === "postgres-js" ||
+            driverType === "cockroachdb"
+        ) {
             for (const subjectGroup of subjectGroups) {
                 await loadSubjectGroup(subjectGroup)
             }

--- a/src/persistence/SubjectExecutor.ts
+++ b/src/persistence/SubjectExecutor.ts
@@ -640,7 +640,11 @@ export class SubjectExecutor {
         // Avoid concurrent queries on the same pg client; see #12238.
         // CockroachDB uses the pg package over a single connection too.
         const driverType = this.queryRunner.dataSource.options.type
-        if (driverType === "postgres" || driverType === "cockroachdb") {
+        if (
+            driverType === "postgres" ||
+            driverType === "postgres-js" ||
+            driverType === "cockroachdb"
+        ) {
             for (const subject of remainingSubjects) {
                 await updateSubject(subject)
             }
@@ -826,7 +830,11 @@ export class SubjectExecutor {
         // Avoid concurrent queries on the same pg client; see #12238.
         // CockroachDB uses the pg package over a single connection too.
         const driverType = this.queryRunner.dataSource.options.type
-        if (driverType === "postgres" || driverType === "cockroachdb") {
+        if (
+            driverType === "postgres" ||
+            driverType === "postgres-js" ||
+            driverType === "cockroachdb"
+        ) {
             for (const subject of this.softRemoveSubjects) {
                 await softRemoveSubject(subject)
             }
@@ -937,7 +945,11 @@ export class SubjectExecutor {
         // Avoid concurrent queries on the same pg client; see #12238.
         // CockroachDB uses the pg package over a single connection too.
         const driverType = this.queryRunner.dataSource.options.type
-        if (driverType === "postgres" || driverType === "cockroachdb") {
+        if (
+            driverType === "postgres" ||
+            driverType === "postgres-js" ||
+            driverType === "cockroachdb"
+        ) {
             for (const subject of this.recoverSubjects) {
                 await recoverSubject(subject)
             }

--- a/src/platform/PlatformTools.ts
+++ b/src/platform/PlatformTools.ts
@@ -59,6 +59,7 @@ export class PlatformTools {
             "pg",
             "pg-native",
             "pg-query-stream",
+            "postgres",
             // React Native
             "react-native-sqlite-storage",
             // SAP HANA

--- a/src/query-builder/QueryBuilder.ts
+++ b/src/query-builder/QueryBuilder.ts
@@ -1144,6 +1144,7 @@ export abstract class QueryBuilder<Entity extends ObjectLiteral> {
             case "ilike":
                 if (
                     driver.options.type === "postgres" ||
+                    driver.options.type === "postgres-js" ||
                     driver.options.type === "cockroachdb"
                 ) {
                     return `${condition.parameters[0]} ILIKE ${condition.parameters[1]}`

--- a/src/query-builder/SelectQueryBuilder.ts
+++ b/src/query-builder/SelectQueryBuilder.ts
@@ -3731,7 +3731,11 @@ export class SelectQueryBuilder<Entity extends ObjectLiteral>
             // Avoid concurrent queries on the same pg client; see #12238.
             // CockroachDB uses the pg package over a single connection too.
             const driverType = this.dataSource.options.type
-            if (driverType === "postgres" || driverType === "cockroachdb") {
+            if (
+                driverType === "postgres" ||
+                driverType === "postgres-js" ||
+                driverType === "cockroachdb"
+            ) {
                 for (const relation of this.relationMetadatas) {
                     await loadRelation(relation)
                 }

--- a/src/query-builder/relation-id/RelationIdLoader.ts
+++ b/src/query-builder/relation-id/RelationIdLoader.ts
@@ -397,7 +397,11 @@ export class RelationIdLoader {
         // Avoid concurrent queries on the same pg client; see #12238.
         // CockroachDB uses the pg package over a single connection too.
         const driverType = this.dataSource.options.type
-        if (driverType === "postgres" || driverType === "cockroachdb") {
+        if (
+            driverType === "postgres" ||
+            driverType === "postgres-js" ||
+            driverType === "cockroachdb"
+        ) {
             const results: RelationIdLoadResult[] = []
             for (const relationIdAttr of this.relationIdAttributes) {
                 results.push(await loadRelationIdAttribute(relationIdAttr))

--- a/src/query-runner/BaseQueryRunner.ts
+++ b/src/query-runner/BaseQueryRunner.ts
@@ -1,4 +1,5 @@
 import type { PostgresDataSourceOptions } from "../driver/postgres/PostgresDataSourceOptions"
+import type { PostgresJsDataSourceOptions } from "../driver/postgres/PostgresJsDataSourceOptions"
 import { Query } from "../driver/Query"
 import { SqlInMemory } from "../driver/SqlInMemory"
 import type { SqlServerDataSourceOptions } from "../driver/sqlserver/SqlServerDataSourceOptions"
@@ -413,7 +414,9 @@ export abstract class BaseQueryRunner implements AsyncDisposable {
 
     protected getTypeormMetadataTableName(): string {
         const options = <
-            SqlServerDataSourceOptions | PostgresDataSourceOptions
+            | SqlServerDataSourceOptions
+            | PostgresDataSourceOptions
+            | PostgresJsDataSourceOptions
         >this.dataSource.driver.options
         return this.dataSource.driver.buildTableName(
             this.dataSource.metadataTableName,

--- a/src/schema-builder/RdbmsSchemaBuilder.ts
+++ b/src/schema-builder/RdbmsSchemaBuilder.ts
@@ -454,7 +454,10 @@ export class RdbmsSchemaBuilder implements SchemaBuilder {
 
             await Promise.all(dropQueries)
         }
-        if (this.dataSource.options.type === "postgres") {
+        if (
+            this.dataSource.options.type === "postgres" ||
+            this.dataSource.options.type === "postgres-js"
+        ) {
             const postgresQueryRunner: PostgresQueryRunner = <
                 PostgresQueryRunner
             >this.queryRunner
@@ -553,7 +556,11 @@ export class RdbmsSchemaBuilder implements SchemaBuilder {
 
     protected async dropOldExclusions(): Promise<void> {
         // Only PostgreSQL supports exclusion constraints
-        if (!(this.dataSource.driver.options.type === "postgres")) return
+        if (
+            this.dataSource.driver.options.type !== "postgres" &&
+            this.dataSource.driver.options.type !== "postgres-js"
+        )
+            return
 
         for (const metadata of this.entityToSyncMetadatas) {
             const table = this.tables.find(
@@ -597,6 +604,7 @@ export class RdbmsSchemaBuilder implements SchemaBuilder {
             if (
                 DriverUtils.isMySQLFamily(this.dataSource.driver) ||
                 this.dataSource.driver.options.type === "postgres" ||
+                this.dataSource.driver.options.type === "postgres-js" ||
                 this.dataSource.driver.options.type === "sap"
             ) {
                 const newComment = metadata.comment
@@ -1011,7 +1019,8 @@ export class RdbmsSchemaBuilder implements SchemaBuilder {
     protected async createNewViewIndices(): Promise<void> {
         // Only PostgreSQL supports indices for materialized views.
         if (
-            this.dataSource.options.type !== "postgres" ||
+            (this.dataSource.options.type !== "postgres" &&
+                this.dataSource.options.type !== "postgres-js") ||
             !DriverUtils.isPostgresFamily(this.dataSource.driver)
         ) {
             return
@@ -1147,7 +1156,11 @@ export class RdbmsSchemaBuilder implements SchemaBuilder {
      */
     protected async createNewExclusions(): Promise<void> {
         // Only PostgreSQL supports exclusion constraints
-        if (!(this.dataSource.driver.options.type === "postgres")) return
+        if (
+            this.dataSource.driver.options.type !== "postgres" &&
+            this.dataSource.driver.options.type !== "postgres-js"
+        )
+            return
 
         for (const metadata of this.entityToSyncMetadatas) {
             const table = this.tables.find(

--- a/test/functional/commands/init.test.ts
+++ b/test/functional/commands/init.test.ts
@@ -1,0 +1,63 @@
+import { expect } from "chai"
+import sinon from "sinon"
+
+import { CommandUtils } from "../../../src/commands/CommandUtils"
+import { InitCommand } from "../../../src/commands/InitCommand"
+
+class TestInitCommand extends InitCommand {
+    static dataSource(database: string): string {
+        return this.getAppDataSourceTemplate(false, database)
+    }
+
+    static docker(database: string): string {
+        return this.getDockerComposeTemplate(database)
+    }
+
+    static packageJson(database: string): Promise<string> {
+        return this.appendPackageJson("{}", database, false, false)
+    }
+}
+
+describe("commands - init - Postgres.js", () => {
+    afterEach(() => sinon.restore())
+
+    it("generates a postgres-js DataSource", () => {
+        const output = TestInitCommand.dataSource("postgres-js")
+
+        expect(output).to.include('type: "postgres-js"')
+        expect(output).to.include('host: "localhost"')
+        expect(output).to.include("port: 5432")
+    })
+
+    it("installs postgres instead of pg", async () => {
+        sinon.stub(CommandUtils, "readFile").resolves(
+            JSON.stringify({
+                version: "1.1.0",
+                dependencies: { "reflect-metadata": "^0.2.2" },
+                devDependencies: {
+                    "@types/node": "^22.0.0",
+                    postgres: "^3.4.9",
+                    "ts-node": "^10.9.2",
+                    typescript: "^5.8.0",
+                },
+            }),
+        )
+
+        const generated = JSON.parse(
+            await TestInitCommand.packageJson("postgres-js"),
+        )
+
+        expect(generated.dependencies.postgres).to.equal("^3.4.9")
+        expect(generated.dependencies).not.to.have.property("pg")
+    })
+
+    it("reuses the PostgreSQL Docker service exactly", () => {
+        const postgres = TestInitCommand.docker("postgres")
+        const postgresJs = TestInitCommand.docker("postgres-js")
+
+        expect(postgresJs).to.equal(postgres)
+        expect(postgresJs).to.include('image: "postgres:17.2"')
+        expect(postgresJs).to.include('"5432:5432"')
+        expect(postgresJs).to.include('POSTGRES_DB: "typeorm"')
+    })
+})

--- a/test/functional/commands/migration-generate-escape.test.ts
+++ b/test/functional/commands/migration-generate-escape.test.ts
@@ -46,7 +46,11 @@ describe("commands - migration generate - template literal escaping", () => {
     ): Promise<string | undefined> {
         const driver = dataSource.driver.options.type
 
-        if (driver === "postgres" || driver === "cockroachdb") {
+        if (
+            driver === "postgres" ||
+            driver === "postgres-js" ||
+            driver === "cockroachdb"
+        ) {
             await dataSource.query(
                 `COMMENT ON COLUMN "post"."title" IS '${comment}'`,
             )
@@ -77,7 +81,11 @@ describe("commands - migration generate - template literal escaping", () => {
             string | undefined
         createFileStub.resetHistory()
 
-        if (driver === "postgres" || driver === "cockroachdb") {
+        if (
+            driver === "postgres" ||
+            driver === "postgres-js" ||
+            driver === "cockroachdb"
+        ) {
             await dataSource.query(`COMMENT ON COLUMN "post"."title" IS NULL`)
         } else {
             await dataSource.query(

--- a/test/functional/commands/templates/result-templates-generate.ts
+++ b/test/functional/commands/templates/result-templates-generate.ts
@@ -12,6 +12,7 @@ export const resultsTemplates: Record<string, any> = {
     sqlite,
     "better-sqlite3": sqlite,
     postgres,
+    "postgres-js": postgres,
     oracle,
     cockroachdb,
 }

--- a/test/functional/data-source/replication.test.ts
+++ b/test/functional/data-source/replication.test.ts
@@ -20,10 +20,15 @@ const expectCurrentApplicationName = async (
     expect(result[0].application_name).to.equal(name)
 }
 
+const expectedDefaultApplicationName = (dataSource: DataSource) =>
+    dataSource.options.type === "postgres-js" ? "postgres.js" : ""
+
 describe("Connection replication", () => {
     const ormConfigConnectionOptionsArray = getTypeOrmConfig()
     const postgresOptions = ormConfigConnectionOptionsArray.find(
-        (options) => options.type == "postgres" && !options.skip,
+        (options) =>
+            (options.type === "postgres" || options.type === "postgres-js") &&
+            !options.skip,
     )
     if (!postgresOptions) {
         return
@@ -227,7 +232,10 @@ describe("Connection replication", () => {
             const queryRunner = dataSource.createQueryRunner()
             expect(queryRunner.getReplicationMode()).to.equal("master")
 
-            await expectCurrentApplicationName(queryRunner, "")
+            await expectCurrentApplicationName(
+                queryRunner,
+                expectedDefaultApplicationName(dataSource),
+            )
             await queryRunner.release()
         })
 
@@ -240,7 +248,9 @@ describe("Connection replication", () => {
                     "current_setting",
                 )
                 .execute()
-            expect(result[0].current_setting).to.equal("")
+            expect(result[0].current_setting).to.equal(
+                expectedDefaultApplicationName(dataSource),
+            )
         })
     })
 })

--- a/test/functional/data-source/testing-driver-selection.test.ts
+++ b/test/functional/data-source/testing-driver-selection.test.ts
@@ -1,0 +1,32 @@
+import { expect } from "chai"
+
+import { isTestingConnectionTypeEnabled } from "../../utils/test-utils"
+
+describe("data source > testing driver selection", () => {
+    it("expands PostgreSQL dialect suites to both client variants", () => {
+        expect(
+            isTestingConnectionTypeEnabled("postgres", ["postgres"]),
+        ).to.equal(true)
+        expect(
+            isTestingConnectionTypeEnabled("postgres-js", ["postgres"]),
+        ).to.equal(true)
+    })
+
+    it("keeps explicit Postgres.js selection connector-specific", () => {
+        expect(
+            isTestingConnectionTypeEnabled("postgres-js", ["postgres-js"]),
+        ).to.equal(true)
+        expect(
+            isTestingConnectionTypeEnabled("postgres", ["postgres-js"]),
+        ).to.equal(false)
+    })
+
+    it("does not alias CockroachDB or Aurora PostgreSQL", () => {
+        expect(
+            isTestingConnectionTypeEnabled("cockroachdb", ["postgres"]),
+        ).to.equal(false)
+        expect(
+            isTestingConnectionTypeEnabled("aurora-postgres", ["postgres"]),
+        ).to.equal(false)
+    })
+})

--- a/test/functional/database-schema/column-types/postgres/column-types-postgres.test.ts
+++ b/test/functional/database-schema/column-types/postgres/column-types-postgres.test.ts
@@ -18,7 +18,10 @@ describe("database schema > column types > postgres", () => {
         })
 
         for (const dataSource of dataSources) {
-            if (dataSource.driver.options.type === "postgres") {
+            if (
+                dataSource.driver.options.type === "postgres" ||
+                dataSource.driver.options.type === "postgres-js"
+            ) {
                 // We want to have UTC as timezone
                 await dataSource.query("SET TIME ZONE 'UTC';")
             }

--- a/test/functional/deferrable/deferrable.test.ts
+++ b/test/functional/deferrable/deferrable.test.ts
@@ -64,7 +64,11 @@ describe("deferrable foreign key constraint", () => {
         Promise.all(
             dataSources.map(async (dataSource) => {
                 // changing the constraint check time is only supported on postgres
-                if (dataSource.driver.options.type !== "postgres") return
+                if (
+                    dataSource.driver.options.type !== "postgres" &&
+                    dataSource.driver.options.type !== "postgres-js"
+                )
+                    return
 
                 await dataSource.manager.transaction(async (entityManager) => {
                     // first set constraints deferred manually

--- a/test/functional/driver/postgres/postgres-js.test.ts
+++ b/test/functional/driver/postgres/postgres-js.test.ts
@@ -1,0 +1,696 @@
+import "reflect-metadata"
+
+import { expect } from "chai"
+import postgres from "postgres"
+import sinon from "sinon"
+
+import type {
+    DataSourceOptions,
+    EntitySubscriberInterface,
+    Logger,
+    MigrationInterface,
+    QueryRunner,
+} from "../../../../src"
+import {
+    DataSource,
+    EntitySchema,
+    EventSubscriber,
+    QueryFailedError,
+} from "../../../../src"
+import type { PostgresJsDataSourceOptions } from "../../../../src/driver/postgres/PostgresJsDataSourceOptions"
+import { PostgresDriver } from "../../../../src/driver/postgres/PostgresDriver"
+import type { PostgresConnectionCredentialsOptions } from "../../../../src/driver/postgres/PostgresConnectionCredentialsOptions"
+import type { PostgresJsFactory } from "../../../../src/driver/postgres/PostgresJsPool"
+import { PlatformTools } from "../../../../src/platform/PlatformTools"
+import { setupSingleTestingConnection } from "../../../utils/test-utils"
+
+interface PortableRow {
+    id: number
+    value: string
+}
+
+const PortableEntity = new EntitySchema<PortableRow>({
+    name: "PostgresJsPortableRow",
+    tableName: "postgres_js_portable_row",
+    columns: {
+        id: {
+            type: Number,
+            primary: true,
+            generated: true,
+        },
+        value: {
+            type: String,
+        },
+    },
+})
+
+class SharedMigration1784413000000 implements MigrationInterface {
+    async up(_queryRunner: QueryRunner): Promise<void> {}
+
+    async down(_queryRunner: QueryRunner): Promise<void> {}
+}
+
+let subscriberInsertCount = 0
+
+@EventSubscriber()
+class SharedSubscriber implements EntitySubscriberInterface {
+    afterInsert(): void {
+        subscriberInsertCount += 1
+    }
+}
+
+describe("driver > postgres > Postgres.js", () => {
+    let variants: [DataSourceOptions, DataSourceOptions]
+
+    before(function () {
+        const configured = setupSingleTestingConnection("postgres-js", {}) as
+            PostgresJsDataSourceOptions | undefined
+        if (!configured) return this.skip()
+
+        const { type, driver, ...configuredPortable } = configured
+        void type
+        void driver
+        const entities = [PortableEntity]
+        const migrations = [SharedMigration1784413000000]
+        const subscribers = [SharedSubscriber]
+        const portable = {
+            ...configuredPortable,
+            dropSchema: true,
+            synchronize: true,
+            entities,
+            migrations,
+            subscribers,
+        }
+
+        variants = [
+            { ...portable, type: "postgres" },
+            { ...portable, type: "postgres-js" },
+        ]
+    })
+
+    it("initializes the shared driver and synchronizes entity metadata", async () => {
+        await forEachClient(variants, async (dataSource) => {
+            expect(dataSource.driver).to.be.instanceOf(PostgresDriver)
+            const driver = dataSource.driver as PostgresDriver
+            expect(driver.version).to.match(/^\d+/)
+            expect(driver.database).to.be.a("string").and.not.empty
+            expect(driver.schema).to.equal("public")
+            expect(dataSource.hasMetadata(PortableEntity)).to.equal(true)
+
+            const queryRunner = dataSource.createQueryRunner()
+            expect(
+                await queryRunner.hasTable("postgres_js_portable_row"),
+            ).to.equal(true)
+            await queryRunner.release()
+        })
+    })
+
+    it("preserves parameters and affected counts for CRUD", async () => {
+        await forEachClient(variants, async (dataSource) => {
+            const repository = dataSource.getRepository(PortableEntity)
+            const injection = "Robert'); DROP TABLE users;--"
+            const inserted = await repository.insert({ value: injection })
+            const id = inserted.identifiers[0].id as number
+
+            expect(await repository.findOneByOrFail({ id })).to.include({
+                id,
+                value: injection,
+            })
+
+            const updated = await repository.update(id, { value: "updated" })
+            expect(updated.affected).to.equal(1)
+            expect((await repository.findOneByOrFail({ id })).value).to.equal(
+                "updated",
+            )
+
+            const deleted = await repository.delete(id)
+            expect(deleted.affected).to.equal(1)
+            expect(await repository.findOneBy({ id })).to.equal(null)
+        })
+    })
+
+    it("commits, rolls back, and preserves Postgres.js error fields", async () => {
+        await forEachClient(variants, async (dataSource) => {
+            const repository = dataSource.getRepository(PortableEntity)
+            let transactionBackend: number | undefined
+
+            await dataSource.transaction(async (manager) => {
+                const first = await manager.query(
+                    "SELECT pg_backend_pid() AS pid",
+                )
+                const second = await manager.query(
+                    "SELECT pg_backend_pid() AS pid",
+                )
+                expect(second[0].pid).to.equal(first[0].pid)
+                transactionBackend = first[0].pid
+                await manager.insert(PortableEntity, { value: "committed" })
+            })
+            expect(transactionBackend).to.be.a("number")
+            expect(await repository.countBy({ value: "committed" })).to.equal(1)
+
+            const rollback = new Error("rollback sentinel")
+            let rolledBack: unknown
+            try {
+                await dataSource.transaction(async (manager) => {
+                    await manager.insert(PortableEntity, {
+                        value: "rolled-back",
+                    })
+                    throw rollback
+                })
+            } catch (error) {
+                rolledBack = error
+            }
+            expect(rolledBack).to.equal(rollback)
+            expect(await repository.countBy({ value: "rolled-back" })).to.equal(
+                0,
+            )
+
+            const query =
+                'SELECT * FROM "postgres_js_missing_table" WHERE "id" = $1'
+            const parameters = [731]
+            let caught: unknown
+            try {
+                await dataSource.query(query, parameters)
+            } catch (error) {
+                caught = error
+            }
+            expect(caught).to.be.instanceOf(QueryFailedError)
+            const failure = caught as QueryFailedError & { code?: string }
+            expect(failure.query).to.equal(query)
+            expect(failure.parameters).to.equal(parameters)
+            expect(failure.driverError).to.have.property("code", "42P01")
+            expect(failure.code).to.equal("42P01")
+        })
+    })
+
+    it("changes only type while reusing configuration and application code", async () => {
+        const [
+            { type: pgType, ...pg },
+            { type: postgresJsType, ...postgresJs },
+        ] = variants
+        expect(pgType).to.equal("postgres")
+        expect(postgresJsType).to.equal("postgres-js")
+        expect(pg).to.deep.equal(postgresJs)
+        expect(pg.entities).to.equal(postgresJs.entities)
+        expect(pg.migrations).to.equal(postgresJs.migrations)
+        expect(pg.subscribers).to.equal(postgresJs.subscribers)
+
+        await forEachClient(variants, async (dataSource) => {
+            subscriberInsertCount = 0
+            expect(dataSource.entityMetadatas).to.have.length(1)
+            expect(dataSource.migrations).to.have.length(1)
+            expect(dataSource.subscribers).to.have.length(1)
+            await runPortableApplication(dataSource)
+            expect(subscriberInsertCount).to.be.greaterThan(0)
+        })
+    })
+})
+
+describe("driver > postgres > Postgres.js advanced behavior", () => {
+    let configured: PostgresJsDataSourceOptions
+
+    before(function () {
+        const options = setupSingleTestingConnection("postgres-js", {}) as
+            PostgresJsDataSourceOptions | undefined
+        if (!options) return this.skip()
+        configured = options
+    })
+
+    it("keeps int8 lossless without changing numeric parsing", async () => {
+        for (const parseInt8 of [false, true]) {
+            const dataSource = new DataSource({
+                ...configured,
+                type: "postgres-js",
+                installExtensions: false,
+                parseInt8,
+            })
+            try {
+                await dataSource.initialize()
+                const [row] = await dataSource.query(
+                    "SELECT 42::int8 AS safe, " +
+                        "9007199254740992::int8 AS unsafe, " +
+                        "1.23456789::numeric AS decimal",
+                )
+                expect(row.safe).to.equal(parseInt8 ? 42 : "42")
+                expect(row.unsafe).to.equal("9007199254740992")
+                expect(row.decimal).to.equal("1.23456789")
+            } finally {
+                if (dataSource.isInitialized) await dataSource.destroy()
+            }
+        }
+    })
+
+    it("streams ordered rows, propagates cursor errors, and releases", async () => {
+        const dataSource = new DataSource({
+            ...configured,
+            type: "postgres-js",
+            installExtensions: false,
+            dropSchema: true,
+            synchronize: true,
+            entities: [PortableEntity],
+        })
+        await dataSource.initialize()
+        const queryRunner = dataSource.createQueryRunner()
+        const load = sinon.stub(PlatformTools, "load")
+        try {
+            await dataSource
+                .getRepository(PortableEntity)
+                .insert([
+                    { value: "a" },
+                    { value: "b" },
+                    { value: "c" },
+                    { value: "d" },
+                ])
+            const stream = await queryRunner.stream(
+                'SELECT "value" FROM "postgres_js_portable_row" ORDER BY "id"',
+            )
+            expect(await collectStream(stream)).to.deep.equal([
+                { value: "a" },
+                { value: "b" },
+                { value: "c" },
+                { value: "d" },
+            ])
+            expect(load.neverCalledWith("pg-query-stream")).to.equal(true)
+
+            const failing = await queryRunner.stream(
+                'SELECT * FROM "postgres_js_missing_stream_table"',
+            )
+            let caught: unknown
+            try {
+                await collectStream(failing)
+            } catch (error) {
+                caught = error
+            }
+            expect(caught).to.have.property("code", "42P01")
+        } finally {
+            load.restore()
+            await queryRunner.release()
+            expect(
+                (dataSource.driver as PostgresDriver).connectedQueryRunners,
+            ).to.have.length(0)
+            await dataSource.destroy()
+        }
+    })
+
+    it("routes replication pools with independent application names", async () => {
+        const credentials = getCredentials(configured)
+        const dataSource = new DataSource({
+            ...configured,
+            type: "postgres-js",
+            applicationName: undefined,
+            installExtensions: false,
+            dropSchema: true,
+            synchronize: true,
+            entities: [PortableEntity],
+            replication: {
+                defaultMode: "slave",
+                master: {
+                    ...credentials,
+                    applicationName: "postgres-js-master",
+                },
+                slaves: [
+                    {
+                        ...credentials,
+                        applicationName: "postgres-js-slave",
+                    },
+                ],
+            },
+        })
+        try {
+            await dataSource.initialize()
+            const driver = dataSource.driver as PostgresDriver
+            expect(driver.master).not.to.equal(driver.slaves[0])
+
+            const master = dataSource.createQueryRunner("master")
+            const slave = dataSource.createQueryRunner("slave")
+            expect(await applicationName(master)).to.equal("postgres-js-master")
+            expect(await applicationName(slave)).to.equal("postgres-js-slave")
+            await master.release()
+            await slave.release()
+
+            const written = await dataSource
+                .createQueryBuilder()
+                .insert()
+                .into(PortableEntity)
+                .values({
+                    value: () => "current_setting('application_name')",
+                })
+                .returning("value")
+                .execute()
+            expect(written.raw[0].value).to.equal("postgres-js-master")
+
+            const read = await dataSource.manager
+                .createQueryBuilder(PortableEntity, "row")
+                .select(
+                    "current_setting('application_name')",
+                    "application_name",
+                )
+                .getRawOne()
+            expect(read.application_name).to.equal("postgres-js-slave")
+        } finally {
+            if (dataSource.isInitialized) await dataSource.destroy()
+        }
+    })
+
+    it("logs native notices and notifications once only when enabled", async () => {
+        const enabled = await exerciseNotifications(configured, true)
+        expect(enabled.noticeCallbacks).to.equal(1)
+        expect(enabled.notificationCallbacks).to.equal(1)
+        expect(enabled.noticeLogs).to.equal(1)
+        expect(enabled.notificationLogs).to.equal(1)
+
+        const disabled = await exerciseNotifications(configured, false)
+        expect(disabled.noticeCallbacks).to.equal(1)
+        expect(disabled.notificationCallbacks).to.equal(1)
+        expect(disabled.noticeLogs).to.equal(0)
+        expect(disabled.notificationLogs).to.equal(0)
+    })
+
+    it("serializes concurrent transaction work on one QueryRunner", async () => {
+        const dataSource = new DataSource({
+            ...configured,
+            type: "postgres-js",
+            installExtensions: false,
+            dropSchema: true,
+            synchronize: true,
+            entities: [PortableEntity],
+        })
+        const queryRunner = dataSource.createQueryRunner()
+        try {
+            await dataSource.initialize()
+            await queryRunner.startTransaction()
+            await Promise.all(
+                Array.from({ length: 12 }, (_, index) =>
+                    queryRunner.query(
+                        'INSERT INTO "postgres_js_portable_row" ("value") VALUES ($1)',
+                        [`queued-${String(index).padStart(2, "0")}`],
+                    ),
+                ),
+            )
+            await queryRunner.commitTransaction()
+            const rows = await queryRunner.query(
+                'SELECT "value" FROM "postgres_js_portable_row" ORDER BY "id"',
+            )
+            expect(rows.map((row: PortableRow) => row.value)).to.deep.equal(
+                Array.from(
+                    { length: 12 },
+                    (_, index) => `queued-${String(index).padStart(2, "0")}`,
+                ),
+            )
+        } finally {
+            if (queryRunner.isTransactionActive) {
+                await queryRunner.rollbackTransaction()
+            }
+            await queryRunner.release()
+            if (dataSource.isInitialized) await dataSource.destroy()
+        }
+    })
+
+    it("repeats lifecycle teardown and rejects post-end queries", async () => {
+        for (let cycle = 0; cycle < 3; cycle += 1) {
+            const lifecycle = instrumentPostgresJs()
+            const credentials = getCredentials(configured)
+            const dataSource = new DataSource({
+                ...configured,
+                type: "postgres-js",
+                driver: lifecycle.factory,
+                applicationName: undefined,
+                installExtensions: false,
+                replication: {
+                    master: {
+                        ...credentials,
+                        applicationName: `lifecycle-master-${cycle}`,
+                    },
+                    slaves: [
+                        {
+                            ...credentials,
+                            applicationName: `lifecycle-slave-${cycle}`,
+                        },
+                    ],
+                },
+            })
+            await dataSource.initialize()
+            const driver = dataSource.driver as PostgresDriver
+            const master = dataSource.createQueryRunner("master")
+            const slave = dataSource.createQueryRunner("slave")
+            await master.query("SELECT 1")
+            await slave.query("SELECT 1")
+            expect(driver.connectedQueryRunners).to.have.length(2)
+
+            await dataSource.destroy()
+
+            expect(driver.connectedQueryRunners).to.have.length(0)
+            expect(lifecycle.counters).to.have.length(2)
+            for (const counter of lifecycle.counters) {
+                expect(counter.releases).to.equal(counter.reserves)
+                expect(counter.ends).to.equal(1)
+                expect(counter.ended).to.equal(true)
+            }
+
+            let postEndError: unknown
+            try {
+                await driver.master.query("SELECT 1")
+            } catch (error) {
+                postEndError = error
+            }
+            expect(postEndError).to.be.instanceOf(Error)
+        }
+    })
+})
+
+async function forEachClient(
+    variants: [DataSourceOptions, DataSourceOptions],
+    assertion: (dataSource: DataSource) => Promise<void>,
+): Promise<void> {
+    for (const options of variants) {
+        const dataSource = new DataSource(options)
+        try {
+            await dataSource.initialize()
+            await assertion(dataSource)
+        } finally {
+            if (dataSource.isInitialized) await dataSource.destroy()
+        }
+    }
+}
+
+async function runPortableApplication(dataSource: DataSource): Promise<void> {
+    const repository = dataSource.getRepository(PortableEntity)
+    const saved = await repository.save({ value: "portable" })
+    expect((await repository.findOneByOrFail({ id: saved.id })).value).to.equal(
+        "portable",
+    )
+    await dataSource.transaction(async (manager) => {
+        await manager.update(PortableEntity, saved.id, { value: "transaction" })
+    })
+    expect((await repository.findOneByOrFail({ id: saved.id })).value).to.equal(
+        "transaction",
+    )
+}
+
+async function applicationName(queryRunner: QueryRunner): Promise<string> {
+    const [row] = await queryRunner.query(
+        "SELECT current_setting('application_name') AS application_name",
+    )
+    return row.application_name
+}
+
+function getCredentials(
+    options: PostgresJsDataSourceOptions,
+): PostgresConnectionCredentialsOptions {
+    return {
+        url: options.url,
+        host: options.host,
+        port: options.port,
+        username: options.username,
+        password: options.password,
+        database: options.database,
+        ssl: options.ssl,
+    }
+}
+
+class RecordingLogger implements Logger {
+    readonly entries: Array<{ level: string; message: unknown }> = []
+
+    logQuery(): void {}
+
+    logQueryError(): void {}
+
+    logQuerySlow(): void {}
+
+    logSchemaBuild(): void {}
+
+    logMigration(): void {}
+
+    log(level: "log" | "info" | "warn", message: unknown): void {
+        this.entries.push({ level, message })
+    }
+}
+
+async function exerciseNotifications(
+    configured: PostgresJsDataSourceOptions,
+    logNotifications: boolean,
+): Promise<{
+    noticeCallbacks: number
+    notificationCallbacks: number
+    noticeLogs: number
+    notificationLogs: number
+}> {
+    const logger = new RecordingLogger()
+    let noticeCallbacks = 0
+    let notificationCallbacks = 0
+    let resolveNotice: (() => void) | undefined
+    let resolveNotification: (() => void) | undefined
+    const notice = new Promise<void>((resolve) => {
+        resolveNotice = resolve
+    })
+    const notification = new Promise<void>((resolve) => {
+        resolveNotification = resolve
+    })
+    const dataSource = new DataSource({
+        ...configured,
+        type: "postgres-js",
+        installExtensions: false,
+        logNotifications,
+        logger,
+        extra: {
+            ...(configured.extra ?? {}),
+            onnotice: () => {
+                noticeCallbacks += 1
+                resolveNotice?.()
+            },
+            onnotify: () => {
+                notificationCallbacks += 1
+                resolveNotification?.()
+            },
+        },
+    })
+    const queryRunner = dataSource.createQueryRunner()
+    try {
+        await dataSource.initialize()
+        await queryRunner.query("LISTEN typeorm_postgres_js_events")
+        await queryRunner.query(
+            "DO $do$ BEGIN RAISE NOTICE 'postgres-js-notice'; END $do$",
+        )
+        await withTimeout(notice)
+        await queryRunner.query(
+            "NOTIFY typeorm_postgres_js_events, 'postgres-js-payload'",
+        )
+        await withTimeout(notification)
+        await queryRunner.query("UNLISTEN typeorm_postgres_js_events")
+    } finally {
+        await queryRunner.release()
+        if (dataSource.isInitialized) await dataSource.destroy()
+    }
+
+    return {
+        noticeCallbacks,
+        notificationCallbacks,
+        noticeLogs: logger.entries.filter(
+            (entry) =>
+                entry.level === "info" &&
+                entry.message === "postgres-js-notice",
+        ).length,
+        notificationLogs: logger.entries.filter(
+            (entry) =>
+                entry.level === "info" &&
+                entry.message ===
+                    "Received NOTIFY on channel typeorm_postgres_js_events: postgres-js-payload.",
+        ).length,
+    }
+}
+
+async function withTimeout(promise: Promise<void>): Promise<void> {
+    let timeout: NodeJS.Timeout | undefined
+    try {
+        await Promise.race([
+            promise,
+            new Promise<never>((_, reject) => {
+                timeout = setTimeout(
+                    () => reject(new Error("notification timeout")),
+                    2000,
+                )
+            }),
+        ])
+    } finally {
+        if (timeout) clearTimeout(timeout)
+    }
+}
+
+async function collectStream(
+    stream: AsyncIterable<unknown>,
+): Promise<unknown[]> {
+    const rows: unknown[] = []
+    for await (const row of stream) rows.push(row)
+    return rows
+}
+
+interface LifecycleCounter {
+    reserves: number
+    releases: number
+    ends: number
+    ended: boolean
+}
+
+function instrumentPostgresJs(): {
+    factory: typeof postgres
+    counters: LifecycleCounter[]
+} {
+    const native = postgres as unknown as PostgresJsFactory
+    const counters: LifecycleCounter[] = []
+    const factory = ((
+        first?: string | Record<string, unknown>,
+        second?: Record<string, unknown>,
+    ) => {
+        const sql =
+            typeof first === "string"
+                ? native(first, second)
+                : native(first ?? {})
+        const counter: LifecycleCounter = {
+            reserves: 0,
+            releases: 0,
+            ends: 0,
+            ended: false,
+        }
+        counters.push(counter)
+
+        return new Proxy(sql, {
+            get(target, property) {
+                if (property === "reserve") {
+                    return async () => {
+                        counter.reserves += 1
+                        const reserved = await target.reserve()
+                        return new Proxy(reserved, {
+                            get(reservedTarget, reservedProperty) {
+                                if (reservedProperty === "release") {
+                                    return () => {
+                                        counter.releases += 1
+                                        reservedTarget.release()
+                                    }
+                                }
+                                const value = Reflect.get(
+                                    reservedTarget,
+                                    reservedProperty,
+                                    reservedTarget,
+                                )
+                                return typeof value === "function"
+                                    ? value.bind(reservedTarget)
+                                    : value
+                            },
+                        })
+                    }
+                }
+                if (property === "end") {
+                    return async () => {
+                        counter.ends += 1
+                        await target.end()
+                        counter.ended = true
+                    }
+                }
+                const value = Reflect.get(target, property, target)
+                return typeof value === "function" ? value.bind(target) : value
+            },
+        })
+    }) as unknown as typeof postgres
+
+    return { factory, counters }
+}

--- a/test/functional/metadata-builder/closure-junction-entity-metadata/closure-junction-metadata.test.ts
+++ b/test/functional/metadata-builder/closure-junction-entity-metadata/closure-junction-metadata.test.ts
@@ -120,6 +120,7 @@ describe("metadata-builder > closure-junction-entity-metadata > schema handling"
         cockroachdb: true,
         mssql: true,
         postgres: true,
+        "postgres-js": true,
         spanner: true,
         oracle: false,
         sap: false,

--- a/test/functional/query-builder/brackets/query-builder-brackets.test.ts
+++ b/test/functional/query-builder/brackets/query-builder-brackets.test.ts
@@ -55,7 +55,10 @@ describe("query builder > brackets", () => {
                 .disableEscaping()
                 .getSql()
 
-            if (dataSource.driver.options.type === "postgres") {
+            if (
+                dataSource.driver.options.type === "postgres" ||
+                dataSource.driver.options.type === "postgres-js"
+            ) {
                 expect(sql).to.be.equal(
                     "SELECT user.id AS user_id, user.firstName AS user_firstName, " +
                         "user.lastName AS user_lastName, user.isAdmin AS user_isAdmin " +

--- a/test/functional/query-builder/insert-on-conflict/query-builder-insert-on-conflict.test.ts
+++ b/test/functional/query-builder/insert-on-conflict/query-builder-insert-on-conflict.test.ts
@@ -223,7 +223,10 @@ describe("query builder > insert > on conflict", () => {
     it("should perform insertion using partial index and skipping update on no change", () =>
         Promise.all(
             dataSources.map(async (dataSource) => {
-                if (dataSource.driver.options.type !== "postgres") {
+                if (
+                    dataSource.driver.options.type !== "postgres" &&
+                    dataSource.driver.options.type !== "postgres-js"
+                ) {
                     return
                 }
 

--- a/test/functional/query-builder/locking/query-builder-locking.test.ts
+++ b/test/functional/query-builder/locking/query-builder-locking.test.ts
@@ -707,7 +707,10 @@ describe("query builder > locking", () => {
     it("should allow using lockTables on all types of locking", () =>
         Promise.all(
             dataSources.map(async (dataSource) => {
-                if (dataSource.driver.options.type !== "postgres") {
+                if (
+                    dataSource.driver.options.type !== "postgres" &&
+                    dataSource.driver.options.type !== "postgres-js"
+                ) {
                     return
                 }
 
@@ -774,6 +777,7 @@ describe("query builder > locking", () => {
         for (const dataSource of dataSources) {
             if (!(
                 dataSource.driver.options.type === "postgres" ||
+                dataSource.driver.options.type === "postgres-js" ||
                 dataSource.driver.options.type === "sap" ||
                 (dataSource.driver.options.type === "mysql" &&
                     DriverUtils.isReleaseVersionOrGreater(
@@ -803,6 +807,7 @@ describe("query builder > locking", () => {
         for (const dataSource of dataSources) {
             if (!(
                 dataSource.driver.options.type === "postgres" ||
+                dataSource.driver.options.type === "postgres-js" ||
                 dataSource.driver.options.type === "sap" ||
                 (dataSource.driver.options.type === "mysql" &&
                     DriverUtils.isReleaseVersionOrGreater(
@@ -833,6 +838,7 @@ describe("query builder > locking", () => {
             dataSources.map(async (dataSource) => {
                 if (
                     dataSource.driver.options.type === "postgres" ||
+                    dataSource.driver.options.type === "postgres-js" ||
                     dataSource.driver.options.type === "sap" ||
                     (dataSource.driver.options.type === "mysql" &&
                         DriverUtils.isReleaseVersionOrGreater(
@@ -855,7 +861,10 @@ describe("query builder > locking", () => {
     it('skip_locked with "for_key_share" check getOne', () =>
         Promise.all(
             dataSources.map(async (dataSource) => {
-                if (dataSource.driver.options.type !== "postgres") {
+                if (
+                    dataSource.driver.options.type !== "postgres" &&
+                    dataSource.driver.options.type !== "postgres-js"
+                ) {
                     return
                 }
 

--- a/test/functional/query-builder/order-by/query-builder-order-by.test.ts
+++ b/test/functional/query-builder/order-by/query-builder-order-by.test.ts
@@ -61,7 +61,10 @@ describe("query builder > order-by", () => {
     it("should be always in right order(custom order)", () =>
         Promise.all(
             dataSources.map(async (dataSource) => {
-                if (!(dataSource.driver.options.type === "postgres"))
+                if (!(
+                    dataSource.driver.options.type === "postgres" ||
+                    dataSource.driver.options.type === "postgres-js"
+                ))
                     // NULLS FIRST / LAST only supported by postgres
                     return
 

--- a/test/functional/query-builder/returning/query-builder-returning.test.ts
+++ b/test/functional/query-builder/returning/query-builder-returning.test.ts
@@ -43,7 +43,10 @@ describe("query builder > insert/update/delete returning", () => {
                     expect(sql).to.equal(
                         `INSERT INTO "user"("name") OUTPUT inserted.* VALUES (@0)`,
                     )
-                } else if (dataSource.driver.options.type === "postgres") {
+                } else if (
+                    dataSource.driver.options.type === "postgres" ||
+                    dataSource.driver.options.type === "postgres-js"
+                ) {
                     expect(sql).to.equal(
                         `INSERT INTO "user"("name") VALUES ($1) RETURNING *`,
                     )
@@ -85,7 +88,10 @@ describe("query builder > insert/update/delete returning", () => {
                     expect(sql).to.equal(
                         `UPDATE "user" SET "name" = @0 OUTPUT inserted.* WHERE "name" = @1`,
                     )
-                } else if (dataSource.driver.options.type === "postgres") {
+                } else if (
+                    dataSource.driver.options.type === "postgres" ||
+                    dataSource.driver.options.type === "postgres-js"
+                ) {
                     expect(sql).to.equal(
                         `UPDATE "user" SET "name" = $1 WHERE "name" = $2 RETURNING *`,
                     )
@@ -127,7 +133,10 @@ describe("query builder > insert/update/delete returning", () => {
                     expect(sql).to.equal(
                         `DELETE FROM "user" OUTPUT deleted.* WHERE "name" = @0`,
                     )
-                } else if (dataSource.driver.options.type === "postgres") {
+                } else if (
+                    dataSource.driver.options.type === "postgres" ||
+                    dataSource.driver.options.type === "postgres-js"
+                ) {
                     expect(sql).to.equal(
                         `DELETE FROM "user" WHERE "name" = $1 RETURNING *`,
                     )

--- a/test/functional/query-runner/add-column.test.ts
+++ b/test/functional/query-runner/add-column.test.ts
@@ -136,6 +136,7 @@ describe("query runner > add column", () => {
                 if (
                     DriverUtils.isMySQLFamily(dataSource.driver) ||
                     dataSource.driver.options.type === "postgres" ||
+                    dataSource.driver.options.type === "postgres-js" ||
                     dataSource.driver.options.type === "spanner"
                 ) {
                     const isMySQL = dataSource.options.type === "mysql"
@@ -143,7 +144,10 @@ describe("query runner > add column", () => {
                         dataSource.driver.options.type === "spanner"
                     let postgresSupported = false
 
-                    if (dataSource.driver.options.type === "postgres") {
+                    if (
+                        dataSource.driver.options.type === "postgres" ||
+                        dataSource.driver.options.type === "postgres-js"
+                    ) {
                         postgresSupported = (
                             dataSource.driver as PostgresDriver
                         ).isGeneratedColumnsSupported

--- a/test/functional/query-runner/change-column.test.ts
+++ b/test/functional/query-runner/change-column.test.ts
@@ -186,7 +186,9 @@ describe("query runner > change column", () => {
     it("should correctly change generated as expression", () =>
         Promise.all(
             dataSources.map(async (dataSource) => {
-                const isPostgres = dataSource.driver.options.type === "postgres"
+                const isPostgres =
+                    dataSource.driver.options.type === "postgres" ||
+                    dataSource.driver.options.type === "postgres-js"
                 const isSpanner = dataSource.driver.options.type === "spanner"
                 const shouldRun =
                     (isPostgres &&

--- a/test/functional/query-runner/create-comment.test.ts
+++ b/test/functional/query-runner/create-comment.test.ts
@@ -33,7 +33,7 @@ describe("create comment", () => {
                     [tableName],
                 )
                 return res.length > 0 ? res[0]["COMMENTS"] : undefined
-            } else if (dbType === "postgres") {
+            } else if (dbType === "postgres" || dbType === "postgres-js") {
                 const res = await dataSource.query(
                     `SELECT obj_description($1::regclass, 'pg_class') AS "comment"`,
                     [tableName],

--- a/test/functional/query-runner/rename-column.test.ts
+++ b/test/functional/query-runner/rename-column.test.ts
@@ -132,7 +132,10 @@ describe("query runner > rename column", () => {
                     categoryTableName = "testDB.testSchema.category"
                     await queryRunner.createDatabase("testDB", true)
                     await queryRunner.createSchema("testDB.testSchema", true)
-                } else if (dataSource.driver.options.type === "postgres") {
+                } else if (
+                    dataSource.driver.options.type === "postgres" ||
+                    dataSource.driver.options.type === "postgres-js"
+                ) {
                     questionTableName = "testSchema.question"
                     categoryTableName = "testSchema.category"
                     await queryRunner.createSchema("testSchema", true)

--- a/test/functional/query-runner/rename-table.test.ts
+++ b/test/functional/query-runner/rename-table.test.ts
@@ -41,7 +41,10 @@ describe("query runner > rename table", () => {
                 }
 
                 // check if sequence "faculty_id_seq" exist
-                if (dataSource.driver.options.type === "postgres") {
+                if (
+                    dataSource.driver.options.type === "postgres" ||
+                    dataSource.driver.options.type === "postgres-js"
+                ) {
                     const facultySeq = await queryRunner.query(
                         sequenceQuery("faculty_id_seq"),
                     )
@@ -55,7 +58,10 @@ describe("query runner > rename table", () => {
                 expect(table).to.exist
 
                 // check if sequence "faculty_id_seq" was renamed to "question_id_seq"
-                if (dataSource.driver.options.type === "postgres") {
+                if (
+                    dataSource.driver.options.type === "postgres" ||
+                    dataSource.driver.options.type === "postgres-js"
+                ) {
                     const facultySeq = await queryRunner.query(
                         sequenceQuery("faculty_id_seq"),
                     )
@@ -71,7 +77,10 @@ describe("query runner > rename table", () => {
                 expect(table).to.exist
 
                 // check if sequence "question_id_seq" was renamed to "answer_id_seq"
-                if (dataSource.driver.options.type === "postgres") {
+                if (
+                    dataSource.driver.options.type === "postgres" ||
+                    dataSource.driver.options.type === "postgres-js"
+                ) {
                     const questionSeq = await queryRunner.query(
                         sequenceQuery("question_id_seq"),
                     )
@@ -88,7 +97,10 @@ describe("query runner > rename table", () => {
                 expect(table).to.exist
 
                 // check if sequence "answer_id_seq" was renamed to "faculty_id_seq"
-                if (dataSource.driver.options.type === "postgres") {
+                if (
+                    dataSource.driver.options.type === "postgres" ||
+                    dataSource.driver.options.type === "postgres-js"
+                ) {
                     const answerSeq = await queryRunner.query(
                         sequenceQuery("answer_id_seq"),
                     )
@@ -183,6 +195,7 @@ describe("query runner > rename table", () => {
                     await queryRunner.createSchema("testDB.testSchema", true)
                 } else if (
                     dataSource.driver.options.type === "postgres" ||
+                    dataSource.driver.options.type === "postgres-js" ||
                     dataSource.driver.options.type === "sap"
                 ) {
                     questionTableName = "testSchema.question"

--- a/test/functional/repository/basic-methods/repository-basic-methods.test.ts
+++ b/test/functional/repository/basic-methods/repository-basic-methods.test.ts
@@ -610,7 +610,11 @@ describe("repository > basic methods", () => {
         it("should skip update when nothing has changed", () =>
             Promise.all(
                 dataSources.map(async (dataSource) => {
-                    if (!(dataSource.driver.options.type === "postgres")) return
+                    if (!(
+                        dataSource.driver.options.type === "postgres" ||
+                        dataSource.driver.options.type === "postgres-js"
+                    ))
+                        return
 
                     const postObjects = dataSource.getRepository(Post)
                     const externalId1 = "external-skip-update-nothing-changed1"

--- a/test/functional/repository/find-options-locking/find-options-locking.test.ts
+++ b/test/functional/repository/find-options-locking/find-options-locking.test.ts
@@ -155,7 +155,10 @@ describe("repository > find options > locking", () => {
                     } else {
                         expect(executedSql[0]).to.contain("LOCK IN SHARE MODE")
                     }
-                } else if (dataSource.driver.options.type === "postgres") {
+                } else if (
+                    dataSource.driver.options.type === "postgres" ||
+                    dataSource.driver.options.type === "postgres-js"
+                ) {
                     expect(executedSql[0]).to.contain("FOR SHARE")
                 } else if (dataSource.driver.options.type === "sap") {
                     expect(executedSql[0]).to.contain("FOR SHARE LOCK")
@@ -172,7 +175,10 @@ describe("repository > find options > locking", () => {
     it("should attach for no key update lock statement on query if locking enabled", () =>
         Promise.all(
             dataSources.map(async (dataSource) => {
-                if (dataSource.driver.options.type !== "postgres") {
+                if (
+                    dataSource.driver.options.type !== "postgres" &&
+                    dataSource.driver.options.type !== "postgres-js"
+                ) {
                     return
                 }
 
@@ -204,7 +210,10 @@ describe("repository > find options > locking", () => {
     it("should attach for key share lock statement on query if locking enabled", () =>
         Promise.all(
             dataSources.map(async (dataSource) => {
-                if (!(dataSource.driver.options.type === "postgres")) {
+                if (!(
+                    dataSource.driver.options.type === "postgres" ||
+                    dataSource.driver.options.type === "postgres-js"
+                )) {
                     return
                 }
 
@@ -238,6 +247,7 @@ describe("repository > find options > locking", () => {
             dataSources.map(async (dataSource) => {
                 if (!(
                     dataSource.driver.options.type === "postgres" ||
+                    dataSource.driver.options.type === "postgres-js" ||
                     dataSource.driver.options.type === "sap" ||
                     (dataSource.driver.options.type === "mysql" &&
                         DriverUtils.isReleaseVersionOrGreater(
@@ -289,6 +299,7 @@ describe("repository > find options > locking", () => {
             dataSources.map(async (dataSource) => {
                 if (!(
                     dataSource.driver.options.type === "postgres" ||
+                    dataSource.driver.options.type === "postgres-js" ||
                     dataSource.driver.options.type === "sap" ||
                     (DriverUtils.isMySQLFamily(dataSource.driver) &&
                         DriverUtils.isReleaseVersionOrGreater(
@@ -640,7 +651,10 @@ describe("repository > find options > locking", () => {
     it("should allow using lockTables on all types of locking", () =>
         Promise.all(
             dataSources.map(async (dataSource) => {
-                if (dataSource.driver.options.type !== "postgres") {
+                if (
+                    dataSource.driver.options.type !== "postgres" &&
+                    dataSource.driver.options.type !== "postgres-js"
+                ) {
                     return
                 }
 

--- a/test/functional/repository/find-options-operators/repository-find-operators.test.ts
+++ b/test/functional/repository/find-options-operators/repository-find-operators.test.ts
@@ -581,7 +581,11 @@ describe("repository > find options > operators", () => {
     it("any", () =>
         Promise.all(
             dataSources.map(async (dataSource) => {
-                if (!(dataSource.driver.options.type === "postgres")) return
+                if (!(
+                    dataSource.driver.options.type === "postgres" ||
+                    dataSource.driver.options.type === "postgres-js"
+                ))
+                    return
 
                 // insert some fake data
                 const post1 = new Post()
@@ -608,7 +612,11 @@ describe("repository > find options > operators", () => {
     it("not(any)", () =>
         Promise.all(
             dataSources.map(async (dataSource) => {
-                if (!(dataSource.driver.options.type === "postgres")) return
+                if (!(
+                    dataSource.driver.options.type === "postgres" ||
+                    dataSource.driver.options.type === "postgres-js"
+                ))
+                    return
 
                 // insert some fake data
                 const post1 = new Post()

--- a/test/functional/schema-builder/column/change/change-column/change-column.test.ts
+++ b/test/functional/schema-builder/column/change/change-column/change-column.test.ts
@@ -245,7 +245,10 @@ describe("schema builder > change column", () => {
 
                 const queryRunner = dataSource.createQueryRunner()
 
-                if (dataSource.driver.options.type === "postgres")
+                if (
+                    dataSource.driver.options.type === "postgres" ||
+                    dataSource.driver.options.type === "postgres-js"
+                )
                     await queryRunner.query(
                         `CREATE EXTENSION IF NOT EXISTS "uuid-ossp"`,
                     )
@@ -256,7 +259,10 @@ describe("schema builder > change column", () => {
                 idColumn.generationStrategy = "uuid"
 
                 // depending on driver, we must change column and referenced column types
-                if (dataSource.driver.options.type === "postgres") {
+                if (
+                    dataSource.driver.options.type === "postgres" ||
+                    dataSource.driver.options.type === "postgres-js"
+                ) {
                     idColumn.type = "uuid"
                 } else if (dataSource.driver.options.type === "mssql") {
                     idColumn.type = "uniqueidentifier"
@@ -273,6 +279,7 @@ describe("schema builder > change column", () => {
 
                 if (
                     dataSource.driver.options.type === "postgres" ||
+                    dataSource.driver.options.type === "postgres-js" ||
                     dataSource.driver.options.type === "mssql"
                 ) {
                     postTable!.findColumnByName("id")!.isGenerated.should.be
@@ -320,7 +327,10 @@ describe("schema builder > change column", () => {
                 idColumn.generationStrategy = "uuid"
 
                 // depending on driver, we must change column and referenced column types
-                if (dataSource.driver.options.type === "postgres") {
+                if (
+                    dataSource.driver.options.type === "postgres" ||
+                    dataSource.driver.options.type === "postgres-js"
+                ) {
                     idColumn.type = "uuid"
                     teacherColumn.type = "uuid"
                 } else if (dataSource.driver.options.type === "mssql") {
@@ -342,6 +352,7 @@ describe("schema builder > change column", () => {
 
                 if (
                     dataSource.driver.options.type === "postgres" ||
+                    dataSource.driver.options.type === "postgres-js" ||
                     dataSource.driver.options.type === "mssql"
                 ) {
                     teacherTable!.findColumnByName("id")!.isGenerated.should.be
@@ -374,6 +385,7 @@ describe("schema builder > change column", () => {
                 if (!(
                     dataSource.driver.options.type === "cockroachdb" ||
                     dataSource.driver.options.type === "postgres" ||
+                    dataSource.driver.options.type === "postgres-js" ||
                     dataSource.driver.options.type === "sap" ||
                     DriverUtils.isMySQLFamily(dataSource.driver)
                 )) {

--- a/test/functional/schema-builder/idempotency/same-name-across-tables/same-name-across-tables.test.ts
+++ b/test/functional/schema-builder/idempotency/same-name-across-tables/same-name-across-tables.test.ts
@@ -29,7 +29,10 @@ describe("schema builder > idempotency > same name across tables", () => {
                     postTableName = "testDB.testSchema.post"
                     await queryRunner.createDatabase("testDB", true)
                     await queryRunner.createSchema("testDB.testSchema", true)
-                } else if (connection.driver.options.type === "postgres") {
+                } else if (
+                    connection.driver.options.type === "postgres" ||
+                    connection.driver.options.type === "postgres-js"
+                ) {
                     postTableName = "testSchema.post"
                     await queryRunner.createSchema("testSchema", true)
                 } else if (DriverUtils.isMySQLFamily(connection.driver)) {

--- a/test/functional/transaction/transaction-with-load-many/transaction-load-many.test.ts
+++ b/test/functional/transaction/transaction-with-load-many/transaction-load-many.test.ts
@@ -17,6 +17,10 @@ describe("transaction > transaction with load many", () => {
         dataSources = await createTestingConnections({
             entities: [__dirname + "/entity/*{.js,.ts}"],
             enabledDrivers: ["postgres", "mariadb", "mysql"],
+            // This test counts pg/mysql pool acquire events directly. The
+            // Postgres.js path verifies connection affinity by backend PID in
+            // the connector integration suite instead of exposing pg's pool API.
+            disabledDrivers: ["postgres-js"],
         })
     })
     beforeEach(() => reloadTestingDatabases(dataSources))
@@ -32,7 +36,10 @@ describe("transaction > transaction with load many", () => {
                 if (DriverUtils.isMySQLFamily(driver)) {
                     const pool = (driver as MysqlDriver).pool
                     pool.on("acquire", () => acquireCount++)
-                } else if (driver.options.type === "postgres") {
+                } else if (
+                    driver.options.type === "postgres" ||
+                    driver.options.type === "postgres-js"
+                ) {
                     const pool = (driver as PostgresDriver).master
                     pool.on("acquire", () => acquireCount++)
                 }

--- a/test/functional/tree-tables/closure-table/schema-handling/schema-handling.test.ts
+++ b/test/functional/tree-tables/closure-table/schema-handling/schema-handling.test.ts
@@ -17,6 +17,7 @@ const driversSupportingSchema = Object.freeze({
     cockroachdb: true,
     mssql: true,
     postgres: true,
+    "postgres-js": true,
     spanner: true,
     oracle: false,
     sap: false,

--- a/test/github-issues/1716/issue-1716.test.ts
+++ b/test/github-issues/1716/issue-1716.test.ts
@@ -32,7 +32,10 @@ describe("github issues > #1716 send timestamp to database without converting it
             })
 
             for (const connection of dataSources) {
-                if (connection.driver.options.type === "postgres") {
+                if (
+                    connection.driver.options.type === "postgres" ||
+                    connection.driver.options.type === "postgres-js"
+                ) {
                     // We want to have UTC as timezone
                     await connection.query("SET TIME ZONE 'UTC';")
                 }

--- a/test/github-issues/2067/issue-2067.test.ts
+++ b/test/github-issues/2067/issue-2067.test.ts
@@ -27,7 +27,10 @@ describe("github issues > #2067 Unhandled promise rejection warning on postgres 
                 const connectionFailureMessage =
                     "Test error to simulate a connection error"
 
-                if (connection.driver.options.type === "postgres") {
+                if (
+                    connection.driver.options.type === "postgres" ||
+                    connection.driver.options.type === "postgres-js"
+                ) {
                     connection.driver.obtainMasterConnection = () =>
                         Promise.reject<any>(new Error(connectionFailureMessage))
                     connection.driver.obtainSlaveConnection = () =>

--- a/test/github-issues/2128/issue-2128.test.ts
+++ b/test/github-issues/2128/issue-2128.test.ts
@@ -43,7 +43,8 @@ describe("github issues > #2128 skip preparePersistentValue for value functions"
                     .update(Post)
                     .set({
                         meta: () =>
-                            connection.driver.options.type === "postgres"
+                            connection.driver.options.type === "postgres" ||
+                            connection.driver.options.type === "postgres-js"
                                 ? `'${metaAddition}'::JSONB || meta::JSONB`
                                 : `JSON_MERGE('${metaAddition}', meta)`,
                     })

--- a/test/github-issues/3047/issue-3047.test.ts
+++ b/test/github-issues/3047/issue-3047.test.ts
@@ -71,7 +71,10 @@ describe("github issues > #3047 Mysqsl on duplicate key update use current value
         Promise.all(
             dataSources.map(async (connection) => {
                 try {
-                    if (connection.driver.options.type === "postgres") {
+                    if (
+                        connection.driver.options.type === "postgres" ||
+                        connection.driver.options.type === "postgres-js"
+                    ) {
                         const UserRepository =
                             connection.manager.getRepository(User)
 

--- a/test/github-issues/6699/issue-6699.test.ts
+++ b/test/github-issues/6699/issue-6699.test.ts
@@ -12,6 +12,8 @@ describe("github issues > #6699 MaxListenersExceededWarning occurs on Postgres",
         dataSources = await createTestingConnections({
             entities: [],
             enabledDrivers: ["postgres"],
+            // This regression asserts the pg Client EventEmitter API directly.
+            disabledDrivers: ["postgres-js"],
         })
     })
     beforeEach(() => reloadTestingDatabases(dataSources))

--- a/test/github-issues/838/issue-838.test.ts
+++ b/test/github-issues/838/issue-838.test.ts
@@ -19,7 +19,9 @@ describe.skip("github issues > #838 Time zones for timestamp columns are incorre
             enabledDrivers: ["postgres"],
         })
         postgresConnection = dataSources.find(
-            (connection) => connection.driver.options.type === "postgres",
+            (connection) =>
+                connection.driver.options.type === "postgres" ||
+                connection.driver.options.type === "postgres-js",
         )!
     })
 

--- a/test/unit/driver/postgres-driver.test.ts
+++ b/test/unit/driver/postgres-driver.test.ts
@@ -1,0 +1,106 @@
+import { expect } from "chai"
+import * as sinon from "sinon"
+import type postgres from "postgres"
+
+import { DataSource } from "../../../src/data-source/DataSource"
+import type { DataSourceOptions } from "../../../src/data-source/DataSourceOptions"
+import { PostgresDriver } from "../../../src/driver/postgres/PostgresDriver"
+import type { PostgresJsDataSourceOptions } from "../../../src/driver/postgres/PostgresJsDataSourceOptions"
+import { PlatformTools } from "../../../src/platform/PlatformTools"
+
+describe("PostgresDriver client selection", () => {
+    let sandbox: sinon.SinonSandbox
+
+    beforeEach(() => {
+        sandbox = sinon.createSandbox()
+    })
+
+    afterEach(() => {
+        sandbox.restore()
+    })
+
+    it("accepts public postgres-js options and creates the shared driver", () => {
+        type PgOnlyKeysAreAbsent =
+            Extract<
+                keyof PostgresJsDataSourceOptions,
+                "nativeDriver" | "poolErrorHandler"
+            > extends never
+                ? true
+                : false
+        const pgOnlyKeysAreAbsent: PgOnlyKeysAreAbsent = true
+        const injected = (() => undefined) as unknown as typeof postgres
+        const options = {
+            type: "postgres-js",
+            database: "public-type-fixture",
+            driver: injected,
+        } satisfies DataSourceOptions
+
+        const dataSource = new DataSource(options)
+
+        expect(dataSource.driver).to.be.instanceOf(PostgresDriver)
+        expect(pgOnlyKeysAreAbsent).to.equal(true)
+        expect((dataSource.driver as PostgresDriver).postgres).to.equal(
+            injected,
+        )
+    })
+
+    it("loads postgres for postgres-js and accepts factory injection", () => {
+        const load = sandbox.stub(PlatformTools, "load")
+        const loaded = (() => undefined) as unknown as typeof postgres
+        load.withArgs("postgres").returns(loaded)
+
+        const loadedDataSource = new DataSource({
+            type: "postgres-js",
+            database: "loaded",
+        })
+        expect((loadedDataSource.driver as PostgresDriver).postgres).to.equal(
+            loaded,
+        )
+        expect(load.calledOnceWithExactly("postgres")).to.equal(true)
+
+        load.resetHistory()
+        const injected = (() => undefined) as unknown as typeof postgres
+        const injectedDataSource = new DataSource({
+            type: "postgres-js",
+            database: "injected",
+            driver: injected,
+        })
+        expect((injectedDataSource.driver as PostgresDriver).postgres).to.equal(
+            injected,
+        )
+        expect(load.notCalled).to.equal(true)
+    })
+
+    it("names postgres in the missing-package error", () => {
+        sandbox.stub(PlatformTools, "load").throws(new Error("missing"))
+
+        expect(
+            () =>
+                new DataSource({
+                    type: "postgres-js",
+                    database: "missing",
+                }),
+        )
+            .to.throw()
+            .with.property("message")
+            .that.includes("postgres")
+    })
+
+    it("keeps postgres on pg and pg-native without loading the adapter", () => {
+        const load = sandbox.stub(PlatformTools, "load")
+        const native = { client: "pg-native" }
+        const pg = { native }
+        load.withArgs("pg").returns(pg)
+        load.withArgs("pg-native").returns({})
+
+        const dataSource = new DataSource({
+            type: "postgres",
+            database: "pg-path",
+        })
+
+        expect((dataSource.driver as PostgresDriver).postgres).to.equal(native)
+        expect(load.calledWithExactly("pg")).to.equal(true)
+        expect(load.calledWithExactly("pg-native")).to.equal(true)
+        expect(load.neverCalledWith("postgres")).to.equal(true)
+    })
+})

--- a/test/unit/driver/postgres-js-pool.test.ts
+++ b/test/unit/driver/postgres-js-pool.test.ts
@@ -1,0 +1,525 @@
+import { expect } from "chai"
+import type { Readable } from "node:stream"
+
+import type { PostgresConnectionCredentialsOptions } from "../../../src/driver/postgres/PostgresConnectionCredentialsOptions"
+import type { PostgresJsDataSourceOptions } from "../../../src/driver/postgres/PostgresJsDataSourceOptions"
+import type { PostgresJsConnection } from "../../../src/driver/postgres/PostgresJsPool"
+import {
+    buildPostgresJsOptions,
+    type PostgresJsFactory,
+    PostgresJsJsonParameter,
+    PostgresJsPool,
+    PostgresJsQueryStream,
+} from "../../../src/driver/postgres/PostgresJsPool"
+
+type Row = Record<string, unknown>
+
+interface FakePending extends PromiseLike<Row[]> {
+    cursor(batchSize?: number): AsyncIterable<Row[]>
+}
+
+interface FakeSql {
+    unsafe(query: string, parameters?: unknown[]): FakePending
+    reserve(): Promise<FakeSql>
+    release(): void
+    end(): Promise<void>
+}
+
+describe("PostgresJsPool", () => {
+    const credentials: PostgresConnectionCredentialsOptions = {
+        url: "postgres://user:pass@localhost:5432/db",
+        host: "localhost",
+        port: 5432,
+        username: "user",
+        password: "pass",
+        database: "db",
+        ssl: true,
+        applicationName: "credential-app",
+    }
+
+    it("maps TypeORM credentials and options without losing zero timeouts", () => {
+        const password = () => Promise.resolve("token")
+        const mapped = buildPostgresJsOptions(
+            options({
+                poolSize: 7,
+                connectTimeoutMS: 0,
+                applicationName: "typeorm-app",
+                extra: { prepare: false },
+            }),
+            { ...credentials, password },
+        )
+
+        expect(mapped.url).to.equal(credentials.url)
+        expect(mapped.options).to.deep.include({
+            host: "localhost",
+            port: 5432,
+            user: "user",
+            database: "db",
+            ssl: true,
+            max: 7,
+            connect_timeout: 0,
+            prepare: false,
+        })
+        expect(mapped.options.password).to.equal(password)
+        expect(mapped.options.connection).to.deep.equal({
+            application_name: "typeorm-app",
+        })
+    })
+
+    it("passes mapped values and native extras to the adapter factory", () => {
+        const fake = createFake()
+        new PostgresJsPool(
+            fake.factory,
+            options({
+                poolSize: 4,
+                connectTimeoutMS: 1500,
+                applicationName: "factory-app",
+                extra: { prepare: false, max_lifetime: 120 },
+            }),
+            credentials,
+        )
+
+        expect(fake.factoryCalls).to.have.length(1)
+        expect(fake.factoryCalls[0][0]).to.equal(credentials.url)
+        expect(fake.factoryCalls[0][1]).to.deep.include({
+            max: 4,
+            connect_timeout: 1.5,
+            prepare: false,
+            max_lifetime: 120,
+        })
+        expect(
+            (fake.factoryCalls[0][1] as Record<string, unknown>).connection,
+        ).to.deep.equal({ application_name: "factory-app" })
+    })
+
+    it("translates pg aliases and gives native Postgres.js keys precedence", () => {
+        const aliased = buildPostgresJsOptions(
+            options({
+                extra: {
+                    connectionTimeoutMillis: 2500,
+                    idleTimeoutMillis: 5000,
+                    application_name: "pg-app",
+                },
+            }),
+            {},
+        )
+        expect(aliased.options.connect_timeout).to.equal(2.5)
+        expect(aliased.options.idle_timeout).to.equal(5)
+        expect(aliased.options.connection).to.deep.equal({
+            application_name: "pg-app",
+        })
+        expect(aliased.options).not.to.have.keys(
+            "connectionTimeoutMillis",
+            "idleTimeoutMillis",
+            "application_name",
+        )
+
+        const native = buildPostgresJsOptions(
+            options({
+                extra: {
+                    connectionTimeoutMillis: 2500,
+                    connect_timeout: 9,
+                    idleTimeoutMillis: 5000,
+                    idle_timeout: 8,
+                    application_name: "pg-app",
+                    connection: { application_name: "native-app" },
+                },
+            }),
+            {},
+        )
+        expect(native.options.connect_timeout).to.equal(9)
+        expect(native.options.idle_timeout).to.equal(8)
+        expect(native.options.connection).to.deep.equal({
+            application_name: "native-app",
+        })
+    })
+
+    it("reports known pg-only options and passes unknown native options", () => {
+        const warnings: string[] = []
+        const mapped = buildPostgresJsOptions(
+            options({
+                extra: {
+                    allowExitOnIdle: true,
+                    maxUses: 10,
+                    query_timeout: 1000,
+                    future_postgres_js_option: "kept",
+                },
+            }),
+            {},
+            { onWarning: (message) => warnings.push(message) },
+        )
+
+        expect(warnings).to.have.length(3)
+        expect(warnings.join("\n")).to.include('"allowExitOnIdle"')
+        expect(warnings.join("\n")).to.include('"maxUses"')
+        expect(warnings.join("\n")).to.include('"query_timeout"')
+        expect(mapped.options.future_postgres_js_option).to.equal("kept")
+        expect(mapped.options).not.to.have.keys(
+            "allowExitOnIdle",
+            "maxUses",
+            "query_timeout",
+        )
+    })
+
+    it("parses int8 only when lossless and preserves native type overrides", () => {
+        const mapped = buildPostgresJsOptions(options({ parseInt8: true }), {})
+        const types = mapped.options.types as Record<
+            string,
+            { parse: (raw: string) => unknown }
+        >
+        expect(types.typeormInt8.parse("42")).to.equal(42)
+        expect(types.typeormInt8.parse("9007199254740992")).to.equal(
+            "9007199254740992",
+        )
+
+        const custom = {
+            to: 20,
+            from: [20],
+            serialize: String,
+            parse: (raw: string) => `custom:${raw}`,
+        }
+        const native = buildPostgresJsOptions(
+            options({ parseInt8: true, extra: { types: { custom } } }),
+            {},
+        )
+        expect(native.options.types).to.have.property("custom", custom)
+        expect(native.options.types).not.to.have.property("typeormInt8")
+        expect(native.options.types).to.have.keys(
+            "custom",
+            "typeormDate",
+            "typeormInterval",
+            "typeormPoint",
+            "typeormCircle",
+        )
+    })
+
+    it("chains a user notice callback with the adapter callback", () => {
+        const calls: string[] = []
+        const mapped = buildPostgresJsOptions(
+            options({
+                extra: {
+                    onnotice: () => calls.push("user"),
+                },
+            }),
+            {},
+            { onNotice: () => calls.push("adapter") },
+        )
+
+        const onnotice = mapped.options.onnotice
+        expect(onnotice).to.be.a("function")
+        if (typeof onnotice === "function") onnotice({ message: "notice" })
+        expect(calls).to.deep.equal(["user", "adapter"])
+    })
+
+    it("chains a user notification callback with the adapter callback", () => {
+        const calls: string[] = []
+        const mapped = buildPostgresJsOptions(
+            options({
+                extra: {
+                    onnotify: (channel: string, payload: string) =>
+                        calls.push(`user:${channel}:${payload}`),
+                },
+            }),
+            {},
+            {
+                onNotification: (channel, payload) =>
+                    calls.push(`adapter:${channel}:${payload}`),
+            },
+        )
+
+        const onnotify = mapped.options.onnotify
+        expect(onnotify).to.be.a("function")
+        if (typeof onnotify === "function") onnotify("events", "ready")
+        expect(calls).to.deep.equal([
+            "user:events:ready",
+            "adapter:events:ready",
+        ])
+    })
+
+    it("uses unsafe parameters unchanged and normalizes command results", async () => {
+        const fake = createFake()
+        const pool = new PostgresJsPool(fake.factory, options(), credentials)
+        const { connection, release } = await connect(pool)
+        const parameters = ["Robert'); DROP TABLE users;--"]
+
+        for (const command of ["SELECT", "INSERT", "UPDATE", "DELETE"]) {
+            fake.setPending(result([{ command }], 3, command))
+            const normalized = await connection.query(
+                `/* ${command} */ SELECT $1`,
+                parameters,
+            )
+            const call = fake.unsafeCalls.at(-1)
+
+            expect(call?.query).to.equal(`/* ${command} */ SELECT $1`)
+            expect(call?.query).not.to.include(parameters[0])
+            expect(call?.parameters).to.equal(parameters)
+            expect(normalized).to.deep.equal({
+                rows: [{ command }],
+                rowCount: 3,
+                command,
+            })
+        }
+
+        release()
+        release()
+        expect(fake.reserveCount()).to.equal(1)
+        expect(fake.releaseCount()).to.equal(1)
+    })
+
+    it("encodes arrays and JSON without relying on stale inferred codecs", async () => {
+        const fake = createFake()
+        const pool = new PostgresJsPool(fake.factory, options(), credentials)
+        const { connection } = await connect(pool)
+
+        await connection.query("SELECT $1, $2, $3", [
+            ['quoted"value', "back\\slash", null, [1, 2]],
+            JSON.stringify({ fromRawSql: true }),
+            new PostgresJsJsonParameter("42"),
+        ])
+
+        const parameters = fake.unsafeCalls.at(-1)?.parameters
+        expect(parameters?.[0]).to.equal(
+            '{"quoted\\"value","back\\\\slash",NULL,{"1","2"}}',
+        )
+        expect(String(parameters?.[1])).to.equal('{"fromRawSql":true}')
+        expect(JSON.stringify(parameters?.[1])).to.equal('{"fromRawSql":true}')
+        expect(JSON.stringify(parameters?.[2])).to.equal('"42"')
+
+        await connection.query("SELECT $1", [undefined])
+        expect(fake.unsafeCalls.at(-1)?.parameters).to.deep.equal([null])
+    })
+
+    it("supports pg-style query callbacks", async () => {
+        const fake = createFake()
+        fake.setPending(result([{ value: 1 }], 1, "SELECT"))
+        const pool = new PostgresJsPool(fake.factory, options(), credentials)
+        const { connection } = await connect(pool)
+
+        const normalized = await new Promise((resolve, reject) => {
+            connection.query("SELECT 1", (error, queryResult) => {
+                if (error) reject(error)
+                else resolve(queryResult)
+            })
+        })
+
+        expect(normalized).to.deep.equal({
+            rows: [{ value: 1 }],
+            rowCount: 1,
+            command: "SELECT",
+        })
+    })
+
+    it("propagates query errors unchanged", async () => {
+        const fake = createFake()
+        const failure = new Error("query failed")
+        fake.setPending(rejected(failure))
+        const pool = new PostgresJsPool(fake.factory, options(), credentials)
+        const { connection } = await connect(pool)
+
+        let caught: unknown
+        try {
+            await connection.query("broken")
+        } catch (error) {
+            caught = error
+        }
+        expect(caught).to.equal(failure)
+    })
+
+    it("serializes concurrent work on one reserved connection", async () => {
+        const fake = createFake()
+        let finishFirst: ((rows: Row[]) => void) | undefined
+        const first = new Promise<Row[]>((resolve) => {
+            finishFirst = resolve
+        })
+        fake.setPending(
+            Object.assign(first, {
+                cursor: async function* () {
+                    yield await first
+                },
+            }),
+        )
+        const pool = new PostgresJsPool(fake.factory, options(), credentials)
+        const { connection } = await connect(pool)
+
+        const firstQuery = connection.query("SELECT 1")
+        await Promise.resolve()
+        fake.setPending(result([{ value: 2 }], 1, "SELECT"))
+        const secondQuery = connection.query("SELECT 2")
+
+        expect(fake.unsafeCalls.map((call) => call.query)).to.deep.equal([
+            "SELECT 1",
+        ])
+        finishFirst?.(result([{ value: 1 }], 1, "SELECT"))
+        expect((await firstQuery).rows).to.deep.equal([{ value: 1 }])
+        expect((await secondQuery).rows).to.deep.equal([{ value: 2 }])
+        expect(fake.unsafeCalls.map((call) => call.query)).to.deep.equal([
+            "SELECT 1",
+            "SELECT 2",
+        ])
+    })
+
+    it("awaits shutdown and invokes the underlying end only once", async () => {
+        let finishEnd: (() => void) | undefined
+        const endGate = new Promise<void>((resolve) => {
+            finishEnd = resolve
+        })
+        const fake = createFake(endGate)
+        const pool = new PostgresJsPool(fake.factory, options(), credentials)
+        let settled = false
+
+        const ending = pool.end().then(() => {
+            settled = true
+        })
+        await Promise.resolve()
+        expect(settled).to.equal(false)
+        finishEnd?.()
+        await ending
+        await pool.end()
+
+        expect(settled).to.equal(true)
+        expect(fake.endCount()).to.equal(1)
+    })
+
+    it("streams cursor batches in order and preserves cursor errors", async () => {
+        const fake = createFake()
+        let requestedBatchSize: number | undefined
+        fake.setPending(
+            pending(result([], 0, "SELECT"), async function* (batchSize) {
+                await Promise.resolve()
+                requestedBatchSize = batchSize
+                yield [{ id: 1 }, { id: 2 }]
+                yield [{ id: 3 }]
+            }),
+        )
+        const pool = new PostgresJsPool(fake.factory, options(), credentials)
+        const { connection } = await connect(pool)
+        const stream = connection.query(
+            new PostgresJsQueryStream("SELECT id", [], 2),
+        )
+
+        expect(stream.readableObjectMode).to.equal(true)
+        expect(stream.readableHighWaterMark).to.equal(1)
+        expect(await collect(stream)).to.deep.equal([
+            { id: 1 },
+            { id: 2 },
+            { id: 3 },
+        ])
+        expect(requestedBatchSize).to.equal(2)
+
+        const cursorFailure = new Error("cursor failed")
+        fake.setPending(
+            pending(result([], 0, "SELECT"), async function* () {
+                await Promise.resolve()
+                yield [{ id: 1 }]
+                throw cursorFailure
+            }),
+        )
+        const failingStream = connection.query(
+            new PostgresJsQueryStream("SELECT broken"),
+        )
+        let caught: unknown
+        try {
+            await collect(failingStream)
+        } catch (error) {
+            caught = error
+        }
+        expect(caught).to.equal(cursorFailure)
+    })
+})
+
+function options(
+    overrides: Partial<PostgresJsDataSourceOptions> = {},
+): PostgresJsDataSourceOptions {
+    return { type: "postgres-js", ...overrides }
+}
+
+function result(rows: Row[], count: number, command: string): Row[] {
+    return Object.assign(rows, { count, command })
+}
+
+function pending(
+    rows: Row[],
+    cursor: (batchSize?: number) => AsyncIterable<Row[]> = async function* () {
+        await Promise.resolve()
+        yield rows
+    },
+): FakePending {
+    return Object.assign(Promise.resolve(rows), { cursor })
+}
+
+function rejected(error: Error): FakePending {
+    const promise = Promise.reject(error)
+    void promise.catch(() => undefined)
+    return Object.assign(promise, {
+        cursor: () => ({
+            [Symbol.asyncIterator]() {
+                return {
+                    next: () => Promise.reject(error),
+                }
+            },
+        }),
+    })
+}
+
+function createFake(endPromise: Promise<void> = Promise.resolve()) {
+    let currentPending = pending(result([], 0, "SELECT"))
+    let reserves = 0
+    let releases = 0
+    let ends = 0
+    const unsafeCalls: Array<{ query: string; parameters?: unknown[] }> = []
+
+    const sql: FakeSql = {
+        unsafe(query, parameters) {
+            unsafeCalls.push({ query, parameters })
+            return currentPending
+        },
+        reserve() {
+            reserves += 1
+            return Promise.resolve(sql)
+        },
+        release() {
+            releases += 1
+        },
+        end() {
+            ends += 1
+            return endPromise
+        },
+    }
+    const factoryCalls: unknown[][] = []
+    const factory = ((...args: unknown[]) => {
+        factoryCalls.push(args)
+        return sql
+    }) as unknown as PostgresJsFactory
+
+    return {
+        factory,
+        factoryCalls,
+        unsafeCalls,
+        setPending(value: FakePending | Row[]) {
+            currentPending = "cursor" in value ? value : pending(value)
+        },
+        reserveCount: () => reserves,
+        releaseCount: () => releases,
+        endCount: () => ends,
+    }
+}
+
+function connect(pool: PostgresJsPool): Promise<{
+    connection: PostgresJsConnection
+    release: (error?: unknown) => void
+}> {
+    return new Promise((resolve, reject) => {
+        pool.connect((error, connection, release) => {
+            if (error) return reject(error)
+            if (!connection || !release)
+                return reject(new Error("connection was not returned"))
+            resolve({ connection, release })
+        })
+    })
+}
+
+async function collect(stream: Readable): Promise<unknown[]> {
+    const rows: unknown[] = []
+    for await (const row of stream) rows.push(row)
+    return rows
+}

--- a/test/utils/test-utils.ts
+++ b/test/utils/test-utils.ts
@@ -235,9 +235,9 @@ export function setupTestingConnections(
                 return false
 
             if (options?.enabledDrivers?.length)
-                return (
-                    options.enabledDrivers.indexOf(connectionOptions.type!) !==
-                    -1
+                return isTestingConnectionTypeEnabled(
+                    connectionOptions.type!,
+                    options.enabledDrivers,
                 ) // ! is temporary
 
             if (connectionOptions.disabledIfNotEnabledImplicitly === true)
@@ -290,6 +290,25 @@ export function setupTestingConnections(
 
             return newOptions
         })
+}
+
+/**
+ * Selects configured test clients while treating Postgres.js as a client
+ * variant of PostgreSQL dialect suites. Explicit Postgres.js suites stay exact.
+ *
+ * @param connectionType Configured connection type.
+ * @param enabledDrivers Types declared by the test suite.
+ * @returns Whether the configured connection should run.
+ */
+export function isTestingConnectionTypeEnabled(
+    connectionType: DatabaseType,
+    enabledDrivers: DatabaseType[],
+): boolean {
+    return (
+        enabledDrivers.includes(connectionType) ||
+        (connectionType === "postgres-js" &&
+            enabledDrivers.includes("postgres"))
+    )
 }
 
 class GeneratedColumnReplacerSubscriber implements EntitySubscriberInterface {


### PR DESCRIPTION
Adds Postgres.js as an alternative PostgreSQL client through the new postgres-js data source type while reusing TypeORM's existing PostgreSQL dialect, query runner, schema builder, migrations, repositories, and transaction APIs.

Introduces a compatibility pool for connection pinning, streaming, replication, notifications, parameter handling, and shutdown. Migration from pg keeps portable options unchanged apart from the client package and data source type; pg-only quirks are documented instead of emulated.

- [ ] Code is up-to-date with the master branch
- [x] This pull request links a relevant issue using a closing keyword: Closes #11994
- [x] There are new or updated tests validating the change
- [x] Documentation has been updated to reflect this change

Closes #11994