### PR TITLE
fix(react-native): await query event subscribers before settling

### DIFF
--- a/src/driver/react-native/ReactNativeQueryRunner.ts
+++ b/src/driver/react-native/ReactNativeQueryRunner.ts
@@ -68,92 +68,106 @@ export class ReactNativeQueryRunner extends AbstractSqliteQueryRunner {
 
         const queryStartTime = Date.now()
 
-        return new Promise(async (ok, fail) => {
+        return new Promise((ok, fail) => {
             try {
                 databaseConnection.executeSql(
                     query,
                     parameters,
                     async (raw: any) => {
-                        // log slow queries if maxQueryExecution time is set
-                        const maxQueryExecutionTime =
-                            this.driver.options.maxQueryExecutionTime
-                        const queryEndTime = Date.now()
-                        const queryExecutionTime = queryEndTime - queryStartTime
-                        this.broadcaster.broadcastAfterQueryEvent(
-                            broadcasterResult,
-                            query,
-                            parameters,
-                            true,
-                            queryExecutionTime,
-                            raw,
-                            undefined,
-                        )
-
-                        if (
-                            maxQueryExecutionTime &&
-                            queryExecutionTime > maxQueryExecutionTime
-                        )
-                            this.driver.dataSource.logger.logQuerySlow(
+                        try {
+                            // log slow queries if maxQueryExecution time is set
+                            const maxQueryExecutionTime =
+                                this.driver.options.maxQueryExecutionTime
+                            const queryEndTime = Date.now()
+                            const queryExecutionTime =
+                                queryEndTime - queryStartTime
+                            this.broadcaster.broadcastAfterQueryEvent(
+                                broadcasterResult,
+                                query,
+                                parameters,
+                                true,
                                 queryExecutionTime,
+                                raw,
+                                undefined,
+                            )
+
+                            if (
+                                maxQueryExecutionTime &&
+                                queryExecutionTime > maxQueryExecutionTime
+                            )
+                                this.driver.dataSource.logger.logQuerySlow(
+                                    queryExecutionTime,
+                                    query,
+                                    parameters,
+                                    this,
+                                )
+
+                            const result = new QueryResult()
+
+                            if (raw?.hasOwnProperty("rowsAffected")) {
+                                result.affected = raw.rowsAffected
+                            }
+
+                            if (raw?.hasOwnProperty("rows")) {
+                                const records = []
+                                for (let i = 0; i < raw.rows.length; i++) {
+                                    records.push(raw.rows.item(i))
+                                }
+
+                                result.raw = records
+                                result.records = records
+                            }
+
+                            // return id of inserted row, if query was insert statement.
+                            if (query.startsWith("INSERT INTO")) {
+                                result.raw = raw.insertId
+                            }
+
+                            // the subscribers have to finish before the caller
+                            // is resumed, otherwise it observes the query as
+                            // complete while they are still running
+                            await broadcasterResult.wait()
+
+                            if (useStructuredResult) {
+                                ok(result)
+                            } else {
+                                ok(result.raw)
+                            }
+                        } catch (err) {
+                            // a subscriber that rejects would otherwise leave this
+                            // promise unsettled forever, since neither "ok" nor
+                            // "fail" is reached
+                            fail(err)
+                        }
+                    },
+                    async (err: any) => {
+                        try {
+                            this.driver.dataSource.logger.logQueryError(
+                                err,
                                 query,
                                 parameters,
                                 this,
                             )
+                            this.broadcaster.broadcastAfterQueryEvent(
+                                broadcasterResult,
+                                query,
+                                parameters,
+                                false,
+                                undefined,
+                                undefined,
+                                err,
+                            )
 
-                        if (broadcasterResult.promises.length > 0)
-                            await Promise.all(broadcasterResult.promises)
+                            await broadcasterResult.wait()
 
-                        const result = new QueryResult()
-
-                        if (raw?.hasOwnProperty("rowsAffected")) {
-                            result.affected = raw.rowsAffected
+                            fail(new QueryFailedError(query, parameters, err))
+                        } catch (subscriberError) {
+                            fail(subscriberError)
                         }
-
-                        if (raw?.hasOwnProperty("rows")) {
-                            const records = []
-                            for (let i = 0; i < raw.rows.length; i++) {
-                                records.push(raw.rows.item(i))
-                            }
-
-                            result.raw = records
-                            result.records = records
-                        }
-
-                        // return id of inserted row, if query was insert statement.
-                        if (query.startsWith("INSERT INTO")) {
-                            result.raw = raw.insertId
-                        }
-
-                        if (useStructuredResult) {
-                            ok(result)
-                        } else {
-                            ok(result.raw)
-                        }
-                    },
-                    (err: any) => {
-                        this.driver.dataSource.logger.logQueryError(
-                            err,
-                            query,
-                            parameters,
-                            this,
-                        )
-                        this.broadcaster.broadcastAfterQueryEvent(
-                            broadcasterResult,
-                            query,
-                            parameters,
-                            false,
-                            undefined,
-                            undefined,
-                            err,
-                        )
-
-                        fail(new QueryFailedError(query, parameters, err))
                     },
                 )
             } catch (err) {
                 fail(err)
-            } finally {
-                await broadcasterResult.wait()
             }
         })
     }


### PR DESCRIPTION
### Description of change

`ReactNativeQueryRunner.query()` waited for `AfterQuery` subscribers on the success callback but not on the error one. @kyungseopk1m reported this in #12769, and fixed the same class of bug for `better-sqlite3` in #12752; this applies the equivalent fix to the React Native driver.

**Current behavior:** on a failed query the runner broadcasts `AfterQuery` and calls `fail()` immediately, so the caller sees the rejection before the subscribers have run, and a subscriber that throws becomes an unhandled rejection.

The success path has a worse variant of the same problem: `await Promise.all(broadcasterResult.promises)` sits inside an async callback with no rejection handler, so if a subscriber rejects, neither `ok()` nor `fail()` is reached and **the query never settles at all** — the caller waits forever rather than getting an error.

The outer `finally { await broadcasterResult.wait() }` cannot cover either case. `executeSql` is callback based, so that `finally` runs while the promise list is still empty and before either callback has fired.

**New behavior:** both callbacks await the subscribers before settling, and a subscriber failure rejects the query rather than being swallowed or hanging.

### Why it is shaped this way

`better-sqlite3` expresses this as `try { … } catch { … } finally { await broadcasterResult.wait() }`, which works there because `query()` is a plain async function. `executeSql` is callback based, so the same semantics have to live inside each callback: broadcast, `await broadcasterResult.wait()`, then settle. The ordering is what matters — the wait has to happen before `ok()`/`fail()`, not after.

On the error path a rejecting subscriber replaces the `QueryFailedError`, which is the same precedence the `finally` gives it in the `better-sqlite3` version. I kept that rather than having the two drivers disagree, though I would happily invert it if you would rather the original query error always won.

The diff looks larger than the change because wrapping the success body in `try` re-indents it. The logic changes are: drop `async` from the promise executor, wrap the success body, move the wait to just before `ok()`, make the error callback async and await there too, and delete the outer `finally`.

### How I verified it

`pnpm run compile` passes, `prettier --check` is clean, and `eslint` reports no new warnings on the file — it actually drops from 17 to 16, and the remaining ones in the changed range (`any` on the driver callbacks, `hasOwnProperty`) are pre-existing lines that were only re-indented. `test:fast` passes apart from an unrelated `cli init` failure that reproduces on a clean `master` on my machine.

### Pull-Request Checklist

- [x] Code is up-to-date with the `master` branch
- [x] This pull request links a relevant issue using a closing keyword: Closes #12769
- [ ] There are new or updated tests validating the change (`tests/**.test.ts`) — see below
- [x] Documentation has been updated to reflect this change (`docs/docs/**.md`) — N/A, no user-facing API change

On tests: there is no react-native test setup in the repository, and this driver needs a `SQLite` object supplied by the host app, so there is nothing in `test:fast` that reaches this code path. The `better-sqlite3` equivalent in #12752 could be covered because that driver runs in CI. If there is a way to exercise the React Native driver that I have missed, I am glad to add coverage.
