### PR TITLE
fix(react-native): wait for AfterQuery subscribers before settling

### DIFF
--- a/src/driver/react-native/ReactNativeQueryRunner.ts
+++ b/src/driver/react-native/ReactNativeQueryRunner.ts
@@ -100,8 +100,12 @@ export class ReactNativeQueryRunner extends AbstractSqliteQueryRunner {
                                 this,
                             )
 
-                        if (broadcasterResult.promises.length > 0)
-                            await Promise.all(broadcasterResult.promises)
+                        try {
+                            await broadcasterResult.wait()
+                        } catch (subscriberErr) {
+                            fail(subscriberErr)
+                            return
+                        }
 
                         const result = new QueryResult()
 
@@ -130,7 +134,7 @@ export class ReactNativeQueryRunner extends AbstractSqliteQueryRunner {
                             ok(result.raw)
                         }
                     },
-                    (err: any) => {
+                    async (err: any) => {
                         this.driver.dataSource.logger.logQueryError(
                             err,
                             query,
@@ -146,14 +150,17 @@ export class ReactNativeQueryRunner extends AbstractSqliteQueryRunner {
                             undefined,
                             err,
                         )
+                        try {
+                            await broadcasterResult.wait()
+                        } catch {
+                            // a subscriber failing must not hide the original query error
+                        }
 
                         fail(new QueryFailedError(query, parameters, err))
                     },
                 )
             } catch (err) {
                 fail(err)
-            } finally {
-                await broadcasterResult.wait()
             }
         })
     }

--- a/test/unit/driver/query-broadcast-events.test.ts
+++ b/test/unit/driver/query-broadcast-events.test.ts
@@ -1,0 +1,146 @@
+import { expect } from "chai"
+import type { ReactNativeDriver } from "../../../src/driver/react-native/ReactNativeDriver"
+import { ReactNativeQueryRunner } from "../../../src/driver/react-native/ReactNativeQueryRunner"
+
+function delay(ms: number): Promise<void> {
+    return new Promise((resolve) => setTimeout(resolve, ms))
+}
+
+// Guards against the fix regressing into a hang: if promise never settles,
+// this rejects instead of leaving the test to mocha's own timeout. 2s gives
+// generous headroom over the 10ms subscriber delay for a stalled CI event
+// loop (this repo has precedent for loosening timing assertions, see the
+// sqljs elapsed/2 -> elapsed/3 change).
+function withTimeout<T>(promise: Promise<T>, label: string): Promise<T> {
+    const timeout = new Promise<never>((_, reject) => {
+        setTimeout(
+            () => reject(new Error(`${label} did not settle (hang?)`)),
+            2000,
+        ).unref()
+    })
+    return Promise.race([promise, timeout])
+}
+
+// Captures process-level unhandledRejection events during a test. The bug
+// this guards against: broadcasting AFTER_QUERY on the error path pushes the
+// subscriber's promise into broadcasterResult.promises without anyone ever
+// attaching a handler to it, so a rejecting subscriber surfaces as a Node
+// unhandledRejection instead of being observed at all. Always call restore()
+// (in a finally) so no listener leaks past the test, since this repo's mocha
+// config runs with check-leaks.
+function captureUnhandledRejections() {
+    const seen: unknown[] = []
+    const listener = (reason: unknown) => seen.push(reason)
+    process.on("unhandledRejection", listener)
+    return {
+        seen,
+        restore: () => process.off("unhandledRejection", listener),
+    }
+}
+
+/**
+ * A minimal DataSource stub with a single subscriber whose afterQuery hook
+ * does real async work, so tests can tell whether query() waited for it.
+ */
+function makeDataSource(afterQuery: () => Promise<void>) {
+    return {
+        logger: {
+            logQuery: () => {},
+            logQueryError: () => {},
+            logQuerySlow: () => {},
+        },
+        subscribers: [{ afterQuery }],
+    }
+}
+
+function settledSubscriber() {
+    let settled = false
+    const dataSource = makeDataSource(async () => {
+        await delay(10)
+        settled = true
+    })
+    return { dataSource, isSettled: () => settled }
+}
+
+function rejectingSubscriber() {
+    return makeDataSource(async () => {
+        await delay(10)
+        throw new Error("subscriber failure")
+    })
+}
+
+describe("query runner > broadcasts AFTER_QUERY before settling", () => {
+    describe("ReactNativeQueryRunner", () => {
+        it("waits for the afterQuery subscriber before rejecting on failure", async () => {
+            const { dataSource, isSettled } = settledSubscriber()
+            const driver = {
+                dataSource,
+                options: {},
+                databaseConnection: {
+                    executeSql: (
+                        _query: string,
+                        _parameters: unknown,
+                        _ok: (raw: unknown) => void,
+                        fail: (err: Error) => void,
+                    ) => setImmediate(() => fail(new Error("boom"))),
+                },
+            } as unknown as ReactNativeDriver
+            const runner = new ReactNativeQueryRunner(driver)
+
+            await expect(runner.query("SELECT 1")).to.be.rejected
+
+            expect(isSettled()).to.be.true
+        })
+
+        it("rejects with the original query error and does not leak the subscriber's rejection as unhandled, when the afterQuery subscriber also rejects on failure", async () => {
+            const driver = {
+                dataSource: rejectingSubscriber(),
+                options: {},
+                databaseConnection: {
+                    executeSql: (
+                        _query: string,
+                        _parameters: unknown,
+                        _ok: (raw: unknown) => void,
+                        fail: (err: Error) => void,
+                    ) => setImmediate(() => fail(new Error("boom"))),
+                },
+            } as unknown as ReactNativeDriver
+            const runner = new ReactNativeQueryRunner(driver)
+
+            const rejections = captureUnhandledRejections()
+            try {
+                await expect(
+                    withTimeout(runner.query("SELECT 1"), "query()"),
+                ).to.be.rejectedWith("boom")
+
+                // the subscriber rejects ~10ms after query() has already
+                // settled; give it room to surface as an unhandled
+                // rejection before asserting it didn't.
+                await delay(50)
+
+                expect(rejections.seen).to.eql([])
+            } finally {
+                rejections.restore()
+            }
+        })
+
+        it("rejects (does not hang) when the afterQuery subscriber rejects on success", async () => {
+            const driver = {
+                dataSource: rejectingSubscriber(),
+                options: {},
+                databaseConnection: {
+                    executeSql: (
+                        _query: string,
+                        _parameters: unknown,
+                        ok: (raw: unknown) => void,
+                    ) => setImmediate(() => ok({})),
+                },
+            } as unknown as ReactNativeDriver
+            const runner = new ReactNativeQueryRunner(driver)
+
+            await expect(
+                withTimeout(runner.query("SELECT 1"), "query()"),
+            ).to.be.rejectedWith("subscriber failure")
+        })
+    })
+})


### PR DESCRIPTION
Fixes #12769.

## Problem

`ReactNativeQueryRunner.query()` treats the two `executeSql` callbacks differently.

The success callback waits for the `AfterQuery` subscribers before resolving:

```ts
if (broadcasterResult.promises.length > 0)
    await Promise.all(broadcasterResult.promises)
...
ok(result)
```

The error callback broadcasts and rejects immediately:

```ts
this.broadcaster.broadcastAfterQueryEvent(broadcasterResult, query, parameters, false, undefined, undefined, err)

fail(new QueryFailedError(query, parameters, err))
```

So on a failed query the caller sees the rejection before the subscribers have run. A subscriber that records failures may still be in flight, and one that throws produces an unhandled rejection, since `fail()` has already been called and nobody is holding its promise.

The outer `finally { await broadcasterResult.wait() }` did not help. `executeSql` is callback based, so the `try` body returns as soon as the call is registered and the `finally` runs while `broadcasterResult.promises` is still empty. Neither callback has fired at that point. That is exactly why the success path had to await a second time inside the callback.

The success path has a related hole. If a subscriber rejects, `await Promise.all(...)` rejects inside an async callback with no handler, so neither `ok()` nor `fail()` is ever called and the query promise hangs forever.

## Fix

Await the subscribers on both paths and drop the outer `finally`, which was dead.

The two paths handle a throwing subscriber differently, matching the cordova and nativescript runners:

- success: the query itself was fine, so the subscriber error is the only failure there is. Reject with it.
- error: there is already a real failure. A subscriber that throws while logging it should not replace the `QueryFailedError` the caller needs to see, so its error is swallowed.

## Tests

`test/unit/driver/query-broadcast-events.test.ts` drives the runner against a mocked `executeSql`:

- a failing query waits for a slow subscriber before rejecting
- a failing query with a rejecting subscriber still rejects with the original error, and the subscriber rejection does not escape as an `unhandledRejection`
- a successful query with a rejecting subscriber rejects instead of hanging

Each case is guarded by a timeout so a regression into the hang fails the test rather than stalling the run. Reverting the error path fails the first two, reverting the success path fails the third.

`pnpm run test:fast` is otherwise unchanged.

## Related

Same class as the cordova and nativescript work. The runners share this callback shape, and react-native was the one left with the asymmetry.

