### PR TITLE
fix(postgres): read `coord_dimension` when loading spatial columns

### DIFF
--- a/docs/docs/help/3-decorator-reference.md
+++ b/docs/docs/help/3-decorator-reference.md
@@ -165,7 +165,7 @@ export class User {
 - `hstoreType: "object"|"string"` - Return type of `HSTORE` column. Returns value as string or as object. Used only in [Postgres](https://www.postgresql.org/docs/9.6/static/hstore.html).
 - `array: boolean` - Used for postgres and cockroachdb column types which can be array (for example int[]).
 - `transformer: ValueTransformer|ValueTransformer[]` - Specifies a value transformer (or array of value transformers) that is to be used to (un)marshal this column when reading or writing to the database. In case of an array, the value transformers will be applied in the natural order from entityValue to databaseValue, and in reverse order from databaseValue to entityValue.
-- `spatialFeatureType: string` - Optional feature type (`Point`, `Polygon`, `LineString`, `Geometry`) used as a constraint on a spatial column. If not specified, it will behave as though `Geometry` was provided. Used only in PostgreSQL and CockroachDB.
+- `spatialFeatureType: string` - Optional feature type (`Point`, `Polygon`, `LineString`, `Geometry`) used as a constraint on a spatial column, optionally with a `Z`, `M` or `ZM` dimensional suffix (`PointZ`, `GeometryZM`). If not specified, it will behave as though `Geometry` was provided. Used only in PostgreSQL and CockroachDB.
 - `srid: number` - Optional [Spatial Reference ID](https://postgis.net/docs/using_postgis_dbmanagement.html#spatial_ref_sys) used as a constraint on a spatial column. If not specified, it will default to `0`. Standard geographic coordinates (latitude/longitude in the WGS84 datum) correspond to [EPSG 4326](http://spatialreference.org/ref/epsg/wgs-84/). Used only in PostgreSQL and CockroachDB.
 
 Learn more about [entity columns](../entity/1-entities.md#entity-columns).

--- a/src/decorator/options/SpatialColumnOptions.ts
+++ b/src/decorator/options/SpatialColumnOptions.ts
@@ -6,9 +6,13 @@ import type { Geometry } from "../../driver/types/GeoJsonTypes"
 export interface SpatialColumnOptions {
     /**
      * Column type's feature type.
-     * Geometry, Point, Polygon, etc.
+     * Geometry, Point, Polygon, etc., optionally with a Z, M or ZM
+     * dimensional suffix, such as PointZ or GeometryZM.
      */
-    spatialFeatureType?: Geometry["type"]
+    spatialFeatureType?:
+        | Geometry["type"]
+        | "Geometry"
+        | `${Geometry["type"] | "Geometry"}${"Z" | "M" | "ZM"}`
 
     /**
      * Column type's SRID.

--- a/src/driver/cockroachdb/CockroachQueryRunner.ts
+++ b/src/driver/cockroachdb/CockroachQueryRunner.ts
@@ -3638,7 +3638,7 @@ export class CockroachQueryRunner
                                 const sql =
                                     `SELECT * FROM (` +
                                     `SELECT "f_table_schema" "table_schema", "f_table_name" "table_name", ` +
-                                    `"f_${tableColumn.type}_column" "column_name", "srid", "type" ` +
+                                    `"f_${tableColumn.type}_column" "column_name", "srid", "type", "coord_dimension" ` +
                                     `FROM "${tableColumn.type}_columns"` +
                                     `) AS _ ` +
                                     `WHERE "column_name" = '${dbColumn["column_name"]}' AND ` +
@@ -3649,8 +3649,40 @@ export class CockroachQueryRunner
                                     await this.query(sql)
 
                                 if (results.length > 0) {
+                                    // "geometry_columns" folds the Z dimension into
+                                    // "coord_dimension" and only keeps the M suffix in
+                                    // "type", while "geography_columns" reports the
+                                    // full suffix in "type", so the suffix is only
+                                    // appended when it is missing.
+                                    //
+                                    // Unlike PostGIS, CockroachDB also drops the M
+                                    // suffix from "geometry_columns"."type", which makes
+                                    // PointM indistinguishable from PointZ there. The
+                                    // declared type in "crdb_sql_type" still carries it.
+                                    let spatialFeatureType: string =
+                                        /^\w+\((\w+)/.exec(
+                                            dbColumn["crdb_sql_type"] ?? "",
+                                        )?.[1] ?? results[0].type
+                                    const coordDimension = parseInt(
+                                        results[0].coord_dimension,
+                                    )
+                                    const upperType =
+                                        spatialFeatureType.toUpperCase()
+                                    if (
+                                        coordDimension === 3 &&
+                                        !upperType.endsWith("Z") &&
+                                        !upperType.endsWith("M")
+                                    ) {
+                                        spatialFeatureType += "Z"
+                                    } else if (
+                                        coordDimension === 4 &&
+                                        !upperType.endsWith("Z") &&
+                                        !upperType.endsWith("M")
+                                    ) {
+                                        spatialFeatureType += "ZM"
+                                    }
                                     tableColumn.spatialFeatureType =
-                                        results[0].type
+                                        spatialFeatureType
                                     tableColumn.srid = results[0].srid
                                         ? parseInt(results[0].srid)
                                         : undefined

--- a/src/driver/postgres/PostgresQueryRunner.ts
+++ b/src/driver/postgres/PostgresQueryRunner.ts
@@ -3951,7 +3951,7 @@ export class PostgresQueryRunner
                                 const sql =
                                     `SELECT * FROM (` +
                                     `SELECT "f_table_schema" "table_schema", "f_table_name" "table_name", ` +
-                                    `"f_${tableColumn.type}_column" "column_name", "srid", "type" ` +
+                                    `"f_${tableColumn.type}_column" "column_name", "srid", "type", "coord_dimension" ` +
                                     `FROM "${tableColumn.type}_columns"` +
                                     `) AS _ ` +
                                     `WHERE "column_name" = '${dbColumn["column_name"]}' AND ` +
@@ -3962,8 +3962,30 @@ export class PostgresQueryRunner
                                     await this.query(sql)
 
                                 if (results.length > 0) {
-                                    tableColumn.spatialFeatureType =
+                                    // "geometry_columns" folds the Z dimension into
+                                    // "coord_dimension" and only keeps the M suffix in
+                                    // "type", while "geography_columns" reports the
+                                    // full suffix in "type", so the suffix is only
+                                    // appended when it is missing.
+                                    let spatialFeatureType: string =
                                         results[0].type
+                                    const upperType =
+                                        spatialFeatureType.toUpperCase()
+                                    if (
+                                        results[0].coord_dimension === 3 &&
+                                        !upperType.endsWith("Z") &&
+                                        !upperType.endsWith("M")
+                                    ) {
+                                        spatialFeatureType += "Z"
+                                    } else if (
+                                        results[0].coord_dimension === 4 &&
+                                        !upperType.endsWith("Z") &&
+                                        !upperType.endsWith("M")
+                                    ) {
+                                        spatialFeatureType += "ZM"
+                                    }
+                                    tableColumn.spatialFeatureType =
+                                        spatialFeatureType
                                     tableColumn.srid = results[0].srid
                                 }
                             }

--- a/test/functional/spatial/cockroachdb/entity/DimensionalPost.ts
+++ b/test/functional/spatial/cockroachdb/entity/DimensionalPost.ts
@@ -1,0 +1,40 @@
+import {
+    Column,
+    Entity,
+    Point,
+    PrimaryGeneratedColumn,
+} from "../../../../../src"
+
+@Entity()
+export class DimensionalPost {
+    @PrimaryGeneratedColumn()
+    id: number
+
+    @Column("geometry", {
+        nullable: true,
+        spatialFeatureType: "PointZ",
+        srid: 4326,
+    })
+    pointZ: Point
+
+    @Column("geometry", {
+        nullable: true,
+        spatialFeatureType: "PointM",
+        srid: 4326,
+    })
+    pointM: Point
+
+    @Column("geometry", {
+        nullable: true,
+        spatialFeatureType: "PointZM",
+        srid: 4326,
+    })
+    pointZM: Point
+
+    @Column("geography", {
+        nullable: true,
+        spatialFeatureType: "PointZ",
+        srid: 4326,
+    })
+    geogZ: Point
+}

--- a/test/functional/spatial/cockroachdb/spatial-cockroachdb.test.ts
+++ b/test/functional/spatial/cockroachdb/spatial-cockroachdb.test.ts
@@ -53,6 +53,41 @@ describe("spatial-cockroachdb", () => {
             }),
         ))
 
+    // see https://github.com/typeorm/typeorm/issues/12747
+    it("should load dimensional spatial feature types from the database", () =>
+        Promise.all(
+            dataSources.map(async (dataSource) => {
+                const queryRunner = dataSource.createQueryRunner()
+                const table = await queryRunner.getTable("dimensional_post")
+                await queryRunner.release()
+
+                const featureTypeOf = (columnName: string) =>
+                    table!
+                        .findColumnByName(columnName)!
+                        .spatialFeatureType!.toLowerCase()
+
+                expect(featureTypeOf("pointZ")).to.equal("pointz")
+                expect(featureTypeOf("pointM")).to.equal("pointm")
+                expect(featureTypeOf("pointZM")).to.equal("pointzm")
+                expect(featureTypeOf("geogZ")).to.equal("pointz")
+            }),
+        ))
+
+    // see https://github.com/typeorm/typeorm/issues/12747
+    it("should not report schema changes for dimensional spatial columns", () =>
+        Promise.all(
+            dataSources.map(async (dataSource) => {
+                const sqlInMemory = await dataSource.driver
+                    .createSchemaBuilder()
+                    .log()
+
+                const dimensionalPostChanges = sqlInMemory.upQueries.filter(
+                    (query) => query.query.includes("dimensional_post"),
+                )
+                expect(dimensionalPostChanges).to.have.length(0)
+            }),
+        ))
+
     it("should create correct schema with geography type", () =>
         Promise.all(
             dataSources.map(async (dataSource) => {

--- a/test/functional/spatial/postgres/entity/DimensionalPost.ts
+++ b/test/functional/spatial/postgres/entity/DimensionalPost.ts
@@ -1,0 +1,40 @@
+import {
+    Column,
+    Entity,
+    Point,
+    PrimaryGeneratedColumn,
+} from "../../../../../src"
+
+@Entity()
+export class DimensionalPost {
+    @PrimaryGeneratedColumn()
+    id: number
+
+    @Column("geometry", {
+        nullable: true,
+        spatialFeatureType: "PointZ",
+        srid: 4326,
+    })
+    pointZ: Point
+
+    @Column("geometry", {
+        nullable: true,
+        spatialFeatureType: "PointM",
+        srid: 4326,
+    })
+    pointM: Point
+
+    @Column("geometry", {
+        nullable: true,
+        spatialFeatureType: "PointZM",
+        srid: 4326,
+    })
+    pointZM: Point
+
+    @Column("geography", {
+        nullable: true,
+        spatialFeatureType: "PointZ",
+        srid: 4326,
+    })
+    geogZ: Point
+}

--- a/test/functional/spatial/postgres/postgis-spatial.test.ts
+++ b/test/functional/spatial/postgres/postgis-spatial.test.ts
@@ -6,6 +6,7 @@ import {
     createTestingConnections,
     reloadTestingDatabases,
 } from "../../../utils/test-utils"
+import { DimensionalPost } from "./entity/DimensionalPost"
 import { Post } from "./entity/Post"
 
 // Tests for PostGIS geometry types
@@ -13,7 +14,7 @@ describe("postgis spatial types", () => {
     let dataSources: DataSource[]
     before(async () => {
         dataSources = await createTestingConnections({
-            entities: [Post],
+            entities: [DimensionalPost, Post],
             schemaCreate: true,
             dropSchema: true,
             enabledDrivers: ["postgres"],
@@ -53,6 +54,44 @@ describe("postgis spatial types", () => {
                     "point",
                 )
                 expect(pointColumn!.srid).to.equal(4326)
+            }),
+        ))
+
+    // see https://github.com/typeorm/typeorm/issues/12747
+    it("should load dimensional spatial feature types from the database", () =>
+        Promise.all(
+            dataSources.map(async (dataSource) => {
+                const queryRunner = dataSource.createQueryRunner()
+                const table = await queryRunner.getTable("dimensional_post")
+                await queryRunner.release()
+
+                const featureTypeOf = (columnName: string) =>
+                    table!
+                        .findColumnByName(columnName)!
+                        .spatialFeatureType!.toLowerCase()
+
+                expect(featureTypeOf("pointZ")).to.equal("pointz")
+                expect(featureTypeOf("pointM")).to.equal("pointm")
+                expect(featureTypeOf("pointZM")).to.equal("pointzm")
+                expect(featureTypeOf("geogZ")).to.equal("pointz")
+            }),
+        ))
+
+    // see https://github.com/typeorm/typeorm/issues/12747
+    it("should not report schema changes for dimensional spatial columns", () =>
+        Promise.all(
+            dataSources.map(async (dataSource) => {
+                const sqlInMemory = await dataSource.driver
+                    .createSchemaBuilder()
+                    .log()
+
+                // Scoped to the dimensional table: the shared Post entity
+                // reports pre-existing drift for spatial columns declared
+                // without explicit options, independently of this fix.
+                const dimensionalPostChanges = sqlInMemory.upQueries.filter(
+                    (query) => query.query.includes("dimensional_post"),
+                )
+                expect(dimensionalPostChanges).to.have.length(0)
             }),
         ))
 


### PR DESCRIPTION
### Description of change

Fixes #12747

When loading tables, the Postgres driver reads `srid` and `type` from the PostGIS `geometry_columns` view but ignores `coord_dimension`. PostGIS folds the Z dimension into `coord_dimension` and only keeps the M suffix in `type`, so a `geometry(PointZ)` column comes back as feature type `POINT`. The loaded table then never matches metadata declaring `PointZ`, and `migration:generate` produces the same ALTER over and over.

Verified against PostGIS 3.6, where the views report:

| declared column | view | `coord_dimension` | `type` |
| --- | --- | --- | --- |
| `geometry(Geometry)` | geometry_columns | 2 | `GEOMETRY` |
| `geometry(GeometryZ)` | geometry_columns | 3 | `GEOMETRY` |
| `geometry(GeometryM)` | geometry_columns | 3 | `GEOMETRYM` |
| `geometry(GeometryZM)` | geometry_columns | 4 | `GEOMETRY` |
| `geography(PointZ)` | geography_columns | 3 | `PointZ` |

The query now also selects `coord_dimension`, and the loader appends the `Z` or `ZM` suffix when the dimension calls for it and the suffix is not already present. The guard keeps `geography_columns` working unchanged, since that view already reports the full suffix in `type`.

`SpatialColumnOptions.spatialFeatureType` previously only accepted the plain GeoJSON type names, so a dimensional column could not even be declared without a cast. The type now also accepts the `Z`, `M` and `ZM` suffixed forms, and the decorator reference documentation mentions them.

The regression test declares geometry `PointZ`, `PointM` and `PointZM` columns plus a geography `PointZ` column, then asserts both that the loaded table reports the dimensional feature types and that the schema builder reports no pending changes, which is the loop from the issue. Reverting the source changes makes both tests fail. The full spatial test suite passes against the postgres-14 PostGIS image from docker-compose.

### CockroachDB

As requested in review, the same change is applied to the CockroachDB driver, with the same block shape so the two can be extracted together later. Probed on CockroachDB v25.2, the views match PostGIS except for one case:

| declared column | view | `coord_dimension` | PostGIS `type` | CockroachDB `type` |
| --- | --- | --- | --- | --- |
| `geometry(PointZ)` | geometry_columns | 3 | `POINT` | `POINT` |
| `geometry(PointM)` | geometry_columns | 3 | `POINTM` | `POINT` |
| `geometry(PointZM)` | geometry_columns | 4 | `POINT` | `POINT` |
| `geometry(GeometryZM)` | geometry_columns | 4 | `GEOMETRY` | `GEOMETRY` |
| `geography(PointZ)` | geography_columns | 3 | `PointZ` | `PointZ` |
| `geography(PointZM)` | geography_columns | 4 | `PointZM` | `PointZM` |

CockroachDB drops the M suffix from `geometry_columns`, which makes `PointM` indistinguishable from `PointZ` there. The driver already loads `crdb_sql_type` for every column (`GEOMETRY(POINTM,4326)`), so the declared feature type is taken from it when present and the `coord_dimension` logic stays as the shared fallback. The only other difference is that `coord_dimension` comes back as a bigint string, parsed the same way the existing code parses `srid`.

The CockroachDB spatial suite gains the same two tests (dimensional feature types loaded, no pending schema changes), and reverting the driver change makes exactly those two fail. Both spatial suites pass: 26 tests across postgres, cockroachdb and mysql.

### Pull-Request Checklist

- [x] Code is up-to-date with the `master` branch
- [x] This pull request links a relevant issue using a closing keyword:
      `Fixes #NNNN`, `Closes #NNNN`, or `Resolves #NNNN`
- [x] There are new or updated tests validating the change (`tests/**.test.ts`)
- [x] Documentation has been updated to reflect this change (`docs/docs/**.md`)
