### PR TITLE
feat(query-builder): add explicit alias handling for DELETE/UPDATE statements

### DIFF
--- a/docs/docs/query-builder/3-update-query-builder.md
+++ b/docs/docs/query-builder/3-update-query-builder.md
@@ -14,6 +14,29 @@ await dataSource
 
 This is the most efficient way in terms of performance to update entities in your database.
 
+## `Update` with an alias
+
+On the PostgreSQL family (Postgres, CockroachDB) you can pass an alias when creating the query
+builder, and use it in `where()`:
+
+```typescript
+await dataSource
+    .createQueryBuilder(User, "user")
+    .update()
+    .set({ firstName: "Timber", lastName: "Saw" })
+    .where("user.id = :id", { id: 1 })
+    .execute()
+```
+
+Which will produce the following SQL query:
+
+```sql
+UPDATE users user SET firstName = 'Timber', lastName = 'Saw' WHERE user.id = 1
+```
+
+On other database drivers `UPDATE` doesn't support aliases, so `where()` conditions must stay
+unqualified (e.g. `"id = :id"`).
+
 ## Raw SQL support
 
 In some cases when you need to execute SQL queries you need to use function style value:

--- a/docs/docs/query-builder/4-delete-query-builder.md
+++ b/docs/docs/query-builder/4-delete-query-builder.md
@@ -16,6 +16,28 @@ await myDataSource
 
 This is the most efficient way in terms of performance to delete entities from your database.
 
+## `Delete` with an alias
+
+On the PostgreSQL family (Postgres, CockroachDB) you can pass an alias when creating the query
+builder, and use it in `where()`:
+
+```typescript
+await myDataSource
+    .createQueryBuilder(User, "user")
+    .delete()
+    .where("user.id = :id", { id: 1 })
+    .execute()
+```
+
+Which will produce the following SQL query:
+
+```sql
+DELETE FROM users user WHERE user.id = 1
+```
+
+On other database drivers `DELETE` doesn't support aliases, so `where()` conditions must stay
+unqualified (e.g. `"id = :id"`).
+
 ## `Soft-Delete`
 
 Applying Soft Delete to QueryBuilder

--- a/src/query-builder/Alias.ts
+++ b/src/query-builder/Alias.ts
@@ -10,6 +10,12 @@ export class Alias {
     name: string
 
     /**
+     * Indicates whether this alias' name was explicitly provided by the caller,
+     * as opposed to being inferred from the entity metadata or table path.
+     */
+    isExplicit: boolean = false
+
+    /**
      * Table on which this alias is applied.
      * Used only for aliases which select custom tables.
      */

--- a/src/query-builder/DeleteQueryBuilder.ts
+++ b/src/query-builder/DeleteQueryBuilder.ts
@@ -27,7 +27,8 @@ export class DeleteQueryBuilder<Entity extends ObjectLiteral>
         queryRunner?: QueryRunner,
     ) {
         super(connectionOrQueryBuilder as any, queryRunner)
-        this.expressionMap.aliasNamePrefixingEnabled = false
+        this.expressionMap.queryType = "delete"
+        this.expressionMap.updateAliasNamePrefixingForWriteQuery()
     }
 
     // -------------------------------------------------------------------------

--- a/src/query-builder/DeleteQueryBuilder.ts
+++ b/src/query-builder/DeleteQueryBuilder.ts
@@ -302,11 +302,12 @@ export class DeleteQueryBuilder<Entity extends ObjectLiteral>
      */
     protected createDeleteExpression() {
         const tableName = this.getTableName(this.getMainTableName())
+        const aliasExpression = this.createDeleteUpdateAliasExpression()
         const whereExpression = this.createWhereExpression()
         const returningExpression = this.createReturningExpression("delete")
 
         if (returningExpression === "") {
-            return `DELETE FROM ${tableName}${whereExpression}`
+            return `DELETE FROM ${tableName}${aliasExpression}${whereExpression}`
         }
         if (this.dataSource.driver.options.type === "mssql") {
             return `DELETE FROM ${tableName} OUTPUT ${returningExpression}${whereExpression}`
@@ -314,6 +315,6 @@ export class DeleteQueryBuilder<Entity extends ObjectLiteral>
         if (this.dataSource.driver.options.type === "spanner") {
             return `DELETE FROM ${tableName}${whereExpression} THEN RETURN ${returningExpression}`
         }
-        return `DELETE FROM ${tableName}${whereExpression} RETURNING ${returningExpression}`
+        return `DELETE FROM ${tableName}${aliasExpression}${whereExpression} RETURNING ${returningExpression}`
     }
 }

--- a/src/query-builder/QueryBuilder.ts
+++ b/src/query-builder/QueryBuilder.ts
@@ -282,15 +282,18 @@ export abstract class QueryBuilder<Entity extends ObjectLiteral> {
             ? entityOrTableNameUpdateSet.options.name
             : entityOrTableNameUpdateSet
 
+        this.expressionMap.queryType = "update"
+
         if (
             typeof entityOrTableNameUpdateSet === "function" ||
             typeof entityOrTableNameUpdateSet === "string"
         ) {
             const mainAlias = this.createFromAlias(entityOrTableNameUpdateSet)
             this.expressionMap.setMainAlias(mainAlias)
+        } else {
+            this.expressionMap.updateAliasNamePrefixingForWriteQuery()
         }
 
-        this.expressionMap.queryType = "update"
         this.expressionMap.valuesSet = updateSet
 
         if (InstanceChecker.isUpdateQueryBuilder(this)) return this as any
@@ -303,6 +306,7 @@ export abstract class QueryBuilder<Entity extends ObjectLiteral> {
      */
     delete(): DeleteQueryBuilder<Entity> {
         this.expressionMap.queryType = "delete"
+        this.expressionMap.updateAliasNamePrefixingForWriteQuery()
 
         if (InstanceChecker.isDeleteQueryBuilder(this)) return this as any
 

--- a/src/query-builder/QueryBuilder.ts
+++ b/src/query-builder/QueryBuilder.ts
@@ -10,6 +10,7 @@ import type { SoftDeleteQueryBuilder } from "./SoftDeleteQueryBuilder"
 import type { InsertQueryBuilder } from "./InsertQueryBuilder"
 import type { RelationQueryBuilder } from "./RelationQueryBuilder"
 import type { EntityTarget } from "../common/EntityTarget"
+import { DriverUtils } from "../driver/DriverUtils"
 import type { Alias } from "./Alias"
 import { Brackets } from "./Brackets"
 import type { QueryDeepPartialEntity } from "./QueryPartialEntity"
@@ -722,6 +723,22 @@ export abstract class QueryBuilder<Entity extends ObjectLiteral> {
                 subQuery: subquery,
             })
         }
+    }
+
+    /**
+     * Builds the ` AS "alias"` fragment for a DELETE/UPDATE statement's target table.
+     */
+    protected createDeleteUpdateAliasExpression(): string {
+        const alias = this.expressionMap.mainAlias
+        if (
+            !alias ||
+            alias.name === alias.tablePath ||
+            (alias.hasMetadata && alias.name === alias.metadata.targetName) ||
+            !DriverUtils.isPostgresFamily(this.dataSource.driver)
+        )
+            return ""
+
+        return ` AS ${this.escape(alias.name)}`
     }
 
     /**

--- a/src/query-builder/QueryBuilder.ts
+++ b/src/query-builder/QueryBuilder.ts
@@ -732,8 +732,7 @@ export abstract class QueryBuilder<Entity extends ObjectLiteral> {
         const alias = this.expressionMap.mainAlias
         if (
             !alias ||
-            alias.name === alias.tablePath ||
-            (alias.hasMetadata && alias.name === alias.metadata.targetName) ||
+            !alias.isExplicit ||
             !DriverUtils.isPostgresFamily(this.dataSource.driver)
         )
             return ""

--- a/src/query-builder/QueryBuilder.ts
+++ b/src/query-builder/QueryBuilder.ts
@@ -730,7 +730,7 @@ export abstract class QueryBuilder<Entity extends ObjectLiteral> {
     }
 
     /**
-     * Builds the ` AS "alias"` fragment for a DELETE/UPDATE statement's target table.
+     * Builds the ` "alias"` fragment for a DELETE/UPDATE statement's target table.
      */
     protected createDeleteUpdateAliasExpression(): string {
         const alias = this.expressionMap.mainAlias
@@ -741,7 +741,7 @@ export abstract class QueryBuilder<Entity extends ObjectLiteral> {
         )
             return ""
 
-        return ` AS ${this.escape(alias.name)}`
+        return ` ${this.escape(alias.name)}`
     }
 
     /**

--- a/src/query-builder/QueryBuilder.ts
+++ b/src/query-builder/QueryBuilder.ts
@@ -807,10 +807,22 @@ export abstract class QueryBuilder<Entity extends ObjectLiteral> {
                 replacements[replaceAliasNamePrefix][column.propertyPath] =
                     column.databaseName
             }
+
+            // UPDATE/DELETE also accept unqualified conditions once aliased.
+            if (
+                replaceAliasNamePrefix &&
+                ["update", "delete"].includes(this.expressionMap.queryType)
+            ) {
+                replacements[""] ??= replacements[replaceAliasNamePrefix]
+            }
         }
 
         const replacementKeys = Object.keys(replacements)
+        // Non-empty prefixes first: regex alternation is greedy left-to-right,
+        // and an empty alternative would otherwise always win.
         const replaceAliasNamePrefixes = replacementKeys
+            .filter((key) => key !== "")
+            .concat(replacementKeys.includes("") ? [""] : [])
             .map((key) => escapeRegExp(key))
             .join("|")
 
@@ -822,7 +834,7 @@ export abstract class QueryBuilder<Entity extends ObjectLiteral> {
                         // followed by our prefix, e.g. 'tablename.' or ''
                         `${
                             replaceAliasNamePrefixes
-                                ? "(" + replaceAliasNamePrefixes + ")"
+                                ? "(" + replaceAliasNamePrefixes + ")?" // optional, else unprefixed names wouldn't match at all
                                 : ""
                         }([^ =(),]+)` + // a possible property name: sequence of anything but ' =(),'
                         // terminated by ' =),' or end of line
@@ -836,10 +848,13 @@ export abstract class QueryBuilder<Entity extends ObjectLiteral> {
                         pre = matches[1]
                         p = matches[3]
 
-                        if (replacements[matches[2]][p]) {
+                        if (matches[2] && replacements[matches[2]]?.[p]) {
                             return `${pre}${this.escape(
                                 matches[2].slice(0, -1),
                             )}.${this.escape(replacements[matches[2]][p])}`
+                        }
+                        if (!matches[2] && replacements[""]?.[p]) {
+                            return `${pre}${this.escape(replacements[""][p])}`
                         }
                     } else {
                         match = matches[0]

--- a/src/query-builder/QueryExpressionMap.ts
+++ b/src/query-builder/QueryExpressionMap.ts
@@ -412,6 +412,7 @@ export class QueryExpressionMap {
         metadata?: EntityMetadata
     }): Alias {
         let aliasName = options.name
+        const isExplicit = !!aliasName
         if (!aliasName && options.tablePath) aliasName = options.tablePath
         if (!aliasName && typeof options.target === "function")
             aliasName = options.target.name
@@ -420,6 +421,7 @@ export class QueryExpressionMap {
 
         const alias = new Alias()
         alias.type = options.type
+        alias.isExplicit = isExplicit
         if (aliasName) alias.name = aliasName
         if (options.metadata) alias.metadata = options.metadata
         if (options.target && !alias.hasMetadata)

--- a/src/query-builder/QueryExpressionMap.ts
+++ b/src/query-builder/QueryExpressionMap.ts
@@ -1,6 +1,7 @@
 import type { ObjectLiteral } from "../common/ObjectLiteral"
 import type { DataSource } from "../data-source/DataSource"
 import type { CockroachDataSourceOptions } from "../driver/cockroachdb/CockroachDataSourceOptions"
+import { DriverUtils } from "../driver/DriverUtils"
 import type { UpsertType } from "../driver/types/UpsertType"
 import { TypeORMError } from "../error"
 import type { OrderByCondition } from "../find-options/OrderByCondition"
@@ -388,8 +389,23 @@ export class QueryExpressionMap {
 
         // set new main alias
         this.mainAlias = alias
+        this.updateAliasNamePrefixingForWriteQuery()
 
         return alias
+    }
+
+    /**
+     * Re-enables alias prefixing for UPDATE/DELETE only when an explicit
+     * alias will be emitted (postgres family). Call after either the main
+     * alias or the query type changes, since either may be set first.
+     */
+    updateAliasNamePrefixingForWriteQuery(): void {
+        if (this.queryType !== "update" && this.queryType !== "delete") return
+
+        this.aliasNamePrefixingEnabled = !!(
+            this.mainAlias?.isExplicit &&
+            DriverUtils.isPostgresFamily(this.dataSource.driver)
+        )
     }
 
     /**

--- a/src/query-builder/UpdateQueryBuilder.ts
+++ b/src/query-builder/UpdateQueryBuilder.ts
@@ -40,7 +40,8 @@ export class UpdateQueryBuilder<Entity extends ObjectLiteral>
         queryRunner?: QueryRunner,
     ) {
         super(connectionOrQueryBuilder as any, queryRunner)
-        this.expressionMap.aliasNamePrefixingEnabled = false
+        this.expressionMap.queryType = "update"
+        this.expressionMap.updateAliasNamePrefixingForWriteQuery()
     }
 
     // -------------------------------------------------------------------------

--- a/src/query-builder/UpdateQueryBuilder.ts
+++ b/src/query-builder/UpdateQueryBuilder.ts
@@ -732,13 +732,16 @@ export class UpdateQueryBuilder<Entity extends ObjectLiteral>
         }
 
         // get a table name and all column database names
+        const aliasExpression = this.createDeleteUpdateAliasExpression()
         const whereExpression = this.createWhereExpression()
         const returningExpression = this.createReturningExpression("update")
 
         if (returningExpression === "") {
             return `UPDATE ${this.getTableName(
                 this.getMainTableName(),
-            )} SET ${updateColumnAndValues.join(", ")}${whereExpression}` // todo: how do we replace aliases in where to nothing?
+            )}${aliasExpression} SET ${updateColumnAndValues.join(
+                ", ",
+            )}${whereExpression}` // todo: how do we replace other aliases in where to nothing?
         }
         if (this.dataSource.driver.options.type === "mssql") {
             return `UPDATE ${this.getTableName(
@@ -757,7 +760,7 @@ export class UpdateQueryBuilder<Entity extends ObjectLiteral>
 
         return `UPDATE ${this.getTableName(
             this.getMainTableName(),
-        )} SET ${updateColumnAndValues.join(
+        )}${aliasExpression} SET ${updateColumnAndValues.join(
             ", ",
         )}${whereExpression} RETURNING ${returningExpression}`
     }

--- a/src/repository/Repository.ts
+++ b/src/repository/Repository.ts
@@ -83,18 +83,15 @@ export class Repository<Entity extends ObjectLiteral> {
         alias?: string,
         queryRunner?: QueryRunner,
     ): SelectQueryBuilder<Entity> {
-        if (alias) {
-            return this.manager.createQueryBuilder<Entity>(
-                this.metadata.target as any,
-                alias,
-                queryRunner ?? this.queryRunner,
-            )
+        const queryBuilder = this.manager.createQueryBuilder<Entity>(
+            this.metadata.target as any,
+            alias ?? this.metadata.targetName,
+            queryRunner ?? this.queryRunner,
+        )
+        if (!alias) {
+            ;(queryBuilder as any).expressionMap.mainAlias.isExplicit = false
         }
-
-        return this.manager
-            .createQueryBuilder(queryRunner ?? this.queryRunner)
-            .select()
-            .from(this.metadata.target as any, undefined as any)
+        return queryBuilder
     }
 
     /**

--- a/src/repository/Repository.ts
+++ b/src/repository/Repository.ts
@@ -83,11 +83,18 @@ export class Repository<Entity extends ObjectLiteral> {
         alias?: string,
         queryRunner?: QueryRunner,
     ): SelectQueryBuilder<Entity> {
-        return this.manager.createQueryBuilder<Entity>(
-            this.metadata.target as any,
-            alias ?? this.metadata.targetName,
-            queryRunner ?? this.queryRunner,
-        )
+        if (alias) {
+            return this.manager.createQueryBuilder<Entity>(
+                this.metadata.target as any,
+                alias,
+                queryRunner ?? this.queryRunner,
+            )
+        }
+
+        return this.manager
+            .createQueryBuilder(queryRunner ?? this.queryRunner)
+            .select()
+            .from(this.metadata.target as any, undefined as any)
     }
 
     /**

--- a/test/functional/query-builder/delete/entity/AliasedPost.ts
+++ b/test/functional/query-builder/delete/entity/AliasedPost.ts
@@ -1,0 +1,17 @@
+import { Entity } from "../../../../../src/decorator/entity/Entity"
+import { PrimaryGeneratedColumn } from "../../../../../src/decorator/columns/PrimaryGeneratedColumn"
+import { Column } from "../../../../../src/decorator/columns/Column"
+
+/**
+ * Target name ("AliasedPost") intentionally differs from the physical table
+ * name ("post_table") to exercise DELETE/UPDATE alias handling when the two
+ * cannot be conflated.
+ */
+@Entity("post_table")
+export class AliasedPost {
+    @PrimaryGeneratedColumn()
+    id: number
+
+    @Column()
+    title: string
+}

--- a/test/functional/query-builder/delete/entity/Person.ts
+++ b/test/functional/query-builder/delete/entity/Person.ts
@@ -1,18 +1,14 @@
+import { Column } from "../../../../../src/decorator/columns/Column"
 import { Entity } from "../../../../../src/decorator/entity/Entity"
 import { PrimaryGeneratedColumn } from "../../../../../src/decorator/columns/PrimaryGeneratedColumn"
-import { Column } from "../../../../../src/decorator/columns/Column"
+import { TableInheritance } from "../../../../../src/decorator/entity/TableInheritance"
 
 @Entity()
-export class User {
+@TableInheritance({ column: { name: "type", type: String } })
+export class Person {
     @PrimaryGeneratedColumn()
     id: number
 
     @Column()
     name: string
-
-    @Column()
-    likesCount: number = 0
-
-    @Column({ name: "team_id", nullable: true })
-    team: number
 }

--- a/test/functional/query-builder/delete/entity/Student.ts
+++ b/test/functional/query-builder/delete/entity/Student.ts
@@ -1,0 +1,9 @@
+import { Column } from "../../../../../src/decorator/columns/Column"
+import { ChildEntity } from "../../../../../src/decorator/entity/ChildEntity"
+import { Person } from "./Person"
+
+@ChildEntity()
+export class Student extends Person {
+    @Column()
+    faculty: string
+}

--- a/test/functional/query-builder/delete/entity/User.ts
+++ b/test/functional/query-builder/delete/entity/User.ts
@@ -9,4 +9,7 @@ export class User {
 
     @Column()
     name: string
+
+    @Column({ name: "team_id", nullable: true })
+    team: number
 }

--- a/test/functional/query-builder/delete/query-builder-delete.test.ts
+++ b/test/functional/query-builder/delete/query-builder-delete.test.ts
@@ -9,6 +9,7 @@ import type { DataSource } from "../../../../src/data-source/DataSource"
 import { User } from "./entity/User"
 import { Photo } from "./entity/Photo"
 import { AliasedPost } from "./entity/AliasedPost"
+import { Student } from "./entity/Student"
 import { EntityPropertyNotFoundError } from "../../../../src/error/EntityPropertyNotFoundError"
 import { DriverUtils } from "../../../../src/driver/DriverUtils"
 
@@ -271,6 +272,60 @@ describe("query builder > delete", () => {
                     .getRepository(User)
                     .findOneBy({ name: "Brad Porter" })
                 expect(loadedUser4).to.not.exist
+            }),
+        ))
+
+    it("should translate an alias-qualified where condition to its database column name on postgres family", () =>
+        Promise.all(
+            dataSources.map(async (dataSource) => {
+                if (!DriverUtils.isPostgresFamily(dataSource.driver)) return
+
+                const user1 = new User()
+                user1.name = "Alex Messer"
+                user1.team = 1
+                await dataSource.manager.save(user1)
+
+                const queryBuilder = dataSource
+                    .getRepository(User)
+                    .createQueryBuilder("tc")
+                    .delete()
+                    .where("tc.team = :team", { team: 1 })
+
+                expect(queryBuilder.getSql()).to.not.contain("tc.team")
+
+                await queryBuilder.execute()
+
+                const loadedUser = await dataSource
+                    .getRepository(User)
+                    .findOneBy({ name: "Alex Messer" })
+                expect(loadedUser).to.not.exist
+            }),
+        ))
+
+    it("should qualify the discriminator column with an explicit alias on postgres family", () =>
+        Promise.all(
+            dataSources.map(async (dataSource) => {
+                if (!DriverUtils.isPostgresFamily(dataSource.driver)) return
+
+                const student = new Student()
+                student.name = "Alex Messer"
+                student.faculty = "Economics"
+                await dataSource.manager.save(student)
+
+                const queryBuilder = dataSource
+                    .getRepository(Student)
+                    .createQueryBuilder("s")
+                    .delete()
+                    .where("name = :name", { name: "Alex Messer" })
+
+                expect(queryBuilder.getSql()).to.contain('"s"."type"')
+
+                await queryBuilder.execute()
+
+                const loadedStudent = await dataSource
+                    .getRepository(Student)
+                    .findOneBy({ name: "Alex Messer" })
+                expect(loadedStudent).to.not.exist
             }),
         ))
 

--- a/test/functional/query-builder/delete/query-builder-delete.test.ts
+++ b/test/functional/query-builder/delete/query-builder-delete.test.ts
@@ -8,6 +8,7 @@ import {
 import type { DataSource } from "../../../../src/data-source/DataSource"
 import { User } from "./entity/User"
 import { Photo } from "./entity/Photo"
+import { AliasedPost } from "./entity/AliasedPost"
 import { EntityPropertyNotFoundError } from "../../../../src/error/EntityPropertyNotFoundError"
 import { DriverUtils } from "../../../../src/driver/DriverUtils"
 
@@ -205,7 +206,7 @@ describe("query builder > delete", () => {
         }
     })
 
-    it("should add an explicit alias on postgres/cockroachdb", () =>
+    it("should add an explicit alias on postgres family", () =>
         Promise.all(
             dataSources.map(async (dataSource) => {
                 if (!DriverUtils.isPostgresFamily(dataSource.driver)) return
@@ -270,6 +271,78 @@ describe("query builder > delete", () => {
                     .getRepository(User)
                     .findOneBy({ name: "Brad Porter" })
                 expect(loadedUser4).to.not.exist
+            }),
+        ))
+
+    it("should not add an alias when the entity's table name differs from its target name and no alias was given explicitly", () => {
+        for (const dataSource of dataSources) {
+            if (!DriverUtils.isPostgresFamily(dataSource.driver)) continue
+
+            const sqlFromEntity = dataSource
+                .createQueryBuilder()
+                .delete()
+                .from(AliasedPost)
+                .where("title = :title", { title: "Hello" })
+                .getSql()
+
+            expect(sqlFromEntity).to.not.contain(" AS ")
+
+            const sqlFromRepository = dataSource
+                .getRepository(AliasedPost)
+                .createQueryBuilder()
+                .delete()
+                .where("title = :title", { title: "Hello" })
+                .getSql()
+
+            expect(sqlFromRepository).to.not.contain(" AS ")
+        }
+    })
+
+    it("should add an explicit alias when the entity's table name differs from its target name on postgres family", () =>
+        Promise.all(
+            dataSources.map(async (dataSource) => {
+                if (!DriverUtils.isPostgresFamily(dataSource.driver)) return
+
+                const post1 = new AliasedPost()
+                post1.title = "Hello"
+                const post2 = new AliasedPost()
+                post2.title = "World"
+                await dataSource.manager.save([post1, post2])
+
+                const queryBuilder = dataSource
+                    .createQueryBuilder()
+                    .delete()
+                    .from(AliasedPost, "p")
+                    .where("p.title = :title", { title: "Hello" })
+
+                expect(queryBuilder.getSql()).to.contain('AS "p"')
+
+                await queryBuilder.execute()
+
+                const loadedPost1 = await dataSource
+                    .getRepository(AliasedPost)
+                    .findOneBy({ title: "Hello" })
+                expect(loadedPost1).to.not.exist
+
+                const loadedPost2 = await dataSource
+                    .getRepository(AliasedPost)
+                    .findOneBy({ title: "World" })
+                expect(loadedPost2).to.exist
+
+                const queryBuilderFromRepository = dataSource
+                    .getRepository(AliasedPost)
+                    .createQueryBuilder("p")
+                    .delete()
+                    .where("p.title = :title", { title: "World" })
+
+                expect(queryBuilderFromRepository.getSql()).to.contain('AS "p"')
+
+                await queryBuilderFromRepository.execute()
+
+                const loadedPost3 = await dataSource
+                    .getRepository(AliasedPost)
+                    .findOneBy({ title: "World" })
+                expect(loadedPost3).to.not.exist
             }),
         ))
 

--- a/test/functional/query-builder/delete/query-builder-delete.test.ts
+++ b/test/functional/query-builder/delete/query-builder-delete.test.ts
@@ -304,6 +304,33 @@ describe("query builder > delete", () => {
             }),
         ))
 
+    it("should still translate an unqualified where condition to its database column name when an explicit alias is set on postgres family", () =>
+        Promise.all(
+            dataSources.map(async (dataSource) => {
+                if (!DriverUtils.isPostgresFamily(dataSource.driver)) return
+
+                const user1 = new User()
+                user1.name = "Alex Messer"
+                user1.team = 1
+                await dataSource.manager.save(user1)
+
+                const queryBuilder = dataSource
+                    .getRepository(User)
+                    .createQueryBuilder("tc")
+                    .delete()
+                    .where("team = :team", { team: 1 })
+
+                expect(queryBuilder.getSql()).to.not.contain(" team ")
+
+                await queryBuilder.execute()
+
+                const loadedUser = await dataSource
+                    .getRepository(User)
+                    .findOneBy({ name: "Alex Messer" })
+                expect(loadedUser).to.not.exist
+            }),
+        ))
+
     it("should qualify the discriminator column with an explicit alias on postgres family", () =>
         Promise.all(
             dataSources.map(async (dataSource) => {

--- a/test/functional/query-builder/delete/query-builder-delete.test.ts
+++ b/test/functional/query-builder/delete/query-builder-delete.test.ts
@@ -224,7 +224,7 @@ describe("query builder > delete", () => {
                     .from(User, "u")
                     .where("u.name = :name", { name: "Alex Messer" })
 
-                expect(queryBuilder.getSql()).to.contain('AS "u"')
+                expect(queryBuilder.getSql()).to.contain('"user" "u"')
 
                 await queryBuilder.execute()
 
@@ -244,7 +244,9 @@ describe("query builder > delete", () => {
                     .delete()
                     .where("u.name = :name", { name: "Dima Zotov" })
 
-                expect(queryBuilderFromRepository.getSql()).to.contain('AS "u"')
+                expect(queryBuilderFromRepository.getSql()).to.contain(
+                    '"user" "u"',
+                )
 
                 await queryBuilderFromRepository.execute()
 
@@ -263,7 +265,7 @@ describe("query builder > delete", () => {
                     .where("u.name = :name", { name: "Brad Porter" })
 
                 expect(queryBuilderFromEntityAlias.getSql()).to.contain(
-                    'AS "u"',
+                    '"user" "u"',
                 )
 
                 await queryBuilderFromEntityAlias.execute()
@@ -370,7 +372,7 @@ describe("query builder > delete", () => {
                     .from(AliasedPost, "p")
                     .where("p.title = :title", { title: "Hello" })
 
-                expect(queryBuilder.getSql()).to.contain('AS "p"')
+                expect(queryBuilder.getSql()).to.contain('"post_table" "p"')
 
                 await queryBuilder.execute()
 
@@ -390,7 +392,9 @@ describe("query builder > delete", () => {
                     .delete()
                     .where("p.title = :title", { title: "World" })
 
-                expect(queryBuilderFromRepository.getSql()).to.contain('AS "p"')
+                expect(queryBuilderFromRepository.getSql()).to.contain(
+                    '"post_table" "p"',
+                )
 
                 await queryBuilderFromRepository.execute()
 

--- a/test/functional/query-builder/delete/query-builder-delete.test.ts
+++ b/test/functional/query-builder/delete/query-builder-delete.test.ts
@@ -9,6 +9,7 @@ import type { DataSource } from "../../../../src/data-source/DataSource"
 import { User } from "./entity/User"
 import { Photo } from "./entity/Photo"
 import { EntityPropertyNotFoundError } from "../../../../src/error/EntityPropertyNotFoundError"
+import { DriverUtils } from "../../../../src/driver/DriverUtils"
 
 describe("query builder > delete", () => {
     let dataSources: DataSource[]
@@ -134,6 +135,141 @@ describe("query builder > delete", () => {
                     .execute()
 
                 expect(result.affected).to.equal(2)
+            }),
+        ))
+
+    it("should not add an alias on unsupported dialects", () => {
+        for (const dataSource of dataSources) {
+            if (DriverUtils.isPostgresFamily(dataSource.driver)) continue
+
+            const sqlWithoutAlias = dataSource
+                .createQueryBuilder()
+                .delete()
+                .from(User)
+                .where("name = :name", { name: "Alex Messer" })
+                .getSql()
+
+            expect(sqlWithoutAlias).to.not.contain(" AS ")
+
+            const sqlWithAlias = dataSource
+                .createQueryBuilder()
+                .delete()
+                .from(User, "u")
+                .where("name = :name", { name: "Alex Messer" })
+                .getSql()
+
+            expect(sqlWithAlias).to.not.contain(" AS ")
+
+            const sqlFromRepository = dataSource
+                .getRepository(User)
+                .createQueryBuilder()
+                .delete()
+                .where("name = :name", { name: "Alex Messer" })
+                .getSql()
+
+            expect(sqlFromRepository).to.not.contain(" AS ")
+        }
+    })
+
+    it("should not add an alias when none was given explicitly", () => {
+        for (const dataSource of dataSources) {
+            if (!DriverUtils.isPostgresFamily(dataSource.driver)) continue
+
+            const sqlFromEntity = dataSource
+                .createQueryBuilder()
+                .delete()
+                .from(User)
+                .where("name = :name", { name: "Alex Messer" })
+                .getSql()
+
+            expect(sqlFromEntity).to.not.contain(" AS ")
+
+            const tableName = dataSource.getMetadata(User).tablePath
+            const sqlFromTableName = dataSource
+                .createQueryBuilder()
+                .delete()
+                .from(tableName)
+                .where("name = :name", { name: "Alex Messer" })
+                .getSql()
+
+            expect(sqlFromTableName).to.not.contain(" AS ")
+
+            const sqlFromRepository = dataSource
+                .getRepository(User)
+                .createQueryBuilder()
+                .delete()
+                .where("name = :name", { name: "Alex Messer" })
+                .getSql()
+
+            expect(sqlFromRepository).to.not.contain(" AS ")
+        }
+    })
+
+    it("should add an explicit alias on postgres/cockroachdb", () =>
+        Promise.all(
+            dataSources.map(async (dataSource) => {
+                if (!DriverUtils.isPostgresFamily(dataSource.driver)) return
+
+                const user1 = new User()
+                user1.name = "Alex Messer"
+                const user2 = new User()
+                user2.name = "Dima Zotov"
+                await dataSource.manager.save([user1, user2])
+
+                const queryBuilder = dataSource
+                    .createQueryBuilder()
+                    .delete()
+                    .from(User, "u")
+                    .where("u.name = :name", { name: "Alex Messer" })
+
+                expect(queryBuilder.getSql()).to.contain('AS "u"')
+
+                await queryBuilder.execute()
+
+                const loadedUser1 = await dataSource
+                    .getRepository(User)
+                    .findOneBy({ name: "Alex Messer" })
+                expect(loadedUser1).to.not.exist
+
+                const loadedUser2 = await dataSource
+                    .getRepository(User)
+                    .findOneBy({ name: "Dima Zotov" })
+                expect(loadedUser2).to.exist
+
+                const queryBuilderFromRepository = dataSource
+                    .getRepository(User)
+                    .createQueryBuilder("u")
+                    .delete()
+                    .where("u.name = :name", { name: "Dima Zotov" })
+
+                expect(queryBuilderFromRepository.getSql()).to.contain('AS "u"')
+
+                await queryBuilderFromRepository.execute()
+
+                const loadedUser3 = await dataSource
+                    .getRepository(User)
+                    .findOneBy({ name: "Dima Zotov" })
+                expect(loadedUser3).to.not.exist
+
+                const user3 = new User()
+                user3.name = "Brad Porter"
+                await dataSource.manager.save(user3)
+
+                const queryBuilderFromEntityAlias = dataSource
+                    .createQueryBuilder(User, "u")
+                    .delete()
+                    .where("u.name = :name", { name: "Brad Porter" })
+
+                expect(queryBuilderFromEntityAlias.getSql()).to.contain(
+                    'AS "u"',
+                )
+
+                await queryBuilderFromEntityAlias.execute()
+
+                const loadedUser4 = await dataSource
+                    .getRepository(User)
+                    .findOneBy({ name: "Brad Porter" })
+                expect(loadedUser4).to.not.exist
             }),
         ))
 

--- a/test/functional/query-builder/update/entity/AliasedPost.ts
+++ b/test/functional/query-builder/update/entity/AliasedPost.ts
@@ -1,0 +1,17 @@
+import { Entity } from "../../../../../src/decorator/entity/Entity"
+import { PrimaryGeneratedColumn } from "../../../../../src/decorator/columns/PrimaryGeneratedColumn"
+import { Column } from "../../../../../src/decorator/columns/Column"
+
+/**
+ * Target name ("AliasedPost") intentionally differs from the physical table
+ * name ("post_table") to exercise DELETE/UPDATE alias handling when the two
+ * cannot be conflated.
+ */
+@Entity("post_table")
+export class AliasedPost {
+    @PrimaryGeneratedColumn()
+    id: number
+
+    @Column()
+    title: string
+}

--- a/test/functional/query-builder/update/entity/Person.ts
+++ b/test/functional/query-builder/update/entity/Person.ts
@@ -1,18 +1,14 @@
+import { Column } from "../../../../../src/decorator/columns/Column"
 import { Entity } from "../../../../../src/decorator/entity/Entity"
 import { PrimaryGeneratedColumn } from "../../../../../src/decorator/columns/PrimaryGeneratedColumn"
-import { Column } from "../../../../../src/decorator/columns/Column"
+import { TableInheritance } from "../../../../../src/decorator/entity/TableInheritance"
 
 @Entity()
-export class User {
+@TableInheritance({ column: { name: "type", type: String } })
+export class Person {
     @PrimaryGeneratedColumn()
     id: number
 
     @Column()
     name: string
-
-    @Column()
-    likesCount: number = 0
-
-    @Column({ name: "team_id", nullable: true })
-    team: number
 }

--- a/test/functional/query-builder/update/entity/Student.ts
+++ b/test/functional/query-builder/update/entity/Student.ts
@@ -1,0 +1,9 @@
+import { Column } from "../../../../../src/decorator/columns/Column"
+import { ChildEntity } from "../../../../../src/decorator/entity/ChildEntity"
+import { Person } from "./Person"
+
+@ChildEntity()
+export class Student extends Person {
+    @Column()
+    faculty: string
+}

--- a/test/functional/query-builder/update/query-builder-update.test.ts
+++ b/test/functional/query-builder/update/query-builder-update.test.ts
@@ -313,7 +313,7 @@ describe("query builder > update", () => {
                     .set({ name: "Muhammad Mirzoev" })
                     .where("u.name = :name", { name: "Alex Messer" })
 
-                expect(queryBuilder.getSql()).to.contain('AS "u"')
+                expect(queryBuilder.getSql()).to.contain('"user" "u"')
 
                 await queryBuilder.execute()
 
@@ -333,7 +333,7 @@ describe("query builder > update", () => {
                     .set({ name: "Brad Porter" })
                     .where("u.name = :name", { name: "Dima Zotov" })
 
-                expect(queryBuilderFromEntity.getSql()).to.contain('AS "u"')
+                expect(queryBuilderFromEntity.getSql()).to.contain('"user" "u"')
 
                 await queryBuilderFromEntity.execute()
 
@@ -443,7 +443,7 @@ describe("query builder > update", () => {
                     .set({ title: "Updated Hello" })
                     .where("p.title = :title", { title: "Hello" })
 
-                expect(queryBuilder.getSql()).to.contain('AS "p"')
+                expect(queryBuilder.getSql()).to.contain('"post_table" "p"')
 
                 await queryBuilder.execute()
 
@@ -463,7 +463,9 @@ describe("query builder > update", () => {
                     .set({ title: "Updated World" })
                     .where("p.title = :title", { title: "World" })
 
-                expect(queryBuilderFromEntity.getSql()).to.contain('AS "p"')
+                expect(queryBuilderFromEntity.getSql()).to.contain(
+                    '"post_table" "p"',
+                )
 
                 await queryBuilderFromEntity.execute()
 

--- a/test/functional/query-builder/update/query-builder-update.test.ts
+++ b/test/functional/query-builder/update/query-builder-update.test.ts
@@ -9,6 +9,7 @@ import type { DataSource } from "../../../../src/data-source/DataSource"
 import { User } from "./entity/User"
 import { LimitOnUpdateNotSupportedError } from "../../../../src/error/LimitOnUpdateNotSupportedError"
 import { Photo } from "./entity/Photo"
+import { AliasedPost } from "./entity/AliasedPost"
 import { UpdateValuesMissingError } from "../../../../src/error/UpdateValuesMissingError"
 import { EntityPropertyNotFoundError } from "../../../../src/error/EntityPropertyNotFoundError"
 import { DriverUtils } from "../../../../src/driver/DriverUtils"
@@ -293,7 +294,7 @@ describe("query builder > update", () => {
         }
     })
 
-    it("should add an explicit alias on postgres/cockroachdb", () =>
+    it("should add an explicit alias on postgres family", () =>
         Promise.all(
             dataSources.map(async (dataSource) => {
                 if (!DriverUtils.isPostgresFamily(dataSource.driver)) return
@@ -339,6 +340,80 @@ describe("query builder > update", () => {
                     .getRepository(User)
                     .findOneBy({ name: "Brad Porter" })
                 expect(loadedUser3).to.exist
+            }),
+        ))
+
+    it("should not add an alias when the entity's table name differs from its target name and no alias was given explicitly", () => {
+        for (const dataSource of dataSources) {
+            if (!DriverUtils.isPostgresFamily(dataSource.driver)) continue
+
+            const sqlFromEntity = dataSource
+                .createQueryBuilder()
+                .update(AliasedPost)
+                .set({ title: "Updated" })
+                .where("title = :title", { title: "Hello" })
+                .getSql()
+
+            expect(sqlFromEntity).to.not.contain(" AS ")
+
+            const sqlFromRepository = dataSource
+                .getRepository(AliasedPost)
+                .createQueryBuilder()
+                .update()
+                .set({ title: "Updated" })
+                .where("title = :title", { title: "Hello" })
+                .getSql()
+
+            expect(sqlFromRepository).to.not.contain(" AS ")
+        }
+    })
+
+    it("should add an explicit alias when the entity's table name differs from its target name on postgres family", () =>
+        Promise.all(
+            dataSources.map(async (dataSource) => {
+                if (!DriverUtils.isPostgresFamily(dataSource.driver)) return
+
+                const post1 = new AliasedPost()
+                post1.title = "Hello"
+                const post2 = new AliasedPost()
+                post2.title = "World"
+                await dataSource.manager.save([post1, post2])
+
+                const queryBuilder = dataSource
+                    .getRepository(AliasedPost)
+                    .createQueryBuilder("p")
+                    .update()
+                    .set({ title: "Updated Hello" })
+                    .where("p.title = :title", { title: "Hello" })
+
+                expect(queryBuilder.getSql()).to.contain('AS "p"')
+
+                await queryBuilder.execute()
+
+                const loadedPost1 = await dataSource
+                    .getRepository(AliasedPost)
+                    .findOneBy({ title: "Updated Hello" })
+                expect(loadedPost1).to.exist
+
+                const loadedPost2 = await dataSource
+                    .getRepository(AliasedPost)
+                    .findOneBy({ title: "World" })
+                expect(loadedPost2).to.exist
+
+                const queryBuilderFromEntity = dataSource
+                    .createQueryBuilder(AliasedPost, "p")
+                    .update()
+                    .set({ title: "Updated World" })
+                    .where("p.title = :title", { title: "World" })
+
+                expect(queryBuilderFromEntity.getSql()).to.contain('AS "p"')
+
+                await queryBuilderFromEntity.execute()
+
+                const loadedPost3 = await dataSource
+                    .getRepository(AliasedPost)
+                    .findOneBy({ title: "Updated World" })
+                expect(loadedPost3).to.exist
             }),
         ))
 

--- a/test/functional/query-builder/update/query-builder-update.test.ts
+++ b/test/functional/query-builder/update/query-builder-update.test.ts
@@ -372,6 +372,34 @@ describe("query builder > update", () => {
             }),
         ))
 
+    it("should still translate an unqualified where condition to its database column name when an explicit alias is set on postgres family", () =>
+        Promise.all(
+            dataSources.map(async (dataSource) => {
+                if (!DriverUtils.isPostgresFamily(dataSource.driver)) return
+
+                const user1 = new User()
+                user1.name = "Alex Messer"
+                user1.team = 1
+                await dataSource.manager.save(user1)
+
+                const queryBuilder = dataSource
+                    .getRepository(User)
+                    .createQueryBuilder("tc")
+                    .update()
+                    .set({ team: 2 })
+                    .where("team = :team", { team: 1 })
+
+                expect(queryBuilder.getSql()).to.not.contain(" team ")
+
+                await queryBuilder.execute()
+
+                const loadedUser = await dataSource
+                    .getRepository(User)
+                    .findOneBy({ name: "Alex Messer" })
+                expect(loadedUser!.team).to.equal(2)
+            }),
+        ))
+
     it("should qualify the discriminator column with an explicit alias on postgres family", () =>
         Promise.all(
             dataSources.map(async (dataSource) => {

--- a/test/functional/query-builder/update/query-builder-update.test.ts
+++ b/test/functional/query-builder/update/query-builder-update.test.ts
@@ -223,6 +223,125 @@ describe("query builder > update", () => {
             }),
         ))
 
+    it("should not add an alias on unsupported dialects", () => {
+        for (const dataSource of dataSources) {
+            if (DriverUtils.isPostgresFamily(dataSource.driver)) continue
+
+            const sqlWithoutAlias = dataSource
+                .createQueryBuilder()
+                .update(User)
+                .set({ name: "Dima Zotov" })
+                .where("name = :name", { name: "Alex Messer" })
+                .getSql()
+
+            expect(sqlWithoutAlias).to.not.contain(" AS ")
+
+            const sqlWithAlias = dataSource
+                .getRepository(User)
+                .createQueryBuilder("u")
+                .update()
+                .set({ name: "Dima Zotov" })
+                .where("u.name = :name", { name: "Alex Messer" })
+                .getSql()
+
+            expect(sqlWithAlias).to.not.contain(" AS ")
+
+            const sqlFromRepository = dataSource
+                .getRepository(User)
+                .createQueryBuilder()
+                .update()
+                .set({ name: "Dima Zotov" })
+                .where("name = :name", { name: "Alex Messer" })
+                .getSql()
+
+            expect(sqlFromRepository).to.not.contain(" AS ")
+        }
+    })
+
+    it("should not add an alias when none was given explicitly", () => {
+        for (const dataSource of dataSources) {
+            if (!DriverUtils.isPostgresFamily(dataSource.driver)) continue
+
+            const sqlFromEntity = dataSource
+                .createQueryBuilder()
+                .update(User)
+                .set({ name: "Dima Zotov" })
+                .where("name = :name", { name: "Alex Messer" })
+                .getSql()
+
+            expect(sqlFromEntity).to.not.contain(" AS ")
+
+            const tableName = dataSource.getMetadata(User).tablePath
+            const sqlFromTableName = dataSource
+                .createQueryBuilder()
+                .update(tableName)
+                .set({ name: "Dima Zotov" })
+                .where("name = :name", { name: "Alex Messer" })
+                .getSql()
+
+            expect(sqlFromTableName).to.not.contain(" AS ")
+
+            const sqlFromRepository = dataSource
+                .getRepository(User)
+                .createQueryBuilder()
+                .update()
+                .set({ name: "Dima Zotov" })
+                .where("name = :name", { name: "Alex Messer" })
+                .getSql()
+
+            expect(sqlFromRepository).to.not.contain(" AS ")
+        }
+    })
+
+    it("should add an explicit alias on postgres/cockroachdb", () =>
+        Promise.all(
+            dataSources.map(async (dataSource) => {
+                if (!DriverUtils.isPostgresFamily(dataSource.driver)) return
+
+                const user1 = new User()
+                user1.name = "Alex Messer"
+                const user2 = new User()
+                user2.name = "Dima Zotov"
+                await dataSource.manager.save([user1, user2])
+
+                const queryBuilder = dataSource
+                    .getRepository(User)
+                    .createQueryBuilder("u")
+                    .update()
+                    .set({ name: "Muhammad Mirzoev" })
+                    .where("u.name = :name", { name: "Alex Messer" })
+
+                expect(queryBuilder.getSql()).to.contain('AS "u"')
+
+                await queryBuilder.execute()
+
+                const loadedUser1 = await dataSource
+                    .getRepository(User)
+                    .findOneBy({ name: "Muhammad Mirzoev" })
+                expect(loadedUser1).to.exist
+
+                const loadedUser2 = await dataSource
+                    .getRepository(User)
+                    .findOneBy({ name: "Dima Zotov" })
+                expect(loadedUser2).to.exist
+
+                const queryBuilderFromEntity = dataSource
+                    .createQueryBuilder(User, "u")
+                    .update()
+                    .set({ name: "Brad Porter" })
+                    .where("u.name = :name", { name: "Dima Zotov" })
+
+                expect(queryBuilderFromEntity.getSql()).to.contain('AS "u"')
+
+                await queryBuilderFromEntity.execute()
+
+                const loadedUser3 = await dataSource
+                    .getRepository(User)
+                    .findOneBy({ name: "Brad Porter" })
+                expect(loadedUser3).to.exist
+            }),
+        ))
+
     it("should throw error when update value is missing", () =>
         Promise.all(
             dataSources.map(async (dataSource) => {

--- a/test/functional/query-builder/update/query-builder-update.test.ts
+++ b/test/functional/query-builder/update/query-builder-update.test.ts
@@ -10,6 +10,7 @@ import { User } from "./entity/User"
 import { LimitOnUpdateNotSupportedError } from "../../../../src/error/LimitOnUpdateNotSupportedError"
 import { Photo } from "./entity/Photo"
 import { AliasedPost } from "./entity/AliasedPost"
+import { Student } from "./entity/Student"
 import { UpdateValuesMissingError } from "../../../../src/error/UpdateValuesMissingError"
 import { EntityPropertyNotFoundError } from "../../../../src/error/EntityPropertyNotFoundError"
 import { DriverUtils } from "../../../../src/driver/DriverUtils"
@@ -340,6 +341,62 @@ describe("query builder > update", () => {
                     .getRepository(User)
                     .findOneBy({ name: "Brad Porter" })
                 expect(loadedUser3).to.exist
+            }),
+        ))
+
+    it("should translate an alias-qualified where condition to its database column name on postgres family", () =>
+        Promise.all(
+            dataSources.map(async (dataSource) => {
+                if (!DriverUtils.isPostgresFamily(dataSource.driver)) return
+
+                const user1 = new User()
+                user1.name = "Alex Messer"
+                user1.team = 1
+                await dataSource.manager.save(user1)
+
+                const queryBuilder = dataSource
+                    .getRepository(User)
+                    .createQueryBuilder("tc")
+                    .update()
+                    .set({ team: 2 })
+                    .where("tc.team = :team", { team: 1 })
+
+                expect(queryBuilder.getSql()).to.not.contain("tc.team")
+
+                await queryBuilder.execute()
+
+                const loadedUser = await dataSource
+                    .getRepository(User)
+                    .findOneBy({ name: "Alex Messer" })
+                expect(loadedUser!.team).to.equal(2)
+            }),
+        ))
+
+    it("should qualify the discriminator column with an explicit alias on postgres family", () =>
+        Promise.all(
+            dataSources.map(async (dataSource) => {
+                if (!DriverUtils.isPostgresFamily(dataSource.driver)) return
+
+                const student = new Student()
+                student.name = "Alex Messer"
+                student.faculty = "Economics"
+                await dataSource.manager.save(student)
+
+                const queryBuilder = dataSource
+                    .getRepository(Student)
+                    .createQueryBuilder("s")
+                    .update()
+                    .set({ faculty: "Physics" })
+                    .where("name = :name", { name: "Alex Messer" })
+
+                expect(queryBuilder.getSql()).to.contain('"s"."type"')
+
+                await queryBuilder.execute()
+
+                const loadedStudent = await dataSource
+                    .getRepository(Student)
+                    .findOneBy({ name: "Alex Messer" })
+                expect(loadedStudent!.faculty).to.equal("Physics")
             }),
         ))
 


### PR DESCRIPTION
<!--
  😀 Wonderful!  Thank you for opening a pull request for TypeORM.

  Please fill in the information below to expedite the review
  and (hopefully) merge of your change.

  If unsure about something.. just do as best as you're able,
  or reach out through our community support channels!
  https://github.com/typeorm/typeorm/blob/master/docs/support.md
  https://github.com/typeorm/typeorm/blob/master/CONTRIBUTING.md
-->

### Description of change

<!--
  Please describe:
  - what the change is intended to do
  - why this change is needed
  - how you've verified it
  - any other context that will help reviewers understand the change

  In some cases it may be helpful to include the current behavior
  and the new behavior.
-->

postgres support aliases on `DELETE`/`UPDATE` queries

### Pull-Request Checklist

<!--
  Please make sure to review and check all of the following.

  If an item is not applicable, you can add "N/A" to the end.
-->

- [x] Code is up-to-date with the `master` branch
- [x] This pull request links a relevant issue using a closing keyword:
      `Fixes #NNNN`, `Closes #NNNN`, or `Resolves #NNNN`
- [x] There are new or updated tests validating the change (`tests/**.test.ts`)
- [x] Documentation has been updated to reflect this change (`docs/docs/**.md`)

Closes #1798, #817, #659
Related: #9722 (reporter hit a since-fixed crash while attempting the same feature), #1706 (MySQL/MariaDB-specific; this PR only adds alias support for Postgres family)


> 🛡️ **Security fixes:** Do not submit security fixes as public PRs — the diff exposes the vulnerability. Use [GitHub Security Advisories](https://github.com/typeorm/typeorm/security/advisories/new) instead.