### PR TITLE
refactor: drop the dayjs dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -93,7 +93,6 @@
   "dependencies": {
     "@sqltools/formatter": "^1.2.5",
     "ansis": "^4.3.1",
-    "dayjs": "^1.11.23",
     "debug": "^4.4.3",
     "dedent": "^1.7.2",
     "reflect-metadata": "^0.2.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -14,9 +14,6 @@ importers:
       ansis:
         specifier: ^4.3.1
         version: 4.3.1
-      dayjs:
-        specifier: ^1.11.23
-        version: 1.11.23
       debug:
         specifier: ^4.4.3
         version: 4.4.3(supports-color@8.1.1)
@@ -1725,9 +1722,6 @@ packages:
   data-uri-to-buffer@4.0.1:
     resolution: {integrity: sha512-0R9ikRb668HB7QDxT1vkpuUBtqc53YyAwMwGeUFKRojY/NWKvdZ+9UYtRfGmhqNbRkTSVpMbmyhXipFFv2cb/A==}
     engines: {node: '>= 12'}
-
-  dayjs@1.11.23:
-    resolution: {integrity: sha512-QDTCU0M0MxR3hQfnlDJfwekQiaanm1ubOD231u73WBckQ/fsamwRLiE2GBz6D3a/xF1NgfiDLJjXBa1hYOYTtQ==}
 
   debug@3.1.0:
     resolution: {integrity: sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==}
@@ -5768,8 +5762,6 @@ snapshots:
       which: 2.0.2
 
   data-uri-to-buffer@4.0.1: {}
-
-  dayjs@1.11.23: {}
 
   debug@3.1.0:
     dependencies:

--- a/src/util/DateUtils.ts
+++ b/src/util/DateUtils.ts
@@ -1,5 +1,4 @@
 import type { ColumnMetadata } from "../metadata/ColumnMetadata"
-import dayjs from "dayjs"
 
 /**
  * Provides utilities to transform hydrated and persisted data.
@@ -86,7 +85,7 @@ export class DateUtils {
          */
         let date =
             typeof mixedDate === "string"
-                ? dayjs(mixedDate).toDate()
+                ? DateUtils.parseDateString(mixedDate)
                 : mixedDate
 
         if (toUtc)
@@ -357,5 +356,44 @@ export class DateUtils {
         } else {
             return String(value)
         }
+    }
+
+    // -------------------------------------------------------------------------
+    // Private Static Methods
+    // -------------------------------------------------------------------------
+
+    /**
+     * Matches the date and date-time forms that carry no timezone. Anything
+     * with a "Z" or a UTC offset deliberately fails to match, so that it falls
+     * through to `new Date`, which already handles those correctly.
+     */
+    private static readonly datePartsRegExp =
+        /^(\d{4})[-/]?(\d{1,2})?[-/]?(\d{0,2})[Tt\s]*(\d{1,2})?:?(\d{1,2})?:?(\d{1,2})?[.:]?(\d+)?$/
+
+    /**
+     * Parses a date string into local time.
+     *
+     * `new Date("2021-04-28")` reads a date-only string as UTC midnight, which
+     * shifts the date for anyone east or west of UTC. Constructing from the
+     * parts instead keeps it local, which is what a bare date in a database
+     * column means. This reproduces the behaviour of the dayjs parser that
+     * previously did the same job here.
+     *
+     * @param value date string taken from the database or from user input
+     * @returns the parsed date, or an invalid Date if it could not be parsed
+     */
+    private static parseDateString(value: string): Date {
+        const parts = value.match(DateUtils.datePartsRegExp)
+        if (!parts) return new Date(value)
+
+        return new Date(
+            Number(parts[1]),
+            Number(parts[2]) - 1 || 0,
+            Number(parts[3] || 1),
+            Number(parts[4] || 0),
+            Number(parts[5] || 0),
+            Number(parts[6] || 0),
+            Number((parts[7] || "0").slice(0, 3)),
+        )
     }
 }

--- a/test/unit/util/date-utils.test.ts
+++ b/test/unit/util/date-utils.test.ts
@@ -12,6 +12,84 @@ describe("DateUtils", () => {
         expect(DateUtils).to.equal(DateUtilsDirect)
     })
 
+    describe("mixedDateToDate", () => {
+        // These assert local components rather than an ISO string, so they hold
+        // in any timezone. The distinction they protect is exactly the one that
+        // "new Date(string)" gets wrong: a bare date is local, not UTC.
+
+        it("reads a date-only string as local midnight", () => {
+            const date = DateUtils.mixedDateToDate("2021-04-28")
+
+            expect(date.getFullYear()).to.equal(2021)
+            expect(date.getMonth()).to.equal(3)
+            expect(date.getDate()).to.equal(28)
+            expect(date.getHours()).to.equal(0)
+            expect(date.getMinutes()).to.equal(0)
+        })
+
+        it("reads a date-time without a zone as local time", () => {
+            const date = DateUtils.mixedDateToDate("2021-04-28T10:20:30")
+
+            expect(date.getFullYear()).to.equal(2021)
+            expect(date.getMonth()).to.equal(3)
+            expect(date.getDate()).to.equal(28)
+            expect(date.getHours()).to.equal(10)
+            expect(date.getMinutes()).to.equal(20)
+            expect(date.getSeconds()).to.equal(30)
+        })
+
+        it("accepts a space between the date and the time", () => {
+            const date = DateUtils.mixedDateToDate("2021-04-28 10:20:30")
+
+            expect(date.getHours()).to.equal(10)
+            expect(date.getSeconds()).to.equal(30)
+        })
+
+        it("honours an explicit UTC marker", () => {
+            const date = DateUtils.mixedDateToDate("2021-04-28T10:20:30Z")
+
+            expect(date.getTime()).to.equal(
+                Date.UTC(2021, 3, 28, 10, 20, 30, 0),
+            )
+        })
+
+        it("honours an explicit offset", () => {
+            const date = DateUtils.mixedDateToDate("2021-04-28T10:20:30+05:30")
+
+            expect(date.getTime()).to.equal(Date.UTC(2021, 3, 28, 4, 50, 30, 0))
+        })
+
+        it("keeps only the first three digits of a fractional second", () => {
+            const date = DateUtils.mixedDateToDate("2021-04-28T10:20:30.123456")
+
+            expect(date.getMilliseconds()).to.equal(123)
+        })
+
+        it("returns an invalid date for a string it cannot parse", () => {
+            const date = DateUtils.mixedDateToDate("not a date")
+
+            expect(Number.isNaN(date.getTime())).to.be.true
+        })
+
+        it("passes a Date through untouched", () => {
+            const source = new Date(2021, 3, 28, 10, 20, 30)
+
+            expect(DateUtils.mixedDateToDate(source).getTime()).to.equal(
+                source.getTime(),
+            )
+        })
+
+        it("drops milliseconds when asked to", () => {
+            const date = DateUtils.mixedDateToDate(
+                "2021-04-28T10:20:30.123",
+                false,
+                false,
+            )
+
+            expect(date.getMilliseconds()).to.equal(0)
+        })
+    })
+
     it("should expose its static helpers through the public export", () => {
         const date = new Date(Date.UTC(2023, 4, 9))
         expect(DateUtils.mixedDateToDateString(date, { utc: true })).to.equal(


### PR DESCRIPTION
### Description of change

`dayjs` is a runtime dependency used in exactly one place — parsing a date string in `DateUtils.mixedDateToDate` — so this ports that parse inline and drops the dependency.

**Current behavior:** `dayjs(mixedDate).toDate()` parses the string.

**New behavior:** a small private parser in `DateUtils` does it, reproducing dayjs's semantics exactly. No user-visible change.

### Why it is not just `new Date(value)`

Because that would be a silent, timezone-dependent data bug. `new Date("2021-04-28")` reads a date-only string as **UTC** midnight, so anyone east or west of UTC gets a different calendar date than the column holds — which, per the comment above the call, is exactly why dayjs was introduced here.

The replacement reproduces dayjs's parser rather than approximating it:

- the same regex, which deliberately does not match anything carrying a `Z` or a UTC offset
- the same fallback to `new Date(value)` for everything it does not match, which is what makes zoned strings and non-ISO forms keep working
- the same defaults — missing month to January, missing day to the 1st, fraction truncated to three digits

Two quirks are preserved **deliberately** rather than fixed, so this stays a dependency removal and not a behaviour change: a one-digit fraction is read as milliseconds rather than tenths (`…30.5` is 5ms, not 500ms), and a two-digit year goes through the `Date` constructor's 1900-offset mapping (`0099` becomes 1999). Both match dayjs today. I would be glad to change either in a separate PR if they are considered wrong, but they seemed like the sort of thing that should not ride along quietly with a refactor.

### How I verified it

I ran the old and new implementations side by side over the date-only, `YYYY-M-D`, slash-separated, compact, date-time, space-separated, `Z`, `+05:30`, `-03:00`, fractional-second, partial (`2021`, `2021-04`, `…T10`), two-digit-year, out-of-range (`2021-13-45`, `2021-04-0`), empty and unparseable forms. All 21 produce identical instants. My machine is on `+05:30`, so the local/UTC distinction is actually exercised rather than masked as it would be in UTC.

Nine unit tests are added in `test/unit/util/date-utils.test.ts`, asserting local date components rather than an ISO string so they hold in any timezone.

`pnpm run compile` passes, `eslint` reports no errors, `prettier --check` is clean, and `test:fast` passes apart from an unrelated `cli init` failure that reproduces on a clean `master` here.

### Pull-Request Checklist

- [x] Code is up-to-date with the `master` branch
- [x] This pull request links a relevant issue using a closing keyword: Closes #12772
- [x] There are new or updated tests validating the change (`tests/**.test.ts`)
- [x] Documentation has been updated to reflect this change (`docs/docs/**.md`) — N/A, no user-facing API change
