### PR TITLE
fix: honor take(0) with joins

### DIFF
--- a/src/query-builder/SelectQueryBuilder.ts
+++ b/src/query-builder/SelectQueryBuilder.ts
@@ -3489,8 +3489,9 @@ export class SelectQueryBuilder<Entity extends ObjectLiteral>
         // first query find ids in skip and take range
         // and second query loads the actual data in given ids range
         if (
-            (this.expressionMap.skip != null ||
-                this.expressionMap.take != null) &&
+            (this.expressionMap.take != null ||
+                (this.expressionMap.skip != null &&
+                    this.expressionMap.skip !== 0)) &&
             this.expressionMap.joinAttributes.length > 0
         ) {
             // we are skipping order by here because its not working in subqueries anyway

--- a/src/query-builder/SelectQueryBuilder.ts
+++ b/src/query-builder/SelectQueryBuilder.ts
@@ -3489,7 +3489,8 @@ export class SelectQueryBuilder<Entity extends ObjectLiteral>
         // first query find ids in skip and take range
         // and second query loads the actual data in given ids range
         if (
-            (this.expressionMap.skip || this.expressionMap.take) &&
+            (this.expressionMap.skip != null ||
+                this.expressionMap.take != null) &&
             this.expressionMap.joinAttributes.length > 0
         ) {
             // we are skipping order by here because its not working in subqueries anyway

--- a/test/functional/query-builder/join/query-builder-joins.test.ts
+++ b/test/functional/query-builder/join/query-builder-joins.test.ts
@@ -1582,6 +1582,30 @@ describe("query builder > joins", () => {
                 }),
             ))
 
+        it("should return no rows when take(0) is used with a join", () =>
+            Promise.all(
+                dataSources.map(async (dataSource) => {
+                    const category = new Category()
+                    category.name = "Category"
+                    await dataSource.manager.save(category)
+
+                    const post = new Post()
+                    post.title = "Post"
+                    post.categories = [category]
+                    await dataSource.manager.save(post)
+
+                    const [posts, count] = await dataSource
+                        .getRepository(Post)
+                        .createQueryBuilder("post")
+                        .leftJoinAndSelect("post.categories", "category")
+                        .take(0)
+                        .getManyAndCount()
+
+                    expect(posts).to.have.lengthOf(0)
+                    expect(count).to.equal(1)
+                }),
+            ))
+
         it("should work correctly with explicit primary key selection", () =>
             Promise.all(
                 dataSources.map(async (dataSource) => {

--- a/test/functional/query-builder/join/query-builder-joins.test.ts
+++ b/test/functional/query-builder/join/query-builder-joins.test.ts
@@ -1606,6 +1606,29 @@ describe("query builder > joins", () => {
                 }),
             ))
 
+        it("should still return all rows when skip(0) is used alone with a join, since offset 0 is a no-op", () =>
+            Promise.all(
+                dataSources.map(async (dataSource) => {
+                    const category = new Category()
+                    category.name = "Category"
+                    await dataSource.manager.save(category)
+
+                    const post = new Post()
+                    post.title = "Post"
+                    post.categories = [category]
+                    await dataSource.manager.save(post)
+
+                    const posts = await dataSource
+                        .getRepository(Post)
+                        .createQueryBuilder("post")
+                        .leftJoinAndSelect("post.categories", "category")
+                        .skip(0)
+                        .getMany()
+
+                    expect(posts).to.have.lengthOf(1)
+                }),
+            ))
+
         it("should work correctly with explicit primary key selection", () =>
             Promise.all(
                 dataSources.map(async (dataSource) => {


### PR DESCRIPTION
`take(0)` was skipped by the join pagination check because `0` is falsy.

Use null checks so `take(0)` enters the pagination path, and cover both `take(0)` and `skip(0)` with join regression tests.

Fixes #12666