### PR TITLE
Fix normalizeWhereCriteria default behavior for invalidWhereValuesBehavior

### DIFF
--- a/src/util/OrmUtils.ts
+++ b/src/util/OrmUtils.ts
@@ -667,7 +667,8 @@ export class OrmUtils {
         },
         path?: string,
     ): ObjectLiteral {
-        if (!options) return criteria
+        // Default to "throw" behavior when options not provided
+        const effectiveOptions = options ?? { null: "throw", undefined: "throw" }
 
         const result: ObjectLiteral = {}
 
@@ -675,7 +676,7 @@ export class OrmUtils {
             const propertyPath = path ? `${path}.${key}` : key
 
             if (value === undefined) {
-                const behavior = options?.undefined ?? "throw"
+                const behavior = effectiveOptions.undefined ?? "throw"
                 if (behavior === "throw") {
                     throw new TypeORMError(
                         `Undefined value encountered in property '${propertyPath}' of a where condition. ` +
@@ -684,7 +685,7 @@ export class OrmUtils {
                 }
                 // "ignore" — skip this key
             } else if (value === null) {
-                const behavior = options?.null ?? "throw"
+                const behavior = effectiveOptions.null ?? "throw"
                 if (behavior === "throw") {
                     throw new TypeORMError(
                         `Null value encountered in property '${propertyPath}' of a where condition. ` +
@@ -703,7 +704,7 @@ export class OrmUtils {
             ) {
                 const nested = OrmUtils.normalizeWhereCriteria(
                     value,
-                    options,
+                    effectiveOptions,
                     propertyPath,
                 )
                 if (Object.keys(nested).length > 0) {


### PR DESCRIPTION
Fixes #12578

## Problem

When `invalidWhereValuesBehavior` is not configured in the DataSource options, `OrmUtils.normalizeWhereCriteria()` immediately returns the criteria as-is without checking for `undefined` or `null` values. This means UPDATE queries can be executed with buggy filters like `WHERE col2 = null` with no warning or error.

The docs state that the default behavior should be `throw`:
> `throw (default)` JavaScript undefined values cause a TypeORMError to be thrown

## Fix

In `src/util/OrmUtils.ts`, replaced the early return `if (!options) return criteria` with a default options object:

```ts
const effectiveOptions = options ?? { null: "throw", undefined: "throw" }
```

This ensures that when no options are provided, the function defaults to `throw` behavior for both `null` and `undefined` values, matching the documented default.

All internal references to `options` within the function body have been updated to use `effectiveOptions`, including the recursive call for nested objects.

/claim #12578