### PR TITLE
fix(better-sqlite3): await query event subscribers and report failed queries

### DIFF
--- a/src/driver/better-sqlite3/BetterSqlite3QueryRunner.ts
+++ b/src/driver/better-sqlite3/BetterSqlite3QueryRunner.ts
@@ -106,16 +106,16 @@ export class BetterSqlite3QueryRunner extends AbstractSqliteQueryRunner {
             normalizedParameters,
             this,
         )
-        this.broadcaster.broadcastBeforeQueryEvent(
-            broadcasterResult,
+        await this.broadcaster.broadcast(
+            "BeforeQuery",
             query,
             normalizedParameters,
         )
         const queryStartTime = Date.now()
 
-        const stmt = await this.getStmt(query)
-
         try {
+            const stmt = await this.getStmt(query)
+
             const result = new QueryResult()
 
             if (stmt.reader) {
@@ -170,7 +170,19 @@ export class BetterSqlite3QueryRunner extends AbstractSqliteQueryRunner {
                 normalizedParameters,
                 this,
             )
+            this.broadcaster.broadcastAfterQueryEvent(
+                broadcasterResult,
+                query,
+                normalizedParameters,
+                false,
+                undefined,
+                undefined,
+                err,
+            )
+
             throw new QueryFailedError(query, normalizedParameters, err)
+        } finally {
+            await broadcasterResult.wait()
         }
     }
 

--- a/test/functional/entity-subscriber/query-events/entity/Example.ts
+++ b/test/functional/entity-subscriber/query-events/entity/Example.ts
@@ -1,0 +1,10 @@
+import { Column, Entity, PrimaryGeneratedColumn } from "../../../../../src/"
+
+@Entity()
+export class Example {
+    @PrimaryGeneratedColumn()
+    id: number
+
+    @Column()
+    value: number = 0
+}

--- a/test/functional/entity-subscriber/query-events/query-events.test.ts
+++ b/test/functional/entity-subscriber/query-events/query-events.test.ts
@@ -1,0 +1,90 @@
+import { expect } from "chai"
+import "reflect-metadata"
+import type { DataSource } from "../../../../src"
+import { QueryFailedError } from "../../../../src"
+import {
+    closeTestingConnections,
+    createTestingConnections,
+    reloadTestingDatabases,
+} from "../../../utils/test-utils"
+import { Example } from "./entity/Example"
+import { QueryEventSubscriber } from "./subscribers/QueryEventSubscriber"
+
+describe("entity subscriber > query events", () => {
+    let dataSources: DataSource[]
+    before(async () => {
+        dataSources = await createTestingConnections({
+            disabledDrivers: ["mongodb", "spanner"],
+            entities: [Example],
+            subscribers: [QueryEventSubscriber],
+            schemaCreate: true,
+            dropSchema: true,
+        })
+    })
+    beforeEach(() => reloadTestingDatabases(dataSources))
+    after(() => closeTestingConnections(dataSources))
+
+    it("should wait for an async afterQuery subscriber before resolving", () =>
+        Promise.all(
+            dataSources.map(async (dataSource) => {
+                const subscriber = dataSource
+                    .subscribers[0] as QueryEventSubscriber
+                subscriber.clearOutcomes()
+
+                await dataSource.manager.find(Example)
+
+                expect(subscriber.pending).to.equal(0)
+                expect(subscriber.outcomes).to.include(true)
+            }),
+        ))
+
+    it("should wait for an async afterQuery subscriber before rejecting", () =>
+        Promise.all(
+            dataSources.map(async (dataSource) => {
+                const subscriber = dataSource
+                    .subscribers[0] as QueryEventSubscriber
+                subscriber.clearOutcomes()
+
+                await expectQueryToFail(dataSource)
+
+                expect(subscriber.pending).to.equal(0)
+            }),
+        ))
+
+    it("should broadcast afterQuery with success false when the query fails", () =>
+        Promise.all(
+            dataSources.map(async (dataSource) => {
+                const subscriber = dataSource
+                    .subscribers[0] as QueryEventSubscriber
+                subscriber.clearOutcomes()
+
+                await expectQueryToFail(dataSource)
+
+                expect(subscriber.outcomes).to.include(false)
+            }),
+        ))
+
+    it("should wrap a failing query in QueryFailedError", () =>
+        Promise.all(
+            dataSources.map(async (dataSource) => {
+                const error = await expectQueryToFail(dataSource)
+
+                expect(error).to.be.instanceOf(QueryFailedError)
+            }),
+        ))
+})
+
+/**
+ * Runs a statement no supported dialect can parse and returns the rejection.
+ */
+async function expectQueryToFail(dataSource: DataSource): Promise<unknown> {
+    try {
+        await dataSource.query("SELCT 1")
+    } catch (error) {
+        return error
+    }
+
+    throw new Error(
+        `Expected the query to fail on ${dataSource.options.type} but it succeeded`,
+    )
+}

--- a/test/functional/entity-subscriber/query-events/subscribers/QueryEventSubscriber.ts
+++ b/test/functional/entity-subscriber/query-events/subscribers/QueryEventSubscriber.ts
@@ -1,0 +1,31 @@
+import {
+    AfterQueryEvent,
+    EntitySubscriberInterface,
+    EventSubscriber,
+} from "../../../../../src"
+
+/**
+ * Reports afterQuery events and, because the hook is asynchronous, whether the
+ * query runner waited for it: pending is back to zero only if the runner
+ * awaited the returned promise before settling the query.
+ */
+@EventSubscriber()
+export class QueryEventSubscriber implements EntitySubscriberInterface {
+    pending: number = 0
+    outcomes: boolean[] = []
+
+    async afterQuery(event: AfterQueryEvent): Promise<void> {
+        this.pending++
+        await new Promise((resolve) => setTimeout(resolve, 5))
+        this.outcomes.push(event.success)
+        this.pending--
+    }
+
+    /**
+     * Only the outcomes are reset: pending is a live counter and zeroing it
+     * would lose the decrement of a hook that is still running.
+     */
+    clearOutcomes(): void {
+        this.outcomes = []
+    }
+}

--- a/test/github-issues/11085/issue-11085.test.ts
+++ b/test/github-issues/11085/issue-11085.test.ts
@@ -13,7 +13,7 @@ describe("github issues > #11085 BeforeQuery promises are not awaited before que
 
     before(async () => {
         dataSources = await createTestingConnections({
-            enabledDrivers: ["postgres"],
+            enabledDrivers: ["postgres", "better-sqlite3"],
             entities: [__dirname + "/entity/*{.js,.ts}"],
             subscribers: [__dirname + "/subscriber/*{.js,.ts}"],
         })


### PR DESCRIPTION
### Description of change

Fixes #12753

`BetterSqlite3QueryRunner.query()` broadcasts the query events but never waits for the subscribers, and among the runners that implement those events it is the only one that doesn't. It calls `broadcastBeforeQueryEvent()` directly instead of awaiting the `BeforeQuery` broadcast, and `broadcasterResult.wait()` appears nowhere in the file. The other eleven (cockroachdb, cordova, expo, mysql, oracle, postgres, react-native, sap, spanner, sqljs, sqlserver) all do both.

This looks like an oversight rather than an intentional difference. #11086 fixed exactly this across 13 runners, including the old `sqlite` one, but `better-sqlite3` is not in that PR's file list. #11836 later dropped `sqlite3` and made `better-sqlite3` the default SQLite driver, so the runner that missed the fix became the one most people end up using.

Reproduced against `master` with a stub connection and an async subscriber:

```
better-sqlite3                sqljs
1. QUERY EXECUTED             1. beforeQuery settled
2. query() resolved           2. QUERY EXECUTED
3. beforeQuery settled        3. afterQuery settled
4. afterQuery settled         4. query() resolved
```

So an async `beforeQuery` hook runs after the query it is meant to precede, and `query()` resolves before `afterQuery` has finished. A rejecting subscriber has nothing awaiting it and surfaces as an unhandled rejection, which ends the process under Node's default behaviour.

Two more gaps in the same method. The `catch` block never broadcasts `afterQuery` with `success` set to false, so subscribers are told nothing when a query fails, and again this is the only broadcasting runner missing that call. And `getStmt()` sits outside the `try`, so a statement that fails to prepare throws the raw better-sqlite3 error instead of `QueryFailedError`:

```
                better-sqlite3        sqljs
error type      SqliteError           QueryFailedError
afterQuery      not broadcast         success: false
```

The fix awaits the `BeforeQuery` broadcast, broadcasts the failure event, waits for the subscribers in a `finally`, and moves the prepare into the `try`. All four match what the sibling runners already do.

One thing I deliberately left alone: if an `afterQuery` subscriber rejects, the `finally` lets that rejection replace the original `QueryFailedError`. That is not introduced here. All twelve broadcasting runners behave that way today, and unmodified sqljs on `master` does the same, so I kept the parity rather than making `better-sqlite3` differ in a new direction. #12724 makes the case for the stricter behaviour and is a better place to settle it for the whole family.

Also worth flagging: #12750 edits the adjacent `queryStartTime` line in this file. The two changes don't overlap semantically and a three way merge applies cleanly, but whichever lands second will want a quick rebase.

### Tests

`test/functional/entity-subscriber/query-events/` is new. It runs on every driver except mongodb, which doesn't go through this path, and spanner, which the existing subscriber tests already exclude. It covers the settle ordering on the success and failure paths, the failure event, and the `QueryFailedError` wrapping.

`test/github-issues/11085/issue-11085.test.ts` gains `better-sqlite3` in `enabledDrivers`. That test was postgres only, which is why the gap went unnoticed. With the driver added it fails on `master` with `expected +0 to equal 1` and passes with this change.

Reverting each of the four parts on its own breaks at least one test, so none of them is decoration.

Full suite against better-sqlite3, postgres, mysql, mariadb and mssql: 3070 passing, 172 pending, 0 failing. Oracle, SAP HANA and Spanner were not run locally.

### Pull-Request Checklist

- [x] Code is up-to-date with the `master` branch
- [x] This pull request links a relevant issue using a closing keyword:
      `Fixes #12753`
- [x] There are new or updated tests validating the change (`tests/**.test.ts`)
- [ ] Documentation has been updated to reflect this change (`docs/docs/**.md`): N/A
