### PR TITLE
fix(sqljs): measure query execution time after the statement runs

### DIFF
--- a/src/driver/sqljs/SqljsQueryRunner.ts
+++ b/src/driver/sqljs/SqljsQueryRunner.ts
@@ -111,6 +111,12 @@ export class SqljsQueryRunner extends AbstractSqliteQueryRunner {
                 statement.bind(parameters)
             }
 
+            const records: any[] = []
+
+            while (statement.step()) {
+                records.push(statement.getAsObject())
+            }
+
             // log slow queries if maxQueryExecution time is set
             const maxQueryExecutionTime =
                 this.driver.options.maxQueryExecutionTime
@@ -127,12 +133,6 @@ export class SqljsQueryRunner extends AbstractSqliteQueryRunner {
                     parameters,
                     this,
                 )
-
-            const records: any[] = []
-
-            while (statement.step()) {
-                records.push(statement.getAsObject())
-            }
 
             this.broadcaster.broadcastAfterQueryEvent(
                 broadcasterResult,

--- a/test/functional/driver/sqljs/query-execution-time.test.ts
+++ b/test/functional/driver/sqljs/query-execution-time.test.ts
@@ -50,7 +50,9 @@ describe("sqljs driver > query execution time", () => {
             dataSources.map(async (dataSource) => {
                 const subscriber = dataSource
                     .subscribers[0] as QueryExecutionTimeSubscriber
+                const logger = dataSource.options.logger as RecordingLogger
                 subscriber.clear()
+                logger.slowQueries.length = 0
 
                 const startedAt = Date.now()
                 await dataSource.query(slowQuery)
@@ -70,20 +72,11 @@ describe("sqljs driver > query execution time", () => {
                 // left loose so that time spent outside the measured section
                 // cannot fail a correct measurement.
                 expect(executionTimes[0]).to.be.at.least(elapsed / 3)
-            }),
-        ))
 
-    it("should report a slow query once it exceeds maxQueryExecutionTime", () =>
-        Promise.all(
-            dataSources.map(async (dataSource) => {
-                const logger = dataSource.options.logger as RecordingLogger
-                logger.slowQueries.length = 0
-
-                await dataSource.query(slowQuery)
-
+                // the same measurement decides whether the query is slow
                 expect(logger.slowQueries).to.have.lengthOf(1)
                 expect(logger.slowQueries[0].query).to.equal(slowQuery)
-                expect(logger.slowQueries[0].time).to.be.greaterThan(1)
+                expect(logger.slowQueries[0].time).to.equal(executionTimes[0])
             }),
         ))
 })

--- a/test/functional/driver/sqljs/query-execution-time.test.ts
+++ b/test/functional/driver/sqljs/query-execution-time.test.ts
@@ -39,7 +39,8 @@ describe("sqljs driver > query execution time", () => {
             entities: [],
             enabledDrivers: ["sqljs"],
             subscribers: [QueryExecutionTimeSubscriber],
-            driverSpecific: { maxQueryExecutionTime: 1 },
+            // above the few milliseconds prepare() takes on its own
+            driverSpecific: { maxQueryExecutionTime: 50 },
             createLogger: () => new RecordingLogger(),
         })
     })

--- a/test/functional/driver/sqljs/query-execution-time.test.ts
+++ b/test/functional/driver/sqljs/query-execution-time.test.ts
@@ -1,0 +1,89 @@
+import "reflect-metadata"
+import { expect } from "chai"
+import type { DataSource } from "../../../../src/data-source/DataSource"
+import type { Logger } from "../../../../src/logger/Logger"
+import {
+    closeTestingConnections,
+    createTestingConnections,
+} from "../../../utils/test-utils"
+import { QueryExecutionTimeSubscriber } from "./subscribers/QueryExecutionTimeSubscriber"
+
+/**
+ * sql.js runs the statement while `step()` is iterated, not while it is
+ * prepared. A query whose work lives entirely in that loop therefore separates
+ * preparation time from execution time.
+ */
+const slowQuery = `WITH RECURSIVE counter(x) AS (
+    SELECT 1 UNION ALL SELECT x + 1 FROM counter WHERE x < 500000
+) SELECT count(*) AS total FROM counter`
+
+class RecordingLogger implements Logger {
+    readonly slowQueries: { time: number; query: string }[] = []
+
+    logQuery(): void {}
+    logQueryError(): void {}
+    logSchemaBuild(): void {}
+    logMigration(): void {}
+    log(): void {}
+
+    logQuerySlow(time: number, query: string): void {
+        this.slowQueries.push({ time, query })
+    }
+}
+
+describe("sqljs driver > query execution time", () => {
+    let dataSources: DataSource[]
+
+    before(async () => {
+        dataSources = await createTestingConnections({
+            entities: [],
+            enabledDrivers: ["sqljs"],
+            subscribers: [QueryExecutionTimeSubscriber],
+            driverSpecific: { maxQueryExecutionTime: 1 },
+            createLogger: () => new RecordingLogger(),
+        })
+    })
+    after(() => closeTestingConnections(dataSources))
+
+    it("should measure the time spent executing the query, not just preparing it", () =>
+        Promise.all(
+            dataSources.map(async (dataSource) => {
+                const subscriber = dataSource
+                    .subscribers[0] as QueryExecutionTimeSubscriber
+                subscriber.clear()
+
+                const startedAt = Date.now()
+                await dataSource.query(slowQuery)
+                const elapsed = Date.now() - startedAt
+
+                const executionTimes = subscriber.getExecutionTimes()
+                expect(executionTimes).to.have.lengthOf(1)
+
+                // Comparing against the caller's own measurement keeps this
+                // independent of how fast the machine is. Timing the statement
+                // before it runs reports the preparation only, which is a small
+                // fraction of the elapsed time.
+                //
+                // The caller's window is the wider one: it also covers the
+                // BeforeQuery broadcast that precedes queryStartTime and the
+                // subscriber settling that follows queryEndTime. The bound is
+                // left loose so that time spent outside the measured section
+                // cannot fail a correct measurement.
+                expect(executionTimes[0]).to.be.at.least(elapsed / 3)
+            }),
+        ))
+
+    it("should report a slow query once it exceeds maxQueryExecutionTime", () =>
+        Promise.all(
+            dataSources.map(async (dataSource) => {
+                const logger = dataSource.options.logger as RecordingLogger
+                logger.slowQueries.length = 0
+
+                await dataSource.query(slowQuery)
+
+                expect(logger.slowQueries).to.have.lengthOf(1)
+                expect(logger.slowQueries[0].query).to.equal(slowQuery)
+                expect(logger.slowQueries[0].time).to.be.greaterThan(1)
+            }),
+        ))
+})

--- a/test/functional/driver/sqljs/subscribers/QueryExecutionTimeSubscriber.ts
+++ b/test/functional/driver/sqljs/subscribers/QueryExecutionTimeSubscriber.ts
@@ -1,0 +1,22 @@
+import {
+    AfterQueryEvent,
+    EntitySubscriberInterface,
+    EventSubscriber,
+} from "../../../../../src"
+
+@EventSubscriber()
+export class QueryExecutionTimeSubscriber implements EntitySubscriberInterface {
+    private executionTimes: (number | undefined)[] = []
+
+    afterQuery(event: AfterQueryEvent): void {
+        this.executionTimes.push(event.executionTime)
+    }
+
+    getExecutionTimes(): (number | undefined)[] {
+        return this.executionTimes
+    }
+
+    clear(): void {
+        this.executionTimes = []
+    }
+}


### PR DESCRIPTION
### Description of change

Fixes #12758.

`SqljsQueryRunner.query()` took `queryEndTime` right after `prepare()` and `bind()`. In sql.js the statement runs as `step()` is iterated, and that loop sits below the measurement, so only the preparation was timed.

Two things follow from that. `maxQueryExecutionTime` is inert on sqljs, because preparation is sub-millisecond and never crosses the threshold no matter how slow the query is. And `AfterQueryEvent.executionTime` carries a number that has nothing to do with the query, which matters for anything using it to instrument.

The fix moves the row collection above the measurement. That is the order every other query runner already uses: postgres measures after `await databaseConnection.query(...)`, better-sqlite3 after `stmt.all()` / `stmt.run()`, expo after `await statement.executeAsync()`, react-native and nativescript inside the completion callback, spanner after `await executor.run(...)`. I read all eleven runners that take a `queryEndTime`, and sqljs was the only one measuring before execution, so the change is limited to this file.

`queryStartTime` is left alone. Every driver starts the clock before preparation, so the start point already matches the convention.

### Before and after

Same query, `maxQueryExecutionTime: 50`, better-sqlite3 as the control. Repro script is in the issue.

```
before
  sqljs            executionTime   4   elapsed 437   logQuerySlow not called
  better-sqlite3   executionTime 158   elapsed 158   logQuerySlow 158

after
  sqljs            executionTime 423   elapsed 424   logQuerySlow 423
  better-sqlite3   executionTime 149   elapsed 149   logQuerySlow 149
```

### Side effect worth naming

If `step()` throws, the slow-query log is now skipped and the failure goes to `logQueryError` and the failed `afterQuery` event. Previously a slow `prepare()` could log the query as slow even though it never ran. The other runners do not log a slow query on a failed execution either, so this brings sqljs in line rather than changing behaviour independently.

### Tests

`test/functional/driver/sqljs/query-execution-time.test.ts` plus a subscriber that records `executionTime`. Both assertions fail on master:

```
1) should measure the time spent executing the query, not just preparing it:
   AssertionError: expected 3 to be at least 33.666666666666664
2) should report a slow query once it exceeds maxQueryExecutionTime:
   AssertionError: expected [] to have a length of 1 but got +0
```

The timing assertion compares against the caller's own measurement rather than a fixed millisecond threshold, so machine speed cancels out. A fixed threshold would let a slow runner pass the test on preparation time alone. The bound is deliberately loose: the caller's window is wider than the measured one, since it also covers the `BeforeQuery` broadcast before `queryStartTime` and the subscriber settling after `queryEndTime`, and time spent there should not be able to fail a correct measurement.

### Note on #12750

#12750 rewrites these same two lines, swapping `Date.now()` for `PlatformTools.performanceNow()` across every driver. It changes the clock source and not the measurement point, so it does not fix this and this does not fix that. Whichever lands second will need a small rebase on these two lines. Happy to be the one to rebase.
