### PR TITLE
fix(query-builder): take(0) with JOIN returns all rows instead of empty result

### DIFF
--- a/src/query-builder/SelectQueryBuilder.ts
+++ b/src/query-builder/SelectQueryBuilder.ts
@@ -3489,7 +3489,8 @@ export class SelectQueryBuilder<Entity extends ObjectLiteral>
         // first query find ids in skip and take range
         // and second query loads the actual data in given ids range
         if (
-            (this.expressionMap.skip || this.expressionMap.take) &&
+            (this.expressionMap.skip != null ||
+                this.expressionMap.take != null) &&
             this.expressionMap.joinAttributes.length > 0
         ) {
             // we are skipping order by here because its not working in subqueries anyway


### PR DESCRIPTION
## Problem
`queryBuilder.take(0).leftJoinAndSelect(...).getMany()` returns all rows instead of an empty array.

`take(0)` is falsy in JavaScript, so the guard `if (skip || take)` at ~line 3492 evaluates to false and skips the paginated-join path. Additionally, `createLimitOffsetExpression` only applies `LIMIT` when there are no join attributes — so with a join and `take=0`, no `LIMIT 0` is emitted and the full result set is returned.

## Fix
Replace the truthiness check with `if (skip != null || take != null)` — consistent with how `hasLimit`/`hasOffset` helpers work elsewhere in the builder.

## Repro
```ts
const result = await dataSource.getRepository(User)
  .createQueryBuilder('user')
  .leftJoinAndSelect('user.posts', 'post')
  .take(0)
  .getMany();

console.log(result.length); // prints non-zero row count instead of 0
```

Existing tests only cover `take(0)` without joins.