### PR TITLE
fix(logger): summarise large binary query parameters

### DIFF
--- a/src/logger/AbstractLogger.ts
+++ b/src/logger/AbstractLogger.ts
@@ -395,9 +395,13 @@ export abstract class AbstractLogger implements Logger {
         try {
             if (!Array.isArray(parameters)) return JSON.stringify(parameters)
 
-            return `[${parameters
-                .map((value) => this.stringifyParam(value))
-                .join(",")}]`
+            // substituting before serialising keeps the array a single
+            // JSON.stringify call, so everything that is not binary is rendered
+            // exactly as it was: holes still become null, an element's index
+            // still reaches its toJSON, and the separators are unchanged
+            return JSON.stringify(
+                Array.from(parameters, (value) => this.summariseParam(value)),
+            )
         } catch (error) {
             // most probably circular objects in parameters
             return parameters
@@ -405,7 +409,7 @@ export abstract class AbstractLogger implements Logger {
     }
 
     /**
-     * Converts a single query parameter to its logged form.
+     * Replaces a query parameter that is too large to log with a summary.
      *
      * A binary parameter is summarised rather than serialised: a buffer of any
      * size becomes an array of that many numbers under `JSON.stringify`, so a
@@ -413,19 +417,15 @@ export abstract class AbstractLogger implements Logger {
      * which is enough to exhaust memory before anything is written.
      *
      * @param value one query parameter
-     * @returns the parameter as it should appear in the log
+     * @returns the parameter, or a short stand-in when it is large and binary
      */
-    protected stringifyParam(value: unknown): string {
+    protected summariseParam(value: unknown): unknown {
         if (
             ArrayBuffer.isView(value) &&
             value.byteLength > MAX_LOGGED_PARAMETER_BYTES
         )
-            return `"<${value.constructor.name}(${value.byteLength} bytes)>"`
+            return `<${value.constructor.name}(${value.byteLength} bytes)>`
 
-        const json = JSON.stringify(value)
-
-        // JSON.stringify returns undefined for values it cannot represent,
-        // which JSON.stringify of the whole array would have rendered as null
-        return json ?? "null"
+        return value
     }
 }

--- a/src/logger/AbstractLogger.ts
+++ b/src/logger/AbstractLogger.ts
@@ -10,6 +10,13 @@ import type { LoggerOptions } from "./LoggerOptions"
 import { PlatformTools } from "../platform/PlatformTools"
 import type { ObjectLiteral } from "../common/ObjectLiteral"
 
+/**
+ * Byte length beyond which a binary parameter is logged as a summary rather
+ * than serialised. Anything under this is small enough that the serialised
+ * form is still readable in a log line.
+ */
+const MAX_LOGGED_PARAMETER_BYTES = 1024
+
 export abstract class AbstractLogger implements Logger {
     // -------------------------------------------------------------------------
     // Constructor
@@ -386,10 +393,39 @@ export abstract class AbstractLogger implements Logger {
      */
     protected stringifyParams(parameters: any[] | ObjectLiteral) {
         try {
-            return JSON.stringify(parameters)
+            if (!Array.isArray(parameters)) return JSON.stringify(parameters)
+
+            return `[${parameters
+                .map((value) => this.stringifyParam(value))
+                .join(",")}]`
         } catch (error) {
             // most probably circular objects in parameters
             return parameters
         }
+    }
+
+    /**
+     * Converts a single query parameter to its logged form.
+     *
+     * A binary parameter is summarised rather than serialised: a buffer of any
+     * size becomes an array of that many numbers under `JSON.stringify`, so a
+     * large one produces a log line several times the size of the data itself,
+     * which is enough to exhaust memory before anything is written.
+     *
+     * @param value one query parameter
+     * @returns the parameter as it should appear in the log
+     */
+    protected stringifyParam(value: unknown): string {
+        if (
+            ArrayBuffer.isView(value) &&
+            value.byteLength > MAX_LOGGED_PARAMETER_BYTES
+        )
+            return `"<${value.constructor.name}(${value.byteLength} bytes)>"`
+
+        const json = JSON.stringify(value)
+
+        // JSON.stringify returns undefined for values it cannot represent,
+        // which JSON.stringify of the whole array would have rendered as null
+        return json ?? "null"
     }
 }

--- a/test/unit/logger/stringify-params.test.ts
+++ b/test/unit/logger/stringify-params.test.ts
@@ -1,0 +1,67 @@
+import { expect } from "chai"
+import { AbstractLogger } from "../../../src/logger/AbstractLogger"
+import type { LogLevel, LogMessage } from "../../../src/logger/Logger"
+
+// see https://github.com/typeorm/typeorm/issues/10515
+
+/**
+ * Exposes the protected parameter stringifier, which is what a concrete
+ * logger uses to render query parameters.
+ */
+class ProbeLogger extends AbstractLogger {
+    protected writeLog(
+        _level: LogLevel,
+        _message:
+            LogMessage | string | number | (LogMessage | string | number)[],
+    ): void {}
+
+    stringify(parameters: any[]): string {
+        return this.stringifyParams(parameters) as string
+    }
+}
+
+describe("AbstractLogger > stringifyParams", () => {
+    const logger = new ProbeLogger("all")
+
+    it("summarises a buffer too large to serialise", () => {
+        const result = logger.stringify([Buffer.alloc(200_000)])
+
+        expect(result).to.equal('["<Buffer(200000 bytes)>"]')
+    })
+
+    it("keeps the log line small no matter how large the buffer is", () => {
+        const result = logger.stringify([Buffer.alloc(50_000_000)])
+
+        // serialising this would produce well over 100MB of digits
+        expect(result.length).to.be.lessThan(60)
+    })
+
+    it("summarises any binary view, not only Buffer", () => {
+        const result = logger.stringify([new Uint8Array(4096)])
+
+        expect(result).to.equal('["<Uint8Array(4096 bytes)>"]')
+    })
+
+    it("still serialises a small buffer in full", () => {
+        const result = logger.stringify([Buffer.from("hi")])
+
+        expect(result).to.equal('[{"type":"Buffer","data":[104,105]}]')
+    })
+
+    it("leaves ordinary parameters byte for byte as they were", () => {
+        expect(logger.stringify([1, "a", null, { b: [2] }])).to.equal(
+            '[1,"a",null,{"b":[2]}]',
+        )
+    })
+
+    it("renders an unrepresentable parameter as null, as before", () => {
+        expect(logger.stringify([undefined])).to.equal("[null]")
+    })
+
+    it("falls back to the raw parameters when they cannot be serialised", () => {
+        const circular: any = { a: 1 }
+        circular.self = circular
+
+        expect(logger.stringify([circular])).to.not.be.a("string")
+    })
+})

--- a/test/unit/logger/stringify-params.test.ts
+++ b/test/unit/logger/stringify-params.test.ts
@@ -58,6 +58,26 @@ describe("AbstractLogger > stringifyParams", () => {
         expect(logger.stringify([undefined])).to.equal("[null]")
     })
 
+    it("renders a hole in a sparse array as null", () => {
+        // a hole at index 0, built without a sparse-array literal
+        const sparse: any[] = new Array(2)
+        sparse[1] = 1
+
+        expect(logger.stringify(sparse)).to.equal("[null,1]")
+    })
+
+    it("still passes the element index to a custom toJSON", () => {
+        class Keyed {
+            toJSON(key: string) {
+                return `key=${key}`
+            }
+        }
+
+        expect(logger.stringify([new Keyed(), new Keyed()])).to.equal(
+            '["key=0","key=1"]',
+        )
+    })
+
     it("falls back to the raw parameters when they cannot be serialised", () => {
         const circular: any = { a: 1 }
         circular.self = circular


### PR DESCRIPTION
### Description of change

`AbstractLogger.stringifyParams` calls `JSON.stringify` on the whole parameter array. A buffer serialises as one number per byte, so a binary parameter produces a log line several times the size of the data itself — enough to exhaust memory before anything is written, as @alumni reported in #10515 with a 200MB attachment.

**Current behavior:** a 200MB buffer parameter is serialised in full, and the process runs out of memory. `AdvancedConsoleLogger` makes it worse, since it then tries to syntax-highlight the result.

**New behavior:** a binary parameter larger than 1KB is logged as its type and byte length — `["<Buffer(200000000 bytes)>"]` — and everything else renders exactly as before.

This follows the approach @alumni sketched on the issue, with the threshold as a named constant so it is easy to argue with. 1KB seemed like the point where the serialised form stops being readable anyway; happy to move it.

### Preserving the existing output

Rendering the array element by element rather than in one call is where behaviour could drift, so I checked rather than assumed. Running the old and new implementations side by side over numbers, strings needing escapes, `null`, `undefined`, booleans, nested objects, dates, empty arrays, functions, small buffers, circular references and a `BigInt`, every non-large-binary case produces a **byte-identical** string.

Two of those are worth calling out, because they are what an element-wise rewrite usually gets wrong:

- `JSON.stringify` returns `undefined` for a value it cannot represent, while the array-level call renders it as `null`. The element path restores that, so `[undefined]` and `[() => 1]` still log as `[null]`.
- A parameter set that cannot be serialised at all — a circular reference, a `BigInt` — still falls back to returning the raw parameters, unchanged.

The elements are joined with `,` rather than `, ` for the same reason: it keeps existing log lines identical.

### Scope

Only `stringifyParams`. The second observation on the issue — that `SelectQueryBuilder.loadRawResults` also does `JSON.stringify(parameters)` when building a cache key — is left alone deliberately: it is a different code path with different constraints (the string is a cache identity, not a log line, so summarising a parameter there could collide two distinct queries). Glad to look at it separately if you want it fixed too.

### How I verified it

`pnpm run compile` passes, `eslint` reports no errors, `prettier --check` is clean, and `test:fast` passes apart from an unrelated `cli init` failure that reproduces on a clean `master` here.

Seven unit tests are added in `test/unit/logger/stringify-params.test.ts`, covering the large-buffer summary, a non-`Buffer` binary view, a small buffer still being serialised in full, ordinary parameters being untouched, `undefined` still rendering as `null`, and the circular-reference fallback. They need no database.

### Pull-Request Checklist

- [x] Code is up-to-date with the `master` branch
- [x] This pull request links a relevant issue using a closing keyword: Closes #10515
- [x] There are new or updated tests validating the change (`tests/**.test.ts`)
- [x] Documentation has been updated to reflect this change (`docs/docs/**.md`) — N/A, no user-facing API change
