### PR TITLE
perf: improve related entity hydration

### DIFF
--- a/src/driver/postgres/PostgresDriver.ts
+++ b/src/driver/postgres/PostgresDriver.ts
@@ -878,7 +878,12 @@ export class PostgresDriver implements Driver {
                   )
                 : value
 
-        if (columnMetadata.type === Boolean) {
+        if (columnMetadata.type === Number) {
+            // convert to number if number
+            value = !isNaN(+value) ? parseInt(value) : value
+        } else if (columnMetadata.type === String) {
+            // nothing to convert
+        } else if (columnMetadata.type === Boolean) {
             value = value ? true : false
         } else if (
             columnMetadata.type === "datetime" ||
@@ -990,9 +995,6 @@ export class PostgresDriver implements Driver {
                         ? parseInt(value)
                         : value
             }
-        } else if (columnMetadata.type === Number) {
-            // convert to number if number
-            value = !isNaN(+value) ? parseInt(value) : value
         }
 
         if (columnMetadata.transformer)

--- a/src/metadata/ColumnMetadata.ts
+++ b/src/metadata/ColumnMetadata.ts
@@ -860,32 +860,16 @@ export class ColumnMetadata {
      */
     setEntityValue(entity: ObjectLiteral, value: any): void {
         if (this.embeddedMetadata) {
-            // first step - we extract all parent properties of the entity relative to this column, e.g. [data, information, counters]
-            const extractEmbeddedColumnValue = (
-                embeddedMetadatas: EmbeddedMetadata[],
-                map: ObjectLiteral,
-            ): any => {
-                // if (!object[embeddedMetadata.propertyName])
-                //     object[embeddedMetadata.propertyName] = embeddedMetadata.create();
-
-                const embeddedMetadata = embeddedMetadatas.shift()
-                if (embeddedMetadata) {
-                    map[embeddedMetadata.propertyName] ??=
-                        embeddedMetadata.create()
-
-                    extractEmbeddedColumnValue(
-                        embeddedMetadatas,
-                        map[embeddedMetadata.propertyName],
-                    )
-                    return map
-                }
-                map[this.propertyName] = value
-                return map
+            // walk down all parent properties of the entity relative to this column,
+            // e.g. [data, information, counters], creating the embeds on the way
+            const embeddedMetadatas = this.embeddedMetadata.embeddedMetadataTree
+            let map = entity
+            for (let i = 0; i < embeddedMetadatas.length; i++) {
+                const propertyName = embeddedMetadatas[i].propertyName
+                map = map[propertyName] ??= embeddedMetadatas[i].create()
             }
-            return extractEmbeddedColumnValue(
-                [...this.embeddedMetadata.embeddedMetadataTree],
-                entity,
-            )
+            map[this.propertyName] = value
+            return
         } else {
             // we write a deep object in this entity only if the column is virtual
             // because if its not virtual it means the user defined a real column for this relation

--- a/src/metadata/EntityMetadata.ts
+++ b/src/metadata/EntityMetadata.ts
@@ -588,13 +588,17 @@ export class EntityMetadata {
             ret[this.dataSource.options.typename] = this.targetName
         }
 
-        this.lazyRelations.forEach((relation) =>
-            this.dataSource.relationLoader.enableLazyLoad(
-                relation,
-                ret,
-                queryRunner,
-            ),
-        )
+        // guarded because create() runs once per hydrated entity, and the callback
+        // would otherwise be allocated for every entity of every non-lazy metadata
+        if (this.lazyRelations.length > 0) {
+            this.lazyRelations.forEach((relation) =>
+                this.dataSource.relationLoader.enableLazyLoad(
+                    relation,
+                    ret,
+                    queryRunner,
+                ),
+            )
+        }
         return ret
     }
 

--- a/src/query-builder/transformer/RawSqlResultsToEntityTransformer.ts
+++ b/src/query-builder/transformer/RawSqlResultsToEntityTransformer.ts
@@ -13,6 +13,69 @@ import type { QueryExpressionMap } from "../QueryExpressionMap"
 import type { RelationIdLoadResult } from "../relation-id/RelationIdLoadResult"
 
 /**
+ * A join attribute reduced to the data needed while hydrating entities.
+ * Resolving a JoinAttribute is expensive (its parentAlias, relationPropertyPath and
+ * mapToProperty* members are getters that re-parse strings on every access), so the
+ * joins applicable to an alias are resolved once and reused for every entity.
+ */
+interface JoinToProcess {
+    alias: Alias
+    isMany: boolean
+    mapToPropertyPropertyName: string | undefined
+    relation: RelationMetadata | undefined
+}
+
+/**
+ * A relation id attribute reduced to the data needed while hydrating entities.
+ */
+interface RelationIdToProcess {
+    /**
+     * Index of the corresponding entry in rawRelationIdResults / relationIdMaps.
+     */
+    index: number
+    relation: RelationMetadata
+    /**
+     * mapToPropertyPropertyPath split into its segments.
+     */
+    properties: string[]
+    /**
+     * Columns of the value map, along with the raw result key to read and the
+     * column metadata to hydrate the raw value with.
+     */
+    valueMapColumns: Array<{
+        databaseName: string
+        rawKey: string
+        hydrateWith: ColumnMetadata
+    }>
+}
+
+/**
+ * Everything needed to hydrate an entity of one alias, resolved once up front.
+ *
+ * None of it depends on the raw results, while hydration runs it once per row group,
+ * so resolving it per alias/metadata pair instead keeps the per-entity work down to
+ * reading already-prepared arrays.
+ */
+interface HydrationPlan {
+    /**
+     * Metadata the plan was built for. Differs from the alias metadata when single
+     * table inheritance selected a child entity.
+     */
+    metadata: EntityMetadata
+    /**
+     * Columns to hydrate, paired with the raw result key holding their value.
+     */
+    columns: Array<{ key: string; column: ColumnMetadata }>
+    joins: JoinToProcess[]
+    relationIds: RelationIdToProcess[]
+    /**
+     * Raw result key of the discriminator column, if the entity uses one.
+     */
+    discriminatorKey: string | undefined
+    hasOnlyVirtualPrimaryColumns: boolean
+}
+
+/**
  * Transforms raw sql results returned from the database into entity object.
  * Entity is constructed based on its entity metadata.
  */
@@ -26,10 +89,10 @@ export class RawSqlResultsToEntityTransformer {
     private pojo: boolean
     private selections: Set<string>
     private aliasCache: Map<string, Map<string, string>>
-    private columnsCache: Map<
-        string,
-        Map<EntityMetadata, [string, ColumnMetadata][]>
-    >
+    private planCache: Map<string, Map<EntityMetadata, HydrationPlan>>
+    private groupKeysCache: Map<string, string[]>
+    private relationIdsCache: Map<string, RelationIdToProcess[]>
+    private relationIdColumnsCache: Map<RelationMetadata, ColumnMetadata[]>
 
     // -------------------------------------------------------------------------
     // Constructor
@@ -46,7 +109,10 @@ export class RawSqlResultsToEntityTransformer {
             this.expressionMap.selects.map((s) => s.selection),
         )
         this.aliasCache = new Map()
-        this.columnsCache = new Map()
+        this.planCache = new Map()
+        this.groupKeysCache = new Map()
+        this.relationIdsCache = new Map()
+        this.relationIdColumnsCache = new Map()
     }
 
     // -------------------------------------------------------------------------
@@ -62,9 +128,10 @@ export class RawSqlResultsToEntityTransformer {
      */
     transform(rawResults: any[], alias: Alias): any[] {
         const group = this.group(rawResults, alias)
+        const plan = this.getHydrationPlan(alias.name, alias.metadata)
         const entities: any[] = []
         for (const results of group.values()) {
-            const entity = this.transformRawResultsGroup(results, alias)
+            const entity = this.transformRawResultsGroup(results, alias, plan)
             if (entity !== undefined) entities.push(entity)
         }
         return entities
@@ -106,52 +173,40 @@ export class RawSqlResultsToEntityTransformer {
      * @param alias
      */
     protected group(rawResults: any[], alias: Alias): Map<string, any[]> {
-        const map = new Map()
-        const keys: string[] = []
-        if (alias.metadata.tableType === "view") {
-            keys.push(
-                ...alias.metadata.columns.map((column) =>
-                    this.buildAlias(alias.name, column.databaseName),
-                ),
-            )
-        } else {
-            keys.push(
-                ...alias.metadata.primaryColumns.map((column) =>
-                    this.buildAlias(alias.name, column.databaseName),
-                ),
-            )
-        }
+        const map = new Map<string, any[]>()
+        const keys = this.getGroupKeys(alias)
 
         // Check if primary key columns are actually selected in the raw results
-        const primaryKeysSelected = keys.some(
-            (key) => key in (rawResults[0] ?? {}),
-        )
+        const firstResult = rawResults[0] ?? {}
+        let primaryKeysSelected = false
+        for (let i = 0; i < keys.length; i++) {
+            if (keys[i] in firstResult) {
+                primaryKeysSelected = true
+                break
+            }
+        }
+
+        // the single key case is by far the most common one, so it gets to skip
+        // the per-row string building below
+        const singleKey = keys.length === 1 ? keys[0] : undefined
 
         for (let rowIndex = 0; rowIndex < rawResults.length; rowIndex++) {
             const rawResult = rawResults[rowIndex]
             let id: string
 
-            if (primaryKeysSelected) {
-                // Use primary key based grouping when available
-                id = keys
-                    .map((key) => {
-                        const keyValue = rawResult[key]
-
-                        if (isUint8Array(keyValue)) {
-                            return uint8ArrayToHex(keyValue)
-                        }
-
-                        if (ObjectUtils.isObject(keyValue)) {
-                            return JSON.stringify(keyValue)
-                        }
-
-                        return keyValue
-                    })
-                    .join("_")
-            } else {
+            if (!primaryKeysSelected) {
                 // Fallback: use row index when primary keys are not available
                 // This ensures each row gets its own group for proper entity mapping
                 id = `row_${rowIndex}`
+            } else if (singleKey !== undefined) {
+                // Use primary key based grouping when available
+                id = this.groupKeyValueToString(rawResult[singleKey])
+            } else {
+                id = ""
+                for (let i = 0; i < keys.length; i++) {
+                    if (i !== 0) id += "_"
+                    id += this.groupKeyValueToString(rawResult[keys[i]])
+                }
             }
 
             const items = map.get(id)
@@ -165,6 +220,46 @@ export class RawSqlResultsToEntityTransformer {
     }
 
     /**
+     * Raw result keys of the columns a given alias is grouped by.
+     * Constant for an alias, so it is computed once per alias instead of once per
+     * group() call - group() runs once per parent entity for every joined alias.
+     */
+    private getGroupKeys(alias: Alias): string[] {
+        let keys = this.groupKeysCache.get(alias.name)
+        if (keys !== undefined) return keys
+
+        const columns =
+            alias.metadata.tableType === "view"
+                ? alias.metadata.columns
+                : alias.metadata.primaryColumns
+        keys = new Array<string>(columns.length)
+        for (let i = 0; i < columns.length; i++) {
+            keys[i] = this.buildAlias(alias.name, columns[i].databaseName)
+        }
+
+        this.groupKeysCache.set(alias.name, keys)
+        return keys
+    }
+
+    /**
+     * Turns a single grouping key value into its string representation.
+     * Mirrors what Array#join did before: null and undefined both collapse to "".
+     */
+    private groupKeyValueToString(keyValue: any): string {
+        if (keyValue === null || keyValue === undefined) return ""
+
+        if (isUint8Array(keyValue)) {
+            return uint8ArrayToHex(keyValue)
+        }
+
+        if (ObjectUtils.isObject(keyValue)) {
+            return JSON.stringify(keyValue)
+        }
+
+        return typeof keyValue === "string" ? keyValue : String(keyValue)
+    }
+
+    /**
      * Transforms set of data results into single entity.
      *
      * @param rawResults
@@ -173,33 +268,33 @@ export class RawSqlResultsToEntityTransformer {
     protected transformRawResultsGroup(
         rawResults: any[],
         alias: Alias,
+        plan: HydrationPlan = this.getHydrationPlan(alias.name, alias.metadata),
     ): ObjectLiteral | undefined {
         // let hasColumns = false; // , hasEmbeddedColumns = false, hasParentColumns = false, hasParentEmbeddedColumns = false;
-        let metadata = alias.metadata
-
-        if (metadata.discriminatorColumn) {
-            const discriminatorValues = rawResults.map(
-                (result) =>
-                    result[
-                        this.buildAlias(
+        if (plan.discriminatorKey !== undefined) {
+            const childEntityMetadatas = plan.metadata.childEntityMetadatas
+            search: for (let i = 0; i < childEntityMetadatas.length; i++) {
+                const discriminatorValue =
+                    childEntityMetadatas[i].discriminatorValue
+                // an undefined discriminator value never matched before, since the
+                // previous implementation could not tell "found undefined" from "not found"
+                if (discriminatorValue === undefined) continue
+                for (let j = 0; j < rawResults.length; j++) {
+                    if (
+                        rawResults[j][plan.discriminatorKey] ===
+                        discriminatorValue
+                    ) {
+                        plan = this.getHydrationPlan(
                             alias.name,
-                            alias.metadata.discriminatorColumn!.databaseName,
+                            childEntityMetadatas[i],
                         )
-                    ],
-            )
-            const discriminatorMetadata = metadata.childEntityMetadatas.find(
-                (childEntityMetadata) => {
-                    return (
-                        typeof discriminatorValues.find(
-                            (value) =>
-                                value ===
-                                childEntityMetadata.discriminatorValue,
-                        ) !== "undefined"
-                    )
-                },
-            )
-            if (discriminatorMetadata) metadata = discriminatorMetadata
+                        break search
+                    }
+                }
+            }
         }
+
+        const metadata = plan.metadata
         const entity: any = metadata.create(this.queryRunner, {
             fromDeserializer: true,
             pojo: this.pojo,
@@ -211,18 +306,21 @@ export class RawSqlResultsToEntityTransformer {
             alias,
             entity,
             metadata,
+            plan,
         )
         const hasRelations = this.transformJoins(
             rawResults,
             entity,
             alias,
             metadata,
+            plan,
         )
         const hasRelationIds = this.transformRelationIds(
             rawResults,
             alias,
             entity,
             metadata,
+            plan,
         )
         // if we have at least one selected column then return this entity
         // since entity must have at least primary columns to be really selected and transformed into entity
@@ -231,10 +329,10 @@ export class RawSqlResultsToEntityTransformer {
         // if we don't have any selected column we should not return entity,
         // except for the case when entity only contain a primary column as a relation to another entity
         // in this case its absolutely possible our entity to not have any columns except a single relation
-        const hasOnlyVirtualPrimaryColumns = metadata.primaryColumns.every(
-            (column) => column.isVirtual === true,
-        ) // todo: create metadata.hasOnlyVirtualPrimaryColumns
-        if (hasOnlyVirtualPrimaryColumns && (hasRelations || hasRelationIds))
+        if (
+            plan.hasOnlyVirtualPrimaryColumns &&
+            (hasRelations || hasRelationIds)
+        )
             return entity
 
         return undefined
@@ -246,18 +344,20 @@ export class RawSqlResultsToEntityTransformer {
         alias: Alias,
         entity: ObjectLiteral,
         metadata: EntityMetadata,
+        plan: HydrationPlan = this.getHydrationPlan(alias.name, metadata),
     ): boolean {
         let hasData = false
         const result = rawResults[0]
-        for (const [key, column] of this.getColumnsToProcess(
-            alias.name,
-            metadata,
-        )) {
-            const value = result[key]
+        const columns = plan.columns
+        for (let i = 0; i < columns.length; i++) {
+            const entry = columns[i]
+            const value = result[entry.key]
 
             if (value === undefined) continue
+
+            const column = entry.column
             // we don't mark it as has data because if we will have all nulls in our object - we don't need such object
-            else if (value !== null && !column.isVirtualProperty) hasData = true
+            if (value !== null && !column.isVirtualProperty) hasData = true
 
             column.setEntityValue(
                 entity,
@@ -280,6 +380,7 @@ export class RawSqlResultsToEntityTransformer {
         entity: ObjectLiteral,
         alias: Alias,
         metadata: EntityMetadata,
+        plan: HydrationPlan = this.getHydrationPlan(alias.name, metadata),
     ) {
         let hasData = false
 
@@ -287,36 +388,9 @@ export class RawSqlResultsToEntityTransformer {
         // if (metadata.discriminatorColumn)
         //     discriminatorValue = rawResults[0][this.buildAlias(alias.name, alias.metadata.discriminatorColumn!.databaseName)];
 
-        for (const join of this.expressionMap.joinAttributes) {
-            // todo: we have problem here - when inner joins are used without selects it still create empty array
-
-            // skip joins without metadata
-            if (!join.metadata) continue
-
-            // if simple left or inner join was performed without selection then we don't need to do anything
-            if (!join.isSelected) continue
-
-            // this check need to avoid setting properties than not belong to entity when single table inheritance used. (todo: check if we still need it)
-            // const metadata = metadata.childEntityMetadatas.find(childEntityMetadata => discriminatorValue === childEntityMetadata.discriminatorValue);
-            if (
-                join.relation &&
-                !metadata.relations.find(
-                    (relation) => relation === join.relation,
-                )
-            )
-                continue
-
-            // some checks to make sure this join is for current alias
-            if (join.mapToProperty) {
-                if (join.mapToPropertyParentAlias !== alias.name) continue
-            } else {
-                if (
-                    !join.relation ||
-                    join.parentAlias !== alias.name ||
-                    join.relationPropertyPath !== join.relation!.propertyPath
-                )
-                    continue
-            }
+        const joins = plan.joins
+        for (let i = 0; i < joins.length; i++) {
+            const join = joins[i]
 
             // transform joined data into entities
             let result: any = this.transform(rawResults, join.alias)
@@ -338,74 +412,122 @@ export class RawSqlResultsToEntityTransformer {
         return hasData
     }
 
+    /**
+     * Everything needed to hydrate entities of the given alias and metadata.
+     *
+     * None of it depends on the raw results, so the (fairly expensive) resolution
+     * happens once per alias/metadata pair rather than once per entity.
+     */
+    private getHydrationPlan(
+        aliasName: string,
+        metadata: EntityMetadata,
+    ): HydrationPlan {
+        let metadatas = this.planCache.get(aliasName)
+        if (!metadatas) {
+            metadatas = new Map()
+            this.planCache.set(aliasName, metadatas)
+        }
+        const cached = metadatas.get(metadata)
+        if (cached !== undefined) return cached
+
+        const plan: HydrationPlan = {
+            metadata,
+            columns: this.buildColumnsToProcess(aliasName, metadata),
+            joins: this.buildJoinsToProcess(aliasName, metadata),
+            relationIds: this.getRelationIdsToProcess(aliasName),
+            discriminatorKey: metadata.discriminatorColumn
+                ? this.buildAlias(
+                      aliasName,
+                      metadata.discriminatorColumn.databaseName,
+                  )
+                : undefined,
+            // todo: create metadata.hasOnlyVirtualPrimaryColumns
+            hasOnlyVirtualPrimaryColumns: metadata.primaryColumns.every(
+                (column) => column.isVirtual === true,
+            ),
+        }
+
+        metadatas.set(metadata, plan)
+        return plan
+    }
+
+    private buildJoinsToProcess(
+        aliasName: string,
+        metadata: EntityMetadata,
+    ): JoinToProcess[] {
+        const joins: JoinToProcess[] = []
+        for (const join of this.expressionMap.joinAttributes) {
+            // todo: we have problem here - when inner joins are used without selects it still create empty array
+
+            // skip joins without metadata
+            if (!join.metadata) continue
+
+            // if simple left or inner join was performed without selection then we don't need to do anything
+            if (!join.isSelected) continue
+
+            const relation = join.relation
+
+            // this check need to avoid setting properties than not belong to entity when single table inheritance used. (todo: check if we still need it)
+            // const metadata = metadata.childEntityMetadatas.find(childEntityMetadata => discriminatorValue === childEntityMetadata.discriminatorValue);
+            if (relation && !metadata.relations.includes(relation)) continue
+
+            // some checks to make sure this join is for current alias
+            if (join.mapToProperty) {
+                if (join.mapToPropertyParentAlias !== aliasName) continue
+            } else {
+                if (
+                    !relation ||
+                    join.parentAlias !== aliasName ||
+                    join.relationPropertyPath !== relation.propertyPath
+                )
+                    continue
+            }
+
+            joins.push({
+                alias: join.alias,
+                isMany: join.isMany,
+                mapToPropertyPropertyName: join.mapToPropertyPropertyName,
+                relation,
+            })
+        }
+
+        return joins
+    }
+
     protected transformRelationIds(
         rawSqlResults: any[],
         alias: Alias,
         entity: ObjectLiteral,
         metadata: EntityMetadata,
+        plan: HydrationPlan = this.getHydrationPlan(alias.name, metadata),
     ): boolean {
-        let hasData = false
-        for (const [
-            index,
-            rawRelationIdResult,
-        ] of this.rawRelationIdResults.entries()) {
-            if (
-                rawRelationIdResult.relationIdAttribute.parentAlias !==
-                alias.name
-            )
-                continue
+        if (this.rawRelationIdResults.length === 0) return false
 
-            const relation = rawRelationIdResult.relationIdAttribute.relation
+        let hasData = false
+        const relationIds = plan.relationIds
+        for (let i = 0; i < relationIds.length; i++) {
+            const relationId = relationIds[i]
+            const relation = relationId.relation
             const valueMap = this.createValueMapFromJoinColumns(
-                relation,
-                rawRelationIdResult.relationIdAttribute.parentAlias,
+                relationId,
                 rawSqlResults,
             )
-            if (valueMap === undefined || valueMap === null) {
-                continue
-            }
 
             // prepare common data for this call
             this.prepareDataForTransformRelationIds()
 
             // Extract idMaps from prepared data by hash
             const hash = this.hashEntityIds(relation, valueMap)
-            const idMaps = this.relationIdMaps[index][hash] || []
+            const idMaps = this.relationIdMaps[relationId.index][hash] || []
 
             // Map data to properties
-            const properties =
-                rawRelationIdResult.relationIdAttribute.mapToPropertyPropertyPath.split(
-                    ".",
-                )
-            const mapToProperty = (
-                properties: string[],
-                map: ObjectLiteral,
-                value: any,
-            ): any => {
-                const property = properties.shift()
-                if (property && properties.length === 0) {
-                    map[property] = value
-                    return map
-                }
-                if (property && properties.length > 0) {
-                    if (
-                        typeof map[property] !== "object" ||
-                        map[property] === null
-                    ) {
-                        map[property] = {}
-                    }
-                    mapToProperty(properties, map[property], value)
-                } else {
-                    return map
-                }
-            }
             if (relation.isOneToOne || relation.isManyToOne) {
                 if (idMaps[0] !== undefined) {
-                    mapToProperty(properties, entity, idMaps[0])
+                    this.mapToProperty(relationId.properties, entity, idMaps[0])
                     hasData = true
                 }
             } else {
-                mapToProperty(properties, entity, idMaps)
+                this.mapToProperty(relationId.properties, entity, idMaps)
                 hasData = hasData || idMaps.length > 0
             }
         }
@@ -413,118 +535,148 @@ export class RawSqlResultsToEntityTransformer {
         return hasData
     }
 
-    private getColumnsToProcess(aliasName: string, metadata: EntityMetadata) {
-        let metadatas = this.columnsCache.get(aliasName)
-        if (!metadatas) {
-            metadatas = new Map()
-            this.columnsCache.set(aliasName, metadatas)
-        }
-        let columns = metadatas.get(metadata)
-        if (!columns) {
-            columns = metadata.columns
-                .filter(
-                    (column) =>
-                        !column.isVirtual &&
-                        // if user does not selected the whole entity or he used partial selection and does not select this particular column
-                        // then we don't add this column and its value into the entity
-                        (this.selections.has(aliasName) ||
-                            this.selections.has(
-                                `${aliasName}.${column.propertyPath}`,
-                            )) &&
-                        // if table inheritance is used make sure this column is not child's column
-                        !metadata.childEntityMetadatas.some(
-                            (childMetadata) =>
-                                childMetadata.target === column.target,
+    /**
+     * Relation ids that must be hydrated into entities of the given alias, with all
+     * of the per-relation data that does not depend on the raw results resolved once.
+     */
+    private getRelationIdsToProcess(aliasName: string): RelationIdToProcess[] {
+        let relationIds = this.relationIdsCache.get(aliasName)
+        if (relationIds !== undefined) return relationIds
+
+        relationIds = []
+        for (let index = 0; index < this.rawRelationIdResults.length; index++) {
+            const attribute =
+                this.rawRelationIdResults[index].relationIdAttribute
+            if (attribute.parentAlias !== aliasName) continue
+
+            const relation = attribute.relation
+            const readsParentPrimaryKeys =
+                relation.isManyToOne || relation.isOneToOneOwner
+
+            relationIds.push({
+                index,
+                relation,
+                properties: attribute.mapToPropertyPropertyPath.split("."),
+                valueMapColumns: this.getRelationIdColumns(relation).map(
+                    (column) => ({
+                        databaseName: column.databaseName,
+                        rawKey: this.buildAlias(
+                            aliasName,
+                            readsParentPrimaryKeys
+                                ? column.databaseName
+                                : column.referencedColumn!.databaseName,
                         ),
-                )
-                .map((column) => [
-                    this.buildAlias(aliasName, column.databaseName),
-                    column,
-                ])
-            metadatas.set(metadata, columns)
+                        hydrateWith: readsParentPrimaryKeys
+                            ? column
+                            : column.referencedColumn!,
+                    }),
+                ),
+            })
         }
+
+        this.relationIdsCache.set(aliasName, relationIds)
+        return relationIds
+    }
+
+    /**
+     * Writes a value into a (possibly nested) property path of the given map.
+     * Stops at the first empty path segment, like the recursive implementation did.
+     */
+    private mapToProperty(
+        properties: string[],
+        map: ObjectLiteral,
+        value: any,
+    ): void {
+        let target = map
+        for (let i = 0; i < properties.length; i++) {
+            const property = properties[i]
+            if (!property) return
+
+            if (i === properties.length - 1) {
+                target[property] = value
+                return
+            }
+
+            if (
+                typeof target[property] !== "object" ||
+                target[property] === null
+            ) {
+                target[property] = {}
+            }
+            target = target[property]
+        }
+    }
+
+    private buildColumnsToProcess(
+        aliasName: string,
+        metadata: EntityMetadata,
+    ): Array<{ key: string; column: ColumnMetadata }> {
+        const aliasSelected = this.selections.has(aliasName)
+        return metadata.columns
+            .filter(
+                (column) =>
+                    !column.isVirtual &&
+                    // if user does not selected the whole entity or he used partial selection and does not select this particular column
+                    // then we don't add this column and its value into the entity
+                    (aliasSelected ||
+                        this.selections.has(
+                            `${aliasName}.${column.propertyPath}`,
+                        )) &&
+                    // if table inheritance is used make sure this column is not child's column
+                    !metadata.childEntityMetadatas.some(
+                        (childMetadata) =>
+                            childMetadata.target === column.target,
+                    ),
+            )
+            .map((column) => ({
+                key: this.buildAlias(aliasName, column.databaseName),
+                column,
+            }))
+    }
+
+    /**
+     * Columns identifying the parent entity of a relation id result.
+     * Both the value map and the entity id hash are built from these.
+     */
+    private getRelationIdColumns(relation: RelationMetadata): ColumnMetadata[] {
+        let columns = this.relationIdColumnsCache.get(relation)
+        if (columns !== undefined) return columns
+
+        if (relation.isManyToOne || relation.isOneToOneOwner) {
+            columns = relation.entityMetadata.primaryColumns
+        } else if (relation.isOneToMany || relation.isOneToOneNotOwner) {
+            columns = relation.inverseRelation!.joinColumns
+        } else {
+            if (relation.isOwning) {
+                columns = relation.joinColumns
+            } else {
+                columns = relation.inverseRelation!.inverseJoinColumns
+            }
+        }
+
+        this.relationIdColumnsCache.set(relation, columns)
         return columns
     }
 
     private createValueMapFromJoinColumns(
-        relation: RelationMetadata,
-        parentAlias: string,
+        relationId: RelationIdToProcess,
         rawSqlResults: any[],
     ): ObjectLiteral {
-        let columns: ColumnMetadata[]
-        if (relation.isManyToOne || relation.isOneToOneOwner) {
-            columns = relation.entityMetadata.primaryColumns.map(
-                (joinColumn) => joinColumn,
-            )
-        } else if (relation.isOneToMany || relation.isOneToOneNotOwner) {
-            columns = relation.inverseRelation!.joinColumns.map(
-                (joinColumn) => joinColumn,
-            )
-        } else {
-            if (relation.isOwning) {
-                columns = relation.joinColumns.map((joinColumn) => joinColumn)
-            } else {
-                columns = relation.inverseRelation!.inverseJoinColumns.map(
-                    (joinColumn) => joinColumn,
-                )
-            }
-        }
-        return columns.reduce((valueMap, column) => {
-            for (const rawSqlResult of rawSqlResults) {
-                if (relation.isManyToOne || relation.isOneToOneOwner) {
-                    valueMap[column.databaseName] =
-                        this.driver.prepareHydratedValue(
-                            rawSqlResult[
-                                this.buildAlias(
-                                    parentAlias,
-                                    column.databaseName,
-                                )
-                            ],
-                            column,
-                        )
-                } else {
-                    valueMap[column.databaseName] =
-                        this.driver.prepareHydratedValue(
-                            rawSqlResult[
-                                this.buildAlias(
-                                    parentAlias,
-                                    column.referencedColumn!.databaseName,
-                                )
-                            ],
-                            column.referencedColumn!,
-                        )
-                }
-            }
-            return valueMap
-        }, {} as ObjectLiteral)
-    }
+        const valueMap: ObjectLiteral = {}
+        // every raw result used to be written into the same value map keys in order,
+        // which left the last one in place - so only the last one is read here
+        if (rawSqlResults.length === 0) return valueMap
 
-    private extractEntityPrimaryIds(
-        relation: RelationMetadata,
-        relationIdRawResult: any,
-    ) {
-        let columns: ColumnMetadata[]
-        if (relation.isManyToOne || relation.isOneToOneOwner) {
-            columns = relation.entityMetadata.primaryColumns.map(
-                (joinColumn) => joinColumn,
+        const rawSqlResult = rawSqlResults[rawSqlResults.length - 1]
+        const columns = relationId.valueMapColumns
+        for (let i = 0; i < columns.length; i++) {
+            const column = columns[i]
+            valueMap[column.databaseName] = this.driver.prepareHydratedValue(
+                rawSqlResult[column.rawKey],
+                column.hydrateWith,
             )
-        } else if (relation.isOneToMany || relation.isOneToOneNotOwner) {
-            columns = relation.inverseRelation!.joinColumns.map(
-                (joinColumn) => joinColumn,
-            )
-        } else {
-            if (relation.isOwning) {
-                columns = relation.joinColumns.map((joinColumn) => joinColumn)
-            } else {
-                columns = relation.inverseRelation!.inverseJoinColumns.map(
-                    (joinColumn) => joinColumn,
-                )
-            }
         }
-        return columns.reduce((data, column) => {
-            data[column.databaseName] = relationIdRawResult[column.databaseName]
-            return data
-        }, {} as ObjectLiteral)
+        return valueMap
     }
 
     /** Prepare data to run #transformRelationIds, as a lot of result independent data is needed in every call */
@@ -639,14 +791,20 @@ export class RawSqlResultsToEntityTransformer {
 
     /**
      * Use a simple JSON.stringify to create a simple hash of the primary ids of an entity.
-     * As this.extractEntityPrimaryIds always creates the primary id object in the same order, if the same relation is
-     * given, a simple JSON.stringify should be enough to get a unique hash per entity!
+     * As the primary id object is always created in the same column order, if the same
+     * relation is given, a simple JSON.stringify should be enough to get a unique hash
+     * per entity!
      *
      * @param relation
      * @param data
      */
     private hashEntityIds(relation: RelationMetadata, data: ObjectLiteral) {
-        const entityPrimaryIds = this.extractEntityPrimaryIds(relation, data)
+        const columns = this.getRelationIdColumns(relation)
+        const entityPrimaryIds: ObjectLiteral = {}
+        for (let i = 0; i < columns.length; i++) {
+            const databaseName = columns[i].databaseName
+            entityPrimaryIds[databaseName] = data[databaseName]
+        }
         return JSON.stringify(entityPrimaryIds)
     }
 }

--- a/test/functional/query-builder/entity-hydration/entity-hydration.test.ts
+++ b/test/functional/query-builder/entity-hydration/entity-hydration.test.ts
@@ -1,0 +1,402 @@
+import "../../../utils/test-setup"
+import {
+    closeTestingConnections,
+    createTestingConnections,
+    reloadTestingDatabases,
+} from "../../../utils/test-utils"
+import { expect } from "chai"
+import type { DataSource } from "../../../../src"
+import { Article } from "./entity/Article"
+import { Author } from "./entity/Author"
+import { Category } from "./entity/Category"
+import { Content } from "./entity/Content"
+import { Enrollment } from "./entity/Enrollment"
+import { Note } from "./entity/Note"
+import { Photo } from "./entity/Photo"
+import { Post } from "./entity/Post"
+import { Video } from "./entity/Video"
+
+describe("query builder > entity hydration", () => {
+    let dataSources: DataSource[]
+    before(async () => {
+        dataSources = await createTestingConnections({
+            entities: [
+                Article,
+                Author,
+                Category,
+                Content,
+                Enrollment,
+                Note,
+                Photo,
+                Post,
+                Video,
+            ],
+        })
+    })
+    beforeEach(() => reloadTestingDatabases(dataSources))
+    after(() => closeTestingConnections(dataSources))
+
+    async function seedPosts(dataSource: DataSource) {
+        const authors = [
+            { id: 1, name: "Author 1" },
+            { id: 2, name: "Author 2" },
+        ]
+        await dataSource.getRepository(Author).save(authors)
+
+        const categories = [
+            { id: 1, name: "Category 1" },
+            { id: 2, name: "Category 2" },
+            { id: 3, name: "Category 3" },
+        ]
+        await dataSource.getRepository(Category).save(categories)
+
+        await dataSource.getRepository(Photo).save([{ id: 1, url: "one.png" }])
+
+        // post 1: two categories, an author, a different editor and a photo
+        // post 2: one category, no author, no editor, no photo
+        // post 3: no categories at all
+        await dataSource.getRepository(Post).save([
+            {
+                id: 1,
+                title: "Post 1",
+                meta: { slug: "post-1", counters: { likes: 10, stars: 5 } },
+                author: authors[0],
+                editor: authors[1],
+                photo: { id: 1 },
+                categories: [categories[0], categories[1]],
+            },
+            {
+                id: 2,
+                title: "Post 2",
+                meta: { slug: "post-2", counters: { likes: 20, stars: null } },
+                categories: [categories[2]],
+            },
+            {
+                id: 3,
+                title: "Post 3",
+                meta: { slug: "post-3", counters: { likes: 30, stars: 15 } },
+                categories: [],
+            },
+        ])
+    }
+
+    describe("joins", () => {
+        it("should keep joined collections separate per entity", () =>
+            Promise.all(
+                dataSources.map(async (dataSource) => {
+                    await seedPosts(dataSource)
+
+                    const posts = await dataSource
+                        .createQueryBuilder(Post, "post")
+                        .leftJoinAndSelect("post.categories", "category")
+                        .orderBy("post.id", "ASC")
+                        .addOrderBy("category.id", "ASC")
+                        .getMany()
+
+                    expect(posts).to.have.lengthOf(3)
+                    expect(
+                        posts.map((post) =>
+                            post.categories.map((category) => category.id),
+                        ),
+                    ).to.eql([[1, 2], [3], []])
+                }),
+            ))
+
+        it("should hydrate two aliases of the same entity independently", () =>
+            Promise.all(
+                dataSources.map(async (dataSource) => {
+                    await seedPosts(dataSource)
+
+                    const post = await dataSource
+                        .createQueryBuilder(Post, "post")
+                        .leftJoinAndSelect("post.author", "author")
+                        .leftJoinAndSelect("post.editor", "editor")
+                        .where("post.id = :id", { id: 1 })
+                        .getOne()
+
+                    expect(post!.author).to.be.instanceOf(Author)
+                    expect(post!.author.id).to.equal(1)
+                    expect(post!.editor).to.be.instanceOf(Author)
+                    expect(post!.editor.id).to.equal(2)
+                }),
+            ))
+
+        it("should return null for a to-one relation that did not match", () =>
+            Promise.all(
+                dataSources.map(async (dataSource) => {
+                    await seedPosts(dataSource)
+
+                    const post = await dataSource
+                        .createQueryBuilder(Post, "post")
+                        .leftJoinAndSelect("post.author", "author")
+                        .leftJoinAndSelect("post.photo", "photo")
+                        .where("post.id = :id", { id: 2 })
+                        .getOne()
+
+                    expect(post!.author).to.be.null
+                    expect(post!.photo).to.be.null
+                }),
+            ))
+
+        it("should map joined results onto the properties given by mapToProperty", () =>
+            Promise.all(
+                dataSources.map(async (dataSource) => {
+                    await seedPosts(dataSource)
+
+                    const post = await dataSource
+                        .createQueryBuilder(Post, "post")
+                        .leftJoinAndMapMany(
+                            "post.mappedCategories",
+                            "post.categories",
+                            "category",
+                        )
+                        .leftJoinAndMapOne(
+                            "post.mappedAuthor",
+                            "post.author",
+                            "author",
+                        )
+                        .where("post.id = :id", { id: 1 })
+                        .orderBy("category.id", "ASC")
+                        .getOne()
+
+                    expect(
+                        post!.mappedCategories.map((category) => category.id),
+                    ).to.eql([1, 2])
+                    expect(post!.mappedAuthor).to.be.instanceOf(Author)
+                    expect(post!.mappedAuthor.id).to.equal(1)
+                }),
+            ))
+    })
+
+    describe("embedded columns", () => {
+        it("should hydrate nested embeddeds, including null leaf values", () =>
+            Promise.all(
+                dataSources.map(async (dataSource) => {
+                    await seedPosts(dataSource)
+
+                    const posts = await dataSource
+                        .createQueryBuilder(Post, "post")
+                        .orderBy("post.id", "ASC")
+                        .getMany()
+
+                    expect(posts[0].meta.slug).to.equal("post-1")
+                    expect(posts[0].meta.counters.likes).to.equal(10)
+                    expect(posts[0].meta.counters.stars).to.equal(5)
+                    expect(posts[1].meta.counters.likes).to.equal(20)
+                    expect(posts[1].meta.counters.stars).to.be.null
+                }),
+            ))
+
+        it("should only hydrate the columns that were selected", () =>
+            Promise.all(
+                dataSources.map(async (dataSource) => {
+                    await seedPosts(dataSource)
+
+                    const posts = await dataSource
+                        .createQueryBuilder(Post, "post")
+                        .select(["post.id", "post.meta.counters.likes"])
+                        .orderBy("post.id", "ASC")
+                        .getMany()
+
+                    expect(posts).to.have.lengthOf(3)
+                    expect(posts[0].title).to.be.undefined
+                    expect(posts[0].meta.slug).to.be.undefined
+                    expect(posts[0].meta.counters.likes).to.equal(10)
+                }),
+            ))
+    })
+
+    describe("composite primary keys", () => {
+        it("should group rows by every primary key column", () =>
+            Promise.all(
+                dataSources.map(async (dataSource) => {
+                    await dataSource.getRepository(Enrollment).save([
+                        { studentId: 1, courseId: 1, grade: "A" },
+                        { studentId: 1, courseId: 2, grade: "B" },
+                        { studentId: 2, courseId: 1, grade: "C" },
+                    ])
+                    await dataSource.getRepository(Note).save([
+                        {
+                            id: 1,
+                            text: "first",
+                            enrollment: { studentId: 1, courseId: 1 },
+                        },
+                        {
+                            id: 2,
+                            text: "second",
+                            enrollment: { studentId: 1, courseId: 1 },
+                        },
+                        {
+                            id: 3,
+                            text: "third",
+                            enrollment: { studentId: 1, courseId: 2 },
+                        },
+                    ])
+
+                    const enrollments = await dataSource
+                        .createQueryBuilder(Enrollment, "enrollment")
+                        .leftJoinAndSelect("enrollment.notes", "note")
+                        .orderBy("enrollment.studentId", "ASC")
+                        .addOrderBy("enrollment.courseId", "ASC")
+                        .addOrderBy("note.id", "ASC")
+                        .getMany()
+
+                    expect(enrollments).to.have.lengthOf(3)
+                    expect(
+                        enrollments.map((enrollment) => [
+                            enrollment.studentId,
+                            enrollment.courseId,
+                            enrollment.notes.map((note) => note.id),
+                        ]),
+                    ).to.eql([
+                        [1, 1, [1, 2]],
+                        [1, 2, [3]],
+                        [2, 1, []],
+                    ])
+                }),
+            ))
+    })
+
+    describe("single table inheritance", () => {
+        it("should hydrate each row into the entity its discriminator selects", () =>
+            Promise.all(
+                dataSources.map(async (dataSource) => {
+                    await dataSource
+                        .getRepository(Article)
+                        .save([{ id: 1, title: "Article 1", body: "body 1" }])
+                    await dataSource
+                        .getRepository(Video)
+                        .save([{ id: 2, title: "Video 2", duration: 120 }])
+                    await dataSource
+                        .getRepository(Article)
+                        .save([{ id: 3, title: "Article 3", body: "body 3" }])
+
+                    const contents = await dataSource
+                        .createQueryBuilder(Content, "content")
+                        .orderBy("content.id", "ASC")
+                        .getMany()
+
+                    expect(contents).to.have.lengthOf(3)
+                    expect(contents[0]).to.be.instanceOf(Article)
+                    expect((contents[0] as Article).body).to.equal("body 1")
+                    expect(contents[1]).to.be.instanceOf(Video)
+                    expect((contents[1] as Video).duration).to.equal(120)
+                    expect(contents[2]).to.be.instanceOf(Article)
+                    expect((contents[2] as Article).body).to.equal("body 3")
+                }),
+            ))
+    })
+
+    describe("relation ids", () => {
+        it("should map many-to-many relation ids, including empty ones", () =>
+            Promise.all(
+                dataSources.map(async (dataSource) => {
+                    await seedPosts(dataSource)
+
+                    const posts = await dataSource
+                        .createQueryBuilder(Post, "post")
+                        .loadRelationIdAndMap(
+                            "post.categoryIds",
+                            "post.categories",
+                        )
+                        .orderBy("post.id", "ASC")
+                        .getMany()
+
+                    expect(posts).to.have.lengthOf(3)
+                    expect(
+                        posts.map((post) => [...post.categoryIds].sort()),
+                    ).to.eql([[1, 2], [3], []])
+                }),
+            ))
+
+        it("should map many-to-one relation ids", () =>
+            Promise.all(
+                dataSources.map(async (dataSource) => {
+                    await seedPosts(dataSource)
+
+                    const posts = await dataSource
+                        .createQueryBuilder(Post, "post")
+                        .loadRelationIdAndMap("post.authorId", "post.author")
+                        .orderBy("post.id", "ASC")
+                        .getMany()
+
+                    // posts without an author get null, not undefined: the loader
+                    // selects the join column for every post, null included
+                    expect(posts.map((post) => post.authorId)).to.eql([
+                        1,
+                        null,
+                        null,
+                    ])
+                }),
+            ))
+
+        it("should map relation ids into a nested property path", () =>
+            Promise.all(
+                dataSources.map(async (dataSource) => {
+                    await seedPosts(dataSource)
+
+                    const posts = await dataSource
+                        .createQueryBuilder(Post, "post")
+                        .loadRelationIdAndMap(
+                            "post.nested.categoryIds",
+                            "post.categories",
+                        )
+                        .orderBy("post.id", "ASC")
+                        .getMany()
+
+                    expect(
+                        posts.map((post) =>
+                            [...post.nested.categoryIds].sort(),
+                        ),
+                    ).to.eql([[1, 2], [3], []])
+                }),
+            ))
+    })
+
+    describe("many entities", () => {
+        it("should hydrate every entity of a large result set independently", () =>
+            Promise.all(
+                dataSources.map(async (dataSource) => {
+                    const categories = Array.from(
+                        { length: 150 },
+                        (_, index) => ({
+                            id: index + 1,
+                            name: `Category ${index + 1}`,
+                        }),
+                    )
+                    await dataSource
+                        .getRepository(Category)
+                        .save(categories, { chunk: 100 })
+
+                    const posts = Array.from({ length: 50 }, (_, index) => ({
+                        id: index + 1,
+                        title: `Post ${index + 1}`,
+                        meta: {
+                            slug: `post-${index + 1}`,
+                            counters: { likes: index, stars: index * 2 },
+                        },
+                        categories: categories.slice(index * 3, index * 3 + 3),
+                    }))
+                    await dataSource
+                        .getRepository(Post)
+                        .save(posts, { chunk: 25 })
+
+                    const loaded = await dataSource
+                        .createQueryBuilder(Post, "post")
+                        .leftJoinAndSelect("post.categories", "category")
+                        .orderBy("post.id", "ASC")
+                        .addOrderBy("category.id", "ASC")
+                        .getMany()
+
+                    expect(loaded).to.have.lengthOf(50)
+                    loaded.forEach((post, index) => {
+                        expect(post.title).to.equal(`Post ${index + 1}`)
+                        expect(post.meta.counters.likes).to.equal(index)
+                        expect(
+                            post.categories.map((category) => category.id),
+                        ).to.eql([index * 3 + 1, index * 3 + 2, index * 3 + 3])
+                    })
+                }),
+            ))
+    })
+})

--- a/test/functional/query-builder/entity-hydration/entity/Article.ts
+++ b/test/functional/query-builder/entity-hydration/entity/Article.ts
@@ -1,0 +1,8 @@
+import { ChildEntity, Column } from "../../../../../src"
+import { Content } from "./Content"
+
+@ChildEntity("article")
+export class Article extends Content {
+    @Column()
+    body: string
+}

--- a/test/functional/query-builder/entity-hydration/entity/Author.ts
+++ b/test/functional/query-builder/entity-hydration/entity/Author.ts
@@ -1,0 +1,10 @@
+import { Column, Entity, PrimaryColumn } from "../../../../../src"
+
+@Entity()
+export class Author {
+    @PrimaryColumn()
+    id: number
+
+    @Column()
+    name: string
+}

--- a/test/functional/query-builder/entity-hydration/entity/Category.ts
+++ b/test/functional/query-builder/entity-hydration/entity/Category.ts
@@ -1,0 +1,10 @@
+import { Column, Entity, PrimaryColumn } from "../../../../../src"
+
+@Entity()
+export class Category {
+    @PrimaryColumn()
+    id: number
+
+    @Column()
+    name: string
+}

--- a/test/functional/query-builder/entity-hydration/entity/Content.ts
+++ b/test/functional/query-builder/entity-hydration/entity/Content.ts
@@ -1,0 +1,16 @@
+import {
+    Column,
+    Entity,
+    PrimaryColumn,
+    TableInheritance,
+} from "../../../../../src"
+
+@Entity()
+@TableInheritance({ column: { type: "varchar", name: "kind" } })
+export class Content {
+    @PrimaryColumn()
+    id: number
+
+    @Column()
+    title: string
+}

--- a/test/functional/query-builder/entity-hydration/entity/Enrollment.ts
+++ b/test/functional/query-builder/entity-hydration/entity/Enrollment.ts
@@ -1,0 +1,20 @@
+import { Column, Entity, OneToMany, PrimaryColumn } from "../../../../../src"
+import { Note } from "./Note"
+
+/**
+ * Composite primary key, so hydration has to group rows by more than one column.
+ */
+@Entity()
+export class Enrollment {
+    @PrimaryColumn()
+    studentId: number
+
+    @PrimaryColumn()
+    courseId: number
+
+    @Column()
+    grade: string
+
+    @OneToMany(() => Note, (note) => note.enrollment)
+    notes: Note[]
+}

--- a/test/functional/query-builder/entity-hydration/entity/Meta.ts
+++ b/test/functional/query-builder/entity-hydration/entity/Meta.ts
@@ -1,0 +1,17 @@
+import { Column } from "../../../../../src"
+
+export class Counters {
+    @Column()
+    likes: number
+
+    @Column({ type: "int", nullable: true })
+    stars: number | null
+}
+
+export class Meta {
+    @Column()
+    slug: string
+
+    @Column(() => Counters)
+    counters: Counters
+}

--- a/test/functional/query-builder/entity-hydration/entity/Note.ts
+++ b/test/functional/query-builder/entity-hydration/entity/Note.ts
@@ -1,0 +1,16 @@
+import { Column, Entity, ManyToOne, PrimaryColumn } from "../../../../../src"
+import { Enrollment } from "./Enrollment"
+
+@Entity()
+export class Note {
+    @PrimaryColumn()
+    id: number
+
+    @Column()
+    text: string
+
+    @ManyToOne(() => Enrollment, (enrollment) => enrollment.notes, {
+        nullable: true,
+    })
+    enrollment: Enrollment
+}

--- a/test/functional/query-builder/entity-hydration/entity/Photo.ts
+++ b/test/functional/query-builder/entity-hydration/entity/Photo.ts
@@ -1,0 +1,10 @@
+import { Column, Entity, PrimaryColumn } from "../../../../../src"
+
+@Entity()
+export class Photo {
+    @PrimaryColumn()
+    id: number
+
+    @Column()
+    url: string
+}

--- a/test/functional/query-builder/entity-hydration/entity/Post.ts
+++ b/test/functional/query-builder/entity-hydration/entity/Post.ts
@@ -1,0 +1,53 @@
+import {
+    Column,
+    Entity,
+    JoinColumn,
+    JoinTable,
+    ManyToMany,
+    ManyToOne,
+    OneToOne,
+    PrimaryColumn,
+} from "../../../../../src"
+import { Author } from "./Author"
+import { Category } from "./Category"
+import { Meta } from "./Meta"
+import { Photo } from "./Photo"
+
+@Entity()
+export class Post {
+    @PrimaryColumn()
+    id: number
+
+    @Column()
+    title: string
+
+    @Column(() => Meta)
+    meta: Meta
+
+    @ManyToOne(() => Author, { nullable: true })
+    author: Author
+
+    /**
+     * Deliberately a second relation to Author: "author" and "editor" are two aliases
+     * sharing one entity metadata, which must still hydrate independently.
+     */
+    @ManyToOne(() => Author, { nullable: true })
+    editor: Author
+
+    @OneToOne(() => Photo, { nullable: true })
+    @JoinColumn()
+    photo: Photo
+
+    @ManyToMany(() => Category)
+    @JoinTable()
+    categories: Category[]
+
+    // filled in by loadRelationIdAndMap
+    categoryIds: number[]
+    authorId: number
+    nested: { categoryIds: number[] }
+
+    // filled in by leftJoinAndMapMany / leftJoinAndMapOne
+    mappedCategories: Category[]
+    mappedAuthor: Author
+}

--- a/test/functional/query-builder/entity-hydration/entity/Video.ts
+++ b/test/functional/query-builder/entity-hydration/entity/Video.ts
@@ -1,0 +1,8 @@
+import { ChildEntity, Column } from "../../../../../src"
+import { Content } from "./Content"
+
+@ChildEntity("video")
+export class Video extends Content {
+    @Column()
+    duration: number
+}


### PR DESCRIPTION
### Description of change

`find()`, `getOne()` and `getMany()` all funnel into `RawSqlResultsToEntityTransformer`,
and it was re-deriving the same per-alias data for every single entity. Since
`transform()` recurses once per parent entity for each joined alias, that cost got
multiplied by the row count. The main culprit was `transformJoins()`, which re-resolved
every `JoinAttribute` per entity, and `parentAlias`, `relationPropertyPath` and
`mapToProperty*` are getters that re-parse their strings on every access.

All of that is now resolved once per alias/metadata pair into a small plan object and
reused. It's passed as an optional trailing argument, so the `protected` method
signatures still work if anyone overrides them.

A few smaller things while I was in there: no per-row array in `group()`, no closure per
entity in the relation-id mapping, no tree copy in `setEntityValue()`, skip the lazy
relation `forEach` in `create()` when there aren't any, and check `Number`/`String`
first in the postgres `prepareHydratedValue()` chain instead of last (every branch
compares `type` against a distinct value, so the order doesn't matter).

Hydration on its own, 2000 posts with 5 categories each, so 10 000 rows:

| | before | after |
|---|---|---|
| 2000 entities, many-to-many + many-to-one join | 4.50 ms | 1.75 ms |
| 10 000 entities, no joins | 3.32 ms | 1.47 ms |

Same fixture end to end, query time included:

| | before | after |
|---|---|---|
| `find()` | 3.0 ms | 2.4 ms |
| `find()` with relations | 19.2 ms | 14.9 ms |
| `getMany()` with two `leftJoinAndSelect` | 18.6 ms | 14.9 ms |

Measured against postgres 17, back to back on the same tree with the change stashed,
median of 60 runs.

Behaviour should be unchanged. Full suite is green, and I also ran the old and new
transformer side by side over identical raw rows and diffed the output: 19 scenarios
(single table inheritance, composite keys, views, relation ids, embeddeds, partial
selects, the no-primary-key fallback) came out identical. The new tests pass on the
parent commit too, so they pin down existing behaviour.

Only postgres got the `prepareHydratedValue` reorder, since that's the driver I could
benchmark and test against.

### Pull-Request Checklist

- [x] Code is up-to-date with the `master` branch
- [ ] This pull request links a relevant issue using a closing keyword:
      `Fixes #NNNN`, `Closes #NNNN`, or `Resolves #NNNN` — N/A
- [x] There are new or updated tests validating the change (`tests/**.test.ts`)
- [ ] Documentation has been updated to reflect this change (`docs/docs/**.md`) — N/A,
      no API or behaviour change