### PR TITLE
fix: use ALTER COLUMN TYPE instead of DROP ADD for column length changes

### DIFF
--- a/docs/docs/migrations/04-generating.md
+++ b/docs/docs/migrations/04-generating.md
@@ -115,3 +115,6 @@ export class PostRefactoringTIMESTAMP {
 See, you don't need to write the queries on your own.
 
 The rule of thumb for generating migrations is that you generate them after **each** change you made to your models. To apply multi-line formatting to your generated migration queries, use the `p` (alias for `--pretty`) flag.
+
+> **Note on column length changes (Postgres / CockroachDB):**  
+> When only a column's `length` changes, TypeORM now generates `ALTER COLUMN ... TYPE` instead of the destructive `DROP COLUMN` + `ADD COLUMN` pattern. This prevents data loss. This behavior also applies when `precision` or `scale` changes alongside `length` — only one `ALTER COLUMN ... TYPE` statement is emitted per column.

--- a/src/driver/aurora-mysql/AuroraMysqlQueryRunner.ts
+++ b/src/driver/aurora-mysql/AuroraMysqlQueryRunner.ts
@@ -889,7 +889,6 @@ export class AuroraMysqlQueryRunner
             (newColumn.isGenerated !== oldColumn.isGenerated &&
                 newColumn.generationStrategy !== "uuid") ||
             oldColumn.type !== newColumn.type ||
-            oldColumn.length !== newColumn.length ||
             oldColumn.generatedType !== newColumn.generatedType
         ) {
             await this.dropColumn(table, oldColumn)

--- a/src/driver/cockroachdb/CockroachQueryRunner.ts
+++ b/src/driver/cockroachdb/CockroachQueryRunner.ts
@@ -1657,25 +1657,9 @@ export class CockroachQueryRunner
 
             if (
                 newColumn.precision !== oldColumn.precision ||
-                newColumn.scale !== oldColumn.scale
+                newColumn.scale !== oldColumn.scale ||
+                newColumn.length !== oldColumn.length
             ) {
-                upQueries.push(
-                    new Query(
-                        `ALTER TABLE ${this.escapePath(table)} ALTER COLUMN "${
-                            newColumn.name
-                        }" TYPE ${this.driver.createFullType(newColumn)}`,
-                    ),
-                )
-                downQueries.push(
-                    new Query(
-                        `ALTER TABLE ${this.escapePath(table)} ALTER COLUMN "${
-                            newColumn.name
-                        }" TYPE ${this.driver.createFullType(oldColumn)}`,
-                    ),
-                )
-            }
-
-            if (newColumn.length !== oldColumn.length) {
                 upQueries.push(
                     new Query(
                         `ALTER TABLE ${this.escapePath(table)} ALTER COLUMN "${

--- a/src/driver/cockroachdb/CockroachQueryRunner.ts
+++ b/src/driver/cockroachdb/CockroachQueryRunner.ts
@@ -1403,7 +1403,6 @@ export class CockroachQueryRunner
 
         if (
             oldColumn.type !== newColumn.type ||
-            oldColumn.length !== newColumn.length ||
             newColumn.isArray !== oldColumn.isArray ||
             oldColumn.generatedType !== newColumn.generatedType ||
             oldColumn.asExpression !== newColumn.asExpression
@@ -1660,6 +1659,23 @@ export class CockroachQueryRunner
                 newColumn.precision !== oldColumn.precision ||
                 newColumn.scale !== oldColumn.scale
             ) {
+                upQueries.push(
+                    new Query(
+                        `ALTER TABLE ${this.escapePath(table)} ALTER COLUMN "${
+                            newColumn.name
+                        }" TYPE ${this.driver.createFullType(newColumn)}`,
+                    ),
+                )
+                downQueries.push(
+                    new Query(
+                        `ALTER TABLE ${this.escapePath(table)} ALTER COLUMN "${
+                            newColumn.name
+                        }" TYPE ${this.driver.createFullType(oldColumn)}`,
+                    ),
+                )
+            }
+
+            if (newColumn.length !== oldColumn.length) {
                 upQueries.push(
                     new Query(
                         `ALTER TABLE ${this.escapePath(table)} ALTER COLUMN "${

--- a/src/driver/mysql/MysqlQueryRunner.ts
+++ b/src/driver/mysql/MysqlQueryRunner.ts
@@ -1138,7 +1138,6 @@ export class MysqlQueryRunner extends BaseQueryRunner implements QueryRunner {
             (newColumn.isGenerated !== oldColumn.isGenerated &&
                 newColumn.generationStrategy !== "uuid") ||
             oldColumn.type !== newColumn.type ||
-            oldColumn.length !== newColumn.length ||
             (oldColumn.generatedType &&
                 newColumn.generatedType &&
                 oldColumn.generatedType !== newColumn.generatedType) ||

--- a/src/driver/oracle/OracleQueryRunner.ts
+++ b/src/driver/oracle/OracleQueryRunner.ts
@@ -1146,7 +1146,6 @@ export class OracleQueryRunner extends BaseQueryRunner implements QueryRunner {
             (newColumn.isGenerated !== oldColumn.isGenerated &&
                 newColumn.generationStrategy !== "uuid") ||
             oldColumn.type !== newColumn.type ||
-            oldColumn.length !== newColumn.length ||
             oldColumn.generatedType !== newColumn.generatedType ||
             oldColumn.asExpression !== newColumn.asExpression
         ) {

--- a/src/driver/postgres/PostgresQueryRunner.ts
+++ b/src/driver/postgres/PostgresQueryRunner.ts
@@ -1328,7 +1328,6 @@ export class PostgresQueryRunner
 
         if (
             oldColumn.type !== newColumn.type ||
-            oldColumn.length !== newColumn.length ||
             newColumn.isArray !== oldColumn.isArray ||
             (!oldColumn.generatedType &&
                 newColumn.generatedType === "STORED") ||
@@ -1622,6 +1621,23 @@ export class PostgresQueryRunner
                 newColumn.precision !== oldColumn.precision ||
                 newColumn.scale !== oldColumn.scale
             ) {
+                upQueries.push(
+                    new Query(
+                        `ALTER TABLE ${this.escapePath(table)} ALTER COLUMN "${
+                            newColumn.name
+                        }" TYPE ${this.driver.createFullType(newColumn)}`,
+                    ),
+                )
+                downQueries.push(
+                    new Query(
+                        `ALTER TABLE ${this.escapePath(table)} ALTER COLUMN "${
+                            newColumn.name
+                        }" TYPE ${this.driver.createFullType(oldColumn)}`,
+                    ),
+                )
+            }
+
+            if (newColumn.length !== oldColumn.length) {
                 upQueries.push(
                     new Query(
                         `ALTER TABLE ${this.escapePath(table)} ALTER COLUMN "${

--- a/src/driver/postgres/PostgresQueryRunner.ts
+++ b/src/driver/postgres/PostgresQueryRunner.ts
@@ -1619,25 +1619,9 @@ export class PostgresQueryRunner
 
             if (
                 newColumn.precision !== oldColumn.precision ||
-                newColumn.scale !== oldColumn.scale
+                newColumn.scale !== oldColumn.scale ||
+                newColumn.length !== oldColumn.length
             ) {
-                upQueries.push(
-                    new Query(
-                        `ALTER TABLE ${this.escapePath(table)} ALTER COLUMN "${
-                            newColumn.name
-                        }" TYPE ${this.driver.createFullType(newColumn)}`,
-                    ),
-                )
-                downQueries.push(
-                    new Query(
-                        `ALTER TABLE ${this.escapePath(table)} ALTER COLUMN "${
-                            newColumn.name
-                        }" TYPE ${this.driver.createFullType(oldColumn)}`,
-                    ),
-                )
-            }
-
-            if (newColumn.length !== oldColumn.length) {
                 upQueries.push(
                     new Query(
                         `ALTER TABLE ${this.escapePath(table)} ALTER COLUMN "${

--- a/src/driver/sap/SapQueryRunner.ts
+++ b/src/driver/sap/SapQueryRunner.ts
@@ -1366,7 +1366,6 @@ export class SapQueryRunner extends BaseQueryRunner implements QueryRunner {
             (newColumn.isGenerated !== oldColumn.isGenerated &&
                 newColumn.generationStrategy !== "uuid") ||
             newColumn.type !== oldColumn.type ||
-            newColumn.length !== oldColumn.length ||
             (newColumn.asExpression ?? "").trim() !==
                 (oldColumn.asExpression ?? "").trim()
         ) {

--- a/src/driver/spanner/SpannerQueryRunner.ts
+++ b/src/driver/spanner/SpannerQueryRunner.ts
@@ -989,7 +989,6 @@ export class SpannerQueryRunner extends BaseQueryRunner implements QueryRunner {
         if (
             oldColumn.name !== newColumn.name ||
             oldColumn.type !== newColumn.type ||
-            oldColumn.length !== newColumn.length ||
             oldColumn.isArray !== newColumn.isArray ||
             oldColumn.generatedType !== newColumn.generatedType ||
             oldColumn.asExpression !== newColumn.asExpression
@@ -1005,6 +1004,23 @@ export class SpannerQueryRunner extends BaseQueryRunner implements QueryRunner {
                 newColumn.precision !== oldColumn.precision ||
                 newColumn.scale !== oldColumn.scale
             ) {
+                upQueries.push(
+                    new Query(
+                        `ALTER TABLE ${this.escapePath(table)} ALTER COLUMN "${
+                            newColumn.name
+                        }" TYPE ${this.driver.createFullType(newColumn)}`,
+                    ),
+                )
+                downQueries.push(
+                    new Query(
+                        `ALTER TABLE ${this.escapePath(table)} ALTER COLUMN "${
+                            newColumn.name
+                        }" TYPE ${this.driver.createFullType(oldColumn)}`,
+                    ),
+                )
+            }
+
+            if (newColumn.length !== oldColumn.length) {
                 upQueries.push(
                     new Query(
                         `ALTER TABLE ${this.escapePath(table)} ALTER COLUMN "${

--- a/src/driver/spanner/SpannerQueryRunner.ts
+++ b/src/driver/spanner/SpannerQueryRunner.ts
@@ -1002,25 +1002,9 @@ export class SpannerQueryRunner extends BaseQueryRunner implements QueryRunner {
         } else {
             if (
                 newColumn.precision !== oldColumn.precision ||
-                newColumn.scale !== oldColumn.scale
+                newColumn.scale !== oldColumn.scale ||
+                newColumn.length !== oldColumn.length
             ) {
-                upQueries.push(
-                    new Query(
-                        `ALTER TABLE ${this.escapePath(table)} ALTER COLUMN "${
-                            newColumn.name
-                        }" TYPE ${this.driver.createFullType(newColumn)}`,
-                    ),
-                )
-                downQueries.push(
-                    new Query(
-                        `ALTER TABLE ${this.escapePath(table)} ALTER COLUMN "${
-                            newColumn.name
-                        }" TYPE ${this.driver.createFullType(oldColumn)}`,
-                    ),
-                )
-            }
-
-            if (newColumn.length !== oldColumn.length) {
                 upQueries.push(
                     new Query(
                         `ALTER TABLE ${this.escapePath(table)} ALTER COLUMN "${

--- a/src/driver/sqlserver/SqlServerQueryRunner.ts
+++ b/src/driver/sqlserver/SqlServerQueryRunner.ts
@@ -1371,7 +1371,6 @@ export class SqlServerQueryRunner
             (newColumn.isGenerated !== oldColumn.isGenerated &&
                 newColumn.generationStrategy !== "uuid") ||
             newColumn.type !== oldColumn.type ||
-            newColumn.length !== oldColumn.length ||
             newColumn.asExpression !== oldColumn.asExpression ||
             newColumn.generatedType !== oldColumn.generatedType
         ) {

--- a/src/query-runner/BaseQueryRunner.ts
+++ b/src/query-runner/BaseQueryRunner.ts
@@ -623,7 +623,7 @@ export abstract class BaseQueryRunner implements AsyncDisposable {
 
     /**
      * Checks if at least one of column properties was changed.
-     * Does not checks column type, length and autoincrement, because these properties changes separately.
+     * Does not check column type and autoincrement, because these properties change separately.
      *
      * @param oldColumn
      * @param newColumn

--- a/src/query-runner/BaseQueryRunner.ts
+++ b/src/query-runner/BaseQueryRunner.ts
@@ -639,6 +639,7 @@ export abstract class BaseQueryRunner implements AsyncDisposable {
         checkEnum = true,
     ): boolean {
         return (
+            oldColumn.length !== newColumn.length ||
             oldColumn.charset !== newColumn.charset ||
             oldColumn.collation !== newColumn.collation ||
             oldColumn.precision !== newColumn.precision ||

--- a/test/functional/schema-builder/column/change/column-length-safe/column-length-safe.test.ts
+++ b/test/functional/schema-builder/column/change/column-length-safe/column-length-safe.test.ts
@@ -139,27 +139,29 @@ describe("schema builder > change column > column length safe", () => {
             dataSources.map(async (dataSource) => {
                 const queryRunner = dataSource.createQueryRunner()
 
-                const table = await queryRunner.getTable("post")
-                const nameCol = table!.findColumnByName("name")!
-                const textCol = table!.findColumnByName("text")!
+                try {
+                    const table = await queryRunner.getTable("post")
+                    const nameCol = table!.findColumnByName("name")!
+                    const textCol = table!.findColumnByName("text")!
 
-                const newNameCol = nameCol.clone()
-                const newTextCol = textCol.clone()
-                newNameCol.length = "200"
-                newTextCol.length = "100"
+                    const newNameCol = nameCol.clone()
+                    const newTextCol = textCol.clone()
+                    newNameCol.length = "200"
+                    newTextCol.length = "100"
 
-                await queryRunner.changeColumn(table!, nameCol, newNameCol)
-                await queryRunner.changeColumn(table!, textCol, newTextCol)
+                    await queryRunner.changeColumn(table!, nameCol, newNameCol)
+                    await queryRunner.changeColumn(table!, textCol, newTextCol)
 
-                const updatedTable = await queryRunner.getTable("post")
-                expect(updatedTable!.findColumnByName("name")!.length).to.equal(
-                    "200",
-                )
-                expect(updatedTable!.findColumnByName("text")!.length).to.equal(
-                    "100",
-                )
-
-                await queryRunner.release()
+                    const updatedTable = await queryRunner.getTable("post")
+                    expect(
+                        updatedTable!.findColumnByName("name")!.length,
+                    ).to.equal("200")
+                    expect(
+                        updatedTable!.findColumnByName("text")!.length,
+                    ).to.equal("100")
+                } finally {
+                    await queryRunner.release()
+                }
             }),
         ))
 })

--- a/test/functional/schema-builder/column/change/column-length-safe/column-length-safe.test.ts
+++ b/test/functional/schema-builder/column/change/column-length-safe/column-length-safe.test.ts
@@ -1,0 +1,165 @@
+import { expect } from "chai"
+import "reflect-metadata"
+import type { DataSource } from "../../../../../../src"
+import {
+    closeTestingConnections,
+    createTestingConnections,
+    reloadTestingDatabases,
+} from "../../../../../utils/test-utils"
+import { Post } from "./entity/Post"
+
+describe("schema builder > change column > column length safe", () => {
+    let dataSources: DataSource[]
+    before(async () => {
+        dataSources = await createTestingConnections({
+            disabledDrivers: ["spanner"],
+            entities: [__dirname + "/entity/*{.js,.ts}"],
+            schemaCreate: true,
+            dropSchema: true,
+        })
+    })
+    beforeEach(() => reloadTestingDatabases(dataSources))
+    after(() => closeTestingConnections(dataSources))
+
+    it("should generate ALTER COLUMN TYPE when length changes, not DROP + ADD", () =>
+        Promise.all(
+            dataSources.map(async (dataSource) => {
+                const postMetadata = dataSource.getMetadata(Post)
+                const nameColumn =
+                    postMetadata.findColumnWithPropertyName("name")!
+                const textColumn =
+                    postMetadata.findColumnWithPropertyName("text")!
+
+                nameColumn.length = "200"
+                textColumn.length = "100"
+
+                const sqlInMemory = await dataSource.driver
+                    .createSchemaBuilder()
+                    .log()
+
+                const upQueries = sqlInMemory.upQueries.map((q) => q.query)
+
+                const driverType = dataSource.driver.options.type
+
+                if (driverType === "postgres" || driverType === "cockroachdb") {
+                    for (const query of upQueries) {
+                        expect(query).to.not.include("DROP COLUMN")
+                        expect(query).to.not.include("ADD COLUMN")
+                    }
+                    expect(
+                        upQueries.some((q) =>
+                            q.includes('ALTER COLUMN "name" TYPE'),
+                        ),
+                    ).to.be.true
+                    expect(
+                        upQueries.some((q) =>
+                            q.includes('ALTER COLUMN "text" TYPE'),
+                        ),
+                    ).to.be.true
+                } else if (
+                    driverType === "mysql" ||
+                    driverType === "mariadb" ||
+                    driverType === "aurora-mysql"
+                ) {
+                    for (const query of upQueries) {
+                        expect(query).to.not.include("DROP COLUMN")
+                    }
+                    expect(upQueries.some((q) => q.includes("ALTER TABLE"))).to
+                        .be.true
+                } else if (driverType === "oracle") {
+                    for (const query of upQueries) {
+                        expect(query).to.not.include("DROP COLUMN")
+                    }
+                    expect(upQueries.some((q) => q.includes("MODIFY"))).to.be
+                        .true
+                } else if (driverType === "sap") {
+                    for (const query of upQueries) {
+                        expect(query).to.not.include("DROP COLUMN")
+                    }
+                } else if (driverType === "mssql") {
+                    for (const query of upQueries) {
+                        expect(query).to.not.include("DROP COLUMN")
+                    }
+                }
+
+                nameColumn.length = "100"
+                textColumn.length = "50"
+            }),
+        ))
+
+    it("should generate ALTER COLUMN TYPE when length decreases, not DROP + ADD", () =>
+        Promise.all(
+            dataSources.map(async (dataSource) => {
+                const postMetadata = dataSource.getMetadata(Post)
+                const nameColumn =
+                    postMetadata.findColumnWithPropertyName("name")!
+                const textColumn =
+                    postMetadata.findColumnWithPropertyName("text")!
+
+                nameColumn.length = "50"
+                textColumn.length = "25"
+
+                const sqlInMemory = await dataSource.driver
+                    .createSchemaBuilder()
+                    .log()
+
+                const upQueries = sqlInMemory.upQueries.map((q) => q.query)
+                const driverType = dataSource.driver.options.type
+
+                if (driverType === "postgres" || driverType === "cockroachdb") {
+                    for (const query of upQueries) {
+                        expect(query).to.not.include("DROP COLUMN")
+                        expect(query).to.not.include("ADD COLUMN")
+                    }
+                    expect(
+                        upQueries.some((q) =>
+                            q.includes('ALTER COLUMN "name" TYPE'),
+                        ),
+                    ).to.be.true
+                } else if (
+                    driverType === "mysql" ||
+                    driverType === "mariadb" ||
+                    driverType === "aurora-mysql" ||
+                    driverType === "oracle" ||
+                    driverType === "sap" ||
+                    driverType === "mssql"
+                ) {
+                    for (const query of upQueries) {
+                        expect(query).to.not.include("DROP COLUMN")
+                    }
+                }
+
+                nameColumn.length = "100"
+                textColumn.length = "50"
+            }),
+        ))
+
+    it("should verify data is preserved after length change (no DROP COLUMN)", () =>
+        Promise.all(
+            dataSources.map(async (dataSource) => {
+                const queryRunner = dataSource.createQueryRunner()
+
+                const table = await queryRunner.getTable("post")
+                const nameCol = table!.findColumnByName("name")!
+                const textCol = table!.findColumnByName("text")!
+
+                const newNameCol = nameCol.clone()
+                const newTextCol = textCol.clone()
+                newNameCol.length = "200"
+                newTextCol.length = "100"
+
+                await queryRunner.changeColumn(table!, nameCol, newNameCol)
+                await queryRunner.changeColumn(table!, textCol, newTextCol)
+
+                const updatedTable = await queryRunner.getTable("post")
+                expect(updatedTable!.findColumnByName("name")!.length).to.equal(
+                    "200",
+                )
+                expect(updatedTable!.findColumnByName("text")!.length).to.equal(
+                    "100",
+                )
+
+                await queryRunner.release()
+            }),
+        ))
+})

--- a/test/functional/schema-builder/column/change/column-length-safe/column-length-safe.test.ts
+++ b/test/functional/schema-builder/column/change/column-length-safe/column-length-safe.test.ts
@@ -8,6 +8,8 @@ import {
 } from "../../../../../utils/test-utils"
 import { Post } from "./entity/Post"
 
+// Regression test for issue #3357: migration should ALTER COLUMN TYPE
+// instead of DROP+ADD when only column length changes
 describe("schema builder > change column > column length safe", () => {
     let dataSources: DataSource[]
     before(async () => {

--- a/test/functional/schema-builder/column/change/column-length-safe/entity/Post.ts
+++ b/test/functional/schema-builder/column/change/column-length-safe/entity/Post.ts
@@ -1,0 +1,15 @@
+import { Entity } from "../../../../../../../src/decorator/entity/Entity"
+import { Column } from "../../../../../../../src/decorator/columns/Column"
+import { PrimaryColumn } from "../../../../../../../src/decorator/columns/PrimaryColumn"
+
+@Entity()
+export class Post {
+    @PrimaryColumn()
+    id: number
+
+    @Column({ length: 100 })
+    name: string
+
+    @Column("varchar", { length: 50 })
+    text: string
+}


### PR DESCRIPTION
## Summary
Fixes #3357 — migration generation drops and recreates columns when only the length changes, causing data loss.

## Problem
When a column length changes (e.g., varchar(50) → varchar(51)), every driver unconditionally performs DROP COLUMN + ADD COLUMN, destroying all existing data.

## Fix
For length-only changes, generate ALTER COLUMN TYPE instead of DROP+ADD.

## Changes
- **Postgres/CockroachDB/Spanner**: Removed length from destructive DROP+ADD; added safe ALTER COLUMN TYPE handler
- **MySQL/AuroraMySQL/Oracle/SAP/SQL Server**: Removed length from DROP+ADD; handled via BaseQueryRunner.isColumnChanged()
- **BaseQueryRunner**: Added length comparison to isColumnChanged()
- **Tests**: Added column-length-safe functional test

Closes #3357