### PR TITLE
fix(query-builder): run count query for getManyAndCount with a join + any pagination (#11744)

### DIFF
--- a/src/query-builder/SelectQueryBuilder.ts
+++ b/src/query-builder/SelectQueryBuilder.ts
@@ -1920,13 +1920,32 @@ export class SelectQueryBuilder<Entity extends ObjectLiteral>
         const hasLimit =
             this.expressionMap.limit !== undefined &&
             this.expressionMap.limit !== null
-        if (this.expressionMap.joinAttributes.length > 0 && hasLimit) {
-            return undefined
-        }
-
         const hasTake =
             this.expressionMap.take !== undefined &&
             this.expressionMap.take !== null
+        const hasSkip =
+            this.expressionMap.skip !== undefined &&
+            this.expressionMap.skip !== null &&
+            this.expressionMap.skip > 0
+        const hasOffset =
+            this.expressionMap.offset !== undefined &&
+            this.expressionMap.offset !== null &&
+            this.expressionMap.offset > 0
+
+        // When a join is combined with any pagination (take/limit/skip/offset)
+        // the number of returned entities cannot be used to derive the total
+        // count: pagination is applied through a distinct-id sub-query, so a
+        // single parent that owns several joined rows consumes several of the
+        // paginated rows and the page can contain fewer distinct parents than
+        // requested (and `skip`/`offset` may skip fewer distinct parents than
+        // their value). In that case we must fall back to the dedicated count
+        // query. See #11744.
+        if (
+            this.expressionMap.joinAttributes.length > 0 &&
+            (hasLimit || hasTake || hasSkip || hasOffset)
+        ) {
+            return undefined
+        }
 
         // limit overrides take when no join is defined
         const maxResults = hasLimit
@@ -1942,15 +1961,6 @@ export class SelectQueryBuilder<Entity extends ObjectLiteral>
             // stop here when the result set contains the max number of rows; we need to execute a full count
             return undefined
         }
-
-        const hasSkip =
-            this.expressionMap.skip !== undefined &&
-            this.expressionMap.skip !== null &&
-            this.expressionMap.skip > 0
-        const hasOffset =
-            this.expressionMap.offset !== undefined &&
-            this.expressionMap.offset !== null &&
-            this.expressionMap.offset > 0
 
         if (entitiesAndRaw.entities.length === 0 && (hasSkip || hasOffset)) {
             // when skip or offset were used and no results found, we need to execute a full count

--- a/test/github-issues/11744/entity/Player.ts
+++ b/test/github-issues/11744/entity/Player.ts
@@ -1,0 +1,17 @@
+import { Column } from "../../../../src/decorator/columns/Column"
+import { Entity } from "../../../../src/decorator/entity/Entity"
+import { ManyToOne } from "../../../../src/decorator/relations/ManyToOne"
+import { PrimaryGeneratedColumn } from "../../../../src/decorator/columns/PrimaryGeneratedColumn"
+import { Sport } from "./Sport"
+
+@Entity()
+export class Player {
+    @PrimaryGeneratedColumn()
+    id: number
+
+    @Column()
+    name: string
+
+    @ManyToOne(() => Sport, (sport) => sport.players)
+    sport: Sport
+}

--- a/test/github-issues/11744/entity/Sport.ts
+++ b/test/github-issues/11744/entity/Sport.ts
@@ -1,0 +1,17 @@
+import { Column } from "../../../../src/decorator/columns/Column"
+import { Entity } from "../../../../src/decorator/entity/Entity"
+import { OneToMany } from "../../../../src/decorator/relations/OneToMany"
+import { PrimaryGeneratedColumn } from "../../../../src/decorator/columns/PrimaryGeneratedColumn"
+import { Player } from "./Player"
+
+@Entity()
+export class Sport {
+    @PrimaryGeneratedColumn()
+    id: number
+
+    @Column()
+    name: string
+
+    @OneToMany(() => Player, (player) => player.sport)
+    players: Player[]
+}

--- a/test/github-issues/11744/issue-11744.test.ts
+++ b/test/github-issues/11744/issue-11744.test.ts
@@ -1,0 +1,85 @@
+import "reflect-metadata"
+import {
+    createTestingConnections,
+    closeTestingConnections,
+    reloadTestingDatabases,
+} from "../../utils/test-utils"
+import type { DataSource } from "../../../src/data-source/DataSource"
+import { expect } from "chai"
+import { Sport } from "./entity/Sport"
+import { Player } from "./entity/Player"
+
+describe("github issues > #11744 getManyAndCount returns wrong count with take() + join when a parent has 0 and another has 2+ joined rows", () => {
+    let dataSources: DataSource[]
+    before(async () => {
+        dataSources = await createTestingConnections({
+            entities: [__dirname + "/entity/*{.js,.ts}"],
+            schemaCreate: true,
+            dropSchema: true,
+        })
+    })
+    beforeEach(async () => {
+        await reloadTestingDatabases(dataSources)
+        await Promise.all(
+            dataSources.map(async (dataSource) => {
+                const sportRepo = dataSource.getRepository(Sport)
+                const playerRepo = dataSource.getRepository(Player)
+
+                // Sport with zero players
+                const basketball = await sportRepo.save(
+                    sportRepo.create({ name: "Basketball" }),
+                )
+
+                // Sport with two players
+                const soccer = await sportRepo.save(
+                    sportRepo.create({ name: "Soccer" }),
+                )
+                await playerRepo.save([
+                    playerRepo.create({ name: "Alice", sport: soccer }),
+                    playerRepo.create({ name: "Zoe", sport: soccer }),
+                ])
+
+                void basketball
+            }),
+        )
+    })
+    after(() => closeTestingConnections(dataSources))
+
+    it("should return the correct count of parent entities", () =>
+        Promise.all(
+            dataSources.map(async (dataSource) => {
+                const [, count] = await dataSource
+                    .getRepository(Sport)
+                    .createQueryBuilder("sports")
+                    .leftJoinAndSelect("sports.players", "players")
+                    .addOrderBy("players.name", "DESC")
+                    .take(2)
+                    .getManyAndCount()
+
+                // Two sports exist (Basketball with 0 players, Soccer with 2
+                // players); the count must reflect both regardless of how many
+                // joined rows each parent has.
+                expect(count).to.equal(2)
+            }),
+        ))
+
+    it("should return the correct count of parent entities with skip and a join", () =>
+        Promise.all(
+            dataSources.map(async (dataSource) => {
+                const [, count] = await dataSource
+                    .getRepository(Sport)
+                    .createQueryBuilder("sports")
+                    .leftJoinAndSelect("sports.players", "players")
+                    .addOrderBy("players.name", "DESC")
+                    .skip(1)
+                    .getManyAndCount()
+
+                // Same root cause as the take() case: with a join, skip is
+                // applied through the distinct-id sub-query over (primaryKey,
+                // order-by) tuples, so it may skip fewer distinct parents than
+                // its value and the derived count overcounts. The count must
+                // still reflect the two real parents.
+                expect(count).to.equal(2)
+            }),
+        ))
+})

--- a/test/other-issues/lazy-count/lazy-count.test.ts
+++ b/test/other-issues/lazy-count/lazy-count.test.ts
@@ -156,7 +156,12 @@ describe("other issues > lazy count", () => {
             }),
         ))
 
-    it("skip count query when joining a relation with a take", () =>
+    // A join combined with a take cannot derive the count from the number of
+    // returned entities: pagination is applied through a distinct-id sub-query,
+    // so a single parent owning several joined rows can consume several
+    // paginated rows and hide other parents. The dedicated count query must run.
+    // See #11744.
+    it("run count query when joining a relation with a take", () =>
         Promise.all(
             dataSources.map(async function (connection) {
                 await savePostEntities(connection, 5)
@@ -179,7 +184,7 @@ describe("other issues > lazy count", () => {
                     afterQuery
                         .getCalledQueries()
                         .filter((query) => query.match(/(count|cnt)/i)),
-                ).to.be.empty
+                ).not.to.be.empty
             }),
         ))
 
@@ -210,7 +215,7 @@ describe("other issues > lazy count", () => {
             }),
         ))
 
-    it("skip count query when joining a relation with a take and a skip", () =>
+    it("run count query when joining a relation with a take and a skip", () =>
         Promise.all(
             dataSources.map(async function (connection) {
                 await savePostEntities(connection, 5)
@@ -234,7 +239,7 @@ describe("other issues > lazy count", () => {
                     afterQuery
                         .getCalledQueries()
                         .filter((query) => query.match(/(count|cnt)/i)),
-                ).to.be.empty
+                ).not.to.be.empty
             }),
         ))
 


### PR DESCRIPTION
fix(query-builder): run count query for getManyAndCount with pagination and a join (#11744)

## Problem

Since TypeORM 0.3.26, `QueryBuilder.getManyAndCount()` returns an incorrect
count when the query combines pagination (`.take()`/`.limit()`, and — as
surfaced during review — `.skip()`/`.offset()`) with a join and at least one
returned parent entity has 0 joined rows while another has 2+ joined rows.

Reproduction (from the issue):

```ts
sportsRepo
    .createQueryBuilder("sports")
    .leftJoinAndSelect("sports.players", "players")
    .addOrderBy("players.name", "DESC")
    .take(2)
    .getManyAndCount()
```

With one sport that has no players and one sport that has two players, the count
returned is `1` on 0.3.26 / 0.3.27, but was `2` on 0.3.25. The maintainers
triaged this and applied the `regression` label.

## Root cause

`src/query-builder/SelectQueryBuilder.ts` — `lazyCount()` (added in
[#11524](https://github.com/typeorm/typeorm/pull/11524), released in 0.3.26)
optimizes `getManyAndCount()` by deriving the total count from the number of
already-fetched entities instead of issuing a second `COUNT` query.

That derivation is unsound whenever a join is combined with pagination. Paged
join queries are executed through a *distinct-id sub-query*
(`executeEntitiesAndRawResults`): the sub-query selects
`DISTINCT(<parentId>, <order-by columns>)` and applies `LIMIT`/`OFFSET`. When the
`ORDER BY` references a joined column, a single parent that owns several joined
rows produces several distinct `(parentId, orderCol)` tuples, each consuming one
row of the window.

- With `take`/`limit`, the window can be fully consumed by one parent's rows, so
  the loaded page contains fewer distinct parents than requested.
- With `skip`/`offset`, the offset is applied to those `(parentId, orderCol)`
  tuples, so it can skip *fewer* distinct parents than its value — and
  `lazyCount()` derives the count as `entities.length + skip`, which then
  **overcounts**.

`lazyCount()` only sees the number of distinct parent entities, not the number
of paginated rows, so it cannot tell "the result set was exhausted" (safe to
derive the count) apart from "pagination truncated/shifted the page" (not safe).
For `join + take` it returned `entities.length` (1) instead of the true count
(2); for `join + skip` (no take) it returned `entities.length + skip` (2 + 1 = 3)
instead of 2.

Concretely, `lazyCount()` already bailed out (returned `undefined`, forcing the
accurate count query) for `join + limit`, but not for `join + take`, nor for
`join + skip`/`offset` — and those are exactly the pagination modes that trigger
the distinct-id sub-query.

Root cause line: `src/query-builder/SelectQueryBuilder.ts`, `lazyCount()`
(the `joinAttributes.length > 0 && (hasLimit || hasTake)` guard, which did not
cover `skip`/`offset`).

## Fix

Extend the existing early-return guard so the optimization is skipped — and the
dedicated count query is run — whenever a join is combined with **any**
pagination (`take`/`limit`/`skip`/`offset`). The `hasSkip`/`hasOffset` flags are
hoisted above the guard so they can participate in it:

```ts
if (
    this.expressionMap.joinAttributes.length > 0 &&
    (hasLimit || hasTake || hasSkip || hasOffset)
) {
    return undefined
}
```

Falling back to the dedicated count query is always correct for a
join + pagination query, so this restores the pre-0.3.26 behavior (an accurate
`COUNT(DISTINCT <primaryKey>)` query) for every paginated join while keeping the
`lazyCount` optimization for the common non-join case and for join queries
without pagination. It mirrors the shape of the previous follow-up fix to
`lazyCount` ([#11634](https://github.com/typeorm/typeorm/pull/11634)).

The original PR guarded only `hasLimit || hasTake`; the `skip`/`offset`
generalization was added after the qodo review bot flagged that the same
distinct-id root cause reaches `getManyAndCount()` through `skip`/`offset`.

## Tests

- Added `test/github-issues/11744/` (entities `Sport` 1—N `Player`, plus
  `issue-11744.test.ts`) with two cases over the same data (one parent with 0
  children, one parent with 2 children, `leftJoinAndSelect` +
  `addOrderBy("players.name","DESC")`), each asserting the count is `2`:
  - `take(2)` + `getManyAndCount()` — **fails before** the fix
    (`AssertionError: expected 1 to equal 2`), **passes after**.
  - `skip(1)` + `getManyAndCount()` (skip, no take) — **fails before** the
    `skip`/`offset` generalization (`AssertionError: expected 3 to equal 2`),
    **passes after**.
- Updated `test/other-issues/lazy-count/lazy-count.test.ts`: the two
  "skip count query when joining a relation with a take[…]" cases now correctly
  **run** the count query (renamed to "run count query…", assertion flipped
  from `.to.be.empty` to `.not.to.be.empty`). Their asserted count/entity
  values are unchanged (still correct) — only whether an extra count query is
  issued changed, which is the intended effect of this fix.

## Verification (before / after)

Ran against `better-sqlite3` and `sqljs` drivers.

`#11744` regression tests:

- **Before the `skip` generalization** (guard = `hasLimit || hasTake`, both test
  cases present): the `take` case passes but the `skip` case fails —
  `AssertionError: expected 3 to equal 2`.
- **After the fix**: both `#11744` cases pass (`✔ ✔`).

Full test suite (`better-sqlite3` + `sqljs`), after fix:
**3040 passing, 175 pending, 1 failing** — the single failure is the pre-existing
`RedisQueryResultCache Integration` test, which needs a Docker/Podman container
runtime that is unavailable in this environment (unrelated to this change).

Non-regression evidence for the untouched paths — `test/other-issues/lazy-count`
all green, including the non-join optimization cases
`skip count query when skip is defined` and `skip count query when an offset is
defined` (proving the non-join `skip`/`offset` fast path is unchanged) and
`run count query when joining a relation with a take` (join + pagination
fallback).

## Compatibility

No public API change. Behavior change is limited to `getManyAndCount()` /
`findAndCount()` when a join is combined with pagination
(`take`/`limit`/`skip`/`offset`): an accurate count query is now executed (as it
was before 0.3.26) instead of deriving the count from the page. Counts that were
already correct remain correct; the only observable difference for
previously-correct queries is one additional `COUNT` query in the
join-with-pagination case. No migration required.

## Scope note

This fixes the reported **count** regression (0.3.25 → 0.3.26). The reporter
also observed that the returned page "may be truncated" for this query shape.
That page truncation is a **separate, pre-existing** behavior of the distinct-id
pagination sub-query when ordering by a joined column (it also affects
`getMany()` and was present in 0.3.25 — it is not part of the 0.3.26
regression), so it is intentionally left out of this minimal regression fix.
