### PR TITLE
fix(cache): release query runners created by clear and getFromCache

### DIFF
--- a/src/cache/DbQueryResultCache.ts
+++ b/src/cache/DbQueryResultCache.ts
@@ -142,57 +142,68 @@ export class DbQueryResultCache implements QueryResultCache {
      * @param options
      * @param queryRunner
      */
-    getFromCache(
+    async getFromCache(
         options: QueryResultCacheOptions,
         queryRunner?: QueryRunner,
     ): Promise<QueryResultCacheOptions | undefined> {
-        queryRunner = this.getQueryRunner(queryRunner)
-        const qb = this.dataSource
-            .createQueryBuilder(queryRunner)
-            .select()
-            .from(this.queryResultCacheTable, "cache")
+        const _queryRunner: QueryRunner = queryRunner ?? this.getQueryRunner()
+        try {
+            const qb = this.dataSource
+                .createQueryBuilder(_queryRunner)
+                .select()
+                .from(this.queryResultCacheTable, "cache")
 
-        if (options.identifier) {
-            return qb
-                .where(
-                    `${qb.escape("cache")}.${qb.escape(
-                        "identifier",
-                    )} = :identifier`,
-                )
-                .setParameters({
-                    identifier:
-                        this.dataSource.driver.options.type === "mssql"
-                            ? new MssqlParameter(options.identifier, "nvarchar")
-                            : options.identifier,
-                })
-                .cache(false) // disable cache to avoid infinite loops when cache is alwaysEnable
-                .getRawOne()
-        } else if (options.query) {
-            if (this.dataSource.driver.options.type === "oracle") {
-                return qb
+            if (options.identifier) {
+                return await qb
                     .where(
-                        `dbms_lob.compare(${qb.escape("cache")}.${qb.escape(
-                            "query",
-                        )}, :query) = 0`,
-                        { query: options.query },
+                        `${qb.escape("cache")}.${qb.escape(
+                            "identifier",
+                        )} = :identifier`,
                     )
+                    .setParameters({
+                        identifier:
+                            this.dataSource.driver.options.type === "mssql"
+                                ? new MssqlParameter(
+                                      options.identifier,
+                                      "nvarchar",
+                                  )
+                                : options.identifier,
+                    })
+                    .cache(false) // disable cache to avoid infinite loops when cache is alwaysEnable
+                    .getRawOne()
+            } else if (options.query) {
+                if (this.dataSource.driver.options.type === "oracle") {
+                    return await qb
+                        .where(
+                            `dbms_lob.compare(${qb.escape("cache")}.${qb.escape(
+                                "query",
+                            )}, :query) = 0`,
+                            { query: options.query },
+                        )
+                        .cache(false) // disable cache to avoid infinite loops when cache is alwaysEnable
+                        .getRawOne()
+                }
+
+                return await qb
+                    .where(
+                        `${qb.escape("cache")}.${qb.escape("query")} = :query`,
+                    )
+                    .setParameters({
+                        query:
+                            this.dataSource.driver.options.type === "mssql"
+                                ? new MssqlParameter(options.query, "nvarchar")
+                                : options.query,
+                    })
                     .cache(false) // disable cache to avoid infinite loops when cache is alwaysEnable
                     .getRawOne()
             }
 
-            return qb
-                .where(`${qb.escape("cache")}.${qb.escape("query")} = :query`)
-                .setParameters({
-                    query:
-                        this.dataSource.driver.options.type === "mssql"
-                            ? new MssqlParameter(options.query, "nvarchar")
-                            : options.query,
-                })
-                .cache(false) // disable cache to avoid infinite loops when cache is alwaysEnable
-                .getRawOne()
+            return undefined
+        } finally {
+            if (!queryRunner) {
+                await _queryRunner.release()
+            }
         }
-
-        return Promise.resolve(undefined)
     }
 
     /**
@@ -305,10 +316,15 @@ export class DbQueryResultCache implements QueryResultCache {
      *
      * @param queryRunner
      */
-    async clear(queryRunner: QueryRunner): Promise<void> {
-        return this.getQueryRunner(queryRunner).clearTable(
-            this.queryResultCacheTable,
-        )
+    async clear(queryRunner?: QueryRunner): Promise<void> {
+        const _queryRunner: QueryRunner = queryRunner ?? this.getQueryRunner()
+        try {
+            return await _queryRunner.clearTable(this.queryResultCacheTable)
+        } finally {
+            if (!queryRunner) {
+                await _queryRunner.release()
+            }
+        }
     }
 
     /**

--- a/test/functional/cache/query-runner-release.test.ts
+++ b/test/functional/cache/query-runner-release.test.ts
@@ -1,0 +1,130 @@
+import { expect } from "chai"
+import "reflect-metadata"
+import type { DataSource } from "../../../src/data-source/DataSource"
+import type { QueryRunner } from "../../../src/query-runner/QueryRunner"
+import {
+    closeTestingConnections,
+    createTestingConnections,
+    reloadTestingDatabases,
+} from "../../utils/test-utils"
+
+describe("cache > query runner release", () => {
+    let dataSources: DataSource[]
+    before(async () => {
+        dataSources = await createTestingConnections({
+            entities: [__dirname + "/entity/*{.js,.ts}"],
+            cache: true,
+        })
+    })
+    beforeEach(() => reloadTestingDatabases(dataSources))
+    after(() => closeTestingConnections(dataSources))
+
+    // Counts query runners that the call creates on its own (no runner passed in)
+    // and makes sure each one gets released. `prepare` runs on each created
+    // runner, so a test can also make the underlying operation fail.
+    //
+    // The stub is installed on the shared DataSource, so it has to come back off
+    // again: every test in this file runs against the same connections, and a
+    // stub left in place would have the next test counting through this one's
+    // wrapper as well.
+    function trackCreatedRunners(
+        dataSource: DataSource,
+        prepare?: (queryRunner: QueryRunner) => void,
+    ): { unreleased: () => number; restore: () => void } {
+        let unreleased = 0
+        const originalCreate = dataSource.createQueryRunner.bind(dataSource)
+        dataSource.createQueryRunner = (...args: any[]): QueryRunner => {
+            const queryRunner: QueryRunner = (originalCreate as any)(...args)
+            unreleased++
+            const originalRelease = queryRunner.release.bind(queryRunner)
+            queryRunner.release = () => {
+                unreleased--
+                return originalRelease()
+            }
+            prepare?.(queryRunner)
+            return queryRunner
+        }
+        return {
+            unreleased: () => unreleased,
+            // `createQueryRunner` is a prototype method, so deleting the own
+            // property the stub added puts the real one back rather than
+            // leaving a bound copy of it behind.
+            restore: () => {
+                delete (dataSource as any).createQueryRunner
+            },
+        }
+    }
+
+    it("should release the query runner it creates in clear()", () =>
+        Promise.all(
+            dataSources.map(async (dataSource) => {
+                const tracker = trackCreatedRunners(dataSource)
+                try {
+                    await dataSource.queryResultCache!.clear()
+
+                    expect(tracker.unreleased()).to.be.equal(0)
+                } finally {
+                    tracker.restore()
+                }
+            }),
+        ))
+
+    it("should release the query runner it creates in getFromCache()", () =>
+        Promise.all(
+            dataSources.map(async (dataSource) => {
+                const tracker = trackCreatedRunners(dataSource)
+                try {
+                    await dataSource.queryResultCache!.getFromCache({
+                        query: "some-query",
+                        duration: 1000,
+                    })
+
+                    expect(tracker.unreleased()).to.be.equal(0)
+                } finally {
+                    tracker.restore()
+                }
+            }),
+        ))
+
+    // Ownership: a runner passed in by the caller must NOT be released here.
+    // Guards against a mutant that releases unconditionally.
+    it("should not release a query runner passed in to clear()", () =>
+        Promise.all(
+            dataSources.map(async (dataSource) => {
+                const queryRunner = dataSource.createQueryRunner()
+                let released = 0
+                const originalRelease = queryRunner.release.bind(queryRunner)
+                queryRunner.release = () => {
+                    released++
+                    return originalRelease()
+                }
+
+                await dataSource.queryResultCache!.clear(queryRunner)
+
+                expect(released).to.be.equal(0)
+                await queryRunner.release()
+            }),
+        ))
+
+    // Failure path: the self-created runner must be released even when the
+    // underlying operation throws. Guards against a mutant that releases only
+    // on the success path (try-end instead of finally).
+    it("should release the self-created runner in clear() even when clearTable throws", () =>
+        Promise.all(
+            dataSources.map(async (dataSource) => {
+                const tracker = trackCreatedRunners(dataSource, (queryRunner) => {
+                    queryRunner.clearTable = () =>
+                        Promise.reject(new Error("boom"))
+                })
+                try {
+                    await expect(
+                        dataSource.queryResultCache!.clear(),
+                    ).to.be.rejectedWith("boom")
+
+                    expect(tracker.unreleased()).to.be.equal(0)
+                } finally {
+                    tracker.restore()
+                }
+            }),
+        ))
+})

--- a/test/functional/cache/query-runner-release.test.ts
+++ b/test/functional/cache/query-runner-release.test.ts
@@ -13,6 +13,9 @@ describe("cache > query runner release", () => {
     let dataSources: DataSource[]
     before(async () => {
         dataSources = await createTestingConnections({
+            // Spanner does not support the built-in cache table name, so the
+            // cache test suites (see custom-cache-provider) opt it out.
+            disabledDrivers: ["spanner"],
             entities: [__dirname + "/entity/*{.js,.ts}"],
             cache: true,
         })

--- a/test/functional/cache/query-runner-release.test.ts
+++ b/test/functional/cache/query-runner-release.test.ts
@@ -2,6 +2,7 @@ import { expect } from "chai"
 import "reflect-metadata"
 import type { DataSource } from "../../../src/data-source/DataSource"
 import type { QueryRunner } from "../../../src/query-runner/QueryRunner"
+import type { ReplicationMode } from "../../../src/driver/types/ReplicationMode"
 import {
     closeTestingConnections,
     createTestingConnections,
@@ -33,8 +34,10 @@ describe("cache > query runner release", () => {
     ): { unreleased: () => number; restore: () => void } {
         let unreleased = 0
         const originalCreate = dataSource.createQueryRunner.bind(dataSource)
-        dataSource.createQueryRunner = (...args: any[]): QueryRunner => {
-            const queryRunner: QueryRunner = (originalCreate as any)(...args)
+        dataSource.createQueryRunner = (
+            mode?: ReplicationMode,
+        ): QueryRunner => {
+            const queryRunner = originalCreate(mode)
             unreleased++
             const originalRelease = queryRunner.release.bind(queryRunner)
             queryRunner.release = () => {
@@ -50,7 +53,7 @@ describe("cache > query runner release", () => {
             // property the stub added puts the real one back rather than
             // leaving a bound copy of it behind.
             restore: () => {
-                delete (dataSource as any).createQueryRunner
+                Reflect.deleteProperty(dataSource, "createQueryRunner")
             },
         }
     }
@@ -112,10 +115,13 @@ describe("cache > query runner release", () => {
     it("should release the self-created runner in clear() even when clearTable throws", () =>
         Promise.all(
             dataSources.map(async (dataSource) => {
-                const tracker = trackCreatedRunners(dataSource, (queryRunner) => {
-                    queryRunner.clearTable = () =>
-                        Promise.reject(new Error("boom"))
-                })
+                const tracker = trackCreatedRunners(
+                    dataSource,
+                    (queryRunner) => {
+                        queryRunner.clearTable = () =>
+                            Promise.reject(new Error("boom"))
+                    },
+                )
                 try {
                     await expect(
                         dataSource.queryResultCache!.clear(),


### PR DESCRIPTION
### Description of change

DbQueryResultCache.clear and getFromCache build a query runner through getQueryRunner when the caller passes none, and never release it. The interface types the argument as optional and CacheClearCommand calls clear with no argument, so calling dataSource.queryResultCache.clear from application code (an admin endpoint, a scheduled job, a test teardown) leaks one pooled connection per call. After poolSize calls the pool is exhausted and every later query waits forever.

The fix releases the self-created runner in a finally block, the same way remove and storeInCache already do, and keeps the original return value. A runner passed in by the caller is left untouched. getFromCache has the same shape and is covered by the same change.

Verified with poolSize 2 on Postgres 16: without the fix the third argument-less clear times out once the pool is drained; with the fix the three clears complete and a following query still runs. Added a test that spies on createQueryRunner and asserts the self-created runner is released by clear and getFromCache, that a runner passed in by the caller is not released, and that the self-created runner is still released when the underlying operation throws.

### Pull-Request Checklist

- [x] Code is up-to-date with the `master` branch
- [ ] This pull request links a relevant issue using a closing keyword: N/A (found while reading the cache code, no existing issue)
- [x] There are new or updated tests validating the change (`test/functional/cache/query-runner-release.test.ts`)
- [ ] Documentation has been updated to reflect this change: N/A (internal behavior, no API surface change)
