### PR TITLE
fix: load entity files through import when require cannot parse them

### DIFF
--- a/src/util/ImportUtils.ts
+++ b/src/util/ImportUtils.ts
@@ -26,10 +26,31 @@ export async function importOrRequireFile(
         return [require(filePath), "commonjs"]
     }
 
+    // Vite based runners such as Vitest transform TypeScript for `import()` but leave
+    // `require` on the plain CommonJS loader, which cannot parse it. Retry with
+    // `import()` when requiring fails to parse the file, and keep the original error
+    // when that does not help either, so genuine syntax errors stay readable.
+    const tryToRequireOrImport = async (): Promise<
+        [any, "esm" | "commonjs"]
+    > => {
+        try {
+            return tryToRequire()
+        } catch (error) {
+            if (!(error instanceof SyntaxError)) throw error
+
+            try {
+                return await tryToImport()
+            } catch {
+                throw error
+            }
+        }
+    }
+
     const extension = filePath.slice(filePath.lastIndexOf(".") + ".".length)
 
     if (extension === "mjs" || extension === "mts") return tryToImport()
-    else if (extension === "cjs" || extension === "cts") return tryToRequire()
+    else if (extension === "cjs" || extension === "cts")
+        return tryToRequireOrImport()
     else if (extension === "js" || extension === "ts") {
         const packageJson = await getNearestPackageJson(filePath)
 
@@ -37,8 +58,8 @@ export async function importOrRequireFile(
             const isModule = (packageJson as any)?.type === "module"
 
             if (isModule) return tryToImport()
-            else return tryToRequire()
-        } else return tryToRequire()
+            else return tryToRequireOrImport()
+        } else return tryToRequireOrImport()
     }
 
     return tryToRequire()

--- a/test/unit/util/import-utils.test.ts
+++ b/test/unit/util/import-utils.test.ts
@@ -4,6 +4,7 @@ import path from "path"
 import { strict as assert } from "assert"
 import sinon from "sinon"
 import fsAsync from "fs"
+import Module from "module"
 
 import { importOrRequireFile } from "../../../src/util/ImportUtils"
 
@@ -179,6 +180,81 @@ describe("ImportUtils.importOrRequireFile", () => {
         expect(exports.test).to.be.eq(6)
 
         await fs.rm(testDir, { recursive: true, force: true })
+    })
+
+    it("should fall back to import when the CommonJS loader cannot parse the file", async () => {
+        // Vite based runners such as Vitest transform TypeScript for `import()` but leave
+        // `require` on the plain CommonJS loader, which throws a SyntaxError on it.
+        // https://github.com/typeorm/typeorm/issues/11570
+        const testDir = path.join(__dirname, "testRequireFallsBackToImport")
+        const srcDir = path.join(testDir, "src")
+
+        const packageJsonPath = path.join(testDir, "package.json")
+        const jsFilePath = path.join(srcDir, "file.js")
+        const jsFileContent = `
+            export default function test() {}
+            export const number = 6;
+        `
+
+        await fs.rm(testDir, { recursive: true, force: true })
+        await fs.mkdir(srcDir, { recursive: true })
+        await fs.writeFile(packageJsonPath, JSON.stringify({}), "utf8")
+        await fs.writeFile(jsFilePath, jsFileContent, "utf8")
+
+        const extensions = (Module as any)._extensions
+        const originalLoader = extensions[".js"]
+        extensions[".js"] = (module: any, filename: string) => {
+            if (filename === jsFilePath)
+                throw new SyntaxError("Invalid or unexpected token")
+
+            return originalLoader(module, filename)
+        }
+
+        try {
+            const [exports, moduleType] = await importOrRequireFile(jsFilePath)
+
+            expect(moduleType).to.be.eq("esm")
+            expect(exports.default).to.be.a("function")
+            expect(exports.number).to.be.eq(6)
+        } finally {
+            extensions[".js"] = originalLoader
+            await fs.rm(testDir, { recursive: true, force: true })
+        }
+    })
+
+    it("should keep the require error when importing does not help either", async () => {
+        const testDir = path.join(__dirname, "testRequireErrorIsKept")
+        const srcDir = path.join(testDir, "src")
+
+        const packageJsonPath = path.join(testDir, "package.json")
+        const jsFilePath = path.join(srcDir, "file.js")
+
+        await fs.rm(testDir, { recursive: true, force: true })
+        await fs.mkdir(srcDir, { recursive: true })
+        await fs.writeFile(packageJsonPath, JSON.stringify({}), "utf8")
+        await fs.writeFile(jsFilePath, "export const = 6", "utf8")
+
+        const extensions = (Module as any)._extensions
+        const originalLoader = extensions[".js"]
+        extensions[".js"] = (module: any, filename: string) => {
+            if (filename === jsFilePath)
+                throw new SyntaxError("error thrown while requiring")
+
+            return originalLoader(module, filename)
+        }
+
+        try {
+            await importOrRequireFile(jsFilePath)
+            expect.fail("importOrRequireFile should have thrown")
+        } catch (error) {
+            expect(error).to.be.instanceOf(SyntaxError)
+            expect((error as SyntaxError).message).to.be.eq(
+                "error thrown while requiring",
+            )
+        } finally {
+            extensions[".js"] = originalLoader
+            await fs.rm(testDir, { recursive: true, force: true })
+        }
     })
 
     it("Should use cache to find package.json", async () => {


### PR DESCRIPTION
### Description of change

Entities, migrations and subscribers passed as file globs (`entities: ["./src/entity/*.ts"]`) fail to load under Vitest with `SyntaxError: Invalid or unexpected token`. Listing every class by hand (`entities: [User]`) is currently the only workaround, which is reported as still broken in 0.3.25 through 0.3.28.

**Cause:** `importOrRequireFile` picks `require` for `.ts`/`.js` whenever the nearest `package.json` is not `"type": "module"`. Vite based runners transform TypeScript for `import()`, but they leave `require` pointing at Node's plain CommonJS loader, which cannot parse TypeScript — so the file blows up before Vitest ever gets to transform it. Under `ts-node`/`tsx` this works only because those tools patch `require` itself.

**Change:** when `require` throws a `SyntaxError`, retry the file through `import()`. Vite based runners intercept dynamic imports, so the file is transformed and loads normally.

Two deliberate details:

- Only `SyntaxError` triggers the retry. A module that requires fine, or that fails for any other reason (a missing dependency, a throwing side effect), behaves exactly as before — this cannot mask a runtime failure as a load failure.
- If the retry also fails, the **original** `require` error is rethrown, not the one from `import()`. Otherwise a genuine syntax error in a user's entity file would surface on plain Node as `ERR_UNKNOWN_FILE_EXTENSION ".ts"`, which says nothing about the actual mistake.

`moduleType` is reported as `"esm"` when the retry succeeds, which is what `ConnectionOptionsReader` needs in order to unwrap `default` off the module namespace.

**Verification.** Reproduced the runner's exact conditions — CommonJS loader unable to parse the file, `import()` able to — and ran the current and patched `importOrRequireFile` against it:

```
=== BEFORE ===
require()             -> SyntaxError: Invalid or unexpected token
importOrRequireFile() -> FAILED: SyntaxError: Invalid or unexpected token

=== AFTER ===
require()             -> SyntaxError: Invalid or unexpected token
importOrRequireFile() -> OK  moduleType=esm  exports=["default","value"]
```

Two tests were added to `test/unit/util/import-utils.test.ts`. The first stubs the CommonJS loader for one fixture file to throw the way Vitest does and asserts the module still loads as ESM — it fails on `master` and passes with this change. The second asserts the original require error survives when the retry cannot help; it guards the error-quality behaviour above rather than reproducing the bug, so it passes either way by design.

Full suite: 3046 passing, 0 failing on the default `sqljs` config. No documented behaviour changes, so no docs update.

Closes #11570

### Pull-Request Checklist

- [x] Code is up-to-date with the `master` branch
- [x] This pull request links a relevant issue using a closing keyword:
      `Fixes #NNNN`, `Closes #NNNN`, or `Resolves #NNNN`
- [x] There are new or updated tests validating the change (`tests/**.test.ts`)
- [ ] Documentation has been updated to reflect this change (`docs/docs/**.md`) — N/A, bug fix with no API or behaviour change to document
