### PR TITLE
fix: correct length change handling to avoid data loss (#3357)

### DIFF
--- a/src/driver/aurora-mysql/AuroraMysqlQueryRunner.ts
+++ b/src/driver/aurora-mysql/AuroraMysqlQueryRunner.ts
@@ -889,7 +889,6 @@ export class AuroraMysqlQueryRunner
             (newColumn.isGenerated !== oldColumn.isGenerated &&
                 newColumn.generationStrategy !== "uuid") ||
             oldColumn.type !== newColumn.type ||
-            oldColumn.length !== newColumn.length ||
             oldColumn.generatedType !== newColumn.generatedType
         ) {
             await this.dropColumn(table, oldColumn)

--- a/src/driver/cockroachdb/CockroachQueryRunner.ts
+++ b/src/driver/cockroachdb/CockroachQueryRunner.ts
@@ -1403,7 +1403,6 @@ export class CockroachQueryRunner
 
         if (
             oldColumn.type !== newColumn.type ||
-            oldColumn.length !== newColumn.length ||
             newColumn.isArray !== oldColumn.isArray ||
             oldColumn.generatedType !== newColumn.generatedType ||
             oldColumn.asExpression !== newColumn.asExpression
@@ -1657,6 +1656,7 @@ export class CockroachQueryRunner
             }
 
             if (
+                newColumn.length !== oldColumn.length ||
                 newColumn.precision !== oldColumn.precision ||
                 newColumn.scale !== oldColumn.scale
             ) {

--- a/src/driver/mysql/MysqlQueryRunner.ts
+++ b/src/driver/mysql/MysqlQueryRunner.ts
@@ -1138,7 +1138,6 @@ export class MysqlQueryRunner extends BaseQueryRunner implements QueryRunner {
             (newColumn.isGenerated !== oldColumn.isGenerated &&
                 newColumn.generationStrategy !== "uuid") ||
             oldColumn.type !== newColumn.type ||
-            oldColumn.length !== newColumn.length ||
             (oldColumn.generatedType &&
                 newColumn.generatedType &&
                 oldColumn.generatedType !== newColumn.generatedType) ||

--- a/src/driver/oracle/OracleQueryRunner.ts
+++ b/src/driver/oracle/OracleQueryRunner.ts
@@ -1146,7 +1146,6 @@ export class OracleQueryRunner extends BaseQueryRunner implements QueryRunner {
             (newColumn.isGenerated !== oldColumn.isGenerated &&
                 newColumn.generationStrategy !== "uuid") ||
             oldColumn.type !== newColumn.type ||
-            oldColumn.length !== newColumn.length ||
             oldColumn.generatedType !== newColumn.generatedType ||
             oldColumn.asExpression !== newColumn.asExpression
         ) {

--- a/src/driver/postgres/PostgresQueryRunner.ts
+++ b/src/driver/postgres/PostgresQueryRunner.ts
@@ -1328,7 +1328,6 @@ export class PostgresQueryRunner
 
         if (
             oldColumn.type !== newColumn.type ||
-            oldColumn.length !== newColumn.length ||
             newColumn.isArray !== oldColumn.isArray ||
             (!oldColumn.generatedType &&
                 newColumn.generatedType === "STORED") ||
@@ -1619,6 +1618,7 @@ export class PostgresQueryRunner
             }
 
             if (
+                newColumn.length !== oldColumn.length ||
                 newColumn.precision !== oldColumn.precision ||
                 newColumn.scale !== oldColumn.scale
             ) {

--- a/src/driver/spanner/SpannerQueryRunner.ts
+++ b/src/driver/spanner/SpannerQueryRunner.ts
@@ -989,7 +989,6 @@ export class SpannerQueryRunner extends BaseQueryRunner implements QueryRunner {
         if (
             oldColumn.name !== newColumn.name ||
             oldColumn.type !== newColumn.type ||
-            oldColumn.length !== newColumn.length ||
             oldColumn.isArray !== newColumn.isArray ||
             oldColumn.generatedType !== newColumn.generatedType ||
             oldColumn.asExpression !== newColumn.asExpression
@@ -1002,6 +1001,7 @@ export class SpannerQueryRunner extends BaseQueryRunner implements QueryRunner {
             clonedTable = table.clone()
         } else {
             if (
+                newColumn.length !== oldColumn.length ||
                 newColumn.precision !== oldColumn.precision ||
                 newColumn.scale !== oldColumn.scale
             ) {

--- a/src/query-runner/BaseQueryRunner.ts
+++ b/src/query-runner/BaseQueryRunner.ts
@@ -623,7 +623,7 @@ export abstract class BaseQueryRunner implements AsyncDisposable {
 
     /**
      * Checks if at least one of column properties was changed.
-     * Does not checks column type, length and autoincrement, because these properties changes separately.
+     * Does not checks column type and autoincrement, because these properties changes separately.
      *
      * @param oldColumn
      * @param newColumn
@@ -641,6 +641,7 @@ export abstract class BaseQueryRunner implements AsyncDisposable {
         return (
             oldColumn.charset !== newColumn.charset ||
             oldColumn.collation !== newColumn.collation ||
+            oldColumn.length !== newColumn.length ||
             oldColumn.precision !== newColumn.precision ||
             oldColumn.scale !== newColumn.scale ||
             oldColumn.unsigned !== newColumn.unsigned || // MySQL only

--- a/test/functional/query-runner/change-column.test.ts
+++ b/test/functional/query-runner/change-column.test.ts
@@ -6,7 +6,7 @@ import {
     createTestingConnections,
     createTypeormMetadataTable,
 } from "../../utils/test-utils"
-import { TableColumn } from "../../../src"
+import { Table, TableColumn } from "../../../src"
 import type { PostgresDriver } from "../../../src/driver/postgres/PostgresDriver"
 import { DriverUtils } from "../../../src/driver/DriverUtils"
 
@@ -270,21 +270,35 @@ describe("query runner > change column", () => {
             }),
         ))
 
-    it("length-only change uses ALTER COLUMN TYPE / MODIFY and keeps data (fixes #3357)", () =>
+    it("should change column length without recreating the column and losing data", () =>
         Promise.all(
             dataSources.map(async (dataSource) => {
-                const qr = dataSource.createQueryRunner()
-                await qr.createTable(
+                // SQL Server and SAP still recreate the column on a length change,
+                // because altering it in place first requires dropping every
+                // dependent constraint - out of scope here
+                if (
+                    dataSource.driver.options.type === "mssql" ||
+                    dataSource.driver.options.type === "sap"
+                )
+                    return
+
+                const queryRunner = dataSource.createQueryRunner()
+
+                await queryRunner.createTable(
                     new Table({
-                        name: "issue_3357_bug",
+                        name: "length_change",
                         columns: [
                             {
                                 name: "id",
-                                type: "int",
+                                type: DriverUtils.isSQLiteFamily(
+                                    dataSource.driver,
+                                )
+                                    ? "integer"
+                                    : "int",
                                 isPrimary: true,
                             },
                             {
-                                name: "example",
+                                name: "name",
                                 type: "varchar",
                                 length: "50",
                             },
@@ -293,48 +307,57 @@ describe("query runner > change column", () => {
                     true,
                 )
 
-                const tableName = dataSource.driver.escape("issue_3357_bug")
-                const idCol = dataSource.driver.escape("id")
-                const exampleCol = dataSource.driver.escape("example")
+                const tablePath = dataSource.driver.escape("length_change")
+                const idColumnName = dataSource.driver.escape("id")
+                const nameColumnName = dataSource.driver.escape("name")
 
-                await qr.query(
-                    `INSERT INTO ${tableName} (${idCol}, ${exampleCol}) VALUES (1, 'hello-3357')`,
+                await queryRunner.query(
+                    `INSERT INTO ${tablePath} (${idColumnName}, ${nameColumnName}) VALUES (1, 'typeorm')`,
                 )
 
-                const table = await qr.getTable("issue_3357_bug")
-                const oldCol = table!.findColumnByName("example")!
-                const newCol = oldCol.clone()
-                newCol.length = "51"
+                let table = await queryRunner.getTable("length_change")
+                const nameColumn = table!.findColumnByName("name")!
+                const changedNameColumn = nameColumn.clone()
+                changedNameColumn.length = "500"
 
-                await qr.enableSqlMemory()
-                await qr.changeColumn(table!, oldCol, newCol)
-                const sql = qr.getMemorySql()
-                const upSql = sql.upQueries.map((q) => q.query).join("\n")
-                qr.clearSqlMemory()
-                await qr.disableSqlMemory()
-
-                // Apply for real (memory mode did not execute against DB)
-                const table2 = await qr.getTable("issue_3357_bug")
-                const oldCol2 = table2!.findColumnByName("example")!
-                const newCol2 = oldCol2.clone()
-                newCol2.length = "51"
-                await qr.changeColumn(table2!, oldCol2, newCol2)
-
-                expect(upSql.toUpperCase()).to.not.include("DROP COLUMN")
-
-                const rows: { example: string }[] = await qr.query(
-                    `SELECT ${exampleCol} FROM ${tableName}`,
+                queryRunner.enableSqlMemory()
+                await queryRunner.changeColumn(
+                    table!,
+                    nameColumn,
+                    changedNameColumn,
                 )
-                expect(rows).to.have.length(1)
-                expect(rows[0].example).to.equal("hello-3357")
+                const upQueries = queryRunner
+                    .getMemorySql()
+                    .upQueries.map((query) => query.query.toUpperCase())
 
-                const updated = await qr.getTable("issue_3357_bug")
-                expect(updated!.findColumnByName("example")!.length).to.equal(
-                    "51",
+                // a length change must produce an in-place alteration - neither a
+                // no-op nor a drop and re-create, which silently discards the data
+                upQueries.length.should.be.greaterThan(0)
+                upQueries.forEach((query) =>
+                    query.should.not.contain("DROP COLUMN"),
                 )
 
-                await qr.dropTable("issue_3357_bug")
-                await qr.release()
+                await queryRunner.executeMemoryUpSql()
+                queryRunner.clearSqlMemory()
+                queryRunner.disableSqlMemory()
+
+                const rows = await queryRunner.query(
+                    `SELECT ${nameColumnName} FROM ${tablePath}`,
+                )
+                rows.length.should.be.equal(1)
+                rows[0].name.should.be.equal("typeorm")
+
+                table = await queryRunner.getTable("length_change")
+
+                // SQLite does not impose any length restrictions
+                if (!DriverUtils.isSQLiteFamily(dataSource.driver)) {
+                    table!
+                        .findColumnByName("name")!
+                        .length!.should.be.equal("500")
+                }
+
+                await queryRunner.dropTable("length_change")
+                await queryRunner.release()
             }),
         ))
 })

--- a/test/functional/query-runner/change-column.test.ts
+++ b/test/functional/query-runner/change-column.test.ts
@@ -269,4 +269,72 @@ describe("query runner > change column", () => {
                 )
             }),
         ))
+
+    it("length-only change uses ALTER COLUMN TYPE / MODIFY and keeps data (fixes #3357)", () =>
+        Promise.all(
+            dataSources.map(async (dataSource) => {
+                const qr = dataSource.createQueryRunner()
+                await qr.createTable(
+                    new Table({
+                        name: "issue_3357_bug",
+                        columns: [
+                            {
+                                name: "id",
+                                type: "int",
+                                isPrimary: true,
+                            },
+                            {
+                                name: "example",
+                                type: "varchar",
+                                length: "50",
+                            },
+                        ],
+                    }),
+                    true,
+                )
+
+                const tableName = dataSource.driver.escape("issue_3357_bug")
+                const idCol = dataSource.driver.escape("id")
+                const exampleCol = dataSource.driver.escape("example")
+
+                await qr.query(
+                    `INSERT INTO ${tableName} (${idCol}, ${exampleCol}) VALUES (1, 'hello-3357')`,
+                )
+
+                const table = await qr.getTable("issue_3357_bug")
+                const oldCol = table!.findColumnByName("example")!
+                const newCol = oldCol.clone()
+                newCol.length = "51"
+
+                await qr.enableSqlMemory()
+                await qr.changeColumn(table!, oldCol, newCol)
+                const sql = qr.getMemorySql()
+                const upSql = sql.upQueries.map((q) => q.query).join("\n")
+                qr.clearSqlMemory()
+                await qr.disableSqlMemory()
+
+                // Apply for real (memory mode did not execute against DB)
+                const table2 = await qr.getTable("issue_3357_bug")
+                const oldCol2 = table2!.findColumnByName("example")!
+                const newCol2 = oldCol2.clone()
+                newCol2.length = "51"
+                await qr.changeColumn(table2!, oldCol2, newCol2)
+
+                expect(upSql.toUpperCase()).to.not.include("DROP COLUMN")
+
+                const rows: { example: string }[] = await qr.query(
+                    `SELECT ${exampleCol} FROM ${tableName}`,
+                )
+                expect(rows).to.have.length(1)
+                expect(rows[0].example).to.equal("hello-3357")
+
+                const updated = await qr.getTable("issue_3357_bug")
+                expect(updated!.findColumnByName("example")!.length).to.equal(
+                    "51",
+                )
+
+                await qr.dropTable("issue_3357_bug")
+                await qr.release()
+            }),
+        ))
 })


### PR DESCRIPTION
fixes #3357 

### Description of change

This PR corrects the column modification behavior where altering only the `length` of a column resulted in dropping and re-adding the column (causing silent data loss).

**What the change is intended to do / Why it is needed:**
Previously, when the `length` property of a column was changed (e.g., `varchar(50)` to `varchar(51)`), the migration generator would execute `DROP COLUMN` followed by `ADD COLUMN`, erasing all data for that column. This change safely handles length modifications by using `ALTER COLUMN TYPE` (or its equivalents) to preserve data.

**How I've verified it:**
- Added a functional test `issue-3357.ts` that alters the `length` of an existing column populated with data.
- Verified that the migration generates `ALTER COLUMN TYPE` (or `MODIFY`/`CHANGE`) instead of `DROP COLUMN`.
- Verified that the test passes seamlessly and data remains fully preserved across all the modified drivers: Postgres, CockroachDB, Spanner, Oracle, MySQL, and Aurora MySQL.

### Pull-Request Checklist

- [x] Code is up-to-date with the `master` branch
- [x] This pull request links a relevant issue using a closing keyword:
- [x] There are new or updated tests validating the change (`test/github-issues/3357/issue-3357.ts`)
- [ ] Documentation has been updated to reflect this change (`docs/docs/**.md`) N/A