### PR TITLE
docs: add rapiq to the extensions list in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -185,6 +185,7 @@ There are several extensions that simplify working with TypeORM and integrating 
 - Easy manipulation of `relations` objects - [typeorm-relations](https://npmjs.com/package/typeorm-relations)
 - Automatically generate `relations` based on a GraphQL query - [typeorm-relations-graphql](https://npmjs.com/package/typeorm-relations-graphql)
 - Generate TypeORM entities from Valibot schemas - [piying-orm](https://github.com/piying-org/piying-orm)
+- Apply REST API query parameters (fields, filters, relations, pagination, sort) to a query builder - [rapiq](https://github.com/tada5hi/rapiq)
 
 ## Contributing
 


### PR DESCRIPTION
### Description of change

Adds [rapiq](https://github.com/tada5hi/rapiq) to the Extensions list in the root `README.md`.

rapiq (**R**est **Api** **Q**uery) defines a scheme for REST request queries (fields, filters, relations, pagination, sort). Client input is parsed into a typed AST, validated against a server-side allow-list schema, and applied to a TypeORM `SelectQueryBuilder` by its TypeORM adapter, so endpoints do not have to hand-roll query-parameter parsing and whitelisting.

The change is a single bullet appended to the existing list, matching the surrounding `<description> - [<name>](<link>)` style. Verified with `prettier --check README.md`.

Closes #12778

### Pull-Request Checklist

- [x] Code is up-to-date with the `master` branch
- [x] This pull request links a relevant issue using a closing keyword:
      `Fixes #NNNN`, `Closes #NNNN`, or `Resolves #NNNN`
- [x] There are new or updated tests validating the change (`tests/**.test.ts`) - N/A, README-only change
- [x] Documentation has been updated to reflect this change (`docs/docs/**.md`) - N/A, this change is the documentation
