### PR TITLE
fix(mssql): place table lock hint inside nested join parentheses

### DIFF
--- a/src/query-builder/SelectQueryBuilder.ts
+++ b/src/query-builder/SelectQueryBuilder.ts
@@ -2576,9 +2576,9 @@ export class SelectQueryBuilder<Entity extends ObjectLiteral>
             tableName +
             " " +
             this.escape(alias) +
+            this.createTableLockExpression() +
             childJoins +
             postfix +
-            this.createTableLockExpression() +
             (condition ? " ON " + condition : "")
         )
     }

--- a/test/functional/query-builder/locking/query-builder-locking.test.ts
+++ b/test/functional/query-builder/locking/query-builder-locking.test.ts
@@ -246,6 +246,28 @@ describe("query builder > locking", () => {
         }
     })
 
+    // https://github.com/typeorm/typeorm/issues/12764
+    it("should attach dirty read lock statement to every table of a nested join", () => {
+        for (const dataSource of dataSources) {
+            if (!(dataSource.driver.options.type === "mssql")) {
+                return
+            }
+
+            const sql = dataSource
+                .createQueryBuilder(Post, "post")
+                .innerJoinAndSelect("post.categories", "categories")
+                .innerJoinAndSelect("categories.images", "images")
+                .setLock("dirty_read")
+                .getSql()
+
+            expect(sql).to.contain(
+                'INNER JOIN ("category" "categories" WITH (NOLOCK)',
+            )
+            expect(sql).to.contain('INNER JOIN "image" "images" WITH (NOLOCK)')
+            expect(sql).not.to.contain(") WITH (NOLOCK)")
+        }
+    })
+
     it("should not attach pessimistic write lock statement on query if locking is not used", () => {
         for (const dataSource of dataSources) {
             if (

--- a/test/functional/query-builder/locking/query-builder-locking.test.ts
+++ b/test/functional/query-builder/locking/query-builder-locking.test.ts
@@ -250,7 +250,7 @@ describe("query builder > locking", () => {
     it("should attach dirty read lock statement to every table of a nested join", () => {
         for (const dataSource of dataSources) {
             if (!(dataSource.driver.options.type === "mssql")) {
-                return
+                continue
             }
 
             const sql = dataSource


### PR DESCRIPTION
Fixes #12764

### Description of change

On SQL Server, a relation chain two levels deep combined with `setLock()` produced invalid T-SQL. The table hint landed after the closing parenthesis of the nested join, where SQL Server does not allow one, and the inner table was left without a hint at all:

```sql
LEFT JOIN ("profile" "p" LEFT JOIN "country" "c" WITH (NOLOCK) ON ...) WITH (NOLOCK) ON ...
```

The query then failed with `Incorrect syntax near the keyword 'with'`. Nesting the joins in parentheses came in with #11137, but `buildJoinClause` still appended the hint after `postfix`, so once a join had children the hint drifted outside the parentheses instead of staying on its own table reference. Moving the call in front of `childJoins` puts the hint straight after the alias it belongs to, which is where the flat (depth 1) case already put it:

```sql
LEFT JOIN ("profile" "p" WITH (NOLOCK) LEFT JOIN "country" "c" WITH (NOLOCK) ON ...) ON ...
```

Verified with a new test in `test/functional/query-builder/locking`, which fails on `master` and passes here. The full suite runs green against SQL Server 2025.

### Pull-Request Checklist

- [x] Code is up-to-date with the `master` branch
- [x] This pull request links a relevant issue using a closing keyword:
      `Fixes #12764`
- [x] There are new or updated tests validating the change (`tests/**.test.ts`)
- [ ] Documentation has been updated to reflect this change (`docs/docs/**.md`) N/A, bug fix with no documented behavior change
