### PR TITLE
fix: add insert and update options to ColumnCommonOptions

### DIFF
--- a/src/decorator/options/ColumnCommonOptions.ts
+++ b/src/decorator/options/ColumnCommonOptions.ts
@@ -11,6 +11,19 @@ export interface ColumnCommonOptions {
     select?: boolean
 
     /**
+     * Indicates if column is inserted by default.
+     * Default value is "true".
+     */
+    insert?: boolean
+
+    /**
+     * Indicates if column value is updated by "save" operation.
+     * If false, you'll be able to write this value only when you first time insert the object.
+     * Default value is "true".
+     */
+    update?: boolean
+
+    /**
      * Column name in the database.
      */
     name?: string


### PR DESCRIPTION
### Description of change

The two-argument `@Column(type, options)` overloads type `options` as
`ColumnCommonOptions`, but `insert` / `update` are only declared on the full
`ColumnOptions` used by the object overload. So they fail to type-check in the
two-argument form, while the object form works:

```ts
@Column("enum", { enum: Status, insert: false, update: false }) // ❌ TS2769: No overload matches this call
@Column({ type: "enum", enum: Status, insert: false, update: false }) // ✅ ok
```

The runtime already handles both for every column type — [`ColumnMetadata`](https://github.com/typeorm/typeorm/blob/master/src/metadata/ColumnMetadata.ts#L387-L392)
reads `options.insert` / `options.update` unconditionally — so this is purely a
type-definition gap. This PR adds both to `ColumnCommonOptions`, with the JSDoc
copied verbatim from `ColumnOptions`, so both decorator forms accept them
consistently.

### Pull-Request Checklist

- [x] Code is up-to-date with the `master` branch
- [ ] This pull request links a relevant issue using a closing keyword — N/A (no existing issue)
- [ ] There are new or updated tests validating the change — N/A (type-definition-only; runtime already covered)
- [ ] Documentation has been updated to reflect this change — N/A (no user-facing behavior change)