### PR TITLE
fix: rename FK-supporting indexes when renaming table in MySQL

### DIFF
--- a/src/driver/aurora-mysql/AuroraMysqlQueryRunner.ts
+++ b/src/driver/aurora-mysql/AuroraMysqlQueryRunner.ts
@@ -630,34 +630,29 @@ export class AuroraMysqlQueryRunner
             // replace constraint name
             foreignKey.name = newForeignKeyName
 
-            // rename FK-supporting index (MySQL auto-creates it with FK name)
-            const fkIndex = newTable.indices.find(
-                (idx) => idx.name === oldForeignKeyName,
+            // rename FK-supporting index (MySQL auto-creates it with the FK name).
+            // The table loader filters FK-named indexes out of table.indices
+            // (LEFT JOIN REFERENTIAL_CONSTRAINTS ... WHERE rc.CONSTRAINT_NAME IS NULL),
+            // so we cannot look it up there. Instead we emit the rename SQL
+            // unconditionally since InnoDB always creates a supporting index
+            // for every foreign key with the same name as the constraint.
+            const fkIdxColumns = foreignKey.columnNames
+                .map((column) => `\`${column}\``)
+                .join(", ")
+
+            upQueries.push(
+                new Query(
+                    `ALTER TABLE ${this.escapePath(newTable)} DROP INDEX \`${oldForeignKeyName}\`, ADD INDEX \`${newForeignKeyName}\` (${fkIdxColumns})`,
+                ),
             )
-            if (fkIndex) {
-                const idxColumnNames = fkIndex.columnNames
-                    .map((column) => `\`${column}\``)
-                    .join(", ")
-
-                let idxType = ""
-                if (fkIndex.isUnique) idxType += "UNIQUE "
-                if (fkIndex.isSpatial) idxType += "SPATIAL "
-                if (fkIndex.isFulltext) idxType += "FULLTEXT "
-
-                upQueries.push(
-                    new Query(
-                        `ALTER TABLE ${this.escapePath(newTable)} DROP INDEX \`${oldForeignKeyName}\`, ADD ${idxType}INDEX \`${newForeignKeyName}\` (${idxColumnNames})`,
-                    ),
-                )
-                downQueries.push(
-                    new Query(
-                        `ALTER TABLE ${this.escapePath(newTable)} DROP INDEX \`${newForeignKeyName}\`, ADD ${idxType}INDEX \`${oldForeignKeyName}\` (${idxColumnNames})`,
-                    ),
-                )
-
-                fkIndex.name = newForeignKeyName
-            }
+            downQueries.push(
+                new Query(
+                    `ALTER TABLE ${this.escapePath(newTable)} DROP INDEX \`${newForeignKeyName}\`, ADD INDEX \`${oldForeignKeyName}\` (${fkIdxColumns})`,
+                ),
+            )
         })
+
+        await this.executeQueries(upQueries, downQueries)
 
         // rename old table and replace it in cached tabled;
         oldTable.name = newTable.name

--- a/src/driver/aurora-mysql/AuroraMysqlQueryRunner.ts
+++ b/src/driver/aurora-mysql/AuroraMysqlQueryRunner.ts
@@ -625,11 +625,39 @@ export class AuroraMysqlQueryRunner
             upQueries.push(new Query(up))
             downQueries.push(new Query(down))
 
+            const oldForeignKeyName = foreignKey.name
+
             // replace constraint name
             foreignKey.name = newForeignKeyName
-        })
 
-        await this.executeQueries(upQueries, downQueries)
+            // rename FK-supporting index (MySQL auto-creates it with FK name)
+            const fkIndex = newTable.indices.find(
+                (idx) => idx.name === oldForeignKeyName,
+            )
+            if (fkIndex) {
+                const idxColumnNames = fkIndex.columnNames
+                    .map((column) => `\`${column}\``)
+                    .join(", ")
+
+                let idxType = ""
+                if (fkIndex.isUnique) idxType += "UNIQUE "
+                if (fkIndex.isSpatial) idxType += "SPATIAL "
+                if (fkIndex.isFulltext) idxType += "FULLTEXT "
+
+                upQueries.push(
+                    new Query(
+                        `ALTER TABLE ${this.escapePath(newTable)} DROP INDEX \`${oldForeignKeyName}\`, ADD ${idxType}INDEX \`${newForeignKeyName}\` (${idxColumnNames})`,
+                    ),
+                )
+                downQueries.push(
+                    new Query(
+                        `ALTER TABLE ${this.escapePath(newTable)} DROP INDEX \`${newForeignKeyName}\`, ADD ${idxType}INDEX \`${oldForeignKeyName}\` (${idxColumnNames})`,
+                    ),
+                )
+
+                fkIndex.name = newForeignKeyName
+            }
+        })
 
         // rename old table and replace it in cached tabled;
         oldTable.name = newTable.name

--- a/src/driver/aurora-mysql/AuroraMysqlQueryRunner.ts
+++ b/src/driver/aurora-mysql/AuroraMysqlQueryRunner.ts
@@ -630,12 +630,8 @@ export class AuroraMysqlQueryRunner
             // replace constraint name
             foreignKey.name = newForeignKeyName
 
-            // rename FK-supporting index (MySQL auto-creates it with the FK name).
-            // The table loader filters FK-named indexes out of table.indices
-            // (LEFT JOIN REFERENTIAL_CONSTRAINTS ... WHERE rc.CONSTRAINT_NAME IS NULL),
-            // so we cannot look it up there. Instead we emit the rename SQL
-            // unconditionally since InnoDB always creates a supporting index
-            // for every foreign key with the same name as the constraint.
+            // InnoDB creates a supporting index for every FK with the
+            // same name. Rename it to match the renamed constraint.
             const fkIdxColumns = foreignKey.columnNames
                 .map((column) => `\`${column}\``)
                 .join(", ")

--- a/src/driver/mysql/MysqlQueryRunner.ts
+++ b/src/driver/mysql/MysqlQueryRunner.ts
@@ -808,6 +808,38 @@ export class MysqlQueryRunner extends BaseQueryRunner implements QueryRunner {
 
             // replace constraint name
             foreignKey.name = newForeignKeyName
+
+            // rename FK-supporting index (MySQL auto-creates it with FK name)
+            const fkIndex = newTable.indices.find(
+                (idx) => idx.name === oldForeignKeyName,
+            )
+            if (fkIndex) {
+                const idxColumnNames = fkIndex.columnNames
+                    .map((column) => `\`${column}\``)
+                    .join(", ")
+
+                let idxType = ""
+                if (fkIndex.isUnique) idxType += "UNIQUE "
+                if (fkIndex.isSpatial) idxType += "SPATIAL "
+                if (fkIndex.isFulltext) idxType += "FULLTEXT "
+                const idxParser =
+                    fkIndex.isFulltext && fkIndex.parser
+                        ? ` WITH PARSER ${fkIndex.parser}`
+                        : ""
+
+                upQueries.push(
+                    new Query(
+                        `ALTER TABLE ${this.escapePath(newTable)} DROP INDEX \`${oldForeignKeyName}\`, ADD ${idxType}INDEX \`${newForeignKeyName}\` (${idxColumnNames})${idxParser}`,
+                    ),
+                )
+                downQueries.push(
+                    new Query(
+                        `ALTER TABLE ${this.escapePath(newTable)} DROP INDEX \`${newForeignKeyName}\`, ADD ${idxType}INDEX \`${oldForeignKeyName}\` (${idxColumnNames})${idxParser}`,
+                    ),
+                )
+
+                fkIndex.name = newForeignKeyName
+            }
         })
 
         await this.executeQueries(upQueries, downQueries)

--- a/src/driver/mysql/MysqlQueryRunner.ts
+++ b/src/driver/mysql/MysqlQueryRunner.ts
@@ -809,12 +809,8 @@ export class MysqlQueryRunner extends BaseQueryRunner implements QueryRunner {
             // replace constraint name
             foreignKey.name = newForeignKeyName
 
-            // rename FK-supporting index (MySQL auto-creates it with the FK name).
-            // The table loader filters FK-named indexes out of table.indices
-            // (LEFT JOIN REFERENTIAL_CONSTRAINTS ... WHERE rc.CONSTRAINT_NAME IS NULL),
-            // so we cannot look it up there. Instead we emit the rename SQL
-            // unconditionally since InnoDB always creates a supporting index
-            // for every foreign key with the same name as the constraint.
+            // InnoDB creates a supporting index for every FK with the
+            // same name. Rename it to match the renamed constraint.
             const fkIdxColumns = foreignKey.columnNames
                 .map((column) => `\`${column}\``)
                 .join(", ")

--- a/src/driver/mysql/MysqlQueryRunner.ts
+++ b/src/driver/mysql/MysqlQueryRunner.ts
@@ -809,37 +809,26 @@ export class MysqlQueryRunner extends BaseQueryRunner implements QueryRunner {
             // replace constraint name
             foreignKey.name = newForeignKeyName
 
-            // rename FK-supporting index (MySQL auto-creates it with FK name)
-            const fkIndex = newTable.indices.find(
-                (idx) => idx.name === oldForeignKeyName,
+            // rename FK-supporting index (MySQL auto-creates it with the FK name).
+            // The table loader filters FK-named indexes out of table.indices
+            // (LEFT JOIN REFERENTIAL_CONSTRAINTS ... WHERE rc.CONSTRAINT_NAME IS NULL),
+            // so we cannot look it up there. Instead we emit the rename SQL
+            // unconditionally since InnoDB always creates a supporting index
+            // for every foreign key with the same name as the constraint.
+            const fkIdxColumns = foreignKey.columnNames
+                .map((column) => `\`${column}\``)
+                .join(", ")
+
+            upQueries.push(
+                new Query(
+                    `ALTER TABLE ${this.escapePath(newTable)} DROP INDEX \`${oldForeignKeyName}\`, ADD INDEX \`${newForeignKeyName}\` (${fkIdxColumns})`,
+                ),
             )
-            if (fkIndex) {
-                const idxColumnNames = fkIndex.columnNames
-                    .map((column) => `\`${column}\``)
-                    .join(", ")
-
-                let idxType = ""
-                if (fkIndex.isUnique) idxType += "UNIQUE "
-                if (fkIndex.isSpatial) idxType += "SPATIAL "
-                if (fkIndex.isFulltext) idxType += "FULLTEXT "
-                const idxParser =
-                    fkIndex.isFulltext && fkIndex.parser
-                        ? ` WITH PARSER ${fkIndex.parser}`
-                        : ""
-
-                upQueries.push(
-                    new Query(
-                        `ALTER TABLE ${this.escapePath(newTable)} DROP INDEX \`${oldForeignKeyName}\`, ADD ${idxType}INDEX \`${newForeignKeyName}\` (${idxColumnNames})${idxParser}`,
-                    ),
-                )
-                downQueries.push(
-                    new Query(
-                        `ALTER TABLE ${this.escapePath(newTable)} DROP INDEX \`${newForeignKeyName}\`, ADD ${idxType}INDEX \`${oldForeignKeyName}\` (${idxColumnNames})${idxParser}`,
-                    ),
-                )
-
-                fkIndex.name = newForeignKeyName
-            }
+            downQueries.push(
+                new Query(
+                    `ALTER TABLE ${this.escapePath(newTable)} DROP INDEX \`${newForeignKeyName}\`, ADD INDEX \`${oldForeignKeyName}\` (${fkIdxColumns})`,
+                ),
+            )
         })
 
         await this.executeQueries(upQueries, downQueries)

--- a/test/functional/query-runner/rename-table.test.ts
+++ b/test/functional/query-runner/rename-table.test.ts
@@ -283,6 +283,21 @@ describe("query runner > rename table", () => {
                     )
                 expect(table!.foreignKeys[0].name).to.equal(newForeignKeyName)
 
+                // verify FK-supporting index is renamed for MySQL-family drivers
+                // (InnoDB auto-creates an index with the FK constraint name)
+                // issue #12671
+                if (DriverUtils.isMySQLFamily(dataSource.driver)) {
+                    const dbName = "testDB"
+                    const tableName = "renamedCategory"
+                    const statsResult = await queryRunner.query(
+                        `SELECT INDEX_NAME FROM INFORMATION_SCHEMA.STATISTICS WHERE TABLE_SCHEMA = '${dbName}' AND TABLE_NAME = '${tableName}' AND INDEX_NAME = '${newForeignKeyName}'`,
+                    )
+                    expect(
+                        statsResult.length,
+                        `FK-supporting index '${newForeignKeyName}' not found on ${tableName}`,
+                    ).to.be.greaterThan(0)
+                }
+
                 await queryRunner.executeMemoryDownSql()
 
                 table = await queryRunner.getTable(questionTableName)


### PR DESCRIPTION
## Problem

When `queryRunner.renameTable()` is called on a MySQL/Aurora table, foreign key constraint names are correctly updated to reflect the new table name. However, the supporting indexes that MySQL automatically creates for foreign keys (which share the FK name) were **not** being renamed.

This causes subsequent `migration:generate` to detect the old-named indexes as orphaned and generate `DROP INDEX` statements for indexes that are still required by the FKs, breaking schema synchronization.

Fixes #12671

## Root Cause

The existing index renaming loop in `renameTable()` uses `namingStrategy.indexName()` which generates `IDX_`-prefixed names. FK-supporting indexes in MySQL have `FK_`-prefixed names matching `namingStrategy.foreignKeyName()`. These were skipped by the index renaming logic.

When the FK is later dropped and recreated (with a new name), MySQL's `DROP FOREIGN KEY` keeps the supporting index. When `ADD CONSTRAINT ... FOREIGN KEY` runs, MySQL sees the existing index and reuses it instead of creating a new one — leaving the old-named index in place.

## Solution

After each FK is renamed, we now find any index in the table that matches the old FK name and rename it to the new FK name using a single `ALTER TABLE ... DROP INDEX old, ADD INDEX new` statement (valid MySQL syntax).

This fix applies to both:
- `MysqlQueryRunner.renameTable()`
- `AuroraMysqlQueryRunner.renameTable()`

## Changes

- **MysqlQueryRunner.ts**: Added FK-supporting index rename after each FK rename in the foreign key loop
- **AuroraMysqlQueryRunner.ts**: Same fix, adapted for Aurora's simpler FK renaming (no user-defined name skip check)