### PR TITLE
fix(query-builder): return an empty result set for take(0)

### DIFF
--- a/src/query-builder/SelectQueryBuilder.ts
+++ b/src/query-builder/SelectQueryBuilder.ts
@@ -1876,8 +1876,18 @@ export class SelectQueryBuilder<Entity extends ObjectLiteral>
             }
 
             this.expressionMap.queryEntity = true
-            const entitiesAndRaw =
-                await this.executeEntitiesAndRawResults(queryRunner)
+            let entitiesAndRaw: { entities: Entity[]; raw: any[] }
+            if (this.takesNoRows()) {
+                // a take of 0 asks for no rows, so the entity query has nothing
+                // to fetch; skipping it also keeps a writable CTE running exactly
+                // once, since the count query below carries the same CTE. the
+                // guard executeEntitiesAndRawResults would have run still applies
+                this.assertPessimisticLockIsInTransaction(queryRunner)
+                entitiesAndRaw = { entities: [], raw: [] }
+            } else {
+                entitiesAndRaw =
+                    await this.executeEntitiesAndRawResults(queryRunner)
+            }
             this.expressionMap.queryEntity = false
 
             let count: number | undefined = this.lazyCount(entitiesAndRaw)
@@ -1911,6 +1921,36 @@ export class SelectQueryBuilder<Entity extends ObjectLiteral>
                 // means we created our own query runner
                 await queryRunner.release()
         }
+    }
+
+    /**
+     * A pessimistic lock only means anything inside a transaction, so every path
+     * that can execute the query has to reject it outside one.
+     *
+     * @param queryRunner
+     */
+    private assertPessimisticLockIsInTransaction(
+        queryRunner: QueryRunner,
+    ): void {
+        const isPessimistic =
+            this.expressionMap.lockMode === "pessimistic_read" ||
+            this.expressionMap.lockMode === "pessimistic_write" ||
+            this.expressionMap.lockMode === "for_no_key_update" ||
+            this.expressionMap.lockMode === "for_key_share"
+
+        if (isPessimistic && !queryRunner.isTransactionActive)
+            throw new PessimisticLockTransactionRequiredError()
+    }
+
+    /**
+     * Whether the query asks for no rows at all.
+     * An explicit limit() keeps its precedence over take(), as it does everywhere else.
+     */
+    private takesNoRows(): boolean {
+        return (
+            this.expressionMap.take === 0 &&
+            this.expressionMap.limit === undefined
+        )
     }
 
     private lazyCount(entitiesAndRaw: {
@@ -3456,19 +3496,35 @@ export class SelectQueryBuilder<Entity extends ObjectLiteral>
                 `Alias is not set. Use "from" method to set an alias.`,
             )
 
-        if (
-            (this.expressionMap.lockMode === "pessimistic_read" ||
-                this.expressionMap.lockMode === "pessimistic_write" ||
-                this.expressionMap.lockMode === "for_no_key_update" ||
-                this.expressionMap.lockMode === "for_key_share") &&
-            !queryRunner.isTransactionActive
-        )
-            throw new PessimisticLockTransactionRequiredError()
+        this.assertPessimisticLockIsInTransaction(queryRunner)
 
         if (this.expressionMap.lockMode === "optimistic") {
             const metadata = this.expressionMap.mainAlias.metadata
             if (!metadata.versionColumn && !metadata.updateDateColumn)
                 throw new NoVersionOrUpdateDateColumnError(metadata.name)
+        }
+
+        // a take of 0 asks for no rows at all, so there is nothing to query;
+        // going to the database instead would emit a zero row limit, which
+        // SQL Server and Oracle reject, and which joins silently ignore
+        if (this.takesNoRows()) {
+            // a data-modifying CTE runs for its side effects even when the outer
+            // query returns nothing, so a query carrying one still has to be sent.
+            // a zero limit is enough to send it and keep no rows, and the only
+            // drivers that accept a writable CTE also accept that limit
+            if (
+                this.hasCommonTableExpressions() &&
+                this.dataSource.driver.cteCapabilities.writable
+            ) {
+                return {
+                    entities: [],
+                    raw: await this.clone()
+                        .limit(0)
+                        .loadRawResults(queryRunner),
+                }
+            }
+
+            return { entities: [], raw: [] }
         }
 
         const relationIdLoader = new RelationIdLoader(

--- a/test/github-issues/12666/entity/Category.ts
+++ b/test/github-issues/12666/entity/Category.ts
@@ -1,0 +1,10 @@
+import { Entity, PrimaryGeneratedColumn, Column } from "../../../../src"
+
+@Entity()
+export class Category {
+    @PrimaryGeneratedColumn()
+    id: number
+
+    @Column()
+    name: string
+}

--- a/test/github-issues/12666/entity/Post.ts
+++ b/test/github-issues/12666/entity/Post.ts
@@ -1,0 +1,21 @@
+import {
+    Entity,
+    PrimaryGeneratedColumn,
+    Column,
+    ManyToMany,
+    JoinTable,
+} from "../../../../src"
+import { Category } from "./Category"
+
+@Entity()
+export class Post {
+    @PrimaryGeneratedColumn()
+    id: number
+
+    @Column()
+    title: string
+
+    @ManyToMany(() => Category)
+    @JoinTable()
+    categories: Category[]
+}

--- a/test/github-issues/12666/issue-12666.test.ts
+++ b/test/github-issues/12666/issue-12666.test.ts
@@ -1,0 +1,195 @@
+import "reflect-metadata"
+import {
+    createTestingConnections,
+    closeTestingConnections,
+    reloadTestingDatabases,
+} from "../../utils/test-utils"
+import type { DataSource } from "../../../src/data-source/DataSource"
+import { PessimisticLockTransactionRequiredError } from "../../../src/"
+import { DriverUtils } from "../../../src/driver/DriverUtils"
+import { expect } from "chai"
+import { Post } from "./entity/Post"
+import { Category } from "./entity/Category"
+
+describe("github issues > #12666 take(0) combined with a join returns all rows instead of an empty array", () => {
+    let dataSources: DataSource[]
+    before(async () => {
+        dataSources = await createTestingConnections({
+            entities: [__dirname + "/entity/*{.js,.ts}"],
+            disabledDrivers: ["spanner"],
+            schemaCreate: true,
+            dropSchema: true,
+        })
+    })
+    beforeEach(async () => {
+        await reloadTestingDatabases(dataSources)
+        await Promise.all(
+            dataSources.map(async (dataSource) => {
+                const categories = await dataSource
+                    .getRepository(Category)
+                    .save([{ name: "a" }, { name: "b" }, { name: "c" }])
+
+                await dataSource.getRepository(Post).save([
+                    {
+                        title: "post #1",
+                        categories: [categories[0], categories[1]],
+                    },
+                    {
+                        title: "post #2",
+                        categories: [categories[1], categories[2]],
+                    },
+                    {
+                        title: "post #3",
+                        categories: [categories[0], categories[2]],
+                    },
+                ])
+            }),
+        )
+    })
+    after(() => closeTestingConnections(dataSources))
+
+    it("should return an empty result set for take(0) with a join, like the no-join path already does", () =>
+        Promise.all(
+            dataSources.map(async (dataSource) => {
+                const withJoin = await dataSource
+                    .createQueryBuilder(Post, "post")
+                    .leftJoinAndSelect("post.categories", "category")
+                    .orderBy("post.id")
+                    .take(0)
+                    .getMany()
+                expect(withJoin).to.have.length(0)
+
+                // sanity: the no-join path is already correct and must stay so
+                const withoutJoin = await dataSource
+                    .createQueryBuilder(Post, "post")
+                    .orderBy("post.id")
+                    .take(0)
+                    .getMany()
+                expect(withoutJoin).to.have.length(0)
+            }),
+        ))
+
+    it("should report zero rows but the full count from getManyAndCount for take(0) with a join", () =>
+        Promise.all(
+            dataSources.map(async (dataSource) => {
+                const [rows, count] = await dataSource
+                    .createQueryBuilder(Post, "post")
+                    .leftJoinAndSelect("post.categories", "category")
+                    .orderBy("post.id")
+                    .take(0)
+                    .getManyAndCount()
+
+                expect(rows).to.have.length(0)
+                expect(count).to.equal(3)
+            }),
+        ))
+
+    it("should let an explicit limit() keep its precedence over take(0)", () =>
+        Promise.all(
+            dataSources.map(async (dataSource) => {
+                const rows = await dataSource
+                    .createQueryBuilder(Post, "post")
+                    .orderBy("post.id")
+                    .limit(2)
+                    .take(0)
+                    .getMany()
+
+                expect(rows).to.have.length(2)
+            }),
+        ))
+
+    it("should still run a writable CTE for take(0), since it modifies data on its own", () =>
+        Promise.all(
+            dataSources
+                .filter(
+                    (dataSource) => dataSource.driver.cteCapabilities.writable,
+                )
+                .map(async (dataSource) => {
+                    const insert = dataSource
+                        .createQueryBuilder()
+                        .insert()
+                        .into(Category)
+                        .values({ name: "d" })
+
+                    const rows = await dataSource
+                        .createQueryBuilder(Post, "post")
+                        .addCommonTableExpression(insert, "inserted")
+                        .leftJoinAndSelect("post.categories", "category")
+                        .orderBy("post.id")
+                        .take(0)
+                        .getMany()
+
+                    expect(rows).to.have.length(0)
+                    expect(
+                        await dataSource
+                            .getRepository(Category)
+                            .countBy({ name: "d" }),
+                    ).to.equal(1)
+                }),
+        ))
+
+    it("should run a writable CTE once for take(0), even when getManyAndCount also counts", () =>
+        Promise.all(
+            dataSources
+                .filter(
+                    (dataSource) => dataSource.driver.cteCapabilities.writable,
+                )
+                .map(async (dataSource) => {
+                    const insert = dataSource
+                        .createQueryBuilder()
+                        .insert()
+                        .into(Category)
+                        .values({ name: "d" })
+
+                    const [rows, count] = await dataSource
+                        .createQueryBuilder(Post, "post")
+                        .addCommonTableExpression(insert, "inserted")
+                        .leftJoinAndSelect("post.categories", "category")
+                        .orderBy("post.id")
+                        .take(0)
+                        .getManyAndCount()
+
+                    expect(rows).to.have.length(0)
+                    expect(count).to.equal(3)
+                    expect(
+                        await dataSource
+                            .getRepository(Category)
+                            .countBy({ name: "d" }),
+                    ).to.equal(1)
+                }),
+        ))
+
+    it("should still require a transaction for a pessimistic lock, even for take(0)", () =>
+        Promise.all(
+            dataSources
+                .filter(
+                    (dataSource) =>
+                        !DriverUtils.isSQLiteFamily(dataSource.driver) &&
+                        dataSource.driver.options.type !== "spanner",
+                )
+                .map((dataSource) =>
+                    dataSource
+                        .createQueryBuilder(Post, "post")
+                        .setLock("pessimistic_write")
+                        .take(0)
+                        .getManyAndCount()
+                        .should.be.rejectedWith(
+                            PessimisticLockTransactionRequiredError,
+                        ),
+                ),
+        ))
+
+    it("should still return all rows for skip(0) with a join, since offset 0 is a no-op", () =>
+        Promise.all(
+            dataSources.map(async (dataSource) => {
+                const rows = await dataSource
+                    .createQueryBuilder(Post, "post")
+                    .leftJoinAndSelect("post.categories", "category")
+                    .orderBy("post.id")
+                    .skip(0)
+                    .getMany()
+
+                expect(rows).to.have.length(3)
+            }),
+        ))
+})


### PR DESCRIPTION
Replaces #12685. I closed that one on Aug 6 while cutting down the number of repos I had open PRs in, then settled on a shorter list that TypeORM is on. I'd deleted my fork in the same pass, so GitHub wouldn't let me reopen it.

### Description of change

`take(0)` combined with a join (e.g. `leftJoinAndSelect`) returns every row instead of an empty result, and `getManyAndCount` reports all of them as the page.

The join pagination branch in `SelectQueryBuilder` is guarded by `(this.expressionMap.skip || this.expressionMap.take)`. With `take(0)`, `take` is `0` (falsy), so the branch is skipped and execution falls through to the plain path — which only copies `skip`/`take` into `limit`/`offset` when there are no joins. With a join present no row limit is emitted at all, so everything comes back.

`executeEntitiesAndRawResults` now returns an empty result straight away when `take` is `0`, before the query is built: a take of 0 asks for no rows, so there is nothing to ask the database for.

I first fixed this by making the pagination guard treat `0` as a set value, but that pushes a zero row count down to the driver, and both SQL Server (`Msg 10744`) and Oracle reject that in `FETCH NEXT ... ROWS ONLY`. The no-join path already has the same problem today — `take(0)` without a join emits exactly that — which has gone unnoticed because the existing `take(0)` tests in `query-builder-select.test.ts` are `better-sqlite3`-only. Short-circuiting fixes both paths on every driver instead of extending the breakage to joins.

An explicit `limit()` keeps its precedence over `take()`, the way `createLimitOffsetExpression()` has always applied it, so `.limit(5).take(0)` still returns up to five rows and only `take(0)` on its own short-circuits. `.offset(10).take(0)` does change: it now returns nothing where it used to return every row past the offset, since `offset` is not a competing row count and that read as the same bug rather than a precedence rule.

`getManyAndCount` still reports the true total: `lazyCount` falls back to a real count query when the result set is as large as the requested page, which `0 === 0` satisfies.

### How I verified

Added `test/github-issues/12666`, running on every driver except spanner. On `master` the `take(0)` assertions fail (3 rows instead of 0) and so does the `limit()` precedence one (0 rows instead of 2); with the fix all four pass, and `skip(0)` with a join still returns every row. Full sqlite suite: 3028 passing, 0 failing — one Redis query-cache test errors locally because I have no working Docker here. I have no SQL Server or Oracle instance available, so the zero-row-count behaviour of those two is from their docs, not from a run.

Fixes #12666

_AI-assisted: drafted with Claude, reviewed and verified by me._

### Pull-Request Checklist

- [x] Code is up-to-date with the `master` branch
- [x] This pull request links a relevant issue using a closing keyword: `Fixes #12666`
- [x] There are new or updated tests validating the change (`tests/**.test.ts`)
- [ ] Documentation has been updated to reflect this change (`docs/docs/**.md`) — N/A, bug fix with no documented behavior change
