### PR TITLE
fix(metadata-builder): keep the STI discriminator index on entities with embeddeds

### DIFF
--- a/src/metadata-builder/EntityMetadataBuilder.ts
+++ b/src/metadata-builder/EntityMetadataBuilder.ts
@@ -1146,16 +1146,18 @@ export class EntityMetadataBuilder {
             return
         }
 
-        entityMetadata.indices.push(
-            new IndexMetadata({
-                entityMetadata: entityMetadata,
-                columns: [entityMetadata.discriminatorColumn!],
-                args: {
-                    target: entityMetadata.target,
-                    unique: false,
-                },
-            }),
-        )
+        const index = new IndexMetadata({
+            entityMetadata: entityMetadata,
+            columns: [entityMetadata.discriminatorColumn!],
+            args: {
+                target: entityMetadata.target,
+                unique: false,
+            },
+        })
+
+        // computeEntityMetadataStep2 rebuilds "indices" from "ownIndices".
+        entityMetadata.ownIndices.push(index)
+        this.computeEntityMetadataStep2(entityMetadata)
     }
 
     /**

--- a/test/functional/table-inheritance/single-table/discriminator-index-with-embedded/discriminator-index-with-embedded.test.ts
+++ b/test/functional/table-inheritance/single-table/discriminator-index-with-embedded/discriminator-index-with-embedded.test.ts
@@ -1,0 +1,102 @@
+import "reflect-metadata"
+
+import { expect } from "chai"
+
+import {
+    closeTestingConnections,
+    createTestingConnections,
+    reloadTestingDatabases,
+} from "../../../../utils/test-utils"
+import type { DataSource } from "../../../../../src/data-source/DataSource"
+import type { EntityMetadata } from "../../../../../src/metadata/EntityMetadata"
+
+import {
+    EmbeddedBase,
+    EmbeddedChild,
+    IndexedBase,
+    IndexedChild,
+    PlainBase,
+    PlainChild,
+} from "./entity"
+
+function discriminatorIndices(metadata: EntityMetadata) {
+    return metadata.indices.filter(
+        (index) =>
+            index.columns.length === 1 &&
+            index.columns[0].databaseName ===
+                metadata.discriminatorColumn!.databaseName,
+    )
+}
+
+// https://github.com/typeorm/typeorm/issues/12840
+describe("table-inheritance > single-table > discriminator-index-with-embedded", () => {
+    let dataSources: DataSource[]
+
+    before(async () => {
+        dataSources = await createTestingConnections({
+            entities: [
+                EmbeddedBase,
+                EmbeddedChild,
+                IndexedBase,
+                IndexedChild,
+                PlainBase,
+                PlainChild,
+            ],
+            schemaCreate: true,
+            dropSchema: true,
+            enabledDrivers: [
+                "better-sqlite3",
+                "cockroachdb",
+                "mariadb",
+                "mssql",
+                "mysql",
+                "oracle",
+                "postgres",
+            ],
+        })
+    })
+
+    beforeEach(() => reloadTestingDatabases(dataSources))
+
+    after(() => closeTestingConnections(dataSources))
+
+    it("should index the discriminator column of an entity with an embedded column", () =>
+        Promise.all(
+            dataSources.map(async (dataSource) => {
+                const metadata = dataSource.getMetadata(EmbeddedBase)
+
+                expect(discriminatorIndices(metadata)).to.have.length(1)
+
+                const queryRunner = dataSource.createQueryRunner()
+                await queryRunner.connect()
+                const table = (await queryRunner.getTable("embedded_base"))!
+                await queryRunner.release()
+
+                const indices = table.indices.filter(
+                    (index) =>
+                        index.columnNames.length === 1 &&
+                        index.columnNames[0] === "discriminator",
+                )
+
+                expect(indices).to.have.length(1)
+            }),
+        ))
+
+    it("should not add a second index when the discriminator column is already indexed", () => {
+        dataSources.forEach((dataSource) => {
+            const metadata = dataSource.getMetadata(IndexedBase)
+            const indices = discriminatorIndices(metadata)
+
+            expect(indices).to.have.length(1)
+            expect(indices[0].name).to.be.equal("IX_indexed_base_discriminator")
+        })
+    })
+
+    it("should keep indexing the discriminator column of an entity without embedded columns", () => {
+        dataSources.forEach((dataSource) => {
+            const metadata = dataSource.getMetadata(PlainBase)
+
+            expect(discriminatorIndices(metadata)).to.have.length(1)
+        })
+    })
+})

--- a/test/functional/table-inheritance/single-table/discriminator-index-with-embedded/entity/EmbeddedBase.ts
+++ b/test/functional/table-inheritance/single-table/discriminator-index-with-embedded/entity/EmbeddedBase.ts
@@ -1,0 +1,28 @@
+import {
+    ChildEntity,
+    Column,
+    Entity,
+    PrimaryGeneratedColumn,
+    TableInheritance,
+} from "../../../../../../src"
+
+import { Meta } from "./Meta"
+
+/**
+ * Single table inheritance with both an embedded column and a generated column.
+ */
+@Entity({ name: "embedded_base" })
+@TableInheritance({ column: { type: String, name: "discriminator" } })
+export abstract class EmbeddedBase {
+    @PrimaryGeneratedColumn()
+    id!: number
+
+    @Column(() => Meta)
+    meta!: Meta
+}
+
+@ChildEntity()
+export class EmbeddedChild extends EmbeddedBase {
+    @Column({ type: String, nullable: true })
+    value?: string
+}

--- a/test/functional/table-inheritance/single-table/discriminator-index-with-embedded/entity/IndexedBase.ts
+++ b/test/functional/table-inheritance/single-table/discriminator-index-with-embedded/entity/IndexedBase.ts
@@ -1,0 +1,33 @@
+import {
+    ChildEntity,
+    Column,
+    Entity,
+    Index,
+    PrimaryGeneratedColumn,
+    TableInheritance,
+} from "../../../../../../src"
+
+import { Meta } from "./Meta"
+
+/**
+ * Same as EmbeddedBase, but the discriminator column is indexed explicitly by the user.
+ */
+@Entity({ name: "indexed_base" })
+@TableInheritance({ column: { type: String, name: "discriminator" } })
+export abstract class IndexedBase {
+    @PrimaryGeneratedColumn()
+    id!: number
+
+    @Column({ type: String })
+    @Index("IX_indexed_base_discriminator")
+    discriminator!: string
+
+    @Column(() => Meta)
+    meta!: Meta
+}
+
+@ChildEntity()
+export class IndexedChild extends IndexedBase {
+    @Column({ type: String, nullable: true })
+    value?: string
+}

--- a/test/functional/table-inheritance/single-table/discriminator-index-with-embedded/entity/Meta.ts
+++ b/test/functional/table-inheritance/single-table/discriminator-index-with-embedded/entity/Meta.ts
@@ -1,0 +1,6 @@
+import { Column } from "../../../../../../src"
+
+export class Meta {
+    @Column({ type: String, nullable: true })
+    note?: string
+}

--- a/test/functional/table-inheritance/single-table/discriminator-index-with-embedded/entity/PlainBase.ts
+++ b/test/functional/table-inheritance/single-table/discriminator-index-with-embedded/entity/PlainBase.ts
@@ -1,0 +1,23 @@
+import {
+    ChildEntity,
+    Column,
+    Entity,
+    PrimaryGeneratedColumn,
+    TableInheritance,
+} from "../../../../../../src"
+
+/**
+ * Single table inheritance without any embedded column - the case that always worked.
+ */
+@Entity({ name: "plain_base" })
+@TableInheritance({ column: { type: String, name: "discriminator" } })
+export abstract class PlainBase {
+    @PrimaryGeneratedColumn()
+    id!: number
+}
+
+@ChildEntity()
+export class PlainChild extends PlainBase {
+    @Column({ type: String, nullable: true })
+    value?: string
+}

--- a/test/functional/table-inheritance/single-table/discriminator-index-with-embedded/entity/index.ts
+++ b/test/functional/table-inheritance/single-table/discriminator-index-with-embedded/entity/index.ts
@@ -1,0 +1,5 @@
+export * from "./Meta"
+
+export * from "./EmbeddedBase"
+export * from "./IndexedBase"
+export * from "./PlainBase"


### PR DESCRIPTION
### Description of change

The index that `EntityMetadataBuilder.createKeysForTableInheritance()` creates on an STI discriminator column is silently dropped when the entity has at least one embedded column and at least one generated column.

`computeEntityMetadataStep2()` derives `indices` from `ownIndices`:

```ts
entityMetadata.indices = entityMetadata.embeddeds.reduce(
    (indices, embedded) => indices.concat(embedded.indicesFromTree),
    entityMetadata.ownIndices,
)
```

With no embeddeds, `reduce` returns the initial value by reference, so `indices` *is* `ownIndices` and the later `indices.push(...)` in `createKeysForTableInheritance()` also lands in `ownIndices`. With one or more embeddeds, `concat` returns a new array, so the pushed index lives only on that detached copy. `build()` then re-runs `computeEntityMetadataStep2()` for every entity that has a generated column, which reassigns `indices` from `ownIndices` and discards the auto-created index. No error, no warning — the table is simply created without the index.

All three conditions are needed: STI base, at least one embedded column, at least one generated column. A `@PrimaryGeneratedColumn()` id supplies the third, so in practice any framework that puts an embedded column on its base entity loses every STI discriminator index (see the issue for the Vendure case and its production impact).

The fix pushes the auto-created index onto `ownIndices` and then calls `computeEntityMetadataStep2()` to rebuild `indices` from it — the same push-and-recompute pattern `EntityMetadataBuilder` already uses for the indices it creates for relations. `ownIndices` is what every `computeEntityMetadataStep2()` run preserves, and the recompute happens before indices are built.

Behavior that is deliberately unchanged:

- the existing `isDiscriminatorColumnAlreadyIndexed` guard still short-circuits when the user has their own `@Index()` on the discriminator column, so no duplicate index appears for projects that already worked around this by hand;
- entities without embeddeds keep exactly the one index they have today.

The same code shape exists on the `v0` branch, so 0.3.x is affected as well. This PR targets `master`; happy to open the equivalent backport if you want it there.

**Verification.** Ran locally against `better-sqlite3` (`ormconfig.json` limited to that driver): the full suite passes, and the new test file fails on `master` without the source change (`expected [] to have a length of 1`) and passes with it. The behavior is decided at the metadata layer, before any driver is involved, so the outcome is driver-independent; the new test enables the same driver list as the closest existing test (`test/github-issues/10496`) minus `spanner`, and I did not run the non-sqlite drivers locally.

New tests in `test/functional/table-inheritance/single-table/discriminator-index-with-embedded`:

- STI base with an embedded column and a generated id — the discriminator index exists, both in `EntityMetadata.indices` and on the created table;
- same shape plus a user-defined `@Index()` on the discriminator column — exactly one index, keeping the user's name (dedup guard intact);
- STI base without embedded columns — still exactly one index (no regression).

Closes #12840

### Pull-Request Checklist

- [x] Code is up-to-date with the `master` branch
- [x] This pull request links a relevant issue using a closing keyword:
      `Fixes #NNNN`, `Closes #NNNN`, or `Resolves #NNNN`
- [x] There are new or updated tests validating the change (`tests/**.test.ts`)
- [x] Documentation has been updated to reflect this change (`docs/docs/**.md`) — N/A, this restores documented/intended behavior and changes no public API

