### PR TITLE
fix: use static require calls in PlatformTools.load for bundler compatibility

### DIFF
--- a/src/platform/PlatformTools.ts
+++ b/src/platform/PlatformTools.ts
@@ -38,57 +38,62 @@ export class PlatformTools {
      * @returns the module
      */
     static load(name: string): any {
-        const KNOWN_MODULES = [
-            // AWS Aurora Data API (PostgreSQL/MySQL)
-            "typeorm-aurora-data-api-driver",
-            // better-sqlite3
-            "better-sqlite3",
-            // Expo
-            "expo-sqlite",
-            // Google Cloud Spanner
-            "@google-cloud/spanner",
-            // Microsoft SQL Server
-            "mssql",
-            // MongoDB
-            "mongodb",
-            // MySQL / MariaDB
-            "mysql2",
-            // Oracle
-            "oracledb",
-            // PostgreSQL
-            "pg",
-            "pg-native",
-            "pg-query-stream",
-            // React Native
-            "react-native-sqlite-storage",
-            // SAP HANA
-            "@sap/hana-client",
-            "@sap/hana-client/extension/Stream",
-            // sql.js
-            "sql.js",
-            // redis
-            "redis",
-            "ioredis",
-        ]
-
-        if (!KNOWN_MODULES.includes(name)) {
-            throw new TypeError(
-                `Invalid Package for PlatformTools.load: ${name}`,
-            )
-        }
-
-        // if name is not absolute or relative, then try to load package from the node_modules of the directory we are currently in
-        // this is useful when we are using typeorm package globally installed and it accesses drivers
-        // that are not installed globally
+        // Use explicit static require() calls for each known module so that
+        // bundlers (Webpack, Vite, esbuild, etc.) can statically analyze
+        // which dependencies need to be included in the bundle.
+        // Dynamic require(name) is invisible to static analysis.
         try {
-            // eslint-disable-next-line @typescript-eslint/no-require-imports
-            return require(name)
+            /* eslint-disable @typescript-eslint/no-require-imports */
+            switch (name) {
+                case "typeorm-aurora-data-api-driver":
+                    return require("typeorm-aurora-data-api-driver")
+                case "better-sqlite3":
+                    return require("better-sqlite3")
+                case "expo-sqlite":
+                    return require("expo-sqlite")
+                case "@google-cloud/spanner":
+                    return require("@google-cloud/spanner")
+                case "mssql":
+                    return require("mssql")
+                case "mongodb":
+                    return require("mongodb")
+                case "mysql2":
+                    return require("mysql2")
+                case "oracledb":
+                    return require("oracledb")
+                case "pg":
+                    return require("pg")
+                case "pg-native":
+                    return require("pg-native")
+                case "pg-query-stream":
+                    return require("pg-query-stream")
+                case "react-native-sqlite-storage":
+                    return require("react-native-sqlite-storage")
+                case "@sap/hana-client":
+                    return require("@sap/hana-client")
+                case "@sap/hana-client/extension/Stream":
+                    return require("@sap/hana-client/extension/Stream")
+                case "sql.js":
+                    return require("sql.js")
+                case "redis":
+                    return require("redis")
+                case "ioredis":
+                    return require("ioredis")
+            }
+            /* eslint-enable @typescript-eslint/no-require-imports */
         } catch {
+            // if module resolution fails (e.g., typeorm is installed globally
+            // but the driver is in the project's node_modules), try loading
+            // from the current working directory as a fallback
             // eslint-disable-next-line @typescript-eslint/no-require-imports
             return require(
                 path.resolve(process.cwd() + "/node_modules/" + name),
             )
         }
+
+        throw new TypeError(
+            `Invalid Package for PlatformTools.load: ${name}`,
+        )
     }
 
     /**

--- a/test/unit/platform/platform-tools.test.ts
+++ b/test/unit/platform/platform-tools.test.ts
@@ -1,5 +1,4 @@
 import { expect } from "chai"
-import "reflect-metadata"
 
 import { PlatformTools } from "../../../src/platform/PlatformTools"
 
@@ -24,9 +23,12 @@ describe("PlatformTools > load", () => {
 
     describe("static require calls for bundler compatibility", () => {
         it("should include all known modules as static require cases", () => {
-            // Verify the switch covers the full set of supported driver modules.
-            // These are the module names that must have explicit require() calls
-            // so bundlers can statically analyze them (issue #12721).
+            // Modules in the switch will throw MODULE_NOT_FOUND (not "Invalid
+            // Package") when uninstalled. Modules missing from the switch will
+            // throw TypeError with "Invalid Package" instead.
+            // This test verifies each supported module is covered by checking
+            // that the error is NOT the "Invalid Package" rejection.
+            // issue #12721
             const expectedModules = [
                 "typeorm-aurora-data-api-driver",
                 "better-sqlite3",

--- a/test/unit/platform/platform-tools.test.ts
+++ b/test/unit/platform/platform-tools.test.ts
@@ -1,0 +1,66 @@
+import { expect } from "chai"
+import "reflect-metadata"
+
+import { PlatformTools } from "../../../src/platform/PlatformTools"
+
+describe("PlatformTools > load", () => {
+    describe("module validation", () => {
+        it("should throw TypeError for unknown module names", () => {
+            expect(() => PlatformTools.load("nonexistent-fake-module-xyz")).to.throw(
+                TypeError,
+                "Invalid Package for PlatformTools.load: nonexistent-fake-module-xyz",
+            )
+        })
+
+        it("should throw TypeError for built-in modules not in the switch", () => {
+            // "path" is a Node.js built-in but not in the PlatformTools switch,
+            // so it must be rejected to prevent loading arbitrary modules
+            expect(() => PlatformTools.load("path")).to.throw(
+                TypeError,
+                "Invalid Package for PlatformTools.load: path",
+            )
+        })
+    })
+
+    describe("static require calls for bundler compatibility", () => {
+        it("should include all known modules as static require cases", () => {
+            // Verify the switch covers the full set of supported driver modules.
+            // These are the module names that must have explicit require() calls
+            // so bundlers can statically analyze them (issue #12721).
+            const expectedModules = [
+                "typeorm-aurora-data-api-driver",
+                "better-sqlite3",
+                "expo-sqlite",
+                "@google-cloud/spanner",
+                "mssql",
+                "mongodb",
+                "mysql2",
+                "oracledb",
+                "pg",
+                "pg-native",
+                "pg-query-stream",
+                "react-native-sqlite-storage",
+                "@sap/hana-client",
+                "@sap/hana-client/extension/Stream",
+                "sql.js",
+                "redis",
+                "ioredis",
+            ]
+
+            for (const mod of expectedModules) {
+                // Each must be recognized (not throw "Invalid Package" TypeError).
+                // Some may fail to resolve at runtime (not installed), but the
+                // key assertion is that they are in the switch and not rejected
+                // as "unknown".
+                try {
+                    PlatformTools.load(mod)
+                } catch (e: any) {
+                    expect(e.message).to.not.include(
+                        "Invalid Package",
+                        `Module "${mod}" is not in the static require switch`,
+                    )
+                }
+            }
+        })
+    })
+})


### PR DESCRIPTION
## Problem

PR #12647 replaced explicit `require()` calls in `PlatformTools.load()` with a dynamic `require(name)`, which is invisible to static analyzers used by bundlers (Webpack, Vite, esbuild, etc.).

This causes errors like:
```
Postgres package has not been found installed. Please run "npm install pg".
```

...because the bundler does not know to include the database driver dependency in the bundle.

Fixes #12721

## Root Cause

Before PR #12647, `PlatformTools.load()` used explicit `require("pg")`, `require("mysql2")` calls that bundlers could statically analyze. After the PR, it was changed to `require(name)` where `name` is a runtime variable — invisible to static analysis.

When the bundler can't see which modules are needed, it excludes them from the bundle. The runtime check `if (!KNOWN_MODULES.includes(name))` validates the name but doesn't help the bundler.

## Solution

Replaced the dynamic `require(name)` with an explicit `switch/case` containing static `require()` calls for each known module. Each case has a literal string argument to `require()`, which bundlers can analyze.

The catch-all fallback preserves the global-install resolution path (when typeorm is installed globally but drivers are in the project).