### PR TITLE
fix(query-builder): keep getManyAndCount count accurate for paginated joins

### DIFF
--- a/src/query-builder/SelectQueryBuilder.ts
+++ b/src/query-builder/SelectQueryBuilder.ts
@@ -1920,13 +1920,29 @@ export class SelectQueryBuilder<Entity extends ObjectLiteral>
         const hasLimit =
             this.expressionMap.limit !== undefined &&
             this.expressionMap.limit !== null
-        if (this.expressionMap.joinAttributes.length > 0 && hasLimit) {
-            return undefined
-        }
-
         const hasTake =
             this.expressionMap.take !== undefined &&
             this.expressionMap.take !== null
+        const hasJoin = this.expressionMap.joinAttributes.length > 0
+
+        // A raw LIMIT on a joined query limits joined rows rather than root
+        // entities, so the loaded page size can never be trusted as the total.
+        if (hasJoin && hasLimit) {
+            return undefined
+        }
+
+        // `take` on a joined query loads entities through a separate distinct-ids
+        // subquery (see executeEntitiesAndRawResults). Any ordering value that is
+        // not functionally determined by the primary key is kept in the
+        // subquery's DISTINCT list, so a single root entity can occupy several
+        // LIMIT slots and the page is truncated below the number of matching
+        // roots — making the page size under-report the total. Only keep the
+        // lazy shortcut when every ordering is a plain main-alias column;
+        // otherwise fall back to a real count query.
+        // https://github.com/typeorm/typeorm/issues/11744
+        if (hasJoin && hasTake && !this.orderByIsPrimaryKeySafe()) {
+            return undefined
+        }
 
         // limit overrides take when no join is defined
         const maxResults = hasLimit
@@ -1966,6 +1982,49 @@ export class SelectQueryBuilder<Entity extends ObjectLiteral>
               : 0
 
         return entitiesAndRaw.entities.length + previousResults
+    }
+
+    /**
+     * Returns true only when every ORDER BY criteria is provably a plain column
+     * of the main alias, whose value is functionally determined by the primary
+     * key and therefore never splits the pagination subquery's DISTINCT list.
+     *
+     * Used by lazyCount: for a paginated joined query the total may only be
+     * inferred from the loaded page size when the page cannot be truncated. This
+     * is intentionally conservative — anything that is not a bare "mainAlias.col"
+     * reference (a joined column, an embedded path, a raw/computed select alias
+     * such as addSelect("a.x || b.y", "k"), or an unresolved identifier) is
+     * treated as unsafe so the caller falls back to a real count query.
+     */
+    private orderByIsPrimaryKeySafe(): boolean {
+        const mainAliasName = this.expressionMap.mainAlias?.name
+
+        // matches exactly `mainAlias.column` — a single, unqualified column of
+        // the main table with no functions, operators or further path segments.
+        const isMainAliasColumn = (expression: string): boolean => {
+            const match = /^(\w+)\.(\w+)$/.exec(expression.trim())
+            return match !== null && match[1] === mainAliasName
+        }
+
+        return Object.keys(this.expressionMap.allOrderBys).every((criteria) => {
+            if (criteria.indexOf(".") !== -1) {
+                return isMainAliasColumn(criteria)
+            }
+
+            // a bare identifier may be a select alias
+            // (addSelect("players.name", "playerName").orderBy("playerName")):
+            // resolve it to the underlying selection and inspect that. A bare
+            // identifier that is not a select alias adds nothing to the DISTINCT
+            // list (see createOrderByCombinedWithSelectExpression) and is safe.
+            const matchedSelect = this.expressionMap.selects.find(
+                (select) =>
+                    select.aliasName === criteria ||
+                    select.selection === criteria,
+            )
+            return matchedSelect
+                ? isMainAliasColumn(matchedSelect.selection)
+                : true
+        })
     }
 
     /**

--- a/src/query-builder/SelectQueryBuilder.ts
+++ b/src/query-builder/SelectQueryBuilder.ts
@@ -1990,11 +1990,13 @@ export class SelectQueryBuilder<Entity extends ObjectLiteral>
      * key and therefore never splits the pagination subquery's DISTINCT list.
      *
      * Used by lazyCount: for a paginated joined query the total may only be
-     * inferred from the loaded page size when the page cannot be truncated. This
-     * is intentionally conservative — anything that is not a bare "mainAlias.col"
-     * reference (a joined column, an embedded path, a raw/computed select alias
-     * such as addSelect("a.x || b.y", "k"), or an unresolved identifier) is
-     * treated as unsafe so the caller falls back to a real count query.
+     * inferred from the loaded page size when the page cannot be truncated.
+     * Anything that is not a bare "mainAlias.col" reference (a joined column,
+     * an embedded path, or a select alias for a raw/computed expression such
+     * as addSelect("a.x || b.y", "k")) is treated as unsafe so the caller
+     * falls back to a real count query. A bare identifier that matches no
+     * select at all stays safe: it adds nothing to the pagination subquery's
+     * DISTINCT list (see createOrderByCombinedWithSelectExpression).
      */
     private orderByIsPrimaryKeySafe(): boolean {
         const mainAliasName = this.expressionMap.mainAlias?.name

--- a/test/functional/query-builder/getManyAndCount-join-pagination/entity/Player.ts
+++ b/test/functional/query-builder/getManyAndCount-join-pagination/entity/Player.ts
@@ -1,0 +1,22 @@
+import { Entity } from "../../../../../src/decorator/entity/Entity"
+import { PrimaryGeneratedColumn } from "../../../../../src/decorator/columns/PrimaryGeneratedColumn"
+import { Column } from "../../../../../src/decorator/columns/Column"
+import { ManyToOne } from "../../../../../src/decorator/relations/ManyToOne"
+import { JoinColumn } from "../../../../../src/decorator/relations/JoinColumn"
+import { Sport } from "./Sport"
+
+@Entity()
+export class Player {
+    @PrimaryGeneratedColumn()
+    id: number
+
+    @Column()
+    name: string
+
+    @Column()
+    sportId: number
+
+    @ManyToOne(() => Sport, (sport) => sport.players)
+    @JoinColumn({ name: "sportId", referencedColumnName: "id" })
+    sport: Sport
+}

--- a/test/functional/query-builder/getManyAndCount-join-pagination/entity/Sport.ts
+++ b/test/functional/query-builder/getManyAndCount-join-pagination/entity/Sport.ts
@@ -1,0 +1,17 @@
+import { Entity } from "../../../../../src/decorator/entity/Entity"
+import { PrimaryGeneratedColumn } from "../../../../../src/decorator/columns/PrimaryGeneratedColumn"
+import { Column } from "../../../../../src/decorator/columns/Column"
+import { OneToMany } from "../../../../../src/decorator/relations/OneToMany"
+import { Player } from "./Player"
+
+@Entity()
+export class Sport {
+    @PrimaryGeneratedColumn()
+    id: number
+
+    @Column()
+    name: string
+
+    @OneToMany(() => Player, (player) => player.sport)
+    players: Player[]
+}

--- a/test/functional/query-builder/getManyAndCount-join-pagination/getManyAndCount-join-pagination.test.ts
+++ b/test/functional/query-builder/getManyAndCount-join-pagination/getManyAndCount-join-pagination.test.ts
@@ -1,0 +1,148 @@
+import {
+    closeTestingConnections,
+    createTestingConnections,
+    reloadTestingDatabases,
+} from "../../../utils/test-utils"
+import type { DataSource } from "../../../../src/data-source/DataSource"
+import { expect } from "chai"
+import { Sport } from "./entity/Sport"
+import { Player } from "./entity/Player"
+
+describe("query builder > getManyAndCount with join + pagination", () => {
+    let dataSources: DataSource[]
+    before(async () => {
+        dataSources = await createTestingConnections({
+            entities: [Sport, Player],
+            schemaCreate: true,
+            dropSchema: true,
+        })
+    })
+    beforeEach(() => reloadTestingDatabases(dataSources))
+    after(() => closeTestingConnections(dataSources))
+
+    // https://github.com/typeorm/typeorm/issues/11744
+    // getManyAndCount() must return the same count as getCount() when
+    // pagination (take) is combined with a join whose rows are unevenly
+    // distributed (one root with 0 joined rows, another with 2+) and the query
+    // orders by the joined column. A single count query is the source of truth;
+    // the paginated page size must not be used to infer it.
+    it("should return the same count as getCount() with take + join + order on the joined column", () =>
+        Promise.all(
+            dataSources.map(async (dataSource) => {
+                const soccer = await dataSource.manager.save(
+                    Object.assign(new Sport(), { name: "soccer" }),
+                )
+                // tennis intentionally has no players (0 joined rows)
+                await dataSource.manager.save(
+                    Object.assign(new Sport(), { name: "tennis" }),
+                )
+                await dataSource.manager.save([
+                    Object.assign(new Player(), {
+                        name: "Alice",
+                        sportId: soccer.id,
+                    }),
+                    Object.assign(new Player(), {
+                        name: "Bob",
+                        sportId: soccer.id,
+                    }),
+                ])
+
+                const buildQuery = () =>
+                    dataSource
+                        .createQueryBuilder(Sport, "sports")
+                        .leftJoinAndSelect("sports.players", "players")
+                        .addOrderBy("players.name", "DESC")
+                        .take(2)
+
+                const expectedCount = await buildQuery().getCount()
+                const [, count] = await buildQuery().getManyAndCount()
+
+                // two sports exist, so the count must be 2 and agree with getCount()
+                expect(expectedCount).to.equal(2)
+                expect(count).to.equal(expectedCount)
+            }),
+        ))
+
+    // https://github.com/typeorm/typeorm/issues/11744
+    // The same truncation happens when the joined column is ordered through a
+    // select alias (addSelect("players.name", "playerName").orderBy("playerName")),
+    // so the count fallback must resolve select aliases to their selection.
+    it("should return the same count as getCount() when ordering by a joined column via a select alias", () =>
+        Promise.all(
+            dataSources.map(async (dataSource) => {
+                const soccer = await dataSource.manager.save(
+                    Object.assign(new Sport(), { name: "soccer" }),
+                )
+                await dataSource.manager.save(
+                    Object.assign(new Sport(), { name: "tennis" }),
+                )
+                await dataSource.manager.save([
+                    Object.assign(new Player(), {
+                        name: "Alice",
+                        sportId: soccer.id,
+                    }),
+                    Object.assign(new Player(), {
+                        name: "Bob",
+                        sportId: soccer.id,
+                    }),
+                ])
+
+                const buildQuery = () =>
+                    dataSource
+                        .createQueryBuilder(Sport, "sports")
+                        .leftJoinAndSelect("sports.players", "players")
+                        .addSelect("players.name", "playerName")
+                        .orderBy("playerName", "DESC")
+                        .take(2)
+
+                const expectedCount = await buildQuery().getCount()
+                const [, count] = await buildQuery().getManyAndCount()
+
+                expect(expectedCount).to.equal(2)
+                expect(count).to.equal(expectedCount)
+            }),
+        ))
+
+    // https://github.com/typeorm/typeorm/issues/11744
+    // A computed select alias whose expression starts with the main alias but
+    // still references a joined column (e.g. addSelect("sports.id + players.id",
+    // "sortKey")) also splits the pagination DISTINCT per joined row. Inspecting
+    // only the first alias token would wrongly treat it as safe, so the lazy
+    // count shortcut must be disabled for anything that is not a plain
+    // main-alias column.
+    it("should return the same count as getCount() when ordering by a computed select alias over a joined column", () =>
+        Promise.all(
+            dataSources.map(async (dataSource) => {
+                const soccer = await dataSource.manager.save(
+                    Object.assign(new Sport(), { name: "soccer" }),
+                )
+                await dataSource.manager.save(
+                    Object.assign(new Sport(), { name: "tennis" }),
+                )
+                await dataSource.manager.save([
+                    Object.assign(new Player(), {
+                        name: "Alice",
+                        sportId: soccer.id,
+                    }),
+                    Object.assign(new Player(), {
+                        name: "Bob",
+                        sportId: soccer.id,
+                    }),
+                ])
+
+                const buildQuery = () =>
+                    dataSource
+                        .createQueryBuilder(Sport, "sports")
+                        .leftJoinAndSelect("sports.players", "players")
+                        .addSelect("sports.id + players.id", "sortKey")
+                        .orderBy("sortKey", "DESC")
+                        .take(2)
+
+                const expectedCount = await buildQuery().getCount()
+                const [, count] = await buildQuery().getManyAndCount()
+
+                expect(expectedCount).to.equal(2)
+                expect(count).to.equal(expectedCount)
+            }),
+        ))
+})

--- a/test/functional/query-builder/getManyAndCount-join-pagination/getManyAndCount-join-pagination.test.ts
+++ b/test/functional/query-builder/getManyAndCount-join-pagination/getManyAndCount-join-pagination.test.ts
@@ -90,7 +90,7 @@ describe("query builder > getManyAndCount with join + pagination", () => {
                 const buildQuery = () =>
                     dataSource
                         .createQueryBuilder(Sport, "sports")
-                        .leftJoinAndSelect("sports.players", "players")
+                        .leftJoin("sports.players", "players")
                         .addSelect("players.name", "playerName")
                         .orderBy("playerName", "DESC")
                         .take(2)


### PR DESCRIPTION
### Description of change

`getManyAndCount()` returns a wrong count since 0.3.26 when a query combines `take`, a join, and an order by a joined column.

The lazy count added in #11524 infers the total from the number of loaded entities. For this kind of query the entities are loaded through the distinct-ids pagination, which keeps the ordered column in its `SELECT DISTINCT` list. A root row that has several joined rows then produces several distinct tuples, each one taking a `LIMIT` slot, so the page comes back with fewer roots than actually match and the inferred count ends up too low.

Example (two sports, one with two players and one with none):

```ts
const [rows, count] = await dataSource
    .createQueryBuilder(Sport, "sports")
    .leftJoinAndSelect("sports.players", "players")
    .addOrderBy("players.name", "DESC")
    .take(2)
    .getManyAndCount()
// count is 1 on 0.3.26+, was 2 on 0.3.25
```

The fix only infers the count from the page when every order by is a plain column of the main alias, whose value is fixed per primary key and cannot split the `DISTINCT`. A joined column, a computed or select-alias expression, or an embedded path now runs a real count query instead. Ordering by the main alias keeps the lazy path, so the optimization from #11524 is unchanged for the common case (still covered by the existing lazy-count tests).

This does not change the loaded page itself: `getMany()` can still return fewer roots than `take` for a to-many join ordered by the joined column. That is an older, separate pagination behaviour and is left out of scope here; this change only makes the count agree with `getCount()`.

Verified with a new test under `test/functional/query-builder/getManyAndCount-join-pagination/` that covers ordering by the joined column directly, through a select alias, and through a computed alias, plus the existing lazy-count suite.

### Pull-Request Checklist

- [x] Code is up-to-date with the `master` branch
- [x] This pull request links a relevant issue using a closing keyword: `Closes #11744`
- [x] There are new or updated tests validating the change (`tests/**.test.ts`)
- [ ] Documentation has been updated to reflect this change (`docs/docs/**.md`) N/A
