### PR TITLE
fix(entity-manager): load eager relations when preloading an entity

### DIFF
--- a/docs/docs/working-with-entity-manager/5-entity-manager-api.md
+++ b/docs/docs/working-with-entity-manager/5-entity-manager-api.md
@@ -125,6 +125,9 @@ manager.merge(User, user, { firstName: "Timber" }, { lastName: "Saw" }) // same 
   and returns the new entity. The new entity is actually loaded from the database entity with all properties
   replaced from the new object.
 
+    > "Everything related to it" means the eager relations of the entity, plus the relations
+    > present in the given object. Non-eager relations that are not part of the given object are not loaded.
+
 ```typescript
 const partialUser = {
     id: 1,

--- a/docs/docs/working-with-entity-manager/6-repository-api.md
+++ b/docs/docs/working-with-entity-manager/6-repository-api.md
@@ -79,6 +79,9 @@ repository.merge(user, { firstName: "Timber" }, { lastName: "Saw" }) // same as 
 
     > Note that given entity-like object must have an entity id / primary key to find entity by. Returns undefined if entity with given id was not found.
 
+    > "Everything related to it" means the eager relations of the entity, plus the relations
+    > present in the given object. Non-eager relations that are not part of the given object are not loaded.
+
 ```typescript
 const partialUser = {
     id: 1,

--- a/src/query-builder/transformer/PlainObjectToDatabaseEntityTransformer.ts
+++ b/src/query-builder/transformer/PlainObjectToDatabaseEntityTransformer.ts
@@ -147,6 +147,9 @@ export class PlainObjectToDatabaseEntityTransformer {
                             targetWithIds.target as any,
                         )
                         .createQueryBuilder()
+                        // preload loads the entity and everything related to it,
+                        // so its eager relations must be loaded as well
+                        .setFindOptions({ loadEagerRelations: true })
                         .whereInIds(targetWithIds.ids)
                         .getMany()
                 }
@@ -167,12 +170,26 @@ export class PlainObjectToDatabaseEntityTransformer {
                 loadMapItem.relation.isManyToMany ||
                 loadMapItem.relation.isOneToMany
             ) {
-                loadMapItem.parentLoadMapItem.entity[
-                    loadMapItem.relation.propertyName
-                ] ??= []
-                loadMapItem.parentLoadMapItem.entity[
-                    loadMapItem.relation.propertyName
-                ].push(loadMapItem.entity)
+                const relatedEntities: ObjectLiteral[] =
+                    (loadMapItem.parentLoadMapItem.entity[
+                        loadMapItem.relation.propertyName
+                    ] ??= [])
+
+                // eagerly loaded relations are already in the array, replace them
+                // instead of pushing a duplicate - the load map is linked against
+                // the entity it holds
+                const relation = loadMapItem.relation
+                const loadedIndex = relatedEntities.findIndex((relatedEntity) =>
+                    relation.inverseEntityMetadata.compareEntities(
+                        relatedEntity,
+                        loadMapItem.entity!,
+                    ),
+                )
+                if (loadedIndex === -1) {
+                    relatedEntities.push(loadMapItem.entity)
+                } else {
+                    relatedEntities[loadedIndex] = loadMapItem.entity
+                }
             } else {
                 loadMapItem.parentLoadMapItem.entity[
                     loadMapItem.relation.propertyName

--- a/test/functional/repository/preload/entity/Author.ts
+++ b/test/functional/repository/preload/entity/Author.ts
@@ -1,0 +1,12 @@
+import { Column } from "../../../../../src/decorator/columns/Column"
+import { Entity } from "../../../../../src/decorator/entity/Entity"
+import { PrimaryGeneratedColumn } from "../../../../../src/decorator/columns/PrimaryGeneratedColumn"
+
+@Entity()
+export class Author {
+    @PrimaryGeneratedColumn()
+    id: number
+
+    @Column()
+    name: string
+}

--- a/test/functional/repository/preload/entity/Category.ts
+++ b/test/functional/repository/preload/entity/Category.ts
@@ -1,0 +1,23 @@
+import { Column } from "../../../../../src/decorator/columns/Column"
+import { Entity } from "../../../../../src/decorator/entity/Entity"
+import { JoinColumn } from "../../../../../src/decorator/relations/JoinColumn"
+import { ManyToOne } from "../../../../../src/decorator/relations/ManyToOne"
+import { PrimaryGeneratedColumn } from "../../../../../src/decorator/columns/PrimaryGeneratedColumn"
+import { Author } from "./Author"
+import { Post } from "./Post"
+
+@Entity()
+export class Category {
+    @PrimaryGeneratedColumn()
+    id: number
+
+    @Column()
+    name: string
+
+    @ManyToOne(() => Post, (post) => post.categories)
+    post: Post
+
+    @ManyToOne(() => Author, { eager: true })
+    @JoinColumn()
+    author: Author
+}

--- a/test/functional/repository/preload/entity/Post.ts
+++ b/test/functional/repository/preload/entity/Post.ts
@@ -1,0 +1,24 @@
+import { Column } from "../../../../../src/decorator/columns/Column"
+import { Entity } from "../../../../../src/decorator/entity/Entity"
+import { OneToMany } from "../../../../../src/decorator/relations/OneToMany"
+import { OneToOne } from "../../../../../src/decorator/relations/OneToOne"
+import { JoinColumn } from "../../../../../src/decorator/relations/JoinColumn"
+import { PrimaryGeneratedColumn } from "../../../../../src/decorator/columns/PrimaryGeneratedColumn"
+import { Category } from "./Category"
+import { Author } from "./Author"
+
+@Entity()
+export class Post {
+    @PrimaryGeneratedColumn()
+    id: number
+
+    @Column()
+    title: string
+
+    @OneToMany(() => Category, (category) => category.post, { eager: true })
+    categories: Category[]
+
+    @OneToOne(() => Author, { eager: true })
+    @JoinColumn()
+    author: Author
+}

--- a/test/functional/repository/preload/repository-preload.test.ts
+++ b/test/functional/repository/preload/repository-preload.test.ts
@@ -1,0 +1,108 @@
+import "reflect-metadata"
+import { expect } from "chai"
+import type { DataSource } from "../../../../src/data-source/DataSource"
+import "../../../utils/test-setup"
+import {
+    closeTestingConnections,
+    createTestingConnections,
+    reloadTestingDatabases,
+} from "../../../utils/test-utils"
+import { Author } from "./entity/Author"
+import { Category } from "./entity/Category"
+import { Post } from "./entity/Post"
+
+describe("repository > preload", () => {
+    let dataSources: DataSource[]
+    before(async () => {
+        dataSources = await createTestingConnections({
+            entities: [Author, Category, Post],
+            schemaCreate: true,
+            dropSchema: true,
+        })
+    })
+    beforeEach(() => reloadTestingDatabases(dataSources))
+    after(() => closeTestingConnections(dataSources))
+
+    async function createPost(dataSource: DataSource) {
+        const author = new Author()
+        author.name = "Timber"
+        await dataSource.manager.save(author)
+
+        const post = new Post()
+        post.title = "About eager relations"
+        post.author = author
+        await dataSource.manager.save(post)
+
+        const category = new Category()
+        category.name = "typeorm"
+        category.post = post
+        category.author = author
+        await dataSource.manager.save(category)
+
+        return { author, category, post }
+    }
+
+    // https://github.com/typeorm/typeorm/issues/8944
+    it("should load eager relations of the preloaded entity", () =>
+        Promise.all(
+            dataSources.map(async (dataSource) => {
+                const { post } = await createPost(dataSource)
+
+                const preloadedPost = await dataSource.manager.preload(Post, {
+                    id: post.id,
+                    title: "Updated title",
+                })
+
+                expect(preloadedPost).to.be.instanceOf(Post)
+                expect(preloadedPost!.title).to.be.equal("Updated title")
+
+                expect(preloadedPost!.categories).to.have.length(1)
+                expect(preloadedPost!.categories[0].name).to.be.equal("typeorm")
+
+                expect(preloadedPost!.author).to.not.be.undefined
+                expect(preloadedPost!.author.name).to.be.equal("Timber")
+            }),
+        ))
+
+    // https://github.com/typeorm/typeorm/issues/8944
+    it("should load eager relations of the entities given in the plain object", () =>
+        Promise.all(
+            dataSources.map(async (dataSource) => {
+                const { category, post } = await createPost(dataSource)
+
+                const preloadedPost = await dataSource.manager.preload(Post, {
+                    id: post.id,
+                    categories: [{ id: category.id, name: "renamed" }],
+                })
+
+                expect(preloadedPost!.categories).to.have.length(1)
+                expect(preloadedPost!.categories[0].name).to.be.equal("renamed")
+                expect(preloadedPost!.categories[0].author).to.not.be.undefined
+                expect(preloadedPost!.categories[0].author.name).to.be.equal(
+                    "Timber",
+                )
+            }),
+        ))
+
+    it("should not duplicate eagerly loaded relations given in the plain object", () =>
+        Promise.all(
+            dataSources.map(async (dataSource) => {
+                const { category, post } = await createPost(dataSource)
+
+                const secondCategory = new Category()
+                secondCategory.name = "orm"
+                secondCategory.post = post
+                await dataSource.manager.save(secondCategory)
+
+                const preloadedPost = await dataSource.manager.preload(Post, {
+                    id: post.id,
+                    categories: [{ id: category.id }],
+                })
+
+                expect(preloadedPost!.categories).to.have.length(2)
+                expect(
+                    preloadedPost!.categories.map((it) => it.id).sort(),
+                ).to.be.eql([category.id, secondCategory.id].sort())
+            }),
+        ))
+})


### PR DESCRIPTION
### Description of change

`Repository#preload` / `EntityManager#preload` are documented as loading the entity **"and everything related to it"**, but eager relations were never loaded — they came back `undefined`.

**Cause:** `PlainObjectToDatabaseEntityTransformer` builds its query directly with

```ts
.createQueryBuilder().whereInIds(ids).getMany()
```

Eager relations are only applied inside `SelectQueryBuilder#applyFindOptions`, which runs from `setFindOptions()`. Since `preload` never calls it, `joinEagerRelations` (join strategy) / `concatRelationMetadata` (query strategy) never run, so no eager relation is fetched.

**Change:**

1. The preload query now calls `.setFindOptions({ loadEagerRelations: true })`, so every entity it fetches loads its eager relations exactly the way `find` / `findOne` do. This applies to the preloaded entity itself and to the related entities referenced in the given plain object.
2. When assigning `*-to-many` relations from the load map, a related entity that is already present (because it was just loaded eagerly) is now **replaced** instead of appended. Without this, `preload(Post, { id, categories: [{ id: 1 }] })` would return `categories` containing the same category twice — once from the eager join, once from the load map. Replacing rather than skipping keeps the load map's own entity in the graph, so nested relations from the plain object are still linked to the object that ends up in the result.

**Before**

```ts
const post = await manager.preload(Post, { id: 1, title: "Updated" })
post.categories // undefined  ❌  (@OneToMany(..., { eager: true }))
post.author     // undefined  ❌  (@OneToOne(..., { eager: true }))
```

**After**

```ts
const post = await manager.preload(Post, { id: 1, title: "Updated" })
post.categories // [ Category { id: 1, name: "typeorm" } ]  ✅
post.author     // Author { id: 1, name: "Timber" }         ✅
```

Non-eager relations that are not part of the given plain object are still not loaded — that would silently make `preload` fetch the whole object graph. The docs for both `EntityManager#preload` and `Repository#preload` are updated to spell out what "everything related to it" means, which was the second half of the report in #8944.

**Verification:** new functional tests in `test/functional/repository/preload` cover eager `@OneToMany` / `@OneToOne` on the preloaded entity, eager relations of entities named in the plain object, and the no-duplicates case. They fail on `master` and pass with this change. The full suite passes (3047 passing, 0 failing) against the default `sqljs` config.

Closes #8944

### Pull-Request Checklist

- [x] Code is up-to-date with the `master` branch
- [x] This pull request links a relevant issue using a closing keyword:
      `Fixes #NNNN`, `Closes #NNNN`, or `Resolves #NNNN`
- [x] There are new or updated tests validating the change (`tests/**.test.ts`)
- [x] Documentation has been updated to reflect this change (`docs/docs/**.md`)
