### PR TITLE
fix: throw error when primitive value passed for relation in findBy

### DIFF
--- a/src/query-builder/SelectQueryBuilder.ts
+++ b/src/query-builder/SelectQueryBuilder.ts
@@ -4464,6 +4464,17 @@ export class SelectQueryBuilder<Entity extends ObjectLiteral>
                         continue
                     }
 
+                    // primitive values like 1 or "str" are not valid for
+                    // relation where conditions -- the user likely meant
+                    // { id: value }
+                    if (typeof where[key] !== "object") {
+                        throw new TypeORMError(
+                            `Invalid value for relation property '${alias}.${key}' in where condition. ` +
+                            `Expected an object with the relation's primary key(s) (e.g. { id: 1 }), ` +
+                            `but received a value of type '${typeof where[key]}'.`,
+                        )
+                    }
+
                     // if all properties of where are undefined we don't need to join anything
                     // this can happen when user defines map with conditional queries inside
                     if (typeof where[key] === "object") {

--- a/test/functional/repository/find-options-relations/repository-find-options-relations.test.ts
+++ b/test/functional/repository/find-options-relations/repository-find-options-relations.test.ts
@@ -11,6 +11,7 @@ import { Category } from "./entity/Category"
 import { Post } from "./entity/Post"
 import { Photo } from "./entity/Photo"
 import { Counters } from "./entity/Counters"
+import { TypeORMError } from "../../../../src/error"
 import { EntityPropertyNotFoundError } from "../../../../src/error/EntityPropertyNotFoundError"
 
 describe("repository > find options > relations", () => {
@@ -549,6 +550,27 @@ describe("repository > find options > relations", () => {
                     .should.eventually.be.rejectedWith(
                         EntityPropertyNotFoundError,
                     )
+            }),
+        ))
+
+    it("should throw error when a primitive value is passed for a relation in findBy", () =>
+        Promise.all(
+            dataSources.map(async (dataSource) => {
+                const postRepository = dataSource.getRepository(Post)
+
+                // passing a primitive (number) for a relation should throw a clear error
+                // instead of silently ignoring the condition and returning all rows
+                // issue #12712
+                try {
+                    await postRepository.findBy({ user: 1 } as any)
+                    expect.fail("Expected findBy with primitive relation value to throw")
+                } catch (error) {
+                    expect(error).to.be.instanceOf(TypeORMError)
+                    expect((error as Error).message).to.include(
+                        "Invalid value for relation property",
+                    )
+                    expect((error as Error).message).to.include("user")
+                }
             }),
         ))
 })


### PR DESCRIPTION
## Problem

When a primitive value (e.g. `1` or a string) is passed for a relation property in `findBy()` or `findOneBy()`, the `buildWhere()` method in `SelectQueryBuilder` silently ignores the condition. The JOIN is created but no WHERE filter is applied, causing the query to return **ALL rows** instead of filtering by the relation.

This is a silent data-corruption bug — particularly dangerous for multi-tenant applications where it may return records belonging to different users.

Fixes #12712

### Example

```ts
// Before: silently returns ALL posts (no filter applied)
await postRepository.findBy({ user: 1 })

// After: throws a clear error
// Error: Invalid value for relation property 'Post.user' in where condition.
// Expected an object with the relation's primary key(s) (e.g. { id: 1 }),
// but received a value of type 'number'.

// Correct usage:
await postRepository.findBy({ user: { id: 1 } })
```

## Changes

- `SelectQueryBuilder.buildWhere()`: Added a check after the null-handling block that throws a `TypeORMError` when a non-object (primitive) value is passed for a relation property
- Added functional test in `repository-find-options-relations.test.ts`