### PR TITLE
fix(driver): broadcast query events in capacitor and nativescript drivers

### DIFF
--- a/src/driver/capacitor/CapacitorQueryRunner.ts
+++ b/src/driver/capacitor/CapacitorQueryRunner.ts
@@ -3,6 +3,7 @@ import { QueryFailedError } from "../../error/QueryFailedError"
 import { QueryRunnerAlreadyReleasedError } from "../../error/QueryRunnerAlreadyReleasedError"
 import { QueryResult } from "../../query-runner/QueryResult"
 import { Broadcaster } from "../../subscriber/Broadcaster"
+import { BroadcasterResult } from "../../subscriber/BroadcasterResult"
 import { AbstractSqliteQueryRunner } from "../sqlite-abstract/AbstractSqliteQueryRunner"
 import type { CapacitorDriver } from "./CapacitorDriver"
 import { NamedPlaceholdersNotSupportedError } from "../../error/NamedPlaceholdersNotSupportedError"
@@ -68,6 +69,10 @@ export class CapacitorQueryRunner extends AbstractSqliteQueryRunner {
         const databaseConnection = await this.connect()
 
         this.driver.dataSource.logger.logQuery(query, parameters, this)
+        await this.broadcaster.broadcast("BeforeQuery", query, parameters)
+
+        const broadcasterResult = new BroadcasterResult()
+        const queryStartTime = Date.now()
 
         const spaceIndex = query.indexOf(" ")
         const command = spaceIndex === -1 ? query : query.slice(0, spaceIndex)
@@ -91,6 +96,19 @@ export class CapacitorQueryRunner extends AbstractSqliteQueryRunner {
             } else {
                 raw = await databaseConnection.query(query, parameters ?? [])
             }
+
+            const queryEndTime = Date.now()
+            const queryExecutionTime = queryEndTime - queryStartTime
+
+            this.broadcaster.broadcastAfterQueryEvent(
+                broadcasterResult,
+                query,
+                parameters,
+                true,
+                queryExecutionTime,
+                raw,
+                undefined,
+            )
 
             const result = new QueryResult()
 
@@ -116,8 +134,19 @@ export class CapacitorQueryRunner extends AbstractSqliteQueryRunner {
                 parameters,
                 this,
             )
+            this.broadcaster.broadcastAfterQueryEvent(
+                broadcasterResult,
+                query,
+                parameters,
+                false,
+                undefined,
+                undefined,
+                err,
+            )
 
             throw new QueryFailedError(query, parameters, err)
+        } finally {
+            await broadcasterResult.wait()
         }
     }
 

--- a/src/driver/capacitor/CapacitorQueryRunner.ts
+++ b/src/driver/capacitor/CapacitorQueryRunner.ts
@@ -77,9 +77,9 @@ export class CapacitorQueryRunner extends AbstractSqliteQueryRunner {
         const spaceIndex = query.indexOf(" ")
         const command = spaceIndex === -1 ? query : query.slice(0, spaceIndex)
 
-        try {
-            let raw: any
+        let raw: any
 
+        try {
             if (
                 [
                     "BEGIN",
@@ -96,37 +96,6 @@ export class CapacitorQueryRunner extends AbstractSqliteQueryRunner {
             } else {
                 raw = await databaseConnection.query(query, parameters ?? [])
             }
-
-            const queryEndTime = Date.now()
-            const queryExecutionTime = queryEndTime - queryStartTime
-
-            this.broadcaster.broadcastAfterQueryEvent(
-                broadcasterResult,
-                query,
-                parameters,
-                true,
-                queryExecutionTime,
-                raw,
-                undefined,
-            )
-
-            const result = new QueryResult()
-
-            if (raw?.hasOwnProperty("values")) {
-                result.raw = raw.values
-                result.records = raw.values
-            }
-
-            if (raw?.hasOwnProperty("changes")) {
-                result.affected = raw.changes.changes
-                result.raw = raw.changes.lastId ?? raw.changes.changes
-            }
-
-            if (!useStructuredResult) {
-                return result.raw
-            }
-
-            return result
         } catch (err) {
             this.driver.dataSource.logger.logQueryError(
                 err,
@@ -143,11 +112,46 @@ export class CapacitorQueryRunner extends AbstractSqliteQueryRunner {
                 undefined,
                 err,
             )
+            try {
+                await broadcasterResult.wait()
+            } catch {
+                // a subscriber failing must not hide the original query error
+            }
 
             throw new QueryFailedError(query, parameters, err)
-        } finally {
-            await broadcasterResult.wait()
         }
+
+        const queryEndTime = Date.now()
+        const queryExecutionTime = queryEndTime - queryStartTime
+
+        this.broadcaster.broadcastAfterQueryEvent(
+            broadcasterResult,
+            query,
+            parameters,
+            true,
+            queryExecutionTime,
+            raw,
+            undefined,
+        )
+        await broadcasterResult.wait()
+
+        const result = new QueryResult()
+
+        if (raw?.hasOwnProperty("values")) {
+            result.raw = raw.values
+            result.records = raw.values
+        }
+
+        if (raw?.hasOwnProperty("changes")) {
+            result.affected = raw.changes.changes
+            result.raw = raw.changes.lastId ?? raw.changes.changes
+        }
+
+        if (!useStructuredResult) {
+            return result.raw
+        }
+
+        return result
     }
 
     // -------------------------------------------------------------------------

--- a/src/driver/nativescript/NativescriptQueryRunner.ts
+++ b/src/driver/nativescript/NativescriptQueryRunner.ts
@@ -4,6 +4,7 @@ import { QueryFailedError } from "../../error/QueryFailedError"
 import { QueryRunnerAlreadyReleasedError } from "../../error/QueryRunnerAlreadyReleasedError"
 import { QueryResult } from "../../query-runner/QueryResult"
 import { Broadcaster } from "../../subscriber/Broadcaster"
+import { BroadcasterResult } from "../../subscriber/BroadcasterResult"
 import { AbstractSqliteQueryRunner } from "../sqlite-abstract/AbstractSqliteQueryRunner"
 import type { NativescriptDriver } from "./NativescriptDriver"
 
@@ -63,11 +64,15 @@ export class NativescriptQueryRunner extends AbstractSqliteQueryRunner {
 
         const databaseConnection = await this.connect()
 
+        connection.logger.logQuery(query, parameters, this)
+        await this.broadcaster.broadcast("BeforeQuery", query, parameters)
+
+        const broadcasterResult = new BroadcasterResult()
+
         return new Promise((ok, fail) => {
             const isInsertQuery = query.startsWith("INSERT INTO")
-            connection.logger.logQuery(query, parameters, this)
 
-            const handler = (err: any, raw: any) => {
+            const handler = async (err: any, raw: any) => {
                 // log slow queries if maxQueryExecution time is set
                 const maxQueryExecutionTime =
                     this.driver.options.maxQueryExecutionTime
@@ -93,7 +98,18 @@ export class NativescriptQueryRunner extends AbstractSqliteQueryRunner {
                         parameters,
                         this,
                     )
+                    this.broadcaster.broadcastAfterQueryEvent(
+                        broadcasterResult,
+                        query,
+                        parameters,
+                        false,
+                        undefined,
+                        undefined,
+                        err,
+                    )
+                    await broadcasterResult.wait()
                     fail(new QueryFailedError(query, parameters, err))
+                    return
                 }
 
                 const result = new QueryResult()
@@ -102,6 +118,17 @@ export class NativescriptQueryRunner extends AbstractSqliteQueryRunner {
                 if (!isInsertQuery && Array.isArray(raw)) {
                     result.records = raw
                 }
+
+                this.broadcaster.broadcastAfterQueryEvent(
+                    broadcasterResult,
+                    query,
+                    parameters,
+                    true,
+                    queryExecutionTime,
+                    raw,
+                    undefined,
+                )
+                await broadcasterResult.wait()
 
                 if (useStructuredResult) {
                     ok(result)

--- a/src/driver/nativescript/NativescriptQueryRunner.ts
+++ b/src/driver/nativescript/NativescriptQueryRunner.ts
@@ -107,7 +107,11 @@ export class NativescriptQueryRunner extends AbstractSqliteQueryRunner {
                         undefined,
                         err,
                     )
-                    await broadcasterResult.wait()
+                    try {
+                        await broadcasterResult.wait()
+                    } catch {
+                        // a subscriber failing must not hide the original query error
+                    }
                     fail(new QueryFailedError(query, parameters, err))
                     return
                 }
@@ -128,7 +132,13 @@ export class NativescriptQueryRunner extends AbstractSqliteQueryRunner {
                     raw,
                     undefined,
                 )
-                await broadcasterResult.wait()
+
+                try {
+                    await broadcasterResult.wait()
+                } catch (subscriberErr) {
+                    fail(subscriberErr)
+                    return
+                }
 
                 if (useStructuredResult) {
                     ok(result)

--- a/test/unit/driver/query-broadcast-events.test.ts
+++ b/test/unit/driver/query-broadcast-events.test.ts
@@ -1,0 +1,110 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import { expect } from "chai"
+import { CapacitorQueryRunner } from "../../../src/driver/capacitor/CapacitorQueryRunner"
+import { NativescriptQueryRunner } from "../../../src/driver/nativescript/NativescriptQueryRunner"
+
+function delay(ms: number): Promise<void> {
+    return new Promise((resolve) => setTimeout(resolve, ms))
+}
+
+/**
+ * A minimal DataSource stub with a single subscriber whose afterQuery hook
+ * does real async work, so tests can tell whether query() waited for it.
+ */
+function makeDataSource() {
+    let subscriberSettled = false
+    const dataSource: any = {
+        logger: { logQuery() {}, logQueryError() {}, logQuerySlow() {} },
+        manager: {},
+        subscribers: [
+            {
+                afterQuery: async () => {
+                    await delay(10)
+                    subscriberSettled = true
+                },
+            },
+        ],
+    }
+    return {
+        dataSource,
+        isSubscriberSettled: () => subscriberSettled,
+    }
+}
+
+describe("query runner > broadcasts AFTER_QUERY before settling", () => {
+    describe("CapacitorQueryRunner", () => {
+        it("waits for the afterQuery subscriber before resolving on success", async () => {
+            const { dataSource, isSubscriberSettled } = makeDataSource()
+            const driver: any = {
+                dataSource,
+                options: {},
+                databaseConnection: {
+                    query: () => Promise.resolve({ values: [{ x: 1 }] }),
+                },
+            }
+            const runner = new CapacitorQueryRunner(driver)
+
+            await runner.query("SELECT 1")
+
+            expect(isSubscriberSettled()).to.be.true
+        })
+
+        it("waits for the afterQuery subscriber before rejecting on failure", async () => {
+            const { dataSource, isSubscriberSettled } = makeDataSource()
+            const driver: any = {
+                dataSource,
+                options: {},
+                databaseConnection: {
+                    query: () => Promise.reject(new Error("boom")),
+                },
+            }
+            const runner = new CapacitorQueryRunner(driver)
+
+            await expect(runner.query("SELECT 1")).to.be.rejected
+
+            expect(isSubscriberSettled()).to.be.true
+        })
+    })
+
+    describe("NativescriptQueryRunner", () => {
+        it("waits for the afterQuery subscriber before resolving on success", async () => {
+            const { dataSource, isSubscriberSettled } = makeDataSource()
+            const driver: any = {
+                dataSource,
+                options: {},
+                databaseConnection: {
+                    all: (
+                        _query: string,
+                        _parameters: any,
+                        cb: (err: any, raw: any) => void,
+                    ) => setImmediate(() => cb(null, [{ x: 1 }])),
+                },
+            }
+            const runner = new NativescriptQueryRunner(driver)
+
+            await runner.query("SELECT 1")
+
+            expect(isSubscriberSettled()).to.be.true
+        })
+
+        it("waits for the afterQuery subscriber before rejecting on failure", async () => {
+            const { dataSource, isSubscriberSettled } = makeDataSource()
+            const driver: any = {
+                dataSource,
+                options: {},
+                databaseConnection: {
+                    all: (
+                        _query: string,
+                        _parameters: any,
+                        cb: (err: any, raw: any) => void,
+                    ) => setImmediate(() => cb(new Error("boom"), null)),
+                },
+            }
+            const runner = new NativescriptQueryRunner(driver)
+
+            await expect(runner.query("SELECT 1")).to.be.rejected
+
+            expect(isSubscriberSettled()).to.be.true
+        })
+    })
+})

--- a/test/unit/driver/query-broadcast-events.test.ts
+++ b/test/unit/driver/query-broadcast-events.test.ts
@@ -1,110 +1,198 @@
-/* eslint-disable @typescript-eslint/no-explicit-any */
 import { expect } from "chai"
+import type { CapacitorDriver } from "../../../src/driver/capacitor/CapacitorDriver"
 import { CapacitorQueryRunner } from "../../../src/driver/capacitor/CapacitorQueryRunner"
+import type { NativescriptDriver } from "../../../src/driver/nativescript/NativescriptDriver"
 import { NativescriptQueryRunner } from "../../../src/driver/nativescript/NativescriptQueryRunner"
 
 function delay(ms: number): Promise<void> {
     return new Promise((resolve) => setTimeout(resolve, ms))
 }
 
+// Guards against the fix regressing into a hang: if promise never settles,
+// this rejects instead of leaving the test to mocha's own timeout.
+function withTimeout<T>(promise: Promise<T>, label: string): Promise<T> {
+    const timeout = new Promise<never>((_, reject) => {
+        setTimeout(
+            () => reject(new Error(`${label} did not settle (hang?)`)),
+            200,
+        ).unref()
+    })
+    return Promise.race([promise, timeout])
+}
+
 /**
  * A minimal DataSource stub with a single subscriber whose afterQuery hook
  * does real async work, so tests can tell whether query() waited for it.
  */
-function makeDataSource() {
-    let subscriberSettled = false
-    const dataSource: any = {
-        logger: { logQuery() {}, logQueryError() {}, logQuerySlow() {} },
-        manager: {},
-        subscribers: [
-            {
-                afterQuery: async () => {
-                    await delay(10)
-                    subscriberSettled = true
-                },
-            },
-        ],
-    }
+function makeDataSource(afterQuery: () => Promise<void>) {
     return {
-        dataSource,
-        isSubscriberSettled: () => subscriberSettled,
+        logger: {
+            logQuery: () => {},
+            logQueryError: () => {},
+            logQuerySlow: () => {},
+        },
+        subscribers: [{ afterQuery }],
     }
+}
+
+function settledSubscriber() {
+    let settled = false
+    const dataSource = makeDataSource(async () => {
+        await delay(10)
+        settled = true
+    })
+    return { dataSource, isSettled: () => settled }
+}
+
+function rejectingSubscriber() {
+    return makeDataSource(async () => {
+        await delay(10)
+        throw new Error("subscriber failure")
+    })
 }
 
 describe("query runner > broadcasts AFTER_QUERY before settling", () => {
     describe("CapacitorQueryRunner", () => {
         it("waits for the afterQuery subscriber before resolving on success", async () => {
-            const { dataSource, isSubscriberSettled } = makeDataSource()
-            const driver: any = {
+            const { dataSource, isSettled } = settledSubscriber()
+            const driver = {
                 dataSource,
                 options: {},
                 databaseConnection: {
                     query: () => Promise.resolve({ values: [{ x: 1 }] }),
                 },
-            }
+            } as unknown as CapacitorDriver
             const runner = new CapacitorQueryRunner(driver)
 
             await runner.query("SELECT 1")
 
-            expect(isSubscriberSettled()).to.be.true
+            expect(isSettled()).to.be.true
         })
 
         it("waits for the afterQuery subscriber before rejecting on failure", async () => {
-            const { dataSource, isSubscriberSettled } = makeDataSource()
-            const driver: any = {
+            const { dataSource, isSettled } = settledSubscriber()
+            const driver = {
                 dataSource,
                 options: {},
                 databaseConnection: {
                     query: () => Promise.reject(new Error("boom")),
                 },
-            }
+            } as unknown as CapacitorDriver
             const runner = new CapacitorQueryRunner(driver)
 
             await expect(runner.query("SELECT 1")).to.be.rejected
 
-            expect(isSubscriberSettled()).to.be.true
+            expect(isSettled()).to.be.true
+        })
+
+        it("rejects (does not hang) when the afterQuery subscriber rejects on success", async () => {
+            const driver = {
+                dataSource: rejectingSubscriber(),
+                options: {},
+                databaseConnection: {
+                    query: () => Promise.resolve({ values: [{ x: 1 }] }),
+                },
+            } as unknown as CapacitorDriver
+            const runner = new CapacitorQueryRunner(driver)
+
+            await expect(
+                withTimeout(runner.query("SELECT 1"), "query()"),
+            ).to.be.rejectedWith("subscriber failure")
+        })
+
+        it("rejects with the original query error (not hang) when the afterQuery subscriber also rejects on failure", async () => {
+            const driver = {
+                dataSource: rejectingSubscriber(),
+                options: {},
+                databaseConnection: {
+                    query: () => Promise.reject(new Error("boom")),
+                },
+            } as unknown as CapacitorDriver
+            const runner = new CapacitorQueryRunner(driver)
+
+            await expect(
+                withTimeout(runner.query("SELECT 1"), "query()"),
+            ).to.be.rejectedWith("boom")
         })
     })
 
     describe("NativescriptQueryRunner", () => {
         it("waits for the afterQuery subscriber before resolving on success", async () => {
-            const { dataSource, isSubscriberSettled } = makeDataSource()
-            const driver: any = {
+            const { dataSource, isSettled } = settledSubscriber()
+            const driver = {
                 dataSource,
                 options: {},
                 databaseConnection: {
                     all: (
                         _query: string,
-                        _parameters: any,
-                        cb: (err: any, raw: any) => void,
+                        _parameters: unknown,
+                        cb: (err: Error | null, raw: unknown) => void,
                     ) => setImmediate(() => cb(null, [{ x: 1 }])),
                 },
-            }
+            } as unknown as NativescriptDriver
             const runner = new NativescriptQueryRunner(driver)
 
             await runner.query("SELECT 1")
 
-            expect(isSubscriberSettled()).to.be.true
+            expect(isSettled()).to.be.true
         })
 
         it("waits for the afterQuery subscriber before rejecting on failure", async () => {
-            const { dataSource, isSubscriberSettled } = makeDataSource()
-            const driver: any = {
+            const { dataSource, isSettled } = settledSubscriber()
+            const driver = {
                 dataSource,
                 options: {},
                 databaseConnection: {
                     all: (
                         _query: string,
-                        _parameters: any,
-                        cb: (err: any, raw: any) => void,
+                        _parameters: unknown,
+                        cb: (err: Error | null, raw: unknown) => void,
                     ) => setImmediate(() => cb(new Error("boom"), null)),
                 },
-            }
+            } as unknown as NativescriptDriver
             const runner = new NativescriptQueryRunner(driver)
 
             await expect(runner.query("SELECT 1")).to.be.rejected
 
-            expect(isSubscriberSettled()).to.be.true
+            expect(isSettled()).to.be.true
+        })
+
+        it("rejects (does not hang) when the afterQuery subscriber rejects on success", async () => {
+            const driver = {
+                dataSource: rejectingSubscriber(),
+                options: {},
+                databaseConnection: {
+                    all: (
+                        _query: string,
+                        _parameters: unknown,
+                        cb: (err: Error | null, raw: unknown) => void,
+                    ) => setImmediate(() => cb(null, [{ x: 1 }])),
+                },
+            } as unknown as NativescriptDriver
+            const runner = new NativescriptQueryRunner(driver)
+
+            await expect(
+                withTimeout(runner.query("SELECT 1"), "query()"),
+            ).to.be.rejectedWith("subscriber failure")
+        })
+
+        it("rejects with the original query error (not hang) when the afterQuery subscriber also rejects on failure", async () => {
+            const driver = {
+                dataSource: rejectingSubscriber(),
+                options: {},
+                databaseConnection: {
+                    all: (
+                        _query: string,
+                        _parameters: unknown,
+                        cb: (err: Error | null, raw: unknown) => void,
+                    ) => setImmediate(() => cb(new Error("boom"), null)),
+                },
+            } as unknown as NativescriptDriver
+            const runner = new NativescriptQueryRunner(driver)
+
+            await expect(
+                withTimeout(runner.query("SELECT 1"), "query()"),
+            ).to.be.rejectedWith("boom")
         })
     })
 })


### PR DESCRIPTION
### Description

The Capacitor and NativeScript query runners never emit the `beforeQuery` / `afterQuery` subscriber events. Subscribers registered through these two drivers are therefore never invoked, unlike every other SQLite-family driver (better-sqlite3, cordova, expo, sqljs, react-native), all of which broadcast these events from their `query()` method.

This has been the case since both drivers were added; they never contained the broadcast calls.

### Fix

Add the `beforeQuery` / `afterQuery` broadcasts to each driver's `query()`, mirroring the existing sibling drivers.

- **Capacitor** already awaits the DB call inside an async method, so the added broadcasts follow the same shape as the other async runners.
- **NativeScript** wraps a callback-based native call, so the DB result is only available inside the callback. The `afterQuery` broadcast and `await broadcasterResult.wait()` are therefore placed inside the callback, right before resolving or rejecting, so that async subscribers settle before the query promise does. This is done on both the success and failure paths. The failure branch also gains a `return` that was missing: without it the handler fell through after `fail()` and produced a second, spurious success result (previously harmless only because resolving an already-rejected promise is a no-op, but it would now emit an incorrect success event).

### Tests

Added `test/unit/driver/query-broadcast-events.test.ts` covering Capacitor and NativeScript, success and failure, each asserting that an async `afterQuery` subscriber has fully settled before `query()` resolves/rejects. With the previous (broken) NativeScript ordering the success/failure cases resolve before the subscriber settles; with the fix all four pass. The rest of the unit suite passes unchanged.

These two drivers target mobile runtimes that are not exercised in CI, so verification is at the unit level against the broadcaster contract.