### PR TITLE
feat(query-builder): add streamEntities() to stream hydrated entities

### DIFF
--- a/docs/docs/query-builder/1-select-query-builder.md
+++ b/docs/docs/query-builder/1-select-query-builder.md
@@ -909,7 +909,13 @@ needs a pass over the complete result set that streaming never has:
   decorator
 - `skip`/`take` combined with a join, where the limit would apply to joined
   rows rather than to entities
-- optimistic and pessimistic locks
+- optimistic locks, and `afterLoad` listeners or subscribers, which would be
+  broadcast while the stream is paused — call `.callListeners(false)` to
+  stream without them
+
+A pessimistic lock is allowed, but only inside a transaction: either one that
+is already active on the query runner, or one this stream starts itself with
+`.useTransaction(true)`.
 
 ## Using pagination
 

--- a/docs/docs/query-builder/1-select-query-builder.md
+++ b/docs/docs/query-builder/1-select-query-builder.md
@@ -867,6 +867,50 @@ const stream = await dataSource
     .stream()
 ```
 
+### Streaming entities
+
+If you want hydrated entities rather than raw rows, use `streamEntities`.
+It groups the streamed rows into entities the same way `getMany` does,
+without holding the whole result set in memory:
+
+```typescript
+const posts = dataSource
+    .getRepository(Post)
+    .createQueryBuilder("post")
+    .leftJoinAndSelect("post.comments", "comment")
+    .orderBy("post.id", "ASC")
+    .streamEntities()
+
+for await (const post of posts) {
+    console.log(post.comments.length)
+}
+```
+
+A root entity is only complete once all of its joined rows have arrived, so
+the query has to be ordered by the root primary key. That ordering is not
+applied for you — an unordered query throws, rather than silently returning
+an entity whose collection is split in half.
+
+Rows are buffered until a chunk can be closed on an entity boundary. Pass
+`chunkSize` to change how many rows are accumulated first; it is a minimum,
+since a chunk always closes at the next boundary at or after it:
+
+```typescript
+.streamEntities({ chunkSize: 500 })
+```
+
+Two differences from `getMany` are worth knowing. `afterLoad` subscribers
+are broadcast once per chunk rather than once for the whole result, and some
+query shapes are rejected instead of being silently mishandled, because each
+needs a pass over the complete result set that streaming never has:
+
+- the `"query"` relation load strategy
+- relation id loading, from either `loadRelationIdAndMap` or a `@RelationId`
+  decorator
+- `skip`/`take` combined with a join, where the limit would apply to joined
+  rows rather than to entities
+- optimistic and pessimistic locks
+
 ## Using pagination
 
 Most of the time when you develop an application, you need pagination functionality.

--- a/src/query-builder/SelectQueryBuilder.ts
+++ b/src/query-builder/SelectQueryBuilder.ts
@@ -2108,7 +2108,7 @@ export class SelectQueryBuilder<Entity extends ObjectLiteral>
                     return queryRunner.release()
                 return
             }
-            const rawStream = queryRunner.stream(
+            const rawStream = await queryRunner.stream(
                 sql,
                 parameters,
                 releaseFn,

--- a/src/query-builder/SelectQueryBuilder.ts
+++ b/src/query-builder/SelectQueryBuilder.ts
@@ -2017,6 +2017,160 @@ export class SelectQueryBuilder<Entity extends ObjectLiteral>
     }
 
     /**
+     * Streams entities, hydrated the same way `getMany()` hydrates them, instead
+     * of the raw alias-prefixed driver rows returned by `stream()`.
+     *
+     * Rows are buffered until a chunk can be closed on a root-entity boundary,
+     * then transformed and yielded. Because a root entity is only complete once
+     * every one of its joined rows has arrived, the query must be ordered by the
+     * root primary key; otherwise rows for one entity can be interleaved with
+     * another's and the grouping would be wrong. That ordering is not applied
+     * implicitly — it has to be requested, so the query plan stays the caller's.
+     *
+     * Note that "afterLoad" subscribers are broadcast per chunk rather than once
+     * for the whole result set, which is an intentional difference from
+     * `getMany()`.
+     *
+     * @param options
+     * @param options.chunkSize minimum number of rows to accumulate before a
+     * chunk is closed at the next root-entity boundary. Defaults to 1000.
+     */
+    streamEntities(options?: {
+        chunkSize?: number
+    }): AsyncIterableIterator<Entity> {
+        if (!this.expressionMap.mainAlias)
+            throw new TypeORMError(
+                `Alias is not set. Use "from" method to set an alias.`,
+            )
+
+        const mainAlias = this.expressionMap.mainAlias
+        if (!mainAlias.hasMetadata)
+            throw new TypeORMError(
+                `"streamEntities" can only be used when selecting from an entity. Use "stream" for raw results.`,
+            )
+
+        const metadata = mainAlias.metadata
+        if (metadata.primaryColumns.length === 0)
+            throw new TypeORMError(
+                `"streamEntities" requires ${metadata.name} to have a primary column, because rows are grouped into entities by primary key.`,
+            )
+
+        const primaryKeyAliases = metadata.primaryColumns.map((column) =>
+            DriverUtils.buildAlias(
+                this.dataSource.driver,
+                undefined,
+                mainAlias.name,
+                column.databaseName,
+            ),
+        )
+
+        this.assertOrderedByPrimaryKey(metadata, mainAlias.name)
+
+        const chunkSize = options?.chunkSize ?? 1000
+        if (chunkSize < 1)
+            throw new TypeORMError(`"chunkSize" must be a positive number.`)
+
+        return this.streamEntitiesInternal(primaryKeyAliases, chunkSize)
+    }
+
+    /**
+     * Does the actual streaming and chunked hydration.
+     *
+     * Kept separate from `streamEntities` so that misuse throws when the method
+     * is called rather than on first iteration — the body of an async generator
+     * does not run until something pulls from it, which would otherwise defer
+     * every validation error above.
+     *
+     * @param primaryKeyAliases column aliases of the root primary key
+     * @param chunkSize minimum rows to buffer before closing a chunk
+     */
+    protected async *streamEntitiesInternal(
+        primaryKeyAliases: string[],
+        chunkSize: number,
+    ): AsyncIterableIterator<Entity> {
+        this.expressionMap.queryEntity = true
+        const [sql, parameters] = this.getQueryAndParameters()
+        const queryRunner = this.obtainQueryRunner()
+        let transactionStartedByUs: boolean = false
+
+        try {
+            if (
+                this.expressionMap.useTransaction === true &&
+                queryRunner.isTransactionActive === false
+            ) {
+                await queryRunner.startTransaction()
+                transactionStartedByUs = true
+            }
+
+            const releaseFn = () => {
+                if (queryRunner !== this.queryRunner)
+                    // means we created our own query runner
+                    return queryRunner.release()
+                return
+            }
+            const rawStream = queryRunner.stream(
+                sql,
+                parameters,
+                releaseFn,
+                releaseFn,
+            )
+
+            const relationIdLoader = new RelationIdLoader(
+                this.dataSource,
+                queryRunner,
+                this.expressionMap.relationIdAttributes,
+                this.expressionMap.withDeleted,
+            )
+
+            let buffer: any[] = []
+            let bufferedRootId: string | undefined
+
+            for await (const rawResult of rawStream as AsyncIterable<any>) {
+                const rootId = primaryKeyAliases
+                    .map((alias) => String(rawResult[alias]))
+                    .join("|")
+
+                // only close a chunk on a root boundary, so every group inside
+                // it is complete
+                if (
+                    buffer.length >= chunkSize &&
+                    bufferedRootId !== undefined &&
+                    rootId !== bufferedRootId
+                ) {
+                    yield* await this.hydrateStreamedChunk(
+                        buffer,
+                        relationIdLoader,
+                        queryRunner,
+                    )
+                    buffer = []
+                }
+
+                bufferedRootId = rootId
+                buffer.push(rawResult)
+            }
+
+            if (buffer.length > 0) {
+                yield* await this.hydrateStreamedChunk(
+                    buffer,
+                    relationIdLoader,
+                    queryRunner,
+                )
+            }
+
+            if (transactionStartedByUs) {
+                await queryRunner.commitTransaction()
+            }
+        } catch (error) {
+            if (transactionStartedByUs) {
+                try {
+                    await queryRunner.rollbackTransaction()
+                } catch (rollbackError) {}
+            }
+            throw error
+        }
+    }
+
+    /**
      * Enables or disables query result caching.
      */
     cache(enabled: boolean): this
@@ -3840,6 +3994,87 @@ export class SelectQueryBuilder<Entity extends ObjectLiteral>
         })
 
         return [selectString, orderByObject]
+    }
+
+    /**
+     * Ensures the query is ordered by the root primary key, which chunked
+     * streaming relies on to know that every row of a root entity has arrived
+     * before the chunk containing it is closed.
+     *
+     * @param metadata metadata of the root entity
+     * @param aliasName alias of the root entity
+     */
+    protected assertOrderedByPrimaryKey(
+        metadata: EntityMetadata,
+        aliasName: string,
+    ): void {
+        const expected = new Set(
+            metadata.primaryColumns.map(
+                (column) => `${aliasName}.${column.propertyPath}`,
+            ),
+        )
+        const leading = Object.keys(this.expressionMap.allOrderBys).slice(
+            0,
+            expected.size,
+        )
+
+        const orderedByPrimaryKey =
+            leading.length === expected.size &&
+            leading.every((key) => expected.has(key))
+
+        if (!orderedByPrimaryKey) {
+            const suggestion = [...expected]
+                .map((key) => `"${key}"`)
+                .join(", then ")
+            throw new TypeORMError(
+                `"streamEntities" requires the query to be ordered by the root primary key so that rows of one entity are not interleaved with another's. ` +
+                    `Add .orderBy(${suggestion}) before streaming.`,
+            )
+        }
+    }
+
+    /**
+     * Transforms one buffered chunk of raw rows into entities.
+     *
+     * The chunk must contain every row of each root entity it covers, otherwise
+     * a to-many relation would be split across two chunks and hydrated twice,
+     * each time with only part of its collection.
+     *
+     * @param rawResults buffered raw rows, closed on a root-entity boundary
+     * @param relationIdLoader loader reused across chunks
+     * @param queryRunner query runner used to broadcast load events
+     */
+    protected async hydrateStreamedChunk(
+        rawResults: any[],
+        relationIdLoader: RelationIdLoader,
+        queryRunner: QueryRunner,
+    ): Promise<Entity[]> {
+        if (rawResults.length === 0) return []
+
+        const rawRelationIdResults = await relationIdLoader.load(rawResults)
+        const transformer = new RawSqlResultsToEntityTransformer(
+            this.expressionMap,
+            this.dataSource.driver,
+            rawRelationIdResults,
+            this.queryRunner,
+        )
+        const entities = transformer.transform(
+            rawResults,
+            this.expressionMap.mainAlias!,
+        )
+
+        if (
+            this.expressionMap.callListeners === true &&
+            this.expressionMap.mainAlias!.hasMetadata
+        ) {
+            await queryRunner.broadcaster.broadcast(
+                "Load",
+                this.expressionMap.mainAlias!.metadata,
+                entities,
+            )
+        }
+
+        return entities
     }
 
     /**

--- a/src/query-builder/SelectQueryBuilder.ts
+++ b/src/query-builder/SelectQueryBuilder.ts
@@ -2088,10 +2088,7 @@ export class SelectQueryBuilder<Entity extends ObjectLiteral>
 
         if (
             this.expressionMap.callListeners === true &&
-            (metadata.afterLoadListeners.length > 0 ||
-                this.dataSource.subscribers.some(
-                    (subscriber) => !!subscriber.afterLoad,
-                ))
+            this.hasAfterLoadHandlers(metadata)
         )
             throw new TypeORMError(
                 `"streamEntities" cannot run "afterLoad" listeners or subscribers, because they are broadcast while the stream is paused between chunks and any query they make would run on the connection that is still streaming. Call ".callListeners(false)" to stream without them.`,
@@ -4103,6 +4100,40 @@ export class SelectQueryBuilder<Entity extends ObjectLiteral>
      * @param metadata metadata of the root entity
      * @param aliasName alias of the root entity
      */
+    /**
+     * Whether loading this query would broadcast an "afterLoad" event to any
+     * listener or subscriber.
+     *
+     * Mirrors what the broadcaster actually does: the load event is broadcast
+     * for the root entity and recursively for each joined relation, and a
+     * subscriber only receives it when its "listenTo" covers that entity.
+     *
+     * @param metadata metadata of the root entity
+     * @returns true when at least one handler would run
+     */
+    protected hasAfterLoadHandlers(metadata: EntityMetadata): boolean {
+        const loaded: EntityMetadata[] = [metadata]
+        for (const join of this.expressionMap.joinAttributes) {
+            if (join.metadata && !loaded.includes(join.metadata))
+                loaded.push(join.metadata)
+        }
+
+        return loaded.some(
+            (loadedMetadata) =>
+                loadedMetadata.afterLoadListeners.length > 0 ||
+                this.dataSource.subscribers.some(
+                    (subscriber) =>
+                        !!subscriber.afterLoad &&
+                        (!subscriber.listenTo?.() ||
+                            subscriber.listenTo() === Object ||
+                            subscriber.listenTo() === loadedMetadata.target ||
+                            subscriber
+                                .listenTo()
+                                .isPrototypeOf(loadedMetadata.target)),
+                ),
+        )
+    }
+
     protected assertOrderedByPrimaryKey(
         metadata: EntityMetadata,
         aliasName: string,

--- a/src/query-builder/SelectQueryBuilder.ts
+++ b/src/query-builder/SelectQueryBuilder.ts
@@ -2027,8 +2027,10 @@ export class SelectQueryBuilder<Entity extends ObjectLiteral>
      * another's and the grouping would be wrong. That ordering is not applied
      * implicitly — it has to be requested, so the query plan stays the caller's.
      *
-     * The "query" relation load strategy is not supported: it loads relations in
-     * a second pass over the complete result set, which streaming never has.
+     * Some query shapes are rejected rather than silently mishandled, because
+     * they need a pass over the complete result set that streaming never has:
+     * the "query" relation load strategy, relation id loading, "skip"/"take"
+     * combined with joins, and locking.
      *
      * Note that "afterLoad" subscribers are broadcast per chunk rather than once
      * for the whole result set, which is an intentional difference from
@@ -2066,6 +2068,39 @@ export class SelectQueryBuilder<Entity extends ObjectLiteral>
                 `"streamEntities" does not support the "query" relation load strategy, because those relations are loaded in a second pass over the complete result set, which streaming never materialises. Use the "join" strategy, or "stream" for raw rows.`,
             )
 
+        if (this.expressionMap.lockMode === "optimistic")
+            throw new OptimisticLockCanNotBeUsedError()
+
+        if (
+            (this.expressionMap.lockMode === "pessimistic_read" ||
+                this.expressionMap.lockMode === "pessimistic_write" ||
+                this.expressionMap.lockMode === "for_no_key_update" ||
+                this.expressionMap.lockMode === "for_key_share") &&
+            !this.queryRunner?.isTransactionActive
+        )
+            throw new PessimisticLockTransactionRequiredError()
+
+        // loading relation ids issues its own query, and at an intermediate
+        // chunk boundary that query would run on the connection whose raw
+        // stream is still open — a second command on one client deadlocks on
+        // postgres and cockroach
+        if (this.expressionMap.relationIdAttributes.length > 0)
+            throw new TypeORMError(
+                `"streamEntities" does not support relation id loading, because loading them issues a second query on the connection that is still streaming. Load the relations with a join instead.`,
+            )
+
+        // entity-level pagination rewrites the query into a distinct-root
+        // subquery, which streaming skips; a row-level LIMIT would cut a
+        // to-many collection in half and yield fewer entities than asked for
+        if (
+            (this.expressionMap.skip !== undefined ||
+                this.expressionMap.take !== undefined) &&
+            this.expressionMap.joinAttributes.length > 0
+        )
+            throw new TypeORMError(
+                `"streamEntities" does not support "skip"/"take" together with joins, because the limit would apply to joined rows rather than to entities.`,
+            )
+
         const primaryKeyAliases = metadata.primaryColumns.map((column) =>
             DriverUtils.buildAlias(
                 this.dataSource.driver,
@@ -2078,8 +2113,10 @@ export class SelectQueryBuilder<Entity extends ObjectLiteral>
         this.assertOrderedByPrimaryKey(metadata, mainAlias.name)
 
         const chunkSize = options?.chunkSize ?? 1000
-        if (chunkSize < 1)
-            throw new TypeORMError(`"chunkSize" must be a positive number.`)
+        // NaN and Infinity both slip past a "< 1" test and make the boundary
+        // threshold unreachable, buffering the whole result set
+        if (!Number.isInteger(chunkSize) || chunkSize < 1)
+            throw new TypeORMError(`"chunkSize" must be a positive integer.`)
 
         return this.streamEntitiesInternal(primaryKeyAliases, chunkSize)
     }
@@ -4029,23 +4066,36 @@ export class SelectQueryBuilder<Entity extends ObjectLiteral>
         metadata: EntityMetadata,
         aliasName: string,
     ): void {
-        const expected = new Set(
-            metadata.primaryColumns.map(
-                (column) => `${aliasName}.${column.propertyPath}`,
-            ),
-        )
+        // order-by criteria resolve by property path or by database name, and
+        // a naming strategy can make those differ, so accept either form
+        const byCriteria = new Map<string, string>()
+        for (const column of metadata.primaryColumns) {
+            byCriteria.set(
+                `${aliasName}.${column.propertyPath}`,
+                column.propertyPath,
+            )
+            byCriteria.set(
+                `${aliasName}.${column.databaseName}`,
+                column.propertyPath,
+            )
+        }
+
         const leading = Object.keys(this.expressionMap.allOrderBys).slice(
             0,
-            expected.size,
+            metadata.primaryColumns.length,
+        )
+        const covered = new Set(
+            leading
+                .map((key) => byCriteria.get(key))
+                .filter((path): path is string => path !== undefined),
         )
 
         const orderedByPrimaryKey =
-            leading.length === expected.size &&
-            leading.every((key) => expected.has(key))
+            covered.size === metadata.primaryColumns.length
 
         if (!orderedByPrimaryKey) {
-            const suggestion = [...expected]
-                .map((key) => `"${key}"`)
+            const suggestion = metadata.primaryColumns
+                .map((column) => `"${aliasName}.${column.propertyPath}"`)
                 .join(", then ")
             throw new TypeORMError(
                 `"streamEntities" requires the query to be ordered by the root primary key so that rows of one entity are not interleaved with another's. ` +

--- a/src/query-builder/SelectQueryBuilder.ts
+++ b/src/query-builder/SelectQueryBuilder.ts
@@ -2027,6 +2027,9 @@ export class SelectQueryBuilder<Entity extends ObjectLiteral>
      * another's and the grouping would be wrong. That ordering is not applied
      * implicitly — it has to be requested, so the query plan stays the caller's.
      *
+     * The "query" relation load strategy is not supported: it loads relations in
+     * a second pass over the complete result set, which streaming never has.
+     *
      * Note that "afterLoad" subscribers are broadcast per chunk rather than once
      * for the whole result set, which is an intentional difference from
      * `getMany()`.
@@ -2053,6 +2056,14 @@ export class SelectQueryBuilder<Entity extends ObjectLiteral>
         if (metadata.primaryColumns.length === 0)
             throw new TypeORMError(
                 `"streamEntities" requires ${metadata.name} to have a primary column, because rows are grouped into entities by primary key.`,
+            )
+
+        const relationLoadStrategy =
+            this.findOptions.relationLoadStrategy ??
+            this.expressionMap.relationLoadStrategy
+        if (relationLoadStrategy === "query")
+            throw new TypeORMError(
+                `"streamEntities" does not support the "query" relation load strategy, because those relations are loaded in a second pass over the complete result set, which streaming never materialises. Use the "join" strategy, or "stream" for raw rows.`,
             )
 
         const primaryKeyAliases = metadata.primaryColumns.map((column) =>

--- a/src/query-builder/SelectQueryBuilder.ts
+++ b/src/query-builder/SelectQueryBuilder.ts
@@ -2102,7 +2102,9 @@ export class SelectQueryBuilder<Entity extends ObjectLiteral>
         this.expressionMap.queryEntity = true
         const [sql, parameters] = this.getQueryAndParameters()
         const queryRunner = this.obtainQueryRunner()
+        const releaseQueryRunner = queryRunner !== this.queryRunner
         let transactionStartedByUs: boolean = false
+        let rawStream: ReadStream | undefined
 
         try {
             if (
@@ -2113,18 +2115,12 @@ export class SelectQueryBuilder<Entity extends ObjectLiteral>
                 transactionStartedByUs = true
             }
 
-            const releaseFn = () => {
-                if (queryRunner !== this.queryRunner)
-                    // means we created our own query runner
-                    return queryRunner.release()
-                return
-            }
-            const rawStream = await queryRunner.stream(
-                sql,
-                parameters,
-                releaseFn,
-                releaseFn,
-            )
+            // deliberately no onEnd/onError release callbacks: the last chunk
+            // is hydrated after the stream has already ended, and that
+            // hydration still needs the query runner. Cleanup happens in
+            // "finally" instead, which also covers a consumer that stops
+            // iterating early.
+            rawStream = await queryRunner.stream(sql, parameters)
 
             const relationIdLoader = new RelationIdLoader(
                 this.dataSource,
@@ -2136,10 +2132,13 @@ export class SelectQueryBuilder<Entity extends ObjectLiteral>
             let buffer: any[] = []
             let bufferedRootId: string | undefined
 
-            for await (const rawResult of rawStream as AsyncIterable<any>) {
-                const rootId = primaryKeyAliases
-                    .map((alias) => String(rawResult[alias]))
-                    .join("|")
+            for await (const rawResult of rawStream) {
+                // serialised rather than joined on a separator, so that a key
+                // value containing the separator cannot collide with the next
+                // entity and merge two roots into one chunk boundary
+                const rootId = JSON.stringify(
+                    primaryKeyAliases.map((alias) => rawResult[alias]),
+                )
 
                 // only close a chunk on a root boundary, so every group inside
                 // it is complete
@@ -2178,6 +2177,17 @@ export class SelectQueryBuilder<Entity extends ObjectLiteral>
                 } catch (rollbackError) {}
             }
             throw error
+        } finally {
+            // a consumer that breaks out of the iteration closes this generator
+            // without the stream having ended, so the driver stream stays open
+            // and a transaction we started stays unresolved
+            rawStream?.destroy()
+            if (transactionStartedByUs && queryRunner.isTransactionActive) {
+                try {
+                    await queryRunner.rollbackTransaction()
+                } catch (rollbackError) {}
+            }
+            if (releaseQueryRunner) await queryRunner.release()
         }
     }
 

--- a/src/query-builder/SelectQueryBuilder.ts
+++ b/src/query-builder/SelectQueryBuilder.ts
@@ -2043,6 +2043,24 @@ export class SelectQueryBuilder<Entity extends ObjectLiteral>
     streamEntities(options?: {
         chunkSize?: number
     }): AsyncIterableIterator<Entity> {
+        // validated here so that misuse throws at the call site, and again when
+        // iteration starts, since the builder can be mutated in between
+        this.assertStreamable(options)
+        return this.streamEntitiesInternal(options)
+    }
+
+    /**
+     * Validates that this query can be streamed as entities, and resolves the
+     * values streaming needs.
+     *
+     * @param options same options object passed to `streamEntities`
+     * @param options.chunkSize
+     * @returns the root primary key aliases and the resolved chunk size
+     */
+    protected assertStreamable(options?: { chunkSize?: number }): {
+        primaryKeyAliases: string[]
+        chunkSize: number
+    } {
         if (!this.expressionMap.mainAlias)
             throw new TypeORMError(
                 `Alias is not set. Use "from" method to set an alias.`,
@@ -2076,7 +2094,8 @@ export class SelectQueryBuilder<Entity extends ObjectLiteral>
                 this.expressionMap.lockMode === "pessimistic_write" ||
                 this.expressionMap.lockMode === "for_no_key_update" ||
                 this.expressionMap.lockMode === "for_key_share") &&
-            !this.queryRunner?.isTransactionActive
+            !this.queryRunner?.isTransactionActive &&
+            this.expressionMap.useTransaction !== true
         )
             throw new PessimisticLockTransactionRequiredError()
 
@@ -2084,9 +2103,12 @@ export class SelectQueryBuilder<Entity extends ObjectLiteral>
         // chunk boundary that query would run on the connection whose raw
         // stream is still open — a second command on one client deadlocks on
         // postgres and cockroach
-        if (this.expressionMap.relationIdAttributes.length > 0)
+        if (
+            this.expressionMap.relationIdAttributes.length > 0 ||
+            metadata.relationIds.length > 0
+        )
             throw new TypeORMError(
-                `"streamEntities" does not support relation id loading, because loading them issues a second query on the connection that is still streaming. Load the relations with a join instead.`,
+                `"streamEntities" does not support relation id loading, whether from a @RelationId decorator or loadRelationIdAndMap, because loading those ids issues a second query on the connection that is still streaming. Load the relation with a join instead.`,
             )
 
         // entity-level pagination rewrites the query into a distinct-root
@@ -2118,7 +2140,7 @@ export class SelectQueryBuilder<Entity extends ObjectLiteral>
         if (!Number.isInteger(chunkSize) || chunkSize < 1)
             throw new TypeORMError(`"chunkSize" must be a positive integer.`)
 
-        return this.streamEntitiesInternal(primaryKeyAliases, chunkSize)
+        return { primaryKeyAliases, chunkSize }
     }
 
     /**
@@ -2129,13 +2151,16 @@ export class SelectQueryBuilder<Entity extends ObjectLiteral>
      * does not run until something pulls from it, which would otherwise defer
      * every validation error above.
      *
-     * @param primaryKeyAliases column aliases of the root primary key
-     * @param chunkSize minimum rows to buffer before closing a chunk
+     * @param options same options object passed to `streamEntities`
+     * @param options.chunkSize
      */
-    protected async *streamEntitiesInternal(
-        primaryKeyAliases: string[],
-        chunkSize: number,
-    ): AsyncIterableIterator<Entity> {
+    protected async *streamEntitiesInternal(options?: {
+        chunkSize?: number
+    }): AsyncIterableIterator<Entity> {
+        // re-validated here because the builder may have been mutated between
+        // the call to "streamEntities" and the first pull from this generator
+        const { primaryKeyAliases, chunkSize } = this.assertStreamable(options)
+
         this.expressionMap.queryEntity = true
         const [sql, parameters] = this.getQueryAndParameters()
         const queryRunner = this.obtainQueryRunner()
@@ -2173,9 +2198,14 @@ export class SelectQueryBuilder<Entity extends ObjectLiteral>
                 // serialised rather than joined on a separator, so that a key
                 // value containing the separator cannot collide with the next
                 // entity and merge two roots into one chunk boundary
-                const rootId = JSON.stringify(
-                    primaryKeyAliases.map((alias) => rawResult[alias]),
+                const keyValues = primaryKeyAliases.map(
+                    (alias) => rawResult[alias],
                 )
+                if (keyValues.some((value) => value === undefined))
+                    throw new TypeORMError(
+                        `"streamEntities" could not find the root primary key in a streamed row, so entity boundaries cannot be detected. Select the primary key under its default alias.`,
+                    )
+                const rootId = JSON.stringify(keyValues)
 
                 // only close a chunk on a root boundary, so every group inside
                 // it is complete

--- a/src/query-builder/SelectQueryBuilder.ts
+++ b/src/query-builder/SelectQueryBuilder.ts
@@ -2086,6 +2086,17 @@ export class SelectQueryBuilder<Entity extends ObjectLiteral>
                 `"streamEntities" does not support the "query" relation load strategy, because those relations are loaded in a second pass over the complete result set, which streaming never materialises. Use the "join" strategy, or "stream" for raw rows.`,
             )
 
+        if (
+            this.expressionMap.callListeners === true &&
+            (metadata.afterLoadListeners.length > 0 ||
+                this.dataSource.subscribers.some(
+                    (subscriber) => !!subscriber.afterLoad,
+                ))
+        )
+            throw new TypeORMError(
+                `"streamEntities" cannot run "afterLoad" listeners or subscribers, because they are broadcast while the stream is paused between chunks and any query they make would run on the connection that is still streaming. Call ".callListeners(false)" to stream without them.`,
+            )
+
         if (this.expressionMap.lockMode === "optimistic")
             throw new OptimisticLockCanNotBeUsedError()
 

--- a/test/functional/query-builder/stream-entities/entity/Audited.ts
+++ b/test/functional/query-builder/stream-entities/entity/Audited.ts
@@ -1,0 +1,24 @@
+import { Entity } from "../../../../../src/decorator/entity/Entity"
+import { PrimaryGeneratedColumn } from "../../../../../src/decorator/columns/PrimaryGeneratedColumn"
+import { Column } from "../../../../../src/decorator/columns/Column"
+import { AfterLoad } from "../../../../../src/decorator/listeners/AfterLoad"
+
+/**
+ * Carries an @AfterLoad listener, which streamEntities() rejects unless
+ * listeners are disabled: the broadcast happens while the stream is paused.
+ */
+@Entity()
+export class Audited {
+    @PrimaryGeneratedColumn()
+    id: number
+
+    @Column()
+    name: string
+
+    loadedAt: number
+
+    @AfterLoad()
+    stampLoadedAt() {
+        this.loadedAt = 1
+    }
+}

--- a/test/functional/query-builder/stream-entities/entity/Bookmark.ts
+++ b/test/functional/query-builder/stream-entities/entity/Bookmark.ts
@@ -1,0 +1,21 @@
+import { Entity } from "../../../../../src/decorator/entity/Entity"
+import { PrimaryGeneratedColumn } from "../../../../../src/decorator/columns/PrimaryGeneratedColumn"
+import { ManyToOne } from "../../../../../src/decorator/relations/ManyToOne"
+import { RelationId } from "../../../../../src/decorator/relations/RelationId"
+import { Post } from "./Post"
+
+/**
+ * Carries a @RelationId decorator, which streamEntities() rejects: those ids
+ * are loaded by a second query that streaming cannot issue.
+ */
+@Entity()
+export class Bookmark {
+    @PrimaryGeneratedColumn()
+    id: number
+
+    @ManyToOne(() => Post)
+    post: Post
+
+    @RelationId((bookmark: Bookmark) => bookmark.post)
+    postId: number
+}

--- a/test/functional/query-builder/stream-entities/entity/Comment.ts
+++ b/test/functional/query-builder/stream-entities/entity/Comment.ts
@@ -1,0 +1,17 @@
+import { Entity } from "../../../../../src/decorator/entity/Entity"
+import { PrimaryGeneratedColumn } from "../../../../../src/decorator/columns/PrimaryGeneratedColumn"
+import { Column } from "../../../../../src/decorator/columns/Column"
+import { ManyToOne } from "../../../../../src/decorator/relations/ManyToOne"
+import { Post } from "./Post"
+
+@Entity()
+export class Comment {
+    @PrimaryGeneratedColumn()
+    id: number
+
+    @Column()
+    text: string
+
+    @ManyToOne(() => Post, (post) => post.comments)
+    post: Post
+}

--- a/test/functional/query-builder/stream-entities/entity/Note.ts
+++ b/test/functional/query-builder/stream-entities/entity/Note.ts
@@ -1,0 +1,17 @@
+import { Entity } from "../../../../../src/decorator/entity/Entity"
+import { PrimaryGeneratedColumn } from "../../../../../src/decorator/columns/PrimaryGeneratedColumn"
+import { ManyToOne } from "../../../../../src/decorator/relations/ManyToOne"
+import { Audited } from "./Audited"
+
+/**
+ * Has no listener of its own, but joins to an entity that does — the load
+ * event is broadcast for joined entities as well as the root.
+ */
+@Entity()
+export class Note {
+    @PrimaryGeneratedColumn()
+    id: number
+
+    @ManyToOne(() => Audited)
+    audited: Audited
+}

--- a/test/functional/query-builder/stream-entities/entity/Post.ts
+++ b/test/functional/query-builder/stream-entities/entity/Post.ts
@@ -1,0 +1,17 @@
+import { Entity } from "../../../../../src/decorator/entity/Entity"
+import { PrimaryGeneratedColumn } from "../../../../../src/decorator/columns/PrimaryGeneratedColumn"
+import { Column } from "../../../../../src/decorator/columns/Column"
+import { OneToMany } from "../../../../../src/decorator/relations/OneToMany"
+import { Comment } from "./Comment"
+
+@Entity()
+export class Post {
+    @PrimaryGeneratedColumn()
+    id: number
+
+    @Column()
+    title: string
+
+    @OneToMany(() => Comment, (comment) => comment.post)
+    comments: Comment[]
+}

--- a/test/functional/query-builder/stream-entities/stream-entities.test.ts
+++ b/test/functional/query-builder/stream-entities/stream-entities.test.ts
@@ -7,12 +7,14 @@ import type { DataSource } from "../../../../src/data-source/DataSource"
 import { expect } from "chai"
 import { Post } from "./entity/Post"
 import { Comment } from "./entity/Comment"
+import { Bookmark } from "./entity/Bookmark"
 
+// see https://github.com/typeorm/typeorm/issues/12714
 describe("query builder > stream entities", () => {
     let dataSources: DataSource[]
     before(async () => {
         dataSources = await createTestingConnections({
-            entities: [Post, Comment],
+            entities: [Post, Comment, Bookmark],
             schemaCreate: true,
             dropSchema: true,
         })
@@ -174,6 +176,57 @@ describe("query builder > stream entities", () => {
             }),
         ))
 
+    it("throws when the entity carries a @RelationId decorator", () =>
+        Promise.all(
+            dataSources.map(async (dataSource) => {
+                const qb = dataSource
+                    .createQueryBuilder(Bookmark, "bookmark")
+                    .orderBy("bookmark.id", "ASC")
+
+                expect(() => qb.streamEntities()).to.throw(
+                    /does not support relation id loading/,
+                )
+            }),
+        ))
+
+    it("allows a pessimistic lock when the stream starts its own transaction", () =>
+        Promise.all(
+            dataSources.map(async (dataSource) => {
+                const qb = dataSource
+                    .createQueryBuilder(Post, "post")
+                    .orderBy("post.id", "ASC")
+                    .useTransaction(true)
+                    .setLock("pessimistic_write")
+
+                expect(() => qb.streamEntities()).to.not.throw()
+            }),
+        ))
+
+    it("revalidates when the builder is mutated after the call", () =>
+        Promise.all(
+            dataSources.map(async (dataSource) => {
+                const qb = dataSource
+                    .createQueryBuilder(Post, "post")
+                    .orderBy("post.id", "ASC")
+
+                // valid at the call, invalid by the time iteration starts
+                const iterator = qb.streamEntities()
+                qb.orderBy("post.title", "ASC")
+
+                let caught: unknown
+                try {
+                    for await (const _ of iterator) break
+                } catch (error) {
+                    caught = error
+                }
+
+                expect(caught)
+                    .to.be.instanceOf(Error)
+                    .and.have.property("message")
+                    .that.matches(/ordered by the root primary key/)
+            }),
+        ))
+
     it("throws when selecting something without entity metadata", () =>
         Promise.all(
             dataSources.map(async (dataSource) => {
@@ -231,7 +284,7 @@ describe("query builder > stream entities > hydration", () => {
     let dataSources: DataSource[]
     before(async () => {
         dataSources = await createTestingConnections({
-            entities: [Post, Comment],
+            entities: [Post, Comment, Bookmark],
             enabledDrivers: ["postgres", "mysql", "mariadb"],
             schemaCreate: true,
             dropSchema: true,

--- a/test/functional/query-builder/stream-entities/stream-entities.test.ts
+++ b/test/functional/query-builder/stream-entities/stream-entities.test.ts
@@ -9,13 +9,14 @@ import { Post } from "./entity/Post"
 import { Comment } from "./entity/Comment"
 import { Bookmark } from "./entity/Bookmark"
 import { Audited } from "./entity/Audited"
+import { Note } from "./entity/Note"
 
 // see https://github.com/typeorm/typeorm/issues/12714
 describe("query builder > stream entities", () => {
     let dataSources: DataSource[]
     before(async () => {
         dataSources = await createTestingConnections({
-            entities: [Post, Comment, Bookmark, Audited],
+            entities: [Post, Comment, Bookmark, Audited, Note],
             schemaCreate: true,
             dropSchema: true,
         })
@@ -215,6 +216,70 @@ describe("query builder > stream entities", () => {
             }),
         ))
 
+    it("throws when a joined entity has an afterLoad listener", () =>
+        Promise.all(
+            dataSources.map(async (dataSource) => {
+                // the root entity has no listener; the joined one does, and the
+                // load event is broadcast for joined entities too
+                const qb = dataSource
+                    .createQueryBuilder(Note, "note")
+                    .leftJoinAndSelect("note.audited", "audited")
+                    .orderBy("note.id", "ASC")
+
+                expect(() => qb.streamEntities()).to.throw(
+                    /cannot run "afterLoad" listeners/,
+                )
+            }),
+        ))
+
+    it("is not blocked by a subscriber listening to another entity", () =>
+        Promise.all(
+            dataSources.map(async (dataSource) => {
+                const subscriber = {
+                    listenTo: () => Comment,
+                    afterLoad: () => {},
+                }
+                dataSource.subscribers.push(subscriber)
+                try {
+                    const qb = dataSource
+                        .createQueryBuilder(Post, "post")
+                        .orderBy("post.id", "ASC")
+
+                    expect(() => qb.streamEntities()).to.not.throw()
+                } finally {
+                    dataSource.subscribers.splice(
+                        dataSource.subscribers.indexOf(subscriber),
+                        1,
+                    )
+                }
+            }),
+        ))
+
+    it("is blocked by a subscriber that listens to the streamed entity", () =>
+        Promise.all(
+            dataSources.map(async (dataSource) => {
+                const subscriber = {
+                    listenTo: () => Post,
+                    afterLoad: () => {},
+                }
+                dataSource.subscribers.push(subscriber)
+                try {
+                    const qb = dataSource
+                        .createQueryBuilder(Post, "post")
+                        .orderBy("post.id", "ASC")
+
+                    expect(() => qb.streamEntities()).to.throw(
+                        /cannot run "afterLoad" listeners/,
+                    )
+                } finally {
+                    dataSource.subscribers.splice(
+                        dataSource.subscribers.indexOf(subscriber),
+                        1,
+                    )
+                }
+            }),
+        ))
+
     it("allows a pessimistic lock when the stream starts its own transaction", () =>
         Promise.all(
             dataSources.map(async (dataSource) => {
@@ -310,7 +375,7 @@ describe("query builder > stream entities > hydration", () => {
     let dataSources: DataSource[]
     before(async () => {
         dataSources = await createTestingConnections({
-            entities: [Post, Comment, Bookmark, Audited],
+            entities: [Post, Comment, Bookmark, Audited, Note],
             enabledDrivers: ["postgres", "mysql", "mariadb"],
             schemaCreate: true,
             dropSchema: true,

--- a/test/functional/query-builder/stream-entities/stream-entities.test.ts
+++ b/test/functional/query-builder/stream-entities/stream-entities.test.ts
@@ -1,0 +1,115 @@
+import {
+    closeTestingConnections,
+    createTestingConnections,
+    reloadTestingDatabases,
+} from "../../../utils/test-utils"
+import type { DataSource } from "../../../../src/data-source/DataSource"
+import { expect } from "chai"
+import { Post } from "./entity/Post"
+import { Comment } from "./entity/Comment"
+
+describe("query builder > stream entities", () => {
+    let dataSources: DataSource[]
+    before(async () => {
+        dataSources = await createTestingConnections({
+            entities: [Post, Comment],
+            schemaCreate: true,
+            dropSchema: true,
+        })
+    })
+    beforeEach(() => reloadTestingDatabases(dataSources))
+    after(() => closeTestingConnections(dataSources))
+
+    // These cover the validation performed before any streaming begins, so they
+    // run on drivers that do not implement QueryRunner.stream (sqlite).
+    // Hydration across chunk boundaries needs a streaming driver and is covered
+    // separately.
+
+    it("throws when the query is not ordered by the root primary key", () =>
+        Promise.all(
+            dataSources.map(async (dataSource) => {
+                const qb = dataSource
+                    .createQueryBuilder(Post, "post")
+                    .leftJoinAndSelect("post.comments", "comment")
+                    .orderBy("post.title", "ASC")
+
+                expect(() => qb.streamEntities()).to.throw(
+                    /ordered by the root primary key/,
+                )
+            }),
+        ))
+
+    it("throws when ordering starts with a non primary key column", () =>
+        Promise.all(
+            dataSources.map(async (dataSource) => {
+                const qb = dataSource
+                    .createQueryBuilder(Post, "post")
+                    .orderBy("post.title", "ASC")
+                    .addOrderBy("post.id", "ASC")
+
+                expect(() => qb.streamEntities()).to.throw(
+                    /ordered by the root primary key/,
+                )
+            }),
+        ))
+
+    it("accepts a query ordered by the root primary key", () =>
+        Promise.all(
+            dataSources.map(async (dataSource) => {
+                const qb = dataSource
+                    .createQueryBuilder(Post, "post")
+                    .leftJoinAndSelect("post.comments", "comment")
+                    .orderBy("post.id", "ASC")
+
+                expect(() => qb.streamEntities()).to.not.throw()
+            }),
+        ))
+
+    it("throws when selecting something without entity metadata", () =>
+        Promise.all(
+            dataSources.map(async (dataSource) => {
+                // a table name that maps to no entity, so the alias carries no
+                // metadata — "post" would resolve to the Post entity
+                const qb = dataSource
+                    .createQueryBuilder()
+                    .select("t.id")
+                    .from("unmapped_table", "t")
+
+                expect(() => qb.streamEntities()).to.throw(
+                    /can only be used when selecting from an entity/,
+                )
+            }),
+        ))
+
+    it("throws on a non positive chunk size", () =>
+        Promise.all(
+            dataSources.map(async (dataSource) => {
+                const qb = dataSource
+                    .createQueryBuilder(Post, "post")
+                    .orderBy("post.id", "ASC")
+
+                expect(() => qb.streamEntities({ chunkSize: 0 })).to.throw(
+                    /"chunkSize" must be a positive number/,
+                )
+            }),
+        ))
+
+    // Validation must happen when the method is called, not when the resulting
+    // iterator is first pulled from, which is what a bare async generator does.
+    it("validates eagerly rather than on first iteration", () =>
+        Promise.all(
+            dataSources.map(async (dataSource) => {
+                const qb = dataSource
+                    .createQueryBuilder(Post, "post")
+                    .orderBy("post.title", "ASC")
+
+                let threwSynchronously = false
+                try {
+                    qb.streamEntities()
+                } catch {
+                    threwSynchronously = true
+                }
+                expect(threwSynchronously).to.be.true
+            }),
+        ))
+})

--- a/test/functional/query-builder/stream-entities/stream-entities.test.ts
+++ b/test/functional/query-builder/stream-entities/stream-entities.test.ts
@@ -205,6 +205,59 @@ describe("query builder > stream entities > hydration", () => {
             }),
         ))
 
+    it("keeps the query runner usable for the final chunk", () =>
+        Promise.all(
+            dataSources.map(async (dataSource) => {
+                await seed(dataSource)
+
+                // loadRelationIdAndMap makes chunk hydration issue its own
+                // query, including for the chunk closed after the driver
+                // stream has already ended
+                const streamed: Post[] = []
+                const iterator = dataSource
+                    .createQueryBuilder(Post, "post")
+                    .loadRelationIdAndMap("post.commentIds", "post.comments")
+                    .orderBy("post.id", "ASC")
+                    .streamEntities({ chunkSize: 2 })
+
+                for await (const post of iterator) streamed.push(post)
+
+                expect(streamed).to.have.length(POSTS)
+                for (const post of streamed) {
+                    expect((post as any).commentIds).to.have.length(
+                        COMMENTS_PER_POST,
+                    )
+                }
+            }),
+        ))
+
+    it("releases the query runner when the consumer stops iterating early", () =>
+        Promise.all(
+            dataSources.map(async (dataSource) => {
+                await seed(dataSource)
+
+                // more iterations than the connection pool holds, so a runner
+                // leaked on early exit would exhaust it
+                for (let attempt = 0; attempt < 12; attempt++) {
+                    const iterator = dataSource
+                        .createQueryBuilder(Post, "post")
+                        .leftJoinAndSelect("post.comments", "comment")
+                        .orderBy("post.id", "ASC")
+                        .streamEntities({ chunkSize: 1 })
+
+                    for await (const post of iterator) {
+                        expect(post.id).to.be.a("number")
+                        break
+                    }
+                }
+
+                // the pool still has capacity for ordinary work
+                expect(await dataSource.getRepository(Post).count()).to.equal(
+                    POSTS,
+                )
+            }),
+        ))
+
     it("matches what getMany returns for the same query", () =>
         Promise.all(
             dataSources.map(async (dataSource) => {

--- a/test/functional/query-builder/stream-entities/stream-entities.test.ts
+++ b/test/functional/query-builder/stream-entities/stream-entities.test.ts
@@ -113,3 +113,114 @@ describe("query builder > stream entities", () => {
             }),
         ))
 })
+
+// The chunked hydration path needs a driver that implements
+// QueryRunner.stream. AbstractSqliteQueryRunner throws "Stream is not
+// supported by sqlite driver", so these are limited to streaming drivers and
+// will silently no-op when none are enabled in ormconfig.json.
+describe("query builder > stream entities > hydration", () => {
+    let dataSources: DataSource[]
+    before(async () => {
+        dataSources = await createTestingConnections({
+            entities: [Post, Comment],
+            enabledDrivers: ["postgres", "mysql", "mariadb"],
+            schemaCreate: true,
+            dropSchema: true,
+        })
+    })
+    beforeEach(() => reloadTestingDatabases(dataSources))
+    after(() => closeTestingConnections(dataSources))
+
+    const POSTS = 5
+    const COMMENTS_PER_POST = 3
+
+    async function seed(dataSource: DataSource) {
+        for (let p = 1; p <= POSTS; p++) {
+            const post = await dataSource
+                .getRepository(Post)
+                .save({ title: `post ${p}` })
+            for (let c = 1; c <= COMMENTS_PER_POST; c++) {
+                await dataSource
+                    .getRepository(Comment)
+                    .save({ text: `post ${p} comment ${c}`, post })
+            }
+        }
+    }
+
+    it("hydrates entities with to-many relations across chunk boundaries", () =>
+        Promise.all(
+            dataSources.map(async (dataSource) => {
+                await seed(dataSource)
+
+                const streamed: Post[] = []
+                const iterator = dataSource
+                    .createQueryBuilder(Post, "post")
+                    .leftJoinAndSelect("post.comments", "comment")
+                    .orderBy("post.id", "ASC")
+                    // deliberately smaller than the row count so chunks close
+                    // mid-result and every boundary is exercised
+                    .streamEntities({ chunkSize: 2 })
+
+                for await (const post of iterator) streamed.push(post)
+
+                expect(streamed).to.have.length(POSTS)
+
+                // each root appears exactly once, not once per joined row
+                const ids = streamed.map((post) => post.id)
+                expect(new Set(ids).size).to.equal(POSTS)
+
+                // and every collection is whole, not split across chunks
+                for (const post of streamed) {
+                    expect(post.comments).to.have.length(COMMENTS_PER_POST)
+                    expect(post.title).to.be.a("string")
+                }
+            }),
+        ))
+
+    it("matches what getMany returns for the same query", () =>
+        Promise.all(
+            dataSources.map(async (dataSource) => {
+                await seed(dataSource)
+
+                const build = () =>
+                    dataSource
+                        .createQueryBuilder(Post, "post")
+                        .leftJoinAndSelect("post.comments", "comment")
+                        .orderBy("post.id", "ASC")
+
+                const expected = await build().getMany()
+
+                const streamed: Post[] = []
+                for await (const post of build().streamEntities({
+                    chunkSize: 2,
+                }))
+                    streamed.push(post)
+
+                const shape = (posts: Post[]) =>
+                    posts.map((post) => ({
+                        id: post.id,
+                        title: post.title,
+                        comments: post.comments
+                            .map((comment) => comment.id)
+                            .sort((a, b) => a - b),
+                    }))
+
+                expect(shape(streamed)).to.eql(shape(expected))
+            }),
+        ))
+
+    it("yields nothing for an empty table", () =>
+        Promise.all(
+            dataSources.map(async (dataSource) => {
+                const streamed: Post[] = []
+                for await (const post of dataSource
+                    .createQueryBuilder(Post, "post")
+                    .leftJoinAndSelect("post.comments", "comment")
+                    .orderBy("post.id", "ASC")
+                    .streamEntities())
+                    streamed.push(post)
+
+                expect(streamed).to.have.length(0)
+            }),
+        ))
+})

--- a/test/functional/query-builder/stream-entities/stream-entities.test.ts
+++ b/test/functional/query-builder/stream-entities/stream-entities.test.ts
@@ -93,6 +93,87 @@ describe("query builder > stream entities", () => {
             }),
         ))
 
+    it("throws when relation ids are loaded", () =>
+        Promise.all(
+            dataSources.map(async (dataSource) => {
+                const qb = dataSource
+                    .createQueryBuilder(Post, "post")
+                    .loadRelationIdAndMap("post.commentIds", "post.comments")
+                    .orderBy("post.id", "ASC")
+
+                expect(() => qb.streamEntities()).to.throw(
+                    /does not support relation id loading/,
+                )
+            }),
+        ))
+
+    it('throws when "take" is combined with a join', () =>
+        Promise.all(
+            dataSources.map(async (dataSource) => {
+                const qb = dataSource
+                    .createQueryBuilder(Post, "post")
+                    .leftJoinAndSelect("post.comments", "comment")
+                    .orderBy("post.id", "ASC")
+                    .take(2)
+
+                expect(() => qb.streamEntities()).to.throw(
+                    /together with joins/,
+                )
+            }),
+        ))
+
+    it('allows "take" when there is no join to inflate the row count', () =>
+        Promise.all(
+            dataSources.map(async (dataSource) => {
+                const qb = dataSource
+                    .createQueryBuilder(Post, "post")
+                    .orderBy("post.id", "ASC")
+                    .take(2)
+
+                expect(() => qb.streamEntities()).to.not.throw()
+            }),
+        ))
+
+    it("throws on an optimistic lock", () =>
+        Promise.all(
+            dataSources.map(async (dataSource) => {
+                const qb = dataSource
+                    .createQueryBuilder(Post, "post")
+                    .orderBy("post.id", "ASC")
+                    .setLock("optimistic", 1)
+
+                expect(() => qb.streamEntities()).to.throw()
+            }),
+        ))
+
+    it("throws on a pessimistic lock outside a transaction", () =>
+        Promise.all(
+            dataSources.map(async (dataSource) => {
+                const qb = dataSource
+                    .createQueryBuilder(Post, "post")
+                    .orderBy("post.id", "ASC")
+                    .setLock("pessimistic_write")
+
+                expect(() => qb.streamEntities()).to.throw()
+            }),
+        ))
+
+    it("throws on a fractional or non finite chunk size", () =>
+        Promise.all(
+            dataSources.map(async (dataSource) => {
+                const build = () =>
+                    dataSource
+                        .createQueryBuilder(Post, "post")
+                        .orderBy("post.id", "ASC")
+
+                for (const chunkSize of [1.5, NaN, Infinity]) {
+                    expect(() =>
+                        build().streamEntities({ chunkSize }),
+                    ).to.throw(/positive integer/)
+                }
+            }),
+        ))
+
     it("throws when selecting something without entity metadata", () =>
         Promise.all(
             dataSources.map(async (dataSource) => {
@@ -117,7 +198,7 @@ describe("query builder > stream entities", () => {
                     .orderBy("post.id", "ASC")
 
                 expect(() => qb.streamEntities({ chunkSize: 0 })).to.throw(
-                    /"chunkSize" must be a positive number/,
+                    /"chunkSize" must be a positive integer/,
                 )
             }),
         ))
@@ -201,32 +282,6 @@ describe("query builder > stream entities > hydration", () => {
                 for (const post of streamed) {
                     expect(post.comments).to.have.length(COMMENTS_PER_POST)
                     expect(post.title).to.be.a("string")
-                }
-            }),
-        ))
-
-    it("keeps the query runner usable for the final chunk", () =>
-        Promise.all(
-            dataSources.map(async (dataSource) => {
-                await seed(dataSource)
-
-                // loadRelationIdAndMap makes chunk hydration issue its own
-                // query, including for the chunk closed after the driver
-                // stream has already ended
-                const streamed: Post[] = []
-                const iterator = dataSource
-                    .createQueryBuilder(Post, "post")
-                    .loadRelationIdAndMap("post.commentIds", "post.comments")
-                    .orderBy("post.id", "ASC")
-                    .streamEntities({ chunkSize: 2 })
-
-                for await (const post of iterator) streamed.push(post)
-
-                expect(streamed).to.have.length(POSTS)
-                for (const post of streamed) {
-                    expect((post as any).commentIds).to.have.length(
-                        COMMENTS_PER_POST,
-                    )
                 }
             }),
         ))

--- a/test/functional/query-builder/stream-entities/stream-entities.test.ts
+++ b/test/functional/query-builder/stream-entities/stream-entities.test.ts
@@ -65,6 +65,34 @@ describe("query builder > stream entities", () => {
             }),
         ))
 
+    it('throws when the "query" relation load strategy is used', () =>
+        Promise.all(
+            dataSources.map(async (dataSource) => {
+                const qb = dataSource
+                    .createQueryBuilder(Post, "post")
+                    .setFindOptions({ relationLoadStrategy: "query" })
+                    .orderBy("post.id", "ASC")
+
+                expect(() => qb.streamEntities()).to.throw(
+                    /does not support the "query" relation load strategy/,
+                )
+            }),
+        ))
+
+    it('throws when the data source defaults to the "query" strategy', () =>
+        Promise.all(
+            dataSources.map(async (dataSource) => {
+                const qb = dataSource
+                    .createQueryBuilder(Post, "post")
+                    .orderBy("post.id", "ASC")
+                qb.expressionMap.relationLoadStrategy = "query"
+
+                expect(() => qb.streamEntities()).to.throw(
+                    /does not support the "query" relation load strategy/,
+                )
+            }),
+        ))
+
     it("throws when selecting something without entity metadata", () =>
         Promise.all(
             dataSources.map(async (dataSource) => {

--- a/test/functional/query-builder/stream-entities/stream-entities.test.ts
+++ b/test/functional/query-builder/stream-entities/stream-entities.test.ts
@@ -8,13 +8,14 @@ import { expect } from "chai"
 import { Post } from "./entity/Post"
 import { Comment } from "./entity/Comment"
 import { Bookmark } from "./entity/Bookmark"
+import { Audited } from "./entity/Audited"
 
 // see https://github.com/typeorm/typeorm/issues/12714
 describe("query builder > stream entities", () => {
     let dataSources: DataSource[]
     before(async () => {
         dataSources = await createTestingConnections({
-            entities: [Post, Comment, Bookmark],
+            entities: [Post, Comment, Bookmark, Audited],
             schemaCreate: true,
             dropSchema: true,
         })
@@ -189,6 +190,31 @@ describe("query builder > stream entities", () => {
             }),
         ))
 
+    it("throws when the entity has an afterLoad listener", () =>
+        Promise.all(
+            dataSources.map(async (dataSource) => {
+                const qb = dataSource
+                    .createQueryBuilder(Audited, "audited")
+                    .orderBy("audited.id", "ASC")
+
+                expect(() => qb.streamEntities()).to.throw(
+                    /cannot run "afterLoad" listeners/,
+                )
+            }),
+        ))
+
+    it("allows an afterLoad entity once listeners are disabled", () =>
+        Promise.all(
+            dataSources.map(async (dataSource) => {
+                const qb = dataSource
+                    .createQueryBuilder(Audited, "audited")
+                    .orderBy("audited.id", "ASC")
+                    .callListeners(false)
+
+                expect(() => qb.streamEntities()).to.not.throw()
+            }),
+        ))
+
     it("allows a pessimistic lock when the stream starts its own transaction", () =>
         Promise.all(
             dataSources.map(async (dataSource) => {
@@ -284,7 +310,7 @@ describe("query builder > stream entities > hydration", () => {
     let dataSources: DataSource[]
     before(async () => {
         dataSources = await createTestingConnections({
-            entities: [Post, Comment, Bookmark],
+            entities: [Post, Comment, Bookmark, Audited],
             enabledDrivers: ["postgres", "mysql", "mariadb"],
             schemaCreate: true,
             dropSchema: true,


### PR DESCRIPTION
### Description of change

`SelectQueryBuilder.stream()` returns raw, alias-prefixed driver rows and leaves entity transformation to the caller. There is no public way to perform that transformation, so streaming users either hand-map columns or deep-import `RawSqlResultsToEntityTransformer`, which is not public API. With a to-many join, correct hydration is genuinely hard by hand: rows of the same root entity have to be grouped, which is what `getMany()` does internally — but `getMany()` buffers the whole result set, which is the thing streaming exists to avoid.

This adds `streamEntities()`, which streams the query and yields entities hydrated the same way `getMany()` hydrates them.

**Current behavior:** `stream()` sets `queryEntity = false` and hands back the driver stream. Relation-id loading, grouping and the `"Load"` broadcast never run.

**New behavior:** `streamEntities()` buffers raw rows and closes a chunk at a root-entity boundary, then hydrates and yields that chunk. Relation-id loading runs once per chunk rather than once per query.

This implements shape **A (chunked hydration)** from my comment on #12714. On the smaller questions raised there, this PR takes the conservative option in each case; all of them are still yours to overrule:

- **A separate method, not an option on `stream()`.** `stream()`'s contract is explicitly raw rows, so widening it seemed worse than adding a sibling.
- **The ordering is required, never injected.** Grouping buckets by primary-key *value*, not adjacency, so a chunk must hold every row of each root it touches. Rather than silently adding an `ORDER BY` and changing the caller's query plan, `streamEntities()` throws and names the ordering to add. Validation happens when the method is called, not on first iteration, so the error arrives at the call site.
- **A fresh transformer per chunk.** `rawRelationIdResults` is constructor-injected and derived from the row set, so rather than adding a setter to an internal class, each chunk constructs its own transformer.

Two behavioral differences from `getMany()` that are documented on the method:

- `"afterLoad"` subscribers are broadcast **per chunk**, not once for the whole result set.
- `chunkSize` (default 1000) is a *minimum*; a chunk is closed at the next root-entity boundary at or after it, so a root entity's rows are never split.

### Rejected query shapes

Several query shapes need a pass over the complete result set that streaming never has. Each one previously produced silently wrong results; all of them now throw at the call site:

- **`relationLoadStrategy: "query"`** — loads relations in a second pass, so streamed entities came back with those relations unpopulated. Covers the `setFindOptions` and data-source-default paths both.
- **Relation id loading**, from `loadRelationIdAndMap` or a `@RelationId` decorator — issues its own query. At an intermediate chunk boundary that query runs on the connection whose raw stream is still open, which deadlocks a single-client driver like postgres or cockroach.
- **`skip`/`take` with a join** — entity pagination rewrites the query into a distinct-root subquery. A streamed row-level `LIMIT` would cut a to-many collection in half and yield fewer entities than asked for.
- **Optimistic and pessimistic locks** — every other entity path validates these; lock SQL was reaching the driver unchecked.

Supporting the first two properly means either chunking that second pass or hydrating on a separate connection, and the second connection cannot see uncommitted rows from the streaming one — a semantic decision I would rather put to you than make quietly. Happy to follow up on either.

### How I verified it

`pnpm run compile` passes, `eslint` reports no new errors on the changed files, and `prettier --check` is clean.

Twenty-one new tests in `test/functional/query-builder/stream-entities/`. The seventeen validation tests run on `better-sqlite3` and need no external database; the four hydration tests are gated to `postgres`/`mysql`/`mariadb`, since they need a driver that implements `QueryRunner.stream`:

- rejects a query not ordered by the root primary key, and one whose ordering starts with a non-primary-key column
- accepts a query ordered by the root primary key
- rejects a selection without entity metadata, and a non-positive `chunkSize`
- rejects the `"query"` relation load strategy, set either through `setFindOptions` or as the data-source default
- rejects relation id loading — from `loadRelationIdAndMap` or a `@RelationId` decorator — `take` with a join, and locks, while still allowing `take` without a join and a pessimistic lock under `useTransaction(true)`
- revalidates when the builder is mutated between the call and the first iteration
- rejects a fractional or non-finite `chunkSize`
- releases the query runner when the consumer stops iterating early
- validates eagerly rather than on first iteration
- hydrates entities with to-many relations across chunk boundaries
- yields exactly what `getMany()` returns for the same query
- yields nothing for an empty table

### Pull-Request Checklist

- [x] Code is up-to-date with the `master` branch
- [x] This pull request links a relevant issue: Closes #12714
- [x] There are new or updated tests validating the change (`tests/**.test.ts`)
- [x] Documentation has been updated to reflect this change (`docs/docs/**.md`) — a `Streaming entities` section in `docs/docs/query-builder/1-select-query-builder.md`, covering the ordering requirement, `chunkSize`, and the rejected query shapes.
